### PR TITLE
I think citrus should be updated to say "apple", not "lemon"

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/slice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/slice/index.md
@@ -88,7 +88,7 @@ let fruits = ['Banana', 'Orange', 'Lemon', 'Apple', 'Mango']
 let citrus = fruits.slice(1, 3)
 
 // fruits contains ['Banana', 'Orange', 'Lemon', 'Apple', 'Mango']
-// citrus contains ['Orange','Lemon']
+// citrus contains ['Orange','Apple']
 ```
 
 ### Using slice


### PR DESCRIPTION
```js
let fruits = ['Banana', 'Orange', 'Lemon', 'Apple', 'Mango']
let citrus = fruits.slice(1, 3)

// fruits contains ['Banana', 'Orange', 'Lemon', 'Apple', 'Mango']
// citrus contains ['Orange','Lemon']
```

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
