### PR TITLE
WebAPI: Update Method pages to modern structure (part 10) 

### DIFF
--- a/files/en-us/web/api/elementinternals/reportvalidity/index.md
+++ b/files/en-us/web/api/elementinternals/reportvalidity/index.md
@@ -20,7 +20,7 @@ This method behaves in a similar way to {{domxref("ElementInternals.checkValidit
 ## Syntax
 
 ```js
-ElementInternals.reportValidity();
+reportValidity()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/elementinternals/setvalidity/index.md
+++ b/files/en-us/web/api/elementinternals/setvalidity/index.md
@@ -16,9 +16,9 @@ The **`setValidity()`** method of the {{domxref("ElementInternals")}} interface 
 ## Syntax
 
 ```js
-ElementInternals.setValidity(flags);
-ElementInternals.setValidity(flags, message);
-ElementInternals.setValidity(flags, message, anchor);
+setValidity(flags)
+setValidity(flags, message)
+setValidity(flags, message, anchor)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/encodedaudiochunk/copyto/index.md
+++ b/files/en-us/web/api/encodedaudiochunk/copyto/index.md
@@ -16,7 +16,7 @@ The **`copyTo()`** method of the {{domxref("EncodedAudioChunk")}} interface copi
 ## Syntax
 
 ```js
-EncodedAudioChunk.copyTo(destination)
+copyTo(destination)
 ```
 
 ### Parameters
@@ -24,7 +24,7 @@ EncodedAudioChunk.copyTo(destination)
 - `destination`
   - : A {{domxref("BufferSource")}} that the data can be copied to.
 
-### Return Value
+### Return value
 
 {{jsxref("Undefined")}}.
 

--- a/files/en-us/web/api/encodedvideochunk/copyto/index.md
+++ b/files/en-us/web/api/encodedvideochunk/copyto/index.md
@@ -16,7 +16,7 @@ The **`copyTo()`** method of the {{domxref("EncodedVideoChunk")}} interface copi
 ## Syntax
 
 ```js
-EncodedVideoChunk.copyTo(destination)
+copyTo(destination)
 ```
 
 ### Parameters
@@ -24,7 +24,7 @@ EncodedVideoChunk.copyTo(destination)
 - `destination`
   - : A {{domxref("BufferSource")}} that the data can be copied to.
 
-### Return Value
+### Return value
 
 {{jsxref("Undefined")}}.
 

--- a/files/en-us/web/api/eventsource/close/index.md
+++ b/files/en-us/web/api/eventsource/close/index.md
@@ -21,7 +21,7 @@ interface closes the connection, if one is made, and sets the
 ## Syntax
 
 ```js
-eventSource.close();
+close()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/extendableevent/waituntil/index.md
+++ b/files/en-us/web/api/extendableevent/waituntil/index.md
@@ -41,14 +41,14 @@ settle.
 ## Syntax
 
 ```js
-extendableEvent.waitUntil(promise);
+waitUntil(promise)
 ```
 
 ### Parameters
 
 A {{jsxref("Promise")}}.
 
-## Example
+## Examples
 
 Using `waitUntil()` within a service worker's `install` event:
 

--- a/files/en-us/web/api/eyedropper/open/index.md
+++ b/files/en-us/web/api/eyedropper/open/index.md
@@ -17,7 +17,7 @@ The **`EyeDropper.prototype.open()`** method starts the eyedropper mode, returni
 
 ```js
 open()
-open( signal: abortControllersignal )
+open( options )
 ```
 
 ### Parameters

--- a/files/en-us/web/api/eyedropper/open/index.md
+++ b/files/en-us/web/api/eyedropper/open/index.md
@@ -16,8 +16,8 @@ The **`EyeDropper.prototype.open()`** method starts the eyedropper mode, returni
 ## Syntax
 
 ```js
-eyeDropper.open();
-eyeDropper.open({ signal: abortController.signal });
+open()
+open( signal: abortControllersignal )
 ```
 
 ### Parameters

--- a/files/en-us/web/api/filereader/abort/index.md
+++ b/files/en-us/web/api/filereader/abort/index.md
@@ -19,7 +19,7 @@ the {{domxref("FileReader.readyState","readyState")}} will be `DONE`.
 ## Syntax
 
 ```js
-instanceOfFileReader.abort();
+abort()
 ```
 
 ## Specifications

--- a/files/en-us/web/api/filereader/readasarraybuffer/index.md
+++ b/files/en-us/web/api/filereader/readasarraybuffer/index.md
@@ -28,7 +28,7 @@ contains an {{jsxref("ArrayBuffer")}} representing the file's data.
 ## Syntax
 
 ```js
-instanceOfFileReader.readAsArrayBuffer(blob);
+readAsArrayBuffer(blob)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/filereader/readasbinarystring/index.md
+++ b/files/en-us/web/api/filereader/readasbinarystring/index.md
@@ -25,7 +25,7 @@ Using {{domxref("FileReader.readAsArrayBuffer()")}} is recommended.
 ## Syntax
 
 ```js
-instanceOfFileReader.readAsBinaryString(blob);
+readAsBinaryString(blob)
 ```
 
 ### Parameters
@@ -33,7 +33,7 @@ instanceOfFileReader.readAsBinaryString(blob);
 - `blob`
   - : The {{domxref("Blob")}} or {{domxref("File")}} from which to read.
 
-## Example
+## Examples
 
 ```js
 var canvas = document.createElement('canvas');

--- a/files/en-us/web/api/filereader/readasdataurl/index.md
+++ b/files/en-us/web/api/filereader/readasdataurl/index.md
@@ -26,7 +26,7 @@ file's data as a base64 encoded string.
 ## Syntax
 
 ```js
-instanceOfFileReader.readAsDataURL(blob);
+readAsDataURL(blob)
 ```
 
 ### Parameters
@@ -34,7 +34,7 @@ instanceOfFileReader.readAsDataURL(blob);
 - `blob`
   - : The {{domxref("Blob")}} or {{domxref("File")}} from which to read.
 
-## Example
+## Examples
 
 ### HTML
 

--- a/files/en-us/web/api/filereader/readastext/index.md
+++ b/files/en-us/web/api/filereader/readastext/index.md
@@ -31,7 +31,7 @@ readAsText(blob, encoding)
 - `encoding` {{optional_inline}}
   - : A string specifying the encoding to use for the returned data. By default, UTF-8 is assumed if this parameter is not specified.
 
-## Example
+## Examples
 
 ### HTML
 

--- a/files/en-us/web/api/filesystemdirectoryentry/createreader/index.md
+++ b/files/en-us/web/api/filesystemdirectoryentry/createreader/index.md
@@ -21,7 +21,7 @@ the directory.
 ## Syntax
 
 ```js
-directoryReader = FileSystemDirectoryEntry.createReader();
+createReader()
 ```
 
 ### Parameters
@@ -33,7 +33,7 @@ None.
 A {{domxref("FileSystemDirectoryReader")}} object which can be used to read the
 directory's entries.
 
-## Example
+## Examples
 
 This example creates a method called `readDirectory()`, which fetches all of
 the entries in the specified {{domxref("FileSystemDirectoryEntry")}} and returns them in

--- a/files/en-us/web/api/filesystemdirectoryreader/readentries/index.md
+++ b/files/en-us/web/api/filesystemdirectoryreader/readentries/index.md
@@ -23,8 +23,8 @@ Generally, they are either {{domxref("FileSystemFileEntry")}} objects, which rep
 ## Syntax
 
 ```js
-readEntries(successCallback);
-readEntries(successCallback, errorCallback);
+readEntries(successCallback)
+readEntries(successCallback, errorCallback)
 ```
 
 ### Parameters
@@ -46,7 +46,7 @@ readEntries(successCallback, errorCallback);
 
 {{jsxref("undefined")}}
 
-## Example
+## Examples
 
 See [`DataTransferItem.webkitGetAsEntry()`](/en-US/docs/Web/API/DataTransferItem/webkitGetAsEntry#example) for example code that uses this method.
 

--- a/files/en-us/web/api/fontface/load/index.md
+++ b/files/en-us/web/api/fontface/load/index.md
@@ -19,7 +19,7 @@ The **`load()`** method of the {{domxref("FontFace")}} interface loads a font ba
 ## Syntax
 
 ```js
-FontFace.load()
+load()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/fontfaceset/add/index.md
+++ b/files/en-us/web/api/fontfaceset/add/index.md
@@ -16,7 +16,7 @@ The **`add()`** method of the {{domxref("FontFaceSet")}} interface adds a new fo
 ## Syntax
 
 ```js
-FontFaceSet.add(font)
+add(font)
 ```
 
 ### Parameters
@@ -24,7 +24,7 @@ FontFaceSet.add(font)
 - `font`
   - : A {{domxref("FontFace")}} to be added to the set.
 
-### Return Value
+### Return value
 
 A new {{domxref("FontFaceSet")}}.
 

--- a/files/en-us/web/api/fontfaceset/check/index.md
+++ b/files/en-us/web/api/fontfaceset/check/index.md
@@ -18,11 +18,11 @@ fonts in the given font list have been loaded and are available.
 ## Syntax
 
 ```js
-aFontFaceSet.check(font);
-aFontFaceSet.check(font, text);
+check(font)
+check(font, text)
 ```
 
-### Returns
+### Return value
 
 A {{jsxref("Boolean")}} value that is `true` if the font list is available.
 

--- a/files/en-us/web/api/fontfaceset/clear/index.md
+++ b/files/en-us/web/api/fontfaceset/clear/index.md
@@ -16,14 +16,14 @@ The **`clear()`** method of the {{domxref("FontFaceSet")}} interface removes all
 ## Syntax
 
 ```js
-FontFaceSet.clear()
+clear()
 ```
 
 ### Parameters
 
 None.
 
-### Return Value
+### Return value
 
 {{jsxref("Undefined")}}.
 

--- a/files/en-us/web/api/fontfaceset/delete/index.md
+++ b/files/en-us/web/api/fontfaceset/delete/index.md
@@ -16,7 +16,7 @@ The **`delete()`** method of the {{domxref("FontFaceSet")}} interface removes a 
 ## Syntax
 
 ```js
-FontFaceSet.delete(font)
+delete(font)
 ```
 
 ### Parameters
@@ -24,7 +24,7 @@ FontFaceSet.delete(font)
 - `font`
   - : A {{domxref("FontFace")}} to be removed from the set.
 
-### Return Value
+### Return value
 
 A boolean value which is `true` if the deletion was successful.
 

--- a/files/en-us/web/api/fontfaceset/entries/index.md
+++ b/files/en-us/web/api/fontfaceset/entries/index.md
@@ -16,14 +16,14 @@ The **`entries()`** method of the {{domxref("FontFaceSet")}} interface returns a
 ## Syntax
 
 ```js
-FontFaceSet.entries()
+entries()
 ```
 
 ### Parameters
 
 None.
 
-### Return Value
+### Return value
 
 A new iterator object that contains an array of `[value, value]` for each element in the `CustomStateSet`, in insertion order.
 

--- a/files/en-us/web/api/fontfaceset/foreach/index.md
+++ b/files/en-us/web/api/fontfaceset/foreach/index.md
@@ -16,8 +16,8 @@ The **`forEach()`** method of the {{domxref("FontFaceSet")}} interface executes 
 ## Syntax
 
 ```js
-FontFaceSet.forEach(callbackFn)
-FontFaceSet.forEach(callbackFn, thisArg)
+forEach(callbackFn)
+forEach(callbackFn, thisArg)
 ```
 
 ### Parameters
@@ -31,7 +31,7 @@ FontFaceSet.forEach(callbackFn, thisArg)
 - `thisArg`
   - : Value to use as {{jsxref('this')}} when executing `callbackFn`.
 
-### Return Value
+### Return value
 
 Undefined.
 

--- a/files/en-us/web/api/fontfaceset/has/index.md
+++ b/files/en-us/web/api/fontfaceset/has/index.md
@@ -16,7 +16,7 @@ The **`has()`** method of the {{domxref("FontFaceSet")}} interface returns a {{j
 ## Syntax
 
 ```js
-FontFaceSet.has(value)
+has(value)
 ```
 
 ### Parameters
@@ -24,7 +24,7 @@ FontFaceSet.has(value)
 - `value`
   - : The value to test for in the `FontFaceSet` object.
 
-### Return Value
+### Return value
 
 A {{jsxref("Boolean")}}, `true` if `value` exists in the `FontFaceSet`.
 

--- a/files/en-us/web/api/fontfaceset/keys/index.md
+++ b/files/en-us/web/api/fontfaceset/keys/index.md
@@ -16,10 +16,10 @@ The **`keys()`** method of the {{domxref("FontFaceSet")}} interface is an alias 
 ## Syntax
 
 ```js
-FontFaceSet.keys()
+keys()
 ```
 
-### Return Value
+### Return value
 
 A new iterator object containing the values for each element in the given `FontFaceSet`, in insertion order.
 

--- a/files/en-us/web/api/fontfaceset/load/index.md
+++ b/files/en-us/web/api/fontfaceset/load/index.md
@@ -18,11 +18,11 @@ given in parameters to be loaded.
 ## Syntax
 
 ```js
-aFontFaceSet.load(font);
-aFontFaceSet.load(font, text);
+load(font)
+load(font, text)
 ```
 
-### Returns
+### Return value
 
 A {{jsxref("Promise")}} of an {{jsxref("Array")}} of {{jsxref("FontFace")}} loaded. The
 promise is fulfilled when all the fonts are loaded; it is rejected if one of the fonts

--- a/files/en-us/web/api/fontfaceset/values/index.md
+++ b/files/en-us/web/api/fontfaceset/values/index.md
@@ -16,10 +16,10 @@ The **`values()`** method of the {{domxref("FontFaceSet")}} interface returns a 
 ## Syntax
 
 ```js
-FontFaceSet.values()
+values()
 ```
 
-### Return Value
+### Return value
 
 A new iterator object containing the values for each element in the given `FontFaceSet`, in insertion order.
 

--- a/files/en-us/web/api/formdata/delete/index.md
+++ b/files/en-us/web/api/formdata/delete/index.md
@@ -20,7 +20,7 @@ The **`delete()`** method of the {{domxref("FormData")}} interface deletes a key
 ## Syntax
 
 ```js
-formData.delete(name);
+delete(name)
 ```
 
 ### Parameters
@@ -28,11 +28,11 @@ formData.delete(name);
 - `name`
   - : The name of the key you want to delete.
 
-### Returns
+### Return value
 
 {{jsxref('undefined')}}.
 
-## Example
+## Examples
 
 The following line creates an empty `FormData` object and prepopulates it with key/value pairs from a form:
 

--- a/files/en-us/web/api/formdata/entries/index.md
+++ b/files/en-us/web/api/formdata/entries/index.md
@@ -14,22 +14,22 @@ browser-compat: api.FormData.entries
 
 The **`FormData.entries()`** method returns an
 {{jsxref("Iteration_protocols",'iterator')}} allowing to go through all key/value
-pairs contained in this object. The key of each pair is a {{domxref("USVString")}}
-object; the value either a {{domxref("USVString")}}, or a {{domxref("Blob")}}.
+pairs contained in this object. The key of each pair is a string
+object; the value either a string, or a {{domxref("Blob")}}.
 
 > **Note:** This method is available in [Web Workers](/en-US/docs/Web/API/Web_Workers_API).
 
 ## Syntax
 
 ```js
-formData.entries();
+entries()
 ```
 
 ### Return value
 
 Returns an {{jsxref("Iteration_protocols","iterator")}}.
 
-## Example
+## Examples
 
 ```js
 // Create a test FormData object

--- a/files/en-us/web/api/formdata/get/index.md
+++ b/files/en-us/web/api/formdata/get/index.md
@@ -22,20 +22,20 @@ object. If you expect multiple values and want all of them, use the
 ## Syntax
 
 ```js
-formData.get(name);
+get(name)
 ```
 
 ### Parameters
 
 - `name`
-  - : A {{domxref("USVString")}} representing the name of the key you want to retrieve.
+  - : A string representing the name of the key you want to retrieve.
 
 ### Return value
 
 A {{domxref("FormDataEntryValue")}} containing the value. If the key doesn't exist, the
 method returns null.
 
-## Example
+## Examples
 
 The following line creates an empty `FormData` object:
 

--- a/files/en-us/web/api/formdata/getall/index.md
+++ b/files/en-us/web/api/formdata/getall/index.md
@@ -19,19 +19,19 @@ The **`getAll()`** method of the {{domxref("FormData")}} interface returns all t
 ## Syntax
 
 ```js
-formData.getAll(name);
+getAll(name)
 ```
 
 ### Parameters
 
 - `name`
-  - : A {{domxref("USVString")}} representing the name of the key you want to retrieve.
+  - : A string representing the name of the key you want to retrieve.
 
-### Returns
+### Return value
 
 An array of {{domxref("FormDataEntryValue")}}s whose key matches the value passed in the `name` parameter. If the key doesn't exist, the method returns an empty list.
 
-## Example
+## Examples
 
 The following line creates an empty `FormData` object:
 

--- a/files/en-us/web/api/formdata/has/index.md
+++ b/files/en-us/web/api/formdata/has/index.md
@@ -20,19 +20,19 @@ The **`has()`** method of the {{domxref("FormData")}} interface returns a boolea
 ## Syntax
 
 ```js
-formData.has(name);
+has(name)
 ```
 
 ### Parameters
 
 - `name`
-  - : A {{domxref("USVString")}} representing the name of the key you want to test for.
+  - : A string representing the name of the key you want to test for.
 
-### Returns
+### Return value
 
 A boolean value.
 
-## Example
+## Examples
 
 The following line creates an empty `FormData` object:
 

--- a/files/en-us/web/api/formdata/keys/index.md
+++ b/files/en-us/web/api/formdata/keys/index.md
@@ -14,21 +14,21 @@ browser-compat: api.FormData.keys
 
 The **`FormData.keys()`** method returns an
 {{jsxref("Iteration_protocols",'iterator')}} allowing to go through all keys contained
-in this object. The keys are {{domxref("USVString")}} objects.
+in this object. The keys are string objects.
 
 > **Note:** This method is available in [Web Workers](/en-US/docs/Web/API/Web_Workers_API).
 
 ## Syntax
 
 ```js
-formData.keys();
+keys()
 ```
 
 ### Return value
 
 Returns an {{jsxref("Iteration_protocols","iterator")}}.
 
-## Example
+## Examples
 
 ```js
 // Create a test FormData object

--- a/files/en-us/web/api/formdata/values/index.md
+++ b/files/en-us/web/api/formdata/values/index.md
@@ -14,7 +14,7 @@ browser-compat: api.FormData.values
 
 The **`FormData.values()`** method returns an
 {{jsxref("Iteration_protocols",'iterator')}} allowing to go through all values
-contained in this object. The values are {{domxref("USVString")}} or
+contained in this object. The values are string or
 {{domxref("Blob")}} objects.
 
 > **Note:** This method is available in [Web Workers](/en-US/docs/Web/API/Web_Workers_API).
@@ -22,14 +22,14 @@ contained in this object. The values are {{domxref("USVString")}} or
 ## Syntax
 
 ```js
-formData.values();
+values()
 ```
 
 ### Return value
 
 Returns an {{jsxref("Iteration_protocols","iterator")}}.
 
-## Example
+## Examples
 
 ```js
 // Create a test FormData object

--- a/files/en-us/web/api/gamepadhapticactuator/playeffect/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/playeffect/index.md
@@ -19,7 +19,7 @@ The **`playEffect()`** method of the {{domxref("GamepadHapticActuator")}} interf
 ## Syntax
 
 ```js
-playEffect(type, params);
+playEffect(type, params)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/geolocation/clearwatch/index.md
+++ b/files/en-us/web/api/geolocation/clearwatch/index.md
@@ -20,7 +20,7 @@ location/error monitoring handlers previously installed using
 ## Syntax
 
 ```js
-navigator.geolocation.clearWatch(id);
+clearWatch(id)
 ```
 
 ### Parameters
@@ -29,7 +29,7 @@ navigator.geolocation.clearWatch(id);
   - : The ID number returned by the {{domxref("Geolocation.watchPosition()")}} method when
     installing the handler you wish to remove.
 
-## Example
+## Examples
 
 ```js
 var id, target, option;

--- a/files/en-us/web/api/geolocation/watchposition/index.md
+++ b/files/en-us/web/api/geolocation/watchposition/index.md
@@ -18,9 +18,9 @@ You can also, optionally, specify an error handling callback function.
 ## Syntax
 
 ```js
-navigator.geolocation.watchPosition(success)
-navigator.geolocation.watchPosition(success, error)
-navigator.geolocation.watchPosition(success, error, options)
+watchPosition(success)
+watchPosition(success, error)
+watchPosition(success, error, options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/headers/append/index.md
+++ b/files/en-us/web/api/headers/append/index.md
@@ -28,7 +28,7 @@ and {{Glossary("Forbidden_response_header_name", "forbidden response header name
 ## Syntax
 
 ```js
-myHeaders.append(name, value);
+append(name, value)
 ```
 
 ### Parameters
@@ -38,11 +38,11 @@ myHeaders.append(name, value);
 - `value`
   - : The value of the HTTP header you want to add.
 
-### Returns
+### Return value
 
 {{jsxref('undefined')}}.
 
-## Example
+## Examples
 
 Creating an empty `Headers` object is simple:
 

--- a/files/en-us/web/api/headers/delete/index.md
+++ b/files/en-us/web/api/headers/delete/index.md
@@ -27,7 +27,7 @@ and {{Glossary("Forbidden_response_header_name", "forbidden response header name
 ## Syntax
 
 ```js
-myHeaders.delete(name);
+delete(name)
 ```
 
 ### Parameters
@@ -35,11 +35,11 @@ myHeaders.delete(name);
 - `name`
   - : The name of the HTTP header you want to delete from the `Headers` object.
 
-### Returns
+### Return value
 
 {{jsxref('undefined')}}.
 
-## Example
+## Examples
 
 Creating an empty `Headers` object is simple:
 

--- a/files/en-us/web/api/headers/entries/index.md
+++ b/files/en-us/web/api/headers/entries/index.md
@@ -21,14 +21,14 @@ contained in this object. The both the key and value of each pairs are
 ## Syntax
 
 ```js
-headers.entries();
+entries()
 ```
 
 ### Return value
 
 Returns an {{jsxref("Iteration_protocols","iterator")}}.
 
-## Example
+## Examples
 
 ```js
 // Create a test Headers object

--- a/files/en-us/web/api/headers/get/index.md
+++ b/files/en-us/web/api/headers/get/index.md
@@ -25,7 +25,7 @@ and {{Glossary("Forbidden_response_header_name", "forbidden response header name
 ## Syntax
 
 ```js
-myHeaders.get(name);
+get(name)
 ```
 
 ### Parameters
@@ -35,12 +35,12 @@ myHeaders.get(name);
     `Headers` object. If the given name is not the name of an HTTP header, this
     method throws a {{jsxref("TypeError")}}. The name is case-insensitive.
 
-### Returns
+### Return value
 
 A {{jsxref("String")}} sequence representing the values of the retrieved header or
 `null` if this header is not set.
 
-## Example
+## Examples
 
 Creating an empty `Headers` object is simple:
 

--- a/files/en-us/web/api/headers/has/index.md
+++ b/files/en-us/web/api/headers/has/index.md
@@ -22,7 +22,7 @@ and {{Glossary("Forbidden_response_header_name", "forbidden response header name
 ## Syntax
 
 ```js
-myHeaders.has(name);
+has(name)
 ```
 
 ### Parameters
@@ -31,11 +31,11 @@ myHeaders.has(name);
   - : The name of the HTTP header you want to test for. If the given name is not a valid
     HTTP header name, this method throws a {{jsxref("TypeError")}}.
 
-### Returns
+### Return value
 
 A boolean value.
 
-## Example
+## Examples
 
 Creating an empty `Headers` object is simple:
 

--- a/files/en-us/web/api/headers/keys/index.md
+++ b/files/en-us/web/api/headers/keys/index.md
@@ -20,14 +20,14 @@ in this object. The keys are {{jsxref("String")}} objects.
 ## Syntax
 
 ```js
-headers.keys();
+keys()
 ```
 
 ### Return value
 
 Returns an {{jsxref("Iteration_protocols","iterator")}}.
 
-## Example
+## Examples
 
 ```js
 // Create a test Headers object

--- a/files/en-us/web/api/headers/set/index.md
+++ b/files/en-us/web/api/headers/set/index.md
@@ -28,7 +28,7 @@ and {{Glossary("Forbidden_response_header_name", "forbidden response header name
 ## Syntax
 
 ```js
-myHeaders.set(name, value);
+set(name, value)
 ```
 
 ### Parameters
@@ -39,11 +39,11 @@ myHeaders.set(name, value);
 - `value`
   - : The new value you want to set.
 
-### Returns
+### Return value
 
 {{jsxref('undefined')}}.
 
-## Example
+## Examples
 
 Creating an empty `Headers` object is simple:
 

--- a/files/en-us/web/api/headers/values/index.md
+++ b/files/en-us/web/api/headers/values/index.md
@@ -20,14 +20,14 @@ in this object. The values are {{jsxref("String")}} objects.
 ## Syntax
 
 ```js
-headers.values();
+values()
 ```
 
 ### Return value
 
 Returns an {{jsxref("Iteration_protocols","iterator")}}.
 
-## Example
+## Examples
 
 ```js
 // Create a test Headers object

--- a/files/en-us/web/api/hid/getdevices/index.md
+++ b/files/en-us/web/api/hid/getdevices/index.md
@@ -16,7 +16,7 @@ The **`getDevices()`** method of the {{domxref("HID")}} interface gets a list of
 ## Syntax
 
 ```js
-HID.getDevices();
+getDevices()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/hid/requestdevice/index.md
+++ b/files/en-us/web/api/hid/requestdevice/index.md
@@ -18,7 +18,7 @@ The user agent will present a permission dialog including a list of connected de
 ## Syntax
 
 ```js
-HID.requestDevice(options);
+requestDevice(options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/hiddevice/close/index.md
+++ b/files/en-us/web/api/hiddevice/close/index.md
@@ -16,7 +16,7 @@ The **`close()`** method of the {{domxref("HIDDevice")}} interface closes the co
 ## Syntax
 
 ```js
-HIDDevice.close();
+close()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/hiddevice/open/index.md
+++ b/files/en-us/web/api/hiddevice/open/index.md
@@ -18,7 +18,7 @@ The **`open()`** method of the {{domxref("HIDDevice")}} interface requests that 
 ## Syntax
 
 ```js
-HIDDevice.open();
+open()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/hiddevice/receivefeaturereport/index.md
+++ b/files/en-us/web/api/hiddevice/receivefeaturereport/index.md
@@ -18,7 +18,7 @@ The `reportId` for each of the report formats that this device supports can be r
 ## Syntax
 
 ```js
-HIDDevice.receiveFeatureReport(reportId);
+receiveFeatureReport(reportId)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/hiddevice/sendfeaturereport/index.md
+++ b/files/en-us/web/api/hiddevice/sendfeaturereport/index.md
@@ -18,7 +18,7 @@ The `reportId` for each of the report formats that this device supports can be r
 ## Syntax
 
 ```js
-HIDDevice.sendFeatureReport(reportId, data);
+sendFeatureReport(reportId, data)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/hiddevice/sendreport/index.md
+++ b/files/en-us/web/api/hiddevice/sendreport/index.md
@@ -18,7 +18,7 @@ The `reportId` for each of the report formats that this device supports can be r
 ## Syntax
 
 ```js
-HIDDevice.sendReport(reportId, data);
+sendReport(reportId, data)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/history/back/index.md
+++ b/files/en-us/web/api/history/back/index.md
@@ -26,7 +26,7 @@ This method is {{glossary("asynchronous")}}. Add a listener for the
 ## Syntax
 
 ```js
-history.back()
+back()
 ```
 
 ## Examples

--- a/files/en-us/web/api/history/forward/index.md
+++ b/files/en-us/web/api/history/forward/index.md
@@ -22,7 +22,7 @@ This method is {{glossary("asynchronous")}}. Add a listener for the
 ## Syntax
 
 ```js
-history.forward()
+forward()
 ```
 
 ## Examples

--- a/files/en-us/web/api/history/pushstate/index.md
+++ b/files/en-us/web/api/history/pushstate/index.md
@@ -24,8 +24,8 @@ session history stack.
 ## Syntax
 
 ```js
-history.pushState(state, unused)
-history.pushState(state, unused, url)
+pushState(state, unused)
+pushState(state, unused, url)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/history/replacestate/index.md
+++ b/files/en-us/web/api/history/replacestate/index.md
@@ -21,8 +21,8 @@ to some user action.
 ## Syntax
 
 ```js
-history.replaceState(stateObj, unused)
-history.replaceState(stateObj, unused, url)
+replaceState(stateObj, unused)
+replaceState(stateObj, unused, url)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/hmdvrdevice/geteyeparameters/index.md
+++ b/files/en-us/web/api/hmdvrdevice/geteyeparameters/index.md
@@ -22,7 +22,7 @@ This includes field of view information, and more.
 ## Syntax
 
 ```js
-getEyeParameters('left')
+getEyeParameters(whichEye)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/hmdvrdevice/geteyeparameters/index.md
+++ b/files/en-us/web/api/hmdvrdevice/geteyeparameters/index.md
@@ -22,15 +22,15 @@ This includes field of view information, and more.
 ## Syntax
 
 ```js
-var myLeftEye = HMDVRDevice.getEyeParameters('left');
+getEyeParameters('left')
 ```
 
 ### Parameters
 
 - `whichEye`
-  - : A {{domxref("DOMString")}} representing the eye you want to return information about. The value can be `left` or `right`.
+  - : A string representing the eye you want to return information about. The value can be `left` or `right`.
 
-### Returns
+### Return value
 
 A {{domxref("VREyeParameters")}} object.
 

--- a/files/en-us/web/api/hmdvrdevice/setfieldofview/index.md
+++ b/files/en-us/web/api/hmdvrdevice/setfieldofview/index.md
@@ -25,13 +25,13 @@ setFieldOfView(leftFOV, rightFOV, zNear, zFar)
 
 ### Parameters
 
-- `leftFOV {{optional_inline}}`
+- `leftFOV` {{optional_inline}}
   - : A `{{domxref("VRFieldOfView")}}` object that defines the new field of view for the left eye. If not specified, the left eye field of view does not change.
 - `rightFOV {{optional_inline}}`
   - : A `{{domxref("VRFieldOfView")}}` object that defines the new field of view for the right eye. If not specified, the right eye field of view does not change.
-- `zNear {{optional_inline}}`
+- `zNear` {{optional_inline}}
   - : The distance from the eyes of the nearest point of the view. The closest things can be and still be in the view. If not specified, the default is used — `0.01`.
-- `zFar {{optional_inline}}`
+- `zFar` {{optional_inline}}
   - : The distance from the eyes of the farthest point of the view. The furthest away things can be and still be in the view. If not specified, the default is used — `10000.0`.
 
 ### Return value

--- a/files/en-us/web/api/hmdvrdevice/setfieldofview/index.md
+++ b/files/en-us/web/api/hmdvrdevice/setfieldofview/index.md
@@ -20,7 +20,7 @@ The **`setFieldOfView()`** method of the {{domxref("HMDVRDevice")}} interface ca
 ## Syntax
 
 ```js
-HMDVRDevice.setFieldOfView(leftFOV,rightFOV,zNear,zFar);
+setFieldOfView(leftFOV, rightFOV, zNear, zFar)
 ```
 
 ### Parameters
@@ -34,7 +34,7 @@ HMDVRDevice.setFieldOfView(leftFOV,rightFOV,zNear,zFar);
 - `zFar {{optional_inline}}`
   - : The distance from the eyes of the farthest point of the view. The furthest away things can be and still be in the view. If not specified, the default is used — `10000.0`.
 
-### Returns
+### Return value
 
 {{jsxref('undefined')}}.
 

--- a/files/en-us/web/api/htmlanchorelement/tostring/index.md
+++ b/files/en-us/web/api/htmlanchorelement/tostring/index.md
@@ -11,13 +11,13 @@ browser-compat: api.HTMLAnchorElement.toString
 {{ApiRef("URL API")}}
 
 The **`HTMLAnchorElement.toString()`** {{Glossary("stringifier")}}
-method returns a {{domxref("USVString")}} containing the whole URL. It is a read-only
+method returns a string containing the whole URL. It is a read-only
 version of {{domxref("HTMLAnchorElement.href")}}.
 
 ## Syntax
 
 ```js
-anchor.toString();
+toString()
 ```
 
 ## Examples

--- a/files/en-us/web/api/htmlareaelement/tostring/index.md
+++ b/files/en-us/web/api/htmlareaelement/tostring/index.md
@@ -11,13 +11,13 @@ browser-compat: api.HTMLAreaElement.toString
 {{ApiRef("URL API")}}
 
 The **`HTMLAreaElement.toString()`** {{Glossary("stringifier")}}
-method returns a {{domxref("USVString")}} containing the whole URL. It is a read-only
+method returns a string containing the whole URL. It is a read-only
 version of {{domxref("HTMLAreaElement.href")}}.
 
 ## Syntax
 
 ```js
-area.toString();
+toString()
 ```
 
 ## Examples

--- a/files/en-us/web/api/htmlcanvaselement/getcontext/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/getcontext/index.md
@@ -56,7 +56,7 @@ getContext(contextType, contextAttributes)
     > implementations under certain [conformance
     > rules](https://www.khronos.org/registry/webgl/sdk/tests/CONFORMANCE_RULES.txt).
 
-- `contextAttributes`
+- `contextAttributes` {{optional_inline}}
 
   - : You can use several context attributes when creating your rendering context, for
     example:

--- a/files/en-us/web/api/htmlcanvaselement/getcontext/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/getcontext/index.md
@@ -24,15 +24,15 @@ different drawing context object on a given canvas element.
 ## Syntax
 
 ```js
-var ctx = canvas.getContext(contextType);
-var ctx = canvas.getContext(contextType, contextAttributes);
+getContext(contextType)
+getContext(contextType, contextAttributes)
 ```
 
 ### Parameters
 
 - `contextType`
 
-  - : Is a {{domxref("DOMString")}} containing the context identifier defining the drawing
+  - : Is a string containing the context identifier defining the drawing
     context associated to the canvas. Possible values are:
 
     - `"2d"`, leading to the creation of a

--- a/files/en-us/web/api/htmlcanvaselement/mozfetchasstream/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/mozfetchasstream/index.md
@@ -19,6 +19,7 @@ canvas as image data. However, this non-standard and internal method has been re
 ## Syntax
 
 ```js
+mozFetchAsStream(callback)
 mozFetchAsStream(callback, type)
 ```
 

--- a/files/en-us/web/api/htmlcanvaselement/mozfetchasstream/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/mozfetchasstream/index.md
@@ -19,7 +19,7 @@ canvas as image data. However, this non-standard and internal method has been re
 ## Syntax
 
 ```js
-void canvas.mozFetchAsStream(callback, type);
+mozFetchAsStream(callback, type)
 ```
 
 ### Parameters
@@ -27,7 +27,7 @@ void canvas.mozFetchAsStream(callback, type);
 - `callback`
   - : An `nsIInputStreamCallback`.
 - `type` {{optional_inline}}
-  - : A {{domxref("DOMString")}} indicating the image format. The default type is
+  - : A string indicating the image format. The default type is
     `image/png`.
 
 ### Return value

--- a/files/en-us/web/api/htmlcanvaselement/mozgetasfile/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/mozgetasfile/index.md
@@ -23,16 +23,16 @@ The non-standard, Firefox-specific the {{domxref("HTMLCanvasElement")}} method
 ## Syntax
 
 ```js
-canvas.mozGetAsFile(name, type);
+mozGetAsFile(name, type)
 ```
 
 ### Parameters
 
 - `name`
-  - : A {{domxref("DOMString")}} indicating the file name to give the file representing
+  - : A string indicating the file name to give the file representing
     the image file in memory.
 - `type` {{optional_inline}}
-  - : A {{domxref("DOMString")}} which specifies the image file format to use when
+  - : A string which specifies the image file format to use when
     creating the new image file. The default type is `image/png`. For other
     options, see our [Image file type
     and format guide](/en-US/docs/Web/Media/Formats/Image_types).

--- a/files/en-us/web/api/htmlcanvaselement/mozgetasfile/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/mozgetasfile/index.md
@@ -23,6 +23,7 @@ The non-standard, Firefox-specific the {{domxref("HTMLCanvasElement")}} method
 ## Syntax
 
 ```js
+mozGetAsFile(name)
 mozGetAsFile(name, type)
 ```
 

--- a/files/en-us/web/api/htmlcanvaselement/toblob/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/toblob/index.md
@@ -23,6 +23,8 @@ The created image will have a resolution of 96dpi for file formats that support 
 ## Syntax
 
 ```js
+toBlob(callback)
+toBlob(callback, type)
 toBlob(callback, type, quality)
 ```
 

--- a/files/en-us/web/api/htmlcanvaselement/toblob/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/toblob/index.md
@@ -32,7 +32,7 @@ toBlob(callback, type, quality)
   - : A callback function with the resulting {{domxref("Blob")}} object as a single argument.
     `null` may be passed if the image cannot be created for any reason.
 - `type` {{optional_inline}}
-  - : A {{domxref("DOMString")}} indicating the image format.
+  - : A string indicating the image format.
     The default type is `image/png`; that type is also used if the given type isn't supported.
 - `quality` {{optional_inline}}
   - : A {{jsxref("Number")}} between `0` and `1` indicating the image quality to be used when creating images using file formats that support lossy compression (such as `image/jpeg` or `image/webp`).

--- a/files/en-us/web/api/htmlcanvaselement/todataurl/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/todataurl/index.md
@@ -24,13 +24,13 @@ The created image data will have a resolution of 96dpi for file formats that sup
 ## Syntax
 
 ```js
-canvas.toDataURL(type, encoderOptions);
+toDataURL(type, encoderOptions)
 ```
 
 ### Parameters
 
 - `type` {{optional_inline}}
-  - : A {{domxref("DOMString")}} indicating the image format.
+  - : A string indicating the image format.
     The default type is `image/png`; this image format will be also used if the specified type is not supported.
 - `encoderOptions` {{optional_inline}}
   - : A {{jsxref("Number")}} between `0` and `1` indicating the image quality to be used when creating images using file formats that support lossy compression (such as `image/jpeg` or `image/webp`).
@@ -38,7 +38,7 @@ canvas.toDataURL(type, encoderOptions);
 
 ### Return value
 
-A {{domxref("DOMString")}} containing the requested [data URI](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs).
+A string containing the requested [data URI](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs).
 
 If the height or width of the canvas is `0` or larger than the [maximum canvas size](/en-US/docs/Web/HTML/Element/canvas#maximum_canvas_size), the string `"data:,"` is returned.
 

--- a/files/en-us/web/api/htmlcanvaselement/todataurl/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/todataurl/index.md
@@ -24,6 +24,8 @@ The created image data will have a resolution of 96dpi for file formats that sup
 ## Syntax
 
 ```js
+toDataURL()
+toDataURL(type)
 toDataURL(type, encoderOptions)
 ```
 

--- a/files/en-us/web/api/htmlcanvaselement/transfercontroltooffscreen/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/transfercontroltooffscreen/index.md
@@ -20,7 +20,7 @@ thread or on a worker.
 ## Syntax
 
 ```js
-OffscreenCanvas HTMLCanvasElement.transferControlToOffscreen()
+transferControlToOffscreen()
 ```
 
 ### Return value

--- a/files/en-us/web/api/htmlcollection/item/index.md
+++ b/files/en-us/web/api/htmlcollection/item/index.md
@@ -1,5 +1,5 @@
 ---
-title: HTMLCollection.item
+title: HTMLCollection.item()
 slug: Web/API/HTMLCollection/item
 tags:
   - API
@@ -23,7 +23,7 @@ returns the node located at the specified offset into the collection.
 ## Syntax
 
 ```js
-var element = HTMLCollection.item(index)
+item(index)
 ```
 
 ### Parameters
@@ -45,7 +45,7 @@ The `item()` method returns a numbered element from an
 `HTMLCollection` as an array and to index it using array notation. See the
 [example](#example) below.
 
-## Example
+## Examples
 
 ```js
 var c = document.images;  // This is an HTMLCollection

--- a/files/en-us/web/api/htmldialogelement/close/index.md
+++ b/files/en-us/web/api/htmldialogelement/close/index.md
@@ -16,19 +16,19 @@ browser-compat: api.HTMLDialogElement.close
 {{ SeeCompatTable() }}
 
 The **`close()`** method of the {{domxref("HTMLDialogElement")}}
-interface closes the dialog. An optional {{domxref("DOMString")}} may be passed as an
+interface closes the dialog. An optional string may be passed as an
 argument, updating the `returnValue` of the dialog.
 
 ## Syntax
 
 ```js
-dialogInstance.close(returnValue);
+close(returnValue)
 ```
 
 ### Parameters
 
 - returnValue {{optional_inline}}
-  - : A {{domxref("DOMString")}} representing an updated value for the
+  - : A string representing an updated value for the
     {{domxref("HTMLDialogElement.returnValue")}} of the dialog.
 
 ### Return value

--- a/files/en-us/web/api/htmldialogelement/close/index.md
+++ b/files/en-us/web/api/htmldialogelement/close/index.md
@@ -22,6 +22,7 @@ argument, updating the `returnValue` of the dialog.
 ## Syntax
 
 ```js
+close()
 close(returnValue)
 ```
 

--- a/files/en-us/web/api/htmldialogelement/show/index.md
+++ b/files/en-us/web/api/htmldialogelement/show/index.md
@@ -20,7 +20,7 @@ outside of the dialog.
 ## Syntax
 
 ```js
-dialogInstance.show();
+show()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/htmldialogelement/showmodal/index.md
+++ b/files/en-us/web/api/htmldialogelement/showmodal/index.md
@@ -22,7 +22,7 @@ the content outside it is rendered inert.
 ## Syntax
 
 ```js
-dialogInstance.showModal();
+showModal()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/htmlelement/attachinternals/index.md
+++ b/files/en-us/web/api/htmlelement/attachinternals/index.md
@@ -16,7 +16,7 @@ The **`HTMLElement.attachInternals()`** method returns a {{domxref("ElementInter
 ## Syntax
 
 ```js
-var internals = element.attachInternals();
+attachInternals()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/htmlelement/blur/index.md
+++ b/files/en-us/web/api/htmlelement/blur/index.md
@@ -17,7 +17,7 @@ removes keyboard focus from the current element.
 ## Syntax
 
 ```js
-element.blur();
+blur()
 ```
 
 ## Examples

--- a/files/en-us/web/api/htmlelement/click/index.md
+++ b/files/en-us/web/api/htmlelement/click/index.md
@@ -22,10 +22,10 @@ events.
 ## Syntax
 
 ```js
-element.click()
+click()
 ```
 
-## Example
+## Examples
 
 Simulate a mouse-click when moving the mouse pointer over a checkbox:
 

--- a/files/en-us/web/api/htmlelement/focus/index.md
+++ b/files/en-us/web/api/htmlelement/focus/index.md
@@ -22,7 +22,7 @@ the element which will receive keyboard and similar events by default.
 ## Syntax
 
 ```js
-element.focus(options);
+focus(options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/htmlelement/focus/index.md
+++ b/files/en-us/web/api/htmlelement/focus/index.md
@@ -22,6 +22,7 @@ the element which will receive keyboard and similar events by default.
 ## Syntax
 
 ```js
+focus()
 focus(options)
 ```
 

--- a/files/en-us/web/api/htmlformelement/requestsubmit/index.md
+++ b/files/en-us/web/api/htmlformelement/requestsubmit/index.md
@@ -22,7 +22,7 @@ that the form be submitted using a specific submit button.
 ## Syntax
 
 ```js
-htmlFormElement.requestSubmit(submitter);
+requestSubmit(submitter)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/htmlformelement/requestsubmit/index.md
+++ b/files/en-us/web/api/htmlformelement/requestsubmit/index.md
@@ -22,6 +22,7 @@ that the form be submitted using a specific submit button.
 ## Syntax
 
 ```js
+requestSubmit()
 requestSubmit(submitter)
 ```
 

--- a/files/en-us/web/api/htmlformelement/reset/index.md
+++ b/files/en-us/web/api/htmlformelement/reset/index.md
@@ -29,10 +29,10 @@ whatever value the {{domxref("Element.setAttribute", "setAttribute()")}} call se
 ## Syntax
 
 ```js
-HTMLFormElement.reset()
+reset()
 ```
 
-## Example
+## Examples
 
 ```js
 document.getElementById('myform').reset();

--- a/files/en-us/web/api/htmlformelement/submit/index.md
+++ b/files/en-us/web/api/htmlformelement/submit/index.md
@@ -36,10 +36,10 @@ submitted when you do it with original HTML form submit.
 ## Syntax
 
 ```js
-HTMLFormElement.submit()
+submit()
 ```
 
-## Example
+## Examples
 
 ```js
 document.forms["myform"].submit();

--- a/files/en-us/web/api/htmlimageelement/decode/index.md
+++ b/files/en-us/web/api/htmlimageelement/decode/index.md
@@ -33,7 +33,7 @@ a delay while the image loads.
 ## Syntax
 
 ```js
-var promise = HTMLImageElement.decode();
+decode()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/htmlinputelement/checkvalidity/index.md
+++ b/files/en-us/web/api/htmlinputelement/checkvalidity/index.md
@@ -19,7 +19,7 @@ The **`HTMLInputElement.checkValidity()`** method returns a boolean value which 
 ## Syntax
 
 ```js
-element.checkValidity();
+checkValidity()
 ```
 
 ### Return value

--- a/files/en-us/web/api/htmlinputelement/mozgetfilenamearray/index.md
+++ b/files/en-us/web/api/htmlinputelement/mozgetfilenamearray/index.md
@@ -23,7 +23,7 @@ an array of the names of the files that were selected by the user on an HTML
 ## Syntax
 
 ```js
-inputElement.mozGetFileNameArray(aLength, aFileNames);
+mozGetFileNameArray(aLength, aFileNames)
 ```
 
 ### Parameters
@@ -33,7 +33,7 @@ inputElement.mozGetFileNameArray(aLength, aFileNames);
 - `aFileNames`
   - : Is an array into which the file names are placed.
 
-## Example
+## Examples
 
 ```js
 var numFiles = 0;

--- a/files/en-us/web/api/htmlinputelement/reportvalidity/index.md
+++ b/files/en-us/web/api/htmlinputelement/reportvalidity/index.md
@@ -19,7 +19,7 @@ The **`reportValidity()`** method of the {{domxref('HTMLInputElement')}} interfa
 ## Syntax
 
 ```js
-element.reportValidity();
+reportValidity()
 ```
 
 ### Return value

--- a/files/en-us/web/api/htmlinputelement/select/index.md
+++ b/files/en-us/web/api/htmlinputelement/select/index.md
@@ -19,10 +19,10 @@ that includes a text field.
 ## Syntax
 
 ```js
-element.select();
+select()
 ```
 
-## Example
+## Examples
 
 Click the button in this example to select all the text in the
 `<input>` element.

--- a/files/en-us/web/api/htmlinputelement/setcustomvalidity/index.md
+++ b/files/en-us/web/api/htmlinputelement/setcustomvalidity/index.md
@@ -19,7 +19,7 @@ The **`HTMLInputElement.setCustomValidity()`** method sets a custom validity mes
 ## Syntax
 
 ```js
-element.setCustomValidity(message);
+setCustomValidity(message)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/htmlinputelement/showpicker/index.md
+++ b/files/en-us/web/api/htmlinputelement/showpicker/index.md
@@ -34,10 +34,10 @@ can also be prepopulated with items from a {{htmlelement("datalist")}} element o
 ## Syntax
 
 ```js
-element.showPicker();
+showPicker()
 ```
 
-## Example
+## Examples
 
 Click the button in this example to show a color picker.
 

--- a/files/en-us/web/api/htmlmediaelement/canplaytype/index.md
+++ b/files/en-us/web/api/htmlmediaelement/canplaytype/index.md
@@ -32,17 +32,17 @@ browser will be able to play media of a given MIME type.
 ## Syntax
 
 ```js
-canPlayResponse = audioOrVideo.canPlayType(mediaType);
+canPlayType(mediaType)
 ```
 
 ### Parameters
 
 - `mediaType`
-  - : A {{domxref("DOMString")}} containing the MIME type of the media.
+  - : A string containing the MIME type of the media.
 
 ### Return value
 
-A {{domxref("DOMString")}} indicating how likely it is that the media can be played.
+A string indicating how likely it is that the media can be played.
 The string will be one of the following values:
 
 - `probably`
@@ -54,7 +54,7 @@ The string will be one of the following values:
 - `""` (empty string)
   - : Media of the given type definitely can't be played on the current device.
 
-## Example
+## Examples
 
 ```js
 var obj = document.createElement('video');

--- a/files/en-us/web/api/htmlmediaelement/capturestream/index.md
+++ b/files/en-us/web/api/htmlmediaelement/capturestream/index.md
@@ -26,7 +26,7 @@ This can be used, for example, as a source for a [WebRTC](/en-US/docs/Web/API/We
 ## Syntax
 
 ```js
-var mediaStream = mediaElement.captureStream()
+captureStream()
 ```
 
 ### Parameters
@@ -38,7 +38,7 @@ None.
 A {{domxref('MediaStream')}} object which can be used as a source for audio and/or
 video data by other media processing code, or as a source for [WebRTC](/en-US/docs/Glossary/WebRTC).
 
-## Example
+## Examples
 
 In this example, an event handler is established so that clicking a button starts
 capturing the contents of a media element with the ID `"playback"` into a

--- a/files/en-us/web/api/htmlmediaelement/fastseek/index.md
+++ b/files/en-us/web/api/htmlmediaelement/fastseek/index.md
@@ -22,7 +22,7 @@ media to the new time with precision tradeoff.
 ## Syntax
 
 ```js
-HTMLMediaElement.fastSeek(time);
+fastSeek(time)
 ```
 
 ### Parameters
@@ -34,7 +34,7 @@ HTMLMediaElement.fastSeek(time);
 
 None.
 
-## Example
+## Examples
 
 This example quickly seeks to 20-second position of the video element.
 

--- a/files/en-us/web/api/htmlmediaelement/load/index.md
+++ b/files/en-us/web/api/htmlmediaelement/load/index.md
@@ -36,7 +36,7 @@ causing the changes to take effect.
 ## Syntax
 
 ```js
-mediaElement.load();
+load()
 ```
 
 ### Parameters
@@ -77,7 +77,7 @@ proceeds:
   **{{event("loadstart")}}** event is delivered.
 - From this point onward, events are sent just like any media load.
 
-## Example
+## Examples
 
 This example finds a {{HTMLElement("video")}} element in the document and resets it by
 calling `load()`.

--- a/files/en-us/web/api/htmlmediaelement/msinsertaudioeffect/index.md
+++ b/files/en-us/web/api/htmlmediaelement/msinsertaudioeffect/index.md
@@ -19,13 +19,13 @@ This proprietary method is specific to Internet Explorer and Microsoft Edge.
 ## Syntax
 
 ```js
-HTMLMediaElement.msInsertAudioEffect(activatableClassId: {{DOMxRef("DOMString")}}, effectRequired: {{JSxRef("Boolean", "boolean")}}, config);
+msInsertAudioEffect(activatableClassId, effectRequired, config)
 ```
 
 ### Parameters
 
 - activatableClassId
-  - : A {{DOMxRef("DOMString")}} defining the audio effects class.
+  - : A string defining the audio effects class.
 - effectRequired
   - : A {{JSxRef("Boolean")}} which if set to _true_ requires an audio effect to be
     defined.

--- a/files/en-us/web/api/htmlmediaelement/pause/index.md
+++ b/files/en-us/web/api/htmlmediaelement/pause/index.md
@@ -18,7 +18,7 @@ of the media, if the media is already in a paused state this method will have no
 ## Syntax
 
 ```js
-HTMLMediaElement.pause()
+pause()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/htmlmediaelement/play/index.md
+++ b/files/en-us/web/api/htmlmediaelement/play/index.md
@@ -26,7 +26,7 @@ permission issues, result in the promise being rejected.
 ## Syntax
 
 ```js
-var promise = HTMLMediaElement.play();
+play()
 ```
 
 ### Parameters
@@ -80,7 +80,7 @@ UI based on whether the returned promise is fulfilled or rejected. See the
 For even more in-depth information about autoplay and autoplay blocking, see our
 article [Autoplay guide for media and Web Audio APIs](/en-US/docs/Web/Media/Autoplay_guide).
 
-## Example
+## Examples
 
 This example demonstrates how to confirm that playback has begun and how to gracefully
 handle blocked automatic playback:

--- a/files/en-us/web/api/htmlmediaelement/seektonextframe/index.md
+++ b/files/en-us/web/api/htmlmediaelement/seektonextframe/index.md
@@ -40,7 +40,7 @@ happens.
 ## Syntax
 
 ```js
-seekToNextFrame();
+seekToNextFrame()
 ```
 
 ### Return value

--- a/files/en-us/web/api/htmlmediaelement/setmediakeys/index.md
+++ b/files/en-us/web/api/htmlmediaelement/setmediakeys/index.md
@@ -23,7 +23,7 @@ playback.
 ## Syntax
 
 ```js
-var Promise = HTMLMediaElement.setMediaKeys(mediaKeys);
+setMediaKeys(mediaKeys)
 ```
 
 ### Parameters
@@ -32,7 +32,7 @@ var Promise = HTMLMediaElement.setMediaKeys(mediaKeys);
   - : A reference to a {{domxref("MediaKeys")}} object that the
     {{domxref("HTMLMediaElement")}} can use for decryption of media data during playback.
 
-### Returns
+### Return value
 
 A {{jsxref("Promise")}} that resolves to the passed instance of `MediaKeys`.
 

--- a/files/en-us/web/api/htmlobjectelement/checkvalidity/index.md
+++ b/files/en-us/web/api/htmlobjectelement/checkvalidity/index.md
@@ -1,5 +1,5 @@
 ---
-title: HTMLObjectElement.checkValidity
+title: HTMLObjectElement.checkValidity()
 slug: Web/API/HTMLObjectElement/checkValidity
 tags:
   - API
@@ -21,7 +21,7 @@ is true, because object objects are never candidates for constraint validation.
 ## Syntax
 
 ```js
-const valid = HTMLObjectElement.checkValidity();
+checkValidity()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/htmlobjectelement/setcustomvalidity/index.md
+++ b/files/en-us/web/api/htmlobjectelement/setcustomvalidity/index.md
@@ -1,5 +1,5 @@
 ---
-title: HTMLObjectElement.setCustomValidity
+title: HTMLObjectElement.setCustomValidity()
 slug: Web/API/HTMLObjectElement/setCustomValidity
 tags:
   - API
@@ -20,7 +20,7 @@ element.
 ## Syntax
 
 ```js
-HTMLObjectElement.setCustomValidity(message);
+setCustomValidity(message)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/htmlscriptelement/supports/index.md
+++ b/files/en-us/web/api/htmlscriptelement/supports/index.md
@@ -20,7 +20,7 @@ The method is expected to return `true` for classic and module scripts, which ar
 ## Syntax
 
 ```js
-HTMLScriptElement.supports(type)
+supports(type)
 ```
 
 ### Parameters
@@ -28,7 +28,7 @@ HTMLScriptElement.supports(type)
 - `type`
   - : A string literal that indicates the type of script for which support is to be checked.
       Supported values are case sensitive, and include:
-  
+
     - `"classic"`: Test if _classic scripts_ are supported.
       "Classic" scripts are the normal/traditional JavaScript files that predate module scripts.
     - `"module"`: Test if [module scripts](/en-US/docs/Web/JavaScript/Guide/Modules) are supported.

--- a/files/en-us/web/api/htmlselectelement/checkvalidity/index.md
+++ b/files/en-us/web/api/htmlselectelement/checkvalidity/index.md
@@ -20,7 +20,7 @@ element, and then returns `false`.
 ## Syntax
 
 ```js
-var result = selectElt.checkValidity();
+checkValidity()
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlselectelement/nameditem/index.md
+++ b/files/en-us/web/api/htmlselectelement/nameditem/index.md
@@ -21,18 +21,18 @@ In JavaScript, using `selectElt.namedItem('value')` is equivalent to `selectElt.
 ## Syntax
 
 ```js
-var item = select.namedItem(str);
+namedItem(str)
 ```
 
 ### Parameters
 
-- `str` is a {{domxref("DOMString")}}.
+- `str` is a string.
 
 ### Return value
 
 - `item` is a {{domxref("HTMLOptionElement")}}.
 
-## Example
+## Examples
 
 ### HTML
 

--- a/files/en-us/web/api/htmlselectelement/remove/index.md
+++ b/files/en-us/web/api/htmlselectelement/remove/index.md
@@ -17,7 +17,7 @@ at the specified index from the options collection for this select element.
 ## Syntax
 
 ```js
-collection.remove(index);
+remove(index)
 ```
 
 ### Parameters
@@ -25,7 +25,7 @@ collection.remove(index);
 - `index` is a zero-based long for the index of the {{ domxref("HTMLOptionElement") }}
   to remove from the collection. If the index is not found the method has no effect.
 
-## Example
+## Examples
 
 ```html
 <select id="existingList" name="existingList">

--- a/files/en-us/web/api/htmlselectelement/setcustomvalidity/index.md
+++ b/files/en-us/web/api/htmlselectelement/setcustomvalidity/index.md
@@ -20,12 +20,12 @@ error.
 ## Syntax
 
 ```js
-selectElt.setCustomValidity(string);
+setCustomValidity(string)
 ```
 
 ### Parameters
 
-- `string` is the {{domxref("DOMString")}} containing the error message.
+- `string` is the string containing the error message.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlslotelement/assignedelements/index.md
+++ b/files/en-us/web/api/htmlslotelement/assignedelements/index.md
@@ -22,8 +22,8 @@ If the `flatten` option is set to `true`, it returns a sequence of both the elem
 ## Syntax
 
 ```js
-HTMLSlotElement.assignedElements()
-HTMLSlotElement.assignedElements(options)
+assignedElements()
+assignedElements(options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/htmlslotelement/assignednodes/index.md
+++ b/files/en-us/web/api/htmlslotelement/assignednodes/index.md
@@ -19,8 +19,8 @@ If the `flatten` option is set to `true`, it returns a sequence of both the node
 ## Syntax
 
 ```js
-HTMLSlotElement.assignedNodes()
-HTMLSlotElement.assignedNodes(options)
+assignedNodes()
+assignedNodes(options)
 ```
 
 ### Parameters


### PR DESCRIPTION
Continuing #14857 

## Summary
Updating the method pages to follow the current templates:
https://developer.mozilla.org/en-US/docs/MDN/Structures/Syntax_sections#constructors_and_methods
https://developer.mozilla.org/en-US/docs/MDN/Structures/Page_types/API_method_subpage_template

Changes Include:
- fix syntax section
- changing section titles to suggested titles in the template
- change `{{DOMxRef("DOMString")}}` to `string`
- remove extra spaces in between words and extra trailing spaces
- other small corrections

### Metadata
- [x] Fixes a typo, bug, or other error
