### PR TITLE
Http ifmatch

### DIFF
--- a/files/en-us/web/http/headers/if-match/index.md
+++ b/files/en-us/web/http/headers/if-match/index.md
@@ -14,7 +14,7 @@ browser-compat: http.headers.If-Match
 The **`If-Match`** HTTP request header makes a request conditional.
 
 A server will only return requested resources for {{HTTPMethod("GET")}} and {{HTTPMethod("HEAD")}} methods, or upload resource for {{HTTPMethod("PUT")}} and other non-safe methods, if the resource matches one of the listed {{HTTPHeader("ETag")}} values.
-If the conditional does not match then the  {{HTTPStatus("412")}} (Precondition Failed) response is returned.
+If the conditional does not match then the {{HTTPStatus("412")}} (Precondition Failed) response is returned.
 
 The comparison with the stored {{HTTPHeader("ETag")}} uses the _strong comparison algorithm_, meaning two files are considered identical byte by byte only.
 If a listed `ETag` has the `W/` prefix indicating a weak entity tag, this comparison algorithm will never match it.

--- a/files/en-us/web/http/headers/if-match/index.md
+++ b/files/en-us/web/http/headers/if-match/index.md
@@ -11,29 +11,20 @@ browser-compat: http.headers.If-Match
 ---
 {{HTTPSidebar}}
 
-The **`If-Match`** HTTP request header makes the request
-conditional. For {{HTTPMethod("GET")}} and {{HTTPMethod("HEAD")}} methods, the server
-will return the requested resource only if it matches one of the listed
-`ETags`. For {{HTTPMethod("PUT")}} and other non-safe methods, it will only
-upload the resource in this case.
+The **`If-Match`** HTTP request header makes the request conditional.
 
-The comparison with the stored {{HTTPHeader("ETag")}} uses the _strong comparison
-algorithm_, meaning two files are considered identical byte by byte only. If a
-listed `ETag` has the `W/` prefix indicating a weak entity tag, this comparison
-algorithm will never match it.
+A server will only return requested resources for {{HTTPMethod("GET")}} and {{HTTPMethod("HEAD")}} methods, or upload resource for {{HTTPMethod("PUT")}} and other non-safe methods, if the resource matches one of the listed {{HTTPHeader("ETag")}} values.
+If the conditional does not match then the  {{HTTPStatus("412")}} (Precondition Failed) response is returned.
+
+The comparison with the stored {{HTTPHeader("ETag")}} uses the _strong comparison algorithm_, meaning two files are considered identical byte by byte only.
+If a listed `ETag` has the `W/` prefix indicating a weak entity tag, this comparison algorithm will never match it.
 
 There are two common use cases:
 
-- For {{HTTPMethod("GET")}} and {{HTTPMethod("HEAD")}} methods, used in combination
-  with a {{HTTPHeader("Range")}} header, it can guarantee that the new ranges requested
-  come from the same resource as the previous one. If it doesn't match, then a
-  {{HTTPStatus("416")}} (Range Not Satisfiable) response is returned.
-- For other methods, and in particular for {{HTTPMethod("PUT")}},
-  `If-Match` can be used to prevent the [lost update problem](https://www.w3.org/1999/04/Editing/#3.1). It can check
-  if the modification of a resource that the user wants to upload will not override
-  another change that has been done since the original resource was fetched. If the
-  request cannot be fulfilled, the {{HTTPStatus("412")}} (Precondition Failed) response
-  is returned.
+- For {{HTTPMethod("GET")}} and {{HTTPMethod("HEAD")}} methods, used in combination with a {{HTTPHeader("Range")}} header, it can guarantee that the new ranges requested
+  come from the same resource as the previous one.
+- For other methods, and in particular for {{HTTPMethod("PUT")}}, `If-Match` can be used to prevent the [lost update problem](https://www.w3.org/1999/04/Editing/#3.1).
+  It can check if the modification of a resource that the user wants to upload will not override another change that has been done since the original resource was fetched.
 
 <table class="properties">
   <tbody>
@@ -57,18 +48,19 @@ If-Match: <etag_value>, <etag_value>, …
 
 ## Directives
 
-- \<etag_value>
-  - : Entity tags uniquely representing the requested resources. They are a string of
-    ASCII characters placed between double quotes (like `"675af34563dc-tr34"`).
-    They may be prefixed by `W/` to indicate that they are "weak", i.e. that
-    they represent the resource semantically but not byte-by-byte. However, in an
-    **`If-Match`** header, weak entity tags will never match.
+- `<etag_value>`
+  - : Entity tags uniquely representing the requested resources.
+    They are a string of ASCII characters placed between double quotes (like `"675af34563dc-tr34"`).
+    They may be prefixed by `W/` to indicate that they are "weak", i.e. that they represent the resource semantically but not byte-by-byte.
+    However, in an **`If-Match`** header, weak entity tags will never match.
 - `*`
   - : The asterisk is a special value representing any resource.
+    Note that this must match as `false` if the origin server does not have a current representation for the target resource.
+    
 
 ## Examples
 
-```
+```http
     If-Match: "bfc13a64729c4290ef5b2c2730249c88ca92d82d"
 
     If-Match: "67ab43", "54ed21", "7892dd"
@@ -90,5 +82,5 @@ If-Match: <etag_value>, <etag_value>, …
 - {{HTTPHeader("If-Unmodified-Since")}}
 - {{HTTPHeader("If-Modified-Since")}}
 - {{HTTPHeader("If-None-Match")}}
-- {{HTTPStatus("416", "416 Range Not Satisfiable")}}
 - {{HTTPStatus("412", "412 Precondition Failed")}}
+- {{HTTPStatus("416", "416 Range Not Satisfiable")}}

--- a/files/en-us/web/http/headers/if-match/index.md
+++ b/files/en-us/web/http/headers/if-match/index.md
@@ -11,7 +11,7 @@ browser-compat: http.headers.If-Match
 ---
 {{HTTPSidebar}}
 
-The **`If-Match`** HTTP request header makes the request conditional.
+The **`If-Match`** HTTP request header makes a request conditional.
 
 A server will only return requested resources for {{HTTPMethod("GET")}} and {{HTTPMethod("HEAD")}} methods, or upload resource for {{HTTPMethod("PUT")}} and other non-safe methods, if the resource matches one of the listed {{HTTPHeader("ETag")}} values.
 If the conditional does not match then the  {{HTTPStatus("412")}} (Precondition Failed) response is returned.
@@ -61,11 +61,11 @@ If-Match: <etag_value>, <etag_value>, …
 ## Examples
 
 ```http
-    If-Match: "bfc13a64729c4290ef5b2c2730249c88ca92d82d"
+If-Match: "bfc13a64729c4290ef5b2c2730249c88ca92d82d"
 
-    If-Match: "67ab43", "54ed21", "7892dd"
+If-Match: "67ab43", "54ed21", "7892dd"
 
-    If-Match: *
+If-Match: *
 ```
 
 ## Specifications


### PR DESCRIPTION
Fixes #14557

The document indicated that you might use `If-Match` with a range request to ensure that the requested range is from the same resource (true) and that if it was not from the same resource you'd get HTTP 416 error. However the specs corroborate the testing in #14557
- `If-Match` returns 412 if the match is false.
- `Range` always is preformed after a conditional. If it fails it returns 416.

So in essence you'll only get 416 if the range is "bad", but from the point of view of the If-Match docs that is a bit irrelevant.

I've tidied the docs to make it clear that you always get 412 - they were written like you might get different behaviour for put vs get/head requests.  Also some minor other points from the spec (e.g. related to `*`).