### PR TITLE
Fix file-selector-button tags

### DIFF
--- a/files/en-us/web/css/_doublecolon_file-selector-button/index.md
+++ b/files/en-us/web/css/_doublecolon_file-selector-button/index.md
@@ -3,11 +3,9 @@ title: '::file-selector-button'
 slug: Web/CSS/::file-selector-button
 tags:
   - CSS
-  - Non-standard
   - Pseudo-element
   - Reference
   - Selector
-  - WebKit
 browser-compat: css.selectors.file-selector-button
 ---
 {{CSSRef}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
I noticed that [::file-selector-button](https://developer.mozilla.org/en-US/docs/Web/CSS/::file-selector-button) was not shown in list of pseudo classes. It's part of CSS Pseudo-Elements Module Level 4, so Non-standard should be removed. I am not sure what WebKit tag means, but probably it is supposed to be gone too.
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
