### PR TITLE
<menu>: removed experimental language

### DIFF
--- a/files/en-us/web/html/element/menu/index.md
+++ b/files/en-us/web/html/element/menu/index.md
@@ -9,7 +9,8 @@ tags:
   - Web
 browser-compat: html.elements.menu
 ---
-
+{{HTMLRef}}
+  
 The **`<menu>`** [HTML](/en-US/docs/Web/HTML) element is a semantic alternative to {{HTMLElement("ul")}}. It represents an unordered list of items (represented by {{HTMLElement("li")}} elements), each of which represents a link or other command that the user can activate.
 
 ## Attributes

--- a/files/en-us/web/html/element/menu/index.md
+++ b/files/en-us/web/html/element/menu/index.md
@@ -3,15 +3,12 @@ title: '<menu>: The Menu element'
 slug: Web/HTML/Element/menu
 tags:
   - Element
-  - Experimental
   - HTML
   - HTML grouping content
   - Reference
   - Web
 browser-compat: html.elements.menu
 ---
-
-{{HTMLRef}}{{SeeCompatTable}}
 
 The **`<menu>`** [HTML](/en-US/docs/Web/HTML) element is a semantic alternative to {{HTMLElement("ul")}}. It represents an unordered list of items (represented by {{HTMLElement("li")}} elements), each of which represents a link or other command that the user can activate.
 
@@ -23,7 +20,7 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Global_a
 
 The `<menu>` and {{HTMLElement("ul")}} elements both represent an unordered list of items. The key difference is that {{HTMLElement("ul")}} primarily contains items for display, while `<menu>` is intended for interactive items.
 
-> **Note:** In previous versions of the HTML specification, the `<menu>` element had an additional use case as a context menu. This functionality is now considered obsolete and has been removed from the specification.
+> **Note:** In early versions of the HTML specification, the `<menu>` element had an additional use case as a context menu. This functionality is considered obsolete and is not in the specification.
 
 ## Examples
 


### PR DESCRIPTION
The `<menu>` element was implemented in IE6, so I don't think it's experimental anymore.
Changed the language for context menu since that was removed a LONG time ago, so gave it wording to make it seem older and less of an issue needing fixing.

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

The role for `<menu>` is `list`, not `menu`, so I could possibly be wrong, and it may still be experimental, but I can't find anything.