### PR TITLE
Remove touchenter and touchleave events from HTMLElement interface page

### DIFF
--- a/files/en-us/web/api/htmlelement/index.md
+++ b/files/en-us/web/api/htmlelement/index.md
@@ -103,10 +103,6 @@ Most event handler properties, of the form `onXYZ`, are defined on the {{DOMxRef
   - : Returns the event handling code for the {{domxref("Element/touchend_event", "touchend")}} event.
 - {{DOMxRef("TouchEventHandlers.ontouchmove")}} {{Non-standard_Inline}}
   - : Returns the event handling code for the {{domxref("Element/touchmove_event", "touchmove")}} event.
-- {{DOMxRef("TouchEventHandlers.ontouchenter")}} {{Non-standard_Inline}}
-  - : Returns the event handling code for the {{event("touchenter")}} event.
-- {{DOMxRef("TouchEventHandlers.ontouchleave")}} {{Non-standard_Inline}}
-  - : Returns the event handling code for the {{event("touchleave")}} event.
 - {{DOMxRef("TouchEventHandlers.ontouchcancel")}} {{Non-standard_Inline}}
   - : Returns the event handling code for the {{domxref("Element/touchcancel_event", "touchcancel")}} event.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Remove `touchenter` and `touchleave` events because they have been removed from draft, and their pages haven't been written.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
