### PR TITLE
Changed "legacy" to "precomposed"

### DIFF
--- a/files/en-us/web/css/display/index.md
+++ b/files/en-us/web/css/display/index.md
@@ -21,7 +21,7 @@ Formally, the **`display`** property sets an element's inner and outer _display 
 The CSS `display` property is specified using keyword values.
 
 ```css
-/* legacy values */
+/* precomposed values */
 display: block;
 display: inline;
 display: inline-block;
@@ -160,10 +160,10 @@ This can be used together with {{CSSxRef("list-style-type")}} and {{CSSxRef("lis
       - : Turns off the display of an element so that it has no effect on layout (the document is rendered as though the element did not exist). All descendant elements also have their display turned off.
         To have an element take up the space that it would normally take, but without actually rendering anything, use the {{CSSxRef("visibility")}} property instead.
 
-### Legacy
+### Precomposed
 
 - {{CSSxRef("&lt;display-legacy&gt;")}}
-  - : CSS 2 used a single-keyword syntax for the `display` property, requiring separate keywords for block-level and inline-level variants of the same layout mode.
+  - : CSS 2 used a single-keyword, precomposed syntax for the `display` property, requiring separate keywords for block-level and inline-level variants of the same layout mode. 
 
     - `inline-block`
 
@@ -193,7 +193,7 @@ This can be used together with {{CSSxRef("list-style-type")}} and {{CSSxRef("lis
 
 The Level 3 specification details two values for the `display` property — enabling the specification of the outer and inner display type explicitly — but this is not yet well-supported by browsers.
 
-The `<display-legacy>` methods allow the same results with single keyword values, and should be favoured by developers until the two keyword values are better supported. For example, using two values you might specify an inline flex container as follows:
+The precomposed `<display-legacy>` methods allow the same results with single keyword values, and should be favoured by developers until the two keyword values are better supported. For example, using two values you might specify an inline flex container as follows:
 
 ```css
 .container {


### PR DESCRIPTION
display legacy are precomposed terms. Both words can be used. While the official definition uses `<display-legacy>`, using the term "legacy" on MDN may confuse readers that the values are no longer supported. They are, always have been, and have better support currently that the separate keyword value syntax. This edit is to remove that confusion.

The spec uses the term precomposed: https://drafts.csswg.org/css-display/#legacy-display


- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

