### PR TITLE
Include 'next' object

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/routes/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/routes/index.md
@@ -219,42 +219,42 @@ Open the **/controllers/authorController.js** file and type in the following cod
 var Author = require('../models/author');
 
 // Display list of all Authors.
-exports.author_list = function(req, res) {
+exports.author_list = function(req, res, next) {
     res.send('NOT IMPLEMENTED: Author list');
 };
 
 // Display detail page for a specific Author.
-exports.author_detail = function(req, res) {
+exports.author_detail = function(req, res, next) {
     res.send('NOT IMPLEMENTED: Author detail: ' + req.params.id);
 };
 
 // Display Author create form on GET.
-exports.author_create_get = function(req, res) {
+exports.author_create_get = function(req, res, next) {
     res.send('NOT IMPLEMENTED: Author create GET');
 };
 
 // Handle Author create on POST.
-exports.author_create_post = function(req, res) {
+exports.author_create_post = function(req, res, next) {
     res.send('NOT IMPLEMENTED: Author create POST');
 };
 
 // Display Author delete form on GET.
-exports.author_delete_get = function(req, res) {
+exports.author_delete_get = function(req, res, next) {
     res.send('NOT IMPLEMENTED: Author delete GET');
 };
 
 // Handle Author delete on POST.
-exports.author_delete_post = function(req, res) {
+exports.author_delete_post = function(req, res, next) {
     res.send('NOT IMPLEMENTED: Author delete POST');
 };
 
 // Display Author update form on GET.
-exports.author_update_get = function(req, res) {
+exports.author_update_get = function(req, res, next) {
     res.send('NOT IMPLEMENTED: Author update GET');
 };
 
 // Handle Author update on POST.
-exports.author_update_post = function(req, res) {
+exports.author_update_post = function(req, res, next) {
     res.send('NOT IMPLEMENTED: Author update POST');
 };
 ```
@@ -271,42 +271,42 @@ Open the **/controllers/bookinstanceController.js** file and copy in the followi
 var BookInstance = require('../models/bookinstance');
 
 // Display list of all BookInstances.
-exports.bookinstance_list = function(req, res) {
+exports.bookinstance_list = function(req, res, next) {
     res.send('NOT IMPLEMENTED: BookInstance list');
 };
 
 // Display detail page for a specific BookInstance.
-exports.bookinstance_detail = function(req, res) {
+exports.bookinstance_detail = function(req, res, next) {
     res.send('NOT IMPLEMENTED: BookInstance detail: ' + req.params.id);
 };
 
 // Display BookInstance create form on GET.
-exports.bookinstance_create_get = function(req, res) {
+exports.bookinstance_create_get = function(req, res, next) {
     res.send('NOT IMPLEMENTED: BookInstance create GET');
 };
 
 // Handle BookInstance create on POST.
-exports.bookinstance_create_post = function(req, res) {
+exports.bookinstance_create_post = function(req, res, next) {
     res.send('NOT IMPLEMENTED: BookInstance create POST');
 };
 
 // Display BookInstance delete form on GET.
-exports.bookinstance_delete_get = function(req, res) {
+exports.bookinstance_delete_get = function(req, res, next) {
     res.send('NOT IMPLEMENTED: BookInstance delete GET');
 };
 
 // Handle BookInstance delete on POST.
-exports.bookinstance_delete_post = function(req, res) {
+exports.bookinstance_delete_post = function(req, res, next) {
     res.send('NOT IMPLEMENTED: BookInstance delete POST');
 };
 
 // Display BookInstance update form on GET.
-exports.bookinstance_update_get = function(req, res) {
+exports.bookinstance_update_get = function(req, res, next) {
     res.send('NOT IMPLEMENTED: BookInstance update GET');
 };
 
 // Handle bookinstance update on POST.
-exports.bookinstance_update_post = function(req, res) {
+exports.bookinstance_update_post = function(req, res, next) {
     res.send('NOT IMPLEMENTED: BookInstance update POST');
 };
 ```
@@ -319,42 +319,42 @@ Open the **/controllers/genreController.js** file and copy in the following text
 var Genre = require('../models/genre');
 
 // Display list of all Genre.
-exports.genre_list = function(req, res) {
+exports.genre_list = function(req, res, next) {
     res.send('NOT IMPLEMENTED: Genre list');
 };
 
 // Display detail page for a specific Genre.
-exports.genre_detail = function(req, res) {
+exports.genre_detail = function(req, res, next) {
     res.send('NOT IMPLEMENTED: Genre detail: ' + req.params.id);
 };
 
 // Display Genre create form on GET.
-exports.genre_create_get = function(req, res) {
+exports.genre_create_get = function(req, res, next) {
     res.send('NOT IMPLEMENTED: Genre create GET');
 };
 
 // Handle Genre create on POST.
-exports.genre_create_post = function(req, res) {
+exports.genre_create_post = function(req, res, next) {
     res.send('NOT IMPLEMENTED: Genre create POST');
 };
 
 // Display Genre delete form on GET.
-exports.genre_delete_get = function(req, res) {
+exports.genre_delete_get = function(req, res, next) {
     res.send('NOT IMPLEMENTED: Genre delete GET');
 };
 
 // Handle Genre delete on POST.
-exports.genre_delete_post = function(req, res) {
+exports.genre_delete_post = function(req, res, next) {
     res.send('NOT IMPLEMENTED: Genre delete POST');
 };
 
 // Display Genre update form on GET.
-exports.genre_update_get = function(req, res) {
+exports.genre_update_get = function(req, res, next) {
     res.send('NOT IMPLEMENTED: Genre update GET');
 };
 
 // Handle Genre update on POST.
-exports.genre_update_post = function(req, res) {
+exports.genre_update_post = function(req, res, next) {
     res.send('NOT IMPLEMENTED: Genre update POST');
 };
 ```
@@ -367,47 +367,47 @@ This follows the same pattern as the other controller modules, but additionally 
 ```js
 var Book = require('../models/book');
 
-exports.index = function(req, res) {
+exports.index = function(req, res, next) {
     res.send('NOT IMPLEMENTED: Site Home Page');
 };
 
 // Display list of all books.
-exports.book_list = function(req, res) {
+exports.book_list = function(req, res, next) {
     res.send('NOT IMPLEMENTED: Book list');
 };
 
 // Display detail page for a specific book.
-exports.book_detail = function(req, res) {
+exports.book_detail = function(req, res, next) {
     res.send('NOT IMPLEMENTED: Book detail: ' + req.params.id);
 };
 
 // Display book create form on GET.
-exports.book_create_get = function(req, res) {
+exports.book_create_get = function(req, res, next) {
     res.send('NOT IMPLEMENTED: Book create GET');
 };
 
 // Handle book create on POST.
-exports.book_create_post = function(req, res) {
+exports.book_create_post = function(req, res, next) {
     res.send('NOT IMPLEMENTED: Book create POST');
 };
 
 // Display book delete form on GET.
-exports.book_delete_get = function(req, res) {
+exports.book_delete_get = function(req, res, next) {
     res.send('NOT IMPLEMENTED: Book delete GET');
 };
 
 // Handle book delete on POST.
-exports.book_delete_post = function(req, res) {
+exports.book_delete_post = function(req, res, next) {
     res.send('NOT IMPLEMENTED: Book delete POST');
 };
 
 // Display book update form on GET.
-exports.book_update_get = function(req, res) {
+exports.book_update_get = function(req, res, next) {
     res.send('NOT IMPLEMENTED: Book update GET');
 };
 
 // Handle book update on POST.
-exports.book_update_post = function(req, res) {
+exports.book_update_post = function(req, res, next) {
     res.send('NOT IMPLEMENTED: Book update POST');
 };
 ```


### PR DESCRIPTION
Have added next object in all Handler functions as they will be useful in handling errors in later part of course.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Added a 'next' object to use Handlers as middleware functions and handles errors effectively 

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Was doing this courser (Very Helpful, tysm :) ) and realized later on all Handlers make use of next for error handling. so why not add them in the start itself 

This PR…

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
