### PR TITLE
Doc: Fix nested console.log bug in code example

### DIFF
--- a/files/en-us/learn/javascript/objects/object_prototypes/index.md
+++ b/files/en-us/learn/javascript/objects/object_prototypes/index.md
@@ -137,7 +137,7 @@ myDate.getYear = function() {
   console.log('something else!')
 };
 
-console.log(myDate.getYear()); // 'something else!'
+myDate.getYear(); // 'something else!'
 ```
 
 This should be predictable, given the description of the prototype chain. When we call `getYear()` the browser first looks in `myDate` for a property with that name, and only checks the prototype if `myDate` does not define it. So when we add `getYear()` to `myDate`, then the version in `myDate` is called.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fixed inaccurate console.log command. Line 140 console.log(myDate.getYear()); produces undefined because myDate.getYear() has a console.log command in it which results in a nested console.log command of console.log(console.log('something else!'))

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Bug fix

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
