### PR TITLE
FF100 RelNote: WebAssembly Exceptions

### DIFF
--- a/files/en-us/mozilla/firefox/releases/100/index.md
+++ b/files/en-us/mozilla/firefox/releases/100/index.md
@@ -54,6 +54,9 @@ This article provides information about the changes in Firefox 100 that will aff
 
 ### WebAssembly
 
+- WebAssembly now supports exceptions that can be thrown and caught in either WebAssembly or Javascript (or some other runtime), crossing between the environment boundaries if not handled.
+  The JavaScript representations of WebAssembly exceptions are [WebAssembly.Exception](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Exception) and [WebAssembly.Tag](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Tag) ({{bug(1759217)}}).
+
 #### Removals
 
 ### WebDriver conformance (Marionette)


### PR DESCRIPTION
This is a kind of placeholder release note. It points to the JavaScript API that will hopefully go in as https://github.com/mdn/content/pull/14925

However  what we really need to link is a higher level conceptual guide that I have not written yet. This will do for the release on Friday.