### PR TITLE
Correct implicit role for body element

### DIFF
--- a/files/en-us/web/html/element/body/index.md
+++ b/files/en-us/web/html/element/body/index.md
@@ -57,8 +57,10 @@ The **`<body>`** [HTML](/en-US/docs/Web/HTML) element represents the content of 
     <tr>
       <th scope="row">Implicit ARIA role</th>
       <td>
-        <a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Document_Role"
-          >document</a
+        <code
+          ><a href="/en-US/docs/Web/Accessibility/ARIA/Roles/Generic_role"
+            >generic</a
+          ></code
         >
       </td>
     </tr>


### PR DESCRIPTION
PR changes the implicit role from `document` to `generic` to be accurate per the HTML AAM spec (where the role is specified) and the ARIA in HTML spec (where the implicit role is referenced)

- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
