### PR TITLE
Update moved URLs with their new locations (part 2)

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_action/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_action/index.md
@@ -47,5 +47,5 @@ For details on how to create icons to use with your browser action, see [Iconogr
 
 The [`webextensions-examples`](https://github.com/mdn/webextensions-examples) repository on GitHub contains two examples of extensions that implement browser actions:
 
-- [bookmark-it](https://github.com/mdn/webextensions-examples/blob/master/bookmark-it/) uses a browser action without a popup
+- [bookmark-it](https://github.com/mdn/webextensions-examples/tree/master/bookmark-it) uses a browser action without a popup
 - [beastify](https://github.com/mdn/webextensions-examples/tree/master/beastify) uses a browser action with a popup

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/devtools_panels/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/devtools_panels/index.md
@@ -66,4 +66,4 @@ For details on how to create icons to use with your developer tools panel, see [
 
 ## Examples
 
-The [webextensions-examples](https://github.com/mdn/webextensions-examples) repository on GitHub includes the [devtools-panels](https://github.com/mdn/webextensions-examples/blob/master/devtools-panels/) example which implements a devtools panel.
+The [webextensions-examples](https://github.com/mdn/webextensions-examples) repository on GitHub includes the [devtools-panels](https://github.com/mdn/webextensions-examples/tree/master/devtools-panels) example which implements a devtools panel.

--- a/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/your_second_webextension/index.md
@@ -101,7 +101,7 @@ Note that all paths given are relative to manifest.json itself.
 
 The extension should have an icon. This will be shown next to the extension's listing in the Add-ons Manager (you can open this by visiting the URL "about:addons"). Our manifest.json promised that we would have an icon for the toolbar at "icons/beasts-48.png".
 
-Create the "icons" directory and save an icon there named "beasts-48.png". You could use [the one from our example](https://github.com/mdn/webextensions-examples/raw/master/beastify/icons/beasts-48.png), which is taken from the [Aha-Soft's Free Retina iconset](https://www.iconfinder.com/iconsets/free-retina-icon-set), and used under the terms of its [license](https://www.aha-soft.com/free-icons/free-retina-icon-set/).
+Create the "icons" directory and save an icon there named "beasts-48.png". You could use [the one from our example](https://raw.githubusercontent.com/mdn/webextensions-examples/master/beastify/icons/beasts-48.png), which is taken from the [Aha-Soft's Free Retina iconset](https://www.iconfinder.com/iconsets/free-retina-icon-set), and used under the terms of its [license](https://www.aha-soft.com/free-icons/free-retina-icon-set/).
 
 If you choose to supply your own icon, It should be 48x48 pixels. You could also supply a 96x96 pixel icon, for high-resolution displays, and if you do this it will be specified as the `96` property of the `icons` object in manifest.json:
 
@@ -116,7 +116,7 @@ If you choose to supply your own icon, It should be 48x48 pixels. You could also
 
 The toolbar button also needs an icon, and our manifest.json promised that we would have an icon for the toolbar at "icons/beasts-32.png".
 
-Save an icon named "beasts-32.png" in the "icons" directory. You could use [the one from our example](https://github.com/mdn/webextensions-examples/raw/master/beastify/icons/beasts-32.png), which is taken from the [IconBeast Lite icon set](http://www.iconbeast.com/free) and used under the terms of its [license](http://www.iconbeast.com/faq/).
+Save an icon named "beasts-32.png" in the "icons" directory. You could use [the one from our example](https://raw.githubusercontent.com/mdn/webextensions-examples/master/beastify/icons/beasts-32.png), which is taken from the [IconBeast Lite icon set](http://www.iconbeast.com/free) and used under the terms of its [license](http://www.iconbeast.com/faq/).
 
 If you don't supply a popup, then a click event is dispatched to your extension when the user clicks the button. If you do supply a popup, the click event is not dispatched, but instead, the popup is opened. We want a popup, so let's create that next.
 

--- a/files/en-us/web/api/element/shadowroot/index.md
+++ b/files/en-us/web/api/element/shadowroot/index.md
@@ -27,7 +27,7 @@ shadow root was attached with its {{DOMxRef("ShadowRoot.mode", "mode")}} set to
 
 The following snippets are taken from our [life-cycle-callbacks](https://github.com/mdn/web-components-examples/tree/master/life-cycle-callbacks)
 example ([see it live
-also](https://mdn.github.io/web-components-examples/life-cycle-callbacks)), which creates an element that displays a square of a size and color
+also](https://mdn.github.io/web-components-examples/life-cycle-callbacks/)), which creates an element that displays a square of a size and color
 specified in the element's attributes.
 
 Inside the `<custom-square>` element's class definition we include

--- a/files/en-us/web/api/idbcursor/source/index.md
+++ b/files/en-us/web/api/idbcursor/source/index.md
@@ -41,7 +41,7 @@ IDBObjectStore {autoIncrement: false, transaction: IDBTransaction, indexNames: D
 The cursor does not require us to select the data based
 on a key; we can just grab all of it. Also note that in each iteration of the loop,
 you can grab data from the current record under the cursor object using `cursor.value.foo`. For a complete working example, see our [IDBCursor
-example](https://github.com/mdn/indexeddb-examples/blob/master/idbcursor) ([view example live](https://mdn.github.io/indexeddb-examples/idbcursor/).)
+example](https://github.com/mdn/indexeddb-examples/tree/master/idbcursor) ([view example live](https://mdn.github.io/indexeddb-examples/idbcursor/).)
 
 ```js
 function displayData() {

--- a/files/en-us/web/api/idbindex/count/index.md
+++ b/files/en-us/web/api/idbindex/count/index.md
@@ -64,7 +64,7 @@ returns.
 Finally, we iterate through each record, and insert the data into an HTML table. For a
 complete working example, see our [IndexedDB-examples
 demo repo](https://github.com/mdn/indexeddb-examples/tree/master/idbindex) ([View the
-example live](https://mdn.github.io/indexeddb-examples/idbindex).)
+example live](https://mdn.github.io/indexeddb-examples/idbindex/).)
 
 ```js
 function displayDataByIndex() {

--- a/files/en-us/web/api/idbindex/get/index.md
+++ b/files/en-us/web/api/idbindex/get/index.md
@@ -69,7 +69,7 @@ the console when its success callback returns.
 Finally, we iterate through each record, and insert the data into an HTML table. For a
 complete working example, see our [IndexedDB-examples
 demo repo](https://github.com/mdn/indexeddb-examples/tree/master/idbindex) ([View the
-example live](https://mdn.github.io/indexeddb-examples/idbindex).)
+example live](https://mdn.github.io/indexeddb-examples/idbindex/).)
 
 ```js
 function displayDataByIndex() {

--- a/files/en-us/web/api/idbindex/getkey/index.md
+++ b/files/en-us/web/api/idbindex/getkey/index.md
@@ -68,7 +68,7 @@ is logged to the console when its success callback returns.
 Finally, we iterate through each record, and insert the data into an HTML table. For a
 complete working example, see our [IndexedDB-examples
 demo repo](https://github.com/mdn/indexeddb-examples/tree/master/idbindex) ([View the
-example live](https://mdn.github.io/indexeddb-examples/idbindex).)
+example live](https://mdn.github.io/indexeddb-examples/idbindex/).)
 
 ```js
 function displayDataByIndex() {

--- a/files/en-us/web/api/idbindex/index.md
+++ b/files/en-us/web/api/idbindex/index.md
@@ -63,7 +63,7 @@ Inherits from: [EventTarget](/en-US/docs/Web/API/EventTarget)
 
 In the following example we open a transaction and an object store, then get the index `lName` from a simple contacts database. We then open a basic cursor on the index using {{domxref("IDBIndex.openCursor")}} — this works the same as opening a cursor directly on an `ObjectStore` using {{domxref("IDBObjectStore.openCursor")}} except that the returned records are sorted based on the index, not the primary key.
 
-Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our [IndexedDB-examples demo repo](https://github.com/mdn/indexeddb-examples/tree/master/idbindex) ([View the example live](https://mdn.github.io/indexeddb-examples/idbindex).)
+Finally, we iterate through each record, and insert the data into an HTML table. For a complete working example, see our [IndexedDB-examples demo repo](https://github.com/mdn/indexeddb-examples/tree/master/idbindex) ([View the example live](https://mdn.github.io/indexeddb-examples/idbindex/).)
 
 ```js
 function displayDataByIndex() {

--- a/files/en-us/web/api/idbindex/keypath/index.md
+++ b/files/en-us/web/api/idbindex/keypath/index.md
@@ -39,7 +39,7 @@ as `lName`.
 Finally, we iterate through each record, and insert the data into an HTML table. For a
 complete working example, see our [IndexedDB-examples
 demo repo](https://github.com/mdn/indexeddb-examples/tree/master/idbindex) ([View the
-example live](https://mdn.github.io/indexeddb-examples/idbindex).)
+example live](https://mdn.github.io/indexeddb-examples/idbindex/).)
 
 ```js
 function displayDataByIndex() {

--- a/files/en-us/web/api/idbindex/multientry/index.md
+++ b/files/en-us/web/api/idbindex/multientry/index.md
@@ -48,7 +48,7 @@ as `false`.
 Finally, we iterate through each record, and insert the data into an HTML table. For a
 complete working example, see our [IndexedDB-examples
 demo repo](https://github.com/mdn/indexeddb-examples/tree/master/idbindex) ([View the
-example live](https://mdn.github.io/indexeddb-examples/idbindex).)
+example live](https://mdn.github.io/indexeddb-examples/idbindex/).)
 
 ```js
 function displayDataByIndex() {

--- a/files/en-us/web/api/idbindex/name/index.md
+++ b/files/en-us/web/api/idbindex/name/index.md
@@ -52,7 +52,7 @@ The name of the index is logged to the console: it should be returned as
 Finally, we iterate through each record, inserting the data into an HTML table. For a
 complete working example, see our [IndexedDB-examples
 demo repo](https://github.com/mdn/indexeddb-examples/tree/master/idbindex) ([View the
-example live](https://mdn.github.io/indexeddb-examples/idbindex)).
+example live](https://mdn.github.io/indexeddb-examples/idbindex/)).
 
 ```js
 function displayDataByIndex() {

--- a/files/en-us/web/api/idbindex/objectstore/index.md
+++ b/files/en-us/web/api/idbindex/objectstore/index.md
@@ -42,7 +42,7 @@ IDBObjectStore { name: "contactsList", keyPath: "id", indexNames: DOMStringList[
 Finally, we iterate through each record, and insert the data into an HTML table. For a
 complete working example, see our [IndexedDB-examples
 demo repo](https://github.com/mdn/indexeddb-examples/tree/master/idbindex) ([View the
-example live](https://mdn.github.io/indexeddb-examples/idbindex).)
+example live](https://mdn.github.io/indexeddb-examples/idbindex/).)
 
 ```js
 function displayDataByIndex() {

--- a/files/en-us/web/api/idbindex/opencursor/index.md
+++ b/files/en-us/web/api/idbindex/opencursor/index.md
@@ -73,7 +73,7 @@ except that the returned records are sorted based on the index, not the primary 
 Finally, we iterate through each record, and insert the data into an HTML table. For a
 complete working example, see our [IndexedDB-examples
 demo repo](https://github.com/mdn/indexeddb-examples/tree/master/idbindex) ([View the
-example live](https://mdn.github.io/indexeddb-examples/idbindex).)
+example live](https://mdn.github.io/indexeddb-examples/idbindex/).)
 
 ```js
 function displayDataByIndex() {

--- a/files/en-us/web/api/idbindex/unique/index.md
+++ b/files/en-us/web/api/idbindex/unique/index.md
@@ -48,7 +48,7 @@ as `false`.
 Finally, we iterate through each record, and insert the data into an HTML table. For a
 complete working example, see our [IndexedDB-examples
 demo repo](https://github.com/mdn/indexeddb-examples/tree/master/idbindex) ([View the
-example live](https://mdn.github.io/indexeddb-examples/idbindex).)
+example live](https://mdn.github.io/indexeddb-examples/idbindex/).)
 
 ```js
 function displayDataByIndex() {

--- a/files/en-us/web/api/idbobjectstore/index/index.md
+++ b/files/en-us/web/api/idbobjectstore/index/index.md
@@ -53,7 +53,7 @@ except that the returned records are sorted based on the index, not the primary 
 
 Finally, we iterate through each record, and insert the data into an HTML table. For a
 complete working example, see our [IDBIndex example
-in IndexedDB-examples demo repo](https://github.com/mdn/indexeddb-examples/tree/master/idbindex) ([View the example live](https://mdn.github.io/indexeddb-examples/idbindex).)
+in IndexedDB-examples demo repo](https://github.com/mdn/indexeddb-examples/tree/master/idbindex) ([View the example live](https://mdn.github.io/indexeddb-examples/idbindex/).)
 
 ```js
 function displayDataByIndex() {

--- a/files/en-us/web/api/mediaerror/message/index.md
+++ b/files/en-us/web/api/mediaerror/message/index.md
@@ -38,7 +38,7 @@ handler outputs a message to a box onscreen describing the error, including both
 `code` and the `message`.
 
 Only the relevant parts of the code are displayed; you can [see the
-complete source code here](https://github.com/mdn/dom-examples/blob/master/media/mediaerror/).
+complete source code here](https://github.com/mdn/dom-examples/tree/master/media/mediaerror).
 
 The example creates an {{HTMLElement("audio")}} element and lets the user assign either
 a valid music file to it, or a link to a file which doesn't exist. This lets us see the

--- a/files/en-us/web/api/shadowroot/index.md
+++ b/files/en-us/web/api/shadowroot/index.md
@@ -59,7 +59,7 @@ You can retrieve a reference to an element's shadow root using its {{domxref("El
 
 ## Examples
 
-The following snippets are taken from our [life-cycle-callbacks](https://github.com/mdn/web-components-examples/tree/master/life-cycle-callbacks) example ([see it live also](https://mdn.github.io/web-components-examples/life-cycle-callbacks)), which creates an element that displays a square of a size and color specified in the element's attributes.
+The following snippets are taken from our [life-cycle-callbacks](https://github.com/mdn/web-components-examples/tree/master/life-cycle-callbacks) example ([see it live also](https://mdn.github.io/web-components-examples/life-cycle-callbacks/)), which creates an element that displays a square of a size and color specified in the element's attributes.
 
 Inside the `<custom-square>` element's class definition we include some life cycle callbacks that make a call to an external function, `updateStyle()`, which actually applies the size and color to the element. You'll see that we are passing it `this` (the custom element itself) as a parameter.
 

--- a/files/en-us/web/api/webrtc_api/signaling_and_video_calling/index.md
+++ b/files/en-us/web/api/webrtc_api/signaling_and_video_calling/index.md
@@ -37,7 +37,7 @@ Our [chat server](https://github.com/mdn/samples-server/tree/master/s/websocket-
 
 To allow the server to support signaling and ICE negotiation, we need to update the code. We'll have to allow directing messages to one specific user instead of broadcasting to all connected users, and ensure unrecognized message types are passed through and delivered, without the server needing to know what they are. This lets us send signaling messages using this same server, instead of needing a separate server.
 
-Let's take a look at changes we need to make to the chat server to support WebRTC signaling. This is in the file [`chatserver.js`](https://github.com/mdn/samples-server/tree/master/s/webrtc-from-chat/chatserver.js).
+Let's take a look at changes we need to make to the chat server to support WebRTC signaling. This is in the file [`chatserver.js`](https://github.com/mdn/samples-server/blob/master/s/webrtc-from-chat/chatserver.js).
 
 First up is the addition of the function `sendToOneUser()`. As the name suggests, this sends a stringified JSON message to a particular username.
 
@@ -181,7 +181,7 @@ The HTML for our client needs a location for video to be presented. This require
 </div>
 ```
 
-The page structure defined here is using {{HTMLElement("div")}} elements, giving us full control over the page layout by enabling the use of CSS. We'll skip layout detail in this guide, but [take a look at the CSS](https://github.com/mdn/samples-server/tree/master/s/webrtc-from-chat/chat.css) on GitHub to see how we handled it. Take note of the two {{HTMLElement("video")}} elements, one for your self-view, one for the connection, and the {{HTMLElement("button")}} element.
+The page structure defined here is using {{HTMLElement("div")}} elements, giving us full control over the page layout by enabling the use of CSS. We'll skip layout detail in this guide, but [take a look at the CSS](https://github.com/mdn/samples-server/blob/master/s/webrtc-from-chat/chat.css) on GitHub to see how we handled it. Take note of the two {{HTMLElement("video")}} elements, one for your self-view, one for the connection, and the {{HTMLElement("button")}} element.
 
 The `<video>` element with the `id` "`received_video`" will present video received from the connected user. We specify the `autoplay` attribute, ensuring once the video starts arriving, it immediately plays. This removes any need to explicitly handle playback in our code. The "`local_video`" `<video>` element presents a preview of the user's camera; specifying the `muted` attribute, as we don't need to hear local audio in this preview panel.
 

--- a/files/en-us/web/api/webrtc_api/simple_rtcdatachannel_sample/index.md
+++ b/files/en-us/web/api/webrtc_api/simple_rtcdatachannel_sample/index.md
@@ -16,7 +16,7 @@ In this example, we will open an {{domxref("RTCDataChannel")}} connection linkin
 
 ## The HTML
 
-First, let's take a quick look at the [HTML that's needed](https://github.com/mdn/samples-server/tree/master/s/webrtc-simple-datachannel/index.html). There's nothing incredibly complicated here. First, we have a couple of buttons for establishing and closing the connection:
+First, let's take a quick look at the [HTML that's needed](https://github.com/mdn/samples-server/blob/master/s/webrtc-simple-datachannel/index.html). There's nothing incredibly complicated here. First, we have a couple of buttons for establishing and closing the connection:
 
 ```html
 <button id="connectButton" name="connectButton" class="buttonleft">
@@ -51,7 +51,7 @@ Finally, there's the little box into which we'll insert the messages. This {{HTM
 
 ## The JavaScript code
 
-While you can just [look at the code itself on GitHub](https://github.com/mdn/samples-server/tree/master/s/webrtc-simple-datachannel/main.js), below we'll review the parts of the code that do the heavy lifting.
+While you can just [look at the code itself on GitHub](https://github.com/mdn/samples-server/blob/master/s/webrtc-simple-datachannel/main.js), below we'll review the parts of the code that do the heavy lifting.
 
 The WebRTC API makes heavy use of {{jsxref("Promise")}}s. They make it very easy to chain the steps of the connection process together; if you haven't already read up on this functionality of [ECMAScript 2015](/en-US/docs/Archive/Web/JavaScript/New_in_JavaScript/ECMAScript_2015_support_in_Mozilla), you should read up on them. Similarly, this example uses [arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) to simplify syntax.
 

--- a/files/en-us/web/css/@counter-style/index.md
+++ b/files/en-us/web/css/@counter-style/index.md
@@ -153,4 +153,4 @@ The [Counter styles converter](https://r12a.github.io/app-counters/) pulls from 
 - {{Cssxref("list-style")}}, {{Cssxref("list-style-image")}}, {{Cssxref("list-style-position")}}, {{Cssxref("list-style-type")}}
 - {{cssxref("symbols", "symbols()")}}, the functional notation creating anonymous counter styles.
 - CSS {{Cssxref("counter", "counter()")}} and {{Cssxref("counters", "counters()")}} functions
-- [Counter style demo](https://mdn.github.io/css-examples/counter-style-demo/) ([code](https://github.com/mdn/css-examples/tree/master/counter-style-demo))
+- [Counter style demo](https://mdn.github.io/css-examples/counter-style-demo/) ([code](https://github.com/mdn/css-examples/tree/main/counter-style-demo))

--- a/files/en-us/web/css/layout_cookbook/breadcrumb_navigation/index.md
+++ b/files/en-us/web/css/layout_cookbook/breadcrumb_navigation/index.md
@@ -25,7 +25,7 @@ The items typically display inline with a separator to indicate a hierarchy betw
 
 > **Callout:**
 >
-> [Download this example](https://github.com/mdn/css-examples/blob/master/css-cookbook/breadcrumb-navigation--download.html)
+> [Download this example](https://github.com/mdn/css-examples/blob/main/css-cookbook/breadcrumb-navigation--download.html)
 
 > **Note:** The example above uses two selectors to insert content before every `li` except the first one. This could also be achieved using one selector only:
 >

--- a/files/en-us/web/css/layout_cookbook/card/index.md
+++ b/files/en-us/web/css/layout_cookbook/card/index.md
@@ -29,7 +29,7 @@ When added to a collection of cards, the cards should line up in two dimensions.
 
 > **Callout:**
 >
-> [Download this example](https://github.com/mdn/css-examples/blob/master/css-cookbook/card--download.html)
+> [Download this example](https://github.com/mdn/css-examples/blob/main/css-cookbook/card--download.html)
 
 ## Choices made
 

--- a/files/en-us/web/css/layout_cookbook/center_an_element/index.md
+++ b/files/en-us/web/css/layout_cookbook/center_an_element/index.md
@@ -27,7 +27,7 @@ To place an item into the center of another box horizontally and vertically.
 
 > **Callout:**
 >
-> [Download this example](https://github.com/mdn/css-examples/blob/master/css-cookbook/center--download.html)
+> [Download this example](https://github.com/mdn/css-examples/blob/main/css-cookbook/center--download.html)
 
 ## Choices made
 

--- a/files/en-us/web/css/layout_cookbook/column_layouts/index.md
+++ b/files/en-us/web/css/layout_cookbook/column_layouts/index.md
@@ -39,7 +39,7 @@ You can control the gaps between columns with the {{cssxref("column-gap")}} prop
 
 > **Callout:**
 >
-> [Download this example](https://github.com/mdn/css-examples/blob/master/css-cookbook/columns-multicol--download.html)
+> [Download this example](https://github.com/mdn/css-examples/blob/main/css-cookbook/columns-multicol--download.html)
 
 Use multicol when:
 
@@ -57,7 +57,7 @@ There is currently no way to add a rule between flex items, and browser support 
 
 > **Callout:**
 >
-> [Download this example](https://github.com/mdn/css-examples/blob/master/css-cookbook/columns-flexbox--download.html)
+> [Download this example](https://github.com/mdn/css-examples/blob/main/css-cookbook/columns-flexbox--download.html)
 
 Flexbox can also be used to create layouts where the flex items wrap onto new rows, by setting the {{cssxref("flex-wrap")}} property on the container to `wrap`. These new flex lines will distribute space along that line only — the items in the new line will not line up with items in the line above, as you'll see in the example below. This is why flexbox is described as one-dimensional. It is designed for controlling layout as a row or a column, but not both at the same time.
 
@@ -65,7 +65,7 @@ Flexbox can also be used to create layouts where the flex items wrap onto new ro
 
 > **Callout:**
 >
-> [Download this example](https://github.com/mdn/css-examples/blob/master/css-cookbook/columns-flexbox-wrapping--download.html)
+> [Download this example](https://github.com/mdn/css-examples/blob/main/css-cookbook/columns-flexbox-wrapping--download.html)
 
 Use flexbox:
 
@@ -81,7 +81,7 @@ If what you want is a layout where items line up in rows and columns then you sh
 
 > **Callout:**
 >
-> [Download this example](https://github.com/mdn/css-examples/blob/master/css-cookbook/columns-grid--download.html)
+> [Download this example](https://github.com/mdn/css-examples/blob/main/css-cookbook/columns-grid--download.html)
 
 Use Grid:
 

--- a/files/en-us/web/css/layout_cookbook/contribute_a_recipe/cookbook_template/index.md
+++ b/files/en-us/web/css/layout_cookbook/contribute_a_recipe/cookbook_template/index.md
@@ -29,7 +29,7 @@ _Change the path to the example below to point to your merged example. The last 
 
 _Change the link to point to your merged download version._
 
-[Download the example](https://github.com/mdn/css-examples/blob/master/css-cookbook/center--download.html)
+[Download the example](https://github.com/mdn/css-examples/blob/main/css-cookbook/center--download.html)
 
 ## Choices made
 

--- a/files/en-us/web/css/layout_cookbook/contribute_a_recipe/index.md
+++ b/files/en-us/web/css/layout_cookbook/contribute_a_recipe/index.md
@@ -44,7 +44,7 @@ Ensure that the HTML and CSS is valid, and test in more than one browser. If you
 
 The live examples that you can see on cookbook pages and elsewhere on MDN allow visitors to play with the code and change relevant parts without being overwhelmed with all of the code needed. You recipe will be demonstrated by way of one or more examples.
 
-Fork the [CSS Examples repo](https://github.com/mdn/css-examples) and then take a look in the `css-cookbook` folder. There is a [cookbook-template.html](https://github.com/mdn/css-examples/blob/master/css-cookbook/cookbook-template.html) file you can copy as a starting point. Save this in the css-cookbook directory with a name that makes sense for your pattern. The template is commented to help you add the various parts to the right place.
+Fork the [CSS Examples repo](https://github.com/mdn/css-examples) and then take a look in the `css-cookbook` folder. There is a [cookbook-template.html](https://github.com/mdn/css-examples/blob/main/css-cookbook/cookbook-template.html) file you can copy as a starting point. Save this in the css-cookbook directory with a name that makes sense for your pattern. The template is commented to help you add the various parts to the right place.
 
 The important parts of this are as follows.
 
@@ -56,7 +56,7 @@ You need to add the HTML for your component twice. First inside the section with
 
 Your editable CSS, from the second block in the head, also needs to be copied into the `playable-css` section.
 
-A simple worked example is [center.html](https://github.com/mdn/css-examples/blob/master/css-cookbook/center.html), which is embedded on the page [Center an element](/en-US/docs/Web/CSS/Layout_cookbook/Center_an_element). You can use this to see how to add the various bits correctly.
+A simple worked example is [center.html](https://github.com/mdn/css-examples/blob/main/css-cookbook/center.html), which is embedded on the page [Center an element](/en-US/docs/Web/CSS/Layout_cookbook/Center_an_element). You can use this to see how to add the various bits correctly.
 
 If you have forked the repo and therefore have our CSS and JavaScript files alongside your example, if you open up your live example in the browser you should see everything working exactly as it will when included in a page.
 
@@ -68,7 +68,7 @@ If you have forked the repo and therefore have our CSS and JavaScript files alon
 
 ### 3. Create a downloadable version
 
-As the examples include all of our live example code, we want to offer visitors a simple example without all of that included. Make a copy of your live example with --download appended. For example, center.html, has a download version named `center--download.html`. This file will be similar to your initial example. It should be a basic version of your pattern as a single HTML page. It can be handy to include the body CSS rules that are in our included stylesheet, if you take a look at [cookbook-template--download.html](https://github.com/mdn/css-examples/blob/master/css-cookbook/cookbook-template--download.html), these are included as a starting point.
+As the examples include all of our live example code, we want to offer visitors a simple example without all of that included. Make a copy of your live example with --download appended. For example, center.html, has a download version named `center--download.html`. This file will be similar to your initial example. It should be a basic version of your pattern as a single HTML page. It can be handy to include the body CSS rules that are in our included stylesheet, if you take a look at [cookbook-template--download.html](https://github.com/mdn/css-examples/blob/main/css-cookbook/cookbook-template--download.html), these are included as a starting point.
 
 ### 4. Make a Pull Request with your example
 
@@ -82,7 +82,7 @@ The template explains what should be part of each section, and you can refer to 
 
 If you need general guidance on using the MDN wiki, see the help pages available here.
 
-If you need to ask any questions, or want someone to take a look at your page then the [MDN Discourse forum](https://discourse.mozilla.org/c/mdn) is a good place to do this, or [chat with us on Matrix](/en-US/docs/MDN/Community/Conversations#Synchronous_chat).
+If you need to ask any questions, or want someone to take a look at your page then the [MDN Discourse forum](https://discourse.mozilla.org/c/mdn/236) is a good place to do this, or [chat with us on Matrix](/en-US/docs/MDN/Community/Conversations#Synchronous_chat).
 
 ## See also
 

--- a/files/en-us/web/css/layout_cookbook/grid_wrapper/index.md
+++ b/files/en-us/web/css/layout_cookbook/grid_wrapper/index.md
@@ -22,7 +22,7 @@ Items placed on the grid should be able to align to a horizontally-centered max-
 
 > **Callout:**
 >
-> [Download this example](https://github.com/mdn/css-examples/blob/master/css-cookbook/grid-wrapper--download.html)
+> [Download this example](https://github.com/mdn/css-examples/blob/main/css-cookbook/grid-wrapper--download.html)
 
 ## Choices made
 

--- a/files/en-us/web/css/layout_cookbook/list_group_with_badges/index.md
+++ b/files/en-us/web/css/layout_cookbook/list_group_with_badges/index.md
@@ -26,7 +26,7 @@ Our list items should be displayed with the badges lined up on the right, no mat
 
 > **Callout:**
 >
-> [Download this example](https://github.com/mdn/css-examples/blob/master/css-cookbook/list-group-badges--download.html)
+> [Download this example](https://github.com/mdn/css-examples/blob/main/css-cookbook/list-group-badges--download.html)
 
 ## Choices made
 

--- a/files/en-us/web/css/layout_cookbook/media_objects/index.md
+++ b/files/en-us/web/css/layout_cookbook/media_objects/index.md
@@ -33,7 +33,7 @@ Media Object pattern needs some or all of the following characteristics:
 
 > **Callout:**
 >
-> [Download this example](https://github.com/mdn/css-examples/blob/master/css-cookbook/media-objects--download.html)
+> [Download this example](https://github.com/mdn/css-examples/blob/main/css-cookbook/media-objects--download.html)
 
 ## Choices made
 
@@ -55,7 +55,7 @@ There are a number of possible fallbacks for this pattern, depending on the brow
 
 > **Callout:**
 >
-> [Download this example](https://github.com/mdn/css-examples/blob/master/css-cookbook/media-objects-fallback--download.html)
+> [Download this example](https://github.com/mdn/css-examples/blob/main/css-cookbook/media-objects-fallback--download.html)
 
 Once floated elements become grid items the float no longer applies so you don't need to do anything special to clear the float.
 

--- a/files/en-us/web/css/layout_cookbook/pagination/index.md
+++ b/files/en-us/web/css/layout_cookbook/pagination/index.md
@@ -27,7 +27,7 @@ Typically, the pagination component will be centered horizontally underneath the
 
 > **Callout:**
 >
-> [Download this example](https://github.com/mdn/css-examples/blob/master/css-cookbook/pagination--download.html)
+> [Download this example](https://github.com/mdn/css-examples/blob/main/css-cookbook/pagination--download.html)
 
 ## Choices made
 

--- a/files/en-us/web/css/layout_cookbook/split_navigation/index.md
+++ b/files/en-us/web/css/layout_cookbook/split_navigation/index.md
@@ -25,7 +25,7 @@ A common navigation pattern is to have one element pushed away from the others. 
 
 > **Callout:**
 >
-> [Download this example](https://github.com/mdn/css-examples/blob/master/css-cookbook/split-navigation--download.html)
+> [Download this example](https://github.com/mdn/css-examples/blob/main/css-cookbook/split-navigation--download.html)
 
 ## Choices made
 

--- a/files/en-us/web/css/layout_cookbook/sticky_footers/index.md
+++ b/files/en-us/web/css/layout_cookbook/sticky_footers/index.md
@@ -29,7 +29,7 @@ The Sticky footer pattern needs to meet the following requirements:
 
 > **Callout:**
 >
-> [Download this example](https://github.com/mdn/css-examples/blob/master/css-cookbook/sticky-footer--download.html)
+> [Download this example](https://github.com/mdn/css-examples/blob/main/css-cookbook/sticky-footer--download.html)
 
 > **Note:** In this example and the following one we are using a wrapper set to `min-height: 100%` in order that our live example works. You could also achieve this for a full page by setting a {{cssxref("min-height")}} of `100vh` on the {{htmlelement("body")}} and then using it as your grid container.
 

--- a/files/en-us/web/css/overscroll-behavior-x/index.md
+++ b/files/en-us/web/css/overscroll-behavior-x/index.md
@@ -55,7 +55,7 @@ The `overscroll-behavior-x` property is specified as a keyword chosen from the l
 
 ### Preventing an underlying element from scrolling horizontally
 
-In our simple [overscroll-behavior-x example](https://mdn.github.io/css-examples/overscroll-behavior/overscroll-behavior-x) (see [source code](https://github.com/mdn/css-examples/blob/master/overscroll-behavior/overscroll-behavior-x.html) also), we have two block-level boxes, one inside the other. The outer box has a large {{cssxref("width")}} set on it so the page will scroll horizontally. The inner box has a small width (and {{cssxref("height")}}) set on it so it sits comfortably inside the viewport, but its content is given a large `width` so it will scroll horizontally.
+In our simple [overscroll-behavior-x example](https://mdn.github.io/css-examples/overscroll-behavior/overscroll-behavior-x) (see [source code](https://github.com/mdn/css-examples/blob/main/overscroll-behavior/overscroll-behavior-x.html) also), we have two block-level boxes, one inside the other. The outer box has a large {{cssxref("width")}} set on it so the page will scroll horizontally. The inner box has a small width (and {{cssxref("height")}}) set on it so it sits comfortably inside the viewport, but its content is given a large `width` so it will scroll horizontally.
 
 By default, when the inner box is scrolled and a scroll boundary is reached, the whole page will begin to scroll, which is probably not what we want. To avoid this, you can set `overscroll-behavior-x: contain` on the inner box:
 

--- a/files/en-us/web/css/overscroll-behavior/index.md
+++ b/files/en-us/web/css/overscroll-behavior/index.md
@@ -64,7 +64,7 @@ Two keywords specifies the `overscroll-behavior` value on the `x` and `y` axes r
 
 ### Preventing an underlying element from scrolling
 
-In our [overscroll-behavior example](https://mdn.github.io/css-examples/overscroll-behavior/) (see the [source code](https://github.com/mdn/css-examples/tree/master/overscroll-behavior) also), we present a full-page list of fake contacts, and a dialog box containing a chat window.
+In our [overscroll-behavior example](https://mdn.github.io/css-examples/overscroll-behavior/) (see the [source code](https://github.com/mdn/css-examples/tree/main/overscroll-behavior) also), we present a full-page list of fake contacts, and a dialog box containing a chat window.
 
 ![A popup chat window titled 'Active chat', showing a conversation between Chris and Bob. Behind the chat window is a contact list titled 'overscroll-behavior demo'.](example.png)
 

--- a/files/en-us/web/html/element/input/search/index.md
+++ b/files/en-us/web/html/element/input/search/index.md
@@ -430,7 +430,7 @@ This renders like so:
 
 ## Examples
 
-You can see a good example of a search form used in context at our [website-aria-roles](https://github.com/mdn/learning-area/tree/master/accessibility/aria/website-aria-roles) example ([see it live](https://mdn.github.io/learning-area/accessibility/aria/website-aria-roles/)).
+You can see a good example of a search form used in context at our [website-aria-roles](https://github.com/mdn/learning-area/tree/main/accessibility/aria/website-aria-roles) example ([see it live](https://mdn.github.io/learning-area/accessibility/aria/website-aria-roles/)).
 
 ## Specifications
 

--- a/files/en-us/webassembly/using_the_javascript_api/index.md
+++ b/files/en-us/webassembly/using_the_javascript_api/index.md
@@ -25,7 +25,7 @@ Let's run through some examples that explain how to use the WebAssembly JavaScri
 
 ### Preparing the example
 
-1. First we need a wasm module! Grab our [simple.wasm](https://github.com/mdn/webassembly-examples/raw/master/js-api-examples/simple.wasm) file and save a copy in a new directory on your local machine.
+1. First we need a wasm module! Grab our [simple.wasm](https://raw.githubusercontent.com/mdn/webassembly-examples/master/js-api-examples/simple.wasm) file and save a copy in a new directory on your local machine.
 2. Next, let's create a simple HTML file called `index.html` in the same directory as your wasm file (can use our [simple template](https://github.com/mdn/webassembly-examples/blob/master/template/template.html) if you haven't got one easily available).
 3. Now, to help us understand what is going on here, let's look at the text representation of our wasm module (which we also meet in [Converting WebAssembly format to wasm](/en-US/docs/WebAssembly/Text_format_to_wasm#a_first_look_at_the_text_format)):
 
@@ -137,7 +137,7 @@ Just like functions, linear memories can be defined inside a module or imported.
 
 ### More involved memory example
 
-Let's make the above assertions clearer by looking at a more involved memory example — a WebAssembly module that imports the memory instance we defined earlier, populates it with an array of integers, then sums them. You can find this at [memory.wasm.](https://github.com/mdn/webassembly-examples/raw/master/js-api-examples/memory.wasm)
+Let's make the above assertions clearer by looking at a more involved memory example — a WebAssembly module that imports the memory instance we defined earlier, populates it with an array of integers, then sums them. You can find this at [memory.wasm.](https://raw.githubusercontent.com/mdn/webassembly-examples/master/js-api-examples/memory.wasm)
 
 1. make a local copy of `memory.wasm` in the same directory as before.
 
@@ -188,7 +188,7 @@ Tables can be mutated via [`Table.prototype.set()`](/en-US/docs/Web/JavaScript/R
 
 ### A table example
 
-Let's look at a simple table example — a WebAssembly module that creates and exports a table with two elements: element 0 returns 13 and element 1 returns 42. You can find this at [table.wasm](https://github.com/mdn/webassembly-examples/raw/master/js-api-examples/table.wasm).
+Let's look at a simple table example — a WebAssembly module that creates and exports a table with two elements: element 0 returns 13 and element 1 returns 42. You can find this at [table.wasm](https://raw.githubusercontent.com/mdn/webassembly-examples/master/js-api-examples/table.wasm).
 
 1. Make a local copy of `table.wasm` in a new directory.
 


### PR DESCRIPTION
Extending #14055

## Summary

After switch from `master` to `main` branch, all MDN GitHub links have changed. Old links to `master` are being redirected to `main`.
If GitHub stops the redirection, all the links will break.

So updating the links as follows:
For directories,
`/tree/master/` -> `/tree/main/`
For files,
`/tree/master/` -> `/blob/main/`
To understand the difference between file and directory links refer [this](https://stackoverflow.com/questions/39400848/in-github-urls-what-is-the-difference-between-a-tree-and-a-blob) discussion.


#### Metadata
- [x] Fixes a typo, bug, or other error