### PR TITLE
Fix example markup

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-hidden/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-hidden/index.md
@@ -54,7 +54,7 @@ Using `aria-hidden="false"` will not re-expose the element to assistive technolo
 Adding `aria-hidden="true"` to the icon hides the icon character from being included in the accessible name.
 
 ```html
-<button type="button" aria-pressed="false">
+<button>
   <span class="fa fa-tweet" aria-hidden="true"></span>
   <span class="label">
     Tweet


### PR DESCRIPTION
Having a native HTML button makes the use of these attributes redundant and confusing in this particular example.