### PR TITLE
Add triage process doc

### DIFF
--- a/meta/content/en/governance/issues/triage.md
+++ b/meta/content/en/governance/issues/triage.md
@@ -30,6 +30,7 @@ For each issue, we ask:
 - is this an issue we want to keep open? If not, close it now with a comment.
 - is this issue in the correct repo? If not, transfer it now with a comment.
 - otherwise:
+    - do we need more information from the reporter? If so, ask, add the `needs-info` label, and move on.
     - is it a bug or a feature request?
     - what does a fix look like? If we can quickly decide and write that up as a comment in the issue. If we can't, don't (so we don't spend 30 minutes discussing one issue - maybe schedule it for the editorial meeting instead?)
     - is it a good first issue? If so, add the `good-first-issue` label.

--- a/meta/content/en/governance/issues/triage.md
+++ b/meta/content/en/governance/issues/triage.md
@@ -17,7 +17,7 @@ We hold triage once a week. Triage meetings alternate timezones, between Europe/
 
 The meeting lasts 30 minutes.
 
-All mdn/content maintainers (that is, all people with merge access to mdn/content) are invited. We need 2 people to have a quorum for triage.
+All mdn/content maintainers (that is, all people with merge access to mdn/content) are invited.
 
 One person is responsible for running the meeting: this includes getting the list of issues to triage and updating issues (adding labels, writing comments).
 

--- a/meta/content/en/governance/issues/triage.md
+++ b/meta/content/en/governance/issues/triage.md
@@ -17,26 +17,24 @@ We hold triage once a week. Triage meetings alternate timezones, between Europe/
 
 The meeting lasts 30 minutes.
 
-All mdn/content maintainers (that is, all people with merge access to mdn/content) are invited. We need 4 people to have a quorum for triage.
+All mdn/content maintainers (that is, all people with merge access to mdn/content) are invited. We need 2 people to have a quorum for triage.
 
 One person is responsible for running the meeting: this includes getting the list of issues to triage and updating issues (adding labels, writing comments).
 
 ## Meeting schedule
 
-The person running the meeting has a list of open issues that don't have a `triaged` label set.
+The person running the meeting has a list of open issues that have the `needs-triage` label set.
 
 For each issue, we ask:
 
 - is this an issue we want to keep open? If not, close it now with a comment.
 - is this issue in the correct repo? If not, transfer it now with a comment.
 - otherwise:
-    - do we need more information from the reporter? If so, ask, add the `needs-info` label, and move on.
+    - do we need more information from the reporter? If so, ask, add the `needs-info` label, and move on. Issues that have had `needs-info` set for a month without a response may be closed.
     - is it a bug or a feature request?
     - what does a fix look like? If we can quickly decide and write that up as a comment in the issue. If we can't, don't (so we don't spend 30 minutes discussing one issue - maybe schedule it for the editorial meeting instead?)
     - is it a good first issue? If so, add the `good-first-issue` label.
     - do we need more/expert opinion? If so, tag an expert in the issue.
-- add the `triaged` label
+- remove the `needs-triage` label
 
 This process does not prioritize issues or assign issues to people.
-
-At the end of 30 minutes we stop.

--- a/meta/content/en/governance/issues/triage.md
+++ b/meta/content/en/governance/issues/triage.md
@@ -13,7 +13,7 @@ We triage new issues filed in the mdn/content repository. The purpose of triage 
 
 ## Triage meeting schedule and participants
 
-We hold triage once a week. Triage meetings alternate timezones, between Europe/Asia-friendly and Europe/North America friendly.
+We hold triage once a week. Triage meetings alternate timezones, between Europe/Asia-friendly and Europe/North America-friendly.
 
 The meeting lasts 30 minutes.
 

--- a/meta/content/en/governance/issues/triage.md
+++ b/meta/content/en/governance/issues/triage.md
@@ -1,10 +1,41 @@
 ---
-title: "Triage an issue"
+title: "Issue triage"
 weight: 0
 description: >
-  This page needs a description.
+  Issue triage process for mdn/content
 ---
 
-{{% pageinfo %}}
-This is a placeholder page.
-{{% /pageinfo %}}
+We triage new issues filed in the mdn/content repository. The purpose of triage is:
+
+1. **Quickly close any issues that don't need further action from mdn/content maintainers**: For example, we often see issues that could be closed with a comment, but it's hard for individual maintainers to feel able (empowered) to do this. It's helpful to have a dedicated space where we can make collective decisions about these issues, and record them as collective decisions.
+
+2. **Help remove blockages to issues being worked on**: We see issues getting stuck because it is not clear how to process with them. An outline of a plan for how to address an issue helps maintainers (both staff and volunteers) fix it.
+
+## Triage meeting schedule and participants
+
+We hold triage once a week. Triage meetings alternate timezones, between Europe/Asia-friendly and Europe/North America friendly.
+
+The meeting lasts 30 minutes.
+
+All mdn/content maintainers (that is, all people with merge access to mdn/content) are invited. We need 4 people to have a quorum for triage.
+
+One person is responsible for running the meeting: this includes getting the list of issues to triage and updating issues (adding labels, writing comments).
+
+## Meeting schedule
+
+The person running the meeting has a list of open issues that don't have a `triaged` label set.
+
+For each issue, we ask:
+
+- is this an issue we want to keep open? If not, close it now with a comment.
+- is this issue in the correct repo? If not, transfer it now with a comment.
+- otherwise:
+    - is it a bug or a feature request?
+    - what does a fix look like? If we can quickly decide and write that up as a comment in the issue. If we can't, don't (so we don't spend 30 minutes discussing one issue - maybe schedule it for the editorial meeting instead?)
+    - is it a good first issue? If so, add the `good-first-issue` label.
+    - do we need more/expert opinion? If so, tag an expert in the issue.
+- add the `triaged` label
+
+This process does not prioritize issues or assign issues to people.
+
+At the end of 30 minutes we stop.


### PR DESCRIPTION
This adds a draft issue triage process for mdn/content.

I think one trick is discussing issues in enough detail to make good decisions, but still get through enough in 30 minutes. I'm especially worried that including a bit about "write an outline of how to fix it" will take too long but it does seem like it would be very useful to include it.

How many is "enough"? We average about 50 issues/week (and have a big backlog). But I hope that some number of incoming issues will just get fixed (or closed) anyway without going through triage.
