### PR TITLE
Fixes the sequential composition equivalent

### DIFF
--- a/files/en-us/web/javascript/guide/using_promises/index.md
+++ b/files/en-us/web/javascript/guide/using_promises/index.md
@@ -258,10 +258,14 @@ Sequential composition is possible using some clever JavaScript:
 .then(result3 => { /* use result3 */ });
 ```
 
-Basically, we reduce an array of asynchronous functions down to a promise chain equivalent to:
+Basically, we reduce an array of asynchronous functions down to a promise chain. The code above is equivalent to:
 
 ```js
-Promise.resolve().then(func1).then(func2).then(func3).then(result3 => { /* use result3 */ });
+Promise.resolve()
+  .then(func1)
+  .then(func2)
+  .then(func3)
+  .then((result3) => { /* use result3 */ });
 ```
 
 This can be made into a reusable compose function, which is common in functional programming:

--- a/files/en-us/web/javascript/guide/using_promises/index.md
+++ b/files/en-us/web/javascript/guide/using_promises/index.md
@@ -258,7 +258,11 @@ Sequential composition is possible using some clever JavaScript:
 .then(result3 => { /* use result3 */ });
 ```
 
-Basically, we reduce an array of asynchronous functions down to a promise chain equivalent to: `Promise.resolve().then(func1).then(func2).then(func3);`
+Basically, we reduce an array of asynchronous functions down to a promise chain equivalent to:
+
+```js
+Promise.resolve().then(func1).then(func2).then(func3).then(result3 => { /* use result3 */ });
+```
 
 This can be made into a reusable compose function, which is common in functional programming:
 


### PR DESCRIPTION
The code written explicitly to match sequential composition is not technically equivalent as it is missing the last `.then()` call.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fixes the explicit equivalence of sequential composition.

#### Motivation
Readers may be confused when two code snippets are stated as being equivalent are not, technically, equivalent.

#### Supporting details
N/A

#### Related issues
N/A

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
