### PR TITLE
Optional Chaining: Add intros to currently context-less examples

### DIFF
--- a/files/en-us/web/javascript/reference/operators/optional_chaining/index.md
+++ b/files/en-us/web/javascript/reference/operators/optional_chaining/index.md
@@ -152,7 +152,7 @@ let nestedProp = obj?.['prop' + 'Name'];
 
 ### Optional chaining not valid on the left-hand side of an assignment
 
-It is invalid to try to assign to the result of a optional chaining expression:
+It is invalid to try to assign to the result of an optional chaining expression:
 
 ```js
 let object = {};
@@ -161,7 +161,7 @@ object?.property = 1; // Uncaught SyntaxError: Invalid left-hand side in assignm
 
 ### Array item access with optional chaining
 
-You can use the [the bracket notation](/en-US/docs/Web/JavaScript/Reference/Operators/Property_Accessors#bracket_notation) to use the optional chaining on arrays:
+You can use [bracket notation](/en-US/docs/Web/JavaScript/Reference/Operators/Property_Accessors#bracket_notation) for optional chaining on arrays:
 
 ```js
 const arr = ['a', 'b', 'c', 'd']

--- a/files/en-us/web/javascript/reference/operators/optional_chaining/index.md
+++ b/files/en-us/web/javascript/reference/operators/optional_chaining/index.md
@@ -152,6 +152,8 @@ let nestedProp = obj?.['prop' + 'Name'];
 
 ### Optional chaining not valid on the left-hand side of an assignment
 
+It is invalid to try to assign to the result of a optional chaining expression:
+
 ```js
 let object = {};
 object?.property = 1; // Uncaught SyntaxError: Invalid left-hand side in assignment
@@ -159,7 +161,10 @@ object?.property = 1; // Uncaught SyntaxError: Invalid left-hand side in assignm
 
 ### Array item access with optional chaining
 
+You can use the [the bracket notation](/en-US/docs/Web/JavaScript/Reference/Operators/Property_Accessors#bracket_notation) to use the optional chaining on arrays:
+
 ```js
+const arr = ['a', 'b', 'c', 'd']
 let arrayItem = arr?.[42];
 ```
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
In the page about optional chaining, there where some sections that included only code with no explanation. Seemed weird to me.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
This adds two short sentences that better explain the code in the 2 examples. One code segment was also extended a little to better illustrate the purpose.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining
- 
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
