### PR TITLE
fixed a negligible typo

### DIFF
--- a/files/en-us/learn/html/tables/advanced/index.md
+++ b/files/en-us/learn/html/tables/advanced/index.md
@@ -60,7 +60,7 @@ As you can infer from the brief example above, the caption is meant to contain a
 
 A caption is placed directly beneath the `<table>` tag.
 
-> **Note:** The {{htmlattrxref("summary","table")}} attribute can also be used on the `<table>` element to provide a description — this is also read out by screenreaders. We'd recommend using the `<caption>` element instead, however, as `summary` is deprecated by the HTML5 spec, and can't be read by sighted users (it doesn't appear on the page.)
+> **Note:** The {{htmlattrxref("summary","table")}} attribute can also be used on the `<table>` element to provide a description — this is also read out by screenreaders. We'd recommend using the `<caption>` element instead, however, as `summary` is deprecated by the HTML5 spec, and can't be read by sighted users (it doesn't appear on the page).
 
 ### Active learning: Adding a caption
 


### PR DESCRIPTION
'period / full-stop' was within 'brackets', in that statement, and i just moved it outside brackets, thanks :)

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
'full-stop / period' symbol was within "first bracket - i.e.()", so i just moved it outside
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
seemed like a typo enough to me, and thus suggesting this fix
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
