### PR TITLE
Fix example heights in the gap page

### DIFF
--- a/files/en-us/web/css/gap/index.md
+++ b/files/en-us/web/css/gap/index.md
@@ -111,7 +111,7 @@ This property is specified as a value for `<'row-gap'>` followed optionally by a
 
 #### Result
 
-{{EmbedLiveSample("Flex_layout", "auto", "120px")}}
+{{EmbedLiveSample("Flex_layout", "auto", 250)}}
 
 ### Grid layout
 
@@ -149,7 +149,7 @@ This property is specified as a value for `<'row-gap'>` followed optionally by a
 
 #### Result
 
-{{EmbedLiveSample("Grid_layout", "auto", "120px")}}
+{{EmbedLiveSample("Grid_layout", "auto", 250)}}
 
 ### Multi-column layout
 


### PR DESCRIPTION
Make examples the right height so we don't have a scrollbar.