### PR TITLE
WebAPI: Update Method pages to modern structure (part 12)

### DIFF
--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithoutresponse/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithoutresponse/index.md
@@ -17,7 +17,7 @@ The **`BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse()`** method s
 ## Syntax
 
 ```js
-writeValueWithoutResponse(value);
+writeValueWithoutResponse(value)
 ```
 
 ### Return value

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithoutresponse/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithoutresponse/index.md
@@ -20,14 +20,14 @@ The **`BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse()`** method s
 writeValueWithoutResponse(value)
 ```
 
-### Return value
-
-A {{jsxref("Promise")}}.
-
 ### Parameters
 
 - value
   - : An {{jsxref("ArrayBuffer")}}.
+
+### Return value
+
+A {{jsxref("Promise")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/cookiestore/set/index.md
+++ b/files/en-us/web/api/cookiestore/set/index.md
@@ -16,8 +16,8 @@ The **`set()`** method of the {{domxref("CookieStore")}} interface sets a cookie
 ## Syntax
 
 ```js
-set(name, value)
-set(options)
+set(name, value);
+set(options);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/datatransfer/getdata/index.md
+++ b/files/en-us/web/api/datatransfer/getdata/index.md
@@ -31,7 +31,10 @@ getData(format)
 
 ### Return value
 
-A string representing the drag data for the specified `format`. If the drag operation has no data or the operation has no data for the specified `format`, this method returns an empty string.
+- string
+  - : A string representing the drag data for the specified
+    `format`. If the drag operation has no data or the operation has no
+    data for the specified `format`, this method returns an empty string.
 
 ### Caveats
 

--- a/files/en-us/web/api/datatransfer/getdata/index.md
+++ b/files/en-us/web/api/datatransfer/getdata/index.md
@@ -31,10 +31,7 @@ getData(format)
 
 ### Return value
 
-- string
-  - : A string representing the drag data for the specified
-    `format`. If the drag operation has no data or the operation has no
-    data for the specified `format`, this method returns an empty string.
+A string representing the drag data for the specified `format`. If the drag operation has no data or the operation has no data for the specified `format`, this method returns an empty string.
 
 ### Caveats
 

--- a/files/en-us/web/api/datatransferitemlist/add/index.md
+++ b/files/en-us/web/api/datatransferitemlist/add/index.md
@@ -23,8 +23,8 @@ given type. If the item is successfully added to the list, the newly-created
 ## Syntax
 
 ```js
-DataTransferItem = DataTransferItemList.add(data, type);
-DataTransferItem = DataTransferItemList.add(file);
+add(data, type)
+add(file)
 ```
 
 ### Parameters
@@ -50,7 +50,7 @@ has no data store), `null` is returned.
     item whose {{domxref("DataTransferItem.kind","kind")}} is `"Plain Unicode string"` and
     whose type is equal to the specified type parameter.
 
-## Example
+## Examples
 
 This example shows the use of the `add()` method.
 

--- a/files/en-us/web/api/datatransferitemlist/clear/index.md
+++ b/files/en-us/web/api/datatransferitemlist/clear/index.md
@@ -23,7 +23,7 @@ in read-only mode, and this method silently does nothing. No exception is thrown
 ## Syntax
 
 ```js
-DataTransferItemList.clear();
+clear()
 ```
 
 ### Parameters
@@ -34,7 +34,7 @@ None.
 
 {{jsxref("undefined")}}
 
-## Example
+## Examples
 
 This example shows the use of the `clear()` method.
 

--- a/files/en-us/web/api/datatransferitemlist/remove/index.md
+++ b/files/en-us/web/api/datatransferitemlist/remove/index.md
@@ -22,7 +22,7 @@ be changed.
 ## Syntax
 
 ```js
-DataTransferItemList.remove(index);
+remove(index)
 ```
 
 ### Parameters
@@ -41,7 +41,7 @@ DataTransferItemList.remove(index);
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the drag data store is not in read/write mode and so the item cannot be removed.
 
-## Example
+## Examples
 
 This example shows the use of the `remove()` method.
 

--- a/files/en-us/web/api/dedicatedworkerglobalscope/close/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/close/index.md
@@ -18,10 +18,10 @@ The **`close()`** method of the {{domxref("DedicatedWorkerGlobalScope")}} interf
 ## Syntax
 
 ```js
-self.close();
+close()
 ```
 
-## Example
+## Examples
 
 If you want to close your worker instance from inside the worker itself, you can call the following:
 

--- a/files/en-us/web/api/dedicatedworkerglobalscope/postmessage/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/postmessage/index.md
@@ -41,11 +41,11 @@ postMessage(aMessage, transferList)
 
     Only {{Glossary("transferable objects")}} can be transferred.
 
-### Returns
+### Return value
 
 {{jsxref('undefined')}}.
 
-## Example
+## Examples
 
 The following code snippet shows `worker.js`, in which an `onmessage` handler is used to handle messages from the main script.
 Inside the handler a calculation is done from which a result message is created; this is then sent back to the main thread using `postMessage(workerResult);`

--- a/files/en-us/web/api/deprecationreportbody/tojson/index.md
+++ b/files/en-us/web/api/deprecationreportbody/tojson/index.md
@@ -16,7 +16,7 @@ The **`toJSON()`** method of the {{domxref("DeprecationReportBody")}} interface 
 ## Syntax
 
 ```js
-DeprecationReportBody.toJSON();
+toJSON()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/document/adoptnode/index.md
+++ b/files/en-us/web/api/document/adoptnode/index.md
@@ -23,7 +23,7 @@ current document. The node can then be inserted into the current document.
 ## Syntax
 
 ```js
-const importedNode = document.adoptNode(externalNode);
+adoptNode(externalNode)
 ```
 
 ### Parameters
@@ -42,7 +42,7 @@ After calling this method, `importedNode` and
 > {{domxref("Node.parentNode")}} is `null`, since it has not yet been
 > inserted into the document tree!
 
-## Example
+## Examples
 
 ```js
 const iframe = document.querySelector('iframe');

--- a/files/en-us/web/api/document/caretpositionfrompoint/index.md
+++ b/files/en-us/web/api/document/caretpositionfrompoint/index.md
@@ -18,7 +18,7 @@ caret's character offset within that node.
 ## Syntax
 
 ```js
-caretPositionFromPoint(x, y);
+caretPositionFromPoint(x, y)
 ```
 
 ### Parameters
@@ -28,11 +28,11 @@ caretPositionFromPoint(x, y);
 - `y`
   - : The vertical coordinate of a point.
 
-### Returns
+### Return value
 
 A {{domxref('CaretPosition')}} object.
 
-## Example
+## Examples
 
 Click anywhere in the **Demo** paragraph below to insert a line break at the point where you click. The code for it is below the demo.
 

--- a/files/en-us/web/api/document/caretrangefrompoint/index.md
+++ b/files/en-us/web/api/document/caretrangefrompoint/index.md
@@ -21,7 +21,7 @@ fragment under the specified coordinates.
 ## Syntax
 
 ```js
-var range = document.caretRangeFromPoint(float x, float y);
+caretRangeFromPoint(x, y)
 ```
 
 ### Parameters
@@ -31,7 +31,7 @@ var range = document.caretRangeFromPoint(float x, float y);
 - _y_
   - : A vertical position within the current viewport.
 
-### Returns
+### Return value
 
 One of the following:
 
@@ -39,7 +39,7 @@ One of the following:
 - `Null`, if _x_ or _y_ are negative, outside viewport,
   or there is no text entry node.
 
-## Example
+## Examples
 
 Click anywhere in the **Demo** paragraph below to insert a line break at the point where you click. The code for it is below the demo.
 

--- a/files/en-us/web/api/document/clear/index.md
+++ b/files/en-us/web/api/document/clear/index.md
@@ -17,7 +17,7 @@ The **`Document.clear()`** method does nothing, but doesn't raise any error.
 ## Syntax
 
 ```js
-document.clear();
+clear()
 ```
 
 ## Specifications

--- a/files/en-us/web/api/document/close/index.md
+++ b/files/en-us/web/api/document/close/index.md
@@ -17,10 +17,10 @@ document, opened with {{domxref("Document.open()")}}.
 ## Syntax
 
 ```js
-document.close();
+close()
 ```
 
-## Example
+## Examples
 
 ```js
 // Open a document to write to it

--- a/files/en-us/web/api/document/createattribute/index.md
+++ b/files/en-us/web/api/document/createattribute/index.md
@@ -20,7 +20,7 @@ added to a particular element in this manner.
 ## Syntax
 
 ```js
-attribute = document.createAttribute(name)
+createAttribute(name)
 ```
 
 ### Parameters
@@ -36,7 +36,7 @@ A {{domxref("Attr")}} node.
 - `InvalidCharacterError` {{domxref("DOMException")}}
   - : Thrown if the [`name`](#name) value is not a valid [XML name](https://www.w3.org/TR/REC-xml/#dt-name); for example, it starts with a number, hyphen, or period, or contains characters other than alphanumeric characters, underscores, hyphens, or periods.
 
-## Example
+## Examples
 
 ```js
 var node = document.getElementById("div1");

--- a/files/en-us/web/api/document/createcdatasection/index.md
+++ b/files/en-us/web/api/document/createcdatasection/index.md
@@ -19,7 +19,7 @@ and returns it.
 createCDATASection(data)
 ```
 
-### Paramee
+### Parameters
 
 - _data_ 
   - : A string containing the data to be added to the CDATA Section.

--- a/files/en-us/web/api/document/createcdatasection/index.md
+++ b/files/en-us/web/api/document/createcdatasection/index.md
@@ -16,14 +16,19 @@ and returns it.
 ## Syntax
 
 ```js
-var CDATASectionNode = document.createCDATASection(data);
+createCDATASection(data)
 ```
 
-- _CDATASectionNode_ is a [CDATA
-  Section](/en-US/docs/Web/API/CDATASection) node.
-- _data_ is a string containing the data to be added to the CDATA Section.
+### Paramee
 
-## Example
+- _data_ 
+  - : A string containing the data to be added to the CDATA Section.
+
+### Return value
+
+A [CDATA Section](/en-US/docs/Web/API/CDATASection) node.
+
+## Examples
 
 ```js
 var docu = new DOMParser().parseFromString('<xml></xml>', 'application/xml')

--- a/files/en-us/web/api/document/createcomment/index.md
+++ b/files/en-us/web/api/document/createcomment/index.md
@@ -16,7 +16,7 @@ it.
 ## Syntax
 
 ```js
-CommentNode = document.createComment(data);
+createComment(data)
 ```
 
 ### Parameters
@@ -24,7 +24,7 @@ CommentNode = document.createComment(data);
 - _data_
   - : A string containing the data to be added to the Comment.
 
-## Example
+## Examples
 
 ```js
 var docu = new DOMParser().parseFromString('<xml></xml>',  'application/xml');

--- a/files/en-us/web/api/document/createdocumentfragment/index.md
+++ b/files/en-us/web/api/document/createdocumentfragment/index.md
@@ -18,10 +18,10 @@ DOM nodes can be added to build an offscreen DOM tree.
 ## Syntax
 
 ```js
-var fragment = document.createDocumentFragment();
+createDocumentFragment()
 ```
 
-### Value
+### Return value
 
 A newly created, empty, {{domxref("DocumentFragment")}} object, which is ready to have
 nodes inserted into it.
@@ -46,7 +46,7 @@ fragment:
 let fragment = new DocumentFragment();
 ```
 
-## Example
+## Examples
 
 This example creates a list of major web browsers in a `DocumentFragment`,
 then adds the new DOM subtree to the document to be displayed.

--- a/files/en-us/web/api/document/createelementns/index.md
+++ b/files/en-us/web/api/document/createelementns/index.md
@@ -18,8 +18,8 @@ To create an element without specifying a namespace URI, use the
 ## Syntax
 
 ```js
-document.createElementNS(namespaceURI, qualifiedName);
-document.createElementNS(namespaceURI, qualifiedName, options);
+createElementNS(namespaceURI, qualifiedName)
+createElementNS(namespaceURI, qualifiedName, options)
 ```
 
 ### Parameters
@@ -57,7 +57,7 @@ The new {{DOMxRef("Element")}}.
 - [XBL](/en-US/docs/Mozilla/Tech/XBL) {{Non-standard_Inline}} {{Deprecated_Inline}}
   - : `http://www.mozilla.org/xbl`
 
-## Example
+## Examples
 
 This creates a new \<div> element in the {{Glossary("XHTML")}} namespace and
 appends it to the vbox element. Although this is not an extremely useful [XUL](/en-US/docs/Mozilla/Tech/XUL) document, it does demonstrate the use of

--- a/files/en-us/web/api/document/createevent/index.md
+++ b/files/en-us/web/api/document/createevent/index.md
@@ -20,16 +20,21 @@ returned object should be first initialized and can then be passed to
 ## Syntax
 
 ```js
-var event = document.createEvent(type);
+createEvent(type)
 ```
+### Parameters
 
-- `event` is the created [Event](/en-US/docs/Web/API/Event) object.
-- `type` is a string that represents the type of event to be
+- `type` 
+  - : A string that represents the type of event to be
   created. Possible event types include `"UIEvents"`,
   `"MouseEvents"`, `"MutationEvents"`, and
   `"HTMLEvents"`. See [Notes](#notes) section for details.
 
-## Example
+### Return value
+
+An [Event](/en-US/docs/Web/API/Event) object.
+
+## Examples
 
 ```js
 // Create the event.

--- a/files/en-us/web/api/document/createexpression/index.md
+++ b/files/en-us/web/api/document/createexpression/index.md
@@ -18,10 +18,23 @@ This method compiles an {{DOMxRef("XPathExpression")}} which can then be used fo
 ## Syntax
 
 ```js
-xpathExpr = document.createExpression(xpathText, namespaceURLMapper);
+createExpression(xpathText, namespaceURLMapper)
 ```
+### Parameters
 
-## Example
+- _xpathText_ is a string which is the XPath expression to be compiled.
+- _namespaceURLMapper_ is a function which maps a namespace prefix to a
+  namespace URL (or null if none needed).
+
+{{Fx_MinVersion_Note(3, "Prior to Firefox 3, you could call this method on documents
+other than the one you planned to run the XPath against. Under Firefox 3, you must call
+it on the same document.")}}
+
+### Return value
+
+{{DOMxRef("XPathExpression")}}
+
+## Examples
 
 ```js
 let xpathExpr = document.createExpression('//div');
@@ -30,20 +43,6 @@ let nodeContext = document.getElementsByTagName('nav')[0];
 // Re-using the XPathExpression "xpathExpr"
 let otherResult = xpathExpr.evaluate(nodeContext); // returns an XPathResult object
 ```
-
-### Parameters
-
-- _xpathText_ is a string which is the XPath expression to be compiled.
-- _namespaceURLMapper_ is a function which maps a namespace prefix to a
-  namespace URL (or null if none needed).
-
-{{Fx_MinVersion_Note(3, "Prior to Firefox 3, you could call this method on documents
-  other than the one you planned to run the XPath against. Under Firefox 3, you must call
-  it on the same document.")}}
-
-### Return value
-
-{{DOMxRef("XPathExpression")}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/document/creatensresolver/index.md
+++ b/files/en-us/web/api/document/creatensresolver/index.md
@@ -16,7 +16,7 @@ Creates an `XPathNSResolver` which resolves namespaces with respect to the defin
 ## Syntax
 
 ```js
-nsResolver = document.createNSResolver(node);
+createNSResolver(node)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/document/createprocessinginstruction/index.md
+++ b/files/en-us/web/api/document/createprocessinginstruction/index.md
@@ -19,7 +19,7 @@ The new node usually will be inserted into an XML document in order to accomplis
 ## Syntax
 
 ```js
-piNode = document.createProcessingInstruction(target, data)
+createProcessingInstruction(target, data)
 ```
 
 ### Parameters
@@ -37,7 +37,7 @@ piNode = document.createProcessingInstruction(target, data)
     - The [`target`](#target) value is not a valid [XML name](https://www.w3.org/TR/REC-xml/#dt-name); for example, it starts with a number, hyphen, or period, or contains characters other than alphanumeric characters, underscores, hyphens, or periods.
     - The _closing processing instruction sequence_ (`?>`) is part of the [`data`](#data) value.
 
-## Example
+## Examples
 
 ```js
 var doc = new DOMParser().parseFromString('<foo />', 'application/xml');

--- a/files/en-us/web/api/document/createrange/index.md
+++ b/files/en-us/web/api/document/createrange/index.md
@@ -19,12 +19,12 @@ The **`Document.createRange()`** method returns a new
 ## Syntax
 
 ```js
-range = document.createRange();
+createRange()
 ```
 
 _range_ is the created {{domxref("Range")}} object.
 
-## Example
+## Examples
 
 ```js
 let range = document.createRange();

--- a/files/en-us/web/api/document/createtextnode/index.md
+++ b/files/en-us/web/api/document/createtextnode/index.md
@@ -21,9 +21,14 @@ characters.
 createTextNode(data)
 ```
 
-- _text_ is a {{domxref("Text")}} node.
+### Parameters
+
 - _data_ is a [string](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)
   containing the data to be put in the text node.
+
+### Return value
+
+A {{domxref("Text")}} node.
 
 ## Examples
 

--- a/files/en-us/web/api/document/createtextnode/index.md
+++ b/files/en-us/web/api/document/createtextnode/index.md
@@ -18,14 +18,14 @@ characters.
 ## Syntax
 
 ```js
-var text = document.createTextNode(data);
+createTextNode(data)
 ```
 
 - _text_ is a {{domxref("Text")}} node.
 - _data_ is a [string](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)
   containing the data to be put in the text node.
 
-## Example
+## Examples
 
 ```html
 <!DOCTYPE html>

--- a/files/en-us/web/api/document/createtouch/index.md
+++ b/files/en-us/web/api/document/createtouch/index.md
@@ -21,7 +21,7 @@ The **`Document.createTouch()`** method creates and returns a new {{DOMxRef("Tou
 ## Syntax
 
 ```js
-var touch = document.createTouch(view, target, identifier, pageX, pageY, screenX, screenY);
+createTouch(view, target, identifier, pageX, pageY, screenX, screenY)
 ```
 
 ### Parameters
@@ -66,7 +66,7 @@ var touch = document.createTouch(view, target, identifier, pageX, pageY, screenX
 - `touch`
   - : A {{DOMxRef("Touch")}} object configured as described by the input parameters.
 
-## Example
+## Examples
 
 This example illustrates using the `Document.createTouch()` method to
 create {{DOMxRef("Touch")}} objects.

--- a/files/en-us/web/api/document/createtreewalker/index.md
+++ b/files/en-us/web/api/document/createtreewalker/index.md
@@ -17,9 +17,9 @@ newly created {{domxref("TreeWalker")}} object.
 ## Syntax
 
 ```js
-document.createTreeWalker(root);
-document.createTreeWalker(root, whatToShow);
-document.createTreeWalker(root, whatToShow, filter);
+createTreeWalker(root)
+createTreeWalker(root, whatToShow)
+createTreeWalker(root, whatToShow, filter)
 ```
 
 ### Parameters
@@ -60,7 +60,7 @@ document.createTreeWalker(root, whatToShow, filter);
 
 A new {{domxref("TreeWalker")}} object.
 
-## Example
+## Examples
 
 The following example goes through all nodes in the body,
 filters out any non nodes that aren't elements (with the \`NodeFilter.SHOW_ELEMENT\` value),

--- a/files/en-us/web/api/document/elementfrompoint/index.md
+++ b/files/en-us/web/api/document/elementfrompoint/index.md
@@ -53,7 +53,7 @@ elementFromPoint(x, y)
 
 The topmost {{domxref("Element")}} object located at the specified coordinates.
 
-## Example
+## Examples
 
 This example creates two buttons which let you set the current color of the paragraph
 element located under the coordinates `(2, 2)`.

--- a/files/en-us/web/api/document/elementsfrompoint/index.md
+++ b/files/en-us/web/api/document/elementsfrompoint/index.md
@@ -21,7 +21,7 @@ It operates in a similar way to the {{domxref("Document.elementFromPoint",
 ## Syntax
 
 ```js
-elementsFromPoint(x, y);
+elementsFromPoint(x, y)
 ```
 
 ### Parameters
@@ -35,7 +35,7 @@ elementsFromPoint(x, y);
 
 An array of {{domxref('element')}} objects.
 
-## Example
+## Examples
 
 ### HTML
 

--- a/files/en-us/web/api/document/enablestylesheetsforset/index.md
+++ b/files/en-us/web/api/document/enablestylesheetsforset/index.md
@@ -21,7 +21,7 @@ enabled).
 ## Syntax
 
 ```js
-document.enableStyleSheetsForSet(name);
+enableStyleSheetsForSet(name)
 ```
 
 ### Parameters
@@ -43,7 +43,7 @@ document.enableStyleSheetsForSet(name);
 - This method never affects the values of {{domxref("document.lastStyleSheetSet")}} or
   {{domxref("document.preferredStyleSheetSet")}}.
 
-## Example
+## Examples
 
 ```js
 document.enableStyleSheetsForSet("Some style sheet set name");

--- a/files/en-us/web/api/document/evaluate/index.md
+++ b/files/en-us/web/api/document/evaluate/index.md
@@ -17,13 +17,7 @@ expression and other given parameters.
 ## Syntax
 
 ```js
-var xpathResult = document.evaluate(
-  xpathExpression,
-  contextNode,
-  namespaceResolver,
-  resultType,
-  result
-);
+evaluate(xpathExpression, contextNode, namespaceResolver, resultType, result)
 ```
 
 - `xpathExpression` is a string representing the XPath to be evaluated.
@@ -44,7 +38,7 @@ var xpathResult = document.evaluate(
   results. `null` is the most common and will create a new
   `XPathResult`
 
-## Example
+## Examples
 
 ```js
 var headings = document.evaluate("/html/body//h2", document, null, XPathResult.ANY_TYPE, null);

--- a/files/en-us/web/api/document/execcommand/index.md
+++ b/files/en-us/web/api/document/execcommand/index.md
@@ -30,7 +30,7 @@ The [Clipboard API](/en-US/docs/Web/API/Clipboard_API) can be used instead of `e
 ## Syntax
 
 ```js
-document.execCommand(aCommandName, aShowDefaultUI, aValueArgument)
+execCommand(aCommandName, aShowDefaultUI, aValueArgument)
 ```
 
 ### Return value
@@ -46,13 +46,13 @@ disabled.
 ### Parameters
 
 - `aCommandName`
-  - : A {{domxref("DOMString")}} specifying the name of the command to execute. See
+  - : A string specifying the name of the command to execute. See
     [Commands](#commands) for a list of possible commands.
 - `aShowDefaultUI`
   - : A boolean value indicating whether the default user interface should be
     shown. This is not implemented in Mozilla.
 - `aValueArgument`
-  - : For commands which require an input argument, is a {{domxref("DOMString")}}
+  - : For commands which require an input argument, is a string
     providing that information. For example, `insertImage` requires the URL of
     the image to insert. Specify `null` if no argument is needed.
 
@@ -218,7 +218,7 @@ disabled.
 - `AutoUrlDetect`
   - : Changes the browser auto-link behavior (Internet Explorer only)
 
-## Example
+## Examples
 
 An example of [how to use
 execCommand with contentEditable elements](https://codepen.io/chrisdavidmills/full/gzYjag/) on CodePen.
@@ -265,7 +265,7 @@ for (const buttonContainer of buttonContainers) {
     const elementName = button.getAttribute('data-el');
     button.addEventListener('click',
       () => insertText(`<${elementName}></${elementName}>`, pasteTarget) )
-  }  
+  }
 }
 
 // Inserts text at cursor, or replaces selected text

--- a/files/en-us/web/api/document/exitfullscreen/index.md
+++ b/files/en-us/web/api/document/exitfullscreen/index.md
@@ -26,7 +26,7 @@ reverses the effects of a previous call to {{domxref("Element.requestFullscreen(
 ## Syntax
 
 ```js
-exitPromise = document.exitFullscreen();
+exitFullscreen()
 ```
 
 ### Parameters
@@ -39,7 +39,7 @@ A {{jsxref("Promise")}} which is resolved once the {{Glossary("user agent")}} ha
 finished exiting fullscreen mode. If an error occurs while attempting to exit
 fullscreen mode, the `catch()` handler for the promise is called.
 
-## Example
+## Examples
 
 This example causes the current document to toggle in and out of a fullscreen
 presentation whenever the mouse button is clicked within it.

--- a/files/en-us/web/api/document/exitpictureinpicture/index.md
+++ b/files/en-us/web/api/document/exitpictureinpicture/index.md
@@ -24,7 +24,7 @@ effects of a previous call to {{domxref("HTMLVideoElement.requestPictureInPictur
 ## Syntax
 
 ```js
-exitPromise = document.exitPictureInPicture();
+exitPictureInPicture()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/document/exitpointerlock/index.md
+++ b/files/en-us/web/api/document/exitpointerlock/index.md
@@ -20,7 +20,7 @@ To track the success or failure of the request, it is necessary to listen for th
 ## Syntax
 
 ```js
-document.exitPointerLock();
+exitPointerLock()
 ```
 
 ## Specifications

--- a/files/en-us/web/api/document/getanimations/index.md
+++ b/files/en-us/web/api/document/getanimations/index.md
@@ -26,7 +26,7 @@ target elements are descendants of the document. This array includes [CSS Animat
 ## Syntax
 
 ```js
-getAnimations();
+getAnimations()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/document/getboxobjectfor/index.md
+++ b/files/en-us/web/api/document/getboxobjectfor/index.md
@@ -19,13 +19,13 @@ Returns a `boxObject` (x, y, width, height) for a specified element.
 ## Syntax
 
 ```js
-boxObject = document.getBoxObjectFor(element);
+getBoxObjectFor(element)
 ```
 
 - _boxObject_ is an `nsIBoxObject`.
 - _element_ is a {{domxref("element","DOMElement")}}.
 
-## Example
+## Examples
 
 ```js
 var myDiv = document.getElementById("myDiv"),

--- a/files/en-us/web/api/document/getelementbyid/index.md
+++ b/files/en-us/web/api/document/getelementbyid/index.md
@@ -22,7 +22,7 @@ If you need to get access to an element which doesn't have an ID, you can use {{
 ## Syntax
 
 ```js
-var element = document.getElementById(id);
+getElementById(id)
 ```
 
 ### Parameters
@@ -34,7 +34,7 @@ var element = document.getElementById(id);
 
 An {{domxref("Element")}} object describing the DOM element object matching the specified ID, or `null` if no matching element was found in the document.
 
-## Example
+## Examples
 
 ### HTML
 

--- a/files/en-us/web/api/document/getelementsbyclassname/index.md
+++ b/files/en-us/web/api/document/getelementsbyclassname/index.md
@@ -31,16 +31,20 @@ descendants of the specified root element with the given class name(s).
 ## Syntax
 
 ```js
-var elements = document.getElementsByClassName(names); // or:
-var elements = rootElement.getElementsByClassName(names);
+getElementsByClassName(names)
 ```
 
-- _elements_ is a live {{domxref("HTMLCollection")}} of found elements.
+### Parameters
+
 - _names_ is a string representing the class name(s) to match; multiple class
   names are separated by whitespace
 - {{domxref("Element.getElementsByClassName", "getElementsByClassName")}} can be
   called on any element, not only on the {{domxref("document")}}. The element on which
   it is called will be used as the root of the search.
+
+### Return value
+
+- A live {{domxref("HTMLCollection")}} of found elements.
 
 ## Examples
 

--- a/files/en-us/web/api/document/getelementsbyname/index.md
+++ b/files/en-us/web/api/document/getelementsbyname/index.md
@@ -19,15 +19,19 @@ elements with a given `name` attribute in the document.
 ## Syntax
 
 ```js
-var elements = document.getElementsByName(name);
+getElementsByName(name)
 ```
 
-- _elements_ is a live {{domxref("NodeList")}} Collection, meaning it
-  automatically updates as new elements with the same `name` are added
-  to/removed from the document.
+### Parameters
+
 - _name_ is the value of the `name` attribute of the element(s).
 
-## Example
+### Return value
+
+A live {{domxref("NodeList")}} Collection, meaning it automatically updates as new elements with the same `name` are added to/removed from the document.
+
+
+## Examples
 
 ```html
 <!DOCTYPE html>

--- a/files/en-us/web/api/document/getelementsbyname/index.md
+++ b/files/en-us/web/api/document/getelementsbyname/index.md
@@ -28,7 +28,7 @@ getElementsByName(name)
 
 ### Return value
 
-A live {{domxref("NodeList")}} Collection, meaning it automatically updates as new elements with the same `name` are added to/removed from the document.
+A live {{domxref("NodeList")}} collection, meaning it automatically updates as new elements with the same `name` are added to, or removed from, the document.
 
 
 ## Examples

--- a/files/en-us/web/api/document/getelementsbytagname/index.md
+++ b/files/en-us/web/api/document/getelementsbytagname/index.md
@@ -22,20 +22,24 @@ without having to call `document.getElementsByTagName()` again.
 ## Syntax
 
 ```js
-var elements = document.getElementsByTagName(name);
+getElementsByTagName(name)
 ```
 
-- _elements_ is a live {{domxref("HTMLCollection")}} (but see the note below)
-  of found elements in the order they appear in the tree.
+### Parameters
+- - 
 - _name_ is a string representing the name of the elements. The special
   string "\*" represents all elements.
 
+### Return value
+
+A live {{domxref("HTMLCollection")}} (but see the note below) of found elements in the order they appear in the tree.
+
 > **Note:** [The
-> latest W3C specification](https://dvcs.w3.org/hg/domcore/raw-file/tip/Overview.html) says _elements_ is an
+> latest W3C specification](https://dvcs.w3.org/hg/domcore/raw-file/tip/Overview.html) says returned value is an
 > `HTMLCollection`; however, this method returns a {{domxref("NodeList")}} in
 > WebKit browsers. See {{bug(14869)}} for details.
 
-## Example
+## Examples
 
 In the following example, `getElementsByTagName()` starts from a particular
 parent element and searches top-down recursively through the DOM from that parent

--- a/files/en-us/web/api/document/getelementsbytagname/index.md
+++ b/files/en-us/web/api/document/getelementsbytagname/index.md
@@ -32,7 +32,7 @@ getElementsByTagName(name)
 
 ### Return value
 
-A live {{domxref("HTMLCollection")}} (but see the note below) of found elements in the order they appear in the tree.
+A live {{domxref("HTMLCollection")}} of found elements in the order they appear in the tree.
 
 > **Note:** [The
 > latest W3C specification](https://dvcs.w3.org/hg/domcore/raw-file/tip/Overview.html) says returned value is an

--- a/files/en-us/web/api/document/getelementsbytagnamens/index.md
+++ b/files/en-us/web/api/document/getelementsbytagnamens/index.md
@@ -24,6 +24,8 @@ getElementsByTagNameNS(namespace, name)
 
 ### Parameters
 
+- _namespace_ is the namespace URI of elements to look for (see
+  {{domxref("Element.namespaceURI", "element.namespaceURI")}}).
 - _name_ is either the local name of elements to look for or the special
   value `*`, which matches all elements (see {{domxref("Element.localName",
     "element.localName")}}).
@@ -32,8 +34,6 @@ getElementsByTagNameNS(namespace, name)
 
 A live {{DOMxRef("NodeList")}} (but see the note below) of
   found elements in the order they appear in the tree.
-- _namespace_ is the namespace URI of elements to look for (see
-  {{domxref("Element.namespaceURI", "element.namespaceURI")}}).
 
 > **Note:** While the W3C specification says returned value is a `NodeList`, this method returns a {{DOMxRef("HTMLCollection")}} both in Gecko and Internet Explorer.
 > Opera returns a `NodeList`, but with a `namedItem` method implemented, which makes it similar to a `HTMLCollection`. As of January 2012, only in WebKit browsers is the returned value a pure `NodeList`.

--- a/files/en-us/web/api/document/getelementsbytagnamens/index.md
+++ b/files/en-us/web/api/document/getelementsbytagnamens/index.md
@@ -19,25 +19,30 @@ The complete document is searched, including the root node.
 ## Syntax
 
 ```js
-elements = document.getElementsByTagNameNS(namespace, name)
+getElementsByTagNameNS(namespace, name)
 ```
 
-- _elements_ is a live {{DOMxRef("NodeList")}} (but see the note below) of
-  found elements in the order they appear in the tree.
-- _namespace_ is the namespace URI of elements to look for (see
-  {{domxref("Element.namespaceURI", "element.namespaceURI")}}).
+### Parameters
+
 - _name_ is either the local name of elements to look for or the special
   value `*`, which matches all elements (see {{domxref("Element.localName",
     "element.localName")}}).
 
-> **Note:** While the W3C specification says `elements` is a `NodeList`, this method returns a {{DOMxRef("HTMLCollection")}} both in Gecko and Internet Explorer.
+### Return value
+
+A live {{DOMxRef("NodeList")}} (but see the note below) of
+  found elements in the order they appear in the tree.
+- _namespace_ is the namespace URI of elements to look for (see
+  {{domxref("Element.namespaceURI", "element.namespaceURI")}}).
+
+> **Note:** While the W3C specification says returned value is a `NodeList`, this method returns a {{DOMxRef("HTMLCollection")}} both in Gecko and Internet Explorer.
 > Opera returns a `NodeList`, but with a `namedItem` method implemented, which makes it similar to a `HTMLCollection`. As of January 2012, only in WebKit browsers is the returned value a pure `NodeList`.
 > See [bug 14869](https://bugzilla.mozilla.org/show_bug.cgi?id=14869) for details.
 
 > **Note:** Currently parameters in this method are case-sensitive, but they were case-insensitive in Firefox 3.5 and before.
 > See the [developer release note for Firefox 3.6](/en-US/docs/Mozilla/Firefox/Releases/3.6#dom) and a note in Browser compatibility section in {{domxref("Element.getElementsByTagNameNS")}} for details.
 
-## Example
+## Examples
 
 In the following example `getElementsByTagNameNS` starts from a particular
 parent element, and searches topdown recursively through the DOM from that parent

--- a/files/en-us/web/api/document/getselection/index.md
+++ b/files/en-us/web/api/document/getselection/index.md
@@ -26,11 +26,11 @@ getSelection()
 
 None.
 
-### Returns
+### Return value
 
 A {{DOMxRef("Selection")}} object.
 
-## Example
+## Examples
 
 ### Getting a Selection object
 

--- a/files/en-us/web/api/document/hasfocus/index.md
+++ b/files/en-us/web/api/document/hasfocus/index.md
@@ -23,7 +23,7 @@ active element in a document has focus.
 ## Syntax
 
 ```js
-var focused = document.hasFocus();
+hasFocus()
 ```
 
 ### Return value
@@ -31,7 +31,7 @@ var focused = document.hasFocus();
 `false` if the active element in the document has no focus;
 `true` if the active element in the document has focus.
 
-## Example
+## Examples
 
 This example checks whether the document has focus every 300 milliseconds. To test the
 functionality of `hasFocus()`, click on the button to open a new window, and

--- a/files/en-us/web/api/document/hasstorageaccess/index.md
+++ b/files/en-us/web/api/document/hasstorageaccess/index.md
@@ -23,7 +23,7 @@ information.
 ## Syntax
 
 ```js
-var promise = document.hasStorageAccess();
+hasStorageAccess()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/document/importnode/index.md
+++ b/files/en-us/web/api/document/importnode/index.md
@@ -55,7 +55,7 @@ The copied `importedNode` in the scope of the importing document.
 
 > **Note:** `importedNode`'s {{domxref("Node.parentNode")}} is `null`, since it has not yet been inserted into the document tree!
 
-## Example
+## Examples
 
 ```js
 const iframe  = document.querySelector("iframe");

--- a/files/en-us/web/api/document/mozsetimageelement/index.md
+++ b/files/en-us/web/api/document/mozsetimageelement/index.md
@@ -19,7 +19,7 @@ element ID.
 ## Syntax
 
 ```js
-document.mozSetImageElement(imageElementId, imageElement);
+mozSetImageElement(imageElementId, imageElement)
 ```
 
 ### Parameters
@@ -31,7 +31,7 @@ document.mozSetImageElement(imageElementId, imageElement);
   to that image element string. Specify `null` to remove the background
   element.
 
-## Example
+## Examples
 
 This example changes the background of a {{ HTMLElement("div") }} block each time the
 block is clicked by the user.

--- a/files/en-us/web/api/document/open/index.md
+++ b/files/en-us/web/api/document/open/index.md
@@ -24,7 +24,7 @@ This does come with some side effects. For example:
 ## Syntax
 
 ```js
-document.open();
+open()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/document/querycommandsupported/index.md
+++ b/files/en-us/web/api/document/querycommandsupported/index.md
@@ -19,7 +19,7 @@ whether or not the specified editor command is supported by the browser.
 ## Syntax
 
 ```js
-isSupported = document.queryCommandSupported(command);
+queryCommandSupported(command)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/document/queryselector/index.md
+++ b/files/en-us/web/api/document/queryselector/index.md
@@ -27,13 +27,13 @@ selector, or group of selectors. If no matches are found, `null` is returned.
 ## Syntax
 
 ```js
-element = document.querySelector(selectors);
+querySelector(selectors)
 ```
 
 ### Parameters
 
 - _selectors_
-  - : A {{domxref("DOMString")}} containing one or more selectors to match. This string
+  - : A string containing one or more selectors to match. This string
     must be a valid CSS selector string; if it isn't, a `SyntaxError` exception
     is thrown. See [Locating
     DOM elements using selectors](/en-US/docs/Web/API/Document_object_model/Locating_DOM_elements_using_selectors) for more about selectors and how to manage them.

--- a/files/en-us/web/api/document/queryselectorall/index.md
+++ b/files/en-us/web/api/document/queryselectorall/index.md
@@ -25,13 +25,13 @@ document's elements that match the specified group of selectors.
 ## Syntax
 
 ```js
-elementList = parentNode.querySelectorAll(selectors);
+querySelectorAll(selectors)
 ```
 
 ### Parameters
 
 - `selectors`
-  - : A {{domxref("DOMString")}} containing one or more selectors to match against. This
+  - : A string containing one or more selectors to match against. This
     string must be a valid [CSS selector](/en-US/docs/Web/CSS/CSS_Selectors)
     string; if it's not, a `SyntaxError` exception is thrown. See [Locating
     DOM elements using selectors](/en-US/docs/Web/API/Document_object_model/Locating_DOM_elements_using_selectors) for more information about using selectors to

--- a/files/en-us/web/api/document/registerelement/index.md
+++ b/files/en-us/web/api/document/registerelement/index.md
@@ -25,7 +25,8 @@ browser and returns a constructor for the new element.
 ## Syntax
 
 ```js
-var constructor = document.registerElement(tag-name, options);
+registerElement(tag-name)
+registerElement(tag-name, options)
 ```
 
 ### Parameters
@@ -37,7 +38,7 @@ var constructor = document.registerElement(tag-name, options);
   - : An object with properties **prototype** to base the custom element on,
     and **extends**, an existing tag to extend. Both of these are optional.
 
-## Example
+## Examples
 
 Here is a very simple example:
 

--- a/files/en-us/web/api/document/releasecapture/index.md
+++ b/files/en-us/web/api/document/releasecapture/index.md
@@ -17,13 +17,13 @@ element is done by calling {{domxref("element.setCapture()")}}.
 ## Syntax
 
 ```js
-document.releaseCapture();
+releaseCapture()
 ```
 
 Once mouse capture is released, mouse events will no longer all be directed to the
 element on which capture is enabled.
 
-## Example
+## Examples
 
 See the [example](/en-US/docs/Web/API/Element/setCapture#example) for
 {{domxref("element.setCapture()")}}.

--- a/files/en-us/web/api/document/requeststorageaccess/index.md
+++ b/files/en-us/web/api/document/requeststorageaccess/index.md
@@ -118,7 +118,7 @@ we have added two preferences in `about:config` that control prompting upon
 ## Syntax
 
 ```js
-var promise = document.requestStorageAccess();
+requestStorageAccess()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/document/write/index.md
+++ b/files/en-us/web/api/document/write/index.md
@@ -19,7 +19,7 @@ The **`Document.write()`** method writes a string of text to a document stream o
 ## Syntax
 
 ```js
-document.write(markup);
+write(markup)
 ```
 
 ### Parameters
@@ -27,7 +27,7 @@ document.write(markup);
 - _markup_
   - : A string containing the text to be written to the document.
 
-### Example
+## Examples
 
 ```html
 <html>

--- a/files/en-us/web/api/document/writeln/index.md
+++ b/files/en-us/web/api/document/writeln/index.md
@@ -15,14 +15,14 @@ Writes a string of text followed by a newline character to a document.
 ## Syntax
 
 ```js
-document.writeln(line);
+writeln(line)
 ```
 
 ### Parameters
 
 - `line` is string containing a line of text.
 
-## Example
+## Examples
 
 ```js
 document.writeln("<p>enter password:</p>");

--- a/files/en-us/web/api/documentfragment/queryselector/index.md
+++ b/files/en-us/web/api/documentfragment/queryselector/index.md
@@ -24,13 +24,13 @@ a `SYNTAX_ERR` value is raised.
 ## Syntax
 
 ```js
-element = documentfragment.querySelector(selectors);
+querySelector(selectors)
 ```
 
 ### Parameters
 
 - _selectors_
-  - : Is a {{domxref("DOMString")}} containing one or more CSS selectors separated by
+  - : Is a string containing one or more CSS selectors separated by
     commas.
 
 ## Examples

--- a/files/en-us/web/api/documentfragment/queryselectorall/index.md
+++ b/files/en-us/web/api/documentfragment/queryselectorall/index.md
@@ -21,13 +21,13 @@ a `SYNTAX_ERR` value is raised.
 ## Syntax
 
 ```js
-elementList = documentfragment.querySelectorAll(selectors);
+querySelectorAll(selectors)
 ```
 
 ### Parameters
 
 - _selectors_
-  - : Is a {{domxref("DOMString")}} containing one or more CSS selectors separated by
+  - : Is a string containing one or more CSS selectors separated by
     commas.
 
 ## Examples

--- a/files/en-us/web/api/domimplementation/createdocument/index.md
+++ b/files/en-us/web/api/domimplementation/createdocument/index.md
@@ -17,22 +17,23 @@ returns an {{domxref("XMLDocument")}}.
 ## Syntax
 
 ```js
-var doc = document.implementation.createDocument(namespaceURI, qualifiedNameStr, documentType);
+createDocument(namespaceURI, qualifiedNameStr)
+createDocument(namespaceURI, qualifiedNameStr, documentType)
 ```
 
 ### Parameters
 
 - `namespaceURI`
-  - : Is a {{domxref("DOMString")}} containing the namespace URI of the document to be
+  - : Is a string containing the namespace URI of the document to be
     created, or `null` if the document doesn't belong to one.
 - `qualifiedNameStr`
-  - : Is a {{domxref("DOMString")}} containing the qualified name, that is an optional
+  - : Is a string containing the qualified name, that is an optional
     prefix and colon plus the local root element name, of the document to be created.
 - `documentType` {{optional_inline}}
   - : Is the {{domxref("DocumentType")}} of the document to be created. It defaults to
     `null`.
 
-## Example
+## Examples
 
 ```js
 var doc = document.implementation.createDocument ('http://www.w3.org/1999/xhtml', 'html', null);

--- a/files/en-us/web/api/domimplementation/createdocumenttype/index.md
+++ b/files/en-us/web/api/domimplementation/createdocumenttype/index.md
@@ -20,20 +20,20 @@ into the document via methods like {{domxref("Node.insertBefore()")}} or
 ## Syntax
 
 ```js
-var doctype = document.implementation.createDocumentType(qualifiedNameStr, publicId, systemId);
+createDocumentType(qualifiedNameStr, publicId, systemId)
 ```
 
 ### Parameters
 
 - `qualifiedNameStr`
-  - : Is a {{domxref("DOMString")}} containing the qualified name, like
+  - : Is a string containing the qualified name, like
     `svg:svg`.
 - `publicId`
-  - : Is a {{domxref("DOMString")}} containing the `PUBLIC` identifier.
+  - : Is a string containing the `PUBLIC` identifier.
 - `systemId`
-  - : Is a {{domxref("DOMString")}} containing the `SYSTEM` identifiers.
+  - : Is a string containing the `SYSTEM` identifiers.
 
-## Example
+## Examples
 
 ```js
 var dt = document.implementation.createDocumentType('svg:svg', '-//W3C//DTD SVG 1.1//EN', 'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd');

--- a/files/en-us/web/api/domimplementation/createhtmldocument/index.md
+++ b/files/en-us/web/api/domimplementation/createhtmldocument/index.md
@@ -19,15 +19,16 @@ new HTML {{ domxref("Document") }}.
 ## Syntax
 
 ```js
-const newDoc = document.implementation.createHTMLDocument(title)
+createHTMLDocument()
+createHTMLDocument(title)
 ```
 
 ### Parameters
 
 - `title`  {{optional_inline}} (except in IE)
-  - : A {{domxref("DOMString")}} containing the title to give the new HTML document.
+  - : A string containing the title to give the new HTML document.
 
-## Example
+## Examples
 
 This example creates a new HTML document and inserts it into an {{
   HTMLElement("iframe") }} in the current document.

--- a/files/en-us/web/api/domimplementation/hasfeature/index.md
+++ b/files/en-us/web/api/domimplementation/hasfeature/index.md
@@ -26,15 +26,15 @@ The latest version of the spec settled to force this method to always return
 ## Syntax
 
 ```js
-const flag = document.implementation.hasFeature(feature, version);
+hasFeature(feature, version)
 ```
 
 ### Parameters
 
 - `feature`
-  - : A {{domxref("DOMString")}} representing the feature name.
+  - : A string representing the feature name.
 - `version`
-  - : A {{domxref("DOMString")}} representing the version of the specification defining
+  - : A string representing the version of the specification defining
     the feature.
 
 ## Specifications

--- a/files/en-us/web/api/domparser/parsefromstring/index.md
+++ b/files/en-us/web/api/domparser/parsefromstring/index.md
@@ -14,18 +14,18 @@ The **`parseFromString()`** method of the {{domxref("DOMParser")}} interface par
 ## Syntax
 
 ```js
-const doc = domparser.parseFromString(string, mimeType)
+parseFromString(string, mimeType)
 ```
 
 ### Parameters
 
 - `string`
-  - : The {{domxref("DOMString")}} to be parsed. It must contain either an
+  - : The string to be parsed. It must contain either an
     {{Glossary("HTML")}}, {{Glossary("xml")}}, {{Glossary("xhtml+xml")}}, or
     {{Glossary("svg")}} document.
 - `mimeType`
 
-  - : A {{domxref("DOMString")}}. This string determines whether the XML parser or the HTML parser is used to parse the string. Valid values are:
+  - : A string. This string determines whether the XML parser or the HTML parser is used to parse the string. Valid values are:
 
     - `text/html`
     - `text/xml`

--- a/files/en-us/web/api/dompoint/frompoint/index.md
+++ b/files/en-us/web/api/dompoint/frompoint/index.md
@@ -31,10 +31,10 @@ the properties within may be changed at will.
 ## Syntax
 
 ```js
-var point = DOMPoint.fromPoint(sourcePoint);
+fromPoint(sourcePoint)
 ```
 
-### Properties
+### Parameters
 
 - `sourcePoint`
 

--- a/files/en-us/web/api/dompointreadonly/frompoint/index.md
+++ b/files/en-us/web/api/dompointreadonly/frompoint/index.md
@@ -27,10 +27,10 @@ You can also create a new `DOMPointReadOnly` object using the
 ## Syntax
 
 ```js
-const point = DOMPointReadOnly.fromPoint(sourcePoint)
+fromPoint(sourcePoint)
 ```
 
-### Properties
+### Parameters
 
 - `sourcePoint`
 

--- a/files/en-us/web/api/dompointreadonly/tojson/index.md
+++ b/files/en-us/web/api/dompointreadonly/tojson/index.md
@@ -24,7 +24,7 @@ The {{domxref("DOMPointReadOnly")}} method
 ## Syntax
 
 ```js
-pointJSON = DOMPointReadOnly.toJSON();
+toJSON()
 ```
 
 ### Parameters
@@ -36,7 +36,7 @@ None.
 A new object whose properties are set to the values in the
 `DOMPoint` or `DOMPointReadOnly` on which the method was called.
 
-## Example
+## Examples
 
 This example creates a {{domxref("DOMPoint")}} object representing the top-left corner
 of the current window, in screen coordinates, then converts that to JSON.

--- a/files/en-us/web/api/domrect/fromrect/index.md
+++ b/files/en-us/web/api/domrect/fromrect/index.md
@@ -18,7 +18,8 @@ object with a given location and dimensions.
 ## Syntax
 
 ```js
-DOMRect.fromRect(rectangle)
+fromRect()
+fromRect(rectangle)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/domrectreadonly/fromrect/index.md
+++ b/files/en-us/web/api/domrectreadonly/fromrect/index.md
@@ -18,7 +18,8 @@ object with a given location and dimensions.
 ## Syntax
 
 ```js
-DOMRectReadOnly.fromRect(rectangle)
+fromRect()
+fromRect(rectangle)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/domtokenlist/replace/index.md
+++ b/files/en-us/web/api/domtokenlist/replace/index.md
@@ -19,7 +19,7 @@ without adding the new token to the token list.
 ## Syntax
 
 ```js
-replace(oldToken, newToken);
+replace(oldToken, newToken)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/element/closest/index.md
+++ b/files/en-us/web/api/element/closest/index.md
@@ -21,12 +21,12 @@ element exists, it returns `null`.
 ## Syntax
 
 ```js
-var closestElement = targetElement.closest(selectors);
+closest(selectors)
 ```
 
 ### Parameters
 
-- `selectors` is a {{domxref("DOMString")}} containing a
+- `selectors` is a string containing a
   selector list.
   ex: `p:hover, .toto + q`
 
@@ -40,7 +40,7 @@ var closestElement = targetElement.closest(selectors);
 - {{exception("SyntaxError")}} is thrown if the `selectors` is
   not a valid selector list string.
 
-## Example
+## Examples
 
 ### HTML
 

--- a/files/en-us/web/api/element/computedstylemap/index.md
+++ b/files/en-us/web/api/element/computedstylemap/index.md
@@ -23,7 +23,7 @@ an alternative to {{domxref("CSSStyleDeclaration")}}.
 ## Syntax
 
 ```js
-var stylePropertyMapReadOnly = element.computedStyleMap()
+computedStyleMap()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/element/createshadowroot/index.md
+++ b/files/en-us/web/api/element/createshadowroot/index.md
@@ -23,7 +23,7 @@ the element that it is attached to is called the {{glossary("shadow root")}}.
 ## Syntax
 
 ```js
-var shadowroot = element.createShadowRoot();
+createShadowRoot()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/element/getanimations/index.md
+++ b/files/en-us/web/api/element/getanimations/index.md
@@ -31,7 +31,8 @@ elements too.
 ## Syntax
 
 ```js
-const animations = Element.getAnimations(options);
+getAnimations()
+getAnimations(options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/element/getattribute/index.md
+++ b/files/en-us/web/api/element/getattribute/index.md
@@ -21,7 +21,7 @@ either be `null` or `""` (the empty string); see [Non-existing attributes](#non-
 ## Syntax
 
 ```js
-let attribute = element.getAttribute(attributeName);
+getAttribute(attributeName)
 ```
 
 where

--- a/files/en-us/web/api/element/getattributenames/index.md
+++ b/files/en-us/web/api/element/getattributenames/index.md
@@ -26,10 +26,10 @@ The names returned by **`getAttributeNames()`** are _qualified_ attribute names,
 ## Syntax
 
 ```js
-let attributeNames = element.getAttributeNames();
+getAttributeNames()
 ```
 
-## Example
+## Examples
 
 The following example shows how:
 

--- a/files/en-us/web/api/element/getattributenode/index.md
+++ b/files/en-us/web/api/element/getattributenode/index.md
@@ -16,13 +16,13 @@ Returns the specified attribute of the specified element, as an `Attr` node.
 ## Syntax
 
 ```js
-var attrNode = element.getAttributeNode(attrName);
+getAttributeNode(attrName)
 ```
 
 - `attrNode` is an `Attr` node for the attribute.
 - `attrName` is a string containing the name of the attribute.
 
-## Example
+## Examples
 
 ```js
 // html: <div id="top" />

--- a/files/en-us/web/api/element/getattributenodens/index.md
+++ b/files/en-us/web/api/element/getattributenodens/index.md
@@ -15,7 +15,7 @@ Returns the `Attr` node for the attribute with the given namespace and name.
 ## Syntax
 
 ```js
-attributeNode = element.getAttributeNodeNS(namespace, nodeName)
+getAttributeNodeNS(namespace, nodeName)
 ```
 
 - `attributeNode` is the node for specified attribute.

--- a/files/en-us/web/api/element/getattributens/index.md
+++ b/files/en-us/web/api/element/getattributens/index.md
@@ -20,7 +20,7 @@ details.
 ## Syntax
 
 ```js
-attrVal = element.getAttributeNS(namespace, name)
+getAttributeNS(namespace, name)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/element/getboundingclientrect/index.md
+++ b/files/en-us/web/api/element/getboundingclientrect/index.md
@@ -33,10 +33,10 @@ position relative to the [viewport](/en-US/docs/Glossary/Viewport).
 ## Syntax
 
 ```js
-domRect = element.getBoundingClientRect();
+getBoundingClientRect()
 ```
 
-### Value
+### Return value
 
 The returned value is a {{domxref("DOMRect")}} object which is the smallest rectangle
 which contains the entire element, including its padding and border-width. The

--- a/files/en-us/web/api/element/getclientrects/index.md
+++ b/files/en-us/web/api/element/getclientrects/index.md
@@ -27,7 +27,7 @@ Most elements only have one border box each, but a multiline [inline element](/e
 ## Syntax
 
 ```js
-let rectCollection = object.getClientRects();
+getClientRects()
 ```
 
 ### Return value

--- a/files/en-us/web/api/element/getelementsbyclassname/index.md
+++ b/files/en-us/web/api/element/getelementsbyclassname/index.md
@@ -24,13 +24,13 @@ on the entire document, starting at the document root.
 ## Syntax
 
 ```js
-var elements = element.getElementsByClassName(names);
+getElementsByClassName(names)
 ```
 
 ### Parameters
 
 - `names`
-  - : A {{domxref("DOMString")}} containing one or more class names to match on, separated
+  - : A string containing one or more class names to match on, separated
     by whitespace.
 
 ### Return value

--- a/files/en-us/web/api/element/getelementsbytagname/index.md
+++ b/files/en-us/web/api/element/getelementsbytagname/index.md
@@ -30,24 +30,26 @@ which preserves the capitalization of the tag name.
 
 `Element.getElementsByTagName` is similar to
 {{domxref("Document.getElementsByTagName()")}}, except that it only searches for
-elements that are descendants of the specified element.
+elements that are descendants of the specified element. 
 
 ## Syntax
 
 ```js
-elements = element.getElementsByTagName(tagName)
+getElementsByTagName(tagName)
 ```
 
-- `elements` is a _live_ {{domxref("HTMLCollection")}} of elements
-  with a matching tag name, in the order they appear. If no elements are found, the
-  `HTMLCollection` is empty.
-- `element` is the element from where the search starts. Only the
-  element's descendants are included, not the element itself.
+- ### Parameters
+- 
 - `tagName` is the qualified name to look for. The special string
   `"*"` represents all elements. For compatibility with XHTML, lower-case
   should be used.
 
-## Example
+### Return value
+
+A _live_ {{domxref("HTMLCollection")}} of elements with a matching tag name, in the order they appear. If no elements are found, the `HTMLCollection` is empty.
+
+
+## Examples
 
 ```js
 // Check the status of each data cell in a table

--- a/files/en-us/web/api/element/getelementsbytagnamens/index.md
+++ b/files/en-us/web/api/element/getelementsbytagnamens/index.md
@@ -19,13 +19,11 @@ that its search is restricted to descendants of the specified element.
 ## Syntax
 
 ```js
-elements = element.getElementsByTagNameNS(namespaceURI, localName)
+getElementsByTagNameNS(namespaceURI, localName)
 ```
 
-- `elements` is a live {{domxref("HTMLCollection")}} of found elements in
-  the order they appear in the tree.
-- `element` is the element from where the search should start. Note that
-  only the descendants of this element are included in the search, not the node itself.
+### Parameters
+
 - `namespaceURI` is the namespace URI of elements to look for (see
   {{domxref("Element.namespaceURI")}} and {{domxref("Attr.namespaceURI")}}). For
   example, if you need to look for XHTML elements, use the XHTML namespace URI,
@@ -34,7 +32,11 @@ elements = element.getElementsByTagNameNS(namespaceURI, localName)
   special value `"*"`, which matches all elements (see
   {{domxref("Element.localName")}} and {{domxref("Attr.localName")}}).
 
-## Example
+### Return value
+
+A live {{domxref("HTMLCollection")}} of found elements in the order they appear in the tree.
+
+## Examples
 
 ```js
 // check the alignment on a number of cells in a table in an XHTML document.

--- a/files/en-us/web/api/element/hasattribute/index.md
+++ b/files/en-us/web/api/element/hasattribute/index.md
@@ -18,15 +18,19 @@ specified attribute or not.
 ## Syntax
 
 ```js
-var result = element.hasAttribute(name);
+hasAttribute(name)
 ```
 
-- `result`
-  - : holds the return value `true` or `false`.
+### Parameters
+
 - `name`
   - : is a string representing the name of the attribute.
 
-## Example
+### Return value
+
+A boolean.
+
+## Examples
 
 ```js
 var foo = document.getElementById("foo");

--- a/files/en-us/web/api/element/hasattributens/index.md
+++ b/files/en-us/web/api/element/hasattributens/index.md
@@ -16,14 +16,19 @@ browser-compat: api.Element.hasAttributeNS
 ## Syntax
 
 ```js
-result = element.hasAttributeNS(namespace,localName)
+hasAttributeNS(namespace,localName)
 ```
 
-- `result` is the boolean value `true` or `false`.
+### Parameters
+
 - `namespace` is a string specifying the namespace of the attribute.
 - `localName` is the name of the attribute.
 
-## Example
+### Return value
+
+A boolean.
+
+## Examples
 
 ```js
 // Check that the attribute exists before you set a value

--- a/files/en-us/web/api/element/hasattributes/index.md
+++ b/files/en-us/web/api/element/hasattributes/index.md
@@ -18,13 +18,12 @@ attributes or not.
 ## Syntax
 
 ```js
-var result = element.hasAttributes();
+hasAttributes()
 ```
 
 ### Return value
 
-- `result`
-  - : holds the return value `true` or `false`.
+A boolean.
 
 ## Examples
 

--- a/files/en-us/web/api/element/haspointercapture/index.md
+++ b/files/en-us/web/api/element/haspointercapture/index.md
@@ -20,7 +20,7 @@ pointer capture for the pointer identified by the given pointer ID.
 ## Syntax
 
 ```js
-targetElement.hasPointerCapture(pointerId);
+hasPointerCapture(pointerId)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/element/insertadjacentelement/index.md
+++ b/files/en-us/web/api/element/insertadjacentelement/index.md
@@ -20,14 +20,14 @@ relative to the element it is invoked upon.
 ## Syntax
 
 ```js
-targetElement.insertAdjacentElement(position, element);
+insertAdjacentElement(position, element)
 ```
 
 ### Parameters
 
 - `position`
 
-  - : A {{domxref("DOMString")}} representing the position relative to the
+  - : A string representing the position relative to the
     `targetElement`; must match (case-insensitively) one of the following
     strings:
 
@@ -70,7 +70,7 @@ The element that was inserted, or `null`, if the insertion failed.
 > `afterend` positions work only if the node is in a tree and has an element
 > parent.
 
-## Example
+## Examples
 
 ```js
 beforeBtn.addEventListener('click', function() {

--- a/files/en-us/web/api/element/insertadjacenthtml/index.md
+++ b/files/en-us/web/api/element/insertadjacenthtml/index.md
@@ -19,7 +19,7 @@ the resulting nodes into the DOM tree at a specified position.
 ## Syntax
 
 ```js
-element.insertAdjacentHTML(position, text);
+insertAdjacentHTML(position, text)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/element/insertadjacenttext/index.md
+++ b/files/en-us/web/api/element/insertadjacenttext/index.md
@@ -18,7 +18,7 @@ The **`insertAdjacentText()`** method of the {{domxref("Element")}} interface, g
 ## Syntax
 
 ```js
-element.insertAdjacentText(where, data);
+insertAdjacentText(where, data)
 ```
 
 ### Parameters
@@ -65,7 +65,7 @@ Void.
 > `afterend` positions work only if the node is in a tree and has an element
 > parent.
 
-## Example
+## Examples
 
 ```js
 beforeBtn.addEventListener('click', function() {

--- a/files/en-us/web/api/element/matches/index.md
+++ b/files/en-us/web/api/element/matches/index.md
@@ -21,7 +21,7 @@ the selector.
 ## Syntax
 
 ```js
-var result = element.matches(selectorString);
+matches(selectorString)
 ```
 
 ### Parameters
@@ -37,7 +37,7 @@ var result = element.matches(selectorString);
 - `SyntaxError` {{domxref("DOMException")}}
   - : Thrown if the specified selector string is invalid.
 
-## Example
+## Examples
 
 ```html
 <ul id="birds">

--- a/files/en-us/web/api/element/mszoomto/index.md
+++ b/files/en-us/web/api/element/mszoomto/index.md
@@ -18,10 +18,10 @@ Zoomed elements can expose their zoom level through {{Event("msContentZoom")}} (
 
 This proprietary method is specific to Internet Explorer and Microsoft Edge.
 
-### Syntax
+## Syntax
 
 ```js
-Element.msZoomTo(arguments);
+msZoomTo(arguments)
 ```
 
 ### Parameters
@@ -63,7 +63,7 @@ This method has no effect if called from a parent document to scroll or zoom con
 
 This method does not return a value.
 
-## Example
+## Examples
 
 ```js
 /* Zooming in on an element while still keeping it centered in the viewport */

--- a/files/en-us/web/api/element/queryselector/index.md
+++ b/files/en-us/web/api/element/queryselector/index.md
@@ -27,7 +27,7 @@ invoked that matches the specified group of selectors.
 ## Syntax
 
 ```js
-element = baseElement.querySelector(selectors);
+querySelector(selectors)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/element/queryselectorall/index.md
+++ b/files/en-us/web/api/element/queryselectorall/index.md
@@ -25,13 +25,13 @@ the method was called.
 ## Syntax
 
 ```js
-elementList = parentNode.querySelectorAll(selectors);
+querySelectorAll(selectors)
 ```
 
 ### Parameters
 
 - `selectors`
-  - : A {{domxref("DOMString")}} containing one or more selectors to match against. This
+  - : A string containing one or more selectors to match against. This
     string must be a valid [CSS selector](/en-US/docs/Web/CSS/CSS_Selectors)
     string; if it's not, a `SyntaxError` exception is thrown. See [Locating
     DOM elements using selectors](/en-US/docs/Web/API/Document_object_model/Locating_DOM_elements_using_selectors) for more information about using selectors to

--- a/files/en-us/web/api/element/releasepointercapture/index.md
+++ b/files/en-us/web/api/element/releasepointercapture/index.md
@@ -23,7 +23,7 @@ element.
 ## Syntax
 
 ```js
-targetElement.releasePointerCapture(pointerId);
+releasePointerCapture(pointerId)
 ```
 
 ### Parameters
@@ -42,7 +42,7 @@ This method returns `undefined`.
 | ------------------ | ---------------------------------------------------- |
 | `InvalidPointerId` | pointerId does not match any of the active pointers. |
 
-## Example
+## Examples
 
 This example sets pointer capture on a {{HtmlElement("div")}} when you press down on
 it. This lets you slide the element horizontally, even when you pointer moves outside of

--- a/files/en-us/web/api/element/removeattribute/index.md
+++ b/files/en-us/web/api/element/removeattribute/index.md
@@ -20,13 +20,13 @@ specified name from the element.
 ## Syntax
 
 ```js
-element.removeAttribute(attrName);
+removeAttribute(attrName)
 ```
 
 ### Parameters
 
 - `attrName`
-  - : A {{domxref("DOMString")}} specifying the name of the attribute to remove from the
+  - : A string specifying the name of the attribute to remove from the
     element. If the specified attribute does not exist, `removeAttribute()`
     returns without generating an error.
 
@@ -43,7 +43,7 @@ You should use `removeAttribute()` instead of setting the attribute value to
 
 {{ DOMAttributeMethods() }}
 
-## Example
+## Examples
 
 ```js
 // Given: <div id="div1" align="left" width="200px">

--- a/files/en-us/web/api/element/removeattributenode/index.md
+++ b/files/en-us/web/api/element/removeattributenode/index.md
@@ -35,7 +35,7 @@ The attribute node that was removed.
 - `NotFoundError` {{DOMxRef("DOMException")}}
   - : Thrown when the element's attribute list does not contain the attribute node.
 
-## Example
+## Examples
 
 ```js
 // Given: <div id="top" align="center" />

--- a/files/en-us/web/api/element/removeattributens/index.md
+++ b/files/en-us/web/api/element/removeattributens/index.md
@@ -18,7 +18,7 @@ The **`removeAttributeNS()`** method of the
 ## Syntax
 
 ```js
-element.removeAttributeNS(namespace, attrName);
+removeAttributeNS(namespace, attrName)
 ```
 
 ### Parameters
@@ -27,7 +27,7 @@ element.removeAttributeNS(namespace, attrName);
 - `attrName` is a string that names the attribute to be removed from the
   current node.
 
-## Example
+## Examples
 
 ```js
 // Given:

--- a/files/en-us/web/api/element/requestfullscreen/index.md
+++ b/files/en-us/web/api/element/requestfullscreen/index.md
@@ -36,7 +36,8 @@ detached from the original document, then the document receives these events ins
 ## Syntax
 
 ```js
-var promise = element.requestFullscreen(options);
+requestFullScreen()
+requestFullScreen(options)
 ```
 
 ### Parameters
@@ -44,7 +45,7 @@ var promise = element.requestFullscreen(options);
 - `options` {{optional_inline}}
   - : An object that controls the behavior of the transition to fullscreen mode. See below for available options.
 
-### Options
+#### Options
 
 - `navigationUI`
 

--- a/files/en-us/web/api/element/requestpointerlock/index.md
+++ b/files/en-us/web/api/element/requestpointerlock/index.md
@@ -24,7 +24,7 @@ To track the success or failure of the request, it is necessary to listen for th
 ## Syntax
 
 ```js
-instanceOfElement.requestPointerLock();
+requestPointerLock()
 ```
 
 ## Specifications

--- a/files/en-us/web/api/element/scroll/index.md
+++ b/files/en-us/web/api/element/scroll/index.md
@@ -18,8 +18,8 @@ element.
 ## Syntax
 
 ```js
-element.scroll(x-coord, y-coord)
-element.scroll(options)
+scroll(x-coord, y-coord)
+scroll(options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/element/scrollby/index.md
+++ b/files/en-us/web/api/element/scrollby/index.md
@@ -18,8 +18,8 @@ interface scrolls an element by the given amount.
 ## Syntax
 
 ```js
-element.scrollBy(x-coord, y-coord);
-element.scrollBy(options)
+scrollBy(x-coord, y-coord)
+scrollBy(options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/element/scrollintoview/index.md
+++ b/files/en-us/web/api/element/scrollintoview/index.md
@@ -23,9 +23,9 @@ visible to the user.
 ## Syntax
 
 ```js
-element.scrollIntoView();
-element.scrollIntoView(alignToTop); // Boolean parameter
-element.scrollIntoView(scrollIntoViewOptions); // Object parameter
+scrollIntoView()
+scrollIntoView(alignToTop)
+scrollIntoView(scrollIntoViewOptions)
 ```
 
 ### Parameters
@@ -59,7 +59,7 @@ element.scrollIntoView(scrollIntoViewOptions); // Object parameter
         One of `start`, `center`, `end`, or
         `nearest`. Defaults to `nearest`.
 
-## Example
+## Examples
 
 ```js
 var element = document.getElementById("box");

--- a/files/en-us/web/api/element/scrollintoviewifneeded/index.md
+++ b/files/en-us/web/api/element/scrollintoviewifneeded/index.md
@@ -17,8 +17,8 @@ The **`Element.scrollIntoViewIfNeeded()`** method scrolls the current element in
 ## Syntax
 
 ```js
-element.scrollIntoViewIfNeeded();
-element.scrollIntoViewIfNeeded(centerIfNeeded); // Boolean parameter
+scrollIntoViewIfNeeded()
+scrollIntoViewIfNeeded(centerIfNeeded)
 ```
 
 ### Parameters
@@ -30,7 +30,7 @@ element.scrollIntoViewIfNeeded(centerIfNeeded); // Boolean parameter
     - If `true`, the element will be aligned so it is centered within the visible area of the scrollable ancestor.
     - If `false`, the element will be aligned to the nearest edge of the visible area of the scrollable ancestor. Depending on which edge of the visible area is closest to the element, either the top of the element will be aligned to the top edge of the visible area, or the bottom edge of the element will be aligned to the bottom edge of the visible area.
 
-## Example
+## Examples
 
 ```js
 var element = document.getElementById("my-el");

--- a/files/en-us/web/api/element/scrollto/index.md
+++ b/files/en-us/web/api/element/scrollto/index.md
@@ -17,8 +17,8 @@ interface scrolls to a particular set of coordinates inside a given element.
 ## Syntax
 
 ```js
-element.scrollTo(x-coord, y-coord)
-element.scrollTo(options)
+scrollTo(x-coord, y-coord)
+scrollTo(options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/element/setattribute/index.md
+++ b/files/en-us/web/api/element/setattribute/index.md
@@ -25,17 +25,17 @@ To get the current value of an attribute, use {{domxref("Element.getAttribute",
 ## Syntax
 
 ```js
-Element.setAttribute(name, value);
+setAttribute(name, value)
 ```
 
 ### Parameters
 
 - `name`
-  - : A {{domxref("DOMString")}} specifying the name of the attribute whose value is to be
+  - : A string specifying the name of the attribute whose value is to be
     set. The attribute name is automatically converted to all lower-case when
     `setAttribute()` is called on an HTML element in an HTML document.
 - `value`
-  - : A {{domxref("DOMString")}} containing the value to assign to the attribute. Any
+  - : A string containing the value to assign to the attribute. Any
     non-string value specified is converted automatically into a string.
 
 Boolean attributes are considered to be `true` if they're present on the
@@ -58,7 +58,7 @@ value to the string `"null"`. If you wish to remove an attribute, call
   - : The specified attribute `name` contains one or more characters which are
     not valid in attribute names.
 
-## Example
+## Examples
 
 In the following example, `setAttribute()` is used to set attributes on a
 {{HTMLElement("button")}}.

--- a/files/en-us/web/api/element/setattributenode/index.md
+++ b/files/en-us/web/api/element/setattributenode/index.md
@@ -25,6 +25,7 @@ setAttributeNode(attribute)
 - `attribute` is the `Attr` node to set on the element.
 - 
 ### Return value
+
 The replaced attribute node, if any, returned by this function.
 
 ## Examples

--- a/files/en-us/web/api/element/setattributenode/index.md
+++ b/files/en-us/web/api/element/setattributenode/index.md
@@ -17,14 +17,17 @@ The **`setAttributeNode()`** method adds a new
 ## Syntax
 
 ```js
-var replacedAttr = element.setAttributeNode(attribute);
+setAttributeNode(attribute)
 ```
 
-- `attribute` is the `Attr` node to set on the element.
-- `replacedAttr` is the replaced attribute node, if any, returned by this
-  function.
+### Parameters
 
-## Example
+- `attribute` is the `Attr` node to set on the element.
+- 
+### Return value
+The replaced attribute node, if any, returned by this function.
+
+## Examples
 
 This example copies the `align` attribute from one element to another.
 

--- a/files/en-us/web/api/element/setattributenodens/index.md
+++ b/files/en-us/web/api/element/setattributenodens/index.md
@@ -16,13 +16,17 @@ browser-compat: api.Element.setAttributeNodeNS
 ## Syntax
 
 ```js
-replacedAttr = element.setAttributeNodeNS(attributeNode)
+setAttributeNodeNS(attributeNode)
 ```
 
-- `replacedAttr` is the replaced attribute node, if any, returned by this function.
+### Parameters
 - `attributeNode` is an `Attr` node.
 
-## Example
+### Return value
+
+The replaced attribute node, if any, returned by this function.
+
+## Examples
 
 ```js
 // <div id="one" xmlns:myNS="http://www.mozilla.org/ns/specialspace"

--- a/files/en-us/web/api/element/setattributens/index.md
+++ b/files/en-us/web/api/element/setattributens/index.md
@@ -20,6 +20,8 @@ with the given namespace and name.
 setAttributeNS(namespace, name, value)
 ```
 
+### Parameters
+
 - `namespace` is a string specifying the namespace of the attribute.
 - `name` is a string identifying the attribute by its qualified name;
   that is, a namespace prefix followed by a colon followed by a local name.

--- a/files/en-us/web/api/element/setattributens/index.md
+++ b/files/en-us/web/api/element/setattributens/index.md
@@ -17,7 +17,7 @@ with the given namespace and name.
 ## Syntax
 
 ```js
-element.setAttributeNS(namespace, name, value)
+setAttributeNS(namespace, name, value)
 ```
 
 - `namespace` is a string specifying the namespace of the attribute.
@@ -25,7 +25,7 @@ element.setAttributeNS(namespace, name, value)
   that is, a namespace prefix followed by a colon followed by a local name.
 - `value` is the desired string value of the new attribute.
 
-## Example
+## Examples
 
 ```js
 let d = document.getElementById('d1');

--- a/files/en-us/web/api/element/setcapture/index.md
+++ b/files/en-us/web/api/element/setcapture/index.md
@@ -24,14 +24,14 @@ to this element until the mouse button is released or {{
 ## Syntax
 
 ```js
-element.setCapture(retargetToElement);
+setCapture(retargetToElement)
 ```
 
 - `retargetToElement`
   - : If `true`, all events are targeted directly to this element; if
     `false`, events can also fire at descendants of this element.
 
-## Example
+## Examples
 
 In this example, the current mouse coordinates are drawn while you mouse around after
 clicking and holding down on an element.

--- a/files/en-us/web/api/element/setpointercapture/index.md
+++ b/files/en-us/web/api/element/setpointercapture/index.md
@@ -38,7 +38,7 @@ moves off the element (such as by scrolling or panning).
 ## Syntax
 
 ```js
-targetElement.setPointerCapture(pointerId);
+setPointerCapture(pointerId)
 ```
 
 ### Parameters
@@ -56,7 +56,7 @@ This method returns {{jsxref("undefined")}}.
 - `NotFoundError` {{domxref("DOMException")}}
   - : Thrown if `pointerId` does not match any active pointer.
 
-## Example
+## Examples
 
 This example sets pointer capture on a {{HtmlElement("div")}} when you press down on
 it. This lets you slide the element horizontally, even when you pointer moves outside of

--- a/files/en-us/web/api/element/toggleattribute/index.md
+++ b/files/en-us/web/api/element/toggleattribute/index.md
@@ -17,14 +17,14 @@ present and adding it if it is not present) on the given element.
 ## Syntax
 
 ```js
-toggleAttribute(name);
-toggleAttribute(name, force);
+toggleAttribute(name)
+toggleAttribute(name, force)
 ```
 
 ### Parameters
 
 - `name`
-  - : A {{domxref("DOMString")}} specifying the name of the attribute to be toggled. The
+  - : A string specifying the name of the attribute to be toggled. The
     attribute name is automatically converted to all lower-case when
     `toggleAttribute()` is called on an HTML element in an HTML document.
 - `force` {{optional_inline}}
@@ -44,7 +44,7 @@ present, and `false` otherwise.
   - : The specified attribute `name` contains one or more characters which
     are not valid in attribute names.
 
-## Example
+## Examples
 
 In the following example, `toggleAttribute()` is used to toggle the
 `disabled` attribute of an {{HTMLElement("input")}}.

--- a/files/en-us/web/api/elementinternals/checkvalidity/index.md
+++ b/files/en-us/web/api/elementinternals/checkvalidity/index.md
@@ -18,7 +18,7 @@ If `checkValidity` returns `false` then a cancelable [invalid event](/en-US/docs
 ## Syntax
 
 ```js
-ElementInternals.checkValidity();
+checkValidity()
 ```
 
 ### Parameters


### PR DESCRIPTION
Continuing #14857 

## Summary
Updating the method pages to follow the current templates:
https://developer.mozilla.org/en-US/docs/MDN/Structures/Syntax_sections#constructors_and_methods
https://developer.mozilla.org/en-US/docs/MDN/Structures/Page_types/API_method_subpage_template

Changes Include:
- fix syntax section
- changing section titles to suggested titles in the template
- change `{{DOMxRef("DOMString")}}` to `string`
- remove extra spaces in between words and extra trailing spaces
- other small corrections

### Metadata
- [x] Fixes a typo, bug, or other error
