### PR TITLE
FF100 Add AbortSignal.timeout() static method

### DIFF
--- a/files/en-us/mozilla/firefox/releases/100/index.md
+++ b/files/en-us/mozilla/firefox/releases/100/index.md
@@ -43,6 +43,9 @@ This article provides information about the changes in Firefox 100 that will aff
 
 #### DOM
 
+- Code can now use the static method [`AbortSignal.timeout()`](/en-US/docs/Web/API/AbortSignal/timeout).
+  This returns an {{domxref("AbortSignal")}} that can be used to automatically abort an operation with `TimeoutError` after a specified time ({{bug(1753309)}}).
+
 #### Media, WebRTC, and Web Audio
 
 #### Removals

--- a/files/en-us/web/api/abortcontroller/index.md
+++ b/files/en-us/web/api/abortcontroller/index.md
@@ -32,6 +32,8 @@ You can create a new `AbortController` object using the {{domxref("AbortControll
 
 ## Examples
 
+> **Note:** There are additional examples in the {{domxref("AbortSignal")}} reference.
+
 In the following snippet, we aim to download a video using the [Fetch API](/en-US/docs/Web/API/Fetch_API).
 
 We first create a controller using the {{domxref("AbortController.AbortController","AbortController()")}} constructor, then grab a reference to its associated {{domxref("AbortSignal")}} object using the {{domxref("AbortController.signal")}} property.

--- a/files/en-us/web/api/abortsignal/index.md
+++ b/files/en-us/web/api/abortsignal/index.md
@@ -36,6 +36,8 @@ _The **`AbortSignal`** interface inherits methods from its parent interface, {{d
 
 - {{domxref("AbortSignal.abort()")}}
   - : Returns an **`AbortSignal`** instance that is already set as aborted.
+- {{domxref("AbortSignal.timeout()")}}
+  - : Returns an **`AbortSignal`** instance that will automatically abort after a specified time.
 
 ## Events
 
@@ -47,11 +49,14 @@ Listen to this event using [`addEventListener()`](/en-US/docs/Web/API/EventTarge
 
 ## Examples
 
+### Aborting a fetch operation using an explicit signal
+
 The following snippet shows how we might use a signal to abort downloading a video using the [Fetch API](/en-US/docs/Web/API/Fetch_API).
 
 We first create an abort controller using the {{domxref("AbortController.AbortController","AbortController()")}} constructor, then grab a reference to its associated {{domxref("AbortSignal")}} object using the {{domxref("AbortController.signal")}} property.
 
-When the [fetch request](/en-US/docs/Web/API/fetch) is initiated, we pass in the `AbortSignal` as an option inside the request's options object (the `{signal}` below). This associates the signal and controller with the fetch request, and allows us to abort it by calling {{domxref("AbortController.abort()")}}, as seen below in the second event listener.
+When the [fetch request](/en-US/docs/Web/API/fetch) is initiated, we pass in the `AbortSignal` as an option inside the request's options object (the `{signal}` below). This associates the signal and controller with the fetch request, and allows us to abort it by calling {{domxref("AbortController.abort()")}}.
+Below you can see that the fetch operation is aborted in the second event listener, which triggered when the abort button (`abortBtn`) is clicked.
 
 ```js
 var controller = new AbortController();
@@ -80,6 +85,62 @@ function fetchVideo() {
 > **Note:** When `abort()` is called, the `fetch()` promise rejects with an "`AbortError`" `DOMException`.
 
 You can find a [full working example on GitHub](https://github.com/mdn/dom-examples/tree/master/abort-api); you can also see it [running live](https://mdn.github.io/dom-examples/abort-api/).
+
+
+### Aborting a fetch operation with a timeout
+
+If you _only_ need to abort the operation on timeout (and not also on a user-triggered signal) then you can use the static {{domxref("AbortSignal.timeout()")}} method.
+This returns an `AbortSignal` that will automatically timeout after a certain number of milliseconds.
+
+The pseudo-code below shows how you would either succeed in downloading a file, or handle a timeout error after 5 seconds.
+Note that when using this signal, the `fetch()` promise rejects with a "`TimeoutError`" `DOMException`.
+
+```js
+try {
+  const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
+  const result = await res.blob();
+  // ...
+} catch (e) {
+    if (e.name === "TimeoutError") {
+      // Notify the user it took more than 5 seconds to get the result!
+    } else {
+      // A network error, or some other problem.
+      console.log(`Type: ${e.name}, Message: ${e.message}`)
+    }
+}
+```
+
+
+### Aborting a fetch with timeout or explicit abort
+
+You can't use the approach in the previous section to abort a download using either a user action or a timeout, because `fetch()` isn't designed to combine multiple signals.
+
+If you need to trigger abort in this case, then the usual approach is to trigger {{domxref("AbortController.abort()")}} from both a user control and from a timeout timer.
+Note that unlike when using {{domxref("AbortSignal.timeout()")}} you will not be able to differentiate the cause of the abort; the reason is always `AbortError`.
+
+The code snippet shows the basic operation:
+
+```js
+try {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), 5000)
+  const res = await fetch(url, { signal: controller.signal })
+  const body = await res.json()
+}
+catch (e) {
+    if (e.name === "AbortError") {
+      // Notify the user of abort.
+      // Note this will never be a timeout error!
+    } else {
+      // A network error, or some other problem.
+      console.log(`Type: ${e.name}, Message: ${e.message}`)
+    }
+
+} finally {
+  clearTimeout(timeoutId); 
+}
+```
+
 
 ## Specifications
 

--- a/files/en-us/web/api/abortsignal/timeout/index.md
+++ b/files/en-us/web/api/abortsignal/timeout/index.md
@@ -1,0 +1,72 @@
+---
+title: AbortSignal.timeout()
+slug: Web/API/AbortSignal/timeout
+tags:
+  - API
+  - AbortSignal
+  - Method
+  - Reference
+  - timeout
+browser-compat: api.AbortSignal.timout
+---
+{{APIRef("DOM")}}
+
+The static **`AbortSignal.timeout()`** method returns an {{domxref("AbortSignal")}} that will automatically abort after a specified time.
+
+The timeout is based on active rather than elapsed time, and will effectively be paused if the code is running in a suspended worker, or while the document is in a back-forward cache ("[bfcache](https://web.dev/bfcache/)").
+
+The signal aborts with a reason of `TimeoutError` {{domxref("DOMException")}}. 
+This allow UIs to differentiate these from user-triggered aborts which that have the abort reason `AbortError`, and which unlike timeouts typically don't require user notification.
+
+> **Note:** This method can only be used for use cases where the associated operation either succeeds or aborts with a timeout.
+> At time of writing there is no way to combine it with other signals, such that the operation can be aborted by _either_ a command or a timeout.
+
+
+## Syntax
+
+```js
+AbortSignal.timeout(time)
+```
+
+### Parameters
+
+- `time`
+  - : The "active" time in milliseconds before the returned {{domxref("AbortSignal")}} will abort.
+
+### Return value
+
+An {{domxref("AbortSignal")}}.
+The signal will abort with its {{domxref("AbortSignal.reason")}} property set to a `TimeoutError` {{domxref("DOMException")}}.
+
+## Examples
+
+A simple example showing a fetch operation that will timeout if unsuccessful after 5 seconds, is shown below.
+Note that this may also fail if the method is not supported or for some other reason.
+
+```js
+url = "https://path_to_large_file.mp4";
+
+try {
+  const res = await fetch(url, { signal: AbortSignal.timeout(5000) });
+  const result = await res.blob();
+  // ...
+} catch (e) {
+    if (e.name === "TimeoutError") {
+      // It took more than 5 seconds to get the result!
+    } else if (e.name === "TypeError") {
+      // AbortSignal.timeout() method is not support 
+    } else {
+      // A network error, or some other problem.
+      console.log(`Type: ${e.name}, Message: ${e.message}`)
+    }
+}
+```
+
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION
FF100 adds support for `AbortSignal.timeout()` in https://bugzilla.mozilla.org/show_bug.cgi?id=1753309

This adds docs for timeout, and also updates the `AbortSignal` parent with more examples showing how it is used. Also important, showing the limits.

Specifically the `timeout` is  static method that returns a self aborting `AbortSignal` that aborts with `TimeoutError` after a specific time. Note that this can also be aborted with `AbortError` by pressing a browser stop button (if it has one) or presumably by shutting down the associated tab if this was called in a worker or whatever. 

However this has no associated `AbortController` so you can't call `abort()` to trigger this signal. Since `fetch()` takes just one signal, this means you can't have your own button for aborting and a timeout using this (ety).

I have tried to capture all that, and added a release note. 
