### PR TITLE
Clarify the return type of Cache.keys()

### DIFF
--- a/files/en-us/web/api/cache/keys/index.md
+++ b/files/en-us/web/api/cache/keys/index.md
@@ -14,8 +14,9 @@ browser-compat: api.Cache.keys
 ---
 {{APIRef("Service Workers API")}}
 
-The **`keys()`** method of the {{domxref("Cache")}} interface
-returns a {{jsxref("Promise")}} that resolves to an array of {{domxref("Cache")}} keys.
+The **`keys()`** method of the {{domxref("Cache")}} interface returns a
+{{jsxref("Promise")}} that resolves to an array of{{domxref("Request")}} objects
+representing the keys of the {{domxref("Cache")}}.
 
 The requests are returned in the same order that they were inserted.
 
@@ -60,7 +61,8 @@ keys(request, options)
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves to an array of {{domxref("Cache")}} keys.
+A {{jsxref("Promise")}} that resolves to an array of {{domxref("Request")}}
+objects.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Mention `Request` as return type of `Cache.keys()`.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The current description is too ambiguous and might be confused with `CacheStorage.keys()`

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://w3c.github.io/ServiceWorker/#ref-for-dom-cache-keys

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #15193 

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
