### PR TITLE
cursor image restrictions: edit

### DIFF
--- a/files/en-us/web/css/cursor/index.md
+++ b/files/en-us/web/css/cursor/index.md
@@ -357,9 +357,8 @@ Each `<url>` may be optionally followed by a pair of space-separated numbers, wh
 ### Icon size limits
 
 While the specification does not limit the `cursor` image size, {{Glossary("user agent", "user agents")}} commonly restrict them to avoid potential misuse.
-For example, on Firefox and Chromium cursor images are restricted to 32x32 pixels by default, and cursor changes using larger images will generally just be ignored.
+For example, on Firefox and Chromium cursor images are restricted to 128x128 pixels by default, but it is recommended to limit the cursor image size to 32x32 pixels. Cursor changes using images that are larger than the user-agent maximum supported size will generally just be ignored.
 
-Check the [Browser compatibility](#browser_compatibility) table for any notes on cursor size limits.
 
 ### Supported image file formats
 


### PR DESCRIPTION
The size limit has been increased.
There is no reference to size limit in the bcd, so that reference was removed.

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

https://github.com/mdn/content/issues/14958