### PR TITLE
Past tense of to string is strung

### DIFF
--- a/files/en-us/web/svg/tutorial/paths/index.md
+++ b/files/en-us/web/svg/tutorial/paths/index.md
@@ -145,7 +145,7 @@ The last set of coordinates here (`x`,`y`) specify where the line should end. Th
 
 The example above creates nine cubic Bézier curves. As the curves move toward the right, the control points become spread out horizontally. As the curves move downward, they become further separated from the end points. The thing to note here is that the curve starts in the direction of the first control point, and then bends so that it arrives along the direction of the second control point.
 
-Several Bézier curves can be stringed together to create extended, smooth shapes. Often, the control point on one side of a point will be a reflection of the control point used on the other side to keep the slope constant. In this case, a shortcut version of the cubic Bézier can be used, designated by the command `S` (or `s`).
+Several Bézier curves can be strung together to create extended, smooth shapes. Often, the control point on one side of a point will be a reflection of the control point used on the other side to keep the slope constant. In this case, a shortcut version of the cubic Bézier can be used, designated by the command `S` (or `s`).
 
 ```html
  S x2 y2, x y


### PR DESCRIPTION
#### Summary
This dictionary.com https://www.dictionary.com/browse/string entry lists strung as the preferred past tense of the verb to string.

#### Motivation
I was pulled out the the text briefly while reading the word stringed.  Reviewing the writing style guidelines it appears this should be strung as the past tense.

#### Supporting details
https://www.dictionary.com/browse/string


This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

