### PR TITLE
Fix developers.google.com links

### DIFF
--- a/files/en-us/web/api/navigator/registerprotocolhandler/web-based_protocol_handlers/index.md
+++ b/files/en-us/web/api/navigator/registerprotocolhandler/web-based_protocol_handlers/index.md
@@ -125,4 +125,4 @@ if ( isset ( $_GET["value"] ) ) {
 
 - [nsIProtocolHandler](/en-US/docs/XPCOM_Interface_Reference/nsIProtocolHandler) (XUL only)
 - [RegisterProtocolHandler Enhancing the Federated Web](http://blog.mozilla.com/webdev/2010/07/26/registerprotocolhandler-enhancing-the-federated-web/) at Mozilla Webdev
-- [Register a custom protocolHandler](https://developers.google.com/web/updates/2011/06/Registering-a-custom-protocol-handler) at Google Developers.
+- [Register a custom protocolHandler](https://web.dev/registering-a-custom-protocol-handler/) at web.dev.

--- a/files/en-us/web/api/navigator/sendbeacon/index.md
+++ b/files/en-us/web/api/navigator/sendbeacon/index.md
@@ -140,7 +140,7 @@ document.addEventListener('visibilitychange', function logData() {
   detail why you should use `visibilitychange`, not
   `beforeunload`/`unload`.
 - [Page
-  Lifecycle API](https://developers.google.com/web/updates/2018/07/page-lifecycle-api#developer-recommendations-for-each-state) gives best-practices guidance on handling
+  Lifecycle API](https://developer.chrome.com/blog/page-lifecycle-api/#developer-recommendations-for-each-state) gives best-practices guidance on handling
   page lifecycle behavior in your web applications.
 - [PageLifecycle.js](https://github.com/GoogleChromeLabs/page-lifecycle): a JavaScript library that deals with cross-browser inconsistencies in page lifecycle behavior.
 - [Back/forward cache](https://web.dev/bfcache/) explains what the back/forward cache is, and its implications for various page lifecycle events.

--- a/files/en-us/web/api/reporting_api/index.md
+++ b/files/en-us/web/api/reporting_api/index.md
@@ -131,7 +131,7 @@ Support is at an early stage right now. Firefox supports the JavaScript API and 
 - JavaScript API: `dom.reporting.enabled` (enabled in nightly only)
 - HTTP header: `dom.reporting.header.enabled`
 
-Chrome is also working on an implementation: [information about Chrome implementation](https://developers.google.com/web/updates/2018/09/reportingapi).
+Chrome is also working on an implementation: [information about Chrome implementation](https://web.dev/reporting-api/).
 
 ## See also
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Fix developers.google.com links. The reason this pr was smaller than the last few is I think I got all the migrated links. Google is only migrating the developers.google.com/web section so most of the other developers.google.com links with be to the other sections of the site.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
It was wrong.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
#7586
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
