### PR TITLE
It is still possible to create `AudioNode`s on `"closed"` `AudioContext`

### DIFF
--- a/files/en-us/web/api/audiocontext/close/index.md
+++ b/files/en-us/web/api/audiocontext/close/index.md
@@ -15,8 +15,6 @@ browser-compat: api.AudioContext.close
 
 The `close()` method of the {{ domxref("AudioContext") }} Interface closes the audio context, releasing any system audio resources that it uses.
 
-Closed contexts cannot have new nodes created, but can decode audio data, create buffers, etc.
-
 This function does not automatically release all `AudioContext`-created objects, unless other references have been released as well; however, it will forcibly release any system audio resources that might prevent additional `AudioContexts` from being created and used, suspend the progression of audio time in the audio context, and stop processing audio data. The returned {{jsxref("Promise")}} resolves when all `AudioContext`-creation-blocking resources have been released. This method throws an `INVALID_STATE_ERR` exception if called on an {{domxref("OfflineAudioContext")}}.
 
 ## Syntax


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
It is still possible to create `AudioNode`s on `"closed"` `AudioContext`. It's useless, because it won't render anything, but it won't throw or anything.

#### Motivation
This is simply incorrect. The behaviour changed in 2018.

#### Supporting details
Source: myself (Web Audio API spec editor), [spec change](https://github.com/WebAudio/web-audio-api/pull/1704/commits/29db014ddc526f63a58d9352424d17dc0329fed5), [spec discussion](https://github.com/WebAudio/web-audio-api/issues/1580)

#### Related issues
None.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
