### PR TITLE
Update moved URLs with their new locations (part 5)

### DIFF
--- a/files/en-us/learn/css/css_layout/fundamental_layout_comprehension/index.md
+++ b/files/en-us/learn/css/css_layout/fundamental_layout_comprehension/index.md
@@ -34,7 +34,7 @@ If you have worked through this module then you will have already covered the ba
 
 ## Starting point
 
-You can download the HTML, CSS, and a set of six images [here](https://github.com/mdn/learning-area/tree/master/css/css-layout/fundamental-layout-comprehension).
+You can download the HTML, CSS, and a set of six images [here](https://github.com/mdn/learning-area/tree/main/css/css-layout/fundamental-layout-comprehension).
 
 Save the HTML document and stylesheet into a directory on your computer, and add the images into a folder named `images`. Opening the `index.html` file in a browser should give you a page with basic styling but no layout, which should look something like the image below.
 

--- a/files/en-us/web/guide/audio_and_video_delivery/cross_browser_video_player/index.md
+++ b/files/en-us/web/guide/audio_and_video_delivery/cross_browser_video_player/index.md
@@ -103,7 +103,7 @@ HTML5 comes with a JavaScript [Media API](/en-US/docs/Web/API/HTMLMediaElement) 
 
 Before dealing with the individual buttons, a number of initialization calls are required.
 
-To begin with, it's a good idea to first check if the browser actually supports the {{ htmlelement("video") }} element and to only setup the custom controls if it does. This is done by checking if a created {{ htmlelement("video") }} element supports [the `canPlayType()` method](https://www.w3.org/html/wg/drafts/html/master/embedded-content.html#dom-navigator-canplaytype), which any supported HTML5 {{ htmlelement("video") }} element should.
+To begin with, it's a good idea to first check if the browser actually supports the {{ htmlelement("video") }} element and to only setup the custom controls if it does. This is done by checking if a created {{ htmlelement("video") }} element supports [the `canPlayType()` method](https://html.spec.whatwg.org/multipage/media.html#dom-navigator-canplaytype), which any supported HTML5 {{ htmlelement("video") }} element should.
 
 ```js
 var supportsVideo = !!document.createElement('video').canPlayType;

--- a/files/en-us/web/html/cors_enabled_image/index.md
+++ b/files/en-us/web/html/cors_enabled_image/index.md
@@ -43,7 +43,7 @@ In this example, we wish to permit images from a foreign origin to be retrieved 
 
 The first thing we need is a server that's configured to host images with the {{HTTPHeader("Access-Control-Allow-Origin")}} header configured to permit cross-origin access to image files.
 
-Let's assume we're serving our site using [Apache](https://httpd.apache.org/). Consider the HTML5 Boilerplate [Apache server configuration file for CORS images](https://github.com/h5bp/server-configs-apache/blob/master/h5bp/cross-origin/images.conf), shown below:
+Let's assume we're serving our site using [Apache](https://httpd.apache.org/). Consider the HTML5 Boilerplate [Apache server configuration file for CORS images](https://github.com/h5bp/server-configs-apache/blob/main/h5bp/cross-origin/images.conf), shown below:
 
 ```xml
 <IfModule mod_setenvif.c>

--- a/files/en-us/web/http/headers/feature-policy/unsized-media/index.md
+++ b/files/en-us/web/http/headers/feature-policy/unsized-media/index.md
@@ -38,4 +38,4 @@ The default value for unsized-media is `'*'`, that is unsized media elements are
 - {{HTTPHeader('Feature-Policy')}} header
 - [Feature Policy](/en-US/docs/Web/HTTP/Feature_Policy)
 - [Using Feature Policy](/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy)
-- [Proposal](https://github.com/w3c/webappsec-feature-policy/blob/master/policies/unsized-media.md)
+- [Proposal](https://github.com/w3c/webappsec-permissions-policy/blob/main/policies/unsized-media.md)

--- a/files/en-us/web/javascript/guide/working_with_private_class_features/index.md
+++ b/files/en-us/web/javascript/guide/working_with_private_class_features/index.md
@@ -202,7 +202,7 @@ class Scalar {
   constructor(value) {
     this.#total = value || this.#total;
   }
-  
+
   add(s) {
     // check the passed object defines #length
     if (!(#total in s)) {
@@ -220,7 +220,7 @@ scalar1.add({}) // throws informative exception
 ## See also
 
 - [Private class features](/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields)
-- [Private Syntax FAQ](https://github.com/tc39/proposal-class-fields/blob/master/PRIVATE_SYNTAX_FAQ.md)
+- [Private Syntax FAQ](https://github.com/tc39/proposal-class-fields/blob/main/PRIVATE_SYNTAX_FAQ.md)
 - [The Semantics of All JS Class Elements](https://rfrn.org/~shu/2018/05/02/the-semantics-of-all-js-class-elements.html)
 
 ## Browser compatibility

--- a/files/en-us/web/javascript/reference/global_objects/atomics/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/atomics/index.md
@@ -129,5 +129,5 @@ Atomics.notify(int32, 0, 1);
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - [Web Workers](/en-US/docs/Web/API/Web_Workers_API)
 - [parlib-simple](https://github.com/lars-t-hansen/parlib-simple) – a simple library providing synchronization and work distribution abstractions.
-- [Shared Memory – a brief tutorial](https://github.com/tc39/ecmascript_sharedmem/blob/master/TUTORIAL.md)
+- [Shared Memory – a brief tutorial](https://github.com/tc39/proposal-ecmascript-sharedmem/blob/main/TUTORIAL.md)
 - [A Taste of JavaScript's New Parallel Primitives – Mozilla Hacks](https://hacks.mozilla.org/2016/05/a-taste-of-javascripts-new-parallel-primitives/)

--- a/files/en-us/web/javascript/reference/global_objects/intl/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/index.md
@@ -72,7 +72,7 @@ A locale identifier is a string that consists of:
 
 Subtags identifying languages, scripts, regions (including countries), and (rarely used) variants are registered in the [IANA Language Subtag Registry](https://www.iana.org/assignments/language-subtag-registry). This registry is periodically updated over time, and implementations may not always be up to date, so don't rely too much on subtags being universally supported.
 
-BCP 47 extension sequences consist of a single digit or letter (other than `"x"`) and one or more two- to eight-letter or digit subtags separated by hyphens. Only one sequence is permitted for each digit or letter: "`de-a-foo-a-foo`" is invalid. BCP 47 extension subtags are defined in the [Unicode CLDR Project](https://github.com/unicode-org/cldr/tree/master/common/bcp47). Currently only two extensions have defined semantics:
+BCP 47 extension sequences consist of a single digit or letter (other than `"x"`) and one or more two- to eight-letter or digit subtags separated by hyphens. Only one sequence is permitted for each digit or letter: "`de-a-foo-a-foo`" is invalid. BCP 47 extension subtags are defined in the [Unicode CLDR Project](https://github.com/unicode-org/cldr/tree/main/common/bcp47). Currently only two extensions have defined semantics:
 
 - The `"u"` (Unicode) extension can be used to request additional customization of {{jsxref("Intl.Collator")}}, {{jsxref("Intl.NumberFormat")}}, or {{jsxref("Intl.DateTimeFormat")}} objects. Examples:
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/casefirst/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/casefirst/index.md
@@ -61,4 +61,4 @@ console.log(locale.caseFirst); // Prints "lower"
 ## See also
 
 - {{jsxref("Intl.Locale")}}
-- [Unicode case first collation spec](https://github.com/unicode-org/cldr/blob/master/common/bcp47/collation.xml#L49)
+- [Unicode case first collation spec](https://github.com/unicode-org/cldr/blob/main/common/bcp47/collation.xml#L49)

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/numberingsystem/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/numberingsystem/index.md
@@ -140,4 +140,4 @@ console.log(locale.numberingSystem); // Prints "latn"
 ## See also
 
 - {{jsxref("Intl/Locale", "Intl.Locale")}}
-- [Details on the standard Unicode numeral systems](https://github.com/unicode-org/cldr/blob/master/common/supplemental/numberingSystems.xml)
+- [Details on the standard Unicode numeral systems](https://github.com/unicode-org/cldr/blob/main/common/supplemental/numberingSystems.xml)

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/numberingsystems/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/numberingsystems/index.md
@@ -139,4 +139,4 @@ console.log(ja.numberingSystems); // logs ["latn"]
 ## See also
 
 - {{jsxref("Intl/Locale", "Intl.Locale")}}
-- [Details on the standard Unicode numeral systems](https://github.com/unicode-org/cldr/blob/master/common/supplemental/numberingSystems.xml)
+- [Details on the standard Unicode numeral systems](https://github.com/unicode-org/cldr/blob/main/common/supplemental/numberingSystems.xml)

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/numberformat/index.md
@@ -146,7 +146,7 @@ new Intl.NumberFormat(locales, options)
       - : The unit to use in `unit` formatting, Possible values are core
         unit identifiers, defined in [UTS #35, Part 2, Section 6](https://unicode.org/reports/tr35/tr35-general.html#Unit_Elements).
         A [subset](https://tc39.es/proposal-unified-intl-numberformat/section6/locales-currencies-tz_proposed_out.html#sec-issanctionedsimpleunitidentifier)
-        of units from the [full list](https://github.com/unicode-org/cldr/blob/master/common/validity/unit.xml)
+        of units from the [full list](https://github.com/unicode-org/cldr/blob/main/common/validity/unit.xml)
         was selected for use in ECMAScript. Pairs of simple units can
         be concatenated with "`-per-`" to make a compound unit. There
         is no default value; if the `style` is "`unit`", the
@@ -204,13 +204,13 @@ new Intl.NumberFormat(locales, options)
         > const nf = new Intl.NumberFormat("en-US", {
         >   style: "currency",
         >   currency: "USD",
-        >   maximumFractionDigits: 2, 
+        >   maximumFractionDigits: 2,
         >   roundingIncrement: 5
         > });
         >
         > console.log(nf.format(11.29));  // > output: "$11.30"
         > console.log(nf.format(11.25));  // > output: "$11.25"
-        > console.log(nf.format(11.22));  // > output: "$11.20"  
+        > console.log(nf.format(11.22));  // > output: "$11.20"
         > ```
         >
         > If you set `minimumFractionDigits` and `maximumFractionDigits`, they must set them to the same value; otherwise a `RangeError` is thrown.

--- a/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/sharedarraybuffer/index.md
@@ -135,5 +135,5 @@ gl.bufferData(gl.ARRAY_BUFFER, sab, gl.STATIC_DRAW);
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - [Web Workers](/en-US/docs/Web/API/Web_Workers_API)
 - [parlib-simple](https://github.com/lars-t-hansen/parlib-simple) – a simple library providing synchronization and work distribution abstractions.
-- [Shared Memory – a brief tutorial](https://github.com/tc39/ecmascript_sharedmem/blob/master/TUTORIAL.md)
+- [Shared Memory – a brief tutorial](https://github.com/tc39/proposal-ecmascript-sharedmem/blob/main/TUTORIAL.md)
 - [A Taste of JavaScript's New Parallel Primitives – Mozilla Hacks](https://hacks.mozilla.org/2016/05/a-taste-of-javascripts-new-parallel-primitives/)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/module/customsections/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/module/customsections/index.md
@@ -45,12 +45,12 @@ If `module` is not a {{jsxref("WebAssembly.Module")}} object instance, a
 A wasm module is comprised of a sequence of **sections**. Most of these
 sections are fully specified and validated by the wasm spec, but modules can also
 contain **custom sections** that are ignored and skipped over during
-validation. (Read [High level structure](https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md#high-level-structure)
+validation. (Read [High level structure](https://github.com/WebAssembly/design/blob/main/BinaryEncoding.md)
 for information on section structures, and how normal sections
 ("known sections") and custom sections are distinguished.)
 
 This provides developers with a way to include custom data inside wasm modules for other purposes,
-for example the [name custom section](https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md#name-section),
+for example the [name custom section](https://github.com/WebAssembly/design/blob/main/BinaryEncoding.md),
 which allows developers to provide names for all the functions and
 locals in the module (like "symbols" in a native build).
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/module/customsections/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/module/customsections/index.md
@@ -45,12 +45,12 @@ If `module` is not a {{jsxref("WebAssembly.Module")}} object instance, a
 A wasm module is comprised of a sequence of **sections**. Most of these
 sections are fully specified and validated by the wasm spec, but modules can also
 contain **custom sections** that are ignored and skipped over during
-validation. (Read [High level structure](https://github.com/WebAssembly/design/blob/main/BinaryEncoding.md)
+validation. (Read [High level structure](https://github.com/WebAssembly/design/blob/main/BinaryEncoding.md#high-level-structure)
 for information on section structures, and how normal sections
 ("known sections") and custom sections are distinguished.)
 
 This provides developers with a way to include custom data inside wasm modules for other purposes,
-for example the [name custom section](https://github.com/WebAssembly/design/blob/main/BinaryEncoding.md),
+for example the [name custom section](https://github.com/WebAssembly/design/blob/main/BinaryEncoding.md#name-section),
 which allows developers to provide names for all the functions and
 locals in the module (like "symbols" in a native build).
 

--- a/files/en-us/web/mathml/element/mfenced/index.md
+++ b/files/en-us/web/mathml/element/mfenced/index.md
@@ -70,7 +70,7 @@ Rendering in your browser: <math><mfenced close="]" open separators="||||,"><mi>
 
 ## Specifications
 
-The \<mfenced> element is no longer part of the [latest MathML standard](https://github.com/mathml-refresh/mathml/issues/2). Use the {{MathMLElement("mrow")}} and {{MathMLElement("mo")}} elements instead, or, for backwards compatibility, see [mathml-polyfills/mfenced.](https://github.com/mathml-refresh/mathml-polyfills/tree/master/mfenced)
+The \<mfenced> element is no longer part of the [latest MathML standard](https://github.com/mathml-refresh/mathml/issues/2). Use the {{MathMLElement("mrow")}} and {{MathMLElement("mo")}} elements instead, or, for backwards compatibility, see [mathml-polyfills/mfenced.](https://github.com/mathml-refresh/mathml-polyfills/tree/main/mfenced)
 
 ## Browser compatibility
 

--- a/files/en-us/web/mathml/fonts/index.md
+++ b/files/en-us/web/mathml/fonts/index.md
@@ -19,7 +19,7 @@ Install the _Latin Modern Math_ and _STIX_ fonts as follows:
 1. Download [latinmodern-math-1959.zip](http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip).
 2. Open the ZIP archive, move inside the `latinmodern-math-1959` directory and then inside the `otf` directory. You will find a `latinmodern-math` font file.
 3. Open the `latinmodern-math` font file and click the `Install` button.
-4. Download [static_otf.zip](https://github.com/stipub/stixfonts/raw/master/zipfiles/static_otf.zip).
+4. Download [static_otf.zip](https://raw.githubusercontent.com/stipub/stixfonts/master/zipfiles/static_otf.zip).
 5. Open the `static_otf.zip` ZIP archive, and then move inside the `static_otf` directory. Among the files there, you will find a `STIXTwoMath-Regular` file.
 6. Open the `STIXTwoMath-Regular` file and click the `Install` button. If desired, you may also do the same for the other font files.
 
@@ -32,7 +32,7 @@ Install the _Latin Modern Math_ and _STIX_ fonts as follows:
 1. Download [latinmodern-math-1959.zip](http://www.gust.org.pl/projects/e-foundry/lm-math/download/latinmodern-math-1959.zip).
 2. Extract the ZIP archive, move inside the `latinmodern-math-1959` directory and then inside the `otf` directory. You will find a `latinmodern-math` font file.
 3. Double-click the `latinmodern-math` font file click the "Install the font" button from the window that opens.
-4. Download [static_otf.zip](https://github.com/stipub/stixfonts/raw/master/zipfiles/static_otf.zip).
+4. Download [static_otf.zip](https://raw.githubusercontent.com/stipub/stixfonts/master/zipfiles/static_otf.zip).
 5. Open the `static_otf.zip` ZIP archive, and then move inside the `static_otf` directory. Among the files there, you will find a `STIXTwoMath-Regular.otf` file.
 6. Open the `STIXTwoMath-Regular.otf` file and click the **Install Font** button from the window that opens. If desired, you may also do the same for the other font files.
 

--- a/files/en-us/web/progressive_web_apps/re-engageable_notifications_push/index.md
+++ b/files/en-us/web/progressive_web_apps/re-engageable_notifications_push/index.md
@@ -72,7 +72,7 @@ A new random notification is created every 30 seconds until it becomes too annoy
 Push is more complicated than notifications — we need to subscribe to a server that will then send the data back to the app. The app's Service Worker will receive data from the push server, which can then be shown using the notifications system, or another mechanism if desired.
 
 The technology is still at a very early stage — some working examples use the Google Cloud Messaging platform, but are being rewritten to support [VAPID](https://blog.mozilla.org/services/2016/08/23/sending-vapid-identified-webpush-notifications-via-mozillas-push-service/) (Voluntary Application Identification), which offers an extra layer of security for your app.
-You can examine the [Service Workers Cookbook examples](https://github.com/mozilla/serviceworker-cookbook/tree/master/push-payload), try to set up a push messaging server using [Firebase](https://firebase.google.com/), or build your own server (using Node.js for example).
+You can examine the [Service Workers Cookbook examples](https://github.com/mdn/serviceworker-cookbook/tree/master/push-payload), try to set up a push messaging server using [Firebase](https://firebase.google.com/), or build your own server (using Node.js for example).
 
 As mentioned before, to be able to receive push messages, you have to have a service worker, the basics of which are already explained in the [Making PWAs work offline with Service workers](/en-US/docs/Web/Progressive_web_apps/Offline_Service_workers) article. Inside the service worker, a push service subscription mechanism is created.
 
@@ -94,13 +94,13 @@ The data can be retrieved and then shown as a notification to the user immediate
 
 ### Push example
 
-Push needs the server part to work, so we're not able to include it in the js13kPWA example hosted on GitHub Pages, as it offers hosting of static files only. It is all explained in the [Service Worker Cookbook](https://github.com/mozilla/serviceworker-cookbook) — see the [Push Payload Demo](https://github.com/mozilla/serviceworker-cookbook/tree/master/push-payload).
+Push needs the server part to work, so we're not able to include it in the js13kPWA example hosted on GitHub Pages, as it offers hosting of static files only. It is all explained in the [Service Worker Cookbook](https://github.com/mozilla/serviceworker-cookbook) — see the [Push Payload Demo](https://github.com/mdn/serviceworker-cookbook/tree/master/push-payload).
 
 This demo consists of three files:
 
-- [index.js](https://github.com/mozilla/serviceworker-cookbook/blob/master/push-payload/index.js), which contains the source code of our app
-- [server.js](https://github.com/mozilla/serviceworker-cookbook/blob/master/push-payload/server.js), which contains the server part (written in Node.js)
-- [service-worker.js](https://github.com/mozilla/serviceworker-cookbook/blob/master/push-payload/service-worker.js), which contains the Service Worker-specific code.
+- [index.js](https://github.com/mdn/serviceworker-cookbook/blob/master/push-payload/index.js), which contains the source code of our app
+- [server.js](https://github.com/mdn/serviceworker-cookbook/blob/master/push-payload/server.js), which contains the server part (written in Node.js)
+- [service-worker.js](https://github.com/mdn/serviceworker-cookbook/blob/master/push-payload/service-worker.js), which contains the Service Worker-specific code.
 
 Let's explore all of these
 


### PR DESCRIPTION
Extending #14055

## Summary

Remaining URLs from `github.com` which are are being redirected from `master` to `main`.
If GitHub stops the redirection, all the links will break.

Updating the links as follows:
For directories,
`/tree/master/` -> `/tree/main/`
For files,
`/tree/master/` -> `/blob/main/`
To understand the difference between file and directory links refer [this](https://stackoverflow.com/questions/39400848/in-github-urls-what-is-the-difference-between-a-tree-and-a-blob) discussion.


#### Metadata
- [x] Fixes a typo, bug, or other error