### PR TITLE
Remove Options subsections in Parameters

### DIFF
--- a/files/en-us/web/api/audiocontext/audiocontext/index.md
+++ b/files/en-us/web/api/audiocontext/audiocontext/index.md
@@ -32,28 +32,29 @@ new AudioContext(options);
 ### Parameters
 
 - `options` {{optional_inline}}
-  - : An object used to configure the context. See below for available properties.
-
-### Options
-
-- `latencyHint`
-
-  - : The type of playback that the context will be used for, as a predefined string (`"balanced"`, `"interactive"` or `"playback"`) or a double-precision floating-point value indicating the preferred maximum latency of the context in seconds. The user agent may or may not choose to meet this request; check the value of {{domxref("AudioContext.baseLatency")}} to determine the true latency after creating the context.
-
-    - `"balanced"`: The browser balances audio output latency and power consumption when selecting a latency value.
-    - `"interactive"` (default value): The audio is involved in interactive elements, such as responding to user actions or needing to coincide with visual cues such as a video or game action. The browser selects the lowest possible latency that doesn't cause glitches in the audio. This is likely to require increased power consumption.
-    - `"playback"`: The browser selects a latency that will maximize playback time by minimizing power consumption at the expense of latency. Useful for non-interactive playback, such as playing music.
-
-- `sampleRate`
-  - : Indicates the sample rate to use for the new context. The value must be a floating-point value indicating the sample
-    rate, in samples per second, for which to configure the new context; additionally, the
-    value must be one which is supported by {{domxref("AudioBuffer.sampleRate")}}.
-    The value will typically be between 8,000 Hz and 96,000 Hz; the default will vary depending on the output device, but the sample rate 44,100 Hz is the most common.
-    If the `sampleRate` property is not included in the options, or the options are not specified when creating the audio context, the new context's output device's preferred sample rate is used by default.
+  - : An object used to configure the context. The available properties are:
+    - `latencyHint` {{optional_inline}}
+      - : The type of playback that the context will be used for, as a predefined string (`"balanced"`, `"interactive"` or `"playback"`)
+        or a double-precision floating-point value indicating the preferred maximum latency of the context in seconds.
+        The user agent may or may not choose to meet this request;
+        check the value of {{domxref("AudioContext.baseLatency")}} to determine the true latency after creating the context.
+        - `"balanced"`: The browser balances audio output latency and power consumption when selecting a latency value.
+        - `"interactive"` (default value): The audio is involved in interactive elements,
+          such as responding to user actions or needing to coincide with visual cues such as a video or game action.
+          The browser selects the lowest possible latency that doesn't cause glitches in the audio. This is likely to require increased power consumption.
+        - `"playback"`: The browser selects a latency that will maximize playback time by minimizing power consumption at the expense of latency.
+          Useful for non-interactive playback, such as playing music.
+    - `sampleRate` {{optional_inline}}
+      - : Indicates the sample rate to use for the new context. The value must be a floating-point value indicating the sample rate,
+        in samples per second, for which to configure the new context;
+        additionally, the value must be one which is supported by {{domxref("AudioBuffer.sampleRate")}}.
+        The value will typically be between 8,000 Hz and 96,000 Hz; the default will vary depending on the output device, but the sample rate 44,100 Hz is the most common.
+        If the `sampleRate` property is not included in the options, or the options are not specified when creating the audio context,
+        the new context's output device's preferred sample rate is used by default.
 
 ### Return value
 
-The newly constructed {{domxref("AudioContext")}} instance.
+A new {{domxref("AudioContext")}} instance.
 
 ### Exceptions
 
@@ -109,5 +110,4 @@ var audioCtx = new AudioContext({
 
 ## See also
 
-- {{domxref("OfflineAudioContext.OfflineAudioContext()", "new
-    OfflineAudioContext()")}} constructor
+- {{domxref("OfflineAudioContext.OfflineAudioContext()", "new OfflineAudioContext()")}} constructor

--- a/files/en-us/web/api/element/requestfullscreen/index.md
+++ b/files/en-us/web/api/element/requestfullscreen/index.md
@@ -43,22 +43,17 @@ requestFullScreen(options)
 ### Parameters
 
 - `options` {{optional_inline}}
-  - : An object that controls the behavior of the transition to fullscreen mode. See below for available options.
-
-#### Options
-
-- `navigationUI`
-
-  - : Controls whether or not to show navigation UI while the element is in fullscreen mode.
-    The default value is "auto", which indicates that the browser should decide what to do.
-
-    - `"hide"`: The browser's navigation interface will be hidden
-      and the entire dimensions of the screen will be allocated to the display of the element.
-    - `"show"`: The browser will present page navigation controls and possibly other
-      user interface; the dimensions of the element (and the perceived size of the screen) will be clamped
-      to leave room for this user interface.
-    - `"auto"`: The browser will choose which of the above settings to apply.
-      This is the default value.
+  - : An object that controls the behavior of the transition to fullscreen mode. The available options are:
+    - `navigationUI` {{optional_inline}}
+      - : Controls whether or not to show navigation UI while the element is in fullscreen mode.
+        The default value is "auto", which indicates that the browser should decide what to do.
+        - `"hide"`: The browser's navigation interface will be hidden
+          and the entire dimensions of the screen will be allocated to the display of the element.
+        - `"show"`: The browser will present page navigation controls and possibly other
+          user interface; the dimensions of the element (and the perceived size of the screen) will be clamped
+          to leave room for this user interface.
+        - `"auto"`: The browser will choose which of the above settings to apply.
+          This is the default value.
 
 ### Return value
 


### PR DESCRIPTION
We had 2 occurrences of an _Options_ subsection in _Parameters_. 

This PR fixes these to match the modern structure of methods.