### PR TITLE
Correct mix up between margins and paddings

### DIFF
--- a/files/en-us/learn/css/building_blocks/the_box_model/index.md
+++ b/files/en-us/learn/css/building_blocks/the_box_model/index.md
@@ -62,8 +62,8 @@ If a box has an outer display type of `inline`, then:
 
 - The box will not break onto a new line.
 - The {{cssxref("width")}} and {{cssxref("height")}} properties will not apply.
-- Vertical padding, margins, and borders will apply but will not cause other inline boxes to move away from the box.
-- Horizontal padding, margins, and borders will apply and will cause other inline boxes to move away from the box.
+- Vertical margins, paddings, and borders will apply but will not cause other inline boxes to move away from the box.
+- Horizontal margins, paddings, and borders will apply and will cause other inline boxes to move away from the box.
 
 Some HTML elements, such as `<a>`, `<span>`, `<em>` and `<strong>` use `inline` as their outer display type by default.
 
@@ -283,7 +283,7 @@ We can control the padding on all sides of an element using the {{cssxref("paddi
 
 All of the above applies fully to block boxes. Some of the properties can apply to inline boxes too, such as those created by a `<span>` element.
 
-In the example below, we have a `<span>` inside a paragraph and have applied a `width`, `height`, `margin`, `border`, and `padding` to it. You can see that the width and height are ignored. The vertical margin, padding, and border are respected but they do not change the relationship of other content to our inline box and so the padding and border overlaps other words in the paragraph. Horizontal padding, margins, and borders are respected and will cause other content to move away from the box.
+In the example below, we have a `<span>` inside a paragraph and have applied a `width`, `height`, `margin`, `border`, and `padding` to it. You can see that the width and height are ignored. The horizontal margin, padding, and border are respected but they do not change the relationship of other content to our inline box and so the padding and border overlaps other words in the paragraph. Horizontal margins, paddings, and borders are respected and will cause other content to move away from the box horizontally.
 
 {{EmbedGHLiveSample("css-examples/learn/box-model/inline-box-model.html", '100%', 700)}}
 


### PR DESCRIPTION
When considering inline elements their margin only is respected horizontally and not vertically.
The corrections were aimed at that mistake of saying that vertical margins are respected and also
that padding has restrictions which is not the case because all 4 paddings are respected although 
they only cause displacement of elements horizontally.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Correct margin and padding mix up when considering their effects on inline elements

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The change helps to make the tutorial correct and to give readers the theoretical box model knowledge that matches the browser rendering.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
