### PR TITLE
fix: typo timout -> timeout

### DIFF
--- a/files/en-us/web/api/abortsignal/timeout/index.md
+++ b/files/en-us/web/api/abortsignal/timeout/index.md
@@ -7,7 +7,7 @@ tags:
   - Method
   - Reference
   - timeout
-browser-compat: api.AbortSignal.timout
+browser-compat: api.AbortSignal.timeout
 ---
 {{APIRef("DOM")}}
 


### PR DESCRIPTION
Assuming the BCD isn't miss-spelling. Something that Yari should probably check/catch