### PR TITLE
Replace {{event}}s with {{domxref}}s for `pointerdown`, `pointerout` …

### DIFF
--- a/files/en-us/web/api/htmlelement/pointercancel_event/index.md
+++ b/files/en-us/web/api/htmlelement/pointercancel_event/index.md
@@ -14,7 +14,7 @@ browser-compat: api.HTMLElement.pointercancel_event
 ---
 {{APIRef}}
 
-The **`pointercancel`** event is fired when the browser determines that there are unlikely to be any more pointer events, or if after the {{event("pointerdown")}} event is fired, the pointer is then used to manipulate the viewport by panning, zooming, or scrolling.
+The **`pointercancel`** event is fired when the browser determines that there are unlikely to be any more pointer events, or if after the {{domxref("HTMLElement/pointerdown_event", "pointerdown")}} event is fired, the pointer is then used to manipulate the viewport by panning, zooming, or scrolling.
 
 <table class="properties">
   <tbody>
@@ -50,7 +50,7 @@ Some examples of situations that will trigger a `pointercancel` event:
 - The browser decides that the user started pointer input accidentally. This can happen if, for example, the hardware supports palm rejection to prevent a hand resting on the display while using a stylus from accidentally triggering events.
 - The {{cssxref("touch-action")}} CSS property prevents the input from continuing.
 
-> **Note:** After the `pointercancel` event is fired, the browser will also send {{event("pointerout")}} followed by {{event("pointerleave")}}.
+> **Note:** After the `pointercancel` event is fired, the browser will also send {{domxref("HTMLElement/pointerout_event", "pointerout")}} followed by {{domxref("HTMLElement/pointerleave_event", "pointerleave")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlelement/pointerenter_event/index.md
+++ b/files/en-us/web/api/htmlelement/pointerenter_event/index.md
@@ -12,7 +12,7 @@ browser-compat: api.HTMLElement.pointerenter_event
 ---
 {{APIRef}}
 
-The `pointerenter` event fires when a pointing device is moved into the hit test boundaries of an element or one of its descendants, including as a result of a {{event("pointerdown")}} event from a device that does not support hover (see {{event("pointerdown")}}).
+The `pointerenter` event fires when a pointing device is moved into the hit test boundaries of an element or one of its descendants, including as a result of a {{domxref("HTMLElement/pointerdown_event", "pointerdown")}} event from a device that does not support hover (see {{domxref("HTMLElement/pointerdown_event", "pointerdown")}}).
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/api/htmlelement/pointerout_event/index.md
+++ b/files/en-us/web/api/htmlelement/pointerout_event/index.md
@@ -11,7 +11,7 @@ browser-compat: api.HTMLElement.pointerout_event
 ---
 {{APIRef}}
 
-The `pointerout` event is fired for several reasons including: pointing device is moved out of the _hit test_ boundaries of an element; firing the {{event("pointerup")}} event for a device that does not support hover (see {{event("pointerup")}}); after firing the {{event("pointercancel")}} event (see {{event("pointercancel")}}); when a pen stylus leaves the hover range detectable by the digitizer.
+The `pointerout` event is fired for several reasons including: pointing device is moved out of the _hit test_ boundaries of an element; firing the {{domxref("HTMLElement/pointerup_event", "pointerup")}} event for a device that does not support hover (see {{domxref("HTMLElement/pointerup_event", "pointerup")}}); after firing the {{domxref("HTMLElement/pointercancel_event", "pointercancel")}} event (see {{domxref("HTMLElement/pointercancel_event", "pointercancel")}}); when a pen stylus leaves the hover range detectable by the digitizer.
 
 <table class="properties">
   <tbody>


### PR DESCRIPTION
…and `pointerleave`

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Replace {{event}}s with {{domxref}}s for `pointerdown`, `pointerout` and `pointerleave`

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
