### PR TITLE
page-orientation descriptor in page at-rule

### DIFF
--- a/files/en-us/web/css/@page/index.md
+++ b/files/en-us/web/css/@page/index.md
@@ -28,11 +28,11 @@ The **`@page`** CSS at-rule is used to modify some CSS properties when printing 
 
 ### Descriptors
 
-- [`size`](/en-US/docs/Web/CSS/@page/size)
-  - : Specifies the target size and orientation of the page box's containing block. In the general case, where one page box is rendered onto one page sheet, it also indicates the size of the destination page sheet.
-
 - [`page-orientation`](/en-US/docs/Web/CSS/@page/page-orientation)
   - : Specifies the orientation of the document on the page, allowing it to be laid out and formatted as normal or be rotated to one either left or right side.
+
+- [`size`](/en-US/docs/Web/CSS/@page/size)
+  - : Specifies the target size and orientation of the page box's containing block. In the general case, where one page box is rendered onto one page sheet, it also indicates the size of the destination page sheet.
 
 ## Description
 

--- a/files/en-us/web/css/@page/index.md
+++ b/files/en-us/web/css/@page/index.md
@@ -31,6 +31,9 @@ The **`@page`** CSS at-rule is used to modify some CSS properties when printing 
 - [`size`](/en-US/docs/Web/CSS/@page/size)
   - : Specifies the target size and orientation of the page box's containing block. In the general case, where one page box is rendered onto one page sheet, it also indicates the size of the destination page sheet.
 
+- [`page-orientation`](/en-US/docs/Web/CSS/@page/page-orientation)
+  - : Specifies the orientation of the document on the page, allowing it to be laid out and formatted as normal or be rotated to one either left or right side.
+
 ## Description
 
 You can't change all CSS properties with `@page`. You can only change the margins, orphans, widows, and page breaks of the document. Attempts to change any other CSS properties will be ignored.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
page-orientation descriptor is supported on Chromium and belongs to [CSS Paged Media Module Level 3](https://drafts.csswg.org/css-page-3/#page-orientation-prop), so I have added it to [@page](https://developer.mozilla.org/en-US/docs/Web/CSS/@page). Its [own page](https://developer.mozilla.org/en-US/docs/Web/CSS/@page/page-orientation) is still missing, but maybe I will add it in the future.
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
