### PR TITLE
Fix typo in earlier commit, and make one wording refinement

### DIFF
--- a/files/en-us/web/api/settimeout/index.md
+++ b/files/en-us/web/api/settimeout/index.md
@@ -79,7 +79,7 @@ setTimeout(() => {
 }, "1000")
 ```
 
-But in many cases, the implicit type coercion can lead to unexpected and surprising results. For example, when the following code runs, the string `"1 second"` effectively gets coerced into the number `0` — and so, the code executes immediately, with no zero delay.
+But in many cases, the implicit type coercion can lead to unexpected and surprising results. For example, when the following code runs, the string `"1 second"` ultimately gets coerced into the number `0` — and so, the code executes immediately, with zero delay.
 
 ```js example-bad
 setTimeout(() => {


### PR DESCRIPTION
A typo crept into 32a7108 (https://github.com/mdn/content/pull/15185) — so this change fixes that, as well as changing another word to be more precise.