### PR TITLE
Update Edge DevTools docs link to current release

### DIFF
--- a/files/en-us/glossary/developer_tools/index.md
+++ b/files/en-us/glossary/developer_tools/index.md
@@ -17,4 +17,4 @@ Current browsers provide integrated developer tools, which allow to inspect a we
 - [Firebug](https://getfirebug.com/) (former developer tool for Firefox)
 - [Chrome DevTools](https://developer.chrome.com/devtools) on chrome.com
 - [Safari Web Inspector](https://developer.apple.com/library/content/documentation/AppleApplications/Conceptual/Safari_Developer_Guide/Introduction/Introduction.html#//apple_ref/doc/uid/TP40007874-CH1-SW1) on apple.com
-- [Edge Dev Tools](https://docs.microsoft.com/microsoft-edge/f12-devtools-guide) on microsoft.com
+- [Edge Dev Tools](https://docs.microsoft.com/microsoft-edge/devtools-guide-chromium/landing/) on microsoft.com


### PR DESCRIPTION
#### Summary
Update Edge DevTools docs link from Edge Legacy docs to modern (Chromium) Edge DevTools docs landing page.

#### Motivation
Modern Edge was released over 2 years ago. MDN DevTools links to legacy documentation. This threw me off, and is likely confusing other web devs who are being sent to outdated docs.

#### Supporting details
Content at top of [current link](https://docs.microsoft.com/archive/microsoft-edge/legacy/developer/) has this disclaimer:

> Thank you for your interest in Microsoft Edge. The following article summarizes content for the legacy product, which is no longer being updated. The new Microsoft Edge content replaces the content for the legacy product and is marked as recommended in the following tables.

#### Related issues

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

(FYI @codepo8)