### PR TITLE
WebAPI: Update Method pages to modern structure (part 17)

### DIFF
--- a/files/en-us/web/api/transformstreamdefaultcontroller/error/index.md
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/error/index.md
@@ -16,7 +16,7 @@ The **`error()`** method of the {{domxref("TransformStreamDefaultController")}} 
 ## Syntax
 
 ```js
-TransformStreamDefaultController.error(reason);
+error(reason)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/transformstreamdefaultcontroller/terminate/index.md
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/terminate/index.md
@@ -16,7 +16,7 @@ The **`terminate()`** method of the {{domxref("TransformStreamDefaultController"
 ## Syntax
 
 ```js
-TransformStreamDefaultController.terminate();
+terminate()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/transitionevent/inittransitionevent/index.md
+++ b/files/en-us/web/api/transitionevent/inittransitionevent/index.md
@@ -31,14 +31,14 @@ method.
 ## Syntax
 
 ```js
-transitionEvent.initTransitionEvent(typeArg, canBubbleArg, cancelableArg, transitionNameArg, elapsedTimeArg);
+initTransitionEvent(typeArg, canBubbleArg, cancelableArg, transitionNameArg, elapsedTimeArg)
 ```
 
 ### Parameters
 
 - _typeArg_
 
-  - : Is a {{domxref("DOMString")}} identifying the specific type of transition event that
+  - : Is a string identifying the specific type of transition event that
     occurred. The following value is allowed:
 
     | Value           | Meaning                   |
@@ -52,7 +52,7 @@ transitionEvent.initTransitionEvent(typeArg, canBubbleArg, cancelableArg, transi
   - : Is a boolean flag indicating if the event associated action can be
     avoided (`true`) or not (`false)`.
 - _transitionNameArg_
-  - : Is a {{domxref("DOMString")}} containing the name of the CSS property associated
+  - : Is a string containing the name of the CSS property associated
     with the transition. This value is not affected by the {{cssxref("transition-delay")}}
     property.
 - _elapsedTimeArg_

--- a/files/en-us/web/api/treewalker/firstchild/index.md
+++ b/files/en-us/web/api/treewalker/firstchild/index.md
@@ -19,10 +19,14 @@ returns `null` and the current node is not changed.
 ## Syntax
 
 ```js
-node = treeWalker.firstChild;
+firstChild()
 ```
 
-## Example
+### Return value
+
+A {{domxref("Node")}} object or `null`.
+
+## Examples
 
 ```js
 var treeWalker = document.createTreeWalker(

--- a/files/en-us/web/api/treewalker/lastchild/index.md
+++ b/files/en-us/web/api/treewalker/lastchild/index.md
@@ -19,10 +19,14 @@ returns `null` and the current node is not changed.
 ## Syntax
 
 ```js
-treeWalker.lastChild();
+lastChild()
 ```
 
-## Example
+### Return value
+
+A {{domxref("Node")}} object or `null`.
+
+## Examples
 
 ```js
 var treeWalker = document.createTreeWalker(

--- a/files/en-us/web/api/treewalker/nextnode/index.md
+++ b/files/en-us/web/api/treewalker/nextnode/index.md
@@ -19,10 +19,14 @@ returns `null` and the current node is not changed.
 ## Syntax
 
 ```js
-node = treeWalker.nextNode();
+nextNode()
 ```
 
-## Example
+### Return value
+
+A {{domxref("Node")}} object or `null`.
+
+## Examples
 
 ```js
 var treeWalker = document.createTreeWalker(

--- a/files/en-us/web/api/treewalker/nextsibling/index.md
+++ b/files/en-us/web/api/treewalker/nextsibling/index.md
@@ -18,10 +18,14 @@ is no such node, return `null` and the current node is not changed.
 ## Syntax
 
 ```js
-node = treeWalker.nextSibling();
+nextSibling()
 ```
 
-## Example
+### Return value
+
+A {{domxref("Node")}} object or `null`.
+
+## Examples
 
 ```js
 var treeWalker = document.createTreeWalker(

--- a/files/en-us/web/api/treewalker/parentnode/index.md
+++ b/files/en-us/web/api/treewalker/parentnode/index.md
@@ -20,10 +20,14 @@ node is not changed.
 ## Syntax
 
 ```js
-node = treeWalker.parentNode();
+parentNode()
 ```
 
-## Example
+### Return value
+
+A {{domxref("Node")}} object or `null`.
+
+## Examples
 
 ```js
 var treeWalker = document.createTreeWalker(

--- a/files/en-us/web/api/treewalker/previousnode/index.md
+++ b/files/en-us/web/api/treewalker/previousnode/index.md
@@ -20,10 +20,14 @@ construction, returns `null` and the current node is not changed.
 ## Syntax
 
 ```js
-node = treeWalker.previousNode();
+previousNode()
 ```
 
-## Example
+### Return value
+
+A {{domxref("Node")}} object or `null`.
+
+## Examples
 
 ```js
 var treeWalker = document.createTreeWalker(

--- a/files/en-us/web/api/treewalker/previoussibling/index.md
+++ b/files/en-us/web/api/treewalker/previoussibling/index.md
@@ -20,10 +20,14 @@ there is no such node, return `null` and the current node is not changed.
 ## Syntax
 
 ```js
-node = treeWalker.previousSibling();
+previousSibling()
 ```
 
-## Example
+### Return value
+
+A {{domxref("Node")}} object or `null`.
+
+## Examples
 
 ```js
 var treeWalker = document.createTreeWalker(

--- a/files/en-us/web/api/trustedhtml/tojson/index.md
+++ b/files/en-us/web/api/trustedhtml/tojson/index.md
@@ -16,7 +16,7 @@ The **`toJSON()`** method of the {{domxref("TrustedHTML")}} interface returns a 
 ## Syntax
 
 ```js
-var json = TrustedHTML.toJSON();
+toJSON()
 ```
 
 ### Return value

--- a/files/en-us/web/api/trustedhtml/tostring/index.md
+++ b/files/en-us/web/api/trustedhtml/tostring/index.md
@@ -16,7 +16,7 @@ The **`toString()`** method of the {{domxref("TrustedHTML")}} interface returns 
 ## Syntax
 
 ```js
-var str = TrustedHTML.toString();
+toString()
 ```
 
 ### Return value

--- a/files/en-us/web/api/trustedscript/tojson/index.md
+++ b/files/en-us/web/api/trustedscript/tojson/index.md
@@ -16,7 +16,7 @@ The **`toJSON()`** method of the {{domxref("TrustedScript")}} interface returns 
 ## Syntax
 
 ```js
-var json = TrustedScript.toJSON();
+toJSON()
 ```
 
 ### Return value

--- a/files/en-us/web/api/trustedscript/tostring/index.md
+++ b/files/en-us/web/api/trustedscript/tostring/index.md
@@ -16,7 +16,7 @@ The **`toString()`** method of the {{domxref("TrustedScript")}} interface return
 ## Syntax
 
 ```js
-var str = TrustedScript.toString();
+toString()
 ```
 
 ### Return value

--- a/files/en-us/web/api/trustedscripturl/tojson/index.md
+++ b/files/en-us/web/api/trustedscripturl/tojson/index.md
@@ -16,7 +16,7 @@ The **`toJSON()`** method of the {{domxref("TrustedScriptURL")}} interface retur
 ## Syntax
 
 ```js
-var json = TrustedScriptURL.toJSON();
+toJSON()
 ```
 
 ### Return value

--- a/files/en-us/web/api/trustedscripturl/tostring/index.md
+++ b/files/en-us/web/api/trustedscripturl/tostring/index.md
@@ -16,7 +16,7 @@ The **`toString()`** method of the {{domxref("TrustedScriptURL")}} interface ret
 ## Syntax
 
 ```js
-var str = TrustedScriptURL.toString();
+toString()
 ```
 
 ### Return value

--- a/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.md
@@ -24,13 +24,13 @@ In Chrome a policy with a name of "default" creates a special policy that will b
 ## Syntax
 
 ```js
-var policy = TrustedTypePolicyFactory.createPolicy(policyName,policyOptions);
+createPolicy(policyName, policyOptions)
 ```
 
 ### Parameters
 
 - `policyName`
-  - : A {{domxref("DOMString")}} with the name of the policy.
+  - : A string with the name of the policy.
 - `policyOptions`{{optional_inline}}
 
   - : User-defined functions for converting strings into trusted values.

--- a/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.md
@@ -17,8 +17,8 @@ The **`getAttributeType()`** method of the {{domxref("TrustedTypePolicyFactory")
 
 ```js
 getAttributeType(tagName, attribute)
-getAttributeType(tagName, attribute, elementNs)
-getAttributeType(tagName, attribute, elementNs, attrNs)
+getAttributeType(tagName, attribute, elementNS)
+getAttributeType(tagName, attribute, elementNS, attrNS)
 ```
 
 ### Parameters
@@ -27,9 +27,9 @@ getAttributeType(tagName, attribute, elementNs, attrNs)
   - : A {{domxref("DOMString","string")}} containing the name of an HTML tag.
 - `attribute`
   - : A {{domxref("DOMString","string")}} containing an attribute.
-- `elementNs`{{optional_inline}}
+- `elementNS`{{optional_inline}}
   - : A {{domxref("DOMString","string")}} containing a namespace, if empty defaults to the HTML namespace.
-- `attrNs`{{optional_inline}}
+- `attrNS`{{optional_inline}}
   - : A {{domxref("DOMString","string")}} containing a namespace, if empty defaults to null.
 
 ### Return value

--- a/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.md
@@ -16,9 +16,9 @@ The **`getAttributeType()`** method of the {{domxref("TrustedTypePolicyFactory")
 ## Syntax
 
 ```js
-TrustedTypePolicyFactory.getAttributeType(tagName, attribute)
-TrustedTypePolicyFactory.getAttributeType(tagName, attribute, elementNs)
-TrustedTypePolicyFactory.getAttributeType(tagName, attribute, elementNs, attrNs)
+getAttributeType(tagName, attribute)
+getAttributeType(tagName, attribute, elementNs)
+getAttributeType(tagName, attribute, elementNs, attrNs)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.md
@@ -26,7 +26,7 @@ getPropertyType(tagName, property, elementNS)
   - : A {{domxref("DOMString","string")}} containing the name of an HTML tag.
 - `property`
   - : A {{domxref("DOMString","string")}} containing a property, for example `"innerHTML"`.
-- `elementNs`{{optional_inline}}
+- `elementNS`{{optional_inline}}
   - : A {{domxref("DOMString","string")}} containing a namespace, if empty defaults to the HTML namespace.
 
 ### Return value

--- a/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.md
@@ -16,8 +16,8 @@ The **`getPropertyType()`** method of the {{domxref("TrustedTypePolicyFactory")}
 ## Syntax
 
 ```js
-TrustedTypePolicyFactory.getPropertyType(tagName, property)
-TrustedTypePolicyFactory.getPropertyType(tagName, property, elementNS)
+getPropertyType(tagName, property)
+getPropertyType(tagName, property, elementNS)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.md
@@ -18,7 +18,7 @@ The **`isHTML()`** method of the {{domxref("TrustedTypePolicyFactory")}} interfa
 ## Syntax
 
 ```js
-var isHTML = TrustedTypePolicyFactory.isHTML(value);
+isHTML(value)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.md
@@ -18,7 +18,7 @@ The **`isScript()`** method of the {{domxref("TrustedTypePolicyFactory")}} inter
 ## Syntax
 
 ```js
-var isScript = TrustedTypePolicyFactory.isScript(value);
+isScript(value)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.md
@@ -18,7 +18,7 @@ The **`isScriptURL()`** method of the {{domxref("TrustedTypePolicyFactory")}} in
 ## Syntax
 
 ```js
-var isScriptURL = TrustedTypePolicyFactory.isScriptURL(value);
+isScriptURL(value)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/uievent/inituievent/index.md
+++ b/files/en-us/web/api/uievent/inituievent/index.md
@@ -28,13 +28,13 @@ dispatched, it doesn't do anything anymore.
 ## Syntax
 
 ```js
-event.initUIEvent(type, canBubble, cancelable, view, detail)
+initUIEvent(type, canBubble, cancelable, view, detail)
 ```
 
 ### Parameters
 
 - _`type`_
-  - : Is a {{domxref("DOMString")}} defining the type of event.
+  - : Is a string defining the type of event.
 - _`canBubble`_
   - : Is a boolean value deciding whether the event should bubble up through the
     event chain or not. Once set, the read-only property {{ domxref("Event.bubbles") }}
@@ -49,7 +49,7 @@ event.initUIEvent(type, canBubble, cancelable, view, detail)
     event, depending on the type of event. For mouse events, it indicates how many times
     the mouse has been clicked on a given screen location.
 
-## Example
+## Examples
 
 ```js
 var e = document.createEvent("UIEvent");

--- a/files/en-us/web/api/url/createobjecturl/index.md
+++ b/files/en-us/web/api/url/createobjecturl/index.md
@@ -16,7 +16,7 @@ browser-compat: api.URL.createObjectURL
 {{APIRef("URL API")}}
 
 The **`URL.createObjectURL()`** static
-method creates a {{domxref("DOMString")}} containing a URL representing the object
+method creates a string containing a URL representing the object
 given in the parameter.
 
 The URL lifetime is tied to the {{domxref("document")}}
@@ -33,7 +33,7 @@ To release an object URL, call {{domxref("URL.revokeObjectURL", "revokeObjectURL
 ## Syntax
 
 ```js
-const objectURL = URL.createObjectURL(object)
+createObjectURL(object)
 ```
 
 ### Parameters
@@ -44,7 +44,7 @@ const objectURL = URL.createObjectURL(object)
 
 ### Return value
 
-A {{domxref("DOMString")}} containing an object URL that can be used to reference the
+A string containing an object URL that can be used to reference the
 contents of the specified source `object`.
 
 ## Examples

--- a/files/en-us/web/api/url/revokeobjecturl/index.md
+++ b/files/en-us/web/api/url/revokeobjecturl/index.md
@@ -28,14 +28,18 @@ longer.
 ## Syntax
 
 ```js
-URL.revokeObjectURL(objectURL)
+revokeObjectURL(objectURL)
 ```
 
 ### Parameters
 
 - `objectURL`
-  - : A {{domxref("DOMString")}} representing a object URL that was previously created by
+  - : A string representing a object URL that was previously created by
     calling {{domxref("URL.createObjectURL", "createObjectURL()") }}.
+
+### Return value
+
+`undefined`.
 
 ## Examples
 

--- a/files/en-us/web/api/url/tojson/index.md
+++ b/files/en-us/web/api/url/tojson/index.md
@@ -13,7 +13,7 @@ browser-compat: api.URL.toJSON
 {{APIRef("URL API")}}
 
 The **`toJSON()`** method of the {{domxref("URL")}} interface
-returns a {{domxref("USVString")}} containing a serialized version of the URL,
+returns a string containing a serialized version of the URL,
 although in practice it seems to have the same effect as
 {{domxref("URL.toString()")}}.
 
@@ -22,12 +22,12 @@ although in practice it seems to have the same effect as
 ## Syntax
 
 ```js
-const href = url.toJSON()
+toJSON()
 ```
 
 ### Return value
 
-A {{domxref("USVString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/url/tostring/index.md
+++ b/files/en-us/web/api/url/tostring/index.md
@@ -13,7 +13,7 @@ browser-compat: api.URL.toString
 {{ApiRef("URL API")}}
 
 The **`URL.toString()`** {{Glossary("stringifier")}} method returns a
-{{domxref("USVString")}} containing the whole URL. It is effectively a read-only version
+string containing the whole URL. It is effectively a read-only version
 of {{domxref("URL.href")}}.
 
 {{AvailableInWorkers}}
@@ -21,12 +21,12 @@ of {{domxref("URL.href")}}.
 ## Syntax
 
 ```js
-const href = url.toString()
+toString()
 ```
 
 ### Return value
 
-A {{domxref("USVString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/urlpattern/exec/index.md
+++ b/files/en-us/web/api/urlpattern/exec/index.md
@@ -24,22 +24,22 @@ pattern.
 ## Syntax
 
 ```js
-exec(input);
-exec(input, baseURL);
+exec(input)
+exec(input, baseURL)
 ```
 
 ### Parameters
 
 - `input`
   - : The URL or URL parts to match against. This can either be a
-    {{domxref("USVString")}}, or an object providing the individual URL parts.
+    string, or an object providing the individual URL parts.
     The object members can be any of `protocol`, `username`, `password`,
     `hostname`, `port`, `pathname`, `search`, `hash`, or `baseURL`. Omitted
     parts in the object will be treated as empty strings. If the input cannot be
     parsed, or a relative URL without a base is provided, the method will return
     `null`.
 - `baseURL` {{optional_inline}}
-  - : A {{domxref("USVString")}} representing the base URL to use in cases where
+  - : A string representing the base URL to use in cases where
     `input` is a relative URL. If not specified, it defaults to `undefined`. If
     this parameter cannot be parsed, the method will return `null`.
 

--- a/files/en-us/web/api/urlpattern/test/index.md
+++ b/files/en-us/web/api/urlpattern/test/index.md
@@ -23,22 +23,22 @@ the current pattern.
 ## Syntax
 
 ```js
-test(input);
-test(input, baseURL);
+test(input)
+test(input, baseURL)
 ```
 
 ### Parameters
 
 - `input`
   - : The URL or URL parts to match against. This can either be a
-    {{domxref("USVString")}}, or an object providing the individual URL parts.
+    string, or an object providing the individual URL parts.
     The object members can be any of `protocol`, `username`, `password`,
     `hostname`, `port`, `pathname`, `search`, `hash`, or `baseURL`. Omitted
     parts in the object will be treated as empty strings. If the input cannot be
     parsed, or a relative URL without a base is provided, the method will return
     `null`.
 - `baseURL` {{optional_inline}}
-  - : A {{domxref("USVString")}} representing the base URL to use in cases where
+  - : A string representing the base URL to use in cases where
     `input` is a relative URL. If not specified, it defaults to `undefined`. If
     this parameter cannot be parsed, the method will return `false`.
 

--- a/files/en-us/web/api/urlsearchparams/append/index.md
+++ b/files/en-us/web/api/urlsearchparams/append/index.md
@@ -22,7 +22,7 @@ appear in the parameter string multiple times for each value.
 ## Syntax
 
 ```js
-URLSearchParams.append(name, value)
+append(name, value)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/urlsearchparams/delete/index.md
+++ b/files/en-us/web/api/urlsearchparams/delete/index.md
@@ -20,7 +20,7 @@ list of all search parameters.
 ## Syntax
 
 ```js
-URLSearchParams.delete(name)
+delete(name)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/urlsearchparams/entries/index.md
+++ b/files/en-us/web/api/urlsearchparams/entries/index.md
@@ -15,14 +15,14 @@ The **`entries()`** method of the
 {{domxref("URLSearchParams")}} interface returns an
 {{jsxref("Iteration_protocols",'iterator')}} allowing iteration through all key/value
 pairs contained in this object. The iterator returns key/value pairs in the same order as they appear in the query string. The key and value of each pair are
-{{domxref("USVString")}} objects.
+string objects.
 
 {{availableinworkers}}
 
 ## Syntax
 
 ```js
-searchParams.entries();
+entries()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/urlsearchparams/foreach/index.md
+++ b/files/en-us/web/api/urlsearchparams/foreach/index.md
@@ -20,7 +20,7 @@ in this object via a callback function.
 ## Syntax
 
 ```js
-searchParams.forEach(callback);
+forEach(callback)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/urlsearchparams/get/index.md
+++ b/files/en-us/web/api/urlsearchparams/get/index.md
@@ -19,7 +19,7 @@ interface returns the first value associated to the given search parameter.
 ## Syntax
 
 ```js
-URLSearchParams.get(name)
+get(name)
 ```
 
 ### Parameters
@@ -29,7 +29,7 @@ URLSearchParams.get(name)
 
 ### Return value
 
-A {{domxref("USVString")}} if the given search parameter is found; otherwise,
+A string if the given search parameter is found; otherwise,
 **`null`**.
 
 ## Examples

--- a/files/en-us/web/api/urlsearchparams/getall/index.md
+++ b/files/en-us/web/api/urlsearchparams/getall/index.md
@@ -19,7 +19,7 @@ interface returns all the values associated with a given search parameter as an 
 ## Syntax
 
 ```js
-URLSearchParams.getAll(name)
+getAll(name)
 ```
 
 ### Parameters
@@ -29,7 +29,7 @@ URLSearchParams.getAll(name)
 
 ### Return value
 
-An array of {{domxref("USVString")}}s.
+An array of strings.
 
 ## Examples
 

--- a/files/en-us/web/api/urlsearchparams/has/index.md
+++ b/files/en-us/web/api/urlsearchparams/has/index.md
@@ -20,7 +20,7 @@ specified name exists.
 ## Syntax
 
 ```js
-var hasName = URLSearchParams.has(name)
+has(name)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/urlsearchparams/keys/index.md
+++ b/files/en-us/web/api/urlsearchparams/keys/index.md
@@ -13,7 +13,7 @@ browser-compat: api.URLSearchParams.keys
 
 The **`keys()`** method of the {{domxref("URLSearchParams")}}
 interface returns an {{jsxref("Iteration_protocols",'iterator')}} allowing iteration
-through all keys contained in this object. The keys are {{domxref("USVString")}}
+through all keys contained in this object. The keys are string
 objects.
 
 > **Note:** This method is available in [Web Workers](/en-US/docs/Web/API/Web_Workers_API).
@@ -21,7 +21,7 @@ objects.
 ## Syntax
 
 ```js
-searchParams.keys();
+keys()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/urlsearchparams/set/index.md
+++ b/files/en-us/web/api/urlsearchparams/set/index.md
@@ -21,7 +21,7 @@ parameter doesn't exist, this method creates it.
 ## Syntax
 
 ```js
-URLSearchParams.set(name, value)
+set(name, value)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/urlsearchparams/sort/index.md
+++ b/files/en-us/web/api/urlsearchparams/sort/index.md
@@ -22,7 +22,7 @@ preserved).
 ## Syntax
 
 ```js
-searchParams.sort();
+sort()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/urlsearchparams/tostring/index.md
+++ b/files/en-us/web/api/urlsearchparams/tostring/index.md
@@ -24,7 +24,7 @@ URL.
 ## Syntax
 
 ```js
-URLSearchParams.toString()
+toString()
 ```
 
 ### Parameters
@@ -33,7 +33,7 @@ None.
 
 ### Return value
 
-A {{domxref("DOMString")}}, without the question mark. (Returns an empty string if no
+A string, without the question mark. (Returns an empty string if no
 search parameters have been set.)
 
 ## Examples

--- a/files/en-us/web/api/urlsearchparams/values/index.md
+++ b/files/en-us/web/api/urlsearchparams/values/index.md
@@ -14,7 +14,7 @@ browser-compat: api.URLSearchParams.values
 
 The **`values()`** method of the {{domxref("URLsearchParams")}}
 interface returns an {{jsxref("Iteration_protocols",'iterator')}} allowing iteration
-through all values contained in this object. The values are {{domxref("USVString")}}
+through all values contained in this object. The values are string
 objects.
 
 {{availableinworkers}}
@@ -22,7 +22,7 @@ objects.
 ## Syntax
 
 ```js
-searchParams.values();
+values()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/usb/getdevices/index.md
+++ b/files/en-us/web/api/usb/getdevices/index.md
@@ -21,7 +21,7 @@ objects for paired attached devices. For information on pairing devices, see
 ## Syntax
 
 ```js
-USB.getDevices()
+getDevices()
 ```
 
 ### Parameters
@@ -33,7 +33,7 @@ None.
 A {{JSxRef("Promise")}} that resolves with an array of {{DOMxRef("USBDevice")}}
 objects.
 
-## Example
+## Examples
 
 The following example logs the product name and serial number of paired devices to the
 console. For information on pairing devices, see

--- a/files/en-us/web/api/usbdevice/claiminterface/index.md
+++ b/files/en-us/web/api/usbdevice/claiminterface/index.md
@@ -21,7 +21,7 @@ the requested interface is claimed for exclusive access.
 ## Syntax
 
 ```js
-var promise = USBDevice.claimInterface(interfaceNumber)
+claimInterface(interfaceNumber)
 ```
 
 ### Parameters
@@ -34,7 +34,7 @@ var promise = USBDevice.claimInterface(interfaceNumber)
 
 A {{jsxref("promise")}}.
 
-## Example
+## Examples
 
 The following example shows `claimInterface()` in the context of connecting
 to a USB device.

--- a/files/en-us/web/api/usbdevice/clearhalt/index.md
+++ b/files/en-us/web/api/usbdevice/clearhalt/index.md
@@ -23,7 +23,7 @@ terminology) to clear that condition. See the for details.
 ## Syntax
 
 ```js
-var promise = USBDevice.clearHalt(direction, endpointNumber)
+clearHalt(direction, endpointNumber)
 ```
 
 ### Parameters
@@ -39,7 +39,7 @@ var promise = USBDevice.clearHalt(direction, endpointNumber)
 
 A {{jsxref("promise")}}.
 
-## Example
+## Examples
 
 The following example shows how to test for and clear a `'stall'` condition
 in the result of a data transfer.

--- a/files/en-us/web/api/usbdevice/close/index.md
+++ b/files/en-us/web/api/usbdevice/close/index.md
@@ -21,7 +21,7 @@ released and the device session has ended.
 ## Syntax
 
 ```js
-var promise = USBDevice.close()
+close()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/usbdevice/controltransferin/index.md
+++ b/files/en-us/web/api/usbdevice/controltransferin/index.md
@@ -22,7 +22,7 @@ been received from the USB device.
 ## Syntax
 
 ```js
-var promise = USBDevice.controlTransferIn(setup, length)
+controlTransferIn(setup, length)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/usbdevice/controltransferout/index.md
+++ b/files/en-us/web/api/usbdevice/controltransferout/index.md
@@ -22,7 +22,7 @@ transmitted to the USB device.
 ## Syntax
 
 ```js
-var promise = USBDevice.controlTransferOut(setup, data)
+controlTransferOut(setup, data)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/usbdevice/isochronoustransferin/index.md
+++ b/files/en-us/web/api/usbdevice/isochronoustransferin/index.md
@@ -22,7 +22,7 @@ transmitted received from the USB device.
 ## Syntax
 
 ```js
-var promise = USBDevice.isochronousTransferIn(endpointNumber, packetLengths)
+isochronousTransferIn(endpointNumber, packetLengths)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/usbdevice/isochronoustransferout/index.md
+++ b/files/en-us/web/api/usbdevice/isochronoustransferout/index.md
@@ -22,7 +22,7 @@ transmitted to the USB device.
 ## Syntax
 
 ```js
-var promise = USBDevice.isochronousTransferOut(endpointNumber, data, packetLengths)
+isochronousTransferOut(endpointNumber, data, packetLengths)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/usbdevice/open/index.md
+++ b/files/en-us/web/api/usbdevice/open/index.md
@@ -21,7 +21,7 @@ started.
 ## Syntax
 
 ```js
-var promise = USBDevice.open()
+open()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/usbdevice/releaseinterface/index.md
+++ b/files/en-us/web/api/usbdevice/releaseinterface/index.md
@@ -21,7 +21,7 @@ claimed interface is released from exclusive access.
 ## Syntax
 
 ```js
-var promise = USBDevice.releaseInterface(interfaceNumber)
+releaseInterface(interfaceNumber)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/usbdevice/reset/index.md
+++ b/files/en-us/web/api/usbdevice/reset/index.md
@@ -21,7 +21,7 @@ app operations canceled and their promises rejected.
 ## Syntax
 
 ```js
-var promise = USBDevice.reset()
+reset()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/usbdevice/selectalternateinterface/index.md
+++ b/files/en-us/web/api/usbdevice/selectalternateinterface/index.md
@@ -21,7 +21,7 @@ the specified alternative endpoint is selected.
 ## Syntax
 
 ```js
-var promise = USBDevice.selectAlternateInterface(interfaceNumber, alternateSetting)
+selectAlternateInterface(interfaceNumber, alternateSetting)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/usbdevice/selectconfiguration/index.md
+++ b/files/en-us/web/api/usbdevice/selectconfiguration/index.md
@@ -21,7 +21,7 @@ the specified configuration is selected.
 ## Syntax
 
 ```js
-var promise = USBDevice.selectConfiguration(configurationValue)
+selectConfiguration(configurationValue)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/usbdevice/transferin/index.md
+++ b/files/en-us/web/api/usbdevice/transferin/index.md
@@ -22,7 +22,7 @@ device.
 ## Syntax
 
 ```js
-var promise = USBDevice.transferIn(endpointNumber, length)
+transferIn(endpointNumber, length)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/usbdevice/transferout/index.md
+++ b/files/en-us/web/api/usbdevice/transferout/index.md
@@ -22,7 +22,7 @@ device.
 ## Syntax
 
 ```js
-var promise = USBDevice.transferOut(endpointNumber, data)
+transferOut(endpointNumber, data)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/videocolorspace/tojson/index.md
+++ b/files/en-us/web/api/videocolorspace/tojson/index.md
@@ -16,14 +16,14 @@ The **`toJSON()`** method of the {{domxref("VideoColorSpace")}} interface is a _
 ## Syntax
 
 ```js
-VideoColorSpace.toJSON()
+toJSON()
 ```
 
 ### Parameters
 
 None.
 
-### Return Value
+### Return value
 
 A JSON object.
 

--- a/files/en-us/web/api/videodecoder/close/index.md
+++ b/files/en-us/web/api/videodecoder/close/index.md
@@ -16,14 +16,14 @@ The **`close()`** method of the {{domxref("VideoDecoder")}} interface ends all p
 ## Syntax
 
 ```js
-VideoDecoder.close()
+close()
 ```
 
 ### Parameters
 
 None.
 
-### Return Value
+### Return value
 
 {{jsxref('undefined')}}.
 

--- a/files/en-us/web/api/videodecoder/configure/index.md
+++ b/files/en-us/web/api/videodecoder/configure/index.md
@@ -16,7 +16,7 @@ The **`configure()`** method of the {{domxref("VideoDecoder")}} interface enqueu
 ## Syntax
 
 ```js
-VideoDecoder.configure(config)
+configure(config)
 ```
 
 ### Parameters
@@ -63,7 +63,7 @@ VideoDecoder.configure(config)
 
 > **Note:** The registrations in the [WebCodecs Codec Registry](https://www.w3.org/TR/webcodecs-codec-registry/#audio-codec-registry) link to a specification detailing whether and how to populate the optional `description` member.
 
-### Return Value
+### Return value
 
 None.
 

--- a/files/en-us/web/api/videodecoder/decode/index.md
+++ b/files/en-us/web/api/videodecoder/decode/index.md
@@ -16,7 +16,7 @@ The **`decode()`** method of the {{domxref("VideoDecoder")}} interface enqueues 
 ## Syntax
 
 ```js
-VideoDecoder.decode(chunk)
+decode(chunk)
 ```
 
 ### Parameters
@@ -24,7 +24,7 @@ VideoDecoder.decode(chunk)
 - `chunk`
   - : An {{domxref("EncodedVideoChunk")}} object representing a chunk of encoded video.
 
-### Return Value
+### Return value
 
 {{jsxref("Undefined")}}.
 

--- a/files/en-us/web/api/videodecoder/flush/index.md
+++ b/files/en-us/web/api/videodecoder/flush/index.md
@@ -16,14 +16,14 @@ The **`flush()`** method of the {{domxref("VideoDecoder")}} interface returns a 
 ## Syntax
 
 ```js
-VideoDecoder.flush()
+flush()
 ```
 
 ### Parameters
 
 None.
 
-### Return Value
+### Return value
 
 A {{jsxref("Promise")}} that resolves with undefined.
 

--- a/files/en-us/web/api/videodecoder/reset/index.md
+++ b/files/en-us/web/api/videodecoder/reset/index.md
@@ -16,14 +16,14 @@ The **`reset()`** method of the {{domxref("VideoDecoder")}} interface resets all
 ## Syntax
 
 ```js
-VideoDecoder.reset()
+reset()
 ```
 
 ### Parameters
 
 None.
 
-### Return Value
+### Return value
 
 {{jsxref("Undefined")}}.
 

--- a/files/en-us/web/api/videoencoder/close/index.md
+++ b/files/en-us/web/api/videoencoder/close/index.md
@@ -16,14 +16,14 @@ The **`close()`** method of the {{domxref("VideoEncoder")}} interface ends all p
 ## Syntax
 
 ```js
-VideoEncoder.close()
+close()
 ```
 
 ### Parameters
 
 None.
 
-### Return Value
+### Return value
 
 {{jsxref('undefined')}}.
 

--- a/files/en-us/web/api/videoencoder/configure/index.md
+++ b/files/en-us/web/api/videoencoder/configure/index.md
@@ -16,7 +16,7 @@ The **`configure()`** method of the {{domxref("VideoEncoder")}} interface enqueu
 ## Syntax
 
 ```js
-VideoEncoder.configure(config)
+configure(config)
 ```
 
 ### Parameters
@@ -57,7 +57,7 @@ VideoEncoder.configure(config)
         - `"quality"` (default)
         - `"realtime"`
 
-### Return Value
+### Return value
 
 None.
 

--- a/files/en-us/web/api/videoencoder/encode/index.md
+++ b/files/en-us/web/api/videoencoder/encode/index.md
@@ -16,8 +16,8 @@ The **`encode()`** method of the {{domxref("VideoEncoder")}} interface enqueues 
 ## Syntax
 
 ```js
-VideoEncoder.encode(frame);
-VideoEncoder.encode(frame, options);
+encode(frame)
+encode(frame, options)
 ```
 
 ### Parameters
@@ -29,7 +29,7 @@ VideoEncoder.encode(frame, options);
     - `keyFrame`
       - : A {{jsxref("boolean")}}, defaulting to `false` giving the user agent flexibility to decide if this frame should be encoded as a key frame. If `true` this indicates that the given frame must be encoded as a key frame.
 
-### Return Value
+### Return value
 
 {{jsxref("Undefined")}}.
 

--- a/files/en-us/web/api/videoencoder/flush/index.md
+++ b/files/en-us/web/api/videoencoder/flush/index.md
@@ -16,14 +16,14 @@ The **`flush()`** method of the {{domxref("VideoEncoder")}} interface returns a 
 ## Syntax
 
 ```js
-VideoEncoder.flush()
+flush()
 ```
 
 ### Parameters
 
 None.
 
-### Return Value
+### Return value
 
 A {{jsxref("Promise")}} that resolves with undefined.
 

--- a/files/en-us/web/api/videoencoder/reset/index.md
+++ b/files/en-us/web/api/videoencoder/reset/index.md
@@ -16,14 +16,14 @@ The **`reset()`** method of the {{domxref("VideoEncoder")}} interface resets all
 ## Syntax
 
 ```js
-VideoEncoder.reset()
+reset()
 ```
 
 ### Parameters
 
 None.
 
-### Return Value
+### Return value
 
 {{jsxref("Undefined")}}.
 

--- a/files/en-us/web/api/videoframe/allocationsize/index.md
+++ b/files/en-us/web/api/videoframe/allocationsize/index.md
@@ -16,8 +16,8 @@ The **`allocationSize()`** method of the {{domxref("VideoFrame")}} interface ret
 ## Syntax
 
 ```js
-VideoFrame.allocationSize();
-VideoFrame.allocationSize(options);
+allocationSize()
+allocationSize(options)
 ```
 
 ### Parameters
@@ -35,7 +35,7 @@ VideoFrame.allocationSize(options);
         - `offset`: An integer representing the offset in bytes where the given plane begins.
         - `stride`: An integer representing the number of bytes, including padding, used by each row of the plane.
 
-### Return Value
+### Return value
 
 An integer containing the number of bytes needed to hold the frame as specified by `options`.
 

--- a/files/en-us/web/api/videoframe/clone/index.md
+++ b/files/en-us/web/api/videoframe/clone/index.md
@@ -16,14 +16,14 @@ The **`clone()`** method of the {{domxref("VideoFrame")}} interface creates a ne
 ## Syntax
 
 ```js
-VideoFrame.clone()
+clone()
 ```
 
 ### Parameters
 
 None.
 
-### Return Value
+### Return value
 
 The cloned {{domxref("VideoData")}} object.
 

--- a/files/en-us/web/api/videoframe/close/index.md
+++ b/files/en-us/web/api/videoframe/close/index.md
@@ -16,14 +16,14 @@ The **`close()`** method of the {{domxref("VideoFrame")}} interface clears all s
 ## Syntax
 
 ```js
-VideoFrame.close()
+close()
 ```
 
 ### Parameters
 
 None.
 
-### Return Value
+### Return value
 
 Undefined.
 

--- a/files/en-us/web/api/videotracklist/gettrackbyid/index.md
+++ b/files/en-us/web/api/videotracklist/gettrackbyid/index.md
@@ -30,13 +30,13 @@ you know its ID string.
 ## Syntax
 
 ```js
-var theTrack = VideoTrackList.getTrackById(id);
+getTrackById(id)
 ```
 
 ### Parameters
 
 - `id`
-  - : A {{domxref("DOMString")}} indicating the ID of the track to locate within the track
+  - : A string indicating the ID of the track to locate within the track
     list.
 
 ### Return value

--- a/files/en-us/web/api/vrdisplay/geteyeparameters/index.md
+++ b/files/en-us/web/api/vrdisplay/geteyeparameters/index.md
@@ -29,7 +29,7 @@ getEyeParameters(whichEye)
 ### Parameters
 
 - `whichEye`
-  - : A {{domxref("DOMString")}} representing the eye you want to return the eye parameters for. Available values are `left` and `right` (defined in the [VREye enum](https://w3c.github.io/webvr/spec/1.1/#interface-vreye)).
+  - : A string representing the eye you want to return the eye parameters for. Available values are `left` and `right` (defined in the [VREye enum](https://w3c.github.io/webvr/spec/1.1/#interface-vreye)).
 
 ### Return value
 

--- a/files/en-us/web/api/vttcue/getcueashtml/index.md
+++ b/files/en-us/web/api/vttcue/getcueashtml/index.md
@@ -16,7 +16,7 @@ The **`getCueAsHTML()`** method of the {{domxref("VTTCue")}} interface returns a
 ## Syntax
 
 ```js
-VTTCue.getCueAsHTML();
+getCueAsHTML()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/wakelock/request/index.md
+++ b/files/en-us/web/api/wakelock/request/index.md
@@ -19,7 +19,7 @@ locking.
 ## Syntax
 
 ```js
-var wakeLock = navigator.wakeLock.request(type);
+request(type)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/beginquery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/beginquery/index.md
@@ -17,7 +17,7 @@ The **`WebGL2RenderingContext.beginQuery()`** method of the [WebGL 2 API](/en-US
 ## Syntax
 
 ```js
-void gl.beginQuery(target, query);
+beginQuery(target, query)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/begintransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/begintransformfeedback/index.md
@@ -18,7 +18,7 @@ feedback operation.
 ## Syntax
 
 ```js
-void gl.beginTransformFeedback(primitiveMode);
+beginTransformFeedback(primitiveMode)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/bindbufferbase/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/bindbufferbase/index.md
@@ -19,7 +19,7 @@ The **`WebGL2RenderingContext.bindBufferBase()`** method of the
 ## Syntax
 
 ```js
-void gl.bindBufferBase(target, index, buffer);
+bindBufferBase(target, index, buffer)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/bindbufferrange/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/bindbufferrange/index.md
@@ -19,7 +19,7 @@ the [WebGL 2 API](/en-US/docs/Web/API/WebGL_API) binds a range of a given
 ## Syntax
 
 ```js
-void gl.bindBufferRange(target, index, buffer, offset, size);
+bindBufferRange(target, index, buffer, offset, size)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/bindsampler/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/bindsampler/index.md
@@ -17,7 +17,7 @@ passed {{domxref("WebGLSampler")}} object to the texture unit at the passed inde
 ## Syntax
 
 ```js
-void gl.bindSampler(unit, sampler);
+bindSampler(unit, sampler)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/bindtransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/bindtransformfeedback/index.md
@@ -18,7 +18,7 @@ passed {{domxref("WebGLTransformFeedback")}} object to the current GL state.
 ## Syntax
 
 ```js
-void gl.bindTransformFeedback(target, transformFeedback);
+bindTransformFeedback(target, transformFeedback)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/bindvertexarray/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/bindvertexarray/index.md
@@ -18,7 +18,7 @@ passed {{domxref("WebGLVertexArrayObject")}} object to the buffer.
 ## Syntax
 
 ```js
-void gl.bindVertexArray(vertexArray);
+bindVertexArray(vertexArray)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/blitframebuffer/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/blitframebuffer/index.md
@@ -19,9 +19,9 @@ using {{domxref("WebGLRenderingContext.bindFramebuffer()")}}.
 ## Syntax
 
 ```js
-void gl.blitFramebuffer(srcX0, srcY0, srcX1, srcY1,
-                        dstX0, dstY0, dstX1, dstY1,
-                        mask, filter);
+blitFramebuffer(srcX0, srcY0, srcX1, srcY1,
+                dstX0, dstY0, dstX1, dstY1,
+                mask, filter);
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/clientwaitsync/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/clientwaitsync/index.md
@@ -18,7 +18,7 @@ The **`WebGL2RenderingContext.clientWaitSync()`** method of the
 ## Syntax
 
 ```js
-GLenum gl.clientWaitSync(sync, flags, timeout);
+clientWaitSync(sync, flags, timeout)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/compressedtexsubimage3d/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/compressedtexsubimage3d/index.md
@@ -18,10 +18,11 @@ three-dimensional sub-rectangle for a texture image in a compressed format.
 ## Syntax
 
 ```js
-// read from the buffer bound to gl.PIXEL_UNPACK_BUFFER
-void gl.compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, offset);
+compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, offset)
 
-void gl.compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, ArrayBufferView srcData, optional srcOffset, optional srcLengthOverride);
+compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, srcData)
+compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, srcData, srcOffset)
+compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, srcData, srcOffset, srcLengthOverride)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/copybuffersubdata/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/copybuffersubdata/index.md
@@ -18,7 +18,7 @@ buffer to another buffer.
 ## Syntax
 
 ```js
-void gl.copyBufferSubData(readTarget, writeTarget, readOffset, writeOffset, size);
+copyBufferSubData(readTarget, writeTarget, readOffset, writeOffset, size)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/copytexsubimage3d/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/copytexsubimage3d/index.md
@@ -18,7 +18,7 @@ the [WebGL API](/en-US/docs/Web/API/WebGL_API) copies pixels from the current
 ## Syntax
 
 ```js
-void gl.copyTexSubImage3D(target, level, xoffset, yoffset, zoffset, x, y, width, height);
+copyTexSubImage3D(target, level, xoffset, yoffset, zoffset, x, y, width, height)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/createquery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/createquery/index.md
@@ -18,7 +18,7 @@ information.
 ## Syntax
 
 ```js
-WebGLQuery gl.createQuery();
+createQuery()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/createsampler/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/createsampler/index.md
@@ -18,7 +18,7 @@ The **`WebGL2RenderingContext.createSampler()`** method of the
 ## Syntax
 
 ```js
-WebGLSampler gl.createSampler();
+createSampler()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/createtransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/createtransformfeedback/index.md
@@ -18,7 +18,7 @@ initializes {{domxref("WebGLTransformFeedback")}} objects.
 ## Syntax
 
 ```js
-WebGLTransformFeedback gl.createTransformFeedback();
+createTransformFeedback()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/createvertexarray/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/createvertexarray/index.md
@@ -20,7 +20,7 @@ data.
 ## Syntax
 
 ```js
-WebGLVertexArrayObject gl.createVertexArray();
+createVertexArray()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/deletequery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/deletequery/index.md
@@ -17,7 +17,7 @@ The **`WebGL2RenderingContext.deleteQuery()`** method of the [WebGL 2 API](/en-U
 ## Syntax
 
 ```js
-void gl.deleteQuery(query);
+deleteQuery(query)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/deletesampler/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/deletesampler/index.md
@@ -18,7 +18,7 @@ The **`WebGL2RenderingContext.deleteSampler()`** method of the
 ## Syntax
 
 ```js
-void gl.deleteSampler(sampler);
+deleteSampler(sampler)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/deletesync/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/deletesync/index.md
@@ -17,7 +17,7 @@ The **`WebGL2RenderingContext.deleteSync()`** method of the [WebGL 2 API](/en-US
 ## Syntax
 
 ```js
-void gl.deleteSync(sync);
+deleteSync(sync)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/deletetransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/deletetransformfeedback/index.md
@@ -18,7 +18,7 @@ method of the [WebGL 2 API](/en-US/docs/Web/API/WebGL_API) deletes a given
 ## Syntax
 
 ```js
-void gl.deleteTransformFeedback(transformFeedback);
+deleteTransformFeedback(transformFeedback)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/deletevertexarray/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/deletevertexarray/index.md
@@ -18,7 +18,7 @@ the [WebGL 2 API](/en-US/docs/Web/API/WebGL_API) deletes a given
 ## Syntax
 
 ```js
-void gl.deleteVertexArray(vertexArray);
+deleteVertexArray(vertexArray)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/drawarraysinstanced/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/drawarraysinstanced/index.md
@@ -23,7 +23,7 @@ method. In addition, it can execute multiple instances of the range of elements.
 ## Syntax
 
 ```js
-void gl.drawArraysInstanced(mode, first, count, instanceCount);
+drawArraysInstanced(mode, first, count, instanceCount)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/drawbuffers/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/drawbuffers/index.md
@@ -18,7 +18,7 @@ currently bound framebuffer or the drawingbuffer if no framebuffer is bound.
 ## Syntax
 
 ```js
-void gl.drawBuffers(buffers);
+drawBuffers(buffers)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/drawelementsinstanced/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/drawelementsinstanced/index.md
@@ -24,7 +24,7 @@ of elements.
 ## Syntax
 
 ```js
-void gl.drawElementsInstanced(mode, count, type, offset, instanceCount);
+drawElementsInstanced(mode, count, type, offset, instanceCount)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/drawrangeelements/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/drawrangeelements/index.md
@@ -18,7 +18,7 @@ data in a given range.
 ## Syntax
 
 ```js
-void gl.drawRangeElements(mode, start, end, count, type, offset);
+drawRangeElements(mode, start, end, count, type, offset)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/endquery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/endquery/index.md
@@ -17,7 +17,7 @@ target.
 ## Syntax
 
 ```js
-void gl.endQuery(target);
+endQuery(target)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/endtransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/endtransformfeedback/index.md
@@ -18,7 +18,7 @@ operation.
 ## Syntax
 
 ```js
-void gl.endTransformFeedback();
+endTransformFeedback()
 ```
 
 ### Parameters


### PR DESCRIPTION
Continuing #14857 

## Summary
Updating the method pages to follow the current templates:
https://developer.mozilla.org/en-US/docs/MDN/Structures/Syntax_sections#constructors_and_methods
https://developer.mozilla.org/en-US/docs/MDN/Structures/Page_types/API_method_subpage_template

Changes Include:
- fix syntax section
- changing section titles to suggested titles in the template
- change `{{DOMxRef("DOMString")}}` to `string`
- remove extra spaces in between words and extra trailing spaces
- other small corrections

### Metadata
- [x] Fixes a typo, bug, or other error
