### PR TITLE
Multiple values in animation-iteration-count

### DIFF
--- a/files/en-us/web/css/animation-iteration-count/index.md
+++ b/files/en-us/web/css/animation-iteration-count/index.md
@@ -13,8 +13,6 @@ browser-compat: css.properties.animation-iteration-count
 
 The **`animation-iteration-count`** [CSS](/en-US/docs/Web/CSS) property sets the number of times an animation sequence should be played before stopping.
 
-If multiple values are specified, each time the animation is played the next value in the list is used, cycling back to the first value after the last one is used.
-
 {{EmbedInteractiveExample("pages/css/animation-iteration-count.html")}}
 
 It is often convenient to use the shorthand property {{cssxref("animation")}} to set all animation properties at once.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Paragraph in [animation-iteration-count](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-iteration-count) suggests that if we set multiple values for the same animation name, additional values will be somehow used, while in fact they will be ignored.
In section [setting multiple animation property values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations#setting_multiple_animation_property_values), it is explained how to attach multiple animations and their values to a single element. That section is linked in a [note of animation-iteration-count](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-iteration-count#values), so I don't think any deeper explanation is needed here.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
