### PR TITLE
Align the allowed values for SVG x1, x2, y1, y2 with spec

### DIFF
--- a/files/en-us/web/svg/attribute/x1/index.md
+++ b/files/en-us/web/svg/attribute/x1/index.md
@@ -55,6 +55,12 @@ For {{SVGElement('line')}}, `x1` defines the x coordinate of the starting point 
             >&#x3C;percentage></a
           ></strong
         >
+        |
+        <strong
+          ><a href="/en-US/docs/Web/SVG/Content_type#number"
+            >&#x3C;number></a
+          ></strong
+        >
       </td>
     </tr>
     <tr>
@@ -100,6 +106,12 @@ For {{SVGElement('linearGradient')}}, `x1` defines the x coordinate of the start
         <strong
           ><a href="/en-US/docs/Web/SVG/Content_type#percentage"
             >&#x3C;percentage></a
+          ></strong
+        >
+        |
+        <strong
+          ><a href="/en-US/docs/Web/SVG/Content_type#number"
+            >&#x3C;number></a
           ></strong
         >
       </td>

--- a/files/en-us/web/svg/attribute/x2/index.md
+++ b/files/en-us/web/svg/attribute/x2/index.md
@@ -50,6 +50,12 @@ For {{SVGElement('line')}}, `x2` defines the x coordinate of the ending point of
             >&#x3C;percentage></a
           ></strong
         >
+        |
+        <strong
+          ><a href="/en-US/docs/Web/SVG/Content_type#number"
+            >&#x3C;number></a
+          ></strong
+        >
       </td>
     </tr>
     <tr>
@@ -95,6 +101,12 @@ For {{SVGElement('linearGradient')}}, `x2` defines the x coordinate of the endin
         <strong
           ><a href="/en-US/docs/Web/SVG/Content_type#percentage"
             >&#x3C;percentage></a
+          ></strong
+        >
+        |
+        <strong
+          ><a href="/en-US/docs/Web/SVG/Content_type#number"
+            >&#x3C;number></a
           ></strong
         >
       </td>

--- a/files/en-us/web/svg/attribute/y1/index.md
+++ b/files/en-us/web/svg/attribute/y1/index.md
@@ -50,6 +50,12 @@ For {{SVGElement('line')}}, `y1` defines the y coordinate of the starting point 
             >&#x3C;percentage></a
           ></strong
         >
+        |
+        <strong
+          ><a href="/en-US/docs/Web/SVG/Content_type#number"
+            >&#x3C;number></a
+          ></strong
+        >
       </td>
     </tr>
     <tr>
@@ -95,6 +101,12 @@ For {{SVGElement('linearGradient')}}, `y1` defines the y coordinate of the start
         <strong
           ><a href="/en-US/docs/Web/SVG/Content_type#percentage"
             >&#x3C;percentage></a
+          ></strong
+        >
+        |
+        <strong
+          ><a href="/en-US/docs/Web/SVG/Content_type#number"
+            >&#x3C;number></a
           ></strong
         >
       </td>

--- a/files/en-us/web/svg/attribute/y2/index.md
+++ b/files/en-us/web/svg/attribute/y2/index.md
@@ -50,6 +50,12 @@ For {{SVGElement('line')}}, `y2` defines the y coordinate of the ending point of
             >&#x3C;percentage></a
           ></strong
         >
+        |
+        <strong
+          ><a href="/en-US/docs/Web/SVG/Content_type#number"
+            >&#x3C;number></a
+          ></strong
+        >
       </td>
     </tr>
     <tr>
@@ -95,6 +101,12 @@ For {{SVGElement('linearGradient')}}, `y2` defines the y coordinate of the endin
         <strong
           ><a href="/en-US/docs/Web/SVG/Content_type#percentage"
             >&#x3C;percentage></a
+          ></strong
+        >
+        |
+        <strong
+          ><a href="/en-US/docs/Web/SVG/Content_type#number"
+            >&#x3C;number></a
           ></strong
         >
       </td>


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/14954

The spec allows <length-percentage> | <number> for all these.

Spec reference: https://svgwg.org/svg2-draft/shapes.html#LineElementX1Attribute