### PR TITLE
Expand live sample height on grid-auto-flow page

### DIFF
--- a/files/en-us/web/css/grid-auto-flow/index.md
+++ b/files/en-us/web/css/grid-auto-flow/index.md
@@ -137,7 +137,7 @@ inputElem.addEventListener('change', changeGridAutoFlow);
 
 #### Result
 
-{{EmbedLiveSample("Setting_grid_auto-placement", "200px", "230px")}}
+{{EmbedLiveSample("Setting_grid_auto-placement", "200px", "260px")}}
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->


#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

It is not very obvious that this example is interactive -- we need to increase the live sample height to make it immediately clear to interact with it.

Before

![image](https://user-images.githubusercontent.com/4408379/165502006-4100fd09-b000-489f-b4ba-5b36e5004872.png)


After

![image](https://user-images.githubusercontent.com/4408379/165501951-aeeb69f9-2158-4bb7-8b81-b09d67052e0c.png)


#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
