### PR TITLE
Google_Chrome: Update outdated link

### DIFF
--- a/files/en-us/glossary/google_chrome/index.md
+++ b/files/en-us/glossary/google_chrome/index.md
@@ -10,7 +10,7 @@ tags:
   - WebMechanics
   - google chrome
 ---
-Google Chrome is a free Web {{glossary("browser")}} developed by Google. It's based on the [Chromium](https://www.chromium.org/) open source project. Some key differences are described on the [Chromium wiki](https://code.google.com/p/chromium/wiki/ChromiumBrowserVsGoogleChrome). Chrome supports its own layout called {{glossary("Blink")}}. Note that the iOS version of Chrome uses that platform's WebView, not Blink.
+Google Chrome is a free Web {{glossary("browser")}} developed by Google. It's based on the [Chromium](https://www.chromium.org/) open source project. Some key differences are described on [BrowserStack](https://www.browserstack.com/guide/difference-between-chrome-and-chromium#toc5). Chrome supports its own layout called {{glossary("Blink")}}. Note that the iOS version of Chrome uses that platform's WebView, not Blink.
 
 ## See also
 


### PR DESCRIPTION
### Summary

The 'Chromium wiki' link is broken. Replacing it with a suitable link: https://www.browserstack.com/guide/difference-between-chrome-and-chromium#toc5

#### Metadata
- [x] Fixes a typo, bug, or other error
