### PR TITLE
WebAPI: Update Method pages to modern structure (part 19)

### DIFF
--- a/files/en-us/web/api/writablestreamdefaultcontroller/error/index.md
+++ b/files/en-us/web/api/writablestreamdefaultcontroller/error/index.md
@@ -24,13 +24,13 @@ the underlying sink.
 ## Syntax
 
 ```js
-writableStreamDefaultController.error(e);
+error(e)
 ```
 
 ### Parameters
 
 - e
-  - : A {{domxref("DOMString")}} representing the error you want future interactions to
+  - : A string representing the error you want future interactions to
     fail with.
 
 ### Return value

--- a/files/en-us/web/api/writablestreamdefaultwriter/abort/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/abort/index.md
@@ -25,13 +25,14 @@ rejected promise.
 ## Syntax
 
 ```js
-var promise = writableStreamDefaultWriter.abort(reason);
+abort()
+abort(reason)
 ```
 
 ### Parameters
 
 - reason {{optional_inline}}
-  - : A {{domxref("DOMString")}} representing a human-readable reason for the abort.
+  - : A string representing a human-readable reason for the abort.
 
 ### Return value
 

--- a/files/en-us/web/api/writablestreamdefaultwriter/close/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/close/index.md
@@ -24,7 +24,7 @@ invoking the close behavior. During this time any further attempts to write will
 ## Syntax
 
 ```js
-var promise = writableStreamDefaultWriter.close();
+close()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/writablestreamdefaultwriter/ready/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/ready/index.md
@@ -3,7 +3,7 @@ title: WritableStreamDefaultWriter.ready
 slug: Web/API/WritableStreamDefaultWriter/ready
 tags:
   - API
-  - Method
+  - Property
   - Ready
   - Reference
   - Streams
@@ -19,17 +19,11 @@ The **`ready`** read-only property of the
 that resolves when the desired size of the stream's internal queue transitions from
 non-positive to positive, signaling that it is no longer applying backpressure.
 
-## Syntax
-
-```js
-var promise = writableStreamDefaultWriter.ready;
-```
-
-### Value
+## Value
 
 A {{jsxref("Promise")}}.
 
-## Example
+## Examples
 
 The following example shows two uses of the `ready` property. The first uses
 `ready` to ensure that the `WritableStream` is done writing and

--- a/files/en-us/web/api/writablestreamdefaultwriter/releaselock/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/releaselock/index.md
@@ -22,7 +22,7 @@ in the same way from now on; otherwise, the writer will appear closed.
 ## Syntax
 
 ```js
-writableStreamDefaultWriter.releaseLock()
+releaseLock()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/writablestreamdefaultwriter/write/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/write/index.md
@@ -26,7 +26,7 @@ destination.
 ## Syntax
 
 ```js
-var promise = writableStreamDefaultWriter.write(chunk);
+write(chunk)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/xmlhttprequest/abort/index.md
+++ b/files/en-us/web/api/xmlhttprequest/abort/index.md
@@ -29,7 +29,7 @@ it has already been sent. When a request is aborted, its
 ## Syntax
 
 ```js
-XMLHttpRequest.abort()
+abort()
 ```
 
 ### Parameters
@@ -40,7 +40,7 @@ None.
 
 `undefined`
 
-## Example
+## Examples
 
 This example begins loading content from the MDN home page, then due to some condition,
 aborts the transfer by calling `abort()`.

--- a/files/en-us/web/api/xmlhttprequest/getallresponseheaders/index.md
+++ b/files/en-us/web/api/xmlhttprequest/getallresponseheaders/index.md
@@ -31,7 +31,7 @@ is returned.
 ## Syntax
 
 ```js
-var headers = XMLHttpRequest.getAllResponseHeaders();
+getAllResponseHeaders()
 ```
 
 ### Parameters
@@ -67,7 +67,7 @@ Each line is terminated by both carriage return and line feed characters
 > **Note:** In modern browsers, the header names are returned in all lower
 > case, as per the latest spec.
 
-## Example
+## Examples
 
 This example examines the headers in the request's {{domxref("XMLHttpRequest/readystatechange_event", "readystatechange")}} event. The code shows how to obtain
 the raw header string, as well as how to convert it into an array of individual headers

--- a/files/en-us/web/api/xmlhttprequest/getresponseheader/index.md
+++ b/files/en-us/web/api/xmlhttprequest/getresponseheader/index.md
@@ -36,7 +36,7 @@ which returns the entire raw header string.
 ## Syntax
 
 ```js
-var myHeader = XMLHttpRequest.getResponseHeader(headerName);
+getResponseHeader(headerName)
 ```
 
 ### Parameters
@@ -51,7 +51,7 @@ A string representing the header's text value, or `null`
 if either the response has not yet been received or the header doesn't exist in the
 response.
 
-## Example
+## Examples
 
 In this example, a request is created and sent, and a {{domxref("XMLHttpRequest/readystatechange_event", "readystatechange")}}
 handler is established to look for the {{DOMxRef("XMLHttpRequest.readyState",

--- a/files/en-us/web/api/xmlhttprequest/overridemimetype/index.md
+++ b/files/en-us/web/api/xmlhttprequest/overridemimetype/index.md
@@ -28,13 +28,13 @@ as such. This method must be called before calling {{domxref("XMLHttpRequest.sen
 ## Syntax
 
 ```js
-XMLHttpRequest.overrideMimeType(mimeType)
+overrideMimeType(mimeType)
 ```
 
 ### Parameters
 
 - `mimeType`
-  - : A {{domxref("DOMString")}} specifying the MIME type to use instead of the one
+  - : A string specifying the MIME type to use instead of the one
     specified by the server. If the server doesn't specify a type,
     `XMLHttpRequest` assumes `"text/xml"`.
 
@@ -42,7 +42,7 @@ XMLHttpRequest.overrideMimeType(mimeType)
 
 `undefined`.
 
-## Example
+## Examples
 
 This example specifies a MIME type of `"text/plain"`, overriding the
 server's stated type for the data being received.

--- a/files/en-us/web/api/xmlhttprequest/send/index.md
+++ b/files/en-us/web/api/xmlhttprequest/send/index.md
@@ -37,7 +37,8 @@ If no {{HTTPHeader("Accept")}} header has been set using the
 ## Syntax
 
 ```js
-XMLHttpRequest.send(body)
+send()
+send(body)
 ```
 
 ### Parameters
@@ -50,7 +51,7 @@ XMLHttpRequest.send(body)
     - An `XMLHttpRequestBodyInit`, which [per the
       Fetch spec](https://fetch.spec.whatwg.org/#typedefdef-xmlhttprequestbodyinit) can be a {{domxref("Blob")}}, {{domxref("BufferSource")}},
       {{domxref("FormData")}}, {{domxref("URLSearchParams")}}, or
-      {{domxref("USVString")}} object.
+      string object.
     - `null`
 
     If no value is specified for the body, a default value of `null` is used.

--- a/files/en-us/web/api/xmlhttprequest/setrequestheader/index.md
+++ b/files/en-us/web/api/xmlhttprequest/setrequestheader/index.md
@@ -46,7 +46,7 @@ and {{Glossary("Forbidden_response_header_name", "forbidden response header name
 ## Syntax
 
 ```js
-XMLHttpRequest.setRequestHeader(header, value)
+setRequestHeader(header, value)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/xpathevaluator/createexpression/index.md
+++ b/files/en-us/web/api/xpathevaluator/createexpression/index.md
@@ -19,13 +19,14 @@ This method compiles an {{domxref("XPathExpression")}} which can then be used fo
 ## Syntax
 
 ```js
-XPathExpression XPathEvaluator.createExpression(expression, resolver);
+createExpression(expression)
+createExpression(expression, resolver)
 ```
 
 ### Parameters
 
 - expression
-  - : A {{domxref("DOMString")}} representing the XPath expression to be created.
+  - : A string representing the XPath expression to be created.
 - resolver {{optional_inline}}
   - : Permits translation of all prefixes, including the `xml` namespace
     prefix, within the XPath expression into appropriate namespace URIs.
@@ -49,7 +50,7 @@ If the expression contains namespace prefixes which cannot be resolved by the sp
 {{domxref("XPathNSResolver")}}, a {{domxref("DOMException")}} of type
 `NAMESPACE_ERROR` is raised.
 
-## Example
+## Examples
 
 The following example shows the use of the `evaluate()` method.
 

--- a/files/en-us/web/api/xpathevaluator/creatensresolver/index.md
+++ b/files/en-us/web/api/xpathevaluator/creatensresolver/index.md
@@ -26,7 +26,7 @@ called, also correctly resolving the implicit `xml` prefix.
 ## Syntax
 
 ```js
-XPathNSResolver XPathEvaluator.createNSResolver(nodeResolver);
+createNSResolver(nodeResolver)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/xpathevaluator/evaluate/index.md
+++ b/files/en-us/web/api/xpathevaluator/evaluate/index.md
@@ -20,13 +20,16 @@ executes an XPath expression on the given node or document and returns an
 ## Syntax
 
 ```js
-XPathResult XPathEvaluator.evaluate(expression, contextNode, resolver, type, result);
+evaluate(expression, contextNode)
+evaluate(expression, contextNode, resolver)
+evaluate(expression, contextNode, resolver, type)
+evaluate(expression, contextNode, resolver, type, result)
 ```
 
 ### Parameters
 
 - expression
-  - : A {{domxref("DOMString")}} representing the XPath expression to be parsed and
+  - : A string representing the XPath expression to be parsed and
     evaluated.
 - contextNode
   - : A {{domxref("Node")}} representing the context to use for evaluating the expression.
@@ -77,7 +80,7 @@ If the provided context node is not a type permitted as an XPath context node or
 request type is not permitted by the {{domxref("XPathEvaluator")}}, a
 {{domxref("DOMException")}} of type `NOT_SUPPORTED_ERR` is raised.
 
-## Example
+## Examples
 
 The following example shows the use of the `evaluate()` method.
 

--- a/files/en-us/web/api/xpathexpression/evaluate/index.md
+++ b/files/en-us/web/api/xpathexpression/evaluate/index.md
@@ -19,7 +19,9 @@ returns an {{domxref("XPathResult")}}.
 ## Syntax
 
 ```js
-XPathResult node.evaluate(contextNode, type, result);
+evaluate(contextNode)
+evaluate(contextNode, type)
+evaluate(contextNode, type, result)
 ```
 
 ### Parameters
@@ -70,7 +72,7 @@ If the provided context node is not a type permitted as an XPath context node or
 request type is not permitted by the {{domxref("XPathEvaluator")}}, a
 {{domxref("DOMException")}} of type `NOT_SUPPORTED_ERR` is raised.
 
-## Example
+## Examples
 
 The following example shows the use of the `evaluate()` method.
 

--- a/files/en-us/web/api/xpathnsresolver/lookupnamespaceuri/index.md
+++ b/files/en-us/web/api/xpathnsresolver/lookupnamespaceuri/index.md
@@ -20,17 +20,17 @@ given namespace prefix within an {{Glossary("XPath")}} expression evaluated by t
 ## Syntax
 
 ```js
-DOMString XPathNSResolver.lookupNamespaceURI(prefix);
+lookupNamespaceURI(prefix)
 ```
 
 ### Parameters
 
 - prefix
-  - : A {{domxref("DOMString")}} representing the prefix to look for.
+  - : A string representing the prefix to look for.
 
 ### Return value
 
-A {{domxref("DOMString")}} representing the associated namespace URI or
+A string representing the associated namespace URI or
 `null` if none is found.
 
 ## Specifications

--- a/files/en-us/web/api/xpathresult/iteratenext/index.md
+++ b/files/en-us/web/api/xpathresult/iteratenext/index.md
@@ -19,7 +19,7 @@ next node from it or `null` if there are no more nodes.
 ## Syntax
 
 ```js
-var node = result.iterateNext();
+iterateNext()
 ```
 
 ### Return value
@@ -39,7 +39,7 @@ In case {{domxref("XPathResult.resultType")}} is not
 If the document is mutated since the result was returned, an
 {{domxref("XPathException")}} of type `INVALID_STATE_ERR` is thrown.
 
-## Example
+## Examples
 
 The following example shows the use of the `iterateNext()` method.
 

--- a/files/en-us/web/api/xpathresult/snapshotitem/index.md
+++ b/files/en-us/web/api/xpathresult/snapshotitem/index.md
@@ -21,8 +21,13 @@ current document if it is mutated.
 ## Syntax
 
 ```js
-var node = result.snapshotItem(i);
+snapshotItem(i)
 ```
+
+### Parameters
+
+- `i`
+  - : A number. Index of the item.
 
 ### Return value
 
@@ -37,7 +42,7 @@ In case {{domxref("XPathResult.resultType")}} is not
 `UNORDERED_NODE_SNAPSHOT_TYPE` or `ORDERED_NODE_SNAPSHOT_TYPE`, an
 {{domxref("XPathException")}} of type `TYPE_ERR` is thrown.
 
-## Example
+## Examples
 
 The following example shows the use of the `snapshotItem()` method.
 

--- a/files/en-us/web/api/xpathresult/snapshotitem/index.md
+++ b/files/en-us/web/api/xpathresult/snapshotitem/index.md
@@ -27,7 +27,7 @@ snapshotItem(i)
 ### Parameters
 
 - `i`
-  - : A number. Index of the item.
+  - : A number, the index of the item.
 
 ### Return value
 

--- a/files/en-us/web/api/xrframe/getdepthinformation/index.md
+++ b/files/en-us/web/api/xrframe/getdepthinformation/index.md
@@ -44,7 +44,7 @@ An {{domxref("XRCPUDepthInformation")}} object.
 ### Obtaining CPU depth information
 
 ```js
-// Make sure  to request a session with depth-sensing enabled
+// Make sure to request a session with depth-sensing enabled
 const session = navigator.xr.requestSession("immersive-ar", {
   requiredFeatures: ["depth-sensing"],
   depthSensing: {

--- a/files/en-us/web/api/xrinputsourcearray/foreach/index.md
+++ b/files/en-us/web/api/xrinputsourcearray/foreach/index.md
@@ -31,7 +31,8 @@ list.
 ## Syntax
 
 ```js
-xrInputSourceArray.forEach(callback, thisArg);
+forEach(callback)
+forEach(callback, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/xrinputsourcearray/keys/index.md
+++ b/files/en-us/web/api/xrinputsourcearray/keys/index.md
@@ -35,7 +35,7 @@ of input sources.
 ## Syntax
 
 ```js
-xrInputSourceArray.keys();
+keys()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/xrinputsourcearray/values/index.md
+++ b/files/en-us/web/api/xrinputsourcearray/values/index.md
@@ -34,7 +34,7 @@ array, from first to last.
 ## Syntax
 
 ```js
-xrInputSourceArray.values();
+values()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/xrsession/cancelanimationframe/index.md
+++ b/files/en-us/web/api/xrsession/cancelanimationframe/index.md
@@ -44,7 +44,7 @@ None.
 
 This function has no effect if the specified `handle` cannot be found.
 
-## Example
+## Examples
 
 In the example below we see code which starts up a WebXR session if immersive VR mode
 is supported. Once started, the session schedules its first frame to be rendered by

--- a/files/en-us/web/api/xrsession/end/index.md
+++ b/files/en-us/web/api/xrsession/end/index.md
@@ -39,7 +39,7 @@ related to shutting down the session have completed. You can use the promise to 
 things like update UI elements to reflect the shut down connection, trigger application
 shut down, or whatever else you might need to do.
 
-## Example
+## Examples
 
 ## Specifications
 

--- a/files/en-us/web/api/xrsession/requestanimationframe/index.md
+++ b/files/en-us/web/api/xrsession/requestanimationframe/index.md
@@ -69,7 +69,7 @@ An integer value which serves as a unique, non-zero ID or handle you may pass to
 {{domxref("XRSession.cancelAnimationFrame", "cancelAnimationFrame()")}} if you need to
 remove the pending animation frame request.
 
-## Example
+## Examples
 
 The following example requests `XRSession` with "inline" mode so that it can
 be displayed in an HTML element (without the need for a separate AR or VR device).

--- a/files/en-us/web/api/xrsession/requestreferencespace/index.md
+++ b/files/en-us/web/api/xrsession/requestreferencespace/index.md
@@ -39,7 +39,7 @@ requestReferenceSpace(referenceSpaceType)
   - : A string specifying the type of reference space for which an instance is to be returned.
     The string must be one of the values below.
 
-### Values
+### Return value
 
 The types of reference space are listed below, with brief information about their use cases and which interface is used to implement them.
 

--- a/files/en-us/web/api/xrsession/updaterenderstate/index.md
+++ b/files/en-us/web/api/xrsession/updaterenderstate/index.md
@@ -17,7 +17,7 @@ browser-compat: api.XRSession.updateRenderState
 ---
 {{APIRef("WebXR Device API")}}
 
-The `updateRenderState()` method of the {{DOMxRef("XRSession")}} interface of the [WebXR API](/en-US/docs/Web/API/WebXR_Device_API) schedules changes to be applied  to the active render state ({{domxref("XRRenderState")}}) prior to rendering of the next frame.
+The `updateRenderState()` method of the {{DOMxRef("XRSession")}} interface of the [WebXR API](/en-US/docs/Web/API/WebXR_Device_API) schedules changes to be applied to the active render state ({{domxref("XRRenderState")}}) prior to rendering of the next frame.
 
 ## Syntax
 
@@ -31,8 +31,8 @@ updateRenderState(state)
 - `state` {{optional_inline}}
   - : An optional object to configure the {{domxref("XRRenderState")}}. If none is provided, a default configuration will be used.
     - `baseLayer`  {{optional_inline}}: An {{domxref("XRWebGLLayer")}} object from which the WebXR compositor will obtain imagery. This is  `null`  by default. To specify other (or multiple) layers, see the `layers` option.
-    - `depthFar`  {{optional_inline}}: A floating-point value specifying the distance in meters from the viewer to the  far clip plane, which is a plane parallel to the display surface beyond which no further rendering will occur. All rendering will take place between the distances specified by  `depthNear`  and  `depthFar`. This is 1000 meters (1 kilometer) by default.
-    - `depthNear`  {{optional_inline}}: A floating-point value indicating the distance in meters from the viewer to a plane parallel to the display surface to be the  **near clip  plane**. No part of the scene on the viewer's side of this plane will be rendered. This is 0.1 meters (10 centimeters) by default.
+    - `depthFar`  {{optional_inline}}: A floating-point value specifying the distance in meters from the viewer to the far clip plane, which is a plane parallel to the display surface beyond which no further rendering will occur. All rendering will take place between the distances specified by  `depthNear`  and  `depthFar`. This is 1000 meters (1 kilometer) by default.
+    - `depthNear`  {{optional_inline}}: A floating-point value indicating the distance in meters from the viewer to a plane parallel to the display surface to be the  **near clip plane**. No part of the scene on the viewer's side of this plane will be rendered. This is 0.1 meters (10 centimeters) by default.
     - `inlineVerticalFieldOfView`  {{optional_inline}}: A floating-point value indicating the default field of view, in radians, to be used when computing the projection matrix for an  `inline`  {{domxref("XRSession")}}. The projection matrix calculation also takes into account the output canvas's aspect ratio. This property _must not_ be specified for immersive sessions, so the value is  `null`  by default for immersive sessions. The default value is otherwise π \* 0.5 (half of the value of pi).
     - `layers`  {{optional_inline}}: An ordered array of {{domxref("XRLayer")}} objects specifying the layers that should be presented to the XR device. Setting `layers` will override the `baseLayer` if one is present, with `baseLayer` reporting `null`. The order of the layers given is "back-to-front". For alpha blending of layers, see the {{domxref("XRCompositionLayer.blendTextureSourceAlpha")}} property.
 

--- a/files/en-us/web/api/xrwebglbinding/getdepthinformation/index.md
+++ b/files/en-us/web/api/xrwebglbinding/getdepthinformation/index.md
@@ -47,7 +47,7 @@ const canvasElement = document.querySelector(".output-canvas");
 const gl = canvasElement.getContext("webgl");
 await gl.makeXRCompatible();
 
-// Make sure  to request a session with depth-sensing enabled
+// Make sure to request a session with depth-sensing enabled
 const session = navigator.xr.requestSession("immersive-ar", {
   requiredFeatures: ["depth-sensing"],
   depthSensing: {

--- a/files/en-us/web/api/xrwebgllayer/getviewport/index.md
+++ b/files/en-us/web/api/xrwebgllayer/getviewport/index.md
@@ -34,7 +34,7 @@ represented by the view.
 ## Syntax
 
 ```js
-getViewport(view);
+getViewport(view)
 ```
 
 ### Parameters
@@ -55,7 +55,7 @@ drawing to the portion of the layer corresponding to the specified `view`.
     that `XRFrame` and the {{domxref("XRWebGLLayer")}} are not part of the same
     [WebXR session](/en-US/docs/Web/API/XRSession).
 
-## Example
+## Examples
 
 This example demonstrates in part what the callback for the
 {{domxref("XRSession.requestAnimationFrame", "requestAnimationFrame()")}} function might


### PR DESCRIPTION
Continuing #14857 

## Summary
Updating the method pages to follow the current templates:
https://developer.mozilla.org/en-US/docs/MDN/Structures/Syntax_sections#constructors_and_methods
https://developer.mozilla.org/en-US/docs/MDN/Structures/Page_types/API_method_subpage_template

Changes Include:
- fix syntax section
- changing section titles to suggested titles in the template
- change `{{DOMxRef("DOMString")}}` to `string`
- remove extra spaces in between words and extra trailing spaces
- other small corrections

### Metadata
- [x] Fixes a typo, bug, or other error
