### PR TITLE
Make GeneratorFunction doc be clear it’s not a property of global object

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/generatorfunction/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/generatorfunction/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.GeneratorFunction
 ---
 {{JSRef}}
 
-In JavaScript, every generator function is actually a `GeneratorFunction` object. There is no global object with the name`GeneratorFunction`, but you can create a `GeneratorFunction()` constructor using the following code:
+In JavaScript, every generator function is actually a `GeneratorFunction` object. There is no global object with the name `GeneratorFunction`, but you can create a `GeneratorFunction()` constructor using the following code:
 
 ```js
 const GeneratorFunction = Object.getPrototypeOf(function*(){}).constructor;
@@ -20,7 +20,7 @@ const GeneratorFunction = Object.getPrototypeOf(function*(){}).constructor;
 
 ## Description
 
-{{jsxref("Statements/function*", "generator function")}} objects created with a
+{{jsxref("Statements/function*", "Generator function", "", "1")}} objects created with a
 constructor are parsed when the function is created. That
 is less efficient than declaring a generator function with a
 {{jsxref("Statements/function*", "function* expression")}} and calling it within your
@@ -40,7 +40,7 @@ parameters in the function to be created, in the order in which they are passed.
 > This is different from using {{jsxref("Global_Objects/eval", "eval")}} with code for
 > a generator function expression.
 
-Invoking a generator-function constructor as a function (without using
+Invoking a generator function constructor as a function (without using
 the `new` operator) has the same effect as invoking it as a constructor.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/generatorfunction/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/generatorfunction/index.md
@@ -12,40 +12,16 @@ browser-compat: javascript.builtins.GeneratorFunction
 ---
 {{JSRef}}
 
-The **`GeneratorFunction` constructor** creates a new
-{{jsxref("Statements/function*", "generator function", "", 1)}} object. In JavaScript,
-every generator function is actually a `GeneratorFunction` object.
-
-Note that `GeneratorFunction` is not a global object. It could be obtained
-by evaluating the following code.
+In JavaScript, every generator function is actually a `GeneratorFunction` object. There is no global object with the name`GeneratorFunction`, but you can create a `GeneratorFunction()` constructor using the following code:
 
 ```js
-Object.getPrototypeOf(function*(){}).constructor
+const GeneratorFunction = Object.getPrototypeOf(function*(){}).constructor;
 ```
-
-## Syntax
-
-```js
-new Function(arg1, functionBody)
-new Function(arg1, arg2, functionBody)
-new Function(arg1, ... , argN, functionBody)
-```
-
-### Parameters
-
-- `arg1, arg2, ... argN`
-
-  - : Names to be used by the function as formal argument names. Each must be a string that corresponds to a valid JavaScript parameter (any of plain [identifier](/en-US/docs/Glossary/Identifier), [rest parameter](/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters), or [destructured](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) parameter, optionally with a default), or a list of such strings separated with commas.
-
-    As the parameters are parsed in the same way as function declarations, whitespace and comments are accepted. For example: `"x", "theValue = 42", "[a, b] /* numbers */"` — or `"x, theValue = 42, [a, b] /* numbers */"`. (`"x, theValue = 42", "[a, b]"` is also correct, though very confusing to read.)
-
-- `functionBody`
-  - : A string containing the JavaScript statements comprising the function definition.
 
 ## Description
 
-{{jsxref("Statements/function*", "generator function")}} objects created with the
-`GeneratorFunction` constructor are parsed when the function is created. This
+{{jsxref("Statements/function*", "generator function")}} objects created with a
+constructor are parsed when the function is created. That
 is less efficient than declaring a generator function with a
 {{jsxref("Statements/function*", "function* expression")}} and calling it within your
 code, because such functions are parsed with the rest of the code.
@@ -54,7 +30,7 @@ All arguments passed to the function are treated as the names of the identifiers
 parameters in the function to be created, in the order in which they are passed.
 
 > **Note:** {{jsxref("Statements/function*", "generator function")}}
-> created with the `GeneratorFunction` constructor do not create closures to
+> created with a constructor do not create closures to
 > their creation contexts; they are always created in the global scope.
 >
 > When running them, they will only be able to access their own local variables and
@@ -64,17 +40,17 @@ parameters in the function to be created, in the order in which they are passed.
 > This is different from using {{jsxref("Global_Objects/eval", "eval")}} with code for
 > a generator function expression.
 
-Invoking the `GeneratorFunction` constructor as a function (without using
+Invoking a generator-function constructor as a function (without using
 the `new` operator) has the same effect as invoking it as a constructor.
 
 ## Examples
 
-### Creating a generator function from a GeneratorFunction() constructor
+### Creating and using a GeneratorFunction() constructor
 
 ```js
-var GeneratorFunction = Object.getPrototypeOf(function*(){}).constructor
-var g = new GeneratorFunction('a', 'yield a * 2');
-var iterator = g(10);
+const GeneratorFunction = Object.getPrototypeOf(function*(){}).constructor;
+const g = new GeneratorFunction('a', 'yield a * 2');
+const iterator = g(10);
 console.log(iterator.next().value); // 20
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/generatorfunction/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/generatorfunction/index.md
@@ -29,7 +29,7 @@ code, because such functions are parsed with the rest of the code.
 All arguments passed to the function are treated as the names of the identifiers of the
 parameters in the function to be created, in the order in which they are passed.
 
-> **Note:** {{jsxref("Statements/function*", "generator function")}}
+> **Note:** {{jsxref("Statements/function*", "generator functions", "", "1")}}
 > created with a constructor do not create closures to
 > their creation contexts; they are always created in the global scope.
 >


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/14781

`GeneratorFunction` is an intrinsic object in the ES spec but it’s not a exposed as a property of the global object. So there is no exposed constructor with the name `GeneratorFunction()`, and we should make that clear in the article. And because there’s no such exposed constructor, we should not include a Syntax section for it.