### PR TITLE
Fix Wikipedia link to avoid redirect

### DIFF
--- a/files/en-us/glossary/function/index.md
+++ b/files/en-us/glossary/function/index.md
@@ -73,7 +73,7 @@ An **Immediately Invoked Function Expressions** ({{glossary("IIFE")}}) is a func
 
 ```js
 // Declared functions can't be called immediately this way
-// Error (https://en.wikipedia.org/wiki/Immediately-invoked_function_expression)
+// Error (https://en.wikipedia.org/wiki/Immediately_invoked_function_expression)
 /*
 function foo() {
     console.log('Hello Foo');
@@ -92,7 +92,7 @@ function foo() {
 (() => console.log('hello world'))();
 ```
 
-If you'd like to know more about IIFEs, check out the following page on Wikipedia : [Immediately Invoked Function Expression](https://en.wikipedia.org/wiki/Immediately-invoked_function_expression)
+If you'd like to know more about IIFEs, check out the following page on Wikipedia : [Immediately Invoked Function Expression](https://en.wikipedia.org/wiki/Immediately_invoked_function_expression)
 
 ## See also
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

I updated the URL slug to avoid the redirect on Wikipedia:

![image](https://user-images.githubusercontent.com/469989/162593579-f72beb7b-261b-411c-b3ba-cce248f9dc77.png)

#### Motivation

Avoiding redirects

#### Supporting details

- https://en.wikipedia.org/wiki/Immediately_invoked_function_expression

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
