### PR TITLE
Update Window.postMessage() syntax

### DIFF
--- a/files/en-us/web/api/window/postmessage/index.md
+++ b/files/en-us/web/api/window/postmessage/index.md
@@ -62,16 +62,7 @@ targetWindow.postMessage(message, targetOrigin, transfer)
 
 ### Return value
 
-- `targetWindow`
-
-  - : A reference to the window that will receive the message. Methods for obtaining such
-    a reference include:
-
-    - {{domxref("window.open")}} (to spawn a new window and then reference it),
-    - {{domxref("window.opener")}} (to reference the window that spawned this one),
-    - {{domxref("HTMLIFrameElement.contentWindow")}} (to reference an embedded {{HTMLElement("iframe")}} from its parent window),
-    - {{domxref("window.parent")}} (to reference the parent window from within an embedded {{HTMLElement("iframe")}}), or
-    - {{domxref("window.frames")}} + an index value (named or numeric).
+`undefined`
 
 ## The dispatched event
 

--- a/files/en-us/web/api/window/postmessage/index.md
+++ b/files/en-us/web/api/window/postmessage/index.md
@@ -31,8 +31,8 @@ receiving window is then free to [handle this event](/en-US/docs/Web/Events/Even
 ## Syntax
 
 ```js
-postMessage(message, targetOrigin)
-postMessage(message, targetOrigin, [transfer])
+targetWindow.postMessage(message, targetOrigin)
+targetWindow.postMessage(message, targetOrigin, [transfer])
 ```
 
 - `targetWindow`

--- a/files/en-us/web/api/window/postmessage/index.md
+++ b/files/en-us/web/api/window/postmessage/index.md
@@ -32,19 +32,10 @@ receiving window is then free to [handle this event](/en-US/docs/Web/Events/Even
 
 ```js
 targetWindow.postMessage(message, targetOrigin)
-targetWindow.postMessage(message, targetOrigin, [transfer])
+targetWindow.postMessage(message, targetOrigin, transfer)
 ```
 
-- `targetWindow`
-
-  - : A reference to the window that will receive the message. Methods for obtaining such
-    a reference include:
-
-    - {{domxref("window.open")}} (to spawn a new window and then reference it),
-    - {{domxref("window.opener")}} (to reference the window that spawned this one),
-    - {{domxref("HTMLIFrameElement.contentWindow")}} (to reference an embedded {{HTMLElement("iframe")}} from its parent window),
-    - {{domxref("window.parent")}} (to reference the parent window from within an embedded {{HTMLElement("iframe")}}), or
-    - {{domxref("window.frames")}} + an index value (named or numeric).
+### Parameters
 
 - `message`
   - : Data to be sent to the other window. The data is serialized using
@@ -68,6 +59,19 @@ targetWindow.postMessage(message, targetOrigin, [transfer])
 - `transfer` {{optional_Inline}}
   - : Is a sequence of {{Glossary("transferable objects")}} that are transferred with the message.
     The ownership of these objects is given to the destination side and they are no longer usable on the sending side.
+
+### Return value
+
+- `targetWindow`
+
+  - : A reference to the window that will receive the message. Methods for obtaining such
+    a reference include:
+
+    - {{domxref("window.open")}} (to spawn a new window and then reference it),
+    - {{domxref("window.opener")}} (to reference the window that spawned this one),
+    - {{domxref("HTMLIFrameElement.contentWindow")}} (to reference an embedded {{HTMLElement("iframe")}} from its parent window),
+    - {{domxref("window.parent")}} (to reference the parent window from within an embedded {{HTMLElement("iframe")}}), or
+    - {{domxref("window.frames")}} + an index value (named or numeric).
 
 ## The dispatched event
 


### PR DESCRIPTION
"targetWindow" variable was missing from primary example. This may cause confusion.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Include `targetWindow` variable in primary example. This is part of the syntax and is mentioned in the proceeding syntax explanation, though the fact that the variable is missing may cause confusion to unfamiliar developers.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
To help improve the clarity and effectiveness of the documentation.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Further examples show "targetWindow" - https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#example

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [✅  ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
