### PR TITLE
Replace unwanted URL with a live sample

### DIFF
--- a/files/en-us/web/guide/user_input_methods/index.md
+++ b/files/en-us/web/guide/user_input_methods/index.md
@@ -141,11 +141,21 @@ in which we:
 
 In open web apps any DOM element can be made directly editable using the [`contenteditable`](/en-US/docs/Web/HTML/Global_attributes#contenteditable) attribute.
 
+```css hidden
+div {
+  width: 300px;
+  height: 130px;
+  border: 1px solid gray;
+}
+```
+
 ```html
 <div contenteditable="true">
     This text can be edited by the user.
 </div>
 ```
+
+{{EmbedLiveSample("contentEditable")}}
 
 > **Note:** Compatibility information, examples and other resources can be found in the [Content Editable guide](/en-US/docs/Web/Guide/HTML/Editable_content).
 
@@ -155,8 +165,6 @@ In open web apps any DOM element can be made directly editable using the [`conte
   - : This example tracks multiple touch points at a time, allowing the user to draw in a `{{htmlelement("canvas")}}` with more than one finger at a time. It will only work on a browser that supports touch events.
 - **[Simple pointer lock demo](/en-US/docs/Web/API/Pointer_Lock_API#example)**
   - : We've written a simple pointer lock demo to show you how to use it to set up a simple control system. The demo uses JavaScript to draw a ball inside a `{{htmlelement("canvas")}}` element. When you click the canvas, pointer lock is then used to remove the mouse pointer and allow you to move the ball directly using the mouse.
-- **[contentEditable demo](http://html5demos.com/contenteditable)**
-  - : This is a working example showing how contenteditable can be used to create an editable document section, the state of which is then saved using [LocalStorage](/en-US/docs/Web/API/Web_Storage_API).
 
 ## Tutorials
 


### PR DESCRIPTION
## Summary
In https://developer.mozilla.org/en-US/docs/Web/Guide/User_input_methods#examples section, the [contentEditable demo](https://html5demos.com/contenteditable) link now redirects to an advertisement domain https://bestvpn.org/html5demos/contenteditable/  
Also, their demo doesn't work because they are using `<section>` element instead of a `<div>`.

We can easily convert current code snippet to a live sample. Then we won't have to use the external link.

#### Metadata
- [x] Fixes a typo, bug, or other error
