### PR TITLE
Add Range to CORS docs as a safelisted request-header

### DIFF
--- a/files/en-us/web/http/cors/index.md
+++ b/files/en-us/web/http/cors/index.md
@@ -72,6 +72,9 @@ Some requests don't trigger a {{Glossary("Preflight_request","CORS preflight")}}
   - {{HTTPHeader("Accept-Language")}}
   - {{HTTPHeader("Content-Language")}}
   - {{HTTPHeader("Content-Type")}} (please note the additional requirements below)
+  - {{HTTPHeader("Range")}} (only with a [simple range header value](https://fetch.spec.whatwg.org/#simple-range-header-value), e.g. `bytes=256-` or `bytes=127-255`)
+
+> **Note:** Firefox has not implemented `Range` as a safelisted request-header yet. See [bug 1733981](https://bugzilla.mozilla.org/show_bug.cgi?id=1733981).
 
 - The only type/subtype combinations allowed for the {{Glossary("MIME type","media type")}} specified in the {{HTTPHeader("Content-Type")}} header are:
 

--- a/files/en-us/web/http/cors/index.md
+++ b/files/en-us/web/http/cors/index.md
@@ -72,7 +72,7 @@ Some requests don't trigger a {{Glossary("Preflight_request","CORS preflight")}}
   - {{HTTPHeader("Accept-Language")}}
   - {{HTTPHeader("Content-Language")}}
   - {{HTTPHeader("Content-Type")}} (please note the additional requirements below)
-  - {{HTTPHeader("Range")}} (only with a [simple range header value](https://fetch.spec.whatwg.org/#simple-range-header-value), e.g. `bytes=256-` or `bytes=127-255`)
+  - {{HTTPHeader("Range")}} (only with a [simple range header value](https://fetch.spec.whatwg.org/#simple-range-header-value); e.g., `bytes=256-` or `bytes=127-255`)
 
 > **Note:** Firefox has not implemented `Range` as a safelisted request-header yet. See [bug 1733981](https://bugzilla.mozilla.org/show_bug.cgi?id=1733981).
 


### PR DESCRIPTION
fixes #14654

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
added missing Range as a safelisted request-header

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Range was added as a safe-listed header as long as the value is in a particular format, which aligns with formats the browser uses when requesting media and resuming downloads.

Please see #14654

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
WPT tests:

https://wpt.fyi/results/cors/cors-safelisted-request-header.any.html
https://github.com/web-platform-tests/wpt/pull/33488 (not merged yet)
My own test: https://dotnetcarpenter.github.io/bug-firefox-fetch-cors/

Shipped in Chromium: https://chromestatus.com/feature/5652396366626816
Patch available for WebKit: https://bugs.webkit.org/show_bug.cgi?id=231174
Not implemented in Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1733981

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #14654

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
