### PR TITLE
WebAPI: Update Method pages to modern structure (part 1)

### DIFF
--- a/files/en-us/web/api/angle_instanced_arrays/vertexattribdivisorangle/index.md
+++ b/files/en-us/web/api/angle_instanced_arrays/vertexattribdivisorangle/index.md
@@ -12,7 +12,7 @@ browser-compat: api.ANGLE_instanced_arrays.vertexAttribDivisorANGLE
 ---
 {{APIRef("WebGL")}}
 
-The **ANGLE_instanced_arrays.vertexAttribDivisorANGLE()** method of the [WebGL API](/en-US/docs/Web/API/WebGL_API)  modifies the rate at which generic vertex attributes advance when rendering multiple instances of primitives with {{domxref("ANGLE_instanced_arrays.drawArraysInstancedANGLE()", "ext.drawArraysInstancedANGLE()")}} and {{domxref("ANGLE_instanced_arrays.drawElementsInstancedANGLE()", "ext.drawElementsInstancedANGLE()")}}.
+The **ANGLE_instanced_arrays.vertexAttribDivisorANGLE()** method of the [WebGL API](/en-US/docs/Web/API/WebGL_API) modifies the rate at which generic vertex attributes advance when rendering multiple instances of primitives with {{domxref("ANGLE_instanced_arrays.drawArraysInstancedANGLE()", "ext.drawArraysInstancedANGLE()")}} and {{domxref("ANGLE_instanced_arrays.drawElementsInstancedANGLE()", "ext.drawElementsInstancedANGLE()")}}.
 
 > **Note:** When using {{domxref("WebGL2RenderingContext", "WebGL2")}}, this method is available as {{domxref("WebGL2RenderingContext.vertexAttribDivisor()", "gl.vertexAttribDivisor()")}} by default.
 

--- a/files/en-us/web/api/animation/play/index.md
+++ b/files/en-us/web/api/animation/play/index.md
@@ -31,7 +31,7 @@ None.
 
 {{jsxref("undefined")}}
 
-## Example
+## Examples
 
 In the [Growing/Shrinking Alice Game](https://codepen.io/rachelnabors/pen/PNYGZQ?editors=0010) example, clicking or tapping the cake causes Alice's growing animation (`aliceChange`) to play forward, causing her to get bigger, as well as triggering the cake's animation. Two `Animation.play()`s, one `EventListener`:
 

--- a/files/en-us/web/api/animation/reverse/index.md
+++ b/files/en-us/web/api/animation/reverse/index.md
@@ -31,7 +31,7 @@ None.
 
 {{jsxref("undefined")}}
 
-## Example
+## Examples
 
 In the [Growing/Shrinking Alice Game](https://codepen.io/rachelnabors/pen/PNYGZQ?editors=0010) example, clicking or tapping the bottle causes Alice's growing animation (`aliceChange`) to play backwards, causing her to get smaller. It is done by setting `aliceChange`'s {{ domxref("Animation.playbackRate") }} to `-1` like so:
 

--- a/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
+++ b/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
@@ -27,14 +27,14 @@ Although many of the attributes of the returned object are common to the object 
 ## Syntax
 
 ```js
-var currentTimeValues = animation.getComputedTiming();
+animationEffect.getComputedTiming();
 ```
 
 ### Parameters
 
 None.
 
-### Return Value
+### Return value
 
 An object which contains the following properties:
 

--- a/files/en-us/web/api/animationeffect/gettiming/index.md
+++ b/files/en-us/web/api/animationeffect/gettiming/index.md
@@ -18,10 +18,10 @@ The `AnimationEffect.getTiming()` method of the {{domxref("AnimationEffect")}} i
 ## Syntax
 
 ```js
-animationTiming = animation.getTiming();
+animationEffect.getTiming();
 ```
 
-### Returns
+### Return value
 
 An object.
 

--- a/files/en-us/web/api/animationeffect/updatetiming/index.md
+++ b/files/en-us/web/api/animationeffect/updatetiming/index.md
@@ -26,7 +26,7 @@ animation.updateTiming(timing);
 - `timing`
   - : An object containing the timing properties to update.
 
-### Return Value
+### Return value
 
 None.
 

--- a/files/en-us/web/api/atob/index.md
+++ b/files/en-us/web/api/atob/index.md
@@ -25,7 +25,7 @@ for {{domxref("btoa", "btoa()")}}.
 ## Syntax
 
 ```js
-var decodedData = atob(encodedData);
+atob(encodedData);
 ```
 
 ### Parameters
@@ -43,7 +43,7 @@ An ASCII string containing decoded data from `encodedData`.
 - `InvalidCharacterError` {{domxref("DOMException")}}
   - : Thrown if `encodedData` is not valid base64.
 
-## Example
+## Examples
 
 ```js
 const encodedData = btoa('Hello, world'); // encode a string

--- a/files/en-us/web/api/audiobuffer/copyfromchannel/index.md
+++ b/files/en-us/web/api/audiobuffer/copyfromchannel/index.md
@@ -60,7 +60,7 @@ myArrayBuffer.copyFromChannel(destination, channelNumber, startInChannel);
       of samples that already exist in the source buffer; that is, it's greater than its
       current {{domxref("AudioBuffer.length", "length")}}.
 
-## Example
+## Examples
 
 This example creates a new audio buffer, then copies the samples from another channel
 into it.

--- a/files/en-us/web/api/audiobuffer/copytochannel/index.md
+++ b/files/en-us/web/api/audiobuffer/copytochannel/index.md
@@ -35,7 +35,7 @@ myArrayBuffer.copyToChannel(source, channelNumber, startInChannel);
   - : An optional offset to copy the data to. If _startInChannel_ is greater than
     {{domxref("AudioBuffer.length")}}, an `INDEX_SIZE_ERR` will be thrown.
 
-## Example
+## Examples
 
 ```js
 var myArrayBuffer = audioCtx.createBuffer(2, frameCount, audioCtx.sampleRate);

--- a/files/en-us/web/api/audiocontext/close/index.md
+++ b/files/en-us/web/api/audiocontext/close/index.md
@@ -20,16 +20,15 @@ This function does not automatically release all `AudioContext`-created objects,
 ## Syntax
 
 ```js
-var audioCtx = new AudioContext();
-audioCtx.close().then(function() { /* ... */ });
-await audioCtx.close();
+audioContext.close().then(function() { /* ... */ });
+await audioContext.close();
 ```
 
-### Returns
+### Return value
 
 A {{jsxref("Promise")}} that resolves with {{jsxref('undefined')}}.
 
-## Example
+## Examples
 
 The following snippet is taken from our [AudioContext states demo](https://github.com/mdn/webaudio-examples/blob/master/audiocontext-states/index.html) ([see it running live](https://mdn.github.io/webaudio-examples/audiocontext-states/).) When the stop button is clicked, `close()` is called. When the promise resolves, the example is reset to its beginning state.
 

--- a/files/en-us/web/api/audiocontext/createjavascriptnode/index.md
+++ b/files/en-us/web/api/audiocontext/createjavascriptnode/index.md
@@ -23,7 +23,7 @@ JavaScript.
 ## Syntax
 
 ```js
-var jsNode = audioCtx.createJavaScriptNode(bufferSize, numInputChannels, numOutputChannels);
+audioCtx.createJavaScriptNode(bufferSize, numInputChannels, numOutputChannels);
 ```
 
 ### Parameters
@@ -37,7 +37,7 @@ var jsNode = audioCtx.createJavaScriptNode(bufferSize, numInputChannels, numOutp
 - `numOutputChannels`
   - : The number of output channels in the audio stream.
 
-## Example
+## Examples
 
 The following script illustrates the use of `createJavaScriptNode()`:
 

--- a/files/en-us/web/api/audiocontext/createmediaelementsource/index.md
+++ b/files/en-us/web/api/audiocontext/createmediaelementsource/index.md
@@ -19,8 +19,7 @@ For more details about media element audio source nodes, check out the {{ domxre
 ## Syntax
 
 ```js
-var audioCtx = new AudioContext();
-var source = audioCtx.createMediaElementSource(myMediaElement);
+audioContext.createMediaElementSource(myMediaElement);
 ```
 
 ### Parameters
@@ -28,11 +27,11 @@ var source = audioCtx.createMediaElementSource(myMediaElement);
 - `myMediaElement`
   - : An {{domxref("HTMLMediaElement")}} object that you want to feed into an audio processing graph to manipulate.
 
-### Returns
+### Return value
 
 A {{domxref("MediaElementAudioSourceNode")}}.
 
-## Example
+## Examples
 
 This simple example creates a source from an {{htmlelement("audio") }} element using `createMediaElementSource()`, then passes the audio through a {{ domxref("GainNode") }} before feeding it into the {{ domxref("AudioDestinationNode") }} for playback. When the mouse pointer is moved, the `updatePage()` function is invoked, which calculates the current gain as a ratio of mouse Y position divided by overall window height. You can therefore increase and decrease the volume of the playing music by moving the mouse pointer up and down.
 

--- a/files/en-us/web/api/audiocontext/createmediastreamsource/index.md
+++ b/files/en-us/web/api/audiocontext/createmediastreamsource/index.md
@@ -30,7 +30,7 @@ For more details about media stream audio source nodes, check out the {{
 ## Syntax
 
 ```js
-audioSourceNode = audioContext.createMediaStreamSource(stream);
+audioContext.createMediaStreamSource(stream);
 ```
 
 ### Parameters
@@ -44,7 +44,7 @@ audioSourceNode = audioContext.createMediaStreamSource(stream);
 A new {{domxref("MediaStreamAudioSourceNode")}} object representing the audio node
 whose media is obtained from the specified source stream.
 
-## Example
+## Examples
 
 In this example, we grab a media (audio + video) stream from {{
     domxref("navigator.getUserMedia") }}, feed the media into a {{ htmlelement("video") }}

--- a/files/en-us/web/api/audiocontext/createmediastreamtracksource/index.md
+++ b/files/en-us/web/api/audiocontext/createmediastreamtracksource/index.md
@@ -33,8 +33,7 @@ first, lexicographically (alphabetically).
 ## Syntax
 
 ```js
-var audioCtx = new AudioContext();
-var track = audioCtx.createMediaStreamTrackSource(track);
+audioContext.createMediaStreamTrackSource(track);
 ```
 
 ### Parameters
@@ -48,7 +47,7 @@ var track = audioCtx.createMediaStreamTrackSource(track);
 A {{domxref("MediaStreamTrackAudioSourceNode")}} object which acts as a source for
 audio data found in the specified audio track.
 
-## Example
+## Examples
 
 In this example, {{domxref("MediaDevices.getUserMedia", "getUserMedia()")}} is used to
 request access to the user's microphone. Once that access is attained, an audio context


### PR DESCRIPTION
Doing same thing to the method pages as we did for property pages in #14195 

## Summary
Updating the method pages to follow the current template:
https://developer.mozilla.org/en-US/docs/MDN/Structures/Page_types/API_method_subpage_template

Changes Include:
- fix syntax section
- changing section titles to suggested titles in the template
- change `{{DOMxRef("DOMString")}}` to `string`
- remove extra spaces in between words and extra trailing spaces

### Metadata
- [x] Fixes a typo, bug, or other error
