### PR TITLE
WebAPI: Clean syntax from property pages, part 21

### DIFF
--- a/files/en-us/web/api/performance/navigation/index.md
+++ b/files/en-us/web/api/performance/navigation/index.md
@@ -26,11 +26,9 @@ This property is not available in workers.
 > **Warning:** This property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the
 > {{domxref("PerformanceNavigationTiming")}} interface instead.
 
-## Syntax
+## Value
 
-```js
-navObject = performance.navigation;
-```
+A {{domxref("PerformanceNavigation")}} object.
 
 ## Specifications
 

--- a/files/en-us/web/api/performance/timing/index.md
+++ b/files/en-us/web/api/performance/timing/index.md
@@ -25,11 +25,9 @@ This property is not available in workers.
 > specification](https://w3c.github.io/navigation-timing/#obsolete). Please use the {{domxref("PerformanceNavigationTiming")}}
 > interface instead.
 
-## Syntax
+## Value
 
-```js
-timingInfo = performance.timing;
-```
+A {{domxref("PerformanceTiming")}} object.
 
 ## Specifications
 

--- a/files/en-us/web/api/performanceentry/duration/index.md
+++ b/files/en-us/web/api/performanceentry/duration/index.md
@@ -37,13 +37,7 @@ The value returned by this property depends on the performance entry's
 
 This property is {{readonlyInline}}.
 
-## Syntax
-
-```js
-entry.duration;
-```
-
-### Return value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}} representing the duration of the
 {{domxref("PerformanceEntry","performance entry")}}. If the duration concept doesn't
@@ -57,7 +51,7 @@ the difference between the {{domxref("PerformanceResourceTiming.responseEnd")}} 
 {{domxref("PerformanceEntry.startTime")}}
 {{domxref("DOMHighResTimeStamp","timestamps")}}.
 
-## Example
+## Examples
 
 The following example shows the use of the `duration` property.
 

--- a/files/en-us/web/api/performanceentry/entrytype/index.md
+++ b/files/en-us/web/api/performanceentry/entrytype/index.md
@@ -18,13 +18,7 @@ example, "`mark`". This property is read only.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var type = entry.entryType;
-```
-
-### Return value
+## Value
 
 The return value depends on the subtype of the `PerformanceEntry` object and
 affects the value of the {{domxref('PerformanceEntry.name')}} property as shown by the
@@ -101,7 +95,7 @@ table below.
   </tbody>
 </table>
 
-## Example
+## Examples
 
 The following example shows the use of the `entryType` property.
 

--- a/files/en-us/web/api/performanceentry/name/index.md
+++ b/files/en-us/web/api/performanceentry/name/index.md
@@ -17,13 +17,7 @@ property is read only.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var name = entry.name;
-```
-
-### Return value
+## Value
 
 The return value depends on the subtype of the `PerformanceEntry` object and
 the value of {{domxref("PerformanceEntry.entryType")}}, as shown by the table below.
@@ -85,7 +79,7 @@ the value of {{domxref("PerformanceEntry.entryType")}}, as shown by the table be
   </tbody>
 </table>
 
-## Example
+## Examples
 
 The following example shows the use of the `name` property.
 

--- a/files/en-us/web/api/performanceentry/starttime/index.md
+++ b/files/en-us/web/api/performanceentry/starttime/index.md
@@ -35,13 +35,7 @@ The value returned by this property depends on the performance entry's
 
 This property is {{readonlyInline}}.
 
-## Syntax
-
-```js
-entry.startTime;
-```
-
-### Return value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}} representing the first timestamp when the
 {{domxref("PerformanceEntry","performance entry")}} was created.
@@ -52,7 +46,7 @@ the entry is a {{domxref("PerformanceResourceTiming")}} object), this property r
 the {{domxref("PerformanceResourceTiming.fetchStart")}}
 {{domxref("DOMHighResTimeStamp","timestamp")}}.
 
-## Example
+## Examples
 
 The following example shows the use of the `startTime` property.
 

--- a/files/en-us/web/api/performancenavigation/redirectcount/index.md
+++ b/files/en-us/web/api/performancenavigation/redirectcount/index.md
@@ -23,11 +23,9 @@ REDIRECTs done before reaching the page.
 > **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete).
 > Please use the {{domxref("PerformanceNavigationTiming")}} interface instead.
 
-## Syntax
+## Value
 
-```js
-amount = performanceNavigation.redirectCount;
-```
+An `unsigned short`.
 
 ## Specifications
 

--- a/files/en-us/web/api/performancenavigation/type/index.md
+++ b/files/en-us/web/api/performancenavigation/type/index.md
@@ -22,6 +22,10 @@ describing how the navigation to this page was done.
 > **Warning:** This interface of this property is deprecated in the [Navigation Timing Level 2 specification](https://w3c.github.io/navigation-timing/#obsolete).
 > Please use the {{domxref("PerformanceNavigationTiming")}} interface instead.
 
+## Value
+
+An `unsigned short`.
+
 Possible values are:
 
 <table class="no-markdown">
@@ -61,12 +65,6 @@ Possible values are:
     </tr>
   </tbody>
 </table>
-
-## Syntax
-
-```js
-type = performanceNavigation.type;
-```
 
 ## Specifications
 

--- a/files/en-us/web/api/performancenavigationtiming/domcomplete/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/domcomplete/index.md
@@ -15,19 +15,13 @@ The **`domComplete`** read-only property returns a
 time immediately before the user agent sets the current document readiness of the
 current document to _[complete](https://html.spec.whatwg.org/multipage/syntax.html#the-end)_.
 
-## Syntax
-
-```js
-perfEntry.domComplete;
-```
-
-### Return Value
+## Value
 
 A {{domxref("DOMHighResTimeStamp","timestamp")}} representing a time value equal to the
 time immediately before the user agent sets the current document readiness of the
 current document to _[complete](https://html.spec.whatwg.org/multipage/syntax.html#the-end)_.
 
-## Example
+## Examples
 
 The following example illustrates this property's usage.
 

--- a/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventend/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventend/index.md
@@ -15,19 +15,13 @@ The **`domContentLoadedEventEnd`** read-only property returns a
 time immediately after the current document's [DOMContentLoaded](https://html.spec.whatwg.org/multipage/syntax.html#the-end)
 event completes.
 
-## Syntax
-
-```js
-perfEntry.domContentLoadedEventEnd;
-```
-
-### Return Value
+## Value
 
 A {{domxref("DOMHighResTimeStamp","timestamp")}} representing the time value equal to
 the time immediately after the current document's [DOMContentLoaded](https://html.spec.whatwg.org/multipage/syntax.html#the-end)
 event completes.
 
-## Example
+## Examples
 
 The following example illustrates this property's usage.
 

--- a/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventstart/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventstart/index.md
@@ -15,19 +15,13 @@ a {{domxref("DOMHighResTimeStamp","timestamp")}} representing the time value equ
 the time immediately before the user agent fires the [DOMContentLoaded](https://html.spec.whatwg.org/multipage/syntax.html#the-end)
 event at the current document.
 
-## Syntax
-
-```js
-perfEntry.domContentLoadedEventStart;
-```
-
-### Return Value
+## Value
 
 A {{domxref("DOMHighResTimeStamp","timestamp")}} representing the time value equal to
 the time immediately before the user agent fires the [DOMContentLoaded](https://html.spec.whatwg.org/multipage/syntax.html#the-end)
 event at the current document.
 
-## Example
+## Examples
 
 The following example illustrates this property's usage.
 

--- a/files/en-us/web/api/performancenavigationtiming/dominteractive/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/dominteractive/index.md
@@ -15,19 +15,13 @@ The **`domInteractive`** read-only property returns a
 time immediately before the user agent sets the current document readiness of the
 current document to [interactive](https://html.spec.whatwg.org/multipage/syntax.html#the-end).
 
-## Syntax
-
-```js
-perfEntry.domInteractive;
-```
-
-### Return Value
+## Value
 
 A {{domxref("DOMHighResTimeStamp","timestamp")}} representing the time value equal to
 the time immediately before the user agent sets the current document readiness of the
 current document to [interactive](https://html.spec.whatwg.org/multipage/syntax.html#the-end).
 
-## Example
+## Examples
 
 The following example illustrates this property's usage.
 

--- a/files/en-us/web/api/performancenavigationtiming/loadeventend/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/loadeventend/index.md
@@ -14,18 +14,12 @@ The **`loadEventEnd`** read-only property returns a
 {{domxref("DOMHighResTimeStamp","timestamp")}} which is equal to the time when the load
 event of the current document is completed.
 
-## Syntax
-
-```js
-perfEntry.loadEventEnd;
-```
-
-### Return Value
+## Value
 
 A {{domxref("DOMHighResTimeStamp","timestamp")}} representing the time when the load
 event of the current document is completed.
 
-## Example
+## Examples
 
 The following example illustrates this property's usage.
 

--- a/files/en-us/web/api/performancenavigationtiming/loadeventstart/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/loadeventstart/index.md
@@ -14,18 +14,12 @@ The **`loadEventStart`** read-only property returns a
 {{domxref("DOMHighResTimeStamp","timestamp")}} representing the time value equal to the
 time immediately before the load event of the current document is fired.
 
-## Syntax
-
-```js
-perfEntry.loadEventStart;
-```
-
-### Return Value
+## Value
 
 A {{domxref("DOMHighResTimeStamp","timestamp")}} representing a time value equal to the
 time immediately before the load event of the current document is fired.
 
-## Example
+## Examples
 
 The following example illustrates this property's usage.
 

--- a/files/en-us/web/api/performancenavigationtiming/redirectcount/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/redirectcount/index.md
@@ -16,18 +16,12 @@ since the last non-redirect navigation under the current browsing context.
 
 This property is {{readonlyInline}}.
 
-## Syntax
-
-```js
-perfEntry.redirectCount;
-```
-
-### Return Value
+## Value
 
 A number representing the number of redirects since the last non-redirect navigation
 under the current browsing context.
 
-## Example
+## Examples
 
 The following example illustrates this property's usage.
 

--- a/files/en-us/web/api/performancenavigationtiming/unloadeventend/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/unloadeventend/index.md
@@ -15,19 +15,13 @@ The **`unloadEventEnd`** read-only property returns a
 time immediately after the user agent finishes the unload event of the previous
 document. If there is no previous document, this property value is `0`.
 
-## Syntax
-
-```js
-perfEntry.unloadEventEnd;
-```
-
-### Return Value
+## Value
 
 A {{domxref("DOMHighResTimeStamp","timestamp")}} representing a time value equal to the
 time immediately after the user agent finishes the unload event of the previous
 document.
 
-## Example
+## Examples
 
 The following example illustrates this property's usage.
 

--- a/files/en-us/web/api/performancenavigationtiming/unloadeventstart/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/unloadeventstart/index.md
@@ -15,19 +15,13 @@ The **`unloadEventStart`** read-only property returns a
 time immediately before the user agent starts the unload event of the previous document.
 If there is no previous document, this property returns `0`.
 
-## Syntax
-
-```js
-perfEntry.unloadEventStart;
-```
-
-### Return Value
+## Value
 
 A {{domxref("DOMHighResTimeStamp","timestamp")}} representing the time value equal to
 the time immediately before the user agent starts the unload event of the previous
 document.
 
-## Example
+## Examples
 
 The following example illustrates this property's usage.
 

--- a/files/en-us/web/api/performanceobserver/supportedentrytypes/index.md
+++ b/files/en-us/web/api/performanceobserver/supportedentrytypes/index.md
@@ -17,17 +17,11 @@ The **`supportedEntryTypes`** read-only property of the
 
 As the list of supported entries varies per browser and is evolving, this property allows web developers to check which are available.
 
-## Syntax
-
-```js
-var supportedEntryTypes = PerformanceObserver.supportedEntryTypes;
-```
-
-### Return value
+## Value
 
 An array of {{domxref("PerformanceEntry.entryType")}} values.
 
-## Example
+## Examples
 
 ### Using the console to check supported types
 

--- a/files/en-us/web/api/performanceresourcetiming/connectend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/connectend/index.md
@@ -18,18 +18,12 @@ intervals such as SSL handshake and SOCKS authentication.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-resource.connectEnd;
-```
-
-### Return value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}} representing the time after a connection is
 established.
 
-## Example
+## Examples
 
 In the following example, the value of the `*Start` and `*End`
 properties of all "`resource`"

--- a/files/en-us/web/api/performanceresourcetiming/connectstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/connectstart/index.md
@@ -16,18 +16,12 @@ establishing the connection to the server to retrieve the resource.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-resource.connectStart;
-```
-
-### Return value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}} immediately before the browser starts to establish
 the connection to the server to retrieve the resource.
 
-## Example
+## Examples
 
 In the following example, the value of the `*Start` and `*End`
 properties of all "`resource`"

--- a/files/en-us/web/api/performanceresourcetiming/decodedbodysize/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/decodedbodysize/index.md
@@ -18,18 +18,12 @@ content-codings.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-resource.decodedBodySize;
-```
-
-### Return value
+## Value
 
 The size (in octets) received from the fetch (HTTP or cache) of the message body, after
 removing any applied content-codings.
 
-## Example
+## Examples
 
 The following example, the value of the size properties of all "`resource`"
 {{domxref("PerformanceEntry.entryType","type")}} events are logged.

--- a/files/en-us/web/api/performanceresourcetiming/domainlookupend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/domainlookupend/index.md
@@ -21,18 +21,12 @@ times when the user agent starts and ends the domain data retrieval from the cac
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-resource.domainLookupEnd;
-```
-
-### Return value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}} representing the time immediately after the
 browser finishes the domain name lookup for the resource.
 
-## Example
+## Examples
 
 In the following example, the value of the `*Start` and `*End`
 properties of all "`resource`"

--- a/files/en-us/web/api/performanceresourcetiming/domainlookupstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/domainlookupstart/index.md
@@ -16,18 +16,12 @@ domain name lookup for the resource.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-resource.domainLookupStart;
-```
-
-### Return value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}} immediately before the browser starts the domain
 name lookup for the resource.
 
-## Example
+## Examples
 
 In the following example, the value of the `*Start` and `*End`
 properties of all "`resource`"

--- a/files/en-us/web/api/performanceresourcetiming/encodedbodysize/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/encodedbodysize/index.md
@@ -19,18 +19,12 @@ before removing any applied content-codings.
 If the resource is retrieved from an application cache or a local resource, it must
 return the size of the payload body before removing any applied content-codings.
 
-## Syntax
-
-```js
-resource.encodedBodySize;
-```
-
-### Return value
+## Value
 
 A `number` representing the size (in octets) received from the fetch (HTTP
 or cache), of the _payload body_, before removing any applied content-codings.
 
-## Example
+## Examples
 
 The following example, the value of the size properties of all "`resource`"
 {{domxref("PerformanceEntry.entryType","type")}} events are logged.

--- a/files/en-us/web/api/performanceresourcetiming/fetchstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/fetchstart/index.md
@@ -19,18 +19,12 @@ agent starts to fetch the final resource in the redirection.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-resource.fetchStart;
-```
-
-### Return value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}} immediately before the browser starts to fetch the
 resource.
 
-## Example
+## Examples
 
 In the following example, the value of the `*Start` and `*End`
 properties of all "`resource`"

--- a/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
@@ -27,18 +27,12 @@ The value of this string is as follows:
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-resource.initiatorType;
-```
-
-### Return value
+## Value
 
 A {{domxref("DOMString","string")}} representing the _type_ of resource that
 initiated the performance event, as specified above.
 
-## Example
+## Examples
 
 ```js
 function print_PerformanceEntries() {

--- a/files/en-us/web/api/performanceresourcetiming/nexthopprotocol/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/nexthopprotocol/index.md
@@ -21,18 +21,12 @@ Protocol ID of the first hop to the proxy.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-resource.nextHopProtocol;
-```
-
-### Return value
+## Value
 
 A {{domxref("DOMString","string")}} representing the _network protocol_ used to
 fetch the resource, as identified by the [ALPN Protocol ID (RFC7301)](https://datatracker.ietf.org/doc/html/rfc7301).
 
-## Example
+## Examples
 
 The following example uses the `nextHopProtocol` property.
 

--- a/files/en-us/web/api/performanceresourcetiming/redirectend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/redirectend/index.md
@@ -22,18 +22,12 @@ otherwise, zero is returned.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-resource.redirectEnd;
-```
-
-### Return value
+## Value
 
 A {{domxref("DOMHighResTimeStamp","timestamp")}} immediately after receiving the last
 byte of the response of the last redirect.
 
-## Example
+## Examples
 
 In the following example, the value of the `*Start` and `*End`
 properties of all "`resource`"

--- a/files/en-us/web/api/performanceresourcetiming/redirectstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/redirectstart/index.md
@@ -21,18 +21,12 @@ fetch that initiates the redirect; otherwise, zero is returned.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-resource.redirectStart;
-```
-
-### Return value
+## Value
 
 A {{domxref("DOMHighResTimeStamp","timestamp")}} representing the start time of the
 fetch which initiates the redirect.
 
-## Example
+## Examples
 
 In the following example, the value of the `*Start` and `*End`
 properties of all "`resource`"

--- a/files/en-us/web/api/performanceresourcetiming/requeststart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/requeststart/index.md
@@ -20,18 +20,12 @@ There is no _end_ property for `requestStart`.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-resource.requestStart;
-```
-
-### Return value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}} representing the time immediately before the
 browser starts requesting the resource from the server
 
-## Example
+## Examples
 
 In the following example, the value of the `*Start` and `*End`
 properties of all "`resource`"

--- a/files/en-us/web/api/performanceresourcetiming/responseend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/responseend/index.md
@@ -17,19 +17,13 @@ whichever comes first.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-resource.responseEnd;
-```
-
-### Return value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}} immediately after the browser receives the last
 byte of the resource or immediately before the transport connection is closed, whichever
 comes first.
 
-## Example
+## Examples
 
 In the following example, the value of the `*Start` and `*End`
 properties of all "`resource`"

--- a/files/en-us/web/api/performanceresourcetiming/responsestart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/responsestart/index.md
@@ -16,18 +16,12 @@ the first byte of the response from the server, cache, or local resource.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-resource.responseStart;
-```
-
-### Return value
+## Value
 
 A {{domxref("DOMHighResTimeStamp")}} immediately after the browser receives the first
 byte of the response from the server.
 
-## Example
+## Examples
 
 In the following example, the value of the `*Start` and `*End`
 properties of all "`resource`"

--- a/files/en-us/web/api/performanceresourcetiming/secureconnectionstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/secureconnectionstart/index.md
@@ -17,20 +17,14 @@ the property returns zero.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-resource.secureConnectionStart;
-```
-
-### Return value
+## Value
 
 If the resource is fetched over a secure connection, a
 {{domxref("DOMHighResTimeStamp")}} immediately before the browser starts the handshake
 process to secure the current connection. If a secure connection is not used, this
 property returns zero.
 
-## Example
+## Examples
 
 In the following example, the value of the `*Start` and `*End`
 properties of all "`resource`"

--- a/files/en-us/web/api/performanceresourcetiming/servertiming/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/servertiming/index.md
@@ -15,11 +15,9 @@ browser-compat: api.PerformanceResourceTiming.serverTiming
 The **`serverTiming`** read-only property returns an array of
 {{domxref("PerformanceServerTiming")}} entries containing server timing metrics.
 
-## Syntax
+## Value
 
-```js
-resource.serverTiming;
-```
+An array of {{domxref("PerformanceServerTiming")}} entries.
 
 ## Specifications
 

--- a/files/en-us/web/api/performanceresourcetiming/transfersize/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/transfersize/index.md
@@ -19,19 +19,13 @@ the response payload body (as defined by [RFC7230](https://httpwg.github.io/spec
 If the resource is fetched from a local cache, or if it is a cross-origin resource,
 this property returns zero.
 
-## Syntax
-
-```js
-resource.transferSize;
-```
-
-### Return value
+## Value
 
 A `number` representing the size (in octets) of the fetched resource. The
 size includes the response header fields plus the [response payload
 body](https://httpwg.github.io/specs/rfc7230.html#message.body) (RFC7230).
 
-## Example
+## Examples
 
 The following example, the value of size properties of all "`resource`"
 {{domxref("PerformanceEntry.entryType","type")}} events are logged.

--- a/files/en-us/web/api/performanceservertiming/description/index.md
+++ b/files/en-us/web/api/performanceservertiming/description/index.md
@@ -14,11 +14,9 @@ The **`description`** read-only property returns a
 {{domxref("DOMString")}} value of the server-specified metric description, or an empty
 string.
 
-## Syntax
+## Value
 
-```js
-serverTiming.description;
-```
+A string.
 
 ## Specifications
 

--- a/files/en-us/web/api/performanceservertiming/duration/index.md
+++ b/files/en-us/web/api/performanceservertiming/duration/index.md
@@ -13,11 +13,9 @@ browser-compat: api.PerformanceServerTiming.duration
 The **`duration`** read-only property returns a double that
 contains the server-specified metric duration, or value `0.0`.
 
-## Syntax
+## Value
 
-```js
-serverTiming.duration;
-```
+A number.
 
 ## Specifications
 

--- a/files/en-us/web/api/performanceservertiming/name/index.md
+++ b/files/en-us/web/api/performanceservertiming/name/index.md
@@ -13,11 +13,9 @@ browser-compat: api.PerformanceServerTiming.name
 The **`name`** read-only property returns a
 {{domxref("DOMString")}} value of the server-specified metric name.
 
-## Syntax
+## Value
 
-```js
-serverTiming.name;
-```
+A string.
 
 ## Specifications
 

--- a/files/en-us/web/api/performancetiming/connectend/index.md
+++ b/files/en-us/web/api/performancetiming/connectend/index.md
@@ -27,11 +27,9 @@ value will be the same as {{domxref("PerformanceTiming.fetchStart")}}. A connect
 considered as opened when all secure connection handshake, or SOCKS authentication, is
 terminated.
 
-## Syntax
+## Value
 
-```js
-time = performanceTiming.connectEnd;
-```
+An `unsigned long long`.
 
 ## Specifications
 

--- a/files/en-us/web/api/performancetiming/connectstart/index.md
+++ b/files/en-us/web/api/performancetiming/connectstart/index.md
@@ -27,11 +27,9 @@ started again, the last connection establishment start time is given. If a persi
 connection is used, the value will be the same as
 {{domxref("PerformanceTiming.fetchStart")}}.
 
-## Syntax
+## Value
 
-```js
-time = performanceTiming.connectStart;
-```
+An `unsigned long long`.
 
 ## Specifications
 

--- a/files/en-us/web/api/performancetiming/domainlookupend/index.md
+++ b/files/en-us/web/api/performancetiming/domainlookupend/index.md
@@ -25,11 +25,9 @@ in milliseconds since the UNIX epoch, where the domain lookup is finished. If a
 persistent connection is used, or the information is stored in a cache or a local
 resource, the value will be the same as {{domxref("PerformanceTiming.fetchStart")}}.
 
-## Syntax
+## Value
 
-```js
-time = performanceTiming.domainLookupEnd;
-```
+An `unsigned long long`.
 
 ## Specifications
 

--- a/files/en-us/web/api/performancetiming/domainlookupstart/index.md
+++ b/files/en-us/web/api/performancetiming/domainlookupstart/index.md
@@ -25,11 +25,9 @@ in milliseconds since the UNIX epoch, where the domain lookup starts. If a persi
 connection is used, or the information is stored in a cache or a local resource, the
 value will be the same as {{domxref("PerformanceTiming.fetchStart")}}.
 
-## Syntax
+## Value
 
-```js
-time = performanceTiming.domainLookupStart;
-```
+An `unsigned long long`.
 
 ## Specifications
 

--- a/files/en-us/web/api/performancetiming/domcomplete/index.md
+++ b/files/en-us/web/api/performancetiming/domcomplete/index.md
@@ -26,11 +26,9 @@ document, that is when its {{domxref("Document.readyState")}} changes to
 `'complete'` and the corresponding {{event("readystatechange")}} event is
 thrown.
 
-## Syntax
+## Value
 
-```js
-time = performanceTiming.domComplete;
-```
+An `unsigned long long`.
 
 ## Specifications
 

--- a/files/en-us/web/api/performancetiming/domcontentloadedeventend/index.md
+++ b/files/en-us/web/api/performancetiming/domcontentloadedeventend/index.md
@@ -24,11 +24,9 @@ read-only property returns an `unsigned long long` representing the moment,
 in milliseconds since the UNIX epoch, right after all the scripts that need to be
 executed as soon as possible, in order or not, has been executed.
 
-## Syntax
+## Value
 
-```js
-time = performanceTiming.domContentLoadedEventEnd;
-```
+An `unsigned long long`.
 
 ## Specifications
 

--- a/files/en-us/web/api/performancetiming/domcontentloadedeventstart/index.md
+++ b/files/en-us/web/api/performancetiming/domcontentloadedeventstart/index.md
@@ -25,11 +25,9 @@ in milliseconds since the UNIX epoch, right before the parser sent the
 {{event("DOMContentLoaded")}} event, that is right after all the scripts that need to be
 executed right after parsing has been executed.
 
-## Syntax
+## Value
 
-```js
-time = performanceTiming.domContentLoadedEventStart;
-```
+An `unsigned long long`.
 
 ## Specifications
 

--- a/files/en-us/web/api/performancetiming/dominteractive/index.md
+++ b/files/en-us/web/api/performancetiming/dominteractive/index.md
@@ -32,11 +32,9 @@ blocking rendering and not loaded asynchronously or with custom Web fonts. [Chec
 if you are in one of these cases](http://www.stevesouders.com/blog/2015/08/07/dominteractive-is-it-really/) before using this property as a proxy for the
 user experience of a Web site's speed of loading.
 
-## Syntax
+## Value
 
-```js
-time = performanceTiming.domInteractive;
-```
+An `unsigned long long`.
 
 ## Specifications
 

--- a/files/en-us/web/api/performancetiming/domloading/index.md
+++ b/files/en-us/web/api/performancetiming/domloading/index.md
@@ -25,11 +25,9 @@ in milliseconds since the UNIX epoch, when the parser started its work, that is 
 {{domxref("Document.readyState")}} changes to `'loading'` and the
 corresponding {{event("readystatechange")}} event is thrown.
 
-## Syntax
+## Value
 
-```js
-time = performanceTiming.domLoading;
-```
+An `unsigned long long`.
 
 ## Specifications
 

--- a/files/en-us/web/api/performancetiming/fetchstart/index.md
+++ b/files/en-us/web/api/performancetiming/fetchstart/index.md
@@ -25,11 +25,9 @@ read-only property returns an `unsigned long long` representing the moment,
 in milliseconds since the UNIX epoch, the browser is ready to fetch the document using
 an HTTP request. This moment is _before_ the check to any application cache.
 
-## Syntax
+## Value
 
-```js
-time = performance.timing.fetchStart;
-```
+An `unsigned long long`.
 
 ## Specifications
 

--- a/files/en-us/web/api/performancetiming/loadeventend/index.md
+++ b/files/en-us/web/api/performancetiming/loadeventend/index.md
@@ -26,11 +26,9 @@ in milliseconds since the UNIX epoch, when the {{event("load")}} event handler
 terminated, that is when the load event is completed. If this event has not yet been
 sent, or is not yet completed, it returns `0.`
 
-## Syntax
+## Value
 
-```js
-time = performanceTiming.loadEventEnd;
-```
+An `unsigned long long`.
 
 ## Specifications
 

--- a/files/en-us/web/api/performancetiming/loadeventstart/index.md
+++ b/files/en-us/web/api/performancetiming/loadeventstart/index.md
@@ -24,11 +24,9 @@ read-only property returns an `unsigned long long` representing the moment,
 in milliseconds since the UNIX epoch, when the {{event("load")}} event was sent for the
 current document. If this event has not yet been sent, it returns `0.`
 
-## Syntax
+## Value
 
-```js
-time = performanceTiming.loadEventStart;
-```
+An `unsigned long long`.
 
 ## Specifications
 

--- a/files/en-us/web/api/performancetiming/navigationstart/index.md
+++ b/files/en-us/web/api/performancetiming/navigationstart/index.md
@@ -26,11 +26,9 @@ in milliseconds since the UNIX epoch, right after the prompt for unload terminat
 the previous document in the same browsing context. If there is no previous document,
 this value will be the same as {{domxref("PerformanceTiming.fetchStart")}}.
 
-## Syntax
+## Value
 
-```js
-time = performanceTiming.navigationStart;
-```
+An `unsigned long long`.
 
 ## Specifications
 


### PR DESCRIPTION
Sequel of #14195 
As per the template API_property_subpage_template, Syntax section is redundant in property pages. So getting rid of the cruft.

Changes:
- Removed syntax sections
- Enforced heading names to ## Value, ## Examples.
- Other small corrections

#### Metadata
- [x] Fixes a typo, bug, or other error