### PR TITLE
WebAPI: Update Method pages to modern structure (part 13)

### DIFF
--- a/files/en-us/web/api/mediakeystatusmap/values/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/values/index.md
@@ -19,14 +19,14 @@ values for each element in the status map, in insertion order.
 ## Syntax
 
 ```js
-var iterator = mediaKeyStatusMap.values()
+values()
 ```
 
 ### Parameters
 
 None.
 
-### Returns
+### Return value
 
 A new iterator.
 

--- a/files/en-us/web/api/mediakeysystemaccess/createmediakeys/index.md
+++ b/files/en-us/web/api/mediakeysystemaccess/createmediakeys/index.md
@@ -22,8 +22,11 @@ The `MediaKeySystemAccess.createMediaKeys()` method returns a
 ## Syntax
 
 ```js
-var mediaKeys = await mediaKeySystemAccess.createMediaKeys();
+createMediaKeys()
 ```
+### Return value
+
+A {{jsxref('Promise')}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/mediakeysystemaccess/getconfiguration/index.md
+++ b/files/en-us/web/api/mediakeysystemaccess/getconfiguration/index.md
@@ -33,8 +33,11 @@ the following configuration options:
 ## Syntax
 
 ```js
-var mediaKeySystemConfiguration = mediaKeySystemAccess.getConfiguration();
+getConfiguration()
 ```
+### Return value
+
+An object.
 
 ## Specifications
 

--- a/files/en-us/web/api/mediaquerylist/addlistener/index.md
+++ b/files/en-us/web/api/mediaquerylist/addlistener/index.md
@@ -26,7 +26,7 @@ available in the browsers you need to support.
 ## Syntax
 
 ```js
-MediaQueryList.addListener(func)
+addListener(func)
 ```
 
 ### Parameters
@@ -39,7 +39,7 @@ MediaQueryList.addListener(func)
 
 Void.
 
-## Example
+## Examples
 
 ```js
 var paragraph = document.querySelector('p');

--- a/files/en-us/web/api/mediaquerylist/removelistener/index.md
+++ b/files/en-us/web/api/mediaquerylist/removelistener/index.md
@@ -25,7 +25,7 @@ available in the browsers you need to support.
 ## Syntax
 
 ```js
-MediaQueryList.removeListener(func)
+removeListener(func)
 ```
 
 ### Parameters
@@ -38,7 +38,7 @@ MediaQueryList.removeListener(func)
 
 Void.
 
-## Example
+## Examples
 
 ```js
 var paragraph = document.querySelector('p');

--- a/files/en-us/web/api/mediarecorder/istypesupported/index.md
+++ b/files/en-us/web/api/mediarecorder/istypesupported/index.md
@@ -1,5 +1,5 @@
 ---
-title: MediaRecorder.isTypeSupported
+title: MediaRecorder.isTypeSupported()
 slug: Web/API/MediaRecorder/isTypeSupported
 tags:
   - API
@@ -24,7 +24,7 @@ should be able to successfully record.
 ## Syntax
 
 ```js
-var canRecord = MediaRecorder.isTypeSupported(mimeType)
+isTypeSupported(mimeType)
 ```
 
 ### Parameters
@@ -40,7 +40,7 @@ fail if there are insufficient resources to support the recording and encoding p
 If the value is `false`, the user agent is incapable of recording the
 specified format.
 
-## Example
+## Examples
 
 ```js
 var types = ["video/webm",

--- a/files/en-us/web/api/mediarecorder/pause/index.md
+++ b/files/en-us/web/api/mediarecorder/pause/index.md
@@ -31,7 +31,7 @@ browser queues a task that runs the below steps:
 ## Syntax
 
 ```js
-MediaRecorder.pause()
+pause()
 ```
 
 ### Return value
@@ -45,7 +45,7 @@ MediaRecorder.pause()
     the recording if the `MediaRecorder` is not active. If you call `pause()` while already paused,
     the method silently does nothing.
 
-## Example
+## Examples
 
 ```js
 ...

--- a/files/en-us/web/api/mediarecorder/requestdata/index.md
+++ b/files/en-us/web/api/mediarecorder/requestdata/index.md
@@ -37,7 +37,7 @@ runs the following steps:
 ## Syntax
 
 ```js
-MediaRecorder.requestData()
+requestData()
 ```
 
 ### Errors
@@ -47,7 +47,7 @@ is called while the `MediaRecorder` object's
 {{domxref("MediaRecorder.state")}} is not "recording" — the media cannot be captured if
 recording is not occurring.
 
-## Example
+## Examples
 
 ```js
 ...

--- a/files/en-us/web/api/mediarecorder/resume/index.md
+++ b/files/en-us/web/api/mediarecorder/resume/index.md
@@ -31,7 +31,7 @@ the following steps:
 ## Syntax
 
 ```js
-MediaRecorder.resume()
+resume()
 ```
 
 ### Errors
@@ -42,7 +42,7 @@ is "inactive" — the recording cannot be resumed if it is not already paused; i
 {{domxref("MediaRecorder.state")}} is already "recording", `resume()` has no
 effect.
 
-## Example
+## Examples
 
 ```js
 ...

--- a/files/en-us/web/api/mediarecorder/start/index.md
+++ b/files/en-us/web/api/mediarecorder/start/index.md
@@ -52,7 +52,8 @@ data gathering stops. A final {{domxref("MediaRecorder.dataavailable_event", "da
 ## Syntax
 
 ```js
-mediaRecorder.start(timeslice)
+start()
+start(timeslice)
 ```
 
 ### Parameters
@@ -94,7 +95,7 @@ handler to respond to these errors.
 - `UnknownError` {{domxref("DOMException")}}
   - : Thrown if something else went wrong during the recording process.
 
-## Example
+## Examples
 
 ```js
 ...

--- a/files/en-us/web/api/mediarecorder/stop/index.md
+++ b/files/en-us/web/api/mediarecorder/stop/index.md
@@ -31,7 +31,7 @@ following steps:
 ## Syntax
 
 ```js
-MediaRecorder.stop()
+stop()
 ```
 
 ### Errors
@@ -40,7 +40,7 @@ An `InvalidState` error is raised if the `stop()` method is
 called while the `MediaRecorder` object's {{domxref("MediaRecorder.state")}}
 is "inactive" — it makes no sense to stop media capture if it is already stopped.
 
-## Example
+## Examples
 
 ```js
 ...

--- a/files/en-us/web/api/mediasession/setactionhandler/index.md
+++ b/files/en-us/web/api/mediasession/setactionhandler/index.md
@@ -22,13 +22,13 @@ These actions let a web app receive notifications when the user engages a device
 ## Syntax
 
 ```js
-navigator.mediaSession.setActionHandler(type, callback)
+setActionHandler(type, callback)
 ```
 
 ### Parameters
 
 - `type`
-  - : A {{domxref("DOMString")}} representing an action type to listen for. It will be one
+  - : A string representing an action type to listen for. It will be one
     of the following:
     - `nexttrack`
       - : Advances playback to the next track.
@@ -57,7 +57,7 @@ navigator.mediaSession.setActionHandler(type, callback)
 - `callback`
   - : A function to call when the specified action type is invoked. The callback should not return a value. The callback receives a dictionary containing the following properties:
     - `action`
-      - : A {{domxref("DOMString")}} representing the action type. This property allows a single callback to handle multiple action types.
+      - : A string representing the action type. This property allows a single callback to handle multiple action types.
     - `fastSeek` {{optional_inline}}
       - : A [`seekto`](#seekto) action may *optionally* include this property, which is a Boolean value indicating whether or not to perform a "fast" seek.
         A "fast" seek is a seek being performed in a rapid sequence, such as when fast-forwarding or reversing through the media, rapidly skipping through it.

--- a/files/en-us/web/api/mediasession/setpositionstate/index.md
+++ b/files/en-us/web/api/mediasession/setpositionstate/index.md
@@ -33,7 +33,8 @@ Call this method on the `navigator` object's
 ## Syntax
 
 ```js
-navigator.mediaSession.setPositionState(stateDict);
+setPositionState()
+setPositionState(stateDict)
 ```
 
 ### Parameters
@@ -68,7 +69,7 @@ navigator.mediaSession.setPositionState(stateDict);
       either negative or greater than `duration`.
     - Its `playbackRate` is zero.
 
-## Example
+## Examples
 
 Below is a function which updates the position state of the current
 {{domxref('MediaSession')}} track.

--- a/files/en-us/web/api/mediasource/addsourcebuffer/index.md
+++ b/files/en-us/web/api/mediasource/addsourcebuffer/index.md
@@ -25,13 +25,13 @@ given {{Glossary("MIME type")}} and adds it to the `MediaSource`'s
 ## Syntax
 
 ```js
-var sourceBuffer = mediaSource.addSourceBuffer(mimeType);
+addSourceBuffer(mimeType)
 ```
 
 ### Parameters
 
 - `mimeType`
-  - : A {{domxref("DOMString")}} specifying the MIME type of the
+  - : A string specifying the MIME type of the
     {{domxref("SourceBuffer")}} to create and add to the {{domxref("MediaSource")}}.
 
 ### Return value
@@ -57,7 +57,7 @@ created and added to the media source.
     a new `SourceBuffer` using the given `mimeType` would result in
     an [unsupported configuration of `SourceBuffer`s](https://w3c.github.io/media-source/#sourcebuffer-configuration).
 
-## Example
+## Examples
 
 The following snippet is from a simple example written by Nick Desaulniers ([view the full demo
 live](https://nickdesaulniers.github.io/netfix/demo/bufferAll.html), or [download

--- a/files/en-us/web/api/mediasource/clearliveseekablerange/index.md
+++ b/files/en-us/web/api/mediasource/clearliveseekablerange/index.md
@@ -23,7 +23,7 @@ to {{domxref("MediaSource.setLiveSeekableRange()","setLiveSeekableRange()")}}.
 ## Syntax
 
 ```js
-mediaSource.clearLiveSeekableRange()
+clearLiveSeekableRange()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/mediasource/endofstream/index.md
+++ b/files/en-us/web/api/mediasource/endofstream/index.md
@@ -22,14 +22,15 @@ The **`endOfStream()`** method of the
 ## Syntax
 
 ```js
-mediaSource.endOfStream(endOfStreamError);
+endOfStream()
+endOfStream(endOfStreamError)
 ```
 
 ### Parameters
 
 - endOfStreamError {{optional_inline}}
 
-  - : A {{domxref("DOMString")}} representing an error to throw when the end of the stream
+  - : A string representing an error to throw when the end of the stream
     is reached. The possible values are:
 
     - `network`: Terminates playback and signals that a network error has
@@ -55,7 +56,7 @@ mediaSource.endOfStream(endOfStreamError);
   - : Thrown if {{domxref("MediaSource.readyState")}} is not equal to `open`, or one or more of the {{domxref("SourceBuffer")}} objects in {{domxref("MediaSource.sourceBuffers")}} are being updated (i.e. their {{domxref("SourceBuffer.updating")}} property is
       `true`.)
 
-## Example
+## Examples
 
 The following snippet is from a simple example written by Nick Desaulniers ([view the full demo
 live](https://nickdesaulniers.github.io/netfix/demo/bufferAll.html), or [download

--- a/files/en-us/web/api/mediasource/istypesupported/index.md
+++ b/files/en-us/web/api/mediasource/istypesupported/index.md
@@ -31,7 +31,7 @@ it _cannot_ access media of the specified format.
 ## Syntax
 
 ```js
-var isItSupported = MediaSource.isTypeSupported(mimeType);
+isTypeSupported(mimeType)
 ```
 
 ### Parameters
@@ -54,7 +54,7 @@ case, "no or probably") when determining if a media type can be used. This is be
 media files are complex, intricate constructs with far too many subtle variations to be
 absolutely certain of anything until you actually use the contents of the media.
 
-## Example
+## Examples
 
 The following snippet is from an example written by Nick Desaulniers ([view the full demo
 live](https://nickdesaulniers.github.io/netfix/demo/bufferAll.html), or [download

--- a/files/en-us/web/api/mediasource/removesourcebuffer/index.md
+++ b/files/en-us/web/api/mediasource/removesourcebuffer/index.md
@@ -24,7 +24,7 @@ object.
 ## Syntax
 
 ```js
-mediaSource.removeSourceBuffer(sourceBuffer);
+removeSourceBuffer(sourceBuffer)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/mediasource/setliveseekablerange/index.md
+++ b/files/en-us/web/api/mediasource/setliveseekablerange/index.md
@@ -23,7 +23,7 @@ media element.
 ## Syntax
 
 ```js
-mediaSource.setLiveSeekableRange(start, end)
+setLiveSeekableRange(start, end)
 ```
 
 ### Parameters
@@ -45,7 +45,7 @@ mediaSource.setLiveSeekableRange(start, end)
 
 {{jsxref('undefined')}}
 
-## Example
+## Examples
 
 ```js
 // TBD

--- a/files/en-us/web/api/mediastream/addtrack/index.md
+++ b/files/en-us/web/api/mediastream/addtrack/index.md
@@ -21,7 +21,7 @@ stream. The track is specified as a parameter of type {{domxref("MediaStreamTrac
 ## Syntax
 
 ```js
-stream.addTrack(track);
+addTrack(track)
 ```
 
 ### Parameters
@@ -33,7 +33,7 @@ stream.addTrack(track);
 
 {{jsxref("undefined")}}
 
-## Example
+## Examples
 
 ## Specifications
 

--- a/files/en-us/web/api/mediastream/clone/index.md
+++ b/files/en-us/web/api/mediastream/clone/index.md
@@ -22,7 +22,7 @@ contains clones of every {{domxref("MediaStreamTrack")}} contained by the
 ## Syntax
 
 ```js
-var stream = MediaStream.clone();
+clone()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/mediastream/getaudiotracks/index.md
+++ b/files/en-us/web/api/mediastream/getaudiotracks/index.md
@@ -27,7 +27,7 @@ is `audio`.
 ## Syntax
 
 ```js
-var mediaStreamTracks = mediaStream.getAudioTracks()
+getAudioTracks()
 ```
 
 ### Parameters
@@ -49,7 +49,7 @@ Early versions of this API included a special `AudioStreamTrack` interface
 which was used as the type for each entry in the list of audio streams; however, this
 has since been merged into the main {{domxref("MediaStreamTrack")}} interface.
 
-## Example
+## Examples
 
 This example gets a webcam's audio and video in a stream using
 {{domxref("MediaDevices.getUserMedia", "getUserMedia()")}}, attaches the stream to a

--- a/files/en-us/web/api/mediastream/gettracks/index.md
+++ b/files/en-us/web/api/mediastream/gettracks/index.md
@@ -23,7 +23,7 @@ regardless of {{domxref("MediaStreamTrack.kind")}}.
 ## Syntax
 
 ```js
-var mediaStreamTracks = mediaStream.getTracks()
+getTracks()
 ```
 
 ### Parameters
@@ -34,7 +34,7 @@ None.
 
 An array of {{domxref("MediaStreamTrack")}} objects.
 
-## Example
+## Examples
 
 ```js
 navigator.mediaDevices.getUserMedia({audio: false, video: true})

--- a/files/en-us/web/api/mediastreamtrack/clone/index.md
+++ b/files/en-us/web/api/mediastreamtrack/clone/index.md
@@ -21,7 +21,7 @@ interface creates a duplicate of the `MediaStreamTrack`. This new
 ## Syntax
 
 ```js
-const newTrack = track.clone()
+clone()
 ```
 
 ### Return value

--- a/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
+++ b/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
@@ -27,14 +27,12 @@ and settings](/en-US/docs/Web/API/Media_Streams_API/Constraints) for details on 
 ## Syntax
 
 ```js
-const capabilities = track.getCapabilities()
+getCapabilities()
 ```
 
 ### Return value
 
-A {{domxref('MediaTrackCapabilities')}} object which specifies the value or range of
-values which are supported for each of the user agent's supported constrainable
-properties.
+A {{domxref('MediaTrackCapabilities')}} object which specifies the value or range of values which are supported for each of the user agent's supported constrainable properties.
 
 ## Specifications
 

--- a/files/en-us/web/api/mediastreamtrack/getconstraints/index.md
+++ b/files/en-us/web/api/mediastreamtrack/getconstraints/index.md
@@ -30,7 +30,7 @@ and settings](/en-US/docs/Web/API/Media_Streams_API/Constraints) for details on 
 ## Syntax
 
 ```js
-const constraints = track.getConstraints()
+getConstraints()
 ```
 
 ### Return value
@@ -47,7 +47,7 @@ properties specifically set by the site or app are included.
 > the currently active settings for all constrainable properties, you should instead
 > call {{domxref("MediaStreamTrack.getSettings", "getSettings()")}}.
 
-## Example
+## Examples
 
 This example obtains the current constraints for a track, sets the
 {{domxref("MediaTrackConstraints.facingMode", "facingMode")}}, and applies the updated

--- a/files/en-us/web/api/mediastreamtrack/getsettings/index.md
+++ b/files/en-us/web/api/mediastreamtrack/getsettings/index.md
@@ -23,10 +23,10 @@ and settings](/en-US/docs/Web/API/Media_Streams_API/Constraints) for details on 
 ## Syntax
 
 ```js
-const settings = track.getSettings()
+getSettings()
 ```
 
-### Returns
+### Return value
 
 A {{domxref("MediaTrackSettings")}} object describing the current configuration of the
 track's constrainable properties.

--- a/files/en-us/web/api/mediastreamtrack/stop/index.md
+++ b/files/en-us/web/api/mediastreamtrack/stop/index.md
@@ -21,7 +21,7 @@ The **`MediaStreamTrack.stop()`** method stops the track.
 ## Syntax
 
 ```js
-track.stop()
+stop()
 ```
 
 ## Description

--- a/files/en-us/web/api/merchantvalidationevent/complete/index.md
+++ b/files/en-us/web/api/merchantvalidationevent/complete/index.md
@@ -24,8 +24,8 @@ All you have to do is call `complete()` from your handler for the {{domxref("Pay
 ## Syntax
 
 ```js
-merchantValidationEvent.complete(validationData);
-merchantValidationEvent.complete(merchantSessionPromise);
+complete(validationData)
+complete(merchantSessionPromise)
 ```
 
 ### Parameters
@@ -44,7 +44,7 @@ This exception may be passed into the rejection handler for the promise:
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Returned if the event did not come directly from the user agent, but was instead dispatched by other code. Another payment request is currently being processed, the current payment request is not currently being displayed to the user, or payment information is currently being updated.
 
-## Example
+## Examples
 
 In this example, we see the client-side code needed to support merchant validation for a payment request called `payRequest`:
 

--- a/files/en-us/web/api/messageport/close/index.md
+++ b/files/en-us/web/api/messageport/close/index.md
@@ -21,10 +21,10 @@ messages to that port.
 ## Syntax
 
 ```js
-port.close()
+close()
 ```
 
-### Returns
+### Return value
 
 {{jsxref('undefined')}}.
 
@@ -32,7 +32,7 @@ port.close()
 
 None.
 
-## Example
+## Examples
 
 In the following code block, you can see a `handleMessage` handler function,
 run when a message is sent back to this document using

--- a/files/en-us/web/api/messageport/postmessage/index.md
+++ b/files/en-us/web/api/messageport/postmessage/index.md
@@ -21,10 +21,10 @@ transfers ownership of objects to other browsing contexts.
 ## Syntax
 
 ```js
-port.postMessage(message, transferList);
+postMessage(message, transferList)
 ```
 
-### Returns
+### Return value
 
 {{jsxref('undefined')}}.
 
@@ -38,7 +38,7 @@ port.postMessage(message, transferList);
     ownership transferred to the receiving browsing context, so are no longer usable by
     the sending browsing context.
 
-## Example
+## Examples
 
 In the following code block, you can see a new channel being created using the
 {{domxref("MessageChannel()", "MessageChannel.MessageChannel")}} constructor. When the

--- a/files/en-us/web/api/messageport/start/index.md
+++ b/files/en-us/web/api/messageport/start/index.md
@@ -22,10 +22,10 @@ when using {{domxref("EventTarget.addEventListener")}}; it is implied when using
 ## Syntax
 
 ```js
-port.start()
+start()
 ```
 
-### Returns
+### Return value
 
 {{jsxref('undefined')}}.
 
@@ -33,7 +33,7 @@ port.start()
 
 None.
 
-## Example
+## Examples
 
 In the following code block, you can see a `handleMessage` handler function,
 run when a message is sent back to this document using `onmessage`:

--- a/files/en-us/web/api/midioutput/clear/index.md
+++ b/files/en-us/web/api/midioutput/clear/index.md
@@ -16,7 +16,7 @@ The **`clear()`** method of the {{domxref("MIDIOutput")}} interface clears the q
 ## Syntax
 
 ```js
-MIDIOutput.clear();
+clear()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/midioutput/send/index.md
+++ b/files/en-us/web/api/midioutput/send/index.md
@@ -16,7 +16,8 @@ The **`send()`** method of the {{domxref("MIDIOutput")}} interface queues messag
 ## Syntax
 
 ```js
-MIDIOutput.send(data, timestamp);
+send(data)
+send(data, timestamp)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/midiport/close/index.md
+++ b/files/en-us/web/api/midiport/close/index.md
@@ -18,7 +18,7 @@ If the port is successfully closed a new {{domxref("MIDIConnectionEvent")}} is q
 ## Syntax
 
 ```js
-MIDIPort.close();
+close()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/midiport/open/index.md
+++ b/files/en-us/web/api/midiport/open/index.md
@@ -20,8 +20,7 @@ If the port is already open when this method is called, then the promise will re
 ## Syntax
 
 ```js
-var output = midiAccess.outputs.get(portID);
-output.open(); // opens the port
+open()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/mouseevent/getmodifierstate/index.md
+++ b/files/en-us/web/api/mouseevent/getmodifierstate/index.md
@@ -23,16 +23,16 @@ See {{domxref("KeyboardEvent.getModifierState","KeyboardEvent.getModifierState()
 getModifierState(keyArg)
 ```
 
-### Returns
-
-A boolean value
-
 ### Parameters
 
 - _`keyArg`_
   - : A modifier key value.
     The value must be one of the {{domxref("KeyboardEvent.key")}} values which represent modifier keys or `"Accel"`{{deprecated_inline}}.
     This is case-sensitive.
+
+### Return value
+
+A boolean value
 
 ## Specifications
 

--- a/files/en-us/web/api/mouseevent/getmodifierstate/index.md
+++ b/files/en-us/web/api/mouseevent/getmodifierstate/index.md
@@ -32,7 +32,7 @@ getModifierState(keyArg)
 
 ### Return value
 
-A boolean value
+A boolean value.
 
 ## Specifications
 

--- a/files/en-us/web/api/mouseevent/initmouseevent/index.md
+++ b/files/en-us/web/api/mouseevent/initmouseevent/index.md
@@ -28,10 +28,10 @@ before it is dispatched, using {{ domxref("EventTarget.dispatchEvent()") }}.
 ## Syntax
 
 ```js
-event.initMouseEvent(type, canBubble, cancelable, view,
+initMouseEvent(type, canBubble, cancelable, view,
                      detail, screenX, screenY, clientX, clientY,
                      ctrlKey, altKey, shiftKey, metaKey,
-                     button, relatedTarget);
+                     button, relatedTarget)
 ```
 
 ### Parameters
@@ -90,7 +90,7 @@ event.initMouseEvent(type, canBubble, cancelable, view,
     with some event types (e.g., `mouseover` and `mouseout`). In
     other cases, pass `null`.
 
-## Example
+## Examples
 
 ### HTML
 

--- a/files/en-us/web/api/msmanipulationevent/initmsmanipulationevent/index.md
+++ b/files/en-us/web/api/msmanipulationevent/initmsmanipulationevent/index.md
@@ -16,10 +16,10 @@ The **`initMSManipulationEvent`** method is used to create a {{DOMxRef("MSManipu
 
 This proprietary method is specific to Internet Explorer. Beginning with the Microsoft Edge browser, the [initEvent()](/en-US/docs/Web/API/Event/initEvent) constructor pattern for synthetic events is deprecated.
 
-### Syntax
+## Syntax
 
 ```js
-MSManipulationEvent.initMSManipulationEvent(typeArg, canBubbleArg, cancelableArg, viewArg, detailArg, lastState, currentState);
+initMSManipulationEvent(typeArg, canBubbleArg, cancelableArg, viewArg, detailArg, lastState, currentState)
 ```
 
 ### Parameters
@@ -70,7 +70,7 @@ Indicates the current state of the manipulation event.
 
 This method does not return a value.
 
-### Example
+## Examples
 
 ```js
 interface MSManipulationEvent extends UIEvent {

--- a/files/en-us/web/api/mutationobserver/disconnect/index.md
+++ b/files/en-us/web/api/mutationobserver/disconnect/index.md
@@ -32,7 +32,7 @@ The observer can be reused by calling its
 ## Syntax
 
 ```js
-mutationObserver.disconnect()
+disconnect()
 ```
 
 ### Parameters
@@ -53,7 +53,7 @@ by the browser's garbage collection mechanism, the `MutationObserver` will stop 
 the removed element. However, the `MutationObserver` itself can continue to exist to observe
 other existing elements.
 
-## Example
+## Examples
 
 This example creates an observer, then disconnects from it, leaving it available for
 possible reuse.

--- a/files/en-us/web/api/mutationobserver/observe/index.md
+++ b/files/en-us/web/api/mutationobserver/observe/index.md
@@ -30,7 +30,7 @@ To stop the `MutationObserver` (so that none of its callbacks will be triggered 
 ## Syntax
 
 ```js
-mutationObserver.observe(target, options)
+observe(target, options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/mutationobserver/takerecords/index.md
+++ b/files/en-us/web/api/mutationobserver/takerecords/index.md
@@ -32,7 +32,7 @@ observer.
 ## Syntax
 
 ```js
-const mutationRecords = mutationObserver.takeRecords()
+takeRecords()
 ```
 
 ### Parameters
@@ -48,7 +48,7 @@ the observed portion of the document's DOM tree.
 > delivered to the observer's callback is left empty after calling
 > `takeRecords()`.
 
-## Example
+## Examples
 
 In this example, we demonstrate how to handle any undelivered
 {{domxref("MutationRecord")}}s by calling `takeRecords()` just before

--- a/files/en-us/web/api/navigationpreloadmanager/disable/index.md
+++ b/files/en-us/web/api/navigationpreloadmanager/disable/index.md
@@ -23,7 +23,7 @@ The method may be called in the service worker's `activate` event handler (befor
 disable()
 ```
 
-### Return Value
+### Return value
 
 A {{jsxref("Promise")}} that resolves with {{jsxref('undefined')}}.
 

--- a/files/en-us/web/api/navigationpreloadmanager/enable/index.md
+++ b/files/en-us/web/api/navigationpreloadmanager/enable/index.md
@@ -23,7 +23,7 @@ The method should be called in the service worker's `activate` event handler, wh
 enable()
 ```
 
-### Return Value
+### Return value
 
 A {{jsxref("Promise")}} that resolves with {{jsxref('undefined')}}.
 

--- a/files/en-us/web/api/navigationpreloadmanager/getstate/index.md
+++ b/files/en-us/web/api/navigationpreloadmanager/getstate/index.md
@@ -19,7 +19,7 @@ The **`getState()`** method of the {{domxref("NavigationPreloadManager")}} inter
 getState()
 ```
 
-### Return Value
+### Return value
 
 A {{jsxref("Promise")}} that resolves with an object that has the following properties:
 

--- a/files/en-us/web/api/navigationpreloadmanager/setheadervalue/index.md
+++ b/files/en-us/web/api/navigationpreloadmanager/setheadervalue/index.md
@@ -30,7 +30,7 @@ setHeaderValue(value)
 - `value`
   - : An arbitrary string value, which the target server uses to determine what should returned for the requested resource.
 
-### Return Value
+### Return value
 
 A {{jsxref("Promise")}} that resolves with {{jsxref('undefined')}}.
 
@@ -52,7 +52,7 @@ navigator.serviceWorker.ready
     console.log("Done!");
   })
   .catch(e => console.error("NavigationPreloadManager not supported: " + e.message));
-  
+
 ```
 
 ## Specifications

--- a/files/en-us/web/api/navigator/canshare/index.md
+++ b/files/en-us/web/api/navigator/canshare/index.md
@@ -26,8 +26,8 @@ The **`canShare()`** method will return `false` if the permission is supported b
 ## Syntax
 
 ```js
-navigator.canShare()
-navigator.canShare(data)
+canShare()
+canShare(data)
 ```
 
 ### Parameters
@@ -42,9 +42,9 @@ navigator.canShare(data)
 
     Possible values are:
 
-    - `url`: A {{domxref("USVString")}} representing a URL to be shared.
-    - `text`: A {{domxref("USVString")}} representing text to be shared.
-    - `title`: A {{domxref("USVString")}} representing the title to be shared.
+    - `url`: A string representing a URL to be shared.
+    - `text`: A string representing text to be shared.
+    - `title`: A string representing the title to be shared.
     - `files`: An array of {{domxref("File")}} objects representing files to be shared.
 
 ### Return value

--- a/files/en-us/web/api/navigator/clearappbadge/index.md
+++ b/files/en-us/web/api/navigator/clearappbadge/index.md
@@ -17,7 +17,7 @@ The **`clearAppBadge()`** method of the {{domxref("Navigator")}} interface clear
 ## Syntax
 
 ```js
-let promise = Navigator.clearAppBadge();
+clearAppBadge()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/navigator/getbattery/index.md
+++ b/files/en-us/web/api/navigator/getbattery/index.md
@@ -24,7 +24,7 @@ documentation for additional details, a guide to using the API, and sample code.
 ## Syntax
 
 ```js
-navigator.getBattery()
+getBattery()
 ```
 
 ### Return value
@@ -33,7 +33,7 @@ A {{JSxRef("Promise")}} which, when resolved, calls its fulfillment handler with
 single parameter: a {{DOMxRef("BatteryManager")}} object which you can use to get
 information about the battery's state.
 
-## Exceptions
+### Exceptions
 
 This method doesn't throw true exceptions; instead, it rejects the returned promise, passing into it a {{domxref("DOMException")}} whose `name` is one of the following:
 
@@ -49,7 +49,7 @@ This method doesn't throw true exceptions; instead, it rejects the returned prom
     > This document is not allowed to use this feature.
     > For example, it might not be explicitly allowed or restricted via {{HTTPHeader("Feature-Policy")}} {{HTTPHeader("Feature-Policy/battery", "battery")}} feature.
 
-## Example
+## Examples
 
 This example fetches the current charging state of the battery and establishes a
 handler for the {{Event("chargingchange")}} event, so that the charging state is

--- a/files/en-us/web/api/navigator/getgamepads/index.md
+++ b/files/en-us/web/api/navigator/getgamepads/index.md
@@ -24,10 +24,10 @@ Calls to this method will throw a `SecurityError` {{domxref('DOMException')}} if
 ## Syntax
 
 ```js
- var gamepads = navigator.getGamepads();
+getGamepads()
 ```
 
-## Example
+## Examples
 
 ```js
 window.addEventListener("gamepadconnected", function(e) {

--- a/files/en-us/web/api/navigator/getusermedia/index.md
+++ b/files/en-us/web/api/navigator/getusermedia/index.md
@@ -36,7 +36,7 @@ executed.
 ## Syntax
 
 ```js
-navigator.getUserMedia(constraints, successCallback, errorCallback);
+getUserMedia(constraints, successCallback, errorCallback)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/navigator/javaenabled/index.md
+++ b/files/en-us/web/api/navigator/javaenabled/index.md
@@ -15,10 +15,10 @@ This method always returns false.
 ## Syntax
 
 ```js
-result = window.navigator.javaEnabled()
+javaEnabled()
 ```
 
-## Example
+## Examples
 
 ```js
 if (window.navigator.javaEnabled()) {

--- a/files/en-us/web/api/navigator/javaenabled/index.md
+++ b/files/en-us/web/api/navigator/javaenabled/index.md
@@ -18,6 +18,10 @@ This method always returns false.
 javaEnabled()
 ```
 
+### Return value
+
+The boolean value `false`.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/navigator/mozislocallyavailable/index.md
+++ b/files/en-us/web/api/navigator/mozislocallyavailable/index.md
@@ -19,7 +19,7 @@ add-ons to determine whether or not a given resource is available.
 ## Syntax
 
 ```js
-navigator.mozIsLocallyAvailable(uri, ifOffline);
+mozIsLocallyAvailable(uri, ifOffline)
 ```
 
 ### Parameters
@@ -30,7 +30,7 @@ navigator.mozIsLocallyAvailable(uri, ifOffline);
   - : Allows you to specify whether or not the offline resources cache should be checked;
     specify `true` to consider the offline resources cache.
 
-## Example
+## Examples
 
 ```js
 var available = navigator.mozIsLocallyAvailable("my-image-file.png", true);

--- a/files/en-us/web/api/navigator/mslaunchuri/index.md
+++ b/files/en-us/web/api/navigator/mslaunchuri/index.md
@@ -18,13 +18,15 @@ This proprietary method is specific to Internet Explorer, and Microsoft Edge ver
 ## Syntax
 
 ```js
-navigator.msLaunchUri(uri, successCallback, noHandlerCallback);
+msLaunchUri(uri)
+msLaunchUri(uri, successCallback)
+msLaunchUri(uri, successCallback, noHandlerCallback)
 ```
 
 ### Parameters
 
 - `uri`
-  - : A {{domxref("DOMString")}} specifying the URL containing including the protocol of the document or resource to be displayed.
+  - : A string specifying the URL containing including the protocol of the document or resource to be displayed.
 - `successCallback`{{Optional_Inline}}
   - : A function matching the signature of {{DOMxRef("MSLaunchUriCallback")}} to be executed if the protocol handler is present.
 - `noHandlerCallback`{{Optional_Inline}}

--- a/files/en-us/web/api/navigator/registerprotocolhandler/index.md
+++ b/files/en-us/web/api/navigator/registerprotocolhandler/index.md
@@ -104,7 +104,7 @@ Otherwise, the scheme must be one of the following:
 
 <!-- This must match: https://html.spec.whatwg.org/multipage/system-state.html#safelisted-scheme -->
 
-## Example
+## Examples
 
 If your site is `burgers.example.com`, you can register a protocol handler for it to handle `web+burger:` links, like so:
 

--- a/files/en-us/web/api/navigator/requestmediakeysystemaccess/index.md
+++ b/files/en-us/web/api/navigator/requestmediakeysystemaccess/index.md
@@ -35,7 +35,7 @@ returned {{domxref("MediaKeySystemAccess")}} object's
 ## Syntax
 
 ```js
-promise = navigator.requestMediaKeySystemAccess(keySystem, supportedConfigurations);
+requestMediaKeySystemAccess(keySystem, supportedConfigurations)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/navigator/requestmidiaccess/index.md
+++ b/files/en-us/web/api/navigator/requestmidiaccess/index.md
@@ -23,8 +23,8 @@ If permission is granted then the {{jsxref('Promise')}} resolves and a [`MIDIAcc
 ## Syntax
 
 ```js
-navigator.requestMIDIAccess();
-navigator.requestMIDIAccess(MIDIOptions);
+requestMIDIAccess()
+requestMIDIAccess(MIDIOptions)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/navigator/sendbeacon/index.md
+++ b/files/en-us/web/api/navigator/sendbeacon/index.md
@@ -26,8 +26,8 @@ legacy techniques for sending analytics, such as the use of
 ## Syntax
 
 ```js
-navigator.sendBeacon(url);
-navigator.sendBeacon(url, data);
+sendBeacon(url)
+sendBeacon(url, data)
 ```
 
 ### Parameters
@@ -36,7 +36,7 @@ navigator.sendBeacon(url, data);
   - : The URL that will receive the _data_. Can be relative or absolute.
 - `data` {{Optional_inline}}
   - : A {{jsxref("ArrayBuffer")}}, {{domxref("ArrayBufferView")}}, {{domxref("Blob")}},
-    {{domxref("DOMString")}}, {{domxref("FormData")}}, or {{domxref("URLSearchParams")}}
+    string, {{domxref("FormData")}}, or {{domxref("URLSearchParams")}}
     object containing the data to send.
 
 ### Return values

--- a/files/en-us/web/api/navigator/setappbadge/index.md
+++ b/files/en-us/web/api/navigator/setappbadge/index.md
@@ -17,7 +17,8 @@ The **`setAppBadge()`** method of the {{domxref("Navigator")}} interface a badge
 ## Syntax
 
 ```js
-let promise = Navigator.setAppBadge(contents);
+setAppBadge()
+setAppBadge(contents)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/navigator/taintenabled/index.md
+++ b/files/en-us/web/api/navigator/taintenabled/index.md
@@ -21,7 +21,7 @@ method only stays for maintaining compatibility with very old scripts.
 ## Syntax
 
 ```js
-result = window.navigator.taintEnabled()
+taintEnabled()
 ```
 
 ## Specifications

--- a/files/en-us/web/api/navigator/vibrate/index.md
+++ b/files/en-us/web/api/navigator/vibrate/index.md
@@ -23,8 +23,10 @@ long vibration, it is truncated: the max length depends on the implementation.
 ## Syntax
 
 ```js
-var successBool = navigator.vibrate(pattern);
+vibrate(pattern)
 ```
+
+### Parameters
 
 - `pattern`
   - : Provides a pattern of vibration and pause intervals. Each value indicates a number
@@ -34,6 +36,10 @@ var successBool = navigator.vibrate(pattern);
 
 Passing a value of `0`, an empty array, or an array containing all zeros
 will cancel any currently ongoing vibration pattern.
+
+### Return value
+
+A boolean.
 
 ## Examples
 

--- a/files/en-us/web/api/navigatoruadata/tojson/index.md
+++ b/files/en-us/web/api/navigatoruadata/tojson/index.md
@@ -18,7 +18,7 @@ The **`toJSON()`** method of the {{domxref("NavigatorUAData")}} interface is a _
 ## Syntax
 
 ```js
-NavigatorUAData.toJSON();
+toJSON()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/nodeiterator/detach/index.md
+++ b/files/en-us/web/api/nodeiterator/detach/index.md
@@ -22,10 +22,10 @@ iterates, releasing any resources used by the set and setting the iterator's sta
 ## Syntax
 
 ```js
-nodeIterator.detach();
+detach()
 ```
 
-## Example
+## Examples
 
 ```js
 var nodeIterator = document.createNodeIterator(

--- a/files/en-us/web/api/nodeiterator/nextnode/index.md
+++ b/files/en-us/web/api/nodeiterator/nextnode/index.md
@@ -25,10 +25,10 @@ throw.
 ## Syntax
 
 ```js
-node = nodeIterator.nextNode();
+nextNode()
 ```
 
-## Example
+## Examples
 
 ```js
 var nodeIterator = document.createNodeIterator(

--- a/files/en-us/web/api/nodeiterator/previousnode/index.md
+++ b/files/en-us/web/api/nodeiterator/previousnode/index.md
@@ -25,10 +25,10 @@ throw.
 ## Syntax
 
 ```js
-node = nodeIterator.previousNode();
+previousNode()
 ```
 
-## Example
+## Examples
 
 ```js
 var nodeIterator = document.createNodeIterator(

--- a/files/en-us/web/api/nodelist/item/index.md
+++ b/files/en-us/web/api/nodelist/item/index.md
@@ -19,14 +19,14 @@ argument is provided.
 ## Syntax
 
 ```js
-nodeItem = nodeList.item(index)
+item(index)
 ```
+### Parameters
 
-- `nodeList` is a `NodeList`. This is usually obtained from
-  another DOM property or method, such as [childNodes](/en-US/docs/Web/API/Node/childNodes).
 - `index` is the index of the node to be fetched. The index is zero-based.
-- `nodeItem` is the `index`th node in the `nodeList`
-  returned by the `item` method.
+ 
+### Return value
+The `index`th node in the `nodeList` returned by the `item` method.
 
 ## Alternate Syntax
 
@@ -37,7 +37,7 @@ NodeList by index:
 nodeItem = nodeList[index]
 ```
 
-## Example
+## Examples
 
 ```js
 var tables = document.getElementsByTagName("table");

--- a/files/en-us/web/api/notification/close/index.md
+++ b/files/en-us/web/api/notification/close/index.md
@@ -27,14 +27,14 @@ close/remove a previously displayed notification.
 ## Syntax
 
 ```js
-Notification.close();
+close()
 ```
 
 ### Parameters
 
 None.
 
-### Returns
+### Return value
 
 {{jsxref('undefined')}}.
 

--- a/files/en-us/web/api/offscreencanvas/getcontext/index.md
+++ b/files/en-us/web/api/offscreencanvas/getcontext/index.md
@@ -23,14 +23,14 @@ supported.
 ## Syntax
 
 ```js
-offscreen.getContext(contextType, contextAttributes);
+getContext(contextType, contextAttributes)
 ```
 
 ### Parameters
 
 - `contextType`
 
-  - : Is a {{domxref("DOMString")}} containing the context identifier defining the drawing
+  - : Is a string containing the context identifier defining the drawing
     context associated to the canvas. Possible values are:
 
     - **`"2d"`** creates a

--- a/files/en-us/web/api/offscreencanvas/transfertoimagebitmap/index.md
+++ b/files/en-us/web/api/offscreencanvas/transfertoimagebitmap/index.md
@@ -19,7 +19,7 @@ the `OffscreenCanvas`.
 ## Syntax
 
 ```js
-ImageBitmap OffscreenCanvas.transferToImageBitmap()
+transferToImageBitmap()
 ```
 
 ### Return value

--- a/files/en-us/web/api/orientationsensor/populatematrix/index.md
+++ b/files/en-us/web/api/orientationsensor/populatematrix/index.md
@@ -38,7 +38,7 @@ instructions.
 ## Syntax
 
 ```js
-orientationInstance.populateMatrix(targetMatrix)
+populateMatrix(targetMatrix)
 ```
 
 Because {{domxref('OrientationSensor')}} is a base class, `populateMatrix`
@@ -53,7 +53,7 @@ may only be read from one of its derived classes.
 
 {{jsxref('undefined')}}
 
-## Example
+## Examples
 
 ```js
 // TBD

--- a/files/en-us/web/api/oscillatornode/setperiodicwave/index.md
+++ b/files/en-us/web/api/oscillatornode/setperiodicwave/index.md
@@ -20,7 +20,7 @@ defining a periodic waveform that can be used to shape the oscillator's output, 
 ## Syntax
 
 ```js
-OscillatorNode.setPeriodicWave(wave);
+setPeriodicWave(wave)
 ```
 
 ### Parameters
@@ -29,11 +29,11 @@ OscillatorNode.setPeriodicWave(wave);
   - : A {{domxref("PeriodicWave")}} object representing the waveform to use as the shape
     of the oscillator's output.
 
-### Returns
+### Return value
 
 {{jsxref("undefined")}}
 
-## Example
+## Examples
 
 The following example illustrates simple usage of `createPeriodicWave()`,
 recreating a sine wave from a periodic wave.

--- a/files/en-us/web/api/paymentrequest/show/index.md
+++ b/files/en-us/web/api/paymentrequest/show/index.md
@@ -54,7 +54,8 @@ to wait asynchronously while results are validated and so forth.
 ## Syntax
 
 ```js
-paymentPromise = paymentRequest.show(detailsPromise);
+show()
+show(detailsPromise)
 ```
 
 ### Parameters
@@ -79,7 +80,7 @@ paymentPromise = paymentRequest.show(detailsPromise);
           - : A Boolean value which is `true` if the specified `amount` has not yet been finalized. This can be used to show items such as shipping or tax amounts that depend upon the selection of shipping address, shipping option, or so forth. The user agent may show this information but is not required to do so.
 
     - `error` {{optional_inline}}{{deprecated_inline}}
-      - : A {{domxref("DOMString")}} specifying an error message to present to the user*.* When calling {{domxref("PaymentRequestUpdateEvent.updateWith", "updateWith()")}}, including `error` in the updated data causes the {{Glossary("user agent")}} to display the text as a general error message. For address field specific errors, use `shippingAddressErrors`.
+      - : A string specifying an error message to present to the user*.* When calling {{domxref("PaymentRequestUpdateEvent.updateWith", "updateWith()")}}, including `error` in the updated data causes the {{Glossary("user agent")}} to display the text as a general error message. For address field specific errors, use `shippingAddressErrors`.
     - `modifiers` {{optional_inline}}
       - : An array of {{domxref("PaymentDetailsModifier")}} objects, each describing a modifier for particular payment method identifiers. For example, you can use one to adjust the total payment amount based on the selected payment method ("5% cash discount!").
     - `shippingAddressErrors` {{optional_inline}}{{deprecated_inline}}

--- a/files/en-us/web/api/paymentrequestevent/openwindow/index.md
+++ b/files/en-us/web/api/paymentrequestevent/openwindow/index.md
@@ -21,7 +21,7 @@ and only if the given URL is on the same origin as the calling page. It returns 
 ## Syntax
 
 ```js
-var aPromise = paymentRequestEvent.openWindow(url)
+openWindow(url)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/paymentrequestupdateevent/updatewith/index.md
+++ b/files/en-us/web/api/paymentrequestupdateevent/updatewith/index.md
@@ -26,7 +26,7 @@ The **`updateWith()`** method of the
 ## Syntax
 
 ```js
-paymentRequestUpdateEvent.updateWith(details);
+updateWith(details)
 ```
 
 ### Parameters
@@ -48,7 +48,7 @@ paymentRequestUpdateEvent.updateWith(details);
           - : A Boolean value which is `true` if the specified `amount` has not yet been finalized. This can be used to show items such as shipping or tax amounts that depend upon the selection of shipping address, shipping option, or so forth. The user agent may show this information but is not required to do so.
 
     - `error` {{optional_inline}}{{deprecated_inline}}
-      - : A {{domxref("DOMString")}} specifying an error message to present to the user*.* When calling `updateWith()`, including `error` in the updated data causes the {{Glossary("user agent")}} to display the text as a general error message. For address field specific errors, use `shippingAddressErrors`.
+      - : A string specifying an error message to present to the user*.* When calling `updateWith()`, including `error` in the updated data causes the {{Glossary("user agent")}} to display the text as a general error message. For address field specific errors, use `shippingAddressErrors`.
     - `modifiers` {{optional_inline}}
       - : An array of {{domxref("PaymentDetailsModifier")}} objects, each describing a modifier for particular payment method identifiers. For example, you can use one to adjust the total payment amount based on the selected payment method ("5% cash discount!").
     - `shippingAddressErrors` {{optional_inline}}{{deprecated_inline}}

--- a/files/en-us/web/api/paymentresponse/retry/index.md
+++ b/files/en-us/web/api/paymentresponse/retry/index.md
@@ -27,7 +27,7 @@ cards.
 ## Syntax
 
 ```js
-retryPromise = paymentRequest.retry(errorFields);
+retry(errorFields)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/performance/clearmarks/index.md
+++ b/files/en-us/web/api/performance/clearmarks/index.md
@@ -21,24 +21,23 @@ removed from the performance entry buffer.
 ## Syntax
 
 ```js
-performance.clearMarks();
-performance.clearMarks(name);
+clearMarks()
+clearMarks(name)
 ```
 
-### Arguments
+### Parameters
 
 - name {{optional_inline}}
-  - : A {{domxref("DOMString")}} representing the name of the timestamp. If this argument
+  - : A string representing the name of the timestamp. If this argument
     is omitted, all {{domxref("PerformanceEntry","performance entries")}} with an
     {{domxref("PerformanceEntry.entryType","entry type")}} of "`mark`" will be
     removed.
 
 ### Return value
 
-- void
-  - :
+void
 
-## Example
+## Examples
 
 The following example shows both uses of the `clearMarks()` method.
 

--- a/files/en-us/web/api/performance/clearmeasures/index.md
+++ b/files/en-us/web/api/performance/clearmeasures/index.md
@@ -21,24 +21,23 @@ removed from the performance entry buffer.
 ## Syntax
 
 ```js
-performance.clearMeasures();
-performance.clearMeasures(name);
+clearMeasures()
+clearMeasures(name)
 ```
 
-### Arguments
+### Parameters
 
 - name {{optional_inline}}
-  - : A {{domxref("DOMString")}} representing the name of the timestamp. If this argument
+  - : A string representing the name of the timestamp. If this argument
     is omitted, all {{domxref("PerformanceEntry","performance entries")}} with an
     {{domxref("PerformanceEntry.entryType","entry type")}} of "`measure`" will
     be removed.
 
 ### Return value
 
-- void
-  - :
+void
 
-## Example
+## Examples
 
 The following example shows both uses of the `clearMeasures()` method.
 

--- a/files/en-us/web/api/performance/clearresourcetimings/index.md
+++ b/files/en-us/web/api/performance/clearresourcetimings/index.md
@@ -22,20 +22,18 @@ to zero. To set the size of the browser's performance data buffer, use the
 ## Syntax
 
 ```js
-performance.clearResourceTimings();
+clearResourceTimings()
 ```
 
-### Arguments
+### Parameters
 
 - void
-  - :
 
 ### Return value
 
-- none
-  - : This method has no return value.
+none
 
-## Example
+## Examples
 
 ```js
 function load_resource() {

--- a/files/en-us/web/api/performance/clearresourcetimings/index.md
+++ b/files/en-us/web/api/performance/clearresourcetimings/index.md
@@ -25,10 +25,6 @@ to zero. To set the size of the browser's performance data buffer, use the
 clearResourceTimings()
 ```
 
-### Parameters
-
-- void
-
 ### Return value
 
 none

--- a/files/en-us/web/api/performance/getentriesbyname/index.md
+++ b/files/en-us/web/api/performance/getentriesbyname/index.md
@@ -21,10 +21,11 @@ _marks_ or _measures_ (for example by calling the
 ## Syntax
 
 ```js
-entries = window.performance.getEntriesByName(name, type);
+getEntriesByName(name)
+getEntriesByName(name, type)
 ```
 
-### Arguments
+### Parameters
 
 - name
   - : The name of the entry to retrieve.
@@ -34,15 +35,14 @@ entries = window.performance.getEntriesByName(name, type);
 
 ### Return value
 
-- entries
-  - : A list of {{domxref("PerformanceEntry")}} objects that have the specified
+A list of {{domxref("PerformanceEntry")}} objects that have the specified
     `name` and `type`. If the `type` argument is not
     specified, only the `name` will be used to determine the entries to return.
     The items will be in chronological order based on the entries'
     {{domxref("PerformanceEntry.startTime","startTime")}}. If no objects meet the
     specified criteria, an empty list is returned.
 
-## Example
+## Examples
 
 ```js
 function use_PerformanceEntry_methods() {

--- a/files/en-us/web/api/performance/getentriesbytype/index.md
+++ b/files/en-us/web/api/performance/getentriesbytype/index.md
@@ -21,10 +21,10 @@ method) at explicit points in time.
 ## Syntax
 
 ```js
-entries = window.performance.getEntriesByType(type);
+getEntriesByType(type)
 ```
 
-### Arguments
+### Parameters
 
 - type
   - : The type of entry to retrieve such as "`mark`". The valid entry types are
@@ -32,13 +32,12 @@ entries = window.performance.getEntriesByType(type);
 
 ### Return value
 
-- entries
-  - : A list of {{domxref("PerformanceEntry")}} objects that have the specified
+A list of {{domxref("PerformanceEntry")}} objects that have the specified
     `type`. The items will be in chronological order based on the entries'
     {{domxref("PerformanceEntry.startTime","startTime")}}. If no objects have the
     specified `type`, or no argument is provided, an empty list is returned.
 
-## Example
+## Examples
 
 ```js
 function usePerformanceEntryMethods() {

--- a/files/en-us/web/api/performance/mark/index.md
+++ b/files/en-us/web/api/performance/mark/index.md
@@ -28,14 +28,14 @@ The `mark()'s` stores its data internally as
 ## Syntax
 
 ```js
-performance.mark(name);
-performance.mark(measureName, markOptions)
+mark(name)
+mark(name, markOptions)
 ```
 
-### Arguments
+### Parameters
 
 - name
-  - : A {{domxref("DOMString")}} representing the name of the mark. If the
+  - : A string representing the name of the mark. If the
     `name` given to this method already exists in the
     {{domxref("PerformanceTiming")}} interface, {{jsxref("SyntaxError")}} is
     thrown.
@@ -50,10 +50,9 @@ performance.mark(measureName, markOptions)
 
 ### Return value
 
-- entry
-  - : The {{domxref("PerformanceMark")}} entry that was created.
+The {{domxref("PerformanceMark")}} entry that was created.
 
-## Example
+## Examples
 
 The following example shows how to use `mark()` to create and retrieve
 {{domxref("PerformanceMark")}} entries.

--- a/files/en-us/web/api/performance/measure/index.md
+++ b/files/en-us/web/api/performance/measure/index.md
@@ -34,10 +34,10 @@ measure(measureName, startMark, endMark)
 
 If only `measureName` is specified, the start timestamp is set to zero, and the end timestamp (which is used to calculate the duration) is the value that would be returned by {{domxref("Performance.now()")}}.
 
-### Arguments
+### Parameters
 
 - `measureName`
-  - : A {{domxref("DOMString")}} representing the name of the measure.
+  - : A string representing the name of the measure.
 
 - `MeasureOptions` {{optional_inline}}
   - : An object that may contain all measure options (the `startMark` and `endMark` may be specified in this object or as their own arguments):
@@ -45,21 +45,21 @@ If only `measureName` is specified, the start timestamp is set to zero, and the 
     - `detail`
       - : Arbitrary metadata to be included in the measure.
     - `start`
-      - : Timestamp {{domxref("DOMHighResTimeStamp")}} to be used as the start time, or {{domxref("DOMString")}} to be used as start mark.
+      - : Timestamp {{domxref("DOMHighResTimeStamp")}} to be used as the start time, or string to be used as start mark.
           If this represents the name of a start mark, then it is defined in the same way as `startMark` (in other words it must be the name of an existing mark or a {{domxref("PerformanceTiming")}} property).
     - `duration`
       - : Duration between the start and end mark times ({{domxref("DOMHighResTimeStamp")}}).
     - `end`
-      - : Timestamp ({{domxref("DOMHighResTimeStamp")}}) to be used as the end time, or {{domxref("DOMString")}} to be used as end mark.
+      - : Timestamp ({{domxref("DOMHighResTimeStamp")}}) to be used as the end time, or string to be used as end mark.
           If this represents the name of an end mark, then it is defined in the same way as `endMark` (in other words it must be the name of an existing mark or a {{domxref("PerformanceTiming")}} property).
 
 - `startMark` {{optional_inline}}
-  - : A {{domxref("DOMString")}} representing the name of the measure's starting mark.
+  - : A string representing the name of the measure's starting mark.
     May also be the name of a {{domxref("PerformanceTiming")}} property.
     Specifying a name that does not represent an existing {{domxref('PerformanceMark')}} or {{domxref("PerformanceTiming")}} raises a `SyntaxError` {{domxref("DOMException")}}.
 
 - `endMark` {{optional_inline}}
-  - : A {{domxref("DOMString")}} representing the name of the measure's ending mark.
+  - : A string representing the name of the measure's ending mark.
     This may also be the name of a {{domxref("PerformanceTiming")}} property.
     Specifying a name that does not represent an existing {{domxref('PerformanceMark')}} or {{domxref("PerformanceTiming")}} raises a `SyntaxError` {{domxref("DOMException")}}.
 
@@ -76,7 +76,7 @@ The returned _measure_ will have the following property values:
   - the {{domxref("DOMHighResTimeStamp","timestamp")}} of a start mark, if specified in `MeasureOptions.start` or `startMark`
   - a timestamp calculated from the `MeasureOptions.end` and `MeasureOptions.duration` (if `MeasureOptions.start` was not specified)
   - 0, if it isn't specified and can't be determined from other values.
-  
+
 - {{domxref("PerformanceEntry.duration","duration")}} - set to a {{domxref("DOMHighResTimeStamp")}} that is the duration of the measure calculated by subtracting the `startTime` from the end timestamp.
 
   The end timestamp is one of:
@@ -86,7 +86,7 @@ The returned _measure_ will have the following property values:
   - the value returned by {{domxref("Performance.now()")}}, if no end mark is specified or can be determined from other values.
 - {{domxref("PerformanceMeasure","detail")}} - set to the value passed in `MeasureOptions`.
 
-## Exceptions
+### Exceptions
 
 - `TypeError` {{domxref("DOMException")}}
   - : This can be thrown in any case where the start, end or duration might be ambiguous:
@@ -109,7 +109,7 @@ The returned _measure_ will have the following property values:
 - `RangeError`
   - : The `MeasureOptions.detail` value is non-`null` and memory cannot be allocated during serialization using the HTML "StructuredSerialize" algorithm.
 
-## Example
+## Examples
 
 The following example shows how `measure()` is used to create a new _measure_ {{domxref("PerformanceEntry","performance entry")}} in the browser's performance entry buffer.
 

--- a/files/en-us/web/api/performance/now/index.md
+++ b/files/en-us/web/api/performance/now/index.md
@@ -38,10 +38,10 @@ are alleviated through other means.
 ## Syntax
 
 ```js
-t = performance.now();
+now()
 ```
 
-## Example
+## Examples
 
 ```js
 const t0 = performance.now();

--- a/files/en-us/web/api/performance/setresourcetimingbuffersize/index.md
+++ b/files/en-us/web/api/performance/setresourcetimingbuffersize/index.md
@@ -23,10 +23,10 @@ A browser's recommended resource timing buffer size is at least 150
 ## Syntax
 
 ```js
-performance.setResourceTimingBufferSize(maxSize);
+setResourceTimingBufferSize(maxSize)
 ```
 
-### Arguments
+### Parameters
 
 - maxSize
   - : A `number` representing the maximum number of
@@ -35,10 +35,9 @@ performance.setResourceTimingBufferSize(maxSize);
 
 ### Return value
 
-- none
-  - : This method has no return value.
+This method has no return value.
 
-## Example
+## Examples
 
 ```js
 function setResourceTimingBufferSize(maxSize) {

--- a/files/en-us/web/api/performance/tojson/index.md
+++ b/files/en-us/web/api/performance/tojson/index.md
@@ -19,20 +19,19 @@ object's properties.
 ## Syntax
 
 ```js
-myPerf = performance.toJSON()
+toJSON()
 ```
 
-### Arguments
+### Parameters
 
 - None
   - :
 
 ### Return value
 
-- myPerf
-  - : A JSON object that is the serialization of the {{domxref("Performance")}} object.
+A JSON object that is the serialization of the {{domxref("Performance")}} object.
 
-## Example
+## Examples
 
 ```js
 var js;

--- a/files/en-us/web/api/performance/tojson/index.md
+++ b/files/en-us/web/api/performance/tojson/index.md
@@ -22,11 +22,6 @@ object's properties.
 toJSON()
 ```
 
-### Parameters
-
-- None
-  - :
-
 ### Return value
 
 A JSON object that is the serialization of the {{domxref("Performance")}} object.

--- a/files/en-us/web/api/performanceelementtiming/tojson/index.md
+++ b/files/en-us/web/api/performanceelementtiming/tojson/index.md
@@ -16,7 +16,7 @@ The **`toJSON()`** method of the {{domxref("PerformanceElementTiming")}} interfa
 ## Syntax
 
 ```js
-var json = PerformanceElementTiming.toJSON();
+toJSON()
 ```
 
 ### Return value

--- a/files/en-us/web/api/performanceentry/tojson/index.md
+++ b/files/en-us/web/api/performanceentry/tojson/index.md
@@ -21,11 +21,6 @@ a JSON representation of the {{domxref("PerformanceEntry","performance entry")}}
 toJSON()
 ```
 
-### Parameters
-
-- None
-  - :
-
 ### Return value
 
 A JSON object that is the serialization of the {{domxref("PerformanceEntry")}} object.

--- a/files/en-us/web/api/performanceentry/tojson/index.md
+++ b/files/en-us/web/api/performanceentry/tojson/index.md
@@ -18,21 +18,19 @@ a JSON representation of the {{domxref("PerformanceEntry","performance entry")}}
 ## Syntax
 
 ```js
-json = perfEntry.toJSON();
+toJSON()
 ```
 
-### Arguments
+### Parameters
 
 - None
   - :
 
 ### Return value
 
-- json
-  - : A JSON object that is the serialization of the {{domxref("PerformanceEntry")}}
-    object.
+A JSON object that is the serialization of the {{domxref("PerformanceEntry")}} object.
 
-## Example
+## Examples
 
 The following example shows the use of the `toJSON()` method.
 

--- a/files/en-us/web/api/performancenavigationtiming/tojson/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/tojson/index.md
@@ -16,21 +16,20 @@ a JSON representation of the {{domxref("PerformanceNavigationTiming")}} object.
 ## Syntax
 
 ```js
-json = resourcePerfEntry.toJSON();
+toJSON()
 ```
 
-### Arguments
+### Parameters
 
 None
 
 ### Return value
 
-- json
-  - : A JSON object that is the serialization of the
+A JSON object that is the serialization of the
     {{domxref("PerformanceNavigationTiming")}} object as a map with entries from the
     closest inherited interface and with entries for each of the serializable attributes.
 
-## Example
+## Examples
 
 ```js
 // Get a resource performance entry

--- a/files/en-us/web/api/performanceobserver/disconnect/index.md
+++ b/files/en-us/web/api/performanceobserver/disconnect/index.md
@@ -22,10 +22,10 @@ events.
 ## Syntax
 
 ```js
-performanceObserver.disconnect();
+disconnect()
 ```
 
-## Example
+## Examples
 
 ```js
 var observer = new PerformanceObserver(function(list, obj) {

--- a/files/en-us/web/api/performanceobserver/observe/index.md
+++ b/files/en-us/web/api/performanceobserver/observe/index.md
@@ -17,7 +17,7 @@ The **`observe()`** method of the
 set of performance entry types to observe.
 
 The performance entry types are
-specified as an array of {{domxref("DOMString")}} objects, each naming one entry type;
+specified as an array of string objects, each naming one entry type;
 the type names are documented in
 {{SectionOnPage("/en-US/docs/Web/API/PerformanceEntry/entryType", "Performance entry
   type names")}}.
@@ -28,7 +28,7 @@ function—set when creating the {{domxref("PerformanceObserver")}}—is invoked
 ## Syntax
 
 ```js
-observer.observe(options);
+observe(options)
 ```
 
 ### Parameters
@@ -38,10 +38,10 @@ observer.observe(options);
   - : A `PerformanceObserverInit` dictionary with the following possible
     members:
 
-    - `entryTypes`: An array of {{domxref("DOMString")}} objects, each
+    - `entryTypes`: An array of string objects, each
       specifying one performance entry type to observe. May not be used together with
       the "`type`" or "`buffered`" options.
-    - `type`: A single {{domxref("DOMString")}} specifying exactly one
+    - `type`: A single string specifying exactly one
       performance entry type to observe. May not be used together with the
       `entryTypes` option.
     - `buffered`: A boolean flag to indicate whether buffered

--- a/files/en-us/web/api/performanceobserver/takerecords/index.md
+++ b/files/en-us/web/api/performanceobserver/takerecords/index.md
@@ -21,7 +21,7 @@ observer, emptying it out.
 ## Syntax
 
 ```js
-var performanceEntryList = performanceObserver.takeRecords();
+takeRecords()
 ```
 
 ### Parameters
@@ -32,7 +32,7 @@ None.
 
 A list of {{domxref("PerformanceEntry")}} objects.
 
-## Example
+## Examples
 
 ```js
 var observer = new PerformanceObserver(function(list, obj) {

--- a/files/en-us/web/api/performanceobserverentrylist/getentriesbyname/index.md
+++ b/files/en-us/web/api/performanceobserverentrylist/getentriesbyname/index.md
@@ -27,15 +27,16 @@ interfaces.
 ## Syntax
 
 ```js
-entries = list.getEntriesByName(name, type);
+getEntriesByName(name)
+getEntriesByName(name, type)
 ```
 
 ### Parameters
 
 - _`name`_
-  - : A {{domxref("DOMString")}} representing the name of the entry to retrieve.
+  - : A string representing the name of the entry to retrieve.
 - _`type`_ {{optional_inline}}
-  - : A {{domxref("DOMString")}} representing the type of entry to retrieve such as
+  - : A string representing the type of entry to retrieve such as
     "`mark`". The valid entry types are listed in
     {{domxref("PerformanceEntry.entryType")}}.
 
@@ -49,7 +50,7 @@ chronological order based on the entries'
 {{domxref("PerformanceEntry.startTime","startTime")}}. If no objects meet the specified
 criteria, an empty list is returned.
 
-## Example
+## Examples
 
 ```js
 function print_perf_entry(pe) {

--- a/files/en-us/web/api/performanceobserverentrylist/getentriesbytype/index.md
+++ b/files/en-us/web/api/performanceobserverentrylist/getentriesbytype/index.md
@@ -18,7 +18,7 @@ This method is exposed to {{domxref("Window")}} and {{domxref("Worker")}} interf
 ## Syntax
 
 ```js
-entries = list.getEntriesByType(type);
+getEntriesByType(type)
 ```
 
 ### Parameters
@@ -30,7 +30,7 @@ entries = list.getEntriesByType(type);
 
 A list of explicitly _observed_ {{domxref("PerformanceEntry")}} objects that have the specified `type`. The items will be in chronological order based on the entries' {{domxref("PerformanceEntry.startTime","startTime")}}. If no objects have the specified `type`, or no argument is provided, an empty list is returned.
 
-## Example
+## Examples
 
 ```js
 function print_perf_entry(pe) {

--- a/files/en-us/web/api/performanceresourcetiming/tojson/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/tojson/index.md
@@ -16,10 +16,10 @@ a JSON representation of the {{domxref("PerformanceResourceTiming")}} object.
 ## Syntax
 
 ```js
-json = resourcePerfEntry.toJSON();
+toJSON()
 ```
 
-### Arguments
+### Parameters
 
 None
 
@@ -30,7 +30,7 @@ None
     {{domxref("PerformanceResourceTiming")}} object as a map with entries from the closest
     inherited interface and with entries for each of the serializable attributes.
 
-## Example
+## Examples
 
 ```js
 // Get a resource performance entry


### PR DESCRIPTION
Continuing #14857 

## Summary
Updating the method pages to follow the current templates:
https://developer.mozilla.org/en-US/docs/MDN/Structures/Syntax_sections#constructors_and_methods
https://developer.mozilla.org/en-US/docs/MDN/Structures/Page_types/API_method_subpage_template

Changes Include:
- fix syntax section
- changing section titles to suggested titles in the template
- change `{{DOMxRef("DOMString")}}` to `string`
- remove extra spaces in between words and extra trailing spaces
- other small corrections

### Metadata
- [x] Fixes a typo, bug, or other error
