### PR TITLE
WebAPI: Update Method pages to modern structure (part 18)

### DIFF
--- a/files/en-us/web/api/webglrenderingcontext/getcontextattributes/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getcontextattributes/index.md
@@ -18,7 +18,7 @@ parameters. Might return {{jsxref("null")}}, if the context is lost.
 ## Syntax
 
 ```js
-gl.getContextAttributes();
+getContextAttributes()
 ```
 
 ### Return value

--- a/files/en-us/web/api/webglrenderingcontext/geterror/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/geterror/index.md
@@ -16,7 +16,7 @@ The **`WebGLRenderingContext.getError()`** method of the [WebGL API](/en-US/docs
 ## Syntax
 
 ```js
-GLenum gl.getError();
+getError()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/getextension/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getextension/index.md
@@ -17,7 +17,7 @@ The **`WebGLRenderingContext.getExtension()`** method enables a
 ## Syntax
 
 ```js
-gl.getExtension(name);
+getExtension(name)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/getframebufferattachmentparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getframebufferattachmentparameter/index.md
@@ -19,7 +19,7 @@ about a framebuffer's attachment.
 ## Syntax
 
 ```js
-any gl.getFramebufferAttachmentParameter(target, attachment, pname);
+getFramebufferAttachmentParameter(target, attachment, pname)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/getparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getparameter/index.md
@@ -17,7 +17,7 @@ parameter name.
 ## Syntax
 
 ```js
-any gl.getParameter(pname);
+getParameter(pname)
 ```
 
 ### Parameters
@@ -416,7 +416,7 @@ You can query the following `pname` parameters when using a
     </tr>
     <tr>
       <td><code>gl.RENDERER</code></td>
-      <td>{{domxref("DOMString")}}</td>
+      <td>string</td>
       <td></td>
     </tr>
     <tr>
@@ -451,7 +451,7 @@ You can query the following `pname` parameters when using a
     </tr>
     <tr>
       <td><code>gl.SHADING_LANGUAGE_VERSION</code></td>
-      <td>{{domxref("DOMString")}}</td>
+      <td>string</td>
       <td></td>
     </tr>
     <tr>
@@ -576,12 +576,12 @@ You can query the following `pname` parameters when using a
     </tr>
     <tr>
       <td><code>gl.VENDOR</code></td>
-      <td>{{domxref("DOMString")}}</td>
+      <td>string</td>
       <td></td>
     </tr>
     <tr>
       <td><code>gl.VERSION</code></td>
-      <td>{{domxref("DOMString")}}</td>
+      <td>string</td>
       <td></td>
     </tr>
     <tr>

--- a/files/en-us/web/api/webglrenderingcontext/getprograminfolog/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getprograminfolog/index.md
@@ -18,7 +18,7 @@ occurred during failed linking or validation of `WebGLProgram` objects.
 ## Syntax
 
 ```js
-gl.getProgramInfoLog(program);
+getProgramInfoLog(program)
 ```
 
 ### Parameters
@@ -28,7 +28,7 @@ gl.getProgramInfoLog(program);
 
 ### Return value
 
-A {{domxref("DOMString")}} that contains diagnostic messages, warning messages, and
+A string that contains diagnostic messages, warning messages, and
 other information about the last linking or validation operation. When a
 {{domxref("WebGLProgram")}} object is initially created, its information log will be a
 string of length 0.

--- a/files/en-us/web/api/webglrenderingcontext/getprogramparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getprogramparameter/index.md
@@ -19,7 +19,7 @@ given program.
 ## Syntax
 
 ```js
-any gl.getProgramParameter(program, pname);
+getProgramParameter(program, pname)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/getrenderbufferparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getrenderbufferparameter/index.md
@@ -18,7 +18,7 @@ about the renderbuffer.
 ## Syntax
 
 ```js
-any gl.getRenderbufferParameter(target, pname);
+getRenderbufferParameter(target, pname)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/getshaderinfolog/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getshaderinfolog/index.md
@@ -18,7 +18,7 @@ compile information.
 ## Syntax
 
 ```js
-gl.getShaderInfoLog(shader);
+getShaderInfoLog(shader)
 ```
 
 ### Parameters
@@ -28,7 +28,7 @@ gl.getShaderInfoLog(shader);
 
 ### Return value
 
-A {{domxref("DOMString")}} that contains diagnostic messages, warning messages, and
+A string that contains diagnostic messages, warning messages, and
 other information about the last compile operation. When a {{domxref("WebGLShader")}}
 object is initially created, its information log will be a string of length 0.
 

--- a/files/en-us/web/api/webglrenderingcontext/getshaderparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getshaderparameter/index.md
@@ -18,7 +18,7 @@ given shader.
 ## Syntax
 
 ```js
-any gl.getShaderParameter(shader, pname);
+getShaderParameter(shader, pname)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/getshaderprecisionformat/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getshaderprecisionformat/index.md
@@ -20,7 +20,7 @@ the specified shader numeric format.
 ## Syntax
 
 ```js
-WebGLShaderPrecisionFormat gl.getShaderPrecisionFormat(shaderType, precisionType);
+getShaderPrecisionFormat(shaderType, precisionType)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/getshadersource/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getshadersource/index.md
@@ -13,12 +13,12 @@ browser-compat: api.WebGLRenderingContext.getShaderSource
 
 The **`WebGLRenderingContext.getShaderSource()`** method of the
 [WebGL API](/en-US/docs/Web/API/WebGL_API) returns the source code of a
-{{domxref("WebGLShader")}} as a {{domxref("DOMString")}}.
+{{domxref("WebGLShader")}} as a string.
 
 ## Syntax
 
 ```js
-DOMString gl.getShaderSource(shader);
+getShaderSource(shader)
 ```
 
 ### Parameters
@@ -28,7 +28,7 @@ DOMString gl.getShaderSource(shader);
 
 ### Return value
 
-A {{domxref("DOMString")}} containing the source code of the shader.
+A string containing the source code of the shader.
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/getsupportedextensions/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getsupportedextensions/index.md
@@ -18,7 +18,7 @@ extensions.
 ## Syntax
 
 ```js
-gl.getSupportedExtensions();
+getSupportedExtensions()
 ```
 
 ### Return value

--- a/files/en-us/web/api/webglrenderingcontext/gettexparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/gettexparameter/index.md
@@ -19,7 +19,7 @@ given texture.
 ## Syntax
 
 ```js
-any gl.getTexParameter(target, pname);
+getTexParameter(target, pname)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/getuniform/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getuniform/index.md
@@ -17,7 +17,7 @@ variable at a given location.
 ## Syntax
 
 ```js
-any gl.getUniform(program, location);
+getUniform(program, location)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.md
@@ -46,7 +46,7 @@ The uniform itself is declared in the shader program using GLSL.
 ## Syntax
 
 ```js
-WebGLUniformLocation = WebGLRenderingContext.getUniformLocation(program, name);
+getUniformLocation(program, name)
 ```
 
 ### Parameters
@@ -55,7 +55,7 @@ WebGLUniformLocation = WebGLRenderingContext.getUniformLocation(program, name);
   - : The {{domxref("WebGLProgram")}} in which to locate the specified uniform variable.
 - `name`
 
-  - : A {{domxref("DOMString")}} specifying the name of the uniform variable whose
+  - : A string specifying the name of the uniform variable whose
     location is to be returned. The name can't have any whitespace in it, and you
     can't use this function to get the location of any uniforms starting with the
     reserved string `"gl_"`, since those are internal to the WebGL
@@ -102,7 +102,7 @@ The following errors may occur; to check for errors after
   - : The `program` parameter doesn't correspond to a GLSL program generated
     by WebGL, or the specified program hasn't been linked successfully.
 
-## Example
+## Examples
 
 In this example, taken from the `animateScene()` method in the article [A
 basic 2D WebGL animation example](/en-US/docs/Web/API/WebGL_API/Basic_2D_animation_example#Drawing_and_animating_the_scene), obtains the locations of three uniforms from

--- a/files/en-us/web/api/webglrenderingcontext/getvertexattrib/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getvertexattrib/index.md
@@ -18,7 +18,7 @@ attribute at a given position.
 ## Syntax
 
 ```js
-any gl.getVertexAttrib(index, pname);
+getVertexAttrib(index, pname)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/getvertexattriboffset/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getvertexattriboffset/index.md
@@ -18,7 +18,7 @@ specified vertex attribute.
 ## Syntax
 
 ```js
-GLintptr gl.getVertexAttribOffset(index, pname);
+getVertexAttribOffset(index, pname)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/hint/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/hint/index.md
@@ -17,7 +17,7 @@ behaviors. The interpretation of these hints depend on the implementation.
 ## Syntax
 
 ```js
-void gl.hint(target, mode);
+hint(target, mode)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/isbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/isbuffer/index.md
@@ -17,7 +17,7 @@ passed {{domxref("WebGLBuffer")}} is valid and `false` otherwise.
 ## Syntax
 
 ```js
-GLboolean gl.isBuffer(buffer);
+isBuffer(buffer)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/iscontextlost/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/iscontextlost/index.md
@@ -22,7 +22,7 @@ must be re-established before rendering can resume.
 ## Syntax
 
 ```js
-let isLost = gl.isContextLost();
+isContextLost()
 ```
 
 ### Return value

--- a/files/en-us/web/api/webglrenderingcontext/isenabled/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/isenabled/index.md
@@ -20,7 +20,7 @@ By default, all capabilities except `gl.DITHER` are
 ## Syntax
 
 ```js
-GLboolean gl.isEnabled(cap);
+isEnabled(cap)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/isframebuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/isframebuffer/index.md
@@ -18,7 +18,7 @@ passed {{domxref("WebGLFramebuffer")}} is valid and `false` otherwise.
 ## Syntax
 
 ```js
-GLboolean gl.isFramebuffer(framebuffer);
+isFramebuffer(framebuffer)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/isprogram/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/isprogram/index.md
@@ -17,7 +17,7 @@ passed {{domxref("WebGLProgram")}} is valid, `false` otherwise.
 ## Syntax
 
 ```js
-GLboolean gl.isProgram(program);
+isProgram(program)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/isrenderbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/isrenderbuffer/index.md
@@ -18,7 +18,7 @@ passed {{domxref("WebGLRenderbuffer")}} is valid and `false` otherwise.
 ## Syntax
 
 ```js
-GLboolean gl.isRenderbuffer(renderbuffer);
+isRenderbuffer(renderbuffer)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/isshader/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/isshader/index.md
@@ -17,7 +17,7 @@ passed {{domxref("WebGLShader")}} is valid, `false` otherwise.
 ## Syntax
 
 ```js
-GLboolean gl.isShader(shader);
+isShader(shader)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/istexture/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/istexture/index.md
@@ -17,7 +17,7 @@ passed {{domxref("WebGLTexture")}} is valid and `false` otherwise.
 ## Syntax
 
 ```js
-GLboolean gl.isTexture(texture);
+isTexture(texture)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/linewidth/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/linewidth/index.md
@@ -26,7 +26,7 @@ lines.
 ## Syntax
 
 ```js
-void gl.lineWidth(width);
+lineWidth(width)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/linkprogram/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/linkprogram/index.md
@@ -19,7 +19,7 @@ program's fragment and vertex shaders.
 ## Syntax
 
 ```js
-void gl.linkProgram(program);
+linkProgram(program)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/pixelstorei/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/pixelstorei/index.md
@@ -16,7 +16,7 @@ The **`WebGLRenderingContext.pixelStorei()`** method of the [WebGL API](/en-US/d
 ## Syntax
 
 ```js
-void gl.pixelStorei(pname, param);
+pixelStorei(pname, param)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/polygonoffset/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/polygonoffset/index.md
@@ -21,7 +21,7 @@ into the depth buffer.
 ## Syntax
 
 ```js
-void gl.polygonOffset(factor, units);
+polygonOffset(factor, units)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/readpixels/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/readpixels/index.md
@@ -19,11 +19,12 @@ specified rectangle of the current color framebuffer into an
 
 ```js
 // WebGL1:
-void gl.readPixels(x, y, width, height, format, type, pixels);
+readPixels(x, y, width, height, format, type, pixels)
 
 // WebGL2:
-void gl.readPixels(x, y, width, height, format, type, GLintptr offset);
-void gl.readPixels(x, y, width, height, format, type, ArrayBufferView pixels, GLuint dstOffset);
+readPixels(x, y, width, height, format, type, offset)
+readPixels(x, y, width, height, format, type, pixels)
+readPixels(x, y, width, height, format, type, pixels, dstOffset)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/renderbufferstorage/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/renderbufferstorage/index.md
@@ -18,7 +18,7 @@ renderbuffer object's data store.
 ## Syntax
 
 ```js
-void gl.renderbufferStorage(target, internalFormat, width, height);
+renderbufferStorage(target, internalFormat, width, height)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/samplecoverage/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/samplecoverage/index.md
@@ -18,7 +18,7 @@ parameters for anti-aliasing effects.
 ## Syntax
 
 ```js
-void gl.sampleCoverage(value, invert);
+sampleCoverage(value, invert)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/scissor/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/scissor/index.md
@@ -17,7 +17,7 @@ the drawing to a specified rectangle.
 ## Syntax
 
 ```js
-void gl.scissor(x, y, width, height);
+scissor(x, y, width, height)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/shadersource/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/shadersource/index.md
@@ -17,7 +17,7 @@ The **`WebGLRenderingContext.shaderSource()`** method of the [WebGL API](/en-US/
 ## Syntax
 
 ```js
-void gl.shaderSource(shader, source);
+shaderSource(shader, source)
 ```
 
 ### Parameters
@@ -25,7 +25,7 @@ void gl.shaderSource(shader, source);
 - shader
   - : A {{domxref("WebGLShader")}} object in which to set the source code.
 - source
-  - : A {{domxref("DOMString")}} containing the GLSL source code to set.
+  - : A string containing the GLSL source code to set.
 
 ### Return value
 

--- a/files/en-us/web/api/webglrenderingcontext/stencilfunc/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilfunc/index.md
@@ -20,7 +20,7 @@ multipass rendering to achieve special effects.
 ## Syntax
 
 ```js
-void gl.stencilFunc(func, ref, mask);
+stencilFunc(func, ref, mask)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/stencilfuncseparate/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilfuncseparate/index.md
@@ -21,7 +21,7 @@ multipass rendering to achieve special effects.
 ## Syntax
 
 ```js
-void gl.stencilFuncSeparate(face, func, ref, mask);
+stencilFuncSeparate(face, func, ref, mask)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/stencilmask/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilmask/index.md
@@ -20,7 +20,7 @@ back stencil writemasks to different values.
 ## Syntax
 
 ```js
-void gl.stencilMask(mask);
+stencilMask(mask)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/stencilmaskseparate/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilmaskseparate/index.md
@@ -21,7 +21,7 @@ and back stencil writemasks to one value at the same time.
 ## Syntax
 
 ```js
-void gl.stencilMaskSeparate(face, mask);
+stencilMaskSeparate(face, mask)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/stencilop/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilop/index.md
@@ -17,7 +17,7 @@ stencil test actions.
 ## Syntax
 
 ```js
-void gl.stencilOp(fail, zfail, zpass);
+stencilOp(fail, zfail, zpass)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/stencilopseparate/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilopseparate/index.md
@@ -18,7 +18,7 @@ back-facing stencil test actions.
 ## Syntax
 
 ```js
-void gl.stencilOpSeparate(face, fail, zfail, zpass);
+stencilOpSeparate(face, fail, zfail, zpass)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/teximage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/teximage2d/index.md
@@ -18,22 +18,17 @@ image.
 ## Syntax
 
 ```js
-// WebGL1:
-void gl.texImage2D(target, level, internalformat, width, height, border, format, type, ArrayBufferView? pixels);
-void gl.texImage2D(target, level, internalformat, format, type, ImageData? pixels);
-void gl.texImage2D(target, level, internalformat, format, type, HTMLImageElement? pixels);
-void gl.texImage2D(target, level, internalformat, format, type, HTMLCanvasElement? pixels);
-void gl.texImage2D(target, level, internalformat, format, type, HTMLVideoElement? pixels);
-void gl.texImage2D(target, level, internalformat, format, type, ImageBitmap? pixels);
+// WebGL1
+texImage2D(target, level, internalformat, width, height, border, format, type)
+texImage2D(target, level, internalformat, width, height, border, format, type, pixels) // pixels is instance of ArrayBufferView
+texImage2D(target, level, internalformat, format, type)
+texImage2D(target, level, internalformat, format, type, pixels)
 
-// WebGL2:
-void gl.texImage2D(target, level, internalformat, width, height, border, format, type, GLintptr offset);
-void gl.texImage2D(target, level, internalformat, width, height, border, format, type, HTMLCanvasElement source);
-void gl.texImage2D(target, level, internalformat, width, height, border, format, type, HTMLImageElement source);
-void gl.texImage2D(target, level, internalformat, width, height, border, format, type, HTMLVideoElement source);
-void gl.texImage2D(target, level, internalformat, width, height, border, format, type, ImageBitmap source);
-void gl.texImage2D(target, level, internalformat, width, height, border, format, type, ImageData source);
-void gl.texImage2D(target, level, internalformat, width, height, border, format, type, ArrayBufferView srcData, srcOffset);
+
+// WebGL2
+texImage2D(target, level, internalformat, width, height, border, format, type, offset)
+texImage2D(target, level, internalformat, width, height, border, format, type, source)
+texImage2D(target, level, internalformat, width, height, border, format, type, srcData, srcOffset)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/texparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/texparameter/index.md
@@ -18,8 +18,8 @@ the [WebGL API](/en-US/docs/Web/API/WebGL_API) set texture parameters.
 ## Syntax
 
 ```js
-void gl.texParameterf(GLenum target, GLenum pname, GLfloat param);
-void gl.texParameteri(GLenum target, GLenum pname, GLint param);
+texParameterf(target, GLenum pname, GLfloat param)
+texParameteri(target, GLenum pname, GLint param)
 ```
 
 ### Parameters
@@ -36,10 +36,13 @@ void gl.texParameteri(GLenum target, GLenum pname, GLint param);
       - `gl.TEXTURE_3D`: A three-dimensional texture.
       - `gl.TEXTURE_2D_ARRAY`: A two-dimensional array texture.
 
-The `pname` parameter is a {{domxref("WebGL_API/Types", "GLenum")}} specifying the texture
-parameter to set. The `param` parameter is a {{domxref("WebGL_API/Types", "GLfloat")}} or
-{{domxref("WebGL_API/Types", "GLint")}} specifying the value for the specified parameter
-`pname`.
+- param
+  - : The `param` parameter is a {{domxref("WebGL_API/Types", "GLfloat")}} or
+    {{domxref("WebGL_API/Types", "GLint")}} specifying the value for the specified parameter
+
+- pname
+  - : The `pname` parameter is a {{domxref("WebGL_API/Types", "GLenum")}} specifying the texture
+  parameter to set. 
 
 <table class="standard-table">
   <thead>

--- a/files/en-us/web/api/webglrenderingcontext/texsubimage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/texsubimage2d/index.md
@@ -19,22 +19,14 @@ current texture.
 ## Syntax
 
 ```js
-// WebGL 1:
-void gl.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, ArrayBufferView? pixels);
-void gl.texSubImage2D(target, level, xoffset, yoffset, format, type, ImageData? pixels);
-void gl.texSubImage2D(target, level, xoffset, yoffset, format, type, HTMLImageElement? pixels);
-void gl.texSubImage2D(target, level, xoffset, yoffset, format, type, HTMLCanvasElement? pixels);
-void gl.texSubImage2D(target, level, xoffset, yoffset, format, type, HTMLVideoElement? pixels);
-void gl.texSubImage2D(target, level, xoffset, yoffset, format, type, ImageBitmap? pixels);
+// WebGL1
+texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels) // pixels is instance of ArrayBufferView
+texSubImage2D(target, level, xoffset, yoffset, format, type, pixels)
 
-// WebGL 2:
-void gl.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, GLintptr offset);
-void gl.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, HTMLCanvasElement source);
-void gl.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, HTMLImageElement source);
-void gl.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, HTMLVideoElement source);
-void gl.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, ImageBitmap source);
-void gl.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, ImageData source);
-void gl.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, ArrayBufferView srcData, srcOffset);
+// WebGL2
+texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, offset)
+texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, source)
+texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels, srcOffset)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/uniform/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/uniform/index.md
@@ -25,25 +25,25 @@ object, when they are once again initialized to 0.
 ## Syntax
 
 ```js
-void gl.uniform1f(location, v0);
-void gl.uniform1fv(location, value);
-void gl.uniform1i(location, v0);
-void gl.uniform1iv(location, value);
+uniform1f(location, v0)
+uniform1fv(location, value)
+uniform1i(location, v0)
+uniform1iv(location, value)
 
-void gl.uniform2f(location, v0, v1);
-void gl.uniform2fv(location, value);
-void gl.uniform2i(location, v0, v1);
-void gl.uniform2iv(location, value);
+uniform2f(location, v0, v1)
+uniform2fv(location, value)
+uniform2i(location, v0, v1)
+uniform2iv(location, value)
 
-void gl.uniform3f(location, v0, v1, v2);
-void gl.uniform3fv(location, value);
-void gl.uniform3i(location, v0, v1, v2);
-void gl.uniform3iv(location, value);
+uniform3f(location, v0, v1, v2)
+uniform3fv(location, value)
+uniform3i(location, v0, v1, v2)
+uniform3iv(location, value)
 
-void gl.uniform4f(location, v0, v1, v2, v3);
-void gl.uniform4fv(location, value);
-void gl.uniform4i(location, v0, v1, v2, v3);
-void gl.uniform4iv(location, value);
+uniform4f(location, v0, v1, v2, v3)
+uniform4fv(location, value)
+uniform4i(location, v0, v1, v2, v3)
+uniform4iv(location, value)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/uniformmatrix/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/uniformmatrix/index.md
@@ -31,9 +31,9 @@ expected to have 4, 9 or 16 floats.
 ## Syntax
 
 ```js
-WebGLRenderingContext.uniformMatrix2fv(location, transpose, value);
-WebGLRenderingContext.uniformMatrix3fv(location, transpose, value);
-WebGLRenderingContext.uniformMatrix4fv(location, transpose, value);
+uniformMatrix2fv(location, transpose, value)
+uniformMatrix3fv(location, transpose, value)
+uniformMatrix4fv(location, transpose, value)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/useprogram/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/useprogram/index.md
@@ -17,7 +17,7 @@ The **`WebGLRenderingContext.useProgram()`** method of the [WebGL API](/en-US/do
 ## Syntax
 
 ```js
-void gl.useProgram(program);
+useProgram(program)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/validateprogram/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/validateprogram/index.md
@@ -19,7 +19,7 @@ used in the current WebGL state.
 ## Syntax
 
 ```js
-void gl.validateProgram(program);
+validateProgram(program)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/vertexattrib/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattrib/index.md
@@ -18,15 +18,15 @@ values for generic vertex attributes.
 ## Syntax
 
 ```js
-void gl.vertexAttrib1f(index, v0);
-void gl.vertexAttrib2f(index, v0, v1);
-void gl.vertexAttrib3f(index, v0, v1, v2);
-void gl.vertexAttrib4f(index, v0, v1, v2, v3);
+vertexAttrib1f(index, v0)
+vertexAttrib2f(index, v0, v1)
+vertexAttrib3f(index, v0, v1, v2)
+vertexAttrib4f(index, v0, v1, v2, v3)
 
-void gl.vertexAttrib1fv(index, value);
-void gl.vertexAttrib2fv(index, value);
-void gl.vertexAttrib3fv(index, value);
-void gl.vertexAttrib4fv(index, value);
+vertexAttrib1fv(index, value)
+vertexAttrib2fv(index, value)
+vertexAttrib3fv(index, value)
+vertexAttrib4fv(index, value)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.md
@@ -20,7 +20,7 @@ buffer object and specifies its layout.
 ## Syntax
 
 ```js
-void gl.vertexAttribPointer(index, size, type, normalized, stride, offset);
+vertexAttribPointer(index, size, type, normalized, stride, offset)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/viewport/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/viewport/index.md
@@ -18,7 +18,7 @@ coordinates.
 ## Syntax
 
 ```js
-void gl.viewport(x, y, width, height);
+viewport(x, y, width, height)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/websocket/close/index.md
+++ b/files/en-us/web/api/websocket/close/index.md
@@ -20,15 +20,9 @@ already `CLOSED`, this method does nothing.
 ## Syntax
 
 ```js
-WebSocket.close();
-```
-
-```js
-WebSocket.close(code);
-```
-
-```js
-WebSocket.close(code, reason);
+close()
+close(code)
+close(code, reason)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/websocket/send/index.md
+++ b/files/en-us/web/api/websocket/send/index.md
@@ -21,7 +21,7 @@ The browser will throw an exception if you call `send()` when the connection is 
 ## Syntax
 
 ```js
-WebSocket.send("Hello server!");
+send(data)
 ```
 
 ### Parameters
@@ -30,7 +30,7 @@ WebSocket.send("Hello server!");
 
   - : The data to send to the server. It may be one of the following types:
 
-    - {{domxref("USVString")}}
+    - string
       - : A text string. The string is added to the buffer in UTF-8 format, and the value
         of `bufferedAmount` is increased by the number of bytes required to
         represent the UTF-8 string.

--- a/files/en-us/web/api/window/alert/index.md
+++ b/files/en-us/web/api/window/alert/index.md
@@ -19,7 +19,8 @@ Under some conditions — for example, when the user switches tabs — the brows
 ## Syntax
 
 ```js
-window.alert(message);
+alert()
+alert(message)
 ```
 
 ### Parameters
@@ -28,7 +29,11 @@ window.alert(message);
   - : A string you want to display in the alert dialog, or, alternatively, an object that
     is converted into a string and displayed.
 
-## Example
+### Return value
+
+`undefined`.
+
+## Examples
 
 ```js
 window.alert("Hello world!");

--- a/files/en-us/web/api/window/back/index.md
+++ b/files/en-us/web/api/window/back/index.md
@@ -23,7 +23,7 @@ Firefox-specific method and was removed in Firefox 31.
 ## Syntax
 
 ```js
-window.back();
+back()
 ```
 
 ### Parameters
@@ -34,7 +34,7 @@ None.
 
 `undefined`.
 
-## Example
+## Examples
 
 This simple example handles a click on a "Back" button by calling `back()`.
 

--- a/files/en-us/web/api/window/blur/index.md
+++ b/files/en-us/web/api/window/blur/index.md
@@ -15,10 +15,14 @@ Shifts focus away from the window.
 ## Syntax
 
 ```js
-window.blur()
+blur()
 ```
 
-## Example
+### Return value
+
+`undefined`.
+
+## Examples
 
 ```js
 window.blur();

--- a/files/en-us/web/api/window/cancelanimationframe/index.md
+++ b/files/en-us/web/api/window/cancelanimationframe/index.md
@@ -21,7 +21,7 @@ animation frame request previously scheduled through a call to
 ## Syntax
 
 ```js
-window.cancelAnimationFrame(requestID);
+cancelAnimationFrame(requestID)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/window/cancelidlecallback/index.md
+++ b/files/en-us/web/api/window/cancelidlecallback/index.md
@@ -22,7 +22,7 @@ previously scheduled with {{domxref("window.requestIdleCallback()")}}.
 ## Syntax
 
 ```js
-window.cancelIdleCallback(handle);
+cancelIdleCallback(handle)
 ```
 
 ### Parameters
@@ -35,7 +35,7 @@ window.cancelIdleCallback(handle);
 
 `undefined`.
 
-## Example
+## Examples
 
 See our [complete example](/en-US/docs/Web/API/Background_Tasks_API#example)
 in the article [Cooperative Scheduling

--- a/files/en-us/web/api/window/captureevents/index.md
+++ b/files/en-us/web/api/window/captureevents/index.md
@@ -16,8 +16,11 @@ capture all events of the specified type.
 ## Syntax
 
 ```js
-window.captureEvents(eventType)
+captureEvents(eventType)
 ```
+### Parameters
+
+-`eventType`
 
 `eventType` is a combination of the following values:
 `Event.ABORT`, `Event.BLUR`, `Event.CLICK`,
@@ -29,7 +32,7 @@ window.captureEvents(eventType)
 `Event.RESET`, `Event.RESIZE`, `Event.SELECT`,
 `Event.SUBMIT`, `Event.UNLOAD`.
 
-## Example
+## Examples
 
 ```html
 <!DOCTYPE html>

--- a/files/en-us/web/api/window/clearimmediate/index.md
+++ b/files/en-us/web/api/window/clearimmediate/index.md
@@ -21,10 +21,13 @@ This method clears the action specified by {{DOMxRef("window.setImmediate")}}.
 ## Syntax
 
 ```js
-window.clearImmediate( immediateID )
+clearImmediate( immediateID )
 ```
+### Parameters
 
-where immediateID is a ID returned by {{DOMxRef("window.setImmediate")}}.
+- immediateID 
+
+  - : The ID returned by {{DOMxRef("window.setImmediate")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/window/clearimmediate/index.md
+++ b/files/en-us/web/api/window/clearimmediate/index.md
@@ -21,11 +21,11 @@ This method clears the action specified by {{DOMxRef("window.setImmediate")}}.
 ## Syntax
 
 ```js
-clearImmediate( immediateID )
+clearImmediate(immediateID)
 ```
 ### Parameters
 
-- immediateID 
+- `immediateID`
 
   - : The ID returned by {{DOMxRef("window.setImmediate")}}.
 

--- a/files/en-us/web/api/window/close/index.md
+++ b/files/en-us/web/api/window/close/index.md
@@ -27,7 +27,7 @@ objects returned by
 ## Syntax
 
 ```js
-window.close();
+close()
 ```
 
 ## Examples

--- a/files/en-us/web/api/window/confirm/index.md
+++ b/files/en-us/web/api/window/confirm/index.md
@@ -19,7 +19,7 @@ Under some conditions — for example, when the user switches tabs — the brows
 ## Syntax
 
 ```js
-result = window.confirm(message);
+confirm(message)
 ```
 
 ### Parameters
@@ -33,7 +33,7 @@ A boolean indicating whether OK (`true`) or Cancel (`false`) was
 selected. If a browser is ignoring in-page dialogs, then the returned value is always
 `false`.
 
-## Example
+## Examples
 
 ```js
 if (window.confirm("Do you really want to leave?")) {

--- a/files/en-us/web/api/window/dump/index.md
+++ b/files/en-us/web/api/window/dump/index.md
@@ -18,9 +18,7 @@ Output from `dump()` is _not_ sent to the browser's developer tools console. To 
 ## Syntax
 
 ```js
-window.dump(message);
-
-dump(message);
+dump(message)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/window/find/index.md
+++ b/files/en-us/web/api/window/find/index.md
@@ -27,6 +27,8 @@ find(aString, aCaseSensitive, aBackwards, aWrapAround,
      aWholeWord, aSearchInFrames, aShowDialog)
 ```
 
+### Parameters
+
 - `aString`
   - : The text string for which to search.
 - `aCaseSensitive`

--- a/files/en-us/web/api/window/find/index.md
+++ b/files/en-us/web/api/window/find/index.md
@@ -23,8 +23,8 @@ The **`Window.find()`** method finds a string in a window sequentially.
 ## Syntax
 
 ```js
-window.find(aString, aCaseSensitive, aBackwards, aWrapAround,
-            aWholeWord, aSearchInFrames, aShowDialog);
+find(aString, aCaseSensitive, aBackwards, aWrapAround,
+     aWholeWord, aSearchInFrames, aShowDialog)
 ```
 
 - `aString`
@@ -41,11 +41,11 @@ window.find(aString, aCaseSensitive, aBackwards, aWrapAround,
 - `aSearchInFrames`
   - : A boolean value. If `true`, specifies a search in frames.
 
-### Returns
+### Return value
 
 `true` if the string is found; otherwise, `false`.
 
-## Example
+## Examples
 
 ### JavaScript
 

--- a/files/en-us/web/api/window/focus/index.md
+++ b/files/en-us/web/api/window/focus/index.md
@@ -16,10 +16,10 @@ Makes a request to bring the window to the front. It may fail due to user settin
 ## Syntax
 
 ```js
-window.focus()
+focus()
 ```
 
-## Example
+## Examples
 
 ```js
 if (clicked) { window.focus(); }

--- a/files/en-us/web/api/window/forward/index.md
+++ b/files/en-us/web/api/window/forward/index.md
@@ -21,7 +21,7 @@ Moves the window one document forward in history. This was a Firefox-specific me
 ## Syntax
 
 ```js
-window.forward();
+forward()
 ```
 
 ### Parameters
@@ -32,7 +32,7 @@ None
 
 `undefined`.
 
-## Example
+## Examples
 
 ```js
 function goForward() {

--- a/files/en-us/web/api/window/getcomputedstyle/index.md
+++ b/files/en-us/web/api/window/getcomputedstyle/index.md
@@ -27,13 +27,17 @@ getComputedStyle(element)
 getComputedStyle(element, pseudoElt)
 ```
 
+### Parameters
+
 - `element`
   - : The {{DOMxRef("Element")}} for which to get the computed style.
 - `pseudoElt`{{Optional_Inline}}
   - : A string specifying the pseudo-element to match. Omitted (or `null`) for
     real elements.
 
-The returned `style` is a _live_ {{DOMxRef("CSSStyleDeclaration")}}
+### Return value
+
+A _live_ {{DOMxRef("CSSStyleDeclaration")}}
 object, which updates automatically when the element's styles are changed.
 
 ### Throws

--- a/files/en-us/web/api/window/getcomputedstyle/index.md
+++ b/files/en-us/web/api/window/getcomputedstyle/index.md
@@ -23,8 +23,8 @@ indexing with CSS property names.
 ## Syntax
 
 ```js
-window.getComputedStyle(element);
-window.getComputedStyle(element, pseudoElt);
+getComputedStyle(element)
+getComputedStyle(element, pseudoElt)
 ```
 
 - `element`

--- a/files/en-us/web/api/window/getselection/index.md
+++ b/files/en-us/web/api/window/getselection/index.md
@@ -20,7 +20,7 @@ the current position of the caret.
 ## Syntax
 
 ```js
-selection = window.getSelection();
+getSelection()
 ```
 
 ### Return value

--- a/files/en-us/web/api/window/matchmedia/index.md
+++ b/files/en-us/web/api/window/matchmedia/index.md
@@ -23,7 +23,7 @@ media query.
 ## Syntax
 
 ```js
-mqList = window.matchMedia(mediaQueryString)
+matchMedia(mediaQueryString)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/window/moveby/index.md
+++ b/files/en-us/web/api/window/moveby/index.md
@@ -21,7 +21,7 @@ interface moves the current window by a specified amount.
 ## Syntax
 
 ```js
-window.moveBy(deltaX, deltaY)
+moveBy(deltaX, deltaY)
 ```
 
 ### Parameters
@@ -31,7 +31,7 @@ window.moveBy(deltaX, deltaY)
 - `deltaY` is the amount of pixels to move the window vertically. Positive
   values are down, while negative values are up.
 
-## Example
+## Examples
 
 This example moves the window 10 pixels to the right and 10 pixels up.
 

--- a/files/en-us/web/api/window/moveto/index.md
+++ b/files/en-us/web/api/window/moveto/index.md
@@ -21,7 +21,7 @@ interface moves the current window to the specified coordinates.
 ## Syntax
 
 ```js
-window.moveTo(x, y)
+moveTo(x, y)
 ```
 
 ### Parameters
@@ -29,7 +29,7 @@ window.moveTo(x, y)
 - `x` is the horizontal coordinate to be moved to.
 - `y` is the vertical coordinate to be moved to.
 
-## Example
+## Examples
 
 This example moves the window to the top-left corner of the screen.
 

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -19,10 +19,10 @@ The **`open()`** method of the {{domxref('Window')}} interface loads a specified
 ## Syntax
 
 ```js
-open();
-open(url);
-open(url, target);
-open(url, target, windowFeatures);
+open()
+open(url)
+open(url, target)
+open(url, target, windowFeatures)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/window/postmessage/index.md
+++ b/files/en-us/web/api/window/postmessage/index.md
@@ -31,8 +31,8 @@ receiving window is then free to [handle this event](/en-US/docs/Web/Events/Even
 ## Syntax
 
 ```js
-targetWindow.postMessage(message, targetOrigin)
-targetWindow.postMessage(message, targetOrigin, transfer)
+postMessage(message, targetOrigin)
+postMessage(message, targetOrigin, transfer)
 ```
 
 ### Parameters
@@ -149,7 +149,7 @@ See also {{jsxref("Global_Objects/SharedArrayBuffer/Planned_changes", "Planned c
   to shared memory", "", 1)}} which is starting to roll out to browsers (Firefox 79, for
 example).
 
-## Example
+## Examples
 
 ```js
 /*

--- a/files/en-us/web/api/window/print/index.md
+++ b/files/en-us/web/api/window/print/index.md
@@ -20,7 +20,7 @@ This method will block while the print dialog is open.
 ## Syntax
 
 ```js
-window.print()
+print()
 ```
 
 ## Specifications

--- a/files/en-us/web/api/window/prompt/index.md
+++ b/files/en-us/web/api/window/prompt/index.md
@@ -20,7 +20,9 @@ Under some conditions — for example, when the user switches tabs — the brows
 ## Syntax
 
 ```js
-result = window.prompt(message, default);
+prompt()
+prompt(message)
+prompt(message, default)
 ```
 
 ### Parameters
@@ -37,7 +39,7 @@ result = window.prompt(message, default);
 
 A string containing the text entered by the user, or `null`.
 
-## Example
+## Examples
 
 ```js
 let sign = prompt("What's your sign?");

--- a/files/en-us/web/api/window/releaseevents/index.md
+++ b/files/en-us/web/api/window/releaseevents/index.md
@@ -19,10 +19,14 @@ Releases the window from trapping events of a specific type.
 ## Syntax
 
 ```js
-window.releaseEvents(eventType)
+releaseEvents(eventType)
 ```
 
-`eventType` is a combination of the following values:
+### Parameters
+
+- `eventType`
+
+  - : `eventType` is a combination of the following values:
 `Event.ABORT`, `Event.BLUR`, `Event.CLICK`,
 `Event.CHANGE`, `Event.DBLCLICK`, `Event.DRAGDDROP`,
 `Event.ERROR`, `Event.FOCUS`, `Event.KEYDOWN`,
@@ -32,7 +36,7 @@ window.releaseEvents(eventType)
 `Event.RESET`, `Event.RESIZE`, `Event.SELECT`,
 `Event.SUBMIT`, `Event.UNLOAD`.
 
-## Example
+## Examples
 
 ```js
 window.releaseEvents(Event.KEYPRESS)

--- a/files/en-us/web/api/window/requestanimationframe/index.md
+++ b/files/en-us/web/api/window/requestanimationframe/index.md
@@ -55,7 +55,7 @@ timestamp is a decimal number, in milliseconds, but with a minimal precision of 
 ## Syntax
 
 ```js
-window.requestAnimationFrame(callback);
+requestAnimationFrame(callback)
 ```
 
 ### Parameters
@@ -74,7 +74,7 @@ in the callback list. This is a non-zero value, but you may not make any other
 assumptions about its value. You can pass this value to
 {{domxref("window.cancelAnimationFrame()")}} to cancel the refresh callback request.
 
-## Example
+## Examples
 
 In this example, an element is animated for 2 seconds (2000 milliseconds). The element
 moves at a speed of 0.1px/ms to the right, so its relative position (in CSS pixels) can

--- a/files/en-us/web/api/window/requestidlecallback/index.md
+++ b/files/en-us/web/api/window/requestidlecallback/index.md
@@ -32,14 +32,9 @@ loop.
 ## Syntax
 
 ```js
-window.requestIdleCallback(callback);
-window.requestIdleCallback(callback, options);
+requestIdleCallback(callback)
+requestIdleCallback(callback, options)
 ```
-
-### Return value
-
-An ID which can be used to cancel the callback by passing it into the
-{{domxref("window.cancelIdleCallback()")}} method.
 
 ### Parameters
 
@@ -54,7 +49,12 @@ An ID which can be used to cancel the callback by passing it into the
 
     - `timeout`: If the number of milliseconds represented by this parameter has elapsed and the callback has not already been called, then a task to execute the callback is queued in the event loop (even if doing so risks causing a negative performance impact). `timeout` must be a positive value or it is ignored.
 
-## Example
+### Return value
+
+An ID which can be used to cancel the callback by passing it into the
+{{domxref("window.cancelIdleCallback()")}} method.
+
+## Examples
 
 See our [complete example](/en-US/docs/Web/API/Background_Tasks_API#example)
 in the article [Cooperative Scheduling

--- a/files/en-us/web/api/window/resizeby/index.md
+++ b/files/en-us/web/api/window/resizeby/index.md
@@ -18,7 +18,7 @@ by a specified amount.
 ## Syntax
 
 ```js
-window.resizeBy(xDelta, yDelta)
+resizeBy(xDelta, yDelta)
 ```
 
 ### Parameters
@@ -26,7 +26,7 @@ window.resizeBy(xDelta, yDelta)
 - `xDelta` is the number of pixels to grow the window horizontally.
 - `yDelta` is the number of pixels to grow the window vertically.
 
-## Example
+## Examples
 
 ```js
 // Shrink the window

--- a/files/en-us/web/api/window/resizeto/index.md
+++ b/files/en-us/web/api/window/resizeto/index.md
@@ -17,7 +17,7 @@ window.
 ## Syntax
 
 ```js
-window.resizeTo(width, height)
+resizeTo(width, height)
 ```
 
 ### Parameters
@@ -30,7 +30,7 @@ window.resizeTo(width, height)
     {{domxref("window.outerHeight","outerHeight")}} in pixels (including scroll bars,
     title bars, etc).
 
-## Example
+## Examples
 
 This function resizes the window so that it takes up one quarter of the available
 screen. See the {{domxref("Screen.availWidth")}} and {{domxref("Screen.availHeight")}}

--- a/files/en-us/web/api/window/scroll/index.md
+++ b/files/en-us/web/api/window/scroll/index.md
@@ -17,8 +17,8 @@ particular place in the document.
 ## Syntax
 
 ```js
-window.scroll(x-coord, y-coord)
-window.scroll(options)
+scroll(x-coord, y-coord)
+scroll(options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/window/scrollby/index.md
+++ b/files/en-us/web/api/window/scrollby/index.md
@@ -16,8 +16,8 @@ window by the given amount.
 ## Syntax
 
 ```js
-window.scrollBy(x-coord, y-coord);
-window.scrollBy(options)
+scrollBy(x-coord, y-coord)
+scrollBy(options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/window/scrollbylines/index.md
+++ b/files/en-us/web/api/window/scrollbylines/index.md
@@ -18,7 +18,7 @@ the specified number of lines.
 ## Syntax
 
 ```js
-window.scrollByLines(lines)
+scrollByLines(lines)
 ```
 
 ### Parameters
@@ -26,7 +26,7 @@ window.scrollByLines(lines)
 - `lines` is the number of lines to scroll the document by. It may be a
   positive or negative integer.
 
-## Example
+## Examples
 
 ```html
 <!-- Scroll up the document by 5 lines -->

--- a/files/en-us/web/api/window/scrollbypages/index.md
+++ b/files/en-us/web/api/window/scrollbypages/index.md
@@ -20,7 +20,7 @@ document by the specified number of pages.
 ## Syntax
 
 ```js
-window.scrollByPages(pages)
+scrollByPages(pages)
 ```
 
 ### Parameters
@@ -28,7 +28,7 @@ window.scrollByPages(pages)
 - `pages` is the number of pages to scroll. It may be a positive or
   negative integer.
 
-## Example
+## Examples
 
 ```js
 // scroll down the document by 1 page

--- a/files/en-us/web/api/window/scrollto/index.md
+++ b/files/en-us/web/api/window/scrollto/index.md
@@ -17,8 +17,8 @@ coordinates in the document.
 ## Syntax
 
 ```js
-window.scrollTo(x-coord, y-coord)
-window.scrollTo(options)
+scrollTo(x-coord, y-coord)
+scrollTo(options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/window/sizetocontent/index.md
+++ b/files/en-us/web/api/window/sizetocontent/index.md
@@ -22,10 +22,10 @@ being too small for the user to interact with.
 ## Syntax
 
 ```js
-window.sizeToContent()
+sizeToContent()
 ```
 
-## Example
+## Examples
 
 ```js
 window.sizeToContent();

--- a/files/en-us/web/api/window/stop/index.md
+++ b/files/en-us/web/api/window/stop/index.md
@@ -23,10 +23,10 @@ objects.
 ## Syntax
 
 ```js
-window.stop()
+stop()
 ```
 
-## Example
+## Examples
 
 ```js
 window.stop();

--- a/files/en-us/web/api/window/updatecommands/index.md
+++ b/files/en-us/web/api/window/updatecommands/index.md
@@ -21,10 +21,10 @@ Updates the state of commands of the current chrome window (UI).
 ## Syntax
 
 ```js
-window.updateCommands("sCommandName")
+updateCommands("sCommandName")
 ```
 
-## Parameters
+### Parameters
 
 - `sCommandName` is a particular string which describes what kind of update event this is (e.g. whether we are in bold right now).
 

--- a/files/en-us/web/api/window/webkitconvertpointfromnodetopage/index.md
+++ b/files/en-us/web/api/window/webkitconvertpointfromnodetopage/index.md
@@ -29,7 +29,7 @@ non-standard and _should not be used_.
 ## Syntax
 
 ```js
-Point = Window.convertPointFromNodeToPage(node, nodePoint);
+convertPointFromNodeToPage(node, nodePoint)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/window/webkitconvertpointfrompagetonode/index.md
+++ b/files/en-us/web/api/window/webkitconvertpointfrompagetonode/index.md
@@ -1,5 +1,5 @@
 ---
-title: Window.convertPointFromPageToNode
+title: Window.convertPointFromPageToNode()
 slug: Web/API/Window/webkitConvertPointFromPageToNode
 tags:
   - API
@@ -28,7 +28,7 @@ system of the specified DOM {{domxref("Node")}}.
 ## Syntax
 
 ```js
-Point = Window.convertPointFromPageToNode(node, pagePoint);
+convertPointFromPageToNode(node, pagePoint)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/windowcontrolsoverlay/gettitlebararearect/index.md
+++ b/files/en-us/web/api/windowcontrolsoverlay/gettitlebararearect/index.md
@@ -18,7 +18,7 @@ This only applies to Progressive Web Apps installed on desktop operating systems
 ## Syntax
 
 ```js
-getTitlebarAreaRect();
+getTitlebarAreaRect()
 ```
 
 ### Return value

--- a/files/en-us/web/api/worker/terminate/index.md
+++ b/files/en-us/web/api/worker/terminate/index.md
@@ -17,18 +17,18 @@ The **`terminate()`** method of the {{domxref("Worker")}} interface immediately 
 ## Syntax
 
 ```js
-myWorker.terminate();
+terminate()
 ```
 
 ### Parameters
 
 None.
 
-### Returns
+### Return value
 
 {{jsxref('undefined')}}.
 
-## Example
+## Examples
 
 The following code snippet shows creation of a {{domxref("Worker")}} object using the {{domxref("Worker.Worker", "Worker()")}} constructor, which is then immediately terminated.
 

--- a/files/en-us/web/api/workerglobalscope/dump/index.md
+++ b/files/en-us/web/api/workerglobalscope/dump/index.md
@@ -19,7 +19,7 @@ Output from `dump()` is _not_ sent to the browser's developer tools console. To 
 ## Syntax
 
 ```js
-dump(message);
+dump(message)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/workerlocation/tostring/index.md
+++ b/files/en-us/web/api/workerlocation/tostring/index.md
@@ -11,12 +11,12 @@ browser-compat: api.WorkerLocation.toString
 ---
 {{ApiRef("WorkerLocation")}}
 
-The **`toString()`** {{Glossary("stringifier")}} method of a {{domxref("WorkerLocation")}} object returns a {{domxref("USVString")}} containing the serialized {{domxref("URL")}} for the worker's location. It is a synonym for {{domxref("WorkerLocation.href")}}.
+The **`toString()`** {{Glossary("stringifier")}} method of a {{domxref("WorkerLocation")}} object returns a string containing the serialized {{domxref("URL")}} for the worker's location. It is a synonym for {{domxref("WorkerLocation.href")}}.
 
 ## Syntax
 
 ```js
-string = location.toString();
+toString()
 ```
 
 ## Examples

--- a/files/en-us/web/api/worklet/addmodule/index.md
+++ b/files/en-us/web/api/worklet/addmodule/index.md
@@ -24,8 +24,8 @@ adds it to the current `Worklet`.
 ## Syntax
 
 ```js
-addPromise = worklet.addModule(moduleURL);
-addPromise = worklet.addModule(moduleURL, options);
+addModule(moduleURL)
+addModule(moduleURL, options)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/writablestream/abort/index.md
+++ b/files/en-us/web/api/writablestream/abort/index.md
@@ -17,13 +17,13 @@ The **`abort()`** method of the {{domxref("WritableStream")}} interface aborts t
 ## Syntax
 
 ```js
-writableStream.abort(reason)
+abort(reason)
 ```
 
 ### Parameters
 
 - `reason`
-  - : A {{domxref("DOMString")}} providing a human-readable reason for the abort.
+  - : A string providing a human-readable reason for the abort.
 
 ### Return value
 


### PR DESCRIPTION
Continuing #14857 

## Summary
Updating the method pages to follow the current templates:
https://developer.mozilla.org/en-US/docs/MDN/Structures/Syntax_sections#constructors_and_methods
https://developer.mozilla.org/en-US/docs/MDN/Structures/Page_types/API_method_subpage_template

Changes Include:
- fix syntax section
- changing section titles to suggested titles in the template
- change `{{DOMxRef("DOMString")}}` to `string`
- remove extra spaces in between words and extra trailing spaces
- other small corrections

### Metadata
- [x] Fixes a typo, bug, or other error
