### PR TITLE
Remove the remaining occurrences of {{draft}}

### DIFF
--- a/files/en-us/mozilla/firefox/releases/3.5/security_changes/index.md
+++ b/files/en-us/mozilla/firefox/releases/3.5/security_changes/index.md
@@ -8,9 +8,6 @@ tags:
   - XUL
 ---
 {{FirefoxSidebar}}
-
-{{ draft() }}
-
 This article covers security-related changes in Firefox 3.5.
 
 ## Changes to chrome registration

--- a/files/en-us/web/api/html_dom_api/microtask_guide/in_depth/index.md
+++ b/files/en-us/web/api/html_dom_api/microtask_guide/in_depth/index.md
@@ -11,7 +11,7 @@ tags:
   - queueMicrotask
   - runtime
 ---
-{{APIRef("HTML DOM")}}{{Draft("This page is very much a work in progress; it contains technical details that may be useful while considering using—and while using—microtasks, but it is not absolutely necessary for most people to know. Additionally, there may be errors here as this draft is just that rough. ~~Sheppy")}}
+{{APIRef("HTML DOM")}}
 
 When debugging or, possibly, when trying to decide upon the best approach to solving a problem around timing and scheduling of tasks and microtasks, there are things about how the JavaScript runtime operates under the hood that may be useful to understand. That's what this section covers
 

--- a/files/en-us/web/api/rtciceserver/credential/index.md
+++ b/files/en-us/web/api/rtciceserver/credential/index.md
@@ -11,12 +11,7 @@ tags:
   - WebRTC
 browser-compat: api.RTCIceServer.credential
 ---
-{{APIRef("WebRTC")}}
-
-{{draft("I'm experimenting with structure for pages documenting members of
-  dictionaries. Please contact ~~sheppy with any feedback.")}}
-
-{{SeeCompatTable}}
+{{APIRef("WebRTC")}}{{SeeCompatTable}}
 
 The {{domxref("RTCIceServer")}} dictionary's
 **`credential`** property is a string providing the credential

--- a/files/en-us/web/api/rtciceserver/url/index.md
+++ b/files/en-us/web/api/rtciceserver/url/index.md
@@ -13,11 +13,6 @@ browser-compat: api.RTCIceServer.url
 ---
 {{APIRef("WebRTC")}}{{deprecated_header}}
 
-{{draft("I'm experimenting with structure for pages documenting members of
-  dictionaries. Please contact ~~sheppy with any feedback.")}}
-
-{{SeeCompatTable}}
-
 The **obsolete** {{domxref("RTCIceServer")}} dictionary's
 **`url`** property specifies the URL of a single ICE server to
 be used while negotiating connections. It was removed from the specification in June

--- a/files/en-us/web/api/rtciceserver/urls/index.md
+++ b/files/en-us/web/api/rtciceserver/urls/index.md
@@ -10,12 +10,7 @@ tags:
   - urls
 browser-compat: api.RTCIceServer.urls
 ---
-{{APIRef("WebRTC")}}
-
-{{draft("I'm experimenting with structure for pages documenting members of
-  dictionaries. Please contact ~~sheppy with any feedback.")}}
-
-{{SeeCompatTable}}
+{{APIRef("WebRTC")}}{{SeeCompatTable}}
 
 The {{domxref("RTCIceServer")}} dictionary's **`urls`**
 property specifies the URL or URLs of the servers to be used for ICE negotiations. These

--- a/files/en-us/web/api/rtciceserver/username/index.md
+++ b/files/en-us/web/api/rtciceserver/username/index.md
@@ -12,9 +12,6 @@ browser-compat: api.RTCIceServer.username
 ---
 {{APIRef("WebRTC")}}
 
-{{draft("I'm experimenting with structure for pages documenting members of
-  dictionaries. Please contact ~~sheppy with any feedback.")}}
-
 {{SeeCompatTable}}
 
 The {{domxref("RTCIceServer")}} dictionary's **`username`**

--- a/files/en-us/web/api/webgl_api/by_example/video_textures/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/video_textures/index.md
@@ -10,8 +10,6 @@ tags:
   - Tutorial
   - WebGL
 ---
-{{ draft() }}
-
 {{Previous("Learn/WebGL/By_example/Textures_from_code")}}
 
 This example demonstrates how to use video files as textures for WebGL surfaces.

--- a/files/en-us/web/api/webxr_device_api/inputs/index.md
+++ b/files/en-us/web/api/webxr_device_api/inputs/index.md
@@ -18,7 +18,7 @@ tags:
   - XR
   - controllers
 ---
-{{APIRef("WebXR Device API")}}{{SecureContext_Header}}{{draft("Artwork is still being produced and will be inserted as it's completed.")}}
+{{APIRef("WebXR Device API")}}{{SecureContext_Header}}
 
 A full WebXR experience isn't just about showing the user a wholly virtual scene or augmenting reality by adding to or altering the world around them. In order to make an experience that's fulfilling and engaging, the user needs to be able to interact with it. To that end, WebXR provides support for a variety of kinds of input devices.
 

--- a/files/en-us/web/api/webxr_device_api/spatial_tracking/index.md
+++ b/files/en-us/web/api/webxr_device_api/spatial_tracking/index.md
@@ -22,7 +22,7 @@ tags:
   - movement
   - tracking
 ---
-{{DefaultAPISidebar("WebXR Device API")}}{{draft("Most but not all of this article is complete; however, there are missing diagrams and examples yet to be added. Contributions and/or patience are welcome!")}}
+{{DefaultAPISidebar("WebXR Device API")}}
 
 The WebXR APIs used for implementing augmented and virtual reality is designed specifically to provide the ability to insert a human into a virtual environment. To accomplish this, software needs the ability to not only track the locations, orientation, and movements of objects in the virtual world, but the user's location, orientation, and movement as well. But WebXR goes beyond that by adding the ability to track the location, orientation, and motion of the input devices which generate data used to determine the position and movement of individual parts of the viewer's body (with appropriate equipment).
 

--- a/files/en-us/web/events/orientation_and_motion_data_explained/index.md
+++ b/files/en-us/web/events/orientation_and_motion_data_explained/index.md
@@ -10,10 +10,6 @@ tags:
   - páginas_a_traducir
   - rotation
 ---
-{{ Draft() }}
-
-## Summary
-
 When using orientation and motion events, it's important to understand what the values you're given by the browser mean. This article provides details about the coordinate systems at play and how you use them.
 
 ## About coordinate frames

--- a/files/en-us/web/security/securing_your_site/index.md
+++ b/files/en-us/web/security/securing_your_site/index.md
@@ -7,8 +7,6 @@ tags:
   - Web Development
   - Website Security
 ---
-{{ draft() }}
-
 There are a number of things you can do to help secure your site. This article offers an assortment of suggestions, as well as links to other articles providing more useful information.
 
 > **Note:** This article is a work in progress, and is neither complete nor does following its suggestions guarantee your site will be fully secure.


### PR DESCRIPTION
Removing the last few occurrences of `{{draft}}`  \o/ 

The last steps will be to mark it as deprecated in the meta-docs and update the macro in yari to raise a flaw.