### PR TITLE
Link formatting makes one symbol look like another

### DIFF
--- a/files/en-us/web/javascript/reference/operators/index.md
+++ b/files/en-us/web/javascript/reference/operators/index.md
@@ -100,7 +100,7 @@ A unary operation is an operation with only one operand.
 
 Arithmetic operators take numerical values (either literals or variables) as their operands and return a single numerical value.
 
-- {{JSxRef("Operators/Addition", "+")}}
+- {{JSxRef("Operators/Addition", "+")}} (Plus)
   - : Addition operator.
 - {{JSxRef("Operators/Subtraction", "-")}}
   - : Subtraction operator.
@@ -121,9 +121,9 @@ A comparison operator compares its operands and returns a boolean value based on
   - : The `in` operator determines whether an object has a given property.
 - {{JSxRef("Operators/instanceof", "instanceof")}}
   - : The `instanceof` operator determines whether an object is an instance of another object.
-- {{JSxRef("Operators/Less_than", "&lt;")}}
+- {{JSxRef("Operators/Less_than", "&lt;")}} (Less than)
   - : Less than operator.
-- {{JSxRef("Operators/Greater_than", "&gt;")}}
+- {{JSxRef("Operators/Greater_than", "&gt;")}} (Greater than)
   - : Greater than operator.
 - {{JSxRef("Operators/Less_than_or_equal", "&lt;=")}}
   - : Less than or equal operator.


### PR DESCRIPTION
In the case of greater than, less than, and plus operators the link underlining makes the symbol look like another symbol with a different meaning (greater than looks like greater than or equal to, less than looks like less than or equal to, and plus looks like plus/minus). Placing the word after the symbol may help disambiguate the presentation.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
