### PR TITLE
Add "fuchsia" as one of the possible values

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformos/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/platformos/index.md
@@ -33,6 +33,8 @@ Values of this type are strings. Possible values are:
   - : The underlying operating system is Linux.
 - `"openbsd"`
   - : The underlying operating system is Open/FreeBSD.
+- `"fuchsia"`
+  - : The underlying operating system is Fuchsia.
 
 ## Browser compatibility
 


### PR DESCRIPTION
#### Summary
Adding this value brings the MDN docs into alignment with the chrome documentation it's derived from. The chrome code/documentation was recently updated to include "fuchsia".

#### Motivation
The value was recently added in chromium and it's good to keep MDN up to date.
