### PR TITLE
WebAPI: Update Method pages to modern structure (part 9)

### DIFF
--- a/files/en-us/web/api/console/log/index.md
+++ b/files/en-us/web/api/console/log/index.md
@@ -25,10 +25,10 @@ or more JavaScript objects.
 ## Syntax
 
 ```js
-log(obj1);
-log(obj1, /* ..., */ objN);
-log(msg);
-log(msg, subst1, /* ..., */ substN]);
+log(obj1)
+log(obj1, /* ..., */ objN)
+log(msg)
+log(msg, subst1, /* ..., */ substN])
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/profile/index.md
+++ b/files/en-us/web/api/console/profile/index.md
@@ -28,7 +28,7 @@ To stop recording call {{domxref("console.profileEnd()")}}.
 ## Syntax
 
 ```js
-profile(profileName);
+profile(profileName)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/profileend/index.md
+++ b/files/en-us/web/api/console/profileend/index.md
@@ -37,7 +37,7 @@ only that profile if you have multiple profiles being recorded.
 ## Syntax
 
 ```js
-profileEnd(profileName);
+profileEnd(profileName)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/table/index.md
+++ b/files/en-us/web/api/console/table/index.md
@@ -132,8 +132,8 @@ You can sort the table by a particular column by clicking on that column's label
 ## Syntax
 
 ```js
-table(data);
-table(data, columns);
+table(data)
+table(data, columns)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/time/index.md
+++ b/files/en-us/web/api/console/time/index.md
@@ -25,7 +25,7 @@ See [Timers](/en-US/docs/Web/API/console#timers) in the
 ## Syntax
 
 ```js
-time(label);
+time(label)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/timeend/index.md
+++ b/files/en-us/web/api/console/timeend/index.md
@@ -23,7 +23,7 @@ details and examples.
 ## Syntax
 
 ```js
-timeEnd(label);
+timeEnd(label)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/timelog/index.md
+++ b/files/en-us/web/api/console/timelog/index.md
@@ -23,7 +23,7 @@ details and examples.
 ## Syntax
 
 ```js
-timeLog(label);
+timeLog(label)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/timestamp/index.md
+++ b/files/en-us/web/api/console/timestamp/index.md
@@ -26,7 +26,7 @@ be shown alongside the marker.
 ## Syntax
 
 ```js
-timeStamp(label);
+timeStamp(label)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/trace/index.md
+++ b/files/en-us/web/api/console/trace/index.md
@@ -29,7 +29,7 @@ See [Stack traces](/en-US/docs/Web/API/console#stack_traces) in the
 
 ```js
 trace()
-trace(objct1, /* ..., */ objectN)
+trace(object1, /* ..., */ objectN)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/console/trace/index.md
+++ b/files/en-us/web/api/console/trace/index.md
@@ -28,12 +28,13 @@ See [Stack traces](/en-US/docs/Web/API/console#stack_traces) in the
 ## Syntax
 
 ```js
-trace( [...any, ...data ]);
+trace()
+trace(objct1, /* ..., */ objectN)
 ```
 
 ### Parameters
 
-- `...any, ...data` {{optional_inline}}
+- `objects` {{optional_inline}}
   - : Zero or more objects to be output to console along with the trace. These are
     assembled and formatted the same way they would be if passed to the
     {{domxref("console.log()")}} method.

--- a/files/en-us/web/api/console/warn/index.md
+++ b/files/en-us/web/api/console/warn/index.md
@@ -23,10 +23,10 @@ console.
 ## Syntax
 
 ```js
-warn(obj1);
-warn(obj1, /* ..., */ objN);
-warn(msg);
-warn(msg, subst1, /* ..., */ substN]);
+warn(obj1)
+warn(obj1, /* ..., */ objN)
+warn(msg)
+warn(msg, subst1, /* ..., */ substN])
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cookiestore/delete/index.md
+++ b/files/en-us/web/api/cookiestore/delete/index.md
@@ -16,8 +16,8 @@ The **`delete()`** method of the {{domxref("CookieStore")}} interface deletes a 
 ## Syntax
 
 ```js
-delete(name);
-delete(options);
+delete(name)
+delete(options)
 ```
 
 ### Parameters
@@ -31,11 +31,11 @@ This method requires one of the following:
   - : An object containing:
 
     - `name`
-      - : A {{domxref("USVString")}} with the name of a cookie.
+      - : A string with the name of a cookie.
     - `url`{{Optional_Inline}}
-      - : A {{domxref("USVString")}} with the URL of a cookie.
+      - : A string with the URL of a cookie.
     - `path`{{Optional_Inline}}
-      - : A {{domxref("USVString")}} containing a path.
+      - : A string containing a path.
 
 > **Note:** The `url` option enables the modification of a cookie scoped under a particular URL. Service workers can obtain cookies that would be sent to any URL under their scope. From a document you may only obtain the cookies at the current URL, so the only valid URL in a document context is the document's URL.
 

--- a/files/en-us/web/api/cookiestore/get/index.md
+++ b/files/en-us/web/api/cookiestore/get/index.md
@@ -16,8 +16,8 @@ The **`get()`** method of the {{domxref("CookieStore")}} interface returns a sin
 ## Syntax
 
 ```js
-get(name);
-get(options);
+get(name)
+get(options)
 ```
 
 ### Parameters
@@ -31,9 +31,9 @@ This method requires one of the following:
   - : An object containing:
 
     - `name`
-      - : A {{domxref("USVString")}} with the name of a cookie.
+      - : A string with the name of a cookie.
     - `url`
-      - : A {{domxref("USVString")}} with the URL of a cookie.
+      - : A string with the URL of a cookie.
 
 > **Note:** The `url` option enables the modification of a cookie scoped under a particular URL. Service workers can obtain cookies that would be sent to any URL under their scope. From a document you may only obtain the cookies at the current URL, so the only valid URL in a document context is the document's URL.
 
@@ -42,13 +42,13 @@ This method requires one of the following:
 A {{jsxref("Promise")}} that resolves with an object containing the first cookie matching the submitted name or options. This object contains the following properties:
 
 - `name`
-  - : A {{domxref("USVString")}} containing the name of the cookie.
+  - : A string containing the name of the cookie.
 - `value`
-  - : A {{domxref("USVString")}} containing the value of the cookie.
+  - : A string containing the value of the cookie.
 - `domain`
-  - : A {{domxref("USVString")}} containing the domain of the cookie.
+  - : A string containing the domain of the cookie.
 - `path`
-  - : A {{domxref("USVString")}} containing the path of the cookie.
+  - : A string containing the path of the cookie.
 - `expires`
   - : A {{domxref("DOMTimeStamp")}} containing the expiration date of the cookie.
 - `secure`

--- a/files/en-us/web/api/cookiestore/getall/index.md
+++ b/files/en-us/web/api/cookiestore/getall/index.md
@@ -16,8 +16,8 @@ The **`getAll()`** method of the {{domxref("CookieStore")}} interface returns a 
 ## Syntax
 
 ```js
-getAll(name);
-getAll(options);
+getAll(name)
+getAll(options)
 ```
 
 ### Parameters
@@ -29,9 +29,9 @@ getAll(options);
   - : An object containing:
 
     - `name`
-      - : A {{domxref("USVString")}} with the name of a cookie.
+      - : A string with the name of a cookie.
     - `url`
-      - : A {{domxref("USVString")}} with the URL of a cookie.
+      - : A string with the URL of a cookie.
 
 > **Note:** The `url` option enables the modification of a cookie scoped under a particular URL. Service workers can obtain cookies that would be sent to any URL under their scope. From a document you may only obtain the cookies at the current URL, so the only valid URL in a document context is the document's URL.
 

--- a/files/en-us/web/api/cookiestore/set/index.md
+++ b/files/en-us/web/api/cookiestore/set/index.md
@@ -16,8 +16,8 @@ The **`set()`** method of the {{domxref("CookieStore")}} interface sets a cookie
 ## Syntax
 
 ```js
-set(name,value);
-set(options);
+set(name,value)
+set(options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cookiestore/set/index.md
+++ b/files/en-us/web/api/cookiestore/set/index.md
@@ -16,7 +16,7 @@ The **`set()`** method of the {{domxref("CookieStore")}} interface sets a cookie
 ## Syntax
 
 ```js
-set(name,value)
+set(name, value)
 set(options)
 ```
 

--- a/files/en-us/web/api/cookiestoremanager/getsubscriptions/index.md
+++ b/files/en-us/web/api/cookiestoremanager/getsubscriptions/index.md
@@ -16,7 +16,7 @@ The **`getSubscriptions()`** method of the {{domxref("CookieStoreManager")}} int
 ## Syntax
 
 ```js
-getSubscriptions();
+getSubscriptions()
 ```
 
 ### Return value

--- a/files/en-us/web/api/cookiestoremanager/subscribe/index.md
+++ b/files/en-us/web/api/cookiestoremanager/subscribe/index.md
@@ -16,7 +16,7 @@ The **`subscribe()`** method of the {{domxref("CookieStoreManager")}} interface 
 ## Syntax
 
 ```js
-subscribe(subscriptions);
+subscribe(subscriptions)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cookiestoremanager/unsubscribe/index.md
+++ b/files/en-us/web/api/cookiestoremanager/unsubscribe/index.md
@@ -16,7 +16,7 @@ The **`unsubscribe()`** method of the {{domxref("CookieStoreManager")}} interfac
 ## Syntax
 
 ```js
-unsubscribe(subscriptions);
+unsubscribe(subscriptions)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/countqueuingstrategy/size/index.md
+++ b/files/en-us/web/api/countqueuingstrategy/size/index.md
@@ -20,7 +20,7 @@ total queue size is a count of the number of chunks in the queue.
 ## Syntax
 
 ```js
-size();
+size()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/createimagebitmap/index.md
+++ b/files/en-us/web/api/createimagebitmap/index.md
@@ -21,10 +21,10 @@ different image sources, and returns a {{jsxref("Promise")}} which resolves to a
 ## Syntax
 
 ```js
-createImageBitmap(image);
-createImageBitmap(image, options);
-createImageBitmap(image, sx, sy, sw, sh);
-createImageBitmap(image, sx, sy, sw, sh, options);
+createImageBitmap(image)
+createImageBitmap(image, options)
+createImageBitmap(image, sx, sy, sw, sh)
+createImageBitmap(image, sx, sy, sw, sh, options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/credentialscontainer/create/index.md
+++ b/files/en-us/web/api/credentialscontainer/create/index.md
@@ -23,8 +23,8 @@ resolves with a new {{domxref("Credential")}} instance based on the provided opt
 ## Syntax
 
 ```js
-create();
-create(options);
+create()
+create(options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/credentialscontainer/get/index.md
+++ b/files/en-us/web/api/credentialscontainer/get/index.md
@@ -35,8 +35,8 @@ example: if options.password exists, then the
 ## Syntax
 
 ```js
-get();
-get(options);
+get()
+get(options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/credentialscontainer/preventsilentaccess/index.md
+++ b/files/en-us/web/api/credentialscontainer/preventsilentaccess/index.md
@@ -31,7 +31,7 @@ compatibility](/en-US/docs/Web/API/CredentialsContainer#browser_compatibility) s
 ## Syntax
 
 ```js
-preventSilentAccess();
+preventSilentAccess()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/credentialscontainer/store/index.md
+++ b/files/en-us/web/api/credentialscontainer/store/index.md
@@ -23,7 +23,7 @@ The **`store()`** method of the
 ## Syntax
 
 ```js
-store(Credential)
+store(Credentials)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/credentialscontainer/store/index.md
+++ b/files/en-us/web/api/credentialscontainer/store/index.md
@@ -23,7 +23,7 @@ The **`store()`** method of the
 ## Syntax
 
 ```js
-store(Credential);
+store(Credential)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/crypto/getrandomvalues/index.md
+++ b/files/en-us/web/api/crypto/getrandomvalues/index.md
@@ -31,7 +31,7 @@ Implementations are required to use a seed with enough entropy, like a system-le
 ## Syntax
 
 ```js
-getRandomValues(typedArray);
+getRandomValues(typedArray)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/crypto/randomuuid/index.md
+++ b/files/en-us/web/api/crypto/randomuuid/index.md
@@ -19,7 +19,7 @@ The **`randomUUID()`** method of the {{domxref("Crypto")}} interface is used to 
 ## Syntax
 
 ```js
-randomUUID();
+randomUUID()
 ```
 
 ### Return value

--- a/files/en-us/web/api/css/escape/index.md
+++ b/files/en-us/web/api/css/escape/index.md
@@ -20,7 +20,7 @@ use as part of a CSS selector.
 ## Syntax
 
 ```js
-escape(str);
+escape(str)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/css/supports/index.md
+++ b/files/en-us/web/api/css/supports/index.md
@@ -18,8 +18,8 @@ indicating if the browser supports a given CSS feature, or not.
 ## Syntax
 
 ```js
-supports(propertyName, value);
-supports(supportCondition);
+supports(propertyName, value)
+supports(supportCondition)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssgroupingrule/deleterule/index.md
+++ b/files/en-us/web/api/cssgroupingrule/deleterule/index.md
@@ -18,7 +18,7 @@ rules.
 ## Syntax
 
 ```js
-deleteRule(index);
+deleteRule(index)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssgroupingrule/insertrule/index.md
+++ b/files/en-us/web/api/cssgroupingrule/insertrule/index.md
@@ -17,8 +17,8 @@ The **`insertRule()`** method of the
 ## Syntax
 
 ```js
-insertRule(rule);
-insertRule(rule, index);
+insertRule(rule)
+insertRule(rule, index)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/csskeyframesrule/appendrule/index.md
+++ b/files/en-us/web/api/csskeyframesrule/appendrule/index.md
@@ -17,7 +17,7 @@ The **`appendRule()`** method of the {{domxref("CSSKeyframeRule")}} interface ap
 ## Syntax
 
 ```js
-appendRule(rule);
+appendRule(rule)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/csskeyframesrule/deleterule/index.md
+++ b/files/en-us/web/api/csskeyframesrule/deleterule/index.md
@@ -17,7 +17,7 @@ The **`deleteRule()`** method of the {{domxref("CSSKeyframeRule")}} interface de
 ## Syntax
 
 ```js
-deleteRule(select);
+deleteRule(select)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/csskeyframesrule/findrule/index.md
+++ b/files/en-us/web/api/csskeyframesrule/findrule/index.md
@@ -17,7 +17,7 @@ The **`findRule()`** method of the {{domxref("CSSKeyframeRule")}} interface find
 ## Syntax
 
 ```js
-findRule(select);
+findRule(select)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssnumericvalue/add/index.md
+++ b/files/en-us/web/api/cssnumericvalue/add/index.md
@@ -21,8 +21,8 @@ The **`add()`** method of the
 ## Syntax
 
 ```js
-add(double);
-add(CSSNumericValue);
+add(double)
+add(CSSNumericValue)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssnumericvalue/div/index.md
+++ b/files/en-us/web/api/cssnumericvalue/div/index.md
@@ -21,7 +21,7 @@ supplied value.
 ## Syntax
 
 ```js
-div(number);
+div(number)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssnumericvalue/equals/index.md
+++ b/files/en-us/web/api/cssnumericvalue/equals/index.md
@@ -23,7 +23,7 @@ equality to be tested quickly.
 ## Syntax
 
 ```js
-equals(number);
+equals(number)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssnumericvalue/max/index.md
+++ b/files/en-us/web/api/cssnumericvalue/max/index.md
@@ -21,7 +21,7 @@ passed. The passed values must be of the same type.
 ## Syntax
 
 ```js
-max(number1, /* ..., */ numberN);
+max(number1, /* ..., */ numberN)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssnumericvalue/min/index.md
+++ b/files/en-us/web/api/cssnumericvalue/min/index.md
@@ -21,7 +21,7 @@ values passed. The passed values must be of the same type.
 ## Syntax
 
 ```js
-min(number1 numberN);
+min(number1 numberN)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssnumericvalue/mul/index.md
+++ b/files/en-us/web/api/cssnumericvalue/mul/index.md
@@ -21,7 +21,7 @@ the supplied value.
 ## Syntax
 
 ```js
-mul(number);
+mul(number)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssnumericvalue/parse/index.md
+++ b/files/en-us/web/api/cssnumericvalue/parse/index.md
@@ -21,7 +21,7 @@ members are value and the units.
 ## Syntax
 
 ```js
-parse(cssText);
+parse(cssText)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssnumericvalue/sub/index.md
+++ b/files/en-us/web/api/cssnumericvalue/sub/index.md
@@ -21,7 +21,7 @@ The **`sub()`** method of the
 ## Syntax
 
 ```js
-sub(number);
+sub(number)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssnumericvalue/to/index.md
+++ b/files/en-us/web/api/cssnumericvalue/to/index.md
@@ -21,7 +21,7 @@ another.
 ## Syntax
 
 ```js
-to(unit);
+to(unit)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssnumericvalue/tosum/index.md
+++ b/files/en-us/web/api/cssnumericvalue/tosum/index.md
@@ -21,7 +21,7 @@ The **`toSum()`** method of the
 ## Syntax
 
 ```js
-toSum(units);
+toSum(units)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssnumericvalue/type/index.md
+++ b/files/en-us/web/api/cssnumericvalue/type/index.md
@@ -23,7 +23,7 @@ The **`type()`** method of the
 ## Syntax
 
 ```js
-type();
+type()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssprimitivevalue/getcountervalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/getcountervalue/index.md
@@ -29,7 +29,7 @@ is raised. Modification to the corresponding style property can be achieved usin
 ## Syntax
 
 ```js
-getCounterValue();
+getCounterValue()
 ```
 
 ### Return value

--- a/files/en-us/web/api/cssprimitivevalue/getfloatvalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/getfloatvalue/index.md
@@ -27,7 +27,7 @@ specified unit, a {{domxref("DOMException")}} is raised.
 ## Syntax
 
 ```js
-getFloatValue(unit);
+getFloatValue(unit)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssprimitivevalue/getrectvalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/getrectvalue/index.md
@@ -28,7 +28,7 @@ Modification to the corresponding style property can be achieved using the
 ## Syntax
 
 ```js
-getRectValue();
+getRectValue()
 ```
 
 ### Return value

--- a/files/en-us/web/api/cssprimitivevalue/getrgbcolorvalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/getrgbcolorvalue/index.md
@@ -28,7 +28,7 @@ Modification to the corresponding style property can be achieved using the
 ## Syntax
 
 ```js
-getRGBColorValue();
+getRGBColorValue()
 ```
 
 ### Return value

--- a/files/en-us/web/api/cssprimitivevalue/getstringvalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/getstringvalue/index.md
@@ -26,7 +26,7 @@ value doesn't contain a string value, a {{domxref("DOMException")}} is raised.
 ## Syntax
 
 ```js
-getStringValue();
+getStringValue()
 ```
 
 ### Return value

--- a/files/en-us/web/api/cssprimitivevalue/setfloatvalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/setfloatvalue/index.md
@@ -28,7 +28,7 @@ will be unchanged and a {{domxref("DOMException")}} will be raised.
 ## Syntax
 
 ```js
-setFloatValue(unitType, floatValue);
+setFloatValue(unitType, floatValue)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssprimitivevalue/setstringvalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/setstringvalue/index.md
@@ -28,7 +28,7 @@ value will be unchanged and a {{domxref("DOMException")}} will be raised.
 ## Syntax
 
 ```js
-setStringValue(stringType, stringValue);
+setStringValue(stringType, stringValue)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssrulelist/item/index.md
+++ b/files/en-us/web/api/cssrulelist/item/index.md
@@ -16,7 +16,7 @@ The **`item()`** method of the {{domxref("CSSRuleList")}} interface returns the 
 ## Syntax
 
 ```js
-item(index);
+item(index)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssstyledeclaration/getpropertycssvalue/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/getpropertycssvalue/index.md
@@ -27,7 +27,7 @@ shorthand property.
 ## Syntax
 
 ```js
-getPropertyCSSValue(property);
+getPropertyCSSValue(property)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssstyledeclaration/getpropertypriority/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/getpropertypriority/index.md
@@ -17,7 +17,7 @@ property.
 ## Syntax
 
 ```js
-getPropertyPriority(property);
+getPropertyPriority(property)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssstyledeclaration/getpropertyvalue/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/getpropertyvalue/index.md
@@ -16,7 +16,7 @@ The **CSSStyleDeclaration.getPropertyValue()** method interface returns a
 ## Syntax
 
 ```js
-getPropertyValue(property);
+getPropertyValue(property)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssstyledeclaration/item/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/item/index.md
@@ -21,7 +21,7 @@ arguments; the empty string is returned if the index is out of range and a
 ## Syntax
 
 ```js
-item(index);
+item(index)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssstyledeclaration/removeproperty/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/removeproperty/index.md
@@ -16,7 +16,7 @@ removes a property from a CSS style declaration object.
 ## Syntax
 
 ```js
-removeProperty(property);
+removeProperty(property)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssstyledeclaration/setproperty/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/setproperty/index.md
@@ -17,7 +17,7 @@ a new value for a property on a CSS style declaration object.
 ## Syntax
 
 ```js
-setProperty(propertyName, value, priority);
+setProperty(propertyName, value, priority)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssstylesheet/addrule/index.md
+++ b/files/en-us/web/api/cssstylesheet/addrule/index.md
@@ -29,7 +29,7 @@ stylesheet. You should avoid using this method, and should instead use the more 
 ## Syntax
 
 ```js
-addRule(selector, styleBlock, index);
+addRule(selector, styleBlock, index)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssstylesheet/deleterule/index.md
+++ b/files/en-us/web/api/cssstylesheet/deleterule/index.md
@@ -27,7 +27,7 @@ object.
 ## Syntax
 
 ```js
-deleteRule(index);
+deleteRule(index)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssstylesheet/insertrule/index.md
+++ b/files/en-us/web/api/cssstylesheet/insertrule/index.md
@@ -22,8 +22,8 @@ method inserts a new [CSS rule](/en-US/docs/Web/API/CSSRule) into the [current s
 ## Syntax
 
 ```js
-insertRule(rule);
-insertRule(rule, index);
+insertRule(rule)
+insertRule(rule, index)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssstylesheet/removerule/index.md
+++ b/files/en-us/web/api/cssstylesheet/removerule/index.md
@@ -34,7 +34,7 @@ object. It is functionally identical to the standard, preferred method
 ## Syntax
 
 ```js
-removeRule(index);
+removeRule(index)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssstylesheet/replace/index.md
+++ b/files/en-us/web/api/cssstylesheet/replace/index.md
@@ -18,7 +18,7 @@ The `replace()` and {{domxref("CSSStyleSheet.replaceSync()")}} methods can only 
 ## Syntax
 
 ```js
-replace(text);
+replace(text)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssstylesheet/replacesync/index.md
+++ b/files/en-us/web/api/cssstylesheet/replacesync/index.md
@@ -18,7 +18,7 @@ The `replaceSync()` and {{domxref("CSSStyleSheet.replace()")}} methods can only 
 ## Syntax
 
 ```js
-replaceSync(text);
+replaceSync(text)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssstylevalue/parse/index.md
+++ b/files/en-us/web/api/cssstylevalue/parse/index.md
@@ -21,7 +21,7 @@ value as a {{domxref('CSSStyleValue')}} object.
 ## Syntax
 
 ```js
-CSSStyleValue.parse(property, cssText)
+parse(property, cssText)
 ```
 
 ### Parameters
@@ -36,7 +36,7 @@ CSSStyleValue.parse(property, cssText)
 
 A `CSSStyleValue` object containing the first supplied value.
 
-## Example
+## Examples
 
 The code below parses a set of declarations for the `transform` property.
 The second code block shows the structure of the returned object as it would be rendered

--- a/files/en-us/web/api/cssstylevalue/parseall/index.md
+++ b/files/en-us/web/api/cssstylevalue/parseall/index.md
@@ -22,7 +22,7 @@ supplied values.
 ## Syntax
 
 ```js
-CSSStyleValue.parseAll(property, value)
+parseAll(property, value)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/csstransformcomponent/tomatrix/index.md
+++ b/files/en-us/web/api/csstransformcomponent/tomatrix/index.md
@@ -25,7 +25,7 @@ All transform functions can be represented mathematically as a 4x4 transformatio
 ## Syntax
 
 ```js
-var matrix = CSSTransformComponent.toMatrix();
+toMatrix()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/csstransformcomponent/tostring/index.md
+++ b/files/en-us/web/api/csstransformcomponent/tostring/index.md
@@ -19,7 +19,7 @@ The **`toString()`** method of the {{domxref("CSSTransformComponent")}} interfac
 ## Syntax
 
 ```js
-var transformString = CSSTransformComponent.toString();
+toString()
 ```
 
 ### Parameters
@@ -28,7 +28,7 @@ None
 
 ### Return value
 
-A {{domxref("DOMString")}} in the form of a CSS {{cssxref("transform-function","Transforms function")}}.
+A string in the form of a CSS {{cssxref("transform-function","Transforms function")}}.
 
 This will use the value of `is2D` to return either a 2D or 3D transform. For example if the component represents {{domxref("CSSRotate")}} and `is2D` is false then the string returned will be in the form of the CSS transformation [`rotate3D()`](</en-US/docs/Web/CSS/transform-function/rotate3d()>) function. If true the string returned will be in the form of the 2-dimensional [`rotate3D()`](</en-US/docs/Web/CSS/transform-function/rotate()>) function.
 

--- a/files/en-us/web/api/csstransformvalue/entries/index.md
+++ b/files/en-us/web/api/csstransformvalue/entries/index.md
@@ -23,7 +23,7 @@ properties in the prototype chain as well).
 ## Syntax
 
 ```js
-CSSTransformValue.entries(obj);
+entries(obj)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/csstransformvalue/keys/index.md
+++ b/files/en-us/web/api/csstransformvalue/keys/index.md
@@ -21,7 +21,7 @@ for each index in the array.
 ## Syntax
 
 ```js
-CSSTransformValue.keys();
+keys()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/csstransformvalue/tomatrix/index.md
+++ b/files/en-us/web/api/csstransformvalue/tomatrix/index.md
@@ -20,7 +20,7 @@ The **`toMatrix()`** method of the
 ## Syntax
 
 ```js
-var matrix = CSSTransformValue.toMatrix();
+toMatrix()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/csstransformvalue/values/index.md
+++ b/files/en-us/web/api/csstransformvalue/values/index.md
@@ -22,7 +22,7 @@ each index in the CSSTransformValue object.
 ## Syntax
 
 ```js
-CSSTransformValue.values();
+values()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssunparsedvalue/entries/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/entries/index.md
@@ -25,7 +25,7 @@ prototype chain as well).
 ## Syntax
 
 ```js
-CSSUnparsedValue.entries(obj)
+entries(obj)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssunparsedvalue/keys/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/keys/index.md
@@ -23,7 +23,7 @@ for each index in the array.
 ## Syntax
 
 ```js
-CSSUnparsedValue.keys()
+keys()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssunparsedvalue/values/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/values/index.md
@@ -23,7 +23,7 @@ values for each index in the CSSUnparsedValue object.
 ## Syntax
 
 ```js
-CSSUnparsedValue.values()
+values()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/cssvaluelist/item/index.md
+++ b/files/en-us/web/api/cssvaluelist/item/index.md
@@ -30,7 +30,7 @@ this method returns `null`.
 ## Syntax
 
 ```js
-var cssValue = cssValueList.item(index);
+item(index)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/customelementregistry/define/index.md
+++ b/files/en-us/web/api/customelementregistry/define/index.md
@@ -26,7 +26,7 @@ There are two types of custom elements you can create:
 ## Syntax
 
 ```js
-customElements.define(name, constructor, options);
+define(name, constructor, options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/customelementregistry/get/index.md
+++ b/files/en-us/web/api/customelementregistry/get/index.md
@@ -21,7 +21,7 @@ previously-defined custom element.
 ## Syntax
 
 ```js
-constructor = customElements.get(name);
+get(name)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/customelementregistry/upgrade/index.md
+++ b/files/en-us/web/api/customelementregistry/upgrade/index.md
@@ -21,7 +21,7 @@ document.
 ## Syntax
 
 ```js
-customElements.upgrade(root);
+upgrade(root)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/customelementregistry/whendefined/index.md
+++ b/files/en-us/web/api/customelementregistry/whendefined/index.md
@@ -20,7 +20,7 @@ resolves when the named element is defined.
 ## Syntax
 
 ```js
-customElements.whenDefined(name): Promise<CustomElementConstructor>;
+whenDefined(name)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/customstateset/add/index.md
+++ b/files/en-us/web/api/customstateset/add/index.md
@@ -16,15 +16,15 @@ The **`add`** method of the {{domxref("CustomStateSet")}} interface adds an item
 ## Syntax
 
 ```js
-CustomStateSet.add(value)
+add(value)
 ```
 
 ### Parameters
 
 - `value`
-  - : A {{domxref("DOMString")}} which must be a `<dashed-ident>`, with the form `--mystate`.
+  - : A string which must be a `<dashed-ident>`, with the form `--mystate`.
 
-### Return Value
+### Return value
 
 Undefined.
 

--- a/files/en-us/web/api/customstateset/clear/index.md
+++ b/files/en-us/web/api/customstateset/clear/index.md
@@ -16,14 +16,14 @@ The **`clear()`** method of the {{domxref("CustomStateSet")}} interface removes 
 ## Syntax
 
 ```js
-CustomStateSet.clear()
+clear()
 ```
 
 ### Parameters
 
 None.
 
-### Return Value
+### Return value
 
 Undefined.
 

--- a/files/en-us/web/api/customstateset/delete/index.md
+++ b/files/en-us/web/api/customstateset/delete/index.md
@@ -16,7 +16,7 @@ The **`delete()`** method of the {{domxref("CustomStateSet")}} interface deletes
 ## Syntax
 
 ```js
-CustomStateSet.delete(value)
+delete(value)
 ```
 
 ### Parameters
@@ -24,7 +24,7 @@ CustomStateSet.delete(value)
 : `value`
   : - The value to remove from the `CustomStateSet`.
 
-### Return Value
+### Return value
 
 Returns `true` if `value` was in the `CustomStateSet`; otherwise `false`.
 

--- a/files/en-us/web/api/customstateset/entries/index.md
+++ b/files/en-us/web/api/customstateset/entries/index.md
@@ -16,14 +16,14 @@ The **`entries`** method of the {{domxref("CustomStateSet")}} interface returns 
 ## Syntax
 
 ```js
-CustomStateSet.entries()
+entries()
 ```
 
 ### Parameters
 
 None.
 
-### Return Value
+### Return value
 
 A new iterator object that contains an array of `[value, value]` for each element in the `CustomStateSet`, in insertion order.
 

--- a/files/en-us/web/api/customstateset/foreach/index.md
+++ b/files/en-us/web/api/customstateset/foreach/index.md
@@ -16,8 +16,8 @@ The **`forEach()`** method of the {{domxref("CustomStateSet")}} interface execut
 ## Syntax
 
 ```js
-CustomStateSet.forEach(callbackFn)
-CustomStateSet.forEach(callbackFn, thisArg)
+forEach(callbackFn)
+forEach(callbackFn, thisArg)
 ```
 
 ### Parameters
@@ -31,7 +31,7 @@ CustomStateSet.forEach(callbackFn, thisArg)
 - `thisArg`
   - : Value to use as `this` when executing `callbackFn`.
 
-### Return Value
+### Return value
 
 Undefined.
 

--- a/files/en-us/web/api/customstateset/has/index.md
+++ b/files/en-us/web/api/customstateset/has/index.md
@@ -16,7 +16,7 @@ The **`has()`** method of the {{domxref("CustomStateSet")}} interface returns a 
 ## Syntax
 
 ```js
-CustomStateSet.has(value)
+has(value)
 ```
 
 ### Parameters
@@ -24,7 +24,7 @@ CustomStateSet.has(value)
 - `value`
   - : The value to test for in the `CustomStateSet` object.
 
-### Return Value
+### Return value
 
 A {{jsxref("Boolean")}}, `true` if `value` exists in the `CustomStateSet`.
 

--- a/files/en-us/web/api/customstateset/keys/index.md
+++ b/files/en-us/web/api/customstateset/keys/index.md
@@ -16,10 +16,10 @@ The **`keys()`** method of the {{domxref("CustomStateSet")}} interface is an ali
 ## Syntax
 
 ```js
-CustomStateSet.keys()
+keys()
 ```
 
-### Return Value
+### Return value
 
 A new iterator object containing the values for each element in the given `CustomStateSet`, in insertion order.
 

--- a/files/en-us/web/api/customstateset/values/index.md
+++ b/files/en-us/web/api/customstateset/values/index.md
@@ -16,10 +16,10 @@ The **`values()`** method of the {{domxref("CustomStateSet")}} interface returns
 ## Syntax
 
 ```js
-CustomStateSet.values()
+values()
 ```
 
-### Return Value
+### Return value
 
 A new iterator object containing the values for each element in the given `CustomStateSet`, in insertion order.
 

--- a/files/en-us/web/api/datatransfer/addelement/index.md
+++ b/files/en-us/web/api/datatransfer/addelement/index.md
@@ -26,7 +26,7 @@ dragged).
 addElement(el)
 ```
 
-### Arguments
+### Parameters
 
 - _el_
   - : The {{domxref("Element")}} to set as the drag source.

--- a/files/en-us/web/api/datatransfer/addelement/index.md
+++ b/files/en-us/web/api/datatransfer/addelement/index.md
@@ -23,7 +23,7 @@ dragged).
 ## Syntax
 
 ```js
-void dataTransfer.addElement(el);
+addElement(el)
 ```
 
 ### Arguments
@@ -35,7 +35,7 @@ void dataTransfer.addElement(el);
 
 None.
 
-## Example
+## Examples
 
 This example shows the use of the `addElement()` method
 

--- a/files/en-us/web/api/datatransfer/cleardata/index.md
+++ b/files/en-us/web/api/datatransfer/cleardata/index.md
@@ -30,7 +30,8 @@ for there still to be an entry with the type `"Files"` left in the object's
 ## Syntax
 
 ```js
-DataTransfer.clearData([format]);
+clearData()
+clearData(format)
 ```
 
 ### Parameters
@@ -40,7 +41,7 @@ DataTransfer.clearData([format]);
     this parameter is an empty string or is not provided, the data for all types is
     removed.
 
-## Example
+## Examples
 
 This example shows the use of the {{domxref("DataTransfer")}} object's
 {{domxref("DataTransfer.getData()","getData()")}},

--- a/files/en-us/web/api/datatransfer/getdata/index.md
+++ b/files/en-us/web/api/datatransfer/getdata/index.md
@@ -24,7 +24,7 @@ Example data types are `text/plain` and `text/uri-list`.
 getData(format)
 ```
 
-### Arguments
+### Parameters
 
 - `format`
   - : A string representing the type of data to retrieve.

--- a/files/en-us/web/api/datatransfer/getdata/index.md
+++ b/files/en-us/web/api/datatransfer/getdata/index.md
@@ -12,7 +12,7 @@ browser-compat: api.DataTransfer.getData
 {{APIRef("HTML DOM")}}
 
 The **`DataTransfer.getData()`**
-method retrieves drag data (as a {{domxref("DOMString")}}) for the specified type.
+method retrieves drag data (as a string) for the specified type.
 If the drag operation does not include data, this method returns an empty
 string.
 
@@ -21,20 +21,17 @@ Example data types are `text/plain` and `text/uri-list`.
 ## Syntax
 
 ```js
-dataTransfer.getData(format);
+getData(format)
 ```
 
 ### Arguments
 
 - `format`
-  - : A {{domxref("DOMString")}} representing the type of data to retrieve.
+  - : A string representing the type of data to retrieve.
 
 ### Return value
 
-- {{domxref("DOMString")}}
-  - : A {{domxref("DOMString")}} representing the drag data for the specified
-    `format`. If the drag operation has no data or the operation has no
-    data for the specified `format`, this method returns an empty string.
+A string representing the drag data for the specified `format`. If the drag operation has no data or the operation has no data for the specified `format`, this method returns an empty string.
 
 ### Caveats
 
@@ -47,7 +44,7 @@ dataTransfer.getData(format);
 
     During the `dragstart` and `drop` events, it is safe to access the data. For all other events, the data should be considered unavailable. Despite this, the items and their formats can still be enumerated.
 
-## Example
+## Examples
 
 This example shows the use of the {{domxref("DataTransfer")}} object's
 {{domxref("DataTransfer.getData()","getData()")}} and

--- a/files/en-us/web/api/datatransfer/mozcleardataat/index.md
+++ b/files/en-us/web/api/datatransfer/mozcleardataat/index.md
@@ -31,7 +31,8 @@ entirely, shifting the remaining items down and changing their indices.
 ## Syntax
 
 ```js
-void dataTransfer.mozClearDataAt([type], index);
+mozClearDataAt(index)
+mozClearDataAt(type, index)
 ```
 
 ### Arguments
@@ -46,7 +47,7 @@ void dataTransfer.mozClearDataAt([type], index);
 
 None.
 
-## Example
+## Examples
 
 This example shows the use of the `mozClearDataAt()` method in a
 {{event("dragend")}} event handler.

--- a/files/en-us/web/api/datatransfer/mozcleardataat/index.md
+++ b/files/en-us/web/api/datatransfer/mozcleardataat/index.md
@@ -35,7 +35,7 @@ mozClearDataAt(index)
 mozClearDataAt(type, index)
 ```
 
-### Arguments
+### Parameters
 
 - _type_
   - : A {{domxref("DOMString","string")}} representing the type of the drag data to remove

--- a/files/en-us/web/api/datatransfer/mozgetdataat/index.md
+++ b/files/en-us/web/api/datatransfer/mozgetdataat/index.md
@@ -29,7 +29,7 @@ mozGetDataAt(index)
 mozGetDataAt(type, index)
 ```
 
-### Arguments
+### Parameters
 
 - _type_
   - : A {{domxref("DOMString","string")}} representing the type of the drag data to

--- a/files/en-us/web/api/datatransfer/mozgetdataat/index.md
+++ b/files/en-us/web/api/datatransfer/mozgetdataat/index.md
@@ -25,7 +25,8 @@ range from zero to the number of items minus one.
 ## Syntax
 
 ```js
-nsIVariant dataTransfer.mozGetDataAt([type], index);
+mozGetDataAt(index)
+mozGetDataAt(type, index)
 ```
 
 ### Arguments
@@ -42,7 +43,7 @@ nsIVariant dataTransfer.mozGetDataAt([type], index);
   - : The data item requested. If the specified item does not exist, `null` is
     returned.
 
-## Example
+## Examples
 
 This example shows the use of the `mozGetDataAt()` method in a
 {{event("drop")}} event handler.

--- a/files/en-us/web/api/datatransfer/mozsetdataat/index.md
+++ b/files/en-us/web/api/datatransfer/mozsetdataat/index.md
@@ -41,7 +41,7 @@ mozSetDataAt(data, index)
 mozSetDataAt(type, data, index)
 ```
 
-### Arguments
+### Parameters
 
 - _type_
   - : A {{domxref("DOMString","string")}} representing the type of the drag data to add to

--- a/files/en-us/web/api/datatransfer/mozsetdataat/index.md
+++ b/files/en-us/web/api/datatransfer/mozsetdataat/index.md
@@ -37,7 +37,8 @@ or number type (which will be converted into a string) or an `nsISupports`.
 ## Syntax
 
 ```js
-void dataTransfer.mozSetDataAt([type], data, index);
+mozSetDataAt(data, index)
+mozSetDataAt(type, data, index)
 ```
 
 ### Arguments
@@ -55,7 +56,7 @@ void dataTransfer.mozSetDataAt([type], data, index);
 
 None.
 
-## Example
+## Examples
 
 This example shows the use of the `mozSetDataAt()` method in a
 {{event("dragstart")}} handler.

--- a/files/en-us/web/api/datatransfer/moztypesat/index.md
+++ b/files/en-us/web/api/datatransfer/moztypesat/index.md
@@ -23,7 +23,7 @@ in the range from 0 to the number of items minus one, an empty string list is re
 ## Syntax
 
 ```js
-mozTypesAt(index);
+mozTypesAt(index)
 ```
 
 ### Arguments
@@ -39,7 +39,7 @@ mozTypesAt(index);
     is not in the range from 0 to the number of items minus one, an empty string list is
     returned.
 
-## Example
+## Examples
 
 This example shows the use of the `mozTypesAt()` method in a
 {{event("drop")}} event handler.

--- a/files/en-us/web/api/datatransfer/moztypesat/index.md
+++ b/files/en-us/web/api/datatransfer/moztypesat/index.md
@@ -26,7 +26,7 @@ in the range from 0 to the number of items minus one, an empty string list is re
 mozTypesAt(index)
 ```
 
-### Arguments
+### Parameters
 
 - _index_
   - : A `unsigned long` that is the index of the data for which to retrieve the

--- a/files/en-us/web/api/datatransfer/setdata/index.md
+++ b/files/en-us/web/api/datatransfer/setdata/index.md
@@ -25,23 +25,23 @@ Example data types are `text/plain` and `text/uri-list`.
 ## Syntax
 
 ```js
-void dataTransfer.setData(format, data);
+setData(format, data)
 ```
 
 ### Arguments
 
 - _format_
-  - : A {{domxref("DOMString")}} representing the type of the drag data to add to the
+  - : A string representing the type of the drag data to add to the
     {{domxref("DataTransfer","drag object")}}.
 - _data_
-  - : A {{domxref("DOMString")}} representing the data to add to the
+  - : A string representing the data to add to the
     {{domxref("DataTransfer","drag object")}}.
 
 ### Return value
 
 None.
 
-## Example
+## Examples
 
 This example shows the use of the {{domxref("DataTransfer")}} object's
 {{domxref("DataTransfer.getData","getData()")}},

--- a/files/en-us/web/api/datatransfer/setdata/index.md
+++ b/files/en-us/web/api/datatransfer/setdata/index.md
@@ -28,7 +28,7 @@ Example data types are `text/plain` and `text/uri-list`.
 setData(format, data)
 ```
 
-### Arguments
+### Parameters
 
 - _format_
   - : A string representing the type of the drag data to add to the

--- a/files/en-us/web/api/datatransfer/setdragimage/index.md
+++ b/files/en-us/web/api/datatransfer/setdragimage/index.md
@@ -33,9 +33,9 @@ This method must be called in the {{event("dragstart")}} event handler.
 setDragImage(imgElement, xOffset, yOffset)
 ```
 
-### Arguments
+### Parameters
 
-- _imgElement
+- imgElement
 
   - : An image {{domxref("Element")}} element to use for the drag feedback image.
 
@@ -46,9 +46,9 @@ setDragImage(imgElement, xOffset, yOffset)
 
     Note: If the {{domxref("Element")}} is an existing {{domxref("HTMLElement")}} it needs to be visible in the viewport in order to be shown as a drag feedback image. Alternatively, you can create a new DOM element that might be off-screen specifically for this purpose.
 
-- _xOffset_
+- xOffset
   - : A `long` indicating the horizontal offset within the image.
-- _yOffset_
+- yOffset
   - : A `long` indicating the vertical offset within the image.
 
 ### Return value

--- a/files/en-us/web/api/datatransfer/setdragimage/index.md
+++ b/files/en-us/web/api/datatransfer/setdragimage/index.md
@@ -30,12 +30,12 @@ This method must be called in the {{event("dragstart")}} event handler.
 ## Syntax
 
 ```js
-void dataTransfer.setDragImage(img | element, xOffset, yOffset);
+setDragImage(imgElement, xOffset, yOffset)
 ```
 
 ### Arguments
 
-- _img |_ element
+- _imgElement
 
   - : An image {{domxref("Element")}} element to use for the drag feedback image.
 
@@ -55,7 +55,7 @@ void dataTransfer.setDragImage(img | element, xOffset, yOffset);
 
 None.
 
-## Example
+## Examples
 
 This example shows how to use the `setDragImage()` method. Note the example
 refers to an image file named `example.gif`. If that file is present, it will

--- a/files/en-us/web/api/datatransferitem/getasfile/index.md
+++ b/files/en-us/web/api/datatransferitem/getasfile/index.md
@@ -20,7 +20,7 @@ file, this method returns `null`.
 ## Syntax
 
 ```js
-File = DataTransferItem.getAsFile();
+getAsFile()
 ```
 
 ### Parameters
@@ -33,7 +33,7 @@ _None._
   - : If the drag data item is a file, a {{domxref("File")}} object is returned; otherwise
     `null` is returned.
 
-## Example
+## Examples
 
 This example shows the use of the `getAsFile()` method in a
 {{event("drop")}} event handler.

--- a/files/en-us/web/api/datatransferitem/getasstring/index.md
+++ b/files/en-us/web/api/datatransferitem/getasstring/index.md
@@ -22,7 +22,7 @@ given callback with the drag data item's string data as the argument if the item
 ## Syntax
 
 ```js
-dataTransferItem.getAsString(callback);
+getAsString(callback)
 ```
 
 ### Parameters
@@ -39,12 +39,12 @@ dataTransferItem.getAsString(callback);
 
 The callback parameter is a callback function which accepts one parameter:
 
-- {{domxref("DOMString")}}
+- string
   - : The drag data item's string data.
 
 The callback return value is `undefined`.
 
-## Example
+## Examples
 
 This example shows the use of the `getAsString()` method as an _inline
 function_ in a {{event("drop")}} event handler.

--- a/files/en-us/web/api/datatransferitem/webkitgetasentry/index.md
+++ b/files/en-us/web/api/datatransferitem/webkitgetasentry/index.md
@@ -38,7 +38,7 @@ A {{domxref("FileSystemEntry")}}-based object describing the dropped item.
 This will be either {{domxref("FileSystemFileEntry")}} or {{domxref("FileSystemDirectoryEntry")}}.
 The method aborts and returns `null` if the dropped item isn't a file, or if the {{domxref("DataTransferItem")}} object is not in read or read/write mode.
 
-## Example
+## Examples
 
 In this example, a drop zone is created, which responds to the {{event("drop")}} event
 by scanning through the dropped files and directories, outputting a hierarchical


### PR DESCRIPTION
Continuing #14857 

## Summary
Updating the method pages to follow the current templates:
https://developer.mozilla.org/en-US/docs/MDN/Structures/Syntax_sections#constructors_and_methods
https://developer.mozilla.org/en-US/docs/MDN/Structures/Page_types/API_method_subpage_template

Changes Include:
- fix syntax section
- changing section titles to suggested titles in the template
- change `{{DOMxRef("DOMString")}}` to `string`
- remove extra spaces in between words and extra trailing spaces
- other small corrections

### Metadata
- [x] Fixes a typo, bug, or other error
