### PR TITLE
HTTP reverse-proxy headers do not need compat data

### DIFF
--- a/files/en-us/web/http/headers/forwarded/index.md
+++ b/files/en-us/web/http/headers/forwarded/index.md
@@ -7,7 +7,6 @@ tags:
   - Reference
   - Request header
   - header
-browser-compat: http.headers.Forwarded
 ---
 {{HTTPSidebar}}
 
@@ -99,10 +98,6 @@ Forwarded: for=192.0.2.43, for="[2001:db8:cafe::17]"
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/headers/forwarded/index.md
+++ b/files/en-us/web/http/headers/forwarded/index.md
@@ -7,6 +7,7 @@ tags:
   - Reference
   - Request header
   - header
+browser-compat: http.headers.Forwarded
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/x-forwarded-for/index.md
+++ b/files/en-us/web/http/headers/x-forwarded-for/index.md
@@ -8,7 +8,6 @@ tags:
   - Reference
   - Request header
   - header
-browser-compat: http.headers.X-Forwarded-For
 ---
 {{HTTPSidebar}}
 
@@ -151,10 +150,6 @@ considered trustworthy or safe for security-related uses.
 
 Not part of any current specification. The standardized version of this header is
 {{HTTPHeader("Forwarded")}}.
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/headers/x-forwarded-host/index.md
+++ b/files/en-us/web/http/headers/x-forwarded-host/index.md
@@ -8,7 +8,6 @@ tags:
   - Reference
   - Request header
   - header
-browser-compat: http.headers.X-Forwarded-Host
 ---
 {{HTTPSidebar}}
 
@@ -61,10 +60,6 @@ X-Forwarded-Host: id42.example-cdn.com
 
 Not part of any current specification. The standardized version of this header is
 {{HTTPHeader("Forwarded")}}.
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/headers/x-forwarded-proto/index.md
+++ b/files/en-us/web/http/headers/x-forwarded-proto/index.md
@@ -8,7 +8,6 @@ tags:
   - Reference
   - Request header
   - header
-browser-compat: http.headers.X-Forwarded-Proto
 ---
 {{HTTPSidebar}}
 
@@ -66,10 +65,6 @@ X-Url-Scheme: https
 
 Not part of any current specification. The standardized version of this header is
 {{HTTPHeader("Forwarded")}}.
-
-## Browser compatibility
-
-{{Compat}}
 
 ## See also
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Remove data entries for reverse-proxy/load balancer headers since they will never be supported by User-Agents and data will always be `false` or `null`.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Tables which just say "No support" for User-Agents are useless (provide no information) and are confusing (imply these headers are not used).

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
These are reverse-proxy headers, not User-Agent headers.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
https://github.com/mdn/browser-compat-data/pull/15857

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
