### PR TITLE
Fixed Internal Link to SVG Core Attributes

### DIFF
--- a/files/en-us/web/svg/element/femergenode/index.md
+++ b/files/en-us/web/svg/element/femergenode/index.md
@@ -47,7 +47,7 @@ The `feMergeNode` takes the result of another filter to be processed by its pare
 
 ### Global attributes
 
-- [Core attributes](/en-US/docs/Web/SVG/Attribute#core)
+- [Core attributes](/en-US/docs/Web/SVG/Attribute/Core)
 
 ### Specific attributes
 


### PR DESCRIPTION
#### Summary
Link to SVG Core Attributes page went to non-existent anchor, so I changed it to the SVG Core Attributes page

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error