### PR TITLE
event.target instead of event

### DIFF
--- a/files/en-us/web/api/rtcpeerconnection/connectionstatechange_event/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/connectionstatechange_event/index.md
@@ -39,7 +39,7 @@ For an {{domxref("RTCPeerConnection")}}, `pc`, this example sets up a handler fo
 
 ```js
 pc.onconnectionstatechange = ev => {
-  switch(pc.connectionState) {
+  switch(pc.target.connectionState) {
     case "new":
     case "checking":
       setOnlineStatus("Connecting...");
@@ -67,7 +67,7 @@ You can also create a handler for `connectionstatechange` by using {{domxref("Ev
 
 ```js
 pc.addEventListener("connectionstatechange", ev => {
-  switch(pc.connectionState) {
+  switch(pc.target.connectionState) {
     /* ... */
   }
 }, false);


### PR DESCRIPTION
Seems to be `event.target`, at least on chrome

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
