### PR TITLE
Add revert-layer to Global Values in Syntax for CSS Properties (initial letter a, d, h, and r)

### DIFF
--- a/files/en-us/web/css/accent-color/index.md
+++ b/files/en-us/web/css/accent-color/index.md
@@ -42,6 +42,7 @@ accent-color: hsl(228, 4%, 24%);
 accent-color: inherit;
 accent-color: initial;
 accent-color: revert;
+accent-color: revert-layer;
 accent-color: unset;
 ```
 

--- a/files/en-us/web/css/align-content/index.md
+++ b/files/en-us/web/css/align-content/index.md
@@ -57,6 +57,7 @@ align-content: unsafe center;
 align-content: inherit;
 align-content: initial;
 align-content: revert;
+align-content: revert-layer;
 align-content: unset;
 ```
 

--- a/files/en-us/web/css/align-items/index.md
+++ b/files/en-us/web/css/align-items/index.md
@@ -41,6 +41,7 @@ align-items: unsafe center;
 align-items: inherit;
 align-items: initial;
 align-items: revert;
+align-items: revert-layer;
 align-items: unset;
 ```
 

--- a/files/en-us/web/css/align-self/index.md
+++ b/files/en-us/web/css/align-self/index.md
@@ -49,6 +49,7 @@ align-self: unsafe center;
 align-self: inherit;
 align-self: initial;
 align-self: revert;
+align-self: revert-layer;
 align-self: unset;
 ```
 

--- a/files/en-us/web/css/animation-delay/index.md
+++ b/files/en-us/web/css/animation-delay/index.md
@@ -32,6 +32,7 @@ animation-delay: 2.1s, 480ms;
 animation-delay: inherit;
 animation-delay: initial;
 animation-delay: revert;
+animation-delay: revert-layer;
 animation-delay: unset;
 ```
 

--- a/files/en-us/web/css/animation-direction/index.md
+++ b/files/en-us/web/css/animation-direction/index.md
@@ -34,6 +34,7 @@ animation-direction: alternate, reverse, normal;
 animation-direction: inherit;
 animation-direction: initial;
 animation-direction: revert;
+animation-direction: revert-layer;
 animation-direction: unset;
 ```
 

--- a/files/en-us/web/css/animation-duration/index.md
+++ b/files/en-us/web/css/animation-duration/index.md
@@ -32,6 +32,7 @@ animation-duration: 10s, 35s, 230ms;
 animation-duration: inherit;
 animation-duration: initial;
 animation-duration: revert;
+animation-duration: revert-layer;
 animation-duration: unset;
 ```
 

--- a/files/en-us/web/css/animation-fill-mode/index.md
+++ b/files/en-us/web/css/animation-fill-mode/index.md
@@ -34,6 +34,7 @@ animation-fill-mode: both, forwards, none;
 animation-fill-mode: inherit;
 animation-fill-mode: initial;
 animation-fill-mode: revert;
+animation-fill-mode: revert-layer;
 animation-fill-mode: unset;
 ```
 

--- a/files/en-us/web/css/animation-iteration-count/index.md
+++ b/files/en-us/web/css/animation-iteration-count/index.md
@@ -36,6 +36,7 @@ animation-iteration-count: 2, 0, infinite;
 animation-iteration-count: inherit;
 animation-iteration-count: initial;
 animation-iteration-count: revert;
+animation-iteration-count: revert-layer;
 animation-iteration-count: unset;
 ```
 

--- a/files/en-us/web/css/animation-name/index.md
+++ b/files/en-us/web/css/animation-name/index.md
@@ -31,9 +31,10 @@ animation-name: test1, animation4;
 animation-name: none, -moz-specific, sliding;
 
 /* Global values */
-animation-name: initial;
 animation-name: inherit;
+animation-name: initial;
 animation-name: revert;
+animation-name: revert-layer;
 animation-name: unset;
 ```
 

--- a/files/en-us/web/css/animation-play-state/index.md
+++ b/files/en-us/web/css/animation-play-state/index.md
@@ -31,6 +31,7 @@ animation-play-state: paused, running, running;
 animation-play-state: inherit;
 animation-play-state: initial;
 animation-play-state: revert;
+animation-play-state: revert-layer;
 animation-play-state: unset;
 ```
 

--- a/files/en-us/web/css/animation-timeline/index.md
+++ b/files/en-us/web/css/animation-timeline/index.md
@@ -31,9 +31,10 @@ animation-timeline: test1, animation4;
 animation-timeline: none, -moz-specific, sliding;
 
 /* Global values */
-animation-timeline: initial;
 animation-timeline: inherit;
+animation-timeline: initial;
 animation-timeline: revert;
+animation-timeline: revert-layer;
 animation-timeline: unset;
 ```
 

--- a/files/en-us/web/css/animation-timing-function/index.md
+++ b/files/en-us/web/css/animation-timing-function/index.md
@@ -48,6 +48,7 @@ animation-timing-function: ease, step-start, cubic-bezier(0.1, 0.7, 1.0, 0.1);
 animation-timing-function: inherit;
 animation-timing-function: initial;
 animation-timing-function: revert;
+animation-timing-function: revert-layer;
 animation-timing-function: unset;
 ```
 

--- a/files/en-us/web/css/appearance/index.md
+++ b/files/en-us/web/css/appearance/index.md
@@ -57,6 +57,7 @@ appearance: progress-bar;
 appearance: inherit;
 appearance: initial;
 appearance: revert;
+appearance: revert-layer;
 appearance: unset;
 ```
 

--- a/files/en-us/web/css/aspect-ratio/index.md
+++ b/files/en-us/web/css/aspect-ratio/index.md
@@ -22,6 +22,7 @@ aspect-ratio: 1;
 aspect-ratio: inherit;
 aspect-ratio: initial;
 aspect-ratio: revert;
+aspect-ratio: revert-layer;
 aspect-ratio: unset;
 ```
 

--- a/files/en-us/web/css/direction/index.md
+++ b/files/en-us/web/css/direction/index.md
@@ -34,6 +34,7 @@ direction: rtl;
 direction: inherit;
 direction: initial;
 direction: revert;
+direction: revert-layer;
 direction: unset;
 ```
 

--- a/files/en-us/web/css/display/index.md
+++ b/files/en-us/web/css/display/index.md
@@ -54,6 +54,7 @@ display: list-item;
 display: inherit;
 display: initial;
 display: revert;
+display: revert-layer;
 display: unset;
 ```
 

--- a/files/en-us/web/css/hanging-punctuation/index.md
+++ b/files/en-us/web/css/hanging-punctuation/index.md
@@ -36,6 +36,7 @@ hanging-punctuation: first allow-end last;
 hanging-punctuation: inherit;
 hanging-punctuation: initial;
 hanging-punctuation: revert;
+hanging-punctuation: revert-layer;
 hanging-punctuation: unset;
 ```
 

--- a/files/en-us/web/css/height/index.md
+++ b/files/en-us/web/css/height/index.md
@@ -41,6 +41,7 @@ height: auto;
 height: inherit;
 height: initial;
 height: revert;
+height: revert-layer;
 height: unset;
 ```
 

--- a/files/en-us/web/css/hyphens/index.md
+++ b/files/en-us/web/css/hyphens/index.md
@@ -35,6 +35,7 @@ hyphens: auto;
 hyphens: inherit;
 hyphens: initial;
 hyphens: revert;
+hyphens: revert-layer;
 hyphens: unset;
 ```
 

--- a/files/en-us/web/css/resize/index.md
+++ b/files/en-us/web/css/resize/index.md
@@ -35,6 +35,7 @@ resize: inline;
 resize: inherit;
 resize: initial;
 resize: revert;
+resize: revert-layer;
 resize: unset;
 ```
 

--- a/files/en-us/web/css/right/index.md
+++ b/files/en-us/web/css/right/index.md
@@ -34,6 +34,7 @@ right: auto;
 right: inherit;
 right: initial;
 right: revert;
+right: revert-layer;
 right: unset;
 ```
 

--- a/files/en-us/web/css/rotate/index.md
+++ b/files/en-us/web/css/rotate/index.md
@@ -39,6 +39,7 @@ rotate: 1 1 1 90deg;
 rotate: inherit;
 rotate: initial;
 rotate: revert;
+rotate: revert-layer;
 rotate: unset;
 ```
 

--- a/files/en-us/web/css/row-gap/index.md
+++ b/files/en-us/web/css/row-gap/index.md
@@ -33,6 +33,7 @@ row-gap: 10%;
 row-gap: inherit;
 row-gap: initial;
 row-gap: revert;
+row-gap: revert-layer;
 row-gap: unset;
 ```
 

--- a/files/en-us/web/css/ruby-align/index.md
+++ b/files/en-us/web/css/ruby-align/index.md
@@ -24,6 +24,7 @@ ruby-align: space-around;
 ruby-align: inherit;
 ruby-align: initial;
 ruby-align: revert;
+ruby-align: revert-layer;
 ruby-align: unset;
 ```
 

--- a/files/en-us/web/css/ruby-position/index.md
+++ b/files/en-us/web/css/ruby-position/index.md
@@ -26,6 +26,7 @@ ruby-position: alternate;
 ruby-position: inherit;
 ruby-position: initial;
 ruby-position: revert;
+ruby-position: revert-layer;
 ruby-position: unset;
 ```
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
- A new global keyword was introduced in FF97, the `revert-layer` keyword. This keyword can be applied to any CSS property.

- This PR adds the `revert-layer` keyword to "Global Values" in the "Syntax" section. This PR covers properties with names starting with "a", "d", "h", and "r".

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://bugzilla.mozilla.org/show_bug.cgi?id=1699220
https://drafts.csswg.org/css-cascade-5/#revert-layer

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Content issue tracking this work: https://github.com/mdn/content/issues/13373
PR for the new revert-layer page: https://github.com/mdn/content/pull/14287

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
- [X] Updates existing content corresponding to a new feature

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
