### PR TITLE
Wasm: remove preference versions

### DIFF
--- a/files/en-us/webassembly/c_to_wasm/index.md
+++ b/files/en-us/webassembly/c_to_wasm/index.md
@@ -62,7 +62,7 @@ At this point in your source directory you should have:
 
 ### Running your example
 
-Now all that remains is for you to load the resulting `hello.html` in a browser that supports WebAssembly. It is enabled by default in Firefox 52+ and Chrome 57+/latest Opera (you can also run wasm code in Firefox 47+ by enabling the `javascript.options.wasm` flag in _about:config_, or Chrome (51+) and Opera (38+) by going to _chrome://flags_ and enabling the _Experimental WebAssembly_ flag.)
+Now all that remains is for you to load the resulting `hello.html` in a browser that supports WebAssembly. It is enabled by default from Firefox 52, Chrome 57, Edge 57, Opera 44)
 
 > **Note:** If you try to open generated HTML file (`hello.html`) directly from your local hard drive (e.g. `file://your_path/hello.html`), you will end up with an error message along the lines of _`both async and sync fetching of the wasm failed`._ You need to run your HTML file through an HTTP server (`http://`) — see [How do you set up a local testing server?](/en-US/docs/Learn/Common_questions/set_up_a_local_testing_server) for more information.
 


### PR DESCRIPTION
This removes notes on how to enable WASM on various platforms using preferences. That was all prior to FF52 timeframes and is IMO irrelevant so this just says the first version in which it was supported by default.
Note, we might reasonably even remove this and just say any recent version of ....