### PR TITLE
Fixing external link anchor to specification

### DIFF
--- a/files/en-us/web/css/frequency/index.md
+++ b/files/en-us/web/css/frequency/index.md
@@ -50,7 +50,7 @@ Invalid frequency values:
 
 {{Specifications}}
 
-> **Note:** This data type was initially introduced in [CSS Level 2](https://www.w3.org/TR/CSS2/aural.html#q19.0) for the now-obsolete [aural](/en-US/docs/Web/CSS/@media/aural) [media type](/en-US/docs/Web/CSS/@media#media_types), where it was used to define the pitch of the voice. However, the `<frequency>` data type has been reintroduced in CSS3, though no CSS property is using it at the moment.
+> **Note:** This data type was initially introduced in [CSS Level 2](https://www.w3.org/TR/CSS2/aural.html#frequencies) for the now-obsolete [aural](/en-US/docs/Web/CSS/@media/aural) [media type](/en-US/docs/Web/CSS/@media#media_types), where it was used to define the pitch of the voice. However, the `<frequency>` data type has been reintroduced in CSS3, though no CSS property is using it at the moment.
 
 ## Browser compatibility
 

--- a/files/en-us/web/css/frequency/index.md
+++ b/files/en-us/web/css/frequency/index.md
@@ -50,7 +50,6 @@ Invalid frequency values:
 
 {{Specifications}}
 
-> **Note:** This data type was initially introduced in [CSS Level 2](https://www.w3.org/TR/CSS2/aural.html#frequencies) for the now-obsolete [aural](/en-US/docs/Web/CSS/@media/aural) [media type](/en-US/docs/Web/CSS/@media#media_types), where it was used to define the pitch of the voice. However, the `<frequency>` data type has been reintroduced in CSS3, though no CSS property is using it at the moment.
 
 ## Browser compatibility
 


### PR DESCRIPTION
#### Summary
I fixed the anchor on the link to the CSS2 specification on https://developer.mozilla.org/en-US/docs/Web/CSS/frequency to `#frequencies`.

#### Motivation
The link to the CSS2 specification links to the anchor `#q19.0` which does not exist. 

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
