### PR TITLE
fix(express_nodejs/mongoose): erroneous code snippet in "Working with related documents" section

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/mongoose/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/mongoose/index.md
@@ -405,8 +405,9 @@ Each story can have a single author.
 The `ref` property tells the schema which model can be assigned to this field.
 
 ```js
-var mongoose = require('mongoose')
-  , Schema = mongoose.Schema
+var mongoose = require('mongoose');
+
+var Schema = mongoose.Schema;
 
 var authorSchema = Schema({
   name    : String,


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

In [Express Tutorial Part 3: Using a Database article](https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/mongoose), there's an erroneous code snippet:

```js
var mongoose = require('mongoose')
  , Schema = mongoose.Schema
  
// other code
```

This pull request fixes it like so: 

```js
var mongoose = require('mongoose');

var Schema = mongoose.Schema;
  
// other code
```    

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

There is an erroneous code snippet.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

n/a

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

n/a

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
