### PR TITLE
Remove intrinsicsize <img> HTML attribute

### DIFF
--- a/files/en-us/web/html/element/img/index.md
+++ b/files/en-us/web/html/element/img/index.md
@@ -131,8 +131,6 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 - {{htmlattrdef("height")}}
   - : The intrinsic height of the image, in pixels. Must be an integer without a unit.
-- {{htmlattrdef("intrinsicsize")}} {{deprecated_inline}}
-  - : This attribute tells the browser to ignore the actual {{glossary("intrinsic size")}} of the image and pretend it's the size specified in the attribute. Specifically, the image would raster at these dimensions and `naturalWidth`/`naturalHeight` on images would return the values specified in this attribute. [Explainer](https://github.com/WICG/intrinsicsize-attribute), [examples](https://googlechrome.github.io/samples/intrinsic-size/index.html)
 - {{htmlattrdef("ismap")}}
 
   - : This Boolean attribute indicates that the image is part of a [server-side map](https://en.wikipedia.org/wiki/Image_map#Server-side). If so, the coordinates where the user clicked on the image are sent to the server.


### PR DESCRIPTION
This PR removes the unsupported `intrinsicsize` HTML attribute of the `<img>` element.

Related BCD PR: https://github.com/mdn/browser-compat-data/pull/15997
