### PR TITLE
onShown: Move BCD table to end of the document

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onshown/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onshown/index.md
@@ -120,10 +120,6 @@ Events have three functions:
     - `tab`
       - : {{WebExtAPIRef('tabs.Tab')}}. The details of the tab where the click took place. If the click did not take place in or on a tab, this parameter will be missing.
 
-## Browser compatibility
-
-{{Compat}}
-
 ## Examples
 
 This example listens for the context menu to be shown over a link, then updates the `openLabelledId` menu item with the link's hostname:
@@ -147,3 +143,7 @@ browser.menus.onShown.addListener(info => {
 ```
 
 {{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
#### Summary
Moved BCD after Examples section.

#### Metadata
- [x] Fixes a typo, bug, or other error
