### PR TITLE
Modernize the structure of TimeRanges.start()/end()

### DIFF
--- a/files/en-us/web/api/timeranges/end/index.md
+++ b/files/en-us/web/api/timeranges/end/index.md
@@ -6,14 +6,13 @@ tags:
   - HTML DOM
   - Media
   - Method
-  - NeedsBrowserCompatibility
   - Reference
   - TimeRanges
 browser-compat: api.TimeRanges.end
 ---
 {{APIRef("DOM")}}
 
-Returns the time offset at which a specified time range ends.
+The **`end()`** method of the {{domxref("TimeRanges")}} interface returns the time offset at which a specified time range ends.
 
 ## Syntax
 
@@ -23,7 +22,8 @@ end(index)
 
 ### Parameters
 
-- `index` is the range number to return the ending time for.
+- `index`
+  - : The range number to return the ending time for.
 
 ### Return value
 
@@ -31,13 +31,12 @@ A number.
 
 ### Exceptions
 
-- INDEX_SIZE_ERR
-  - : A `DOMException` thrown if the specified index doesn't correspond to an
-    existing range.
+- `IndexSizeError` {{domxref("DOMException")}}
+  - : Thrown if the specified index doesn't correspond to an existing range.
 
 ## Examples
 
-Given a video element with the ID "myVideo":
+Given a video element with the ID `"myVideo"`:
 
 ```js
 var v = document.getElementById("myVideo");

--- a/files/en-us/web/api/timeranges/start/index.md
+++ b/files/en-us/web/api/timeranges/start/index.md
@@ -6,14 +6,13 @@ tags:
   - HTML DOM
   - Media
   - Method
-  - NeedsBrowserCompatibility
   - Reference
   - TimeRanges
 browser-compat: api.TimeRanges.start
 ---
 {{APIRef("DOM")}}
 
-Returns the time offset at which a specified time range begins.
+The **`start()`** method of the {{domxref("TimeRanges")}} interface returns the time offset at which a specified time range begins.
 
 ## Syntax
 
@@ -23,7 +22,8 @@ start(index)
 
 ### Parameters
 
-- `index` is the range number to return the starting time for.
+- `index`
+  - :Tthe range number to return the starting time for.
 
 ### Return value
 
@@ -31,8 +31,8 @@ A number.
 
 ### Exceptions
 
-- INDEX_SIZE_ERR
-  - : A `DOMException` thrown if the specified index doesn't correspond to an
+- `IndexSizeError` {{domxref("DOMException")}}
+  - : Thrown if the specified index doesn't correspond to an
     existing range.
 
 ## Examples


### PR DESCRIPTION
Adapted the old-school structure to the current standard.