### PR TITLE
Use JSON replacer and reviver in BigInt examples

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/bigint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/index.md
@@ -231,17 +231,41 @@ The operations supported on BigInt values are not constant-time, and are thus op
 
 ### Use within JSON
 
-Using [`JSON.stringify()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) with any BigInt value will raise a `TypeError`, as BigInt values aren't serialized in JSON by default. However, you can implement your own `toJSON` method:
+Using [`JSON.stringify()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) with any BigInt value will raise a `TypeError`, as BigInt values aren't serialized in JSON by default. However, you can use the [replacer](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#the_replacer_parameter) parameter of `JSON.stringify` to serialize BigInt properties without error:
 
 ```js
-BigInt.prototype.toJSON = function() { return this.toString()  }
+function replacer(key, value) {
+  if (key === 'big') {
+    return value.toString();
+  }
+  return value;
+}
+
+const data = {
+  number: 1,
+  big: BigInt('18014398509481982'),
+};
+const stringified = JSON.stringify(data, replacer);
+
+console.log(stringified);
+// ↪ '{"number":1,"big":"18014398509481982"}'
 ```
 
-Instead of throwing, `JSON.stringify` now produces a string like this:
+If you have JSON data containing values you know will be large integers, you can use the [reviver](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#using_the_reviver_parameter) parameter of `JSON.parse` to handle them:
 
 ```js
-JSON.stringify(BigInt(1))
-// '"1"'
+function reviver(key, value) {
+  if (key === 'big') {
+    return BigInt(value);
+  }
+  return value;
+}
+
+const payload = '{"number":1,"big":"18014398509481982"}';
+const parsed = JSON.parse(payload, reviver);
+
+console.log(parsed);
+// ↪ {number: 1, big: 18014398509481982n}
 ```
 
 ## Examples


### PR DESCRIPTION
#### Summary

The [BigInt documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) currently contains this example code in order to serialize BigInt objects to JSON:

```js
BigInt.prototype.toJSON = function() { return this.toString()  }
```

This PR replaces that example with one using `JSON.stringify(object, replacer)` to avoid modifying global prototypes. It also adds a section using `JSON.parse(payload, reviver)` to demonstrate getting BigInts _out_ of JSON.

#### Motivation

1. Docs should not encourage modifying a global object's prototype other than correctly polyfilling behaviour
2. Using replacer and reviver allows parsing BigInts from JSON, not only stringifying them

#### Related issues

Fixes #14676

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
