### PR TITLE
Add .avif to Navigator.share() shareable file types.

### DIFF
--- a/files/en-us/web/api/navigator/share/index.md
+++ b/files/en-us/web/api/navigator/share/index.md
@@ -80,6 +80,7 @@ The following is a list of usually shareable file types. However, you should alw
   - `.wav` - `audio/wav`
   - `.weba` - `audio/webm`
 - Image
+  - `.avif` - `image/avif`
   - `.bmp` - `image/bmp`
   - `.gif` - `image/gif`
   - `.ico` - `image/x-icon`


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Chromium adds .avif to permitted Web share file extension.
This PR adds .avif to Navigator.share() shareable file types.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
A website might like their users to be able to share their pictures and other files through social media, email, chat, etc.
.avif showed better compression efficiency and better detail preservation than JPEG.
In this regard, adding avif to web share will helpful to user and spread the use of avif.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
https://crbug.com/1190122

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
