### PR TITLE
Fix: Incorrect error message

### DIFF
--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
@@ -443,7 +443,7 @@ An arrow function cannot contain a line break between its parameters and its arr
 ```js
 var func = (a, b, c)
   => 1;
-// SyntaxError: expected expression, got '=>'
+// SyntaxError: Unexpected token '=>'
 ```
 
 However, this can be amended by putting the line break after the arrow or using


### PR DESCRIPTION
#### Summary
The console throws the error `SyntaxError: Unexpected token '=>'`

#### Motivation
Typo in `unexpected` and error has no "got", which might lead to minor confusion for beginners.

This PR…
- [ ] Fixes a typo, bug, or other error
