### PR TITLE
WebExtension menu.overrideContext() - add browser compat

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/overridecontext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/overridecontext/index.md
@@ -9,6 +9,7 @@ tags:
   - Method
   - WebExtensions
   - contextMenus
+browser-compat: webextensions.api.menus.overrideContext
 ---
 {{AddonSidebar}}
 
@@ -60,3 +61,7 @@ document.addEventListener('contextmenu', event => {
 ```
 
 See [this blog post](https://blog.mozilla.org/addons/2018/11/08/extensions-in-firefox-64/#cm) for more details.
+
+## Browser compatibility
+
+{{ Compat }}


### PR DESCRIPTION
FF64 added support for Web Extensions > [menus.overrideContext()](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/menus/overrideContext) - see https://blog.mozilla.org/addons/2018/11/08/extensions-in-firefox-64/#cm

This adds compatibility information to page so that people can tell the browsers/versions in which it is supported.

BCD done in https://github.com/mdn/browser-compat-data/pull/15642

Part of fixing #14562