### PR TITLE
WebAPI: Update Method pages to modern structure (part 5)

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/rotate/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/rotate/index.md
@@ -18,7 +18,7 @@ method of the Canvas 2D API adds a rotation to the transformation matrix.
 ## Syntax
 
 ```js
-void ctx.rotate(angle);
+rotate(angle);
 ```
 
 ![](canvas_grid_rotate.png)

--- a/files/en-us/web/api/canvasrenderingcontext2d/save/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/save/index.md
@@ -47,7 +47,7 @@ The drawing state that gets saved onto a stack consists of:
 ## Syntax
 
 ```js
-void ctx.save();
+save();
 ```
 
 ## Examples

--- a/files/en-us/web/api/canvasrenderingcontext2d/scale/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/scale/index.md
@@ -25,7 +25,7 @@ drawn at twice the normal size.
 ## Syntax
 
 ```js
-void ctx.scale(x, y);
+scale(x, y);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/scrollpathintoview/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/scrollpathintoview/index.md
@@ -20,8 +20,8 @@ to {{domxref("Element.scrollIntoView()")}}.
 ## Syntax
 
 ```js
-void ctx.scrollPathIntoView();
-void ctx.scrollPathIntoView(path);
+scrollPathIntoView();
+scrollPathIntoView(path);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/setlinedash/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/setlinedash/index.md
@@ -26,7 +26,7 @@ and gaps which describe the pattern.
 ## Syntax
 
 ```js
-ctx.setLineDash(segments);
+setLineDash(segments);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/settransform/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/settransform/index.md
@@ -24,8 +24,8 @@ method. This lets you scale, rotate, translate (move), and skew the context.
 ## Syntax
 
 ```js
-ctx.setTransform(a, b, c, d, e, f);
-ctx.setTransform(matrix);
+setTransform(a, b, c, d, e, f);
+setTransform(matrix);
 ```
 
 The transformation matrix is described by: <math><semantics><mrow><mo>[</mo>

--- a/files/en-us/web/api/canvasrenderingcontext2d/stroke/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/stroke/index.md
@@ -25,8 +25,8 @@ means that path intersections will still get filled.
 ## Syntax
 
 ```js
-void ctx.stroke();
-void ctx.stroke(path);
+stroke();
+stroke(path);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/strokerect/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/strokerect/index.md
@@ -25,7 +25,7 @@ on it.
 ## Syntax
 
 ```js
-void ctx.strokeRect(x, y, width, height);
+strokeRect(x, y, width, height);
 ```
 
 The `strokeRect()` method draws a stroked rectangle whose starting point is

--- a/files/en-us/web/api/canvasrenderingcontext2d/stroketext/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/stroketext/index.md
@@ -36,13 +36,14 @@ on it.
 ## Syntax
 
 ```js
-CanvasRenderingContext2D.strokeText(text, x, y [, maxWidth]);
+strokeText(text, x, y);
+strokeText(text, x, y, maxWidth);
 ```
 
 ### Parameters
 
 - `text`
-  - : A {{domxref("DOMString")}} specifying the text string to render into the context.
+  - : A string specifying the text string to render into the context.
     The text is rendered using the settings specified by
     {{domxref("CanvasRenderingContext2D.font","font")}},
     {{domxref("CanvasRenderingContext2D.textAlign","textAlign")}},

--- a/files/en-us/web/api/canvasrenderingcontext2d/transform/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/transform/index.md
@@ -25,7 +25,7 @@ described by the arguments of this method. This lets you scale, rotate, translat
 ## Syntax
 
 ```js
-void ctx.transform(a, b, c, d, e, f);
+transform(a, b, c, d, e, f);
 ```
 
 The transformation matrix is described by: <math><semantics><mrow><mo>[</mo>

--- a/files/en-us/web/api/canvasrenderingcontext2d/translate/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/translate/index.md
@@ -18,7 +18,7 @@ method of the Canvas 2D API adds a translation transformation to the current mat
 ## Syntax
 
 ```js
-void ctx.translate(x, y);
+translate(x, y);
 ```
 
 The `translate()` method adds a translation transformation to the current

--- a/files/en-us/web/api/characterdata/replacewith/index.md
+++ b/files/en-us/web/api/characterdata/replacewith/index.md
@@ -20,7 +20,7 @@ Strings are inserted as {{domxref("Text")}} nodes; the string is being passed as
 ## Syntax
 
 ```js
-replaceWith(... nodes)
+replaceWith(nodes);
 ```
 
 ### Parameters
@@ -35,7 +35,7 @@ replaceWith(... nodes)
 - `HierarchyRequestError` {{DOMxRef("DOMException")}}
   - : Thrown when the node cannot be inserted at the specified point in the hierarchy.
 
-## Example
+## Examples
 
 ```html
 <p id="myText">Some text</p>

--- a/files/en-us/web/api/clearinterval/index.md
+++ b/files/en-us/web/api/clearinterval/index.md
@@ -18,7 +18,7 @@ was previously established by a call to {{domxref("setInterval", "setInterval()"
 ## Syntax
 
 ```js
-clearInterval(intervalID)
+clearInterval(intervalID);
 ```
 
 ### Parameters
@@ -38,7 +38,7 @@ However, for clarity, you should avoid doing so.
 
 {{jsxref("undefined")}}
 
-## Example
+## Examples
 
 See the [`setInterval()`
 examples](/en-US/docs/Web/API/setInterval#Examples).

--- a/files/en-us/web/api/cleartimeout/index.md
+++ b/files/en-us/web/api/cleartimeout/index.md
@@ -17,7 +17,7 @@ by calling {{domxref("setTimeout()")}}.
 ## Syntax
 
 ```js
-clearTimeout(timeoutID)
+clearTimeout(timeoutID);
 ```
 
 ### Parameters
@@ -33,7 +33,7 @@ means you can technically use `clearTimeout()` and
 {{domxref("clearInterval", "clearInterval()")}}
 interchangeably. However, for clarity, you should avoid doing so.
 
-## Example
+## Examples
 
 Run the script below in the context of a web page and click on the page once. You'll
 see a message popping up in a second. If you click the page multiple times in

--- a/files/en-us/web/api/client/postmessage/index.md
+++ b/files/en-us/web/api/client/postmessage/index.md
@@ -24,8 +24,8 @@ message is received in the "`message`" event on
 ## Syntax
 
 ```js
-client.postMessage(message[, transfer]);
-client.postMessage(message[, { transfer }]);
+postMessage(message);
+postMessage(message, transferables);
 ```
 
 ### Parameters
@@ -33,7 +33,7 @@ client.postMessage(message[, { transfer }]);
 - `message`
   - : The message to send to the client. This can be any [structured-clonable
     type](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
-- `transfer` {{optional_inline}}
+- `transferables` {{optional_inline}}
   - : A sequence of objects that are [transferred](/en-US/docs/Web/API/Transferable) with the message. The
     ownership of these objects is given to the destination side and they are no longer
     usable on the sending side.

--- a/files/en-us/web/api/clients/claim/index.md
+++ b/files/en-us/web/api/clients/claim/index.md
@@ -25,7 +25,7 @@ regularly over the network, or possibly via a different service worker.
 ## Syntax
 
 ```js
-await clients.claim();
+claim();
 ```
 
 ### Parameters
@@ -36,7 +36,7 @@ None.
 
 A {{jsxref("Promise")}} that resolves to `undefined`.
 
-## Example
+## Examples
 
 The following example uses `claim()` inside service worker's "`activate`" event listener so that clients loaded in the same scope do not need to be reloaded before their fetches will go through this service worker.
 

--- a/files/en-us/web/api/clients/get/index.md
+++ b/files/en-us/web/api/clients/get/index.md
@@ -20,9 +20,7 @@ The **`get()`** method of the
 ## Syntax
 
 ```js
-self.clients.get(id).then(function(client) {
-  // do something with your returned client
-});
+get(id);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/clients/matchall/index.md
+++ b/files/en-us/web/api/clients/matchall/index.md
@@ -23,9 +23,7 @@ service worker.
 ## Syntax
 
 ```js
-self.clients.matchAll(options).then(function(clients) {
-  // do something with your clients list
-});
+matchAll(options);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/clients/openwindow/index.md
+++ b/files/en-us/web/api/clients/openwindow/index.md
@@ -30,15 +30,13 @@ Chrome for Windows.
 ## Syntax
 
 ```js
-self.clients.openWindow(url).then(function(windowClient) {
-  // Do something with your WindowClient
-});
+openWindow(url);
 ```
 
 ### Parameters
 
 - `url`
-  - : A {{domxref("USVString")}} representing the URL of the client you want to open in
+  - : A string representing the URL of the client you want to open in
     the window. Generally this value must be a URL from the same origin as the calling
     script.
 

--- a/files/en-us/web/api/clipboard/read/index.md
+++ b/files/en-us/web/api/clipboard/read/index.md
@@ -36,7 +36,7 @@ permission.
 ## Syntax
 
 ```js
-var promise = navigator.clipboard.read();
+read();
 ```
 
 ### Parameters
@@ -49,7 +49,7 @@ A {{jsxref("Promise")}} that resolves with a sequence of {{domxref("ClipboardIte
 containing the clipboard's contents. The promise is rejected if permission to access the
 clipboard is not granted.
 
-## Example
+## Examples
 
 After using {{domxref("Permissions.query", "navigator.permissions.query()")}} to find
 out if we have (or if the user will be prompted to allow) `"clipboard-read"`

--- a/files/en-us/web/api/clipboard/readtext/index.md
+++ b/files/en-us/web/api/clipboard/readtext/index.md
@@ -31,7 +31,7 @@ you can read data from the clipboard.
 ## Syntax
 
 ```js
-var promise = navigator.clipboard.readText()
+readText();
 ```
 
 ### Parameters
@@ -49,7 +49,7 @@ To read non-text contents from the clipboard, use the {{domxref("Clipboard.read"
   "read()")}} method instead. You can write text to the clipboard using
 {{domxref("Clipboard.writeText", "writeText()")}}.
 
-## Example
+## Examples
 
 This example retrieves the textual contents of the clipboard and inserts the returned
 text into an element's contents.

--- a/files/en-us/web/api/clipboard/write/index.md
+++ b/files/en-us/web/api/clipboard/write/index.md
@@ -26,14 +26,14 @@ The `"clipboard-write"` permission of the [Permissions API](/en-US/docs/Web/API/
 automatically to pages when they are in the active tab.
 
 > **Note:** Browser support for the asynchronous clipboard APIs is still
-> in the process of being implemented. Be sure to check the  [compatibility table](#browser_compatibility) as well as
+> in the process of being implemented. Be sure to check the [compatibility table](#browser_compatibility) as well as
 > {{SectionOnPage("/en-US/docs/Web/API/Clipboard", "Clipboard availability")}} for more
 > information.
 
 ## Syntax
 
 ```js
-var promise = navigator.clipboard.write(data)
+write(data);
 ```
 
 ### Parameters
@@ -48,7 +48,7 @@ A {{jsxref("Promise")}} which is resolved when the data has been written to the
 clipboard. The promise is rejected if the clipboard is unable to complete the clipboard
 access.
 
-## Example
+## Examples
 
 This example function replaces the current contents of the clipboard with a specified
 string.
@@ -79,7 +79,7 @@ Next, we create a new {{domxref("ClipboardItem")}} object into which the blob wi
 The key of the object passed to the {{domxref("ClipboardItem")}} constructor indicates the content type, the value indicates the content. Then `write()` is called, specifying both a fulfillment function
 and an error function.
 
-### Example of copying canvas contents to the clipboard
+## Examplesof copying canvas contents to the clipboard
 
 ```js
 function copyCanvasContentsToClipboard(canvas, onDone, onError) {

--- a/files/en-us/web/api/clipboard/write/index.md
+++ b/files/en-us/web/api/clipboard/write/index.md
@@ -79,7 +79,7 @@ Next, we create a new {{domxref("ClipboardItem")}} object into which the blob wi
 The key of the object passed to the {{domxref("ClipboardItem")}} constructor indicates the content type, the value indicates the content. Then `write()` is called, specifying both a fulfillment function
 and an error function.
 
-## Examplesof copying canvas contents to the clipboard
+### Example of copying canvas contents to the clipboard
 
 ```js
 function copyCanvasContentsToClipboard(canvas, onDone, onError) {

--- a/files/en-us/web/api/clipboard/writetext/index.md
+++ b/files/en-us/web/api/clipboard/writetext/index.md
@@ -29,7 +29,7 @@ automatically to pages when they are in the active tab.
 ## Syntax
 
 ```js
-var promise = navigator.clipboard.writeText(newClipText)
+writeText(newClipText);
 ```
 
 ### Parameters
@@ -43,7 +43,7 @@ A {{jsxref("Promise")}} which is resolved once the clipboard's contents have bee
 updated. The promise is rejected if the caller does not have permission to write to the
 clipboard.
 
-## Example
+## Examples
 
 This example sets the clipboard's contents to the string "\<empty clipboard>".
 

--- a/files/en-us/web/api/closeevent/initcloseevent/index.md
+++ b/files/en-us/web/api/closeevent/initcloseevent/index.md
@@ -28,7 +28,7 @@ Once dispatched, it doesn't do anything anymore.
 ## Syntax
 
 ```js
-event.initMouseEvent(type, canBubble, cancelable, wasClean, reasonCode, reason);
+initMouseEvent(type, canBubble, cancelable, wasClean, reasonCode, reason);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/compositionevent/initcompositionevent/index.md
+++ b/files/en-us/web/api/compositionevent/initcompositionevent/index.md
@@ -22,7 +22,7 @@ method of the {{domxref("CompositionEvent")}} interface initializes the attribut
 ## Syntax
 
 ```js
- compositionEventInstance.initCompositionEvent(typeArg, canBubbleArg, cancelableArg, viewArg, dataArg, localeArg)
+initCompositionEvent(typeArg, canBubbleArg, cancelableArg, viewArg, dataArg, localeArg);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/assert/index.md
+++ b/files/en-us/web/api/console/assert/index.md
@@ -21,8 +21,10 @@ the console if the assertion is false. If the assertion is true, nothing happens
 ## Syntax
 
 ```js
-console.assert(assertion, obj1 [, obj2, ..., objN]);
-console.assert(assertion, msg [, subst1, ..., substN]); // C-like message formatting
+console.assert(assertion, obj1);
+console.assert(assertion, obj1, obj2, /* ... ,*/ objN);
+console.assert(assertion, msg);
+console.assert(assertion, msg, subst1, /* ... ,*/ substN);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/clear/index.md
+++ b/files/en-us/web/api/console/clear/index.md
@@ -18,7 +18,7 @@ environment allows it.
 ## Syntax
 
 ```js
-console.clear();
+clear();
 ```
 
 ## Specifications

--- a/files/en-us/web/api/console/count/index.md
+++ b/files/en-us/web/api/console/count/index.md
@@ -21,7 +21,8 @@ this particular call to `count()` has been called.
 ## Syntax
 
 ```js
-console.count([label]);
+count();
+count(label);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/countreset/index.md
+++ b/files/en-us/web/api/console/countreset/index.md
@@ -22,7 +22,8 @@ The **`console.countReset()`** method resets counter used with
 ## Syntax
 
 ```js
-console.countReset([label]);
+countReset();
+countReset(label);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/debug/index.md
+++ b/files/en-us/web/api/console/debug/index.md
@@ -27,8 +27,10 @@ level might correspond to the \`Debug\` or \`Verbose\` log level.
 ## Syntax
 
 ```js
-console.debug(obj1 [, obj2, ..., objN]);
-console.debug(msg [, subst1, ..., substN]);
+debug(obj1);
+debug(obj1, /* ..., */ objN);
+debug(msg);
+debug(msg, subst1, /* ..., */ substN]);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/dir/index.md
+++ b/files/en-us/web/api/console/dir/index.md
@@ -29,7 +29,7 @@ properties of the object.
 ## Syntax
 
 ```js
-console.dir(object);
+dir(object);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/dirxml/index.md
+++ b/files/en-us/web/api/console/dirxml/index.md
@@ -20,10 +20,10 @@ that let you see the contents of child nodes.
 ## Syntax
 
 ```js
-console.dirxml(object);
+dirxml(object);
 ```
 
-## Parameters
+### Parameters
 
 - `object`
   - : A JavaScript object whose properties should be output.

--- a/files/en-us/web/api/console/error/index.md
+++ b/files/en-us/web/api/console/error/index.md
@@ -19,8 +19,10 @@ The **`console.error()`** method outputs an error message to the Web console.
 ## Syntax
 
 ```js
-console.error(obj1 [, obj2, ..., objN]);
-console.error(msg [, subst1, ..., substN]);
+error(obj1);
+error(obj1, /* ..., */ objN);
+error(msg);
+error(msg, subst1, /* ..., */ substN]);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/group/index.md
+++ b/files/en-us/web/api/console/group/index.md
@@ -21,10 +21,11 @@ until {{domxref("console.groupEnd()")}} is called.
 ## Syntax
 
 ```js
-console.group([label]);
+group();
+group(label);
 ```
 
-## Parameters
+### Parameters
 
 - `label`
   - : Label for the group. Optional. (Chrome 59 tested) Does not work with

--- a/files/en-us/web/api/console/groupcollapsed/index.md
+++ b/files/en-us/web/api/console/groupcollapsed/index.md
@@ -29,10 +29,11 @@ examples.
 ## Syntax
 
 ```js
-console.groupCollapsed([label]);
+groupCollapsed();
+groupCollapsed(label);
 ```
 
-## Parameters
+### Parameters
 
 - `label`
   - : Label for the group. Optional.

--- a/files/en-us/web/api/console/groupend/index.md
+++ b/files/en-us/web/api/console/groupend/index.md
@@ -21,10 +21,10 @@ console](/en-US/docs/Web/API/console#using_groups_in_the_console) in the {{domxr
 ## Syntax
 
 ```js
-console.groupEnd();
+groupEnd();
 ```
 
-## Parameters
+### Parameters
 
 None.
 

--- a/files/en-us/web/api/console/info/index.md
+++ b/files/en-us/web/api/console/info/index.md
@@ -20,11 +20,13 @@ next to these items in the Web console's log.
 ## Syntax
 
 ```js
-console.info(obj1 [, obj2, ..., objN]);
-console.info(msg [, subst1, ..., substN]);
+info(obj1);
+info(obj1, /* ..., */ objN);
+info(msg);
+info(msg, subst1, /* ..., */ substN]);
 ```
 
-## Parameters
+### Parameters
 
 - `obj1` ... `objN`
   - : A list of JavaScript objects to output. The string representations of each of these

--- a/files/en-us/web/api/console/log/index.md
+++ b/files/en-us/web/api/console/log/index.md
@@ -25,8 +25,10 @@ or more JavaScript objects.
 ## Syntax
 
 ```js
-console.log(obj1 [, obj2, ..., objN]);
-console.log(msg [, subst1, ..., substN]);
+log(obj1);
+log(obj1, /* ..., */ objN);
+log(msg);
+log(msg, subst1, /* ..., */ substN]);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/profile/index.md
+++ b/files/en-us/web/api/console/profile/index.md
@@ -28,10 +28,10 @@ To stop recording call {{domxref("console.profileEnd()")}}.
 ## Syntax
 
 ```js
-console.profile(profileName);
+profile(profileName);
 ```
 
-## Parameters
+### Parameters
 
 - `profileName`
   - : The name to give the profile. Optional.

--- a/files/en-us/web/api/console/profileend/index.md
+++ b/files/en-us/web/api/console/profileend/index.md
@@ -37,10 +37,10 @@ only that profile if you have multiple profiles being recorded.
 ## Syntax
 
 ```js
-console.profileEnd(profileName);
+profileEnd(profileName);
 ```
 
-## Parameters
+### Parameters
 
 - `profileName`
   - : The name to give the profile. This parameter is optional.

--- a/files/en-us/web/api/console/table/index.md
+++ b/files/en-us/web/api/console/table/index.md
@@ -132,8 +132,8 @@ You can sort the table by a particular column by clicking on that column's label
 ## Syntax
 
 ```js
-console.table(data);
-console.table(data, columns);
+table(data);
+table(data, columns);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/time/index.md
+++ b/files/en-us/web/api/console/time/index.md
@@ -25,10 +25,10 @@ See [Timers](/en-US/docs/Web/API/console#timers) in the
 ## Syntax
 
 ```js
-console.time(label);
+time(label);
 ```
 
-## Parameters
+### Parameters
 
 - `label`
   - : The name to give the new timer. This will identify the timer; use the same name when

--- a/files/en-us/web/api/console/timeend/index.md
+++ b/files/en-us/web/api/console/timeend/index.md
@@ -23,7 +23,7 @@ details and examples.
 ## Syntax
 
 ```js
-console.timeEnd(label);
+timeEnd(label);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/timelog/index.md
+++ b/files/en-us/web/api/console/timelog/index.md
@@ -23,7 +23,7 @@ details and examples.
 ## Syntax
 
 ```js
-console.timeLog(label);
+timeLog(label);
 ```
 
 ### Parameters
@@ -31,7 +31,7 @@ console.timeLog(label);
 - `label`
   - : The name of the timer to log to the console.
 
-### Return
+### Return value
 
 If no label parameter included:
 

--- a/files/en-us/web/api/console/timestamp/index.md
+++ b/files/en-us/web/api/console/timestamp/index.md
@@ -26,10 +26,10 @@ be shown alongside the marker.
 ## Syntax
 
 ```js
-console.timeStamp(label);
+timeStamp(label);
 ```
 
-## Parameters
+### Parameters
 
 - `label`
   - : Label for the timestamp. Optional.

--- a/files/en-us/web/api/console/trace/index.md
+++ b/files/en-us/web/api/console/trace/index.md
@@ -28,7 +28,7 @@ See [Stack traces](/en-US/docs/Web/API/console#stack_traces) in the
 ## Syntax
 
 ```js
-console.trace( [...any, ...data ]);
+trace( [...any, ...data ]);
 ```
 
 ### Parameters
@@ -38,7 +38,7 @@ console.trace( [...any, ...data ]);
     assembled and formatted the same way they would be if passed to the
     {{domxref("console.log()")}} method.
 
-## Example
+## Examples
 
 ```js
 function foo() {

--- a/files/en-us/web/api/console/warn/index.md
+++ b/files/en-us/web/api/console/warn/index.md
@@ -23,11 +23,13 @@ console.
 ## Syntax
 
 ```js
-console.warn(obj1 [, obj2, ..., objN]);
-console.warn(msg [, subst1, ..., substN]);
+warn(obj1);
+warn(obj1, /* ..., */ objN);
+warn(msg);
+warn(msg, subst1, /* ..., */ substN]);
 ```
 
-## Parameters
+### Parameters
 
 - `obj1` ... `objN`
   - : A list of JavaScript objects to output. The string representations of each of these

--- a/files/en-us/web/api/cookiestore/delete/index.md
+++ b/files/en-us/web/api/cookiestore/delete/index.md
@@ -16,8 +16,8 @@ The **`delete()`** method of the {{domxref("CookieStore")}} interface deletes a 
 ## Syntax
 
 ```js
-var promise = cookieStore.delete(name);
-var promise = cookieStore.delete(options);
+delete(name);
+delete(options);
 ```
 
 ### Parameters
@@ -25,7 +25,7 @@ var promise = cookieStore.delete(options);
 This method requires one of the following:
 
 - `name`
-  - : A {{domxref("USVString")}} with the name of a cookie.
+  - : A string with the name of a cookie.
 - options
 
   - : An object containing:

--- a/files/en-us/web/api/cookiestore/get/index.md
+++ b/files/en-us/web/api/cookiestore/get/index.md
@@ -16,8 +16,8 @@ The **`get()`** method of the {{domxref("CookieStore")}} interface returns a sin
 ## Syntax
 
 ```js
-var cookie = CookieStore.get(name);
-var cookie = CookieStore.get(options);
+get(name);
+get(options);
 ```
 
 ### Parameters
@@ -25,7 +25,7 @@ var cookie = CookieStore.get(options);
 This method requires one of the following:
 
 - `name`
-  - : A {{domxref("USVString")}} with the name of a cookie.
+  - : A string with the name of a cookie.
 - options
 
   - : An object containing:

--- a/files/en-us/web/api/cookiestore/getall/index.md
+++ b/files/en-us/web/api/cookiestore/getall/index.md
@@ -16,14 +16,14 @@ The **`getAll()`** method of the {{domxref("CookieStore")}} interface returns a 
 ## Syntax
 
 ```js
-var list = cookieStore.getAll(name);
-var list = cookieStore.getAll(options);
+getAll(name);
+getAll(options);
 ```
 
 ### Parameters
 
 - `name`{{Optional_Inline}}
-  - : A {{domxref("USVString")}} with the name of a cookie.
+  - : A string with the name of a cookie.
 - `options`{{Optional_Inline}}
 
   - : An object containing:

--- a/files/en-us/web/api/cookiestore/set/index.md
+++ b/files/en-us/web/api/cookiestore/set/index.md
@@ -16,8 +16,8 @@ The **`set()`** method of the {{domxref("CookieStore")}} interface sets a cookie
 ## Syntax
 
 ```js
-var promise = cookieStore.set(name,value);
-var promise = cookieStore.set(options);
+set(name,value);
+set(options);
 ```
 
 ### Parameters
@@ -25,7 +25,7 @@ var promise = cookieStore.set(options);
 This method requires one of the following:
 
 - `name`
-  - : A {{domxref("USVString")}} with the name of the cookie.
+  - : A string with the name of the cookie.
 - `value`
   - : A {{domxref("USVString")}} with the value of the cookie.
 - options


### PR DESCRIPTION
Continuing #14857 

## Summary
Updating the method pages to follow the current templates:
https://developer.mozilla.org/en-US/docs/MDN/Structures/Syntax_sections#constructors_and_methods
https://developer.mozilla.org/en-US/docs/MDN/Structures/Page_types/API_method_subpage_template

Changes Include:
- fix syntax section
- changing section titles to suggested titles in the template
- change `{{DOMxRef("DOMString")}}` to `string`
- remove extra spaces in between words and extra trailing spaces
- other small corrections

### Metadata
- [x] Fixes a typo, bug, or other error
