### PR TITLE
Remove outdated information about `xlink:href`

### DIFF
--- a/files/en-us/web/svg/element/use/index.md
+++ b/files/en-us/web/svg/element/use/index.md
@@ -42,8 +42,6 @@ Since the cloned nodes are not exposed, care must be taken when using [CSS](/en-
 
 For security reasons, browsers may apply the [same-origin policy](/en-US/docs/Web/Security/Same-origin_policy) on `use` elements and may refuse to load a cross-origin URL in the {{SVGAttr("href")}} attribute. There is currently no defined way to set a cross-origin policy for `use` elements.
 
-> **Warning:** Since SVG 2, the {{SVGAttr("xlink:href")}} attribute is deprecated in favor of {{SVGAttr("href")}}. See {{SVGAttr("xlink:href")}} page for more information. However, {{SVGAttr("xlink:href")}} can still be required in practice for cross-browser compatibility (see the [compatibility table](#browser_compatibility) below).
-
 ## Attributes
 
 - {{SVGAttr("href")}}


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

This warning suggests that `xlink:href` may still be necessary for cross-browser compatibility; however, the table at the bottom shows that the stable version of all browsers (including IE) now support `href`, so this warning is now misleading. In addition, it conflicts with the more accurate warning further down the page that `xlink:href` is deprecated.

#### Motivation

The current warning is misleading, and suggests that a property which may soon be deprecated should still be used.

#### Supporting details

See the support chart at the bottom of the page, - https://developer.mozilla.org/en-US/docs/Web/SVG/Element/use#browser_compatibility

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
