### PR TITLE
put badges after names

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/index.md
@@ -251,7 +251,7 @@ The `CanvasRenderingContext2D` rendering context contains a variety of drawing s
 
 ### Filters
 
-- {{experimental_inline}} {{domxref("CanvasRenderingContext2D.filter")}}
+- {{domxref("CanvasRenderingContext2D.filter")}} {{experimental_inline}}
   - : Applies a CSS or SVG filter to the canvas, e.g., to change its brightness or blurriness.
 
 ## Non-standard APIs

--- a/files/en-us/web/api/navigation_timing_api/index.md
+++ b/files/en-us/web/api/navigation_timing_api/index.md
@@ -30,9 +30,9 @@ This API lets you measure data that was previously difficult to obtain, such as 
   - : The {{domxref("window.performance")}} property returns a `Performance` object. While this interface is defined by the High Resolution Time API, the Navigation Timing API adds two properties: {{domxref("Performance.timing", "timing")}} and {{domxref("Performance.navigation", "navigation")}}, of the types below.
 - {{domxref("PerformanceNavigationTiming")}}
   - : Provides methods and properties to store and retrieve metrics regarding the browser's document navigation events. For example, this interface can be used to determine how much time it takes to load or unload a document.
-- {{deprecated_inline}} {{domxref("PerformanceTiming")}}
+- {{domxref("PerformanceTiming")}} {{deprecated_inline}}
   - : Used as the type for the value of {{domxref("Performance.timing", "timing")}}, objects of this type contain timing information that can provide insight into web page performance.
-- {{deprecated_inline}}  {{domxref("PerformanceNavigation")}}
+- {{domxref("PerformanceNavigation")}} {{deprecated_inline}}
   - : The type used to return the value of {{domxref("Performance.navigation", "navigation")}}, which contains information explaining the context of the load operation described by this `Performance` instance.
 
 The Navigation Timing API can be used to gather performance data on the client side to be sent to a server via XHR as well as measure data that was very difficult to measure by other means such as time to unload a previous page, domain look up time, `window.onload` total time, etc.

--- a/files/en-us/web/api/performancenavigation/index.md
+++ b/files/en-us/web/api/performancenavigation/index.md
@@ -28,7 +28,7 @@ An object of this type can be obtained by calling the {{domxref("Performance.nav
 
 _The `PerformanceNavigation` interface doesn't inherit any properties._
 
-- {{deprecated_inline}} {{domxref("PerformanceNavigation.type")}} {{readonlyInline}}
+- {{domxref("PerformanceNavigation.type")}} {{readonlyInline}} {{deprecated_inline}}
 
   - : An `unsigned short` which indicates how the navigation to this page was done. Possible values are:
 
@@ -41,7 +41,7 @@ _The `PerformanceNavigation` interface doesn't inherit any properties._
     - `TYPE_RESERVED` (255)
       - : Any other way.
 
-- {{deprecated_inline}} {{domxref("PerformanceNavigation.redirectCount")}} {{readonlyInline}}
+- {{domxref("PerformanceNavigation.redirectCount")}} {{readonlyInline}} {{deprecated_inline}}
   - : An `unsigned short` representing the number of REDIRECTs done before reaching the page.
 
 ## Methods

--- a/files/en-us/web/api/performancetiming/index.md
+++ b/files/en-us/web/api/performancetiming/index.md
@@ -31,47 +31,47 @@ Each time is provided as a {{interwiki("wikipedia", "Unix_time", "Unix time")}} 
 
 These properties are listed in the order in which they occur during the navigation process.
 
-- {{deprecated_inline}} {{domxref("PerformanceTiming.navigationStart")}} {{readonlyInline}}
+- {{domxref("PerformanceTiming.navigationStart")}} {{readonlyInline}} {{deprecated_inline}}
   - : When the prompt for unload terminates on the previous document in the same browsing context. If there is no previous document, this value will be the same as `PerformanceTiming.fetchStart`.
-- {{deprecated_inline}} {{domxref("PerformanceTiming.unloadEventStart")}} {{readonlyInline}}
+- {{domxref("PerformanceTiming.unloadEventStart")}} {{readonlyInline}} {{deprecated_inline}}
   - : When the {{event("unload")}} event has been thrown, indicating the time at which the previous document in the window began to unload. If there is no previous document, or if the previous document or one of the needed redirects is not of the same origin, the value returned is `0`.
-- {{deprecated_inline}} {{domxref("PerformanceTiming.unloadEventEnd")}} {{readonlyInline}}
+- {{domxref("PerformanceTiming.unloadEventEnd")}} {{readonlyInline}} {{deprecated_inline}}
   - : When the {{event("unload")}} event handler finishes. If there is no previous document, or if the previous document, or one of the needed redirects, is not of the same origin, the value returned is `0`.
-- {{deprecated_inline}} {{domxref("PerformanceTiming.redirectStart")}} {{readonlyInline}}
+- {{domxref("PerformanceTiming.redirectStart")}} {{readonlyInline}} {{deprecated_inline}}
   - : When the first HTTP redirect starts. If there is no redirect, or if one of the redirects is not of the same origin, the value returned is `0`.
-- {{deprecated_inline}} {{domxref("PerformanceTiming.redirectEnd")}} {{readonlyInline}}
+- {{domxref("PerformanceTiming.redirectEnd")}} {{readonlyInline}} {{deprecated_inline}}
   - : When the last HTTP redirect is completed, that is when the last byte of the HTTP response has been received. If there is no redirect, or if one of the redirects is not of the same origin, the value returned is `0`.
-- {{deprecated_inline}} {{domxref("PerformanceTiming.fetchStart")}} {{readonlyInline}}
+- {{domxref("PerformanceTiming.fetchStart")}} {{readonlyInline}} {{deprecated_inline}}
   - : When the browser is ready to fetch the document using an HTTP request. This moment is _before_ the check to any application cache.
-- {{deprecated_inline}} {{domxref("PerformanceTiming.domainLookupStart")}} {{readonlyInline}}
+- {{domxref("PerformanceTiming.domainLookupStart")}} {{readonlyInline}} {{deprecated_inline}}
   - : When the domain lookup starts. If a persistent connection is used, or the information is stored in a cache or a local resource, the value will be the same as `PerformanceTiming.fetchStart`.
-- {{deprecated_inline}} {{domxref("PerformanceTiming.domainLookupEnd")}} {{readonlyInline}}
+- {{domxref("PerformanceTiming.domainLookupEnd")}} {{readonlyInline}} {{deprecated_inline}}
   - : When the domain lookup is finished. If a persistent connection is used, or the information is stored in a cache or a local resource, the value will be the same as `PerformanceTiming.fetchStart`.
-- {{deprecated_inline}} {{domxref("PerformanceTiming.connectStart")}} {{readonlyInline}}
+- {{domxref("PerformanceTiming.connectStart")}} {{readonlyInline}} {{deprecated_inline}}
   - : When the request to open a connection is sent to the network. If the transport layer reports an error and the connection establishment is started again, the last connection establishment start time is given. If a persistent connection is used, the value will be the same as `PerformanceTiming.fetchStart`.
-- {{deprecated_inline}} {{domxref("PerformanceTiming.connectEnd")}} {{readonlyInline}}
+- {{domxref("PerformanceTiming.connectEnd")}} {{readonlyInline}} {{deprecated_inline}}
   - : When the connection is opened network. If the transport layer reports an error and the connection establishment is started again, the last connection establishment end time is given. If a persistent connection is used, the value will be the same as `PerformanceTiming.fetchStart`. A connection is considered as opened when all secure connection handshake, or SOCKS authentication, is terminated.
-- {{deprecated_inline}} {{domxref("PerformanceTiming.secureConnectionStart")}} {{readonlyInline}}
+- {{domxref("PerformanceTiming.secureConnectionStart")}} {{readonlyInline}} {{deprecated_inline}}
   - : When the secure connection handshake starts. If no such connection is requested, it returns `0`.
-- {{deprecated_inline}} {{domxref("PerformanceTiming.requestStart")}} {{readonlyInline}}
+- {{domxref("PerformanceTiming.requestStart")}} {{readonlyInline}} {{deprecated_inline}}
   - : When the browser sent the request to obtain the actual document, from the server or from a cache. If the transport layer fails after the start of the request and the connection is reopened, this property will be set to the time corresponding to the new request.
-- {{deprecated_inline}} {{domxref("PerformanceTiming.responseStart")}} {{readonlyInline}}
+- {{domxref("PerformanceTiming.responseStart")}} {{readonlyInline}} {{deprecated_inline}}
   - : When the browser received the first byte of the response, from the server from a cache, or from a local resource.
-- {{deprecated_inline}} {{domxref("PerformanceTiming.responseEnd")}} {{readonlyInline}}
+- {{domxref("PerformanceTiming.responseEnd")}} {{readonlyInline}} {{deprecated_inline}}
   - : When the browser received the last byte of the response, or when the connection is closed if this happened first, from the server, the cache, or from a local resource.
-- {{deprecated_inline}} {{domxref("PerformanceTiming.domLoading")}} {{readonlyInline}}
+- {{domxref("PerformanceTiming.domLoading")}} {{readonlyInline}} {{deprecated_inline}}
   - : When the parser started its work, that is when its {{domxref("Document.readyState")}} changes to `'loading'` and the corresponding {{event("readystatechange")}} event is thrown.
-- {{deprecated_inline}} {{domxref("PerformanceTiming.domInteractive")}} {{readonlyInline}}
+- {{domxref("PerformanceTiming.domInteractive")}} {{readonlyInline}} {{deprecated_inline}}
   - : When the parser finished its work on the main document, that is when its {{domxref("Document.readyState")}} changes to `'interactive'` and the corresponding {{event("readystatechange")}} event is thrown.
-- {{deprecated_inline}} {{domxref("PerformanceTiming.domContentLoadedEventStart")}} {{readonlyInline}}
+- {{domxref("PerformanceTiming.domContentLoadedEventStart")}} {{readonlyInline}} {{deprecated_inline}}
   - : Right before the parser sent the {{event("DOMContentLoaded")}} event, that is right after all the scripts that need to be executed right after parsing have been executed.
-- {{deprecated_inline}} {{domxref("PerformanceTiming.domContentLoadedEventEnd")}} {{readonlyInline}}
+- {{domxref("PerformanceTiming.domContentLoadedEventEnd")}} {{readonlyInline}} {{deprecated_inline}}
   - : Right after all the scripts that need to be executed as soon as possible, in order or not, have been executed.
-- {{deprecated_inline}} {{domxref("PerformanceTiming.domComplete")}} {{readonlyInline}}
+- {{domxref("PerformanceTiming.domComplete")}} {{readonlyInline}} {{deprecated_inline}}
   - : When the parser finished its work on the main document, that is when its {{domxref("Document.readyState")}} changes to `'complete'` and the corresponding {{event("readystatechange")}} event is thrown.
-- {{deprecated_inline}} {{domxref("PerformanceTiming.loadEventStart")}} {{readonlyInline}}
+- {{domxref("PerformanceTiming.loadEventStart")}} {{readonlyInline}} {{deprecated_inline}}
   - : When the {{event("load")}} event was sent for the current document. If this event has not yet been sent, it returns `0.`
-- {{deprecated_inline}} {{domxref("PerformanceTiming.loadEventEnd")}} {{readonlyInline}}
+- {{domxref("PerformanceTiming.loadEventEnd")}} {{readonlyInline}} {{deprecated_inline}}
   - : When the {{event("load")}} event handler terminated, that is when the load event is completed. If this event has not yet been sent, or is not yet completed, it returns `0.`
 
 ## Methods

--- a/files/en-us/web/guide/html/content_categories/index.md
+++ b/files/en-us/web/guide/html/content_categories/index.md
@@ -103,7 +103,7 @@ Form-associated content is a subset of flow content comprising elements that hav
 - {{HTMLElement("button")}}
 - {{HTMLElement("fieldset")}}
 - {{HTMLElement("input")}}
-- {{deprecated_inline}}{{HTMLElement("keygen")}}
+- {{HTMLElement("keygen")}} {{deprecated_inline}}
 - {{HTMLElement("label")}}
 - {{HTMLElement("meter")}}
 - {{HTMLElement("object")}}

--- a/files/en-us/web/javascript/reference/global_objects/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/index.md
@@ -45,9 +45,9 @@ These global functions—functions which are called globally, rather than on an 
 - {{JSxRef("Global_Objects/decodeURIComponent", "decodeURIComponent()")}}
 - **Deprecated**
 
-  - {{Deprecated_Inline}} {{JSxRef("Global_Objects/escape", "escape()")}}
-  - {{Deprecated_Inline}} {{JSxRef("Global_Objects/unescape", "unescape()")}}
-  - {{Deprecated_Inline}} {{JSxRef("Global_Objects/uneval", "uneval()")}}
+  - {{JSxRef("Global_Objects/escape", "escape()")}} {{Deprecated_Inline}}
+  - {{JSxRef("Global_Objects/unescape", "unescape()")}} {{Deprecated_Inline}}
+  - {{JSxRef("Global_Objects/uneval", "uneval()")}} {{Deprecated_Inline}}
 
 ### Fundamental objects
 


### PR DESCRIPTION
#### Summary
At some places badges were in front of API names.

#### Motivation
Make it consistent with rest of the documents.

#### Metadata
- [x] Fixes a typo, bug, or other error
