### PR TITLE
Fixed internal link to Typed Array

### DIFF
--- a/files/en-us/glossary/transferable_objects/index.md
+++ b/files/en-us/glossary/transferable_objects/index.md
@@ -43,7 +43,7 @@ worker.postMessage(uInt8Array, [uInt8Array.buffer]);
 console.log(uInt8Array.byteLength);  // 0
 ```
 
-> **Note:** [Typed arrays](en-US/docs/Web/JavaScript/Typed_arrays) like {{jsxref("Int32Array")}} and {{jsxref("Uint8Array")}}, are serializable, but not transferable.
+> **Note:** [Typed arrays](en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) like {{jsxref("Int32Array")}} and {{jsxref("Uint8Array")}}, are serializable, but not transferable.
 > However their underlying buffer is an {{jsxref("ArrayBuffer")}}, which is a transferable object.
 > We could have sent `uInt8Array.buffer` in the data parameter, but not `uInt8Array` in the transfer array.
 


### PR DESCRIPTION
#### Summary
The existing link for typed arrays was empty, so I changed it to where the page currently is.

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error
