### PR TITLE
fix: using space instead to show the recommend

### DIFF
--- a/files/en-us/web/html/element/dialog/index.md
+++ b/files/en-us/web/html/element/dialog/index.md
@@ -81,7 +81,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 - {{htmlattrdef("open")}}
   - : Indicates that the dialog is active and can be interacted with. When the `open` attribute is not set, the dialog _shouldn't_ be shown to the user.
-  - : It is recommended to use the `.show()` or `.showModal()` methods to render dialogs, rather than the `open` attribute.
+      It is recommended to use the `.show()` or `.showModal()` methods to render dialogs, rather than the `open` attribute.
 
 ## Accessibility considerations
 


### PR DESCRIPTION
#### Summary

using space to replace the `- :`. Or the recommend cannot be shown.

#### Supporting details

before

![image](https://user-images.githubusercontent.com/15844309/161411935-a9116490-0bba-4fc0-8736-bc21191f3b27.png)

after

![image](https://user-images.githubusercontent.com/15844309/161411893-44c26e2b-e8f8-47ab-bc5b-7b2977565f6f.png)

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

