### PR TITLE
Doc: Fix confusing endIndex description.

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/slice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/slice/index.md
@@ -41,8 +41,7 @@ slice(beginIndex, endIndex)
 
 - `endIndex` {{optional_inline}}
 
-  - : The zero-based index _before_ which to end extraction. The character at this
-    index will not be included.
+  - : The index of the first character to exclude from the returned substring.
 
     If `endIndex` is omitted, undefined, or cannot be converted to a number (using
     {{jsxref('Number', 'Number(endIndex)')}}) `slice()` extracts to the end of the


### PR DESCRIPTION
#### Summary

Doc: Fix confusing endIndex description. Simply reuse the clearer and shorter endIndex description from `.substring()`.

#### Motivation

'index _before_ which to end extraction' was confusing. Since `endIndex` is not the index _before_ the last char you want to extract, but the index _after_ the last char you want to extract. The user is originally oriented towards the last char they want, not the one after that. The new description is now also shorter and equal to the `endIndex` description in `.substring()`, so it's easier to compare the two and realize that they refer to the same index.