### PR TITLE
Remove experimental header box from WritableStreamDefaultController pages

### DIFF
--- a/files/en-us/web/api/writablestreamdefaultcontroller/error/index.md
+++ b/files/en-us/web/api/writablestreamdefaultcontroller/error/index.md
@@ -4,14 +4,13 @@ slug: Web/API/WritableStreamDefaultController/error
 tags:
   - API
   - Error
-  - Experimental
   - Method
   - Reference
   - Streams
   - WritableStreamDefaultController
 browser-compat: api.WritableStreamDefaultController.error
 ---
-{{SeeCompatTable}}{{APIRef("Streams")}}
+{{APIRef("Streams")}}
 
 The **`error()`** method of the
 {{domxref("WritableStreamDefaultController")}} interface causes any future interactions

--- a/files/en-us/web/api/writablestreamdefaultcontroller/index.md
+++ b/files/en-us/web/api/writablestreamdefaultcontroller/index.md
@@ -11,7 +11,7 @@ tags:
   - WritableStreamDefaultController
 browser-compat: api.WritableStreamDefaultController
 ---
-{{SeeCompatTable}}{{APIRef("Streams")}}
+{{APIRef("Streams")}}
 
 The **`WritableStreamDefaultController`** interface of the [Streams API](/en-US/docs/Web/API/Streams_API) represents a controller allowing control of a {{domxref("WritableStream")}}'s state. When constructing a `WritableStream`, the underlying sink is given a corresponding `WritableStreamDefaultController` instance to manipulate.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Remove experimental header box from WritableStreamDefaultController pages

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

The support data shows it's supported by at least two browsers which meets the requirements for no longer being experimental, and as such isn't marked as experimental in the support data. This PR matches that in the content.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

All supporting information is contained within the support data box on the page.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
