### PR TITLE
Add array form of export

### DIFF
--- a/files/en-us/web/javascript/reference/statements/export/index.md
+++ b/files/en-us/web/javascript/reference/statements/export/index.md
@@ -45,6 +45,7 @@ export { variable1 as name1, variable2 as name2, …, nameN };
 
 // Exporting destructured assignments with renaming
 export const { name1, name2: bar } = o;
+export const [ name1, name2 ] = array;
 
 // Default exports
 export default expression;


### PR DESCRIPTION
#### Summary
[`export` supports exporting any declaration](https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-exports). Notably absent from the current list of forms of `export` is array destructuring. This PR adds an example of that.

#### Motivation
In [SolidJS](https://www.solidjs.com/), it's reasonable to want to export global state from a module like this:
```js
export const [name, setName] = createSignal();
```
(For those familiar with React but not Solid, this is similar to React's `useState`, except that it can be used outside a component, in particular at the top level of a module.)

Reading the MDN page, I assumed this wasn't possible. But testing on Node 17, it definitely is. TypeScript also allows it.

#### Supporting details
I'm certain that I added the example in the right "group", but it does also feel like renaming.
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
