### PR TITLE
Fix embedded example scrollbars

### DIFF
--- a/files/en-us/learn/accessibility/test_your_skills_colon__html_accessibility/index.md
+++ b/files/en-us/learn/accessibility/test_your_skills_colon__html_accessibility/index.md
@@ -24,7 +24,7 @@ We want you to update it use appropriate semantic HTML. You don't need to worry 
 
 Try updating the live code below to recreate the finished example:
 
-{{EmbedGHLiveSample("learning-area/accessibility/tasks/html-css/html/html-a11y1.html", '100%', 700)}}
+{{EmbedGHLiveSample("learning-area/accessibility/tasks/html-css/html/html-a11y1.html", '100%', 1100)}}
 
 > **Callout:**
 >
@@ -71,7 +71,7 @@ In our final HTML accessibility task, you are given a simple image gallery, whic
 
 Try updating the live code below to recreate the finished example:
 
-{{EmbedGHLiveSample("learning-area/accessibility/tasks/html-css/html/html-a11y4.html", '100%', 700)}}
+{{EmbedGHLiveSample("learning-area/accessibility/tasks/html-css/html/html-a11y4.html", '100%', 1100)}}
 
 > **Callout:**
 >

--- a/files/en-us/learn/css/building_blocks/advanced_styling_effects/index.md
+++ b/files/en-us/learn/css/building_blocks/advanced_styling_effects/index.md
@@ -178,7 +178,7 @@ In the example below we have used two different values for filter. The `first` i
 
 The second is `grayscale()`; by using a percentage we are setting how much color we want to be removed.
 
-{{EmbedGHLiveSample("css-examples/learn/images/filter.html", '100%', 700)}}
+{{EmbedGHLiveSample("css-examples/learn/images/filter.html", '100%', 900)}}
 
 **Play with the percentage and pixel parameters in the live example to see how the images change. You could also swap the values for some others. Try `contrast(200%)`, `invert(100%)` or `hue-rotate(20deg)` on the live example above. Take a look at the MDN page for [`filter`](/en-US/docs/Web/CSS/filter) for many other options you could try.**
 
@@ -186,7 +186,7 @@ You can apply filters to any element and not just images. Some of the filter opt
 
 In this next example we are applying our filter to a box, and comparing it to a box shadow. As you can see, the drop-shadow filter follows the exact shape of the text and border dashes. The box shadow just follows the square of the box.
 
-{{EmbedGHLiveSample("css-examples/learn/images/filter-text.html", '100%', 600)}}
+{{EmbedGHLiveSample("css-examples/learn/images/filter-text.html", '100%', 700)}}
 
 ## Blend modes
 
@@ -232,7 +232,7 @@ div {
 
 The result we get is this — you can see the original on the left, and the multiply blend mode on the right:
 
-{{ EmbedLiveSample('background-blend-mode', '100%', 200) }}
+{{ EmbedLiveSample('background-blend-mode', '100%', 300) }}
 
 ### mix-blend-mode
 
@@ -299,7 +299,7 @@ article div:last-child {
 
 This gives us the following results:
 
-{{ EmbedLiveSample('mix-blend-mode', '100%', 200) }}
+{{ EmbedLiveSample('mix-blend-mode', '100%', 300) }}
 
 You can see here that the multiply mix blend has blended together not only the two background images, but also the color from the `<div>` below it too.
 

--- a/files/en-us/learn/css/building_blocks/backgrounds_and_borders/index.md
+++ b/files/en-us/learn/css/building_blocks/backgrounds_and_borders/index.md
@@ -63,7 +63,7 @@ In the example below, we have used various color values to add a background colo
 
 **Play around with these, using any available [\<color>](/en-US/docs/Web/CSS/color_value) value.**
 
-{{EmbedGHLiveSample("css-examples/learn/backgrounds-borders/color.html", '100%', 600)}}
+{{EmbedGHLiveSample("css-examples/learn/backgrounds-borders/color.html", '100%', 700)}}
 
 ### Background images
 
@@ -71,7 +71,7 @@ The {{cssxref("background-image")}} property enables the display of an image in 
 
 This example demonstrates two things about background images. By default, the large image is not scaled down to fit the box, so we only see a small corner of it, whereas the small image is tiled to fill the box.
 
-{{EmbedGHLiveSample("css-examples/learn/backgrounds-borders/background-image.html", '100%', 600)}}
+{{EmbedGHLiveSample("css-examples/learn/backgrounds-borders/background-image.html", '100%', 700)}}
 
 **If you specify a background color in addition to a background image then the image displays on top of the color. Try adding a `background-color` property to the example above to see that in action.**
 
@@ -169,7 +169,7 @@ You can read more about the different types of gradients and things you can do w
 
 Try some different gradients in the example below. In the two boxes respectively, we have a linear gradient that is stretched over the whole box, and a radial gradient with a set size, which therefore repeats.
 
-{{EmbedGHLiveSample("css-examples/learn/backgrounds-borders/gradients.html", '100%', 600)}}
+{{EmbedGHLiveSample("css-examples/learn/backgrounds-borders/gradients.html", '100%', 700)}}
 
 ### Multiple background images
 
@@ -216,7 +216,7 @@ There are a few rules that need to be followed when writing background image sho
 
 Take a look at the MDN page for {{cssxref("background")}} to see all of the considerations.
 
-{{EmbedGHLiveSample("css-examples/learn/backgrounds-borders/background.html", '100%', 600)}}
+{{EmbedGHLiveSample("css-examples/learn/backgrounds-borders/background.html", '100%', 900)}}
 
 ### Accessibility considerations with backgrounds
 

--- a/files/en-us/learn/css/building_blocks/handling_different_text_directions/index.md
+++ b/files/en-us/learn/css/building_blocks/handling_different_text_directions/index.md
@@ -95,7 +95,7 @@ To make this easier, CSS has recently developed a set of mapped properties. Thes
 
 The property mapped to `width` when in a horizontal writing mode is called {{cssxref("inline-size")}} — it refers to the size in the inline dimension. The property for `height` is named {{cssxref("block-size")}} and is the size in the block dimension. You can see how this works in the example below where we have replaced `width` with `inline-size`.
 
-{{EmbedGHLiveSample("css-examples/learn/writing-modes/inline-size.html", '100%', 950)}}
+{{EmbedGHLiveSample("css-examples/learn/writing-modes/inline-size.html", '100%', 1000)}}
 
 ### Logical margin, border, and padding properties
 
@@ -111,7 +111,7 @@ You can see a comparison between physical and logical properties below.
 
 **You can also see that the {{htmlelement("h2")}} has a black `border-bottom`. Can you work out how to make that bottom border always go below the text in both writing modes?**
 
-{{EmbedGHLiveSample("css-examples/learn/writing-modes/logical-mbp.html", '100%', 1200)}}
+{{EmbedGHLiveSample("css-examples/learn/writing-modes/logical-mbp.html", '100%', 1300)}}
 
 There are a huge number of properties when you consider all of the individual border longhands, and you can see all of the mapped properties on the MDN page for [Logical Properties and Values](/en-US/docs/Web/CSS/CSS_Logical_Properties).
 
@@ -123,7 +123,7 @@ For example, you can float an image left to cause text to wrap round the image. 
 
 **Change the writing mode on this example to `vertical-rl` to see what happens to the image. Change `inline-start` to `inline-end` to change the float.**
 
-{{EmbedGHLiveSample("css-examples/learn/writing-modes/float.html", '100%', 850)}}
+{{EmbedGHLiveSample("css-examples/learn/writing-modes/float.html", '100%', 1000)}}
 
 Here we are also using logical margin values to ensure the margin is in the correct place no matter what the writing mode is.
 

--- a/files/en-us/learn/css/building_blocks/overflow_tasks/index.md
+++ b/files/en-us/learn/css/building_blocks/overflow_tasks/index.md
@@ -21,7 +21,7 @@ The content is overflowing the box because it has a fixed height. Keep the heigh
 
 Try updating the live code below to recreate the finished example:
 
-{{EmbedGHLiveSample("css-examples/learn/tasks/overflow/overflow-scroll.html", '100%', 800)}}
+{{EmbedGHLiveSample("css-examples/learn/tasks/overflow/overflow-scroll.html", '100%', 1000)}}
 
 > **Callout:**
 >
@@ -35,7 +35,7 @@ In this task an image is in the box, it is bigger than the dimensions of the box
 
 Try updating the live code below to recreate the example as displayed in the image:
 
-{{EmbedGHLiveSample("css-examples/learn/tasks/overflow/overflow-hidden.html", '100%', 1100)}}
+{{EmbedGHLiveSample("css-examples/learn/tasks/overflow/overflow-hidden.html", '100%', 1200)}}
 
 > **Callout:**
 >

--- a/files/en-us/learn/css/building_blocks/overflowing_content/index.md
+++ b/files/en-us/learn/css/building_blocks/overflowing_content/index.md
@@ -50,11 +50,11 @@ Let's consider two examples that demonstrate the default behavior of CSS when th
 
 The first example is a box that has been restricted by setting a `height`. Then we add content that exceeds the allocated space. The content overflows the box and falls into the paragraph below.
 
-{{EmbedGHLiveSample("css-examples/learn/overflow/block-overflow.html", '100%', 600)}}
+{{EmbedGHLiveSample("css-examples/learn/overflow/block-overflow.html", '100%', 700)}}
 
 The second example is a word in a box. The box has been made too small for the word and so it breaks out of the box.
 
-{{EmbedGHLiveSample("css-examples/learn/overflow/inline-overflow.html", '100%', 500)}}
+{{EmbedGHLiveSample("css-examples/learn/overflow/inline-overflow.html", '100%', 600)}}
 
 You might wonder why CSS works in such a messy way, displaying content outside of its intended container. Why not hide overflowing content? Why not scale the size of the container to fit all the content?
 
@@ -70,21 +70,21 @@ The {{cssxref("overflow")}} property is how you take control of an element's ove
 
 To crop content when it overflows, you can set `overflow: hidden`. This does exactly what it says: it hides overflow. Beware that this can make some content invisible. You should only do this if hiding content won't cause problems.
 
-{{EmbedGHLiveSample("css-examples/learn/overflow/hidden.html", '100%', 600)}}
+{{EmbedGHLiveSample("css-examples/learn/overflow/hidden.html", '100%', 700)}}
 
 Instead, perhaps you would like to add scrollbars when content overflows? Using `overflow: scroll`, browsers with visible scrollbars will always display them—even if there is not enough content to overflow. This offers the advantage of keeping the layout consistent, instead of scrollbars appearing or disappearing, depending upon the amount of content in the container.
 
 **Remove some content from the box below. Notice how the scrollbars remain, even if there is no need for scrolling.**
 
-{{EmbedGHLiveSample("css-examples/learn/overflow/scroll.html", '100%', 600)}}
+{{EmbedGHLiveSample("css-examples/learn/overflow/scroll.html", '100%', 700)}}
 
 In the example above, we only need to scroll on the `y` axis, however we get scrollbars in both axes. To just scroll on the `y` axis, you could use the {{cssxref("overflow-y")}} property, setting `overflow-y: scroll`.
 
-{{EmbedGHLiveSample("css-examples/learn/overflow/scroll-y.html", '100%', 600)}}
+{{EmbedGHLiveSample("css-examples/learn/overflow/scroll-y.html", '100%', 700)}}
 
 You can also scroll on the x axis using {{cssxref("overflow-x")}}, although this is not a recommended way to accommodate long words! If you have a long word in a small box, you might consider using the {{cssxref("word-break")}} or {{cssxref("overflow-wrap")}} properties. In addition, some of the methods discussed in [Sizing items in CSS](/en-US/docs/Learn/CSS/Building_blocks/Sizing_items_in_CSS) may help you create boxes that scale better with varying amounts of content.
 
-{{EmbedGHLiveSample("css-examples/learn/overflow/scroll-x.html", '100%', 500)}}
+{{EmbedGHLiveSample("css-examples/learn/overflow/scroll-x.html", '100%', 600)}}
 
 As with `scroll`, you get a scrollbar in the scrolling dimension whether or not there is enough content to cause a scrollbar.
 
@@ -94,7 +94,7 @@ If you only want scrollbars to appear when there is more content than can fit in
 
 **In the example below, remove content until it fits into the box. You should see the scrollbars disappear.**
 
-{{EmbedGHLiveSample("css-examples/learn/overflow/auto.html", '100%', 600)}}
+{{EmbedGHLiveSample("css-examples/learn/overflow/auto.html", '100%', 700)}}
 
 ## Overflow establishes a Block Formatting Context
 

--- a/files/en-us/learn/css/building_blocks/selectors/index.md
+++ b/files/en-us/learn/css/building_blocks/selectors/index.md
@@ -85,7 +85,7 @@ h1,
 
 In the live example below try combining the two selectors which have identical declarations. The visual display should be the same after combining them.
 
-{{EmbedGHLiveSample("css-examples/learn/selectors/selector-list.html", '100%', 1000)}}
+{{EmbedGHLiveSample("css-examples/learn/selectors/selector-list.html", '100%', 1100)}}
 
 When you group selectors in this way, if any selector is invalid the whole rule will be ignored.
 

--- a/files/en-us/learn/css/building_blocks/sizing_items_in_css/index.md
+++ b/files/en-us/learn/css/building_blocks/sizing_items_in_css/index.md
@@ -77,7 +77,7 @@ This is because percentages resolve against the size of the containing block. Wi
 
 If you set `margins` and `padding` as a percentage, you may notice some strange behavior. In the below example we have a box. We have given the inner box a {{cssxref("margin")}} of 10% and a {{cssxref("padding")}} of 10%. The padding and margin on the top and bottom of the box are the same size as the margin on the left and right.
 
-{{EmbedGHLiveSample("css-examples/learn/sizing/percent-mp.html", '100%', 700)}}
+{{EmbedGHLiveSample("css-examples/learn/sizing/percent-mp.html", '100%', 800)}}
 
 You might expect for example the percentage top and bottom margins to be a percentage of the element's height, and the percentage left and right margins to be a percentage of the element's width. However, this is not the case!
 

--- a/files/en-us/learn/css/building_blocks/the_box_model/index.md
+++ b/files/en-us/learn/css/building_blocks/the_box_model/index.md
@@ -91,7 +91,7 @@ The second is a list, which is laid out using `display: flex`. This establishes 
 
 Below this, we have a block-level paragraph, inside which are two `<span>` elements. These elements would normally be `inline`, however, one of the elements has a class of block, and we have set it to `display: block`.
 
-{{EmbedGHLiveSample("css-examples/learn/box-model/block.html", '100%', 1050)}}
+{{EmbedGHLiveSample("css-examples/learn/box-model/block.html", '100%', 1100)}}
 
 In the next example, we can see how `inline` elements behave. The `<span>` elements in the first paragraph are inline by default and so do not force line breaks.
 
@@ -101,7 +101,7 @@ Finally, we have two paragraphs both set to `display: inline`. The inline flex c
 
 **In the example, you can change `display: inline` to `display: block` or `display: inline-flex` to `display: flex` to toggle between these display modes.**
 
-{{EmbedGHLiveSample("css-examples/learn/box-model/inline.html", '100%', 1000)}}
+{{EmbedGHLiveSample("css-examples/learn/box-model/inline.html", '100%', 1100)}}
 
 You will encounter things like flex layout later in these lessons; the key thing to remember for now is that changing the value of the `display` property can change whether the outer display type of a box is block or inline, which changes the way it displays alongside other elements in the layout.
 
@@ -179,7 +179,7 @@ In the example below, you can see two boxes. Both have a class of `.box`, which 
 
 **Can you change the size of the second box (by adding CSS to the `.alternate` class) to make it match the first box in width and height?**
 
-{{EmbedGHLiveSample("css-examples/learn/box-model/box-models.html", '100%', 1000)}}
+{{EmbedGHLiveSample("css-examples/learn/box-model/box-models.html", '100%', 1100)}}
 
 > **Note:** You can find a solution for this task [here](https://github.com/mdn/css-examples/blob/master/learn/solutions.md#the-box-model).
 
@@ -208,7 +208,7 @@ We can control all margins of an element at once using the {{cssxref("margin")}}
 
 **In the example below, try changing the margin values to see how the box is pushed around due to the margin creating or removing space (if it is a negative margin) between this element and the containing element.**
 
-{{EmbedGHLiveSample("css-examples/learn/box-model/margin.html", '100%', 700)}}
+{{EmbedGHLiveSample("css-examples/learn/box-model/margin.html", '100%', 800)}}
 
 #### Margin collapsing
 
@@ -218,7 +218,7 @@ In the example below, we have two paragraphs. The top paragraph has a `margin-bo
 
 **You can test this by setting the `margin-top` of paragraph two to 0. The visible margin between the two paragraphs will not change — it retains the 50 pixels set in the `margin-bottom` of paragraph one. If you set it to -10px, you'll see that the overall margin becomes 40px — it subtracts from the 50px.**
 
-{{EmbedGHLiveSample("css-examples/learn/box-model/margin-collapse.html", '100%', 700)}}
+{{EmbedGHLiveSample("css-examples/learn/box-model/margin-collapse.html", '100%', 800)}}
 
 There are a number of rules that dictate when margins do and do not collapse. For further information see the detailed page on [mastering margin collapsing](/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing). The main thing to remember for now is that margin collapsing is a thing that happens. If you are creating space with margins and don't get the space you expect, this is probably what is happening.
 
@@ -277,7 +277,7 @@ We can control the padding on all sides of an element using the {{cssxref("paddi
 
 **You can also change the padding on the class `.container,` which will make space between the container and the box. Padding can be changed on any element, and will make space between its border and whatever is inside the element.**
 
-{{EmbedGHLiveSample("css-examples/learn/box-model/padding.html", '100%', 600)}}
+{{EmbedGHLiveSample("css-examples/learn/box-model/padding.html", '100%', 700)}}
 
 ## The box model and inline boxes
 
@@ -285,7 +285,7 @@ All of the above applies fully to block boxes. Some of the properties can apply 
 
 In the example below, we have a `<span>` inside a paragraph and have applied a `width`, `height`, `margin`, `border`, and `padding` to it. You can see that the width and height are ignored. The vertical margin, padding, and border are respected but they do not change the relationship of other content to our inline box and so the padding and border overlaps other words in the paragraph. Horizontal padding, margins, and borders are respected and will cause other content to move away from the box.
 
-{{EmbedGHLiveSample("css-examples/learn/box-model/inline-box-model.html", '100%', 600)}}
+{{EmbedGHLiveSample("css-examples/learn/box-model/inline-box-model.html", '100%', 700)}}
 
 ## Using display: inline-block
 
@@ -300,7 +300,7 @@ It does not, however, break onto a new line, and will only become larger than it
 
 **In this next example, we have added `display: inline-block` to our `<span>` element. Try changing this to `display: block` or removing the line completely to see the difference in display models.**
 
-{{EmbedGHLiveSample("css-examples/learn/box-model/inline-block.html", '100%', 700)}}
+{{EmbedGHLiveSample("css-examples/learn/box-model/inline-block.html", '100%', 800)}}
 
 Where this can be useful is when you want to give a link a larger hit area by adding `padding`. `<a>` is an inline element like `<span>`; you can use `display: inline-block` to allow padding to be set on it, making it easier for a user to click the link.
 
@@ -308,7 +308,7 @@ You see this fairly frequently in navigation bars. The navigation below is displ
 
 **Add `display: inline-block` to the rule with the `.links-list a` selector, and you will see how it fixes this issue by causing the padding to be respected by other elements.**
 
-{{EmbedGHLiveSample("css-examples/learn/box-model/inline-block-nav.html", '100%', 600)}}
+{{EmbedGHLiveSample("css-examples/learn/box-model/inline-block-nav.html", '100%', 700)}}
 
 ## Test your skills!
 

--- a/files/en-us/learn/css/building_blocks/values_and_units/index.md
+++ b/files/en-us/learn/css/building_blocks/values_and_units/index.md
@@ -227,7 +227,7 @@ The third box uses `em` units. These are relative to the font size. I've set a f
 
 After following the instructions above, try playing with the values in other ways, to see what you get.
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/length.html", '100%', 820)}}
+{{EmbedGHLiveSample("css-examples/learn/values-units/length.html", '100%', 900)}}
 
 #### ems and rems
 
@@ -243,7 +243,7 @@ To start with, we set 16px as the font size on the `<html>` element.
 
 However, if you change the `<html>` `font-size` in the CSS you will see that everything else changes relative to it — both `rem`- and `em`-sized text.
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/em-rem.html", '100%', 1000)}}
+{{EmbedGHLiveSample("css-examples/learn/values-units/em-rem.html", '100%', 1100)}}
 
 ### Percentages
 
@@ -255,11 +255,11 @@ The difference is that the second set of two boxes is inside a wrapper that is 4
 
 **Try changing the width of the wrapper or the percentage value to see how this works.**
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/percentage.html", '100%', 850)}}
+{{EmbedGHLiveSample("css-examples/learn/values-units/percentage.html", '100%', 1000)}}
 
 The next example has font sizes set in percentages. Each `<li>` has a `font-size` of 80%; therefore, the nested list items become progressively smaller as they inherit their sizing from their parent.
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/percentage-fonts.html", '100%', 650)}}
+{{EmbedGHLiveSample("css-examples/learn/values-units/percentage-fonts.html", '100%', 800)}}
 
 Note that, while many value types accept a length or a percentage, there are some that only accept length. You can see which values are accepted on the MDN property reference pages. If the allowed value includes [`<length-percentage>`](/en-US/docs/Web/CSS/length-percentage) then you can use a length or a percentage. If the allowed value only includes `<length>`, it is not possible to use a percentage.
 
@@ -269,7 +269,7 @@ Some value types accept numbers, without any unit added to them. An example of a
 
 **In the below example, try changing the value of `opacity` to various decimal values between `0` and `1` and see how the box and its contents become more or less opaque.**
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/opacity.html", '100%', 500)}}
+{{EmbedGHLiveSample("css-examples/learn/values-units/opacity.html", '100%', 600)}}
 
 > **Note:** When you use a number in CSS as a value it should not be surrounded in quotes.
 
@@ -287,7 +287,7 @@ Quite often in examples here in the learn section or elsewhere on MDN you will s
 
 **Try playing with different color values in the live examples below, to get more of an idea how they work.**
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/color-keywords.html", '100%', 700)}}
+{{EmbedGHLiveSample("css-examples/learn/values-units/color-keywords.html", '100%', 800)}}
 
 ### Hexadecimal RGB values
 
@@ -295,7 +295,7 @@ The next type of color value you are likely to encounter is hexadecimal codes. E
 
 These values are a bit more complex and less easy to understand, but they are a lot more versatile than keywords — you can use hex values to represent any color you want to use in your color scheme.
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/color-hex.html", '100%', 700)}}
+{{EmbedGHLiveSample("css-examples/learn/values-units/color-hex.html", '100%', 800)}}
 
 **Again, try changing the values to see how the colors vary.**
 
@@ -305,7 +305,7 @@ The third scheme we'll talk about here is RGB. An RGB value is a function — `r
 
 Let's rewrite our last example to use RGB colors:
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/color-rgb.html", '100%', 700)}}
+{{EmbedGHLiveSample("css-examples/learn/values-units/color-rgb.html", '100%', 800)}}
 
 You can also use RGBA colors — these work in exactly the same way as RGB colors, and so you can use any RGB values. However, there is a fourth value that represents the alpha channel of the color, which controls opacity. If you set this value to `0` it will make the color fully transparent, whereas `1` will make it fully opaque. Values in between give you different levels of transparency.
 
@@ -313,7 +313,7 @@ You can also use RGBA colors — these work in exactly the same way as RGB color
 
 In the example below, we have added a background image to the containing block of our colored boxes. We have then set the boxes to have different opacity values — notice how the background shows through more when the alpha channel value is smaller.
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/color-rgba.html", '100%', 770)}}
+{{EmbedGHLiveSample("css-examples/learn/values-units/color-rgba.html", '100%', 900)}}
 
 **In this example, try changing the alpha channel values to see how it affects the color output.**
 
@@ -329,11 +329,11 @@ Slightly less well-supported than RGB is the HSL color model (not supported on o
 
 We can update the RGB example to use HSL colors like this:
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/color-hsl.html", '100%', 700)}}
+{{EmbedGHLiveSample("css-examples/learn/values-units/color-hsl.html", '100%', 800)}}
 
 Just as RGB has RGBA, HSL has an HSLA equivalent, which gives you the same ability to specify the alpha channel. I've demonstrated this below by changing my RGBA example to use HSLA colors.
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/color-hsla.html", '100%', 770)}}
+{{EmbedGHLiveSample("css-examples/learn/values-units/color-hsla.html", '100%', 900)}}
 
 You can use any of these color values in your projects. It is likely that for most projects you will decide on a color palette and then use those colors — and your chosen method of specifying color — throughout the whole project. You can mix and match color models, however for consistency it is usually best if your entire project uses the same one!
 
@@ -343,7 +343,7 @@ The [`<image>`](/en-US/docs/Web/CSS/image) value type is used wherever an image 
 
 In the example below, we have demonstrated an image and a gradient in use as a value for the CSS `background-image` property.
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/image.html", '100%', 740)}}
+{{EmbedGHLiveSample("css-examples/learn/values-units/image.html", '100%', 900)}}
 
 > **Note:** there are some other possible values for `<image>`, however these are newer and currently have poor browser support. Check out the page on MDN for the [`<image>`](/en-US/docs/Web/CSS/image) data type if you want to read about them.
 
@@ -355,7 +355,7 @@ A typical position value consists of two values — the first sets the position 
 
 In the following example we have positioned a background image 40px from the top and to the right of the container using a keyword.
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/position.html", '100%', 720)}}
+{{EmbedGHLiveSample("css-examples/learn/values-units/position.html", '100%', 800)}}
 
 **Play around with these values to see how you can push the image around.**
 
@@ -365,7 +365,7 @@ Throughout the examples above, we've seen places where keywords are used as a va
 
 There are places where you use strings in CSS. For example [when specifying generated content](/en-US/docs/Learn/CSS/Building_blocks/Selectors/Pseudo-classes_and_pseudo-elements#generating_content_with_before_and_after). In this case, the value is quoted to demonstrate that it is a string. In the below example we use unquoted color keywords along with a quoted generated content string.
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/strings-idents.html", '100%', 550)}}
+{{EmbedGHLiveSample("css-examples/learn/values-units/strings-idents.html", '100%', 600)}}
 
 ## Functions
 
@@ -375,7 +375,7 @@ A value that behaves more like something you might find in a traditional program
 
 For example, below we are using `calc()` to make the box `20% + 100px` wide. The 20% is calculated from the width of the parent container `.wrapper` and so will change if that width changes. We can't do this calculation beforehand because we don't know what 20% of the parent will be, so we use `calc()` to tell the browser to do it for us.
 
-{{EmbedGHLiveSample("css-examples/learn/values-units/calc.html", '100%', 450)}}
+{{EmbedGHLiveSample("css-examples/learn/values-units/calc.html", '100%', 500)}}
 
 ## Test your skills!
 

--- a/files/en-us/learn/css/css_layout/flexbox_skills/index.md
+++ b/files/en-us/learn/css/css_layout/flexbox_skills/index.md
@@ -70,7 +70,7 @@ In this final task arrange these items into rows as in the image.
 
 Try updating the live code below to recreate the finished example:
 
-{{EmbedGHLiveSample("css-examples/learn/tasks/flexbox/flexbox4.html", '100%', 800)}}
+{{EmbedGHLiveSample("css-examples/learn/tasks/flexbox/flexbox4.html", '100%', 1100)}}
 
 > **Callout:**
 >

--- a/files/en-us/learn/css/css_layout/floats_skills/index.md
+++ b/files/en-us/learn/css/css_layout/floats_skills/index.md
@@ -25,7 +25,7 @@ In this task, you need to float the two elements with a class of `float1` and `f
 
 Try updating the live code below to recreate the finished example:
 
-{{EmbedGHLiveSample("css-examples/learn/tasks/float/float1.html", '100%', 700)}}
+{{EmbedGHLiveSample("css-examples/learn/tasks/float/float1.html", '100%', 900)}}
 
 > **Callout:**
 >

--- a/files/en-us/learn/css/css_layout/grid_skills/index.md
+++ b/files/en-us/learn/css/css_layout/grid_skills/index.md
@@ -37,7 +37,7 @@ In this example we already have a grid defined. By editing the CSS rules for the
 
 Try updating the live code below to recreate the finished example:
 
-{{EmbedGHLiveSample("css-examples/learn/tasks/grid/grid2.html", '100%', 800)}}
+{{EmbedGHLiveSample("css-examples/learn/tasks/grid/grid2.html", '100%', 900)}}
 
 Additional questions:
 
@@ -69,7 +69,7 @@ You will need to use both Grid Layout and Flexbox to recreate the example as see
 
 Try updating the code below to create your example:
 
-{{EmbedGHLiveSample("css-examples/learn/tasks/grid/grid4.html", '100%', 1200)}}
+{{EmbedGHLiveSample("css-examples/learn/tasks/grid/grid4.html", '100%', 2000)}}
 
 > **Callout:**
 >

--- a/files/en-us/learn/css/css_layout/grids/index.md
+++ b/files/en-us/learn/css/css_layout/grids/index.md
@@ -284,7 +284,7 @@ body {
 }
 ```
 
-{{ EmbedLiveSample('The_implicit_and_explicit_grid', '100%', 400) }}
+{{ EmbedLiveSample('The_implicit_and_explicit_grid', '100%', 500) }}
 
 ### The minmax() function
 
@@ -598,7 +598,7 @@ aside {
 </div>
 ```
 
-{{ EmbedLiveSample('A_CSS_Grid_grid_framework', '100%', 600) }}
+{{ EmbedLiveSample('Grid frameworks in CSS Grid', '100%', 600) }}
 
 If you use the [Firefox Grid Inspector](/en-US/docs/Tools/Page_Inspector/How_to/Examine_grid_layouts) to overlay the grid lines on your design, you can see how our 12-column grid works.
 

--- a/files/en-us/learn/css/css_layout/introduction/index.md
+++ b/files/en-us/learn/css/css_layout/introduction/index.md
@@ -636,7 +636,7 @@ form p {
 
 This gives us the following result:
 
-{{ EmbedLiveSample('Table_layout', '100%', '170') }}
+{{ EmbedLiveSample('Table_layout', '100%', '200') }}
 
 You can also see this example live at [css-tables-example.html](https://mdn.github.io/learning-area/css/styling-boxes/box-model-recap/css-tables-example.html) (see the [source code](https://github.com/mdn/learning-area/blob/main/css/styling-boxes/box-model-recap/css-tables-example.html) too.)
 
@@ -686,7 +686,7 @@ body { max-width: 800px; margin: 0 auto; }
 }
 ```
 
-{{ EmbedLiveSample('Multi-column_layout', '100%', 200) }}
+{{ EmbedLiveSample('Multi-column_layout', '100%', 250) }}
 
 ## Summary
 

--- a/files/en-us/learn/css/css_layout/position_skills/index.md
+++ b/files/en-us/learn/css/css_layout/position_skills/index.md
@@ -38,7 +38,7 @@ In the below example if you scroll the box the sidebar scrolls with the content.
 
 Try updating the live code below to recreate the finished example:
 
-{{EmbedGHLiveSample("css-examples/learn/tasks/position/position2.html", '100%', 1000)}}
+{{EmbedGHLiveSample("css-examples/learn/tasks/position/position2.html", '100%', 1300)}}
 
 > **Callout:**
 >

--- a/files/en-us/learn/css/first_steps/getting_started/index.md
+++ b/files/en-us/learn/css/first_steps/getting_started/index.md
@@ -245,7 +245,7 @@ a:hover {
 
 In the live example below, you can play with different values for the various states of a link. I have added the rules above to it, and now realize that the pink color is quite light and hard to read — why not change that to a better color? Can you make the links bold?
 
-{{EmbedGHLiveSample("css-examples/learn/getting-started/started3.html", '100%', 900)}}
+{{EmbedGHLiveSample("css-examples/learn/getting-started/started3.html", '100%', 1000)}}
 
 We have removed the underline on our link on hover. You could remove the underline from all states of a link. It is worth remembering however that in a real site, you want to ensure that visitors know that a link is a link. Leaving the underline in place can be an important clue for people to realize that some text inside a paragraph can be clicked on — this is the behavior they are used to. As with everything in CSS, there is the potential to make the document less accessible with your changes — we will aim to highlight potential pitfalls in appropriate places.
 

--- a/files/en-us/learn/css/styling_text/styling_links/index.md
+++ b/files/en-us/learn/css/styling_text/styling_links/index.md
@@ -78,7 +78,7 @@ p {
 }
 ```
 
-{{ EmbedLiveSample('Default_styles', '100%', 120) }}
+{{ EmbedLiveSample('Default_styles', '100%', 130) }}
 
 > **Note:** All the links in the examples on this page are fake links — a `#` (hash/pound sign) is put in place of the real URL. This is because if the real links were included, clicking on them would break the examples (you'd end up with an error or a page loaded in the embedded example that you couldn't get back from.) `#` just links to the current page.
 
@@ -209,7 +209,7 @@ Firefox</a>, <a href="#">Google Chrome</a>, and
 
 Putting the two together gives us this result:
 
-{{ EmbedLiveSample('Styling_some_links', '100%', 150) }}
+{{ EmbedLiveSample('Styling_some_links', '100%', 200) }}
 
 So what did we do here? This certainly looks different to the default styling, but it still provides a familiar enough experience for users to know what's going on:
 
@@ -439,7 +439,7 @@ a:active {
 
 This gives us the following result:
 
-{{ EmbedLiveSample('Styling_links_as_buttons', '100%', 100) }}
+{{ EmbedLiveSample('Styling_links_as_buttons', '100%', 120) }}
 
 Let's explain what's going on here, focusing on the most interesting parts:
 

--- a/files/en-us/learn/html/introduction_to_html/advanced_text_formatting/index.md
+++ b/files/en-us/learn/html/introduction_to_html/advanced_text_formatting/index.md
@@ -626,7 +626,7 @@ You will occasionally need to use superscript and subscript when marking up item
 
 The output of this code looks like so:
 
-{{ EmbedLiveSample('Superscript_and_subscript', '100%', '141px') }}
+{{ EmbedLiveSample('Superscript_and_subscript', '100%', 160) }}
 
 ## Representing computer code
 
@@ -660,7 +660,7 @@ para.onclick = function() {
 
 The above code will look like so:
 
-{{ EmbedLiveSample('Representing_computer_code','100%',300) }}
+{{ EmbedLiveSample('Representing_computer_code','100%',350) }}
 
 ## Marking up times and dates
 

--- a/files/en-us/learn/html/introduction_to_html/document_and_website_structure/index.md
+++ b/files/en-us/learn/html/introduction_to_html/document_and_website_structure/index.md
@@ -241,7 +241,7 @@ and his markup didn't read very well.</p>
 
 Without the `<br>` elements, the paragraph would just be rendered in one long line (as we said earlier in the course, [HTML ignores most whitespace](/en-US/docs/Learn/HTML/Introduction_to_HTML/Getting_started#whitespace_in_html)); with `<br>` elements in the code, the markup renders like this:
 
-{{EmbedLiveSample('br_the_line_break_element', '100%', '125px')}}
+{{EmbedLiveSample('br_the_line_break_element', '100%', 150)}}
 
 #### \<hr>: the thematic break element
 

--- a/files/en-us/learn/html/introduction_to_html/index.md
+++ b/files/en-us/learn/html/introduction_to_html/index.md
@@ -14,7 +14,7 @@ tags:
 ---
 {{LearnSidebar}}
 
-At its heart, {{glossary("HTML")}} is a fairly simple language made up of {{Glossary("Element","elements")}}, which can be applied to pieces of text to give them different meaning in a document (Is it a paragraph? Is it a bulleted list? Is it part of a table?), structure a document into logical sections (Does it have a header? Three columns of content? A navigation menu?), and embed content such as images and videos into a page. This module will introduce the first two of these and introduce fundamental concepts and syntax you need to know to understand HTML.
+At its heart, {{glossary("HTML")}} is a language made up of {{Glossary("Element","elements")}}, which can be applied to pieces of text to give them different meaning in a document (Is it a paragraph? Is it a bulleted list? Is it part of a table?), structure a document into logical sections (Does it have a header? Three columns of content? A navigation menu?), and embed content such as images and videos into a page. This module will introduce the first two of these and introduce fundamental concepts and syntax you need to know to understand HTML.
 
 > **Callout:**
 >

--- a/files/en-us/learn/html/introduction_to_html/test_your_skills_colon__links/index.md
+++ b/files/en-us/learn/html/introduction_to_html/test_your_skills_colon__links/index.md
@@ -48,7 +48,7 @@ In this task we want you to fill in the four links so that they link to the appr
 
 Try updating the live code below to recreate the finished example:
 
-{{EmbedGHLiveSample("learning-area/html/introduction-to-html/tasks/links/links2.html", '100%', 700)}}
+{{EmbedGHLiveSample("learning-area/html/introduction-to-html/tasks/links/links2.html", '100%', 800)}}
 
 > **Callout:**
 >

--- a/files/en-us/learn/html/multimedia_and_embedding/images_in_html/test_your_skills_colon__html_images/index.md
+++ b/files/en-us/learn/html/multimedia_and_embedding/images_in_html/test_your_skills_colon__html_images/index.md
@@ -39,7 +39,7 @@ In this task you already have a full-featured image, but we'd like you to add a 
 
 Try updating the live code below to recreate the finished example:
 
-{{EmbedGHLiveSample("learning-area/html/multimedia-and-embedding/tasks/images/images2.html", '100%', 700)}}
+{{EmbedGHLiveSample("learning-area/html/multimedia-and-embedding/tasks/images/images2.html", '100%', 1000)}}
 
 > **Callout:**
 >
@@ -51,7 +51,7 @@ In this final task you are provided with both a full-featured image and some cap
 
 Try updating the live code below to recreate the finished example:
 
-{{EmbedGHLiveSample("learning-area/html/multimedia-and-embedding/tasks/images/images3.html", '100%', 700)}}
+{{EmbedGHLiveSample("learning-area/html/multimedia-and-embedding/tasks/images/images3.html", '100%', 1000)}}
 
 > **Callout:**
 >

--- a/files/en-us/learn/javascript/building_blocks/test_your_skills_colon__events/index.md
+++ b/files/en-us/learn/javascript/building_blocks/test_your_skills_colon__events/index.md
@@ -48,7 +48,7 @@ Now we'll look at keyboard events. To pass this assessment you need to build an 
 
 Try updating the live code below to recreate the finished example:
 
-{{EmbedGHLiveSample("learning-area/javascript/building-blocks/tasks/events/events2.html", '100%', 400)}}
+{{EmbedGHLiveSample("learning-area/javascript/building-blocks/tasks/events/events2.html", '100%', 650)}}
 
 > **Callout:**
 >
@@ -62,7 +62,7 @@ We want you to solve this without looping through all the buttons and giving eac
 
 Try updating the live code below to recreate the finished example:
 
-{{EmbedGHLiveSample("learning-area/javascript/building-blocks/tasks/events/events3.html", '100%', 400)}}
+{{EmbedGHLiveSample("learning-area/javascript/building-blocks/tasks/events/events3.html", '100%', 600)}}
 
 > **Callout:**
 >

--- a/files/en-us/learn/javascript/first_steps/test_your_skills_colon__math/index.md
+++ b/files/en-us/learn/javascript/first_steps/test_your_skills_colon__math/index.md
@@ -59,7 +59,7 @@ Try updating the live code below to recreate the finished example, following the
 
 In the final task for this article, we want you to write some tests. You've got three groups, each consisting of a statement and two variables. For each one, write a test that proves or disproves the statement made. Store the results of those tests in variables called `weightComparison`, `heightComparison`, and `pwdMatch`, respectively.
 
-{{EmbedGHLiveSample("learning-area/javascript/introduction-to-js-1/tasks/math/math3.html", '100%', 400)}}
+{{EmbedGHLiveSample("learning-area/javascript/introduction-to-js-1/tasks/math/math3.html", '100%', 550)}}
 
 > **Callout:**
 >

--- a/files/en-us/learn/javascript/first_steps/useful_string_methods/index.md
+++ b/files/en-us/learn/javascript/first_steps/useful_string_methods/index.md
@@ -556,7 +556,7 @@ textarea.onkeyup = function(){
 };
 ```
 
-{{ EmbedLiveSample('Fixing_capitalization', '100%', 550) }}
+{{ EmbedLiveSample('Fixing_capitalization', '100%', 570) }}
 
 ### Making new strings from old parts
 


### PR DESCRIPTION
The Learn area has these hacky little embedded code editors that use `EmbedLiveSample` and sometimes `EmbedGHLiveSample`. Without wishing to go into how awful this bit of infrastructure is, sometimes the iframe is too small for the embedded editor, and we get an external scrollbar on it, and sometimes that even means the buttons in the editor are hidden.

In this PR I've tried to fix it throughout the Learn area - at least through Getting Started, HTML, CSS, JS, Accessibility, which is where most (all?) of these things are to be found.

I also:

* tweaked a few normal `EmbedLiveSample` calls that are overflowing their iframe
* removed "fairly simple" because it's nails on a chalkboard
* fixed [a reference to an `EmbedLiveSample`](https://github.com/mdn/content/compare/main...wbamberg:editor-scrollbars?expand=1#diff-f6b92cb9399f7c6a8d6874c117dd718ffa1a2e8175023722583ddca7d083376f) - interestingly this does not break on prod, because that uses the (Auto)EmbedLiveSample fallback when the referenced section isn't found, but this doesn't happen in the `yarn start` version. It's unfortunate that we have these divergent code paths.
