### PR TITLE
Remove deprecated param `expandEntityReferences` from examples

### DIFF
--- a/files/en-us/web/api/document/createtreewalker/index.md
+++ b/files/en-us/web/api/document/createtreewalker/index.md
@@ -17,7 +17,9 @@ newly created {{domxref("TreeWalker")}} object.
 ## Syntax
 
 ```js
-document.createTreeWalker(root[, whatToShow[, filter[, expandEntityReferences]]]);
+document.createTreeWalker(root);
+document.createTreeWalker(root, whatToShow);
+document.createTreeWalker(root, whatToShow, filter);
 ```
 
 ### Parameters
@@ -53,9 +55,6 @@ document.createTreeWalker(root[, whatToShow[, filter[, expandEntityReferences]]]
   - : A {{domxref("NodeFilter")}}, that is an object with a method
     `acceptNode`, which is called by the {{domxref("TreeWalker")}} to determine
     whether or not to accept a node that has passed the `whatToShow` check.
-- `expandEntityReferences` {{optional_inline}} {{deprecated_inline}}
-  - : A boolean flag indicating if when discarding an
-    entity reference its whole sub-tree must be discarded at the same time.
 
 ### Return value
 
@@ -74,8 +73,7 @@ array.
 var treeWalker = document.createTreeWalker(
   document.body,
   NodeFilter.SHOW_ELEMENT,
-  { acceptNode: function(node) { return NodeFilter.FILTER_ACCEPT; } },
-  false
+  { acceptNode: function(node) { return NodeFilter.FILTER_ACCEPT; } }
 );
 
 var nodeList = [];

--- a/files/en-us/web/api/nodefilter/acceptnode/index.md
+++ b/files/en-us/web/api/nodefilter/acceptnode/index.md
@@ -78,7 +78,7 @@ tailoring the `acceptNode()` method to its needs, and using it with some
 ## Syntax
 
 ```js
-result = nodeFilter.acceptNode(node)
+nodeFilter.acceptNode(node)
 ```
 
 ### Parameters
@@ -106,8 +106,7 @@ var nodeIterator = document.createNodeIterator(
         return NodeFilter.FILTER_ACCEPT;
       }
     }
-  },
-  false
+  }
 );
 
 // Show the content of every non-empty text node that is a child of root

--- a/files/en-us/web/api/nodefilter/index.md
+++ b/files/en-us/web/api/nodefilter/index.md
@@ -97,8 +97,7 @@ const nodeIterator = document.createNodeIterator(
         return NodeFilter.FILTER_ACCEPT
       }
     }
-  },
-  false
+  }
 );
 
 // Show the content of every non-empty text node that is a child of root

--- a/files/en-us/web/api/nodeiterator/detach/index.md
+++ b/files/en-us/web/api/nodeiterator/detach/index.md
@@ -31,8 +31,7 @@ nodeIterator.detach();
 var nodeIterator = document.createNodeIterator(
     document.body,
     NodeFilter.SHOW_ELEMENT,
-    { acceptNode: function(node) { return NodeFilter.FILTER_ACCEPT; } },
-    false
+    { acceptNode: function(node) { return NodeFilter.FILTER_ACCEPT; } }
 );
 nodeIterator.detach(); // detaches the iterator
 

--- a/files/en-us/web/api/nodeiterator/filter/index.md
+++ b/files/en-us/web/api/nodeiterator/filter/index.md
@@ -31,8 +31,7 @@ A {{domxref("NodeFilter")}} object.
 const nodeIterator = document.createNodeIterator(
     document.body,
     NodeFilter.SHOW_ELEMENT,
-    { acceptNode: function(node) { return NodeFilter.FILTER_ACCEPT; } },
-    false
+    { acceptNode: function(node) { return NodeFilter.FILTER_ACCEPT; } }
 );
 nodeFilter = nodeIterator.filter;
 ```

--- a/files/en-us/web/api/nodeiterator/nextnode/index.md
+++ b/files/en-us/web/api/nodeiterator/nextnode/index.md
@@ -34,8 +34,7 @@ node = nodeIterator.nextNode();
 var nodeIterator = document.createNodeIterator(
     document.body,
     NodeFilter.SHOW_ELEMENT,
-    { acceptNode: function(node) { return NodeFilter.FILTER_ACCEPT; } },
-    false // this optional argument is not used any more
+    { acceptNode: function(node) { return NodeFilter.FILTER_ACCEPT; } }
 );
 currentNode = nodeIterator.nextNode(); // returns the next node
 ```

--- a/files/en-us/web/api/nodeiterator/pointerbeforereferencenode/index.md
+++ b/files/en-us/web/api/nodeiterator/pointerbeforereferencenode/index.md
@@ -27,8 +27,7 @@ A boolean.
 var nodeIterator = document.createNodeIterator(
     document.body,
     NodeFilter.SHOW_ELEMENT,
-    { acceptNode: function(node) { return NodeFilter.FILTER_ACCEPT; } },
-    false
+    { acceptNode: function(node) { return NodeFilter.FILTER_ACCEPT; } }
 );
 flag = nodeIterator.pointerBeforeReferenceNode;
 ```

--- a/files/en-us/web/api/nodeiterator/previousnode/index.md
+++ b/files/en-us/web/api/nodeiterator/previousnode/index.md
@@ -34,8 +34,7 @@ node = nodeIterator.previousNode();
 var nodeIterator = document.createNodeIterator(
     document.body,
     NodeFilter.SHOW_ELEMENT,
-    { acceptNode: function(node) { return NodeFilter.FILTER_ACCEPT; } },
-    false // this optional argument is not used any more
+    { acceptNode: function(node) { return NodeFilter.FILTER_ACCEPT; } }
 );
 currentNode = nodeIterator.nextNode(); // returns the next node
 previousNode = nodeIterator.previousNode(); // same result, since we backtracked to the previous node

--- a/files/en-us/web/api/nodeiterator/referencenode/index.md
+++ b/files/en-us/web/api/nodeiterator/referencenode/index.md
@@ -25,8 +25,7 @@ A {{domxref("Node")}}.
 var nodeIterator = document.createNodeIterator(
     document.body,
     NodeFilter.SHOW_ELEMENT,
-    { acceptNode: function(node) { return NodeFilter.FILTER_ACCEPT; } },
-    false
+    { acceptNode: function(node) { return NodeFilter.FILTER_ACCEPT; } }
 );
 node = nodeIterator.referenceNode;
 ```

--- a/files/en-us/web/api/nodeiterator/root/index.md
+++ b/files/en-us/web/api/nodeiterator/root/index.md
@@ -24,8 +24,7 @@ A {{DOMxref("Node")}}.
 var nodeIterator = document.createNodeIterator(
     document.body,
     NodeFilter.SHOW_ELEMENT,
-    { acceptNode: function(node) { return NodeFilter.FILTER_ACCEPT; } },
-    false
+    { acceptNode: function(node) { return NodeFilter.FILTER_ACCEPT; } }
 );
 root = nodeIterator.root; // document.body in this case
 ```

--- a/files/en-us/web/api/nodeiterator/whattoshow/index.md
+++ b/files/en-us/web/api/nodeiterator/whattoshow/index.md
@@ -122,8 +122,7 @@ The values that can be combined to form the bitmask are:
 var nodeIterator = document.createNodeIterator(
     document.body,
     ( NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_COMMENT | NodeFilter.SHOW_TEXT ),
-    { acceptNode: function(node) { return NodeFilter.FILTER_ACCEPT; } },
-    false
+    { acceptNode: function(node) { return NodeFilter.FILTER_ACCEPT; } }
 );
 if ((nodeIterator.whatToShow & NodeFilter.SHOW_ALL) ||
     (nodeIterator.whatToShow & NodeFilter.SHOW_COMMENT)) {

--- a/files/en-us/web/api/treewalker/lastchild/index.md
+++ b/files/en-us/web/api/treewalker/lastchild/index.md
@@ -19,7 +19,7 @@ returns `null` and the current node is not changed.
 ## Syntax
 
 ```js
-node = treeWalker.lastChild();
+treeWalker.lastChild();
 ```
 
 ## Example
@@ -28,8 +28,7 @@ node = treeWalker.lastChild();
 var treeWalker = document.createTreeWalker(
     document.body,
     NodeFilter.SHOW_ELEMENT,
-    { acceptNode: function(node) { return NodeFilter.FILTER_ACCEPT; } },
-    false
+    { acceptNode: function(node) { return NodeFilter.FILTER_ACCEPT; } }
 );
 var node = treeWalker.lastChild(); // returns the last visible child of the root element
 ```


### PR DESCRIPTION
Fixes #13683 

## Summary
The parameter `expandEntityReferences` has been deprecated so there is no point in using it in code examples.

#### Supporting details
https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/21#dom

#### Metadata
- [x] Fixes a typo, bug, or other error
