### PR TITLE
Simpler example for Element.animate()

### DIFF
--- a/files/en-us/web/api/element/animate/index.md
+++ b/files/en-us/web/api/element/animate/index.md
@@ -46,6 +46,65 @@ Returns an {{domxref("Animation")}}.
 
 ## Examples
 
+### Rotating and scaling
+
+In this example we use the `animate()` method to rotate and scale an element.
+
+#### HTML
+
+```html
+<div class="newspaper">Spinning newspaper<br>causes dizziness</div>
+```
+
+#### CSS
+
+```css
+html, body {
+  height: 100%;
+}
+
+body {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: black;
+}
+
+.newspaper {
+  padding: .5rem;
+  text-transform: uppercase;
+  text-align: center;
+  background-color: white;
+  cursor: pointer;
+}
+```
+
+#### JavaScript
+
+```js
+const newspaperSpinning = [
+  { transform: 'rotate(0) scale(1)' },
+  { transform: 'rotate(360deg) scale(0)' }
+];
+
+const newspaperTiming = {
+  duration: 2000,
+  iterations: 1,
+}
+
+const newspaper = document.querySelector(".newspaper");
+
+newspaper.addEventListener('click', () => {
+  newspaper.animate(newspaperSpinning, newspaperTiming);
+});
+```
+
+#### Result
+
+{{EmbedLiveSample("Rotating and scaling")}}
+
+### Down the Rabbit Hole demo
+
 In the demo [Down the
 Rabbit Hole (with the Web Animation API)](https://codepen.io/rachelnabors/pen/rxpmJL/?editors=0010), we use the convenient
 `animate()` method to immediately create and play an animation on the


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/13796.

This PR adds a simpler, self contained, example to the page for `Element.animate()`.