### PR TITLE
Remove Experimental flags

### DIFF
--- a/files/en-us/web/css/_colon_any-link/index.md
+++ b/files/en-us/web/css/_colon_any-link/index.md
@@ -4,7 +4,6 @@ slug: Web/CSS/:any-link
 tags:
   - ':any-link'
   - CSS
-  - Experimental
   - Layout
   - Links
   - Pseudo-class

--- a/files/en-us/web/css/_colon_dir/index.md
+++ b/files/en-us/web/css/_colon_dir/index.md
@@ -4,7 +4,6 @@ slug: Web/CSS/:dir
 tags:
   - BiDi
   - CSS
-  - Experimental
   - Pseudo-class
   - Reference
   - Selector

--- a/files/en-us/web/css/_colon_has/index.md
+++ b/files/en-us/web/css/_colon_has/index.md
@@ -4,7 +4,6 @@ slug: Web/CSS/:has
 tags:
   - ':has'
   - CSS
-  - Experimental
   - Pseudo-class
   - Reference
   - Selector

--- a/files/en-us/web/css/_colon_host-context/index.md
+++ b/files/en-us/web/css/_colon_host-context/index.md
@@ -4,7 +4,6 @@ slug: Web/CSS/:host-context
 tags:
   - ':host-context()'
   - CSS
-  - Experimental
   - Layout
   - Pseudo-class
   - Reference

--- a/files/en-us/web/css/_colon_is/index.md
+++ b/files/en-us/web/css/_colon_is/index.md
@@ -4,7 +4,6 @@ slug: Web/CSS/:is
 tags:
   - ':is'
   - CSS
-  - Experimental
   - Pseudo-class
   - Reference
   - Selector

--- a/files/en-us/web/css/_colon_where/index.md
+++ b/files/en-us/web/css/_colon_where/index.md
@@ -4,7 +4,6 @@ slug: Web/CSS/:where
 tags:
   - ':where'
   - CSS
-  - Experimental
   - NeedsBrowserCompatibility
   - NeedsContent
   - NeedsExample

--- a/files/en-us/web/css/_doublecolon_marker/index.md
+++ b/files/en-us/web/css/_doublecolon_marker/index.md
@@ -4,7 +4,6 @@ slug: Web/CSS/::marker
 tags:
   - CSS
   - CSS Lists
-  - Experimental
   - Layout
   - Pseudo-element
   - Reference

--- a/files/en-us/web/css/_doublecolon_part/index.md
+++ b/files/en-us/web/css/_doublecolon_part/index.md
@@ -5,7 +5,6 @@ tags:
   - '::part'
   - CSS
   - Draft
-  - Experimental
   - NeedsBrowserCompatibility
   - NeedsExample
   - Pseudo-element


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
I removed Experimental flag from every pseudo-element and pseudo-class, that doesn't have "Experimental" icon in browser compatibility table. That's basically every one of them, except for [:blank](https://developer.mozilla.org/en-US/docs/Web/CSS/:blank), [::grammar-error](https://developer.mozilla.org/en-US/docs/Web/CSS/::grammar-error) and [::spelling-error](https://developer.mozilla.org/en-US/docs/Web/CSS/::spelling-error)
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
