### PR TITLE
Use HTML in no-markdown tables for crossorigin docs

### DIFF
--- a/files/en-us/web/html/attributes/crossorigin/index.md
+++ b/files/en-us/web/html/attributes/crossorigin/index.md
@@ -16,7 +16,7 @@ spec-urls:
 
 {{HTMLSidebar}}
 
-The crossorigin attribute, valid on the {{ HTMLElement("audio") }}, {{ HTMLElement("img") }}, {{ HTMLElement("link") }}, {{ HTMLElement("script") }}, and {{ HTMLElement("video") }} elements, provides support for [CORS](/docs/Web/HTTP/CORS), defining how the element handles crossorigin requests, thereby enabling the configuration of the CORS requests for the element's fetched data. Depending on the element, the attribute can be a CORS settings attribute.
+The crossorigin attribute, valid on the {{ HTMLElement("audio") }}, {{ HTMLElement("img") }}, {{ HTMLElement("link") }}, {{ HTMLElement("script") }}, and {{ HTMLElement("video") }} elements, provides support for [CORS](/en-US/docs/Web/HTTP/CORS), defining how the element handles crossorigin requests, thereby enabling the configuration of the CORS requests for the element's fetched data. Depending on the element, the attribute can be a CORS settings attribute.
 
 The `crossorigin` content attribute on media elements is a CORS settings attribute.
 
@@ -64,7 +64,7 @@ By default (that is, when the attribute is not specified), CORS is not used at a
     <tr>
       <td><code>img</code>, <code>audio</code>, <code>video</code></td>
       <td>
-        When resource is placed in {{HTMLElement("canvas")}}, element is marked as "<a href="/docs/Web/HTML/CORS_enabled_image#security_and_tainted_canvases">tainted</a>".
+        When resource is placed in {{HTMLElement("canvas")}}, element is marked as "<a href="/en-US/docs/Web/HTML/CORS_enabled_image#security_and_tainted_canvases">tainted</a>".
       </td>
     </tr>
     <tr>
@@ -94,7 +94,7 @@ You can use the following {{HTMLElement("script")}} element to tell a browser to
 
 ### Example: Webmanifest with credentials
 
-The `use-credentials` value must be used when fetching a [manifest](/docs/Web/Manifest) that requires credentials, even if the file is from the same origin.
+The `use-credentials` value must be used when fetching a [manifest](/en-US/docs/Web/Manifest) that requires credentials, even if the file is from the same origin.
 
 ```html
 <link rel="manifest" href="/app.webmanifest" crossorigin="use-credentials">
@@ -120,7 +120,7 @@ The `use-credentials` value must be used when fetching a [manifest](/docs/Web/Ma
 
 ## See also
 
-- [Cross-Origin Resource Sharing (CORS)](/docs/Web/HTTP/CORS)
-- [HTML attribute: `rel`](/docs/Web/HTML/Attributes/rel)
+- [Cross-Origin Resource Sharing (CORS)](/en-US/docs/Web/HTTP/CORS)
+- [HTML attribute: `rel`](/en-US/docs/Web/HTML/Attributes/rel)
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/HTML/")}}

--- a/files/en-us/web/html/attributes/crossorigin/index.md
+++ b/files/en-us/web/html/attributes/crossorigin/index.md
@@ -16,7 +16,7 @@ spec-urls:
 
 {{HTMLSidebar}}
 
-The crossorigin attribute, valid on the {{ HTMLElement("audio") }}, {{ HTMLElement("img") }}, {{ HTMLElement("link") }}, {{ HTMLElement("script") }}, and {{ HTMLElement("video") }} elements, provides support for [CORS](/en-US/docs/Web/HTTP/CORS), defining how the element handles crossorigin requests, thereby enabling the configuration of the CORS requests for the element's fetched data. Depending on the element, the attribute can be a CORS settings attribute.
+The crossorigin attribute, valid on the {{ HTMLElement("audio") }}, {{ HTMLElement("img") }}, {{ HTMLElement("link") }}, {{ HTMLElement("script") }}, and {{ HTMLElement("video") }} elements, provides support for [CORS](/docs/Web/HTTP/CORS), defining how the element handles crossorigin requests, thereby enabling the configuration of the CORS requests for the element's fetched data. Depending on the element, the attribute can be a CORS settings attribute.
 
 The `crossorigin` content attribute on media elements is a CORS settings attribute.
 
@@ -31,13 +31,13 @@ These attributes are enumerated, and have the following possible values:
     <tr>
       <td><code>anonymous</code></td>
       <td>
-        Request uses CORS headers and credentials flag is set to 'same-origin'. There is no exchange of **user credentials** via cookies, client-side SSL certificates or HTTP authentication, unless destination is the same origin.
+        Request uses CORS headers and credentials flag is set to <code>'same-origin'</code>. There is no exchange of <b>user credentials</b> via cookies, client-side SSL certificates or HTTP authentication, unless destination is the same origin.
       </td>
     </tr>
     <tr>
       <td><code>use-credentials</code></td>
       <td>
-        Request uses CORS headers, credentials flag is set to 'include' and **user credentials** are always included.
+        Request uses CORS headers, credentials flag is set to <code>'include'</code> and <b>user credentials</b> are always included.
       </td>
     </tr>
     <tr>
@@ -64,7 +64,7 @@ By default (that is, when the attribute is not specified), CORS is not used at a
     <tr>
       <td><code>img</code>, <code>audio</code>, <code>video</code></td>
       <td>
-        When resource is placed in {{HTMLElement("canvas")}}, element is marked as "[tainted](/en-US/docs/Web/HTML/CORS_enabled_image#what_is_a_tainted_canvas)".
+        When resource is placed in {{HTMLElement("canvas")}}, element is marked as "<a href="/docs/Web/HTML/CORS_enabled_image#security_and_tainted_canvases">tainted</a>".
       </td>
     </tr>
     <tr>
@@ -76,7 +76,7 @@ By default (that is, when the attribute is not specified), CORS is not used at a
     <tr>
       <td><code>link</code></td>
       <td>
-        Request with no appropriate `crossorigin` header may be discarded.
+        Request with no appropriate <code>crossorigin</code> header may be discarded.
       </td>
     </tr>
   </tbody>
@@ -94,7 +94,7 @@ You can use the following {{HTMLElement("script")}} element to tell a browser to
 
 ### Example: Webmanifest with credentials
 
-The `use-credentials` value must be used when fetching a [manifest](/en-US/docs/Web/Manifest) that requires credentials, even if the file is from the same origin.
+The `use-credentials` value must be used when fetching a [manifest](/docs/Web/Manifest) that requires credentials, even if the file is from the same origin.
 
 ```html
 <link rel="manifest" href="/app.webmanifest" crossorigin="use-credentials">
@@ -120,7 +120,7 @@ The `use-credentials` value must be used when fetching a [manifest](/en-US/docs/
 
 ## See also
 
-- [Cross-Origin Resource Sharing (CORS)](/en-US/docs/Web/HTTP/CORS)
-- [HTML attribute: `rel`](/en-US/docs/Web/HTML/Attributes/rel)
+- [Cross-Origin Resource Sharing (CORS)](/docs/Web/HTTP/CORS)
+- [HTML attribute: `rel`](/docs/Web/HTML/Attributes/rel)
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/HTML/")}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
- Substitutes HTML for Markdown inside of `<table class="no-markdown">`.
- Removes the `/en-US` prefix from various URLs on the page.

#### Motivation
Removing the `/en-US` prefix from intra-site links ensures that folks whose language preference is not `en-US` will get redirected to the appropriate localized version of the target pages (if they exist). This is something we have gotten in the habit of doing on https://web.dev/, and I assume it's a best practice here as well, but if it's not, I can re-add those prefixes.

The [page](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin) currently renders incorrectly, with literal Markdown instead of HTML inside tables. E.g.:

![Screen Shot 2022-04-26 at 11 35 07 AM](https://user-images.githubusercontent.com/1749548/165338471-d8478ed7-474e-42e1-a995-224c960b0cb8.png)

#### Supporting details
n/a

#### Related issues
n/a

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
