### PR TITLE
CSS: Fix a typos at the `font-stretch` page.

### DIFF
--- a/files/en-us/web/css/@font-face/font-stretch/index.md
+++ b/files/en-us/web/css/@font-face/font-stretch/index.md
@@ -35,10 +35,10 @@ font-stretch: 200%;
 
 /* multiple values */
 font-stretch: 75% 125%;
-font-stretch: condensed ultra-condensed;;
+font-stretch: condensed ultra-condensed;
 ```
 
-The `font-weight` property is described using any one of the values listed below.
+The `font-stretch` property is described using any one of the values listed below.
 
 ### Values
 


### PR DESCRIPTION
#### Summary
Fix typos left after copy-pasting from `font-weight` page, used as template

#### Motivation
Clarity

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error