### PR TITLE
URLSearchParams does not support nesting

### DIFF
--- a/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
+++ b/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
@@ -30,7 +30,7 @@ new URLSearchParams(init)
   - : One of:
     - A string, which will be parsed from `application/x-www-form-urlencoded` format. A leading `'?'` character is ignored.
     - A literal sequence of name-value string pairs, or any object — such as a {{domxref("FormData")}} object — with an [iterator](/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#iterators) that produces a sequence of string pairs. Note that {{domxref("File")}} entries will be serialized as `[object File]` rather than as their filename (as they would in an `application/x-www-form-urlencoded` form).
-    - A record of string keys and string values.
+    - A record of string keys and string values. Note that nesting is not supported.
 
 ### Return value
 
@@ -39,7 +39,7 @@ A {{domxref("URLSearchParams")}} object instance.
 ## Examples
 
 The following example shows how to create a {{domxref("URLSearchParams")}} object from
-a URL string.
+various inputs.
 
 ```js
 // Retrieve params via url.search, passed into ctor


### PR DESCRIPTION
#### Summary
Document that constructing a URLSearchParams from a record does not support nested records.

Also fix what the object was creating from in [Examples](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams#examples).

#### Motivation
This was undocumented, and several very popular modules a [deprecating themselves](https://github.com/sindresorhus/query-string/issues/307) in favor of `URLSearchParams`.

#### Metadata

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
