### PR TITLE
Remove scrollbar-width and scrollbar-color interactive examples

### DIFF
--- a/files/en-us/web/css/scrollbar-color/index.md
+++ b/files/en-us/web/css/scrollbar-color/index.md
@@ -18,8 +18,6 @@ The **track** refers to the background of the scrollbar, which is generally fixe
 
 The **thumb** refers to the moving part of the scrollbar, which usually floats on top of the track.
 
-{{EmbedInteractiveExample("pages/css/scrollbar-color.html")}}
-
 ## Syntax
 
 ```css

--- a/files/en-us/web/css/scrollbar-width/index.md
+++ b/files/en-us/web/css/scrollbar-width/index.md
@@ -14,8 +14,6 @@ browser-compat: css.properties.scrollbar-width
 
 The **`scrollbar-width`** property allows the author to set the maximum thickness of an element's scrollbars when they are shown.
 
-{{EmbedInteractiveExample("pages/css/scrollbar-width.html")}}
-
 ## Syntax
 
 ```css


### PR DESCRIPTION
As @NiedziolkaMichal points out in https://github.com/mdn/bob/pull/759, Chrome doesn't support [`scrollbar-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width) so we should not have an interactive example for it.