### PR TITLE
WebAPI: Update Method pages to modern structure (part 4) 

### DIFF
--- a/files/en-us/web/api/abortsignal/throwifaborted/index.md
+++ b/files/en-us/web/api/abortsignal/throwifaborted/index.md
@@ -22,7 +22,7 @@ This method can also be used to abort operations at particular points in code, r
 ## Syntax
 
 ```js
-throwIfAborted()
+throwIfAborted();
 ```
 
 ### Return value

--- a/files/en-us/web/api/analysernode/getbytefrequencydata/index.md
+++ b/files/en-us/web/api/analysernode/getbytefrequencydata/index.md
@@ -22,11 +22,7 @@ If the array has fewer elements than the {{domxref("AnalyserNode.frequencyBinCou
 ## Syntax
 
 ```js
-var audioCtx = new AudioContext();
-var analyser = audioCtx.createAnalyser();
-var dataArray = new Uint8Array(analyser.frequencyBinCount); // Uint8Array should be the same length as the frequencyBinCount
-
-void analyser.getByteFrequencyData(dataArray); // fill the Uint8Array with data returned from getByteFrequencyData()
+getByteFrequencyData(array);
 ```
 
 ### Parameters
@@ -39,7 +35,7 @@ void analyser.getByteFrequencyData(dataArray); // fill the Uint8Array with data 
 
 None.
 
-## Example
+## Examples
 
 The following example shows basic usage of an {{domxref("AudioContext")}} to create an `AnalyserNode`, then {{domxref("window.requestAnimationFrame()","requestAnimationFrame")}} and {{htmlelement("canvas")}} to collect frequency data repeatedly and draw a "winamp bargraph style" output of the current audio input. For more examples/information, check out our [Voice-change-O-matic](https://mdn.github.io/voice-change-o-matic/) demo (see [app.js lines 128–205](https://github.com/mdn/voice-change-o-matic/blob/gh-pages/scripts/app.js#L128-L205) for relevant code).
 

--- a/files/en-us/web/api/analysernode/getbytetimedomaindata/index.md
+++ b/files/en-us/web/api/analysernode/getbytetimedomaindata/index.md
@@ -18,10 +18,7 @@ If the array has fewer elements than the {{domxref("AnalyserNode.fftSize")}}, ex
 ## Syntax
 
 ```js
-const audioCtx = new AudioContext();
-const analyser = audioCtx.createAnalyser();
-const dataArray = new Uint8Array(analyser.fftSize); // Uint8Array should be the same length as the fftSize
-analyser.getByteTimeDomainData(dataArray); // fill the Uint8Array with data returned from getByteTimeDomainData()
+getByteTimeDomainData(array);
 ```
 
 ### Parameters
@@ -34,7 +31,7 @@ analyser.getByteTimeDomainData(dataArray); // fill the Uint8Array with data retu
 
 **`void`** | None
 
-## Example
+## Examples
 
 The following example shows basic usage of an {{domxref("AudioContext")}} to create an `AnalyserNode`, then {{domxref("window.requestAnimationFrame()","requestAnimationFrame")}} and {{htmlelement("canvas")}} to collect time domain data repeatedly and draw an "oscilloscope style" output of the current audio input. For more complete applied examples/information, check out our [Voice-change-O-matic](https://mdn.github.io/voice-change-o-matic/) demo (see [app.js lines 128–205](https://github.com/mdn/voice-change-o-matic/blob/gh-pages/scripts/app.js#L128-L205) for relevant code).
 

--- a/files/en-us/web/api/analysernode/getfloatfrequencydata/index.md
+++ b/files/en-us/web/api/analysernode/getfloatfrequencydata/index.md
@@ -20,11 +20,7 @@ If you need higher performance and don't care about precision, you can use {{dom
 ## Syntax
 
 ```js
-var audioCtx = new AudioContext();
-var analyser = audioCtx.createAnalyser();
-var dataArray = new Float32Array(analyser.frequencyBinCount); // Float32Array should be the same length as the frequencyBinCount
-
-void analyser.getFloatFrequencyData(dataArray); // fill the Float32Array with data returned from getFloatFrequencyData()
+getFloatFrequencyData(array);
 ```
 
 ### Parameters
@@ -37,7 +33,7 @@ void analyser.getFloatFrequencyData(dataArray); // fill the Float32Array with da
 
 None.
 
-## Example
+## Examples
 
 ```js
 const audioCtx = new AudioContext();

--- a/files/en-us/web/api/analysernode/getfloattimedomaindata/index.md
+++ b/files/en-us/web/api/analysernode/getfloattimedomaindata/index.md
@@ -16,10 +16,7 @@ The **`getFloatTimeDomainData()`** method of the {{ domxref("AnalyserNode") }} I
 ## Syntax
 
 ```js
-var audioCtx = new AudioContext();
-var analyser = audioCtx.createAnalyser();
-var dataArray = new Float32Array(analyser.fftSize); // Float32Array needs to be the same length as the fftSize
-analyser.getFloatTimeDomainData(dataArray); // fill the Float32Array with data returned from getFloatTimeDomainData()
+getFloatTimeDomainData(array);
 ```
 
 ### Parameters
@@ -32,7 +29,7 @@ analyser.getFloatTimeDomainData(dataArray); // fill the Float32Array with data r
 
 None.
 
-## Example
+## Examples
 
 The following example shows basic usage of an {{domxref("AudioContext")}} to create an `AnalyserNode`, then {{domxref("window.requestAnimationFrame()","requestAnimationFrame")}} and {{htmlelement("canvas")}} to collect time domain data repeatedly and draw an "oscilloscope style" output of the current audio input. For more complete applied examples/information, check out our [Voice-change-O-matic-float-data](https://mdn.github.io/voice-change-o-matic-float-data/) demo (see the [source code](https://github.com/mdn/voice-change-o-matic-float-data) too).
 

--- a/files/en-us/web/api/animation/commitstyles/index.md
+++ b/files/en-us/web/api/animation/commitstyles/index.md
@@ -17,7 +17,7 @@ The `commitStyles()` method of the [Web Animations API](/en-US/docs/Web/API/Web_
 ## Syntax
 
 ```js
-animation.commitStyles();
+commitStyles();
 ```
 
 ### Parameters

--- a/files/en-us/web/api/animation/persist/index.md
+++ b/files/en-us/web/api/animation/persist/index.md
@@ -17,7 +17,7 @@ The `persist()` method of the [Web Animations API](/en-US/docs/Web/API/Web_Anima
 ## Syntax
 
 ```js
-animation.persist();
+persist();
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audiolistener/setorientation/index.md
+++ b/files/en-us/web/api/audiolistener/setorientation/index.md
@@ -24,20 +24,10 @@ The two vectors must be separated by an angle of 90° — in linear analysis ter
 ## Syntax
 
 ```js
-var audioCtx = new AudioContext();
-var myListener = audioCtx.listener;
-myListener.setOrientation(0,0,-1,0,1,0);
+setOrientation(x, y, z, xUp, yUp, zUp);
 ```
 
-### Returns
-
-{{jsxref('undefined')}}.
-
-## Example
-
-See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/createPanner#example) for example code.
-
-## Parameters
+### Parameters
 
 - x
   - : The x value of the front vector of the listener.
@@ -51,6 +41,14 @@ See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/cre
   - : The y value of the up vector of the listener.
 - zUp
   - : The z value of the up vector of the listener.
+
+### Return value
+
+{{jsxref('undefined')}}.
+
+## Examples
+
+See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/createPanner#example) for example code.
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/audiolistener/setposition/index.md
+++ b/files/en-us/web/api/audiolistener/setposition/index.md
@@ -22,20 +22,10 @@ The default value of the position vector is `(0,` `0,` `0)`.
 ## Syntax
 
 ```js
-var audioCtx = new AudioContext();
-var myListener = audioCtx.listener;
-myListener.setPosition(1,1,1);
+setPosition(x, y, z);
 ```
 
-### Returns
-
-{{jsxref('undefined')}}.
-
-## Example
-
-See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/createPanner#example) for example code.
-
-## Parameters
+### Parameters
 
 - x
   - : The x position of the listener in 3D space.
@@ -43,6 +33,14 @@ See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/cre
   - : The y position of the listener in 3D space.
 - z
   - : The z position of the listener in 3D space.
+
+### Return value
+
+{{jsxref('undefined')}}.
+
+## Examples
+
+See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/createPanner#example) for example code.
 
 ## Specifications
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptor/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptor/index.md
@@ -21,10 +21,10 @@ first {{domxref("BluetoothRemoteGATTDescriptor")}} for a given descriptor UUID.
 ## Syntax
 
 ```js
-BluetoothRemoteGATTCharacteristic.getDescriptor(bluetoothDescriptorUUID).then(function(bluetoothGATTDescriptor) { /* ... */ })
+getDescriptor(bluetoothDescriptorUUID);
 ```
 
-### Returns
+### Return value
 
 A {{jsxref("Promise")}} that resolves to the
 first {{domxref("BluetoothRemoteGATTDescriptor")}}.

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptors/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptors/index.md
@@ -21,10 +21,10 @@ returns a {{jsxref("Promise")}} that resolves to an {{jsxref("Array")}} of all
 ## Syntax
 
 ```js
-BluetoothRemoteGATTCharacteristic.getDescriptors(bluetoothDescriptorUUID).then(function(bluetoothGATTDescriptors[]) { /* ... */ })
+getDescriptors(bluetoothDescriptorUUID);
 ```
 
-### Returns
+### Return value
 
 A {{jsxref("Promise")}} that resolves to an {{jsxref("Array")}}
 of {{domxref("BluetoothRemoteGATTDescriptor")}} objects.

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevalue/index.md
@@ -21,10 +21,10 @@ The **`BluetoothRemoteGATTCharacteristic.writeValue()`** method sets a {{domxref
 ## Syntax
 
 ```js
-BluetoothRemoteGATTCharacteristic.writeValue(value).then(function() { /* ... */ })
+writeValue(value);
 ```
 
-### Returns
+### Return value
 
 A {{jsxref("Promise")}}.
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithoutresponse/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithoutresponse/index.md
@@ -17,10 +17,10 @@ The **`BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse()`** method s
 ## Syntax
 
 ```js
-BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse(value).then(function() { /* ... */ })
+writeValueWithoutResponse(value);
 ```
 
-### Returns
+### Return value
 
 A {{jsxref("Promise")}}.
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithresponse/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithresponse/index.md
@@ -17,10 +17,10 @@ The **`BluetoothRemoteGATTCharacteristic.writeValueWithResponse()`** method sets
 ## Syntax
 
 ```js
-BluetoothRemoteGATTCharacteristic.writeValueWithResponse(value).then(function() { /* ... */ })
+writeValueWithResponse(value);
 ```
 
-### Returns
+### Return value
 
 A {{jsxref("Promise")}}.
 

--- a/files/en-us/web/api/bluetoothremotegattserver/connect/index.md
+++ b/files/en-us/web/api/bluetoothremotegattserver/connect/index.md
@@ -21,11 +21,10 @@ script execution environment to connect to `this.device`.
 ## Syntax
 
 ```js
-BluetoothRemoteGATTServer.connect()
-  .then(function(bluetoothRemoteGATTServer) { /* ... */ })
+connect();
 ```
 
-### Returns
+### Return value
 
 A {{jsxref("Promise")}} that resolves to a {{domxref("BluetoothRemoteGATTServer")}}.
 

--- a/files/en-us/web/api/bluetoothremotegattserver/getprimaryservice/index.md
+++ b/files/en-us/web/api/bluetoothremotegattserver/getprimaryservice/index.md
@@ -21,10 +21,10 @@ bluetooth device for a specified {{domxref("BluetoothServiceUUID")}}.
 ## Syntax
 
 ```js
-BluetoothRemoteGATTServer.getPrimaryService(bluetoothServiceUUID).then(function(bluetoothGATTService) { /* ... */ })
+getPrimaryService(bluetoothServiceUUID);
 ```
 
-### Returns
+### Return value
 
 A {{jsxref("Promise")}} that resolves to a {{domxref("BluetoothRemoteGATTService")}} object.
 

--- a/files/en-us/web/api/bluetoothremotegattserver/getprimaryservices/index.md
+++ b/files/en-us/web/api/bluetoothremotegattserver/getprimaryservices/index.md
@@ -21,10 +21,10 @@ bluetooth device for a specified `BluetoothServiceUUID`.
 ## Syntax
 
 ```js
-BluetoothRemoteGATTServer.getPrimaryServices(bluetoothServiceUUID).then(function(bluetoothGATTServices) { /* ... */ })
+getPrimaryServices(bluetoothServiceUUID);
 ```
 
-### Returns
+### Return value
 
 A {{jsxref("Promise")}} that resolves to a list of {{domxref("BluetoothRemoteGATTService")}}
 objects.

--- a/files/en-us/web/api/bluetoothremotegattservice/getcharacteristic/index.md
+++ b/files/en-us/web/api/bluetoothremotegattservice/getcharacteristic/index.md
@@ -22,10 +22,10 @@ returns a {{jsxref("Promise")}} to an instance of
 ## Syntax
 
 ```js
-bluetoothGATTServiceInstance.getCharacteristic(characteristic).then(function(BluetoothGATTCharacteristic) { /* ... */ } )
+getCharacteristic(characteristic);
 ```
 
-### Returns
+### Return value
 
 A {{jsxref("Promise")}} to an instance of {{domxref("BluetoothRemoteGATTCharacteristic")}}
 

--- a/files/en-us/web/api/bluetoothremotegattservice/getcharacteristics/index.md
+++ b/files/en-us/web/api/bluetoothremotegattservice/getcharacteristics/index.md
@@ -21,10 +21,10 @@ instances for a given universally unique identifier (UUID).
 ## Syntax
 
 ```js
-bluetoothGATTServiceInstance.getCharacteristics(characteristics).then(function(BluetoothGATTCharacteristic[]) { /* ... */ } )
+getCharacteristics(characteristics);
 ```
 
-### Returns
+### Return value
 
 A {{jsxref("Promise")}} to an
 {{jsxref("Array")}} of {{domxref("BluetoothRemoteGATTCharacteristic")}} instances.

--- a/files/en-us/web/api/cache/addall/index.md
+++ b/files/en-us/web/api/cache/addall/index.md
@@ -29,9 +29,7 @@ retrieval become keys to the stored response operations.
 ## Syntax
 
 ```js
-cache.addAll(requests[]).then(function() {
-  // requests have been added to the cache
-});
+addAll(requests);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cache/match/index.md
+++ b/files/en-us/web/api/cache/match/index.md
@@ -24,9 +24,7 @@ to {{jsxref("undefined")}}.
 ## Syntax
 
 ```js
-cache.match(request, options).then(function(response) {
-  // Do something with the response
-});
+match(request, options);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cache/matchall/index.md
+++ b/files/en-us/web/api/cache/matchall/index.md
@@ -21,9 +21,7 @@ responses in the {{domxref("Cache")}} object.
 ## Syntax
 
 ```js
-cache.matchAll(request, options).then(function(response) {
-  // do something with the response array
-});
+matchAll(request, options);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cache/put/index.md
+++ b/files/en-us/web/api/cache/put/index.md
@@ -47,9 +47,7 @@ fetch(url).then(function(response) {
 ## Syntax
 
 ```js
-cache.put(request, response).then(function() {
-  // request/response pair has been added to the cache
-});
+put(request, response);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cachestorage/delete/index.md
+++ b/files/en-us/web/api/cachestorage/delete/index.md
@@ -26,9 +26,7 @@ You can access `CacheStorage` through the global
 ## Syntax
 
 ```js
-caches.delete(cacheName).then(function(boolean) {
-  // your cache is now deleted
-});
+delete(cacheName);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cachestorage/has/index.md
+++ b/files/en-us/web/api/cachestorage/has/index.md
@@ -24,9 +24,7 @@ You can access `CacheStorage` through the global
 ## Syntax
 
 ```js
-caches.has(cacheName).then(function(boolean) {
-  // true: your cache exists!
-});
+has(cacheName);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cachestorage/keys/index.md
+++ b/files/en-us/web/api/cachestorage/keys/index.md
@@ -29,9 +29,7 @@ You can access `CacheStorage` through the global
 ## Syntax
 
 ```js
-caches.keys().then(function(keyList) {
-  //do something with your keyList
-});
+keys();
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cachestorage/match/index.md
+++ b/files/en-us/web/api/cachestorage/match/index.md
@@ -35,9 +35,7 @@ You can access `CacheStorage` through the global
 ## Syntax
 
 ```js
-caches.match(request, options).then(function(response) {
-  // Do something with the response
-});
+match(request, options);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cachestorage/open/index.md
+++ b/files/en-us/web/api/cachestorage/open/index.md
@@ -29,9 +29,7 @@ You can access `CacheStorage` through the global
 ## Syntax
 
 ```js
-caches.open(cacheName).then(function(cache) {
-  // Do something with your cache
-});
+open(cacheName);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/createconicgradient/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createconicgradient/index.md
@@ -22,7 +22,7 @@ This method returns a conic {{domxref("CanvasGradient")}}. To be applied to a sh
 ## Syntax
 
 ```js
-CanvasGradient ctx.createConicGradient(startAngle, x, y);
+createConicGradient(startAngle, x, y);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/createimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createimagedata/index.md
@@ -18,8 +18,8 @@ specified dimensions. All of the pixels in the new object are transparent black.
 ## Syntax
 
 ```js
-ImageData ctx.createImageData(width, height);
-ImageData ctx.createImageData(imagedata);
+createImageData(width, height);
+createImageData(imagedata);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/createlineargradient/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createlineargradient/index.md
@@ -31,7 +31,7 @@ the gradient must first be assigned to the
 ## Syntax
 
 ```js
-CanvasGradient ctx.createLinearGradient(x0, y0, x1, y1);
+createLinearGradient(x0, y0, x1, y1);
 ```
 
 The `createLinearGradient()` method is specified by four parameters defining

--- a/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.md
@@ -24,7 +24,7 @@ applied to any subsequent drawing.
 ## Syntax
 
 ```js
-CanvasPattern ctx.createPattern(image, repetition);
+createPattern(image, repetition);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/createradialgradient/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createradialgradient/index.md
@@ -29,7 +29,7 @@ properties.
 ## Syntax
 
 ```js
-CanvasGradient ctx.createRadialGradient(x0, y0, r0, x1, y1, r1);
+createRadialGradient(x0, y0, r0, x1, y1, r1);
 ```
 
 The `createRadialGradient()` method is specified by six parameters, three

--- a/files/en-us/web/api/canvasrenderingcontext2d/drawfocusifneeded/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawfocusifneeded/index.md
@@ -20,8 +20,8 @@ specified element is focused.
 ## Syntax
 
 ```js
-void ctx.drawFocusIfNeeded(element);
-void ctx.drawFocusIfNeeded(path, element);
+drawFocusIfNeeded(element);
+drawFocusIfNeeded(path, element);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/drawimage/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawimage/index.md
@@ -17,9 +17,9 @@ Canvas 2D API provides different ways to draw an image onto the canvas.
 ## Syntax
 
 ```js
-void ctx.drawImage(image, dx, dy);
-void ctx.drawImage(image, dx, dy, dWidth, dHeight);
-void ctx.drawImage(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
+drawImage(image, dx, dy);
+drawImage(image, dx, dy, dWidth, dHeight);
+drawImage(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
 ```
 
 ![drawImage](canvas_drawimage.jpg)

--- a/files/en-us/web/api/canvasrenderingcontext2d/drawwidgetasonscreen/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawwidgetasonscreen/index.md
@@ -26,7 +26,7 @@ only from within the chrome process.
 ## Syntax
 
 ```js
-void ctx.drawWidgetAsOnScreen(window);
+drawWidgetAsOnScreen(window);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/drawwindow/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawwindow/index.md
@@ -30,7 +30,8 @@ from the parent process.
 ## Syntax
 
 ```js
-void ctx.drawWindow(window, x, y, w, h, bgColor [, flags]);
+drawWindow(window, x, y, w, h, bgColor);
+drawWindow(window, x, y, w, h, bgColor, flags);
 ```
 
 ### Parameters
@@ -72,7 +73,7 @@ void ctx.drawWindow(window, x, y, w, h, bgColor [, flags]);
     | `DRAWWINDOW_USE_WIDGET_LAYERS`   | `0x08` | Use the widget layer manager if available. This means hardware acceleration may be used, but it might actually be slower or lower quality than normal. It will, however, more accurately reflect the pixels rendered to the screen. |
     | `DRAWWINDOW_ASYNC_DECODE_IMAGES` | `0x10` | Do not synchronously decode images - draw what we have.                                                                                                                                                                             |
 
-## Example
+## Examples
 
 This method draws a snapshot of the contents of a DOM `window` into the
 canvas. For example,

--- a/files/en-us/web/api/canvasrenderingcontext2d/ellipse/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/ellipse/index.md
@@ -18,7 +18,8 @@ method of the Canvas 2D API adds an elliptical arc to the current sub-path.
 ## Syntax
 
 ```js
-void ctx.ellipse(x, y, radiusX, radiusY, rotation, startAngle, endAngle [, counterclockwise]);
+ellipse(x, y, radiusX, radiusY, rotation, startAngle, endAngle);
+ellipse(x, y, radiusX, radiusY, rotation, startAngle, endAngle, counterclockwise);
 ```
 
 The `ellipse()` method creates an elliptical arc centered at

--- a/files/en-us/web/api/canvasrenderingcontext2d/fill/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fill/index.md
@@ -19,8 +19,10 @@ method of the Canvas 2D API fills the current or given path with the current
 ## Syntax
 
 ```js
-void ctx.fill([fillRule]);
-void ctx.fill(path [, fillRule]);
+fill();
+fill(path);
+fill(fillRule);
+fill(path, fillRule);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/fillrect/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fillrect/index.md
@@ -24,7 +24,7 @@ on it.
 ## Syntax
 
 ```js
-void ctx.fillRect(x, y, width, height);
+fillRect(x, y, width, height);
 ```
 
 The `fillRect()` method draws a filled rectangle whose starting point is at

--- a/files/en-us/web/api/canvasrenderingcontext2d/filltext/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/filltext/index.md
@@ -43,7 +43,8 @@ The text is rendered using the font and text layout configuration as defined by 
 ## Syntax
 
 ```js
-CanvasRenderingContext2D.fillText(text, x, y [, maxWidth]);
+fillText(text, x, y);
+fillText(text, x, y, maxWidth);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/getcontextattributes/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getcontextattributes/index.md
@@ -21,7 +21,7 @@ on context creation.
 ## Syntax
 
 ```js
-ctx.getContextAttributes();
+getContextAttributes();
 ```
 
 ### Return value

--- a/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
@@ -38,7 +38,7 @@ manipulation with canvas](/en-US/docs/Web/API/Canvas_API/Tutorial/Pixel_manipula
 ## Syntax
 
 ```js
-ctx.getImageData(sx, sy, sw, sh);
+getImageData(sx, sy, sw, sh);
 ```
 
 ### Parameters
@@ -74,7 +74,7 @@ canvas specified. The coordinates of the rectangle's top-left corner are
     configure CORS to allow the source image to be used in this way.
     See [Allowing cross-origin use of images and canvas](/en-US/docs/Web/HTML/CORS_enabled_image).
 
-## Example
+## Examples
 
 ### Getting image data from a canvas
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/getlinedash/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getlinedash/index.md
@@ -17,7 +17,7 @@ The **`getLineDash()`** method of the Canvas 2D API's
 ## Syntax
 
 ```js
-ctx.getLineDash();
+getLineDash();
 ```
 
 ### Return value

--- a/files/en-us/web/api/canvasrenderingcontext2d/gettransform/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/gettransform/index.md
@@ -19,7 +19,7 @@ the context.
 ## Syntax
 
 ```js
-let storedTransform = ctx.getTransform();
+getTransform();
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/ispointinpath/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/ispointinpath/index.md
@@ -19,8 +19,10 @@ the current path.
 ## Syntax
 
 ```js
-ctx.isPointInPath(x, y [, fillRule]);
-ctx.isPointInPath(path, x, y [, fillRule]);
+isPointInPath(x, y);
+isPointInPath(x, y, fillRule);
+isPointInPath(path, x, y);
+isPointInPath(path, x, y, fillRule);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/ispointinstroke/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/ispointinstroke/index.md
@@ -19,8 +19,8 @@ area contained by the stroking of a path.
 ## Syntax
 
 ```js
-ctx.isPointInStroke(x, y);
-ctx.isPointInStroke(path, x, y);
+isPointInStroke(x, y);
+isPointInStroke(path, x, y);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/lineto/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/lineto/index.md
@@ -24,7 +24,7 @@ anything. To draw the path onto a canvas, you can use the
 ## Syntax
 
 ```js
-ctx.lineTo(x, y);
+lineTo(x, y);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/measuretext/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/measuretext/index.md
@@ -19,7 +19,7 @@ measured text (such as its width, for example).
 ## Syntax
 
 ```js
-ctx.measureText(text);
+measureText(text);
 ```
 
 ### Parameters
@@ -31,7 +31,7 @@ ctx.measureText(text);
 
 A {{domxref("TextMetrics")}} object.
 
-## Example
+## Examples
 
 Given this {{HTMLElement("canvas")}} element:
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/moveto/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/moveto/index.md
@@ -19,7 +19,7 @@ method of the Canvas 2D API begins a new sub-path at the point specified by the 
 ## Syntax
 
 ```js
-void ctx.moveTo(x, y);
+moveTo(x, y);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/putimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/putimagedata/index.md
@@ -25,8 +25,8 @@ manipulation of canvas contents in the article [Pixel manipulation with canvas](
 ## Syntax
 
 ```js
-void ctx.putImageData(imageData, dx, dy);
-void ctx.putImageData(imageData, dx, dy, dirtyX, dirtyY, dirtyWidth, dirtyHeight);
+putImageData(imageData, dx, dy);
+putImageData(imageData, dx, dy, dirtyX, dirtyY, dirtyWidth, dirtyHeight);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/quadraticcurveto/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/quadraticcurveto/index.md
@@ -22,7 +22,7 @@ the quadratic Bézier curve.
 ## Syntax
 
 ```js
-void ctx.quadraticCurveTo(cpx, cpy, x, y);
+quadraticCurveTo(cpx, cpy, x, y);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/rect/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/rect/index.md
@@ -27,7 +27,7 @@ anything.  To draw the rectangle onto a canvas, you can use the
 ## Syntax
 
 ```js
-void ctx.rect(x, y, width, height);
+rect(x, y, width, height);
 ```
 
 The `rect()` method creates a rectangular path whose starting point is at

--- a/files/en-us/web/api/canvasrenderingcontext2d/restore/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/restore/index.md
@@ -23,7 +23,7 @@ state](/en-US/docs/Web/API/CanvasRenderingContext2D/save#drawing_state), see {{d
 ## Syntax
 
 ```js
-void ctx.restore();
+restore();
 ```
 
 ## Examples


### PR DESCRIPTION
Continuing #14857 

## Summary
Updating the method pages to follow the current templates:
https://developer.mozilla.org/en-US/docs/MDN/Structures/Syntax_sections#constructors_and_methods
https://developer.mozilla.org/en-US/docs/MDN/Structures/Page_types/API_method_subpage_template

Changes Include:
- fix syntax section
- changing section titles to suggested titles in the template
- change `{{DOMxRef("DOMString")}}` to `string`
- remove extra spaces in between words and extra trailing spaces
- other small corrections

### Metadata
- [x] Fixes a typo, bug, or other error
