### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/web/api/htmlelement/offsettop/index.md
+++ b/files/en-us/web/api/htmlelement/offsettop/index.md
@@ -14,8 +14,8 @@ browser-compat: api.HTMLElement.offsetTop
 
 The **`HTMLElement.offsetTop`** read-only property returns the
 distance of the outer border of the current element relative to the inner border of
-the top of the {{domxref("HTMLelement.offsetParent","offsetParent")}}, *closest
-  relatively positioned* parent element.
+the top of the {{domxref("HTMLelement.offsetParent","offsetParent")}}, the *closest
+positioned* ancestor element.
 
 ## Value
 


### PR DESCRIPTION
`offsetTop` appears to be calculated with respect to the closest positioned ancestor element, not necessarily the closest relatively positioned ancestor element.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Fixing docs

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
See https://codepen.io/swseverance/pen/XWVYdrN

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [X] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
