### PR TITLE
Structures/Syntax_sections: Add instructions about not to use semicolons

### DIFF
--- a/files/en-us/mdn/structures/syntax_sections/index.md
+++ b/files/en-us/mdn/structures/syntax_sections/index.md
@@ -17,32 +17,33 @@ The syntax section of an MDN reference page contains a syntax box defining the e
 ## API reference syntax
 
 Syntax sections for API reference pages are written manually, and may differ slightly based on the feature being documented.
-The section starts with a heading (typically {{HTMLElement("H2")}}) named "Syntax", and must be included at the top of the reference page (just below the introductory material).
-Below the heading is a code block showing the feature's exact syntax, styled using the `brush: [markup-language]` class.
+The section starts with a heading (typically level two heading `##`) named "Syntax", and must be included at the top of the reference page (just below the introductory material).
+Below the heading is a code block showing the feature's exact syntax, demarcated using code fence `` ``` [markup-language] `` class.
 
-The example below shows the source code for a typical Syntax section (for a JavaScript function):
+The example below shows the markdown code for a typical Syntax section (for a JavaScript function):
 
-```html
-  <h2 id="Syntax">Syntax</h2>
+````
+## Syntax
 
-  <pre class="brush: js">slice();
-  slice(start);
-  slice(start, end);
-  </pre>
+``` js
+slice()
+slice(start)
+slice(start, end)
 ```
+````  
 
 ### General style rules
 
 A few rules to follow in terms of markup within the syntax block:
-
+- Do **not** use semicolon `;` to terminate the lines. Syntax sections are not meant to show runnable code. So, it makes no sense to show semicolons.
 - Do **not** use \<code> within the syntax block (or within any code sample block on MDN, either). Not only is it generally useless, but our markup does not want it, and will not render the way you want it to look if you include it.
 - Only specify the function and arguments. Example showing "corrected" examples below
 
   ```js
-  querySelector(selector);
+  querySelector(selector)
   //responseStr = element.querySelector(selector);
 
-  new IntersectionObserver(callback, options);
+  new IntersectionObserver(callback, options)
   // var observer = new IntersectionObserver(callback, options);
   ```
 
@@ -53,13 +54,13 @@ A few rules to follow in terms of markup within the syntax block:
 Start with a syntax block, like this (from the {{DOMxRef("IntersectionObserver.IntersectionObserver", "IntersectionObserver constructor")}} page):
 
 ```js
-new IntersectionObserver(callback, options);
+new IntersectionObserver(callback, options)
 ```
 
 or this (from {{DOMxRef("Document.hasStorageAccess")}}):
 
 ```js
-hasStorageAccess();
+hasStorageAccess()
 ```
 
 ##### Multiple lines/Optional parameters
@@ -69,30 +70,30 @@ Methods that can be used in many different ways should be expanded out into mult
 Each option should be on its own line, omitting both per-option comments and assignment. For example, {{jsxref("Array.prototype.slice()")}} has two optional parameters, and would be documented as shown below:
 
 ```js
-slice();
-slice(begin);
-slice(begin, end);
+slice()
+slice(begin)
+slice(begin, end)
 ```
 
 Similarly, for {{DOMxRef("CanvasRenderingContext2D.drawImage")}}:
 
 ```js
-drawImage(image, dx, dy);
-drawImage(image, dx, dy, dWidth, dHeight);
-drawImage(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
+drawImage(image, dx, dy)
+drawImage(image, dx, dy, dWidth, dHeight)
+drawImage(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight)
 ```
 
 Similarly for the {{jsxref("Date")}} constructor:
 
 ```js
-new Date();
-new Date(value);
-new Date(dateString);
-new Date(year, monthIndex);
-new Date(year, monthIndex, day);
-new Date(year, monthIndex, day, hours);
-new Date(year, monthIndex, day, hours, minutes);
-new Date(year, monthIndex, day, hours, minutes, seconds, milliseconds);
+new Date()
+new Date(value)
+new Date(dateString)
+new Date(year, monthIndex)
+new Date(year, monthIndex, day)
+new Date(year, monthIndex, day, hours)
+new Date(year, monthIndex, day, hours, minutes)
+new Date(year, monthIndex, day, hours, minutes, seconds, milliseconds)
 ```
 
 ##### Formal syntax
@@ -114,13 +115,13 @@ The aim is to make the syntax block as pure and unambiguous a definition of the 
 ```js
 caches.match(request, options).then(function(response) {
   // Do something with the response
-});
+})
 ```
 
 But this version is much more concise, and doesn't include the superfluous {{JSxRef("Promise.prototype.then()")}} method call:
 
 ```js
-match(request, options);
+match(request, options)
 ```
 
 ##### Callback syntax blocks
@@ -199,7 +200,7 @@ JavaScript built-in object reference pages follow the same basic rules as API re
 
 CSS property reference pages include a "Syntax" section, which used to be found at the top of the page but is increasingly commonly found below a section containing a block of code showing typical usage of the feature, plus a live example to illustrate what the feature does (see {{CSSxRef("animation")}} for example).
 
-> **Note:** We do this because CSS formal syntax is complex, not used by many of the MDN readership, and offputting for beginners. Real syntax and examples are more useful to the majority of people.
+> **Note:** We do this because CSS formal syntax is complex, not used by many of the MDN readership, and off-putting for beginners. Real syntax and examples are more useful to the majority of people.
 
 Inside the syntax section you'll find the following contents.
 

--- a/files/en-us/mdn/structures/syntax_sections/index.md
+++ b/files/en-us/mdn/structures/syntax_sections/index.md
@@ -283,3 +283,7 @@ SVG element syntax sections are non-existent — just like HTML element syntax s
 ### SVG attributes
 
 SVG attribute reference pages also do not include syntax sections.
+
+## See also
+
+- [Markdown in MDN](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Markdown_in_MDN#example_code_blocks)


### PR DESCRIPTION
## Summary
It has been decided to not use semicolons `;` in syntax section. [reference](https://github.com/mdn/content/pull/14952#issuecomment-1097521119)

Hence updating the document accordingly.

## Motivation
Syntax sections are not meant to show runnable code. So, it makes no sense to show semicolons.

#### Supporting details
https://github.com/mdn/content/pull/14952#issuecomment-1097521119

#### Metadata
- [x] Fixes a typo, bug, or other error
