### PR TITLE
clarifications for the html element

### DIFF
--- a/files/en-us/web/html/element/html/index.md
+++ b/files/en-us/web/html/element/html/index.md
@@ -35,7 +35,7 @@ The **`<html>`** [HTML](/en-US/docs/Web/HTML) element represents the root (top-l
       <th scope="row">Tag omission</th>
       <td>
         The start tag may be omitted if the first thing inside the
-        <code>&#x3C;html></code> element is not a comment.<br />The end tag may
+        <code>&#x3C;html></code> element is not a comment.<br>The end tag may
         be omitted if the <code>&#x3C;html></code> element is not immediately
         followed by a comment.
       </td>
@@ -47,8 +47,8 @@ The **`<html>`** [HTML](/en-US/docs/Web/HTML) element represents the root (top-l
     <tr>
       <th scope="row">Implicit ARIA role</th>
       <td>
-        <a href="https://www.w3.org/TR/html-aria/#dfn-no-corresponding-role"
-          >No corresponding role</a
+        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Document_role"
+          >document</a
         >
       </td>
     </tr>
@@ -86,12 +86,12 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 ## Accessibility concerns
 
-Providing a {{htmlattrxref("lang")}} attribute with a valid language tag according to {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}} on the `<html>` element will help screen reading technology determine the proper language to announce. The identifying language tag should describe the language used by the majority of the content of the page. Without it, screen readers will typically default to the operating system's set language, which may cause mispronunciations.
+While HTML does not require authors to specify `<html>` element start and ending tags, it is important for authors to do so as it will allow them to specify the {{htmlattrxref("lang")}} for the webpage. Providing a `lang` attribute with a valid language tag according to {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}} on the `<html>` element will help screen reading technology determine the proper language to announce. The identifying language tag should describe the language used by the majority of the content of the page. Without it, screen readers will typically default to the operating system's set language, which may cause mispronunciations.
 
 Including a valid `lang` declaration on the `<html>` element also ensures that important metadata contained in the page's {{HTMLElement("head")}}, such as the page's {{HTMLElement("title")}}, are also announced properly.
 
 - [MDN Understanding WCAG, Guideline 3.1 explanations](/en-US/docs/Web/Accessibility/Understanding_WCAG/Understandable#guideline_3.1_%e2%80%94_readable_make_text_content_readable_and_understandable)
-- [Understanding Success Criterion 3.1.1 | W3C Understanding WCAG 2.0](https://www.w3.org/TR/2016/NOTE-UNDERSTANDING-WCAG20-20161007/meaning-doc-lang-id.html)
+- [Understanding Success Criterion 3.1.1 | W3C Understanding WCAG 2.1](https://www.w3.org/WAI/WCAG21/Understanding/language-of-page.html)
 
 ## Specifications
 


### PR DESCRIPTION
- its role is `document` not 'no corresponding role'
- directly address the discrepancy of HTML allowing the `html` start/end tags to be omitted by authors, but doing so will mean that a necessary `lang` attribute cannot be set.
- Update the WCAG understanding doc reference from the outdated 2.0 version to the latest 2.1 reference.
