### PR TITLE
Add info that these exceptions are `DOMException`s

### DIFF
--- a/files/en-us/web/api/navigator/requestmidiaccess/index.md
+++ b/files/en-us/web/api/navigator/requestmidiaccess/index.md
@@ -42,13 +42,13 @@ A {{jsxref('Promise')}} that resolves with a [`MIDIAccess`](/en-US/docs/Web/API/
 
 ### Exceptions
 
-- `AbortError`
+- `AbortError` {{domxref("DOMException")}}
   - : If the document or page is closed due to user navigation.
-- `InvalidStateError`
+- `InvalidStateError` {{domxref("DOMException")}}
   - : If the underlying system raises any errors.
-- `NotSupportedError`
+- `NotSupportedError` {{domxref("DOMException")}}
   - : If the feature or options are not supported by the system.
-- `SecurityError`
+- `SecurityError` {{domxref("DOMException")}}
   - : If the user or system denies the application from creating a [MIDIAccess](/en-US/docs/Web/API/MIDIAccess) object with the requested options, or if the document is not allowed to use the feature (for example, an iframe without the correct [Permission Policy](/en-US/docs/Web/HTTP/Feature_Policy), or when the user has previously denied a permissions access to the feature).
 
 ## Examples


### PR DESCRIPTION
To help beginners, we explicitly state when exceptions are DOMExceptions. (To help devs distinguish between them and raw js exceptions, like `TypeError` and `RangeError`: the code they have to write is different.)