### PR TITLE
fix:table ~ fixes first table on RegEx cheatsheet page

### DIFF
--- a/files/en-us/web/javascript/guide/regular_expressions/cheatsheet/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/cheatsheet/index.md
@@ -22,7 +22,6 @@ This page provides an overall cheat sheet of all the capabilities of `RegExp` sy
       <th scope="col">Meaning</th>
     </tr>
   </thead>
-  <tbody></tbody>
   <tbody>
     <tr>
       <td><code>.</code></td>


### PR DESCRIPTION
Remove duplicate `tbody` element from first table.
This fixes the problem originally reported in https://github.com/mdn/yari/issues/5058

This PR…

- [x] Fixes a typo, bug, or other error

fix #15103