### PR TITLE
HTTP priority should be set using fetch - deprecate old approach

### DIFF
--- a/files/en-us/mozilla/firefox/releases/1.5/changing_the_priority_of_http_requests/index.md
+++ b/files/en-us/mozilla/firefox/releases/1.5/changing_the_priority_of_http_requests/index.md
@@ -1,14 +1,21 @@
 ---
-title: Changing the Priority of HTTP Requests
+title: Changing the Priority of HTTP Requests (Non-Standard)
 slug: Mozilla/Firefox/Releases/1.5/Changing_the_priority_of_HTTP_requests
 tags:
   - HTTP
 ---
 {{FirefoxSidebar}}
 
+> **Warning:** The approach described in this topic is non-standard, and not recommended.
+>
+> The best way to request resources over HTTP is to use [`fetch()`](/en-US/docs/Web/API/fetch), which allows you to specify the priority in [`Request.priority`](/en-US/docs/Web/API/Request/priority).
+> You can also set the HTTP priority on [`HTMLLinkElement`](/en-US/docs/Web/API/HTMLLinkElement/fetchpriority), [`HTMLIFrameElement`](/en-US/docs/Web/API/HTMLIFrameElement/fetchpriority), and [`HTMLImageElement`](/en-US/docs/Web/API/HTMLImageElement/fetchpriority) elements (and associated tags) using the `fetchpriority` attribute.
+
+
+
 ### Introduction
 
-In [Firefox 1.5](/en-US/docs/Mozilla/Firefox/Releases/1.5) (Gecko 1.8), an API was added to support changing the priority of [HTTP](/en-US/docs/Web/HTTP) requests. Prior to this, there was no way to directly indicate that a request was of a different priority. The API is defined in [nsISupportsPriority](/en-US/docs/nsISupportsPriority), but is defined in very generic terms so that any object can implement this interface to enable the concept of priority. This article deals specifically with using that interface to change the priority of HTTP requests.
+In [Firefox 1.5](/en-US/docs/Mozilla/Firefox/Releases/1.5), an API was added to support changing the priority of [HTTP](/en-US/docs/Web/HTTP) requests. Prior to this, there was no way to directly indicate that a request was of a different priority. The API is defined in [nsISupportsPriority](/en-US/docs/nsISupportsPriority), but is defined in very generic terms so that any object can implement this interface to enable the concept of priority. This article deals specifically with using that interface to change the priority of HTTP requests.
 
 At the time of this writing, changing the priority of an HTTP request only affects the order in which connection attempts are made. This means that the priority only has an effect when there are more connections (to a server) than are allowed.
 


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/1.5/Changing_the_priority_of_HTTP_requests recommends use of a non-standard (Firefox only) way for setting HTTP priorities in Firefox using XMLHTTPRequest. 
The right way to do that is to use `fetch()` or the appropriate HTML attributes.

This makes it clear the approach is non standard and points to the correct approach.

Fixes #14561