### PR TITLE
Add high-res display scaling hint to “Optimizing canvas” doc

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/optimizing_canvas/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/optimizing_canvas/index.md
@@ -100,7 +100,7 @@ var ctx = canvas.getContext('2d', { alpha: false });
 
 ### Scaling for high resolution displays
 
-You may find that canvas items appear blury on higher resolution displays. While many solutions may exist, a simple first step is to scale the canvas size up and down simultaneously, using the canvas' attributes, styling, and its context's scale.
+You may find that canvas items appear blurry on higher-resolution displays. While many solutions may exist, a simple first step is to scale the canvas size up and down simultaneously, using the its attributes, styling, and its context's scale.
 
 ```js
 // Get the DPR and size of the canvas

--- a/files/en-us/web/api/canvas_api/tutorial/optimizing_canvas/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/optimizing_canvas/index.md
@@ -98,6 +98,27 @@ If your application uses canvas and doesn't need a transparent backdrop, set the
 var ctx = canvas.getContext('2d', { alpha: false });
 ```
 
+### Scaling for high resolution displays
+
+You may find that canvas items appear blury on higher resolution displays. While many solutions may exist, a simple first step is to scale the canvas size up and down simultaneously, using the canvas' attributes, styling, and its context's scale.
+
+```js
+// Get the DPR and size of the canvas
+var dpr = window.devicePixelRatio;
+var rect = canvas.getBoundingClientRect();
+
+// Set the "actual" size of the canvas
+canvas.width = rect.width * dpr;
+canvas.height = rect.height * dpr;
+
+// Scale the context to ensure correct drawing operations
+ctx.scale(dpr, dpr);
+
+// Set the "drawn" size of the canvas
+canvas.style.width = rect.width + 'px';
+canvas.style.height = rect.height + 'px';
+```
+
 ### More tips
 
 - Batch canvas calls together. For example, draw a polyline instead of multiple separate lines.

--- a/files/en-us/web/api/canvas_api/tutorial/optimizing_canvas/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/optimizing_canvas/index.md
@@ -100,7 +100,7 @@ var ctx = canvas.getContext('2d', { alpha: false });
 
 ### Scaling for high resolution displays
 
-You may find that canvas items appear blurry on higher-resolution displays. While many solutions may exist, a simple first step is to scale the canvas size up and down simultaneously, using the its attributes, styling, and its context's scale.
+You may find that canvas items appear blurry on higher-resolution displays. While many solutions may exist, a simple first step is to scale the canvas size up and down simultaneously, using its attributes, styling, and its context's scale.
 
 ```js
 // Get the DPR and size of the canvas


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
This PR adds a hint for those who are trying to solve the "blur" problem when working with high resolution displays. The problem occurs because the canvas is upscaled to the desired size after being downsampled to the original size. This leads to a blur in the images/paths that are drawn to the canvas. This solution, while not an "optimisation", will save a lot of people a lot of time, because surprisingly, there aren't many references to this problem on StackOverflow!

#### Motivation
This change helps readers by identifying to them how they can eliminate the blur that comes with the Canvas on High Resolution displays (ie, 4K displays).

#### Supporting details
[This webpage](https://www.kirupa.com/canvas/canvas_high_dpi_retina.htm) explained how this works, and how it solves this blur problem.

#### Related issues
Nil.

#### Metadata
This PR…
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document (adds a new hint)
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
