### PR TITLE
Luxon docs link is broken

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/displaying_data/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/displaying_data/index.md
@@ -74,7 +74,7 @@ In our next article, we'll build on our knowledge, creating HTML forms and form 
 - [Async module](https://caolan.github.io/async/) (Async docs)
 - [Using Template engines with Express](https://expressjs.com/en/guide/using-template-engines.html) (Express docs)
 - [Pug](https://pugjs.org/api/getting-started.html) (Pug docs)
-- [Luxon](https://moment.github.io/luxon/docs/) (Luxon docs)
+- [Luxon](https://moment.github.io/luxon/api-docs/index.html) (Luxon docs)
 
 {{PreviousMenuNext("Learn/Server-side/Express_Nodejs/routes", "Learn/Server-side/Express_Nodejs/forms", "Learn/Server-side/Express_Nodejs")}}
 

--- a/files/en-us/learn/server-side/express_nodejs/displaying_data/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/displaying_data/index.md
@@ -74,7 +74,7 @@ In our next article, we'll build on our knowledge, creating HTML forms and form 
 - [Async module](https://caolan.github.io/async/) (Async docs)
 - [Using Template engines with Express](https://expressjs.com/en/guide/using-template-engines.html) (Express docs)
 - [Pug](https://pugjs.org/api/getting-started.html) (Pug docs)
-- [Luxon](https://moment.github.io/luxon/api-docs/index.html) (Luxon docs)
+- [Luxon](https://moment.github.io/luxon/#/) (Luxon docs)
 
 {{PreviousMenuNext("Learn/Server-side/Express_Nodejs/routes", "Learn/Server-side/Express_Nodejs/forms", "Learn/Server-side/Express_Nodejs")}}
 


### PR DESCRIPTION
In the see also section the Lexon link takes you to a file not found page and not the actual Luxon docs.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
