### PR TITLE
Add more APIs in "Built-in APIs accepting iterables"

### DIFF
--- a/files/en-us/web/javascript/reference/iteration_protocols/index.md
+++ b/files/en-us/web/javascript/reference/iteration_protocols/index.md
@@ -213,7 +213,9 @@ new WeakSet(function* () {
 #### See also
 
 - {{jsxref("Promise.all()", "Promise.all(<var>iterable</var>)")}}
+- {{jsxref("Promise.allSettled()", "Promise.allSettled(<var>iterable</var>)")}}
 - {{jsxref("Promise.race()", "Promise.race(<var>iterable</var>)")}}
+- {{jsxref("Promise.any()", "Promise.any(<var>iterable</var>)")}}
 - {{jsxref("Array.from()", "Array.from(<var>iterable</var>)")}}
 
 ### Syntaxes expecting iterables


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Add two APIs in "Built-in APIs accepting iterables".

#### Motivation
In my opinion, both of the `Promise.allSettled(iterable)` API and the `Promise.any(iterable)` API, like the `Promise.all(iterable)` API and the `Promise.race(iterable)` API, belong to `Promise` and should be listed in "See also" too.

#### Supporting details
See https://tc39.es/ecma262/#sec-promise.allsettled and https://tc39.es/ecma262/#sec-promise.any

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
