### PR TITLE
CSS Grid: Fix sentence: there must be at least one white space instead of no white space for it to count as one cell.

### DIFF
--- a/files/en-us/web/css/css_grid_layout/grid_template_areas/index.md
+++ b/files/en-us/web/css/css_grid_layout/grid_template_areas/index.md
@@ -159,7 +159,7 @@ We have completely filled our grid with areas in this example, leaving no white 
 
 {{ EmbedLiveSample('Leaving_a_grid_cell_empty', '300', '330') }}
 
-In order to make the layout neater I can use multiple `.` characters. As long as there is no white space between the full stops it will be counted as one cell. For a complex layout there is a benefit to having the rows and columns neatly aligned. It means that you can actually see, right there in the CSS, what this layout looks like.
+In order to make the layout neater I can use multiple `.` characters. As long as there is at least one white space between the full stops it will be counted as one cell. For a complex layout there is a benefit to having the rows and columns neatly aligned. It means that you can actually see, right there in the CSS, what this layout looks like.
 
 ## Spanning multiple cells
 


### PR DESCRIPTION
Fix sentence: there must be at least one white space instead of no white space for it to count as one cell.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
If I remove all the white space between two full stops it does not count as one cell anymore, yet the sentence seems to suggest that.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Because it seems wrong.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
