### PR TITLE
Add reference to Promise.allSettled

### DIFF
--- a/files/en-us/web/javascript/guide/using_promises/index.md
+++ b/files/en-us/web/javascript/guide/using_promises/index.md
@@ -251,6 +251,9 @@ Promise.all([func1(), func2(), func3()])
 .then(([result1, result2, result3]) => { /* use result1, result2 and result3 */ });
 ```
 
+It is important to note that if one of the promises in the array rejects, `Promise.all()` will throw the error and abort the other operations. This may cause unexpected state or behavior. {{jsxref("Promise.allSettled()")}} is another composition tool that ensures all operations are complete before resolving. 
+
+
 Sequential composition is possible using some clever JavaScript:
 
 ```js


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Added mention of Promise.all failure behavior and reference to Promise.allSettled.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Even with proper exception handling, Promise.all can sometimes cause unexpected state to be created as async operations often involve state manipulation. `Promise.allSettled()` is often overlooked but is a great tool to more predictably handle failure in concurrent operations. 

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/allSettled

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
