### PR TITLE
Add DOMException (in WebSocket.*)

### DIFF
--- a/files/en-us/web/api/websocket/close/index.md
+++ b/files/en-us/web/api/websocket/close/index.md
@@ -42,9 +42,9 @@ close(code, reason)
 
 ### Exceptions
 
-- `InvalidAccessError`
+- `InvalidAccessError` {{domxref("DOMException")}}
   - : Thrown if [`code`](#code) is neither an integer equal to `1000` nor an integer in the range `3000`–`4999`.
-- `SyntaxError`
+- `SyntaxError`  {{domxref("DOMException")}}
   - : Thrown if the UTF-8-encoded [`reason`](#reason) value is longer than 123 bytes.
 
 ## Specifications

--- a/files/en-us/web/api/websocket/send/index.md
+++ b/files/en-us/web/api/websocket/send/index.md
@@ -50,7 +50,7 @@ send(data)
 
 ### Exceptions
 
-- `InvalidStateError`
+- `InvalidStateError`  {{domxref("DOMException")}}
   - : Thrown if {{domxref("WebSocket/readyState", "WebSocket.readyState")}} is `CONNECTING`.
 
 ## Specifications

--- a/files/en-us/web/api/websocket/websocket/index.md
+++ b/files/en-us/web/api/websocket/websocket/index.md
@@ -37,7 +37,7 @@ new WebSocket(url, protocols)
 
 ### Exceptions
 
-- [`SyntaxError`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError)
+- `SyntaxError` {{domxref("DOMException")}}
   - : Thrown if:
     - parsing of [`url`](#url) fails
     - [`url`](#url) has a scheme other than `ws` or `wss`


### PR DESCRIPTION
Fixes the _Exceptions_ sections by linking to `DOMException` (and fixing the link for `SyntaxError` that was wrong (double-checked in the spec that it is really a `DOMException` that is raised in that case.