### PR TITLE
Remove unnecessary HTML tag

### DIFF
--- a/files/en-us/web/api/keyboardevent/keyboardevent/index.md
+++ b/files/en-us/web/api/keyboardevent/keyboardevent/index.md
@@ -41,8 +41,7 @@ new KeyboardEvent(typeArg, KeyboardEventInit);
     - `"altKey"`, optional boolean value, defaulting to `false`,
       that sets the value of {{domxref("KeyboardEvent.altKey")}}.
     - `"metaKey"`, optional boolean value, defaulting to `false`,
-      that sets the value of {{domxref("KeyboardEvent.metaKey")}}.<
-      /li>
+      that sets the value of {{domxref("KeyboardEvent.metaKey")}}.
     - `"repeat"`, optional boolean value, defaulting to `false`,
       that sets the value of {{domxref("KeyboardEvent.repeat")}}.
     - `"isComposing"`, optional boolean value, defaulting to `false`,


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

This PR removes an unnecessary `</li>` tag inside of a markdown block.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

Clean up the docs for other developers.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

You can see the typo on [`KeyboardEvent`](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent), on the `meta` line.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

N/A

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
