### PR TITLE
Font fix for description of abbreviation

### DIFF
--- a/files/en-us/glossary/codec/index.md
+++ b/files/en-us/glossary/codec/index.md
@@ -5,7 +5,7 @@ tags:
   - Glossary
   - WebMechanics
 ---
-A *codec* (a blend word derived from "**_co_**der-**_dec_**oder") is a program, algorithm, or device that encodes or decodes a data stream. A given codec knows how to handle a specific encoding or compression technology.
+A *codec* (a blend word derived from "<strong><i>co</i></strong>der-<strong><i>dec</i></strong>oder") is a program, algorithm, or device that encodes or decodes a data stream. A given codec knows how to handle a specific encoding or compression technology.
 
 ## See also
 

--- a/files/en-us/glossary/codec/index.md
+++ b/files/en-us/glossary/codec/index.md
@@ -5,7 +5,7 @@ tags:
   - Glossary
   - WebMechanics
 ---
-A *codec* (a blend word derived from "<strong><i>co</i></strong>der-<strong><i>dec</i></strong>oder") is a program, algorithm, or device that encodes or decodes a data stream. A given codec knows how to handle a specific encoding or compression technology.
+A *codec* (a blend word derived from "**co**der-**dec**oder") is a program, algorithm, or device that encodes or decodes a data stream. A given codec knows how to handle a specific encoding or compression technology.
 
 ## See also
 


### PR DESCRIPTION
#### Summary
I replaced the markdown for italics and bold in the abbreviation description with HTML tags.

#### Motivation
The markdown for italics and bold didn't render properly because there was no space between them.

#### Supporting details
This Stack Exchange post describes how they now have intra-word emphasis in their markdown: https://meta.stackexchange.com/questions/240354/markdown-change-intra-word-emphasis-now-works

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
