### PR TITLE
Deprecate the param element and HTMLParamElement API

### DIFF
--- a/files/en-us/web/api/html_dom_api/index.md
+++ b/files/en-us/web/api/html_dom_api/index.md
@@ -131,7 +131,6 @@ These interfaces represent specific HTML elements (or sets of related elements w
 - {{DOMxRef("HTMLOptionElement")}}
 - {{DOMxRef("HTMLOutputElement")}}
 - {{DOMxRef("HTMLParagraphElement")}}
-- {{DOMxRef("HTMLParamElement")}}
 - {{DOMxRef("HTMLPictureElement")}}
 - {{DOMxRef("HTMLPreElement")}}
 - {{DOMxRef("HTMLProgressElement")}}

--- a/files/en-us/web/api/htmlparamelement/index.md
+++ b/files/en-us/web/api/htmlparamelement/index.md
@@ -6,9 +6,10 @@ tags:
   - HTML DOM
   - Interface
   - Reference
+  - Deprecated
 browser-compat: api.HTMLParamElement
 ---
-{{ APIRef("HTML DOM") }}
+{{ APIRef("HTML DOM") }}{{Deprecated_Header}}
 
 The **`HTMLParamElement`** interface provides special properties (beyond those of the regular {{domxref("HTMLElement")}} object interface it inherits) for manipulating {{HTMLElement("param")}} elements, representing a pair of a key and a value that acts as a parameter for an {{HTMLElement("object")}} element.
 

--- a/files/en-us/web/html/element/param/index.md
+++ b/files/en-us/web/html/element/param/index.md
@@ -4,13 +4,13 @@ slug: Web/HTML/Element/param
 tags:
   - Element
   - HTML
-  - HTML embedded content
   - Reference
   - Web
+  - Deprecated
 browser-compat: html.elements.param
 ---
 
-{{HTMLRef}}
+{{HTMLRef}}{{Deprecated_Header}}
 
 The **`<param>`** [HTML](/en-US/docs/Web/HTML) element defines parameters for an {{HTMLElement("object")}} element.
 
@@ -67,13 +67,10 @@ The **`<param>`** [HTML](/en-US/docs/Web/HTML) element defines parameters for an
 
 This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attributes).
 
-- {{htmlattrdef("name")}}
+- {{htmlattrdef("name")}} {{deprecated_inline}}
   - : Name of the parameter.
-- {{htmlattrdef("value")}}
+- {{htmlattrdef("value")}} {{deprecated_inline}}
   - : Specifies the value of the parameter.
-
-### Deprecated attributes
-
 - {{htmlattrdef("type")}} {{deprecated_inline}}
   - : Only used if the `valuetype` is set to `ref`. Specifies the MIME type of values found at the URI specified by value.
 - {{htmlattrdef("valuetype")}} {{deprecated_inline}}
@@ -83,10 +80,6 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
     - `data`: Default value. The value is passed to the object's implementation as a string.
     - `ref`: The value is a URI to a resource where run-time values are stored.
     - `object`: An ID of another {{HTMLElement("object")}} in the same document.
-
-## Examples
-
-Please see the {{HTMLElement("object")}} page for examples on `<param>`.
 
 ## Specifications
 

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -632,7 +632,6 @@
         "HTMLOptionsCollection",
         "HTMLOutputElement",
         "HTMLParagraphElement",
-        "HTMLParamElement",
         "HTMLPictureElement",
         "HTMLPreElement",
         "HTMLProgressElement",


### PR DESCRIPTION
https://github.com/whatwg/html/commit/04a11f2 (https://github.com/whatwg/html/pull/7816) obsoletes the HTML `param` element and the `HTMLParamElement` API.
Related BCD change: https://github.com/mdn/browser-compat-data/pull/15955