### PR TITLE
WebAPI: Clean syntax from property pages, part 25

### DIFF
--- a/files/en-us/web/api/windoweventhandlers/onpopstate/index.md
+++ b/files/en-us/web/api/windoweventhandlers/onpopstate/index.md
@@ -31,13 +31,9 @@ by a call to `history.replaceState()`, the `popstate` event's
 > clicking on the back button (or calling `history.back()` in JavaScript),
 > when navigating between two history entries for the same document.
 
-## Syntax
+## Value
 
-```js
-window.onpopstate = funcRef;
-```
-
-- `funcRef` is a handler function.
+An [event handler](/en-US/docs/Web/Events/Event_handlers).
 
 ## Examples
 

--- a/files/en-us/web/api/windoweventhandlers/onrejectionhandled/index.md
+++ b/files/en-us/web/api/windoweventhandlers/onrejectionhandled/index.md
@@ -21,14 +21,11 @@ The **`onrejectionhandled`** property of the
 processing {{event("rejectionhandled")}} events. These events are raised when
 {{jsxref("Promise")}}s are rejected.
 
-## Syntax
+## Value
 
-```js
-window.addEventListener("rejectionhandled", function(event) { /* ... */ });
-window.onrejectionhandled = function(event) { ...};
-```
+An [event handler](/en-US/docs/Web/Events/Event_handlers).
 
-## Example
+## Examples
 
 ```js
 window.onrejectionhandled = function(e) {

--- a/files/en-us/web/api/windoweventhandlers/onunload/index.md
+++ b/files/en-us/web/api/windoweventhandlers/onunload/index.md
@@ -34,12 +34,9 @@ its content and resources. The resource removal is processed _after_ the
 > See discussion comments in the blog post [Beacon API is
 > broken](https://volument.com/blog/sendbeacon-is-broken#comments).
 
-## Syntax
+## Value
 
-```js
-window.addEventListener("unload", function(event) { /* ... */ });
-window.onunload = function(event) { /* ... */ };
-```
+An [event handler](/en-US/docs/Web/Events/Event_handlers).
 
 Typically, it is better to use {{domxref("EventTarget.addEventListener",
   "window.addEventListener()")}} and the {{event("unload")}} event, instead of

--- a/files/en-us/web/api/workerlocation/hash/index.md
+++ b/files/en-us/web/api/workerlocation/hash/index.md
@@ -13,11 +13,9 @@ browser-compat: api.WorkerLocation.hash
 
 The **`hash`** property of a {{domxref("WorkerLocation")}} object returns the {{domxref("URL.hash", "hash")}} part of the worker's location.
 
-## Syntax
+## Value
 
-```js
-string = location.hash;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/workerlocation/host/index.md
+++ b/files/en-us/web/api/workerlocation/host/index.md
@@ -13,11 +13,9 @@ browser-compat: api.WorkerLocation.host
 
 The **`host`** property of a {{domxref("WorkerLocation")}} object returns the {{domxref("URL.host", "host")}} part of the worker's location.
 
-## Syntax
+## Value
 
-```js
-string = location.host;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/workerlocation/hostname/index.md
+++ b/files/en-us/web/api/workerlocation/hostname/index.md
@@ -13,11 +13,9 @@ browser-compat: api.WorkerLocation.hostname
 
 The **`hostname`** property of a {{domxref("WorkerLocation")}} object returns the {{domxref("URL.hostname", "hostname")}} part of the worker's location.
 
-## Syntax
+## Value
 
-```js
-string = location.hostname;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/workerlocation/href/index.md
+++ b/files/en-us/web/api/workerlocation/href/index.md
@@ -13,11 +13,9 @@ browser-compat: api.WorkerLocation.href
 
 The **`href`** property of a {{domxref("WorkerLocation")}} object returns a {{domxref("USVString")}} containing the serialized {{domxref("URL")}} for the worker's location.
 
-## Syntax
+## Value
 
-```js
-string = location.href;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/workerlocation/origin/index.md
+++ b/files/en-us/web/api/workerlocation/origin/index.md
@@ -13,11 +13,9 @@ browser-compat: api.WorkerLocation.origin
 
 The **`origin`** property of a {{domxref("WorkerLocation")}} object returns the worker's {{domxref("URL.origin", "origin")}}.
 
-## Syntax
+## Value
 
-```js
-string = object.origin;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/workerlocation/pathname/index.md
+++ b/files/en-us/web/api/workerlocation/pathname/index.md
@@ -13,11 +13,9 @@ browser-compat: api.WorkerLocation.pathname
 
 The **`pathname`** property of a {{domxref("WorkerLocation")}} object returns the {{domxref("URL.pathname", "pathname")}} part of the worker's location.
 
-## Syntax
+## Value
 
-```js
-string = location.pathname;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/workerlocation/port/index.md
+++ b/files/en-us/web/api/workerlocation/port/index.md
@@ -13,11 +13,9 @@ browser-compat: api.WorkerLocation.port
 
 The **`port`** property of a {{domxref("WorkerLocation")}} object returns the {{domxref("URL.port", "port")}} part of the worker's location.
 
-## Syntax
+## Value
 
-```js
-string = location.port;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/workerlocation/protocol/index.md
+++ b/files/en-us/web/api/workerlocation/protocol/index.md
@@ -13,11 +13,9 @@ browser-compat: api.WorkerLocation.protocol
 
 The **`protocol`** property of a {{domxref("WorkerLocation")}} object returns the {{domxref("URL.protocol", "protocol")}} part of the worker's location.
 
-## Syntax
+## Value
 
-```js
-string = location.protocol;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/workerlocation/search/index.md
+++ b/files/en-us/web/api/workerlocation/search/index.md
@@ -13,11 +13,9 @@ browser-compat: api.WorkerLocation.search
 
 The **`search`** property of a {{domxref("WorkerLocation")}} object returns the {{domxref("URL.search", "search")}} part of the worker's location.
 
-## Syntax
+## Value
 
-```js
-string = location.search;
-```
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/workernavigator/connection/index.md
+++ b/files/en-us/web/api/workernavigator/connection/index.md
@@ -18,11 +18,9 @@ connection, such as the current bandwidth of the user's device or whether the co
 is metered. This could be used to select high definition content or low definition
 content based on the user's connection.
 
-## Syntax
+## Value
 
-```js
-connectionInfo = navigator.connection
-```
+A {{domxref("NetworkInformation")}} object.
 
 ## Specifications
 

--- a/files/en-us/web/api/workernavigator/languages/index.md
+++ b/files/en-us/web/api/workernavigator/languages/index.md
@@ -29,11 +29,9 @@ The `Accept-Language` HTTP header in every HTTP request from the user's
 browser uses the same value for the `navigator.languages` property except for
 the extra `qvalues` (quality values) field (e.g. `en-US;q=0.8`).
 
-## Syntax
+## Value
 
-```js
-preferredLanguages = globalObj.navigator.languages
-```
+An array or strings.
 
 ## Examples
 

--- a/files/en-us/web/api/xmldocument/async/index.md
+++ b/files/en-us/web/api/xmldocument/async/index.md
@@ -19,7 +19,11 @@ browser-compat: api.XMLDocument.async
 
 (It has been possible to load documents synchronously since 1.4 alpha.)
 
-## Example
+## Value
+
+A boolean.
+
+## Examples
 
 ```js
 function loadXMLData(e) {

--- a/files/en-us/web/api/xmlhttprequest/status/index.md
+++ b/files/en-us/web/api/xmlhttprequest/status/index.md
@@ -18,7 +18,11 @@ The read-only **`XMLHttpRequest.status`** property returns the numerical HTTP [s
 
 Before the request completes, the value of `status` is 0. Browsers also report a status of 0 in case of `XMLHttpRequest` errors.
 
-## Example
+## Value
+
+A number.
+
+## Examples
 
 ```js
 var xhr = new XMLHttpRequest();

--- a/files/en-us/web/api/xmlhttprequest/statustext/index.md
+++ b/files/en-us/web/api/xmlhttprequest/statustext/index.md
@@ -19,7 +19,11 @@ If the server response doesn't explicitly specify a status text, `statusText` wi
 
 > **Note:** Responses over an HTTP/2 connection will always have a empty string as status message as HTTP/2 does not support them.
 
-## Example
+## Value
+
+A string.
+
+## Examples
 
 ```js
 var xhr = new XMLHttpRequest();

--- a/files/en-us/web/api/xmlhttprequest/withcredentials/index.md
+++ b/files/en-us/web/api/xmlhttprequest/withcredentials/index.md
@@ -23,7 +23,11 @@ In addition, this flag is also used to indicate when cookies are to be ignored i
 
 > **Note:** `XMLHttpRequest` responses from a different domain *cannot* set cookie values for their own domain unless `withCredentials` is set to `true` before making the request, regardless of `Access-Control-` header values.
 
-## Example
+## Value
+
+A boolean.
+
+## Examples
 
 ```js
 var xhr = new XMLHttpRequest();

--- a/files/en-us/web/api/xpathresult/booleanvalue/index.md
+++ b/files/en-us/web/api/xpathresult/booleanvalue/index.md
@@ -18,13 +18,7 @@ The read-only **`booleanValue`** property of the
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var value = result.booleanValue;
-```
-
-### Return value
+## Value
 
 The return value is the boolean value of the `XPathResult` returned by
 {{domxref("Document.evaluate()")}}.
@@ -36,7 +30,7 @@ The return value is the boolean value of the `XPathResult` returned by
 In case {{domxref("XPathResult.resultType")}} is not `BOOLEAN_TYPE`, an
 {{domxref("XPathException")}} of type `TYPE_ERR` is thrown.
 
-## Example
+## Examples
 
 The following example shows the use of the `booleanValue` property.
 

--- a/files/en-us/web/api/xpathresult/invaliditeratorstate/index.md
+++ b/files/en-us/web/api/xpathresult/invaliditeratorstate/index.md
@@ -20,17 +20,11 @@ the document has been modified since this result was returned.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var iteratorState = result.invalidIteratorState;
-```
-
-### Return value
+## Value
 
 A boolean value indicating whether the iterator has become invalid.
 
-## Example
+## Examples
 
 The following example shows the use of the `invalidIteratorState` property.
 

--- a/files/en-us/web/api/xpathresult/numbervalue/index.md
+++ b/files/en-us/web/api/xpathresult/numbervalue/index.md
@@ -18,13 +18,7 @@ The read-only **`numberValue`** property of the
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var value = result.numberValue;
-```
-
-### Return value
+## Value
 
 The return value is the numeric value of the `XPathResult` returned by
 {{domxref("Document.evaluate()")}}.
@@ -36,7 +30,7 @@ The return value is the numeric value of the `XPathResult` returned by
 In case {{domxref("XPathResult.resultType")}} is not `NUMBER_TYPE`, an
 {{domxref("XPathException")}} of type `TYPE_ERR` is thrown.
 
-## Example
+## Examples
 
 The following example shows the use of the `numberValue` property.
 

--- a/files/en-us/web/api/xpathresult/resulttype/index.md
+++ b/files/en-us/web/api/xpathresult/resulttype/index.md
@@ -18,13 +18,7 @@ the type constants.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var resultType = result.resultType;
-```
-
-### Return value
+## Value
 
 An integer value representing the type of the result, as defined by the type constants.
 
@@ -125,7 +119,7 @@ An integer value representing the type of the result, as defined by the type con
   </tbody>
 </table>
 
-## Example
+## Examples
 
 The following example shows the use of the `resultType` property.
 

--- a/files/en-us/web/api/xpathresult/singlenodevalue/index.md
+++ b/files/en-us/web/api/xpathresult/singlenodevalue/index.md
@@ -18,13 +18,7 @@ The read-only **`singleNodeValue`** property of the
 {{domxref("XPathResult.resultType")}} being `ANY_UNORDERED_NODE_TYPE` or
 `FIRST_ORDERED_NODE_TYPE`.
 
-## Syntax
-
-```js
-var value = result.singleNodeValue;
-```
-
-### Return value
+## Value
 
 The return value is the {{domxref("Node")}} value of the `XPathResult`
 returned by {{domxref("Document.evaluate()")}}.
@@ -37,7 +31,7 @@ In case {{domxref("XPathResult.resultType")}} is not
 `ANY_UNORDERED_NODE_TYPE` or `FIRST_ORDERED_NODE_TYPE`, an
 {{domxref("XPathException")}} of type `TYPE_ERR` is thrown.
 
-## Example
+## Examples
 
 The following example shows the use of the `singleNodeValue` property.
 

--- a/files/en-us/web/api/xpathresult/snapshotlength/index.md
+++ b/files/en-us/web/api/xpathresult/snapshotlength/index.md
@@ -18,13 +18,7 @@ snapshot.
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var snapshotLength = result.snapshotLength;
-```
-
-### Return value
+## Value
 
 An integer value representing the number of nodes in the result snapshot.
 
@@ -36,7 +30,7 @@ In case {{domxref("XPathResult.resultType")}} is not
 `UNORDERED_NODE_SNAPSHOT_TYPE` or `ORDERED_NODE_SNAPSHOT_TYPE`, an
 {{domxref("XPathException")}} of type `TYPE_ERR` is thrown.
 
-## Example
+## Examples
 
 The following example shows the use of the `snapshotLength` property.
 

--- a/files/en-us/web/api/xpathresult/stringvalue/index.md
+++ b/files/en-us/web/api/xpathresult/stringvalue/index.md
@@ -18,13 +18,7 @@ The read-only **`stringValue`** property of the
 
 {{AvailableInWorkers}}
 
-## Syntax
-
-```js
-var value = result.stringValue;
-```
-
-### Return value
+## Value
 
 The return value is the string value of the `XPathResult` returned by
 {{domxref("Document.evaluate()")}}.
@@ -36,7 +30,7 @@ The return value is the string value of the `XPathResult` returned by
 In case {{domxref("XPathResult.resultType")}} is not `STRING_TYPE`, an
 {{domxref("XPathException")}} of type `TYPE_ERR` is thrown.
 
-## Example
+## Examples
 
 The following example shows the use of the `stringValue` property.
 


### PR DESCRIPTION
Sequel of #14195 
As per the template API_property_subpage_template, Syntax section is redundant in property pages. So getting rid of the cruft.

Changes:
- Removed syntax sections
- Enforced heading names to ## Value, ## Examples.
- Other small corrections

#### Metadata
- [x] Fixes a typo, bug, or other error