### PR TITLE
Update length limits for data URIs across browsers

### DIFF
--- a/files/en-us/web/http/basics_of_http/data_uris/index.md
+++ b/files/en-us/web/http/basics_of_http/data_uris/index.md
@@ -99,13 +99,13 @@ lots of text...<p><a name="bottom">bottom</a>?arg=val
 - Formatting in HTML
   - : A `data` URL provides a file within a file, which can potentially be very wide relative to the width of the enclosing document. As a URL, the `data` should be formattable with whitespace (linefeed, tab, or spaces), but there are practical issues that arise [when using base64 encoding](https://bugzilla.mozilla.org/show_bug.cgi?id=73026#c12).
 - Length limitations
-  - : Although Firefox supports `data` URLs of essentially unlimited length, browsers are not required to support any particular maximum length of data. For example, the Opera 11 browser limited URLs to 65535 characters long which limits `data` URLs to 65529 characters (65529 characters being the length of the encoded data, not the source, if you use the plain `data:`, without specifying a MIME type).
+  - : Browsers are not required to support any particular maximum length of data. For example, the Opera 11 browser limited URLs to 65535 characters long which limits `data` URLs to 65529 characters (65529 characters being the length of the encoded data, not the source, if you use the plain `data:`, without specifying a MIME type). Firefox version 97 and newer supports `data` URLs of up to 32MB (before 97 the limit was close to 256MB). Chromium objects to URLs over 512MB, and Webkit (Safari) to URLs over 2048MB.
 - Lack of error handling
   - : Invalid parameters in media, or typos when specifying `'base64'`, are ignored, but no error is provided.
 - No support for query strings, etc.
   - : The data portion of a data URL is opaque, so an attempt to use a query string (page-specific parameters, with the syntax `<url>?parameter-data`) with a data URL will just include the query string in the data the URL represents.
 - Security issues
-  - : A number of security issues (for example, phishing) have been associated with data URLs, and navigating to them in the browser's top level. To mitigate such issues, top-level navigation to `data://` URLs is blocked in all modern browsers. See [this blog post from the Mozilla Security Team](https://blog.mozilla.org/security/2017/11/27/blocking-top-level-navigations-data-urls-firefox-58/) for more details.
+  - : A number of security issues (for example, phishing) have been associated with data URLs, and navigating to them in the browser's top level. To mitigate such issues, top-level navigation to `data:` URLs is blocked in all modern browsers. See [this blog post from the Mozilla Security Team](https://blog.mozilla.org/security/2017/11/27/blocking-top-level-navigations-data-urls-firefox-58/) for more details.
 
 ## Specifications
 


### PR DESCRIPTION
Source: https://bugzilla.mozilla.org/show_bug.cgi?id=1721448#c7, and earlier comments on that bug for the IPC length limit.

#### Summary
There are length limits to data URIs, even in modern browsers, and this documents them. The length limit in Firefox changed recently.

#### Motivation
I noticed that the docs hadn't been updated yet after the Firefox change.

#### Supporting details
https://bugzilla.mozilla.org/show_bug.cgi?id=1721448#c7


#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
