### PR TITLE
Make “Recording a media element” example handle camera-less systems

### DIFF
--- a/files/en-us/web/api/mediastream_recording_api/recording_a_media_element/index.md
+++ b/files/en-us/web/api/mediastream_recording_api/recording_a_media_element/index.md
@@ -236,7 +236,13 @@ startButton.addEventListener("click", function() {
     log("Successfully recorded " + recordedBlob.size + " bytes of " +
         recordedBlob.type + " media.");
   })
-  .catch(log);
+  .catch((error) => {
+    if (error.name === "NotFoundError") {
+      log("Camera or microphone not found. Can’t record.");
+    } else {
+      log(error);
+    }
+  });
 }, false);
 ```
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/15030. This makes the example code in the “Recording a media element” article handle the case where the code is run on a system without a camera or microphone — or on a system where the user has changed the OS/platform system settings to disable the system’s camera or microphone.

You can test this by using your OS system settings to disable your browser’s access to the camera and/or microphone. For example, on a macOS system, see https://support.apple.com/guide/mac-help/control-access-to-the-microphone-on-mac-mchla1b1e1fe/mac

![image](https://user-images.githubusercontent.com/194984/163655618-e5de3e4a-cd6e-47f5-93b1-cd0184b9f71e.png)
