### PR TITLE
WASM: Better spec link for "Trap"

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/webassembly/runtimeerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/runtimeerror/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.WebAssembly.RuntimeError
 ---
 {{JSRef}}
 
-The **`WebAssembly.RuntimeError`** object is the error type that is thrown whenever WebAssembly specifies a [trap](https://webassembly.org/docs/semantics/#traps).
+The **`WebAssembly.RuntimeError`** object is the error type that is thrown whenever WebAssembly specifies a [trap](https://webassembly.github.io/spec/core/intro/overview.html#trap).
 
 ## Constructor
 


### PR DESCRIPTION
Existing link did not mention traps. I believe this is the most useful definition in the spec: https://webassembly.github.io/spec/core/intro/overview.html#trap