### PR TITLE
Added redirect for moz-border-left-colors

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -10629,6 +10629,7 @@
 /en-US/docs/Web/CSS/-moz-border-image-slice	/en-US/docs/Web/CSS/border-image-slice
 /en-US/docs/Web/CSS/-moz-border-image-source	/en-US/docs/Web/CSS/border-image-source
 /en-US/docs/Web/CSS/-moz-border-image-width	/en-US/docs/Web/CSS/border-image-width
+/en-US/docs/Web/CSS/-moz-border-left-colors	/en-US/docs/Web/CSS/Mozilla_Extensions#b
 /en-US/docs/Web/CSS/-moz-border-radius	/en-US/docs/Web/CSS/border-radius
 /en-US/docs/Web/CSS/-moz-border-radius-bottomleft	/en-US/docs/Web/CSS/border-bottom-left-radius
 /en-US/docs/Web/CSS/-moz-border-radius-bottomright	/en-US/docs/Web/CSS/border-bottom-right-radius


### PR DESCRIPTION
#### Summary
Redirected https://developer.mozilla.org/en-US/docs/Web/CSS/-moz-border-left-colors link to https://developer.mozilla.org/en-US/docs/Web/CSS/Mozilla_Extensions#b 

#### Motivation
`-moz-border-left-colors` is deprecated and therefore unlikely to ever get its own page

#### Related issues
Fixes #14748

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
