### PR TITLE
Fix example for Intl.Locale.prototype.timeZones

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/timezones/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/timezones/index.md
@@ -38,12 +38,12 @@ console.log(arEG.timeZones); // logs ["Africa/Cairo"]
 
 ```js
 let jaJP = new Intl.Locale("ja-JP");
-console.log(jaJP.hourCycles); // logs ["Asia/Tokyo"]
+console.log(jaJP.timeZones); // logs ["Asia/Tokyo"]
 ```
 
 ```js
 let ar = new Intl.Locale("ar");
-console.log(ar.hourCycles); // logs undefined
+console.log(ar.timeZones); // logs undefined
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Fixed examples in documentation for `Intl.Locale.prototype.timeZones`. They were using `hourCycles` instead of `timeZones`.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

The examples were wrong.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
