### PR TITLE
understanding_client-side_tools: get rid of unnecessary link

### DIFF
--- a/files/en-us/learn/tools_and_testing/understanding_client-side_tools/index.md
+++ b/files/en-us/learn/tools_and_testing/understanding_client-side_tools/index.md
@@ -17,8 +17,6 @@ tags:
 
 Client-side tooling can be intimidating, but this series of articles aims to illustrate the purpose of some of the most common client-side tool types, explain the tools you can chain together, how to install them using package managers, and control them using the command line. We finish up by providing a complete toolchain example showing you how to get productive.
 
-**[Get started now, with our "Client-side tooling overview"](/en-US/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Overview)**
-
 ## Prerequisites
 
 You should really learn the basics of the core [HTML](/en-US/docs/Learn/HTML), [CSS](/en-US/docs/Learn/CSS), and [JavaScript](/en-US/docs/Learn/JavaScript) languages first before attempting to use the tools detailed here.


### PR DESCRIPTION
### Summary
The link `Get started now, with our "Client-side tooling overview"` has been provided immediately before one prerequisite sentence to the main link "1. Client-side tooling overview".

### Motivation
Why would we want readers to skip, already short, prerequisite section?
Providing the same link before the main content creates confusion, when the reader is not really skipping much.

### Related issues
Same is the case with document https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Client-side_JavaScript_frameworks

### Metadata
- [x] Fixes a typo, bug, or other error