### PR TITLE
WebAPI: Clean syntax from property pages, part 23

### DIFF
--- a/files/en-us/web/api/screen/width/index.md
+++ b/files/en-us/web/api/screen/width/index.md
@@ -13,13 +13,11 @@ browser-compat: api.Screen.width
 The **`Screen.width`** read-only property returns the width of
 the screen in CSS pixels.
 
-## Syntax
+## Value
 
-```js
-lWidth = window.screen.width
-```
+A number.
 
-## Example
+## Examples
 
 ```js
 // Crude way to check that the screen is at least 1024x768

--- a/files/en-us/web/api/screenorientation/lock/index.md
+++ b/files/en-us/web/api/screenorientation/lock/index.md
@@ -4,7 +4,7 @@ slug: Web/API/ScreenOrientation/lock
 tags:
   - API
   - Orientation
-  - Property
+  - Method
   - Reference
   - Screen Orientation API
   - ScreenOrientation

--- a/files/en-us/web/api/screenorientation/unlock/index.md
+++ b/files/en-us/web/api/screenorientation/unlock/index.md
@@ -4,7 +4,7 @@ slug: Web/API/ScreenOrientation/unlock
 tags:
   - API
   - Orientation
-  - Property
+  - Method
   - Reference
   - Screen Orientation API
   - ScreenOrientation

--- a/files/en-us/web/api/selection/anchornode/index.md
+++ b/files/en-us/web/api/selection/anchornode/index.md
@@ -21,11 +21,9 @@ be visualized by holding the Shift key and pressing the arrow keys on your keybo
 selection's anchor does not move, but the selection's focus, the other end of the
 selection, does move.
 
-## Syntax
+## Value
 
-```js
-node = sel.anchorNode
-```
+A {{domxref("Node")}} object.
 
 ## Specifications
 

--- a/files/en-us/web/api/selection/anchoroffset/index.md
+++ b/files/en-us/web/api/selection/anchoroffset/index.md
@@ -19,11 +19,9 @@ number of characters that the selection's anchor is offset within the
 This number is zero-based. If the selection begins with the first character in the
 {{domxref("Selection.anchorNode")}}, `0` is returned.
 
-## Syntax
+## Value
 
-```js
-number = sel.anchorOffset
-```
+A number.
 
 ## Specifications
 

--- a/files/en-us/web/api/selection/focusnode/index.md
+++ b/files/en-us/web/api/selection/focusnode/index.md
@@ -21,11 +21,9 @@ be visualized by holding the <kbd>Shift</kbd> key and pressing the arrow keys on
 keyboard to modify the current selection. The selection's focus moves, but the
 selection's anchor, the other end of the selection, does not move.
 
-## Syntax
+## Value
 
-```js
-node = sel.focusNode
-```
+A {{domxref("Node")}} object.
 
 ## Specifications
 

--- a/files/en-us/web/api/selection/focusoffset/index.md
+++ b/files/en-us/web/api/selection/focusoffset/index.md
@@ -19,11 +19,9 @@ number of characters that the selection's focus is offset within the
 This number is zero-based. If the selection ends with the first character in the
 {{domxref("Selection.focusNode")}}, `0` is returned.
 
-## Syntax
+## Value
 
-```js
-offset = sel.focusOffset
-```
+A number.
 
 ## Specifications
 

--- a/files/en-us/web/api/selection/iscollapsed/index.md
+++ b/files/en-us/web/api/selection/iscollapsed/index.md
@@ -23,11 +23,9 @@ Keep in mind that a collapsed selection may still have one (or more, in Gecko)
 scenario, calling a {{domxref("Selection")}} object's {{domxref("Selection.getRangeAt",
   "getRangeAt()")}} method may return a `Range` object which is collapsed.
 
-## Syntax
+## Value
 
-```js
-bool = sel.isCollapsed
-```
+A boolean.
 
 ## Specifications
 

--- a/files/en-us/web/api/selection/rangecount/index.md
+++ b/files/en-us/web/api/selection/rangecount/index.md
@@ -27,13 +27,11 @@ Gecko browsers allow multiple selections across table cells. Firefox allows to s
 multiple ranges in the document by using Ctrl+click (unless the click occurs within an
 element that has the `display: table-cell` CSS property assigned).
 
-## Syntax
+## Value
 
-```js
-value = sel.rangeCount
-```
+A number.
 
-## Example
+## Examples
 
 The following example will show the `rangeCount` every second. Select text
 in the browser to see it change.

--- a/files/en-us/web/api/serviceworkerregistration/scope/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/scope/index.md
@@ -19,11 +19,9 @@ document that registers the {{domxref("ServiceWorker")}}.
 
 > **Note:** This feature is available in [Web Workers](/en-US/docs/Web/API/Web_Workers_API).
 
-## Syntax
+## Value
 
-```js
-var swScope = serviceWorkerRegistration.scope;
-```
+A unique identifier.
 
 ## Specifications
 

--- a/files/en-us/web/api/speechrecognitionalternative/confidence/index.md
+++ b/files/en-us/web/api/speechrecognitionalternative/confidence/index.md
@@ -22,13 +22,7 @@ confident the speech recognition system is that the recognition is correct.
 > **Note:** Mozilla's implementation of `confidence` is still
 > being worked on — at the moment, it always seems to return 1.
 
-## Syntax
-
-```js
-var myConfidence = speechRecognitionAlternativeInstance.confidence;
-```
-
-### Returns
+## Value
 
 A number between 0 and 1.
 

--- a/files/en-us/web/api/speechrecognitionalternative/transcript/index.md
+++ b/files/en-us/web/api/speechrecognitionalternative/transcript/index.md
@@ -23,15 +23,9 @@ For continuous recognition, leading or trailing whitespace will be included wher
 necessary so that concatenation of consecutive {{domxref("SpeechRecognitionResult")}}s
 produces a proper transcript of the session.
 
-## Syntax
+## Value
 
-```js
-var myTranscript = speechRecognitionAlternativeInstance.transcript;
-```
-
-### Returns
-
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/speechrecognitionresult/isfinal/index.md
+++ b/files/en-us/web/api/speechrecognitionresult/isfinal/index.md
@@ -21,13 +21,7 @@ whether this result is final (`true`) or not (`false`) — if so,
 then this is the final time this result will be returned; if not, then this result is an
 interim result, and may be updated later on.
 
-## Syntax
-
-```js
-var myIsFinal = speechRecognitionResultInstance.isFinal;
-```
-
-### Returns
+## Value
 
 A boolean value.
 

--- a/files/en-us/web/api/speechrecognitionresult/length/index.md
+++ b/files/en-us/web/api/speechrecognitionresult/length/index.md
@@ -24,13 +24,7 @@ The number of alternatives contained in the result depends on what the
 {{domxref("SpeechRecognition.maxAlternatives")}} property was set to when the speech
 recognition was first initiated.
 
-## Syntax
-
-```js
-var myLength = speechRecognitionResultInstance.length;
-```
-
-### Returns
+## Value
 
 A number.
 

--- a/files/en-us/web/api/speechrecognitionresultlist/length/index.md
+++ b/files/en-us/web/api/speechrecognitionresultlist/length/index.md
@@ -20,13 +20,7 @@ The **`length`** read-only property of the
 "array" — the number of {{domxref("SpeechRecognitionResult")}} objects in the
 list.
 
-## Syntax
-
-```js
-var myLength = speechRecognitionResultListInstance.length;
-```
-
-### Returns
+## Value
 
 A number.
 

--- a/files/en-us/web/api/stereopannernode/pan/index.md
+++ b/files/en-us/web/api/stereopannernode/pan/index.md
@@ -14,21 +14,13 @@ browser-compat: api.StereoPannerNode.pan
 
 The `pan` property of the {{ domxref("StereoPannerNode") }} interface is an [a-rate](/en-US/docs/Web/API/AudioParam#a-rate) {{domxref("AudioParam")}} representing the amount of panning to apply. The value can range between `-1` (full left pan) and `1` (full right pan).
 
-## Syntax
-
-```js
-var audioCtx = new AudioContext();
-var panNode = audioCtx.createStereoPanner();
-panNode.pan.value = -0.5;
-```
-
-### Returned value
+## Value
 
 An [a-rate](/en-US/docs/Web/API/AudioParam#a-rate) {{domxref("AudioParam")}} containing the panning to apply.
 
 > **Note:** Though the `AudioParam` returned is read-only, the value it represents is not.
 
-## Example
+## Examples
 
 See [`BaseAudioContext.createStereoPanner()`](/en-US/docs/Web/API/BaseAudioContext/createStereoPanner#example) for example code.
 

--- a/files/en-us/web/api/storage/length/index.md
+++ b/files/en-us/web/api/storage/length/index.md
@@ -16,17 +16,11 @@ The **`length`** read-only property of the
 {{domxref("Storage")}} interface returns the number of data items stored in a given
 `Storage` object.
 
-## Syntax
-
-```js
-length = storage.length;
-```
-
-### Return value
+## Value
 
 The number of items stored in the `Storage` object.
 
-## Example
+## Examples
 
 The following function adds three data items to the local storage for the current
 domain, then returns the number of items in the storage:

--- a/files/en-us/web/api/stylesheet/disabled/index.md
+++ b/files/en-us/web/api/stylesheet/disabled/index.md
@@ -21,13 +21,11 @@ if it's an inactive [alternative
 style sheet](/en-US/docs/Web/CSS/Alternative_style_sheets). Note that `disabled == false` does not guarantee the style
 sheet is applied (it could be removed from the document, for instance).
 
-## Syntax
+## Value
 
-```js
-bool = stylesheet.disabled
-```
+A boolean.
 
-## Example
+## Examples
 
 ```js
 // If the stylesheet is disabled...

--- a/files/en-us/web/api/stylesheet/href/index.md
+++ b/files/en-us/web/api/stylesheet/href/index.md
@@ -13,17 +13,11 @@ browser-compat: api.StyleSheet.href
 The **`href`** property of the {{domxref("StyleSheet")}}
 interface returns the location of the style sheet.
 
-## Syntax
+## Value
 
-```js
-uri = stylesheet.href
-```
+A string containing the stylesheet's URI.
 
-### Parameters
-
-- `uri` is a string containing the stylesheet's URI.
-
-## Example
+## Examples
 
 On a local machine:
 

--- a/files/en-us/web/api/stylesheet/media/index.md
+++ b/files/en-us/web/api/stylesheet/media/index.md
@@ -12,7 +12,11 @@ browser-compat: api.StyleSheet.media
 
 The **`media`** property of the {{domxref("StyleSheet")}} interface specifies the intended destination media for style information. It is a read-only, array-like `MediaList` object and can be removed with `deleteMedium()` and added with `appendMedium()`.
 
-## Example
+## Value
+
+A read-only array-like `MediaList` object.
+
+## Examples
 
 ```html
 <!doctype html>

--- a/files/en-us/web/api/stylesheet/ownernode/index.md
+++ b/files/en-us/web/api/stylesheet/ownernode/index.md
@@ -21,13 +21,11 @@ This is usually an HTML
 can also return a [processing
 instruction node](/en-US/docs/Web/API/ProcessingInstruction) in the case of `<?xml-stylesheet ?>`.
 
-## Syntax
+## Value
 
-```js
-nodeRef = stylesheet.ownerNode
-```
+A {{domxref("Node")}} object.
 
-## Example
+## Examples
 
 ```html
 <html lang="en">

--- a/files/en-us/web/api/stylesheet/parentstylesheet/index.md
+++ b/files/en-us/web/api/stylesheet/parentstylesheet/index.md
@@ -15,13 +15,11 @@ The **`parentStyleSheet`** property of the
 {{domxref("StyleSheet")}} interface returns the style sheet, if any, that is including
 the given style sheet.
 
-## Syntax
+## Value
 
-```js
-objRef = stylesheet.parentStyleSheet
-```
+A {{domxref("StyleSheet")}} object.
 
-## Example
+## Examples
 
 ```js
 // Find the top level stylesheet

--- a/files/en-us/web/api/stylesheet/type/index.md
+++ b/files/en-us/web/api/stylesheet/type/index.md
@@ -14,13 +14,11 @@ browser-compat: api.StyleSheet.type
 The **`type`** property of the {{domxref("StyleSheet")}}
 interface specifies the style sheet language for the given style sheet.
 
-## Syntax
+## Value
 
-```js
-string = stylesheet.type
-```
+A string.
 
-## Example
+## Examples
 
 ```js
  myStyleSheet.type = 'text/css';

--- a/files/en-us/web/api/svganimationelement/targetelement/index.md
+++ b/files/en-us/web/api/svganimationelement/targetelement/index.md
@@ -18,11 +18,9 @@ the element which is being animated. If no target element is being animated (for
 example, because the {{SVGAttr("href")}} attribute specifies an unknown element), the
 value returned is `null`.
 
-## Syntax
+## Value
 
-```js
-var targetElement = someElement.targetElement;
-```
+A SVGElement object.
 
 ## Specifications
 

--- a/files/en-us/web/api/svggeometryelement/pathlength/index.md
+++ b/files/en-us/web/api/svggeometryelement/pathlength/index.md
@@ -14,14 +14,11 @@ browser-compat: api.SVGGeometryElement.pathLength
 {{APIRef("SVG")}}
 
 The **`SVGGeometryElement.pathLength`** property reflects the
-{{SVGAttr("pathLength")}} attribute and returns the total length of the path, in user
-units.
+{{SVGAttr("pathLength")}} attribute and returns the total length of the path, in user units.
 
-## Syntax
+## Value
 
-```js
-var pathLength = someElement.pathLength;
-```
+A number.
 
 ## Specifications
 

--- a/files/en-us/web/api/textdecoder/encoding/index.md
+++ b/files/en-us/web/api/textdecoder/encoding/index.md
@@ -70,11 +70,9 @@ It can be one of the following values:
   between the client and server. It can happen with `ISO-2022-CN` and
   `ISO-2022-CN-ext`.
 
-## Syntax
+## Value
 
-```js
-var b = decoder.decoding;
-```
+A string.
 
 ## Specifications
 

--- a/files/en-us/web/api/textencoder/encoding/index.md
+++ b/files/en-us/web/api/textencoder/encoding/index.md
@@ -18,11 +18,9 @@ specific encoder.
 
 It can only have the following value `utf-8`.
 
-## Syntax
+## Value
 
-```js
-b = encoder.encoding;
-```
+A string.
 
 ## Specifications
 

--- a/files/en-us/web/api/timeranges/length/index.md
+++ b/files/en-us/web/api/timeranges/length/index.md
@@ -16,13 +16,11 @@ browser-compat: api.TimeRanges.length
 The **`TimeRanges.length`** read-only property returns the
 number of ranges in the object.
 
-## Syntax
+## Value
 
-```js
-length = TimeRanges.length;
-```
+A number.
 
-## Example
+## Examples
 
 Given a video element with the ID "myVideo":
 

--- a/files/en-us/web/api/touch/clientx/index.md
+++ b/files/en-us/web/api/touch/clientx/index.md
@@ -15,18 +15,12 @@ browser-compat: api.Touch.clientX
 The `Touch.clientX` read-only property returns the X coordinate of the touch
 point relative to the viewport, not including any scroll offset.
 
-## Syntax
-
-```js
-touchItem.clientX;
-```
-
-### Return value
+## Value
 
 A `long` representing the X coordinate of the touch point relative to the
 viewport, not including any scroll offset.
 
-## Example
+## Examples
 
 This example illustrates using the {{domxref("Touch")}} object's
 {{domxref("Touch.clientX")}} and {{domxref("Touch.clientY")}} properties. The

--- a/files/en-us/web/api/touch/clienty/index.md
+++ b/files/en-us/web/api/touch/clienty/index.md
@@ -16,18 +16,12 @@ The **`Touch.clientY`** read-only property returns the Y
 coordinate of the touch point relative to the browser's viewport, not including any
 scroll offset.
 
-## Syntax
-
-```js
-touchItem.clientY;
-```
-
-### Return value
+## Value
 
 A `long` value representing the Y coordinate of the touch point relative to
 the viewport, not including any scroll offset.
 
-## Example
+## Examples
 
 This example illustrates using the {{domxref("Touch")}} object's
 {{domxref("Touch.clientX")}} and {{domxref("Touch.clientY")}} properties. The

--- a/files/en-us/web/api/touch/force/index.md
+++ b/files/en-us/web/api/touch/force/index.md
@@ -14,13 +14,7 @@ browser-compat: api.Touch.force
 The **`Touch.force`** read-only property returns the amount of
 pressure the user is applying to the touch surface for a {{ domxref("Touch") }} point.
 
-## Syntax
-
-```js
-touchItem.force;
-```
-
-### Return value
+## Value
 
 A `float` that represents the amount of pressure the user is applying to the
 touch surface. This is a value between `0.0` (no pressure) and
@@ -29,7 +23,7 @@ touch surface. This is a value between `0.0` (no pressure) and
 support this property). In environments where force is known, the absolute pressure
 represented by the force attribute, and the sensitivity in levels of pressure, may vary.
 
-## Example
+## Examples
 
 This example illustrates using the {{domxref("Touch")}} interface's
 {{domxref("Touch.force")}} property. This property is a relative value of pressure

--- a/files/en-us/web/api/touch/identifier/index.md
+++ b/files/en-us/web/api/touch/identifier/index.md
@@ -18,17 +18,11 @@ this point of contact with the touch surface. This value remains consistent for 
 event involving this finger's (or stylus's) movement on the surface until it is lifted
 off the surface.
 
-## Syntax
-
-```js
-touchItem.identifier;
-```
-
-### Return value
+## Value
 
 A `long` that represents the unique ID of the {{ domxref("Touch") }} object.
 
-## Example
+## Examples
 
 ```js
 someElement.addEventListener('touchmove', function(e) {

--- a/files/en-us/web/api/touch/pagex/index.md
+++ b/files/en-us/web/api/touch/pagex/index.md
@@ -14,18 +14,12 @@ browser-compat: api.Touch.pageX
 The **`Touch.pageX`** read-only property returns the X
 coordinate of the touch point relative to the viewport, including any scroll offset.
 
-## Syntax
-
-```js
-touchItem.pageX;
-```
-
-### Return value
+## Value
 
 A `long` representing the X coordinate of the touch point relative to the
 viewport, including any scroll offset.
 
-## Example
+## Examples
 
 This example illustrates how to access the {{domxref("Touch")}} object's
 {{domxref("Touch.pageX")}} and {{domxref("Touch.pageY")}} properties. The

--- a/files/en-us/web/api/touch/pagey/index.md
+++ b/files/en-us/web/api/touch/pagey/index.md
@@ -14,18 +14,12 @@ browser-compat: api.Touch.pageY
 The **`Touch.pageY`** read-only property returns the Y
 coordinate of the touch point relative to the viewport, including any scroll offset.
 
-## Syntax
-
-```js
-touchItem.pageY;
-```
-
-### Return value
+## Value
 
 A `long` value that represents the Y coordinate of the touch point relative
 to the viewport, including any scroll offset.
 
-## Example
+## Examples
 
 This example illustrates how to access the {{domxref("Touch")}} object's
 {{domxref("Touch.pageX")}} and {{domxref("Touch.pageY")}} properties. The

--- a/files/en-us/web/api/touch/radiusx/index.md
+++ b/files/en-us/web/api/touch/radiusx/index.md
@@ -20,18 +20,11 @@ This value, in combination with {{ domxref("Touch.radiusY") }} and {{ domxref("T
 
 > **Note:** This attribute has _not_ been formally standardized. It is specified in the {{SpecName('Touch Events 2')}} {{Spec2('Touch Events 2')}} specification and not in {{SpecName('Touch Events')}} {{Spec2('Touch Events')}}. This attribute is not widely implemented.
 
-## Syntax
+## Value
 
-```js
-var xRadius = touchItem.radiusX;
-```
+A number.
 
-### Return value
-
-- `xRadius`
-  - : The X radius of the ellipse that most closely circumscribes the area of contact with the touch surface.
-
-## Example
+## Examples
 
 This example illustrates using the {{domxref("Touch")}} interface's {{domxref("Touch.radiusX")}}, {{domxref("Touch.radiusX")}} and {{domxref("Touch.rotationAngle")}} properties. The {{domxref("Touch.radiusX")}} property is the radius of the ellipse which most closely circumscribes the touching area (e.g. finger, stylus) along the axis **indicated** by the touch point's {{domxref("Touch.rotationAngle")}}. Likewise, the {{domxref("Touch.radiusY")}} property is the radius of the ellipse which most closely circumscribes the touching area (e.g. finger, stylus) along the axis **perpendicular** to that indicated by {{domxref("Touch.rotationAngle")}}. The {{domxref("Touch.rotationAngle")}} is the angle (in degrees) that the ellipse described by `radiusX` and `radiusY` is rotated clockwise about its center.
 

--- a/files/en-us/web/api/touch/radiusy/index.md
+++ b/files/en-us/web/api/touch/radiusy/index.md
@@ -20,18 +20,11 @@ This value, in combination with {{ domxref("Touch.radiusX") }} and {{ domxref("T
 
 > **Note:** This attribute has _not_ been formally standardized. It is specified in the {{SpecName('Touch Events 2')}} {{Spec2('Touch Events 2')}} specification and not in {{SpecName('Touch Events')}} {{Spec2('Touch Events')}}. This attribute is not widely implemented.
 
-## Syntax
+## Value
 
-```js
-var yRadius = touchItem.radiusY;
-```
+A number.
 
-### Return value
-
-- `yRadius`
-  - : The Y radius of the ellipse that most closely circumscribes the area of contact with the screen.
-
-## Example
+## Examples
 
 The [Touch.radiusX example](/en-US/docs/Web/API/Touch/radiusX#example) includes an example of this property's usage.
 

--- a/files/en-us/web/api/touch/rotationangle/index.md
+++ b/files/en-us/web/api/touch/rotationangle/index.md
@@ -18,18 +18,11 @@ Returns the rotation angle, in degrees, of the contact area ellipse defined by {
 
 > **Note:** This attribute has _not_ been formally standardized. It is specified in the {{SpecName('Touch Events 2')}} {{Spec2('Touch Events 2')}} specification and not in {{SpecName('Touch Events')}} {{Spec2('Touch Events')}}. This attribute is not widely implemented.
 
-## Syntax
+## Value
 
-```js
-var angle = touchItem.rotationAngle;
-```
+A number.
 
-### Return value
-
-- `angle`
-  - : The number of degrees of rotation to apply to the described ellipse to align with the contact area between the user and the touch surface.
-
-## Example
+## Examples
 
 The [Touch.radiusX example](/en-US/docs/Web/API/Touch/radiusX#example) includes an example of this property's usage.
 

--- a/files/en-us/web/api/touch/screenx/index.md
+++ b/files/en-us/web/api/touch/screenx/index.md
@@ -15,18 +15,11 @@ browser-compat: api.Touch.screenX
 
 Returns the X coordinate of the touch point relative to the screen, not including any scroll offset.
 
-## Syntax
+## Value
 
-```js
-var x = touchItem.screenX;
-```
+A number.
 
-### Return value
-
-- `x`
-  - : The X coordinate of the touch point relative to the screen, not including any scroll offset.
-
-## Example
+## Examples
 
 This example illustrates how to access the {{domxref("Touch")}} object's {{domxref("Touch.screenX")}} and {{domxref("Touch.screenY")}} properties. The {{domxref("Touch.screenX")}} property is the horizontal (x) coordinate of a touch point relative to the screen in CSS pixels. The {{domxref("Touch.screenY")}} property is the vertical coordinate of a touch point relative to the screen in CSS pixels.
 

--- a/files/en-us/web/api/touch/screeny/index.md
+++ b/files/en-us/web/api/touch/screeny/index.md
@@ -15,18 +15,11 @@ browser-compat: api.Touch.screenY
 
 Returns the Y coordinate of the touch point relative to the screen, not including any scroll offset.
 
-## Syntax
+## Value
 
-```js
-var y = touchItem.screenY;
-```
+A number.
 
-### Return value
-
-- `y`
-  - : The Y coordinate of the touch point relative to the screen, not including any scroll offset.
-
-## Example
+## Examples
 
 The [Touch.screenX example](/en-US/docs/Web/API/Touch/screenX#example) includes an example of this property's usage.
 

--- a/files/en-us/web/api/touch/target/index.md
+++ b/files/en-us/web/api/touch/target/index.md
@@ -14,18 +14,11 @@ browser-compat: api.Touch.target
 
 The read-only **`target`**  property of the `Touch` interface returns the ({{domxref("EventTarget")}}) on which the touch contact started when it was first placed on the surface, even if the touch point has since moved outside the interactive area of that element or even been removed from the document. Note that if the target element is removed from the document, events will still be targeted at it, and hence won't necessarily bubble up to the window or document anymore. If there is any risk of an element being removed while it is being touched, the best practice is to attach the touch listeners directly to the target.
 
-## Syntax
-
-```js
-var el = touchPoint.target;
-
-```
-
-### Return value
+## Value
 
 The {{domxref("EventTarget")}} the {{domxref("Touch")}} object applies to.
 
-## Example
+## Examples
 
 This example illustrates how to access the {{domxref("Touch")}} object's {{domxref("Touch.target")}} property. The {{domxref("Touch.target")}} property is an {{domxref("Element")}} ({{domxref("EventTarget")}}) on which a touch point is started when contact is first placed on the surface.
 

--- a/files/en-us/web/api/touchevent/altkey/index.md
+++ b/files/en-us/web/api/touchevent/altkey/index.md
@@ -20,7 +20,7 @@ This property is {{readonlyInline}}.
 
 ## Value
 
-A boolean.
+A boolean value that is `true` if the <kbd>alt</kbd> key is enabled for this event; and `false` if the <kbd>alt</kbd> is not enabled.
 
 ## Examples
 

--- a/files/en-us/web/api/touchevent/altkey/index.md
+++ b/files/en-us/web/api/touchevent/altkey/index.md
@@ -18,18 +18,11 @@ A boolean value indicating whether or not the <kbd>alt</kbd> (Alternate) key is 
 
 This property is {{readonlyInline}}.
 
-## Syntax
+## Value
 
-```js
-var altEnabled = touchEvent.altKey;
-```
+A boolean.
 
-### Return value
-
-- `altEnabled`
-  - : `true` if the <kbd>alt</kbd> key is enabled for this event; and `false` if the <kbd>alt</kbd> is not enabled.
-
-## Example
+## Examples
 
 This example illustrates how to access the {{domxref("TouchEvent")}} key modifier properties: {{domxref("TouchEvent.altKey")}}, {{domxref("TouchEvent.ctrlKey")}}, {{domxref("TouchEvent.metaKey")}} and {{domxref("TouchEvent.shiftKey")}}.
 

--- a/files/en-us/web/api/touchevent/changedtouches/index.md
+++ b/files/en-us/web/api/touchevent/changedtouches/index.md
@@ -21,18 +21,11 @@ The **`changedTouches`** read-only property is a {{ domxref("TouchList") }} whos
 - For the {{event("touchmove")}} event, it is a list of the touch points that have changed since the last event.
 - For the {{event("touchend")}} event, it is a list of the touch points that have been removed from the surface (that is, the set of touch points corresponding to fingers no longer touching the surface).
 
-## Syntax
+## Value
 
-```js
-var changes = touchEvent.changedTouches;
-```
+A {{ domxref("TouchList") }} whose {{ domxref("Touch") }} objects include all the touch points that contributed to this touch event.
 
-### Return value
-
-- `changes`
-  - : A {{ domxref("TouchList") }} whose {{ domxref("Touch") }} objects include all the touch points that contributed to this touch event.
-
-## Example
+## Examples
 
 This example illustrates the {{domxref("TouchEvent")}} object's {{domxref("TouchEvent.changedTouches")}} property. The {{domxref("TouchEvent.changedTouches")}} property is a {{domxref("TouchList")}} object that contains one {{domxref("Touch")}} object for each touch point which contributed to the event.
 

--- a/files/en-us/web/api/touchevent/ctrlkey/index.md
+++ b/files/en-us/web/api/touchevent/ctrlkey/index.md
@@ -20,7 +20,7 @@ This property is {{readonlyInline}}.
 
 ## Value
 
-A boolean.
+A boolean value that is `true` if the <kbd>control</kbd> key is enabled for this event; and `false` if the <kbd>control</kbd> is not enabled.
 
 ## Examples
 

--- a/files/en-us/web/api/touchevent/ctrlkey/index.md
+++ b/files/en-us/web/api/touchevent/ctrlkey/index.md
@@ -18,18 +18,11 @@ A boolean value indicating whether the <kbd>control</kbd> (Control) key is enabl
 
 This property is {{readonlyInline}}.
 
-## Syntax
+## Value
 
-```js
-var ctrlEnabled = touchEvent.ctrlKey;
-```
+A boolean.
 
-### Return value
-
-- `ctrlEnabled`
-  - : `true` if the <kbd>control</kbd> key is enabled for this event; and `false` if the <kbd>control</kbd> is not enabled.
-
-## Example
+## Examples
 
 The [TouchEvent.altKey example](/en-US/docs/Web/API/TouchEvent/altKey#example) includes an example of this property's usage.
 

--- a/files/en-us/web/api/touchevent/metakey/index.md
+++ b/files/en-us/web/api/touchevent/metakey/index.md
@@ -22,7 +22,7 @@ This property is {{readonlyInline}}.
 
 ## Value
 
-A boolean.
+A boolean value that is `true` if the <kbd>Meta</kbd> key is enabled for this event; and `false` if the <kbd>Meta</kbd> is not enabled.
 
 ## Examples
 

--- a/files/en-us/web/api/touchevent/metakey/index.md
+++ b/files/en-us/web/api/touchevent/metakey/index.md
@@ -20,18 +20,11 @@ This property is {{readonlyInline}}.
 
 > **Note:** On Macintosh keyboards, this is the <kbd>⌘ Command</kbd> key. On Windows keyboards, this is the Windows key (<kbd>⊞</kbd>).
 
-## Syntax
+## Value
 
-```js
-var metaEnabled = touchEvent.metaKey;
-```
+A boolean.
 
-### Return value
-
-- `metaEnabled`
-  - : `true` if the <kbd>Meta</kbd> key is enabled for this event; and `false` if the <kbd>Meta</kbd> is not enabled.
-
-## Example
+## Examples
 
 The [TouchEvent.altKey example](/en-US/docs/Web/API/TouchEvent/altKey#example) includes an example of this property's usage.
 

--- a/files/en-us/web/api/touchevent/shiftkey/index.md
+++ b/files/en-us/web/api/touchevent/shiftkey/index.md
@@ -14,17 +14,11 @@ browser-compat: api.TouchEvent.shiftKey
 
 The read-only **`shiftKey`** property of the `TouchEvent` interface returns a boolean value indicating whether or not the <kbd>shift</kbd> key is enabled when the touch event is created. If this key is enabled, the attribute's value is `true`. Otherwise, it is `false`.
 
-## Syntax
-
-```
-var shiftEnabled = touchEvent.shiftKey;
-```
-
-### Return value
+## Value
 
 The boolean value `true` if the <kbd>shift</kbd> key is enabled for this event; and `false` if the <kbd>shift</kbd> key is not enabled.
 
-## Example
+## Examples
 
 The [TouchEvent.altKey example](/en-US/docs/Web/API/TouchEvent/altKey#example) includes an example of this property's usage.
 

--- a/files/en-us/web/api/touchevent/targettouches/index.md
+++ b/files/en-us/web/api/touchevent/targettouches/index.md
@@ -17,18 +17,11 @@ browser-compat: api.TouchEvent.targetTouches
 
 The **`targetTouches`** read-only property is a {{ domxref("TouchList") }} listing all the {{ domxref("Touch") }} objects for touch points that are still in contact with the touch surface **and** whose {{event("touchstart")}} event occurred inside the same target {{ domxref("element") }} as the current target element.
 
-## Syntax
+## Value
 
-```js
-var touches = touchEvent.targetTouches;
-```
+A {{ domxref("TouchList") }} listing all the {{ domxref("Touch") }} objects for touch points that are still in contact with the touch surface **and** whose `touchstart` event occurred inside the same target {{ domxref("element") }} as the current target element.
 
-### Return value
-
-- `touches`
-  - : A {{ domxref("TouchList") }} listing all the {{ domxref("Touch") }} objects for touch points that are still in contact with the touch surface **and** whose `touchstart` event occurred inside the same target {{ domxref("element") }} as the current target element.
-
-## Example
+## Examples
 
 This example illustrates the {{domxref("TouchEvent")}} object's {{domxref("TouchEvent.targetTouches")}} property. The {{domxref("TouchEvent.targetTouches")}} property is a {{domxref("TouchList")}} object that includes those TPs that are currently touching the surface _and_ started on the element that is the target of the current event. As such, the `targetTouches` list is a strict subset of the `touches` list.
 

--- a/files/en-us/web/api/touchevent/touches/index.md
+++ b/files/en-us/web/api/touchevent/touches/index.md
@@ -23,21 +23,12 @@ target element was at {{event("touchstart")}} time.
 You can think of it as how many separate fingers are able to be identified as touching
 the screen.
 
-## Syntax
+## Value
 
-```js
-var touches = touchEvent.touches;
-```
-
-### Return value
-
-- `touches`
-  - : A {{ domxref("TouchList") }} listing all the {{ domxref("Touch") }} objects for
-    touch points that are still in contact with the touch surface, regardless of whether
-    or not they've changed or what their target element was at `touchstart`
+A {{ domxref("TouchList") }} listing all the {{ domxref("Touch") }} objects for  touch points that are still in contact with the touch surface, regardless of whether or not they've changed or what their target element was at `touchstart`
     time.
 
-## Example
+## Examples
 
 This example illustrates the {{domxref("TouchEvent")}} object's
 {{domxref("TouchEvent.touches")}} property. The {{domxref("TouchEvent.touches")}}

--- a/files/en-us/web/api/touchlist/length/index.md
+++ b/files/en-us/web/api/touchlist/length/index.md
@@ -17,18 +17,11 @@ browser-compat: api.TouchList.length
 The **`length`** read-only property indicates the number of
 items (touch points) in a given {{domxref("TouchList")}}.
 
-## Syntax
+## Value
 
-```js
-var numTouches = touchList.length;
-```
+The number of touch points in `touchList`.
 
-### Return value
-
-- `numTouches`
-  - : The number of touch points in `touchList`.
-
-## Example
+## Examples
 
 This code example illustrates the use of the {{domxref("TouchList")}} interface's
 {{domxref("TouchList.item()","item")}} method and the

--- a/files/en-us/web/api/transitionevent/elapsedtime/index.md
+++ b/files/en-us/web/api/transitionevent/elapsedtime/index.md
@@ -19,11 +19,9 @@ The **`TransitionEvent.elapsedTime`** read-only property is a
 when this event fired. This value is not affected by the {{cssxref("transition-delay")}}
 property.
 
-## Syntax
+## Value
 
-```js
-name = TransitionEvent.elapsedTime
-```
+A number.
 
 ## Specifications
 

--- a/files/en-us/web/api/transitionevent/propertyname/index.md
+++ b/files/en-us/web/api/transitionevent/propertyname/index.md
@@ -15,11 +15,9 @@ browser-compat: api.TransitionEvent.propertyName
 
 The **`propertyName`** read-only property of {{domxref("TransitionEvent")}} objects is a {{domxref("DOMString")}} containing the name of the CSS property associated with the transition.
 
-## Syntax
+## Value
 
-```js
-name = TransitionEvent.propertyName
-```
+A string.
 
 ## Specifications
 

--- a/files/en-us/web/api/transitionevent/pseudoelement/index.md
+++ b/files/en-us/web/api/transitionevent/pseudoelement/index.md
@@ -19,11 +19,9 @@ The **`TransitionEvent.pseudoElement`** read-only property is a
 If the transition doesn't run on a pseudo-element but on the element, an empty string:
 ` ''``. `
 
-## Syntax
+## Value
 
-```js
-name = TransitionEvent.pseudoElement
-```
+A string.
 
 ## Specifications
 


### PR DESCRIPTION
Sequel of #14195 
As per the template API_property_subpage_template, Syntax section is redundant in property pages. So getting rid of the cruft.

Changes:
- Removed syntax sections
- Enforced heading names to ## Value, ## Examples.
- Other small corrections

#### Metadata
- [x] Fixes a typo, bug, or other error