### PR TITLE
Deduplicate <textarea> autocapitalize

### DIFF
--- a/files/en-us/web/html/element/textarea/index.md
+++ b/files/en-us/web/html/element/textarea/index.md
@@ -31,17 +31,6 @@ The `<textarea>` element also accepts several attributes common to form `<input>
 
 This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attributes).
 
-- {{htmlattrdef("autocapitalize")}} {{non-standard_inline}}
-
-  - : This is a non-standard attribute supported by WebKit on iOS (therefore nearly all browsers running on iOS, including Safari, Firefox, and Chrome), which controls whether and how the text value should be automatically capitalized as it is entered/edited by the user. The non-deprecated values are available in iOS 5 and later. Possible values are:
-
-    - `none`: Completely disables automatic capitalization.
-    - `sentences`: Automatically capitalize the first letter of sentences.
-    - `words`: Automatically capitalize the first letter of words.
-    - `characters`: Automatically capitalize all characters.
-    - `on`: {{deprecated_inline}} Deprecated since iOS 5.
-    - `off`: {{deprecated_inline}} Deprecated since iOS 5.
-
 - {{htmlattrdef("autocomplete")}}
 
   - : This attribute indicates whether the value of the control can be automatically completed by the browser. Possible values are:


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
This PR removes [`autocapitalize` section](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#attr-autocapitalize) because there is already [`autocapitalize` global attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize).
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Remove duplication.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
N/A

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Vaguely related: https://github.com/mdn/browser-compat-data/pull/15851

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
