### PR TITLE
Fix all {{cssxref}} references to scroll-padding-block-start

### DIFF
--- a/files/en-us/web/css/css_scroll_snap/index.md
+++ b/files/en-us/web/css/css_scroll_snap/index.md
@@ -27,7 +27,7 @@ spec-urls: https://drafts.csswg.org/css-scroll-snap/
 - {{cssxref("scroll-padding-inline-start")}}
 - {{cssxref("scroll-padding-inline-end")}}
 - {{cssxref("scroll-padding-block")}}
-- {{cssxref("scroll-padding-block-start")}}
+- [scroll-padding-block-start](/en-US/docs/Web/CSS/scroll-padding-block-start)
 - {{cssxref("scroll-padding-block-end")}}
 
 ### CSS Properties on Children


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Fix all {{cssxref}} references to scroll-padding-block-start.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The {{cssxref}} links are being replaced.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
