### PR TITLE
Un-link obsolete XPCOM mentions in “Changing the Priority of HTTP Requests”

### DIFF
--- a/files/en-us/mozilla/firefox/releases/1.5/changing_the_priority_of_http_requests/index.md
+++ b/files/en-us/mozilla/firefox/releases/1.5/changing_the_priority_of_http_requests/index.md
@@ -15,11 +15,11 @@ tags:
 
 ### Introduction
 
-In [Firefox 1.5](/en-US/docs/Mozilla/Firefox/Releases/1.5), an API was added to support changing the priority of [HTTP](/en-US/docs/Web/HTTP) requests. Prior to this, there was no way to directly indicate that a request was of a different priority. The API is defined in [nsISupportsPriority](/en-US/docs/nsISupportsPriority), but is defined in very generic terms so that any object can implement this interface to enable the concept of priority. This article deals specifically with using that interface to change the priority of HTTP requests.
+In [Firefox 1.5](/en-US/docs/Mozilla/Firefox/Releases/1.5), an API was added to support changing the priority of [HTTP](/en-US/docs/Web/HTTP) requests. Prior to this, there was no way to directly indicate that a request was of a different priority. The API is defined in `nsISupportsPriority`, but is defined in very generic terms so that any object can implement this interface to enable the concept of priority. This article deals specifically with using that interface to change the priority of HTTP requests.
 
 At the time of this writing, changing the priority of an HTTP request only affects the order in which connection attempts are made. This means that the priority only has an effect when there are more connections (to a server) than are allowed.
 
-The examples in this document are all written in [JavaScript](/en-US/docs/Web/JavaScript) using [XPCOM](/en-US/docs/XPCOM).
+The examples in this document are all written in [JavaScript](/en-US/docs/Web/JavaScript) using XPCOM.
 
 ### Using the API
 
@@ -27,7 +27,7 @@ It should be noted that the value of the `priority` attribute follows UNIX conve
 
 #### Accessing priority from an nsIChannel
 
-To change the priority of an HTTP request, you need access to the [nsIChannel](/en-US/docs/XPCOM_Interface_Reference/nsIChannel) that the request is being made on. If you do not have an existing channel, then you can create one as follows:
+To change the priority of an HTTP request, you need access to the `nsIChannel` that the request is being made on. If you do not have an existing channel, then you can create one as follows:
 
 ```js
 var ios = Components.classes["@mozilla.org/network/io-service;1"]
@@ -35,7 +35,7 @@ var ios = Components.classes["@mozilla.org/network/io-service;1"]
 var ch = ios.newChannel("https://www.example.com/", null, null);
 ```
 
-Once you have an [nsIChannel](/en-US/docs/XPCOM_Interface_Reference/nsIChannel), you can access the priority as follows:
+Once you have an `nsIChannel`, you can access the priority as follows:
 
 ```js
 if (ch instanceof Components.interfaces.nsISupportsPriority) {
@@ -62,7 +62,7 @@ req.send(null);
 
 #### Adjusting priority
 
-[nsISupportsPriority](/en-US/docs/nsISupportsPriority#adjustPriority) includes a convenience method named `adjustPriority`. You should use this if you want to alter the priority of a request by a certain amount. For example, if you would like to make a request have slightly higher priority than it currently has, you could do the following:
+`nsISupportsPriority` includes a convenience method named `adjustPriority`. You should use this if you want to alter the priority of a request by a certain amount. For example, if you would like to make a request have slightly higher priority than it currently has, you could do the following:
 
 ```js
 // assuming we already have a nsIChannel from above


### PR DESCRIPTION
The linked docs are all obsolete and now only existing in the archived-content repo.

Fixes https://github.com/mdn/content/issues/14854