### PR TITLE
Update yield docs

### DIFF
--- a/files/en-us/web/javascript/reference/operators/yield/index.md
+++ b/files/en-us/web/javascript/reference/operators/yield/index.md
@@ -105,7 +105,7 @@ console.log(appleStore.next())      // { value: undefined, done: true }
 ```
 
 You can also send a value with `next(value)` into the generator. `step` evaluates as a
-return value in this syntax `[_rv_] = **yield** [expression]`. Although a value passed
+return value in this syntax `[_rv_] = **yield** [expression]` — although a value passed
 to the generator's `next()` method is ignored the first time `next()` is called.
 
 ```js

--- a/files/en-us/web/javascript/reference/operators/yield/index.md
+++ b/files/en-us/web/javascript/reference/operators/yield/index.md
@@ -104,16 +104,16 @@ console.log(appleStore.next())      // { value: 5, done: false }
 console.log(appleStore.next())      // { value: undefined, done: true }
 ```
 
-You can also send a value with next(value) into the generator. 'step' evaluates as a
-return value in this syntax \[_rv_] = **yield**
-\[_expression_]
+You can also send a value with `next(value)` into the generator. `step` evaluates as a
+return value in this syntax `[_rv_] = **yield** [expression]`. Although a value passed
+to the generator's `next()` method is ignored the first time `next()` is called.
 
 ```js
 function* counter(value) {
  let step;
 
  while (true) {
-   step = yield ++value;
+   step = yield value++;
 
    if (step) {
      value += step;
@@ -122,6 +122,7 @@ function* counter(value) {
 }
 
 const generatorFunc = counter(0);
+console.log(generatorFunc.next().value);   // 0
 console.log(generatorFunc.next().value);   // 1
 console.log(generatorFunc.next().value);   // 2
 console.log(generatorFunc.next().value);   // 3


### PR DESCRIPTION
`yield ++value` resulted in the first call to `generatorFunc.next().value` returning `1`. While this is reasonable I suggest that post-incrementing `value` provides two important benefits.

Teaching the iterator to yield its initial value as the first result offers a clean interface for consuming the iterator result value. The initial value is then treated like every other value from the counter. Eg, consider a user interface which displays the counter value. With `++value`, a special case is necessary to display the current value or the initial value. Using `value++` eliminates this case.

The post-increment also accounts for the way the initial value provided to `next()` is dropped. So, in the original example, the first call to `console.log(generatorFunc.next().value);` would always log `1` regardless of the value passed to `next()`. I got tripped up when the first `.next().value` yielded `1` and ignored the `step` value.

Overall the existing example is sufficient but these couple small changes could help pilot newcomers away from gotchas.

Related, I had trouble visualizing where execution paused/resumed. A bit of logging helped a lot: https://replit.com/@MattSeeley/TechnicalSeveralPlot#index.js. A tidy visualization of the execution flow could be really meaningful to folks. Then again, the MDN example was simple and adding logging myself helped me grok the flow.

Thanks for considering the edits. :)

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
