### PR TITLE
Fix typo xnsIDOMDOMConfigurationxx

### DIFF
--- a/files/en-us/mozilla/firefox/releases/3.6/interfaces_moved/index.md
+++ b/files/en-us/mozilla/firefox/releases/3.6/interfaces_moved/index.md
@@ -42,7 +42,7 @@ The following interfaces moved from `dom/public/idl/core/` to `dom/interfaces/co
 | `nsIDOM3Node`        | `nsIDOM3Text`                 |
 | `nsIDOM3TypeInfo`    | `nsIDOMAttr`                  |
 | `nsIDOMCDATASection` | `nsIDOMCharacterData`         |
-| `nsIDOMComment`      | `xnsIDOMDOMConfiguration`   |
+| `nsIDOMComment`      | `nsIDOMDOMConfiguration`   |
 | `nsIDOMDOMError`     | `nsIDOMDOMErrorHandler`       |
 | `nsIDOMDOMException` | `nsIDOMDOMImplementation`     |
 | `nsIDOMDOMLocator`   | `nsIDOMDOMStringList`         |

--- a/files/en-us/mozilla/firefox/releases/3.6/interfaces_moved/index.md
+++ b/files/en-us/mozilla/firefox/releases/3.6/interfaces_moved/index.md
@@ -42,7 +42,7 @@ The following interfaces moved from `dom/public/idl/core/` to `dom/interfaces/co
 | `nsIDOM3Node`        | `nsIDOM3Text`                 |
 | `nsIDOM3TypeInfo`    | `nsIDOMAttr`                  |
 | `nsIDOMCDATASection` | `nsIDOMCharacterData`         |
-| `nsIDOMComment`      | `xnsIDOMDOMConfigurationxx`   |
+| `nsIDOMComment`      | `xnsIDOMDOMConfiguration`   |
 | `nsIDOMDOMError`     | `nsIDOMDOMErrorHandler`       |
 | `nsIDOMDOMException` | `nsIDOMDOMImplementation`     |
 | `nsIDOMDOMLocator`   | `nsIDOMDOMStringList`         |


### PR DESCRIPTION
Fixes typo xnsIDOMDOMConfigurationxx to nsIDOMDOMConfiguration reported in https://github.com/mdn/content/pull/14881#pullrequestreview-938293246