### PR TITLE
Adapt SubtleCrypto pages to modern structure

### DIFF
--- a/files/en-us/web/api/subtlecrypto/decrypt/index.md
+++ b/files/en-us/web/api/subtlecrypto/decrypt/index.md
@@ -30,7 +30,6 @@ decrypt(algorithm, key, data)
   - : An object specifying the [algorithm](#supported_algorithms) to be used, and any extra parameters as
     required. The values given for the extra parameters must match those passed into the
     corresponding {{domxref("SubtleCrypto.encrypt()", "encrypt()")}} call.
-
     - To use [RSA-OAEP](#rsa-oaep), pass an {{domxref("RsaOaepParams")}} object.
     - To use [AES-CTR](#aes-ctr), pass an {{domxref("AesCtrParams")}} object.
     - To use [AES-CBC](#aes-cbc), pass an {{domxref("AesCbcParams")}} object.
@@ -41,7 +40,7 @@ decrypt(algorithm, key, data)
     of the {{domxref("CryptoKeyPair")}} object.
 - `data`
   - : A {{domxref("BufferSource")}} containing the data to
-   be decrypted (also known as {{glossary("ciphertext")}}).
+    be decrypted (also known as {{glossary("ciphertext")}}).
 
 ### Return value
 

--- a/files/en-us/web/api/subtlecrypto/decrypt/index.md
+++ b/files/en-us/web/api/subtlecrypto/decrypt/index.md
@@ -26,24 +26,21 @@ decrypt(algorithm, key, data)
 
 ### Parameters
 
-- _`algorithm`_ is an object specifying the [algorithm](#supported_algorithms) to be used, and any extra parameters as
-  required. The values given for the extra parameters must match those passed into the
-  corresponding {{domxref("SubtleCrypto.encrypt()", "encrypt()")}} call.
-
-  - To use [RSA-OAEP](#rsa-oaep), pass an {{domxref("RsaOaepParams")}}
-    object.
-  - To use [AES-CTR](#aes-ctr), pass an {{domxref("AesCtrParams")}}
-    object.
-  - To use [AES-CBC](#aes-cbc), pass an {{domxref("AesCbcParams")}}
-    object.
-  - To use [AES-GCM](#aes-gcm), pass an {{domxref("AesGcmParams")}}
-    object.
-
-- `key` is a {{domxref("CryptoKey")}} containing the key to be
-  used for decryption. If using RSA-OAEP, this is the `privateKey` property
-  of the {{domxref("CryptoKeyPair")}} object.
-- *`data`* is a {{domxref("BufferSource")}} containing the data to
-  be decrypted (also known as {{glossary("ciphertext")}}).
+- `algorithm`
+  - : An object specifying the [algorithm](#supported_algorithms) to be used, and any extra parameters as
+    required. The values given for the extra parameters must match those passed into the
+    corresponding {{domxref("SubtleCrypto.encrypt()", "encrypt()")}} call.
+    - To use [RSA-OAEP](#rsa-oaep), pass an {{domxref("RsaOaepParams")}} object.
+    - To use [AES-CTR](#aes-ctr), pass an {{domxref("AesCtrParams")}} object.
+    - To use [AES-CBC](#aes-cbc), pass an {{domxref("AesCbcParams")}} object.
+    - To use [AES-GCM](#aes-gcm), pass an {{domxref("AesGcmParams")}} object.
+- `key`
+  - : A {{domxref("CryptoKey")}} containing the key to be
+    used for decryption. If using RSA-OAEP, this is the `privateKey` property
+    of the {{domxref("CryptoKeyPair")}} object.
+- `data`
+  - : A {{domxref("BufferSource")}} containing the data to
+   be decrypted (also known as {{glossary("ciphertext")}}).
 
 ### Return value
 
@@ -54,10 +51,10 @@ A {{jsxref("Promise")}} that fulfills with an
 
 The promise is rejected when the following exceptions are encountered:
 
-- InvalidAccessError
+- `InvalidAccessError` {{domxref("DOMException")}}
   - : Raised when the requested operation is not valid for the provided key (e.g. invalid
     encryption algorithm, or invalid key for the specified encryption algorithm*)*.
-- OperationError
+- `OperationError` {{domxref("DOMException")}}
   - : Raised when the operation failed for an operation-specific reason (e.g. algorithm
     parameters of invalid sizes, or there was an error decrypting the ciphertext).
 
@@ -69,8 +66,7 @@ method.
 
 ## Examples
 
-> **Note:** You can [try
-> the working examples](https://mdn.github.io/dom-examples/web-crypto/encrypt-decrypt/index.html) on GitHub.
+> **Note:** You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/encrypt-decrypt/index.html) on GitHub.
 
 ### RSA-OAEP
 
@@ -155,11 +151,7 @@ function decryptMessage(key, ciphertext) {
 
 - {{domxref("SubtleCrypto.encrypt()")}}.
 - [RFC 3447](https://datatracker.ietf.org/doc/html/rfc3447) specifies RSAOAEP.
-- [NIST
-  SP800-38A](https://csrc.nist.gov/publications/detail/sp/800-38a/final) specifies CTR mode.
-- [NIST
-  SP800-38A](https://csrc.nist.gov/publications/detail/sp/800-38a/final) specifies CBC mode.
-- [NIST
-  SP800-38D](https://csrc.nist.gov/publications/detail/sp/800-38d/final) specifies GCM mode.
-- [FIPS
-  198-1](https://csrc.nist.gov/csrc/media/publications/fips/198/1/final/documents/fips-198-1_final.pdf) specifies HMAC.
+- [NIST SP800-38A](https://csrc.nist.gov/publications/detail/sp/800-38a/final) specifies CTR mode.
+- [NIST SP800-38A](https://csrc.nist.gov/publications/detail/sp/800-38a/final) specifies CBC mode.
+- [NIST SP800-38D](https://csrc.nist.gov/publications/detail/sp/800-38d/final) specifies GCM mode.
+- [FIPS 198-1](https://csrc.nist.gov/csrc/media/publications/fips/198/1/final/documents/fips-198-1_final.pdf) specifies HMAC.

--- a/files/en-us/web/api/subtlecrypto/decrypt/index.md
+++ b/files/en-us/web/api/subtlecrypto/decrypt/index.md
@@ -30,6 +30,7 @@ decrypt(algorithm, key, data)
   - : An object specifying the [algorithm](#supported_algorithms) to be used, and any extra parameters as
     required. The values given for the extra parameters must match those passed into the
     corresponding {{domxref("SubtleCrypto.encrypt()", "encrypt()")}} call.
+
     - To use [RSA-OAEP](#rsa-oaep), pass an {{domxref("RsaOaepParams")}} object.
     - To use [AES-CTR](#aes-ctr), pass an {{domxref("AesCtrParams")}} object.
     - To use [AES-CBC](#aes-cbc), pass an {{domxref("AesCbcParams")}} object.

--- a/files/en-us/web/api/subtlecrypto/decrypt/index.md
+++ b/files/en-us/web/api/subtlecrypto/decrypt/index.md
@@ -44,8 +44,7 @@ decrypt(algorithm, key, data)
 
 ### Return value
 
-A {{jsxref("Promise")}} that fulfills with an
-  {{jsxref("ArrayBuffer")}} containing the plaintext.
+A {{jsxref("Promise")}} that fulfills with an {{jsxref("ArrayBuffer")}} containing the plaintext.
 
 ### Exceptions
 

--- a/files/en-us/web/api/subtlecrypto/decrypt/index.md
+++ b/files/en-us/web/api/subtlecrypto/decrypt/index.md
@@ -27,20 +27,17 @@ decrypt(algorithm, key, data)
 ### Parameters
 
 - `algorithm`
-  - : An object specifying the [algorithm](#supported_algorithms) to be used, and any extra parameters as
-    required. The values given for the extra parameters must match those passed into the
-    corresponding {{domxref("SubtleCrypto.encrypt()", "encrypt()")}} call.
+  - : An object specifying the [algorithm](#supported_algorithms) to be used, and any extra parameters as required.
+    The values given for the extra parameters must match those passed into the corresponding {{domxref("SubtleCrypto.encrypt()", "encrypt()")}} call.
     - To use [RSA-OAEP](#rsa-oaep), pass an {{domxref("RsaOaepParams")}} object.
     - To use [AES-CTR](#aes-ctr), pass an {{domxref("AesCtrParams")}} object.
     - To use [AES-CBC](#aes-cbc), pass an {{domxref("AesCbcParams")}} object.
     - To use [AES-GCM](#aes-gcm), pass an {{domxref("AesGcmParams")}} object.
 - `key`
-  - : A {{domxref("CryptoKey")}} containing the key to be
-    used for decryption. If using RSA-OAEP, this is the `privateKey` property
-    of the {{domxref("CryptoKeyPair")}} object.
+  - : A {{domxref("CryptoKey")}} containing the key to be used for decryption.
+    If using RSA-OAEP, this is the `privateKey` property of the {{domxref("CryptoKeyPair")}} object.
 - `data`
-  - : A {{domxref("BufferSource")}} containing the data to
-    be decrypted (also known as {{glossary("ciphertext")}}).
+  - : A {{domxref("BufferSource")}} containing the data to be decrypted (also known as {{glossary("ciphertext")}}).
 
 ### Return value
 

--- a/files/en-us/web/api/subtlecrypto/derivebits/index.md
+++ b/files/en-us/web/api/subtlecrypto/derivebits/index.md
@@ -31,8 +31,8 @@ except that `deriveKey()` returns a
 [`importKey()`](/en-US/docs/Web/API/SubtleCrypto/importKey).
 
 This function supports the same derivation algorithms as `deriveKey()`:
-ECDH, HKDF, and PBKDF2. See [Supported
-algorithms](/en-US/docs/Web/API/SubtleCrypto/deriveKey#supported_algorithms) for some more detail on these algorithms.
+ECDH, HKDF, and PBKDF2. See [Supported algorithms](/en-US/docs/Web/API/SubtleCrypto/deriveKey#supported_algorithms)
+for some more detail on these algorithms.
 
 ## Syntax
 
@@ -42,26 +42,22 @@ deriveBits(algorithm, baseKey, length)
 
 ### Parameters
 
-- `algorithm` is an object defining the [derivation
-  algorithm](/en-US/docs/Web/API/SubtleCrypto/deriveKey#supported_algorithms) to use.
-
-  - To use [ECDH](/en-US/docs/Web/API/SubtleCrypto/deriveKey#ecdh), pass
-    an
-    [`EcdhKeyDeriveParams`](/en-US/docs/Web/API/EcdhKeyDeriveParams)
-    object.
-  - To use [HKDF](/en-US/docs/Web/API/SubtleCrypto/deriveKey#hkdf), pass
-    an [`HkdfParams`](/en-US/docs/Web/API/HkdfParams) object.
-  - To use [PBKDF2](/en-US/docs/Web/API/SubtleCrypto/deriveKey#pbkdf2),
-    pass a [`Pbkdf2Params`](/en-US/docs/Web/API/Pbkdf2Params)
-    object.
-
-- _`baseKey`_ is a {{domxref("CryptoKey")}} representing the input
-  to the derivation algorithm. If `algorithm` is ECDH, this will be the ECDH
-  private key. Otherwise it will be the initial key material for the derivation
-  function: for example, for PBKDF2 it might be a password, imported as a
-  `CryptoKey` using
-  [`SubtleCrypto.importKey()`](/en-US/docs/Web/API/SubtleCrypto/importKey).
-- `length` is a number representing the number of bits to derive. To be compatible with all browsers, the number should be a multiple of 8.
+- `algorithm`
+  - : An object defining the [derivation algorithm](/en-US/docs/Web/API/SubtleCrypto/deriveKey#supported_algorithms) to use.
+    - To use [ECDH](/en-US/docs/Web/API/SubtleCrypto/deriveKey#ecdh), pass an
+      [`EcdhKeyDeriveParams`](/en-US/docs/Web/API/EcdhKeyDeriveParams) object.
+    - To use [HKDF](/en-US/docs/Web/API/SubtleCrypto/deriveKey#hkdf), pass
+      an [`HkdfParams`](/en-US/docs/Web/API/HkdfParams) object.
+    - To use [PBKDF2](/en-US/docs/Web/API/SubtleCrypto/deriveKey#pbkdf2),
+      pass a [`Pbkdf2Params`](/en-US/docs/Web/API/Pbkdf2Params) object.
+- `baseKey`
+  - : A {{domxref("CryptoKey")}} representing the input
+    to the derivation algorithm. If `algorithm` is ECDH, this will be the ECDH
+    private key. Otherwise it will be the initial key material for the derivation
+    function: for example, for PBKDF2 it might be a password, imported as a
+    `CryptoKey` using [`SubtleCrypto.importKey()`](/en-US/docs/Web/API/SubtleCrypto/importKey).
+- `length`
+  - : A number representing the number of bits to derive. To be compatible with all browsers, the number should be a multiple of 8.
 
 ### Return value
 
@@ -73,26 +69,24 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
 
 The promise is rejected when one of the following exceptions are encountered:
 
-- {{exception("OperationError")}}
+- `OperationError` {{domxref("DOMException")}}
   - : Raised if the _length_ parameter of the `deriveBits()` call is null, and also in some cases if the _length_ parameter is not a multiple of 8.
-- {{exception("InvalidAccessError")}}
+- `InvalidAccessError` {{domxref("DOMException")}}
   - : Raised when the base key is not a key for the requested derivation algorithm or if
     the [`CryptoKey.usages`](/en-US/docs/Web/API/CryptoKey) value of that key doesn't contain
     `deriveBits`.
-- {{exception("NotSupported")}}
+- `NotSupported` {{domxref("DOMException")}}
   - : Raised when trying to use an algorithm that is either unknown or isn't suitable for
     derivation, or if the algorithm requested for the derived key doesn't define a key
     length.
 
 ## Supported algorithms
 
-See the [Supported
-algorithms section of the `deriveKey()` documentation](/en-US/docs/Web/API/SubtleCrypto/deriveKey#supported_algorithms).
+See the [Supported algorithms section of the `deriveKey()` documentation](/en-US/docs/Web/API/SubtleCrypto/deriveKey#supported_algorithms).
 
 ## Examples
 
-> **Note:** You can [try the
-> working examples](https://mdn.github.io/dom-examples/web-crypto/derive-bits/index.html) on GitHub.
+> **Note:** You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/derive-bits/index.html) on GitHub.
 
 ### ECDH
 
@@ -222,9 +216,6 @@ deriveBitsButton.addEventListener("click", () => {
 ## See also
 
 - [HKDF specification](https://datatracker.ietf.org/doc/html/rfc5869).
-- [NIST guidelines
-  for password-based key derivation](https://csrc.nist.gov/publications/detail/sp/800-132/final).
-- [Password
-  storage cheat sheet](https://www.owasp.org/index.php/Password_Storage_Cheat_Sheet).
-- [Advice
-  on choosing an iteration count for PBKDF2](https://security.stackexchange.com/questions/3959/recommended-of-iterations-when-using-pkbdf2-sha256/3993#3993).
+- [NIST guidelines for password-based key derivation](https://csrc.nist.gov/publications/detail/sp/800-132/final).
+- [Password storage cheat sheet](https://www.owasp.org/index.php/Password_Storage_Cheat_Sheet).
+- [Advice on choosing an iteration count for PBKDF2](https://security.stackexchange.com/questions/3959/recommended-of-iterations-when-using-pkbdf2-sha256/3993#3993).

--- a/files/en-us/web/api/subtlecrypto/derivekey/index.md
+++ b/files/en-us/web/api/subtlecrypto/derivekey/index.md
@@ -31,75 +31,63 @@ deriveKey(algorithm, baseKey, derivedKeyAlgorithm, extractable, keyUsages)
 
 ### Parameters
 
-- `algorithm` is an object defining the [derivation algorithm](#supported_algorithms) to use.
-
-  - To use [ECDH](#ecdh), pass an
-    [`EcdhKeyDeriveParams`](/en-US/docs/Web/API/EcdhKeyDeriveParams)
-    object.
-  - To use [HKDF](#hkdf), pass
-    an [`HkdfParams`](/en-US/docs/Web/API/HkdfParams) object.
-  - To use [PBKDF2](#pbkdf2), pass
-    a [`Pbkdf2Params`](/en-US/docs/Web/API/Pbkdf2Params) object.
-
-- _`baseKey`_ is a {{domxref("CryptoKey")}} representing the input
-  to the derivation algorithm. If `algorithm` is ECDH, then this will be the
-  ECDH private key. Otherwise it will be the initial key material for the derivation
-  function: for example, for PBKDF2 it might be a password, imported as a
-  `CryptoKey` using
-  [`SubtleCrypto.importKey()`](/en-US/docs/Web/API/SubtleCrypto/importKey).
-- `derivedKeyAlgorithm` is an object defining the algorithm the
-  derived key will be used for.
-
-  - For [HMAC](/en-US/docs/Web/API/SubtleCrypto/sign#hmac): pass an
-    [`HmacKeyGenParams`](/en-US/docs/Web/API/HmacKeyGenParams)
-    object.
-  - For [AES-CTR](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-ctr), [AES-CBC](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-cbc), [AES-GCM](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-gcm), or [AES-KW](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-kw): pass an
-    [`AesKeyGenParams`](/en-US/docs/Web/API/AesKeyGenParams)
-    object.
-
-- `extractable` is a boolean value indicating whether it
-  will be possible to export the key using {{domxref("SubtleCrypto.exportKey()")}} or
-  {{domxref("SubtleCrypto.wrapKey()")}}.
-- `keyUsages`  is an {{jsxref("Array")}} indicating what can be
-  done with the derived key. Note that the key usages must be allowed by the algorithm
-  set in `derivedKeyAlgorithm`. Possible values of the array are:
-
-  - `encrypt`: The key may be used to {{domxref("SubtleCrypto.encrypt()",
-        "encrypt")}} messages.
-  - `decrypt`: The key may be used to {{domxref("SubtleCrypto.decrypt()",
-        "decrypt")}} messages.
-  - `sign`: The key may be used to {{domxref("SubtleCrypto.sign()",
-        "sign")}} messages.
-  - `verify`: The key may be used to {{domxref("SubtleCrypto.verify()",
-        "verify")}} signatures.
-  - `deriveKey`: The key may be used in
-    {{domxref("SubtleCrypto.deriveKey()", "deriving a new key")}}.
-  - `deriveBits`: The key may be used in
-    {{domxref("SubtleCrypto.deriveBits()", "deriving bits")}}.
-  - `wrapKey`: The key may be used to
-    {{domxref("SubtleCrypto.wrapKey()", "wrap a key")}}.
-  - `unwrapKey`: The key may be used to
-    {{domxref("SubtleCrypto.unwrapKey()", "unwrap a key")}}.
+- `algorithm`
+  - : An object defining the [derivation algorithm](#supported_algorithms) to use.
+    - To use [ECDH](#ecdh), pass an
+      [`EcdhKeyDeriveParams`](/en-US/docs/Web/API/EcdhKeyDeriveParams) object.
+    - To use [HKDF](#hkdf), pass
+      an [`HkdfParams`](/en-US/docs/Web/API/HkdfParams) object.
+    - To use [PBKDF2](#pbkdf2), pass
+      a [`Pbkdf2Params`](/en-US/docs/Web/API/Pbkdf2Params) object.
+- `baseKey`
+  - : A {{domxref("CryptoKey")}} representing the input
+    to the derivation algorithm. If `algorithm` is ECDH, then this will be the
+    ECDH private key. Otherwise it will be the initial key material for the derivation
+    function: for example, for PBKDF2 it might be a password, imported as a
+    `CryptoKey` using
+    [`SubtleCrypto.importKey()`](/en-US/docs/Web/API/SubtleCrypto/importKey).
+- `derivedKeyAlgorithm`
+  - : An object defining the algorithm the derived key will be used for.
+    - For [HMAC](/en-US/docs/Web/API/SubtleCrypto/sign#hmac): pass an
+      [`HmacKeyGenParams`](/en-US/docs/Web/API/HmacKeyGenParams) object.
+    - For [AES-CTR](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-ctr), [AES-CBC](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-cbc),
+      [AES-GCM](/en-US/docs/Web/API/SubtleCrypto/ encrypt#aes-gcm), or [AES-KW](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-kw): pass an
+      [`AesKeyGenParams`](/en-US/docs/Web/API/AesKeyGenParams) object.
+- `extractable`
+  - : A boolean value indicating whether it
+    will be possible to export the key using {{domxref("SubtleCrypto.exportKey()")}} or
+    {{domxref("SubtleCrypto.wrapKey()")}}.
+- `keyUsages`
+  - : An {{jsxref("Array")}} indicating what can be
+    done with the derived key. Note that the key usages must be allowed by the algorithm
+    set in `derivedKeyAlgorithm`. Possible values of the array are:
+    - `encrypt`: The key may be used to {{domxref("SubtleCrypto.encrypt()", "encrypt")}} messages.
+    - `decrypt`: The key may be used to {{domxref("SubtleCrypto.decrypt()", "decrypt")}} messages.
+    - `sign`: The key may be used to {{domxref("SubtleCrypto.sign()", "sign")}} messages.
+    - `verify`: The key may be used to {{domxref("SubtleCrypto.verify()", "verify")}} signatures.
+    - `deriveKey`: The key may be used in {{domxref("SubtleCrypto.deriveKey()", "deriving a new key")}}.
+    - `deriveBits`: The key may be used in {{domxref("SubtleCrypto.deriveBits()", "deriving bits")}}.
+    - `wrapKey`: The key may be used to {{domxref("SubtleCrypto.wrapKey()", "wrap a key")}}.
+    - `unwrapKey`: The key may be used to {{domxref("SubtleCrypto.unwrapKey()", "unwrap a key")}}.
 
 ### Return value
 
-A {{jsxref("Promise")}} that fulfills with a
-  {{domxref("CryptoKey")}}.
+A {{jsxref("Promise")}} that fulfills with a {{domxref("CryptoKey")}}.
 
 ### Exceptions
 
 The promise is rejected when one of the following exceptions are encountered:
 
-- {{exception("InvalidAccessError")}}
-- Raised when the master key is not a key for the requested derivation algorithm
-  or if the _keyUsages_ value of that key doesn't contain `deriveKey`.
-- {{exception("NotSupported")}}
-- Raised when trying to use an algorithm that is either unknown or isn't suitable for
-  derivation, or if the algorithm requested for the derived key doesn't define a key
-  length.
-- {{exception("SyntaxError")}}
-- Raised when _`keyUsages`_ is empty but the unwrapped key is of
-  type `secret` or `private`.
+- `InvalidAccessError` {{domxref("DOMException")}}
+  - : Raised when the master key is not a key for the requested derivation algorithm
+    or if the `keyUsages` value of that key doesn't contain `deriveKey`.
+- `NotSupported` {{domxref("DOMException")}}
+  - : Raised when trying to use an algorithm that is either unknown or isn't suitable for
+    derivation, or if the algorithm requested for the derived key doesn't define a key
+    length.
+- `SyntaxError` {{domxref("DOMException")}}
+  - : Raised when `keyUsages` is empty but the unwrapped key is of
+    type `secret` or `private`.
 
 ## Supported algorithms
 
@@ -215,7 +203,8 @@ async function agreeSharedSecretKey() {
 ### PBKDF2
 
 In this example we ask the user for a password, then use it to derive an AES key using
-PBKDF2, then use the AES key to encrypt a message. [See the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/derive-key/pbkdf2.js)
+PBKDF2, then use the AES key to encrypt a message.
+[See the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/derive-key/pbkdf2.js)
 
 ```js
 /*
@@ -271,9 +260,6 @@ async function encrypt(plaintext, salt, iv) {
 ## See also
 
 - [HKDF specification](https://datatracker.ietf.org/doc/html/rfc5869).
-- [NIST guidelines
-  for password-based key derivation](https://csrc.nist.gov/publications/detail/sp/800-132/final).
-- [Password
-  storage cheat sheet](https://www.owasp.org/index.php/Password_Storage_Cheat_Sheet).
-- [Advice
-  on choosing an iteration count for PBKDF2](https://security.stackexchange.com/questions/3959/recommended-of-iterations-when-using-pkbdf2-sha256/3993#3993).
+- [NIST guidelines for password-based key derivation](https://csrc.nist.gov/publications/detail/sp/800-132/final).
+- [Password storage cheat sheet](https://www.owasp.org/index.php/Password_Storage_Cheat_Sheet).
+- [Advice on choosing an iteration count for PBKDF2](https://security.stackexchange.com/questions/3959/recommended-of-iterations-when-using-pkbdf2-sha256/3993#3993).

--- a/files/en-us/web/api/subtlecrypto/digest/index.md
+++ b/files/en-us/web/api/subtlecrypto/digest/index.md
@@ -31,12 +31,10 @@ digest(algorithm, data)
 
 - `algorithm`
   - : This may be a string or an object with a single property `name` that is a string. The string names the hash function to use. Supported values are:
-
     - `"SHA-1"` (but don't use this in cryptographic applications)
     - `"SHA-256"`
     - `"SHA-384"`
     - `"SHA-512"`.
-
 - `data`
   - : An {{jsxref("ArrayBuffer")}} or {{domxref("ArrayBufferView")}} containing the data to be digested.
 
@@ -46,8 +44,8 @@ A {{jsxref("Promise")}} that fulfills with an {{jsxref("ArrayBuffer")}} containi
 
 ## Supported algorithms
 
-Digest algorithms, also known as [cryptographic hash
-functions](/en-US/docs/Glossary/Cryptographic_hash_function), transform an arbitrarily large block of data into a fixed-size output,
+Digest algorithms, also known as [cryptographic hash functions](/en-US/docs/Glossary/Cryptographic_hash_function),
+transform an arbitrarily large block of data into a fixed-size output,
 usually much shorter than the input. They have a variety of applications in
 cryptography.
 
@@ -164,6 +162,5 @@ digestMessage(text)
 ## See also
 
 - [Non-cryptographic uses of SubtleCrypto](/en-US/docs/Web/API/Web_Crypto_API/Non-cryptographic_uses_of_subtle_crypto)
-- [Chromium
-  secure origins specification](https://www.chromium.org/Home/chromium-security/prefer-secure-origins-for-powerful-new-features)
+- [Chromium secure origins specification](https://www.chromium.org/Home/chromium-security/prefer-secure-origins-for-powerful-new-features)
 - [FIPS 180-4](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf) specifies the SHA family of digest algorithms.

--- a/files/en-us/web/api/subtlecrypto/encrypt/index.md
+++ b/files/en-us/web/api/subtlecrypto/encrypt/index.md
@@ -28,22 +28,18 @@ encrypt(algorithm, key, data)
 
 ### Parameters
 
-- _`algorithm`_ is an object specifying the [algorithm](#supported_algorithms) to be used and any extra parameters if
-  required:
+- `algorithm`
+  - : An object specifying the [algorithm](#supported_algorithms) to be used and any extra parameters if required:
+    - To use [RSA-OAEP](#rsa-oaep), pass an {{domxref("RsaOaepParams")}} object.
+    - To use [AES-CTR](#aes-ctr), pass an {{domxref("AesCtrParams")}} object.
+    - To use [AES-CBC](#aes-cbc), pass an {{domxref("AesCbcParams")}} object.
+    - To use [AES-GCM](#aes-gcm), pass an {{domxref("AesGcmParams")}} object.
 
-  - To use [RSA-OAEP](#rsa-oaep), pass an {{domxref("RsaOaepParams")}}
-    object.
-  - To use [AES-CTR](#aes-ctr), pass an {{domxref("AesCtrParams")}}
-    object.
-  - To use [AES-CBC](#aes-cbc), pass an {{domxref("AesCbcParams")}}
-    object.
-  - To use [AES-GCM](#aes-gcm), pass an {{domxref("AesGcmParams")}}
-    object.
-
-- `key` is a {{domxref("CryptoKey")}} containing the key to be
-  used for encryption.
-- _`data`_ is a {{domxref("BufferSource")}} containing the data to
-  be encrypted (also known as the {{glossary("plaintext")}}).
+- `key`
+  - : A {{domxref("CryptoKey")}} containing the key to be used for encryption.
+- `data`
+  - : A {{domxref("BufferSource")}} containing the data to
+    be encrypted (also known as the {{glossary("plaintext")}}).
 
 ### Return value
 
@@ -54,10 +50,10 @@ A {{jsxref("Promise")}} that fulfills with an
 
 The promise is rejected when the following exceptions are encountered:
 
-- InvalidAccessError
+- `InvalidAccessError` {{domxref("DOMException")}}
   - : Raised when the requested operation is not valid for the provided key (e.g. invalid
     encryption algorithm, or invalid key for the specified encryption algorithm*)*.
-- OperationError
+- `OperationError` {{domxref("DOMException")}}
   - : Raised when the operation failed for an operation-specific reason (e.g. algorithm
     parameters of invalid sizes, or AES-GCM plaintext longer than 2³⁹−256 bytes).
 
@@ -110,8 +106,7 @@ an attacker.
 
 ## Examples
 
-> **Note:** You can [try
-> the working examples](https://mdn.github.io/dom-examples/web-crypto/encrypt-decrypt/index.html) out on GitHub.
+> **Note:** You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/encrypt-decrypt/index.html) out on GitHub.
 
 ### RSA-OAEP
 
@@ -257,9 +252,6 @@ function encryptMessage(key) {
 
 - {{domxref("SubtleCrypto.decrypt()")}}.
 - [RFC 3447](https://datatracker.ietf.org/doc/html/rfc3447) specifies RSAOAEP.
-- [NIST
-  SP800-38A](https://csrc.nist.gov/publications/detail/sp/800-38a/final) specifies CTR mode.
-- [NIST
-  SP800-38A](https://csrc.nist.gov/publications/detail/sp/800-38a/final) specifies CBC mode.
-- [NIST
-  SP800-38D](https://csrc.nist.gov/publications/detail/sp/800-38d/final) specifies GCM mode.
+- [NIST SP800-38A](https://csrc.nist.gov/publications/detail/sp/800-38a/final) specifies CTR mode.
+- [NIST SP800-38A](https://csrc.nist.gov/publications/detail/sp/800-38a/final) specifies CBC mode.
+- [NIST SP800-38D](https://csrc.nist.gov/publications/detail/sp/800-38d/final) specifies GCM mode.

--- a/files/en-us/web/api/subtlecrypto/exportkey/index.md
+++ b/files/en-us/web/api/subtlecrypto/exportkey/index.md
@@ -37,17 +37,15 @@ exportKey(format, key)
 
 ### Parameters
 
-- _`format`_ is a string value describing the data format in which
-  the key should be exported. It can be one of the following:
-
-  - `raw`: [Raw](/en-US/docs/Web/API/SubtleCrypto/importKey#raw) format.
-  - `pkcs8`: [PKCS #8](/en-US/docs/Web/API/SubtleCrypto/importKey#pkcs_8) format.
-  - `spki`: [SubjectPublicKeyInfo](/en-US/docs/Web/API/SubtleCrypto/importKey#subjectpublickeyinfo)
-    format.
-  - `jwk`: [JSON Web Key](/en-US/docs/Web/API/SubtleCrypto/importKey#json_web_key)
-    format.
-
-- `key` is the {{domxref("CryptoKey")}} to export.
+- `format`
+  - : A string value describing the data format in which
+    the key should be exported. It can be one of the following:
+    - `raw`: [Raw](/en-US/docs/Web/API/SubtleCrypto/importKey#raw) format.
+    - `pkcs8`: [PKCS #8](/en-US/docs/Web/API/SubtleCrypto/importKey#pkcs_8) format.
+    - `spki`: [SubjectPublicKeyInfo](/en-US/docs/Web/API/SubtleCrypto/importKey#subjectpublickeyinfo) format.
+    - `jwk`: [JSON Web Key](/en-US/docs/Web/API/SubtleCrypto/importKey#json_web_key) format.
+- `key`
+  - : The {{domxref("CryptoKey")}} to export.
 
 ### Return value
 
@@ -63,17 +61,16 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 
 The promise is rejected when one of the following exceptions is encountered:
 
-- {{exception("InvalidAccessError")}}
+- `InvalidAccessError` {{domxref("DOMException")}}
   - : Raised when trying to export a non-extractable key.
-- {{exception("NotSupported")}}
+- `NotSupported` {{domxref("DOMException")}}
   - : Raised when trying to export in an unknown format.
 - {{jsxref("TypeError")}}
   - : Raised when trying to use an invalid format.
 
 ## Examples
 
-> **Note:** You can [try the
-> working examples](https://mdn.github.io/dom-examples/web-crypto/export-key/index.html) out on GitHub.
+> **Note:** You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/export-key/index.html) out on GitHub.
 
 ### Raw export
 

--- a/files/en-us/web/api/subtlecrypto/generatekey/index.md
+++ b/files/en-us/web/api/subtlecrypto/generatekey/index.md
@@ -24,44 +24,34 @@ generateKey(algorithm, extractable, keyUsages)
 
 ### Parameters
 
-- _`algorithm`_ is a dictionary object defining the type of key to
-  generate and providing extra algorithm-specific parameters.
+- `algorithm`
+  - : An object defining the type of key to generate and providing extra algorithm-specific parameters.
 
-  - For [RSASSA-PKCS1-v1_5](/en-US/docs/Web/API/SubtleCrypto/sign#rsassa-pkcs1-v1_5), [RSA-PSS](/en-US/docs/Web/API/SubtleCrypto/sign#rsa-pss), or [RSA-OAEP](/en-US/docs/Web/API/SubtleCrypto/encrypt#rsa-oaep): pass an
-    [`RsaHashedKeyGenParams`](/en-US/docs/Web/API/RsaHashedKeyGenParams)
-    object.
-  - For [ECDSA](/en-US/docs/Web/API/SubtleCrypto/sign#ecdsa) or [ECDH](/en-US/docs/Web/API/SubtleCrypto/deriveKey#ecdh): pass
-    an [`EcKeyGenParams`](/en-US/docs/Web/API/EcKeyGenParams)
-    object.
-  - For [HMAC](/en-US/docs/Web/API/SubtleCrypto/sign#hmac): pass an
-    [`HmacKeyGenParams`](/en-US/docs/Web/API/HmacKeyGenParams)
-    object.
-  - For [AES-CTR](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-ctr), [AES-CBC](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-cbc), [AES-GCM](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-gcm), or [AES-KW](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-kw): pass an
-    [`AesKeyGenParams`](/en-US/docs/Web/API/AesKeyGenParams)
-    object.
-
-- `extractable` is a boolean value indicating whether it
-  will be possible to export the key using {{domxref("SubtleCrypto.exportKey()")}} or
-  {{domxref("SubtleCrypto.wrapKey()")}}.
-- `keyUsages`  is an {{jsxref("Array")}} indicating what can be
-  done with the newly generated key. Possible values for array elements are:
-
-  - `encrypt`: The key may be used to {{domxref("SubtleCrypto.encrypt()",
-        "encrypt")}} messages.
-  - `decrypt`: The key may be used to {{domxref("SubtleCrypto.decrypt()",
-        "decrypt")}} messages.
-  - `sign`: The key may be used to {{domxref("SubtleCrypto.sign()",
-        "sign")}} messages.
-  - `verify`: The key may be used to {{domxref("SubtleCrypto.verify()",
-        "verify")}} signatures.
-  - `deriveKey`: The key may be used in
-    {{domxref("SubtleCrypto.deriveKey()", "deriving a new key")}}.
-  - `deriveBits`: The key may be used in
-    {{domxref("SubtleCrypto.deriveBits()", "deriving bits")}}.
-  - `wrapKey`: The key may be used to {{domxref("SubtleCrypto.wrapKey()",
-        "wrap a key")}}.
-  - `unwrapKey`: The key may be used to
-    {{domxref("SubtleCrypto.unwrapKey()", "unwrap a key")}}.
+    - For [RSASSA-PKCS1-v1_5](/en-US/docs/Web/API/SubtleCrypto/sign#rsassa-pkcs1-v1_5), [RSA-PSS](/en-US/docs/Web/API/SubtleCrypto/sign#rsa-pss),
+      or [RSA-OAEP](/en-US/docs/Web/API/SubtleCrypto/encrypt#rsa-oaep):
+      pass an [`RsaHashedKeyGenParams`](/en-US/docs/Web/API/RsaHashedKeyGenParams) object.
+    - For [ECDSA](/en-US/docs/Web/API/SubtleCrypto/sign#ecdsa) or [ECDH](/en-US/docs/Web/API/SubtleCrypto/deriveKey#ecdh):
+      pass an [`EcKeyGenParams`](/en-US/docs/Web/API/EcKeyGenParams) object.
+    - For [HMAC](/en-US/docs/Web/API/SubtleCrypto/sign#hmac):
+      pass an [`HmacKeyGenParams`](/en-US/docs/Web/API/HmacKeyGenParams) object.
+    - For [AES-CTR](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-ctr), [AES-CBC](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-cbc),
+      [AES-GCM](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-gcm), or [AES-KW](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-kw):
+      pass an [`AesKeyGenParams`](/en-US/docs/Web/API/AesKeyGenParams) object.
+- `extractable`
+  - : A boolean value indicating whether it
+    will be possible to export the key using {{domxref("SubtleCrypto.exportKey()")}} or
+    {{domxref("SubtleCrypto.wrapKey()")}}.
+- `keyUsages`
+  - : An {{jsxref("Array")}} indicating what can be
+    done with the newly generated key. Possible values for array elements are:
+    - `encrypt`: The key may be used to {{domxref("SubtleCrypto.encrypt()", "encrypt")}} messages.
+    - `decrypt`: The key may be used to {{domxref("SubtleCrypto.decrypt()", "decrypt")}} messages.
+    - `sign`: The key may be used to {{domxref("SubtleCrypto.sign()", "sign")}} messages.
+    - `verify`: The key may be used to {{domxref("SubtleCrypto.verify()", "verify")}} signatures.
+    - `deriveKey`: The key may be used in {{domxref("SubtleCrypto.deriveKey()", "deriving a new key")}}.
+    - `deriveBits`: The key may be used in {{domxref("SubtleCrypto.deriveBits()", "deriving bits")}}.
+    - `wrapKey`: The key may be used to {{domxref("SubtleCrypto.wrapKey()", "wrap a key")}}.
+    - `unwrapKey`: The key may be used to {{domxref("SubtleCrypto.unwrapKey()", "unwrap a key")}}.
 
 ### Return value
 
@@ -73,22 +63,21 @@ A {{jsxref("Promise")}} that fulfills with a
 
 The promise is rejected when the following exception is encountered:
 
-- {{exception("SyntaxError")}}
+- `SyntaxError` {{domxref("DOMException")}}
   - : Raised when the result is a {{domxref("CryptoKey")}} of type `secret` or
     `private` but _`keyUsages`_ is empty.
-- {{exception("SyntaxError")}}
+- `SyntaxError` {{domxref("DOMException")}}
   - : Raised when the result is a {{domxref("CryptoKeyPair")}} and its
     `privateKey.usages` attribute is empty.
 
 ## Examples
 
-> **Note:** You can [try
-> the working examples](https://mdn.github.io/dom-examples/web-crypto/encrypt-decrypt/index.html) on GitHub.
+> **Note:** You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/encrypt-decrypt/index.html) on GitHub.
 
 ### RSA key pair generation
 
-This code generates an RSA-OAEP encryption key pair. [See
-the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/encrypt-decrypt/rsa-oaep.js)
+This code generates an RSA-OAEP encryption key pair.
+[See the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/encrypt-decrypt/rsa-oaep.js)
 
 ```js
 let keyPair = await window.crypto.subtle.generateKey(
@@ -105,8 +94,8 @@ let keyPair = await window.crypto.subtle.generateKey(
 
 ### Elliptic curve key pair generation
 
-This code generates an ECDSA signing key pair. [See
-the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/sign-verify/ecdsa.js)
+This code generates an ECDSA signing key pair.
+[See the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/sign-verify/ecdsa.js)
 
 ```js
 let keyPair = await window.crypto.subtle.generateKey(
@@ -121,8 +110,8 @@ let keyPair = await window.crypto.subtle.generateKey(
 
 ### HMAC key generation
 
-This code generates an HMAC signing key. [See
-the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/sign-verify/hmac.js)
+This code generates an HMAC signing key.
+[See the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/sign-verify/hmac.js)
 
 ```js
 let key = await window.crypto.subtle.generateKey(
@@ -137,8 +126,8 @@ let key = await window.crypto.subtle.generateKey(
 
 ### AES key generation
 
-This code generates an AES-GCM encryption key. [See
-the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/encrypt-decrypt/aes-gcm.js)
+This code generates an AES-GCM encryption key.
+[See the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/encrypt-decrypt/aes-gcm.js)
 
 ```js
 let key = await window.crypto.subtle.generateKey(
@@ -162,5 +151,4 @@ let key = await window.crypto.subtle.generateKey(
 ## See also
 
 - [Cryptographic key length recommendations](https://www.keylength.com/).
-- [NIST
-  cryptographic algorithm and key length recommendations](https://csrc.nist.gov/publications/detail/sp/800-131a/rev-1/final).
+- [NIST cryptographic algorithm and key length recommendations](https://csrc.nist.gov/publications/detail/sp/800-131a/rev-1/final).

--- a/files/en-us/web/api/subtlecrypto/importkey/index.md
+++ b/files/en-us/web/api/subtlecrypto/importkey/index.md
@@ -16,8 +16,7 @@ The **`importKey()`** method of the {{domxref("SubtleCrypto")}}
 interface imports a key: that is, it takes as input a key in an external, portable
 format and gives you a {{domxref("CryptoKey")}} object that you can use in the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API).
 
-The function accepts several import formats: see [Supported
-formats](#supported_formats) for details.
+The function accepts several import formats: see [Supported formats](#supported_formats) for details.
 
 ## Syntax
 
@@ -27,61 +26,43 @@ importKey(format, keyData, algorithm, extractable, keyUsages)
 
 ### Parameters
 
-- _`format`_ is a string describing the data format of the key to
-  import. It can be one of the following:
-
-  - `raw`: [Raw](#raw) format.
-  - `pkcs8`: [PKCS #8](#pkcs_8) format.
-  - `spki`: [SubjectPublicKeyInfo](#subjectpublickeyinfo)
-    format.
-  - `jwk`: [JSON Web Key](#json_web_key) format.
-
-- `keyData` is an {{jsxref("ArrayBuffer")}}, a [TypedArray](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray),
-  a {{jsxref("DataView")}}, or a `JSONWebKey` object containing the key in
-  the given format.
-- _`algorithm`_ is a dictionary object defining the type of key to
-  import and providing extra algorithm-specific parameters.
-
-  - For [RSASSA-PKCS1-v1_5](/en-US/docs/Web/API/SubtleCrypto/sign#rsassa-pkcs1-v1_5), [RSA-PSS](/en-US/docs/Web/API/SubtleCrypto/sign#rsa-pss), or [RSA-OAEP](/en-US/docs/Web/API/SubtleCrypto/encrypt#rsa-oaep): Pass an
-    [`RsaHashedImportParams`](/en-US/docs/Web/API/RsaHashedImportParams)
-    object.
-  - For [ECDSA](/en-US/docs/Web/API/SubtleCrypto/sign#ecdsa) or [ECDH](/en-US/docs/Web/API/SubtleCrypto/deriveKey#ecdh): Pass
-    an [`EcKeyImportParams`](/en-US/docs/Web/API/EcKeyImportParams)
-    object.
-  - For [HMAC](/en-US/docs/Web/API/SubtleCrypto/sign#hmac): Pass an
-    [`HmacImportParams`](/en-US/docs/Web/API/HmacImportParams)
-    object.
-  - For [AES-CTR](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-ctr), [AES-CBC](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-cbc), [AES-GCM](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-gcm), or [AES-KW](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-kw): Pass the
-    string identifying the algorithm or an object of the form
-    `{ "name": ALGORITHM }`, where `ALGORITHM` is the name of
-    the algorithm.
-  - For [PBKDF2](/en-US/docs/Web/API/SubtleCrypto/deriveKey#pbkdf2) :
-    Pass the string `PBKDF2`.
-  - For [HKDF](/en-US/docs/Web/API/SubtleCrypto/deriveKey#hkdf): Pass the
-    string `HKDF`.
-
-- `extractable` is a boolean value indicating whether it
-  will be possible to export the key using {{domxref("SubtleCrypto.exportKey()")}} or
-  {{domxref("SubtleCrypto.wrapKey()")}}.
-- `keyUsages` is an {{jsxref("Array")}} indicating what can be
-  done with the key. Possible array values are:
-
-  - `encrypt`: The key may be used to {{domxref("SubtleCrypto.encrypt()",
-        "encrypt")}} messages.
-  - `decrypt`: The key may be used to {{domxref("SubtleCrypto.decrypt()",
-        "decrypt")}} messages.
-  - `sign`: The key may be used to {{domxref("SubtleCrypto.sign()",
-        "sign")}} messages.
-  - `verify`: The key may be used to {{domxref("SubtleCrypto.verify()",
-        "verify")}} signatures.
-  - `deriveKey`: The key may be used in
-    {{domxref("SubtleCrypto.deriveKey()", "deriving a new key")}}.
-  - `deriveBits`: The key may be used in
-    {{domxref("SubtleCrypto.deriveBits()", "deriving bits")}}.
-  - `wrapKey`: The key may be used to {{domxref("SubtleCrypto.wrapKey()",
-        "wrap a key")}}.
-  - `unwrapKey`: The key may be used to
-    {{domxref("SubtleCrypto.unwrapKey()", "unwrap a key")}}.
+- `format`
+  - : A string describing the data format of the key to import. It can be one of the following:
+    - `raw`: [Raw](#raw) format.
+    - `pkcs8`: [PKCS #8](#pkcs_8) format.
+    - `spki`: [SubjectPublicKeyInfo](#subjectpublickeyinfo) format.
+    - `jwk`: [JSON Web Key](#json_web_key) format.
+- `keyData`
+  - : An {{jsxref("ArrayBuffer")}}, a [TypedArray](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray),
+    a {{jsxref("DataView")}}, or a `JSONWebKey` object containing the key in
+    the given format.
+- `algorithm`
+  - : An object defining the type of key to import and providing extra algorithm-specific parameters.
+    - For [RSASSA-PKCS1-v1_5](/en-US/docs/Web/API/SubtleCrypto/sign#rsassa-pkcs1-v1_5), [RSA-PSS](/en-US/docs/Web/API/SubtleCrypto/sign#rsa-pss),
+      or [RSA-OAEP](/en-US/docs/Web/API/SubtleCrypto/encrypt#rsa-oaep):
+      Pass an [`RsaHashedImportParams`](/en-US/docs/Web/API/RsaHashedImportParams) object.
+    - For [ECDSA](/en-US/docs/Web/API/SubtleCrypto/sign#ecdsa) or [ECDH](/en-US/docs/Web/API/SubtleCrypto/deriveKey#ecdh):
+      Pass an [`EcKeyImportParams`](/en-US/docs/Web/API/EcKeyImportParams) object.
+    - For [HMAC](/en-US/docs/Web/API/SubtleCrypto/sign#hmac):
+      Pass an [`HmacImportParams`](/en-US/docs/Web/API/HmacImportParams) object.
+    - For [AES-CTR](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-ctr), [AES-CBC](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-cbc),
+      [AES-GCM](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-gcm), or [AES-KW](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-kw):
+      Pass the string identifying the algorithm or an object of the form `{ "name": ALGORITHM }`, where `ALGORITHM` is the name of the algorithm.
+    - For [PBKDF2](/en-US/docs/Web/API/SubtleCrypto/deriveKey#pbkdf2): Pass the string `PBKDF2`.
+    - For [HKDF](/en-US/docs/Web/API/SubtleCrypto/deriveKey#hkdf): Pass the string `HKDF`.
+- `extractable`
+  - : A boolean value indicating whether it will be possible to export the key
+    using {{domxref("SubtleCrypto.exportKey()")}} or {{domxref("SubtleCrypto.wrapKey()")}}.
+- `keyUsages`
+  - : An {{jsxref("Array")}} indicating what can be done with the key. Possible array values are:
+    - `encrypt`: The key may be used to {{domxref("SubtleCrypto.encrypt()", "encrypt")}} messages.
+    - `decrypt`: The key may be used to {{domxref("SubtleCrypto.decrypt()", "decrypt")}} messages.
+    - `sign`: The key may be used to {{domxref("SubtleCrypto.sign()", "sign")}} messages.
+    - `verify`: The key may be used to {{domxref("SubtleCrypto.verify()", "verify")}} signatures.
+    - `deriveKey`: The key may be used in {{domxref("SubtleCrypto.deriveKey()", "deriving a new key")}}.
+    - `deriveBits`: The key may be used in {{domxref("SubtleCrypto.deriveBits()", "deriving bits")}}.
+    - `wrapKey`: The key may be used to {{domxref("SubtleCrypto.wrapKey()", "wrap a key")}}.
+    - `unwrapKey`: The key may be used to {{domxref("SubtleCrypto.unwrapKey()", "unwrap a key")}}.
 
 ### Return value
 
@@ -92,7 +73,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
 
 The promise is rejected when one of the following exceptions is encountered:
 
-- {{exception("SyntaxError")}}
+- `SyntaxError` {{domxref("DOMException")}}
   - : Raised when _`keyUsages`_ is empty but the unwrapped key is of
     type `secret` or `private`.
 - {{jsxref("TypeError")}}
@@ -117,8 +98,8 @@ containing the raw bytes for the key.
 
 You can use this format to import or export RSA or Elliptic Curve private keys.
 
-The PKCS #8 format is defined in [RFC
-5208](https://datatracker.ietf.org/doc/html/rfc5208)., using the [ASN.1 notation](https://en.wikipedia.org/wiki/Abstract_Syntax_Notation_One):
+The PKCS #8 format is defined in [RFC 5208](https://datatracker.ietf.org/doc/html/rfc5208),
+using the [ASN.1 notation](https://en.wikipedia.org/wiki/Abstract_Syntax_Notation_One):
 
 ```plain
 PrivateKeyInfo ::= SEQUENCE {
@@ -163,8 +144,7 @@ See the [Examples](#examples) section for more concrete guidance.
 You can use this format to import or export RSA or Elliptic Curve public keys.
 
 `SubjectPublicKey` is defined in [RFC 5280, Section 4.1](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1) using
-the [ASN.1
-notation:](https://en.wikipedia.org/wiki/Abstract_Syntax_Notation_One)
+the [ASN.1 notation:](https://en.wikipedia.org/wiki/Abstract_Syntax_Notation_One)
 
 ```plain
 SubjectPublicKeyInfo  ::=  SEQUENCE  {
@@ -178,8 +158,8 @@ receive this object as an
 containing the [DER-encoded](https://luca.ntop.org/Teaching/Appunti/asn1.html)
 form of the `SubjectPublicKeyInfo`.
 
-Again, you are most likely to encounter this object in [PEM format](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail). A
-PEM-encoded `SubjectPublicKeyInfo` looks like this:
+Again, you are most likely to encounter this object in [PEM format](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail).
+A PEM-encoded `SubjectPublicKeyInfo` looks like this:
 
 ```plain
 -----BEGIN PUBLIC KEY-----
@@ -208,9 +188,8 @@ See the [Examples](#examples) section for more concrete guidance.
 You can use JSON Web Key format to import or export RSA or Elliptic Curve public or
 private keys, as well as AES and HMAC secret keys.
 
-JSON Web Key format is defined in [RFC
-7517](https://datatracker.ietf.org/doc/html/rfc7517). It describes a way to represent public, private, and secret keys as JSON
-objects.
+JSON Web Key format is defined in [RFC 7517](https://datatracker.ietf.org/doc/html/rfc7517).
+It describes a way to represent public, private, and secret keys as JSON objects.
 
 A JSON Web Key looks something like this (this is an EC private key):
 
@@ -228,8 +207,7 @@ A JSON Web Key looks something like this (this is an EC private key):
 
 ## Examples
 
-> **Note:** You can [try the
-> working examples](https://mdn.github.io/dom-examples/web-crypto/import-key/index.html) on GitHub.
+> **Note:** You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/import-key/index.html) on GitHub.
 
 ### Raw import
 
@@ -257,7 +235,8 @@ function importSecretKey(rawKey) {
 
 ### PKCS #8 import
 
-This example imports an RSA private signing key from a PEM-encoded PKCS #8 object. [See the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/import-key/pkcs8.js)
+This example imports an RSA private signing key from a PEM-encoded PKCS #8 object.
+[See the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/import-key/pkcs8.js)
 
 ```js
 /*
@@ -395,6 +374,5 @@ function importPrivateKey(jwk) {
 
 - [`SubtleCrypto.exportKey()`](/en-US/docs/Web/API/SubtleCrypto/exportKey)
 - [PKCS #8 format](https://datatracker.ietf.org/doc/html/rfc5208).
-- [SubjectPublicKeyInfo
-  format](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1).
+- [SubjectPublicKeyInfo format](https://datatracker.ietf.org/doc/html/rfc5280#section-4.1).
 - [JSON Web Key format](https://datatracker.ietf.org/doc/html/rfc7517).

--- a/files/en-us/web/api/subtlecrypto/sign/index.md
+++ b/files/en-us/web/api/subtlecrypto/sign/index.md
@@ -30,23 +30,19 @@ sign(algorithm, key, data)
 
 ### Parameters
 
-- _`algorithm`_ is a string or object that specifies the signature
-  algorithm to use and its parameters:
-
-  - To use [RSASSA-PKCS1-v1_5](#rsassa-pkcs1-v1_5), pass the string
-    `"RSASSA-PKCS1-v1_5"` or an object of the form
-    `{ "name": "RSASSA-PKCS1-v1_5" }`.
-  - To use [RSA-PSS](#rsa-pss), pass an {{domxref("RsaPssParams")}}
-    object.
-  - To use [ECDSA](#ecdsa), pass an {{domxref("EcdsaParams")}} object.
-  - To use [HMAC](#hmac), pass the string `"HMAC"` or an
-    object of the form `{ "name": "HMAC" }`.
-
-- `key` is a {{domxref("CryptoKey")}} object containing the key to
-  be used for signing. If algorithm identifies a public-key cryptosystem, this is the
-  private key.
-- _`data`_ is an {{jsxref("ArrayBuffer")}} or
-  {{domxref("ArrayBufferView")}} object containing the data to be signed.
+- `algorithm`
+  - : A string or object that specifies the signature algorithm to use and its parameters:
+    - To use [RSASSA-PKCS1-v1_5](#rsassa-pkcs1-v1_5), pass the string `"RSASSA-PKCS1-v1_5"`
+      or an object of the form `{ "name": "RSASSA-PKCS1-v1_5" }`.
+    - To use [RSA-PSS](#rsa-pss), pass an {{domxref("RsaPssParams")}} object.
+    - To use [ECDSA](#ecdsa), pass an {{domxref("EcdsaParams")}} object.
+    - To use [HMAC](#hmac), pass the string `"HMAC"`
+      or an object of the form `{ "name": "HMAC" }`.
+- `key`
+  - : A {{domxref("CryptoKey")}} object containing the key to be used for signing.
+    If `algorithm` identifies a public-key cryptosystem, this is the private key.
+- `data`
+  - : An {{jsxref("ArrayBuffer")}} or {{domxref("ArrayBufferView")}} object containing the data to be signed.
 
 ### Return value
 
@@ -57,7 +53,7 @@ A {{jsxref("Promise")}} that fulfills with an
 
 The promise is rejected when the following exception is encountered:
 
-- {{exception("InvalidAccessError")}}
+- `InvalidAccessError` {{domxref("DOMException")}}
   - : Raised when the signing key is not a key for the request signing algorithm or when
     trying to use an algorithm that is either unknown or isn't suitable for signing.
 
@@ -68,10 +64,11 @@ verification.
 
 Three of these algorithms — RSASSA-PKCS1-v1_5, RSA-PSS, and ECDSA — are
 {{Glossary("public-key cryptography", "public-key cryptosystems")}} that use the private
-key for signing and the public key for verification. These systems all use a [digest
-algorithm](/en-US/docs/Web/API/SubtleCrypto/digest#supported_algorithms) to hash the message to a short fixed size before signing. The choice of
-digest algorithm is passed into the {{domxref("SubtleCrypto.generateKey()",
-  "generateKey()")}} or {{domxref("SubtleCrypto.importKey()", "importKey()")}} functions.
+key for signing and the public key for verification.
+These systems all use a [digest algorithm](/en-US/docs/Web/API/SubtleCrypto/digest#supported_algorithms)
+to hash the message to a short fixed size before signing.
+The choice of digest algorithm is passed into the
+{{domxref("SubtleCrypto.generateKey()", "generateKey()")}} or {{domxref("SubtleCrypto.importKey()", "importKey()")}} functions.
 
 The fourth algorithm — HMAC — uses the same algorithm and key for signing and for
 verification: this means that the verification key must be kept secret, which in turn
@@ -84,8 +81,7 @@ The RSASSA-PKCS1-v1_5 algorithm is specified in [RFC 3447](https://datatracker.i
 
 ### RSA-PSS
 
-The RSA-PSS algorithm is specified in [RFC
-3447](https://datatracker.ietf.org/doc/html/rfc3447).
+The RSA-PSS algorithm is specified in [RFC 3447](https://datatracker.ietf.org/doc/html/rfc3447).
 
 It's different from RSASSA-PKCS1-v1_5 in that it incorporates a random salt in the
 signature operation, so the same message signed with the same key will not result in the
@@ -111,9 +107,8 @@ produced by some tools and libraries such as [OpenSSL](https://www.openssl.org).
 
 ### HMAC
 
-The HMAC algorithm calculates and verifies hash-based message authentication codes
-according to the [FIPS
-198-1 standard](https://csrc.nist.gov/csrc/media/publications/fips/198/1/final/documents/fips-198-1_final.pdf).
+The HMAC algorithm calculates and verifies hash-based message authentication codes according to the
+[FIPS 198-1 standard](https://csrc.nist.gov/csrc/media/publications/fips/198/1/final/documents/fips-198-1_final.pdf).
 
 The digest algorithm to use is specified in the
 [`HmacKeyGenParams`](/en-US/docs/Web/API/HmacKeyGenParams) object
@@ -123,14 +118,13 @@ that you pass into {{domxref("SubtleCrypto.importKey()", "importKey()")}}.
 
 ## Examples
 
-> **Note:** You can [try the
-> working examples](https://mdn.github.io/dom-examples/web-crypto/sign-verify/index.html) out on GitHub.
+> **Note:** You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/sign-verify/index.html) out on GitHub.
 
 ### RSASSA-PKCS1-v1_5
 
 This code fetches the contents of a text box, encodes it for signing, and signs it with
-a private key. [See
-the complete source code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/sign-verify/rsassa-pkcs1.js)
+a private key.
+[See the complete source code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/sign-verify/rsassa-pkcs1.js)
 
 ```js
 /*
@@ -155,8 +149,8 @@ let signature = await window.crypto.subtle.sign(
 ### RSA-PSS
 
 This code fetches the contents of a text box, encodes it for signing, and signs it with
-a private key. [See
-the complete source code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/sign-verify/rsa-pss.js)
+a private key.
+[See the complete source code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/sign-verify/rsa-pss.js)
 
 ```js
 /*
@@ -184,8 +178,8 @@ let signature = await window.crypto.subtle.sign(
 ### ECDSA
 
 This code fetches the contents of a text box, encodes it for signing, and signs it with
-a private key. [See
-the complete source code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/sign-verify/ecdsa.js)
+a private key.
+[See the complete source code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/sign-verify/ecdsa.js)
 
 ```js
 /*
@@ -213,8 +207,8 @@ let signature = await window.crypto.subtle.sign(
 ### HMAC
 
 This code fetches the contents of a text box, encodes it for signing, and signs it with
-a secret key. [See
-the complete source code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/sign-verify/hmac.js)
+a secret key.
+[See the complete source code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/sign-verify/hmac.js)
 
 ```js
 /*
@@ -247,10 +241,7 @@ let signature = await window.crypto.subtle.sign(
 ## See also
 
 - {{domxref("SubtleCrypto.verify()")}}.
-- [RFC 3447](https://datatracker.ietf.org/doc/html/rfc3447) specifies
-  RSASSA-PKCS1-v1_5.
+- [RFC 3447](https://datatracker.ietf.org/doc/html/rfc3447) specifies RSASSA-PKCS1-v1_5.
 - [RFC 3447](https://datatracker.ietf.org/doc/html/rfc3447) specifies RSA-PSS.
-- [FIPS-186](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf) specifies
-  ECDSA.
-- [FIPS
-  198-1](https://csrc.nist.gov/csrc/media/publications/fips/198/1/final/documents/fips-198-1_final.pdf) specifies HMAC.
+- [FIPS-186](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf) specifies ECDSA.
+- [FIPS 198-1](https://csrc.nist.gov/csrc/media/publications/fips/198/1/final/documents/fips-198-1_final.pdf) specifies HMAC.

--- a/files/en-us/web/api/subtlecrypto/unwrapkey/index.md
+++ b/files/en-us/web/api/subtlecrypto/unwrapkey/index.md
@@ -17,8 +17,7 @@ interface "unwraps" a key. This means that it takes as its input a key that has 
 exported and then encrypted (also called "wrapped"). It decrypts the key and then
 imports it, returning a {{domxref("CryptoKey")}} object that can be used in the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API).
 
-As with
-[`SubtleCrypto.importKey()`](/en-US/docs/Web/API/SubtleCrypto/importKey),
+As with [`SubtleCrypto.importKey()`](/en-US/docs/Web/API/SubtleCrypto/importKey),
 you specify the key's [import format](/en-US/docs/Web/API/SubtleCrypto/importKey#supported_formats)
 and other attributes of the key to import details such as whether it is extractable, and
 which operations it can be used for.
@@ -39,74 +38,55 @@ unwrapKey(format, wrappedKey, unwrappingKey, unwrapAlgo, unwrappedKeyAlgo, extra
 
 ### Parameters
 
-- _`format`_ is a string describing the data format of the key to
-  unwrap. It can be one of the following:
-
-  - `raw`: [Raw](/en-US/docs/Web/API/SubtleCrypto/importKey#raw) format.
-  - `pkcs8`: [PKCS #8](/en-US/docs/Web/API/SubtleCrypto/importKey#pkcs_8) format.
-  - `spki`: [SubjectPublicKeyInfo](/en-US/docs/Web/API/SubtleCrypto/importKey#subjectpublickeyinfo)
-    format.
-  - `jwk`: [JSON Web Key](/en-US/docs/Web/API/SubtleCrypto/importKey#json_web_key)
-    format.
-
-- `wrappedKey` is an {{jsxref("ArrayBuffer")}} containing the
-  wrapped key in the given format.
-- `unwrappingKey` is the {{domxref("CryptoKey")}} to use to
-  decrypt the wrapped key. The key must have the `unwrapKey` usage set.
-- `unwrapAlgo` is an object specifying the [algorithm](/en-US/docs/Web/API/SubtleCrypto/encrypt#supported_algorithms)
-  to be used to encrypt the exported key, and any extra parameters as required:
-
-  - To use [RSA-OAEP](/en-US/docs/Web/API/SubtleCrypto/encrypt#rsa-oaep),
-    pass an [`RsaOaepParams`](/en-US/docs/Web/API/RsaOaepParams)
-    object.
-  - To use [AES-CTR](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-ctr),
-    pass an [`AesCtrParams`](/en-US/docs/Web/API/AesCtrParams)
-    object.
-  - To use [AES-CBC](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-cbc),
-    pass an [`AesCbcParams`](/en-US/docs/Web/API/AesCbcParams)
-    object.
-  - To use [AES-GCM](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-gcm),
-    pass an [`AesGcmParams`](/en-US/docs/Web/API/AesGcmParams)
-    object.
-  - To use [AES-KW](/en-US/docs/Web/API/SubtleCrypto/wrapKey#aes-kw),
-    pass the string `"AES-KW"` or an object of the form
-    `{ "name": "AES-KW }`.
-
-- `unwrappedKeyAlgo` is a dictionary object defining the type of
-  key to unwrap and providing extra algorithm-specific parameters as required.
-
-  - For [RSASSA-PKCS1-v1_5](/en-US/docs/Web/API/SubtleCrypto/sign#rsassa-pkcs1-v1_5), [RSA-PSS](/en-US/docs/Web/API/SubtleCrypto/sign#rsa-pss), or [RSA-OAEP](/en-US/docs/Web/API/SubtleCrypto/encrypt#rsa-oaep): Pass an
-    [`RsaHashedImportParams`](/en-US/docs/Web/API/RsaHashedImportParams)
-    object.
-  - For [ECDSA](/en-US/docs/Web/API/SubtleCrypto/sign#ecdsa) or [ECDH](/en-US/docs/Web/API/SubtleCrypto/deriveKey#ecdh): Pass
-    an [`EcKeyImportParams`](/en-US/docs/Web/API/EcKeyImportParams)
-    object.
-  - For [HMAC](/en-US/docs/Web/API/SubtleCrypto/sign#hmac): Pass an
-    [`HmacImportParams`](/en-US/docs/Web/API/HmacImportParams)
-    object.
-  - For [AES-CTR](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-ctr), [AES-CBC](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-cbc), [AES-GCM](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-gcm), or [AES-KW](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-kw): Pass the
-    string identifying the algorithm or an object of the form
-    `{ "name": ALGORITHM }`, where `ALGORITHM` is the name of
-    the algorithm.
-
-- `extractable` is a [`Boolean`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)
-  indicating whether it will be possible to export the key using [`SubtleCrypto.exportKey()`](/en-US/docs/Web/API/SubtleCrypto/exportKey)
-  or [`SubtleCrypto.wrapKey()`](/en-US/docs/Web/API/SubtleCrypto/wrapKey).
-- `keyUsages` is an [`Array`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)
-  indicating what can be done with the key. Possible values of the array are:
-
-  - `encrypt`: The key may be used to [`encrypt`](/en-US/docs/Web/API/SubtleCrypto/encrypt)
-    messages.
-  - `decrypt`: The key may be used to [`decrypt`](/en-US/docs/Web/API/SubtleCrypto/decrypt)
-    messages.
-  - `sign`: The key may be used to [`sign`](/en-US/docs/Web/API/SubtleCrypto/sign)
-    messages.
-  - `verify`: The key may be used to [`verify`](/en-US/docs/Web/API/SubtleCrypto/verify)
-    signatures.
-  - `deriveKey`: The key may be used in [`deriving a new key`](/en-US/docs/Web/API/SubtleCrypto/deriveKey).
-  - `deriveBits`: The key may be used in [`deriving bits`](/en-US/docs/Web/API/SubtleCrypto/deriveBits).
-  - `wrapKey`: The key may be used to [`wrap a key`](/en-US/docs/Web/API/SubtleCrypto/wrapKey).
-  - `unwrapKey`: The key may be used to unwrap a key.
+- `format`
+  - : A string describing the data format of the key to unwrap. It can be one of the following:
+    - `raw`: [Raw](/en-US/docs/Web/API/SubtleCrypto/importKey#raw) format.
+    - `pkcs8`: [PKCS #8](/en-US/docs/Web/API/SubtleCrypto/importKey#pkcs_8) format.
+    - `spki`: [SubjectPublicKeyInfo](/en-US/docs/Web/API/SubtleCrypto/importKey#subjectpublickeyinfo) format.
+    - `jwk`: [JSON Web Key](/en-US/docs/Web/API/SubtleCrypto/importKey#json_web_key) format.
+- `wrappedKey`
+  - : An {{jsxref("ArrayBuffer")}} containing the wrapped key in the given format.
+- `unwrappingKey`
+  - : The {{domxref("CryptoKey")}} to use to decrypt the wrapped key. The key must have the `unwrapKey` usage set.
+- `unwrapAlgo`
+  - : An object specifying the [algorithm](/en-US/docs/Web/API/SubtleCrypto/encrypt#supported_algorithms)
+    to be used to encrypt the exported key, and any extra parameters as required:
+    - To use [RSA-OAEP](/en-US/docs/Web/API/SubtleCrypto/encrypt#rsa-oaep),
+      pass an [`RsaOaepParams`](/en-US/docs/Web/API/RsaOaepParams) object.
+    - To use [AES-CTR](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-ctr),
+      pass an [`AesCtrParams`](/en-US/docs/Web/API/AesCtrParams) object.
+    - To use [AES-CBC](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-cbc),
+      pass an [`AesCbcParams`](/en-US/docs/Web/API/AesCbcParams) object.
+    - To use [AES-GCM](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-gcm),
+      pass an [`AesGcmParams`](/en-US/docs/Web/API/AesGcmParams) object.
+    - To use [AES-KW](/en-US/docs/Web/API/SubtleCrypto/wrapKey#aes-kw),
+      pass the string `"AES-KW"` or an object of the form `{ "name": "AES-KW }`.
+- `unwrappedKeyAlgo`
+  - : An object defining the type of key to unwrap and providing extra algorithm-specific parameters as required.
+    - For [RSASSA-PKCS1-v1_5](/en-US/docs/Web/API/SubtleCrypto/sign#rsassa-pkcs1-v1_5), [RSA-PSS](/en-US/docs/Web/API/SubtleCrypto/sign#rsa-pss),
+      or [RSA-OAEP](/en-US/docs/Web/API/SubtleCrypto/encrypt#rsa-oaep):
+      Pass an [`RsaHashedImportParams`](/en-US/docs/Web/API/RsaHashedImportParams) object.
+    - For [ECDSA](/en-US/docs/Web/API/SubtleCrypto/sign#ecdsa) or [ECDH](/en-US/docs/Web/API/SubtleCrypto/deriveKey#ecdh): Pass
+      an [`EcKeyImportParams`](/en-US/docs/Web/API/EcKeyImportParams) object.
+    - For [HMAC](/en-US/docs/Web/API/SubtleCrypto/sign#hmac): Pass an
+      [`HmacImportParams`](/en-US/docs/Web/API/HmacImportParams) object.
+    - For [AES-CTR](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-ctr), [AES-CBC](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-cbc),
+      [AES-GCM](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-gcm), or [AES-KW](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-kw):
+      Pass the string identifying the algorithm or an object of the form `{ "name": ALGORITHM }`, where `ALGORITHM` is the name of
+      the algorithm.
+- `extractable`
+  - : A boolean indicating whether it will be possible to export the key
+    using [`SubtleCrypto.exportKey()`](/en-US/docs/Web/API/SubtleCrypto/exportKey) or [`SubtleCrypto.wrapKey()`](/en-US/docs/Web/API/SubtleCrypto/wrapKey).
+- `keyUsages`
+  - : An [`Array`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) indicating what can be done with the key. Possible values of the array are:
+    - `encrypt`: The key may be used to [`encrypt`](/en-US/docs/Web/API/SubtleCrypto/encrypt) messages.
+    - `decrypt`: The key may be used to [`decrypt`](/en-US/docs/Web/API/SubtleCrypto/decrypt) messages.
+    - `sign`: The key may be used to [`sign`](/en-US/docs/Web/API/SubtleCrypto/sign) messages.
+    - `verify`: The key may be used to [`verify`](/en-US/docs/Web/API/SubtleCrypto/verify) signatures.
+    - `deriveKey`: The key may be used in [`deriving a new key`](/en-US/docs/Web/API/SubtleCrypto/deriveKey).
+    - `deriveBits`: The key may be used in [`deriving bits`](/en-US/docs/Web/API/SubtleCrypto/deriveBits).
+    - `wrapKey`: The key may be used to [`wrap a key`](/en-US/docs/Web/API/SubtleCrypto/wrapKey).
+    - `unwrapKey`: The key may be used to unwrap a key.
 
 ### Return value
 
@@ -118,16 +98,14 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise)
 
 The promise is rejected when one of the following exceptions is encountered:
 
-- {{exception("InvalidAccessError")}}
+- `InvalidAccessError` {{domxref("DOMException")}}
   - : Raised when the unwrapping key is not a key for the requested unwrap algorithm or if
-    the `keyUsages` value of that key doesn't contain
-    `unwrap`.
-- {{exception("NotSupported")}}
+    the `keyUsages` value of that key doesn't contain `unwrap`.
+- `NotSupported` {{domxref("DOMException")}}
   - : Raised when trying to use an algorithm that is either unknown or isn't suitable for
     encryption or wrapping.
-- {{exception("SyntaxError")}}
-  - : Raised when _`keyUsages`_ is empty but the unwrapped key is of
-    type `secret` or `private`.
+- `SyntaxError` {{domxref("DOMException")}}
+  - : Raised when `keyUsages` is empty but the unwrapped key is of type `secret` or `private`.
 - {{jsxref("TypeError")}}
   - : Raised when trying to use an invalid format.
 
@@ -139,8 +117,7 @@ method.
 
 ## Examples
 
-> **Note:** You can [try the
-> working examples](https://mdn.github.io/dom-examples/web-crypto/unwrap-key/index.html) on GitHub.
+> **Note:** You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/unwrap-key/index.html) on GitHub.
 
 ### Unwrapping a "raw" key
 

--- a/files/en-us/web/api/subtlecrypto/verify/index.md
+++ b/files/en-us/web/api/subtlecrypto/verify/index.md
@@ -29,10 +29,8 @@ verify(algorithm, key, signature, data)
 ### Parameters
 
 - `algorithm`
-  - : A string or object defining the
-  algorithm to use, and for some algorithm choices, some extra parameters. The values
-  given for the extra parameters must match those passed into the corresponding
-  {{domxref("SubtleCrypto.sign()", "sign()")}} call.
+  - : A string or object defining the algorithm to use, and for some algorithm choices, some extra parameters.
+    The values given for the extra parameters must match those passed into the corresponding {{domxref("SubtleCrypto.sign()", "sign()")}} call.
     - To use [RSASSA-PKCS1-v1_5](/en-US/docs/Web/API/SubtleCrypto/sign#rsassa-pkcs1-v1_5),
     pass the string `"RSASSA-PKCS1-v1_5"` or an object of the form `{ "name": "RSASSA-PKCS1-v1_5" }`.
     - To use [RSA-PSS](/en-US/docs/Web/API/SubtleCrypto/sign#rsa-pss), pass an {{domxref("RsaPssParams")}} object.

--- a/files/en-us/web/api/subtlecrypto/verify/index.md
+++ b/files/en-us/web/api/subtlecrypto/verify/index.md
@@ -37,8 +37,7 @@ verify(algorithm, key, signature, data)
     pass the string `"RSASSA-PKCS1-v1_5"` or an object of the form `{ "name": "RSASSA-PKCS1-v1_5" }`.
     - To use [RSA-PSS](/en-US/docs/Web/API/SubtleCrypto/sign#rsa-pss), pass an {{domxref("RsaPssParams")}} object.
     - To use [ECDSA](/en-US/docs/Web/API/SubtleCrypto/sign#ecdsa), pass an {{domxref("EcdsaParams")}} object.
-    - To use [HMAC](/en-US/docs/Web/API/SubtleCrypto/sign#hmac), pass the string `"HMAC"` or an object of the form
-    `{ "name": "HMAC" }`.
+    - To use [HMAC](/en-US/docs/Web/API/SubtleCrypto/sign#hmac), pass the string `"HMAC"` or an object of the form `{ "name": "HMAC" }`.
 - `key`
   - : A {{domxref("CryptoKey")}} containing the key that will be used to verify the signature.
     It is the secret key for a symmetric algorithm and the public key for a public-key system.

--- a/files/en-us/web/api/subtlecrypto/verify/index.md
+++ b/files/en-us/web/api/subtlecrypto/verify/index.md
@@ -28,29 +28,24 @@ verify(algorithm, key, signature, data)
 
 ### Parameters
 
-- _`algorithm`_ is a string or object defining the
+- `algorithm`
+  - : A string or object defining the
   algorithm to use, and for some algorithm choices, some extra parameters. The values
   given for the extra parameters must match those passed into the corresponding
   {{domxref("SubtleCrypto.sign()", "sign()")}} call.
-
-  - To use [RSASSA-PKCS1-v1_5](/en-US/docs/Web/API/SubtleCrypto/sign#rsassa-pkcs1-v1_5),
-    pass the string `"RSASSA-PKCS1-v1_5"` or an object of the form
-    `{ "name": "RSASSA-PKCS1-v1_5" }`.
-  - To use [RSA-PSS](/en-US/docs/Web/API/SubtleCrypto/sign#rsa-pss), pass
-    an {{domxref("RsaPssParams")}} object.
-  - To use [ECDSA](/en-US/docs/Web/API/SubtleCrypto/sign#ecdsa), pass an
-    {{domxref("EcdsaParams")}} object.
-  - To use [HMAC](/en-US/docs/Web/API/SubtleCrypto/sign#hmac), pass the
-    string `"HMAC"` or an object of the form
+    - To use [RSASSA-PKCS1-v1_5](/en-US/docs/Web/API/SubtleCrypto/sign#rsassa-pkcs1-v1_5),
+    pass the string `"RSASSA-PKCS1-v1_5"` or an object of the form `{ "name": "RSASSA-PKCS1-v1_5" }`.
+    - To use [RSA-PSS](/en-US/docs/Web/API/SubtleCrypto/sign#rsa-pss), pass an {{domxref("RsaPssParams")}} object.
+    - To use [ECDSA](/en-US/docs/Web/API/SubtleCrypto/sign#ecdsa), pass an {{domxref("EcdsaParams")}} object.
+    - To use [HMAC](/en-US/docs/Web/API/SubtleCrypto/sign#hmac), pass the string `"HMAC"` or an object of the form
     `{ "name": "HMAC" }`.
-
-- `key` is a {{domxref("CryptoKey")}} containing the key that will
-  be used to verify the signature. It is the secret key for a symmetric algorithm and
-  the public key for a public-key system.
-- `signature` is a {{jsxref("ArrayBuffer")}} containing the
-  {{glossary("signature")}} to verify.
-- _`data`_ is a {{jsxref("ArrayBuffer")}} containing the data whose
-  signature is to be verified.
+- `key`
+  - : A {{domxref("CryptoKey")}} containing the key that will be used to verify the signature.
+    It is the secret key for a symmetric algorithm and the public key for a public-key system.
+- `signature`
+  - : A {{jsxref("ArrayBuffer")}} containing the {{glossary("signature")}} to verify.
+- `data`
+  - : A {{jsxref("ArrayBuffer")}} containing the data whose signature is to be verified.
 
 ### Return value
 
@@ -62,7 +57,7 @@ A {{jsxref("Promise")}} that fulfills with a
 
 The promise is rejected when the following exception is encountered:
 
-- {{exception("InvalidAccessError")}}
+- `InvalidAccessError` {{domxref("DOMException")}}
   - : Raised when the encryption key is not a key for the requested verifying algorithm or
     when trying to use an algorithm that is either unknown or isn't suitable for a verify
     operation.
@@ -75,13 +70,12 @@ method.
 
 ## Examples
 
-> **Note:** You can [try the
-> working examples](https://mdn.github.io/dom-examples/web-crypto/sign-verify/index.html) out on GitHub.
+> **Note:** You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/sign-verify/index.html) out on GitHub.
 
 ### RSASSA-PKCS1-v1_5
 
-This code uses a public key to verify a signature. [See
-the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/sign-verify/rsassa-pkcs1.js)
+This code uses a public key to verify a signature.
+[See the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/sign-verify/rsassa-pkcs1.js)
 
 ```js
 /*
@@ -118,8 +112,8 @@ async function verifyMessage(publicKey) {
 
 ### RSA-PSS
 
-This code uses a public key to verify a signature. [See
-the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/sign-verify/rsa-pss.js)
+This code uses a public key to verify a signature.
+[See the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/sign-verify/rsa-pss.js)
 
 ```js
 /*
@@ -159,8 +153,8 @@ async function verifyMessage(publicKey) {
 
 ### ECDSA
 
-This code uses a public key to verify a signature. [See
-the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/sign-verify/ecdsa.js)
+This code uses a public key to verify a signature.
+[See the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/sign-verify/ecdsa.js)
 
 ```js
 /*
@@ -200,8 +194,8 @@ async function verifyMessage(publicKey) {
 
 ### HMAC
 
-This code uses a secret key to verify a signature. [See
-the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/sign-verify/hmac.js)
+This code uses a secret key to verify a signature.
+[See the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/sign-verify/hmac.js)
 
 ```js
 /*
@@ -247,10 +241,7 @@ async function verifyMessage(key) {
 ## See also
 
 - {{domxref("SubtleCrypto.sign()")}}.
-- [RFC 3447](https://datatracker.ietf.org/doc/html/rfc3447) specifies
-  RSASSA-PKCS1-v1_5.
+- [RFC 3447](https://datatracker.ietf.org/doc/html/rfc3447) specifies RSASSA-PKCS1-v1_5.
 - [RFC 3447](https://datatracker.ietf.org/doc/html/rfc3447) specifies RSA-PSS.
-- [FIPS-186](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf) specifies
-  ECDSA.
-- [FIPS
-  198-1](https://csrc.nist.gov/csrc/media/publications/fips/198/1/final/documents/fips-198-1_final.pdf) specifies HMAC.
+- [FIPS-186](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.186-4.pdf) specifies ECDSA.
+- [FIPS 198-1](https://csrc.nist.gov/csrc/media/publications/fips/198/1/final/documents/fips-198-1_final.pdf) specifies HMAC.

--- a/files/en-us/web/api/subtlecrypto/wrapkey/index.md
+++ b/files/en-us/web/api/subtlecrypto/wrapkey/index.md
@@ -39,37 +39,29 @@ wrapKey(format, key, wrappingKey, wrapAlgo)
 
 ### Parameters
 
-- _`format`_ is a string describing the data format in which the key
-  will be exported before it is encrypted. It can be one of the following:
-
-  - `raw`: [Raw](/en-US/docs/Web/API/SubtleCrypto/importKey#raw) format.
-  - `pkcs8`: [PKCS #8](/en-US/docs/Web/API/SubtleCrypto/importKey#pkcs_8) format.
-  - `spki`: [SubjectPublicKeyInfo](/en-US/docs/Web/API/SubtleCrypto/importKey#subjectpublickeyinfo)
-    format.
-  - `jwk`: [JSON Web Key](/en-US/docs/Web/API/SubtleCrypto/importKey#json_web_key)
-    format.
-
-- `key` is the {{domxref("CryptoKey")}} to wrap.
-- `wrappingkey` is the {{domxref("CryptoKey")}} used to encrypt
-  the exported key. The key must have the `wrapKey` usage set.
-- `wrapAlgo` is an object specifying the [algorithm](/en-US/docs/Web/API/SubtleCrypto/encrypt#supported_algorithms)
-  to be used to encrypt the exported key, and any required extra parameters:
-
-  - To use [RSA-OAEP](/en-US/docs/Web/API/SubtleCrypto/encrypt#rsa-oaep),
-    pass an [`RsaOaepParams`](/en-US/docs/Web/API/RsaOaepParams)
-    object.
-  - To use [AES-CTR](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-ctr),
-    pass an [`AesCtrParams`](/en-US/docs/Web/API/AesCtrParams)
-    object.
-  - To use [AES-CBC](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-cbc),
-    pass an [`AesCbcParams`](/en-US/docs/Web/API/AesCbcParams)
-    object.
-  - To use [AES-GCM](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-gcm),
-    pass an [`AesGcmParams`](/en-US/docs/Web/API/AesGcmParams)
-    object.
-  - To use [AES-KW](#aes-kw),
-    pass the string `"AES-KW"`, or an object of the form
-    `{ "name": "AES-KW }`.
+- `format`
+  - : A string describing the data format in which the key will be exported before it is encrypted. It can be one of the following:
+    - `raw`: [Raw](/en-US/docs/Web/API/SubtleCrypto/importKey#raw) format.
+    - `pkcs8`: [PKCS #8](/en-US/docs/Web/API/SubtleCrypto/importKey#pkcs_8) format.
+    - `spki`: [SubjectPublicKeyInfo](/en-US/docs/Web/API/SubtleCrypto/importKey#subjectpublickeyinfo) format.
+    - `jwk`: [JSON Web Key](/en-US/docs/Web/API/SubtleCrypto/importKey#json_web_key) format.
+- `key`¨
+  - : The {{domxref("CryptoKey")}} to wrap.
+- `wrappingkey`
+  - : The {{domxref("CryptoKey")}} used to encrypt the exported key. The key must have the `wrapKey` usage set.
+- `wrapAlgo`
+  - : An object specifying the [algorithm](/en-US/docs/Web/API/SubtleCrypto/encrypt#supported_algorithms)
+    to be used to encrypt the exported key, and any required extra parameters:
+    - To use [RSA-OAEP](/en-US/docs/Web/API/SubtleCrypto/encrypt#rsa-oaep),
+      pass an [`RsaOaepParams`](/en-US/docs/Web/API/RsaOaepParams) object.
+    - To use [AES-CTR](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-ctr),
+      pass an [`AesCtrParams`](/en-US/docs/Web/API/AesCtrParams) object.
+    - To use [AES-CBC](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-cbc),
+      pass an [`AesCbcParams`](/en-US/docs/Web/API/AesCbcParams) object.
+    - To use [AES-GCM](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-gcm),
+      pass an [`AesGcmParams`](/en-US/docs/Web/API/AesGcmParams) object.
+    - To use [AES-KW](#aes-kw),
+      pass the string `"AES-KW"`, or an object of the form `{ "name": "AES-KW }`.
 
 ### Return value
 
@@ -82,9 +74,9 @@ wrapKey(format, key, wrappingKey, wrapAlgo)
 
 The promise is rejected when one of the following exceptions is encountered:
 
-- {{exception("InvalidAccessError")}}
+- `InvalidAccessError` {{domxref("DOMException")}}
   - : Raised when the wrapping key is not a key for the requested wrap algorithm.
-- {{exception("NotSupported")}}
+- `NotSupported` {{domxref("DOMException")}}
   - : Raised when trying to use an algorithm that is either unknown or isn't suitable for
     encryption or wrapping.
 - {{jsxref("TypeError")}}
@@ -92,10 +84,8 @@ The promise is rejected when one of the following exceptions is encountered:
 
 ## Supported algorithms
 
-All [algorithms
-that are usable for encryption](/en-US/docs/Web/API/SubtleCrypto/encrypt#supported_algorithms) are also usable for key wrapping, as long as the
-key has the "wrapKey" usage set. For key wrapping you have the additional option of
-AES-KW.
+All [algorithms that are usable for encryption](/en-US/docs/Web/API/SubtleCrypto/encrypt#supported_algorithms) are also usable for key wrapping,
+as long as the key has the "wrapKey" usage set. For key wrapping you have the additional option of AES-KW.
 
 ### AES-KW
 
@@ -109,8 +99,7 @@ AES-KW is specified in [RFC 3394](https://datatracker.ietf.org/doc/html/rfc3394)
 
 ## Examples
 
-> **Note:** You can [try the
-> working examples](https://mdn.github.io/dom-examples/web-crypto/wrap-key/index.html) out on GitHub.
+> **Note:** You can [try the working examples](https://mdn.github.io/dom-examples/web-crypto/wrap-key/index.html) out on GitHub.
 
 ### Raw wrap
 
@@ -196,7 +185,8 @@ window.crypto.subtle.generateKey(
 ### PKCS #8 wrap
 
 This example wraps an RSA private signing key. It uses "pkcs8" as the export format and
-AES-GCM, with a password-derived key, to encrypt it. [See the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/wrap-key/pkcs8.js)
+AES-GCM, with a password-derived key, to encrypt it.
+[See the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/wrap-key/pkcs8.js)
 
 ```js
 let salt;
@@ -285,7 +275,8 @@ window.crypto.subtle.generateKey(
 ### SubjectPublicKeyInfo wrap
 
 This example wraps an RSA public encryption key. It uses "spki" as the export format
-and AES-CBC, with a password-derived key, to encrypt it. [See the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/wrap-key/spki.js)
+and AES-CBC, with a password-derived key, to encrypt it.
+[See the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/wrap-key/spki.js)
 
 ```js
 let salt;
@@ -374,7 +365,8 @@ window.crypto.subtle.generateKey(
 ### JSON Web Key import
 
 This code wraps an ECDSA private signing key. It uses "jwk" as the export format and
-AES-GCM, with a password-derived key, to encrypt it. [See the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/wrap-key/jwk.js)
+AES-GCM, with a password-derived key, to encrypt it.
+[See the complete code on GitHub.](https://github.com/mdn/dom-examples/blob/master/web-crypto/wrap-key/jwk.js)
 
 ```js
 let salt;


### PR DESCRIPTION
Parameters list were not using a definition list. This fixes this.

I also added the missing `{{domxref("DOMException")}}` links (and removed the outdated `{{exception}}` macro).

I also fixed some multiline MD links (that are difficult to read).