### PR TITLE
Fix description of string value in grid-template-areas

### DIFF
--- a/files/en-us/web/css/grid-template-areas/index.md
+++ b/files/en-us/web/css/grid-template-areas/index.md
@@ -41,7 +41,7 @@ grid-template-areas: unset;
 - `none`
   - : The grid container doesn't define any named grid areas.
 - `{{cssxref("&lt;string&gt;")}}+`
-  - : A row is created for every separate string listed, and a column is created for each cell in the string. Multiple named cell tokens within and between rows create a single named grid area that spans the corresponding grid cells. Unless those cells form a rectangle, the declaration is invalid.
+  - : A row is created for every separate string listed, and a column is created for each cell in the string. Multiple cell tokens with the same name within and between rows create a single named grid area that spans the corresponding grid cells. Unless those cells form a rectangle, the declaration is invalid.
 
 ## Formal definition
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
This description of the string value doesn't have the information that cell tokens should have the same name to form a single named grid area:

#### Motivation
It's a mistake but a minor one. But I think for the sake of correctness we have to fix it.

#### Related issues
#15392 

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
