### PR TITLE
Fix sectioning problem

### DIFF
--- a/files/en-us/web/api/console/group/index.md
+++ b/files/en-us/web/api/console/group/index.md
@@ -31,15 +31,12 @@ group(label)
   - : Label for the group. Optional. (Chrome 59 tested) Does not work with
     `console.groupEnd()`.
 
-{{h3_gecko_minversion("Using groups in the console", "9.0")}}
+## Examples
 
 You can use nested groups to help organize your output by visually associating related
 messages. To create a new nested block, call `console.group()`. The
 `console.groupCollapsed()` method is similar, but the new block is
 collapsed and requires clicking a disclosure button to read it.
-
-> **Note:** From Gecko 9 until Gecko 51, the `groupCollapsed()` method was the same as `group()`.
-> Collapsed groups are fully supported starting in Gecko 52. See {{bug("1088360")}}.
 
 To exit the current group, call `console.groupEnd()`.
 For example, given this code:
@@ -61,8 +58,7 @@ The output looks like this:
 
 ![A screenshot of messages nested in the console output.](nesting.png)
 
-See [Using groups in
-the console](/en-US/docs/Web/API/console#using_groups_in_the_console) in the documentation of {{domxref("console")}} for more details.
+See [Using groups in the console](/en-US/docs/Web/API/console#using_groups_in_the_console) in the documentation of {{domxref("console")}} for more details.
 
 ## Specifications
 


### PR DESCRIPTION
This PR fixes a sectioning problem, by removing the info that was saying that the example applied only to Firefox (9 and later). This works everywhere.