### PR TITLE
Added links to description for "Chained Promises"

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/index.md
@@ -41,7 +41,7 @@ As the `{{JSxRef("Promise.then", "Promise.prototype.then()")}}` and `{{JSxRef("P
 
 ### Chained Promises
 
-The methods `promise.then()`, `promise.catch()`, and `promise.finally()` are used to associate further action with a promise that becomes settled.
+The methods `{{jsxref("Promise.prototype.then()")}}`, `{{jsxref("Promise.prototype.catch()")}}`, and `{{jsxref("Promise.prototype.finally()")}}` are used to associate further action with a promise that becomes settled.
 
 The `.then()` method takes up to two arguments; the first argument is a callback function for the resolved case of the promise, and the second argument is a callback function for the rejected case. Each `.then()` returns a newly generated promise object, which can optionally be used for chaining; for example:
 


### PR DESCRIPTION
The promise functions mentioned in "Chained Promises" section can better described by providing actual description links to the respective functions.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The description of "Chained Promises" section just mentions various functions without actually providing supporting links to describe further use of these functions in the section.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The user has to scroll deep down to find the description of the functions, which might be made easier.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
The links are fetched from description of functions further down in the same page.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
None.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
