### PR TITLE
Documenting some regex group limitations

### DIFF
--- a/files/en-us/web/api/url_pattern_api/index.md
+++ b/files/en-us/web/api/url_pattern_api/index.md
@@ -151,8 +151,8 @@ Some regex patterns do not work as you may expect:
   ```
 - Parentheses need to be escaped in range expressions within URLPattern even though they don't in RegExp.
   ```js
-  const pattern = new URLPattern({ pathname: '[()]' }); // throws
-  const pattern = new URLPattern({ pathname: '[\\(\\)]' }); // ok
+  const pattern = new URLPattern({ pathname: '([()])' }); // throws
+  const pattern = new URLPattern({ pathname: '([\\(\\)])' }); // ok
 
   const regex = new RegExp('[()]'); // ok
   const regex = new RegExp('[\\(\\)]'); // ok

--- a/files/en-us/web/api/url_pattern_api/index.md
+++ b/files/en-us/web/api/url_pattern_api/index.md
@@ -93,13 +93,13 @@ console.log(pattern.test('https://example.com/books/')); // false
 ### Regex matchers limitations
 
 Some regex patterns do not work as you may expect. Starts with `^`, 
-ends with `$`, Lookaheads, and lookbehineds will never match.
+ends with `$`, lookaheads, and lookbehineds will never match.
 
 ```js
 // starts with `^`
-const pattern = new URLPattern('(^a)', 'https://example.com');
-console.log(pattern.test('https://example.com/ab')); // false
-console.log(pattern.test('https://example.com/ax')); // false
+const pattern = new URLPattern('(^b)', 'https://example.com');
+console.log(pattern.test('https://example.com/ba')); // false
+console.log(pattern.test('https://example.com/xa')); // false
 
 // ends with `$`
 const pattern = new URLPattern('(b$)', 'https://example.com');

--- a/files/en-us/web/api/url_pattern_api/index.md
+++ b/files/en-us/web/api/url_pattern_api/index.md
@@ -29,8 +29,8 @@ can contain:
 - Named groups (`/books/:id`) which extract a part of the matched URL.
 - Non-capturing groups (`/books{/old}?`) which make parts of a pattern optional
   or be matched multiple times.
-- {{jsxref("RegExp")}} groups (`/books/(^\d)`) which make arbitrarily complex
-  regex matches.
+- {{jsxref("RegExp")}} groups (`/books/(\\d+)`) which make arbitrarily complex
+  regex matches with a few [limitations](#regex_matchers_limitations).
 
 You can find details about the syntax in the [pattern syntax](#pattern_syntax)
 section below.

--- a/files/en-us/web/api/url_pattern_api/index.md
+++ b/files/en-us/web/api/url_pattern_api/index.md
@@ -90,6 +90,43 @@ console.log(pattern.test('https://example.com/books/abc')); // false
 console.log(pattern.test('https://example.com/books/')); // false
 ```
 
+### Regex matchers limitations
+
+Some regex patterns do not work as you may expect. Starts with `^`, 
+ends with `$`, Lookaheads, and lookbehineds will never match.
+
+```js
+// starts with `^`
+const pattern = new URLPattern('(^a)', 'https://example.com');
+console.log(pattern.test('https://example.com/ab')); // false
+console.log(pattern.test('https://example.com/ax')); // false
+
+// ends with `$`
+const pattern = new URLPattern('(b$)', 'https://example.com');
+console.log(pattern.test('https://example.com/ab')); // false
+console.log(pattern.test('https://example.com/ax')); // false
+
+// lookahead
+const pattern = new URLPattern('(a(?=b))', 'https://example.com');
+console.log(pattern.test('https://example.com/ab')); // false
+console.log(pattern.test('https://example.com/ax')); // false
+
+// negative-lookahead
+const pattern = new URLPattern('/(a(?!b))', 'https://example.com');
+console.log(pattern.test('https://example.com/ab')); // false
+console.log(pattern.test('https://example.com/ax')); // false
+
+// lookbehind
+const pattern = new URLPattern('((?<=b)a)', 'https://example.com');
+console.log(pattern.test('https://example.com/ba')); // false
+console.log(pattern.test('https://example.com/xa')); // false
+
+// negative-lookbehind
+const pattern = new URLPattern('((?<!b)a)', 'https://example.com');
+console.log(pattern.test('https://example.com/ba')); // false
+console.log(pattern.test('https://example.com/xa')); // false
+```
+
 ### Unnamed and named groups
 
 Groups can either be named or unnamed. Named groups are specified by prefixing


### PR DESCRIPTION
There are some regex patterns that do not work as one might expect.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Documented some regex pattern limitations.

#### Motivation
I came across some regex patterns that didn't behave as I expected so I thought I would add them here to help others.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
N/A

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
N/A

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
