### PR TITLE
WebAPI: Update Method pages to modern structure (part 20) 

### DIFF
--- a/files/en-us/web/api/abortsignal/timeout/index.md
+++ b/files/en-us/web/api/abortsignal/timeout/index.md
@@ -24,7 +24,7 @@ The timeout is based on active rather than elapsed time, and will effectively be
 ## Syntax
 
 ```js
-AbortSignal.timeout(time)
+timeout(time)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/angle_instanced_arrays/drawarraysinstancedangle/index.md
+++ b/files/en-us/web/api/angle_instanced_arrays/drawarraysinstancedangle/index.md
@@ -19,7 +19,7 @@ The **`ANGLE_instanced_arrays.drawArraysInstancedANGLE()`** method of the [WebGL
 ## Syntax
 
 ```js
-void ext.drawArraysInstancedANGLE(mode, first, count, primcount);
+drawArraysInstancedANGLE(mode, first, count, primcount)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/angle_instanced_arrays/drawelementsinstancedangle/index.md
+++ b/files/en-us/web/api/angle_instanced_arrays/drawelementsinstancedangle/index.md
@@ -19,7 +19,7 @@ The **`ANGLE_instanced_arrays.drawElementsInstancedANGLE()`** method of the [Web
 ## Syntax
 
 ```js
-void ext.drawElementsInstancedANGLE(mode, count, type, offset, primcount);
+drawElementsInstancedANGLE(mode, count, type, offset, primcount)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/angle_instanced_arrays/vertexattribdivisorangle/index.md
+++ b/files/en-us/web/api/angle_instanced_arrays/vertexattribdivisorangle/index.md
@@ -19,7 +19,7 @@ The **ANGLE_instanced_arrays.vertexAttribDivisorANGLE()** method of the [WebGL A
 ## Syntax
 
 ```js
-void ext.vertexAttribDivisorANGLE(index, divisor);
+vertexAttribDivisorANGLE(index, divisor)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/baseaudiocontext/decodeaudiodata/index.md
+++ b/files/en-us/web/api/baseaudiocontext/decodeaudiodata/index.md
@@ -27,21 +27,18 @@ data.
 
 ## Syntax
 
-Older callback syntax:
-
 ```js
-baseAudioContext.decodeAudioData(ArrayBuffer, successCallback, errorCallback);
-```
+// Older callback syntax:
+decodeAudioData(arrayBuffer, successCallback)
+decodeAudioData(arrayBuffer, successCallback, errorCallback)
 
-Newer promise-based syntax:
-
-```js
-Promise<decodedData> baseAudioContext.decodeAudioData(ArrayBuffer);
+// Newer promise-based syntax:
+decodeAudioData(arrayBuffer)
 ```
 
 ### Parameters
 
-- _ArrayBuffer_
+- _arrayBuffer_
   - : An ArrayBuffer containing the audio data to be decoded, usually grabbed from
     {{domxref("XMLHttpRequest")}}, {{domxref("fetch()")}} or
     {{domxref("FileReader")}}.
@@ -51,7 +48,7 @@ Promise<decodedData> baseAudioContext.decodeAudioData(ArrayBuffer);
     _decodedData_ (the decoded PCM audio data). Usually you'll want to put the
     decoded data into an {{domxref("AudioBufferSourceNode")}}, from which it can be played
     and manipulated how you want.
-- _errorCallback_
+- _errorCallback_ {{optional_inline}}
   - : An optional error callback, to be invoked if an error occurs when the audio data is
     being decoded.
 

--- a/files/en-us/web/api/ext_disjoint_timer_query/beginqueryext/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/beginqueryext/index.md
@@ -17,7 +17,7 @@ the [WebGL API](/en-US/docs/Web/API/WebGL_API) starts a timer query.
 ## Syntax
 
 ```js
-void ext.beginQueryEXT(target, query);
+beginQueryEXT(target, query)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/ext_disjoint_timer_query/createqueryext/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/createqueryext/index.md
@@ -19,7 +19,7 @@ a set of GL commands.
 ## Syntax
 
 ```js
-WebGLTimerQueryEXT ext.createQueryEXT();
+createQueryEXT()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/ext_disjoint_timer_query/deletequeryext/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/deletequeryext/index.md
@@ -18,7 +18,7 @@ the [WebGL API](/en-US/docs/Web/API/WebGL_API) deletes a given
 ## Syntax
 
 ```js
-void ext.deleteQueryEXT(query);
+deleteQueryEXT(query)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/ext_disjoint_timer_query/endqueryext/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/endqueryext/index.md
@@ -17,7 +17,7 @@ The **`EXT_disjoint_timer_query.endQueryEXT()`** method of the
 ## Syntax
 
 ```js
-void ext.endQueryEXT(target);
+endQueryEXT(target)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/ext_disjoint_timer_query/getqueryext/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/getqueryext/index.md
@@ -18,7 +18,7 @@ target.
 ## Syntax
 
 ```js
-any ext.getQueryEXT(target, pname);
+getQueryEXT(target, pname)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/ext_disjoint_timer_query/getqueryobjectext/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/getqueryobjectext/index.md
@@ -18,7 +18,7 @@ query object.
 ## Syntax
 
 ```js
-any ext.getQueryObjectEXT(query, pname);
+getQueryObjectEXT(query, pname)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/ext_disjoint_timer_query/isqueryext/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/isqueryext/index.md
@@ -18,7 +18,7 @@ passed object is a {{domxref("WebGLQuery")}} object.
 ## Syntax
 
 ```js
-GLBoolean ext.isQueryEXT(query);
+isQueryEXT(query)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/ext_disjoint_timer_query/querycounterext/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/querycounterext/index.md
@@ -18,7 +18,7 @@ the corresponding query object.
 ## Syntax
 
 ```js
-void ext.queryCounterEXT(query, target);
+queryCounterEXT(query, target)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/fetchevent/respondwith/index.md
+++ b/files/en-us/web/api/fetchevent/respondwith/index.md
@@ -73,14 +73,13 @@ resulting {{domxref("Window.location")}}. This means sites can still provide an
 ## Syntax
 
 ```js
-fetchEvent.respondWith(
-  // Promise that resolves to a Response.
-);
+respondWith(response)
 ```
 
 ### Parameters
 
-A {{domxref("Response")}} or a {{jsxref("Promise")}} that resolves to a
+- `response`
+  - : A {{domxref("Response")}} or a {{jsxref("Promise")}} that resolves to a
 `Response`. Otherwise, a network error is returned to Fetch.
 
 ### Return value

--- a/files/en-us/web/api/formdata/append/index.md
+++ b/files/en-us/web/api/formdata/append/index.md
@@ -21,11 +21,9 @@ The difference between {{domxref("FormData.set")}} and `append()` is that if the
 
 ## Syntax
 
-There are two versions of this method: a two and a three parameter version:
-
 ```js
-formData.append(name, value);
-formData.append(name, value, filename);
+append(name, value)
+append(name, value, filename)
 ```
 
 ### Parameters
@@ -39,7 +37,7 @@ formData.append(name, value, filename);
 
 > **Note:** If you specify a {{domxref("Blob")}} as the data to append to the `FormData` object, the filename that will be reported to the server in the "Content-Disposition" header used to vary from browser to browser.
 
-### Returns
+### Return value
 
 {{jsxref('undefined')}}.
 

--- a/files/en-us/web/api/formdata/set/index.md
+++ b/files/en-us/web/api/formdata/set/index.md
@@ -21,11 +21,9 @@ The difference between `set()` and {{domxref("FormData.append")}} is that if the
 
 ## Syntax
 
-There are two versions of this method: a two and a three parameter version:
-
 ```js
-formData.set(name, value);
-formData.set(name, value, filename);
+set(name, value)
+set(name, value, filename)
 ```
 
 #### Parameters

--- a/files/en-us/web/api/idbfactory/deletedatabase/index.md
+++ b/files/en-us/web/api/idbfactory/deletedatabase/index.md
@@ -32,16 +32,13 @@ particular database will get a [versionchange](/en-US/docs/Web/API/IDBDatabase/v
 
 ## Syntax
 
-For the current standard:
-
 ```js
-var request = indexedDB.deleteDatabase(name);
-```
+// For the current standard:
+deleteDatabase(name)
 
-For the experimental version with `options` (see below):
-
-```js
-var request = indexedDB.deleteDatabase(name, options);
+// For the experimental version with `options` (see below):
+deleteDatabase(name)
+deleteDatabase(name, options)
 ```
 
 ### Parameters
@@ -51,7 +48,7 @@ var request = indexedDB.deleteDatabase(name, options);
     database that doesn't exist does not throw an exception, in contrast to
     {{DOMxRef("IDBDatabase.deleteObjectStore()")}}, which does throw an exception if the
     named object store does not exist.
-- options{{NonStandardBadge}}
+- options {{optional_inline}} {{NonStandardBadge}} 
   - : In Gecko, since [version 26](/en-US/docs/Mozilla/Firefox/Releases/26), you can include
     a non-standard optional storage parameter that specifies whether you want to delete a
     `permanent` (the default value) IndexedDB, or an indexedDB in

--- a/files/en-us/web/api/idbfactory/open/index.md
+++ b/files/en-us/web/api/idbfactory/open/index.md
@@ -30,11 +30,9 @@ May trigger `upgradeneeded`, `blocked` or
 
 ## Syntax
 
-For the current standard:
-
 ```js
-var IDBOpenDBRequest = indexedDB.open(name);
-var IDBOpenDBRequest = indexedDB.open(name, version);
+open(name)
+open(name, version)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/lockmanager/request/index.md
+++ b/files/en-us/web/api/lockmanager/request/index.md
@@ -32,8 +32,8 @@ In the [IndexedDB API](/en-US/docs/Web/API/IndexedDB_API), this is exposed as `"
 ## Syntax
 
 ```js
-LockManager.request(name, callback)
-LockManager.request(name, {options}, callback)
+request(name, callback)
+request(name, options, callback)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/mediakeys/setservercertificate/index.md
+++ b/files/en-us/web/api/mediakeys/setservercertificate/index.md
@@ -20,8 +20,17 @@ server certificate to be used to encrypt messages to the license server.
 ## Syntax
 
 ```js
-MediaKeys.setServerCertificate(serverCertificate).then(function() { /* ... */ });
+setServerCertificate(serverCertificate)
 ```
+
+### Parameters
+
+- `serverCertificate`
+  - : A BufferSource object containing the server certificate. The contents are Key System-specific. It MUST NOT contain executable code.
+
+### Return value
+
+A {{jsxref('Promise')}} that resolves to a boolean. If the Key System implementation represented by this object's cdm implementation value does not support server certificates, return a promise resolved with false.
 
 ## Specifications
 

--- a/files/en-us/web/api/mediakeysession/remove/index.md
+++ b/files/en-us/web/api/mediakeysession/remove/index.md
@@ -16,6 +16,12 @@ browser-compat: api.MediaKeySession.remove
 
 The `MediaKeySession.remove()` method returns a {{jsxref('Promise')}} after removing any session data associated with the current object.
 
+## Syntax
+
+```js
+remove()
+```
+
 ## Return value
 
 A {{jsxref('Promise')}} that resolves to a boolean indicating whether the load succeeded or failed.

--- a/files/en-us/web/api/navigator/getvrdisplays/index.md
+++ b/files/en-us/web/api/navigator/getvrdisplays/index.md
@@ -25,9 +25,7 @@ computer.
 ## Syntax
 
 ```js
-navigator.getVRDisplays().then(function(displays) {
-  // Do something with the available VR displays
-});
+getVRDisplays()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/notification/requestpermission/index.md
+++ b/files/en-us/web/api/notification/requestpermission/index.md
@@ -18,16 +18,12 @@ The **`requestPermission()`** method of the {{domxref("Notification")}} interfac
 
 ## Syntax
 
-The latest spec has updated this method to a promise-based syntax that works like this:
-
 ```js
-Notification.requestPermission().then(function(permission) { /* ... */ });
-```
+// The latest spec has updated this method to a promise-based syntax that works like this:
+requestPermission()
 
-Previously, the syntax was based on a simple callback; this version is now deprecated:
-
-```js
-Notification.requestPermission(callback);
+// Previously, the syntax was based on a simple callback; this version is now deprecated:
+requestPermission(callback)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/oes_vertex_array_object/bindvertexarrayoes/index.md
+++ b/files/en-us/web/api/oes_vertex_array_object/bindvertexarrayoes/index.md
@@ -19,7 +19,7 @@ passed {{domxref("WebGLVertexArrayObject")}} object to the buffer.
 ## Syntax
 
 ```js
-void ext.bindVertexArrayOES(arrayObject);
+bindVertexArrayOES(arrayObject)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/oes_vertex_array_object/createvertexarrayoes/index.md
+++ b/files/en-us/web/api/oes_vertex_array_object/createvertexarrayoes/index.md
@@ -21,7 +21,7 @@ data.
 ## Syntax
 
 ```js
-WebGLVertexArrayObjectOES ext.createVertexArrayOES();
+createVertexArrayOES()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/oes_vertex_array_object/deletevertexarrayoes/index.md
+++ b/files/en-us/web/api/oes_vertex_array_object/deletevertexarrayoes/index.md
@@ -19,7 +19,7 @@ of the [WebGL API](/en-US/docs/Web/API/WebGL_API) deletes a given
 ## Syntax
 
 ```js
-void ext.deleteVertexArrayOES(arrayObject);
+deleteVertexArrayOES(arrayObject)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/oes_vertex_array_object/isvertexarrayoes/index.md
+++ b/files/en-us/web/api/oes_vertex_array_object/isvertexarrayoes/index.md
@@ -19,7 +19,7 @@ the passed object is a {{domxref("WebGLVertexArrayObject")}} object.
 ## Syntax
 
 ```js
-GLBoolean ext.isVertexArrayOES(arrayObject);
+isVertexArrayOES(arrayObject)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/offlineaudiocontext/startrendering/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/startrendering/index.md
@@ -26,21 +26,8 @@ eventually be removed, but currently both mechanisms are provided for legacy rea
 
 ## Syntax
 
-Event-based version:
-
 ```js
-offlineAudioCtx.startRendering();
-offlineAudioCtx.oncomplete = function(e) {
-  // e.renderedBuffer contains the output buffer
-}
-```
-
-Promise-based version:
-
-```js
-offlineAudioCtx.startRendering().then(function(buffer) {
-  // buffer contains the output buffer
-});
+startRendering();
 ```
 
 ### Parameters

--- a/files/en-us/web/api/ovr_multiview2/framebuffertexturemultiviewovr/index.md
+++ b/files/en-us/web/api/ovr_multiview2/framebuffertexturemultiviewovr/index.md
@@ -21,7 +21,7 @@ texture to a {{domxref("WebGLFramebuffer")}}.
 ## Syntax
 
 ```js
-void ext.framebufferTextureMultiviewOVR(target, attachment, texture, level, baseViewIndex, numViews);
+framebufferTextureMultiviewOVR(target, attachment, texture, level, baseViewIndex, numViews)
 ```
 
 ### Parameters
@@ -86,7 +86,7 @@ None.
 - A `gl.INVALID_VALUE` error is thrown if
 
   - `level` is not 0.
-  - if `numViews` is less than one or  more than
+  - if `numViews` is less than one or more than
     `MAX_VIEWS_OVR`.
 
 - A `gl.INVALID_OPERATION` error is thrown if `texture` isn't 0

--- a/files/en-us/web/api/pannernode/setorientation/index.md
+++ b/files/en-us/web/api/pannernode/setorientation/index.md
@@ -21,20 +21,10 @@ The three parameters `x`, `y` and `z` are unitless and describe a direction vect
 ## Syntax
 
 ```js
-var audioCtx = new AudioContext();
-var panner = audioCtx.createPanner();
-panner.setOrientation(1,0,0);
+setOrientation(x, y, z)
 ```
 
-### Returns
-
-{{jsxref('undefined')}}.
-
-## Example
-
-See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/createPanner#example) for example code.
-
-## Parameters
+### Parameters
 
 - x
   - : The x value of the panner's direction vector in 3D space.
@@ -42,6 +32,14 @@ See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/cre
   - : The y value of the panner's direction vector in 3D space.
 - z
   - : The z value of the panner's direction vector in 3D space.
+  - 
+### Return value
+
+{{jsxref('undefined')}}.
+
+## Examples
+
+See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/createPanner#example) for example code.
 
 ## Specifications
 

--- a/files/en-us/web/api/pannernode/setposition/index.md
+++ b/files/en-us/web/api/pannernode/setposition/index.md
@@ -19,20 +19,10 @@ The `setPosition()` method's default value of the position is `(0,` `0,` `0)`.
 ## Syntax
 
 ```js
-var audioCtx = new AudioContext();
-var panner = audioCtx.createPanner();
-panner.setPosition(0,0,0);
+setPosition(x, y, z)
 ```
 
-### Returns
-
-{{jsxref('undefined')}}.
-
-## Example
-
-See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/createPanner#example) for example code.
-
-## Parameters
+### Parameters
 
 - x
   - : The x position of the panner in 3D space.
@@ -40,6 +30,14 @@ See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/cre
   - : The y position of the panner in 3D space.
 - z
   - : The z position of the panner in 3D space.
+
+### Return value
+
+{{jsxref('undefined')}}.
+
+## Examples
+
+See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/createPanner#example) for example code.
 
 ## Specifications
 

--- a/files/en-us/web/api/pannernode/setvelocity/index.md
+++ b/files/en-us/web/api/pannernode/setvelocity/index.md
@@ -28,20 +28,10 @@ As the vector controls both the direction of travel and its velocity, the three 
 ## Syntax
 
 ```js
-var audioCtx = new AudioContext();
-var panner = audioCtx.createPanner();
-panner.setVelocity(0,0,17);
+setVelocity(x, y, z)
 ```
 
-### Returns
-
-{{jsxref('undefined')}}.
-
-## Example
-
-See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/createPanner#example) for example code.
-
-## Parameters
+### Parameters
 
 - `x`
   - : The x value of the panner's velocity vector.
@@ -49,6 +39,14 @@ See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/cre
   - : The y value of the panner's velocity vector.
 - `z`
   - : The z value of the panner's velocity vector.
+
+### Return value
+
+{{jsxref('undefined')}}.
+
+## Examples
+
+See [`BaseAudioContext.createPanner()`](/en-US/docs/Web/API/BaseAudioContext/createPanner#example) for example code.
 
 ## Specifications
 

--- a/files/en-us/web/api/paymentrequestevent/respondwith/index.md
+++ b/files/en-us/web/api/paymentrequestevent/respondwith/index.md
@@ -21,9 +21,7 @@ object yourself.
 ## Syntax
 
 ```js
-paymentRequestEvent.respondWith(
-  // Promise that resolves with a PaymentResponse.
-)
+respondWith(promise)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/paymentresponse/complete/index.md
+++ b/files/en-us/web/api/paymentresponse/complete/index.md
@@ -27,14 +27,15 @@ the payment request and the {{jsxref("Promise")}} returned by the
 ## Syntax
 
 ```js
-completePromise = paymentRequest.complete(result);
+complete()
+complete(result)
 ```
 
 ### Parameters
 
 - `result` {{optional_inline}}
 
-  - : A {{domxref("DOMString")}} indicating the state of the payment operation upon
+  - : A string indicating the state of the payment operation upon
     completion. It must be one of the following:
 
     - `success`

--- a/files/en-us/web/api/performance/getentries/index.md
+++ b/files/en-us/web/api/performance/getentries/index.md
@@ -23,10 +23,8 @@ certain types or that have certain names, see {{domxref("Performance.getEntriesB
 
 ## Syntax
 
-General syntax:
-
 ```js
-entries = window.performance.getEntries();
+getEntries()
 ```
 
 ### Return value

--- a/files/en-us/web/api/performanceobserverentrylist/getentries/index.md
+++ b/files/en-us/web/api/performanceobserverentrylist/getentries/index.md
@@ -24,24 +24,16 @@ interfaces.
 
 ## Syntax
 
-General syntax:
-
 ```js
-entries = list.getEntries();
-entries = list.getEntries(PerformanceEntryFilterOptions);
-```
-
-Specific usage:
-
-```js
-entries = list.getEntries({name: "entry_name", entryType: "mark"});
+getEntries()
+getEntries(performanceEntryFilterOptions)
 ```
 
 ### Parameters
 
-- `PerformanceEntryFilterOptions`{{optional_inline}}
+- `performanceEntryFilterOptions` {{optional_inline}}
 
-  - : Is a `PerformanceEntryFilterOptions` dictionary, having the following
+  - : Is a `PerformanceEntryFilterOptions` object, having the following
     fields:
 
     - `"name"`, the name of a performance entry.

--- a/files/en-us/web/api/permissions/revoke/index.md
+++ b/files/en-us/web/api/permissions/revoke/index.md
@@ -16,14 +16,13 @@ browser-compat: api.Permissions.revoke
 The **`Permissions.revoke()`** method of the
 {{domxref("Permissions")}} interface reverts a currently set permission back to its
 default state, which is usually `prompt`.
-
-## Syntax
-
 This method is called on the global {{domxref("Permissions")}} object
 {{domxref("navigator.permissions")}}.
 
+## Syntax
+
 ```js
-var revokePromise = navigator.permissions.revoke(descriptor);
+revoke(descriptor)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/presentationconnection/close/index.md
+++ b/files/en-us/web/api/presentationconnection/close/index.md
@@ -16,6 +16,12 @@ browser-compat: api.PresentationConnection.close
 
 When the `close()` method is called on a {{domxref("PresentationConnection")}}, the {{Glossary("user agent")}} begins the process of closing the connection by sending an empty `closeMessage` with the `closeReason` set to `closed`.
 
+## Syntax
+
+```js
+close()
+```
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/presentationconnection/terminate/index.md
+++ b/files/en-us/web/api/presentationconnection/terminate/index.md
@@ -18,6 +18,12 @@ browser-compat: api.PresentationConnection.terminate
 
 When the `terminate()` method is called on a {{domxref("PresentationConnection")}}, the {{Glossary("user agent")}} begins the process of terminating the presentation. The exact process differs depending on whether `terminate()` is called in the controlling or the presenting context.
 
+## Syntax
+
+```js
+terminate()
+```
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/request/arraybuffer/index.md
+++ b/files/en-us/web/api/request/arraybuffer/index.md
@@ -18,9 +18,7 @@ reads the request body and returns it as a promise that resolves with an {{jsxre
 ## Syntax
 
 ```js
-request.arrayBuffer().then(function(buffer) {
-   // do something with the buffer
-});
+arrayBuffer()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/request/blob/index.md
+++ b/files/en-us/web/api/request/blob/index.md
@@ -18,9 +18,7 @@ reads the request body and returns it as a promise that resolves with a {{domxre
 ## Syntax
 
 ```js
-request.blob().then(function(myBlob) {
-  // do something with myBlob
-});
+blob()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/request/formdata/index.md
+++ b/files/en-us/web/api/request/formdata/index.md
@@ -18,9 +18,7 @@ reads the request body and returns it as a promise that resolves with a {{domxre
 ## Syntax
 
 ```js
-request.formData().then(function(formdata) {
-  // do something with your formdata
-});
+formData()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/request/json/index.md
+++ b/files/en-us/web/api/request/json/index.md
@@ -20,9 +20,7 @@ Note that despite the method being named `json()`, the result is not JSON but is
 ## Syntax
 
 ```js
-request.json().then(data => {
-  // do something with your data
-});
+json()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/request/text/index.md
+++ b/files/en-us/web/api/request/text/index.md
@@ -19,9 +19,7 @@ The response is *always* decoded using UTF-8.
 ## Syntax
 
 ```js
-request.text().then(function (text) {
-  // do something with the text sent in the request
-});
+text()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/response/arraybuffer/index.md
+++ b/files/en-us/web/api/response/arraybuffer/index.md
@@ -19,9 +19,7 @@ that resolves with an {{jsxref("ArrayBuffer")}}.
 ## Syntax
 
 ```js
-response.arrayBuffer().then(function(buffer) {
-  // do something with buffer
-});
+arrayBuffer()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/response/blob/index.md
+++ b/files/en-us/web/api/response/blob/index.md
@@ -19,9 +19,7 @@ resolves with a {{domxref("Blob")}}.
 ## Syntax
 
 ```js
-response.blob().then(function(myBlob) {
-  // do something with myBlob
-});
+blob()
 ```
 
 ### Parameters
@@ -38,7 +36,7 @@ None.
 
 A promise that resolves with a {{domxref("Blob")}}.
 
-## Example
+## Examples
 
 In our [fetch
 request example](https://github.com/mdn/fetch-examples/tree/master/fetch-request) (run [fetch request live](https://mdn.github.io/fetch-examples/fetch-request/)), we

--- a/files/en-us/web/api/response/formdata/index.md
+++ b/files/en-us/web/api/response/formdata/index.md
@@ -26,10 +26,7 @@ that resolves with a {{domxref("FormData")}} object.
 ## Syntax
 
 ```js
-response.formData()
-.then(function(formdata) {
-  // do something with your formdata
-});
+formData()
 ```
 
 ### Parameters
@@ -40,7 +37,7 @@ None.
 
 A {{jsxref("Promise")}} that resolves with a {{domxref("FormData")}} object.
 
-## Example
+## Examples
 
 TBD.
 

--- a/files/en-us/web/api/response/json/index.md
+++ b/files/en-us/web/api/response/json/index.md
@@ -21,9 +21,7 @@ Note that despite the method being named `json()`, the result is not JSON but is
 ## Syntax
 
 ```js
-response.json().then(data => {
-  // do something with your data
-});
+json()
 ```
 
 ### Parameters
@@ -35,7 +33,7 @@ None.
 A {{jsxref("Promise")}} that resolves to a JavaScript object. This object could be
 anything that can be represented by JSON — an object, an array, a string, a number...
 
-## Example
+## Examples
 
 In our [fetch JSON example](https://github.com/mdn/fetch-examples/tree/master/fetch-json) (run [fetch JSON live](https://mdn.github.io/fetch-examples/fetch-json/)), we create a new request using the {{DOMxRef("Request.Request",
   "Request()")}} constructor, then use it to fetch a `.json` file. When the

--- a/files/en-us/web/api/response/text/index.md
+++ b/files/en-us/web/api/response/text/index.md
@@ -19,9 +19,7 @@ The response is *always* decoded using UTF-8.
 ## Syntax
 
 ```js
-response.text().then(function (text) {
-  // do something with the text response
-});
+text()
 ```
 
 ### Parameters
@@ -32,13 +30,13 @@ None.
 
 A Promise that resolves with a {{jsxref("String")}}.
 
-## Example
+## Examples
 
 In our [fetch text example](https://github.com/mdn/fetch-examples/tree/master/fetch-text) (run [fetch text live](https://mdn.github.io/fetch-examples/fetch-text/)), we have an {{htmlelement("article")}} element and three links (stored in the `myLinks` array.)
 First, we loop through all of these and give each one an `onclick` event handler so that the `getData()` function is run — with the link's `data-page` identifier passed to it as an argument — when one of the links is clicked.
 
 When `getData()` is run, we create a new request using the {{domxref("Request.Request","Request()")}} constructor, then use it to fetch a specific `.txt` file.
-When the fetch is successful, we read a {{domxref("USVString")}} (text) object out of the response using `text()`, then set the {{domxref("Element.innerHTML","innerHTML")}} of the {{htmlelement("article")}} element equal to the text object.
+When the fetch is successful, we read a string out of the response using `text()`, then set the {{domxref("Element.innerHTML","innerHTML")}} of the {{htmlelement("article")}} element equal to the text object.
 
 ```js
 let myArticle = document.querySelector('article');

--- a/files/en-us/web/api/serviceworkerglobalscope/skipwaiting/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/skipwaiting/index.md
@@ -20,16 +20,14 @@ Use this method with {{domxref("Clients.claim()")}} to ensure that updates to th
 ## Syntax
 
 ```js
-ServiceWorkerGlobalScope.skipWaiting().then(function() {
-  //Do something
-});
+skipWaiting()
 ```
 
-### Returns
+### Return value
 
 A {{jsxref("Promise")}} that immediately resolves with `undefined`.
 
-## Example
+## Examples
 
 While `self.skipWaiting()` can be called at any point during the service worker's execution, it will only have an effect if there's a newly installed service worker that might otherwise remain in the `waiting` state. Therefore, it's common to call `self.skipWaiting()` from inside of an {{domxref("InstallEvent")}} handler.
 

--- a/files/en-us/web/api/serviceworkerregistration/unregister/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/unregister/index.md
@@ -26,8 +26,7 @@ unregistered.
 ## Syntax
 
 ```js
-serviceWorkerRegistration.unregister().then(function(boolean) {
-});
+unregister()
 ```
 
 ### Parameters
@@ -39,7 +38,7 @@ None.
 {{jsxref("Promise")}} resolves with a boolean indicating whether the service worker has
 unregistered or not.
 
-## Example
+## Examples
 
 The following simple example registers a service worker example, but then immediately
 unregisters it again:

--- a/files/en-us/web/api/subtlecrypto/wrapkey/index.md
+++ b/files/en-us/web/api/subtlecrypto/wrapkey/index.md
@@ -34,12 +34,7 @@ of import + decrypt.
 ## Syntax
 
 ```js
-const result = crypto.subtle.wrapKey(
-    format,
-    key,
-    wrappingKey,
-    wrapAlgo
-);
+wrapKey(format, key, wrappingKey, wrapAlgo)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/vrdisplay/exitpresent/index.md
+++ b/files/en-us/web/api/vrdisplay/exitpresent/index.md
@@ -22,9 +22,7 @@ The **`exitPresent()`** method of the {{domxref("VRDisplay")}} interface stops t
 ## Syntax
 
 ```js
-vrDisplayInstance.exitPresent().then(function() {
-  // Do something after the presentation has ended
-});
+exitPresent()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/vrdisplay/requestpresent/index.md
+++ b/files/en-us/web/api/vrdisplay/requestpresent/index.md
@@ -22,9 +22,7 @@ The **`requestPresent()`** method of the {{domxref("VRDisplay")}} interface star
 ## Syntax
 
 ```js
-vrDisplayInstance.requestPresent(layers).then(function() {
-  // Do something after the presentation has begun
-});
+requestPresent(layers)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl2renderingcontext/clearbuffer/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/clearbuffer/index.md
@@ -18,10 +18,16 @@ currently bound framebuffer.
 ## Syntax
 
 ```js
-void gl.clearBufferfv(buffer, drawbuffer, values, optional srcOffset);
-void gl.clearBufferiv(buffer, drawbuffer, values, optional srcOffset);
-void gl.clearBufferuiv(buffer, drawbuffer, values, optional srcOffset);
-void gl.clearBufferfi(buffer, drawbuffer, depth, stencil);
+clearBufferfv(buffer, drawbuffer, values)
+clearBufferfv(buffer, drawbuffer, values, srcOffset)
+
+clearBufferiv(buffer, drawbuffer, values)
+clearBufferiv(buffer, drawbuffer, values, srcOffset)
+
+clearBufferuiv(buffer, drawbuffer, values)
+clearBufferuiv(buffer, drawbuffer, values, srcOffset)
+
+clearBufferfi(buffer, drawbuffer, depth, stencil)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl_compressed_texture_astc/getsupportedprofiles/index.md
+++ b/files/en-us/web/api/webgl_compressed_texture_astc/getsupportedprofiles/index.md
@@ -19,12 +19,12 @@ by the implementation.
 ## Syntax
 
 ```js
-sequence<DOMString> ext.getSupportedProfiles();
+getSupportedProfiles()
 ```
 
 ### Return value
 
-An {{jsxref("Array")}} of {{domxref("DOMString")}} elements indicating which ASTC
+An {{jsxref("Array")}} of string elements indicating which ASTC
 profiles are supported by the implementation. Currently, this can be:
 
 - "ldr": Low Dynamic Range.

--- a/files/en-us/web/api/webgl_debug_shaders/gettranslatedshadersource/index.md
+++ b/files/en-us/web/api/webgl_debug_shaders/gettranslatedshadersource/index.md
@@ -18,7 +18,7 @@ you to debug a translated shader.
 ## Syntax
 
 ```js
-gl.getExtension('WEBGL_debug_shaders').getTranslatedShaderSource(shader);
+getTranslatedShaderSource(shader)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl_draw_buffers/drawbufferswebgl/index.md
+++ b/files/en-us/web/api/webgl_draw_buffers/drawbufferswebgl/index.md
@@ -24,7 +24,7 @@ This method is part of the {{domxref("WEBGL_draw_buffers")}} extension.
 ## Syntax
 
 ```js
-void gl.getExtension('WEBGL_draw_buffers').drawBuffersWEBGL(buffers);
+drawBuffersWEBGL(buffers)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webgl_lose_context/losecontext/index.md
+++ b/files/en-us/web/api/webgl_lose_context/losecontext/index.md
@@ -21,7 +21,7 @@ called.
 ## Syntax
 
 ```js
-gl.getExtension('WEBGL_lose_context').loseContext();
+loseContext()
 ```
 
 ## Examples

--- a/files/en-us/web/api/webgl_lose_context/restorecontext/index.md
+++ b/files/en-us/web/api/webgl_lose_context/restorecontext/index.md
@@ -17,7 +17,7 @@ restoring the context of a {{domxref("WebGLRenderingContext")}} object.
 ## Syntax
 
 ```js
-gl.getExtension('WEBGL_lose_context').restoreContext();
+restoreContext()
 ```
 
 ### Errors thrown

--- a/files/en-us/web/api/webglrenderingcontext/compressedteximage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/compressedteximage2d/index.md
@@ -25,18 +25,22 @@ using these methods.
 
 ```js
 // WebGL 1:
-void gl.compressedTexImage2D(target, level, internalformat, width, height, border, ArrayBufferView? pixels);
+compressedTexImage2D(target, level, internalformat, width, height, border)
+compressedTexImage2D(target, level, internalformat, width, height, border, pixels)
 
 // Additionally available in WebGL 2:
 // read from buffer bound to gl.PIXEL_UNPACK_BUFFER
-void gl.compressedTexImage2D(target, level, internalformat, width, height, border, GLsizei imageSize, GLintptr offset);
-void gl.compressedTexImage2D(target, level, internalformat, width, height, border,
-                             ArrayBufferView srcData, optional srcOffset, optional srcLengthOverride);
+compressedTexImage2D(target, level, internalformat, width, height, border, imageSize, offset)
+compressedTexImage2D(target, level, internalformat, width, height, border, srcData)
+compressedTexImage2D(target, level, internalformat, width, height, border, srcData, srcOffset)
+compressedTexImage2D(target, level, internalformat, width, height, border, srcData, srcOffset, srcLengthOverride)
 
- // read from buffer bound to gl.PIXEL_UNPACK_BUFFER
-void gl.compressedTexImage3D(target, level, internalformat, width, height, depth, border, GLsizei imageSize, GLintptr offset);
-void gl.compressedTexImage3D(target, level, internalformat, width, height, depth, border,
-                             ArrayBufferView srcData, optional srcOffset, optional srcLengthOverride);
+// read from buffer bound to gl.PIXEL_UNPACK_BUFFER
+compressedTexImage3D(target, level, internalformat, width, height, depth, border, imageSize, offset)
+
+compressedTexImage3D(target, level, internalformat, width, height, depth, border, srcData)
+compressedTexImage3D(target, level, internalformat, width, height, depth, border, srcData, srcOffset)
+compressedTexImage3D(target, level, internalformat, width, height, depth, border, srcData, srcOffset, srcLengthOverride)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/webglrenderingcontext/getattachedshaders/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getattachedshaders/index.md
@@ -18,7 +18,7 @@ the [WebGL API](/en-US/docs/Web/API/WebGL_API) returns a list of
 ## Syntax
 
 ```js
-gl.getAttachedShaders(program)
+getAttachedShaders(program)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/window/requestfilesystem/index.md
+++ b/files/en-us/web/api/window/requestfilesystem/index.md
@@ -24,12 +24,13 @@ The non-standard {{domxref("Window")}} method
 method which lets a web site or app gain access to a sandboxed file system for its own
 use. The returned {{domxref("FileSystem")}} is then available for use with the other [file system APIs](/en-US/docs/Web/API/File_and_Directory_Entries_API).
 
-## Syntax
-
 > **Note:** This method is prefixed with `webkit` in all browsers that implement it.
 
+## Syntax
+
 ```js
-window.requestFileSystem(type, size, successCallback[, errorCallback]);
+requestFileSystem(type, size, successCallback)
+requestFileSystem(type, size, successCallback, errorCallback)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/windowclient/focus/index.md
+++ b/files/en-us/web/api/windowclient/focus/index.md
@@ -22,9 +22,7 @@ interface gives user input focus to the current client and returns a
 ## Syntax
 
 ```js
-windowClient.focus().then(function(windowClient) {
-  // do something with your WindowClient once it has been focused
-});
+focus()
 ```
 
 ### Parameters
@@ -35,7 +33,7 @@ None.
 
 A {{jsxref("Promise")}} that resolves to the existing {{domxref("WindowClient")}}.
 
-## Example
+## Examples
 
 ```js
 self.addEventListener('notificationclick', function(event) {

--- a/files/en-us/web/api/windowclient/navigate/index.md
+++ b/files/en-us/web/api/windowclient/navigate/index.md
@@ -21,9 +21,7 @@ interface loads a specified URL into a controlled client page then returns a
 ## Syntax
 
 ```js
-windowClient.navigate(url).then(function(windowClient) {
-  // do something with your WindowClient after navigation
-});
+navigate(url)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/writablestreamdefaultwriter/abort/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/abort/index.md
@@ -32,7 +32,7 @@ abort(reason)
 ### Parameters
 
 - reason {{optional_inline}}
-  - : A string representing a human-readable reason for the abort.
+  - : A {{domxref("DOMString")}} representing a human-readable reason for the abort.
 
 ### Return value
 

--- a/files/en-us/web/api/writablestreamdefaultwriter/abort/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/abort/index.md
@@ -32,7 +32,7 @@ abort(reason)
 ### Parameters
 
 - reason {{optional_inline}}
-  - : A {{domxref("DOMString")}} representing a human-readable reason for the abort.
+  - : A string representing a human-readable reason for the abort.
 
 ### Return value
 

--- a/files/en-us/web/api/xmldocument/load/index.md
+++ b/files/en-us/web/api/xmldocument/load/index.md
@@ -15,6 +15,12 @@ browser-compat: api.XMLDocument.load
 
 `document.load()` is a part of an old version of the W3C [DOM Level 3 Load & Save module](https://www.w3.org/TR/2003/WD-DOM-Level-3-LS-20030619/load-save.html#LS-DocumentLS). Can be used with {{DOMxRef("XMLDocument.async")}} to indicate whether the request is synchronous or asynchronous (the default). As of at least Gecko 1.9, this no longer supports cross-site loading of documents (Use {{DOMxRef("XMLHttpRequest")}} or {{DOMxRef("fetch()")}} instead).
 
+## Syntax
+
+```js
+load()
+```
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/xpathevaluator/createexpression/index.md
+++ b/files/en-us/web/api/xpathevaluator/createexpression/index.md
@@ -50,7 +50,7 @@ If the expression contains namespace prefixes which cannot be resolved by the sp
 {{domxref("XPathNSResolver")}}, a {{domxref("DOMException")}} of type
 `NAMESPACE_ERROR` is raised.
 
-## Examples
+## Example
 
 The following example shows the use of the `evaluate()` method.
 

--- a/files/en-us/web/api/xpathevaluator/evaluate/index.md
+++ b/files/en-us/web/api/xpathevaluator/evaluate/index.md
@@ -80,7 +80,7 @@ If the provided context node is not a type permitted as an XPath context node or
 request type is not permitted by the {{domxref("XPathEvaluator")}}, a
 {{domxref("DOMException")}} of type `NOT_SUPPORTED_ERR` is raised.
 
-## Examples
+## Example
 
 The following example shows the use of the `evaluate()` method.
 


### PR DESCRIPTION
Continuing #14857 

## Summary
Updating the method pages to follow the current templates:
https://developer.mozilla.org/en-US/docs/MDN/Structures/Syntax_sections#constructors_and_methods
https://developer.mozilla.org/en-US/docs/MDN/Structures/Page_types/API_method_subpage_template

Changes Include:
- fix syntax section
- changing section titles to suggested titles in the template
- change `{{DOMxRef("DOMString")}}` to `string`
- remove extra spaces in between words and extra trailing spaces
- other small corrections

### Metadata
- [x] Fixes a typo, bug, or other error
