### PR TITLE
DOMTimeStamp note that about IDL change

### DIFF
--- a/files/en-us/web/api/domtimestamp/index.md
+++ b/files/en-us/web/api/domtimestamp/index.md
@@ -12,8 +12,8 @@ spec-urls: https://webidl.spec.whatwg.org/#common-DOMTimeStamp
 
 The **`DOMTimeStamp`** type represents an absolute or relative number of milliseconds, depending on the specification in which it appears.
 
-> **Note:** `DOMTimeStamp` has been removed from the IDL in the linked specification, but is referenced in other specifications.
-> In the High Resolution Time specification `DOMTimeStamp` has been redefined as [`EpochTimeStamp`](/en-US/docs/Web/API/EpochTimeStamp).
+> **Note:** `DOMTimeStamp` has been removed from the WebIDL specification, but is referenced in other specifications.
+> In the High Resolution Time specification, `DOMTimeStamp` has been redefined as [`EpochTimeStamp`](/en-US/docs/Web/API/EpochTimeStamp).
 
 
 

--- a/files/en-us/web/api/domtimestamp/index.md
+++ b/files/en-us/web/api/domtimestamp/index.md
@@ -6,13 +6,17 @@ tags:
   - DOM
   - Interface
   - Reference
+spec-urls: https://webidl.spec.whatwg.org/#common-DOMTimeStamp
 ---
 {{APIRef("DOM")}}
 
 The **`DOMTimeStamp`** type represents an absolute or relative number of milliseconds, depending on the specification in which it appears.
 
+> **Note:** `DOMTimeStamp` has been removed from the IDL in the linked specification, but is referenced in other specifications.
+> In the High Resolution Time specification `DOMTimeStamp` has been redefined as [`EpochTimeStamp`](/en-US/docs/Web/API/EpochTimeStamp).
+
+
+
 ## Specifications
 
-| Specification                                                                        | Status                   | Comment               |
-| ------------------------------------------------------------------------------------ | ------------------------ | --------------------- |
-| {{SpecName("WebIDL", "#common-DOMTimeStamp", "DOMTimeStamp")}} | {{Spec2("WebIDL")}} | Initial specification |
+{{Specifications}}


### PR DESCRIPTION
Fixes #14667

Makes it clear that `DOMTimeStamp` cannot be removed/redirected to `EpochTimeStamp` because it is still linked in other specs.

@simonvarey FYI