### PR TITLE
Update return value text when there is no returned value

### DIFF
--- a/files/en-us/mdn/structures/syntax_sections/index.md
+++ b/files/en-us/mdn/structures/syntax_sections/index.md
@@ -162,7 +162,7 @@ Next, include a "Parameters" subsection, which explains what each parameter shou
 
 The name of each parameter in the list should be contained in a {{HTMLElement("code")}} block.
 
-> **Note:** If the feature does not take any parameters, you don't need to include a "Parameters" section, but you can if you wish include it with content of "None".
+> **Note:** Even if the feature does not take any parameters, you need to include a "Parameters" section, with content of "None".
 
 #### Return value section
 

--- a/files/en-us/mdn/structures/syntax_sections/index.md
+++ b/files/en-us/mdn/structures/syntax_sections/index.md
@@ -170,7 +170,7 @@ Next, include a "Return value" subsection, which explains what the return value 
 
 If there is no return value, use the following text:
 
-> None, that is an \{{jsxref("undefined")}} object.
+> None, that is an \{\{jsxref("undefined")}} object will be returned when trying to access it.
 
 #### Exceptions section
 

--- a/files/en-us/mdn/structures/syntax_sections/index.md
+++ b/files/en-us/mdn/structures/syntax_sections/index.md
@@ -166,7 +166,7 @@ The name of each parameter in the list should be contained in a {{HTMLElement("c
 
 #### Return value section
 
-Next, include a "Return value" subsection, which explains what the return value of the constructor or method. See the above links for examples.
+Next, include a "Return value" subsection, which explains what the return value of the constructor or method is. See the above links as examples.
 
 If there is no return value, use the following text:
 

--- a/files/en-us/mdn/structures/syntax_sections/index.md
+++ b/files/en-us/mdn/structures/syntax_sections/index.md
@@ -170,7 +170,7 @@ Next, include a "Return value" subsection, which explains what the return value 
 
 If there is no return value, use the following text:
 
-> None, that is an \{\{jsxref("undefined")}} object will be returned when trying to access it.
+None (\{\{jsxref("undefined")}}).
 
 #### Exceptions section
 

--- a/files/en-us/mdn/structures/syntax_sections/index.md
+++ b/files/en-us/mdn/structures/syntax_sections/index.md
@@ -166,7 +166,11 @@ The name of each parameter in the list should be contained in a {{HTMLElement("c
 
 #### Return value section
 
-Next, include a "Return value" subsection, which explains what the return value of the constructor or method is, even if it is `undefined`. See the above links for examples.
+Next, include a "Return value" subsection, which explains what the return value of the constructor or method. See the above links for examples.
+
+If there is no return value, use the following text:
+
+> None, that is an \{{jsxref("undefined")}} object.
 
 #### Exceptions section
 


### PR DESCRIPTION
This has been raised in mdn/content#15118.

The idea here is double:
- Reach consistency (we currently have: _Void_, _None_, `undefined` or `{{jsxref("undefined")}}`.
- Explain clearly that _no return value_ means that a JS `undefined` object is returned, and link to it for additional information. This will help beginners.