### PR TITLE
Deprecated viewport at-rule

### DIFF
--- a/files/en-us/web/css/@document/index.md
+++ b/files/en-us/web/css/@document/index.md
@@ -5,6 +5,7 @@ tags:
   - At-rule
   - CSS
   - Reference
+  - Deprecated
 browser-compat: css.at-rules.document
 ---
 {{CSSRef}}{{Deprecated_header}}

--- a/files/en-us/web/css/@property/index.md
+++ b/files/en-us/web/css/@property/index.md
@@ -8,6 +8,7 @@ tags:
   - Web
   - Property
   - Houdini
+  - Experimental
 browser-compat: css.at-rules.property
 ---
 {{CSSRef}}{{SeeCompatTable}}

--- a/files/en-us/web/css/@scroll-timeline/index.md
+++ b/files/en-us/web/css/@scroll-timeline/index.md
@@ -7,6 +7,7 @@ tags:
   - At-rule
   - CSS
   - Reference
+  - Experimental
 browser-compat: css.at-rules.scroll-timeline
 ---
 

--- a/files/en-us/web/css/@viewport/index.md
+++ b/files/en-us/web/css/@viewport/index.md
@@ -5,7 +5,7 @@ tags:
   - '@viewport'
   - At-rule
   - CSS
-  - Experimental
+  - Deprecated
   - Layout
   - Mobile
   - Reference


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
It looks like I forgot about this in previous PR about Experimental flags. Since [@viewport](https://developer.mozilla.org/en-US/docs/Web/CSS/@viewport) is deprecated, this change should make trash bin icon be shown next to its name, instead of experimental icon.

@teoli2003 
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
