### PR TITLE
Clarify global attributes for input elements

### DIFF
--- a/files/en-us/web/html/element/input/index.md
+++ b/files/en-us/web/html/element/input/index.md
@@ -323,16 +323,15 @@ The available types are as follows:
 
 The `<input>` element is so powerful because of its attributes; the [`type`](#type) attribute, described with examples above, being the most important. Since every `<input>` element, regardless of type, is based on the {{domxref("HTMLInputElement")}} interface, they technically share the exact same set of attributes. However, in reality, most attributes have an effect on only a specific subset of input types. In addition, the way some attributes impact an input depends on the input type, impacting different input types in different ways.
 
-This section provides a table listing all the attributes with a brief description. This table is followed by a list describing each attribute in greater detail, along with which input types they are associated with. Those that are common to most or all input types are defined in greater detail below. Attributes that are unique to particular input types—or attributes which are common to all input types but have special behaviors when used on a given input type—are instead documented on those types' pages. This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attributes). Those with extra importance as it relates to `<input>` are highlighted.
+This section provides a table listing all the attributes with a brief description. This table is followed by a list describing each attribute in greater detail, along with which input types they are associated with. Those that are common to most or all input types are defined in greater detail below. Attributes that are unique to particular input types—or attributes which are common to all input types but have special behaviors when used on a given input type—are instead documented on those types' pages.
 
-Attributes for the `<input`> element include [global HTML attributes](/en-US/docs/Web/HTML/Global_attributes) and:
+Attributes for the `<input`> element include the [global HTML attributes](/en-US/docs/Web/HTML/Global_attributes) and additionally:
 
 | Attribute                           | Type or Types                    | Description                                                                           |
 | ----------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------- |
 | [`accept`](#accept)                 | file                             | Hint for expected file type in file upload controls                                   |
 | [`alt`](#alt)                       | image                            | alt attribute for the image type. Required for accessibility                          |
 | [`autocomplete`](#autocomplete)     | all                              | Hint for form autofill feature                                                        |
-| [`autofocus`](#autofocus)           | all                              | Automatically focus the form control when the page is loaded                          |
 | [`capture`](#capture)               | file                             | Media capture input method in file upload controls                                    |
 | [`checked`](#checked)               | radio, checkbox                  | Whether the command or control is checked                                             |
 | [`dirname`](#dirname)               | text, search                     | Name of form field to use for sending the element's directionality in form submission |
@@ -839,7 +838,7 @@ Inputs, being replaced elements, have a few features not applicable to non form 
       <td>{{Cssxref(":required")}}</td>
       <td>
         <code>&#x3C;input></code>, {{HTMLElement("select")}}, or {{HTMLElement("textarea")}} element that has the <a href="#required"><code>required</code></a> attribute set on it.
-        Only matches elements that can be required. 
+        Only matches elements that can be required.
         The attribute included on a non-requirable element will not make for a match.
       </td>
     </tr>


### PR DESCRIPTION
@hamishwillee , now https://github.com/mdn/content/pull/14870 is merged, this is an attempt to close https://github.com/mdn/content/issues/14823 along the lines suggested in https://github.com/mdn/content/issues/14823#issuecomment-1095747508: that is, to be clear that the table does not include global attributes, and to remove from the table any global attributes, which is I think only `autofocus`.