### PR TITLE
WebAPI: updated constructor pages part 5

### DIFF
--- a/files/en-us/web/api/audioworkletnode/audioworkletnode/index.md
+++ b/files/en-us/web/api/audioworkletnode/audioworkletnode/index.md
@@ -77,7 +77,7 @@ If `outputChannelCount` isn't specified, and `numberOfInputs` and `numberOfOutpu
 
 Otherwise, if `outputChannelCount` is provided *and* if the values of `numberOfInputs` and `numberOfOutputs` are both 1, the audio worklet node's channel count is set to the value of `outputChannelCount`. Otherwise, the channel count of each channel in the set of output channels is set to match the corresponding value in the `outputChannelCount` array.
 
-## Example
+## Examples
 
 _For a complete example demonstrating user-defined audio processing, see the
 {{domxref("AudioWorkletNode")}} page._

--- a/files/en-us/web/api/audioworkletprocessor/audioworkletprocessor/index.md
+++ b/files/en-us/web/api/audioworkletprocessor/audioworkletprocessor/index.md
@@ -60,7 +60,7 @@ new AudioWorkletProcessor(options);
 
 The newly constructed {{domxref("AudioWorkletProcessor")}} instance.
 
-## Example
+## Examples
 
 In this example we pass custom options to the
 {{domxref("AudioWorkletNode.AudioWorkletNode", "AudioWorkletNode constructor")}} and

--- a/files/en-us/web/api/blob/blob/index.md
+++ b/files/en-us/web/api/blob/blob/index.md
@@ -47,7 +47,7 @@ new Blob(array, options);
 
 A new {{domxref("Blob")}} object containing the specified data.
 
-## Example
+## Examples
 
 ```js
 const array = ['<a id="a"><b id="b">hey!</b></a>']; // an array consisting of a single DOMString

--- a/files/en-us/web/api/broadcastchannel/broadcastchannel/index.md
+++ b/files/en-us/web/api/broadcastchannel/broadcastchannel/index.md
@@ -30,7 +30,7 @@ new BroadcastChannel(channelName);
     single channel with this name for all {{glossary("browsing context", "browsing
     contexts")}} with the same {{glossary("origin")}}.
 
-## Example
+## Examples
 
 ```js
 // create a new channel listening to the "internal_notification" channel.

--- a/files/en-us/web/api/channelmergernode/channelmergernode/index.md
+++ b/files/en-us/web/api/channelmergernode/channelmergernode/index.md
@@ -52,7 +52,7 @@ A new {{domxref("ChannelMergerNode")}} object instance.
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if an option such as `channelCount` or `channelCountMode` has been given an invalid value.
 
-## Example
+## Examples
 
 ```js
 var ac = new AudioContext();

--- a/files/en-us/web/api/channelsplitternode/channelsplitternode/index.md
+++ b/files/en-us/web/api/channelsplitternode/channelsplitternode/index.md
@@ -49,7 +49,7 @@ new ChannelSpitterNode(context, options);
 
 A new {{domxref("ChannelSplitterNode")}} object instance.
 
-## Example
+## Examples
 
 ```js
 var ac = new AudioContext();

--- a/files/en-us/web/api/constantsourcenode/constantsourcenode/index.md
+++ b/files/en-us/web/api/constantsourcenode/constantsourcenode/index.md
@@ -38,7 +38,7 @@ new ConstantSourceNode(context, options);
       \-1.0 to 1.0, but the value can be anywhere in the range from
       `-Infinity` to `+Infinity`.
 
-## Example
+## Examples
 
 In this example, an audio context is created, then a `ConstantSourceNode` is
 established with its `offset` initialized to 0.5.

--- a/files/en-us/web/api/delaynode/delaynode/index.md
+++ b/files/en-us/web/api/delaynode/delaynode/index.md
@@ -56,7 +56,7 @@ new DelayNode(context, options);
 
 A new {{domxref("DelayNode")}} object instance.
 
-## Example
+## Examples
 
 ```js
 const audioCtx = new AudioContext();

--- a/files/en-us/web/api/documentfragment/documentfragment/index.md
+++ b/files/en-us/web/api/documentfragment/documentfragment/index.md
@@ -20,7 +20,7 @@ The **`DocumentFragment()`** constructor returns a new, empty
 new DocumentFragment()
 ```
 
-## Example
+## Examples
 
 ```js
 let fragment = new DocumentFragment();

--- a/files/en-us/web/api/dommatrix/dommatrix/index.md
+++ b/files/en-us/web/api/dommatrix/dommatrix/index.md
@@ -33,7 +33,7 @@ new DOMMatrix(init)
     - for a 6-element array of components in the form `[a, b, c, d, e, f]`, a 2D matrix is created, initialized with the provided components.
     - for a 16-element array of components (in the column-major order) in the form `[m11, m12, m13, …, m42, m43, m44]`, a 3D matrix is created, initialized with the provided components.
 
-## Example
+## Examples
 
 This example creates a DOMMatrix to use as an argument for calling
 {{domxref("Point.matrixTransform()")}}.

--- a/files/en-us/web/api/file/file/index.md
+++ b/files/en-us/web/api/file/file/index.md
@@ -40,7 +40,7 @@ new File(bits, name, options);
       between the Unix time epoch and when the file was last modified. Defaults to a
       value of {{jsxref("Date.now()")}}.
 
-## Example
+## Examples
 
 ```js
 var file = new File(["foo"], "foo.txt", {

--- a/files/en-us/web/api/filereader/filereader/index.md
+++ b/files/en-us/web/api/filereader/filereader/index.md
@@ -22,7 +22,7 @@ new FileReader();
 
 None.
 
-## Example
+## Examples
 
 The following code snippet shows creation of a [`FileReader`](/en-US/docs/Web/API/FileReader) object using the `FileReader()` constructor and subsequent usage of the object:
 

--- a/files/en-us/web/api/fontface/fontface/index.md
+++ b/files/en-us/web/api/fontface/fontface/index.md
@@ -61,7 +61,7 @@ new FontFace(family, source, descriptors);
     - `weight`
       - : With an allowable value for {{cssxref("@font-face/font-weight")}}.
 
-## Example
+## Examples
 
 ```js
 async function loadFonts() {

--- a/files/en-us/web/api/formdata/formdata/index.md
+++ b/files/en-us/web/api/formdata/formdata/index.md
@@ -27,7 +27,7 @@ new FormData(form)
 - `form` {{optional_inline}}
   - : An HTML {{HTMLElement("form")}} element — when specified, the {{domxref("FormData")}} object will be populated with the form's current keys/values using the name property of each element for the keys and their submitted value for the values. It will also encode file input content.
 
-## Example
+## Examples
 
 The following line creates an empty {{domxref("FormData")}} object:
 

--- a/files/en-us/web/api/headers/headers/index.md
+++ b/files/en-us/web/api/headers/headers/index.md
@@ -28,7 +28,7 @@ new Headers(init);
     `Headers` object. In the last case, the new `Headers` object
     copies its data from the existing `Headers` object.
 
-## Example
+## Examples
 
 Creating an empty `Headers` object is simple:
 

--- a/files/en-us/web/api/imagecapture/imagecapture/index.md
+++ b/files/en-us/web/api/imagecapture/imagecapture/index.md
@@ -36,7 +36,7 @@ new ImageCapture(videoTrack)
 A new `ImageCapture` object which can be used to capture still frames from
 the specified video track.
 
-## Example
+## Examples
 
 The following example shows how to use a call to
 {{domxref("MediaDevices.getUserMedia()")}} to retrieve the

--- a/files/en-us/web/api/intersectionobserver/intersectionobserver/index.md
+++ b/files/en-us/web/api/intersectionobserver/intersectionobserver/index.md
@@ -75,7 +75,7 @@ Call its {{domxref("IntersectionObserver.observe", "observe()")}} method to begi
 - `RangeError`
   - : One or more of the values in `threshold` is outside the range 0.0 to 1.0.
 
-## Example
+## Examples
 
 This example creates a new intersection observer which calls the function `myObserverCallback` every time the visible area of the element being observed changes by at least 10%.
 

--- a/files/en-us/web/api/mediaelementaudiosourcenode/mediaelementaudiosourcenode/index.md
+++ b/files/en-us/web/api/mediaelementaudiosourcenode/mediaelementaudiosourcenode/index.md
@@ -47,7 +47,7 @@ new MediaElementAudioSourceNode(context, options);
 
 A new {{domxref("MediaElementAudioSourceNode")}} object instance.
 
-## Example
+## Examples
 
 ```js
 var ac = new AudioContext();

--- a/files/en-us/web/api/mediarecorder/mediarecorder/index.md
+++ b/files/en-us/web/api/mediarecorder/mediarecorder/index.md
@@ -70,7 +70,7 @@ new MediaRecorder(stream, options)
 - `NotSupportedError` {{domxref("DOMException")}}
   - : Thrown if the specified MIME type is not supported by the user agent.
 
-## Example
+## Examples
 
 This example shows how to create a media recorder for a specified stream, whose audio
 bit rate is set to 128 Kbit/sec and whose video bit rate is set to 2.5 Mbit/sec. The

--- a/files/en-us/web/api/mediasource/mediasource/index.md
+++ b/files/en-us/web/api/mediasource/mediasource/index.md
@@ -29,7 +29,7 @@ new MediaSource();
 
 None.
 
-## Example
+## Examples
 
 The following snippet is taken from a simple example written by Nick Desaulniers ([view the full demo
 live](https://nickdesaulniers.github.io/netfix/demo/bufferAll.html), or [download

--- a/files/en-us/web/api/mediastreamaudiodestinationnode/mediastreamaudiodestinationnode/index.md
+++ b/files/en-us/web/api/mediastreamaudiodestinationnode/mediastreamaudiodestinationnode/index.md
@@ -46,7 +46,7 @@ new MediaStreamAudioDestinationNode(context, options);
 
 A new {{domxref("MediaStreamAudioDestinationNode")}} object instance.
 
-## Example
+## Examples
 
 ```js
 var ac = new AudioContext();

--- a/files/en-us/web/api/messagechannel/messagechannel/index.md
+++ b/files/en-us/web/api/messagechannel/messagechannel/index.md
@@ -27,7 +27,7 @@ new MessageChannel();
 
 A newly created {{domxref("MessageChannel")}} object.
 
-## Example
+## Examples
 
 In the following code block, you can see a new channel being created using the
 {{domxref("MessageChannel()", "MessageChannel.MessageChannel")}} constructor. When the

--- a/files/en-us/web/api/messageevent/messageevent/index.md
+++ b/files/en-us/web/api/messageevent/messageevent/index.md
@@ -45,7 +45,7 @@ new MessageEvent(type, init)
       appropriate, e.g. in channel messaging or when sending a message to a shared
       worker). This defaults to an empty array (`[]`) if not specified.
 
-## Example
+## Examples
 
 ```js
 var myMessage = new MessageEvent('message', {

--- a/files/en-us/web/api/mutationobserver/mutationobserver/index.md
+++ b/files/en-us/web/api/mutationobserver/mutationobserver/index.md
@@ -53,7 +53,7 @@ new MutationObserver(callback)
 A new {{domxref("MutationObserver")}} object, configured to call the specified
 `callback` when DOM mutations occur.
 
-## Example
+## Examples
 
 This example creates a new `MutationObserver` configured to watch a node and
 all of its children for additions and removals of elements to the tree, as well as any

--- a/files/en-us/web/api/notification/notification/index.md
+++ b/files/en-us/web/api/notification/notification/index.md
@@ -74,7 +74,7 @@ new Notification(title, options);
       notification is silent (no sounds or vibrations issued), regardless of the device
       settings. The default is `false`, which means it won't be silent.
 
-## Example
+## Examples
 
 In our
 [`Emogotchi demo`](https://chrisdavidmills.github.io/emogotchi/)

--- a/files/en-us/web/api/notificationevent/notificationevent/index.md
+++ b/files/en-us/web/api/notificationevent/notificationevent/index.md
@@ -31,7 +31,7 @@ new NotificationEvent(type, NotificationEventInit);
     the notification the event is dispatched on. In later drafts of the specification,
     this parameter is not optional.
 
-## Example
+## Examples
 
 ```js
 var n = new Notification('Hello');

--- a/files/en-us/web/api/offlineaudiocontext/offlineaudiocontext/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/offlineaudiocontext/index.md
@@ -65,7 +65,7 @@ Like a regular `AudioContext`, an
 `OfflineAudioContext` can be the target of events, therefore it implements
 the {{domxref("EventTarget")}} interface.
 
-## Example
+## Examples
 
 ```js
 const offlineCtx = new OfflineAudioContext({

--- a/files/en-us/web/api/oscillatornode/index.md
+++ b/files/en-us/web/api/oscillatornode/index.md
@@ -3,7 +3,6 @@ title: OscillatorNode
 slug: Web/API/OscillatorNode
 tags:
   - API
-  - Constructor
   - Interface
   - Media
   - OscillatorNode

--- a/files/en-us/web/api/pannernode/pannernode/index.md
+++ b/files/en-us/web/api/pannernode/pannernode/index.md
@@ -67,7 +67,7 @@ A new {{domxref("PannerNode")}} object instance.
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the `coneOuterGain` property has been given a value outside the accepted range (0–1).
 
-## Example
+## Examples
 
 ```js
 var ctx = new AudioContext();

--- a/files/en-us/web/api/performanceobserver/performanceobserver/index.md
+++ b/files/en-us/web/api/performanceobserver/performanceobserver/index.md
@@ -38,7 +38,7 @@ new PerformanceObserver(callback);
 A new {{domxref("PerformanceObserver")}} object which will call the specified
 `callback` when observed performance events occur.
 
-## Example
+## Examples
 
 ```js
 var observer = new PerformanceObserver(function(list, obj) {

--- a/files/en-us/web/api/periodicwave/periodicwave/index.md
+++ b/files/en-us/web/api/periodicwave/periodicwave/index.md
@@ -58,7 +58,7 @@ new PeriodicWave(context, options);
 
 A new {{domxref("PeriodicWave")}} object instance.
 
-## Example
+## Examples
 
 ```js
 var real = new Float32Array(2);

--- a/files/en-us/web/api/pointerevent/pointerevent/index.md
+++ b/files/en-us/web/api/pointerevent/pointerevent/index.md
@@ -53,7 +53,7 @@ new PointerEvent(type, PointerEventInit);
     > accepts fields from the {{domxref("MouseEvent.MouseEvent","MouseEvent")}},
     > {{domxref("UIEvent.UIEvent", "UIEventInit")}} and {{domxref("Event.Event", "EventInit")}} dictionaries.
 
-## Example
+## Examples
 
 ```js
 var moveEvent = new PointerEvent("pointermove");

--- a/files/en-us/web/api/pushevent/pushevent/index.md
+++ b/files/en-us/web/api/pushevent/pushevent/index.md
@@ -40,7 +40,7 @@ new PushEvent(type, eventInitDict);
       to a new {{domxref("PushMessageData")}} object containing bytes extracted
       from the `eventInitDict data` member.
 
-## Example
+## Examples
 
 ```js
 var dataInit = {

--- a/files/en-us/web/api/range/range/index.md
+++ b/files/en-us/web/api/range/range/index.md
@@ -23,7 +23,7 @@ object.
 new Range();
 ```
 
-## Example
+## Examples
 
 In this example we create a new range with the `Range()` constructor, and
 set its beginning and end positions using the {{domxref("Range.setStartBefore()")}} and

--- a/files/en-us/web/api/request/request/index.md
+++ b/files/en-us/web/api/request/request/index.md
@@ -102,7 +102,7 @@ new Request(input, init)
   </tbody>
 </table>
 
-## Example
+## Examples
 
 In our [Fetch
 Request example](https://github.com/mdn/fetch-examples/tree/master/fetch-request) (see [Fetch Request live](https://mdn.github.io/fetch-examples/fetch-request/)) we

--- a/files/en-us/web/api/securitypolicyviolationevent/securitypolicyviolationevent/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/securitypolicyviolationevent/index.md
@@ -84,7 +84,7 @@ new SecurityPolicyViolationEvent(type, init);
 
 A `SecurityPolicyViolationEvent` object instance.
 
-## Example
+## Examples
 
 ```js
 let SPVEvt = new SecurityPolicyViolationEvent('foo', {

--- a/files/en-us/web/api/textdecoder/textdecoder/index.md
+++ b/files/en-us/web/api/textdecoder/textdecoder/index.md
@@ -39,7 +39,7 @@ new TextDecoder(utfLabel, options);
         flag indicating if the {{DOMxRef("TextDecoder.decode()")}} method must throw a
         {{jsxref("TypeError")}} when an coding error is found. It defaults to `false`.
 
-## Example
+## Examples
 
 ```js
 var textDecoder1 = new TextDecoder("iso-8859-2");

--- a/files/en-us/web/api/vttcue/vttcue/index.md
+++ b/files/en-us/web/api/vttcue/vttcue/index.md
@@ -47,7 +47,7 @@ new VTTCue(startTime, endTime, text);
 A new {{domxref("VTTCue")}} object representing a cue which will be presented during
 the time span given.
 
-## Example
+## Examples
 
 ```js
 // Create a cue that is shown from 2 to 3 seconds and uses the given text.

--- a/files/en-us/web/api/xrinputsourceschangeevent/xrinputsourceschangeevent/index.md
+++ b/files/en-us/web/api/xrinputsourceschangeevent/xrinputsourceschangeevent/index.md
@@ -58,7 +58,7 @@ the input parameters provided.
 - {{domxref("XRSession.inputsourceschange_event", "inputsourceschange")}}
   - : Delivered to the {{domxref("XRSession")}} when the set of input devices available to it changes.
 
-## Example
+## Examples
 
 The following snippet of code creates a new `XRInputSourcesChangeEvent`
 object indicating that a single new input source, described by an

--- a/files/en-us/web/api/xrmediabinding/xrmediabinding/index.md
+++ b/files/en-us/web/api/xrmediabinding/xrmediabinding/index.md
@@ -36,7 +36,7 @@ A newly-created {{domxref("XRMediaBinding")}}.
     - The {{domxref("XRSession")}} specified by `session` has already been stopped.
     - The specified `session` is not immersive.
 
-## Example
+## Examples
 
 ### Creating a new `XRMediaBinding`
 

--- a/files/en-us/web/api/xrray/xrray/index.md
+++ b/files/en-us/web/api/xrray/xrray/index.md
@@ -43,7 +43,7 @@ A `TypeError` is thrown,
 - if `direction`'s `w` coordinate is not 0.0.
 - if `origin`'s `w` coordinate is not 1.0.
 
-## Example
+## Examples
 
 ### Creating `XRRay` objects
 

--- a/files/en-us/web/api/xrwebglbinding/xrwebglbinding/index.md
+++ b/files/en-us/web/api/xrwebglbinding/xrwebglbinding/index.md
@@ -45,7 +45,7 @@ A newly-created {{domxref("XRWebGLBinding")}}.
     - The specified `session` is immersive but the `context` is
       not WebXR compatible.
 
-## Example
+## Examples
 
 ```js
 const canvasElement = document.querySelector(".output-canvas");

--- a/files/en-us/web/api/xrwebgllayer/xrwebgllayer/index.md
+++ b/files/en-us/web/api/xrwebgllayer/xrwebgllayer/index.md
@@ -79,7 +79,7 @@ are used to tailor the rendering system's configuration.
   - : Thrown if the resources (including memory buffers) needed for the layer to operate could not
     be allocated.
 
-## Example
+## Examples
 
 In this example, a new {{domxref("XRWebGLLayer")}} is created for a WebXR session,
 `xrSession`.


### PR DESCRIPTION
#### Summary
Related to https://github.com/mdn/content/pull/14001

Enforced section names as per the template. https://developer.mozilla.org/en-US/docs/MDN/Structures/Page_types/API_constructor_subpage_template


#### Metadata
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
