### PR TITLE
FF100 WebAssembly Exceptions - JS API

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/webassembly/exception/exception/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/exception/exception/index.md
@@ -32,7 +32,7 @@ new Exception(tag, payload, options)
 - `tag`
   - : An {{jsxref("WebAssembly.Tag")}} defining the data types expected for each of the values in the `payload`.
 - `payload`
-  - : An array of one or more data fields comprising the payload the exception.
+  - : An array of one or more data fields comprising the payload of the exception.
     The elements must match the data types of the corresponding elements in the `tag`.
     If the number of data fields in the payload and their types don't match, a {{jsxref("TypeError")}} exception is thrown.
 - `options` {{optional_inline}}
@@ -70,6 +70,6 @@ The [`stack` example](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAss
 
 ## See also
 
-- [WebAssembly](/en-US/docs/WebAssembly) overview page
+- [WebAssembly](/en-US/docs/WebAssembly) overview
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
 - [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/exception/exception/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/exception/exception/index.md
@@ -1,0 +1,75 @@
+---
+title: WebAssembly.Exception constructor
+slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/Exception
+tags:
+  - API
+  - Constructor
+  - Exception
+  - JavaScript
+  - Reference
+  - WebAssembly
+browser-compat: javascript.builtins.WebAssembly.Exception.Exception
+---
+{{JSRef}}
+
+The **`WebAssembly.Exception()`** constructor is used to create a new [`WebAssembly.Exception`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception).
+
+The constructor accepts a [`Tag`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception) argument and a `payload` array of data fields.
+The data types of each of the payload elements must match the corresponding data type specified in the `Tag`.
+
+The constructor may also take an `options` object.
+The `options.traceStack` property can be set true (by default it is `false`) to indicate that WebAssembly code that throws the exception may populate the exception's [`stack`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/stack) property with a stack track.
+
+
+## Syntax
+
+```js
+new Exception(tag, payload, options)
+```
+
+### Parameters
+
+- `tag`
+  - : An {{jsxref("WebAssembly.Tag")}} defining the data types expected for each of the values in the `payload`.
+- `payload`
+  - : An array of one or more data fields comprising the payload the exception.
+    The elements must match the data types of the corresponding elements in the `tag`.
+    If the number of data fields in the payload and their types don't match, a {{jsxref("TypeError")}} exception is thrown.
+- `options` {{optional_inline}}
+  - : An object with the following optional fields:
+
+     - `traceStack` {{optional_inline}}
+       - : `true` if the `Exception` may have a stack trace attached to its [`stack`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/stack) property, otherwise `false`.
+         This is `false` by default (if `options` or `options.traceStack` are not provided).
+
+
+### Exceptions
+
+- `TypeError`
+  - : The `payload` and `tag` sequences do not have the same number of elements and/or the elements are not of matching types.
+
+
+## Examples
+
+This example shows the creation of an exception using a simple tag.
+```js
+// Create tag and use it to create an exception 
+const tag = new WebAssembly.Tag({ parameters: ["i32", "f32"] });
+const exception = new WebAssembly.Exception(tag, [42, 42.3]);
+```
+
+The [`stack` example](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/stack#examples) shows the creation of an exception that uses the `options` parameter.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [WebAssembly](/en-US/docs/WebAssembly) overview page
+- [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/exception/getarg/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/exception/getarg/index.md
@@ -1,0 +1,164 @@
+---
+title: WebAssembly.Exception.prototype.getArg()
+slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/getArg
+tags:
+  - API
+  - JavaScript
+  - Method
+  - Reference
+  - WebAssembly
+  - getArg
+  - Exception
+browser-compat: javascript.builtins.WebAssembly.Exception.getArg
+---
+{{JSRef}}
+
+The **`getArg()`** prototype method of the [`Exception`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception) object can be used to get the value of a specified item in the exception's data arguments.
+
+The method passes a {{jsxref("WebAssembly.Tag")}}, and will only succeed if the thrown `Exception` was created using the same tag (otherwise it will throw a `TypeError`).
+This ensures that the exception can only be read if the calling code has access to the tag.
+Tags that are neither imported into, or exported from, the WebAssembly code are internal, and their associated runtime exceptions cannot be queried using this method!
+
+> **Note:** It is not enough that the tag has an identical sequence of data types — it must have the same _identity_ (be the same tag).
+
+## Syntax
+
+```js
+getArg(exceptionTag, index)
+```
+
+### Parameters
+
+- `exceptionTag`
+  - : A {{jsxref("WebAssembly.Tag")}}, which must match the tag associated with this exception.
+    If the tags don't match the method will throw a {{jsxref("TypeError")}} exception. 
+- `index`
+  - : The index of the value in the data arguments to return, 0-indexed.
+    If the index exceeds the available elements, the method will throw a {{jsxref("RangeError")}} exception. 
+
+### Return value
+
+The value of the argument at `index`.
+
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : The exception was not created with the tag passed to the method.
+- {{jsxref("RangeError")}}
+  - : The `index` parameter is ≥ the number of fields in the data.
+  
+
+## Examples
+
+In order to get the values of an exception, the tag must be "known" to the calling code;
+It may be either imported into or exported from the calling code.
+
+### Getting exception value from imported tag
+
+Consider the following WebAssembly code, which is assumed to be compiled to a file **example.wasm**.
+This imports a tag, which it refers to internally as `$tagname`, and exports a method `run1` that can be called by external code to thow an exception using the tag.
+
+```wasm
+(module
+  ;; import tag that will be referred to here as $tagname
+  (import "extmod" "exttag" (tag $tagname (param i32)) )
+
+  ;; $throwException function throws i32 param as a $tagname exception
+  (func $throwException (param i32)
+    local.get 0
+    throw $tagname
+  )
+
+  ;; Exported function "run1" that calls $throwException
+  (func (export "run1")
+    i32.const 1
+    call $throwException
+  )
+)
+```
+
+The code below below calls [`WebAssembly.instantiateStreaming`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming) to import the  'example.wasm' file, passing in an "import object" (`importObject`) that includes a new {{jsxref("WebAssembly.Tag")}} named `tag_to_import`.
+The import object defines an object with properties that match the `import` statement in the web assembly code.
+
+Once the file is instantiated, the code calls the exported WebAssembly `run1()` method, which will immediately throw an exception.
+
+```js
+const tag_to_import = new WebAssembly.Tag( { parameters: ['i32']} );
+
+//Note: the import object properties match the import statement in WebAssembly code!
+const importObject = { "extmod": {"exttag": tag_to_import} }
+WebAssembly.instantiateStreaming(fetch('example.wasm'), importObject )
+  .then(obj => {
+    console.log(obj.instance.exports.run1());
+  })
+  .catch((e) => {
+    console.log(`${ e }`);
+    console.log(`getArg 0 : ${ e.getArg(tag_to_import, 0) }`);
+  });
+
+// Log output
+example.js:40 WebAssembly.Exception: wasm exception
+example.js:41 getArg 0 : 1
+```
+
+The code catches the exception and uses `getArg()` to print the value at the first index.
+In this case it is just "1".
+
+
+### Getting exception value from an exported tag
+
+The process for using an exported tag is very similar to that shown in the previous section.
+Here is the same WebAssembly module, simply replacing the import with an export.
+
+```wasm
+(module
+
+  ;; Export tag giving it external name: "exptag"
+  (tag $tagname (export "exptag") (param i32) )  
+  (func $throwException (param i32)
+	local.get 0
+	throw $tagname
+  ) 
+  (func (export "run1")
+	i32.const 1
+	call $throwException
+  )
+)
+```
+
+The JavaScript is similar too. In this case we have no imports, but instead we get the exported tag and use that to get the argument.
+To make it a little more "safe", here we also test that we have the right tag using the [`is()` method](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/is).
+
+```js
+let tag_exported_from_wasm;
+WebAssembly.instantiateStreaming(fetch('example.wasm') )
+  .then(obj => {
+    // Import the tag using its name from WebAssembly
+    tag_exported_from_wasm=obj.instance.exports.exptag;
+
+    console.log(obj.instance.exports.run1());
+  })
+  .catch((e) => {
+    console.log(`${ e }`);
+    // If the tag is correct, get the value
+    if ( e.is(tag_exported_from_wasm) ) {
+      console.log(`getArg 0 : ${ e.getArg(tag_exported_from_wasm, 0) }`);
+    }
+  });
+
+```
+
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [WebAssembly](/en-US/docs/WebAssembly) overview page
+- [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/exception/getarg/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/exception/getarg/index.md
@@ -15,11 +15,11 @@ browser-compat: javascript.builtins.WebAssembly.Exception.getArg
 
 The **`getArg()`** prototype method of the [`Exception`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception) object can be used to get the value of a specified item in the exception's data arguments.
 
-The method passes a {{jsxref("WebAssembly.Tag")}}, and will only succeed if the thrown `Exception` was created using the same tag (otherwise it will throw a `TypeError`).
+The method passes a {{jsxref("WebAssembly.Tag")}} and will only succeed if the thrown `Exception` was created using the same tag; otherwise it will throw a `TypeError`.
 This ensures that the exception can only be read if the calling code has access to the tag.
-Tags that are neither imported into, or exported from, the WebAssembly code are internal, and their associated runtime exceptions cannot be queried using this method!
+Tags that are neither imported into or exported from the WebAssembly code are internal, and their associated runtime exceptions cannot be queried using this method!
 
-> **Note:** It is not enough that the tag has an identical sequence of data types — it must have the same _identity_ (be the same tag).
+> **Note:** It is not enough that the tag has an identical sequence of data types — it must have the same _identity_ (be the same tag) as was used to create the exception.
 
 ## Syntax
 
@@ -30,8 +30,8 @@ getArg(exceptionTag, index)
 ### Parameters
 
 - `exceptionTag`
-  - : A {{jsxref("WebAssembly.Tag")}}, which must match the tag associated with this exception.
-    If the tags don't match the method will throw a {{jsxref("TypeError")}} exception. 
+  - : A {{jsxref("WebAssembly.Tag")}} that must match the tag associated with this exception.
+    If the tags don't match, the method will throw a {{jsxref("TypeError")}} exception. 
 - `index`
   - : The index of the value in the data arguments to return, 0-indexed.
     If the index exceeds the available elements, the method will throw a {{jsxref("RangeError")}} exception. 
@@ -45,13 +45,13 @@ The value of the argument at `index`.
 - {{jsxref("TypeError")}}
   - : The exception was not created with the tag passed to the method.
 - {{jsxref("RangeError")}}
-  - : The `index` parameter is ≥ the number of fields in the data.
+  - : The value of the `index` parameter is greater than or equal to the number of fields in the data.
   
 
 ## Examples
 
 In order to get the values of an exception, the tag must be "known" to the calling code;
-It may be either imported into or exported from the calling code.
+it may be either imported into or exported from the calling code.
 
 ### Getting exception value from imported tag
 
@@ -102,7 +102,7 @@ example.js:41 getArg 0 : 1
 ```
 
 The code catches the exception and uses `getArg()` to print the value at the first index.
-In this case it is just "1".
+In this case, it is just "1".
 
 
 ### Getting exception value from an exported tag
@@ -126,7 +126,7 @@ Here is the same WebAssembly module, simply replacing the import with an export.
 )
 ```
 
-The JavaScript is similar too. In this case we have no imports, but instead we get the exported tag and use that to get the argument.
+The JavaScript is similar too. In this case, we have no imports, but instead we get the exported tag and use that to get the argument.
 To make it a little more "safe", here we also test that we have the right tag using the [`is()` method](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/is).
 
 ```js

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/exception/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/exception/index.md
@@ -52,11 +52,11 @@ Once the exception is available to the WebAssembly module, it can attach a stack
 
 This example shows how to define a tag and import it into a module, then use it to throw an exception that is caught in JavaScript.
 
-The following WebAssembly code, is assumed to be compiled to a file **example.wasm**.
-- The module imports a tag referred to internally as `$tagname` that has a single `i32` param.
+Consider the following WebAssembly code, which is assumed to be compiled to a file **example.wasm**.
+- The module imports a tag that is referred to as `$tagname` internally and that has a single `i32` param.
   The tag expects the tag to be passed using module `extmod` and tag `exttag`. 
 - The `$throwException` fnction throws an exception using the `throw` keyword, taking the `$tagname` and the parameter argument.
-- The module exports a function `run1()` that throws an exception with the value "42".
+- The module exports the function `run1()` that throws an exception with the value "42".
 
 ```wasm
 (module
@@ -77,7 +77,7 @@ The following WebAssembly code, is assumed to be compiled to a file **example.wa
 )
 ```
 
-The code below below calls [`WebAssembly.instantiateStreaming`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming) to import the  **example.wasm** file, passing in an "import object" (`importObject`) that includes a new {{jsxref("WebAssembly.Tag")}} named `tag_to_import`.
+The code below below calls [`WebAssembly.instantiateStreaming`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming) to import the **example.wasm** file, passing in an "import object" (`importObject`) that includes a new {{jsxref("WebAssembly.Tag")}} named `tag_to_import`.
 The import object defines an object with properties that match the `import` statement in the WebAssembly code.
 
 Once the file is instantiated, the code calls the exported WebAssembly `run1()` method, which will immediately throw an exception.
@@ -108,7 +108,7 @@ example.js:41 getArg 0 : 42
 The exception is caught in JavaScript using the `catch` block.
 We can see it is of type `WebAssembly.Exception`, but if we didn't have the right tag we couldn't do much else.
 
-However because we have the tag we use [`Exception.protoytpe.is()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/is) to check it's the right one, and because it is correct we call [`Exception.protoytpe.getArg()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/getArg) to read the value of "42".
+However, because we have the tag, we use [`Exception.protoytpe.is()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/is) to check that it's the right one, and because it is correct, we call [`Exception.protoytpe.getArg()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/getArg) to read the value of "42".
 
 ## Specifications
 
@@ -120,6 +120,6 @@ However because we have the tag we use [`Exception.protoytpe.is()`](/en-US/docs/
 
 ## See also
 
-- [WebAssembly](/en-US/docs/WebAssembly) overview page
+- [WebAssembly](/en-US/docs/WebAssembly) overview
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
 - [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/exception/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/exception/index.md
@@ -1,0 +1,125 @@
+---
+title: WebAssembly.Exception
+slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception
+tags:
+  - API
+  - Class
+  - Exception
+  - JavaScript
+  - Reference
+  - WebAssembly
+browser-compat: javascript.builtins.WebAssembly.Exception
+---
+{{JSRef}}
+
+The **`WebAssembly.Exception`** object represents a runtime exception thrown from WebAssembly to JavaScript, or thrown from JavaScript to a WebAssembly exception handler.
+
+The [constructor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/Exception) accepts a {{jsxref("WebAssembly.Tag")}}, an array of values, and an `options` object as arguments.
+The tag uniquely defines the _type_ of an exception, including the order of its arguments and their data types.
+The same tag that was used to create the `Exception` is required to access the arguments of a thrown exception.
+Methods are provided to test whether an exception matches a particular tag, and also to get a particular value by index (if the exception matches specified tag).
+
+JavaScript and other client code can only access WebAssembly exception values, and visa versa, when the associated tag is shared (you can't just use another tag that happens to define the same data types).
+Without the matching tag, exceptions can be caught and re-thrown, but they can't be inspected.
+
+In order to make exception-throwing faster, exceptions thrown from WebAssembly generally do not include a stack trace.
+WebAssembly code that needs to provide a stack trace must call a JavaScript function to create the exception, passing `options.traceStack=true` parameter in the constructor.
+Once the exception is available to the WebAssembly module, it can attach a stack trace to the [`stack`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/stack) property and throw the exception.
+
+{{AvailableInWorkers}}
+
+
+## Constructor
+
+- [`WebAssembly.Exception()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/Exception)
+  - : Creates a new [`WebAssembly.Exception`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception) object.
+
+## Instance methods
+
+- [`Exception.protoytpe.is()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/is)
+  - : Tests whether the exception matches a particular tag.
+
+- [`Exception.protoytpe.getArg()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/getArg)
+  - : Returns the data fields of an exception that matches a specified tag.
+
+## Instance properties
+
+- [`Exception.protoytpe.stack`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/stack)
+  - : Returns the stack trace for the exception, or `undefined`.
+
+
+## Examples
+
+This example shows how to define a tag and import it into a module, then use it to throw an exception that is caught in JavaScript.
+
+The following WebAssembly code, is assumed to be compiled to a file **example.wasm**.
+- The module imports a tag referred to internally as `$tagname` that has a single `i32` param.
+  The tag expects the tag to be passed using module `extmod` and tag `exttag`. 
+- The `$throwException` fnction throws an exception using the `throw` keyword, taking the `$tagname` and the parameter argument.
+- The module exports a function `run1()` that throws an exception with the value "42".
+
+```wasm
+(module
+  ;; import tag that will be referred to here as $tagname
+  (import "extmod" "exttag" (tag $tagname (param i32)) )
+
+  ;; $throwException function throws i32 param as a $tagname exception
+  (func $throwException (param i32)
+    local.get 0
+    throw $tagname
+  )
+
+  ;; Exported function "run1" that calls $throwException
+  (func (export "run1")
+    i32.const 42
+    call $throwException
+  )
+)
+```
+
+The code below below calls [`WebAssembly.instantiateStreaming`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming) to import the  **example.wasm** file, passing in an "import object" (`importObject`) that includes a new {{jsxref("WebAssembly.Tag")}} named `tag_to_import`.
+The import object defines an object with properties that match the `import` statement in the WebAssembly code.
+
+Once the file is instantiated, the code calls the exported WebAssembly `run1()` method, which will immediately throw an exception.
+
+```js
+const tag_to_import = new WebAssembly.Tag( { parameters: ['i32']} );
+
+//Note: import object properties match the WebAssebly import statement!
+const importObject = { "extmod": {"exttag": tag_to_import} }
+WebAssembly.instantiateStreaming(fetch('example.wasm'), importObject )
+  .then(obj => {
+    console.log(obj.instance.exports.run1());
+  })
+  .catch((e) => {
+    console.log(`${ e }`);
+    // Check we have the right tag for the exception
+    // If so, use getArg() to inspect it
+    if (e.is(tag_to_import) {
+      console.log(`getArg 0 : ${ e.getArg(tag_to_import, 0) }`);
+    }
+  });
+
+// Log output
+example.js:40 WebAssembly.Exception: wasm exception
+example.js:41 getArg 0 : 42
+```
+
+The exception is caught in JavaScript using the `catch` block.
+We can see it is of type `WebAssembly.Exception`, but if we didn't have the right tag we couldn't do much else.
+
+However because we have the tag we use [`Exception.protoytpe.is()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/is) to check it's the right one, and because it is correct we call [`Exception.protoytpe.getArg()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/getArg) to read the value of "42".
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [WebAssembly](/en-US/docs/WebAssembly) overview page
+- [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/exception/is/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/exception/is/index.md
@@ -1,0 +1,77 @@
+---
+title: WebAssembly.Exception.prototype.is()
+slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/is
+tags:
+  - API
+  - JavaScript
+  - Method
+  - Reference
+  - WebAssembly
+  - is
+  - Exception
+browser-compat: javascript.builtins.WebAssembly.Exception.is
+---
+{{JSRef}}
+
+The **`is()`** prototype method of the [`Exception`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception) object can be used to test if the `Exception` matches a given tag.
+
+The method might be used to test that a tag is correct before passing it to [`Exception.prototype.getArg()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/getArg) to get the passed values.
+It can be used on tags created in JavaScript or created in WebAssembly code and exported to JavaScript.
+
+> **Note:** It is not enough that the tag has an identical sequence of data types — it must have the same _identity_ (be the same tag) as was used to create the exception.
+
+## Syntax
+
+```js
+is(tag)
+```
+
+### Parameters
+
+- `tag`
+  - : An {{jsxref("WebAssembly.Tag")}} that can be checked to verify the type of the exception.
+
+### Return value
+
+A boolean `true` if the specified tag matches the exception, and `false` otherwise.
+
+
+## Examples
+
+The code below shows how to use `is()` to verify that a tag matches an [`Exception`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception).
+
+```js
+// Create tag and use it to create an exception 
+const tag1 = new WebAssembly.Tag({ parameters: ["i32", "f64"] });
+const exception1 = new WebAssembly.Exception(tag1, [42, 42.3]);
+
+// Verify that "tag1" matches this exception
+console.log(`Tag1: ${ exception1.is(tag1) }`);
+
+// Log output:
+// Tag1: true
+```
+
+We can also demonstrate that this exception will not match another tag, event if is created with the same parameters.
+```js
+// Create a new tag (with same parameters) and verify it does not match the exception
+const tag2 = new WebAssembly.Tag({ parameters: ["i32", "f64"] });
+console.log(`Tag2: ${ exception1.is(tag2) }`);
+
+// Log output:
+// Tag2: false
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [WebAssembly](/en-US/docs/WebAssembly) overview page
+- [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/exception/is/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/exception/is/index.md
@@ -52,7 +52,7 @@ console.log(`Tag1: ${ exception1.is(tag1) }`);
 // Tag1: true
 ```
 
-We can also demonstrate that this exception will not match another tag, event if is created with the same parameters.
+We can also demonstrate that this exception will not match another tag even if the tag is created with the same parameters.
 ```js
 // Create a new tag (with same parameters) and verify it does not match the exception
 const tag2 = new WebAssembly.Tag({ parameters: ["i32", "f64"] });
@@ -72,6 +72,6 @@ console.log(`Tag2: ${ exception1.is(tag2) }`);
 
 ## See also
 
-- [WebAssembly](/en-US/docs/WebAssembly) overview page
+- [WebAssembly](/en-US/docs/WebAssembly) overview
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
 - [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/exception/stack/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/exception/stack/index.md
@@ -17,7 +17,7 @@ browser-compat: javascript.builtins.WebAssembly.Exception.stack
 The read-only **`stack`** property of an object instance of type [`Exception`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception) _may_ contain a stack trace for an exception thrown from WebAssembly code.
 
 Exceptions thrown from WebAssembly code do not include a stack trace by default.
-If WebAssembly code needs to provide a stack trace it must call a JavaScript function to create the exception, passing `options.traceStack=true` parameter in the [constructor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/Exception).
+If WebAssembly code needs to provide a stack trace, it must call a JavaScript function to create the exception, passing `options.traceStack=true` parameter in the [constructor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/Exception).
 The virtual machine can then attach a stack trace to the exception when it is thrown.
 
 > **Note:** Stack traces are not normally sent from WebAssembly code to improve performance.
@@ -42,8 +42,8 @@ ${url}:wasm-function[${funcIndex}]:${pcOffset}
 This example demonstrate how to throw an exception from WebAssembly that includes a stack trace.
 
 Consider the following WebAssembly code, which is assumed to be compiled to a file named **example.wasm**.
-This imports a tag, which it refers to internally as `$tagname`, and imports a function that it refers to as $throwExnWithStack.
-It exports a method `run1` that can be called by external code to call $throwExnWithStack (and hence the JavaScript function)
+This imports a tag, which it refers to as `$tagname` internally, and imports a function that it refers to as `$throwExnWithStack`.
+It exports the method `run1` that can be called by external code to call `$throwExnWithStack` (and hence the JavaScript function)
 
 ```wasm
 (module
@@ -95,7 +95,7 @@ The most "relevant" part of this code is the line where the Exception is created
 ```js
 new WebAssembly.Exception(tag, [param], {traceStack: true});
 ```
-Passing in `{traceStack: true}` tells the WebAssembly virtual machine that it should attached the stack to the exception that it is throwing.
+Passing in `{traceStack: true}` tells the WebAssembly virtual machine that it should attach the stack to the exception that it is throwing.
 Without this, the stack would be `undefined`.
 
 ## Specifications
@@ -108,6 +108,6 @@ Without this, the stack would be `undefined`.
 
 ## See also
 
-- [WebAssembly](/en-US/docs/WebAssembly) overview page
+- [WebAssembly](/en-US/docs/WebAssembly) overview
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
 - [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/exception/stack/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/exception/stack/index.md
@@ -1,0 +1,113 @@
+---
+title: WebAssembly.Exception.prototype.stack
+slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/stack
+tags:
+  - API
+  - JavaScript
+  - Property
+  - Reference
+  - WebAssembly
+  - stack
+  - Exception
+  - Non-standard
+browser-compat: javascript.builtins.WebAssembly.Exception.stack
+---
+{{JSRef}}
+
+The read-only **`stack`** property of an object instance of type [`Exception`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception) _may_ contain a stack trace for an exception thrown from WebAssembly code.
+
+Exceptions thrown from WebAssembly code do not include a stack trace by default.
+If WebAssembly code needs to provide a stack trace it must call a JavaScript function to create the exception, passing `options.traceStack=true` parameter in the [constructor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/Exception).
+The virtual machine can then attach a stack trace to the exception when it is thrown.
+
+> **Note:** Stack traces are not normally sent from WebAssembly code to improve performance.
+> The ability to add stack traces to these exceptions is provided for developer tooling, and is not generally recommended for broader use.
+
+
+## Value
+
+A {{domxref("DOMString")}} containing the stack trace, or {{jsxref("undefined")}} if no trace has been assigned.
+
+The stack trace string lists the locations of each operation on the stack in WebAssembly format.
+This is a human readable string indicating the URL, name of the function type called, the function index, and its offset in the module binary.
+It has approximately this format (see [stack trace conventions](https://webassembly.github.io/spec/web-api/index.html#conventions) in the specification for more information):
+
+```
+${url}:wasm-function[${funcIndex}]:${pcOffset}
+```
+
+
+## Examples
+
+This example demonstrate how to throw an exception from WebAssembly that includes a stack trace.
+
+Consider the following WebAssembly code, which is assumed to be compiled to a file named **example.wasm**.
+This imports a tag, which it refers to internally as `$tagname`, and imports a function that it refers to as $throwExnWithStack.
+It exports a method `run1` that can be called by external code to call $throwExnWithStack (and hence the JavaScript function)
+
+```wasm
+(module
+  ;; import tag that will be referred to here as $tagname
+  (import "extmod" "exttag" (tag $tagname (param i32)) )
+
+  ;; import function that will be referred to here as $throwExnWithStack
+  (import "extmod" "throwExnWithStack" (func $throwExnWithStack (param i32) ) )
+  
+  ;; call $throwExnWithStack passing 42 as parameter
+  (func (export "run1")
+	i32.const 42
+	call $throwExnWithStack
+  )
+)
+```
+
+The JavaScript code below defines a new tag `tag` and the function `throwExceptionWithStack`.
+These are passed to the WebAssembly module in the `importObject` when it is instantiated.
+
+Once the file is instantiated, the code calls the exported WebAssembly `run1()` method, which will immediately throw an exception.
+The stack is then logged from the `catch` statement.
+
+```js
+let tag = new WebAssembly.Tag( { parameters: ['i32']} );
+
+let throwExceptionWithStack = (param) => {
+  //Note: We declare the exception with  '{traceStack: true}'
+  throw new WebAssembly.Exception(tag, [param], {traceStack: true});
+};
+
+//Note: importObject propeties match the WebAssembly import statements.
+const importObject = { "extmod": {"exttag": tag, "throwExnWithStack": throwExceptionWithStack} }
+WebAssembly.instantiateStreaming(fetch('example.wasm'), importObject )
+  .then(obj => {
+    console.log(obj.instance.exports.run1(12));  // Note, we do nothing with the value passed in
+  })
+  .catch((e) => {
+    console.log(`stack: ${ e.stack }`);
+  });
+
+//Log output (something like):
+stack: throwExceptionWithStack@http://<url>/main.js:76:9
+@http://<url>/example.wasm:wasm-function[3]:0x73
+@http://<url>/main.js:82:38
+```
+
+The most "relevant" part of this code is the line where the Exception is created:
+```js
+new WebAssembly.Exception(tag, [param], {traceStack: true});
+```
+Passing in `{traceStack: true}` tells the WebAssembly virtual machine that it should attached the stack to the exception that it is throwing.
+Without this, the stack would be `undefined`.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [WebAssembly](/en-US/docs/WebAssembly) overview page
+- [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/index.md
@@ -42,6 +42,10 @@ The primary uses for the `WebAssembly` object are:
   - : Error type that is thrown whenever WebAssembly specifies a [trap](https://webassembly.github.io/spec/core/exec/index.html).
 - [`WebAssembly.Table()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Table/Table)
   - : An array-like structure representing a WebAssembly Table, which stores function references.
+- [`WebAssembly.Tag()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag/Tag)
+  - : An object that represents a type of WebAssembly exception.
+- [`WebAssembly.Exception()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/Exception)
+  - : A WebAssembly exception object that can be thrown, caught, and rethrown both within and across WebAssembly/JavaScript boundaries.
 
 ## Static methods
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/tag/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/tag/index.md
@@ -1,0 +1,83 @@
+---
+title: WebAssembly.Tag
+slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag
+tags:
+  - API
+  - Class
+  - Tag
+  - JavaScript
+  - Reference
+  - WebAssembly
+browser-compat: javascript.builtins.WebAssembly.Tag
+---
+{{JSRef}}
+
+The **`WebAssembly.Tag`** object defines a _type_ of a WebAssembly exception that can be thrown to/from WebAssembly code.
+
+When creating a [`WebAssembly.Exception`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception) the tag defines data-types and order of the values carried by the exception.
+The same unique tag instance must be used to access the values of the exception (for example, when using [`Exception.protoytpe.getArg()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/getArg)).
+
+[Constructing](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag/Tag) an instance of `Tag` creates a new unique tag.
+This tag can be passed to a WebAssembly module as a tag import, where it will become a typed tag defined in the _tag section_ of the WebAssembly module.
+You can also export a tag defined in a module and use it to inspect exceptions thrown from the module.
+
+> **Note:** You can't access the values of an exception with a new tag that just happens to have the same parameters; it's a different tag!
+> This ensures that WebAssembly modules can keep exception information internal if required.
+> Code can still catch and rethrow exceptions that it does not understand.
+
+
+## Constructor
+
+- [`WebAssembly.Tag()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag/Tag)
+  - : Creates a new `WebAssembly.Tag` object.
+
+## Instance methods
+
+- [`Tag.prototype.type()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag/type)
+  - : Returns the object defining the data-types array for the tag (as set in its constructor).
+
+
+## Examples
+
+This code snippet creates a new `Tag` instance.
+
+```js
+const tag_to_import = new WebAssembly.Tag({ parameters: ["i32", "f32"] });
+```
+
+The snippet below shows how we might pass it to a module **example.wasm** during instantiation, using an "import object".
+
+```js
+const importObject = { "extmod": {"exttag": tag_to_import} }
+WebAssembly.instantiateStreaming(fetch('example.wasm'), importObject )
+  .then(obj => {
+    ...
+```
+
+The WebAssembly module might then import the tag as shown below: 
+
+```wasm
+(module
+
+  (import "extmod" "exttag" (tag $tagname (param i32 f32)) )
+```
+
+If the tag was used to throw an exception that propagated to JavaScript we could use the tag to inspect its values.
+
+> **Note:** There are many alternatives. We could also use the tag to create a [`WebAssembly.Exception`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception) and throw that from a function called by WebAssebly.
+
+
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [WebAssembly](/en-US/docs/WebAssembly) overview page
+- [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/tag/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/tag/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.WebAssembly.Tag
 
 The **`WebAssembly.Tag`** object defines a _type_ of a WebAssembly exception that can be thrown to/from WebAssembly code.
 
-When creating a [`WebAssembly.Exception`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception) the tag defines data-types and order of the values carried by the exception.
+When creating a [`WebAssembly.Exception`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception), the tag defines the data types and order of the values carried by the exception.
 The same unique tag instance must be used to access the values of the exception (for example, when using [`Exception.protoytpe.getArg()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception/getArg)).
 
 [Constructing](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag/Tag) an instance of `Tag` creates a new unique tag.
@@ -62,7 +62,7 @@ The WebAssembly module might then import the tag as shown below:
   (import "extmod" "exttag" (tag $tagname (param i32 f32)) )
 ```
 
-If the tag was used to throw an exception that propagated to JavaScript we could use the tag to inspect its values.
+If the tag was used to throw an exception that propagated to JavaScript, we could use the tag to inspect its values.
 
 > **Note:** There are many alternatives. We could also use the tag to create a [`WebAssembly.Exception`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception) and throw that from a function called by WebAssebly.
 
@@ -78,6 +78,6 @@ If the tag was used to throw an exception that propagated to JavaScript we could
 
 ## See also
 
-- [WebAssembly](/en-US/docs/WebAssembly) overview page
+- [WebAssembly](/en-US/docs/WebAssembly) overview
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
 - [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/tag/tag/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/tag/tag/index.md
@@ -53,6 +53,6 @@ const tag = new WebAssembly.Tag({ parameters: ["i32", "i64"] });
 
 ## See also
 
-- [WebAssembly](/en-US/docs/WebAssembly) overview page
+- [WebAssembly](/en-US/docs/WebAssembly) overview
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
 - [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/tag/tag/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/tag/tag/index.md
@@ -1,0 +1,58 @@
+---
+title: WebAssembly.Tag() constructor
+slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag/Tag
+tags:
+  - Constructor
+  - JavaScript
+  - Reference
+  - WebAssembly
+  - Tag
+browser-compat: javascript.builtins.WebAssembly.Tag.Tag
+---
+{{JSRef}}
+
+The **`WebAssembly.Tag()`** constructor creates a new [`WebAssembly.Tag`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag) object.    
+
+## Syntax
+
+```js
+new WebAssembly.Tag(type)
+```
+
+### Parameters
+
+- `type`
+
+  - : An object that can contain the following members:
+
+    - `parameters`
+      - : An array of [data types](/en-US/docs/WebAssembly/Understanding_the_text_format#types) (`"i32"`, `"i64"`, `"f32"`, `"f64"`, `"v128"`, `"externref"`, `"anyfunc"`).
+
+### Exceptions
+
+- `TypeError`
+  - : The `type.parameters` argument is not supplied, does not contain at least one value, or contains an unsupported tag descriptor.
+
+
+## Examples
+
+This creates a tag with two values.
+
+```js
+const tag = new WebAssembly.Tag({ parameters: ["i32", "i64"] });
+```
+
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [WebAssembly](/en-US/docs/WebAssembly) overview page
+- [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/tag/type/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/tag/type/index.md
@@ -31,7 +31,7 @@ None
 
 An object with a property named `parameters` that references the array of data types associated with this [`Tag`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag).
 
-This is the same as the `type` object that was originally passed into the [`Tag()` constructor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag/Tag)
+This is the same as the `type` object that was originally passed into the [`Tag()` constructor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag/Tag).
 
 
 ## Examples
@@ -59,6 +59,6 @@ console.log(tag.type());
 
 ## See also
 
-- [WebAssembly](/en-US/docs/WebAssembly) overview page
+- [WebAssembly](/en-US/docs/WebAssembly) overview
 - [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
 - [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/tag/type/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/tag/type/index.md
@@ -1,0 +1,64 @@
+---
+title: WebAssembly.Tag.prototype.type()
+slug: Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag/type
+tags:
+  - API
+  - JavaScript
+  - Method
+  - Reference
+  - WebAssembly
+  - getArg
+  - Exception
+browser-compat: javascript.builtins.WebAssembly.Tag.type
+---
+{{JSRef}}
+
+The **`type()`** prototype method of the [`Tag`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag) object can be used to get the sequence of data types associated with the tag.
+
+The returned object will be the same as was originally passed into the [`Tag()` constructor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag/Tag).
+
+## Syntax
+
+```js
+type()
+```
+
+### Parameters
+
+None
+
+### Return value
+
+An object with a property named `parameters` that references the array of data types associated with this [`Tag`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag).
+
+This is the same as the `type` object that was originally passed into the [`Tag()` constructor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag/Tag)
+
+
+## Examples
+
+This code snippet creates a tag defining two data types and then exports them using `type()`.
+The result is printed to the console:
+
+```js
+const tag = new WebAssembly.Tag({ parameters: ["i32", "i64"] });
+console.log(tag.type());
+
+//Console output: 
+// Object { parameters: (2) […] }
+//   parameters: Array [ "i32", "i64" ]
+//   <prototype>: Object { … }
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [WebAssembly](/en-US/docs/WebAssembly) overview page
+- [WebAssembly concepts](/en-US/docs/WebAssembly/Concepts)
+- [Using the WebAssembly JavaScript API](/en-US/docs/WebAssembly/Using_the_JavaScript_API)

--- a/files/en-us/webassembly/understanding_the_text_format/index.md
+++ b/files/en-us/webassembly/understanding_the_text_format/index.md
@@ -72,7 +72,8 @@ The signature is a sequence of parameter type declarations followed by a list of
 - The absence of a `(result)` means the function doesn't return anything.
 - In the current iteration, there can be at most 1 return type, but [later this will be relaxed](https://github.com/WebAssembly/spec/blob/master/proposals/multi-value/Overview.md) to any number.
 
-Each parameter has a type explicitly declared; wasm currently has four available number types (plus reference types; see the [Reference types](#reference_types)) section below):
+Each parameter has a type explicitly declared; wasm [Number types](#number_types), [Reference types](#reference_types), [Vector types](#vector_types).
+The number types are:
 
 - `i32`: 32-bit integer
 - `i64`: 64-bit integer
@@ -574,7 +575,23 @@ The new operations are:
 
 > **Note:** You can find more information in the [Bulk Memory Operations and Conditional Segment Initialization](https://github.com/WebAssembly/bulk-memory-operations/blob/master/proposals/bulk-memory-operations/Overview.md) proposal.
 
-## Reference types
+
+## Types
+
+### Number types
+
+Web assembly currently has four available _number types_:
+
+- `i32`: 32-bit integer
+- `i64`: 64-bit integer
+- `f32`: 32-bit float
+- `f64`: 64-bit float
+
+### Vector types
+
+- `v128`: 128 bit vector of packed integer, floating-point data, or a single 128 bit type.
+
+### Reference types
 
 The [reference types proposal](https://github.com/WebAssembly/reference-types/blob/master/proposals/reference-types/Overview.md) (supported in [Firefox 79](/en-US/docs/Mozilla/Firefox/Releases/79)) provides two main features:
 


### PR DESCRIPTION
FF100 is shipping WebAssembly exceptions: https://bugzilla.mozilla.org/show_bug.cgi?id=1759217

This is the JavaScript API. This is perhaps a bit "rough" but I think not in awful state. Took a long time to get my head around it well enough to write.

The next step would be a WebAssembly Exceptions overview that explains a bit more about the exceptions conceptual framework. This doc is just about JavaScript API for creating tags and exceptions and has some examples. But how everything fits in still not covered.

Other docs work can be tracked in #14392