### PR TITLE
Replace {{event)}} with domxref (batch #5)

### DIFF
--- a/files/en-us/mozilla/firefox/releases/32/index.md
+++ b/files/en-us/mozilla/firefox/releases/32/index.md
@@ -45,7 +45,7 @@ Highlights:
 
 ### Interfaces/APIs/DOM
 
-- The {{domxref("NavigatorLanguage.languages", "navigator.languages")}} property and {{event("languagechange")}} event have been implemented ({{Bug(889335)}}).
+- The {{domxref("NavigatorLanguage.languages", "navigator.languages")}} property and {{domxref("Window.languagechange_event", "languagechange")}} event have been implemented ({{Bug(889335)}}).
 - The {{domxref("Navigator.vibrate()")}} method behavior has been adapted to the latest specification: too long vibrations are now truncated ({{bug(1014581)}}).
 - The {{domxref("KeyboardEvent.getModifierState()")}} and {{domxref("MouseEvent.getModifierState()")}} methods have been extended to support the `Accel` virtual modifier ({{Bug(1009388)}}).
 - The {{domxref("KeyboardEvent.code")}} property have been experimentally implemented: it is disabled on release build ({{Bug(865649)}}).

--- a/files/en-us/web/api/document/onoffline/index.md
+++ b/files/en-us/web/api/document/onoffline/index.md
@@ -10,4 +10,4 @@ tags:
 ---
 {{APIRef("DOM")}}
 
-The **`Document.onoffline`** event handler is called when an {{event("offline")}} is fired on the {{HtmlElement("body")}} element and bubbles up, when {{domxref("Navigator.onLine")}} property changes and becomes `false`.
+The **`Document.onoffline`** event handler is called when an {{domxref("Window.offline_event", "offline")}} is fired on the {{HtmlElement("body")}} element and bubbles up, when {{domxref("Navigator.onLine")}} property changes and becomes `false`.

--- a/files/en-us/web/api/htmlbodyelement/index.md
+++ b/files/en-us/web/api/htmlbodyelement/index.md
@@ -49,11 +49,11 @@ _No specific event handlers; inherits event handlers from its parent, {{domxref(
 - {{domxref("WindowEventHandlers.onhashchange")}}
   - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("hashchange")}} event is raised.
 - {{domxref("WindowEventHandlers.onlanguagechange")}} {{experimental_inline}}
-  - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("languagechange")}} event is raised.
+  - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("Window.languagechange_event", "languagechange")}} event is raised.
 - {{domxref("WindowEventHandlers.onoffline")}}
-  - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("offline")}} event is raised.
+  - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("Window.offline_event", "offline")}} event is raised.
 - {{domxref("WindowEventHandlers.ononline")}}
-  - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("online")}} event is raised.
+  - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("Window.online_event", "online")}} event is raised.
 - {{domxref("WindowEventHandlers.onpagehide")}}
   - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("pagehide")}} event is raised.
 - {{domxref("WindowEventHandlers.onpageshow")}}
@@ -65,9 +65,9 @@ _No specific event handlers; inherits event handlers from its parent, {{domxref(
 - {{domxref("GlobalEventHandlers.onresize")}}
   - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("resize")}} event is raised.
 - {{domxref("WindowEventHandlers.onstorage")}}
-  - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("storage")}} event is raised.
+  - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("Window.storage_event", "storage")}} event is raised.
 - {{domxref("WindowEventHandlers.onunhandledrejection")}}
-  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code executed when the {{event("unhandledrejection")}} event is raised, indicating that a {{jsxref("Promise")}} was rejected but the rejection was not handled.
+  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code executed when the {{domxref("Window.unhandledrejection_event", "unhandledrejection")}} event is raised, indicating that a {{jsxref("Promise")}} was rejected but the rejection was not handled.
 - {{domxref("WindowEventHandlers.onunload")}}
   - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("unload")}} event is raised.
 

--- a/files/en-us/web/api/htmlframesetelement/index.md
+++ b/files/en-us/web/api/htmlframesetelement/index.md
@@ -42,11 +42,11 @@ _No specific event handler; inherits event handlers from its parent, {{domxref("
 - {{domxref("WindowEventHandlers.onhashchange")}}
   - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("hashchange")}} event is raised.
 - {{domxref("WindowEventHandlers.onlanguagechange")}} {{experimental_inline}}
-  - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("languagechange")}} event is raised.
+  - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("Window.languagechange_event", "languagechange")}} event is raised.
 - {{domxref("WindowEventHandlers.onoffline")}}
-  - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("offline")}} event is raised.
+  - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("Window.offline_event", "offline")}} event is raised.
 - {{domxref("WindowEventHandlers.ononline")}}
-  - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("online")}} event is raised.
+  - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("Window.online_event", "online")}} event is raised.
 - {{domxref("WindowEventHandlers.onpagehide")}}
   - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("pagehide")}} event is raised.
 - {{domxref("WindowEventHandlers.onpageshow")}}
@@ -56,7 +56,7 @@ _No specific event handler; inherits event handlers from its parent, {{domxref("
 - {{domxref("WindowEventHandlers.onresize")}}
   - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("resize")}} event is raised.
 - {{domxref("WindowEventHandlers.onstorage")}}
-  - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("storage")}} event is raised.
+  - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("Window.storage_event", "storage")}} event is raised.
 - {{domxref("WindowEventHandlers.onunload")}}
   - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("unload")}} event is raised.
 

--- a/files/en-us/web/api/navigator/languages/index.md
+++ b/files/en-us/web/api/navigator/languages/index.md
@@ -23,7 +23,7 @@ The value of {{domxref("Navigator.language","navigator.language")}} is the
 first element of the returned array.
 
 When its value changes, as the user's preferred languages are changed a
-{{event("languagechange")}} event is fired on the {{domxref("Window")}} object.
+{{domxref("Window.languagechange_event", "languagechange")}} event is fired on the {{domxref("Window")}} object.
 
 The `Accept-Language` HTTP header in every HTTP request from the user's
 browser uses the same value for the `navigator.languages` property except for

--- a/files/en-us/web/api/promiserejectionevent/promise/index.md
+++ b/files/en-us/web/api/promiserejectionevent/promise/index.md
@@ -64,4 +64,4 @@ window.onunhandledrejection = function(event) {
 - {{jsxref("Promise")}}
 - {{domxref("PromiseRejectionEvent")}}
 - {{event("rejectionhandled")}}
-- {{event("unhandledrejection")}}
+- {{domxref("Window.unhandledrejection_event", "unhandledrejection")}}

--- a/files/en-us/web/api/promiserejectionevent/promiserejectionevent/index.md
+++ b/files/en-us/web/api/promiserejectionevent/promiserejectionevent/index.md
@@ -23,7 +23,7 @@ fail and whose failures go unnoticed. It also becomes easier to write a global h
 for errors.
 
 There are two types of `PromiseRejectionEvent`:
-{{event("unhandledrejection")}} is sent by the JavaScript runtime when a promise is
+{{domxref("Window.unhandledrejection_event", "unhandledrejection")}} is sent by the JavaScript runtime when a promise is
 rejected but the rejection goes unhandled. A {{event("rejectionhandled")}} event is
 emitted if a promise is rejected but the rejection is caught by a rejection handler..
 
@@ -62,7 +62,7 @@ A new `PromiseRejectionEvent` configured as specified by the parameters.
 
 ## Examples
 
-This example creates a new {{event("unhandledrejection")}} event for the promise
+This example creates a new {{domxref("Window.unhandledrejection_event", "unhandledrejection")}} event for the promise
 `myPromise` with the reason being the string "My house is on fire". The
 `reason` could just as easily be a number, or even an object with detailed
 information including the home address, how serious the fire is, and the phone number of

--- a/files/en-us/web/api/promiserejectionevent/reason/index.md
+++ b/files/en-us/web/api/promiserejectionevent/reason/index.md
@@ -47,4 +47,4 @@ window.onunhandledrejection = function(e) {
 - {{jsxref("Promise")}}
 - {{domxref("PromiseRejectionEvent")}}
 - {{event("rejectionhandled")}}
-- {{event("unhandledrejection")}}
+- {{domxref("Window.unhandledrejection_event", "unhandledrejection")}}

--- a/files/en-us/web/api/window/index.md
+++ b/files/en-us/web/api/window/index.md
@@ -351,7 +351,7 @@ _This interface inherits event handlers from the {{domxref("EventTarget")}} inte
 - {{domxref("GlobalEventHandlers.onkeyup")}}
   - : Called when you finish releasing ANY key. See {{event("keyup")}} event.
 - {{domxref("WindowEventHandlers.onlanguagechange")}}
-  - : An event handler property for {{event("languagechange")}} events on the window.
+  - : An event handler property for {{domxref("Window.languagechange_event", "languagechange")}} events on the window.
 - {{domxref("GlobalEventHandlers.onload")}}
   - : Called after all resources and the DOM are fully loaded. WILL NOT get called when the page is loaded from cache, such as with back button.
 - {{domxref("GlobalEventHandlers.onmousedown")}}
@@ -365,9 +365,9 @@ _This interface inherits event handlers from the {{domxref("EventTarget")}} inte
 - {{domxref("GlobalEventHandlers.onmouseup")}}
   - : Called when ANY mouse button is released
 - {{domxref("WindowEventHandlers.onoffline")}}
-  - : Called when network connection is lost. See {{event("offline")}} event.
+  - : Called when network connection is lost. See {{domxref("Window.offline_event", "offline")}} event.
 - {{domxref("WindowEventHandlers.ononline")}}
-  - : Called when network connection is established. See {{event("online")}} event.
+  - : Called when network connection is established. See {{domxref("Window.online_event", "online")}} event.
 - {{domxref("WindowEventHandlers.onpagehide")}}
   - : Called when the user navigates away from the page, before the onunload event. See {{event("pagehide")}} event.
 - {{domxref("WindowEventHandlers.onpageshow")}}
@@ -387,7 +387,7 @@ _This interface inherits event handlers from the {{domxref("EventTarget")}} inte
 - {{domxref("GlobalEventHandlers.onselectionchange")}}
   - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("selectionchange")}} event is raised.
 - {{domxref("WindowEventHandlers.onstorage")}}
-  - : Called when there is a change in session storage or local storage. See {{event("storage")}} event
+  - : Called when there is a change in session storage or local storage. See {{domxref("Window.storage_event", "storage")}} event
 - {{domxref("GlobalEventHandlers.onsubmit")}}
   - : Called when a form is submitted
 - {{domxref("WindowEventHandlers.onunhandledrejection")}} {{experimental_inline}}

--- a/files/en-us/web/api/windoweventhandlers/index.md
+++ b/files/en-us/web/api/windoweventhandlers/index.md
@@ -29,11 +29,11 @@ _The events properties, of the form `onXYZ`, are defined on the {{domxref("Windo
 - {{domxref("WindowEventHandlers.onhashchange")}}
   - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("hashchange")}} event is raised.
 - {{domxref("WindowEventHandlers.onlanguagechange")}} {{experimental_inline}}
-  - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("languagechange")}} event is raised.
+  - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("Window.languagechange_event", "languagechange")}} event is raised.
 - {{domxref("WindowEventHandlers.onoffline")}}
-  - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("offline")}} event is raised.
+  - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("Window.offline_event", "offline")}} event is raised.
 - {{domxref("WindowEventHandlers.ononline")}}
-  - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("online")}} event is raised.
+  - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("Window.online_event", "online")}} event is raised.
 - {{domxref("WindowEventHandlers.onpagehide")}}
   - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("pagehide")}} event is raised.
 - {{domxref("WindowEventHandlers.onpageshow")}}
@@ -43,9 +43,9 @@ _The events properties, of the form `onXYZ`, are defined on the {{domxref("Windo
 - {{domxref("WindowEventHandlers.onrejectionhandled")}}
   - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("rejectionhandled")}} event is raised, indicating that a {{jsxref("Promise")}} was rejected and the rejection has been handled.
 - {{domxref("WindowEventHandlers.onstorage")}}
-  - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("storage")}} event is raised.
+  - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("Window.storage_event", "storage")}} event is raised.
 - {{domxref("WindowEventHandlers.onunhandledrejection")}}
-  - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("unhandledrejection")}} event is raised, indicating that a {{jsxref("Promise")}} was rejected but the rejection was not handled.
+  - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("Window.unhandledrejection_event", "unhandledrejection")}} event is raised, indicating that a {{jsxref("Promise")}} was rejected but the rejection was not handled.
 - {{domxref("WindowEventHandlers.onunload")}}
   - : Is an [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("unload")}} event is raised.
 

--- a/files/en-us/web/api/windoweventhandlers/onlanguagechange/index.md
+++ b/files/en-us/web/api/windoweventhandlers/onlanguagechange/index.md
@@ -14,7 +14,7 @@ browser-compat: api.WindowEventHandlers.onlanguagechange
 
 The **`onlanguagechange`** property of the
 {{domxref("WindowEventHandlers")}} mixin is the [event handler](/en-US/docs/Web/Events/Event_handlers) for
-processing {{event("languagechange")}} events.
+processing {{domxref("Window.languagechange_event", "languagechange")}} events.
 
 These events are received by the object implementing this interface, usually a
 {{domxref("Window")}}, an {{domxref("HTMLBodyElement")}}, or an
@@ -44,4 +44,4 @@ window.onlanguagechange = function(event) {
 
 ## See also
 
-- The {{event("languagechange")}} event and its type, {{domxref("Event")}}
+- The {{domxref("Window.languagechange_event", "languagechange")}} event and its type, {{domxref("Event")}}

--- a/files/en-us/web/api/windoweventhandlers/onunhandledrejection/index.md
+++ b/files/en-us/web/api/windoweventhandlers/onunhandledrejection/index.md
@@ -17,7 +17,7 @@ browser-compat: api.WindowEventHandlers.onunhandledrejection
 
 The **`onunhandledrejection`** property of the
 {{domxref("WindowEventHandlers")}} mixin is the [event handler](/en-US/docs/Web/Events/Event_handlers) for
-processing {{event("unhandledrejection")}} events. These events are raised for unhandled
+processing {{domxref("Window.unhandledrejection_event", "unhandledrejection")}} events. These events are raised for unhandled
 {{jsxref("Promise")}} rejections.
 
 ## Value

--- a/files/en-us/web/api/workernavigator/languages/index.md
+++ b/files/en-us/web/api/workernavigator/languages/index.md
@@ -23,7 +23,7 @@ The value of {{domxref("WorkerNavigator.language","navigator.language")}} is the
 first element of the returned array.
 
 When its value changes, as the user's preferred languages are changed a
-{{event("languagechange")}} event is fired on the {{domxref("WorkerGlobalScope")}} object.
+{{domxref("Window.languagechange_event", "languagechange")}} event is fired on the {{domxref("WorkerGlobalScope")}} object.
 
 The `Accept-Language` HTTP header in every HTTP request from the user's
 browser uses the same value for the `navigator.languages` property except for


### PR DESCRIPTION
Now that we have updated events on `MDN/content`, we can replace `{{event}}` (that is ambiguous or lead to unwanted redirects) with the `{{domxref}}` macros.

This is the final PR of the easy cases: events linked to one single interface.