### PR TITLE
Remove Selection.selectionLanguageChange page

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -1693,7 +1693,6 @@
 /en-US/docs/DOM/Selection/removeAllRanges	/en-US/docs/Web/API/Selection/removeAllRanges
 /en-US/docs/DOM/Selection/removeRange	/en-US/docs/Web/API/Selection/removeRange
 /en-US/docs/DOM/Selection/selectAllChildren	/en-US/docs/Web/API/Selection/selectAllChildren
-/en-US/docs/DOM/Selection/selectionLanguageChange	/en-US/docs/Web/API/Selection/selectionLanguageChange
 /en-US/docs/DOM/Selection/toString	/en-US/docs/Web/API/Selection/toString
 /en-US/docs/DOM/SharedWorker	/en-US/docs/Web/API/SharedWorker
 /en-US/docs/DOM/Storage	/en-US/docs/Web/API/Web_Storage_API
@@ -9264,7 +9263,6 @@
 /en-US/docs/Web/API/Selection.removeAllRanges	/en-US/docs/Web/API/Selection/removeAllRanges
 /en-US/docs/Web/API/Selection.removeRange	/en-US/docs/Web/API/Selection/removeRange
 /en-US/docs/Web/API/Selection.selectAllChildren	/en-US/docs/Web/API/Selection/selectAllChildren
-/en-US/docs/Web/API/Selection.selectionLanguageChange	/en-US/docs/Web/API/Selection/selectionLanguageChange
 /en-US/docs/Web/API/Selection.toString	/en-US/docs/Web/API/Selection/toString
 /en-US/docs/Web/API/Selection/empty	/en-US/docs/Web/API/Selection/removeAllRanges
 /en-US/docs/Web/API/Selection/setPosition	/en-US/docs/Web/API/Selection/collapse

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -71924,19 +71924,6 @@
       "Jonnyq"
     ]
   },
-  "Web/API/Selection/selectionLanguageChange": {
-    "modified": "2019-03-24T00:11:08.047Z",
-    "contributors": [
-      "Nickolay",
-      "fscholz",
-      "teoli",
-      "SphinxKnight",
-      "kscarfone",
-      "namolmes",
-      "Sheppy",
-      "trevorh"
-    ]
-  },
   "Web/API/Selection/setBaseAndExtent": {
     "modified": "2020-10-15T21:52:25.472Z",
     "contributors": [

--- a/files/en-us/web/api/selection/selectionlanguagechange/index.md
+++ b/files/en-us/web/api/selection/selectionlanguagechange/index.md
@@ -1,7 +1,0 @@
----
-title: Selection.selectionLanguageChange()
-slug: Web/API/Selection/selectionLanguageChange
----
-{{ApiRef("DOM")}}{{deprecated_header}}
-
-**`Selection.selectionLanguageChange()`** method is a Gecko/Firefox internal method that was exposed to web pages until Firefox 29. It was removed in {{bug("949445")}} and should not be used.


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/web/api/selection/selectionlanguagechange seems like a very useless page. Proposing to remove it.