### PR TITLE
Remove left & right values from align

### DIFF
--- a/files/en-us/web/css/align-content/index.md
+++ b/files/en-us/web/css/align-content/index.md
@@ -211,8 +211,6 @@ select {
 
     <option value="start">start</option>
     <option value="end">end</option>
-    <option value="left">left</option>
-    <option value="right">right</option>
 
     <option value="baseline">baseline</option>
     <option value="first baseline">first baseline</option>

--- a/files/en-us/web/css/align-items/index.md
+++ b/files/en-us/web/css/align-items/index.md
@@ -193,8 +193,6 @@ select {
     <option value="end">end</option>
     <option value="self-start">self-start</option>
     <option value="self-end">self-end</option>
-    <option value="left">left</option>
-    <option value="right">right</option>
 
     <option value="first baseline">first baseline</option>
     <option value="last baseline">last baseline</option>


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Removed invalid values left and right from align-content and align-items, as suggested in PR [#15475](https://github.com/mdn/browser-compat-data/pull/15475)

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
