### PR TITLE
Use reg. ex. in `Headers.get` example

### DIFF
--- a/files/en-us/web/api/headers/get/index.md
+++ b/files/en-us/web/api/headers/get/index.md
@@ -64,7 +64,7 @@ the values, in the order they were added to the Headers object:
 myHeaders.append('Accept-Encoding', 'deflate');
 myHeaders.append('Accept-Encoding', 'gzip');
 myHeaders.get('Accept-Encoding'); // Returns "deflate, gzip"
-myHeaders.get('Accept-Encoding').split(',').map(v => v.trimStart()); // Returns [ "deflate", "gzip" ]
+myHeaders.get('Accept-Encoding').split(/,\s*/); // Returns [ "deflate", "gzip" ]
 ```
 
 ## Specifications


### PR DESCRIPTION
#### Summary
Use of a reg. ex. to split a string of header values into an array, arguably better expresses intent vs. using a `map` and `trimStart`.

#### Motivation

I believe the change makes the example easier to read and understand as it contains fewer additional constructs such as calls to `map` and `trimStart` to distract from what the example purports to principally demonstrate.