### PR TITLE
Doc: Fix confusing end index description for Array.prototype.slice()

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/slice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/slice/index.md
@@ -43,7 +43,7 @@ slice(start, end)
 
 - `end` {{optional_inline}}
 
-  - : Zero-based index _before_ which to end extraction. `slice`
+  - : The index of the first element to exclude from the returned array. `slice`
     extracts up to but not including `end`. For example,
     `slice(1,4)` extracts the second element through the fourth element
     (elements indexed 1, 2, and 3).


### PR DESCRIPTION
Minor change to doc of `end` index for `Array.prototype.slice()` so it is in line with the new `endIndex` description of `String.prototype.slice()`. With the same reason as in the merged PR for that one: https://github.com/mdn/content/pull/14646