### PR TITLE
Add arguments object & Intl.Segments to iterables list; note NodeList

### DIFF
--- a/files/en-us/web/javascript/reference/iteration_protocols/index.md
+++ b/files/en-us/web/javascript/reference/iteration_protocols/index.md
@@ -164,7 +164,7 @@ console.log(someString + ''); // "hi"
 
 ### Built-in iterables
 
-{{jsxref("String")}}, {{jsxref("Array")}}, {{jsxref("TypedArray")}}, {{jsxref("Map")}}, and {{jsxref("Set")}} are all built-in iterables, because each of their prototype objects implements an `@@iterator` method.
+{{jsxref("String")}}, {{jsxref("Array")}}, {{jsxref("TypedArray")}}, {{jsxref("Map")}}, {{jsxref("Set")}}, and {{jsxref("Intl.Segments")}} are all built-in iterables, because each of their prototype objects implements an `@@iterator` method. In addition, the [`arguments`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments) object and some DOM collection types such as {{domxref("NodeList")}} are also iterables.
 
 ### User-defined iterables
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/15203. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segments/@@iterator and http://localhost:3000/en-US/docs/Web/JavaScript/Reference/Functions/arguments/@@iterator and see https://dom.spec.whatwg.org/#interface-nodelist and https://webidl.spec.whatwg.org/#idl-iterable (the WebIDL `iterable` notation maps to the ES `@@iterator` property).