### PR TITLE
Nullish coalescing operator for simpler syntax

### DIFF
--- a/files/en-us/web/guide/ajax/getting_started/index.md
+++ b/files/en-us/web/guide/ajax/getting_started/index.md
@@ -279,7 +279,7 @@ function alertContents() {
 The `test.php` file should contain the following:
 
 ```php
-$name = (isset($_POST['userName'])) ? $_POST['userName'] : 'no name';
+$name = $_POST['userName'] ?? 'no name';
 $computedString = "Hi, " . $name . "!";
 $array = ['userName' => $name, 'computedString' => $computedString];
 echo json_encode($array);


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Replaces a ternary operator used with `isset()` with the nullish coalescing operator

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Simpler, updated and more readable syntax added in PHP 7.0. This suggestion was made by a contributor at translated-content. I admit that I’m by no means an expert in PHP so I’m not sure if this is a “good”/correct change.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

PHP docs: https://www.php.net/manual/en/migration70.new-features.php

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
