### PR TITLE
WebAPI: Update Method pages to modern structure (part 3)

### DIFF
--- a/files/en-us/web/api/backgroundfetchupdateuievent/updateui/index.md
+++ b/files/en-us/web/api/backgroundfetchupdateuievent/updateui/index.md
@@ -18,7 +18,7 @@ This method may only be run once, to notify the user on a failed or a successful
 ## Syntax
 
 ```js
-let updateUI = BackgroundFetchUpdateUIEvent.updateUI(options);
+updateUI(options);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/baseaudiocontext/createanalyser/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createanalyser/index.md
@@ -27,14 +27,14 @@ can be used to expose audio time and frequency data and create data visualizatio
 ## Syntax
 
 ```js
-var analyserNode = baseAudioContext.createAnalyser();
+createAnalyser();
 ```
 
-### Returns
+### Return value
 
 An {{domxref("AnalyserNode")}}.
 
-## Example
+## Examples
 
 The following example shows basic usage of an AudioContext to create an Analyser node,
 then use requestAnimationFrame() to collect time domain data repeatedly and draw an

--- a/files/en-us/web/api/baseaudiocontext/createbiquadfilter/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createbiquadfilter/index.md
@@ -24,14 +24,14 @@ filter configurable as several different common filter types.
 ## Syntax
 
 ```js
-baseAudioContext.createBiquadFilter();
+createBiquadFilter();
 ```
 
-### Returns
+### Return value
 
 A {{domxref("BiquadFilterNode")}}.
 
-## Example
+## Examples
 
 The following example shows basic usage of an AudioContext to create a Biquad filter
 node. For a complete working example, check out our [voice-change-o-matic](https://mdn.github.io/voice-change-o-matic/) demo (look

--- a/files/en-us/web/api/baseaudiocontext/createbuffer/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createbuffer/index.md
@@ -37,7 +37,7 @@ reference page.
 ## Syntax
 
 ```js
-var buffer = baseAudioContext.createBuffer(numOfChannels, length, sampleRate);
+createBuffer(numOfChannels, length, sampleRate);
 ```
 
 ### Parameters
@@ -58,7 +58,7 @@ var buffer = baseAudioContext.createBuffer(numOfChannels, length, sampleRate);
   - : The sample rate of the linear audio data in sample-frames per second. All browsers
     must support sample rates in at least the range 8,000 Hz to 96,000 Hz.
 
-### Returns
+### Return value
 
 An {{domxref("AudioBuffer")}} configured based on the specified options.
 

--- a/files/en-us/web/api/baseaudiocontext/createbuffersource/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createbuffersource/index.md
@@ -28,14 +28,14 @@ track.
 ## Syntax
 
 ```js
-var source = baseAudioContext.createBufferSource();
+createBufferSource();
 ```
 
-### Returns
+### Return value
 
 An {{domxref("AudioBufferSourceNode")}}.
 
-## Example
+## Examples
 
 In this example, we create a two second buffer, fill it with white noise, and then play
 it via an {{ domxref("AudioBufferSourceNode") }}. The comments should clearly explain

--- a/files/en-us/web/api/baseaudiocontext/createchannelmerger/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createchannelmerger/index.md
@@ -24,7 +24,7 @@ which combines channels from multiple audio streams into a single audio stream.
 ## Syntax
 
 ```js
-createChannelMerger(numberOfInputs)
+createChannelMerger(numberOfInputs);
 ```
 
 ### Parameters
@@ -33,11 +33,11 @@ createChannelMerger(numberOfInputs)
   - : The number of channels in the input audio streams, which the output stream will
     contain; the default is 6 if this parameter is not specified.
 
-### Returns
+### Return value
 
 A {{domxref("ChannelMergerNode")}}.
 
-## Example
+## Examples
 
 The following example shows how you could separate a stereo track (say, a piece of
 music), and process the left and right channel differently. To use them, you need to use

--- a/files/en-us/web/api/baseaudiocontext/createchannelsplitter/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createchannelsplitter/index.md
@@ -23,7 +23,7 @@ which is used to access the individual channels of an audio stream and process t
 ## Syntax
 
 ```js
-createChannelSplitter(numberOfOutputs)
+createChannelSplitter(numberOfOutputs);
 ```
 
 ### Parameters
@@ -32,11 +32,11 @@ createChannelSplitter(numberOfOutputs)
   - : The number of channels in the input audio stream that you want to output separately;
     the default is 6 if this parameter is not specified.
 
-### Returns
+### Return value
 
 A {{domxref("ChannelSplitterNode")}}.
 
-## Example
+## Examples
 
 The following simple example shows how you could separate a stereo track (say, a piece
 of music), and process the left and right channel differently. To use them, you need to

--- a/files/en-us/web/api/baseaudiocontext/createconstantsource/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createconstantsource/index.md
@@ -27,14 +27,14 @@ value.
 ## Syntax
 
 ```js
-var constantSourceNode = AudioContext.createConstantSource()
+createConstantSource();
 ```
 
 ### Parameters
 
 None.
 
-### Returns
+### Return value
 
 A {{domxref('ConstantSourceNode')}} instance.
 

--- a/files/en-us/web/api/baseaudiocontext/createconvolver/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createconvolver/index.md
@@ -25,14 +25,14 @@ Convolution](https://webaudio.github.io/web-audio-api/#background-3) for more in
 ## Syntax
 
 ```js
-baseAudioContext.createConvolver();
+createConvolver();
 ```
 
-### Returns
+### Return value
 
 A {{domxref("ConvolverNode")}}.
 
-## Example
+## Examples
 
 The following example shows basic usage of an AudioContext to create a convolver node.
 The basic premise is that you create an AudioBuffer containing a sound sample to be used

--- a/files/en-us/web/api/baseaudiocontext/createdelay/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createdelay/index.md
@@ -24,7 +24,7 @@ which is used to delay the incoming audio signal by a certain amount of time.
 ## Syntax
 
 ```js
-var delayNode = audioCtx.createDelay(maxDelayTime);
+createDelay(maxDelayTime);
 ```
 
 ### Parameters
@@ -33,12 +33,12 @@ var delayNode = audioCtx.createDelay(maxDelayTime);
   - : The maximum amount of time, in seconds, that the audio signal can be delayed by.
     Must be less than 180 seconds, and defaults to 1 second if not specified.
 
-### Returns
+### Return value
 
 A {{domxref("DelayNode")}}. The default {{domxref("DelayNode.delayTime")}} is 0
 seconds.
 
-## Example
+## Examples
 
 We have created a simple example that allows you to play three different samples on a
 constant loop — see [create-delay](https://chrisdavidmills.github.io/create-delay/) (you can also

--- a/files/en-us/web/api/baseaudiocontext/createdynamicscompressor/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createdynamicscompressor/index.md
@@ -31,14 +31,14 @@ help avoid clipping (distorting) of the audio output.
 ## Syntax
 
 ```js
-baseAudioCtx.createDynamicsCompressor();
+createDynamicsCompressor();
 ```
 
-### Returns
+### Return value
 
 A {{domxref("DynamicsCompressorNode")}}.
 
-## Example
+## Examples
 
 The code below demonstrates a simple usage of `createDynamicsCompressor()`
 to add compression to an audio track. For a more complete example, have a look at our [basic Compressor

--- a/files/en-us/web/api/baseaudiocontext/creategain/index.md
+++ b/files/en-us/web/api/baseaudiocontext/creategain/index.md
@@ -27,7 +27,7 @@ overall gain (or volume) of the audio graph.
 ## Syntax
 
 ```js
-var gainNode = AudioContext.createGain();
+createGain();
 ```
 
 ### Return value
@@ -37,7 +37,7 @@ audio whose volume has been adjusted in gain (volume) to a level specified by th
 {{domxref("GainNode.gain")}} [a-rate](/en-US/docs/Web/API/AudioParam#a-rate)
 parameter.
 
-## Example
+## Examples
 
 The following example shows basic usage of an {{domxref("AudioContext")}} to create a
 `GainNode`, which is then used to mute and unmute the audio when a Mute

--- a/files/en-us/web/api/baseaudiocontext/createiirfilter/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createiirfilter/index.md
@@ -28,7 +28,7 @@ of filter.
 ## Syntax
 
 ```js
-var iirFilter = AudioContext.createIIRFilter(feedforward, feedback);
+createIIRFilter(feedforward, feedback);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/baseaudiocontext/createoscillator/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createoscillator/index.md
@@ -24,14 +24,14 @@ waveform. It basically generates a constant tone.
 ## Syntax
 
 ```js
-var oscillatorNode = audioCtx.createOscillator();
+createOscillator();
 ```
 
-### Returns
+### Return value
 
 An {{domxref("OscillatorNode")}}.
 
-## Example
+## Examples
 
 The following example shows basic usage of an AudioContext to create an oscillator
 node. For applied examples/information, check out our [Violent Theremin demo](https://mdn.github.io/violent-theremin/) ([see

--- a/files/en-us/web/api/baseaudiocontext/createpanner/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createpanner/index.md
@@ -32,11 +32,11 @@ audio.
 createPanner();
 ```
 
-### Returns
+### Return value
 
 A {{domxref("PannerNode")}}.
 
-## Example
+## Examples
 
 In the following example, you can see an example of how the `createPanner()`
 method, {{domxref("AudioListener")}}  and {{domxref("PannerNode")}} would be used to

--- a/files/en-us/web/api/baseaudiocontext/createperiodicwave/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createperiodicwave/index.md
@@ -22,10 +22,11 @@ that can be used to shape the output of an {{ domxref("OscillatorNode") }}.
 ## Syntax
 
 ```js
-var wave = AudioContext.createPeriodicWave(real, imag[, constraints]);
+createPeriodicWave(real, imag);
+createPeriodicWave(real, imag, constraints);
 ```
 
-### Returns
+### Return value
 
 A {{domxref("PeriodicWave")}}.
 
@@ -50,7 +51,7 @@ otherwise an error is thrown.
 
 > **Note:** If normalized, the resulting wave will have a maximum absolute peak value of 1.
 
-## Example
+## Examples
 
 The following example illustrates simple usage of `createPeriodicWave()`, to
 create a {{domxref("PeriodicWave")}} object containing a simple sine wave.

--- a/files/en-us/web/api/baseaudiocontext/createscriptprocessor/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createscriptprocessor/index.md
@@ -21,7 +21,7 @@ creates a {{domxref("ScriptProcessorNode")}} used for direct audio processing.
 ## Syntax
 
 ```js
-var scriptProcessor = audioCtx.createScriptProcessor(bufferSize, numberOfInputChannels, numberOfOutputChannels);
+createScriptProcessor(bufferSize, numberOfInputChannels, numberOfOutputChannels);
 ```
 
 ### Parameters
@@ -54,11 +54,11 @@ var scriptProcessor = audioCtx.createScriptProcessor(bufferSize, numberOfInputCh
 > **Note:** It is invalid for both `numberOfInputChannels` and
 > `numberOfOutputChannels` to be zero.
 
-### Returns
+### Return value
 
 A {{domxref("ScriptProcessorNode")}}.
 
-## Example
+## Examples
 
 The following example shows basic usage of a `ScriptProcessorNode` to take a
 track loaded via {{domxref("BaseAudioContext/decodeAudioData", "AudioContext.decodeAudioData()")}}, process it, adding a bit

--- a/files/en-us/web/api/baseaudiocontext/createstereopanner/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createstereopanner/index.md
@@ -25,14 +25,14 @@ It positions an incoming audio stream in a stereo image using a [low-cost pannin
 ## Syntax
 
 ```js
-baseAudioContext.createStereoPanner();
+createStereoPanner();
 ```
 
-### Returns
+### Return value
 
 A {{domxref("StereoPannerNode")}}.
 
-## Example
+## Examples
 
 In our [StereoPannerNode
 example](https://mdn.github.io/webaudio-examples/stereo-panner-node/) ([see

--- a/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.md
@@ -24,14 +24,14 @@ distortion. It is used to apply distortion effects to your audio.
 ## Syntax
 
 ```js
-baseAudioCtx.createWaveShaper();
+createWaveShaper();
 ```
 
-### Returns
+### Return value
 
 A {{domxref("WaveShaperNode")}}.
 
-## Example
+## Examples
 
 The following example shows basic usage of an AudioContext to create a wave shaper
 node. For applied examples/information, check out our [Voice-change-O-matic](https://mdn.github.io/voice-change-o-matic/) [demo](https://mdn.github.io/voice-change-o-matic/) ([see

--- a/files/en-us/web/api/beforeinstallpromptevent/prompt/index.md
+++ b/files/en-us/web/api/beforeinstallpromptevent/prompt/index.md
@@ -17,18 +17,18 @@ install prompt at a time of their own choosing.
 ## Syntax
 
 ```js
-BeforeInstallPromptEvent.prompt()
+prompt();
 ```
 
 ### Parameters
 
 None.
 
-### Returns
+### Return value
 
 An empty {{jsxref("Promise")}}.
 
-## Example
+## Examples
 
 ```js
 var isTooSoon = true;

--- a/files/en-us/web/api/biquadfilternode/getfrequencyresponse/index.md
+++ b/files/en-us/web/api/biquadfilternode/getfrequencyresponse/index.md
@@ -26,7 +26,7 @@ must be the same size as the array of input frequency values
 ## Syntax
 
 ```js
-BiquadFilterNode.getFrequencyResponse(frequencyArray, magResponseOutput, phaseResponseOutput);
+getFrequencyResponse(frequencyArray, magResponseOutput, phaseResponseOutput);
 ```
 
 ### Parameters
@@ -58,7 +58,7 @@ BiquadFilterNode.getFrequencyResponse(frequencyArray, magResponseOutput, phaseRe
 - `InvalidAccessError`
   - : The three arrays provided are not all of the same length.
 
-## Example
+## Examples
 
 In the following example we are using a biquad filter on a media stream (for the full
 demo, see our [stream-source-buffer
@@ -95,7 +95,7 @@ var freqResponseOutput = document.querySelector('.freq-response-output');
 
 Finally, after creating our biquad filter, we use `getFrequencyResponse()`
 to generate the response data and put it in our arrays, then loop through each data set
-and output  them in a human-readable list at the bottom of the page:
+and output them in a human-readable list at the bottom of the page:
 
 ```js
 var biquadFilter = audioCtx.createBiquadFilter();

--- a/files/en-us/web/api/blob/text/index.md
+++ b/files/en-us/web/api/blob/text/index.md
@@ -23,7 +23,7 @@ text();
 
 ### Return value
 
-A promise that resolves with a {{domxref("USVString")}} which contains the blob's data
+A promise that resolves with a string which contains the blob's data
 as a text string. The data is _always_ presumed to be in UTF-8 format.
 
 ## Usage notes

--- a/files/en-us/web/api/bluetooth/requestdevice/index.md
+++ b/files/en-us/web/api/bluetooth/requestdevice/index.md
@@ -20,8 +20,8 @@ UI, this method returns the first device matching the criteria.
 ## Syntax
 
 ```js
-Bluetooth.requestDevice([options])
-  .then(function(bluetoothDevice) { /* ... */ })
+requestDevice();
+requestDevice(options);
 ```
 
 ### Return value
@@ -42,7 +42,7 @@ A {{jsxref("Promise")}} to a {{domxref("BluetoothDevice")}} object.
       requesting script can accept all Bluetooth devices. The default is
       `false`.
 
-## Exceptions
+### Exceptions
 
 - `TypeError` {{domxref("DOMException")}}
   - : Thrown if the provided `options` do not make sense. For example,
@@ -56,7 +56,7 @@ A {{jsxref("Promise")}} to a {{domxref("BluetoothDevice")}} object.
   - : Thrown if this operation is not permitted in this context due to security concerns. For
     example, it is called from insecure origin.
 
-## Example
+## Examples
 
 ```js
 // Discovery options match any devices advertising:

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/readvalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/readvalue/index.md
@@ -22,10 +22,10 @@ it throws an error.
 ## Syntax
 
 ```js
-BluetoothRemoteGATTCharacteristic.readValue().then(function(dataView) { /* ... */ })
+readValue();
 ```
 
-### Returns
+### Return value
 
 A {{jsxref("Promise")}} that resolves to an {{jsxref("DataView")}}.
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/startnotifications/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/startnotifications/index.md
@@ -21,10 +21,10 @@ there is an active notification on it.
 ## Syntax
 
 ```js
-BluetoothRemoteGATTCharacteristic.startNotifications().then(function(BluetoothRemoteGATTCharacteristic) { /* ... */ })
+startNotifications();
 ```
 
-### Returns
+### Return value
 
 A {{jsxref("Promise")}} to the BluetoothRemoteGATTCharacteristic instance.
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/stopnotifications/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/stopnotifications/index.md
@@ -21,10 +21,10 @@ there is no longer an active notification on it.
 ## Syntax
 
 ```js
-BluetoothRemoteGATTCharacteristic.stopNotifications().then(function(BluetoothRemoteGATTCharacteristic) { /* ... */ })
+stopNotifications();
 ```
 
-### Returns
+### Return value
 
 A {{jsxref("Promise")}}.
 

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/readvalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/readvalue/index.md
@@ -18,16 +18,16 @@ browser-compat: api.BluetoothRemoteGATTDescriptor.readValue
 The
 **`BluetoothRemoteGATTDescriptor.readValue()`**
 method returns a {{jsxref("Promise")}} that resolves to
-an {{jsxref("ArrayBuffer")}} holding a duplicate  of the `value` property if
+an {{jsxref("ArrayBuffer")}} holding a duplicate of the `value` property if
 it is available and supported. Otherwise it throws an error.
 
 ## Syntax
 
 ```js
-BluetoothRemoteGATTDescriptor.readValue().then(function(value[]) { /* ... */ })
+readValue();
 ```
 
-### Returns
+### Return value
 
 A {{jsxref("Promise")}} that resolves to an {{jsxref("ArrayBuffer")}}.
 

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/writevalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/writevalue/index.md
@@ -22,7 +22,7 @@ an {{jsxref("ArrayBuffer")}} and returns a {{jsxref("Promise")}}.
 ## Syntax
 
 ```js
-BluetoothRemoteGATTDescriptor.writeValue(array[]).then(function() { /* ... */ })
+writeValue(array);
 ```
 
 ### Parameters
@@ -30,7 +30,7 @@ BluetoothRemoteGATTDescriptor.writeValue(array[]).then(function() { /* ... */ })
 - array
   - : Sets the value with the bytes contained in the array.
 
-### Returns
+### Return value
 
 A {{jsxref("Promise")}}.
 

--- a/files/en-us/web/api/bluetoothremotegattserver/disconnect/index.md
+++ b/files/en-us/web/api/bluetoothremotegattserver/disconnect/index.md
@@ -20,10 +20,10 @@ the script execution environment to disconnect from `this.device`.
 ## Syntax
 
 ```js
-BluetoothRemoteGATTServer.disconnect()
+disconnect();
 ```
 
-### Returns
+### Return value
 
 None.
 

--- a/files/en-us/web/api/bluetoothuuid/canonicaluuid/index.md
+++ b/files/en-us/web/api/bluetoothuuid/canonicaluuid/index.md
@@ -16,7 +16,7 @@ The **`canonicalUUID()`**  method of the {{domxref("BluetoothUUID")}} interface 
 ## Syntax
 
 ```js
-BluetoothUUID.canonicalUUID(alias);
+canonicalUUID(alias);
 ```
 
 ### Parameters
@@ -24,7 +24,7 @@ BluetoothUUID.canonicalUUID(alias);
 - `alias`
   - : A {{domxref("DOMString","string")}} containing a 16- or 32- bit UUID alias.
 
-### Returns
+### Return value
 
 A 128-bit UUID.
 

--- a/files/en-us/web/api/bluetoothuuid/getcharacteristic/index.md
+++ b/files/en-us/web/api/bluetoothuuid/getcharacteristic/index.md
@@ -16,7 +16,7 @@ The **`getCharacteristic()`**  method of the {{domxref("BluetoothUUID")}} interf
 ## Syntax
 
 ```js
-BluetoothUUID.getCharacteristic(name);
+getCharacteristic(name);
 ```
 
 ### Parameters
@@ -24,7 +24,7 @@ BluetoothUUID.getCharacteristic(name);
 - `name`
   - : A {{domxref("DOMString","string")}} containing the name of the characteristic.
 
-### Returns
+### Return value
 
 A 128-bit UUID.
 

--- a/files/en-us/web/api/bluetoothuuid/getdescriptor/index.md
+++ b/files/en-us/web/api/bluetoothuuid/getdescriptor/index.md
@@ -16,7 +16,7 @@ The **`getDescriptor()`**  method of the {{domxref("BluetoothUUID")}} interface 
 ## Syntax
 
 ```js
-BluetoothUUID.getDescriptor(name);
+getDescriptor(name);
 ```
 
 ### Parameters
@@ -24,7 +24,7 @@ BluetoothUUID.getDescriptor(name);
 - `name`
   - : A {{domxref("DOMString","string")}} containing the name of the descriptor.
 
-### Returns
+### Return value
 
 A 128-bit UUID.
 

--- a/files/en-us/web/api/bluetoothuuid/getservice/index.md
+++ b/files/en-us/web/api/bluetoothuuid/getservice/index.md
@@ -16,7 +16,7 @@ The **`getService()`**  method of the {{domxref("BluetoothUUID")}} interface ret
 ## Syntax
 
 ```js
-BluetoothUUID.getService(name);
+getService(name);
 ```
 
 ### Parameters
@@ -24,7 +24,7 @@ BluetoothUUID.getService(name);
 - `name`
   - : A {{domxref("DOMString","string")}} containing the name of the service.
 
-### Returns
+### Return value
 
 A 128-bit UUID.
 

--- a/files/en-us/web/api/btoa/index.md
+++ b/files/en-us/web/api/btoa/index.md
@@ -28,7 +28,7 @@ characters such as ASCII values 0 through 31.
 ## Syntax
 
 ```js
-var encodedData = btoa(stringToEncode);
+btoa(stringToEncode);
 ```
 
 ### Parameters
@@ -47,7 +47,7 @@ An ASCII string containing the Base64 representation of
   - : The string contained a character that did not fit in a single byte. See "Unicode
     strings" below for more detail.
 
-## Example
+## Examples
 
 ```js
 const encodedData = btoa('Hello, world'); // encode a string

--- a/files/en-us/web/api/bytelengthqueuingstrategy/size/index.md
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/size/index.md
@@ -20,7 +20,7 @@ The **`size()`** method of the
 ## Syntax
 
 ```js
-var size = byteLengthQueuingStrategy.size(chunk);
+size(chunk);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cache/add/index.md
+++ b/files/en-us/web/api/cache/add/index.md
@@ -34,15 +34,13 @@ For more complex operations, you'll need to use {{domxref("Cache.put","Cache.put
 ## Syntax
 
 ```js
-cache.add(request).then(function() {
-  // request has been added to the cache
-});
+add(request);
 ```
 
 ### Parameters
 
 - request
-  - : The request you want to add to the cache. This can be a  {{domxref("Request")}} object or a URL.
+  - : The request you want to add to the cache. This can be a {{domxref("Request")}} object or a URL.
 
 ### Return value
 

--- a/files/en-us/web/api/cache/delete/index.md
+++ b/files/en-us/web/api/cache/delete/index.md
@@ -25,9 +25,7 @@ to `false`.
 ## Syntax
 
 ```js
-cache.delete(request, {options}).then(function(found) {
-  // your cache entry has been deleted if found
-});
+delete(request, {options});
 ```
 
 ### Parameters
@@ -52,7 +50,7 @@ cache.delete(request, {options}).then(function(found) {
     - `ignoreVary`: A boolean value that, when set to
       `true,` tells the matching operation not to perform `VARY`
       header matching.  In other words, if the URL matches you will get a match
-      regardless of  whether the {{domxref("Response")}} object has a `VARY`
+      regardless of whether the {{domxref("Response")}} object has a `VARY`
       header. It defaults to `false`.
     - `cacheName`: A {{domxref("DOMString")}} that represents a specific
       cache to search within. Note that this option is ignored by

--- a/files/en-us/web/api/cache/delete/index.md
+++ b/files/en-us/web/api/cache/delete/index.md
@@ -25,7 +25,8 @@ to `false`.
 ## Syntax
 
 ```js
-delete(request, {options});
+delete(request);
+delete(request, options);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cache/keys/index.md
+++ b/files/en-us/web/api/cache/keys/index.md
@@ -25,9 +25,9 @@ The requests are returned in the same order that they were inserted.
 ## Syntax
 
 ```js
-cache.keys(request, {options}).then(function(keys) {
-  // do something with your array of requests
-});
+keys();
+keys(request);
+keys(request, options);
 ```
 
 ### Parameters
@@ -52,7 +52,7 @@ cache.keys(request, {options}).then(function(keys) {
     - `ignoreVary`: A boolean value that, when set to
       `true,` tells the matching operation not to perform `VARY`
       header matching.  In other words, if the URL matches you will get a match
-      regardless of  whether the {{domxref("Response")}} object has a `VARY`
+      regardless of whether the {{domxref("Response")}} object has a `VARY`
       header. It defaults to `false`.
     - `cacheName`: A {{domxref("DOMString")}} that represents a specific
       cache to search within. Note that this option is ignored by

--- a/files/en-us/web/api/canvasgradient/addcolorstop/index.md
+++ b/files/en-us/web/api/canvasgradient/addcolorstop/index.md
@@ -20,7 +20,7 @@ method adds a new color stop, defined by an `offset` and a
 ## Syntax
 
 ```js
-void gradient.addColorStop(offset, color);
+addColorStop(offset, color);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvaspattern/settransform/index.md
+++ b/files/en-us/web/api/canvaspattern/settransform/index.md
@@ -20,7 +20,7 @@ pattern's transformation matrix and invokes it on the pattern.
 ## Syntax
 
 ```js
-void pattern.setTransform(matrix);
+setTransform(matrix);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/arc/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/arc/index.md
@@ -19,7 +19,8 @@ method of the [Canvas 2D API
 ## Syntax
 
 ```js
-void ctx.arc(x, y, radius, startAngle, endAngle [, counterclockwise]);
+arc(x, y, radius, startAngle, endAngle);
+arc(x, y, radius, startAngle, endAngle, counterclockwise);
 ```
 
 The `arc()` method creates a circular arc centered at `(x, y)`

--- a/files/en-us/web/api/canvasrenderingcontext2d/arcto/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/arcto/index.md
@@ -26,7 +26,7 @@ This method is commonly used for making rounded corners.
 ## Syntax
 
 ```js
-void ctx.arcTo(x1, y1, x2, y2, radius);
+arcTo(x1, y1, x2, y2, radius);
 ```
 
 ### Parameters
@@ -208,7 +208,7 @@ const control    = document.getElementById('radius');
 
 const mouse = { x: 0, y: 0 };
 
-let   r  = 100; // Radius
+let r  = 100; // Radius
 const p0 = { x: 0, y: 50 };
 
 const p1 = { x: 100, y: 100 };

--- a/files/en-us/web/api/canvasrenderingcontext2d/beginpath/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/beginpath/index.md
@@ -22,7 +22,7 @@ this method when you want to create a new path.
 ## Syntax
 
 ```js
-void ctx.beginPath();
+beginPath();
 ```
 
 ## Examples

--- a/files/en-us/web/api/canvasrenderingcontext2d/beziercurveto/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/beziercurveto/index.md
@@ -22,7 +22,7 @@ creating the Bézier curve.
 ## Syntax
 
 ```js
-void ctx.bezierCurveTo(cp1x, cp1y, cp2x, cp2y, x, y);
+bezierCurveTo(cp1x, cp1y, cp2x, cp2y, x, y);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/clearrect/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/clearrect/index.md
@@ -25,7 +25,7 @@ transparent black.
 ## Syntax
 
 ```js
-void ctx.clearRect(x, y, width, height);
+clearRect(x, y, width, height);
 ```
 
 The `clearRect()` method sets the pixels in a rectangular area to

--- a/files/en-us/web/api/canvasrenderingcontext2d/clip/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/clip/index.md
@@ -32,8 +32,10 @@ drawn.
 ## Syntax
 
 ```js
-void ctx.clip([fillRule]);
-void ctx.clip(path [, fillRule]);
+clip();
+clip(path);
+clip(fillRule);
+clip(path, fillRule);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/closepath/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/closepath/index.md
@@ -24,7 +24,7 @@ the {{domxref("CanvasRenderingContext2D.stroke()", "stroke()")}} or
 ## Syntax
 
 ```js
-void ctx.closePath();
+closePath();
 ```
 
 ## Examples


### PR DESCRIPTION
Continuing #14857 

## Summary
Updating the method pages to follow the current templates:
https://developer.mozilla.org/en-US/docs/MDN/Structures/Syntax_sections#constructors_and_methods
https://developer.mozilla.org/en-US/docs/MDN/Structures/Page_types/API_method_subpage_template

Changes Include:
- fix syntax section
- changing section titles to suggested titles in the template
- change `{{DOMxRef("DOMString")}}` to `string`
- remove extra spaces in between words and extra trailing spaces
- other small corrections

### Metadata
- [x] Fixes a typo, bug, or other error
