### PR TITLE
WebAPI: Update Method pages to modern structure (part 15)

### DIFF
--- a/files/en-us/web/api/rtcrtptransceiver/stop/index.md
+++ b/files/en-us/web/api/rtcrtptransceiver/stop/index.md
@@ -31,7 +31,7 @@ This method does nothing if the transceiver is already stopped.
 ## Syntax
 
 ```js
-RTCRtpTransceiver.stop()
+stop()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/screen/lockorientation/index.md
+++ b/files/en-us/web/api/screen/lockorientation/index.md
@@ -24,7 +24,7 @@ interface locks the screen into a specified orientation.
 ## Syntax
 
 ```js
-lockAllowed = window.screen.lockOrientation(orientation);
+lockOrientation(orientation)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/screen/unlockorientation/index.md
+++ b/files/en-us/web/api/screen/unlockorientation/index.md
@@ -24,7 +24,7 @@ method should be used instead.
 ## Syntax
 
 ```js
-var unlocked = window.screen.unlockOrientation();
+unlockOrientation()
 ```
 
 ### Return value
@@ -32,7 +32,7 @@ var unlocked = window.screen.unlockOrientation();
 Returns `true` if the orientation was successfully unlocked or
 `false` if the orientation couldn't be unlocked.
 
-## Example
+## Examples
 
 ```js
 var unlockOrientation = screen.unlockOrientation || screen.mozUnlockOrientation || screen.msUnlockOrientation || (screen.orientation && screen.orientation.unlock);

--- a/files/en-us/web/api/screenorientation/lock/index.md
+++ b/files/en-us/web/api/screenorientation/lock/index.md
@@ -21,7 +21,7 @@ If locking is supported, then it must work for all the parameter values listed b
 ## Syntax
 
 ```js
-screen.orientation.lock(orientation)
+lock(orientation)
 ```
 
 ### Parameters
@@ -75,7 +75,7 @@ The promise may be rejected with the following exceptions:
 - `TypeError`
   - : The `orientation` argument was not supplied.
 
-## Example
+## Examples
 
 This example shows how to lock the screen to the opposite orientation of the current one.
 Note that this example will only work on mobile devices and other devices that support orientation changes.
@@ -92,9 +92,9 @@ Note that this example will only work on mobile devices and other devices that s
 ```js
 const log = document.getElementById("log");
 
-// Lock button: Lock the screen to the other orientation (rotated by 90 degrees) 
+// Lock button: Lock the screen to the other orientation (rotated by 90 degrees)
 const rotate_btn = document.querySelector('#lock_button');
-rotate_btn.addEventListener('click', () => { 
+rotate_btn.addEventListener('click', () => {
   log.textContent+=`Lock pressed \n`;
 
   const oppositeOrientation = screen.orientation.type.startsWith("portrait") ? "landscape" : "portrait";
@@ -110,14 +110,14 @@ rotate_btn.addEventListener('click', () => {
 
 // Unlock button: Unlock the screen orientation (if locked)
 const unlock_btn = document.querySelector('#unlock_button');
-unlock_btn.addEventListener('click', () => { 
+unlock_btn.addEventListener('click', () => {
   log.textContent+='Unlock pressed \n';
   screen.orientation.unlock();
 } );
 
 // Full screen button: Set the example to fullscreen.
 const fullscreen_btn = document.querySelector('#fullscreen_button');
-fullscreen_btn.addEventListener('click', () => { 
+fullscreen_btn.addEventListener('click', () => {
   log.textContent+='Fullscreen pressed \n';
   document.querySelector("#example_container").requestFullscreen();
 } );

--- a/files/en-us/web/api/screenorientation/unlock/index.md
+++ b/files/en-us/web/api/screenorientation/unlock/index.md
@@ -20,7 +20,7 @@ document from its default orientation.
 ## Syntax
 
 ```js
-screen.orientation.unlock()
+unlock()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/selection/addrange/index.md
+++ b/files/en-us/web/api/selection/addrange/index.md
@@ -17,7 +17,7 @@ The **`Selection.addRange()`** method adds a
 ## Syntax
 
 ```js
-selection.addRange(range);
+addRange(range)
 ```
 
 ### Parameters
@@ -26,7 +26,7 @@ selection.addRange(range);
   - : A {{ domxref("Range") }} object that will be added to the {{ domxref("Selection")
     }}.
 
-## Example
+## Examples
 
 > **Note:** Currently only Firefox supports multiple selection ranges, other browsers will not
 > add new ranges to the selection if it already contains one.

--- a/files/en-us/web/api/selection/collapse/index.md
+++ b/files/en-us/web/api/selection/collapse/index.md
@@ -18,7 +18,8 @@ editable, the caret will blink there.
 ## Syntax
 
 ```js
-sel.collapse(node, offset);
+collapse(node)
+collapse(node, offset)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/selection/collapsetoend/index.md
+++ b/files/en-us/web/api/selection/collapsetoend/index.md
@@ -18,7 +18,7 @@ is focused and editable, the caret will blink there.
 ## Syntax
 
 ```js
-sel.collapseToEnd()
+collapseToEnd()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/selection/collapsetostart/index.md
+++ b/files/en-us/web/api/selection/collapsetostart/index.md
@@ -18,7 +18,7 @@ selection is focused and editable, the caret will blink there.
 ## Syntax
 
 ```js
-sel.collapseToStart()
+collapseToStart()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/selection/containsnode/index.md
+++ b/files/en-us/web/api/selection/containsnode/index.md
@@ -17,7 +17,7 @@ specified node is part of the selection.
 ## Syntax
 
 ```js
-sel.containsNode(node, partialContainment)
+containsNode(node, partialContainment)
 ```
 
 ### Parameters
@@ -30,7 +30,7 @@ sel.containsNode(node, partialContainment)
     `containsNode()` only returns `true` when the entire node is
     part of the selection. If not specified, the default value `false` is used.
 
-## Example
+## Examples
 
 ### Check for selection
 

--- a/files/en-us/web/api/selection/deletefromdocument/index.md
+++ b/files/en-us/web/api/selection/deletefromdocument/index.md
@@ -18,14 +18,14 @@ The **`deleteFromDocument()`** method of the
 ## Syntax
 
 ```js
-sel.deleteFromDocument()
+deleteFromDocument()
 ```
 
 ### Parameters
 
 _None._
 
-## Example
+## Examples
 
 This example lets you delete selected text by clicking a button. Upon clicking the
 button, the

--- a/files/en-us/web/api/selection/extend/index.md
+++ b/files/en-us/web/api/selection/extend/index.md
@@ -18,7 +18,8 @@ will be from the anchor to the new focus, regardless of direction.
 ## Syntax
 
 ```js
-sel.extend(node, offset)
+extend(node)
+extend(node, offset)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/selection/getrangeat/index.md
+++ b/files/en-us/web/api/selection/getrangeat/index.md
@@ -17,7 +17,7 @@ representing one of the ranges currently selected.
 ## Syntax
 
 ```js
-range = sel.getRangeAt(index)
+getRangeAt(index)
 ```
 
 ### Parameters
@@ -30,7 +30,7 @@ range = sel.getRangeAt(index)
 
 The specified {{domxref("Range")}} object.
 
-## Example
+## Examples
 
 ```js
 let ranges = [];

--- a/files/en-us/web/api/selection/modify/index.md
+++ b/files/en-us/web/api/selection/modify/index.md
@@ -20,7 +20,7 @@ current selection or cursor position, using simple textual commands.
 ## Syntax
 
 ```js
-sel.modify(alter, direction, granularity)
+modify(alter, direction, granularity)
 ```
 
 ### Parameters
@@ -50,7 +50,7 @@ sel.modify(alter, direction, granularity)
 > behavior. This makes the behavior more consistent, as well as making it work the same
 > way WebKit used to work, but unfortunately they have recently changed their behavior.
 
-## Example
+## Examples
 
 This example demonstrates the various `granularity` options for modifying a
 selection. Click somewhere inside the example (optionally selecting some text), and then

--- a/files/en-us/web/api/selection/removeallranges/index.md
+++ b/files/en-us/web/api/selection/removeallranges/index.md
@@ -19,7 +19,7 @@ leaving nothing selected.
 ## Syntax
 
 ```js
-sel.removeAllRanges();
+removeAllRanges()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/selection/removerange/index.md
+++ b/files/en-us/web/api/selection/removerange/index.md
@@ -17,7 +17,7 @@ selection.
 ## Syntax
 
 ```js
-sel.removeRange(range)
+removeRange(range)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/selection/selectallchildren/index.md
+++ b/files/en-us/web/api/selection/selectallchildren/index.md
@@ -17,7 +17,7 @@ children of the specified node to the selection. Previous selection is lost.
 ## Syntax
 
 ```js
-sel.selectAllChildren(parentNode)
+selectAllChildren(parentNode)
 ```
 
 ### Parameters
@@ -26,7 +26,7 @@ sel.selectAllChildren(parentNode)
   - : All children of `parentNode` will be selected. `parentNode`
     itself is not part of the selection.
 
-## Example
+## Examples
 
 ### HTML
 

--- a/files/en-us/web/api/selection/setbaseandextent/index.md
+++ b/files/en-us/web/api/selection/setbaseandextent/index.md
@@ -18,7 +18,7 @@ parts of two specified DOM nodes, and any content located between them.
 ## Syntax
 
 ```js
-sel.setBaseAndExtent(anchorNode,anchorOffset,focusNode,focusOffset)
+setBaseAndExtent(anchorNode,anchorOffset,focusNode,focusOffset)
 ```
 
 ### Parameters
@@ -42,7 +42,7 @@ sel.setBaseAndExtent(anchorNode,anchorOffset,focusNode,focusOffset)
 > might follow. For example, <kbd>Shift</kbd> + <kbd>➡︎</kbd> would cause the selection
 > to narrow from the beginning rather than grow at the end.
 
-### Return Value
+### Return value
 
 None.
 

--- a/files/en-us/web/api/selection/tostring/index.md
+++ b/files/en-us/web/api/selection/tostring/index.md
@@ -17,7 +17,7 @@ currently being represented by the selection object, i.e. the currently selected
 ## Syntax
 
 ```js
-sel.toString()
+toString()
 ```
 
 ### Return value

--- a/files/en-us/web/api/sensor/start/index.md
+++ b/files/en-us/web/api/sensor/start/index.md
@@ -20,7 +20,7 @@ of the sensors based on `Sensor`.
 ## Syntax
 
 ```js
-Sensor.start()
+start()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/sensor/stop/index.md
+++ b/files/en-us/web/api/sensor/stop/index.md
@@ -20,7 +20,7 @@ The **`stop`** method of the
 ## Syntax
 
 ```js
-Sensor.stop()
+stop()
 ```
 
 ### Parameters
@@ -31,7 +31,7 @@ None.
 
 {{jsxref('undefined')}}
 
-## Example
+## Examples
 
 ```js
 // TBD

--- a/files/en-us/web/api/serial/getports/index.md
+++ b/files/en-us/web/api/serial/getports/index.md
@@ -16,7 +16,7 @@ The **`getPorts()`** method of the {{domxref("Serial")}} interface returns a {{j
 ## Syntax
 
 ```js
-var promise = Serial.getPorts();
+getPorts()
 ```
 
 ### Return value

--- a/files/en-us/web/api/serialport/close/index.md
+++ b/files/en-us/web/api/serialport/close/index.md
@@ -16,7 +16,7 @@ The **`SerialPort.close()`** method of the {{domxref("SerialPort")}} interface r
 ## Syntax
 
 ```js
-var promise = SerialPort.close();
+close()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/serialport/getinfo/index.md
+++ b/files/en-us/web/api/serialport/getinfo/index.md
@@ -16,7 +16,7 @@ The **`getInfo()`** method of the {{domxref("SerialPort")}} interface returns an
 ## Syntax
 
 ```js
-SerialPort.getInfo();
+getInfo()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/serialport/getsignals/index.md
+++ b/files/en-us/web/api/serialport/getsignals/index.md
@@ -16,7 +16,7 @@ The **`SerialPort.getSignals()`** method of the {{domxref("SerialPort")}} interf
 ## Syntax
 
 ```js
-var promise = SerialPort.getSignals();
+getSignals()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/serialport/open/index.md
+++ b/files/en-us/web/api/serialport/open/index.md
@@ -16,7 +16,7 @@ The **`open()`** method of the {{domxref("SerialPort")}} interface returns a {{j
 ## Syntax
 
 ```js
-var promise = SerialPort.open(options);
+open(options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/serialport/setsignals/index.md
+++ b/files/en-us/web/api/serialport/setsignals/index.md
@@ -16,7 +16,8 @@ The **`setSignals()`** method of the {{domxref("SerialPort")}} interface sets co
 ## Syntax
 
 ```js
-var promise = SerialPort.setSignals(options);
+setSignals()
+setSignals(options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/serviceworkerregistration/update/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/update/index.md
@@ -23,7 +23,7 @@ bypasses any browser caches if the previous fetch occurred over 24 hours ago.
 ## Syntax
 
 ```js
-serviceWorkerRegistration.update();
+update()
 ```
 
 ### Parameters
@@ -35,7 +35,7 @@ None.
 A {{jsxref("Promise")}} that resolves with a {{domxref("ServiceWorkerRegistration")}}
 object.
 
-## Example
+## Examples
 
 The following simple example registers a service worker example then adds an event
 handler to a button so you can explicitly update the service worker whenever desired:

--- a/files/en-us/web/api/shadowroot/getanimations/index.md
+++ b/files/en-us/web/api/shadowroot/getanimations/index.md
@@ -26,7 +26,7 @@ target elements are descendants of the shadow tree. This array includes [CSS Ani
 ## Syntax
 
 ```js
-getAnimations();
+getAnimations()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/sharedworkerglobalscope/close/index.md
+++ b/files/en-us/web/api/sharedworkerglobalscope/close/index.md
@@ -18,10 +18,10 @@ The **`close()`** method of the {{domxref("SharedWorkerGlobalScope")}} interface
 ## Syntax
 
 ```js
-self.close();
+close()
 ```
 
-## Example
+## Examples
 
 If you want to close your worker instance from inside the worker itself, you can call the following:
 

--- a/files/en-us/web/api/sourcebuffer/abort/index.md
+++ b/files/en-us/web/api/sourcebuffer/abort/index.md
@@ -22,7 +22,7 @@ interface aborts the current segment and resets the segment parser.
 ## Syntax
 
 ```js
-sourceBuffer.abort();
+abort()
 ```
 
 ### Parameters
@@ -41,7 +41,7 @@ None.
         `SourceBuffer` has been removed from the
         {{domxref("MediaSource")}}.
 
-## Example
+## Examples
 
 The spec description of `abort()` is somewhat confusing — consider for
 example step 1 of [reset

--- a/files/en-us/web/api/sourcebuffer/appendbuffer/index.md
+++ b/files/en-us/web/api/sourcebuffer/appendbuffer/index.md
@@ -25,7 +25,7 @@ The **`appendBuffer()`** method of the
 ## Syntax
 
 ```js
-sourceBuffer.appendBuffer(source);
+appendBuffer(source)
 ```
 
 ### Parameters
@@ -43,7 +43,7 @@ sourceBuffer.appendBuffer(source);
 
 None.
 
-## Example
+## Examples
 
 TBD.
 

--- a/files/en-us/web/api/sourcebuffer/appendbufferasync/index.md
+++ b/files/en-us/web/api/sourcebuffer/appendbufferasync/index.md
@@ -27,7 +27,7 @@ returns a {{jsxref("Promise")}} which is fulfilled once the buffer has been appe
 ## Syntax
 
 ```js
-appendPromise = sourceBuffer.appendBufferAsync(source);
+appendBufferAsync(source)
 ```
 
 ### Parameters
@@ -43,7 +43,7 @@ A {{jsxref("Promise")}} which is fulfilled when the buffer has been added succes
 to the `SourceBuffer`, or `null` if the request could not be
 initiated.
 
-## Example
+## Examples
 
 This simplified example async function, `fillSourceBuffer()`, takes as input
 parameters {{domxref("BufferSource")}}, `buffer`, and a

--- a/files/en-us/web/api/sourcebuffer/appendstream/index.md
+++ b/files/en-us/web/api/sourcebuffer/appendstream/index.md
@@ -23,7 +23,7 @@ The **`appendStream()`** method of the
 ## Syntax
 
 ```js
-sourceBuffer.appendStream(stream, maxSize);
+appendStream(stream, maxSize)
 ```
 
 ### Parameters
@@ -43,7 +43,7 @@ sourceBuffer.appendStream(stream, maxSize);
 
 None.
 
-## Example
+## Examples
 
 TBD.
 

--- a/files/en-us/web/api/sourcebuffer/changetype/index.md
+++ b/files/en-us/web/api/sourcebuffer/changetype/index.md
@@ -30,13 +30,13 @@ constraints change.
 ## Syntax
 
 ```js
-sourceBuffer.changeType(type);
+changeType(type)
 ```
 
 ### Parameters
 
 - `type`
-  - : A {{domxref("DOMString")}} specifying the MIME type that future buffers will conform
+  - : A string specifying the MIME type that future buffers will conform
     to.
 
 ### Return value

--- a/files/en-us/web/api/sourcebuffer/remove/index.md
+++ b/files/en-us/web/api/sourcebuffer/remove/index.md
@@ -26,7 +26,7 @@ interface removes media segments within a specific time range from the
 ## Syntax
 
 ```js
-sourceBuffer.remove(start, end);
+remove(start, end)
 ```
 
 ### Parameters
@@ -50,7 +50,7 @@ sourceBuffer.remove(start, end);
         to `true`, or this `SourceBuffer` has been removed
         from {{domxref("MediaSource")}}.
 
-## Example
+## Examples
 
 TBD.
 

--- a/files/en-us/web/api/sourcebuffer/removeasync/index.md
+++ b/files/en-us/web/api/sourcebuffer/removeasync/index.md
@@ -31,7 +31,7 @@ This method can only be called when {{domxref("SourceBuffer.updating", "updating
 ## Syntax
 
 ```js
-removePromise = sourceBuffer.removeAsync(start, end);
+removeAsync(start, end)
 ```
 
 ### Parameters
@@ -46,7 +46,7 @@ removePromise = sourceBuffer.removeAsync(start, end);
 A {{jsxref("Promise")}} whose fulfillment handler is executed once the buffers in the
 specified time range have been removed from the `SourceBuffer`.
 
-## Example
+## Examples
 
 This example establishes an asynchronous function, `emptySourceBuffer()`,
 which clears the contents of the specified `SourceBuffer`.

--- a/files/en-us/web/api/speechgrammarlist/addfromstring/index.md
+++ b/files/en-us/web/api/speechgrammarlist/addfromstring/index.md
@@ -23,7 +23,8 @@ the `SpeechGrammarList` as a new {{domxref("SpeechGrammar")}} object.
 ## Syntax
 
 ```js
-addFromString(string,weight)
+addFromString(string)
+addFromString(string, weight)
 ```
 
 ### Return value

--- a/files/en-us/web/api/speechgrammarlist/addfromstring/index.md
+++ b/files/en-us/web/api/speechgrammarlist/addfromstring/index.md
@@ -27,10 +27,6 @@ addFromString(string)
 addFromString(string, weight)
 ```
 
-### Return value
-
-{{jsxref('undefined')}}.
-
 ### Parameters
 
 - string
@@ -41,6 +37,10 @@ addFromString(string, weight)
     or the likelihood that it will be recognized by the speech recognition service. The
     value can be between `0.0` and `1.0`; If not specified, the
     default used is `1.0`.
+
+### Return value
+
+{{jsxref('undefined')}}.
 
 ## Examples
 

--- a/files/en-us/web/api/speechgrammarlist/addfromstring/index.md
+++ b/files/en-us/web/api/speechgrammarlist/addfromstring/index.md
@@ -17,23 +17,23 @@ browser-compat: api.SpeechGrammarList.addFromString
 
 The **`addFromString()`** method of the
 {{domxref("SpeechGrammarList")}} interface takes a grammar present in a specific
-{{domxref("DOMString")}} within the code base (e.g. stored in a variable) and adds it to
+string within the code base (e.g. stored in a variable) and adds it to
 the `SpeechGrammarList` as a new {{domxref("SpeechGrammar")}} object.
 
 ## Syntax
 
 ```js
-speechGrammarListInstance.addFromString(string,weight);
+addFromString(string,weight)
 ```
 
-### Returns
+### Return value
 
 {{jsxref('undefined')}}.
 
 ### Parameters
 
 - string
-  - : A {{domxref("DOMString")}} representing the grammar to be added.
+  - : A string representing the grammar to be added.
 - weight {{optional_inline}}
   - : A float representing the weight of the grammar relative to other grammars present in
     the {{domxref("SpeechGrammarList")}}. The weight means the importance of this grammar,

--- a/files/en-us/web/api/speechgrammarlist/addfromuri/index.md
+++ b/files/en-us/web/api/speechgrammarlist/addfromuri/index.md
@@ -26,7 +26,8 @@ specified by URI.
 ## Syntax
 
 ```js
-addFromURI(src,weight)
+addFromURI(src)
+addFromURI(src, weight)
 ```
 
 ### Return value

--- a/files/en-us/web/api/speechgrammarlist/addfromuri/index.md
+++ b/files/en-us/web/api/speechgrammarlist/addfromuri/index.md
@@ -26,17 +26,17 @@ specified by URI.
 ## Syntax
 
 ```js
-speechGrammarListInstance.addFromURI(src,weight);
+addFromURI(src,weight)
 ```
 
-### Returns
+### Return value
 
 {{jsxref('undefined')}}.
 
 ### Parameters
 
 - src
-  - : A {{domxref("DOMString")}} representing the URI of the grammar to be added.
+  - : A string representing the URI of the grammar to be added.
 - weight {{optional_inline}}
   - : A float representing the weight of the grammar relative to other grammars present in
     the {{domxref("SpeechGrammarList")}}. The weight means the importance of this grammar,

--- a/files/en-us/web/api/speechgrammarlist/addfromuri/index.md
+++ b/files/en-us/web/api/speechgrammarlist/addfromuri/index.md
@@ -30,10 +30,6 @@ addFromURI(src)
 addFromURI(src, weight)
 ```
 
-### Return value
-
-{{jsxref('undefined')}}.
-
 ### Parameters
 
 - src
@@ -44,6 +40,10 @@ addFromURI(src, weight)
     or the likelihood that it will be recognized by the speech recognition service. The
     value can be between `0.0` and `1.0`; If not specified, the
     default used is `1.0`.
+
+### Return value
+
+{{jsxref('undefined')}}.
 
 ## Examples
 

--- a/files/en-us/web/api/speechrecognition/abort/index.md
+++ b/files/en-us/web/api/speechrecognition/abort/index.md
@@ -24,7 +24,7 @@ recognition service from listening to incoming audio, and doesn't attempt to ret
 abort()
 ```
 
-### Returns
+### Return value
 
 {{jsxref('undefined')}}.
 

--- a/files/en-us/web/api/speechrecognition/stop/index.md
+++ b/files/en-us/web/api/speechrecognition/stop/index.md
@@ -21,10 +21,10 @@ recognition service from listening to incoming audio, and attempts to return a
 ## Syntax
 
 ```js
-stop();
+stop()
 ```
 
-### Returns
+### Return value
 
 {{jsxref('undefined')}}.
 

--- a/files/en-us/web/api/speechsynthesis/cancel/index.md
+++ b/files/en-us/web/api/speechsynthesis/cancel/index.md
@@ -25,7 +25,7 @@ If an utterance is currently being spoken, speaking will stop immediately.
 cancel()
 ```
 
-### Returns
+### Return value
 
 {{jsxref('undefined')}}.
 

--- a/files/en-us/web/api/speechsynthesis/getvoices/index.md
+++ b/files/en-us/web/api/speechsynthesis/getvoices/index.md
@@ -33,7 +33,7 @@ None.
 
 A list (array) of {{domxref("SpeechSynthesisVoice")}} objects.
 
-## Example
+## Examples
 
 ### JavaScript
 

--- a/files/en-us/web/api/speechsynthesis/pause/index.md
+++ b/files/en-us/web/api/speechsynthesis/pause/index.md
@@ -23,13 +23,13 @@ interface puts the `SpeechSynthesis` object into a paused state.
 pause()
 ```
 
-### Returns
-
-{{jsxref('undefined')}}.
-
 ### Parameters
 
 None.
+
+### Return value
+
+{{jsxref('undefined')}}.
 
 ## Examples
 

--- a/files/en-us/web/api/speechsynthesis/resume/index.md
+++ b/files/en-us/web/api/speechsynthesis/resume/index.md
@@ -24,13 +24,13 @@ resumes it if it was already paused.
 resume()
 ```
 
-### Returns
-
-{{jsxref('undefined')}}.
-
 ### Parameters
 
 None.
+
+### Return value
+
+{{jsxref('undefined')}}.
 
 ## Examples
 

--- a/files/en-us/web/api/speechsynthesis/speak/index.md
+++ b/files/en-us/web/api/speechsynthesis/speak/index.md
@@ -24,14 +24,14 @@ queue; it will be spoken when any other utterances queued before it have been sp
 speak(utterance)
 ```
 
-### Returns
-
-{{jsxref('undefined')}}.
-
 ### Parameters
 
 - `utterance`
   - : A {{domxref("SpeechSynthesisUtterance")}} object.
+
+### Return value
+
+{{jsxref('undefined')}}.
 
 ## Examples
 

--- a/files/en-us/web/api/storage/clear/index.md
+++ b/files/en-us/web/api/storage/clear/index.md
@@ -17,7 +17,7 @@ interface clears all keys stored in a given `Storage` object.
 ## Syntax
 
 ```js
-storage.clear();
+clear()
 ```
 
 ### Return value

--- a/files/en-us/web/api/storage/getitem/index.md
+++ b/files/en-us/web/api/storage/getitem/index.md
@@ -18,21 +18,21 @@ the key does not exist, in the given `Storage` object.
 ## Syntax
 
 ```js
-var aValue = storage.getItem(keyName);
+getItem(keyName)
 ```
 
 ### Parameters
 
 - `keyName`
-  - : A {{domxref("DOMString")}} containing the name of the key you want to retrieve the
+  - : A string containing the name of the key you want to retrieve the
     value of.
 
 ### Return value
 
-A {{domxref("DOMString")}} containing the value of the key. If the key does not exist,
+A string containing the value of the key. If the key does not exist,
 `null` is returned.
 
-## Example
+## Examples
 
 The following function retrieves three data items from local storage, then uses them to
 set custom styles on a page.

--- a/files/en-us/web/api/storage/key/index.md
+++ b/files/en-us/web/api/storage/key/index.md
@@ -18,7 +18,7 @@ object. The order of keys is user-agent defined, so you should not rely on it.
 ## Syntax
 
 ```js
-var aKeyName = storage.key(index);
+key(index)
 ```
 
 ### Parameters
@@ -29,7 +29,7 @@ var aKeyName = storage.key(index);
 
 ### Return value
 
-A {{domxref("DOMString")}} containing the name of the key. If the index does not exist,
+A string containing the name of the key. If the index does not exist,
 `null` is returned.
 
 ## Examples

--- a/files/en-us/web/api/storage/removeitem/index.md
+++ b/files/en-us/web/api/storage/removeitem/index.md
@@ -22,19 +22,19 @@ If there is no item associated with the given key, this method will do nothing.
 ## Syntax
 
 ```js
-storage.removeItem(keyName);
+removeItem(keyName)
 ```
 
 ### Parameters
 
 - `keyName`
-  - : A {{domxref("DOMString")}} containing the name of the key you want to remove.
+  - : A string containing the name of the key you want to remove.
 
 ### Return value
 
 {{jsxref("undefined")}}.
 
-## Example
+## Examples
 
 The following function creates three data items inside local storage, then removes the
 `image` data item.

--- a/files/en-us/web/api/storage/setitem/index.md
+++ b/files/en-us/web/api/storage/setitem/index.md
@@ -18,15 +18,15 @@ interface, when passed a key name and value, will add that key to the given
 ## Syntax
 
 ```js
-storage.setItem(keyName, keyValue);
+setItem(keyName, keyValue)
 ```
 
 ### Parameters
 
 - `keyName`
-  - : A {{domxref("DOMString")}} containing the name of the key you want to create/update.
+  - : A string containing the name of the key you want to create/update.
 - `keyValue`
-  - : A {{domxref("DOMString")}} containing the value you want to give the key you are
+  - : A string containing the value you want to give the key you are
     creating/updating.
 
 ### Return value
@@ -38,7 +38,7 @@ storage.setItem(keyName, keyValue);
 `setItem()` may throw an exception if the storage is full. Developers should make sure to
 **always catch possible exceptions from `setItem()`**.
 
-## Example
+## Examples
 
 The following function creates three data items inside local storage.
 

--- a/files/en-us/web/api/storagemanager/estimate/index.md
+++ b/files/en-us/web/api/storagemanager/estimate/index.md
@@ -23,7 +23,7 @@ This method operates asynchronously, so it returns a {{jsxref("Promise")}} which
 ## Syntax
 
 ```js
-const estimatePromise = StorageManager.estimate();
+estimate()
 ```
 
 ### Parameters
@@ -49,7 +49,7 @@ You may find that the `quota` varies from origin to origin. This variance is bas
 - Public site popularity data
 - User engagement signals like bookmarking, adding to homescreen, or accepting push notifications
 
-## Example
+## Examples
 
 In this example, we obtain the usage estimates and present the percentage of storage capacity currently used to the user.
 

--- a/files/en-us/web/api/stylepropertymap/append/index.md
+++ b/files/en-us/web/api/stylepropertymap/append/index.md
@@ -20,7 +20,7 @@ The **`append()`** method of the
 ## Syntax
 
 ```js
-StylePropertyMap.append(property,value)
+append(property,value)
 ```
 
 ### Parameters
@@ -35,7 +35,7 @@ StylePropertyMap.append(property,value)
 
 {{jsxref('undefined')}}.
 
-## Example
+## Examples
 
 This example shows an extra background image value being added to the
 {{cssxref('background-image')}} property of the element, using

--- a/files/en-us/web/api/stylepropertymap/clear/index.md
+++ b/files/en-us/web/api/stylepropertymap/clear/index.md
@@ -19,7 +19,7 @@ interface removes all declarations in the `StylePropertyMap`.
 ## Syntax
 
 ```js
-StylePropertyMap.clear()
+clear()
 ```
 
 ### Parameters
@@ -30,7 +30,7 @@ None.
 
 {{jsxref('undefined')}}
 
-## Example
+## Examples
 
 The following example removes all styles within the elements [style attribute](/en-US/docs/Web/HTML/Global_attributes/style).
 

--- a/files/en-us/web/api/stylepropertymap/delete/index.md
+++ b/files/en-us/web/api/stylepropertymap/delete/index.md
@@ -20,7 +20,7 @@ property.
 ## Syntax
 
 ```js
-StylePropertyMap.delete(property)
+delete(property)
 ```
 
 ### Parameters
@@ -33,7 +33,7 @@ StylePropertyMap.delete(property)
 
 {{jsxref('undefined')}}
 
-## Example
+## Examples
 
 The following example removes the {{cssxref('background-image')}} property from the
 element's [style attribute](/en-US/docs/Web/HTML/Global_attributes/style).

--- a/files/en-us/web/api/stylepropertymap/set/index.md
+++ b/files/en-us/web/api/stylepropertymap/set/index.md
@@ -19,7 +19,7 @@ interface changes the CSS declaration with the given property.
 ## Syntax
 
 ```js
-StylePropertyMap.set(property,value)
+set(property,value)
 ```
 
 ### Parameters
@@ -34,7 +34,7 @@ StylePropertyMap.set(property,value)
 
 {{jsxref('undefined')}}
 
-## Example
+## Examples
 
 This example sets the {{cssxref('padding-top')}} property, with the given value, within
 the element's [style

--- a/files/en-us/web/api/stylepropertymapreadonly/entries/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/entries/index.md
@@ -23,7 +23,7 @@ well).
 ## Syntax
 
 ```js
-StylePropertyMapReadOnly.entries()
+entries()
 ```
 
 ### Parameters
@@ -35,7 +35,7 @@ None.
 An array of the given `StylePropertyMapReadOnly` object's own enumerable
 property `[key, value]` pairs.
 
-## Example
+## Examples
 
 Here shows an example of using `StylePropertyMapReadOnly.entries()` method
 on an elements computed styles.

--- a/files/en-us/web/api/stylepropertymapreadonly/get/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/get/index.md
@@ -20,7 +20,7 @@ object for the first value of the specified property.
 ## Syntax
 
 ```js
-var declarationBlock = StylePropertyMapReadOnly.get(property)
+get(property)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/stylepropertymapreadonly/has/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/has/index.md
@@ -21,7 +21,7 @@ property is in the `StylePropertyMapReadOnly` object.
 ## Syntax
 
 ```js
-var boolean = StylePropertyMapReadOnly.has(property)
+has(property)
 ```
 
 ### Parameters
@@ -33,7 +33,7 @@ var boolean = StylePropertyMapReadOnly.has(property)
 
 A boolean value.
 
-## Example
+## Examples
 
 Here we use the `has()` method to see if the padding-top property is present
 within the button elements style attribute.

--- a/files/en-us/web/api/stylepropertymapreadonly/keys/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/keys/index.md
@@ -21,7 +21,7 @@ in `StylePropertyMapReadOnly`
 ## Syntax
 
 ```js
-StylePropertyMapReadOnly.keys()
+keys()
 ```
 
 ### Parameters
@@ -32,7 +32,7 @@ None.
 
 A new {{jsxref("Array")}}.
 
-## Example
+## Examples
 
 In this example we use the `keys()` method to be able to access the
 properties within our {{domxref('Element.computedStyleMap()')}}.

--- a/files/en-us/web/api/stylepropertymapreadonly/values/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/values/index.md
@@ -21,7 +21,7 @@ new _array iterator_ containing the values for each index in the
 ## Syntax
 
 ```js
-StylePropertyMapReadOnly.values()
+values()
 ```
 
 ### Parameters
@@ -32,7 +32,7 @@ None.
 
 A new {{jsxref("Array")}}.
 
-## Example
+## Examples
 
 In this example we use the `values()` method to be able to access the values
 within our [`Element.computedStyleMap()`](/en-US/docs/Web/API/Element/computedStyleMap).

--- a/files/en-us/web/api/stylesheetlist/item/index.md
+++ b/files/en-us/web/api/stylesheetlist/item/index.md
@@ -16,7 +16,7 @@ The **`item()`** method of the {{domxref("StyleSheetList")}} interface returns a
 ## Syntax
 
 ```js
-StyleSheetList.item(index);
+item(index)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/subtlecrypto/decrypt/index.md
+++ b/files/en-us/web/api/subtlecrypto/decrypt/index.md
@@ -21,7 +21,7 @@ decrypted data (also known as "plaintext").
 ## Syntax
 
 ```js
-const result = crypto.subtle.decrypt(algorithm, key, data);
+decrypt(algorithm, key, data)
 ```
 
 ### Parameters
@@ -47,7 +47,7 @@ const result = crypto.subtle.decrypt(algorithm, key, data);
 
 ### Return value
 
-- `result` is a {{jsxref("Promise")}} that fulfills with an
+A {{jsxref("Promise")}} that fulfills with an
   {{jsxref("ArrayBuffer")}} containing the plaintext.
 
 ### Exceptions

--- a/files/en-us/web/api/subtlecrypto/derivebits/index.md
+++ b/files/en-us/web/api/subtlecrypto/derivebits/index.md
@@ -37,11 +37,7 @@ algorithms](/en-US/docs/Web/API/SubtleCrypto/deriveKey#supported_algorithms) for
 ## Syntax
 
 ```js
-const result = crypto.subtle.deriveBits(
-    algorithm,
-    baseKey,
-    length
-);
+deriveBits(algorithm, baseKey, length)
 ```
 
 ### Parameters
@@ -69,7 +65,7 @@ const result = crypto.subtle.deriveBits(
 
 ### Return value
 
-- `result` is a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
   that fulfills with an [`ArrayBuffer`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer)
   containing the derived bits.
 

--- a/files/en-us/web/api/subtlecrypto/derivekey/index.md
+++ b/files/en-us/web/api/subtlecrypto/derivekey/index.md
@@ -26,13 +26,7 @@ different characteristics and are appropriate in quite different situations. See
 ## Syntax
 
 ```js
-const result = crypto.subtle.deriveKey(
-    algorithm,
-    baseKey,
-    derivedKeyAlgorithm,
-    extractable,
-    keyUsages
-);
+deriveKey(algorithm, baseKey, derivedKeyAlgorithm, extractable, keyUsages)
 ```
 
 ### Parameters
@@ -64,7 +58,7 @@ const result = crypto.subtle.deriveKey(
     object.
 
 - `extractable` is a boolean value indicating whether it
-  will be possible to export  the key using {{domxref("SubtleCrypto.exportKey()")}} or
+  will be possible to export the key using {{domxref("SubtleCrypto.exportKey()")}} or
   {{domxref("SubtleCrypto.wrapKey()")}}.
 - `keyUsages`  is an {{jsxref("Array")}} indicating what can be
   done with the derived key. Note that the key usages must be allowed by the algorithm
@@ -89,7 +83,7 @@ const result = crypto.subtle.deriveKey(
 
 ### Return value
 
-- `result` is a {{jsxref("Promise")}} that fulfills with a
+A {{jsxref("Promise")}} that fulfills with a
   {{domxref("CryptoKey")}}.
 
 ### Exceptions

--- a/files/en-us/web/api/subtlecrypto/digest/index.md
+++ b/files/en-us/web/api/subtlecrypto/digest/index.md
@@ -24,7 +24,7 @@ digest. It returns a {{jsxref("Promise")}} which will be fulfilled with the dige
 ## Syntax
 
 ```js
-const digest = crypto.subtle.digest(algorithm, data);
+digest(algorithm, data)
 ```
 
 ### Parameters
@@ -42,8 +42,7 @@ const digest = crypto.subtle.digest(algorithm, data);
 
 ### Return value
 
-- `digest`
-  - : {{jsxref("Promise")}} that fulfills with an {{jsxref("ArrayBuffer")}} containing the digest.
+A {{jsxref("Promise")}} that fulfills with an {{jsxref("ArrayBuffer")}} containing the digest.
 
 ## Supported algorithms
 

--- a/files/en-us/web/api/subtlecrypto/encrypt/index.md
+++ b/files/en-us/web/api/subtlecrypto/encrypt/index.md
@@ -23,7 +23,7 @@ known as "ciphertext").
 ## Syntax
 
 ```js
-const result = crypto.subtle.encrypt(algorithm, key, data);
+encrypt(algorithm, key, data)
 ```
 
 ### Parameters
@@ -47,7 +47,7 @@ const result = crypto.subtle.encrypt(algorithm, key, data);
 
 ### Return value
 
-- `result` is a {{jsxref("Promise")}} that fulfills with an
+A {{jsxref("Promise")}} that fulfills with an
   {{jsxref("ArrayBuffer")}} containing the "ciphertext".
 
 ### Exceptions

--- a/files/en-us/web/api/subtlecrypto/exportkey/index.md
+++ b/files/en-us/web/api/subtlecrypto/exportkey/index.md
@@ -32,7 +32,7 @@ API instead.
 ## Syntax
 
 ```js
-const result = crypto.subtle.exportKey(format, key);
+exportKey(format, key)
 ```
 
 ### Parameters
@@ -51,7 +51,7 @@ const result = crypto.subtle.exportKey(format, key);
 
 ### Return value
 
-- `result` is a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 
   - If `format` was `jwk`, then the promise fulfills
     with a JSON object containing the key.
@@ -121,7 +121,7 @@ is then PEM-encoded. [See the complete code on GitHub.](https://github.com/mdn/d
 
 ```js
 /*
-Convert  an ArrayBuffer into a string
+Convert an ArrayBuffer into a string
 from https://developer.chrome.com/blog/how-to-convert-arraybuffer-to-and-from-string/
 */
 function ab2str(buf) {
@@ -174,7 +174,7 @@ object. [See the complete code on GitHub.](https://github.com/mdn/dom-examples/b
 
 ```js
 /*
-Convert  an ArrayBuffer into a string
+Convert an ArrayBuffer into a string
 from https://developer.chrome.com/blog/how-to-convert-arraybuffer-to-and-from-string/
 */
 function ab2str(buf) {

--- a/files/en-us/web/api/subtlecrypto/generatekey/index.md
+++ b/files/en-us/web/api/subtlecrypto/generatekey/index.md
@@ -19,7 +19,7 @@ or key pair (for public-key algorithms).
 ## Syntax
 
 ```js
-const result = crypto.subtle.generateKey(algorithm, extractable, keyUsages);
+generateKey(algorithm, extractable, keyUsages)
 ```
 
 ### Parameters
@@ -41,7 +41,7 @@ const result = crypto.subtle.generateKey(algorithm, extractable, keyUsages);
     object.
 
 - `extractable` is a boolean value indicating whether it
-  will be possible to export  the key using {{domxref("SubtleCrypto.exportKey()")}} or
+  will be possible to export the key using {{domxref("SubtleCrypto.exportKey()")}} or
   {{domxref("SubtleCrypto.wrapKey()")}}.
 - `keyUsages`  is an {{jsxref("Array")}} indicating what can be
   done with the newly generated key. Possible values for array elements are:
@@ -65,7 +65,7 @@ const result = crypto.subtle.generateKey(algorithm, extractable, keyUsages);
 
 ### Return value
 
-- `result` is a {{jsxref("Promise")}} that fulfills with a
+A {{jsxref("Promise")}} that fulfills with a
   {{domxref("CryptoKey")}} (for symmetric algorithms) or a {{domxref("CryptoKeyPair")}}
   (for public-key algorithms).
 

--- a/files/en-us/web/api/subtlecrypto/importkey/index.md
+++ b/files/en-us/web/api/subtlecrypto/importkey/index.md
@@ -22,13 +22,7 @@ formats](#supported_formats) for details.
 ## Syntax
 
 ```js
-const result = crypto.subtle.importKey(
-    format,
-    keyData,
-    algorithm,
-    extractable,
-    keyUsages
-);
+importKey(format, keyData, algorithm, extractable, keyUsages)
 ```
 
 ### Parameters
@@ -91,7 +85,7 @@ const result = crypto.subtle.importKey(
 
 ### Return value
 
-- `result` is a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
   that fulfills with the imported key as a {{domxref("CryptoKey")}} object.
 
 ### Exceptions

--- a/files/en-us/web/api/subtlecrypto/sign/index.md
+++ b/files/en-us/web/api/subtlecrypto/sign/index.md
@@ -25,7 +25,7 @@ signature.
 ## Syntax
 
 ```js
-const signature = crypto.subtle.sign(algorithm, key, data);
+sign(algorithm, key, data)
 ```
 
 ### Parameters
@@ -50,7 +50,7 @@ const signature = crypto.subtle.sign(algorithm, key, data);
 
 ### Return value
 
-- `signature` is a {{jsxref("Promise")}} that fulfills with an
+A {{jsxref("Promise")}} that fulfills with an
   {{jsxref("ArrayBuffer")}} containing the signature.
 
 ### Exceptions
@@ -117,7 +117,7 @@ according to the [FIPS
 
 The digest algorithm to use is specified in the
 [`HmacKeyGenParams`](/en-US/docs/Web/API/HmacKeyGenParams) object
-that you pass into  {{domxref("SubtleCrypto.generateKey()", "generateKey()")}}, or the
+that you pass into {{domxref("SubtleCrypto.generateKey()", "generateKey()")}}, or the
 [`HmacImportParams`](/en-US/docs/Web/API/HmacImportParams) object
 that you pass into {{domxref("SubtleCrypto.importKey()", "importKey()")}}.
 

--- a/files/en-us/web/api/subtlecrypto/unwrapkey/index.md
+++ b/files/en-us/web/api/subtlecrypto/unwrapkey/index.md
@@ -34,15 +34,7 @@ of encrypt + export.
 ## Syntax
 
 ```js
-const result = crypto.subtle.unwrapKey(
-    format,
-    wrappedKey,
-    unwrappingKey,
-    unwrapAlgo,
-    unwrappedKeyAlgo,
-    extractable,
-    keyUsages
-);
+unwrapKey(format, wrappedKey, unwrappingKey, unwrapAlgo, unwrappedKeyAlgo, extractable, keyUsages)
 ```
 
 ### Parameters
@@ -118,7 +110,7 @@ const result = crypto.subtle.unwrapKey(
 
 ### Return value
 
-- `result` is a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
   that fulfills with the unwrapped key as a [`CryptoKey`](/en-US/docs/Web/API/CryptoKey)
   object.
 

--- a/files/en-us/web/api/subtlecrypto/verify/index.md
+++ b/files/en-us/web/api/subtlecrypto/verify/index.md
@@ -23,12 +23,12 @@ indicating whether the signature is valid.
 ## Syntax
 
 ```js
-const result = crypto.subtle.verify(algorithm, key, signature, data);
+verify(algorithm, key, signature, data)
 ```
 
 ### Parameters
 
-- _`algorithm`_ is a {{domxref("DOMString")}} or object defining the
+- _`algorithm`_ is a string or object defining the
   algorithm to use, and for some algorithm choices, some extra parameters. The values
   given for the extra parameters must match those passed into the corresponding
   {{domxref("SubtleCrypto.sign()", "sign()")}} call.
@@ -54,7 +54,7 @@ const result = crypto.subtle.verify(algorithm, key, signature, data);
 
 ### Return value
 
-- `result` is a {{jsxref("Promise")}} that fulfills with a
+A {{jsxref("Promise")}} that fulfills with a
   boolean value: `true` if the signature is valid, `false`
   otherwise.
 

--- a/files/en-us/web/api/svggeometryelement/getpointatlength/index.md
+++ b/files/en-us/web/api/svggeometryelement/getpointatlength/index.md
@@ -20,7 +20,7 @@ point at a given distance along the path.
 ## Syntax
 
 ```js
-DOMPoint someElement.getPointAtLength(float distance);
+getPointAtLength(float distance)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/svggeometryelement/getpointatlength/index.md
+++ b/files/en-us/web/api/svggeometryelement/getpointatlength/index.md
@@ -20,7 +20,7 @@ point at a given distance along the path.
 ## Syntax
 
 ```js
-getPointAtLength(float distance)
+getPointAtLength(distance)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/svggeometryelement/gettotallength/index.md
+++ b/files/en-us/web/api/svggeometryelement/gettotallength/index.md
@@ -19,7 +19,7 @@ the user agent's computed value for the total length of the path in user units.
 ## Syntax
 
 ```js
-float someElement.getTotalLength();
+getTotalLength()
 ```
 
 ### Return value

--- a/files/en-us/web/api/svggeometryelement/ispointinfill/index.md
+++ b/files/en-us/web/api/svggeometryelement/ispointinfill/index.md
@@ -21,20 +21,20 @@ interpreted as a point in the local coordinate system of the element.
 ## Syntax
 
 ```js
-boolean someElement.isPointInFill(DOMPointInit point);
+isPointInFill(point)
 ```
 
 ### Parameters
 
 - point
-  - : An object interpreted as a point in the local coordinate system
+  - : A DOMPointInit object interpreted as a point in the local coordinate system
     of the element.
 
 ### Return value
 
 A boolean indicating whether the given point is within the fill or not.
 
-## Example
+## Examples
 
 ### SVG
 

--- a/files/en-us/web/api/svggeometryelement/ispointinstroke/index.md
+++ b/files/en-us/web/api/svggeometryelement/ispointinstroke/index.md
@@ -22,20 +22,20 @@ the element.
 ## Syntax
 
 ```js
-boolean someElement.isPointInStroke(DOMPointInit point);
+isPointInStroke(point)
 ```
 
 ### Parameters
 
 - point
-  - : An object interpreted as a point in the local coordinate system
+  - : A DOMPointInit object interpreted as a point in the local coordinate system
     of the element.
 
 ### Return value
 
 A boolean indicating whether the given point is within the stroke or not.
 
-## Example
+## Examples
 
 ### SVG
 

--- a/files/en-us/web/api/svggraphicselement/getbbox/index.md
+++ b/files/en-us/web/api/svggraphicselement/getbbox/index.md
@@ -28,12 +28,13 @@ geometry attributes on all the elements contained in the target element).
 ## Syntax
 
 ```js
-let bboxRect = object.getBBox();
+getBBox()
+getBBox(options)
 ```
 
 ### Parameters
 
-- `Options` {{experimental_inline}} {{optional_inline}}
+- `options` {{experimental_inline}} {{optional_inline}}
 
   - : An options dictionary used to control which parts of the element are included in the
     bounding box. The available options are:
@@ -57,7 +58,7 @@ The returned value is a {{domxref("SVGRect")}} object, which defines the boundin
 This value is irrespective of any transformation attribute applied to it or the parent
 elements.
 
-## Example
+## Examples
 
 ### HTML
 

--- a/files/en-us/web/api/svgimageelement/decode/index.md
+++ b/files/en-us/web/api/svgimageelement/decode/index.md
@@ -1,5 +1,5 @@
 ---
-title: SVGImageElement.decode
+title: SVGImageElement.decode()
 slug: Web/API/SVGImageElement/decode
 tags:
   - API
@@ -25,7 +25,7 @@ for use.
 ## Syntax
 
 ```js
-var promise = svgImageElement.decode();
+decode()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/svgmarkerelement/setorienttoangle/index.md
+++ b/files/en-us/web/api/svgmarkerelement/setorienttoangle/index.md
@@ -16,7 +16,7 @@ The **`setOrientToAngle()`** method of the {{domxref("SVGMarkerElement")}} inter
 ## Syntax
 
 ```js
-setOrientToAngle(angle);
+setOrientToAngle(angle)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/svgmarkerelement/setorienttoauto/index.md
+++ b/files/en-us/web/api/svgmarkerelement/setorienttoauto/index.md
@@ -16,7 +16,7 @@ The **`setOrientToAuto()`** method of the {{domxref("SVGMarkerElement")}} interf
 ## Syntax
 
 ```js
-setOrientToAuto();
+setOrientToAuto()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/svgpointlist/appenditem/index.md
+++ b/files/en-us/web/api/svgpointlist/appenditem/index.md
@@ -16,7 +16,7 @@ The **`appendItem()`** method of the {{domxref("SVGPointList")}} interface adds 
 ## Syntax
 
 ```js
-SVGPointList.appendItem(obj);
+appendItem(obj)
 ```
 
 - `obj`

--- a/files/en-us/web/api/svgpointlist/clear/index.md
+++ b/files/en-us/web/api/svgpointlist/clear/index.md
@@ -16,7 +16,7 @@ The **`clear()`** method of the {{domxref("SVGPointList")}} interface removes al
 ## Syntax
 
 ```js
-SVGPointList.clear();
+clear()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/svgpointlist/getitem/index.md
+++ b/files/en-us/web/api/svgpointlist/getitem/index.md
@@ -16,7 +16,7 @@ The **`getItem()`** method of the {{domxref("SVGPointList")}} interface gets one
 ## Syntax
 
 ```js
-SVGPointList.getItem(index);
+getItem(index)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/svgpointlist/initialize/index.md
+++ b/files/en-us/web/api/svgpointlist/initialize/index.md
@@ -16,7 +16,7 @@ The **`initialize()`** method of the {{domxref("SVGPointList")}} interface clear
 ## Syntax
 
 ```js
-SVGPointList.initialize(obj);
+initialize(obj)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/svgpointlist/insertitembefore/index.md
+++ b/files/en-us/web/api/svgpointlist/insertitembefore/index.md
@@ -16,8 +16,10 @@ The **`insertItemBefore()`** method of the {{domxref("SVGPointList")}} interface
 ## Syntax
 
 ```js
-SVGPointList.insertItemBefore(obj,index);
+insertItemBefore(obj,index)
 ```
+
+### Parameters
 
 - `obj`
   - : An {{domxref("SVGPoint")}} object containing the coordinates of the point to be inserted.

--- a/files/en-us/web/api/svgpointlist/insertitembefore/index.md
+++ b/files/en-us/web/api/svgpointlist/insertitembefore/index.md
@@ -16,7 +16,7 @@ The **`insertItemBefore()`** method of the {{domxref("SVGPointList")}} interface
 ## Syntax
 
 ```js
-insertItemBefore(obj,index)
+insertItemBefore(obj, index)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/svgpointlist/removeitem/index.md
+++ b/files/en-us/web/api/svgpointlist/removeitem/index.md
@@ -16,8 +16,10 @@ The **`removeItem()`** method of the {{domxref("SVGPointList")}} interface remov
 ## Syntax
 
 ```js
-SVGPointList.removeItem(index);
+removeItem(index)
 ```
+
+### Parameters
 
 - `index`
   - : The index of the item to remove.

--- a/files/en-us/web/api/svgpointlist/replaceitem/index.md
+++ b/files/en-us/web/api/svgpointlist/replaceitem/index.md
@@ -16,7 +16,7 @@ The **`replaceItem()`** method of the {{domxref("SVGPointList")}} interface repl
 ## Syntax
 
 ```js
-replaceItem(obj,index)
+replaceItem(obj, index)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/svgpointlist/replaceitem/index.md
+++ b/files/en-us/web/api/svgpointlist/replaceitem/index.md
@@ -16,8 +16,10 @@ The **`replaceItem()`** method of the {{domxref("SVGPointList")}} interface repl
 ## Syntax
 
 ```js
-SVGPointList.replaceItem(obj,index);
+replaceItem(obj,index)
 ```
+
+### Parameters
 
 - `obj`
   - : An {{domxref("SVGPoint","point")}} object containing the coordinates of the point to be inserted.

--- a/files/en-us/web/api/textdecoder/decode/index.md
+++ b/files/en-us/web/api/textdecoder/decode/index.md
@@ -12,15 +12,15 @@ browser-compat: api.TextDecoder.decode
 {{APIRef("Encoding API")}}{{SeeCompatTable}}
 
 The **`TextDecoder.prototype.decode()`** method returns a
-{{DOMxRef("DOMString")}} containing the text, given in parameters, decoded with the
+string containing the text, given in parameters, decoded with the
 specific method for that `TextDecoder` object.
 
 ## Syntax
 
 ```js
-b1 = decoder.decode(buffer, options);
-b2 = decoder.decode(buffer);
-b3 = decoder.decode();
+decode()
+decode(buffer)
+decode(buffer, options)
 ```
 
 ### Parameters
@@ -39,7 +39,11 @@ b3 = decoder.decode();
         subsequent calls to decode(). Set to true if processing the data in chunks, and
         false for the final chunk or if the data is not chunked. It defaults to false.
 
-## Example
+### Return value
+
+A string.
+
+## Examples
 
 This example encodes and decodes the euro symbol, €.
 

--- a/files/en-us/web/api/textencoder/encode/index.md
+++ b/files/en-us/web/api/textencoder/encode/index.md
@@ -13,20 +13,20 @@ browser-compat: api.TextEncoder.encode
 {{APIRef("Encoding API")}}
 
 The **`TextEncoder.prototype.encode()`** method takes a
-{{domxref("USVString")}} as input, and returns a {{jsxref("Global_Objects/Uint8Array",
+string as input, and returns a {{jsxref("Global_Objects/Uint8Array",
   "Uint8Array")}} containing the text given in parameters encoded with the specific method
 for that `TextEncoder` object.
 
 ## Syntax
 
 ```js
-b1 = encoder.encode(string);
+encode(string)
 ```
 
 ### Parameters
 
 - `string`
-  - : Is a {{DOMxRef("USVString")}} containing the text to encode.
+  - : Is a string containing the text to encode.
 
 ### Return value
 

--- a/files/en-us/web/api/textencoder/encodeinto/index.md
+++ b/files/en-us/web/api/textencoder/encodeinto/index.md
@@ -13,7 +13,7 @@ browser-compat: api.TextEncoder.encodeInto
 {{APIRef("Encoding API")}}{{SeeCompatTable}}
 
 The **`TextEncoder.prototype.encodeInto()`** method takes a
-{{domxref("USVString")}} to encode and a destination {{jsxref("Uint8Array")}} to put
+string to encode and a destination {{jsxref("Uint8Array")}} to put
 resulting UTF-8 encoded text into, and returns a dictionary object indicating the
 progress of the encoding. This is potentially more performant than the older
 `encode()` method especially when the target buffer is a view into a Wasm
@@ -22,13 +22,13 @@ heap.
 ## Syntax
 
 ```js
-b1 = encoder.encodeInto(string, uint8Array);
+encodeInto(string, uint8Array)
 ```
 
 ### Parameters
 
 - `string`
-  - : Is a {{DOMxRef("USVString")}} containing the text to encode.
+  - : Is a string containing the text to encode.
 - `uint8Array`
   - : Is a {{jsxref("Uint8Array")}} object instance to place the resulting UTF-8
     encoded text into.

--- a/files/en-us/web/api/texttrack/addcue/index.md
+++ b/files/en-us/web/api/texttrack/addcue/index.md
@@ -16,7 +16,7 @@ The **`addCue()`** method of the {{domxref("TextTrack")}} interface adds a new c
 ## Syntax
 
 ```js
-TextTrack.addCue(cue);
+addCue(cue)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/texttrack/removecue/index.md
+++ b/files/en-us/web/api/texttrack/removecue/index.md
@@ -16,7 +16,7 @@ The **`removeCue()`** method of the {{domxref("TextTrack")}} interface removes a
 ## Syntax
 
 ```js
-TextTrack.removeCue(cue);
+removeCue(cue)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/texttrackcuelist/getcuebyid/index.md
+++ b/files/en-us/web/api/texttrackcuelist/getcuebyid/index.md
@@ -18,13 +18,13 @@ The **`getCueById()`** method of the {{domxref("TextTrackCueList")}} interface r
 ## Syntax
 
 ```js
-var cue = TextTrackCueList.getCueById(id);
+getCueById(id)
 ```
 
 ### Parameters
 
 - id
-  - : A {{domxref("DOMString")}} which is an identifier for the cue.
+  - : A string which is an identifier for the cue.
 
 ### Return value
 
@@ -38,7 +38,7 @@ The {{domxref("TextTrack.cues")}} property returns a {{domxref("TextTrackCueList
 WEBVTT
 
 first
-00:00:00.000 --> 00:00:00.999  line:80%
+00:00:00.000 --> 00:00:00.999 line:80%
 Hildy!
 
 second

--- a/files/en-us/web/api/texttracklist/gettrackbyid/index.md
+++ b/files/en-us/web/api/texttracklist/gettrackbyid/index.md
@@ -30,13 +30,13 @@ string.
 ## Syntax
 
 ```js
-var theTrack = TextTrackList.getTrackById(id);
+getTrackById(id)
 ```
 
 ### Parameters
 
 - `id`
-  - : A {{domxref("DOMString")}} indicating the ID of the track to locate within the track
+  - : A string indicating the ID of the track to locate within the track
     list.
 
 ### Return value

--- a/files/en-us/web/api/timeranges/end/index.md
+++ b/files/en-us/web/api/timeranges/end/index.md
@@ -18,12 +18,16 @@ Returns the time offset at which a specified time range ends.
 ## Syntax
 
 ```js
-endTime = TimeRanges.end(index)
+end(index)
 ```
 
 ### Parameters
 
 - `index` is the range number to return the ending time for.
+
+### Return value
+
+A number.
 
 ### Exceptions
 
@@ -31,7 +35,7 @@ endTime = TimeRanges.end(index)
   - : A `DOMException` thrown if the specified index doesn't correspond to an
     existing range.
 
-## Example
+## Examples
 
 Given a video element with the ID "myVideo":
 

--- a/files/en-us/web/api/timeranges/start/index.md
+++ b/files/en-us/web/api/timeranges/start/index.md
@@ -18,12 +18,16 @@ Returns the time offset at which a specified time range begins.
 ## Syntax
 
 ```js
-startTime = TimeRanges.start(index)
+start(index)
 ```
 
 ### Parameters
 
 - `index` is the range number to return the starting time for.
+
+### Return value
+
+A number.
 
 ### Exceptions
 
@@ -31,7 +35,7 @@ startTime = TimeRanges.start(index)
   - : A `DOMException` thrown if the specified index doesn't correspond to an
     existing range.
 
-## Example
+## Examples
 
 Given a video element with the ID "myVideo":
 

--- a/files/en-us/web/api/touchlist/item/index.md
+++ b/files/en-us/web/api/touchlist/item/index.md
@@ -20,7 +20,7 @@ object at the specified index in the {{ domxref("TouchList") }}.
 ## Syntax
 
 ```js
-var touchPoint = touchList.item(index);
+item(index)
 ```
 
 ### Parameters
@@ -35,7 +35,7 @@ var touchPoint = touchList.item(index);
   - : The requested {{ domxref("Touch") }} object from the {{ domxref("TouchList") }}.
     Returns `null` if the index is not less than the length of the list.
 
-## Example
+## Examples
 
 This code example illustrates the use of the {{domxref("TouchList")}} interface's
 {{domxref("TouchList.item()","item")}} method and the

--- a/files/en-us/web/api/transformstreamdefaultcontroller/enqueue/index.md
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/enqueue/index.md
@@ -18,7 +18,7 @@ For more information on readable streams and chunks see [Using Readable Streams]
 ## Syntax
 
 ```js
-TransformStreamDefaultController.enqueue(chunk);
+enqueue(chunk)
 ```
 
 ### Parameters


### PR DESCRIPTION
Continuing #14857 

## Summary
Updating the method pages to follow the current templates:
https://developer.mozilla.org/en-US/docs/MDN/Structures/Syntax_sections#constructors_and_methods
https://developer.mozilla.org/en-US/docs/MDN/Structures/Page_types/API_method_subpage_template

Changes Include:
- fix syntax section
- changing section titles to suggested titles in the template
- change `{{DOMxRef("DOMString")}}` to `string`
- remove extra spaces in between words and extra trailing spaces
- other small corrections

### Metadata
- [x] Fixes a typo, bug, or other error
