### PR TITLE
Remove prototype + mention of dictionaries

### DIFF
--- a/files/en-us/web/api/textdecoder/decode/index.md
+++ b/files/en-us/web/api/textdecoder/decode/index.md
@@ -1,5 +1,5 @@
 ---
-title: TextDecoder.prototype.decode()
+title: TextDecoder.decode()
 slug: Web/API/TextDecoder/decode
 tags:
   - API
@@ -11,9 +11,9 @@ browser-compat: api.TextDecoder.decode
 ---
 {{APIRef("Encoding API")}}{{SeeCompatTable}}
 
-The **`TextDecoder.prototype.decode()`** method returns a
+The **`TextDecode.decode()`** method returns a
 string containing the text, given in parameters, decoded with the
-specific method for that `TextDecoder` object.
+specific method for that {{domxref("TextDecoder")}}> object.
 
 ## Syntax
 
@@ -32,7 +32,7 @@ decode(buffer, options)
     containing the text to decode.
 - `options` {{Optional_Inline}}
 
-  - : Is a `TextDecodeOptions` dictionary with the property:
+  - : An object with the property:
 
     - `stream`
       - : A boolean flag indicating that additional data will follow in

--- a/files/en-us/web/api/textdecoder/encoding/index.md
+++ b/files/en-us/web/api/textdecoder/encoding/index.md
@@ -1,5 +1,5 @@
 ---
-title: TextDecoder.prototype.encoding
+title: TextDecoder.encoding
 slug: Web/API/TextDecoder/encoding
 tags:
   - API
@@ -12,7 +12,7 @@ browser-compat: api.TextDecoder.encoding
 ---
 {{APIRef("Encoding API")}}{{SeeCompatTable}}
 
-The **`TextDecoder.prototype.encoding`** read-only property
+The **`TextDecoder.encoding`** read-only property
 returns a {{DOMxRef("DOMString")}} containing the name of the decoding algorithm used by
 the specific decoder.
 

--- a/files/en-us/web/api/textdecoder/index.md
+++ b/files/en-us/web/api/textdecoder/index.md
@@ -58,18 +58,18 @@ console.log(win1251decoder.decode(bytes)); // Привет, мир!
 
 _The `TextDecoder` interface doesn't inherit any properties._
 
-- {{DOMxRef("TextDecoder.prototype.encoding")}}{{ReadOnlyInline}}
+- {{DOMxRef("TextDecoder.encoding")}}{{ReadOnlyInline}}
   - : A {{DOMxRef("DOMString")}} containing the name of the decoder, that is a string describing the method the `TextDecoder` will use.
-- {{DOMxRef("TextDecoder.prototype.fatal")}}{{ReadOnlyInline}}
+- {{DOMxRef("TextDecoder.fatal")}}{{ReadOnlyInline}}
   - : A {{jsxref('Boolean')}} indicating whether the error mode is fatal.
-- {{DOMxRef("TextDecoder.prototype.ignoreBOM")}}{{ReadOnlyInline}}
+- {{DOMxRef("TextDecoder.ignoreBOM")}}{{ReadOnlyInline}}
   - : A {{jsxref('Boolean')}} indicating whether the [byte order mark](https://www.w3.org/International/questions/qa-byte-order-mark) is ignored.
 
 ## Methods
 
 _The `TextDecoder` interface doesn't inherit any method_.
 
-- {{DOMxRef("TextDecoder.prototype.decode()")}}
+- {{DOMxRef("TextDecoder.decode()")}}
   - : Returns a {{DOMxRef("DOMString")}} containing the text decoded with the method of the specific `TextDecoder` object.
 
 ## Specifications

--- a/files/en-us/web/api/textencoder/encode/index.md
+++ b/files/en-us/web/api/textencoder/encode/index.md
@@ -1,5 +1,5 @@
 ---
-title: TextEncoder.prototype.encode()
+title: TextEncode.encode()
 slug: Web/API/TextEncoder/encode
 tags:
   - API
@@ -12,10 +12,10 @@ browser-compat: api.TextEncoder.encode
 ---
 {{APIRef("Encoding API")}}
 
-The **`TextEncoder.prototype.encode()`** method takes a
+The **`TextEncoder.encode()`** method takes a
 string as input, and returns a {{jsxref("Global_Objects/Uint8Array",
   "Uint8Array")}} containing the text given in parameters encoded with the specific method
-for that `TextEncoder` object.
+for that {{domxref("TextEncoder")}} object.
 
 ## Syntax
 

--- a/files/en-us/web/api/textencoder/encodeinto/index.md
+++ b/files/en-us/web/api/textencoder/encodeinto/index.md
@@ -1,5 +1,5 @@
 ---
-title: TextEncoder.prototype.encodeInto()
+title: TextEncoder.encodeInto()
 slug: Web/API/TextEncoder/encodeInto
 tags:
   - API
@@ -12,7 +12,7 @@ browser-compat: api.TextEncoder.encodeInto
 ---
 {{APIRef("Encoding API")}}{{SeeCompatTable}}
 
-The **`TextEncoder.prototype.encodeInto()`** method takes a
+The **`TextEncoder.encodeInto()`** method takes a
 string to encode and a destination {{jsxref("Uint8Array")}} to put
 resulting UTF-8 encoded text into, and returns a dictionary object indicating the
 progress of the encoding. This is potentially more performant than the older
@@ -35,7 +35,7 @@ encodeInto(string, uint8Array)
 
 ### Return value
 
-A `TextEncoderEncodeIntoResult` dictionary, which contains two members:
+An object, which contains two members:
 
 - `read`
   - : The number of UTF-16 units of code from the source that has been converted over to

--- a/files/en-us/web/api/textencoder/index.md
+++ b/files/en-us/web/api/textencoder/index.md
@@ -40,9 +40,9 @@ _The `TextEncoder` interface doesn't inherit any property._
 
 _The `TextEncoder` interface doesn't inherit any method_.
 
-- {{DOMxRef("TextEncoder.prototype.encode()")}}
+- {{DOMxRef("TextEncoder.encode()")}}
   - : Takes a {{domxref("USVString")}} as input, and returns a {{jsxref("Uint8Array")}} containing UTF-8 encoded text.
-- {{DOMxRef("TextEncoder.prototype.encodeInto()")}}
+- {{DOMxRef("TextEncoder.encodeInto()")}}
   - : Takes a {{domxref("USVString")}} to encode and a destination {{jsxref("Uint8Array")}} to put resulting UTF-8 encoded text into, and returns a dictionary object indicating the progress of the encoding. This is potentially more performant than the older `encode()` method.
 
 ## Specifications


### PR DESCRIPTION
In `TextEncoder` and `TextDecoder` some properties/methods were prefixed with `prototype`. We do this in the JS area, but not in the Web API area.

In addition, I removed the name of 2 dictionaries that are invisible to web devs and only used inside the spec.