### PR TITLE
WebAPI: Update Method pages to modern structure (part 8)

### DIFF
--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithresponse/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithresponse/index.md
@@ -17,7 +17,7 @@ The **`BluetoothRemoteGATTCharacteristic.writeValueWithResponse()`** method sets
 ## Syntax
 
 ```js
-writeValueWithResponse(value);
+writeValueWithResponse(value)
 ```
 
 ### Return value

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/readvalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/readvalue/index.md
@@ -24,7 +24,7 @@ it is available and supported. Otherwise it throws an error.
 ## Syntax
 
 ```js
-readValue();
+readValue()
 ```
 
 ### Return value

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/writevalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/writevalue/index.md
@@ -22,7 +22,7 @@ an {{jsxref("ArrayBuffer")}} and returns a {{jsxref("Promise")}}.
 ## Syntax
 
 ```js
-writeValue(array);
+writeValue(array)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/bluetoothremotegattserver/connect/index.md
+++ b/files/en-us/web/api/bluetoothremotegattserver/connect/index.md
@@ -21,7 +21,7 @@ script execution environment to connect to `this.device`.
 ## Syntax
 
 ```js
-connect();
+connect()
 ```
 
 ### Return value

--- a/files/en-us/web/api/bluetoothremotegattserver/disconnect/index.md
+++ b/files/en-us/web/api/bluetoothremotegattserver/disconnect/index.md
@@ -20,7 +20,7 @@ the script execution environment to disconnect from `this.device`.
 ## Syntax
 
 ```js
-disconnect();
+disconnect()
 ```
 
 ### Return value

--- a/files/en-us/web/api/bluetoothremotegattserver/getprimaryservice/index.md
+++ b/files/en-us/web/api/bluetoothremotegattserver/getprimaryservice/index.md
@@ -21,7 +21,7 @@ Bluetooth device for a specified {{domxref("BluetoothServiceUUID")}}.
 ## Syntax
 
 ```js
-getPrimaryService(bluetoothServiceUUID);
+getPrimaryService(bluetoothServiceUUID)
 ```
 
 ### Return value

--- a/files/en-us/web/api/bluetoothremotegattserver/getprimaryservices/index.md
+++ b/files/en-us/web/api/bluetoothremotegattserver/getprimaryservices/index.md
@@ -21,7 +21,7 @@ Bluetooth device for a specified `BluetoothServiceUUID`.
 ## Syntax
 
 ```js
-getPrimaryServices(bluetoothServiceUUID);
+getPrimaryServices(bluetoothServiceUUID)
 ```
 
 ### Return value

--- a/files/en-us/web/api/bluetoothremotegattservice/getcharacteristic/index.md
+++ b/files/en-us/web/api/bluetoothremotegattservice/getcharacteristic/index.md
@@ -22,7 +22,7 @@ returns a {{jsxref("Promise")}} to an instance of
 ## Syntax
 
 ```js
-getCharacteristic(characteristic);
+getCharacteristic(characteristic)
 ```
 
 ### Return value

--- a/files/en-us/web/api/bluetoothremotegattservice/getcharacteristics/index.md
+++ b/files/en-us/web/api/bluetoothremotegattservice/getcharacteristics/index.md
@@ -21,7 +21,7 @@ instances for a given universally unique identifier (UUID).
 ## Syntax
 
 ```js
-getCharacteristics(characteristics);
+getCharacteristics(characteristics)
 ```
 
 ### Return value

--- a/files/en-us/web/api/bluetoothuuid/canonicaluuid/index.md
+++ b/files/en-us/web/api/bluetoothuuid/canonicaluuid/index.md
@@ -16,7 +16,7 @@ The **`canonicalUUID()`**  method of the {{domxref("BluetoothUUID")}} interface 
 ## Syntax
 
 ```js
-canonicalUUID(alias);
+canonicalUUID(alias)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/bluetoothuuid/getcharacteristic/index.md
+++ b/files/en-us/web/api/bluetoothuuid/getcharacteristic/index.md
@@ -16,7 +16,7 @@ The **`getCharacteristic()`**  method of the {{domxref("BluetoothUUID")}} interf
 ## Syntax
 
 ```js
-getCharacteristic(name);
+getCharacteristic(name)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/bluetoothuuid/getdescriptor/index.md
+++ b/files/en-us/web/api/bluetoothuuid/getdescriptor/index.md
@@ -16,7 +16,7 @@ The **`getDescriptor()`**  method of the {{domxref("BluetoothUUID")}} interface 
 ## Syntax
 
 ```js
-getDescriptor(name);
+getDescriptor(name)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/bluetoothuuid/getservice/index.md
+++ b/files/en-us/web/api/bluetoothuuid/getservice/index.md
@@ -16,7 +16,7 @@ The **`getService()`**  method of the {{domxref("BluetoothUUID")}} interface ret
 ## Syntax
 
 ```js
-getService(name);
+getService(name)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/btoa/index.md
+++ b/files/en-us/web/api/btoa/index.md
@@ -28,7 +28,7 @@ characters such as ASCII values 0 through 31.
 ## Syntax
 
 ```js
-btoa(stringToEncode);
+btoa(stringToEncode)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/bytelengthqueuingstrategy/size/index.md
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/size/index.md
@@ -20,7 +20,7 @@ The **`size()`** method of the
 ## Syntax
 
 ```js
-size(chunk);
+size(chunk)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cache/add/index.md
+++ b/files/en-us/web/api/cache/add/index.md
@@ -34,7 +34,7 @@ For more complex operations, you'll need to use {{domxref("Cache.put","Cache.put
 ## Syntax
 
 ```js
-add(request);
+add(request)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cache/addall/index.md
+++ b/files/en-us/web/api/cache/addall/index.md
@@ -29,7 +29,7 @@ retrieval become keys to the stored response operations.
 ## Syntax
 
 ```js
-addAll(requests);
+addAll(requests)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cache/delete/index.md
+++ b/files/en-us/web/api/cache/delete/index.md
@@ -25,8 +25,8 @@ to `false`.
 ## Syntax
 
 ```js
-delete(request);
-delete(request, options);
+delete(request)
+delete(request, options)
 ```
 
 ### Parameters
@@ -53,7 +53,7 @@ delete(request, options);
       header matching.  In other words, if the URL matches you will get a match
       regardless of whether the {{domxref("Response")}} object has a `VARY`
       header. It defaults to `false`.
-    - `cacheName`: A {{domxref("DOMString")}} that represents a specific
+    - `cacheName`: A string that represents a specific
       cache to search within. Note that this option is ignored by
       `Cache.delete()`.
 

--- a/files/en-us/web/api/cache/keys/index.md
+++ b/files/en-us/web/api/cache/keys/index.md
@@ -25,9 +25,9 @@ The requests are returned in the same order that they were inserted.
 ## Syntax
 
 ```js
-keys();
-keys(request);
-keys(request, options);
+keys()
+keys(request)
+keys(request, options)
 ```
 
 ### Parameters
@@ -54,7 +54,7 @@ keys(request, options);
       header matching.  In other words, if the URL matches you will get a match
       regardless of whether the {{domxref("Response")}} object has a `VARY`
       header. It defaults to `false`.
-    - `cacheName`: A {{domxref("DOMString")}} that represents a specific
+    - `cacheName`: A string that represents a specific
       cache to search within. Note that this option is ignored by
       `Cache.keys()`.
 

--- a/files/en-us/web/api/cache/match/index.md
+++ b/files/en-us/web/api/cache/match/index.md
@@ -24,7 +24,7 @@ to {{jsxref("undefined")}}.
 ## Syntax
 
 ```js
-match(request, options);
+match(request, options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cache/matchall/index.md
+++ b/files/en-us/web/api/cache/matchall/index.md
@@ -21,7 +21,7 @@ responses in the {{domxref("Cache")}} object.
 ## Syntax
 
 ```js
-matchAll(request, options);
+matchAll(request, options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cache/put/index.md
+++ b/files/en-us/web/api/cache/put/index.md
@@ -47,7 +47,7 @@ fetch(url).then(function(response) {
 ## Syntax
 
 ```js
-put(request, response);
+put(request, response)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cachestorage/delete/index.md
+++ b/files/en-us/web/api/cachestorage/delete/index.md
@@ -26,7 +26,7 @@ You can access `CacheStorage` through the global
 ## Syntax
 
 ```js
-delete(cacheName);
+delete(cacheName)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cachestorage/has/index.md
+++ b/files/en-us/web/api/cachestorage/has/index.md
@@ -24,13 +24,13 @@ You can access `CacheStorage` through the global
 ## Syntax
 
 ```js
-has(cacheName);
+has(cacheName)
 ```
 
 ### Parameters
 
 - `cacheName`
-  - : A {{domxref("DOMString")}} representing the name of the {{domxref("Cache")}} object
+  - : A string representing the name of the {{domxref("Cache")}} object
     you are looking for in the {{domxref("CacheStorage")}}.
 
 ### Return value

--- a/files/en-us/web/api/cachestorage/keys/index.md
+++ b/files/en-us/web/api/cachestorage/keys/index.md
@@ -29,7 +29,7 @@ You can access `CacheStorage` through the global
 ## Syntax
 
 ```js
-keys();
+keys()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cachestorage/match/index.md
+++ b/files/en-us/web/api/cachestorage/match/index.md
@@ -35,7 +35,7 @@ You can access `CacheStorage` through the global
 ## Syntax
 
 ```js
-match(request, options);
+match(request, options)
 ```
 
 ### Parameters
@@ -62,7 +62,7 @@ match(request, options);
       header matching. In other words, if the URL matches you will get a match
       regardless of whether the {{domxref("Response")}} object has a `VARY`
       header or not. It defaults to `false`.
-    - `cacheName`: A {{domxref("DOMString")}} that represents a specific
+    - `cacheName`: A string that represents a specific
       cache to search within.
 
 ### Return value

--- a/files/en-us/web/api/cachestorage/open/index.md
+++ b/files/en-us/web/api/cachestorage/open/index.md
@@ -29,7 +29,7 @@ You can access `CacheStorage` through the global
 ## Syntax
 
 ```js
-open(cacheName);
+open(cacheName)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasgradient/addcolorstop/index.md
+++ b/files/en-us/web/api/canvasgradient/addcolorstop/index.md
@@ -20,7 +20,7 @@ method adds a new color stop, defined by an `offset` and a
 ## Syntax
 
 ```js
-addColorStop(offset, color);
+addColorStop(offset, color)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvaspattern/settransform/index.md
+++ b/files/en-us/web/api/canvaspattern/settransform/index.md
@@ -20,7 +20,7 @@ pattern's transformation matrix and invokes it on the pattern.
 ## Syntax
 
 ```js
-setTransform(matrix);
+setTransform(matrix)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/arc/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/arc/index.md
@@ -19,8 +19,8 @@ method of the [Canvas 2D API
 ## Syntax
 
 ```js
-arc(x, y, radius, startAngle, endAngle);
-arc(x, y, radius, startAngle, endAngle, counterclockwise);
+arc(x, y, radius, startAngle, endAngle)
+arc(x, y, radius, startAngle, endAngle, counterclockwise)
 ```
 
 The `arc()` method creates a circular arc centered at `(x, y)`

--- a/files/en-us/web/api/canvasrenderingcontext2d/arcto/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/arcto/index.md
@@ -26,7 +26,7 @@ This method is commonly used for making rounded corners.
 ## Syntax
 
 ```js
-arcTo(x1, y1, x2, y2, radius);
+arcTo(x1, y1, x2, y2, radius)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/beginpath/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/beginpath/index.md
@@ -22,7 +22,7 @@ this method when you want to create a new path.
 ## Syntax
 
 ```js
-beginPath();
+beginPath()
 ```
 
 ## Examples

--- a/files/en-us/web/api/canvasrenderingcontext2d/beziercurveto/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/beziercurveto/index.md
@@ -22,7 +22,7 @@ creating the Bézier curve.
 ## Syntax
 
 ```js
-bezierCurveTo(cp1x, cp1y, cp2x, cp2y, x, y);
+bezierCurveTo(cp1x, cp1y, cp2x, cp2y, x, y)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/clearrect/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/clearrect/index.md
@@ -25,7 +25,7 @@ transparent black.
 ## Syntax
 
 ```js
-clearRect(x, y, width, height);
+clearRect(x, y, width, height)
 ```
 
 The `clearRect()` method sets the pixels in a rectangular area to

--- a/files/en-us/web/api/canvasrenderingcontext2d/clip/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/clip/index.md
@@ -32,10 +32,10 @@ drawn.
 ## Syntax
 
 ```js
-clip();
-clip(path);
-clip(fillRule);
-clip(path, fillRule);
+clip()
+clip(path)
+clip(fillRule)
+clip(path, fillRule)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/closepath/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/closepath/index.md
@@ -24,7 +24,7 @@ the {{domxref("CanvasRenderingContext2D.stroke()", "stroke()")}} or
 ## Syntax
 
 ```js
-closePath();
+closePath()
 ```
 
 ## Examples

--- a/files/en-us/web/api/canvasrenderingcontext2d/createconicgradient/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createconicgradient/index.md
@@ -22,7 +22,7 @@ This method returns a conic {{domxref("CanvasGradient")}}. To be applied to a sh
 ## Syntax
 
 ```js
-createConicGradient(startAngle, x, y);
+createConicGradient(startAngle, x, y)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/createimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createimagedata/index.md
@@ -18,8 +18,8 @@ specified dimensions. All of the pixels in the new object are transparent black.
 ## Syntax
 
 ```js
-createImageData(width, height);
-createImageData(imagedata);
+createImageData(width, height)
+createImageData(imagedata)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/createlineargradient/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createlineargradient/index.md
@@ -31,7 +31,7 @@ the gradient must first be assigned to the
 ## Syntax
 
 ```js
-createLinearGradient(x0, y0, x1, y1);
+createLinearGradient(x0, y0, x1, y1)
 ```
 
 The `createLinearGradient()` method is specified by four parameters defining

--- a/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.md
@@ -24,7 +24,7 @@ applied to any subsequent drawing.
 ## Syntax
 
 ```js
-createPattern(image, repetition);
+createPattern(image, repetition)
 ```
 
 ### Parameters
@@ -44,7 +44,7 @@ createPattern(image, repetition);
 
 - `repetition`
 
-  - : A {{domxref("DOMString")}} indicating how to repeat the pattern's image. Possible
+  - : A string indicating how to repeat the pattern's image. Possible
     values are:
 
     - `"repeat"` (both directions)

--- a/files/en-us/web/api/canvasrenderingcontext2d/createradialgradient/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createradialgradient/index.md
@@ -29,7 +29,7 @@ properties.
 ## Syntax
 
 ```js
-createRadialGradient(x0, y0, r0, x1, y1, r1);
+createRadialGradient(x0, y0, r0, x1, y1, r1)
 ```
 
 The `createRadialGradient()` method is specified by six parameters, three

--- a/files/en-us/web/api/canvasrenderingcontext2d/drawfocusifneeded/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawfocusifneeded/index.md
@@ -20,8 +20,8 @@ specified element is focused.
 ## Syntax
 
 ```js
-drawFocusIfNeeded(element);
-drawFocusIfNeeded(path, element);
+drawFocusIfNeeded(element)
+drawFocusIfNeeded(path, element)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/drawimage/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawimage/index.md
@@ -17,9 +17,9 @@ Canvas 2D API provides different ways to draw an image onto the canvas.
 ## Syntax
 
 ```js
-drawImage(image, dx, dy);
-drawImage(image, dx, dy, dWidth, dHeight);
-drawImage(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight);
+drawImage(image, dx, dy)
+drawImage(image, dx, dy, dWidth, dHeight)
+drawImage(image, sx, sy, sWidth, sHeight, dx, dy, dWidth, dHeight)
 ```
 
 ![drawImage](canvas_drawimage.jpg)

--- a/files/en-us/web/api/canvasrenderingcontext2d/drawwidgetasonscreen/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawwidgetasonscreen/index.md
@@ -26,7 +26,7 @@ only from within the chrome process.
 ## Syntax
 
 ```js
-drawWidgetAsOnScreen(window);
+drawWidgetAsOnScreen(window)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/drawwindow/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawwindow/index.md
@@ -30,8 +30,8 @@ from the parent process.
 ## Syntax
 
 ```js
-drawWindow(window, x, y, w, h, bgColor);
-drawWindow(window, x, y, w, h, bgColor, flags);
+drawWindow(window, x, y, w, h, bgColor)
+drawWindow(window, x, y, w, h, bgColor, flags)
 ```
 
 ### Parameters
@@ -48,7 +48,7 @@ drawWindow(window, x, y, w, h, bgColor, flags);
   - : The height of the window.
 - `bgColor`
 
-  - : A {{domxref("DOMString")}} that specifies the color the canvas is filled with before
+  - : A string that specifies the color the canvas is filled with before
     the window is rendered into it. This color may be transparent/translucent. It is given
     as a CSS color string (for example, `rgb()` or `rgba()`).
     Notes:

--- a/files/en-us/web/api/canvasrenderingcontext2d/ellipse/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/ellipse/index.md
@@ -18,8 +18,8 @@ method of the Canvas 2D API adds an elliptical arc to the current sub-path.
 ## Syntax
 
 ```js
-ellipse(x, y, radiusX, radiusY, rotation, startAngle, endAngle);
-ellipse(x, y, radiusX, radiusY, rotation, startAngle, endAngle, counterclockwise);
+ellipse(x, y, radiusX, radiusY, rotation, startAngle, endAngle)
+ellipse(x, y, radiusX, radiusY, rotation, startAngle, endAngle, counterclockwise)
 ```
 
 The `ellipse()` method creates an elliptical arc centered at

--- a/files/en-us/web/api/canvasrenderingcontext2d/fill/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fill/index.md
@@ -19,10 +19,10 @@ method of the Canvas 2D API fills the current or given path with the current
 ## Syntax
 
 ```js
-fill();
-fill(path);
-fill(fillRule);
-fill(path, fillRule);
+fill()
+fill(path)
+fill(fillRule)
+fill(path, fillRule)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/fillrect/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fillrect/index.md
@@ -24,7 +24,7 @@ on it.
 ## Syntax
 
 ```js
-fillRect(x, y, width, height);
+fillRect(x, y, width, height)
 ```
 
 The `fillRect()` method draws a filled rectangle whose starting point is at

--- a/files/en-us/web/api/canvasrenderingcontext2d/filltext/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/filltext/index.md
@@ -43,14 +43,14 @@ The text is rendered using the font and text layout configuration as defined by 
 ## Syntax
 
 ```js
-fillText(text, x, y);
-fillText(text, x, y, maxWidth);
+fillText(text, x, y)
+fillText(text, x, y, maxWidth)
 ```
 
 ### Parameters
 
 - `text`
-  - : A {{domxref("DOMString")}} specifying the text string to render into the context.
+  - : A string specifying the text string to render into the context.
     The text is rendered using the settings specified by
     {{domxref("CanvasRenderingContext2D.font","font")}},
     {{domxref("CanvasRenderingContext2D.textAlign","textAlign")}},

--- a/files/en-us/web/api/canvasrenderingcontext2d/getcontextattributes/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getcontextattributes/index.md
@@ -21,7 +21,7 @@ on context creation.
 ## Syntax
 
 ```js
-getContextAttributes();
+getContextAttributes()
 ```
 
 ### Return value

--- a/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
@@ -38,7 +38,7 @@ manipulation with canvas](/en-US/docs/Web/API/Canvas_API/Tutorial/Pixel_manipula
 ## Syntax
 
 ```js
-getImageData(sx, sy, sw, sh);
+getImageData(sx, sy, sw, sh)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/getlinedash/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getlinedash/index.md
@@ -17,7 +17,7 @@ The **`getLineDash()`** method of the Canvas 2D API's
 ## Syntax
 
 ```js
-getLineDash();
+getLineDash()
 ```
 
 ### Return value

--- a/files/en-us/web/api/canvasrenderingcontext2d/gettransform/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/gettransform/index.md
@@ -19,7 +19,7 @@ the context.
 ## Syntax
 
 ```js
-getTransform();
+getTransform()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/ispointinpath/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/ispointinpath/index.md
@@ -19,10 +19,10 @@ the current path.
 ## Syntax
 
 ```js
-isPointInPath(x, y);
-isPointInPath(x, y, fillRule);
-isPointInPath(path, x, y);
-isPointInPath(path, x, y, fillRule);
+isPointInPath(x, y)
+isPointInPath(x, y, fillRule)
+isPointInPath(path, x, y)
+isPointInPath(path, x, y, fillRule)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/ispointinstroke/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/ispointinstroke/index.md
@@ -19,8 +19,8 @@ area contained by the stroking of a path.
 ## Syntax
 
 ```js
-isPointInStroke(x, y);
-isPointInStroke(path, x, y);
+isPointInStroke(x, y)
+isPointInStroke(path, x, y)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/lineto/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/lineto/index.md
@@ -24,7 +24,7 @@ anything. To draw the path onto a canvas, you can use the
 ## Syntax
 
 ```js
-lineTo(x, y);
+lineTo(x, y)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/measuretext/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/measuretext/index.md
@@ -19,7 +19,7 @@ measured text (such as its width, for example).
 ## Syntax
 
 ```js
-measureText(text);
+measureText(text)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/moveto/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/moveto/index.md
@@ -19,7 +19,7 @@ method of the Canvas 2D API begins a new sub-path at the point specified by the 
 ## Syntax
 
 ```js
-moveTo(x, y);
+moveTo(x, y)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/putimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/putimagedata/index.md
@@ -25,8 +25,8 @@ manipulation of canvas contents in the article [Pixel manipulation with canvas](
 ## Syntax
 
 ```js
-putImageData(imageData, dx, dy);
-putImageData(imageData, dx, dy, dirtyX, dirtyY, dirtyWidth, dirtyHeight);
+putImageData(imageData, dx, dy)
+putImageData(imageData, dx, dy, dirtyX, dirtyY, dirtyWidth, dirtyHeight)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/quadraticcurveto/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/quadraticcurveto/index.md
@@ -22,7 +22,7 @@ the quadratic Bézier curve.
 ## Syntax
 
 ```js
-quadraticCurveTo(cpx, cpy, x, y);
+quadraticCurveTo(cpx, cpy, x, y)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/rect/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/rect/index.md
@@ -27,7 +27,7 @@ anything.  To draw the rectangle onto a canvas, you can use the
 ## Syntax
 
 ```js
-rect(x, y, width, height);
+rect(x, y, width, height)
 ```
 
 The `rect()` method creates a rectangular path whose starting point is at

--- a/files/en-us/web/api/canvasrenderingcontext2d/restore/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/restore/index.md
@@ -23,7 +23,7 @@ state](/en-US/docs/Web/API/CanvasRenderingContext2D/save#drawing_state), see {{d
 ## Syntax
 
 ```js
-restore();
+restore()
 ```
 
 ## Examples

--- a/files/en-us/web/api/canvasrenderingcontext2d/rotate/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/rotate/index.md
@@ -18,7 +18,7 @@ method of the Canvas 2D API adds a rotation to the transformation matrix.
 ## Syntax
 
 ```js
-rotate(angle);
+rotate(angle)
 ```
 
 ![](canvas_grid_rotate.png)

--- a/files/en-us/web/api/canvasrenderingcontext2d/save/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/save/index.md
@@ -47,7 +47,7 @@ The drawing state that gets saved onto a stack consists of:
 ## Syntax
 
 ```js
-save();
+save()
 ```
 
 ## Examples

--- a/files/en-us/web/api/canvasrenderingcontext2d/scale/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/scale/index.md
@@ -25,7 +25,7 @@ drawn at twice the normal size.
 ## Syntax
 
 ```js
-scale(x, y);
+scale(x, y)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/scrollpathintoview/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/scrollpathintoview/index.md
@@ -20,8 +20,8 @@ to {{domxref("Element.scrollIntoView()")}}.
 ## Syntax
 
 ```js
-scrollPathIntoView();
-scrollPathIntoView(path);
+scrollPathIntoView()
+scrollPathIntoView(path)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/setlinedash/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/setlinedash/index.md
@@ -26,7 +26,7 @@ and gaps which describe the pattern.
 ## Syntax
 
 ```js
-setLineDash(segments);
+setLineDash(segments)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/settransform/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/settransform/index.md
@@ -24,8 +24,8 @@ method. This lets you scale, rotate, translate (move), and skew the context.
 ## Syntax
 
 ```js
-setTransform(a, b, c, d, e, f);
-setTransform(matrix);
+setTransform(a, b, c, d, e, f)
+setTransform(matrix)
 ```
 
 The transformation matrix is described by: <math><semantics><mrow><mo>[</mo>

--- a/files/en-us/web/api/canvasrenderingcontext2d/stroke/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/stroke/index.md
@@ -25,8 +25,8 @@ means that path intersections will still get filled.
 ## Syntax
 
 ```js
-stroke();
-stroke(path);
+stroke()
+stroke(path)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/strokerect/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/strokerect/index.md
@@ -25,7 +25,7 @@ on it.
 ## Syntax
 
 ```js
-strokeRect(x, y, width, height);
+strokeRect(x, y, width, height)
 ```
 
 The `strokeRect()` method draws a stroked rectangle whose starting point is

--- a/files/en-us/web/api/canvasrenderingcontext2d/stroketext/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/stroketext/index.md
@@ -36,8 +36,8 @@ on it.
 ## Syntax
 
 ```js
-strokeText(text, x, y);
-strokeText(text, x, y, maxWidth);
+strokeText(text, x, y)
+strokeText(text, x, y, maxWidth)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/canvasrenderingcontext2d/transform/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/transform/index.md
@@ -25,7 +25,7 @@ described by the arguments of this method. This lets you scale, rotate, translat
 ## Syntax
 
 ```js
-transform(a, b, c, d, e, f);
+transform(a, b, c, d, e, f)
 ```
 
 The transformation matrix is described by: <math><semantics><mrow><mo>[</mo>

--- a/files/en-us/web/api/canvasrenderingcontext2d/translate/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/translate/index.md
@@ -18,7 +18,7 @@ method of the Canvas 2D API adds a translation transformation to the current mat
 ## Syntax
 
 ```js
-translate(x, y);
+translate(x, y)
 ```
 
 The `translate()` method adds a translation transformation to the current

--- a/files/en-us/web/api/characterdata/replacewith/index.md
+++ b/files/en-us/web/api/characterdata/replacewith/index.md
@@ -20,7 +20,7 @@ Strings are inserted as {{domxref("Text")}} nodes; the string is being passed as
 ## Syntax
 
 ```js
-replaceWith(nodes);
+replaceWith(nodes)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/clearinterval/index.md
+++ b/files/en-us/web/api/clearinterval/index.md
@@ -18,7 +18,7 @@ was previously established by a call to {{domxref("setInterval", "setInterval()"
 ## Syntax
 
 ```js
-clearInterval(intervalID);
+clearInterval(intervalID)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cleartimeout/index.md
+++ b/files/en-us/web/api/cleartimeout/index.md
@@ -17,7 +17,7 @@ by calling {{domxref("setTimeout()")}}.
 ## Syntax
 
 ```js
-clearTimeout(timeoutID);
+clearTimeout(timeoutID)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/client/postmessage/index.md
+++ b/files/en-us/web/api/client/postmessage/index.md
@@ -24,8 +24,8 @@ message is received in the "`message`" event on
 ## Syntax
 
 ```js
-postMessage(message);
-postMessage(message, transferables);
+postMessage(message)
+postMessage(message, transferables)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/clients/claim/index.md
+++ b/files/en-us/web/api/clients/claim/index.md
@@ -25,7 +25,7 @@ regularly over the network, or possibly via a different service worker.
 ## Syntax
 
 ```js
-claim();
+claim()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/clients/get/index.md
+++ b/files/en-us/web/api/clients/get/index.md
@@ -20,13 +20,13 @@ The **`get()`** method of the
 ## Syntax
 
 ```js
-get(id);
+get(id)
 ```
 
 ### Parameters
 
 - `id`
-  - : A {{domxref("DOMString")}} representing the id of the client you want to get.
+  - : A string representing the id of the client you want to get.
 
 ### Return value
 

--- a/files/en-us/web/api/clients/matchall/index.md
+++ b/files/en-us/web/api/clients/matchall/index.md
@@ -23,7 +23,7 @@ service worker.
 ## Syntax
 
 ```js
-matchAll(options);
+matchAll(options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/clients/openwindow/index.md
+++ b/files/en-us/web/api/clients/openwindow/index.md
@@ -30,7 +30,7 @@ Chrome for Windows.
 ## Syntax
 
 ```js
-openWindow(url);
+openWindow(url)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/clipboard/read/index.md
+++ b/files/en-us/web/api/clipboard/read/index.md
@@ -36,7 +36,7 @@ permission.
 ## Syntax
 
 ```js
-read();
+read()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/clipboard/readtext/index.md
+++ b/files/en-us/web/api/clipboard/readtext/index.md
@@ -31,7 +31,7 @@ you can read data from the clipboard.
 ## Syntax
 
 ```js
-readText();
+readText()
 ```
 
 ### Parameters
@@ -40,7 +40,7 @@ None.
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves with a {{domxref("DOMString")}} containing the
+A {{jsxref("Promise")}} that resolves with a string containing the
 textual contents of the clipboard. Returns an empty string if the clipboard is empty,
 does not contain text, or does not include a textual representation among the
 {{domxref("DataTransfer")}} objects representing the clipboard's contents.

--- a/files/en-us/web/api/clipboard/write/index.md
+++ b/files/en-us/web/api/clipboard/write/index.md
@@ -33,7 +33,7 @@ automatically to pages when they are in the active tab.
 ## Syntax
 
 ```js
-write(data);
+write(data)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/clipboard/writetext/index.md
+++ b/files/en-us/web/api/clipboard/writetext/index.md
@@ -29,13 +29,13 @@ automatically to pages when they are in the active tab.
 ## Syntax
 
 ```js
-writeText(newClipText);
+writeText(newClipText)
 ```
 
 ### Parameters
 
 - `newClipText`
-  - : The {{domxref("DOMString")}} to be written to the clipboard.
+  - : The string to be written to the clipboard.
 
 ### Return value
 

--- a/files/en-us/web/api/closeevent/initcloseevent/index.md
+++ b/files/en-us/web/api/closeevent/initcloseevent/index.md
@@ -28,7 +28,7 @@ Once dispatched, it doesn't do anything anymore.
 ## Syntax
 
 ```js
-initMouseEvent(type, canBubble, cancelable, wasClean, reasonCode, reason);
+initMouseEvent(type, canBubble, cancelable, wasClean, reasonCode, reason)
 ```
 
 ### Parameters
@@ -49,7 +49,7 @@ initMouseEvent(type, canBubble, cancelable, wasClean, reasonCode, reason);
 - `reasonCode`
   - : the reason of the close.
 - `reason`
-  - : a {{domxref("DOMString")}} describing the reason of the close in shuman-readable
+  - : a string describing the reason of the close in shuman-readable
     way.
 
 ## Specifications

--- a/files/en-us/web/api/compositionevent/initcompositionevent/index.md
+++ b/files/en-us/web/api/compositionevent/initcompositionevent/index.md
@@ -22,13 +22,13 @@ method of the {{domxref("CompositionEvent")}} interface initializes the attribut
 ## Syntax
 
 ```js
-initCompositionEvent(typeArg, canBubbleArg, cancelableArg, viewArg, dataArg, localeArg);
+initCompositionEvent(typeArg, canBubbleArg, cancelableArg, viewArg, dataArg, localeArg)
 ```
 
 ### Parameters
 
 - `typeArg`
-  - : A {{domxref("DOMString")}} representing the type of composition event; this will be
+  - : A string representing the type of composition event; this will be
     one of `compositionstart`, `compositionupdate`, or
     `compositionend`.
 - `canBubbleArg`
@@ -38,10 +38,10 @@ initCompositionEvent(typeArg, canBubbleArg, cancelableArg, viewArg, dataArg, loc
 - `viewArg`
   - : The {{domxref("Window")}} object from which the event was generated.
 - `dataArg`
-  - : A {{domxref("DOMString")}} representing the value of the `data`
+  - : A string representing the value of the `data`
     attribute.
 - `localeArg`
-  - : A {{domxref("DOMString")}} representing the value of the `locale`
+  - : A string representing the value of the `locale`
     attribute.
 
 ### Return value

--- a/files/en-us/web/api/console/assert/index.md
+++ b/files/en-us/web/api/console/assert/index.md
@@ -21,10 +21,10 @@ the console if the assertion is false. If the assertion is true, nothing happens
 ## Syntax
 
 ```js
-console.assert(assertion, obj1);
-console.assert(assertion, obj1, obj2, /* ... ,*/ objN);
-console.assert(assertion, msg);
-console.assert(assertion, msg, subst1, /* ... ,*/ substN);
+console.assert(assertion, obj1)
+console.assert(assertion, obj1, obj2, /* ... ,*/ objN)
+console.assert(assertion, msg)
+console.assert(assertion, msg, subst1, /* ... ,*/ substN)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/clear/index.md
+++ b/files/en-us/web/api/console/clear/index.md
@@ -18,7 +18,7 @@ environment allows it.
 ## Syntax
 
 ```js
-clear();
+clear()
 ```
 
 ## Specifications

--- a/files/en-us/web/api/console/count/index.md
+++ b/files/en-us/web/api/console/count/index.md
@@ -21,8 +21,8 @@ this particular call to `count()` has been called.
 ## Syntax
 
 ```js
-count();
-count(label);
+count()
+count(label)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/countreset/index.md
+++ b/files/en-us/web/api/console/countreset/index.md
@@ -22,8 +22,8 @@ The **`console.countReset()`** method resets counter used with
 ## Syntax
 
 ```js
-countReset();
-countReset(label);
+countReset()
+countReset(label)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/debug/index.md
+++ b/files/en-us/web/api/console/debug/index.md
@@ -27,10 +27,10 @@ level might correspond to the \`Debug\` or \`Verbose\` log level.
 ## Syntax
 
 ```js
-debug(obj1);
-debug(obj1, /* ..., */ objN);
-debug(msg);
-debug(msg, subst1, /* ..., */ substN]);
+debug(obj1)
+debug(obj1, /* ..., */ objN)
+debug(msg)
+debug(msg, subst1, /* ..., */ substN])
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/dir/index.md
+++ b/files/en-us/web/api/console/dir/index.md
@@ -29,7 +29,7 @@ properties of the object.
 ## Syntax
 
 ```js
-dir(object);
+dir(object)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/dirxml/index.md
+++ b/files/en-us/web/api/console/dirxml/index.md
@@ -20,7 +20,7 @@ that let you see the contents of child nodes.
 ## Syntax
 
 ```js
-dirxml(object);
+dirxml(object)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/error/index.md
+++ b/files/en-us/web/api/console/error/index.md
@@ -19,10 +19,10 @@ The **`console.error()`** method outputs an error message to the Web console.
 ## Syntax
 
 ```js
-error(obj1);
-error(obj1, /* ..., */ objN);
-error(msg);
-error(msg, subst1, /* ..., */ substN]);
+error(obj1)
+error(obj1, /* ..., */ objN)
+error(msg)
+error(msg, subst1, /* ..., */ substN])
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/group/index.md
+++ b/files/en-us/web/api/console/group/index.md
@@ -21,8 +21,8 @@ until {{domxref("console.groupEnd()")}} is called.
 ## Syntax
 
 ```js
-group();
-group(label);
+group()
+group(label)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/groupcollapsed/index.md
+++ b/files/en-us/web/api/console/groupcollapsed/index.md
@@ -29,8 +29,8 @@ examples.
 ## Syntax
 
 ```js
-groupCollapsed();
-groupCollapsed(label);
+groupCollapsed()
+groupCollapsed(label)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/groupend/index.md
+++ b/files/en-us/web/api/console/groupend/index.md
@@ -21,7 +21,7 @@ console](/en-US/docs/Web/API/console#using_groups_in_the_console) in the {{domxr
 ## Syntax
 
 ```js
-groupEnd();
+groupEnd()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/info/index.md
+++ b/files/en-us/web/api/console/info/index.md
@@ -20,10 +20,10 @@ next to these items in the Web console's log.
 ## Syntax
 
 ```js
-info(obj1);
-info(obj1, /* ..., */ objN);
-info(msg);
-info(msg, subst1, /* ..., */ substN]);
+info(obj1)
+info(obj1, /* ..., */ objN)
+info(msg)
+info(msg, subst1, /* ..., */ substN])
 ```
 
 ### Parameters


### PR DESCRIPTION
Continuing #14857 

## Summary
Updating the method pages to follow the current templates:
https://developer.mozilla.org/en-US/docs/MDN/Structures/Syntax_sections#constructors_and_methods

**Note:** Recently it has been decided not to use semicolons `;` in the syntax sections ([ref](https://github.com/mdn/content/pull/15021)), So, updating all the previous pages first before continuing forward with the series.

Changes Include:
- fix syntax section
- other small corrections

### Metadata
- [x] Fixes a typo, bug, or other error
