### PR TITLE
Add note on pointerdown's implicit pointer capture

### DIFF
--- a/files/en-us/web/api/document/pointerdown_event/index.md
+++ b/files/en-us/web/api/document/pointerdown_event/index.md
@@ -15,6 +15,8 @@ browser-compat: api.Document.pointerdown_event
 
 The `pointerdown` event is fired when a pointer becomes active. For mouse, it is fired when the device transitions from no buttons depressed to at least one button depressed. For touch, it is fired when physical contact is made with the digitizer. For pen, it is fired when the stylus makes physical contact with the digitizer.
 
+> **Note:** For touchscreen browsers that allow [direct manipulation](https://w3c.github.io/pointerevents/#dfn-direct-manipulation), a `pointerdown` event triggers [implicit pointer capture](https://w3c.github.io/pointerevents/#dfn-implicit-pointer-capture), which causes the target to capture all subsequent pointer events as if they were occurring over the capturing target. Accordingly, `pointerover`, `pointerenter`, `pointerleave`, and `pointerout` **will not fire** as long as this capture is set. The capture can be released manually by calling {{domxref('element.releasePointerCapture')}} on the target element, or it will be implicitly released after a `pointerup` or `pointercancel` event.
+
 <table class="properties">
   <tbody>
     <tr>

--- a/files/en-us/web/api/htmlelement/pointerdown_event/index.md
+++ b/files/en-us/web/api/htmlelement/pointerdown_event/index.md
@@ -13,6 +13,8 @@ browser-compat: api.HTMLElement.pointerdown_event
 
 The `pointerdown` event is fired when a pointer becomes active. For mouse, it is fired when the device transitions from no buttons depressed to at least one button depressed. For touch, it is fired when physical contact is made with the digitizer. For pen, it is fired when the stylus makes physical contact with the digitizer.
 
+> **Note:** For touchscreen browsers that allow [direct manipulation](https://w3c.github.io/pointerevents/#dfn-direct-manipulation), a `pointerdown` event triggers [implicit pointer capture](https://w3c.github.io/pointerevents/#dfn-implicit-pointer-capture), which causes the target to capture all subsequent pointer events as if they were occurring over the capturing target. Accordingly, `pointerover`, `pointerenter`, `pointerleave`, and `pointerout` **will not fire** as long as this capture is set. The capture can be released manually by calling {{domxref('element.releasePointerCapture')}} on the target element, or it will be implicitly released after a `pointerup` or `pointercancel` event.
+
 <table class="properties">
   <tbody>
     <tr>

--- a/files/en-us/web/api/pointerevent/index.md
+++ b/files/en-us/web/api/pointerevent/index.md
@@ -67,9 +67,12 @@ The `PointerEvent` interface has several event types. To determine which event f
 - {{event('pointerover')}}
   - : This event is fired when a pointing device is moved into an element's hit test boundaries.
 - {{event('pointerenter')}}
-  - : This event is fired when a pointing device is moved into the hit test boundaries of an element or one of its descendants, including as a result of a pointerdown event from a device that does not support hover (see pointerdown). This event type is similar to `pointerover`, but differs in that it does not bubble.
+  - : This event is fired when a pointing device is moved into the hit test boundaries of an element or one of its descendants, including as a result of a `pointerdown` event from a device that does not support hover (see `pointerdown`). This event type is similar to `pointerover`, but differs in that it does not bubble.
 - {{event('pointerdown')}}
   - : The event is fired when a pointer becomes _active_. For mouse, it is fired when the device transitions from no buttons depressed to at least one button depressed. For touch, it is fired when physical contact is made with the digitizer. For pen, it is fired when the stylus makes physical contact with the digitizer.
+
+  > **Note:** For touchscreen browsers that allow [direct manipulation](https://w3c.github.io/pointerevents/#dfn-direct-manipulation), a `pointerdown` event triggers [implicit pointer capture](https://w3c.github.io/pointerevents/#dfn-implicit-pointer-capture), which causes the target to capture all subsequent pointer events as if they were occurring over the capturing target. Accordingly, `pointerover`, `pointerenter`, `pointerleave`, and `pointerout` **will not fire** as long as this capture is set. The capture can be released manually by calling {{ domxref('element.releasePointerCapture') }} on the target element, or it will be implicitly released after a `pointerup` or `pointercancel` event.
+
 - {{event('pointermove')}}
   - : This event is fired when a pointer changes coordinates.
 - {{event('pointerrawupdate')}} {{Experimental_Inline}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
This PR adds a note to the various descriptions of the `pointerdown` event indicating the circumstances in which the event will trigger implicit pointer capture. (It also briefly describes the effects and extent of this capture.)

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Implicit pointer capture is not an inherently obvious effect of `pointerdown`. It also occurs only in a specific touchscreen situation--so, for example, code that works without issue on a laptop browser will suddenly fail on a touchscreen--and it manifests by keeping *other* pointer events from firing, making bugs difficult to track down. Providing documentation for this implicit behavior should help readers--especially those new to pointer events--by making them aware of it. 

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
