### PR TITLE
Update material shading property.

### DIFF
--- a/files/en-us/learn/javascript/client-side_web_apis/drawing_graphics/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/drawing_graphics/index.md
@@ -741,7 +741,7 @@ Let's look at a simple example of how to create something with a WebGL library. 
       texture.repeat.set(2, 2);
 
       const geometry = new THREE.BoxGeometry(2.4,2.4,2.4);
-      const material = new THREE.MeshLambertMaterial( { map: texture, shading: THREE.FlatShading } );
+      const material = new THREE.MeshLambertMaterial( { map: texture } );
       cube = new THREE.Mesh(geometry, material);
       scene.add(cube);
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Removing 'shading' property because it was removed from 'MeshLambertMaterial'.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
A warning message is displayed when i run the example: 
   "THREE.MeshLambertMaterial: .shading has been removed. Use the boolean .flatShading instead."
We can use 'MeshPhongMaterial' which has the boolean 'flatShading' property like this :
   `const material = new THREE.MeshPhongMaterial({ map: texture, flatShading: true });`
but for this example i think is ok just to remove the shading property.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
MeshLambertMaterial -> https://threejs.org/docs/#api/en/materials/MeshLambertMaterial 
MeshPhongMaterial -> https://threejs.org/docs/?q=meshlam#api/en/materials/MeshPhongMaterial
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
