### PR TITLE
Interactive Example in querySelector

### DIFF
--- a/files/en-us/web/api/document/queryselector/index.md
+++ b/files/en-us/web/api/document/queryselector/index.md
@@ -20,6 +20,8 @@ The {{domxref("Document")}} method **`querySelector()`**
 returns the first {{domxref("Element")}} within the document that matches the specified
 selector, or group of selectors. If no matches are found, `null` is returned.
 
+{{EmbedInteractiveExample("pages/webapi-tabbed/document-queryselector.html")}}
+
 > **Note:** The matching is done using depth-first pre-order traversal of
 > the document's nodes starting with the first element in the document's markup and
 > iterating through sequential nodes by order of the number of child nodes.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
I have noticed that [querySelector](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector) method has an interactive example that is not used. It seems ok, so why not to use it? :)
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
