### PR TITLE
update banner role documentation

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/banner_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/banner_role/index.md
@@ -8,7 +8,7 @@ tags:
   - Reference
 ---
 
-The `banner` role is for defining a global site header, which usually includes a logo, company name, search feature, and possibly a slogan, generally at the top of the page.
+The `banner` role is for defining a global site header, which usually includes a logo, company name, search feature, and possibly the global navigation or a slogan. It is generally located at the top of the page.
 
 By default, the HTML's {{htmlelement("header")}} element has an identical meaning to the `banner` landmark, unless it is a descendant of {{htmlelement("aside")}}, {{htmlelement("article")}}, {{htmlelement("main")}}, {{htmlelement("nav")}}, or {{htmlelement("section")}}, at which point {{htmlelement("header")}} exposes a [`generic`](/en-US/docs/Web/Accessibility/ARIA/Roles/generic_role) role, and not the equivalent of the site-wide banner.
 
@@ -40,10 +40,11 @@ Here's a fake simple banner with a skip to navigation link, a logo, a title and 
 
 ```html
 <div role="banner">
-  <a href="#nav" id="skipToMenu" class="skiptocontent">Skip To Keyboard Navigation</a>
+  <a href="#main" id="skipToMain" class="skiptocontent">Skip To main content</a>
   <img src="images/w3c.png" alt="W3C Logo">
   <h1>ARIA Landmarks</h1>
   <p>Identifying page subsections for easy navigation</p>
+  <nav>...</nav>
 </div>
 ```
 
@@ -51,10 +52,11 @@ We could also have written the above with the HTML `header` element:
 
 ```html
 <header>
-  <a href="#nav" id="skipToMenu" class="skiptocontent">Skip To Keyboard Navigation</a>
+  <a href="#main" id="skipToMain" class="skiptocontent">Skip To main content</a>
   <img src="images/w3c.png" alt="W3C Logo">
   <h1>ARIA Landmarks</h1>
   <p>Identifying page subsections for easy navigation</p>
+  <nav>...</nav>
 </header>
 ```
 

--- a/files/en-us/web/accessibility/aria/roles/banner_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/banner_role/index.md
@@ -8,27 +8,19 @@ tags:
   - Reference
 ---
 
-The `banner` role is for defining a global site header, which usually includes a logo, company name, search icon, and possibly a slogan, generally at the top of the page.
+The `banner` role is for defining a global site header, which usually includes a logo, company name, search feature, and possibly a slogan, generally at the top of the page.
 
-```html
-<div role="banner">
-  <img src="companylogo.svg" alt="my company name" />
-  <h1>Title</h1>
-  <p>Subtitle</p>
-</div>
-```
-
-By default, the HTML5 {{htmlelement("header")}} element has an identical meaning to the `banner` landmark, unless it is a descendant of {{htmlelement("aside")}}, {{htmlelement("article")}}, {{htmlelement("main")}}, {{htmlelement("nav")}}, or {{htmlelement("section")}}, at which point {{htmlelement("header")}} is the heading for that section, and not the equivalent of the site-wide banner.
+By default, the HTML's {{htmlelement("header")}} element has an identical meaning to the `banner` landmark, unless it is a descendant of {{htmlelement("aside")}}, {{htmlelement("article")}}, {{htmlelement("main")}}, {{htmlelement("nav")}}, or {{htmlelement("section")}}, at which point {{htmlelement("header")}} exposes a [`generic`](/en-US/docs/Web/Accessibility/ARIA/Roles/generic_role) role, and not the equivalent of the site-wide banner.
 
 ## Description
 
-A `banner` landmark role converts the container element upon which it is applied into a header. It should be reserved for the site header content that is common across the site generally at the top of every page.
+A `banner` landmark role overwrites the implicit ARIA role of the container element upon which it is applied. It should be reserved for globally repeating site-wide content that is generally located at the top of every page.
 
 The banner typically includes things such as a logo or corporate identity, or possibly a site-specific search tool, and is generally what your marketing team would call the "header" or "top banner" of the site. If the [`header` element](/en-US/docs/Web/HTML/Element/header) technique is not being used for that banner, a declaration of `role="banner"` should be used to define a banner landmark to assistive technologies.
 
-Assistive technologies can identify the main `header` element of a page as the `banner` if is a descendant of the [`body` element](/en-US/docs/Web/HTML/Element/body), and not nested within an `article`, `aside`, `main`, `nav` or `section` subsection.
+Assistive technologies can identify the `header` element of a page as the `banner` if is a descendant of the [`body` element](/en-US/docs/Web/HTML/Element/body), and not nested within an `article`, `aside`, `main`, `nav` or `section` subsection.
 
-Each page may have a `banner` landmark, but each page should be limited to only one `header` with the role of banner. In the case of a page containing nested `document` and/or `application` roles, each nested `document` or `application` role may also have one `banner` landmark. If a page includes more than one `banner` landmark, each should have a unique label.
+Each page may have a `banner` landmark, but each page should generally be limited to a single element with the role of banner. In the case of a page containing nested `document` and/or `application` roles, each nested `document` or `application` role may also have one `banner` landmark. If a page includes more than one `banner` landmark, each should have a unique accessible name.
 
 ### Associated ARIA roles, states, and properties
 
@@ -59,6 +51,7 @@ We could also have written the above with the HTML `header` element:
 
 ```html
 <header>
+  <a href="#nav" id="skipToMenu" class="skiptocontent">Skip To Keyboard Navigation</a>
   <img src="images/w3c.png" alt="W3C Logo">
   <h1>ARIA Landmarks</h1>
   <p>Identifying page subsections for easy navigation</p>
@@ -67,7 +60,7 @@ We could also have written the above with the HTML `header` element:
 
 ## Best practices
 
-While it is best to use the `header` element and ensure it is not a descendant of any subsection of the page, sometimes you don't have access to the underlying HTML. If this is the case, you can add the role of `banner` to the main header of the page with JavaScript. Identifying the page's banner in this way will help improve the site's accessibility.
+While it is best to use the `header` element and ensure it is not a descendant of any subsection of the page, sometimes you don't have access to the underlying HTML. If this is the case, you can add the role of `banner` to the element of the page which should be exposed as a `banner` with JavaScript. Identifying the page's banner in this way will help improve the site's accessibility.
 
 ## Specifications
 


### PR DESCRIPTION
- removes the initial example from the intro of the page. It's not really a good illustration of a site-wide banner.  The examples present later in the page are better.
- when not scoped to the body the header doesn't become a heading. This was inaccurate information. It has a generic role if not a banner.
- other wording updates/corrections