### PR TITLE
Interactive Example in margin-block, margin-inline & ruby-position

### DIFF
--- a/files/en-us/web/css/margin-block/index.md
+++ b/files/en-us/web/css/margin-block/index.md
@@ -14,6 +14,17 @@ browser-compat: css.properties.margin-block
 
 The **`margin-block`** [CSS](/en-US/docs/Web/CSS) [shorthand property](/en-US/docs/Web/CSS/Shorthand_properties) defines the logical block start and end margins of an element, which maps to physical margins depending on the element's writing mode, directionality, and text orientation.
 
+{{EmbedInteractiveExample("pages/css/margin-block.html")}}
+
+## Constituent properties
+
+This property is a shorthand for the following CSS properties:
+
+- {{cssxref("margin-block-start")}}
+- {{cssxref("margin-block-end")}}
+
+## Syntax
+
 ```css
 /* <length> values */
 margin-block: 10px 20px;  /* An absolute length */
@@ -33,15 +44,6 @@ margin-block: unset;
 ```
 
 This property corresponds to the {{CSSxRef("margin-top")}} and {{CSSxRef("margin-bottom")}}, or the {{CSSxRef("margin-right")}} and {{CSSxRef("margin-left")}} properties, depending on the values defined for {{CSSxRef("writing-mode")}}, {{CSSxRef("direction")}}, and {{CSSxRef("text-orientation")}}.
-
-## Constituent properties
-
-This property is a shorthand for the following CSS properties:
-
-- {{cssxref("margin-block-start")}}
-- {{cssxref("margin-block-end")}}
-
-## Syntax
 
 The `margin-block` property may be specified using one or two values.
 

--- a/files/en-us/web/css/margin-inline/index.md
+++ b/files/en-us/web/css/margin-inline/index.md
@@ -14,6 +14,17 @@ browser-compat: css.properties.margin-inline
 
 The **`margin-inline`** [CSS](/en-US/docs/Web/CSS) [shorthand property](/en-US/docs/Web/CSS/Shorthand_properties) is a shorthand property that defines both the logical inline start and end margins of an element, which maps to physical margins depending on the element's writing mode, directionality, and text orientation.
 
+{{EmbedInteractiveExample("pages/css/margin-inline.html")}}
+
+## Constituent properties
+
+This property is a shorthand for the following CSS properties:
+
+- {{cssxref("margin-inline-start")}}
+- {{cssxref("margin-inline-end")}}
+
+## Syntax
+
 ```css
 /* <length> values */
 margin-inline: 10px 20px;  /* An absolute length */
@@ -33,15 +44,6 @@ margin-inline: unset;
 ```
 
 This property corresponds to the {{CSSxRef("margin-top")}} and {{CSSxRef("margin-bottom")}}, or the {{CSSxRef("margin-right")}} and {{CSSxRef("margin-left")}} properties, depending on the values defined for {{CSSxRef("writing-mode")}}, {{CSSxRef("direction")}}, and {{CSSxRef("text-orientation")}}.
-
-## Constituent properties
-
-This property is a shorthand for the following CSS properties:
-
-- {{cssxref("margin-inline-start")}}
-- {{cssxref("margin-inline-end")}}
-
-## Syntax
 
 The `margin-inline` property may be specified using one or two values.
 

--- a/files/en-us/web/css/ruby-position/index.md
+++ b/files/en-us/web/css/ruby-position/index.md
@@ -13,6 +13,8 @@ browser-compat: css.properties.ruby-position
 
 The **`ruby-position`** CSS property defines the position of a ruby element relatives to its base element. It can be positioned over the element (`over`), under it (`under`), or between the characters on their right side (`inter-character`).
 
+{{EmbedInteractiveExample("pages/css/ruby-position.html")}}
+
 ## Syntax
 
 ```css


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Added [margin-block](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-block) & [margin-inline](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline) from [PR #2098](https://github.com/mdn/interactive-examples/pull/2098) and [ruby-position](https://developer.mozilla.org/en-US/docs/Web/CSS/ruby-position) from [PR #2099](https://github.com/mdn/interactive-examples/pull/2099).

I have moved "Constituent properties" up, because that's how it is ordered in [padding](https://developer.mozilla.org/en-US/docs/Web/CSS/padding#constituent_properties) and [margin](https://developer.mozilla.org/en-US/docs/Web/CSS/margin).
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
