### PR TITLE
fix: HTMLCollection.namedItem(): included use of id in the example

### DIFF
--- a/files/en-us/web/api/htmlcollection/nameditem/index.md
+++ b/files/en-us/web/api/htmlcollection/nameditem/index.md
@@ -58,11 +58,13 @@ const lastnameSpan = container.children.lastname;
 // Returns the span element with the id "degree"
 const degreeSpan = container.children.namedItem('degree');
 
-console.log( titleSpan.textContent,
-             firstnameSpan.textContent,
-             lastnameSpan.textContent,
-             degreeSpan.textContent );
+const output = document.createElement('div');
+output.textContent = `Result: ${titleSpan.textContent} ${firstnameSpan.textContent} ${lastnameSpan.textContent} ${degreeSpan.textContent}`;
+
+document.body.insertAdjacentElement('afterend', output);
 ```
+
+{{EmbedLiveSample("Example")}}
 
 ## Specification
 

--- a/files/en-us/web/api/htmlcollection/nameditem/index.md
+++ b/files/en-us/web/api/htmlcollection/nameditem/index.md
@@ -39,6 +39,7 @@ const item = collection.namedItem(key);
   <span name="title">Dr.</span>
   <span name="firstname">John</span>
   <span name="lastname">Doe</span>
+  <span id="degree">(MD)</span>
 </div>
 ```
 
@@ -46,11 +47,21 @@ const item = collection.namedItem(key);
 
 ```js
 const container = document.getElementById('personal');
+
 // Returns the HTMLSpanElement with the name "title" if no such element exists null is returned
 const titleSpan = container.children.namedItem('title');
+
 // The following variants return undefined instead of null if there's no element with a matching name or id
 const firstnameSpan = container.children['firstname'];
 const lastnameSpan = container.children.lastname;
+
+// Returns the span element with the id "degree"
+const degreeSpan = container.children.namedItem('degree');
+
+console.log( titleSpan.textContent,
+             firstnameSpan.textContent,
+             lastnameSpan.textContent,
+             degreeSpan.textContent );
 ```
 
 ## Specification

--- a/files/en-us/web/api/htmlcollection/nameditem/index.md
+++ b/files/en-us/web/api/htmlcollection/nameditem/index.md
@@ -61,7 +61,7 @@ const degreeSpan = container.children.namedItem('degree');
 const output = document.createElement('div');
 output.textContent = `Result: ${titleSpan.textContent} ${firstnameSpan.textContent} ${lastnameSpan.textContent} ${degreeSpan.textContent}`;
 
-document.body.insertAdjacentElement('afterend', output);
+container.insertAdjacentElement('afterend', output);
 ```
 
 {{EmbedLiveSample("Example")}}


### PR DESCRIPTION
#### Summary
Fixes #13572

Updated the example to demonstrate `id` can be used with the API. 
Also turned the example into live sample.

#### Metadata
- [x] Rewrites (or significantly expands) a document
