### PR TITLE
Fix skewY redirect

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -11112,7 +11112,7 @@
 /en-US/docs/Web/CSS/transform-function/scaleZ()	/en-US/docs/Web/CSS/transform-function/scaleZ
 /en-US/docs/Web/CSS/transform-function/skew()	/en-US/docs/Web/CSS/transform-function/skew
 /en-US/docs/Web/CSS/transform-function/skewX()	/en-US/docs/Web/CSS/transform-function/skewX
-/en-US/docs/Web/CSS/transform-function/skewY()	/en-US/docs/Web/CSS/transform-function/skewX
+/en-US/docs/Web/CSS/transform-function/skewY()	/en-US/docs/Web/CSS/transform-function/skewY
 /en-US/docs/Web/CSS/transform-function/translate()	/en-US/docs/Web/CSS/transform-function/translate
 /en-US/docs/Web/CSS/transform-function/translate3d()	/en-US/docs/Web/CSS/transform-function/translate3d
 /en-US/docs/Web/CSS/transform-function/translateX()	/en-US/docs/Web/CSS/transform-function/translateX


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
It should fix invalid redirect to [skewY](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function/skewY), which I noticed in [transform-function page](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#skewing_distortion).

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
