### PR TITLE
Fix assertion about abbreviated S command

### DIFF
--- a/files/en-us/web/svg/tutorial/paths/index.md
+++ b/files/en-us/web/svg/tutorial/paths/index.md
@@ -153,7 +153,7 @@ Several Bézier curves can be stringed together to create extended, smooth shape
  s dx2 dy2, dx dy
 ```
 
-`S` produces the same type of curve as earlier—but if it follows another `S` command or a `C` command, the first control point is assumed to be a reflection of the one used previously. If the `S` command doesn't follow another `S` or `C` command, then the current position of the cursor is used as the first control point. In this case the result is the same as what the `Q` command would have produced with the same parameters.
+`S` produces the same type of curve as earlier—but if it follows another `S` command or a `C` command, the first control point is assumed to be a reflection of the one used previously. If the `S` command doesn't follow another `S` or `C` command, then the current position of the cursor is used as the first control point. The result is not the same as what the `Q` command would have produced with the same parameters, but is similar.
 
 An example of this syntax is shown below, and in the figure to the left the specified control points are shown in red, and the inferred control point in blue.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

Fixes the following incorrect assertion regarding using `S` in an SVG Path to describe a cubic Bézier: "In this case the result is the same as what the Q command would have produced with the same parameters."

#### Motivation

It's wrong on the internet.

#### Supporting details

In general a cubic Bézier can be reduced to a quadratic only if the two off-curve control points are coincident. The `S` command does not produce this.

More concretely, you can see for yourself with the following SVG:

```
<svg width="190" height="160" xmlns="http://www.w3.org/2000/svg">
  <path d="M 10 80 S 150 150, 180 80" stroke="black" fill="transparent"/>
  <path d="M 10 80 Q 150 150, 180 80" stroke="red" fill="transparent"/>
</svg>
```

#### Related issues

None

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
