### PR TITLE
Add case that affects identifying containing block

### DIFF
--- a/files/en-us/web/css/containing_block/index.md
+++ b/files/en-us/web/css/containing_block/index.md
@@ -47,6 +47,7 @@ The process for identifying the containing block depends entirely on the value o
     2. A {{cssxref("will-change")}} value of `transform` or `perspective`
     3. A {{cssxref("filter")}} value other than `none` or a `will-change` value of `filter` (only works on Firefox).
     4. A {{cssxref("contain")}} value of `paint` (e.g. `contain: paint;`)
+    5. A {{cssxref("backdrop-filter")}} other than `none` (e.g. `backdrop-filter: blur(10px);`)
 
 > **Note:** The containing block in which the root element ({{HTMLElement("html")}}) resides is a rectangle called the **initial containing block**. It has the dimensions of the viewport (for continuous media) or the page area (for paged media).
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->

#### Summary
Added a case that affects the containing block in chromium browsers.

#### Motivation
Spent a lot of time debugging a weird containing-block case, and it was caused by an ancestor having the backdrop-filter property (in chromium). Saw that it wasn't documented, so thought it would be helpful for others.

This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error
