### PR TITLE
Fix nuance in behavior of alpha component of :visited styles in Firefox

### DIFF
--- a/files/en-us/web/css/_colon_visited/index.md
+++ b/files/en-us/web/css/_colon_visited/index.md
@@ -29,7 +29,7 @@ For privacy reasons, browsers strictly limit which styles you can apply using th
 
 - Allowable CSS properties are {{ cssxref("color") }}, {{ cssxref("background-color") }}, {{ cssxref("border-color") }}, {{ cssxref("border-bottom-color") }}, {{ cssxref("border-left-color") }}, {{ cssxref("border-right-color") }}, {{ cssxref("border-top-color") }}, {{ cssxref("column-rule-color") }}, {{ cssxref("outline-color") }}, {{ cssxref("text-decoration-color") }}, and {{ cssxref("text-emphasis-color") }}.
 - Allowable SVG attributes are {{SVGAttr("fill")}} and {{SVGAttr("stroke")}}.
-- The alpha component of the allowed styles will be ignored. The alpha component of the element's non-`:visited` state will be used instead, except when that component is `0`, in which case the style set in `:visited` will be ignored entirely.
+- The alpha component of the allowed styles will be ignored. The alpha component of the element's non-`:visited` state will be used instead. In Firefox when the alpha component is `0`, the style set in `:visited` will be ignored entirely.
 - Although these styles can change the appearance of colors to the end user, the {{domxref("window.getComputedStyle")}} method will lie and always return the value of the non-`:visited` color.
 - The [`<link>`](/en-US/docs/Web/HTML/Element/link) element is never matched by `:visited`.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

Fix nuance in behavior of alpha component of `:visited` styles in Firefox

#### Motivation
The exception in the text is only applicable to Firefox. In Safari and Chrome styling of :visited keeps working with alpha-channel set to zero.

#### Supporting details

Playground with example https://codepen.io/Myshov/pen/xxpzxPN

#### Related issues

Fixes #14898

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
