### PR TITLE
WebAPI: Update Method pages to modern structure (part 11)

### DIFF
--- a/files/en-us/web/api/htmltableelement/createcaption/index.md
+++ b/files/en-us/web/api/htmltableelement/createcaption/index.md
@@ -25,14 +25,14 @@ it, and then returns it.
 ## Syntax
 
 ```js
-HTMLTableElement = table.createCaption();
+createCaption()
 ```
 
 ### Return value
 
 {{domxref("HTMLTableCaptionElement")}}
 
-## Example
+## Examples
 
 This example uses JavaScript to add a caption to a table that initially lacks one.
 

--- a/files/en-us/web/api/htmltableelement/createtbody/index.md
+++ b/files/en-us/web/api/htmltableelement/createtbody/index.md
@@ -25,14 +25,14 @@ The **`createTBody()`** method of
 ## Syntax
 
 ```js
-table.createTBody();
+createTBody()
 ```
 
 ### Return value
 
 {{domxref("HTMLTableSectionElement")}}
 
-## Example
+## Examples
 
 ```js
 let mybody = mytable.createTBody();

--- a/files/en-us/web/api/htmltableelement/createtfoot/index.md
+++ b/files/en-us/web/api/htmltableelement/createtfoot/index.md
@@ -25,14 +25,14 @@ method creates it, and then returns it.
 ## Syntax
 
 ```js
-table.createTFoot();
+createTFoot()
 ```
 
 ### Return value
 
 {{domxref("HTMLTableSectionElement")}}
 
-## Example
+## Examples
 
 ```js
 let myfoot = mytable.createTFoot();

--- a/files/en-us/web/api/htmltableelement/createthead/index.md
+++ b/files/en-us/web/api/htmltableelement/createthead/index.md
@@ -25,14 +25,14 @@ method creates it, and then returns it.
 ## Syntax
 
 ```js
-table.createTHead();
+createTHead()
 ```
 
 ### Return value
 
 {{domxref("HTMLTableSectionElement")}}
 
-## Example
+## Examples
 
 ```js
 let myhead = mytable.createTHead();

--- a/files/en-us/web/api/htmltableelement/deletecaption/index.md
+++ b/files/en-us/web/api/htmltableelement/deletecaption/index.md
@@ -20,10 +20,10 @@ nothing.
 ## Syntax
 
 ```js
-HTMLTableElement.deleteCaption()
+deleteCaption()
 ```
 
-## Example
+## Examples
 
 This example uses JavaScript to delete a table's caption.
 

--- a/files/en-us/web/api/htmltableelement/deleterow/index.md
+++ b/files/en-us/web/api/htmltableelement/deleterow/index.md
@@ -18,7 +18,7 @@ specific row ({{HtmlElement("tr")}}) from a given {{HtmlElement("table")}}.
 ## Syntax
 
 ```js
-HTMLTableElement.deleteRow(index)
+deleteRow(index)
 ```
 
 ### Parameters
@@ -39,7 +39,7 @@ the number of available rows, or if it is negative and not equal to the special 
 `-1`, representing the last row of the table, the exception
 `INDEX_SIZE_ERR` is thrown.
 
-## Example
+## Examples
 
 This example uses JavaScript to delete a table's second row.
 

--- a/files/en-us/web/api/htmltableelement/deletetfoot/index.md
+++ b/files/en-us/web/api/htmltableelement/deletetfoot/index.md
@@ -18,10 +18,10 @@ The **`HTMLTableElement.deleteTFoot()`** method removes the
 ## Syntax
 
 ```js
-HTMLTableElement.deleteTFoot();
+deleteTFoot()
 ```
 
-## Example
+## Examples
 
 This example uses JavaScript to delete a table's footer.
 

--- a/files/en-us/web/api/htmltableelement/deletethead/index.md
+++ b/files/en-us/web/api/htmltableelement/deletethead/index.md
@@ -18,10 +18,10 @@ The **`HTMLTableElement.deleteTHead()`** removes the
 ## Syntax
 
 ```js
-HTMLTableElement.deleteTHead();
+deleteTHead()
 ```
 
-## Example
+## Examples
 
 This example uses JavaScript to delete a table's header.
 

--- a/files/en-us/web/api/htmltableelement/insertrow/index.md
+++ b/files/en-us/web/api/htmltableelement/insertrow/index.md
@@ -33,6 +33,7 @@ let row = specific_tbody.insertRow(index)
 ## Syntax
 
 ```js
+insertRow()
 insertRow(index)
 ```
 

--- a/files/en-us/web/api/htmltableelement/insertrow/index.md
+++ b/files/en-us/web/api/htmltableelement/insertrow/index.md
@@ -33,7 +33,7 @@ let row = specific_tbody.insertRow(index)
 ## Syntax
 
 ```js
-var newRow = HTMLTableElement.insertRow(index);
+insertRow(index)
 ```
 
 {{domxref("HTMLTableElement")}} is a reference to an HTML {{HtmlElement("table")}}
@@ -56,7 +56,7 @@ row.
 - `IndexSizeError` {{domxref("DOMException")}}
   - : Thrown if `index` is greater than the number of rows.
 
-## Example
+## Examples
 
 This example uses `insertRow(-1)` to append a new row to a table.
 

--- a/files/en-us/web/api/htmltablerowelement/insertcell/index.md
+++ b/files/en-us/web/api/htmltablerowelement/insertcell/index.md
@@ -27,7 +27,7 @@ reference to the cell.
 ## Syntax
 
 ```js
-var newCell = HTMLTableRowElement.insertCell(index);
+insertCell(index)
 ```
 
 {{domxref("HTMLTableRowElement")}} is a reference to an HTML {{HtmlElement("tr")}}
@@ -48,7 +48,7 @@ cell.
 - `IndexSizeError` {{domxref("DOMException")}}
   - : Thrown if `index` is greater than the number of cells.
 
-## Example
+## Examples
 
 This example uses {{domxref("HTMLTableElement.insertRow()")}} to append a new row to a
 table.

--- a/files/en-us/web/api/htmltablerowelement/insertcell/index.md
+++ b/files/en-us/web/api/htmltablerowelement/insertcell/index.md
@@ -27,6 +27,7 @@ reference to the cell.
 ## Syntax
 
 ```js
+insertCell()
 insertCell(index)
 ```
 

--- a/files/en-us/web/api/htmlvideoelement/getvideoplaybackquality/index.md
+++ b/files/en-us/web/api/htmlvideoelement/getvideoplaybackquality/index.md
@@ -31,7 +31,7 @@ The data returned can be used to evaluate the quality of the video stream.
 ## Syntax
 
 ```js
-videoPQ = videoElement.getVideoPlaybackQuality();
+getVideoPlaybackQuality()
 ```
 
 ### Return value
@@ -39,7 +39,7 @@ videoPQ = videoElement.getVideoPlaybackQuality();
 A {{domxref("VideoPlaybackQuality")}} object providing information about the video
 element's current playback quality.
 
-## Example
+## Examples
 
 This example updates an element to indicate the total number of video frames that have
 elapsed so far in the playback process. This value includes any dropped or corrupted

--- a/files/en-us/web/api/htmlvideoelement/msframestep/index.md
+++ b/files/en-us/web/api/htmlvideoelement/msframestep/index.md
@@ -19,7 +19,7 @@ This proprietary method is specific to Internet Explorer and Microsoft Edge.
 ## Syntax
 
 ```js
-HTMLVideoElement.msFrameStep(forward);
+msFrameStep(forward)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/htmlvideoelement/msinsertvideoeffect/index.md
+++ b/files/en-us/web/api/htmlvideoelement/msinsertvideoeffect/index.md
@@ -19,13 +19,13 @@ This proprietary method is specific to Internet Explorer and Microsoft Edge.
 ## Syntax
 
 ```js
-str = HTMLMediaElement.msInsertVideoEffect(activatableClassId: {{DOMxRef("DOMString")}}, effectRequired: {{JSxRef("Boolean", "boolean")}}, config);
+msInsertVideoEffect(activatableClassId, effectRequired, config)
 ```
 
 ### Parameters
 
 - activatableClassId
-  - : A {{DOMxRef("DOMString")}} defining the video effects class.
+  - : A string defining the video effects class.
 - effectRequired
   - : A {{JSxRef("Boolean")}} which if set to
     _true_ requires a video effect to be defined.
@@ -37,7 +37,7 @@ str = HTMLMediaElement.msInsertVideoEffect(activatableClassId: {{DOMxRef("DOMStr
 
 This method does not return a value.
 
-## Example
+## Examples
 
 ```js
 var oVideo1 = document.getElementById("video1");

--- a/files/en-us/web/api/htmlvideoelement/msinsertvideoeffect/index.md
+++ b/files/en-us/web/api/htmlvideoelement/msinsertvideoeffect/index.md
@@ -19,6 +19,7 @@ This proprietary method is specific to Internet Explorer and Microsoft Edge.
 ## Syntax
 
 ```js
+msInsertVideoEffect(activatableClassId, effectRequired)
 msInsertVideoEffect(activatableClassId, effectRequired, config)
 ```
 

--- a/files/en-us/web/api/htmlvideoelement/requestpictureinpicture/index.md
+++ b/files/en-us/web/api/htmlvideoelement/requestpictureinpicture/index.md
@@ -29,7 +29,7 @@ video will receive a {{domxref("HTMLVideoElement.enterpictureinpicture_event",
 ## Syntax
 
 ```js
-videoElement.requestPictureInPicture();
+requestPictureInPicture()
 ```
 
 ### Return value

--- a/files/en-us/web/api/idbcursor/advance/index.md
+++ b/files/en-us/web/api/idbcursor/advance/index.md
@@ -23,7 +23,7 @@ its position forward.
 ## Syntax
 
 ```js
-cursor.advance(count);
+advance(count)
 ```
 
 ### Parameters
@@ -42,7 +42,7 @@ This method may raise a {{domxref("DOMException")}} of one of the following type
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the cursor is currently being iterated or has iterated past its end.
 
-## Example
+## Examples
 
 In this simple fragment we create a transaction, retrieve an object store, then use a
 cursor to iterate through the records in the object store. Here we use

--- a/files/en-us/web/api/idbcursor/continue/index.md
+++ b/files/en-us/web/api/idbcursor/continue/index.md
@@ -24,6 +24,7 @@ advances to the immediate next position, based on its direction.
 ## Syntax
 
 ```js
+continue()
 continue(key)
 ```
 

--- a/files/en-us/web/api/idbcursor/continue/index.md
+++ b/files/en-us/web/api/idbcursor/continue/index.md
@@ -24,7 +24,7 @@ advances to the immediate next position, based on its direction.
 ## Syntax
 
 ```js
-cursor.continue(key);
+continue(key)
 ```
 
 ### Parameters
@@ -46,7 +46,7 @@ This method may raise a {{domxref("DOMException")}} of one of the following type
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the cursor is currently being iterated or has iterated past its end.
 
-## Example
+## Examples
 
 In this simple fragment we create a transaction, retrieve an object store, then use a
 cursor to iterate through all the records in the object store. The cursor does not

--- a/files/en-us/web/api/idbcursor/continueprimarykey/index.md
+++ b/files/en-us/web/api/idbcursor/continueprimarykey/index.md
@@ -34,7 +34,7 @@ from an object store will throw an error.
 ## Syntax
 
 ```js
-cursor.continuePrimaryKey(key, primaryKey);
+continuePrimaryKey(key, primaryKey)
 ```
 
 ### Parameters
@@ -60,7 +60,7 @@ This method may raise a {{domxref("DOMException")}} of one of the following type
 - `InvalidAccessError` {{domxref("DOMException")}}
   - : Thrown if the cursor's direction is not `prev` or `next`.
 
-## Example
+## Examples
 
 here's how you can resume an iteration of all articles tagged with
 `"javascript"` since your last visit:

--- a/files/en-us/web/api/idbcursor/delete/index.md
+++ b/files/en-us/web/api/idbcursor/delete/index.md
@@ -29,10 +29,10 @@ Be aware that you can't call `delete()` (or
 ## Syntax
 
 ```js
-myIDBCursor.delete();
+delete()
 ```
 
-### Returns
+### Return value
 
 An {{domxref("IDBRequest")}} object on which subsequent events related to this
 operation are fired. The result attribute is set to undefined.
@@ -48,7 +48,7 @@ This method may raise a {{domxref("DOMException")}} of one of the following type
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the cursor was created using {{domxref("IDBindex.openKeyCursor")}}, is currently being iterated, or has iterated past its end.
 
-## Example
+## Examples
 
 In this simple fragment we create a transaction, retrieve an object store, then use a
 cursor to iterate through all the records in the object store. If the

--- a/files/en-us/web/api/idbcursor/update/index.md
+++ b/files/en-us/web/api/idbcursor/update/index.md
@@ -29,7 +29,7 @@ Be aware that you can't call `update()` (or
 ## Syntax
 
 ```js
-var anIDBRequest = myIDBCursor.update(value);
+update(value)
 ```
 
 ### Parameters
@@ -59,7 +59,7 @@ This method may raise a {{domxref("DOMException")}} of one of the following type
   - : Thrown if the data being stored could not be cloned by the internal structured
         cloning algorithm.
 
-## Example
+## Examples
 
 In this simple fragment we create a transaction, retrieve an object store, then use a
 cursor to iterate through all the records in the object store. If the

--- a/files/en-us/web/api/idbdatabase/close/index.md
+++ b/files/en-us/web/api/idbdatabase/close/index.md
@@ -26,10 +26,10 @@ operation is pending.
 ## Syntax
 
 ```js
-IDBDatabase.close();
+close()
 ```
 
-## Example
+## Examples
 
 ```js
 // Let us open our database

--- a/files/en-us/web/api/idbdatabase/createobjectstore/index.md
+++ b/files/en-us/web/api/idbdatabase/createobjectstore/index.md
@@ -29,8 +29,8 @@ transaction.
 ## Syntax
 
 ```js
-IDBDatabase.createObjectStore(name);
-IDBDatabase.createObjectStore(name, options);
+createObjectStore(name)
+createObjectStore(name, options)
 ```
 
 ### Parameters
@@ -81,7 +81,7 @@ IDBDatabase.createObjectStore(name, options);
 
     Unknown parameters are ignored.
 
-### Returns
+### Return value
 
 A new {{domxref("IDBObjectStore")}}.
 
@@ -105,7 +105,7 @@ one of the following types:
   - : Thrown if `autoIncrement` is set to true and `keyPath` is
         either an empty string or an array containing an empty string.
 
-## Example
+## Examples
 
 ```js
 // Let us open our database

--- a/files/en-us/web/api/idbdatabase/createobjectstore/index.md
+++ b/files/en-us/web/api/idbdatabase/createobjectstore/index.md
@@ -38,7 +38,7 @@ createObjectStore(name, options)
 - `name`
   - : The name of the new object store to be created. Note that it is possible to create
     an object store with an empty name.
-- `optionalParameters` {{optional_inline}}
+- `options` {{optional_inline}}
 
   - : An options object whose attributes are optional parameters to the method. It
     includes the following properties:

--- a/files/en-us/web/api/idbdatabase/deleteobjectstore/index.md
+++ b/files/en-us/web/api/idbdatabase/deleteobjectstore/index.md
@@ -26,7 +26,7 @@ transaction.
 ## Syntax
 
 ```js
-dbInstance.deleteObjectStore(name);
+deleteObjectStore(name)
 ```
 
 ### Parameters
@@ -44,7 +44,7 @@ dbInstance.deleteObjectStore(name);
 - `NotFoundError` {{domxref("DOMException")}}
   - : Thrown when trying to delete an object store that does not exist.
 
-## Example
+## Examples
 
 ```js
 var dbName = "sampleDB";

--- a/files/en-us/web/api/idbdatabase/transaction/index.md
+++ b/files/en-us/web/api/idbdatabase/transaction/index.md
@@ -23,9 +23,9 @@ object store.
 ## Syntax
 
 ```js
-IDBDatabase.transaction(storeNames);
-IDBDatabase.transaction(storeNames, mode);
-IDBDatabase.transaction(storeNames, mode, options);
+transaction(storeNames)
+transaction(storeNames, mode)
+transaction(storeNames, mode, options)
 ```
 
 ### Parameters
@@ -115,7 +115,7 @@ An {{domxref("IDBTransaction")}} object.
 - `InvalidAccessError` {{domxref("DOMException")}}
   - : Thrown if the function was called with an empty list of store names.
 
-## Example
+## Examples
 
 In this example we open a database connection, then use transaction() to open a
 transaction on the database. For a complete example, see our

--- a/files/en-us/web/api/idbfactory/cmp/index.md
+++ b/files/en-us/web/api/idbfactory/cmp/index.md
@@ -30,7 +30,7 @@ operations, such as storing and iterating.
 ## Syntax
 
 ```js
-var result = indexedDB.cmp(first, second);
+cmp(first, second)
 ```
 
 ### Parameters
@@ -59,7 +59,7 @@ This method may raise a {{domxref("DOMException")}} of the following types:
 | ------------------------------------------- | --------------------------------------------- |
 | [`DataError`](/en-US/docs/Web/API/DOMError) | One of the supplied keys was not a valid key. |
 
-## Example
+## Examples
 
 ```js
 var a = 1;

--- a/files/en-us/web/api/idbfactory/databases/index.md
+++ b/files/en-us/web/api/idbfactory/databases/index.md
@@ -1,5 +1,5 @@
 ---
-title: IDBFactory.databases
+title: IDBFactory.databases()
 slug: Web/API/IDBFactory/databases
 tags:
   - API
@@ -22,7 +22,7 @@ The **`databases`** method of the {{domxref("IDBFactory")}} interface returns a 
 ## Syntax
 
 ```js
-const promise = indexedDB.databases()
+databases()
 ```
 
 ### Parameters
@@ -47,7 +47,7 @@ This method may raise a {{domxref("DOMException")}} of the following types:
 | {{exception("SecurityError")}} | The method is called from an opaque origin.          |
 | Other error                              | Specification does not describe all possible errors. |
 
-## Example
+## Examples
 
 ```js
 const promise = indexedDB.databases()

--- a/files/en-us/web/api/idbindex/count/index.md
+++ b/files/en-us/web/api/idbindex/count/index.md
@@ -23,8 +23,8 @@ returns the number of records within a key range.
 ## Syntax
 
 ```js
-var request = myIndex.count();
-var request = myIndex.count(key);
+count()
+count(key)
 ```
 
 ### Parameters
@@ -48,7 +48,7 @@ This method may raise a {{domxref("DOMException")}} of one of the following type
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the {{domxref("IDBIndex")}} has been deleted or removed.
 
-## Example
+## Examples
 
 In the following example we open a transaction and an object store, then get the
 index `lName` from a simple contacts database. We then open a basic cursor on

--- a/files/en-us/web/api/idbindex/get/index.md
+++ b/files/en-us/web/api/idbindex/get/index.md
@@ -28,6 +28,7 @@ with.
 ## Syntax
 
 ```js
+get()
 get(key)
 ```
 

--- a/files/en-us/web/api/idbindex/get/index.md
+++ b/files/en-us/web/api/idbindex/get/index.md
@@ -28,7 +28,7 @@ with.
 ## Syntax
 
 ```js
-var request = myIndex.get(key);
+get(key)
 ```
 
 ### Parameters
@@ -53,7 +53,7 @@ This method may raise a {{domxref("DOMException")}} of one of the following type
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the {{domxref("IDBIndex")}} has been deleted or removed.
 
-## Example
+## Examples
 
 In the following example we open a transaction and an object store, then get the
 index `lName` from a simple contacts database. We then open a basic cursor on

--- a/files/en-us/web/api/idbindex/getall/index.md
+++ b/files/en-us/web/api/idbindex/getall/index.md
@@ -26,9 +26,9 @@ use `getAll()`.
 ## Syntax
 
 ```js
-var getAllKeysRequest = IDBIndex.getAll();
-var getAllKeysRequest = IDBIndex.getAll(query);
-var getAllKeysRequest = IDBIndex.getAll(query, count);
+getAll()
+getAll(query)
+getAll(query, count)
 ```
 
 ### Parameters
@@ -59,7 +59,7 @@ This method may raise a {{domxref("DOMException")}} of the following types:
 A {{jsxref("TypeError")}} exception is thrown if the `count` parameter is
 not between `0` and `2^32> - 1` included.
 
-## Example
+## Examples
 
 ```js
 var myIndex = objectStore.index('index');

--- a/files/en-us/web/api/idbindex/getallkeys/index.md
+++ b/files/en-us/web/api/idbindex/getallkeys/index.md
@@ -18,9 +18,9 @@ setting them as the `result` of the request object.
 ## Syntax
 
 ```js
-var allKeysRequest = IDBIndex.getAllKeys();
-var allKeysRequest = IDBIndex.getAllKeys(query);
-var allKeysRequest = IDBIndex.getAllKeys(query, count);
+getAllKeys()
+getAllKeys(query)
+getAllKeys(query, count)
 ```
 
 ### Parameters
@@ -51,7 +51,7 @@ This method may raise a {{domxref("DOMException")}} of the following types:
 A {{jsxref("TypeError")}} exception is thrown if the `count` parameter is
 not between `0` and `2^32 - 1` included.
 
-## Example
+## Examples
 
 ```js
 var myIndex = objectStore.index('index');

--- a/files/en-us/web/api/idbindex/getkey/index.md
+++ b/files/en-us/web/api/idbindex/getkey/index.md
@@ -27,6 +27,7 @@ Note that this doesn't return the whole record as {{domxref("IDBIndex.get")}} do
 ## Syntax
 
 ```js
+getKey()
 getKey(key)
 ```
 

--- a/files/en-us/web/api/idbindex/getkey/index.md
+++ b/files/en-us/web/api/idbindex/getkey/index.md
@@ -27,7 +27,7 @@ Note that this doesn't return the whole record as {{domxref("IDBIndex.get")}} do
 ## Syntax
 
 ```js
-var request = myIndex.getKey(key);
+getKey(key)
 ```
 
 ### Parameters
@@ -52,7 +52,7 @@ This method may raise a {{domxref("DOMException")}} of one of the following type
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the {{domxref("IDBIndex")}} has been deleted or removed.
 
-## Example
+## Examples
 
 In the following example we open a transaction and an object store, then get the
 index `lName` from a simple contacts database. We then open a basic cursor on

--- a/files/en-us/web/api/idbindex/opencursor/index.md
+++ b/files/en-us/web/api/idbindex/opencursor/index.md
@@ -29,9 +29,9 @@ If the key range is not specified or is null, then the range includes all the re
 ## Syntax
 
 ```js
-var request = myIndex.openCursor();
-var request = myIndex.openCursor(range);
-var request = myIndex.openCursor(range, direction);
+openCursor()
+openCursor(range)
+openCursor(range, direction)
 ```
 
 ### Parameters
@@ -62,7 +62,7 @@ This method may raise a {{domxref("DOMException")}} of one of the following type
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the {{domxref("IDBIndex")}} has been deleted or removed.
 
-## Example
+## Examples
 
 In the following example we open a transaction and an object store, then get the
 index `lName` from a simple contacts database. We then open a basic cursor on

--- a/files/en-us/web/api/idbindex/openkeycursor/index.md
+++ b/files/en-us/web/api/idbindex/openkeycursor/index.md
@@ -33,9 +33,9 @@ If the key range is not specified or is null, then the range includes all the ke
 ## Syntax
 
 ```js
-var request = myIndex.openKeyCursor();
-var request = myIndex.openKeyCursor(range);
-var request = myIndex.openKeyCursor(range, direction);
+openKeyCursor()
+openKeyCursor(range)
+openKeyCursor(range, direction)
 ```
 
 ### Parameters
@@ -66,7 +66,7 @@ This method may raise a {{domxref("DOMException")}} of one of the following type
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the {{domxref("IDBIndex")}} has been deleted or removed.
 
-## Example
+## Examples
 
 In the following example we open a transaction and an object store, then get the
 index `lName` from a simple contacts database. We then open a key cursor on

--- a/files/en-us/web/api/idbkeyrange/bound/index.md
+++ b/files/en-us/web/api/idbkeyrange/bound/index.md
@@ -24,9 +24,9 @@ is, the bounds include the endpoint values). By default, the bounds are closed.
 ## Syntax
 
 ```js
-var myIDBKeyRange = IDBKeyRange.bound(lower, upper);
-var myIDBKeyRange = IDBKeyRange.bound(lower, upper, lowerOpen);
-var myIDBKeyRange = IDBKeyRange.bound(lower, upper, lowerOpen, upperOpen);
+bound(lower, upper)
+bound(lower, upper, lowerOpen)
+bound(lower, upper, lowerOpen, upperOpen)
 ```
 
 ### Parameters
@@ -75,7 +75,7 @@ the following type:
   </tbody>
 </table>
 
-## Example
+## Examples
 
 The following example illustrates how you'd use a bound key range. Here we declare
 a `keyRangeValue = IDBKeyRange.bound("A", "F");` — a range between values of
@@ -83,7 +83,7 @@ a `keyRangeValue = IDBKeyRange.bound("A", "F");` — a range between values of
 store, and open a Cursor with {{domxref("IDBObjectStore.openCursor")}},
 declaring `keyRangeValue` as its optional key range value. This means that
 the cursor will only retrieve records with keys inside that range. This range includes
-the values "A" and "F", as we haven't declared that they should be open  bounds. If we
+the values "A" and "F", as we haven't declared that they should be open bounds. If we
 used `IDBKeyRange.bound("A", "F", true, true);`, then the range would not
 include `"A"` and `"F"`, only the values between them.
 

--- a/files/en-us/web/api/idbkeyrange/includes/index.md
+++ b/files/en-us/web/api/idbkeyrange/includes/index.md
@@ -23,7 +23,7 @@ range.
 ## Syntax
 
 ```js
-var isIncluded = myKeyRange.includes(key)
+includes(key)
 ```
 
 ### Parameters
@@ -42,7 +42,7 @@ This method may raise a {{domxref("DOMException")}} of the following type:
 | ------------------------------------------- | ------------------------------------- |
 | [`DataError`](/en-US/docs/Web/API/DOMError) | The supplied key was not a valid key. |
 
-## Example
+## Examples
 
 ```js
 var keyRangeValue = IDBKeyRange.bound('A', 'K', false, false);

--- a/files/en-us/web/api/idbkeyrange/lowerbound/index.md
+++ b/files/en-us/web/api/idbkeyrange/lowerbound/index.md
@@ -23,8 +23,8 @@ By default, it includes the lower endpoint value and is closed.
 ## Syntax
 
 ```js
-var myIDBKeyRange = IDBKeyRange.lowerBound(lower);
-var myIDBKeyRange = IDBKeyRange.lowerBound(lower, open);
+lowerBound(lower)
+lowerBound(lower, open)
 ```
 
 ### Parameters
@@ -47,7 +47,7 @@ This method may raise a {{domxref("DOMException")}} of the following type:
 | ----------- | ----------------------------------------------- |
 | `DataError` | The value parameter passed was not a valid key. |
 
-## Example
+## Examples
 
 The following example illustrates how you'd use a lower bound key range. Here we
 declare `keyRangeValue = IDBKeyRange.lowerBound("F", false);` — a range that

--- a/files/en-us/web/api/idbkeyrange/only/index.md
+++ b/files/en-us/web/api/idbkeyrange/only/index.md
@@ -22,7 +22,7 @@ interface creates a new key range containing a single value.
 ## Syntax
 
 ```js
-var myIDBKeyRange = IDBKeyRange.only(value);
+only(value)
 ```
 
 ### Parameters
@@ -41,7 +41,7 @@ This method may raise a {{domxref("DOMException")}} of the following types:
 | ----------- | ----------------------------------------------- |
 | `DataError` | The value parameter passed was not a valid key. |
 
-## Example
+## Examples
 
 The following example illustrates how you'd use an only key range. Here we declare
 a `keyRangeValue = IDBKeyRange.only("A");` — a range that only includes the

--- a/files/en-us/web/api/idbmutablefile/getfile/index.md
+++ b/files/en-us/web/api/idbmutablefile/getfile/index.md
@@ -19,10 +19,10 @@ file in the form of a {{domxref("File")}} object.
 ## Syntax
 
 ```js
-var request = instanceOfFileHandle.getFile();
+getFile()
 ```
 
-### Return
+### Return value
 
 A {{domxref("DOMRequest")}} object. In case of success, the request's
 `result` is a {{domxref("File")}} object.

--- a/files/en-us/web/api/idbmutablefile/open/index.md
+++ b/files/en-us/web/api/idbmutablefile/open/index.md
@@ -19,7 +19,7 @@ safely write in the file.
 ## Syntax
 
 ```js
-var myFile = instanceOfFileHandle.open(mode);
+open(mode)
 ```
 
 ### Parameters
@@ -28,7 +28,7 @@ var myFile = instanceOfFileHandle.open(mode);
   - : A string that specifies the writing mode for the file. It can be
     `readonly` or `readwrite`.
 
-### Return
+### Return value
 
 A {{domxref("LockedFile")}} object.
 

--- a/files/en-us/web/api/idbobjectstore/add/index.md
+++ b/files/en-us/web/api/idbobjectstore/add/index.md
@@ -32,8 +32,8 @@ object. For updating existing records, you should use the
 ## Syntax
 
 ```js
-var request = objectStore.add(value);
-var request = objectStore.add(value, key);
+add(value)
+add(value, key)
 ```
 
 ### Parameters
@@ -43,7 +43,7 @@ var request = objectStore.add(value, key);
 - key {{optional_inline}}
   - : The key to use to identify the record. If unspecified, it results to null.
 
-### Returns
+### Return value
 
 An {{domxref("IDBRequest")}} object on which
 subsequent events related to this operation are fired.
@@ -72,7 +72,7 @@ one of the following types:
         violated (due to an already existing record with the same primary key
         value).
 
-## Example
+## Examples
 
 In the following code snippet, we open a read/write transaction on our database and add
 some data to an object store using `add()`. Note also the functions attached

--- a/files/en-us/web/api/idbobjectstore/clear/index.md
+++ b/files/en-us/web/api/idbobjectstore/clear/index.md
@@ -29,10 +29,10 @@ or {{domxref("IDBKeyRange")}}.
 ## Syntax
 
 ```js
-var request = objectStore.clear();
+clear()
 ```
 
-### Returns
+### Return value
 
 An {{domxref("IDBRequest")}} object on which subsequent events related to this
 operation are fired.
@@ -68,7 +68,7 @@ This method may raise a {{domxref("DOMException")}} of one of the following type
   </tbody>
 </table>
 
-## Example
+## Examples
 
 In the following code snippet, we open a read/write transaction on our database and
 clear all the current data out of the object store using `clear()`. For a

--- a/files/en-us/web/api/idbobjectstore/count/index.md
+++ b/files/en-us/web/api/idbobjectstore/count/index.md
@@ -25,8 +25,8 @@ of records in the store.
 ## Syntax
 
 ```js
-var request = ObjectStore.count();
-var request = ObjectStore.count(query);
+count()
+count(query)
 ```
 
 ### Parameters
@@ -51,7 +51,7 @@ This method may raise a {{domxref("DOMException")}} of one of the following type
 - `DataError` {{domxref("DOMException")}}
   - : Thrown if the specified key or key range is invalid.
 
-## Example
+## Examples
 
 In this simple fragment we create a transaction, retrieve an object store, then count
 the number of records in the store using `count()` — when the success handler

--- a/files/en-us/web/api/idbobjectstore/createindex/index.md
+++ b/files/en-us/web/api/idbobjectstore/createindex/index.md
@@ -32,8 +32,8 @@ mode callback.
 ## Syntax
 
 ```js
-var myIDBIndex = objectStore.createIndex(indexName, keyPath);
-var myIDBIndex = objectStore.createIndex(indexName, keyPath, objectParameters);
+createIndex(indexName, keyPath)
+createIndex(indexName, keyPath, objectParameters)
 ```
 
 ### Parameters
@@ -128,7 +128,7 @@ This method may raise a {{domxref("DOMException")}} of one of the following type
         this case as well, which was misleading; this has now been fixed (see
         {{Bug("1176165")}}.)
 
-## Example
+## Examples
 
 In the following example you can see
 the {{domxref("IDBOpenDBRequest.upgradeneeded_event", "onupgradeneeded")}} handler being used to update the

--- a/files/en-us/web/api/idbobjectstore/delete/index.md
+++ b/files/en-us/web/api/idbobjectstore/delete/index.md
@@ -28,7 +28,6 @@ record — without having to explicitly look up the record's key.
 
 ```js
 delete(Key)
-delete(Key)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/idbobjectstore/delete/index.md
+++ b/files/en-us/web/api/idbobjectstore/delete/index.md
@@ -28,7 +28,7 @@ record — without having to explicitly look up the record's key.
 
 ```js
 delete(Key)
-delete(KeyRange)
+delete(Key)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/idbobjectstore/delete/index.md
+++ b/files/en-us/web/api/idbobjectstore/delete/index.md
@@ -27,9 +27,8 @@ record — without having to explicitly look up the record's key.
 ## Syntax
 
 ```js
-var request = objectStore.delete(Key);
-
-var request = objectStore.delete(KeyRange);
+delete(Key)
+delete(KeyRange)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/idbobjectstore/deleteindex/index.md
+++ b/files/en-us/web/api/idbobjectstore/deleteindex/index.md
@@ -27,7 +27,7 @@ mode callback. Note that this method synchronously modifies the
 ## Syntax
 
 ```js
-objectStore.deleteIndex(indexName);
+deleteIndex(indexName)
 ```
 
 ### Parameters
@@ -48,7 +48,7 @@ None.
 - `NotFoundError` {{domxref("DOMException")}}
   - : Thrown if there is no index with the given name (case-sensitive) in the database.
 
-## Example
+## Examples
 
 In the following example you can see
 the {{domxref("IDBOpenDBRequest.upgradeneeded_event", "onupgradeneeded")}} handler being used to update the

--- a/files/en-us/web/api/idbobjectstore/get/index.md
+++ b/files/en-us/web/api/idbobjectstore/get/index.md
@@ -30,7 +30,7 @@ request object.
 ## Syntax
 
 ```js
-var request = objectStore.get(key);
+get(key)
 ```
 
 ### Parameters
@@ -54,12 +54,12 @@ This method may raise a {{domxref("DOMException")}} of one of the following type
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the {{domxref("IDBObjectStore")}} has been deleted or removed.
 
-## Example
+## Examples
 
 In the following code snippet, we open a read/write transaction on our database and get
 one specific record from object store using `get()` — a sample record with
 the key "Walk dog". Once this data object is retrieved, you could then update it using
-normal JavaScript, then put it back into the database using  a
+normal JavaScript, then put it back into the database using a
 {{domxref("IDBObjectStore.put")}} operation. For a full working example, see our [To-do Notifications](https://github.com/mdn/to-do-notifications/) app
 ([view
 example live](https://mdn.github.io/to-do-notifications/).)

--- a/files/en-us/web/api/idbobjectstore/getall/index.md
+++ b/files/en-us/web/api/idbobjectstore/getall/index.md
@@ -37,9 +37,9 @@ To tell these situations apart, you either call
 ## Syntax
 
 ```js
-var request = objectStore.getAll();
-var request = objectStore.getAll(query);
-var request = objectStore.getAll(query, count);
+getAll()
+getAll(query)
+getAll(query, count)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/idbobjectstore/getallkeys/index.md
+++ b/files/en-us/web/api/idbobjectstore/getallkeys/index.md
@@ -32,9 +32,9 @@ method provides a cursor if the record exists, and no cursor if it does not.
 ## Syntax
 
 ```js
-var request = objectStore.getAllKeys();
-var request = objectStore.getAllKeys(query);
-var request = objectStore.getAllKeys(query, count);
+getAllKeys()
+getAllKeys(query)
+getAllKeys(query, count)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/idbobjectstore/index/index.md
+++ b/files/en-us/web/api/idbobjectstore/index/index.md
@@ -24,7 +24,7 @@ to, for example, return a series of records sorted by that index using a cursor.
 ## Syntax
 
 ```js
-var index = objectStore.index(name);
+index(name)
 ```
 
 ### Parameters
@@ -43,7 +43,7 @@ An {{domxref("IDBIndex")}} object for accessing the index.
 - `NotFoundError` {{domxref("DOMException")}}
   - : Thrown if there is no index with the given name (case-sensitive) in the database.
 
-## Example
+## Examples
 
 In the following example we open a transaction and an object store, then get the index
 `lName` from a simple contacts database. We then open a basic cursor on the

--- a/files/en-us/web/api/idbobjectstore/opencursor/index.md
+++ b/files/en-us/web/api/idbobjectstore/opencursor/index.md
@@ -27,9 +27,9 @@ To determine if the add operation has completed successfully, listen for the res
 ## Syntax
 
 ```js
-var request = ObjectStore.openCursor();
-var request = ObjectStore.openCursor(query);
-var request = ObjectStore.openCursor(query, direction);
+openCursor()
+openCursor(query)
+openCursor(query, direction)
 ```
 
 ### Parameters
@@ -59,7 +59,7 @@ This method may raise a {{domxref("DOMException")}} of one of the following type
 - `DataError` {{domxref("DOMException")}}
   - : Thrown if the specified key or key range is invalid.
 
-## Example
+## Examples
 
 In this simple fragment we create a transaction, retrieve an object store, then use a
 cursor to iterate through all the records in the object store:

--- a/files/en-us/web/api/idbobjectstore/openkeycursor/index.md
+++ b/files/en-us/web/api/idbobjectstore/openkeycursor/index.md
@@ -25,9 +25,9 @@ results's `success` event.
 ## Syntax
 
 ```js
-var request = objectStore.openKeyCursor();
-var request = objectStore.openKeyCursor(query);
-var request = objectStore.openKeyCursor(query, direction);
+openKeyCursor()
+openKeyCursor(query)
+openKeyCursor(query, direction)
 ```
 
 ### Parameters
@@ -57,7 +57,7 @@ This method may raise a {{domxref("DOMException")}} of one of the following type
 - `DataError` {{domxref("DOMException")}}
   - : Thrown if the specified key or key range is invalid.
 
-## Example
+## Examples
 
 In this simple fragment we create a transaction, retrieve an object store, then use a
 cursor to iterate through all the records in the object store:

--- a/files/en-us/web/api/idbobjectstore/put/index.md
+++ b/files/en-us/web/api/idbobjectstore/put/index.md
@@ -31,8 +31,8 @@ record will be updated, instead of a new record being inserted.
 ## Syntax
 
 ```js
-let request = objectStore.put(item);
-let request = objectStore.put(item, key);
+put(item)
+put(item, key)
 ```
 
 ### Parameters
@@ -70,7 +70,7 @@ This method may raise a {{domxref("DOMException")}} of one of the following type
 - `DataCloneError` {{domxref("DOMException")}}
   - : Thrown if the data being stored could not be cloned by the internal structured cloning algorithm.
 
-## Parameters
+### Parameters
 
 - value
   - : The value to be stored.
@@ -79,7 +79,7 @@ This method may raise a {{domxref("DOMException")}} of one of the following type
     object store has a key generator (e.g. autoincrement) the key of the object must be
     passed in to update the object.
 
-## Example
+## Examples
 
 The following example requests a given record title; when that request is successful
 the `onsuccess` function gets the associated record from the

--- a/files/en-us/web/api/idbtransaction/abort/index.md
+++ b/files/en-us/web/api/idbtransaction/abort/index.md
@@ -26,7 +26,7 @@ their {{domxref("IDBRequest.error")}} attribute set to {{exception("AbortError")
 ## Syntax
 
 ```js
-transaction.abort();
+abort()
 ```
 
 ### Exceptions
@@ -34,7 +34,7 @@ transaction.abort();
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the transaction has already been committed or aborted.
 
-## Example
+## Examples
 
 In the following code snippet, we open a read/write transaction on our database and add
 some data to an object store. Note also the functions attached to transaction event

--- a/files/en-us/web/api/idbtransaction/commit/index.md
+++ b/files/en-us/web/api/idbtransaction/commit/index.md
@@ -23,7 +23,7 @@ If it is called on a transaction that is not active, it throws an {{exception("I
 ## Syntax
 
 ```js
-transaction.commit();
+commit()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/idbtransaction/objectstore/index.md
+++ b/files/en-us/web/api/idbtransaction/objectstore/index.md
@@ -27,7 +27,7 @@ transaction object, a different {{domxref("IDBObjectStore")}} instance is return
 ## Syntax
 
 ```js
-IDBTransaction.objectStore(name);
+objectStore(name)
 ```
 
 ### Parameters
@@ -46,7 +46,7 @@ An {{domxref("IDBObjectStore")}} object for accessing an object store.
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the request was made on a source object that has been deleted or removed, or if the transaction has finished.
 
-## Example
+## Examples
 
 In the following code snippet, we open a read/write transaction on our database and add
 some data to an object store. Note also the functions attached to transaction event

--- a/files/en-us/web/api/idledeadline/timeremaining/index.md
+++ b/files/en-us/web/api/idledeadline/timeremaining/index.md
@@ -27,7 +27,7 @@ should return control to the user agent's event loop.
 ## Syntax
 
 ```js
-timeRemaining = IdleDeadline.timeRemaining();
+timeRemaining()
 ```
 
 ### Return value
@@ -39,7 +39,7 @@ idle period. The value is ideally accurate to within about 5 microseconds.
 If the {{domxref("IdleDeadline")}} object's {{domxref("IdleDeadline.didTimeout",
   "didTimeout")}} property is true, this method returns zero.
 
-## Example
+## Examples
 
 See our [complete example](/en-US/docs/Web/API/Background_Tasks_API#example)
 in the article [Cooperative Scheduling

--- a/files/en-us/web/api/idledetector/requestpermission/index.md
+++ b/files/en-us/web/api/idledetector/requestpermission/index.md
@@ -19,14 +19,14 @@ whether to grant the origin access to their idle state. Resolves with
 ## Syntax
 
 ```js
-IdleDetector.requestPermission()
+requestPermission()
 ```
 
 ### Parameters
 
 None.
 
-### Return Value
+### Return value
 
 A `Promise` that resolves with `"granted"` or `"denied"`.
 

--- a/files/en-us/web/api/idledetector/start/index.md
+++ b/files/en-us/web/api/idledetector/start/index.md
@@ -21,8 +21,8 @@ the idle detector.
 ## Syntax
 
 ```js
-IdleDetector.start();
-IdleDetector.start(options);
+start()
+start(options)
 ```
 
 ### Parameters
@@ -32,7 +32,7 @@ IdleDetector.start(options);
     - `threshold`: The minimum number of idle milliseconds before reporting should begin.
     - `signal`: A reference to an {{domxref('AbortSignal')}} instance allowing you to abort idle detection.
 
-### Return Value
+### Return value
 
 A {{jsxref("Promise")}}.
 

--- a/files/en-us/web/api/iirfilternode/getfrequencyresponse/index.md
+++ b/files/en-us/web/api/iirfilternode/getfrequencyresponse/index.md
@@ -26,7 +26,7 @@ must be the same size as the array of input frequency values
 ## Syntax
 
 ```js
-IIRFilterNode.getFrequencyResponse(frequencyArray, magResponseOutput, phaseResponseOutput);
+getFrequencyResponse(frequencyArray, magResponseOutput, phaseResponseOutput)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/imagebitmap/close/index.md
+++ b/files/en-us/web/api/imagebitmap/close/index.md
@@ -18,7 +18,7 @@ method disposes of all graphical resources associated with an `ImageBitmap`.
 ## Syntax
 
 ```js
-void ImageBitmap.close()
+close()
 ```
 
 ## Examples

--- a/files/en-us/web/api/imagebitmaprenderingcontext/transferfromimagebitmap/index.md
+++ b/files/en-us/web/api/imagebitmaprenderingcontext/transferfromimagebitmap/index.md
@@ -24,7 +24,7 @@ a spec change. The old name is being kept as an alias to avoid code breakage.
 ## Syntax
 
 ```js
-void ImageBitmapRenderingContext.transferFromImageBitmap(bitmap)
+transferFromImageBitmap(bitmap)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/imagecapture/getphotocapabilities/index.md
+++ b/files/en-us/web/api/imagecapture/getphotocapabilities/index.md
@@ -24,7 +24,7 @@ available configuration options.
 ## Syntax
 
 ```js
-const capabilitiesPromise = imageCaptureObj.getPhotoCapabilities()
+getPhotoCapabilities()
 ```
 
 ### Return value
@@ -40,7 +40,7 @@ A {{jsxref("Promise")}} that resolves with an object containing the following pr
 - `fillLightMode`
   - : Returns an array of available fill light options. Options include `auto`, `off`, or `flash`.
 
-## Example
+## Examples
 
 The following example, extracted from [Chrome's
 Image Capture / Photo Resolution Sample](https://googlechrome.github.io/samples/image-capture/photo-resolution.html), uses the results from

--- a/files/en-us/web/api/imagecapture/getphotosettings/index.md
+++ b/files/en-us/web/api/imagecapture/getphotosettings/index.md
@@ -24,7 +24,7 @@ configuration settings.
 ## Syntax
 
 ```js
-const settingsPromise = imageCapture.getPhotoSettings()
+getPhotoSettings()
 ```
 
 ### Return value
@@ -41,7 +41,7 @@ containing the following properties:
 - `redEyeReduction`: A boolean indicating whether the red-eye reduction
   should be used if it is available.
 
-## Example
+## Examples
 
 The following example, extracted from [Chrome's
 Image Capture / Photo Resolution Sample](https://googlechrome.github.io/samples/image-capture/photo-resolution.html), uses the results from

--- a/files/en-us/web/api/imagecapture/grabframe/index.md
+++ b/files/en-us/web/api/imagecapture/grabframe/index.md
@@ -24,14 +24,14 @@ a {{domxref("ImageBitmap")}} containing the snapshot.
 ## Syntax
 
 ```js
-const bitmapPromise = imageCapture.grabFrame()
+grabFrame()
 ```
 
 ### Return value
 
 A {{jsxref("Promise")}} that resolves to an {{domxref("ImageBitmap")}} object.
 
-## Example
+## Examples
 
 This example is extracted from this [Simple
 Image Capture demo](https://simpl.info/imagecapture/). It shows how to use the {{jsxref("Promise")}} returned by

--- a/files/en-us/web/api/imagecapture/takephoto/index.md
+++ b/files/en-us/web/api/imagecapture/takephoto/index.md
@@ -23,8 +23,8 @@ that resolves with a {{domxref("Blob")}} containing the data.
 ## Syntax
 
 ```js
-const blobPromise = imageCaptureObj.takePhoto()
-const blobPromise = imageCaptureObj.takePhoto(photoSettings)
+takePhoto()
+takePhoto(photoSettings)
 ```
 
 ### Parameters
@@ -48,7 +48,7 @@ const blobPromise = imageCaptureObj.takePhoto(photoSettings)
 
 A {{jsxref("Promise")}} that resolves with a {{domxref("Blob")}}.
 
-## Example
+## Examples
 
 This example is extracted from this [Simple
 Image Capture demo](https://simpl.info/imagecapture/). It shows how to use the {{jsxref("Promise")}} returned by

--- a/files/en-us/web/api/imagedecoder/close/index.md
+++ b/files/en-us/web/api/imagedecoder/close/index.md
@@ -16,14 +16,14 @@ The **`close()`** method of the {{domxref("ImageDecoder")}} interface ends all p
 ## Syntax
 
 ```js
-ImageDecoder.close()
+close()
 ```
 
 ### Parameters
 
 None.
 
-### Return Value
+### Return value
 
 {{jsxref('undefined')}}.
 

--- a/files/en-us/web/api/imagedecoder/decode/index.md
+++ b/files/en-us/web/api/imagedecoder/decode/index.md
@@ -16,7 +16,7 @@ The **`decode()`** method of the {{domxref("ImageDecoder")}} interface enqueues 
 ## Syntax
 
 ```js
-ImageDecoder.decode(options)
+decode(options)
 ```
 
 ### Parameters
@@ -28,7 +28,7 @@ ImageDecoder.decode(options)
     - `completeFramesOnly`{{Optional_Inline}}
       - : A {{jsxref("boolean")}} defaulting to `true`. When `false` indicates that for progressive images the decoder may output an image with reduced detail.
 
-### Return Value
+### Return value
 
 A {{jsxref("promise")}} that resolves with an object containing the following members:
 

--- a/files/en-us/web/api/imagedecoder/decode/index.md
+++ b/files/en-us/web/api/imagedecoder/decode/index.md
@@ -16,6 +16,7 @@ The **`decode()`** method of the {{domxref("ImageDecoder")}} interface enqueues 
 ## Syntax
 
 ```js
+decode()
 decode(options)
 ```
 

--- a/files/en-us/web/api/imagedecoder/reset/index.md
+++ b/files/en-us/web/api/imagedecoder/reset/index.md
@@ -16,14 +16,14 @@ The **`reset()`** method of the {{domxref("ImageDecoder")}} interface resets all
 ## Syntax
 
 ```js
-ImageDecoder.reset()
+reset()
 ```
 
 ### Parameters
 
 None.
 
-### Return Value
+### Return value
 
 {{jsxref("Undefined")}}.
 

--- a/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.md
+++ b/files/en-us/web/api/inputdeviceinfo/getcapabilities/index.md
@@ -16,7 +16,7 @@ The **`getCapabilities()`** method of the {{domxref("InputDeviceInfo")}} interfa
 ## Syntax
 
 ```js
-InputDeviceInfo.getCapabilities();
+getCapabilities()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/intersectionobserver/disconnect/index.md
+++ b/files/en-us/web/api/intersectionobserver/disconnect/index.md
@@ -20,7 +20,7 @@ for visibility changes.
 ## Syntax
 
 ```js
-intersectionObserver.disconnect();
+disconnect()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/intersectionobserver/observe/index.md
+++ b/files/en-us/web/api/intersectionobserver/observe/index.md
@@ -31,7 +31,7 @@ be processed by a single call to the callback.
 ## Syntax
 
 ```js
-IntersectionObserver.observe(targetElement);
+observe(targetElement)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/intersectionobserver/takerecords/index.md
+++ b/files/en-us/web/api/intersectionobserver/takerecords/index.md
@@ -28,7 +28,7 @@ call to the observer's callback.
 ## Syntax
 
 ```js
-intersectionObserverEntries = intersectionObserver.takeRecords();
+takeRecords()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/intersectionobserver/unobserve/index.md
+++ b/files/en-us/web/api/intersectionobserver/unobserve/index.md
@@ -21,7 +21,7 @@ element.
 ## Syntax
 
 ```js
-IntersectionObserver.unobserve(target);
+unobserve(target)
 ```
 
 ### Parameters
@@ -34,7 +34,7 @@ IntersectionObserver.unobserve(target);
 
 `undefined`.
 
-## Example
+## Examples
 
 This snippet shows an observer being created, an element being observed, and then being
 unobserved.

--- a/files/en-us/web/api/interventionreportbody/tojson/index.md
+++ b/files/en-us/web/api/interventionreportbody/tojson/index.md
@@ -16,7 +16,7 @@ The **`toJSON()`** method of the {{domxref("InterventionReportBody")}} interface
 ## Syntax
 
 ```js
-InterventionReportBody.toJSON();
+toJSON()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/keyboard/getlayoutmap/index.md
+++ b/files/en-us/web/api/keyboard/getlayoutmap/index.md
@@ -22,7 +22,7 @@ functions for retrieving the strings associated with specific physical keys.
 ## Syntax
 
 ```js
-navigator.keyboard.getLayoutMap()
+getLayoutMap()
 ```
 
 ### Parameters
@@ -34,7 +34,7 @@ None.
 A {{jsxref('Promise')}} that resolves with an instance of
 {{domxref('KeyboardLayoutMap')}}.
 
-## Example
+## Examples
 
 The following example demonstrates how to get the location- or layout-specific string
 associated with the key that corresponds to the 'W' key on an English QWERTY keyboard.

--- a/files/en-us/web/api/keyboard/lock/index.md
+++ b/files/en-us/web/api/keyboard/lock/index.md
@@ -22,8 +22,8 @@ system.
 ## Syntax
 
 ```js
-navigator.keyboard.lock()
-navigator.keyboard.lock(keyCodes)
+lock()
+lock(keyCodes)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/keyboard/unlock/index.md
+++ b/files/en-us/web/api/keyboard/unlock/index.md
@@ -20,7 +20,7 @@ The **`unlock()`** method of the
 ## Syntax
 
 ```js
-navigator.keyboard.unlock()
+unlock()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/keyboardevent/getmodifierstate/index.md
+++ b/files/en-us/web/api/keyboardevent/getmodifierstate/index.md
@@ -19,10 +19,10 @@ current state of the specified modifier key: `true` if the modifier is active
 ## Syntax
 
 ```js
-var active = event.getModifierState(keyArg);
+getModifierState(keyArg)
 ```
 
-### Returns
+### Return value
 
 A boolean value
 
@@ -214,7 +214,7 @@ Note that which modifier key makes it return true depends on platforms, browsers
 user settings. For example, Firefox users can customize this with a pref,
 `"ui.key.accelKey"`.
 
-## Example
+## Examples
 
 ```js
 // Ignore if following modifier is active.

--- a/files/en-us/web/api/keyboardevent/initkeyboardevent/index.md
+++ b/files/en-us/web/api/keyboardevent/initkeyboardevent/index.md
@@ -20,7 +20,7 @@ Web applications should use constructor instead of this if it's available.
 ## Syntax
 
 ```js
-kbdEvent.initKeyboardEvent(typeArg, canBubbleArg, cancelableArg,
+initKeyboardEvent(typeArg, canBubbleArg, cancelableArg,
                            viewArg, charArg, keyArg,
                            locationArg, modifiersListArg, repeat)
 ```

--- a/files/en-us/web/api/keyboardevent/initkeyevent/index.md
+++ b/files/en-us/web/api/keyboardevent/initkeyevent/index.md
@@ -29,7 +29,7 @@ this way must have been created with the
 ## Syntax
 
 ```js
-event.initKeyEvent (type, bubbles, cancelable, viewArg,
+initKeyEvent (type, bubbles, cancelable, viewArg,
                     ctrlKeyArg, altKeyArg, shiftKeyArg, metaKeyArg,
                     keyCodeArg, charCodeArg)
 ```
@@ -37,7 +37,7 @@ event.initKeyEvent (type, bubbles, cancelable, viewArg,
 ### Parameters
 
 - _`type`_
-  - : Is a {{domxref("DOMString")}} representing the type of event.
+  - : Is a string representing the type of event.
 - _`bubbles`_
   - : Is a boolean value indicating whether the event should bubble up through the
     event chain or not (see [bubbles](/en-US/docs/Web/API/Event/bubbles)).
@@ -89,7 +89,7 @@ event.initKeyEvent (type, bubbles, cancelable, viewArg,
   - : Is a `unsigned long` representing the Unicode character associated with
     the depressed key otherwise `0`.
 
-## Example
+## Examples
 
 ```js
 var event = document.createEvent('KeyboardEvent'); // create a key event

--- a/files/en-us/web/api/keyboardlayoutmap/get/index.md
+++ b/files/en-us/web/api/keyboardlayoutmap/get/index.md
@@ -25,7 +25,7 @@ KeyboardEvent code Values](https://www.w3.org/TR/uievents-code/#key-alphanumeric
 ## Syntax
 
 ```js
-var value = KeyboardLayoutMap.get(key)
+get(key)
 ```
 
 ### Parameters
@@ -37,7 +37,7 @@ var value = KeyboardLayoutMap.get(key)
 
 The value of the specified key.
 
-## Example
+## Examples
 
 The following example demonstrates how to get the location- or layout-specific string
 associated with the key that corresponds to the 'W' key on an English QWERTY keyboard.

--- a/files/en-us/web/api/keyboardlayoutmap/has/index.md
+++ b/files/en-us/web/api/keyboardlayoutmap/has/index.md
@@ -26,7 +26,7 @@ Events KeyboardEvent code Values](https://www.w3.org/TR/uievents-code/#key-alpha
 ## Syntax
 
 ```js
-var aBoolean = KeyboardLayoutMap.has(key)
+has(key)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/keyframeeffect/getkeyframes/index.md
+++ b/files/en-us/web/api/keyframeeffect/getkeyframes/index.md
@@ -20,7 +20,7 @@ The **`getKeyframes()`** method of a {{domxref("KeyframeEffect")}} returns an Ar
 ## Syntax
 
 ```js
-var keyframes = keyframeEffect.getKeyframes();
+getKeyframes()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/keyframeeffect/setkeyframes/index.md
+++ b/files/en-us/web/api/keyframeeffect/setkeyframes/index.md
@@ -20,7 +20,7 @@ The **`setKeyframes()`** method of the {{domxref("KeyframeEffect")}} interface r
 ## Syntax
 
 ```js
-existingKeyframeEffect.setKeyframes(keyframes);
+setKeyframes(keyframes)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/largestcontentfulpaint/tojson/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/tojson/index.md
@@ -16,7 +16,7 @@ The **`toJSON()`** method of the {{domxref("LargestContentfulPaint")}} interface
 ## Syntax
 
 ```js
-LargestContentfulPaint.toJSON();
+toJSON()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/layoutshiftattribution/tojson/index.md
+++ b/files/en-us/web/api/layoutshiftattribution/tojson/index.md
@@ -16,7 +16,7 @@ The **`toJSON()`** method of the {{domxref("LayoutShiftAttribution")}} interface
 ## Syntax
 
 ```js
-LayoutShiftAttribution.toJSON();
+toJSON()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/location/assign/index.md
+++ b/files/en-us/web/api/location/assign/index.md
@@ -28,15 +28,15 @@ If the provided URL is not valid, a {{domxref("DOMException")}} of the
 ## Syntax
 
 ```js
-location.assign(url);
+assign(url)
 ```
 
 ### Parameters
 
 - `url`
-  - : Is a {{domxref("DOMString")}} containing the URL of the page to navigate to.
+  - : Is a string containing the URL of the page to navigate to.
 
-## Example
+## Examples
 
 ```js
 // Navigate to the Location.reload article

--- a/files/en-us/web/api/location/reload/index.md
+++ b/files/en-us/web/api/location/reload/index.md
@@ -22,7 +22,7 @@ information.
 ## Syntax
 
 ```js
-location.reload();
+reload()
 ```
 
 ## location.reload() has no parameter

--- a/files/en-us/web/api/location/replace/index.md
+++ b/files/en-us/web/api/location/replace/index.md
@@ -30,13 +30,13 @@ If the provided URL is not valid, a {{domxref("DOMException")}} of the
 ## Syntax
 
 ```js
-object.replace(url);
+replace(url)
 ```
 
 ### Parameters
 
 - `url`
-  - : Is a {{domxref("DOMString")}} containing the URL of the page to navigate to.
+  - : Is a string containing the URL of the page to navigate to.
 
 ## Examples
 

--- a/files/en-us/web/api/location/tostring/index.md
+++ b/files/en-us/web/api/location/tostring/index.md
@@ -12,13 +12,13 @@ browser-compat: api.Location.toString
 {{ApiRef("Location")}}
 
 The **`toString()`** {{Glossary("stringifier")}} method of the
-{{domxref("Location")}} interface returns a {{domxref("USVString")}} containing the
+{{domxref("Location")}} interface returns a string containing the
 whole URL. It is a read-only version of {{domxref("Location.href")}}.
 
 ## Syntax
 
 ```js
-string = object.toString();
+toString()
 ```
 
 ## Examples

--- a/files/en-us/web/api/lockedfile/abort/index.md
+++ b/files/en-us/web/api/lockedfile/abort/index.md
@@ -24,10 +24,10 @@ The `abort` method is used to release the lock on the
 ## Syntax
 
 ```js
-var request = instanceOfLockedFile.abort();
+abort()
 ```
 
-### Return
+### Return value
 
 A {{domxref("FileRequest")}} object to handle the success or failure of the operation.
 

--- a/files/en-us/web/api/lockedfile/append/index.md
+++ b/files/en-us/web/api/lockedfile/append/index.md
@@ -22,7 +22,7 @@ The write operation is performed at the end of the file, regardless of the
 ## Syntax
 
 ```js
-var request = instanceOfLockedFile.append(data);
+append(data)
 ```
 
 ### Parameters
@@ -31,7 +31,7 @@ var request = instanceOfLockedFile.append(data);
   - : The data to write into the file. It can be a string or an
     {{jsxref("ArrayBuffer")}}.
 
-### Return
+### Return value
 
 A {{domxref("FileRequest")}} object to handle the success or failure of the operation.
 

--- a/files/en-us/web/api/lockedfile/flush/index.md
+++ b/files/en-us/web/api/lockedfile/flush/index.md
@@ -25,10 +25,10 @@ lost. To avoid that, it's possible to force a write onto the disk by calling the
 ## Syntax
 
 ```js
-var request = instanceOfLockedFile.flush();
+flush()
 ```
 
-### Return
+### Return value
 
 A {{domxref("FileRequest")}} object to handle the success or failure of the operation.
 

--- a/files/en-us/web/api/lockedfile/getmetadata/index.md
+++ b/files/en-us/web/api/lockedfile/getmetadata/index.md
@@ -19,6 +19,7 @@ file.
 ## Syntax
 
 ```js
+getMetaData()
 getMetaData(param)
 ```
 

--- a/files/en-us/web/api/lockedfile/getmetadata/index.md
+++ b/files/en-us/web/api/lockedfile/getmetadata/index.md
@@ -19,7 +19,7 @@ file.
 ## Syntax
 
 ```js
-var request = instanceOfLockedFile.getMetadata(param);
+getMetaData(param)
 ```
 
 ### Parameters
@@ -35,7 +35,7 @@ var request = instanceOfLockedFile.getMetadata(param);
 - `size` : will provide the size of the file
 - `lastModified` : will provide the date when the file was last modified
 
-### Return
+### Return value
 
 A {{domxref("FileRequest")}} object. In case of success, the request's
 `result` is an object with the metadata requested through the param object.

--- a/files/en-us/web/api/lockedfile/readasarraybuffer/index.md
+++ b/files/en-us/web/api/lockedfile/readasarraybuffer/index.md
@@ -24,7 +24,7 @@ The reading operation starts at the position given by the
 ## Syntax
 
 ```js
-var request = instanceOfLockedFile.readAsArrayBuffer(size);
+readAsArrayBuffer(size)
 ```
 
 ### Parameters
@@ -32,7 +32,7 @@ var request = instanceOfLockedFile.readAsArrayBuffer(size);
 - `size`
   - : A number representing the number of bytes to read in the file.
 
-### Return
+### Return value
 
 A {{domxref("FileRequest")}} object to handle the success or failure of the operation.
 In case of success, the request's `result` is an {{jsxref("ArrayBuffer")}}

--- a/files/en-us/web/api/lockedfile/truncate/index.md
+++ b/files/en-us/web/api/lockedfile/truncate/index.md
@@ -25,7 +25,7 @@ at the index corresponding to the parameter and regardless of the value of
 ## Syntax
 
 ```js
-var request = instanceOfLockedFile.truncate(start);
+truncate(start)
 ```
 
 ### Parameters
@@ -33,7 +33,7 @@ var request = instanceOfLockedFile.truncate(start);
 - `start` {{optional_inline}}
   - : A number representing the index where to start the operation.
 
-### Return
+### Return value
 
 A {{domxref("FileRequest")}} object to handle the success or failure of the operation.
 

--- a/files/en-us/web/api/lockedfile/write/index.md
+++ b/files/en-us/web/api/lockedfile/write/index.md
@@ -21,7 +21,7 @@ that position by the number of written bytes.
 ## Syntax
 
 ```js
-var request = instanceOfLockedFile.write(data);
+write(data)
 ```
 
 ### Parameters
@@ -30,7 +30,7 @@ var request = instanceOfLockedFile.write(data);
   - : The data to write into the file. It can be a string or an
     {{jsxref("ArrayBuffer")}}.
 
-### Return
+### Return value
 
 A {{domxref("FileRequest")}} object to handle the success or failure of the operation.
 

--- a/files/en-us/web/api/lockmanager/query/index.md
+++ b/files/en-us/web/api/lockmanager/query/index.md
@@ -18,7 +18,7 @@ The **`query()`** method of the {{domxref("LockManager")}} interface returns a {
 ## Syntax
 
 ```js
-LockManager.query()
+query()
 ```
 
 ### Parameters
@@ -42,7 +42,7 @@ This method may return a promise rejected with a {{domxref("DOMException")}} of 
 - `SecurityError` {{domxref("DOMException")}}
   - : If a lock manager cannot be obtained for the current environment.
 
-## Example
+## Examples
 
 ```js
 const state = await navigator.locks.query();

--- a/files/en-us/web/api/mediacapabilities/decodinginfo/index.md
+++ b/files/en-us/web/api/mediacapabilities/decodinginfo/index.md
@@ -20,7 +20,7 @@ The **`MediaCapabilities.decodingInfo()`** method, part of the [Media Capabiliti
 ## Syntax
 
 ```js
-mediaCapabilities.decodingInfo(MediaDecodingConfiguration)
+decodingInfo(MediaDecodingConfiguration)
 ```
 
 ### Parameters
@@ -42,7 +42,7 @@ Browsers will report a supported media configuration as `smooth` and `powerEffic
 
 A `TypeError` is raised if the `MediaConfiguration` passed to the `decodingInfo()` method is invalid, either because the type is not video or audio, the `contentType` is not a valid codec MIME type, the media decoding configuration is not a valid value for the [media decoding type](/en-US/docs/Web/API/MediaDecodingType), or any other error in the media configuration passed to the method, including omitting values required in the [media decoding configuration](/en-US/docs/Web/API/MediaDecodingConfiguration).
 
-## Example
+## Examples
 
 ```js
 //Create media configuration to be tested

--- a/files/en-us/web/api/mediacapabilities/encodinginfo/index.md
+++ b/files/en-us/web/api/mediacapabilities/encodinginfo/index.md
@@ -25,7 +25,7 @@ of media.
 ## Syntax
 
 ```js
-mediaCapabilities.encodingInfo(mediaEncodingConfiguration)
+encodingInfo(mediaEncodingConfiguration)
 ```
 
 ### Parameters
@@ -54,7 +54,7 @@ audio, the `contentType` is not a valid codec MIME type, or any other error
 in the media configuration passed to the method, including omitting any of the [media encoding configuration](/en-US/docs/Web/API/MediaEncodingConfiguration)
 elements.
 
-## Example
+## Examples
 
 ```js
 //Create media configuration to be tested

--- a/files/en-us/web/api/mediadevices/enumeratedevices/index.md
+++ b/files/en-us/web/api/mediadevices/enumeratedevices/index.md
@@ -20,7 +20,7 @@ The list of returned devices will omit any devices for which the corresponding p
 ## Syntax
 
 ```js
-navigator.mediaDevices.enumerateDevices()
+enumerateDevices()
 ```
 
 ### Return value
@@ -31,7 +31,7 @@ The order is significant - the default capture devices will be listed first.
 
 If enumeration fails, the promise is rejected.
 
-## Example
+## Examples
 
 Here's an example of using `enumerateDevices()`. It outputs a list of the [device IDs](/en-US/docs/Web/API/MediaDeviceInfo/deviceId), with their labels if available.
 

--- a/files/en-us/web/api/mediadevices/getdisplaymedia/index.md
+++ b/files/en-us/web/api/mediadevices/getdisplaymedia/index.md
@@ -35,7 +35,7 @@ Screen Capture API](/en-US/docs/Web/API/Screen_Capture_API/Using_Screen_Capture)
 ## Syntax
 
 ```js
-var promise = navigator.mediaDevices.getDisplayMedia(constraints);
+getDisplayMedia(constraints)
 ```
 
 ### Parameters
@@ -106,7 +106,7 @@ details measures browsers are required to take in order to fully support
   windows that contain browsers, and to keep a close eye on what other content might be
   getting captured and shown to other users.
 
-## Example
+## Examples
 
 In the example below, a `startCapture()` method is created which initiates
 screen capture given a set of options specified by the `displayMediaOptions`

--- a/files/en-us/web/api/mediadevices/getsupportedconstraints/index.md
+++ b/files/en-us/web/api/mediadevices/getsupportedconstraints/index.md
@@ -24,7 +24,7 @@ specify one of the constrainable properties the {{Glossary("user agent")}} under
 ## Syntax
 
 ```js
-var supportedConstraints = navigator.mediaDevices.getSupportedConstraints();
+getSupportedConstraints()
 ```
 
 ### Parameters
@@ -38,7 +38,7 @@ listing the constraints supported by the user agent. Because only constraints su
 by the user agent are included in the list, each of these Boolean properties has the
 value `true`.
 
-## Example
+## Examples
 
 This example outputs a list of the constraints supported by your browser.
 

--- a/files/en-us/web/api/mediadevices/getusermedia/index.md
+++ b/files/en-us/web/api/mediadevices/getusermedia/index.md
@@ -74,7 +74,7 @@ navigator.mediaDevices.getUserMedia(constraints)
 ## Syntax
 
 ```js
-var promise = navigator.mediaDevices.getUserMedia(constraints);
+getUserMedia(constraints)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/mediadevices/selectaudiooutput/index.md
+++ b/files/en-us/web/api/mediadevices/selectaudiooutput/index.md
@@ -24,8 +24,8 @@ The prompt will not be displayed if the `speaker-selection` permission has not b
 ## Syntax
 
 ```js
-navigator.mediaDevices.selectAudioOutput()
-navigator.mediaDevices.selectAudioOutput(options)
+selectAudioOutput()
+selectAudioOutput(options)
 ```
 
 ### Parameters
@@ -36,7 +36,7 @@ navigator.mediaDevices.selectAudioOutput(options)
 
     - `deviceId` {{Optional_Inline}}
 
-      - : A {{domxref("DOMString")}} representing the id of the (only) device to display in the prompt (with default value: "").
+      - : A string representing the id of the (only) device to display in the prompt (with default value: "").
 
         > **Note:** A user agent may choose to skip prompting the user if a specified non-null id was previously exposed to the user by `selectAudioOutput()` in an earlier session.
         > In this case the user agent may simply resolve with this device id, or a new id for the same device if it has changed.
@@ -58,7 +58,7 @@ The object describes the user-selected audio output device.
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Returned if there hasn't been a {{Glossary("transient activation")}} (you must trigger it from some kind of UI event).
 
-## Example
+## Examples
 
 Here's an example of using `selectAudioOutput()`, which you might call within a function that is triggered by a button click.
 It outputs the selected [device IDs](/en-US/docs/Web/API/MediaDeviceInfo/deviceId) and labels (if available) or an error message.

--- a/files/en-us/web/api/mediakeystatusmap/entries/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/entries/index.md
@@ -20,14 +20,14 @@ insertion order.
 ## Syntax
 
 ```js
-// TBD
+entries()
 ```
 
 ### Parameters
 
 None.
 
-### Returns
+### Return value
 
 ### Exceptions
 

--- a/files/en-us/web/api/mediakeystatusmap/get/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/get/index.md
@@ -19,7 +19,7 @@ key, or `undefined` if there is none.
 ## Syntax
 
 ```js
-var value = mediaKeyStatusMap.get(key);
+get(key)
 ```
 
 ### Parameters
@@ -27,7 +27,7 @@ var value = mediaKeyStatusMap.get(key);
 - key
   - : The key whose value you want returned.
 
-### Returns
+### Return value
 
 The value associated with the given key, or `undefined`.
 

--- a/files/en-us/web/api/mediakeystatusmap/has/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/has/index.md
@@ -19,7 +19,7 @@ whether a value has been associated with the given key.
 ## Syntax
 
 ```js
-var boolean = mediaKeyStatusMap(key)
+has(key)
 ```
 
 ### Parameters
@@ -27,7 +27,7 @@ var boolean = mediaKeyStatusMap(key)
 - key
   - : The key whose value you want returned
 
-### Returns
+### Return value
 
 A {{jsxref('Boolean')}}.
 

--- a/files/en-us/web/api/mediakeystatusmap/keys/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/keys/index.md
@@ -19,14 +19,14 @@ keys for each element in the status map, in insertion order.
 ## Syntax
 
 ```js
-var iterator = mediaKeyStatusMap.keys()
+keys()
 ```
 
 ### Parameters
 
 None.
 
-### Returns
+### Return value
 
 A new iterator.
 


### PR DESCRIPTION
Continuing #14857 

## Summary
Updating the method pages to follow the current templates:
https://developer.mozilla.org/en-US/docs/MDN/Structures/Syntax_sections#constructors_and_methods
https://developer.mozilla.org/en-US/docs/MDN/Structures/Page_types/API_method_subpage_template

Changes Include:
- fix syntax section
- changing section titles to suggested titles in the template
- change `{{DOMxRef("DOMString")}}` to `string`
- remove extra spaces in between words and extra trailing spaces
- other small corrections

### Metadata
- [x] Fixes a typo, bug, or other error
