### PR TITLE
Change opening sentence to more generic

### DIFF
--- a/files/en-us/web/css/row-gap/index.md
+++ b/files/en-us/web/css/row-gap/index.md
@@ -13,7 +13,7 @@ browser-compat: css.properties.row-gap
 ---
 {{CSSRef}}
 
-The **`row-gap`** [CSS](/en-US/docs/Web/CSS) property sets the size of the gap ({{glossary("gutters","gutter")}}) between an element's grid rows.
+The **`row-gap`** [CSS](/en-US/docs/Web/CSS) property sets the size of the gap ({{glossary("gutters","gutter")}}) between an element's rows.
 
 {{EmbedInteractiveExample("pages/css/row-gap.html")}}
 


### PR DESCRIPTION
`row-gap` can be used now with the `flex` layout also.