### PR TITLE
WebAPI: Clean syntax from property pages, part 18

### DIFF
--- a/files/en-us/web/api/batterymanager/charging/index.md
+++ b/files/en-us/web/api/batterymanager/charging/index.md
@@ -13,7 +13,11 @@ The **`BatteryManager.charging`** property is a Boolean value indicating whether
 
 If the battery is charging, this value is `true`. Otherwise, it is `false`.
 
-## Example
+## Value
+
+A boolean.
+
+## Examples
 
 ### HTML Content
 

--- a/files/en-us/web/api/batterymanager/chargingtime/index.md
+++ b/files/en-us/web/api/batterymanager/chargingtime/index.md
@@ -17,7 +17,11 @@ discharging, its value is
 > browsers round them to a higher interval
 > (typically to the closest 15 minutes) for privacy reasons.
 
-## Example
+## Value
+
+A number.
+
+## Examples
 
 ### HTML Content
 

--- a/files/en-us/web/api/batterymanager/dischargingtime/index.md
+++ b/files/en-us/web/api/batterymanager/dischargingtime/index.md
@@ -19,7 +19,11 @@ When its value changes, the [`dischargingtimechange`](/en-US/docs/Web/API/Batter
 > **Note:** Even if the time returned is precise to the second, browsers round them to a higher
 > interval (typically to the closest 15 minutes) for privacy reasons.
 
-## Example
+## Value
+
+A number.
+
+## Examples
 
 ### HTML Content
 

--- a/files/en-us/web/api/batterymanager/level/index.md
+++ b/files/en-us/web/api/batterymanager/level/index.md
@@ -16,7 +16,11 @@ A value of `1.0` is also returned if the implementation isn't able to determine 
 or if the system is not battery-powered.
 When its value changes, the [`levelchange`](/en-US/docs/Web/API/BatteryManager/levelchange_event) event is fired.
 
-## Example
+## Value
+
+A number.
+
+## Examples
 
 ### HTML Content
 

--- a/files/en-us/web/api/document/ononline/index.md
+++ b/files/en-us/web/api/document/ononline/index.md
@@ -22,7 +22,11 @@ You can register listeners for these events in a few familiar ways:
 - By setting the `.ononline` or `.onoffline` properties on `document` or `document.body` to a JavaScript `Function` object. (**Note:** using `window.ononline` or `window.onoffline` will not work for compatibility reasons.)
 - By specifying `ononline="..."` or `onoffline="..."` attributes on the `<body>` tag in the HTML markup.
 
-## Example
+## Value
+
+A boolean.
+
+## Examples
 
 There's [a simple test case](https://bugzilla.mozilla.org/attachment.cgi?id=220609) that you can run to verify that the events are working.
 

--- a/files/en-us/web/api/hid/onconnect/index.md
+++ b/files/en-us/web/api/hid/onconnect/index.md
@@ -13,14 +13,11 @@ browser-compat: api.HID.onconnect
 
 The **`onconnect`** [event handler](/en-US/docs/Web/Events/Event_handlers) of the {{domxref("HID")}} interface processes the events fired when the user agent connects to the HID device.
 
-## Syntax
+## Value
 
-```js
-HID.onconnect = function;
-HID.addEventListener('connect', function);
-```
+A function reference or a [function expression](/en-US/docs/Web/JavaScript/Reference/Operators/function).
 
-## Example
+## Examples
 
 In the following example an event listener is registered to listen for the connection of a device. The name of the device is then printed to the console using {{domxref("HIDDevice.productName")}}
 

--- a/files/en-us/web/api/hid/ondisconnect/index.md
+++ b/files/en-us/web/api/hid/ondisconnect/index.md
@@ -13,14 +13,11 @@ browser-compat: api.HID.ondisconnect
 
 The **`ondisconnect`** [event handler](/en-US/docs/Web/Events/Event_handlers) of the {{domxref("HID")}} interface processes the events when the user agent disconnects from the HID device.
 
-## Syntax
+## Value
 
-```js
-HID.ondisconnect = function;
-HID.addEventListener('disconnect', function);
-```
+A function reference or a [function expression](/en-US/docs/Web/JavaScript/Reference/Operators/function).
 
-## Example
+## Examples
 
 In the following example an event listener is registered to listen for the disconnection of a device. The name of the device is then printed to the console using {{domxref("HIDDevice.productName")}}
 

--- a/files/en-us/web/api/history/length/index.md
+++ b/files/en-us/web/api/history/length/index.md
@@ -17,14 +17,11 @@ The **`History.length`** read-only
 property returns an integer representing the number of elements in the session
 history, including the currently loaded page.
 
-For example, for a page loaded in
-a new tab this property returns `1`.
+For example, for a page loaded in a new tab this property returns `1`.
 
-## Syntax
+## Value
 
-```js
-const length = history.length
-```
+A number.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlanchorelement/download/index.md
+++ b/files/en-us/web/api/htmlanchorelement/download/index.md
@@ -21,12 +21,9 @@ is not a valid file name in the underlying OS, the browser will adjust it.
 > **Note:** This value might not be used for download. This value cannot
 > be used to determine whether the download will occur.
 
-## Syntax
+## Value
 
-```js
-var dnload = anchorElt.download;
-anchorElt.download = dnload;
-```
+A string.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlanchorelement/hash/index.md
+++ b/files/en-us/web/api/htmlanchorelement/hash/index.md
@@ -18,14 +18,9 @@ identifier of the URL.
 The fragment is not [percent-decoded](/en-US/docs/Glossary/percent-encoding). If the URL does not
 have a fragment identifier, this property contains an empty string, `""`.
 
-## Syntax
+## Value
 
-```js
-// Getter
-string = anchor.hash;
-// Setter
-anchor.hash = string;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlanchorelement/host/index.md
+++ b/files/en-us/web/api/htmlanchorelement/host/index.md
@@ -15,14 +15,9 @@ The **`HTMLAnchorElement.host`** property is a
 if the _port_ of the URL is nonempty, a `':'`, and the _port_
 of the URL.
 
-## Syntax
+## Value
 
-```js
-// Getter
-string = anchor.host;
-// Setter
-anchor.host = string;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlanchorelement/hostname/index.md
+++ b/files/en-us/web/api/htmlanchorelement/hostname/index.md
@@ -13,14 +13,9 @@ browser-compat: api.HTMLAnchorElement.hostname
 The **`HTMLAnchorElement.hostname`** property is a
 {{domxref("USVString")}} containing the domain of the URL.
 
-## Syntax
+## Value
 
-```js
-// Getter
-string = anchor.hostname;
-// Setter
-anchor.hostname = string;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlanchorelement/href/index.md
+++ b/files/en-us/web/api/htmlanchorelement/href/index.md
@@ -15,14 +15,9 @@ The **`HTMLAnchorElement.href`** property is a
 {{Glossary("stringifier")}} that returns a {{domxref("USVString")}} containing the whole URL, and allows
 the href to be updated.
 
-## Syntax
+## Value
 
-```js
-// Getter
-string = anchor.href;
-// Setter
-anchor.href = string;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlanchorelement/origin/index.md
+++ b/files/en-us/web/api/htmlanchorelement/origin/index.md
@@ -27,14 +27,9 @@ That is:
   `blob:`. E.g `"blob:https://mozilla.org"` will have
   `"https://mozilla.org".`
 
-## Syntax
+## Value
 
-```js
-// Getter
-string = anchor.origin;
-
-// No setter; read-only property
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlanchorelement/password/index.md
+++ b/files/en-us/web/api/htmlanchorelement/password/index.md
@@ -16,14 +16,9 @@ If it is set without first setting the
 [`username`](/en-US/docs/Web/API/HTMLAnchorElement/username)
 property, it silently fails.
 
-## Syntax
+## Value
 
-```js
-// Getter
-string = anchor.password;
-// Setter
-anchor.password = string;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlanchorelement/pathname/index.md
+++ b/files/en-us/web/api/htmlanchorelement/pathname/index.md
@@ -15,14 +15,9 @@ The **`HTMLAnchorElement.pathname`** property is a
 the URL not including the query string or fragment (or the empty string if there is no
 path).
 
-## Syntax
+## Value
 
-```js
-// Getter
-string = anchor.pathname;
-// Setter
-anchor.pathname = string;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlanchorelement/port/index.md
+++ b/files/en-us/web/api/htmlanchorelement/port/index.md
@@ -14,14 +14,9 @@ The **`HTMLAnchorElement.port`** property is a
 {{domxref("USVString")}} containing the port number of the URL. If the URL does not
 contain an explicit port number, it will be set to `''`.
 
-## Syntax
+## Value
 
-```js
-// Getter
-string = anchor.port;
-// Setter
-anchor.port = string;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlanchorelement/protocol/index.md
+++ b/files/en-us/web/api/htmlanchorelement/protocol/index.md
@@ -14,14 +14,9 @@ The
 property is a {{domxref("USVString")}} representing the protocol scheme of the URL,
 including the final `':'`.
 
-## Syntax
+## Value
 
-```js
-// Getter
-string = anchor.protocol;
-// Setter
-anchor.protocol = string;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlanchorelement/rel/index.md
+++ b/files/en-us/web/api/htmlanchorelement/rel/index.md
@@ -17,14 +17,11 @@ space-separated list of [link types](/en-US/docs/Web/HTML/Link_types)
 indicating the relationship between the resource represented by the {{HTMLElement("a")}}
 element and the current document.
 
-## Syntax
+## Value
 
-```js
-var relstr = anchorElt.rel;
-anchorElt.rel = relstr;
-```
+A string.
 
-## Example
+## Examples
 
 ```js
 var anchors = document.getElementsByTagName("a");

--- a/files/en-us/web/api/htmlanchorelement/rellist/index.md
+++ b/files/en-us/web/api/htmlanchorelement/rellist/index.md
@@ -21,13 +21,11 @@ element and the current document.
 The property itself is read-only, meaning you can't substitute the
 {{domxref("DOMTokenList")}} with another one, but its contents can still be changed.
 
-## Syntax
+## Value
 
-```js
-var relstr = anchorElt.relList;
-```
+A string.
 
-## Example
+## Examples
 
 ```js
 var anchors = document.getElementsByTagName("a");

--- a/files/en-us/web/api/htmlanchorelement/search/index.md
+++ b/files/en-us/web/api/htmlanchorelement/search/index.md
@@ -20,14 +20,9 @@ and
 [`URL.searchParams`](/en-US/docs/Web/API/URL/searchParams#examples)
 to make it easy to parse out the parameters from the querystring.
 
-## Syntax
+## Value
 
-```js
-// Getter
-string = anchor.search;
-// Setter
-anchor.search = string;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlanchorelement/username/index.md
+++ b/files/en-us/web/api/htmlanchorelement/username/index.md
@@ -13,14 +13,9 @@ browser-compat: api.HTMLAnchorElement.username
 The **`HTMLAnchorElement.username`** property is a
 {{domxref("USVString")}} containing the username specified before the domain name.
 
-## Syntax
+## Value
 
-```js
-// Getter
-string = anchor.username;
-// Setter
-anchor.username = string;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlareaelement/hash/index.md
+++ b/files/en-us/web/api/htmlareaelement/hash/index.md
@@ -18,14 +18,9 @@ identifier of the URL.
 The fragment is not [percent-decoded](/en-US/docs/Glossary/percent-encoding). If the URL does not
 have a fragment identifier, this property contains an empty string, `""`.
 
-## Syntax
+## Value
 
-```js
-// Getter
-string = area.hash;
-// Setter
-area.hash = string;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlareaelement/host/index.md
+++ b/files/en-us/web/api/htmlareaelement/host/index.md
@@ -15,14 +15,9 @@ The **`HTMLAreaElement.host`** property is a
 if the _port_ of the URL is nonempty, a `':'`, and the _port_
 of the URL.
 
-## Syntax
+## Value
 
-```js
-// Getter
-string = area.host;
-// Setter
-area.host = string;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlareaelement/href/index.md
+++ b/files/en-us/web/api/htmlareaelement/href/index.md
@@ -15,14 +15,9 @@ The **`HTMLAreaElement.href`** property is a
 {{Glossary("stringifier")}} that returns a {{domxref("USVString")}} containing the whole URL, and allows
 the href to be updated.
 
-## Syntax
+## Value
 
-```js
-// Getter
-string = area.href;
-// Setter
-area.href = string;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlareaelement/origin/index.md
+++ b/files/en-us/web/api/htmlareaelement/origin/index.md
@@ -27,14 +27,9 @@ That is:
   `blob:`. E.g `"blob:https://mozilla.org"` will have
   `"https://mozilla.org".`
 
-## Syntax
+## Value
 
-```js
-// Getter
-string = area.origin;
-
-// No setter; read-only property
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlareaelement/password/index.md
+++ b/files/en-us/web/api/htmlareaelement/password/index.md
@@ -16,14 +16,9 @@ If it is set without first setting the
 [`username`](/en-US/docs/Web/API/HTMLAreaElement/username)
 property, it silently fails.
 
-## Syntax
+## Value
 
-```js
-// Getter
-string = area.password;
-// Setter
-area.password = string;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlareaelement/pathname/index.md
+++ b/files/en-us/web/api/htmlareaelement/pathname/index.md
@@ -15,14 +15,9 @@ The **`HTMLAreaElement.pathname`** property is a
 the URL not including the query string or fragment (or the empty string if there is no
 path).
 
-## Syntax
+## Value
 
-```js
-// Getter
-string = area.pathname;
-// Setter
-area.pathname = string;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlareaelement/port/index.md
+++ b/files/en-us/web/api/htmlareaelement/port/index.md
@@ -14,14 +14,9 @@ The **`HTMLAreaElement.port`** property is a
 {{domxref("USVString")}} containing the port number of the URL. If the URL does not
 contain an explicit port number, it will be set to `''`.
 
-## Syntax
+## Value
 
-```js
-// Getter
-string = area.port;
-// Setter
-area.port = string;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlareaelement/protocol/index.md
+++ b/files/en-us/web/api/htmlareaelement/protocol/index.md
@@ -14,14 +14,9 @@ The
 property is a {{domxref("USVString")}} representing the protocol scheme of the URL,
 including the final `':'`.
 
-## Syntax
+## Value
 
-```js
-// Getter
-string = area.protocol;
-// Setter
-area.protocol = string;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlareaelement/rel/index.md
+++ b/files/en-us/web/api/htmlareaelement/rel/index.md
@@ -17,14 +17,11 @@ space-separated list of [link types](/en-US/docs/Web/HTML/Link_types)
 indicating the relationship between the resource represented by the
 {{HTMLElement("area")}} element and the current document.
 
-## Syntax
+## Value
 
-```js
-var relstr = areaElt.rel;
-areaElt.rel = relstr;
-```
+A string.
 
-## Example
+## Examples
 
 ```js
 var areas = document.getElementsByTagName("area");

--- a/files/en-us/web/api/htmlareaelement/rellist/index.md
+++ b/files/en-us/web/api/htmlareaelement/rellist/index.md
@@ -21,13 +21,11 @@ The property itself is read-only, meaning you can't substitute the
 {{domxref("DOMTokenList")}} by another one, but the content of the returned list can be
 changed.
 
-## Syntax
+## Value
 
-```js
-var relstr = areaElt.relList;
-```
+A string.
 
-## Example
+## Examples
 
 ```js
 var areas = document.getElementsByTagName("area");

--- a/files/en-us/web/api/htmlareaelement/search/index.md
+++ b/files/en-us/web/api/htmlareaelement/search/index.md
@@ -20,14 +20,9 @@ and
 [`URL.searchParams`](/en-US/docs/Web/API/URL/searchParams#examples)
 to make it easy to parse out the parameters from the querystring.
 
-## Syntax
+## Value
 
-```js
-// Getter
-string = area.search;
-// Setter
-area.search = string;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlareaelement/username/index.md
+++ b/files/en-us/web/api/htmlareaelement/username/index.md
@@ -13,14 +13,9 @@ browser-compat: api.HTMLAreaElement.username
 The **`HTMLAreaElement.username`** property is a
 {{domxref("USVString")}} containing the username specified before the domain name.
 
-## Syntax
+## Value
 
-```js
-// Getter
-string = area.username;
-// Setter
-area.username = string;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlbuttonelement/labels/index.md
+++ b/files/en-us/web/api/htmlbuttonelement/labels/index.md
@@ -14,18 +14,12 @@ The **`HTMLButtonElement.labels`** read-only property returns a
 {{domxref("NodeList")}} of the {{HTMLElement("label")}} elements associated with the
 {{HTMLElement("button")}} element.
 
-## Syntax
-
-```js
-var labelElements = button.labels;
-```
-
-### Return value
+## Value
 
 A {{domxref("NodeList")}} containing the `<label>` elements associated
 with the `<button>` element.
 
-## Example
+## Examples
 
 ### HTML
 

--- a/files/en-us/web/api/htmlcanvaselement/height/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/height/index.md
@@ -19,12 +19,9 @@ default value of `150` is used.
 This is one of the two properties, the other being
 {{domxref("HTMLCanvasElement.width")}}, that controls the size of the canvas.
 
-## Syntax
+## Value
 
-```js
-var pxl = canvas.height;
-canvas.height = pxl;
-```
+A number.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlcanvaselement/mozopaque/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/mozopaque/index.md
@@ -24,12 +24,9 @@ performance can be optimized.
 > {{domxref("HTMLCanvasElement.getContext()")}}. Use of `mozOpaque` should be
 > avoided. Firefox will stop supporting it in the future.
 
-## Syntax
+## Value
 
-```js
-var opaque = canvas.mozOpaque;
-canvas.mozOpaque = true;
-```
+A boolean value.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlcanvaselement/width/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/width/index.md
@@ -19,12 +19,9 @@ default value of `300` is used.
 This is one of the two properties, the other being
 {{domxref("HTMLCanvasElement.height")}}, that controls the size of the canvas.
 
-## Syntax
+## Value
 
-```js
-var pxl = canvas.width;
-canvas.width = pxl;
-```
+A number.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlcollection/length/index.md
+++ b/files/en-us/web/api/htmlcollection/length/index.md
@@ -14,16 +14,11 @@ browser-compat: api.HTMLCollection.length
 The **`HTMLCollection.length`** property returns the number of
 items in a {{domxref("HTMLCollection")}}.
 
-## Syntax
+## Value
 
-```js
-numItems = htmlCollection.length
-```
+An integer value representing the number of items in a `HTMLCollection`.
 
-- `numItems` is an integer value representing the number of items in a
-  `HTMLCollection`.
-
-## Example
+## Examples
 
 The `length` property is often useful in DOM programming. It's often used to
 test the length of a list, to see if it exists at all. It's also commonly used as the

--- a/files/en-us/web/api/htmlcontentelement/getdistributednodes/index.md
+++ b/files/en-us/web/api/htmlcontentelement/getdistributednodes/index.md
@@ -16,13 +16,11 @@ The **`HTMLContentElement.getDistributedNodes()`** method
 returns a static {{domxref("NodeList")}} of the {{glossary("distributed nodes")}}
 associated with this `<content>` element.
 
-## Syntax
+## Value
 
-```js
-var nodeList = object.getDistributedNodes()
-```
+A {{domxref("NodeList")}} object.
 
-## Example
+## Examples
 
 ```js
 // Get the distributed nodes

--- a/files/en-us/web/api/htmlcontentelement/select/index.md
+++ b/files/en-us/web/api/htmlcontentelement/select/index.md
@@ -17,13 +17,11 @@ The **`HTMLContentElement.select`** property reflects the
 space-separated list of CSS selectors that select the content to insert in place of the
 \<content> element.
 
-## Syntax
+## Value
 
-```js
-object.select = "CSSselector CSSselector ...";
-```
+A string.
 
-## Example
+## Examples
 
 ```js
 // Select <h1> elements and elements with class="error"

--- a/files/en-us/web/api/htmlelement/contenteditable/index.md
+++ b/files/en-us/web/api/htmlelement/contenteditable/index.md
@@ -25,12 +25,9 @@ This enumerated attribute can have the following values:
 You can use the {{domxref("HTMLElement.isContentEditable")}} property to test the
 computed boolean value of this property.
 
-## Syntax
+## Value
 
-```js
-editable = element.contentEditable
-element.contentEditable = 'true'
-```
+A string.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlelement/contextmenu/index.md
+++ b/files/en-us/web/api/htmlelement/contextmenu/index.md
@@ -18,13 +18,11 @@ The **`HTMLElement.contextMenu`** property refers to the
 context menu assigned to an element using the {{htmlattrxref("contextmenu")}}
 attribute. The menu itself is created using the {{HTMLElement("menu")}} element.
 
-## Syntax
+## Value
 
-```js
-var elementContextMenu = element.contextMenu;
-```
+A {{HTMLElement("menu")}} element.
 
-## Example
+## Examples
 
 ```js
 var contextMenu = document.getElementById("element").contextMenu;

--- a/files/en-us/web/api/htmlelement/dir/index.md
+++ b/files/en-us/web/api/htmlelement/dir/index.md
@@ -35,23 +35,15 @@ directionality of its parent element.
 > while Internet Explorer and Edge use the key combinations <kbd>Ctrl</kbd> + <kbd>Left Shift</kbd> and <kbd>Ctrl</kbd> + <kbd>Right Shift</kbd>. Firefox uses <kbd>Ctrl</kbd>/<kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>X</kbd> but does NOT update
 > the **`dir`** attribute value.
 
-## Syntax
+## Value
 
-```js
-var currentWritingDirection = elementNodeReference.dir;
-elementNodeReference.dir = newWritingDirection;
-```
+One of the followings:
 
-- `currentWritingDirection` is a string variable representing
-  the text writing direction of the current element.
-- `newWritingDirection` is a string variable representing the
-  text writing direction value.
+- `ltr`, for left-to-right
+- `rtl`, for right-to-left
+- `auto` for specifying that the direction of the element must be determined based on the contents of the element.
 
-Possible values for `dir` are `ltr`, for left-to-right,
-`rtl`, for right-to-left, and `auto` for specifying that the
-direction of the element must be determined based on the contents of the element.
-
-## Example
+## Examples
 
 ```js
 var parg = document.getElementById("para1");

--- a/files/en-us/web/api/htmlelement/iscontenteditable/index.md
+++ b/files/en-us/web/api/htmlelement/iscontenteditable/index.md
@@ -17,13 +17,11 @@ The **`HTMLElement.isContentEditable`** read-only property
 returns a boolean value that is `true` if the contents of the element
 are editable; otherwise it returns `false`.
 
-## Syntax
+## Value
 
-```js
-editable = element.isContentEditable
-```
+A boolean value.
 
-## Example
+## Examples
 
 ### HTML
 

--- a/files/en-us/web/api/htmlelement/lang/index.md
+++ b/files/en-us/web/api/htmlelement/lang/index.md
@@ -24,18 +24,11 @@ level described here, is most often specified for the root element of the docume
 This also only works with the `lang` attribute and not with
 `xml:lang`.
 
-## Syntax
+## Value
 
-```js
-var languageUsed = elementNodeReference.lang; // Get the value of lang
-elementNodeReference.lang = NewLanguage; // Set new value for lang
-```
+A string.
 
-_languageUsed_ is a string variable that gets the language in which the text
-of the current element is written. _NewLanguage_ is a string variable with its
-value setting the language in which the text of the current element is written.
-
-## Example
+## Examples
 
 ```js
 // this snippet compares the base language and

--- a/files/en-us/web/api/htmlelement/offsetheight/index.md
+++ b/files/en-us/web/api/htmlelement/offsetheight/index.md
@@ -29,17 +29,11 @@ returned.
 > **Note:** This property will round the value to an integer. If you need a fractional value, use
 > {{ domxref("element.getBoundingClientRect()") }}.
 
-## Syntax
+## Value
 
-```js
-var intElemOffsetHeight = element.offsetHeight;
-```
+A number.
 
-`intElemOffsetHeight` is a variable storing an integer
-corresponding to the `offsetHeight` pixel value of the element. The
-`offsetHeight` property is read-only.
-
-## Example
+## Examples
 
 ![](dimensions-offset.png)
 

--- a/files/en-us/web/api/htmlelement/offsetleft/index.md
+++ b/files/en-us/web/api/htmlelement/offsetleft/index.md
@@ -18,15 +18,11 @@ For block-level elements, `offsetTop`, `offsetLeft`, `offsetWidth`, and `offsetH
 
 However, for inline-level elements (such as **span**) that can wrap from one line to the next, `offsetTop` and `offsetLeft` describe the positions of the _first_ border box (use {{domxref("Element.getClientRects()")}} to get its width and height), while `offsetWidth` and `offsetHeight` describe the dimensions of the _bounding_ border box (use {{domxref("Element.getBoundingClientRect()")}} to get its position). Therefore, a box with the left, top, width and height of `offsetLeft`, `offsetTop`, `offsetWidth` and `offsetHeight` will not be a bounding box for a span with wrapped text.
 
-## Syntax
+## Value
 
-```js
-left = element.offsetLeft;
-```
+An integer.
 
-`left` is an integer representing the offset to the left in pixels _from the closest relatively positioned_ parent element.
-
-## Example
+## Examples
 
 ```js
 var colorTable = document.getElementById("t1");

--- a/files/en-us/web/api/htmlelement/offsetparent/index.md
+++ b/files/en-us/web/api/htmlelement/offsetparent/index.md
@@ -32,7 +32,7 @@ ancestor `td`, `th`, `table` will be returned, or the
 
 ## Value
 
-A {{domxref("HTMLElement)}} or `null`.
+An object reference to the element in which the current element is offset.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlelement/offsetparent/index.md
+++ b/files/en-us/web/api/htmlelement/offsetparent/index.md
@@ -30,14 +30,9 @@ ancestor `td`, `th`, `table` will be returned, or the
 {{domxref("HTMLElement.offsetTop","offsetTop")}} and
 {{domxref("HTMLElement.offsetLeft","offsetLeft")}} are relative to its padding edge.
 
-## Syntax
+## Value
 
-```js
-parentObj = element.offsetParent;
-```
-
-- _parentObj_ is an object reference to the element in which the current
-  element is offset.
+A {{domxref("HTMLElement)}} or `null`.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlelement/offsettop/index.md
+++ b/files/en-us/web/api/htmlelement/offsettop/index.md
@@ -14,20 +14,14 @@ browser-compat: api.HTMLElement.offsetTop
 
 The **`HTMLElement.offsetTop`** read-only property returns the
 distance of the outer border of the current element relative to the inner border of
-the top of the {{domxref("HTMLelement.offsetParent","offsetParent")}} node.
-
-## Syntax
-
-```js
-topPos = element.offsetTop;
-```
-
-### Parameters
-
-- `topPos` is the number of pixels from the top of the *closest
+the top of the {{domxref("HTMLelement.offsetParent","offsetParent")}}, *closest
   relatively positioned* parent element.
 
-## Example
+## Value
+
+A number.
+
+## Examples
 
 ```js
 var d = document.getElementById("div1");


### PR DESCRIPTION
## Summary

Sequel of #14195 
As per the template API_property_subpage_template, Syntax section is redundant in property pages. So getting rid of the cruft.

Changes:
- Removed syntax sections
- Enforced heading names to ## Value, ## Examples.
- Other small corrections

#### Metadata
- [x] Fixes a typo, bug, or other error