### PR TITLE
Remove indeterminate from Additional attributes

### DIFF
--- a/files/en-us/web/html/element/input/checkbox/index.md
+++ b/files/en-us/web/html/element/input/checkbox/index.md
@@ -91,14 +91,6 @@ In addition to the common attributes shared by all {{HTMLElement("input")}} elem
     > **Note:** Unlike other input controls, a checkbox's value is only included in the submitted data if the checkbox is currently `checked`. If it is, then the value of the checkbox's `value` attribute is reported as the input's value.
     > Unlike other browsers, Firefox by default [persists the dynamic checked state](https://stackoverflow.com/questions/5985839/bug-with-firefox-disabled-attribute-of-input-not-resetting-when-refreshing) of an `<input>` across page loads. Use the {{htmlattrxref("autocomplete","input")}} attribute to control this feature.
 
-- {{htmlattrdef("indeterminate")}}
-
-  - : If the `indeterminate` attribute is present on the {{HTMLElement("input")}} element defining a checkbox, the checkbox's value is neither `true` nor `false`, but is instead **indeterminate**, meaning that its state cannot be determined or stated in pure binary terms. This may happen, for instance, if the state of the checkbox depends on multiple other checkboxes, and those checkboxes have different values.
-
-    Essentially, then, the `indeterminate` attribute adds a third possible state to the checkbox: "I don't know." In this state, the browser may draw the checkbox in grey or with a different mark inside the checkbox. For instance, browsers on macOS may draw the checkbox with a hyphen "-" inside to indicate an unexpected state.
-
-    > **Note:** No browser currently supports `indeterminate` as an attribute. It must be set via JavaScript. See [Indeterminate state checkboxes](#indeterminate_state_checkboxes) for details.
-
 - {{htmlattrdef("value")}}
 
   - : The `value` attribute is one which all {{HTMLElement("input")}}s share; however, it serves a special purpose for inputs of type `checkbox`: when a form is submitted, only checkboxes which are currently checked are submitted to the server, and the reported value is the value of the `value` attribute. If the `value` is not otherwise specified, it is the string `on` by default. This is demonstrated in the section [Value](#value) above.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Removed the `indeterminate` attribute from `<input type="checkbox">` doc.

#### Motivation
The `indeterminate` was _never a content attribute_. (https://github.com/whatwg/html/issues/6578)

See the spec: [Checkbox state](https://html.spec.whatwg.org/multipage/input.html#checkbox-state-(type=checkbox))

> If the element's [`indeterminate`](https://html.spec.whatwg.org/multipage/input.html#dom-input-indeterminate) IDL attribute is set to true, then the control's selection should be obscured as if the control was in a third, indeterminate, state.

`indeterminate` is explicitly stated as an IDL attribute.

See also: [The `input` element](https://html.spec.whatwg.org/multipage/input.html#the-input-element). There is no `indeterminate` under its content attributes, only under the DOM interface.

Current MDN document is giving an impression that `indeterminate` is a content attribute in paper, but it's browser vendors not implementing the standard correctly. This shouldn't happen.

I decided to remove the content altogether. It shouldn't harm much since there's [a dedicated section about indeterminate checkboxes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox#indeterminate_state_checkboxes) already. It should be able to cover everything itself.

#### Supporting details
- https://github.com/whatwg/html/issues/6578
- https://html.spec.whatwg.org/multipage/input.html#the-input-element
- https://html.spec.whatwg.org/multipage/input.html#checkbox-state-(type=checkbox)
- https://html.spec.whatwg.org/multipage/input.html#dom-input-indeterminate

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
