### PR TITLE
Fix 15329: link to CSP header page for policy directives

### DIFF
--- a/files/en-us/web/http/csp/index.md
+++ b/files/en-us/web/http/csp/index.md
@@ -74,6 +74,8 @@ A policy needs to include a {{CSP("default-src")}} or {{CSP("script-src")}} dire
 A policy needs to include a {{CSP("default-src")}} or {{CSP("style-src")}} directive to restrict inline styles from being applied from a {{HTMLElement("style")}} element or a `style` attribute.
 There are specific directives for a wide variety of types of items, so that each type can have its own policy, including fonts, frames, images, audio and video media, scripts, and workers.
 
+For a complete list of policy directives, see the reference page for the [Content-Security-Policy header](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy).
+
 ## Examples: Common use cases
 
 This section provides examples of some common security policy scenarios.


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/15329 as suggested in https://github.com/mdn/content/issues/15329#issuecomment-1107933345. I linked to the page as a whole because linking to anchors is quite fragile, and it's easy to find the list of directives in the page.