### PR TITLE
fix: add missing arguement in js example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/function/apply/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/apply/index.md
@@ -146,7 +146,7 @@ Function.prototype.construct = function(aArgs) {
 Example usage:
 
 ```js
-function MyConstructor() {
+function MyConstructor(arguments) {
   for (let nProp = 0; nProp < arguments.length; nProp++) {
     this['property' + nProp] = arguments[nProp];
   }


### PR DESCRIPTION
#### Summary

add missing param `arguements` to function.

#### Supporting details

The param `arguements` is used in function, but is not defined.

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

