### PR TITLE
Update documentation for Storage.setItem() 

### DIFF
--- a/files/en-us/web/api/storage/setitem/index.md
+++ b/files/en-us/web/api/storage/setitem/index.md
@@ -35,10 +35,7 @@ storage.setItem(keyName, keyValue);
 
 ### Exceptions
 
-`setItem()` may throw an exception if the storage is full. Particularly, in
-Mobile Safari (since iOS 5) it always throws when the user enters private mode. (Safari
-sets the quota to 0 bytes in private mode, unlike other browsers, which allow storage in
-private mode using separate data containers.) Hence developers should make sure to
+`setItem()` may throw an exception if the storage is full. Developers should make sure to
 **always catch possible exceptions from `setItem()`**.
 
 ## Example


### PR DESCRIPTION
#### Summary
The documentation needs updating, specifically the paragraphs that says
> Safari sets the quota to 0 bytes in private mode...

#### Motivation
The documentation is obsolete as the issue has already been fixed on Safari.

#### Supporting details
- https://webkit.org/blog/7532/release-notes-for-safari-technology-preview-29
- https://trac.webkit.org/changeset/215315/webkit
- https://developer.apple.com/safari/technology-preview/release-notes

This PR…
- [x] Updated documentation
