### PR TITLE
Document global beforexrselect event

### DIFF
--- a/files/en-us/web/api/globaleventhandlers/beforexrselect_event/index.md
+++ b/files/en-us/web/api/globaleventhandlers/beforexrselect_event/index.md
@@ -1,0 +1,69 @@
+---
+title: 'beforexrselect event'
+slug: Web/API/GlobalEventHandlers/beforexrselect_event
+tags:
+  - API
+  - Event
+  - Reference
+  - Global event
+browser-compat: api.GlobalEventHandlers.beforexrselect_event
+---
+{{APIRef}}
+
+The global **`beforexrselect`** event is fired before WebXR select events ({{domxref("XRSession/select_event", "select")}}, {{domxref("XRSession/selectstart_event", "selectstart")}}, {{domxref("XRSession/selectend_event", "selectend")}}) are dispatched. It can be used to suppress XR world input events while the user is interacting with a DOM overlay UI.
+
+This event [bubbles](/en-US/docs/Learn/JavaScript/Building_blocks/Events#event_bubbling_and_capture), is [cancelable](/en-US/docs/Web/API/Event/cancelable) and is [composed](/en-US/docs/Web/API/Event/composed).
+
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener('beforexrselect', event => { });
+
+onbeforexrselect = event => { };
+```
+
+## Event type
+
+An {{domxref("XRSessionEvent")}}. Inherits from {{domxref("Event")}}.
+
+{{InheritanceDiagram("XRSessionEvent")}}
+
+## Event properties
+
+- {{domxref("XRSessionEvent.session", "session")}} {{ReadOnlyInline}}
+  - : The {{domxref("XRSession")}} to which the event refers.
+
+## Event availability
+
+The **`beforexrselect`** event is a global event and available to the following interfaces:
+
+- {{domxref("Window")}}
+- {{domxref("Document")}}
+- {{domxref("HTMLElement")}}
+- {{domxref("SVGElement")}}
+- {{domxref("MathMLElement")}}
+
+## Examples
+
+To suppress WebXR select events ({{domxref("XRSession/select_event", "select")}}, {{domxref("XRSession/selectstart_event", "selectstart")}}, {{domxref("XRSession/selectend_event", "selectend")}}), an application can listen for the `beforexrselect` event. The event bubbles, so a call to {{domxref("Event/preventDefault", "preventDefault()")}} on the DOM overlay element will prevent any WebXR select events within this container allowing interaction with the DOM element and avoiding duplicate event input to the XR world.
+
+```js
+document.getElementById('xr-overlay').addEventListener(
+  'beforexrselect', ev => ev.preventDefault());
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("XRSession/select_event", "select")}} event
+- {{domxref("XRSession/selectstart_event", "selectstart")}} event
+- {{domxref("XRSession/selectend_event", "selectend")}} event

--- a/files/en-us/web/api/xrsession/domoverlaystate/index.md
+++ b/files/en-us/web/api/xrsession/domoverlaystate/index.md
@@ -51,3 +51,6 @@ if (session.domOverlayState) {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+- {{domxref("GlobalEventHandlers.beforexrselect_event", "beforexrselect")}}

--- a/files/en-us/web/api/xrsession/select_event/index.md
+++ b/files/en-us/web/api/xrsession/select_event/index.md
@@ -94,3 +94,4 @@ xrSession.onselect = event => {
 ## See also
 
 - {{domxref("XRSession.selectstart_event", "selectstart")}} and {{domxref("XRSession.selectend_event", "selectend")}}
+- {{domxref("GlobalEventHandlers.beforexrselect_event", "beforexrselect")}}

--- a/files/en-us/web/api/xrsession/selectend_event/index.md
+++ b/files/en-us/web/api/xrsession/selectend_event/index.md
@@ -80,3 +80,4 @@ See the [`selectstart`](/en-US/docs/Web/API/XRSession/selectstart_event#examples
 ## See also
 
 - {{domxref("XRSession.select_event", "select")}} and {{domxref("XRSession.selectstart_event", "selectstart")}}
+- {{domxref("GlobalEventHandlers.beforexrselect_event", "beforexrselect")}}

--- a/files/en-us/web/api/xrsession/selectstart_event/index.md
+++ b/files/en-us/web/api/xrsession/selectstart_event/index.md
@@ -130,3 +130,4 @@ xrSession.onselectend = onSelectionEvent;
 ## See also
 
 - {{domxref("XRSession.select_event", "select")}} and {{domxref("XRSession.selectend_event", "selectend")}}
+- {{domxref("GlobalEventHandlers.beforexrselect_event", "beforexrselect")}}


### PR DESCRIPTION
This is a PR to discuss how to document events that are defined as `GlobalEventHandlers`.

Spec: https://immersive-web.github.io/dom-overlays/#onbeforexrselect

WebIDL:

```webidl
partial interface mixin GlobalEventHandlers {
  attribute EventHandler onbeforexrselect;
};

Document includes GlobalEventHandlers
Window includes GlobalEventHandlers
HTMLElement includes GlobalEventHandlers
MathMLElement includes GlobalEventHandlers
SVGElement includes GlobalEventHandlers
```

If we would avoid the `GlobalEventHandlers` mixin, then the specific interfaces for the `beforexrselect` event would be `Document`, `Window`, `HTMLElement`, `MathMLElement`, `SVGElement`. I think it makes no sense to create pages under all these interfaces. So, here I'm instead creating a single page `beforexrselect_event` under `GlobalEventHandlers` along with a section on the page called "Event availability". The title of the page is just 'beforexrselect event' without an interface.

In BCD, the data would live in `api.GlobalEventHandlers.beforexrselect_event`. See https://github.com/mdn/browser-compat-data/pull/16026
