### PR TITLE
WebAPI: Clean syntax from property pages, part 24

### DIFF
--- a/files/en-us/web/api/treewalker/currentnode/index.md
+++ b/files/en-us/web/api/treewalker/currentnode/index.md
@@ -13,14 +13,11 @@ browser-compat: api.TreeWalker.currentNode
 The **`TreeWalker.currentNode`** property represents the
 {{domxref("Node")}} on which the {{domxref("TreeWalker")}} is currently pointing at.
 
-## Syntax
+## Value
 
-```js
-node = treeWalker.currentNode;
-treeWalker.currentNode = node;
-```
+A {{domxref("Node")}}.
 
-## Example
+## Examples
 
 ```js
 var treeWalker = document.createTreeWalker(

--- a/files/en-us/web/api/treewalker/expandentityreferences/index.md
+++ b/files/en-us/web/api/treewalker/expandentityreferences/index.md
@@ -19,13 +19,11 @@ If this value is `false`, the children of entity reference nodes (as well as
 all of their descendants) are rejected. This takes precedence over the value of the
 {{domxref("TreeWalker.whatToShow")}} method and the associated filter.
 
-## Syntax
+## Value
 
-```js
-expand = treeWalker.expandEntityReferences;
-```
+A boolean.
 
-## Example
+## Examples
 
 ```js
 var treeWalker = document.createTreeWalker(

--- a/files/en-us/web/api/treewalker/filter/index.md
+++ b/files/en-us/web/api/treewalker/filter/index.md
@@ -18,13 +18,11 @@ When creating the `TreeWalker`, the filter object is passed in as the third
 parameter, and its method {{domxref("NodeFilter.acceptNode()")}} is called on every
 single node to determine whether or not to accept it.
 
-## Syntax
+## Value
 
-```js
-nodeFilter = treeWalker.filter;
-```
+A {{domxref("NodeFilter")}} object.
 
-## Example
+## Examples
 
 ```js
 var treeWalker = document.createTreeWalker(

--- a/files/en-us/web/api/treewalker/root/index.md
+++ b/files/en-us/web/api/treewalker/root/index.md
@@ -13,13 +13,11 @@ browser-compat: api.TreeWalker.root
 The **`TreeWalker.root`** read-only property returns the node
 that is the root of what the TreeWalker traverses.
 
-## Syntax
+## Value
 
-```js
-root = TreeWalker.root;
-```
+A {{domxref("Node")}} object.
 
-## Example
+## Examples
 
 ```js
 var treeWalker = document.createTreeWalker(

--- a/files/en-us/web/api/treewalker/whattoshow/index.md
+++ b/files/en-us/web/api/treewalker/whattoshow/index.md
@@ -110,13 +110,11 @@ children may be included, if relevant. The possible values are:
   </tbody>
 </table>
 
-## Syntax
+## Value
 
-```js
-nodeTypes = treeWalker.whatToShow;
-```
+A bitmask.
 
-## Example
+## Examples
 
 ```js
 var treeWalker = document.createTreeWalker(

--- a/files/en-us/web/api/uievent/layerx/index.md
+++ b/files/en-us/web/api/uievent/layerx/index.md
@@ -19,13 +19,9 @@ This property takes scrolling of the page into account and returns a value relat
 the whole of the document unless the event occurs inside a positioned element, where the
 returned value is relative to the top left of the positioned element.
 
-## Syntax
+## Value
 
-```js
-var xpos = event.layerX
-```
-
-- `xpos` is an integer value in pixels for the x-coordinate of the mouse
+An integer value in pixels for the x-coordinate of the mouse
   pointer, when the mouse event fired.
 
 ## Examples

--- a/files/en-us/web/api/uievent/layery/index.md
+++ b/files/en-us/web/api/uievent/layery/index.md
@@ -19,16 +19,12 @@ This property takes scrolling of the page into account, and returns a value rela
 the whole of the document, unless the event occurs inside a positioned element, where
 the returned value is relative to the top left of the positioned element.
 
-## Syntax
+## Value
 
-```js
-var ypos = event.layerY;
-```
-
-- `ypos` is an integer value in pixels for the y-coordinate of the mouse
+An integer value in pixels for the y-coordinate of the mouse
   pointer, when the mouse event fired.
 
-## Example
+## Examples
 
 ```html
 <html>

--- a/files/en-us/web/api/uievent/view/index.md
+++ b/files/en-us/web/api/uievent/view/index.md
@@ -17,13 +17,9 @@ The **`UIEvent.view`** read-only property returns the
 {{domxref("WindowProxy")}} object from which the event was generated. In browsers, this
 is the {{ domxref("Window") }} object the event happened in.
 
-## Syntax
+## Value
 
-```js
-var view = event.view;
-```
-
-- `view` is a reference to an `AbstractView` object.
+A reference to an `AbstractView` object.
 
 ## Specifications
 

--- a/files/en-us/web/api/validitystate/badinput/index.md
+++ b/files/en-us/web/api/validitystate/badinput/index.md
@@ -14,7 +14,11 @@ browser-compat: api.ValidityState.badInput
 
 The read-only **`badInput`** property of a [ValidityState](/en-US/docs/Web/API/ValidityState) object indicates if the user has provided input that the browser is unable to convert. For example, if you have a number input element whose content is a string.
 
-## Example
+## Value
+
+A boolean.
+
+## Examples
 
 ```html
 <input type="number" id="age">

--- a/files/en-us/web/api/videoplaybackquality/totalframedelay/index.md
+++ b/files/en-us/web/api/videoplaybackquality/totalframedelay/index.md
@@ -21,13 +21,11 @@ creation of the associated {{domxref("HTMLVideoElement")}}. The frame delay is t
 difference between a frame's theoretical presentation time and its effective display
 time.
 
-## Syntax
+## Value
 
-```js
-value = videoPlaybackQuality.totalFrameDelay;
-```
+A number.
 
-## Example
+## Examples
 
 ```js
 var videoElt = document.getElementById('my_vid');

--- a/files/en-us/web/api/webglrenderingcontext/drawingbufferheight/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/drawingbufferheight/index.md
@@ -18,11 +18,9 @@ property represents the actual height of the current drawing buffer. It should m
 this context, but might differ if the implementation is not able to provide the
 requested height.
 
-## Syntax
+## Value
 
-```js
-gl.drawingBufferHeight;
-```
+A number.
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/drawingbufferwidth/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/drawingbufferwidth/index.md
@@ -18,11 +18,9 @@ property represents the actual width of the current drawing buffer. It should ma
 this context, but might differ if the implementation is not able to provide the
 requested width.
 
-## Syntax
+## Value
 
-```js
-gl.drawingBufferWidth;
-```
+A number.
 
 ## Examples
 

--- a/files/en-us/web/api/wheelevent/deltamode/index.md
+++ b/files/en-us/web/api/wheelevent/deltamode/index.md
@@ -22,13 +22,11 @@ Permitted values are:
 | `DOM_DELTA_LINE`  | `0x01` | The delta values are specified in lines.  |
 | `DOM_DELTA_PAGE`  | `0x02` | The delta values are specified in pages.  |
 
-## Syntax
+## Value
 
-```js
-var unit = event.deltaMode;
-```
+An `unsigned long`.
 
-## Example
+## Examples
 
 ```js
 var syntheticEvent = new WheelEvent("syntheticWheel", {"deltaX": 4, "deltaMode": 0});

--- a/files/en-us/web/api/wheelevent/deltax/index.md
+++ b/files/en-us/web/api/wheelevent/deltax/index.md
@@ -16,13 +16,11 @@ The **`WheelEvent.deltaX`** read-only property is a
 `double` representing the horizontal scroll amount in the
 {{domxref("WheelEvent.deltaMode")}} unit.
 
-## Syntax
+## Value
 
-```js
-var dX = event.deltaX;
-```
+A number.
 
-## Example
+## Examples
 
 ```js
 var syntheticEvent = new WheelEvent("syntheticWheel", {"deltaX": 4, "deltaMode": 0});

--- a/files/en-us/web/api/wheelevent/deltay/index.md
+++ b/files/en-us/web/api/wheelevent/deltay/index.md
@@ -16,13 +16,11 @@ The **`WheelEvent.deltaY`** read-only property is a
 `double` representing the vertical scroll amount in the
 {{domxref("WheelEvent.deltaMode")}} unit.
 
-## Syntax
+## Value
 
-```js
-var dY = event.deltaY;
-```
+A number.
 
-## Example
+## Examples
 
 ```js
 var syntheticEvent = new WheelEvent("syntheticWheel", {"deltaY": 4, "deltaMode": 0});

--- a/files/en-us/web/api/wheelevent/deltaz/index.md
+++ b/files/en-us/web/api/wheelevent/deltaz/index.md
@@ -17,13 +17,11 @@ The **`WheelEvent.deltaZ`** read-only property is a
 `double` representing the scroll amount along the z-axis, in the
 {{domxref("WheelEvent.deltaMode")}} unit.
 
-## Syntax
+## Value
 
-```js
-var dZ = event.deltaZ;
-```
+A number.
 
-## Example
+## Examples
 
 ```js
 var syntheticEvent = new WheelEvent("syntheticWheel", {"deltaZ": 4, "deltaMode": 0});

--- a/files/en-us/web/api/window/applicationcache/index.md
+++ b/files/en-us/web/api/window/applicationcache/index.md
@@ -19,15 +19,9 @@ browser-compat: api.SharedWorkerGlobalScope.applicationCache
 
 Returns a reference to the application cache object for the window.
 
-## Syntax
+## Value
 
-```js
-cache = window.applicationCache
-```
-
-### Parameters
-
-- `cache` is an object reference to an `OfflineResourceList`.
+An object reference to an `OfflineResourceList`.
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/window/defaultstatus/index.md
+++ b/files/en-us/web/api/window/defaultstatus/index.md
@@ -21,18 +21,11 @@ tags:
 
 Gets/sets the status bar text for the given window.
 
-## Syntax
+## Value
 
-```js
-var sMsg = window.defaultStatus;
-window.defaultStatus = sMsg;
-```
+A string containing the text to be displayed by default in the statusbar.
 
-### Parameters
-
-- `sMsg` is a string containing the text to be displayed by default in the statusbar.
-
-## Example
+## Examples
 
 ```html
 <html>

--- a/files/en-us/web/api/window/dialogarguments/index.md
+++ b/files/en-us/web/api/window/dialogarguments/index.md
@@ -22,11 +22,9 @@ method.
 This lets you determine what parameters were specified when the modal
 dialog was created.
 
-## Syntax
+## Value
 
-```js
-value = window.dialogArguments;
-```
+The arguments passed to the dialog.
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/window/document/index.md
+++ b/files/en-us/web/api/window/document/index.md
@@ -13,7 +13,11 @@ browser-compat: api.Window.document
 
 **`window.document`** returns a reference to the [document](/en-US/docs/Web/API/Document) contained in the window.
 
-## Example
+## Value
+
+A [document](/en-US/docs/Web/API/Document) object.
+
+## Examples
 
 ```js
 console.log(window.document.title);

--- a/files/en-us/web/api/window/frames/index.md
+++ b/files/en-us/web/api/window/frames/index.md
@@ -17,13 +17,9 @@ browser-compat: api.Window.frames
 Returns the window itself, which is an array-like object, listing the direct sub-frames
 of the current window.
 
-## Syntax
+## Value
 
-```js
-frameList = window.frames;
-```
-
-- `frameList` is a list of frame objects. It is similar to an
+A list of frame objects. It is similar to an
   array in that it has a `length` property and its items can be accessed
   using the `[i]` notation.
 - `frameList === window` evaluates to true.
@@ -35,7 +31,7 @@ frameList = window.frames;
 - For more details about the returned value, refer to this [thread
   on mozilla.dev.platform](http://groups.google.com/group/mozilla.dev.platform/browse_thread/thread/5628c6f346859d4f/169aa7004565066?hl=en&ie=UTF-8&oe=utf-8&q=window.frames&pli=1).
 
-## Example
+## Examples
 
 ```js
 var frames = window.frames; // or // var frames = window.parent.frames;

--- a/files/en-us/web/api/window/fullscreen/index.md
+++ b/files/en-us/web/api/window/fullscreen/index.md
@@ -16,33 +16,21 @@ browser-compat: api.Window.fullScreen
 The **`fullScreen`** property of the `Window`
 interface indicates whether the window is displayed in full screen mode or not.
 
-## Syntax
-
-```js
-isInFullScreen = windowRef.fullScreen;
-```
-
 With chrome privileges, the property is read-write, otherwise it is read-only. Bear in
 mind that if you try to set this property without chrome privileges, it will not throw
 an exception and instead just silently fail. This is to prevent scripts designed to set
 this property in Internet Explorer from breaking.
 
-### Return value
+## Value
 
-- `isInFullScreen`
-  - : A boolean. Possible Values:
-
-<!---->
-
-- `true`: The window is in full screen mode.
-- `false`: The window is not in full screen mode.
+A boolean.
 
 ## Notes
 
 - Switching between regular window and full screen will fire the "resize" event on the
   corresponding window.
 
-## Example
+## Examples
 
 ```js
 if (window.fullScreen) {

--- a/files/en-us/web/api/window/fullscreen/index.md
+++ b/files/en-us/web/api/window/fullscreen/index.md
@@ -23,7 +23,7 @@ this property in Internet Explorer from breaking.
 
 ## Value
 
-A boolean.
+A boolean value with `true` meaning that the window is in full-screen mode and `false` meaning it isn't.
 
 ## Notes
 

--- a/files/en-us/web/api/window/history/index.md
+++ b/files/en-us/web/api/window/history/index.md
@@ -16,7 +16,11 @@ The `Window.history` read-only property returns a reference to the {{domxref("Hi
 
 See [Manipulating the browser history](/en-US/docs/Web/API/History_API) for examples and details. In particular, that article explains security features of the {{domxref("History.pushState", "pushState()")}} and {{domxref("History.replaceState", "replaceState()")}} methods that you should be aware of before using them.
 
-## Example
+## Value
+
+A reference to the {{domxref("History")}} object.
+
+## Examples
 
 ```js
 history.back();     // equivalent to clicking back button

--- a/files/en-us/web/api/window/length/index.md
+++ b/files/en-us/web/api/window/length/index.md
@@ -15,15 +15,11 @@ browser-compat: api.Window.length
 Returns the number of frames (either {{HTMLElement("frame")}} or
 {{HTMLElement("iframe")}} elements) in the window.
 
-## Syntax
+## Value
 
-```js
-framesCount = window.length;
-```
+A number.
 
-- `framesCount` is the number of frames.
-
-## Example
+## Examples
 
 ```js
 if (window.length) {

--- a/files/en-us/web/api/window/location/index.md
+++ b/files/en-us/web/api/window/location/index.md
@@ -24,12 +24,9 @@ work with `location` as if it were a string in most cases:
 
 See {{domxref("Location")}} for all available properties.
 
-## Syntax
+## Value
 
-```js
-var oldLocation = location;
-location = newLocation;
-```
+A {{domxref("Location")}} object.
 
 ## Examples
 

--- a/files/en-us/web/api/window/locationbar/index.md
+++ b/files/en-us/web/api/window/locationbar/index.md
@@ -15,13 +15,11 @@ browser-compat: api.Window.locationbar
 
 Returns the `locationbar` object, whose visibility can be checked.
 
-## Syntax
+## Value
 
-```js
-objRef = window.locationbar
-```
+A `locationbar` object.
 
-## Example
+## Examples
 
 The following complete HTML example shows how the `visible` property of the
 `locationbar` object is used.

--- a/files/en-us/web/api/window/menubar/index.md
+++ b/files/en-us/web/api/window/menubar/index.md
@@ -14,13 +14,11 @@ browser-compat: api.Window.menubar
 The **`Window.menubar`** property returns the
 `menubar` object, whose visibility can be checked.
 
-## Syntax
+## Value
 
-```js
-objRef = window.menubar
-```
+A `menubar` object.
 
-## Example
+## Examples
 
 The following complete HTML example demonstrates how the `visible` property
 of the `menubar` object is used.

--- a/files/en-us/web/api/window/mozpaintcount/index.md
+++ b/files/en-us/web/api/window/mozpaintcount/index.md
@@ -20,17 +20,9 @@ browser-compat: api.Window.mozPaintCount
 Returns the number of times the current document has been painted to the screen in this
 window.
 
-## Syntax
+## Value
 
-```js
-var paintCount = window.mozPaintCount;
-```
-
-- `paintCount` stores the `window.mozPaintCount`
-  property value.
-- The `window.mozPaintCount` value is a `long long`, and starts
-  at zero when the document is first created, incrementing by one each time the document
-  is painted.
+The `window.mozPaintCount` property value. The `window.mozPaintCount` value is a `long long`, and starts at zero when the document is first created, incrementing by one each time the document is painted.
 
 ## Specifications
 

--- a/files/en-us/web/api/window/mozpaintcount/index.md
+++ b/files/en-us/web/api/window/mozpaintcount/index.md
@@ -22,7 +22,7 @@ window.
 
 ## Value
 
-The `window.mozPaintCount` property value. The `window.mozPaintCount` value is a `long long`, and starts at zero when the document is first created, incrementing by one each time the document is painted.
+A `long long` value that starts at zero when the document is first created and is incremented by one each time the document is painted.
 
 ## Specifications
 

--- a/files/en-us/web/api/window/name/index.md
+++ b/files/en-us/web/api/window/name/index.md
@@ -13,12 +13,9 @@ browser-compat: api.Window.name
 The `Window.name` property
 gets/sets the name of the window's browsing context.
 
-## Syntax
+## Value
 
-```js
-string = window.name;
-window.name = string;
-```
+A string.
 
 ## Description
 

--- a/files/en-us/web/api/window/navigator/index.md
+++ b/files/en-us/web/api/window/navigator/index.md
@@ -16,11 +16,9 @@ The **`Window.navigator`** read-only property returns a
 reference to the {{domxref("Navigator")}} object, which has methods and properties about
 the application running the script.
 
-## Syntax
+## Value
 
-```js
-navigatorObject = window.navigator
-```
+A {{domxref("Navigator")}} object
 
 ## Examples
 

--- a/files/en-us/web/api/window/navigator/index.md
+++ b/files/en-us/web/api/window/navigator/index.md
@@ -18,7 +18,7 @@ the application running the script.
 
 ## Value
 
-A {{domxref("Navigator")}} object
+The {{domxref("navigator")}} object.
 
 ## Examples
 

--- a/files/en-us/web/api/window/ondragdrop/index.md
+++ b/files/en-us/web/api/window/ondragdrop/index.md
@@ -17,18 +17,13 @@ tags:
 
 An event handler for drag and drop events sent to the window.
 
-## Syntax
+## Value
 
-```js
-window.ondragdrop = funcRef;
-```
-
-- funcRef
-  - : The event handler function to be registered.
+The event handler function to be registered.
 
 The `window.ondragdrop` property and the `ondragdrop` attribute are not implemented in [Gecko](/en-US/Gecko) ({{ Bug(112288) }}), you have to use `addEventListener`. See [addEventListener](/en-US/docs/DOM/element.addEventListener) for details.
 
-## Example
+## Examples
 
 ### Fire an alert on dragdrop
 

--- a/files/en-us/web/api/window/parent/index.md
+++ b/files/en-us/web/api/window/parent/index.md
@@ -22,13 +22,12 @@ When a window is loaded in an {{htmlelement("iframe")}}, {{htmlelement("object")
 {{htmlelement("frame")}}, its parent is the window with the element embedding the
 window.
 
-## Syntax
+## Value
 
-```js
-var parentWindow = window.parent;
-```
+A `Window` or {{htmlelement("iframe")}} object. 
+ 
 
-## Example
+## Examples
 
 ```js
 if (window.parent != window.top) {

--- a/files/en-us/web/api/window/personalbar/index.md
+++ b/files/en-us/web/api/window/personalbar/index.md
@@ -16,13 +16,11 @@ browser-compat: api.Window.personalbar
 Returns the `personalbar` object, whose visibility can be toggled in the
 window.
 
-## Syntax
+## Value
 
-```js
-objRef =window.personalbar
-```
+A `personalbar` object.
 
-## Example
+## Examples
 
 {{todo('https://bugzilla.mozilla.org/show_bug.cgi?id=790023')}}
 

--- a/files/en-us/web/api/window/screen/index.md
+++ b/files/en-us/web/api/window/screen/index.md
@@ -16,13 +16,11 @@ reference to the screen object associated with the window. The `screen`
 object, implementing the {{DOMxRef("Screen")}} interface, is a special object for
 inspecting properties of the screen on which the current window is being rendered.
 
-## Syntax
+## Value
 
-```js
-let screenObj = window.screen;
-```
+A {{DOMxRef("Screen")}} object.
 
-## Example
+## Examples
 
 ```js
 if (screen.pixelDepth < 8) {

--- a/files/en-us/web/api/window/screenleft/index.md
+++ b/files/en-us/web/api/window/screenleft/index.md
@@ -21,13 +21,7 @@ to the left side of the screen.
 > {{domxref("Window.screenX")}} property. `screenLeft` was originally
 > supported only in IE but was introduced everywhere due to popularity.
 
-## Syntax
-
-```js
-leftWindowPos = window.screenLeft
-```
-
-### Returns
+## Value
 
 A number equal to the number of CSS pixels from the left edge of the browser viewport
 to the  left edge of the screen.

--- a/files/en-us/web/api/window/screentop/index.md
+++ b/files/en-us/web/api/window/screentop/index.md
@@ -21,13 +21,7 @@ the top side of the screen.
 > {{domxref("Window.screenY")}} property. `screenTop` was originally
 > supported only in IE but was introduced everywhere due to popularity.
 
-## Syntax
-
-```js
-topWindowPos = window.screenTop
-```
-
-### Returns
+## Value
 
 A number equal to the number of CSS pixels from the top edge of the browser viewport to
 the  top edge of the screen.

--- a/files/en-us/web/api/window/screenx/index.md
+++ b/files/en-us/web/api/window/screenx/index.md
@@ -21,13 +21,7 @@ the left side of the screen.
 > browsers in more recent times — {{domxref("Window.screenLeft")}}. This was originally
 > supported only in IE but was introduced everywhere due to popularity.
 
-## Syntax
-
-```js
-leftWindowPos = window.screenX
-```
-
-### Returns
+## Value
 
 A number equal to the number of CSS pixels from the left edge of the browser viewport
 to the  left edge of the screen.

--- a/files/en-us/web/api/window/screeny/index.md
+++ b/files/en-us/web/api/window/screeny/index.md
@@ -16,13 +16,7 @@ The **`Window.screenY`** read-only property returns the vertical distance, in CS
 
 > **Note:** An alias of `screenY` was implemented across modern browsers in more recent times — {{domxref("Window.screenTop")}}. This was originally supported only in IE but was introduced everywhere due to popularity.
 
-## Syntax
-
-```js
-topWindowPos = window.screenY
-```
-
-### Returns
+## Value
 
 A number equal to the number of CSS pixels from the top edge of the browser viewport to the  top edge of the screen.
 

--- a/files/en-us/web/api/window/scrollbars/index.md
+++ b/files/en-us/web/api/window/scrollbars/index.md
@@ -15,13 +15,11 @@ browser-compat: api.Window.scrollbars
 The **`Window.scrollbars`** property returns the
 `scrollbars` object, whose visibility can be checked.
 
-## Syntax
+## Value
 
-```js
-objRef = window.scrollbars
-```
+A `scrollbars` object.
 
-## Example
+## Examples
 
 The following complete HTML example shows how the `visible` property of the
 scrollbars object is used.

--- a/files/en-us/web/api/window/scrollmaxx/index.md
+++ b/files/en-us/web/api/window/scrollmaxx/index.md
@@ -15,15 +15,11 @@ browser-compat: api.Window.scrollMaxX
 The **`Window.scrollMaxX`** read-only property returns the
 maximum number of pixels that the document can be scrolled horizontally.
 
-## Syntax
+## Value
 
-```js
-xMax = window.scrollMaxX
-```
+A number.
 
-- `xMax` is the number of pixels.
-
-## Example
+## Examples
 
 ```js
 // Scroll to right edge of the page

--- a/files/en-us/web/api/window/scrollmaxy/index.md
+++ b/files/en-us/web/api/window/scrollmaxy/index.md
@@ -19,15 +19,11 @@ browser-compat: api.Window.scrollMaxY
 The **`Window.scrollMaxY`** read-only property returns the
 maximum number of pixels that the document can be scrolled vertically.
 
-## Syntax
+## Value
 
-```js
-yMax = window.scrollMaxY
-```
+A number.
 
-- `yMax` is the number of pixels.
-
-## Example
+## Examples
 
 ```js
 // Scroll to the bottom of the page

--- a/files/en-us/web/api/window/self/index.md
+++ b/files/en-us/web/api/window/self/index.md
@@ -14,7 +14,11 @@ browser-compat: api.Window.self
 
 The **`Window.self`** read-only property returns the window itself, as a {{domxref("WindowProxy")}}. It can be used with dot notation on a `window` object (that is, `window.self`) or standalone (`self`). The advantage of the standalone notation is that a similar notation exists for non-window contexts, such as in {{domxref("Worker", "Web Workers", "", 1)}}. By using `self`, you can refer to the global scope in a way that will work not only in a window context (`self` will resolve to `window.self`) but also in a worker context (`self` will then resolve to {{domxref("WorkerGlobalScope.self")}}).
 
-## Example
+## Value
+
+A {{domxref("WindowProxy")}} object.
+
+## Examples
 
 Uses of `window.self` like the following could just as well be replaced by `window`.
 

--- a/files/en-us/web/api/window/status/index.md
+++ b/files/en-us/web/api/window/status/index.md
@@ -19,11 +19,9 @@ bar at the bottom of the browser window. However, the HTML standard now requires
 setting `window.status` to have no effect on the text displayed in the
 status bar.
 
-## Syntax
+## Value
 
-```js
-window.status = string; var value = window.status;
-```
+A string.
 
 ## Specifications
 

--- a/files/en-us/web/api/window/statusbar/index.md
+++ b/files/en-us/web/api/window/statusbar/index.md
@@ -16,13 +16,11 @@ browser-compat: api.Window.statusbar
 The **`Window.statusbar`** property returns the statusbar
 object, whose visibility can be toggled in the window.
 
-## Syntax
+## Value
 
-```js
-objRef = window.statusbar
-```
+A `statusbar` object.
 
-## Example
+## Examples
 
 The following complete HTML example shows a way that the visible property of the
 various "bar" objects is used, and also the change to the privileges necessary to write

--- a/files/en-us/web/api/window/toolbar/index.md
+++ b/files/en-us/web/api/window/toolbar/index.md
@@ -16,13 +16,11 @@ browser-compat: api.Window.toolbar
 The **`Window.toolbar`** property returns the toolbar object,
 which can be used to check the browser toolbar visibility.
 
-## Syntax
+## Value
 
-```js
-objRef = window.toolbar
-```
+A `toolbar` object.
 
-## Example
+## Examples
 
 The following complete HTML example demonstrates how the `visible` property
 of the `toolbar` object is used.

--- a/files/en-us/web/api/window/top/index.md
+++ b/files/en-us/web/api/window/top/index.md
@@ -17,7 +17,7 @@ Returns a reference to the topmost window in the window hierarchy.
 
 ## Value
 
-Referenct to the topmost window.
+The reference to the topmost window.
 
 ## Notes
 

--- a/files/en-us/web/api/window/top/index.md
+++ b/files/en-us/web/api/window/top/index.md
@@ -15,11 +15,9 @@ browser-compat: api.Window.top
 
 Returns a reference to the topmost window in the window hierarchy.
 
-## Syntax
+## Value
 
-```js
-var topWindow = window.top;
-```
+Referenct to the topmost window.
 
 ## Notes
 

--- a/files/en-us/web/api/windowcontrolsoverlay/visible/index.md
+++ b/files/en-us/web/api/windowcontrolsoverlay/visible/index.md
@@ -19,11 +19,9 @@ The window controls overlay is not be visible if:
 - The Web App Manifest's [`display_override`](/en-US/docs/Web/Manifest/display_override) member is not set to `window-controls-overlay`.
 - Or, if the user has opted-out of the feature.
 
-## Syntax
+## Value
 
-```js
-const isOverlayVisible = navigator.windowControlsOverlay.visible;
-```
+A boolean.
 
 ## Examples
 

--- a/files/en-us/web/api/windoweventhandlers/onbeforeunload/index.md
+++ b/files/en-us/web/api/windoweventhandlers/onbeforeunload/index.md
@@ -28,18 +28,15 @@ event is still cancelable.
 > [`Navigator.sendBeacon()`](/en-US/docs/Web/API/Navigator/sendBeacon)
 > page for more details and best practices.
 
-## Syntax
-
-```js
-window.addEventListener("beforeunload", function(event) { /* ... */ });
-window.onbeforeunload = function(event) { /* ... */ };
-```
-
 Typically, it is better to use {{domxref("EventTarget.addEventListener",
   "window.addEventListener()")}} and the {{domxref("Window.beforeunload_event", "beforeunload")}} event, instead of
 `onbeforeunload`.
 
-## Example
+## Value
+
+An [event handler](/en-US/docs/Web/Events/Event_handlers).
+
+## Examples
 
 This example prompts the user before unloading.
 


### PR DESCRIPTION
Sequel of #14195 
As per the template API_property_subpage_template, Syntax section is redundant in property pages. So getting rid of the cruft.

Changes:
- Removed syntax sections
- Enforced heading names to ## Value, ## Examples.
- Other small corrections

#### Metadata
- [x] Fixes a typo, bug, or other error