### PR TITLE
Fix Issue #15058

### DIFF
--- a/files/en-us/web/svg/attribute/fr/index.md
+++ b/files/en-us/web/svg/attribute/fr/index.md
@@ -14,7 +14,7 @@ You can use this attribute with the following SVG elements:
 
 - {{SVGElement("radialGradient")}}
 
-## Example
+## Example #1
 
 ```css hidden
 html, body, svg {
@@ -42,7 +42,7 @@ html, body, svg {
 </svg>
 ```
 
-{{EmbedLiveSample("Example", "480", "200")}}
+{{EmbedLiveSample("Example #1", "480", "200")}}
 
 ## Usage notes
 
@@ -63,10 +63,10 @@ html, body, svg {
   </tbody>
 </table>
 
-## Example
+## Example #2
 
 ```html
-<svg viewBox="0 0 120 120" width="200" height="200" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 120 120" width="165" height="165" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <radialGradient id="Gradient" cx="0.5" cy="0.5" r="0.5"
         fx="0.35" fy="0.35" fr="5%">
@@ -86,7 +86,7 @@ html, body, svg {
 </svg>
 ```
 
-{{EmbedLiveSample("Example", "200", "200")}}
+{{EmbedLiveSample("Example #2", "200", "200")}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/attribute/fr/index.md
+++ b/files/en-us/web/svg/attribute/fr/index.md
@@ -14,7 +14,7 @@ You can use this attribute with the following SVG elements:
 
 - {{SVGElement("radialGradient")}}
 
-## Example #1
+## Examples
 
 ```css hidden
 html, body, svg {
@@ -22,8 +22,12 @@ html, body, svg {
 }
 ```
 
+### Changing the value of `fr`
+
+The following example presents two circles, the first one has `fr` set to `5%` while the other circle has `fr` equal to `25%`.
+
 ```html
-<svg viewBox="0 0 480 200" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 480 200" width="420" height="160" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <radialGradient id="gradient1" cx="0.5" cy="0.5" r="0.5"
         fx="0.35" fy="0.35" fr="5%">
@@ -42,7 +46,35 @@ html, body, svg {
 </svg>
 ```
 
-{{EmbedLiveSample("Example #1", "480", "200")}}
+{{EmbedLiveSample("Changing the gradient's radius", "480", "200")}}
+
+
+### The focal point's relationship to `(fx, fy)`
+
+This example has `fr` equal to `5%` and is representing how the attributes `fx` and `fy` (the points labeled as such in the SVG) act as the origin for the focal point of the radial gradient. This focal point is a circle whose radius (the value of `fr`) defines when the first color stop, in this case the color red, should start transitioning into the other color stop, which in this case is the color blue.
+
+```html
+<svg viewBox="0 0 120 120" width="165" height="165" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="Gradient" cx="0.5" cy="0.5" r="0.5"
+        fx="0.35" fy="0.35" fr="5%">
+      <stop offset="0%" stop-color="red"/>
+      <stop offset="100%" stop-color="blue"/>
+    </radialGradient>
+  </defs>
+
+  <rect x="10" y="10" rx="15" ry="15" width="100" height="100"
+      fill="url(#Gradient)" stroke="black" stroke-width="2"/>
+
+  <circle cx="60" cy="60" r="50" fill="transparent" stroke="white" stroke-width="2"/>
+  <circle cx="45" cy="45" r="2" fill="white" stroke="white"/>
+  <circle cx="60" cy="60" r="2" fill="white" stroke="white"/>
+  <text x="38" y="40" fill="white" font-family="sans-serif" font-size="10pt">(fx,fy)</text>
+  <text x="63" y="63" fill="white" font-family="sans-serif" font-size="10pt">(cx,cy)</text>
+</svg>
+```
+
+{{EmbedLiveSample("The radial gradient's relationship to (fx, fy)", "200", "200")}}
 
 ## Usage notes
 
@@ -62,31 +94,6 @@ html, body, svg {
     </tr>
   </tbody>
 </table>
-
-## Example #2
-
-```html
-<svg viewBox="0 0 120 120" width="165" height="165" xmlns="http://www.w3.org/2000/svg">
-  <defs>
-    <radialGradient id="Gradient" cx="0.5" cy="0.5" r="0.5"
-        fx="0.35" fy="0.35" fr="5%">
-      <stop offset="0%" stop-color="red"/>
-      <stop offset="100%" stop-color="blue"/>
-    </radialGradient>
-  </defs>
-
-  <rect x="10" y="10" rx="15" ry="15" width="100" height="100"
-      fill="url(#Gradient)" stroke="black" stroke-width="2"/>
-
-  <circle cx="60" cy="60" r="50" fill="transparent" stroke="white" stroke-width="2"/>
-  <circle cx="35" cy="35" r="2" fill="white" stroke="white"/>
-  <circle cx="60" cy="60" r="2" fill="white" stroke="white"/>
-  <text x="38" y="40" fill="white" font-family="sans-serif" font-size="10pt">(fx,fy)</text>
-  <text x="63" y="63" fill="white" font-family="sans-serif" font-size="10pt">(cx,cy)</text>
-</svg>
-```
-
-{{EmbedLiveSample("Example #2", "200", "200")}}
 
 ## Specifications
 

--- a/files/en-us/web/svg/attribute/fr/index.md
+++ b/files/en-us/web/svg/attribute/fr/index.md
@@ -24,7 +24,7 @@ html, body, svg {
 
 ### Changing the value of `fr`
 
-The following example presents two circles, the first one has `fr` set to `5%` while the other circle has `fr` equal to `25%`.
+The following example presents two circles: the first one has `fr` set to `5%` while the other circle has `fr` set to `25%`.
 
 ```html
 <svg viewBox="0 0 480 200" width="420" height="160" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
#### Summary
Fixed a bug that caused the first and second example on https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/fr to use the same image by changing the label on both headers and their respective EmbedLiveSample funtions. Also, changed the sizing of the second example's svg to make it fit within the white rectangle.

#### Motivation
This fix makes it so that the example HTML displayed in the web page coincides with the image shown, making it less confusing for readers and learners.

This PR rewrote some lines of code on the content/files/en-us/web/svg/attribute/fr/index.md file.

Fixes #15058 