### PR TITLE
WebAPI: Update Method pages to modern structure (part 7)

### DIFF
--- a/files/en-us/web/api/abortcontroller/abort/index.md
+++ b/files/en-us/web/api/abortcontroller/abort/index.md
@@ -19,8 +19,8 @@ This is able to abort [fetch requests](/en-US/docs/Web/API/fetch), the consumpti
 ## Syntax
 
 ```js
-abort();
-abort(reason);
+abort()
+abort(reason)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/abortsignal/abort/index.md
+++ b/files/en-us/web/api/abortsignal/abort/index.md
@@ -28,8 +28,8 @@ This could, for example, be passed to a fetch method in order to run its abort l
 ## Syntax
 
 ```js
-abort();
-abort(reason);
+abort()
+abort(reason)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/abortsignal/throwifaborted/index.md
+++ b/files/en-us/web/api/abortsignal/throwifaborted/index.md
@@ -22,7 +22,7 @@ This method can also be used to abort operations at particular points in code, r
 ## Syntax
 
 ```js
-throwIfAborted();
+throwIfAborted()
 ```
 
 ### Return value

--- a/files/en-us/web/api/analysernode/getbytefrequencydata/index.md
+++ b/files/en-us/web/api/analysernode/getbytefrequencydata/index.md
@@ -22,7 +22,7 @@ If the array has fewer elements than the {{domxref("AnalyserNode.frequencyBinCou
 ## Syntax
 
 ```js
-getByteFrequencyData(array);
+getByteFrequencyData(array)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/analysernode/getbytetimedomaindata/index.md
+++ b/files/en-us/web/api/analysernode/getbytetimedomaindata/index.md
@@ -18,7 +18,7 @@ If the array has fewer elements than the {{domxref("AnalyserNode.fftSize")}}, ex
 ## Syntax
 
 ```js
-getByteTimeDomainData(array);
+getByteTimeDomainData(array)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/analysernode/getfloatfrequencydata/index.md
+++ b/files/en-us/web/api/analysernode/getfloatfrequencydata/index.md
@@ -20,7 +20,7 @@ If you need higher performance and don't care about precision, you can use {{dom
 ## Syntax
 
 ```js
-getFloatFrequencyData(array);
+getFloatFrequencyData(array)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/analysernode/getfloattimedomaindata/index.md
+++ b/files/en-us/web/api/analysernode/getfloattimedomaindata/index.md
@@ -16,7 +16,7 @@ The **`getFloatTimeDomainData()`** method of the {{ domxref("AnalyserNode") }} I
 ## Syntax
 
 ```js
-getFloatTimeDomainData(array);
+getFloatTimeDomainData(array)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/animation/cancel/index.md
+++ b/files/en-us/web/api/animation/cancel/index.md
@@ -21,7 +21,7 @@ The Web Animations API's **`cancel()`** method of the {{domxref("Animation")}} i
 ## Syntax
 
 ```js
-cancel();
+cancel()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/animation/commitstyles/index.md
+++ b/files/en-us/web/api/animation/commitstyles/index.md
@@ -17,7 +17,7 @@ The `commitStyles()` method of the [Web Animations API](/en-US/docs/Web/API/Web_
 ## Syntax
 
 ```js
-commitStyles();
+commitStyles()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/animation/finish/index.md
+++ b/files/en-us/web/api/animation/finish/index.md
@@ -22,7 +22,7 @@ That is, if the animation is playing forward, it sets the playback time to the l
 ## Syntax
 
 ```js
-finish();
+finish()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/animation/persist/index.md
+++ b/files/en-us/web/api/animation/persist/index.md
@@ -17,7 +17,7 @@ The `persist()` method of the [Web Animations API](/en-US/docs/Web/API/Web_Anima
 ## Syntax
 
 ```js
-persist();
+persist()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/animation/play/index.md
+++ b/files/en-us/web/api/animation/play/index.md
@@ -20,7 +20,7 @@ The **`play()`** method of the [Web Animations API](/en-US/docs/Web/API/Web_Anim
 ## Syntax
 
 ```js
-play();
+play()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/animation/reverse/index.md
+++ b/files/en-us/web/api/animation/reverse/index.md
@@ -20,7 +20,7 @@ The **`Animation.reverse()`** method of the {{ domxref("Animation") }} Interface
 ## Syntax
 
 ```js
-reverse();
+reverse()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/animation/updateplaybackrate/index.md
+++ b/files/en-us/web/api/animation/updateplaybackrate/index.md
@@ -37,7 +37,7 @@ animation's {{domxref("Animation.ready", "ready")}} promise is resolved.
 ## Syntax
 
 ```js
-updatePlaybackRate(playbackRate);
+updatePlaybackRate(playbackRate)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
+++ b/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
@@ -27,7 +27,7 @@ Although many of the attributes of the returned object are common to the object 
 ## Syntax
 
 ```js
-getComputedTiming();
+getComputedTiming()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/animationeffect/gettiming/index.md
+++ b/files/en-us/web/api/animationeffect/gettiming/index.md
@@ -18,7 +18,7 @@ The `AnimationEffect.getTiming()` method of the {{domxref("AnimationEffect")}} i
 ## Syntax
 
 ```js
-getTiming();
+getTiming()
 ```
 
 ### Return value

--- a/files/en-us/web/api/animationeffect/updatetiming/index.md
+++ b/files/en-us/web/api/animationeffect/updatetiming/index.md
@@ -18,7 +18,7 @@ The `updateTiming()` method of the {{domxref("AnimationEffect")}} interface upda
 ## Syntax
 
 ```js
-updateTiming(timing);
+updateTiming(timing)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/atob/index.md
+++ b/files/en-us/web/api/atob/index.md
@@ -25,7 +25,7 @@ for {{domxref("btoa", "btoa()")}}.
 ## Syntax
 
 ```js
-atob(encodedData);
+atob(encodedData)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audiobuffer/copyfromchannel/index.md
+++ b/files/en-us/web/api/audiobuffer/copyfromchannel/index.md
@@ -28,7 +28,7 @@ channel of the `AudioBuffer` to a specified
 ## Syntax
 
 ```js
-copyFromChannel(destination, channelNumber, startInChannel);
+copyFromChannel(destination, channelNumber, startInChannel)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audiobuffer/copytochannel/index.md
+++ b/files/en-us/web/api/audiobuffer/copytochannel/index.md
@@ -19,7 +19,7 @@ the samples to the specified channel of the `AudioBuffer`, from the source array
 ## Syntax
 
 ```js
-copyToChannel(source, channelNumber, startInChannel);
+copyToChannel(source, channelNumber, startInChannel)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audiobuffer/getchanneldata/index.md
+++ b/files/en-us/web/api/audiobuffer/getchanneldata/index.md
@@ -16,7 +16,7 @@ The **`getChannelData()`** method of the {{ domxref("AudioBuffer") }} Interface 
 ## Syntax
 
 ```js
-getChannelData(channel);
+getChannelData(channel)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audiobuffersourcenode/start/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/start/index.md
@@ -22,9 +22,9 @@ to begin playback immediately.
 ## Syntax
 
 ```js
-start(when);
-start(when, offset);
-start(when, offset, duration);
+start(when)
+start(when, offset)
+start(when, offset, duration)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audiocontext/close/index.md
+++ b/files/en-us/web/api/audiocontext/close/index.md
@@ -20,7 +20,7 @@ This function does not automatically release all `AudioContext`-created objects,
 ## Syntax
 
 ```js
-close();
+close()
 ```
 
 ### Return value

--- a/files/en-us/web/api/audiocontext/createjavascriptnode/index.md
+++ b/files/en-us/web/api/audiocontext/createjavascriptnode/index.md
@@ -20,7 +20,7 @@ The `AudioContext.createJavaScriptNode()` method creates a {{domxref("JavaScript
 ## Syntax
 
 ```js
-createJavaScriptNode(bufferSize, numInputChannels, numOutputChannels);
+createJavaScriptNode(bufferSize, numInputChannels, numOutputChannels)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audiocontext/createmediaelementsource/index.md
+++ b/files/en-us/web/api/audiocontext/createmediaelementsource/index.md
@@ -19,7 +19,7 @@ For more details about media element audio source nodes, check out the {{ domxre
 ## Syntax
 
 ```js
-createMediaElementSource(myMediaElement);
+createMediaElementSource(myMediaElement)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audiocontext/createmediastreamdestination/index.md
+++ b/files/en-us/web/api/audiocontext/createmediastreamdestination/index.md
@@ -21,7 +21,7 @@ For more details about media stream destination nodes, check out the {{domxref("
 ## Syntax
 
 ```js
-createMediaStreamDestination();
+createMediaStreamDestination()
 ```
 
 ### Return value

--- a/files/en-us/web/api/audiocontext/createmediastreamsource/index.md
+++ b/files/en-us/web/api/audiocontext/createmediastreamsource/index.md
@@ -30,7 +30,7 @@ For more details about media stream audio source nodes, check out the {{
 ## Syntax
 
 ```js
-createMediaStreamSource(stream);
+createMediaStreamSource(stream)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audiocontext/createmediastreamtracksource/index.md
+++ b/files/en-us/web/api/audiocontext/createmediastreamtracksource/index.md
@@ -33,7 +33,7 @@ first, lexicographically (alphabetically).
 ## Syntax
 
 ```js
-createMediaStreamTrackSource(track);
+createMediaStreamTrackSource(track)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audiocontext/getoutputtimestamp/index.md
+++ b/files/en-us/web/api/audiocontext/getoutputtimestamp/index.md
@@ -34,7 +34,7 @@ The two values are as follows:
 ## Syntax
 
 ```js
-getOutputTimestamp();
+getOutputTimestamp()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audiocontext/resume/index.md
+++ b/files/en-us/web/api/audiocontext/resume/index.md
@@ -23,7 +23,7 @@ called on an {{domxref("OfflineAudioContext")}}.
 ## Syntax
 
 ```js
-resume();
+resume()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audiocontext/suspend/index.md
+++ b/files/en-us/web/api/audiocontext/suspend/index.md
@@ -20,7 +20,7 @@ This method will cause an `INVALID_STATE_ERR` exception to be thrown if called o
 ## Syntax
 
 ```js
-suspend();
+suspend()
 ```
 
 ### Return value

--- a/files/en-us/web/api/audiodata/allocationsize/index.md
+++ b/files/en-us/web/api/audiodata/allocationsize/index.md
@@ -16,7 +16,7 @@ The **`allocationSize()`** method of the {{domxref("AudioData")}} interface retu
 ## Syntax
 
 ```js
-allocationSize(options);
+allocationSize(options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audiodata/clone/index.md
+++ b/files/en-us/web/api/audiodata/clone/index.md
@@ -16,7 +16,7 @@ The **`clone()`** method of the {{domxref("AudioData")}} interface creates a new
 ## Syntax
 
 ```js
-clone();
+clone()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audiodata/close/index.md
+++ b/files/en-us/web/api/audiodata/close/index.md
@@ -16,7 +16,7 @@ The **`close()`** method of the {{domxref("AudioData")}} interface clears all st
 ## Syntax
 
 ```js
-close();
+close()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audiodata/copyto/index.md
+++ b/files/en-us/web/api/audiodata/copyto/index.md
@@ -16,7 +16,7 @@ The **`copyTo()`** method of the {{domxref("AudioData")}} interface copies a pla
 ## Syntax
 
 ```js
-copyTo(destination, options);
+copyTo(destination, options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audiodecoder/close/index.md
+++ b/files/en-us/web/api/audiodecoder/close/index.md
@@ -16,7 +16,7 @@ The **`close()`** method of the {{domxref("AudioDecoder")}} interface ends all p
 ## Syntax
 
 ```js
-close();
+close()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audiodecoder/configure/index.md
+++ b/files/en-us/web/api/audiodecoder/configure/index.md
@@ -16,7 +16,7 @@ The **`configure()`** method of the {{domxref("AudioDecoder")}} interface enqueu
 ## Syntax
 
 ```js
-configure(config);
+configure(config)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audiodecoder/decode/index.md
+++ b/files/en-us/web/api/audiodecoder/decode/index.md
@@ -16,7 +16,7 @@ The **`decode()`** method of the {{domxref("AudioDecoder")}} interface enqueues 
 ## Syntax
 
 ```js
-decode(chunk);
+decode(chunk)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audiodecoder/flush/index.md
+++ b/files/en-us/web/api/audiodecoder/flush/index.md
@@ -16,7 +16,7 @@ The **`flush()`** method of the {{domxref("AudioDecoder")}} interface returns a 
 ## Syntax
 
 ```js
-flush();
+flush()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audiodecoder/reset/index.md
+++ b/files/en-us/web/api/audiodecoder/reset/index.md
@@ -16,7 +16,7 @@ The **`reset()`** method of the {{domxref("AudioDecoder")}} interface resets all
 ## Syntax
 
 ```js
-reset();
+reset()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audioencoder/close/index.md
+++ b/files/en-us/web/api/audioencoder/close/index.md
@@ -16,7 +16,7 @@ The **`close()`** method of the {{domxref("AudioEncoder")}} interface ends all p
 ## Syntax
 
 ```js
-close();
+close()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audioencoder/configure/index.md
+++ b/files/en-us/web/api/audioencoder/configure/index.md
@@ -16,7 +16,7 @@ The **`configure()`** method of the {{domxref("AudioEncoder")}} interface enqueu
 ## Syntax
 
 ```js
-configure(config);
+configure(config)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audioencoder/encode/index.md
+++ b/files/en-us/web/api/audioencoder/encode/index.md
@@ -16,7 +16,7 @@ The **`encode()`** method of the {{domxref("AudioEncoder")}} interface enqueues 
 ## Syntax
 
 ```js
-encode(data);
+encode(data)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audioencoder/flush/index.md
+++ b/files/en-us/web/api/audioencoder/flush/index.md
@@ -16,7 +16,7 @@ The **`flush()`** method of the {{domxref("AudioEncoder")}} interface returns a 
 ## Syntax
 
 ```js
-flush();
+flush()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audioencoder/reset/index.md
+++ b/files/en-us/web/api/audioencoder/reset/index.md
@@ -16,7 +16,7 @@ The **`reset()`** method of the {{domxref("AudioEncoder")}} interface resets all
 ## Syntax
 
 ```js
-reset();
+reset()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audiolistener/setorientation/index.md
+++ b/files/en-us/web/api/audiolistener/setorientation/index.md
@@ -24,7 +24,7 @@ The two vectors must be separated by an angle of 90° — in linear analysis ter
 ## Syntax
 
 ```js
-setOrientation(x, y, z, xUp, yUp, zUp);
+setOrientation(x, y, z, xUp, yUp, zUp)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audiolistener/setposition/index.md
+++ b/files/en-us/web/api/audiolistener/setposition/index.md
@@ -22,7 +22,7 @@ The default value of the position vector is `(0,` `0,` `0)`.
 ## Syntax
 
 ```js
-setPosition(x, y, z);
+setPosition(x, y, z)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audionode/connect/index.md
+++ b/files/en-us/web/api/audionode/connect/index.md
@@ -23,9 +23,9 @@ change the value of that parameter over time.
 ## Syntax
 
 ```js
-connect(destination);
-connect(destination, outputIndex);
-connect(destination, outputIndex, inputIndex);
+connect(destination)
+connect(destination, outputIndex)
+connect(destination, outputIndex, inputIndex)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audionode/disconnect/index.md
+++ b/files/en-us/web/api/audionode/disconnect/index.md
@@ -18,7 +18,7 @@ The **`disconnect()`** method of the {{ domxref("AudioNode") }} interface lets y
 ## Syntax
 
 ```js
-disconnect();
+disconnect()
 ```
 
 ### Return value

--- a/files/en-us/web/api/audioparam/cancelandholdattime/index.md
+++ b/files/en-us/web/api/audioparam/cancelandholdattime/index.md
@@ -23,7 +23,7 @@ made using other methods.
 ## Syntax
 
 ```js
-cancelAndHoldAtTime(cancelTime);
+cancelAndHoldAtTime(cancelTime)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audioparam/cancelscheduledvalues/index.md
+++ b/files/en-us/web/api/audioparam/cancelscheduledvalues/index.md
@@ -18,7 +18,7 @@ Interface cancels all scheduled future changes to the `AudioParam`.
 ## Syntax
 
 ```js
-cancelScheduledValues(startTime);
+cancelScheduledValues(startTime)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audioparam/exponentialramptovalueattime/index.md
+++ b/files/en-us/web/api/audioparam/exponentialramptovalueattime/index.md
@@ -26,7 +26,7 @@ _previous_ event, follows an exponential ramp to the new value given in the
 ## Syntax
 
 ```js
-exponentialRampToValueAtTime(value, endTime);
+exponentialRampToValueAtTime(value, endTime)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audioparam/linearramptovalueattime/index.md
+++ b/files/en-us/web/api/audioparam/linearramptovalueattime/index.md
@@ -23,7 +23,7 @@ _previous_ event, follows a linear ramp to the new value given in the
 ## Syntax
 
 ```js
-linearRampToValueAtTime(value, endTime);
+linearRampToValueAtTime(value, endTime)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audioparam/settargetattime/index.md
+++ b/files/en-us/web/api/audioparam/settargetattime/index.md
@@ -20,7 +20,7 @@ envelopes.
 ## Syntax
 
 ```js
-setTargetAtTime(target, startTime, timeConstant);
+setTargetAtTime(target, startTime, timeConstant)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audioparam/setvalueattime/index.md
+++ b/files/en-us/web/api/audioparam/setvalueattime/index.md
@@ -20,7 +20,7 @@ The `setValueAtTime()` method of the
 ## Syntax
 
 ```js
-setValueAtTime(value, startTime);
+setValueAtTime(value, startTime)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audioparam/setvaluecurveattime/index.md
+++ b/files/en-us/web/api/audioparam/setvaluecurveattime/index.md
@@ -28,7 +28,7 @@ values, which are scaled to fit into the given interval starting at
 ## Syntax
 
 ```js
-setValueCurveAtTime(values, startTime, duration);
+setValueCurveAtTime(values, startTime, duration)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audioscheduledsourcenode/start/index.md
+++ b/files/en-us/web/api/audioscheduledsourcenode/start/index.md
@@ -26,8 +26,8 @@ immediately.
 ## Syntax
 
 ```js
-start();
-start(when);
+start()
+start(when)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audioscheduledsourcenode/stop/index.md
+++ b/files/en-us/web/api/audioscheduledsourcenode/stop/index.md
@@ -29,8 +29,8 @@ stopped, this method has no effect.
 ## Syntax
 
 ```js
-stop();
-stop(when);
+stop()
+stop(when)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audiotracklist/gettrackbyid/index.md
+++ b/files/en-us/web/api/audiotracklist/gettrackbyid/index.md
@@ -28,13 +28,13 @@ you know its ID string.
 ## Syntax
 
 ```js
-getTrackById(id);
+getTrackById(id)
 ```
 
 ### Parameters
 
 - `id`
-  - : A {{domxref("DOMString")}} indicating the ID of the track to locate within the track
+  - : A string indicating the ID of the track to locate within the track
     list.
 
 ### Return value

--- a/files/en-us/web/api/audioworkletglobalscope/registerprocessor/index.md
+++ b/files/en-us/web/api/audioworkletglobalscope/registerprocessor/index.md
@@ -20,7 +20,7 @@ from {{domxref("AudioWorkletProcessor")}} interface under a specified _name_.
 ## Syntax
 
 ```js
-registerProcessor(name, processorCtor);
+registerProcessor(name, processorCtor)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/audioworkletprocessor/process/index.md
+++ b/files/en-us/web/api/audioworkletprocessor/process/index.md
@@ -43,7 +43,7 @@ invoked to do so.
 ## Syntax
 
 ```js
-process(inputs, outputs, parameters);
+process(inputs, outputs, parameters)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/authenticatorattestationresponse/gettransports/index.md
+++ b/files/en-us/web/api/authenticatorattestationresponse/gettransports/index.md
@@ -30,7 +30,7 @@ not removable from the device).
 ## Syntax
 
 ```js
-getTransports();
+getTransports()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/backgroundfetchmanager/fetch/index.md
+++ b/files/en-us/web/api/backgroundfetchmanager/fetch/index.md
@@ -19,8 +19,8 @@ The **`fetch()`** method of the {{domxref("BackgroundFetchManager")}} interface 
 ## Syntax
 
 ```js
-fetch(id, requests);
-fetch(id, requests, options);
+fetch(id, requests)
+fetch(id, requests, options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/backgroundfetchmanager/get/index.md
+++ b/files/en-us/web/api/backgroundfetchmanager/get/index.md
@@ -19,7 +19,7 @@ The **`get()`** method of the {{domxref("BackgroundFetchManager")}} interface re
 ## Syntax
 
 ```js
-get(id);
+get(id)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/backgroundfetchmanager/getids/index.md
+++ b/files/en-us/web/api/backgroundfetchmanager/getids/index.md
@@ -19,7 +19,7 @@ The **`getIds()`** method of the {{domxref("BackgroundFetchManager")}} interface
 ## Syntax
 
 ```js
-getIds();
+getIds()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/backgroundfetchregistration/abort/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/abort/index.md
@@ -16,7 +16,7 @@ The **`abort()`** method of the {{domxref("BackgroundFetchRegistration")}} inter
 ## Syntax
 
 ```js
-abort();
+abort()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/backgroundfetchregistration/match/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/match/index.md
@@ -16,8 +16,8 @@ The **`match()`** method of the {{domxref("BackgroundFetchRegistration")}} inter
 ## Syntax
 
 ```js
-match(request);
-match(request, options);
+match(request)
+match(request, options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/backgroundfetchregistration/matchall/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/matchall/index.md
@@ -16,8 +16,8 @@ The **`matchAll()`** method of the {{domxref("BackgroundFetchRegistration")}} in
 ## Syntax
 
 ```js
-matchAll(request);
-matchAll(request,options);
+matchAll(request)
+matchAll(request,options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/backgroundfetchupdateuievent/updateui/index.md
+++ b/files/en-us/web/api/backgroundfetchupdateuievent/updateui/index.md
@@ -18,7 +18,7 @@ This method may only be run once, to notify the user on a failed or a successful
 ## Syntax
 
 ```js
-updateUI(options);
+updateUI(options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/baseaudiocontext/createanalyser/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createanalyser/index.md
@@ -27,7 +27,7 @@ can be used to expose audio time and frequency data and create data visualizatio
 ## Syntax
 
 ```js
-createAnalyser();
+createAnalyser()
 ```
 
 ### Return value

--- a/files/en-us/web/api/baseaudiocontext/createbiquadfilter/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createbiquadfilter/index.md
@@ -24,7 +24,7 @@ filter configurable as several different common filter types.
 ## Syntax
 
 ```js
-createBiquadFilter();
+createBiquadFilter()
 ```
 
 ### Return value

--- a/files/en-us/web/api/baseaudiocontext/createbuffer/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createbuffer/index.md
@@ -37,7 +37,7 @@ reference page.
 ## Syntax
 
 ```js
-createBuffer(numOfChannels, length, sampleRate);
+createBuffer(numOfChannels, length, sampleRate)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/baseaudiocontext/createbuffersource/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createbuffersource/index.md
@@ -28,7 +28,7 @@ track.
 ## Syntax
 
 ```js
-createBufferSource();
+createBufferSource()
 ```
 
 ### Return value

--- a/files/en-us/web/api/baseaudiocontext/createchannelmerger/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createchannelmerger/index.md
@@ -24,7 +24,7 @@ which combines channels from multiple audio streams into a single audio stream.
 ## Syntax
 
 ```js
-createChannelMerger(numberOfInputs);
+createChannelMerger(numberOfInputs)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/baseaudiocontext/createchannelsplitter/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createchannelsplitter/index.md
@@ -23,7 +23,7 @@ which is used to access the individual channels of an audio stream and process t
 ## Syntax
 
 ```js
-createChannelSplitter(numberOfOutputs);
+createChannelSplitter(numberOfOutputs)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/baseaudiocontext/createconstantsource/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createconstantsource/index.md
@@ -27,7 +27,7 @@ value.
 ## Syntax
 
 ```js
-createConstantSource();
+createConstantSource()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/baseaudiocontext/createconvolver/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createconvolver/index.md
@@ -25,7 +25,7 @@ Convolution](https://webaudio.github.io/web-audio-api/#background-3) for more in
 ## Syntax
 
 ```js
-createConvolver();
+createConvolver()
 ```
 
 ### Return value

--- a/files/en-us/web/api/baseaudiocontext/createdelay/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createdelay/index.md
@@ -24,7 +24,7 @@ which is used to delay the incoming audio signal by a certain amount of time.
 ## Syntax
 
 ```js
-createDelay(maxDelayTime);
+createDelay(maxDelayTime)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/baseaudiocontext/createdynamicscompressor/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createdynamicscompressor/index.md
@@ -31,7 +31,7 @@ help avoid clipping (distorting) of the audio output.
 ## Syntax
 
 ```js
-createDynamicsCompressor();
+createDynamicsCompressor()
 ```
 
 ### Return value

--- a/files/en-us/web/api/baseaudiocontext/creategain/index.md
+++ b/files/en-us/web/api/baseaudiocontext/creategain/index.md
@@ -27,7 +27,7 @@ overall gain (or volume) of the audio graph.
 ## Syntax
 
 ```js
-createGain();
+createGain()
 ```
 
 ### Return value

--- a/files/en-us/web/api/baseaudiocontext/createiirfilter/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createiirfilter/index.md
@@ -28,7 +28,7 @@ of filter.
 ## Syntax
 
 ```js
-createIIRFilter(feedforward, feedback);
+createIIRFilter(feedforward, feedback)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/baseaudiocontext/createoscillator/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createoscillator/index.md
@@ -24,7 +24,7 @@ waveform. It basically generates a constant tone.
 ## Syntax
 
 ```js
-createOscillator();
+createOscillator()
 ```
 
 ### Return value

--- a/files/en-us/web/api/baseaudiocontext/createpanner/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createpanner/index.md
@@ -29,7 +29,7 @@ audio.
 ## Syntax
 
 ```js
-createPanner();
+createPanner()
 ```
 
 ### Return value

--- a/files/en-us/web/api/baseaudiocontext/createperiodicwave/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createperiodicwave/index.md
@@ -22,8 +22,8 @@ that can be used to shape the output of an {{ domxref("OscillatorNode") }}.
 ## Syntax
 
 ```js
-createPeriodicWave(real, imag);
-createPeriodicWave(real, imag, constraints);
+createPeriodicWave(real, imag)
+createPeriodicWave(real, imag, constraints)
 ```
 
 ### Return value

--- a/files/en-us/web/api/baseaudiocontext/createscriptprocessor/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createscriptprocessor/index.md
@@ -21,7 +21,7 @@ creates a {{domxref("ScriptProcessorNode")}} used for direct audio processing.
 ## Syntax
 
 ```js
-createScriptProcessor(bufferSize, numberOfInputChannels, numberOfOutputChannels);
+createScriptProcessor(bufferSize, numberOfInputChannels, numberOfOutputChannels)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/baseaudiocontext/createstereopanner/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createstereopanner/index.md
@@ -25,7 +25,7 @@ It positions an incoming audio stream in a stereo image using a [low-cost pannin
 ## Syntax
 
 ```js
-createStereoPanner();
+createStereoPanner()
 ```
 
 ### Return value

--- a/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.md
@@ -24,7 +24,7 @@ distortion. It is used to apply distortion effects to your audio.
 ## Syntax
 
 ```js
-createWaveShaper();
+createWaveShaper()
 ```
 
 ### Return value

--- a/files/en-us/web/api/beforeinstallpromptevent/prompt/index.md
+++ b/files/en-us/web/api/beforeinstallpromptevent/prompt/index.md
@@ -17,7 +17,7 @@ install prompt at a time of their own choosing.
 ## Syntax
 
 ```js
-prompt();
+prompt()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/biquadfilternode/getfrequencyresponse/index.md
+++ b/files/en-us/web/api/biquadfilternode/getfrequencyresponse/index.md
@@ -26,7 +26,7 @@ must be the same size as the array of input frequency values
 ## Syntax
 
 ```js
-getFrequencyResponse(frequencyArray, magResponseOutput, phaseResponseOutput);
+getFrequencyResponse(frequencyArray, magResponseOutput, phaseResponseOutput)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/blob/arraybuffer/index.md
+++ b/files/en-us/web/api/blob/arraybuffer/index.md
@@ -18,7 +18,7 @@ binary data contained in an {{jsxref("ArrayBuffer")}}.
 ## Syntax
 
 ```js
-arrayBuffer();
+arrayBuffer()
 ```
 
 ### Return value

--- a/files/en-us/web/api/blob/slice/index.md
+++ b/files/en-us/web/api/blob/slice/index.md
@@ -18,10 +18,10 @@ the blob on which it's called.
 ## Syntax
 
 ```js
-slice();
-slice(start);
-slice(start, end);
-slice(start, end, contentType);
+slice()
+slice(start)
+slice(start, end)
+slice(start, end, contentType)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/blob/stream/index.md
+++ b/files/en-us/web/api/blob/stream/index.md
@@ -18,7 +18,7 @@ which upon reading returns the data contained within the `Blob`.
 ## Syntax
 
 ```js
-stream();
+stream()
 ```
 
 ### Return value

--- a/files/en-us/web/api/blob/text/index.md
+++ b/files/en-us/web/api/blob/text/index.md
@@ -18,7 +18,7 @@ string containing the contents of the blob, interpreted as UTF-8.
 ## Syntax
 
 ```js
-text();
+text()
 ```
 
 ### Return value

--- a/files/en-us/web/api/bluetooth/requestdevice/index.md
+++ b/files/en-us/web/api/bluetooth/requestdevice/index.md
@@ -20,8 +20,8 @@ UI, this method returns the first device matching the criteria.
 ## Syntax
 
 ```js
-requestDevice();
-requestDevice(options);
+requestDevice()
+requestDevice(options)
 ```
 
 ### Return value

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptor/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptor/index.md
@@ -21,7 +21,7 @@ first {{domxref("BluetoothRemoteGATTDescriptor")}} for a given descriptor UUID.
 ## Syntax
 
 ```js
-getDescriptor(bluetoothDescriptorUUID);
+getDescriptor(bluetoothDescriptorUUID)
 ```
 
 ### Return value

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptors/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptors/index.md
@@ -21,7 +21,7 @@ returns a {{jsxref("Promise")}} that resolves to an {{jsxref("Array")}} of all
 ## Syntax
 
 ```js
-getDescriptors(bluetoothDescriptorUUID);
+getDescriptors(bluetoothDescriptorUUID)
 ```
 
 ### Return value

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/readvalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/readvalue/index.md
@@ -22,7 +22,7 @@ it throws an error.
 ## Syntax
 
 ```js
-readValue();
+readValue()
 ```
 
 ### Return value

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/startnotifications/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/startnotifications/index.md
@@ -21,7 +21,7 @@ there is an active notification on it.
 ## Syntax
 
 ```js
-startNotifications();
+startNotifications()
 ```
 
 ### Return value

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/stopnotifications/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/stopnotifications/index.md
@@ -21,7 +21,7 @@ there is no longer an active notification on it.
 ## Syntax
 
 ```js
-stopNotifications();
+stopNotifications()
 ```
 
 ### Return value

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevalue/index.md
@@ -21,7 +21,7 @@ The **`BluetoothRemoteGATTCharacteristic.writeValue()`** method sets a {{domxref
 ## Syntax
 
 ```js
-writeValue(value);
+writeValue(value)
 ```
 
 ### Return value


### PR DESCRIPTION
Continuing #14857 

## Summary
Updating the method pages to follow the current templates:
https://developer.mozilla.org/en-US/docs/MDN/Structures/Syntax_sections#constructors_and_methods

**Note:** Recently it has been decided not to use semicolons `;` in the syntax sections ([ref](https://github.com/mdn/content/pull/15021)), So, updating all the previous pages first before continuing forward with the series.

Changes Include:
- fix syntax section
- other small corrections

### Metadata
- [x] Fixes a typo, bug, or other error
