### PR TITLE
A note for empty string returned for default ports

### DIFF
--- a/files/en-us/web/api/url/port/index.md
+++ b/files/en-us/web/api/url/port/index.md
@@ -13,8 +13,7 @@ browser-compat: api.URL.port
 {{ApiRef("URL API")}}
 
 The **`port`** property of the {{domxref("URL")}} interface is
-a {{domxref("USVString")}} containing the port number of the URL. If the URL does not
-contain an explicit port number, or the given port number matches the protocol's default, it will be set to `''`.
+a {{domxref("USVString")}} containing the port number of the URL. If an input string passed to URL() constructor doesn’t contain an explicit port number (e.g., https://localhost) or contains a port number that’s the default port number corresponding to the protocol part of the input string (e.g., https://localhost:443), then in the URL object the constructor returns, the value of the port property will be an empty string: `''`.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/url/port/index.md
+++ b/files/en-us/web/api/url/port/index.md
@@ -13,7 +13,9 @@ browser-compat: api.URL.port
 {{ApiRef("URL API")}}
 
 The **`port`** property of the {{domxref("URL")}} interface is
-a {{domxref("USVString")}} containing the port number of the URL. If an input string passed to URL() constructor doesn’t contain an explicit port number (e.g., https://localhost) or contains a port number that’s the default port number corresponding to the protocol part of the input string (e.g., https://localhost:443), then in the URL object the constructor returns, the value of the port property will be an empty string: `''`.
+a {{domxref("USVString")}} containing the port number of the URL.
+
+> **Note:** If an input string passed to the [`URL()`](/en-US/docs/Web/API/URL/URL) constructor doesn’t contain an explicit port number (e.g., `https://localhost`) or contains a port number that’s the default port number corresponding to the protocol part of the input string (e.g., `https://localhost:443`), then in the [`URL`](/en-US/docs/Web/API/URL) object the constructor returns, the value of the port property will be the empty string: `''`.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/url/port/index.md
+++ b/files/en-us/web/api/url/port/index.md
@@ -14,7 +14,7 @@ browser-compat: api.URL.port
 
 The **`port`** property of the {{domxref("URL")}} interface is
 a {{domxref("USVString")}} containing the port number of the URL. If the URL does not
-contain an explicit port number, it will be set to `''`.
+contain an explicit port number, or the given port number matches the protocol's default, it will be set to `''`.
 
 {{AvailableInWorkers}}
 


### PR DESCRIPTION
#### Summary

Currently it's only noted that an empty string is returned when no port is included in the given url. This does not cover when a port is given, but with a protocol that has a matching default port. So `new URL('http://localhost:80').port` returns `''`, same with `new URL('https://localhost:443').port`, `new URL('ssh://localhost:22').port`, etc. Not sure if an example showing this should be added in the Examples section as well, but my assumption is that the note in the description is enough.

Also happy to take feedback on the wording, not sure if `given port number` is too explicit or `protocol's default` is too ambiguous.

#### Motivation

My assumption of what was returned when explicitly providing a port in a URL to parse was that it would populate regardless of protocol, so I think it's worthwhile to describe that difference.

#### Supporting details

_N/A_

#### Related issues

_N/A_

#### Metadata

- [ ] Adds a new document
- [X] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
