### PR TITLE
Make syntax sections of group() and groupEnd() comply with guideline

### DIFF
--- a/files/en-us/web/api/console/group/index.md
+++ b/files/en-us/web/api/console/group/index.md
@@ -32,7 +32,7 @@ group(label)
 
 ### Return value
 
-`undefined`.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/console/group/index.md
+++ b/files/en-us/web/api/console/group/index.md
@@ -27,9 +27,12 @@ group(label)
 
 ### Parameters
 
-- `label`
-  - : Label for the group. Optional. (Chrome 59 tested) Does not work with
-    `console.groupEnd()`.
+- `label` {{optional_inline}}
+  - : Label for the group.
+
+### Return value
+
+`undefined`.
 
 ## Examples
 
@@ -67,3 +70,7 @@ See [Using groups in the console](/en-US/docs/Web/API/console#using_groups_in_th
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("console.groupEnd()")}}

--- a/files/en-us/web/api/console/groupend/index.md
+++ b/files/en-us/web/api/console/groupend/index.md
@@ -28,6 +28,10 @@ groupEnd()
 
 None.
 
+### Return value
+
+`undefined`.
+
 ## Specifications
 
 {{Specifications}}
@@ -35,3 +39,7 @@ None.
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("console.group()")}}

--- a/files/en-us/web/api/console/groupend/index.md
+++ b/files/en-us/web/api/console/groupend/index.md
@@ -30,7 +30,7 @@ None.
 
 ### Return value
 
-`undefined`.
+None ({{jsxref("undefined")}}).
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Updates `group()` and `groupEnd()`'s syntax sections to follow [the guideline](https://developer.mozilla.org/en-US/docs/MDN/Structures/Syntax_sections#javascript_reference_syntax).

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Looks more in-line 👼

#### Supporting details
https://developer.mozilla.org/en-US/docs/MDN/Structures/Syntax_sections#javascript_reference_syntax

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
