### PR TITLE
WebAPI: Clean syntax from property pages, part 19

### DIFF
--- a/files/en-us/web/api/htmlelement/offsetwidth/index.md
+++ b/files/en-us/web/api/htmlelement/offsetwidth/index.md
@@ -24,20 +24,14 @@ If the element is hidden (for example, by setting `style.display` on the
 element or one of its ancestors to `"none"`), then `0` is
 returned.
 
-## Syntax
+## Value
 
-```js
-var intElemOffsetWidth = element.offsetWidth;
-```
-
-`intElemOffsetWidth` is a variable storing an integer corresponding to the
-`offsetWidth` pixel value of the element. The `offsetWidth`
-property is a read-only.
+An integer corresponding to the `offsetWidth` pixel value of the element. The `offsetWidth` property is a read-only.
 
 > **Note:** This property will round the value to an integer. If you need a fractional value, use
 > {{ domxref("element.getBoundingClientRect()") }}.
 
-## Example
+## Examples
 
 ![](dimensions-offset.png)
 

--- a/files/en-us/web/api/htmlelement/title/index.md
+++ b/files/en-us/web/api/htmlelement/title/index.md
@@ -15,14 +15,11 @@ The **`HTMLElement.title`** property
 represents the title of the element: the text usually displayed in a 'tooltip' popup
 when the mouse is over the node.
 
-## Syntax
+## Value
 
-```js
-var str = element.title;
-element.title = str;
-```
+A string.
 
-## Example
+## Examples
 
 ```js
 const link = document.createElement('a');

--- a/files/en-us/web/api/htmlfontelement/color/index.md
+++ b/files/en-us/web/api/htmlfontelement/color/index.md
@@ -26,12 +26,9 @@ The format of the string must follow one of the following HTML microsyntaxes:
 | Valid hex color string   | _in_ {{cssxref("color_value", "RGB format", "#rgb")}}_: #RRGGBB_ | `#008000`               |
 | RGB using decimal values | _rgb(x,x,x) (x in 0-255 range)_                                                  | `rgb(0,128,0)`          |
 
-## Syntax
+## Value
 
-```js
-colorString = fontObj.color;
-fontObj.color = colorString;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlfontelement/face/index.md
+++ b/files/en-us/web/api/htmlfontelement/face/index.md
@@ -28,12 +28,9 @@ The format of the string must follow one of the following HTML microsyntax:
 | ------------------------------------------- | ------------------------------------------------------------------- | ----------------- |
 | List of one or more valid font family names | _A list of font names, that have to be present on the local system_ | `courier,verdana` |
 
-## Syntax
+## Value
 
-```js
-faceString = fontObj.face;
-fontObj.face = faceString;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlfontelement/size/index.md
+++ b/files/en-us/web/api/htmlfontelement/size/index.md
@@ -51,12 +51,9 @@ The format of the string must follow one of the following HTML microsyntaxes:
   </tbody>
 </table>
 
-## Syntax
+## Value
 
-```js
-sizeString = fontObj.size;
-fontObj.size = sizeString;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlformelement/acceptcharset/index.md
+++ b/files/en-us/web/api/htmlformelement/acceptcharset/index.md
@@ -18,14 +18,11 @@ list of the supported [character
 encodings](/en-US/docs/Glossary/character_encoding) for the given {{htmlelement("form")}} element. This list can be
 comma-separated or space-separated.
 
-## Syntax
+## Value
 
-```js
-var string = form.acceptCharset;
-form.acceptCharset = string;
-```
+A string.
 
-## Example
+## Examples
 
 ```js
 let inputs = document.forms['myform'].acceptCharset;

--- a/files/en-us/web/api/htmlformelement/action/index.md
+++ b/files/en-us/web/api/htmlformelement/action/index.md
@@ -20,14 +20,11 @@ of the {{HTMLElement("form")}} element.
 The action of a form is the program that is executed on the server when the form is
 submitted. This property can be retrieved or set.
 
-## Syntax
+## Value
 
-```js
-var string = form.action;
-form.action = string;
-```
+A string.
 
-## Example
+## Examples
 
 ```js
 form.action = '/cgi-bin/publish';

--- a/files/en-us/web/api/htmlformelement/enctype/index.md
+++ b/files/en-us/web/api/htmlformelement/enctype/index.md
@@ -23,14 +23,11 @@ to submit the form to the server. Possible values are:
 This value can be overridden by a {{htmlattrxref("formenctype", "button")}} attribute
 on a {{HTMLElement("button")}} or {{HTMLElement("input")}} element.
 
-## Syntax
+## Value
 
-```js
-var string = form.enctype;
-form.enctype = string;
-```
+A string.
 
-## Example
+## Examples
 
 ```js
 form.enctype = 'application/x-www-form-urlencoded';

--- a/files/en-us/web/api/htmlformelement/method/index.md
+++ b/files/en-us/web/api/htmlformelement/method/index.md
@@ -17,14 +17,11 @@ The **`HTMLFormElement.method`** property represents the
 
 Unless explicitly specified, the default method is 'get'.
 
-## Syntax
+## Value
 
-```js
-var string = form.method;
-form.method = string;
-```
+A string.
 
-## Example
+## Examples
 
 ```js
 document.forms['myform'].method = 'post';

--- a/files/en-us/web/api/htmlformelement/name/index.md
+++ b/files/en-us/web/api/htmlformelement/name/index.md
@@ -20,14 +20,11 @@ that element overrides the `form.name` property, so that you can't access it.
 Internet Explorer (IE) does not allow the name attribute of an element created using
 `createElement()` to be set or modified using the `name` property.
 
-## Syntax
+## Value
 
-```js
-var string = form.name;
-form.name = string;
-```
+A string.
 
-## Example
+## Examples
 
 ```js
 var form1name = document.getElementById('form1').name;

--- a/files/en-us/web/api/htmlformelement/target/index.md
+++ b/files/en-us/web/api/htmlformelement/target/index.md
@@ -16,14 +16,11 @@ The **`target`** property of the {{domxref("HTMLFormElement")}}
 interface represents the target of the form's action (i.e., the frame in which to render
 its output).
 
-## Syntax
+## Value
 
-```js
-string = HTMLFormElement.target
-HTMLFormElement.target = string
-```
+A string.
 
-## Example
+## Examples
 
 ```js
 myForm.target = document.frames[1].name;

--- a/files/en-us/web/api/htmliframeelement/contentwindow/index.md
+++ b/files/en-us/web/api/htmliframeelement/contentwindow/index.md
@@ -15,7 +15,11 @@ browser-compat: api.HTMLIFrameElement.contentWindow
 
 The **`contentWindow`** property returns the [Window](/en-US/docs/Web/API/Window) object of an [HTMLIFrameElement](/en-US/docs/Web/API/HTMLIFrameElement). You can use this `Window` object to access the iframe's document and its internal DOM. This attribute is read-only, but its properties can be manipulated like the global `Window` object.
 
-## Example of contentWindow
+## Value
+
+A [Window](/en-US/docs/Web/API/Window) object.
+
+## Examples
 
 ```js
 var x = document.getElementsByTagName("iframe")[0].contentWindow;

--- a/files/en-us/web/api/htmlinputelement/labels/index.md
+++ b/files/en-us/web/api/htmlinputelement/labels/index.md
@@ -16,18 +16,12 @@ The **`HTMLInputElement.labels`** read-only property returns a
 {{HTMLElement("input")}} element, if the element is not hidden. If the element has the
 type `hidden`, the property returns `null`.
 
-## Syntax
-
-```js
-var labelElements = input.labels;
-```
-
-### Return value
+## Value
 
 A {{domxref("NodeList")}} containing the `<label>` elements associated
 with the `<input>` element.
 
-## Example
+## Examples
 
 ### HTML
 

--- a/files/en-us/web/api/htmlinputelement/multiple/index.md
+++ b/files/en-us/web/api/htmlinputelement/multiple/index.md
@@ -15,7 +15,11 @@ browser-compat: api.HTMLInputElement.multiple
 
 The **`HTMLInputElement.multiple`** property indicates if an input can have more than one value. Firefox currently only supports `multiple` for `<input type="file">`.
 
-## Example
+## Value
+
+A boolean value.
+
+## Examples
 
 ```js
 // fileInput is a <input type=file multiple>

--- a/files/en-us/web/api/htmllinkelement/rel/index.md
+++ b/files/en-us/web/api/htmllinkelement/rel/index.md
@@ -21,14 +21,11 @@ The most common use of this attribute is to specify a link to an external style 
 the property is set to `stylesheet`, and the {{htmlattrxref("href", "link")}}
 attribute is set to the URL of an external style sheet to format the page.
 
-## Syntax
+## Value
 
-```js
-var relstr = linkElt.rel;
-linkElt.rel = relstr;
-```
+A string.
 
-## Example
+## Examples
 
 ```js
 var links = document.getElementsByTagName('link');

--- a/files/en-us/web/api/htmllinkelement/rellist/index.md
+++ b/files/en-us/web/api/htmllinkelement/rellist/index.md
@@ -22,13 +22,11 @@ The property itself is read-only, meaning you can substitute the
 {{domxref("DOMTokenList")}} by another one, but the content of the returned list can be
 changed.
 
-## Syntax
+## Value
 
-```js
-var relstr = linkElt.relList;
-```
+A live {{domxref("DOMTokenList")}}.
 
-## Example
+## Examples
 
 ```js
 var links = document.getElementsByTagName("link");

--- a/files/en-us/web/api/htmlmediaelement/sinkid/index.md
+++ b/files/en-us/web/api/htmlmediaelement/sinkid/index.md
@@ -21,11 +21,9 @@ the {{domxref("MediaDeviceInfo.deviceId")}} values returned from
 {{domxref("MediaDevices.enumerateDevices()")}}, `id-multimedia`, or
 `id-communications`.
 
-## Syntax
+## Value
 
-```js
-var sinkId = HTMLMediaElement.sinkId
-```
+A string.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlmeterelement/labels/index.md
+++ b/files/en-us/web/api/htmlmeterelement/labels/index.md
@@ -15,18 +15,12 @@ The **`HTMLMeterElement.labels`** read-only property returns a
 {{domxref("NodeList")}} of the {{HTMLElement("label")}} elements associated with the
 {{HTMLElement("meter")}} element.
 
-## Syntax
-
-```js
-var labelElements = meter.labels;
-```
-
-### Return value
+## Value
 
 A {{domxref("NodeList")}} containing the `<label>` elements associated
 with the `<meter>` element.
 
-## Example
+## Examples
 
 ### HTML
 

--- a/files/en-us/web/api/htmloutputelement/labels/index.md
+++ b/files/en-us/web/api/htmloutputelement/labels/index.md
@@ -15,18 +15,12 @@ The **`HTMLOutputElement.labels`** read-only property returns a
 {{domxref("NodeList")}} of the {{HTMLElement("label")}} elements associated with the
 {{HTMLElement("output")}} element.
 
-## Syntax
-
-```js
-var labelElements = output.labels;
-```
-
-### Return value
+## Value
 
 A {{domxref("NodeList")}} containing the `<label>` elements associated
 with the `<output>` element.
 
-## Example
+## Examples
 
 ### HTML
 

--- a/files/en-us/web/api/htmlprogresselement/labels/index.md
+++ b/files/en-us/web/api/htmlprogresselement/labels/index.md
@@ -15,18 +15,12 @@ The **`HTMLProgressElement.labels`** read-only property returns
 a {{domxref("NodeList")}} of the {{HTMLElement("label")}} elements associated with the
 {{HTMLElement("progress")}} element.
 
-## Syntax
-
-```js
-var labelElements = progress.labels;
-```
-
-### Return value
+## Value
 
 A {{domxref("NodeList")}} containing the `<label>` elements associated
 with the `<progress>` element.
 
-## Example
+## Examples
 
 ### HTML
 

--- a/files/en-us/web/api/htmlselectelement/autofocus/index.md
+++ b/files/en-us/web/api/htmlselectelement/autofocus/index.md
@@ -24,14 +24,11 @@ such element on the page, get the initial focus.
 > _the element is inserted_ in the document. Setting it after the insertion, that
 > is most of the time after the document load, has no visible effect.
 
-## Syntax
+## Value
 
-```js
-aBool = aSelectElement.autofocus; // Get the value of autofocus
-aSelectElement.autofocus = aBool; // Set the value of autofocus
-```
+A boolean value.
 
-## Example
+## Examples
 
 ### HTML
 

--- a/files/en-us/web/api/htmlselectelement/disabled/index.md
+++ b/files/en-us/web/api/htmlselectelement/disabled/index.md
@@ -15,13 +15,11 @@ The **`HTMLSelectElement.disabled`** is a boolean value that reflects the
 HTML attribute, which indicates whether the control is disabled. If it is disabled, it
 does not accept clicks. A disabled element is unusable and un-clickable.
 
-## Syntax
+## Value
 
-```js
-aSelectElement.disabled = aBool;
-```
+A boolean value.
 
-## Example
+## Examples
 
 ### HTML
 

--- a/files/en-us/web/api/htmlselectelement/form/index.md
+++ b/files/en-us/web/api/htmlselectelement/form/index.md
@@ -16,7 +16,11 @@ The **`HTMLSelectElement.form`** read-only property returns a
 with. If the element is not associated with of a {{HTMLElement("form")}} element, then
 it returns `null`.
 
-## Example
+## Value
+
+A {{domxref("HTMLFormElement")}}.
+
+## Examples
 
 ```html
 <form id="pet-form">

--- a/files/en-us/web/api/htmlselectelement/labels/index.md
+++ b/files/en-us/web/api/htmlselectelement/labels/index.md
@@ -15,18 +15,12 @@ The **`HTMLSelectElement.labels`** read-only property returns a
 {{domxref("NodeList")}} of the {{HTMLElement("label")}} elements associated with the
 {{HTMLElement("select")}} element.
 
-## Syntax
-
-```js
-var labelElements = select.labels;
-```
-
-### Return value
+## Value
 
 A {{domxref("NodeList")}} containing the `<label>` elements associated
 with the `<select>` element.
 
-## Example
+## Examples
 
 ### HTML
 

--- a/files/en-us/web/api/htmlselectelement/options/index.md
+++ b/files/en-us/web/api/htmlselectelement/options/index.md
@@ -16,18 +16,12 @@ The **`HTMLSelectElement.options`** read-only property returns
 a {{domxref("HTMLOptionsCollection")}} of the {{HTMLElement("option")}} elements
 contained by the {{HTMLElement("select")}} element.
 
-## Syntax
-
-```js
-var options = select.options;
-```
-
-### Return value
+## Value
 
 A {{domxref("HTMLOptionsCollection")}} containing the `<option>`
 elements contained by the `<select>` element.
 
-## Example
+## Examples
 
 ### HTML
 

--- a/files/en-us/web/api/htmlselectelement/selectedindex/index.md
+++ b/files/en-us/web/api/htmlselectelement/selectedindex/index.md
@@ -17,14 +17,11 @@ The **`HTMLSelectElement.selectedIndex`** is a
 {{HTMLElement("option")}} element, depending on the value of `multiple`. The
 value `-1` indicates that no element is selected.
 
-## Syntax
+## Value
 
-```js
-var index = selectElem.selectedIndex;
-selectElem.selectedIndex = index;
-```
+A number.
 
-## Example
+## Examples
 
 ### HTML
 

--- a/files/en-us/web/api/htmlselectelement/type/index.md
+++ b/files/en-us/web/api/htmlselectelement/type/index.md
@@ -15,18 +15,14 @@ browser-compat: api.HTMLSelectElement.type
 The **`HTMLSelectElement.type`**
 read-only property returns the form control's `type`.
 
-## Syntax
+## Value
 
-```js
-var str = selectElt.type;
-```
-
-The possible values are:
+One of the followings:
 
 - `"select-multiple"` if multiple values can be selected.
 - `"select-one"` if only one value can be selected.
 
-## Example
+## Examples
 
 ```js
 switch (select.type) {

--- a/files/en-us/web/api/htmlshadowelement/getdistributednodes/index.md
+++ b/files/en-us/web/api/htmlshadowelement/getdistributednodes/index.md
@@ -16,13 +16,11 @@ The **`HTMLShadowElement.getDistributedNodes()`** method
 returns a static {{domxref("NodeList")}} of the {{glossary("distributed nodes")}}
 associated with this `<shadow>` element.
 
-## Syntax
+## Value
 
-```js
-var nodeList = object.getDistributedNodes()
-```
+A {{domxref("NodeList")}}.
 
-## Example
+## Examples
 
 ```js
 // Get the distributed nodes

--- a/files/en-us/web/api/htmlstyleelement/media/index.md
+++ b/files/en-us/web/api/htmlstyleelement/media/index.md
@@ -15,19 +15,11 @@ browser-compat: api.HTMLStyleElement.media
 The **`HTMLStyleElement.media`** property specifies the
 intended destination medium for style information.
 
-## Syntax
+## Value
 
-```js
-medium = style.media
-style.media = medium
-```
+A string describing a single medium or a comma-separated list.
 
-### Parameters
-
-- `medium` is a string describing a single medium or a comma-separated
-  list.
-
-## Example
+## Examples
 
 ```html
 <!doctype html>

--- a/files/en-us/web/api/htmlstyleelement/scoped/index.md
+++ b/files/en-us/web/api/htmlstyleelement/scoped/index.md
@@ -21,12 +21,9 @@ sub-tree (`true`).
 By default it contains the value of the {{htmlattrxref("scoped", "style")}} content
 attribute.
 
-## Syntax
+## Value
 
-```js
-value = style.scoped;
-style.scoped = true;
-```
+A boolean value.
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/htmlstyleelement/type/index.md
+++ b/files/en-us/web/api/htmlstyleelement/type/index.md
@@ -22,13 +22,11 @@ expectation is that binding-specific casting methods can be used to cast down fr
 instance of the CSSRule interface to the specific derived interface implied by the
 type."
 
-## Syntax
+## Value
 
-```js
-string = style.type;
-```
+A string.
 
-## Example
+## Examples
 
 ```js
 if (newStyle.type != "text/css"){

--- a/files/en-us/web/api/htmltableelement/align/index.md
+++ b/files/en-us/web/api/htmltableelement/align/index.md
@@ -17,24 +17,15 @@ browser-compat: api.HTMLTableElement.align
 The **`HTMLTableElement.align`** property represents the
 alignment of the table.
 
-## Syntax
+## Value
 
-```js
-HTMLTableElement.align = alignment;
-var alignment = HTMLTableElement.align;
-```
+One of the following string values:
 
-### Parameters
+- `left`
+- `center`
+- `right`
 
-- `alignment`
-
-  - : {{DOMxRef("DOMString")}} with one of the following values:
-
-    - left
-    - center
-    - right
-
-## Example
+## Examples
 
 ```js
 // Set the alignment of a table

--- a/files/en-us/web/api/htmltableelement/bgcolor/index.md
+++ b/files/en-us/web/api/htmltableelement/bgcolor/index.md
@@ -24,18 +24,11 @@ or using a style rule.
 
 Also available on DOM [`tbody`](/en-US/docs/Web/API/HTMLTableElement/tBodies), [`row`](/en-US/docs/Web/API/HTMLTableElement/rows) and [`cell`](/en-US/docs/DOM/table.cells) objects.
 
-## Syntax
+## Value
 
-```js
-color = table.bgColor
-table.bgColor = color
-```
+A string representing a color value.
 
-### Parameters
-
-- `color` is a string representing a color value.
-
-## Example
+## Examples
 
 ```js
 // Set table background color to lightblue

--- a/files/en-us/web/api/htmltableelement/border/index.md
+++ b/files/en-us/web/api/htmltableelement/border/index.md
@@ -15,16 +15,11 @@ browser-compat: api.HTMLTableElement.border
 The **`HTMLTableElement.border`** property represents the
 border width of the {{HtmlElement("table")}} element.
 
-## Syntax
+## Value
 
-```js
-HTMLTableElement.border = border;
-var border = HTMLTableElement.border;
-```
+A string representing the width of the border in pixels.
 
-- `border` is a string representing the width of the border in pixels.
-
-## Example
+## Examples
 
 ```js
 // Set the width of a table border to 2 pixels

--- a/files/en-us/web/api/htmltableelement/caption/index.md
+++ b/files/en-us/web/api/htmltableelement/caption/index.md
@@ -14,13 +14,11 @@ The **`HTMLTableElement.caption`** property represents the
 table caption. If no caption element is associated with the table, this property is
 `null`.
 
-## Syntax
+## Value
 
-```js
-var string = tableElement.caption;
-```
+A string.
 
-## Example
+## Examples
 
 ```js
 if (table.caption) {

--- a/files/en-us/web/api/htmltableelement/cellpadding/index.md
+++ b/files/en-us/web/api/htmltableelement/cellpadding/index.md
@@ -15,17 +15,11 @@ browser-compat: api.HTMLTableElement.cellPadding
 The **`HTMLTableElement.cellPadding`** property represents the
 padding around the individual cells of the table.
 
-## Syntax
+## Value
 
-```js
-HTMLTableElement.cellPadding = padding;
-var padding = HTMLTableElement.cellPadding;
-```
+A string representing pixels (e.g. "10") or a percentage value (e.g. "10%").
 
-- `padding` is either a number of pixels (e.g. "10") or a percentage value
-  (e.g. "10%").
-
-## Example
+## Examples
 
 ```js
 // Set cell padding to 10 pixels

--- a/files/en-us/web/api/htmltableelement/frame/index.md
+++ b/files/en-us/web/api/htmltableelement/frame/index.md
@@ -19,16 +19,9 @@ The {{domxref("HTMLTableElement")}} interface's **`frame`**
 property is a string that indicates which of the table's exterior borders should be
 drawn.
 
-## Syntax
+## Value
 
-```js
-HTMLTableElement.frame = frameSides;
-var frameSides = HTMLTableElement.frame;
-```
-
-### Parameters
-
-`frameSides` is a string whose value is one of the following values:
+One of the followings:
 
 - `void`
   - : No sides. This is the default.
@@ -49,7 +42,7 @@ var frameSides = HTMLTableElement.frame;
 - `"border"`
   - : All four sides
 
-## Example
+## Examples
 
 ```js
 // Set the frame of TableA to 'border'

--- a/files/en-us/web/api/htmltableelement/rules/index.md
+++ b/files/en-us/web/api/htmltableelement/rules/index.md
@@ -17,16 +17,9 @@ browser-compat: api.HTMLTableElement.rules
 The **`HTMLTableElement.rules`** property indicates which cell
 borders to render in the table.
 
-## Syntax
+## Value
 
-```js
-HTMLTableElement.rules = rules;
-var rules = HTMLTableElement.rules;
-```
-
-### Parameters
-
-`rules` is a string with one of the following values:
+One of the followings:
 
 - `none`
   - : No rules
@@ -39,7 +32,7 @@ var rules = HTMLTableElement.rules;
 - `all`
   - : Lines between all cells
 
-## Example
+## Examples
 
 ```js
 // Turn on all the internal borders of a table

--- a/files/en-us/web/api/htmltableelement/summary/index.md
+++ b/files/en-us/web/api/htmltableelement/summary/index.md
@@ -17,14 +17,11 @@ browser-compat: api.HTMLTableElement.summary
 The **`HTMLTableElement.summary`** property represents the
 table description.
 
-## Syntax
+## Value
 
-```js
-HTMLTableElement.summary = string;
-varstring = HTMLTableElement.summary;
-```
+A string.
 
-## Example
+## Examples
 
 ```js
 HTMLTableElement.summary = "Usage statistics";

--- a/files/en-us/web/api/htmltableelement/tbodies/index.md
+++ b/files/en-us/web/api/htmltableelement/tbodies/index.md
@@ -32,13 +32,11 @@ example:
 The HTML DOM generated from the above HTML will have a {{HTMLElement("tbody")}} element
 even though the tags are not included in the source HTML.
 
-## Syntax
+## Value
 
-```js
-HTMLCollectionObject = table.tBodies
-```
+A live {{domxref("HTMLCollection")}}.
 
-## Example
+## Examples
 
 This snippet gets the number of bodies in a table.
 

--- a/files/en-us/web/api/htmltableelement/tfoot/index.md
+++ b/files/en-us/web/api/htmltableelement/tfoot/index.md
@@ -15,14 +15,11 @@ The **`HTMLTableElement.tFoot`** property represents the
 {{HTMLElement("tfoot")}} element of a {{HTMLElement("table")}}. Its value will be
 `null` if there is no such element.
 
-## Syntax
+## Value
 
-```js
-HTMLTableSectionElementObject = table.tFoot
-table.tFoot = HTMLTableSectionElementObject
-```
+A {{HTMLElement("tfoot")}} element or `null`.
 
-## Example
+## Examples
 
 ```js
 if (table.tFoot == my_foot) {

--- a/files/en-us/web/api/htmltableelement/thead/index.md
+++ b/files/en-us/web/api/htmltableelement/thead/index.md
@@ -15,18 +15,11 @@ The **`HTMLTableElement.tHead`** represents the
 {{HTMLElement("thead")}} element of a {{HTMLElement("table")}} . Its value will be
 `null` if there is no such element.
 
-## Syntax
+## Value
 
-```js
-thead_element = table.tHead;
-table.tHead = thead_element;
-```
+A {{domxref("HTMLTableSectionElement")}}.
 
-### Parameters
-
-- `thead_element` is a {{domxref("HTMLTableSectionElement")}}.
-
-## Example
+## Examples
 
 ```js
 if (table.tHead == my_head_el) {

--- a/files/en-us/web/api/htmltableelement/width/index.md
+++ b/files/en-us/web/api/htmltableelement/width/index.md
@@ -17,17 +17,11 @@ browser-compat: api.HTMLTableElement.width
 The **`HTMLTableElement.width`** property represents the
 desired width of the table.
 
-## Syntax
+## Value
 
-```js
-HTMLTableElement.width = width;
-var width = HTMLTableElement.width;
-```
+A string representing the width in number of pixels or as a percentage value.
 
-Where `width` is a string representing the width in number of pixels or as a
-percentage value.
-
-## Example
+## Examples
 
 ```js
 mytable.width = "75%";

--- a/files/en-us/web/api/htmltemplateelement/content/index.md
+++ b/files/en-us/web/api/htmltemplateelement/content/index.md
@@ -16,13 +16,11 @@ The **`HTMLTemplateElement.content`** property returns a
 `<template>` element's template contents (a
 {{domxref("DocumentFragment")}}).
 
-## Syntax
+## Value
 
-```js
-var documentFragment = templateElement.content
-```
+A {{domxref("DocumentFragment")}}.
 
-## Example
+## Examples
 
 ```js
 var templateElement = document.querySelector("#foo");

--- a/files/en-us/web/api/htmltextareaelement/labels/index.md
+++ b/files/en-us/web/api/htmltextareaelement/labels/index.md
@@ -15,18 +15,12 @@ The **`HTMLTextAreaElement.labels`** read-only property returns
 a {{domxref("NodeList")}} of the {{HTMLElement("label")}} elements associated with the
 {{HTMLElement("textArea")}} element.
 
-## Syntax
-
-```js
-var labelElements = textArea.labels;
-```
-
-### Return value
+## Value
 
 A {{domxref("NodeList")}} containing the `<label>` elements associated
 with the `<textArea>` element.
 
-## Example
+## Examples
 
 ### HTML
 

--- a/files/en-us/web/api/htmltimeelement/datetime/index.md
+++ b/files/en-us/web/api/htmltimeelement/datetime/index.md
@@ -152,14 +152,11 @@ The format of the string must follow one of the following HTML microsyntaxes:
   </tbody>
 </table>
 
-## Syntax
+## Value
 
-```js
-dateTimeString = timeElt.dateTime;
-timeElt.dateTime = dateTimeString
-```
+A string.
 
-## Example
+## Examples
 
 ```js
 // Assumes there is <time id="t"> element in the HTML

--- a/files/en-us/web/api/idbmutablefile/onabort/index.md
+++ b/files/en-us/web/api/idbmutablefile/onabort/index.md
@@ -15,13 +15,9 @@ tags:
 
 Specifies an event listener to receive {{event("abort")}} events. These events occur when the associated locked file has been aborted with the {{domxref("LockedFile.abort()")}} method.
 
-## Syntax
+## Value
 
-```js
-instanceOfFileHandle.onabort = funcRef;
-```
-
-Where `funcRef` is a function to be called when the {{event("abort")}} event occurs.
+A function to be called when the {{event("abort")}} event occurs.
 
 ## Specifications
 

--- a/files/en-us/web/api/idbmutablefile/onerror/index.md
+++ b/files/en-us/web/api/idbmutablefile/onerror/index.md
@@ -15,13 +15,9 @@ tags:
 
 Specifies an event listener to receive {{event("error")}} events. These events occur when something goes wrong.
 
-## Syntax
+## Value
 
-```js
-instanceOfFileHandle.onerror = funcRef;
-```
-
-Where `funcRef` is a function to be called when the {{event("error")}} event occurs.
+A function to be called when the {{event("error")}} event occurs.
 
 ## Specifications
 

--- a/files/en-us/web/api/idbtransaction/objectstorenames/index.md
+++ b/files/en-us/web/api/idbtransaction/objectstorenames/index.md
@@ -18,13 +18,7 @@ The **`objectStoreNames`** read-only property of the
 {{domxref("IDBTransaction")}} interface returns a {{domxref("DOMStringList")}} of names
 of {{domxref("IDBObjectStore")}} objects.
 
-## Syntax
-
-```js
-var myDatabase = transactionObj.objectStoreNames;
-```
-
-### Returns
+## Value
 
 A {{domxref("DOMStringList")}} of names of {{domxref("IDBObjectStore")}} objects.
 

--- a/files/en-us/web/api/imagedata/data/index.md
+++ b/files/en-us/web/api/imagedata/data/index.md
@@ -16,11 +16,9 @@ The readonly **`ImageData.data`** property returns a
 pixel data. Data is stored as a one-dimensional array in the RGBA order, with integer
 values between `0` and `255` (inclusive).
 
-## Syntax
+## Value
 
-```js
-imageData.data
-```
+A {{jsxref("Uint8ClampedArray")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/imagedata/height/index.md
+++ b/files/en-us/web/api/imagedata/height/index.md
@@ -14,13 +14,11 @@ browser-compat: api.ImageData.height
 The readonly **`ImageData.height`** property returns the number
 of rows in the {{domxref("ImageData")}} object.
 
-## Syntax
+## Value
 
-```js
-imageData.height
-```
+A number.
 
-## Example
+## Examples
 
 This example creates an `ImageData` object that is 200 pixels wide and 100
 pixels tall. Thus, the `height` property is `100`.

--- a/files/en-us/web/api/imagedata/width/index.md
+++ b/files/en-us/web/api/imagedata/width/index.md
@@ -14,13 +14,11 @@ browser-compat: api.ImageData.width
 The readonly **`ImageData.width`** property returns the number
 of pixels per row in the {{domxref("ImageData")}} object.
 
-## Syntax
+## Value
 
-```js
-imageData.width
-```
+A number.
 
-## Example
+## Examples
 
 This example creates an `ImageData` object that is 200 pixels wide and 100
 pixels tall. Thus, the `width` property is `200`.

--- a/files/en-us/web/api/inputevent/iscomposing/index.md
+++ b/files/en-us/web/api/inputevent/iscomposing/index.md
@@ -15,13 +15,11 @@ The **`InputEvent.isComposing`** read-only property returns a
 boolean value indicating if the event is fired after
 {{event("compositionstart")}} and before {{event("compositionend")}}.
 
-## Syntax
+## Value
 
-```js
-var bool = event.isComposing;
-```
+A boolean.
 
-## Example
+## Examples
 
 ```js
 var inputEvent = new InputEvent('syntheticInput', false);


### PR DESCRIPTION
Sequel of #14195 
As per the template API_property_subpage_template, Syntax section is redundant in property pages. So getting rid of the cruft.

Changes:
- Removed syntax sections
- Enforced heading names to ## Value, ## Examples.
- Other small corrections

#### Metadata
- [x] Fixes a typo, bug, or other error