### PR TITLE
RangeError and TypeError are JS exception; SyntaxError normally not

### DIFF
--- a/files/en-us/web/api/audiobuffer/audiobuffer/index.md
+++ b/files/en-us/web/api/audiobuffer/audiobuffer/index.md
@@ -69,7 +69,7 @@ A new {{domxref("AudioBuffer")}} object instance.
   - : Thrown if one or more of the options are negative or otherwise has an invalid value
     (such as `numberOfChannels` being higher than supported,
     or a `sampleRate` outside the nominal range).
-- `RangeError` {{domxref("DOMException")}}
+- {{jsxref("RangeError")}}
   - : Thrown if there isn't enough memory available to allocate the buffer.
 
 ## Specifications

--- a/files/en-us/web/api/audiobuffersourcenode/start/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/start/index.md
@@ -59,7 +59,7 @@ start(when, offset, duration)
 
 ### Exceptions
 
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Thrown if a negative value was specified for one or more of the three time parameters. Please
     don't attempt to tamper with the laws of temporal physics.
 - `InvalidStateError` {{domxref("DOMException")}}

--- a/files/en-us/web/api/audiocontext/audiocontext/index.md
+++ b/files/en-us/web/api/audiocontext/audiocontext/index.md
@@ -81,7 +81,7 @@ tab_ at a time.
 #### Non-standard exceptions in Chrome
 
 If the value of the `latencyHint` property isn't valid,
-Chrome throws a `TypeError` exception with the message
+Chrome throws a {{jsxref("TypeError")}} exception with the message
 "The provided value '...' is not a valid enum value of type
 AudioContextLatencyCategory".
 

--- a/files/en-us/web/api/audiodata/audiodata/index.md
+++ b/files/en-us/web/api/audiodata/audiodata/index.md
@@ -45,7 +45,7 @@ new AudioData(init);
 
 ## Exceptions
 
-- {{domxref("DOMException")}} `TypeError`
+- {{jsxref("TypeError")}}
   - : Thrown if `init` is in an incorrect format.
 
 ## Specifications

--- a/files/en-us/web/api/audiodata/copyto/index.md
+++ b/files/en-us/web/api/audiodata/copyto/index.md
@@ -40,12 +40,11 @@ Undefined.
 
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the `AudioData` object has been {{Glossary("Transferable Objects","transferred")}}.
-- `RangeError` {{domxref("DOMException")}}
-  - : Thrown if the length of the sample is longer than the destination length.
-- `RangeError` {{domxref("DOMException")}}
-  - : Thrown if the format of the `AudioData` object describes a planar format, but `options.planeIndex` is outside of the number of planes available.
-- `RangeError` {{domxref("DOMException")}}
-  - : Thrown if the format of the `AudioData` object describes an interleaved format, but `options.planeIndex` is greater than `0`.
+- {{jsxref("RangeError")}}
+  - : Thrown if one of the following conditions is met:
+    - The length of the sample is longer than the destination length.
+    - The format of the `AudioData` object describes a planar format, but `options.planeIndex` is outside of the number of planes available.
+    - The format of the `AudioData` object describes an interleaved format, but `options.planeIndex` is greater than `0`.
 
 ## Examples
 

--- a/files/en-us/web/api/audiodecoder/configure/index.md
+++ b/files/en-us/web/api/audiodecoder/configure/index.md
@@ -40,7 +40,7 @@ configure(config)
 
 ### Exceptions
 
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Thrown if the provided `config` is invalid.
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the {{domxref("AudioDecoder.state","state")}} is `"closed"`.

--- a/files/en-us/web/api/audioencoder/configure/index.md
+++ b/files/en-us/web/api/audioencoder/configure/index.md
@@ -38,7 +38,7 @@ None.
 
 ### Exceptions
 
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Thrown if the provided `config` is invalid.
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the {{domxref("AudioEncoder.state","state")}} is `"closed"`.

--- a/files/en-us/web/api/audioencoder/encode/index.md
+++ b/files/en-us/web/api/audioencoder/encode/index.md
@@ -32,7 +32,7 @@ encode(data)
 
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the {{domxref("AudioEncoder.state","state")}} is not `"configured"`.
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Thrown if the `AudioData` object has been {{Glossary("Transferable Objects","transferred")}}.
 
 ## Examples

--- a/files/en-us/web/api/audioparam/setvaluecurveattime/index.md
+++ b/files/en-us/web/api/audioparam/setvaluecurveattime/index.md
@@ -37,8 +37,7 @@ setValueCurveAtTime(values, startTime, duration)
   - : An array of floating-point numbers representing the value curve the
     {{domxref("AudioParam")}} will change through along the specified
     `duration`. Every value in the array must be a finite number; if any value
-    is `NaN`, `Infinity`, or `-Infinity`, a
-    `TypeError` exception is thrown.
+    is `NaN`, `Infinity`, or `-Infinity`, a {{jsxref("TypeError")}} exception is thrown.
 - `startTime`
   - : A double representing the time (in seconds) after the {{ domxref("AudioContext") }}
     was first created that the change in value will happen. If this value is lower than
@@ -57,10 +56,10 @@ of this interface return `undefined`.
 
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the specified array of `values` has fewer than 2 items in it.
-- `RangeError` {{domxref("DOMException")}}
+- {{jsxref("RangeError")}}
   - : Thrown if the specified `startTime` is either negative or a non-finite value, or
     `duration` is not a finite, strictly positive number.
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Thrown if one or more of the values in the `values` array is non-finite. Non-finite
     values are `NaN`, `Infinity`, and `-Infinity`.
 

--- a/files/en-us/web/api/audioscheduledsourcenode/start/index.md
+++ b/files/en-us/web/api/audioscheduledsourcenode/start/index.md
@@ -45,12 +45,12 @@ start(when)
 
 ### Exceptions
 
-- `InvalidStateNode`
-  - : The node has already been started. This error occurs even if the node is no longer
+- `InvalidStateNode` {{domxref("DOMException")}}
+  - : Thrown if the node has already been started. This error occurs even if the node is no longer
     running because of a prior call to {{domxref("AudioScheduledSourceNode.stop",
     "stop()")}}.
-- `RangeError`
-  - : The value specified for `when` is negative.
+- {{jsxref("RangeError")}}
+  - : Thrown if the value specified for `when` is negative.
 
 ## Examples
 

--- a/files/en-us/web/api/audioscheduledsourcenode/stop/index.md
+++ b/files/en-us/web/api/audioscheduledsourcenode/stop/index.md
@@ -48,11 +48,11 @@ stop(when)
 
 ### Exceptions
 
-- `InvalidStateNode`
-  - : The node has not been started by calling {{domxref("AudioScheduledSourceNode.start",
+- `InvalidStateNode` {{domxref("DOMException")}}
+  - : Thrown if the node has not been started by calling {{domxref("AudioScheduledSourceNode.start",
     "start()")}}.
-- `RangeError`
-  - : The value specified for `when` is negative.
+- {{jsxref("RangeError")}}
+  - : Thrown if the value specified for `when` is negative.
 
 ## Examples
 

--- a/files/en-us/web/api/audioworkletglobalscope/registerprocessor/index.md
+++ b/files/en-us/web/api/audioworkletglobalscope/registerprocessor/index.md
@@ -50,7 +50,7 @@ registerProcessor(name, processorCtor)
     - A constructor under the given _name_ is already registered. Registering
       the same name twice is not allowed.
 
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
 
   - : Thrown under the following conditions:
 

--- a/files/en-us/web/api/backgroundfetchmanager/fetch/index.md
+++ b/files/en-us/web/api/backgroundfetchmanager/fetch/index.md
@@ -41,7 +41,7 @@ A {{jsxref("Promise")}} that resolves with a {{domxref("BackgroundFetchRegistrat
 - {{jsxref("TypeError")}}
   - : Raised if no request is provided, if the mode of a request is 'no-cors', if no service worker is present, a request already exists with the requested `id`, or the request fails.
 - `AbortError` {{domxref("DOMException")}}
-  - : Indicates the fetch was aborted.
+  - : Indicates that the fetch was aborted.
 - `NotAllowedError` {{domxref("DOMException")}}
   - : Indicates that user permission has not been granted to make background fetches.
 

--- a/files/en-us/web/api/backgroundfetchmanager/fetch/index.md
+++ b/files/en-us/web/api/backgroundfetchmanager/fetch/index.md
@@ -38,16 +38,12 @@ A {{jsxref("Promise")}} that resolves with a {{domxref("BackgroundFetchRegistrat
 
 ### Exceptions
 
-- TypeError
+- {{jsxref("TypeError")}}
   - : Raised if no request is provided, if the mode of a request is 'no-cors', if no service worker is present, a request already exists with the requested `id`, or the request fails.
-- DOMException
-
-  - : This method may raise a {{domxref("DOMException")}} of the following types:
-
-    | Exception         | Description                                                                     |
-    | ----------------- | ------------------------------------------------------------------------------- |
-    | `AbortError`      | Indicates the fetch was aborted.                                                |
-    | `NotAllowedError` | Indicates that user permission has not been granted to make background fetches. |
+- `AbortError` {{domxref("DOMException")}}
+  - : Indicates the fetch was aborted.
+- `NotAllowedError` {{domxref("DOMException")}}
+  - : Indicates that user permission has not been granted to make background fetches.
 
 ## Examples
 

--- a/files/en-us/web/api/barcodedetector/detect/index.md
+++ b/files/en-us/web/api/barcodedetector/detect/index.md
@@ -46,7 +46,7 @@ Returns a {{jsxref('Promise')}} which fulfills with an array of
 
 ### Exceptions
 
-- `TypeError`
+- {{jsxref("TypeError")}}
   - : No parameter is specified or the `type` is not that of an
     `ImageBitmapSource`.
 

--- a/files/en-us/web/api/baseaudiocontext/createbuffer/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createbuffer/index.md
@@ -68,7 +68,7 @@ An {{domxref("AudioBuffer")}} configured based on the specified options.
   - : Thrown if one or more of the options are negative or otherwise has an invalid value (such as
     `numberOfChannels` being higher than supported, or a
     `sampleRate` outside the nominal range).
-- `RangeError` {{domxref("DOMException")}}
+- {{jsxref("RangeError")}}
   - : Thrown if there isn't enough memory available to allocate the buffer.
 
 ## Examples

--- a/files/en-us/web/api/bluetooth/requestdevice/index.md
+++ b/files/en-us/web/api/bluetooth/requestdevice/index.md
@@ -44,7 +44,7 @@ A {{jsxref("Promise")}} to a {{domxref("BluetoothDevice")}} object.
 
 ### Exceptions
 
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Thrown if the provided `options` do not make sense. For example,
     `options.filters` is present and `options.acceptAllDevices` is
     `true`, or if `options.filters` is not present and

--- a/files/en-us/web/api/bluetoothuuid/getcharacteristic/index.md
+++ b/files/en-us/web/api/bluetoothuuid/getcharacteristic/index.md
@@ -30,7 +30,7 @@ A 128-bit UUID.
 
 ### Exceptions
 
-- {{domxref("DOMException")}} `TypeError`
+- {{jsxref("TypeError")}}
   - : Thrown if `name` does not appear in the registry.
 
 ## Examples

--- a/files/en-us/web/api/bluetoothuuid/getdescriptor/index.md
+++ b/files/en-us/web/api/bluetoothuuid/getdescriptor/index.md
@@ -30,7 +30,7 @@ A 128-bit UUID.
 
 ### Exceptions
 
-- {{domxref("DOMException")}} `TypeError`
+- {{jsxref("TypeError")}}
   - : Thrown if `name` does not appear in the registry.
 
 ## Examples

--- a/files/en-us/web/api/bluetoothuuid/getservice/index.md
+++ b/files/en-us/web/api/bluetoothuuid/getservice/index.md
@@ -30,7 +30,7 @@ A 128-bit UUID.
 
 ### Exceptions
 
-- {{domxref("DOMException")}} `TypeError`
+- {{jsxref("TypeError")}}
   - : Thrown if `name` does not appear in the registry.
 
 ## Examples

--- a/files/en-us/web/api/cache/add/index.md
+++ b/files/en-us/web/api/cache/add/index.md
@@ -48,7 +48,7 @@ A {{jsxref("Promise")}} that resolves with `undefined`.
 
 ### Exceptions
 
-- `TypeError`
+- {{jsxref("TypeError")}}
 
   - : The URL scheme is not `http` or `https`.
 

--- a/files/en-us/web/api/cache/addall/index.md
+++ b/files/en-us/web/api/cache/addall/index.md
@@ -44,7 +44,7 @@ A {{jsxref("Promise")}} that resolves with `undefined`.
 
 ### Exceptions
 
-- `TypeError`
+- {{jsxref("TypeError")}}
 
   - : The URL scheme is not `http` or `https`.
 

--- a/files/en-us/web/api/cache/put/index.md
+++ b/files/en-us/web/api/cache/put/index.md
@@ -61,8 +61,10 @@ put(request, response)
 
 A {{jsxref("Promise")}} that resolves with `undefined`.
 
-> **Note:** The promise will reject with a `TypeError` if the
-> URL scheme is not `http` or `https`.
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Returned if the URL scheme is not `http` or `https`.
 
 ## Examples
 

--- a/files/en-us/web/api/clipboarditem/gettype/index.md
+++ b/files/en-us/web/api/clipboarditem/gettype/index.md
@@ -33,9 +33,9 @@ A {{jsxref("Promise")}} that resolves with a {{domxref("Blob")}} object.
 
 ### Exceptions
 
-- `DOMException`
+- `NotFoundError` {{domxref("DOMException")}}
   - : The `type` does not match a known {{Glossary("MIME type")}}.
-- `TypeError`
+- {{jsxref("TypeError")}}
   - : No parameter is specified or the `type` is not that of the
     {{domxref("ClipboardItem")}}.
 

--- a/files/en-us/web/api/contactsmanager/select/index.md
+++ b/files/en-us/web/api/contactsmanager/select/index.md
@@ -62,11 +62,11 @@ Returns a {{jsxref('Promise')}} that resolves with an array of objects containin
 ### Exceptions
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the browsing context is not top-level or the contact picker is showing a flag. A flag denotes an already existing contact picker; only one picker can exist at any time.
+  - : Returned if the browsing context is not top-level or the contact picker is showing a flag. A flag denotes an already existing contact picker; only one picker can exist at any time.
 - `SecurityError` {{domxref("DOMException")}}
-  - : Thrown if the method is not triggered by user interaction.
+  - : Returned if the method is not triggered by user interaction.
 - {{jsxref("TypeError")}}
-  - : Thrown if `properties` is empty, or if any of the specified properties are not
+  - : Returned if `properties` is empty, or if any of the specified properties are not
     supported.
 
 ## Examples

--- a/files/en-us/web/api/contactsmanager/select/index.md
+++ b/files/en-us/web/api/contactsmanager/select/index.md
@@ -62,11 +62,11 @@ Returns a {{jsxref('Promise')}} that resolves with an array of objects containin
 ### Exceptions
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Returned if the browsing context is not top-level or the contact picker is showing a flag. A flag denotes an already existing contact picker; only one picker can exist at any time.
+  - : Thrown if the browsing context is not top-level or the contact picker is showing a flag. A flag denotes an already existing contact picker; only one picker can exist at any time.
 - `SecurityError` {{domxref("DOMException")}}
-  - : Returned if the method is not triggered by user interaction.
-- `TypeError` {{domxref("DOMException")}}
-  - : Returned if `properties` is empty, or if any of the specified properties are not
+  - : Thrown if the method is not triggered by user interaction.
+- {{jsxref("TypeError")}}
+  - : Thrown if `properties` is empty, or if any of the specified properties are not
     supported.
 
 ## Examples

--- a/files/en-us/web/api/contentindex/add/index.md
+++ b/files/en-us/web/api/contentindex/add/index.md
@@ -64,7 +64,7 @@ Returns a {{jsxref("Promise")}} that resolves with `undefined`
 
 ### Exceptions
 
-- `TypeError`
+- {{jsxref("TypeError")}}
 
   - : This exception is thrown in the following conditions:
 

--- a/files/en-us/web/api/css/registerproperty/index.md
+++ b/files/en-us/web/api/css/registerproperty/index.md
@@ -47,12 +47,12 @@ members:
 
 ### Exceptions
 
-- `InvalidModificationError`
+- `InvalidModificationError` {{domxref("DOMException")}}
   - : The given `name` has already been registered.
-- `SyntaxError`
+- `SyntaxError` {{domxref("DOMException")}}
   - : The given `name` isn't a valid custom property name (starts with two
     dashes, e.g. `--foo`).
-- `TypeError`
+- {{jsxref("TypeError")}}
   - : The required `name` and/or `inherits` dictionary members were
     not provided.
 

--- a/files/en-us/web/api/csskeywordvalue/csskeywordvalue/index.md
+++ b/files/en-us/web/api/csskeywordvalue/csskeywordvalue/index.md
@@ -30,8 +30,8 @@ new CSSKeywordValue(val)
 
 ### Exceptions
 
-- `TypeError`
-  - : If the `value` parameter is not specified or it is not of type {{jsxref('String')}}.
+- {{jsxref("TypeError")}}
+  - : Thrown if the `value` parameter is not specified or it is not of type {{jsxref('String')}}.
 
 ## Examples
 

--- a/files/en-us/web/api/csskeywordvalue/value/index.md
+++ b/files/en-us/web/api/csskeywordvalue/value/index.md
@@ -24,8 +24,8 @@ A {{domxref('USVString')}}.
 
 ### Exceptions
 
-- `TypeError`
-  - : If the `value` property is an empty {{jsxref('String')}} when being set.
+- {{jsxref("TypeError")}}
+  - : Thrown if the `value` property is an empty {{jsxref('String')}} when being set.
 
 ## Examples
 

--- a/files/en-us/web/api/cssnumericvalue/add/index.md
+++ b/files/en-us/web/api/cssnumericvalue/add/index.md
@@ -36,8 +36,8 @@ A {{domxref('CSSMathSum')}}
 
 ### Exceptions
 
-- TypeError
-  - : Indicates that an invalid type was passed to the method.
+- {{jsxref("TypeError")}}
+  - : Thrown if an invalid type was passed to the method.
 
 ## Examples
 

--- a/files/en-us/web/api/cssnumericvalue/div/index.md
+++ b/files/en-us/web/api/cssnumericvalue/div/index.md
@@ -35,8 +35,8 @@ A {{domxref('CSSMathProduct')}}.
 
 ### Exceptions
 
-- TypeError
-  - : Indicates that an invalid type was passed to the method.
+- {{jsxref("TypeError")}}
+  - : Thrown if an invalid type was passed to the method.
 
 ## Examples
 

--- a/files/en-us/web/api/cssnumericvalue/max/index.md
+++ b/files/en-us/web/api/cssnumericvalue/max/index.md
@@ -35,8 +35,8 @@ A {{domxref('CSSUnitValue')}}.
 
 ### Exceptions
 
-- TypeError
-  - : Indicates that an invalid type was passed to the method.
+- {{jsxref("TypeError")}}
+  - : Thrown if an invalid type was passed to the method.
 
 ## Examples
 

--- a/files/en-us/web/api/cssnumericvalue/min/index.md
+++ b/files/en-us/web/api/cssnumericvalue/min/index.md
@@ -35,8 +35,8 @@ A {{domxref('CSSUnitValue')}}.
 
 ### Exceptions
 
-- TypeError
-  - : Indicates that an invalid type was passed to the method.
+- {{jsxref("TypeError")}}
+  - : Thrown if an invalid type was passed to the method.
 
 ## Examples
 

--- a/files/en-us/web/api/cssnumericvalue/mul/index.md
+++ b/files/en-us/web/api/cssnumericvalue/mul/index.md
@@ -35,8 +35,8 @@ A {{domxref('CSSMathProduct')}}
 
 ### Exceptions
 
-- TypeError
-  - : Indicates that an invalid type was passed to the method.
+- {{jsxref("TypeError")}}
+  - : Thrown if an invalid type was passed to the method.
 
 ## Examples
 

--- a/files/en-us/web/api/cssnumericvalue/parse/index.md
+++ b/files/en-us/web/api/cssnumericvalue/parse/index.md
@@ -35,7 +35,7 @@ A {{domxref('CSSNumericValue')}}.
 
 ### Exceptions
 
-- SyntaxError
+- `SyntaxError` {{domxref("DOMException")}}
   - : TBD
 
 ## Examples

--- a/files/en-us/web/api/cssnumericvalue/sub/index.md
+++ b/files/en-us/web/api/cssnumericvalue/sub/index.md
@@ -35,8 +35,8 @@ A {{domxref('CSSMathSum')}}
 
 ### Exceptions
 
-- TypeError
-  - : Indicates that an invalid type was passed to the method.
+- {{jsxref("TypeError")}}
+  - : Thrown if an invalid type was passed to the method.
 
 ## Examples
 

--- a/files/en-us/web/api/cssnumericvalue/to/index.md
+++ b/files/en-us/web/api/cssnumericvalue/to/index.md
@@ -35,10 +35,10 @@ A {{domxref('CSSMathSum')}}.
 
 ### Exceptions
 
-- SyntaxError
-  - : Indicates that an invalid type was passed to the method.
-- TypeError
-  - : Indicates that the passed values cannot be summed.
+- `SyntaxError` {{domxref("DOMException")}}
+  - : Thrown if an invalid type was passed to the method.
+- {{jsxref("TypeError")}}
+  - : Thrown if the passed values cannot be summed.
 
 ## Examples
 

--- a/files/en-us/web/api/cssnumericvalue/tosum/index.md
+++ b/files/en-us/web/api/cssnumericvalue/tosum/index.md
@@ -35,10 +35,8 @@ A {{domxref('CSSNumericValue')}}.
 
 ### Exceptions
 
-- SyntaxError
-  - : undefined
-- TypeError
-  - : Indicates that an invalid type was passed to the method.
+- {{jsxref("TypeError")}}
+  - : Thrown if an invalid type was passed to the method.
 
 ## Examples
 

--- a/files/en-us/web/api/cssstyledeclaration/item/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/item/index.md
@@ -16,7 +16,7 @@ by index.
 
 This method doesn't throw exceptions as long as you provide
 arguments; the empty string is returned if the index is out of range and a
-`TypeError` is thrown if no argument is provided.
+{{jsxref("TypeError")}} is thrown if no argument is provided.
 
 ## Syntax
 
@@ -31,14 +31,18 @@ item(index)
 
 ### Return value
 
-- *`propertyName`* is a {{domxref('DOMString')}} that is the name of
-  the CSS property at the specified index.
+A string that is the name of the CSS property at the specified index.
 
 JavaScript has a special simpler syntax for obtaining an item from a NodeList by index:
 
 ```js
 var propertyName = style[index];
 ```
+
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Thrown if no argument is provided.
 
 ## Examples
 

--- a/files/en-us/web/api/customelementregistry/define/index.md
+++ b/files/en-us/web/api/customelementregistry/define/index.md
@@ -57,7 +57,7 @@ Void.
     or <code>extends</code> is specified but the element it is trying to extend is an unknown element.
 - `SyntaxError` {{domxref("DOMException")}}
   - : Thrown if the provided name is not a [valid custom element name](https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name).
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Thrown if the referenced constructor is not a constructor.
 
 > **Note:** You'll often get `NotSupportedError`s thrown that

--- a/files/en-us/web/api/customstateset/add/index.md
+++ b/files/en-us/web/api/customstateset/add/index.md
@@ -30,7 +30,7 @@ Undefined.
 
 ### Exceptions
 
-- {{domxref("DOMException")}} `SyntaxError`
+- `SyntaxError` {{domxref("DOMException")}}
   - : Thrown if the string is not a `<dashed-ident>`.
 
 ## Examples

--- a/files/en-us/web/api/document/queryselector/index.md
+++ b/files/en-us/web/api/document/queryselector/index.md
@@ -54,8 +54,8 @@ If you need a list of all elements matching the specified selectors, you should 
 
 ### Exceptions
 
-- `SyntaxError`
-  - : The syntax of the specified _selectors_ is invalid.
+- `SyntaxError` {{domxref("DOMException")}}
+  - : Thrown if the syntax of the specified _selectors_ is invalid.
 
 ## Usage notes
 

--- a/files/en-us/web/api/document/queryselectorall/index.md
+++ b/files/en-us/web/api/document/queryselectorall/index.md
@@ -54,8 +54,8 @@ each element that matches at least one of the specified selectors or an empty
 
 ### Exceptions
 
-- `SyntaxError`
-  - : The syntax of the specified `selectors` string is not valid.
+- `SyntaxError` {{domxref("DOMException")}}
+  - : Thrown if the syntax of the specified `selectors` string is not valid.
 
 ## Examples
 

--- a/files/en-us/web/api/dommatrix/index.md
+++ b/files/en-us/web/api/dommatrix/index.md
@@ -86,9 +86,9 @@ _This interface includes the following methods, as well as the methods it inheri
 _This interface inherits methods from {{domxref("DOMMatrixReadOnly")}}._
 
 - {{domxref("DOMMatrix.fromFloat32Array", "fromFloat32Array()")}}
-  - : Creates a new mutable `DOMMatrix` object given an array of single-precision (32-bit) floating-point values. If the array has six values, the result is a 2D matrix; if the array has 16 values, the result is a 3D matrix. Otherwise, a `TypeError` exception is thrown.
+  - : Creates a new mutable `DOMMatrix` object given an array of single-precision (32-bit) floating-point values. If the array has six values, the result is a 2D matrix; if the array has 16 values, the result is a 3D matrix. Otherwise, a {{jsxref("TypeError")}} exception is thrown.
 - {{domxref("DOMMatrix.fromFloat64Array", "fromFloat64Array()")}}
-  - : Creates a new mutable `DOMMatrix` object given an array of double-precision (64-bit) floating-point values. If the array has six values, the result is a 2D matrix; if the array has 16 values, the result is a 3D matrix. Otherwise, a `TypeError` exception is thrown.
+  - : Creates a new mutable `DOMMatrix` object given an array of double-precision (64-bit) floating-point values. If the array has six values, the result is a 2D matrix; if the array has 16 values, the result is a 3D matrix. Otherwise, a {{jsxref("TypeError")}} exception is thrown.
 - {{domxref("DOMMatrix.fromMatrix", "fromMatrix()")}}
   - : Creates a new mutable `DOMMatrix` object given an existing matrix or a {{domxref("DOMMatrixInit")}} dictionary which provides the values for its properties.
 

--- a/files/en-us/web/api/dommatrixreadonly/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/index.md
@@ -94,9 +94,9 @@ _This interface doesn't inherit any methods. None of the following methods alter
 _This interface inherits methods from {{domxref("DOMMatrixReadOnly")}}._
 
 - {{domxref("DOMMatrix.fromFloat32Array", "fromFloat32Array()")}}
-  - : Creates a new mutable `DOMMatrix` object given an array of single-precision (32-bit) floating-point values. If the array has six values, the result is a 2D matrix; if the array has 16 values, the result is a 3D matrix. Otherwise, a `TypeError` exception is thrown.
+  - : Creates a new mutable `DOMMatrix` object given an array of single-precision (32-bit) floating-point values. If the array has six values, the result is a 2D matrix; if the array has 16 values, the result is a 3D matrix. Otherwise, a {{jsxref("TypeError")}} exception is thrown.
 - {{domxref("DOMMatrix.fromFloat64Array", "fromFloat64Array()")}}
-  - : Creates a new mutable `DOMMatrix` object given an array of double-precision (64-bit) floating-point values. If the array has six values, the result is a 2D matrix; if the array has 16 values, the result is a 3D matrix. Otherwise, a `TypeError` exception is thrown.
+  - : Creates a new mutable `DOMMatrix` object given an array of double-precision (64-bit) floating-point values. If the array has six values, the result is a 2D matrix; if the array has 16 values, the result is a 3D matrix. Otherwise, a {{jsxref("TypeError")}} exception is thrown.
 - {{domxref("DOMMatrix.fromMatrix", "fromMatrix()")}}
   - : Creates a new mutable `DOMMatrix` object given an existing matrix or a {{domxref("DOMMatrixInit")}} dictionary which provides the values for its properties. If no matrix is specified, the matrix is initialized with every element set to `0` _except_ the bottom-right corner and the element immediately above and to its left: `m33` and `m34`. These have the default value of `1`.
 

--- a/files/en-us/web/api/domtokenlist/add/index.md
+++ b/files/en-us/web/api/domtokenlist/add/index.md
@@ -30,9 +30,9 @@ None.
 ### Exceptions
 
 - `SyntaxError` {{domxref("DOMException")}}
-  - : One of the arguments is the empty string
+  - : Thrown if one of the arguments is the empty string
 - `InvalidCharacterError` {{domxref("DOMException")}}
-  - : A token contains ASCII whitespace.
+  - : Thrown if a token contains ASCII whitespace.
 
 ## Examples
 

--- a/files/en-us/web/api/element/queryselector/index.md
+++ b/files/en-us/web/api/element/queryselector/index.md
@@ -53,8 +53,8 @@ If no matches are found, the returned value is `null`.
 
 ### Exceptions
 
-- `SyntaxError`
-  - : The specified `selectors` are invalid.
+- `SyntaxError` {{domxref("DOMException")}}
+  - : Thrown if the specified `selectors` are invalid.
 
 ## Examples
 

--- a/files/en-us/web/api/element/queryselectorall/index.md
+++ b/files/en-us/web/api/element/queryselectorall/index.md
@@ -53,8 +53,8 @@ each descendant node that matches at least one of the specified selectors.
 
 ### Exceptions
 
-- `SyntaxError`
-  - : The syntax of the specified `selectors` string is not valid.
+- `SyntaxError` {{domxref("DOMException")}}
+  - : Thrown if the syntax of the specified `selectors` string is not valid.
 
 ## Examples
 

--- a/files/en-us/web/api/elementinternals/setvalidity/index.md
+++ b/files/en-us/web/api/elementinternals/setvalidity/index.md
@@ -63,7 +63,7 @@ None.
 
 - `NotSupportedError` {{domxref("DOMException")}}
   - : Thrown if the element does not have its `formAssociated` property set to `true`.
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Thrown if one or more `flags` is `true`.
 - `NotFoundError` {{domxref("DOMException")}}
   - : Thrown if `anchor` is given, but the anchor is not a shadow-including descendant of the element.

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -131,10 +131,10 @@ A {{jsxref("Promise")}} that resolves to a {{domxref("Response")}} object.
 
 ### Exceptions
 
-- `AbortError`
+- `AbortError` {{domxref("DOMException")}}
   - : The request was aborted due to a call to the {{domxref("AbortController")}}
     {{domxref("AbortController.abort", "abort()")}} method.
-- `TypeError`
+- {{jsxref("TypeError")}}
   - : Can occur for the following reasons:
 
 <table>

--- a/files/en-us/web/api/fetch_api/basic_concepts/index.md
+++ b/files/en-us/web/api/fetch_api/basic_concepts/index.md
@@ -68,7 +68,7 @@ When a new {{domxref("Headers")}} object is created using the {{domxref("Headers
   </tbody>
 </table>
 
-A header's guard affects the {{domxref("Headers.set","set()")}}, {{domxref("Headers.delete","delete()")}}, and {{domxref("Headers.append","append()")}} methods which change the header's contents. A `TypeError` is thrown if you try to modify a {{domxref("Headers")}} object whose guard is `immutable`. However, the operation will work if
+A header's guard affects the {{domxref("Headers.set","set()")}}, {{domxref("Headers.delete","delete()")}}, and {{domxref("Headers.append","append()")}} methods which change the header's contents. A {{jsxref("TypeError")}} is thrown if you try to modify a {{domxref("Headers")}} object whose guard is `immutable`. However, the operation will work if
 
 - guard is `request` and the header _name_ isn't a {{Glossary("forbidden header name")}} .
 - guard is `request-no-cors` and the header _name_/_value_ is a {{Glossary("simple header")}} .

--- a/files/en-us/web/api/filesystemdirectoryhandle/getfilehandle/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/getfilehandle/index.md
@@ -43,7 +43,7 @@ A {{jsxref('Promise')}} which resolves with a {{domxref('FileSystemFileHandle')}
 
 - `NotAllowedError` {{domxref("DOMException")}}
   - : Thrown if {{domxref('PermissionStatus')}} is not 'granted'.
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Thrown if the name specified is not a valid string or contains characters that would
     interfere with the native file system
 - `TypeMismatchError` {{domxref("DOMException")}}

--- a/files/en-us/web/api/filesystemdirectoryhandle/removeentry/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/removeentry/index.md
@@ -39,7 +39,7 @@ A {{jsxref('Promise')}} which resolves with `undefined`.
 
 ### Exceptions
 
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Thrown if the name is not a valid string or contains characters not allowed on the file
     system
 - `NotAllowedError` {{domxref("DOMException")}}

--- a/files/en-us/web/api/filesystemhandle/querypermission/index.md
+++ b/files/en-us/web/api/filesystemhandle/querypermission/index.md
@@ -44,8 +44,8 @@ the user revoking permission, a handle retrieved from IndexedDB is also likely t
 
 ### Exceptions
 
-- `TypeError`
-  - : If `mode` is specified with a value other than
+- {{jsxref("TypeError")}}
+  - : Thrown if `mode` is specified with a value other than
     `'read'` or `'readwrite'`
 
 ## Examples

--- a/files/en-us/web/api/filesystemhandle/requestpermission/index.md
+++ b/files/en-us/web/api/filesystemhandle/requestpermission/index.md
@@ -37,8 +37,8 @@ var PermissionState = FileSystemHandle.requestPermission(FileSystemHandlePermiss
 
 ### Exceptions
 
-- `TypeError`
-  - : No parameter is specified or the `mode` is not that of
+- {{jsxref("TypeError")}}
+  - : Thrown if no parameter is specified or the `mode` is not that of
     `'read'` or `'readwrite'`
 
 ## Examples

--- a/files/en-us/web/api/filesystemwritablefilestream/seek/index.md
+++ b/files/en-us/web/api/filesystemwritablefilestream/seek/index.md
@@ -33,9 +33,9 @@ FileSystemWritableStream.seek(position).then(...);
 
 ### Exceptions
 
-- NotAllowedError
+- `NotAllowedError` {{domxref("DOMException")}}
   - : If the {{domxref('PermissionStatus.state')}} is not 'granted'.
-- TypeError
+- {{jsxref("TypeError")}}
   - : If `position` is not defined or of type unsigned long.
 
 ## Examples

--- a/files/en-us/web/api/filesystemwritablefilestream/truncate/index.md
+++ b/files/en-us/web/api/filesystemwritablefilestream/truncate/index.md
@@ -43,9 +43,9 @@ A {{jsxref('Promise')}} which returns undefined.
 
 ### Exceptions
 
-- NotAllowedError
+- `NotAllowedError`{{domxref("DOMException")}}
   - : If the {{domxref('PermissionState')}} is not 'granted'.
-- TypeError
+- {{jsxref("TypeError")}}
   - : If the size is undefined or not an unsigned long.
 
 ## Examples

--- a/files/en-us/web/api/filesystemwritablefilestream/write/index.md
+++ b/files/en-us/web/api/filesystemwritablefilestream/write/index.md
@@ -57,7 +57,7 @@ FileSystemWritableFileStream.write(data).then(...);
 
 - `NotAllowedError` {{domxref("DOMException")}}
   - : Returned if {{domxref('PermissionStatus')}} is not granted.
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Returned if data is undefined, or if `position` or `size` aren't valid.
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Returned if the `position` is set and larger than the bytes available.

--- a/files/en-us/web/api/fontface/index.md
+++ b/files/en-us/web/api/fontface/index.md
@@ -35,7 +35,7 @@ The **`FontFace`** interface represents a single usable font face. It allows con
 - {{domxref("FontFace.lineGapOverride")}}
   - : A {{domxref("CSSOMString")}} that retrieves or sets the _line-gap metric_ of the font. It is equivalent to the {{cssxref("@font-face/line-gap-override", "line-gap-override")}} descriptor.
 - {{domxref("FontFace.loaded")}} {{readonlyinline}}
-  - : Returns a {{jsxref("Promise")}} that resolves with the current `FontFace` object when the font specified in the object's constructor is done loading or rejects with a `SyntaxError`.
+  - : Returns a {{jsxref("Promise")}} that resolves with the current `FontFace` object when the font specified in the object's constructor is done loading or rejects with a `SyntaxError` {{domxref("DOMException")}}.
 - {{domxref("FontFace.status")}} {{readonlyinline}}
   - : Returns an enumerated value indicating the status of the font, one of  `"unloaded"`, `"loading"`, `"loaded"`, or `"error"`.
 - {{domxref("FontFace.stretch")}}

--- a/files/en-us/web/api/headers/index.md
+++ b/files/en-us/web/api/headers/index.md
@@ -55,7 +55,7 @@ An object implementing `Headers` can directly be used in a {{jsxref("Statements/
 
 > **Note:** To be clear, the difference between {{domxref("Headers.set()")}} and {{domxref("Headers.append()")}} is that if the specified header does already exist and does accept multiple values, {{domxref("Headers.set()")}} will overwrite the existing value with the new one, whereas {{domxref("Headers.append()")}} will append the new value onto the end of the set of values. See their dedicated pages for example code.
 
-> **Note:** All of the Headers methods will throw a `TypeError` if you try to pass in a reference to a name that isn't a [valid HTTP Header name](https://fetch.spec.whatwg.org/#concept-header-name). The mutation operations will throw a `TypeError` if the header has an immutable {{Glossary("Guard")}}. In any other failure case they fail silently.
+> **Note:** All of the Headers methods will throw a {{jsxref("TypeError")}} if you try to pass in a reference to a name that isn't a [valid HTTP Header name](https://fetch.spec.whatwg.org/#concept-header-name). The mutation operations will throw a `TypeError` if the header has an immutable {{Glossary("Guard")}}. In any other failure case they fail silently.
 
 > **Note:** When Header values are iterated over, they are automatically sorted in lexicographical order, and values from duplicate header names are combined.
 

--- a/files/en-us/web/api/htmlformelement/requestsubmit/index.md
+++ b/files/en-us/web/api/htmlformelement/requestsubmit/index.md
@@ -44,7 +44,7 @@ None.
 
 ### Exceptions
 
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Thrown if the specified `submitter` is not a submit button.
 - `NotFoundError` {{domxref("DOMException")}}
   - : Thrown if the specified `submitter` isn't a member of the form on

--- a/files/en-us/web/api/idbcursor/advance/index.md
+++ b/files/en-us/web/api/idbcursor/advance/index.md
@@ -37,7 +37,7 @@ This method may raise a {{domxref("DOMException")}} of one of the following type
 
 - `TransactionInactiveError` {{domxref("DOMException")}}
   - : Thrown if this IDBCursor's transaction is inactive.
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Thrown if the value passed into the `count` parameter was zero or a negative number.
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the cursor is currently being iterated or has iterated past its end.

--- a/files/en-us/web/api/idbdatabase/transaction/index.md
+++ b/files/en-us/web/api/idbdatabase/transaction/index.md
@@ -110,7 +110,7 @@ An {{domxref("IDBTransaction")}} object.
   - : Thrown if the {{domxref("IDBDatabase.close", "close()")}} method has previously been called on this {{domxref("IDBDatabase")}} instance.
 - `NotFoundError` {{domxref("DOMException")}}
   - : Thrown if an object store specified in the 'storeNames' parameter has been deleted or removed.
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Thrown if the value for the `mode` parameter is invalid.
 - `InvalidAccessError` {{domxref("DOMException")}}
   - : Thrown if the function was called with an empty list of store names.

--- a/files/en-us/web/api/idbindex/opencursor/index.md
+++ b/files/en-us/web/api/idbindex/opencursor/index.md
@@ -55,7 +55,7 @@ This method may raise a {{domxref("DOMException")}} of one of the following type
 
 - `TransactionInactiveError` {{domxref("DOMException")}}
   - : Thrown if this {{domxref("IDBIndex")}}'s transaction is inactive.
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Thrown if the value for the direction parameter is invalid.
 - `DataError` {{domxref("DOMException")}}
   - : Thrown if the key or key range provided contains an invalid key.

--- a/files/en-us/web/api/idbindex/openkeycursor/index.md
+++ b/files/en-us/web/api/idbindex/openkeycursor/index.md
@@ -59,7 +59,7 @@ This method may raise a {{domxref("DOMException")}} of one of the following type
 
 - `TransactionInactiveError` {{domxref("DOMException")}}
   - : Thrown if this {{domxref("IDBIndex")}}'s transaction is inactive.
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Thrown if the value for the direction parameter is invalid.
 - `DataError` {{domxref("DOMException")}}
   - : Thrown if the key or key range provided contains an invalid key.

--- a/files/en-us/web/api/intersectionobserver/intersectionobserver/index.md
+++ b/files/en-us/web/api/intersectionobserver/intersectionobserver/index.md
@@ -70,9 +70,9 @@ Call its {{domxref("IntersectionObserver.observe", "observe()")}} method to begi
 
 ### Exceptions
 
-- `SyntaxError`
+- `SyntaxError` {{domxref("DOMException")}}
   - : The specified `rootMargin` is invalid.
-- `RangeError`
+- {{jsxref("RangeError")}}
   - : One or more of the values in `threshold` is outside the range 0.0 to 1.0.
 
 ## Examples

--- a/files/en-us/web/api/media_capabilities_api/using_the_media_capabilities_api/index.md
+++ b/files/en-us/web/api/media_capabilities_api/using_the_media_capabilities_api/index.md
@@ -105,7 +105,7 @@ navigator.mediaCapabilities.decodingInfo(videoConfiguration).then(result => {
 
 ## Handling errors
 
-In our video decoding example, a `TypeError` would be raised if the media configuration passed to the {{domxref("MediaCapabilities.decodingInfo", "decodingInfo()")}} method was invalid. There are a few reasons why an error might occur, including:
+In our video decoding example, a {{jsxref("TypeError")}} would be raised if the media configuration passed to the {{domxref("MediaCapabilities.decodingInfo", "decodingInfo()")}} method was invalid. There are a few reasons why an error might occur, including:
 
 - The specified `type` isn't one of the two permitted values: `file` or `media-source`
 - The `contentType` given is

--- a/files/en-us/web/api/mediacapabilities/decodinginfo/index.md
+++ b/files/en-us/web/api/mediacapabilities/decodinginfo/index.md
@@ -40,7 +40,8 @@ Browsers will report a supported media configuration as `smooth` and `powerEffic
 
 ### Exceptions
 
-A `TypeError` is raised if the `MediaConfiguration` passed to the `decodingInfo()` method is invalid, either because the type is not video or audio, the `contentType` is not a valid codec MIME type, the media decoding configuration is not a valid value for the [media decoding type](/en-US/docs/Web/API/MediaDecodingType), or any other error in the media configuration passed to the method, including omitting values required in the [media decoding configuration](/en-US/docs/Web/API/MediaDecodingConfiguration).
+- {{jsxref("TypeError")}}
+  - : Thrown if the `MediaConfiguration` passed to the `decodingInfo()` method is invalid, either because the type is not video or audio, the `contentType` is not a valid codec MIME type, the media decoding configuration is not a valid value for the [media decoding type](/en-US/docs/Web/API/MediaDecodingType), or any other error in the media configuration passed to the method, including omitting values required in the [media decoding configuration](/en-US/docs/Web/API/MediaDecodingConfiguration).
 
 ## Examples
 

--- a/files/en-us/web/api/mediacapabilities/encodinginfo/index.md
+++ b/files/en-us/web/api/mediacapabilities/encodinginfo/index.md
@@ -48,11 +48,11 @@ Browsers will report a supported media configuration as `smooth` and `powerEffic
 
 ### Exceptions
 
-A `TypeError` is raised if the `MediaConfiguration` passed to the
-`encodingInfo()` method is invalid, either because the type is not video or
-audio, the `contentType` is not a valid codec MIME type, or any other error
-in the media configuration passed to the method, including omitting any of the [media encoding configuration](/en-US/docs/Web/API/MediaEncodingConfiguration)
-elements.
+- {{jsxref("TypeError")}}
+  - : Thrown if the `MediaConfiguration` passed to the `encodingInfo()` method is invalid,
+    either because the type is not video or audio, the `contentType` is not a valid codec MIME type,
+    or any other error in the media configuration passed to the method,
+    including omitting any of the [media encoding configuration](/en-US/docs/Web/API/MediaEncodingConfiguration) elements.
 
 ## Examples
 

--- a/files/en-us/web/api/mediacapabilities/encodinginfo/index.md
+++ b/files/en-us/web/api/mediacapabilities/encodinginfo/index.md
@@ -49,10 +49,10 @@ Browsers will report a supported media configuration as `smooth` and `powerEffic
 ### Exceptions
 
 - {{jsxref("TypeError")}}
-  - : Thrown if the `MediaConfiguration` passed to the `encodingInfo()` method is invalid,
-    either because the type is not video or audio, the `contentType` is not a valid codec MIME type,
-    or any other error in the media configuration passed to the method,
-    including omitting any of the [media encoding configuration](/en-US/docs/Web/API/MediaEncodingConfiguration) elements.
+  - : Thrown if the `MediaConfiguration` passed to the `encodingInfo()` method is invalid, which may be for any of the following reasons:
+    - the type is not video or audio,
+    - the `contentType` is not a valid codec MIME type,
+    - there is some other error in the media configuration passed to the method, including omitting any of the [media encoding configuration](/en-US/docs/Web/API/MediaEncodingConfiguration) elements.
 
 ## Examples
 

--- a/files/en-us/web/api/mediadevices/getdisplaymedia/index.md
+++ b/files/en-us/web/api/mediadevices/getdisplaymedia/index.md
@@ -80,7 +80,7 @@ audio track.
 - `OverconstrainedError` {{domxref("DOMException")}}
   - : Returned if, after creating the stream, applying the specified `constraints` fails
     because no compatible stream could be generated.
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Returned if the specified `constraints` include constraints which are not permitted
     when calling `getDisplayMedia()`. These unsupported constraints are
     `advanced` and any constraints which in turn have a member named

--- a/files/en-us/web/api/mediadevices/getusermedia/index.md
+++ b/files/en-us/web/api/mediadevices/getusermedia/index.md
@@ -236,7 +236,7 @@ object when the requested media has successfully been obtained.
   - : Thrown if user media support is disabled on the {{domxref("Document")}} on which
     `getUserMedia()` was called. The mechanism by which user media support is
     enabled and disabled is left up to the individual user agent.
-- `TypeError`  {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Thrown if the list of constraints specified is empty, or has all constraints set to
     `false`. This can also happen if you try to call
     `getUserMedia()` in an insecure context, since
@@ -352,7 +352,7 @@ isn't loaded in a secure context, the {{domxref("navigator.mediaDevices")}} prop
 `undefined`, making access to `getUserMedia()` impossible.
 
 Attempting to access `getUserMedia()` in this situation will result in a
-`TypeError`.
+{{jsxref("TypeError")}}.
 
 #### Document source security
 

--- a/files/en-us/web/api/mediasession/setpositionstate/index.md
+++ b/files/en-us/web/api/mediasession/setpositionstate/index.md
@@ -59,7 +59,7 @@ setPositionState(stateDict)
 
 ### Exceptions
 
-- `TypeError`
+- {{jsxref("TypeError")}}
 
   - : This error can occur in an array of circumstances:
 

--- a/files/en-us/web/api/mediastreamtrackgenerator/mediastreamtrackgenerator/index.md
+++ b/files/en-us/web/api/mediastreamtrackgenerator/mediastreamtrackgenerator/index.md
@@ -29,7 +29,7 @@ new MediaStreamTrackGenerator(options);
 
 ## Exceptions
 
-- {{domxref("DOMException")}} `TypeError`
+- {{jsxref("TypeError")}}
   - : Thrown if `init.kind` is not `"video"` or `"audio"`.
 
 ## Examples

--- a/files/en-us/web/api/merchantvalidationevent/complete/index.md
+++ b/files/en-us/web/api/merchantvalidationevent/complete/index.md
@@ -42,7 +42,7 @@ complete(merchantSessionPromise)
 This exception may be passed into the rejection handler for the promise:
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Thrown if the event did not come directly from the user agent, but was instead dispatched by other code. Another payment request is currently being processed, the current payment request is not currently being displayed to the user, or payment information is currently being updated.
+  - : Returned if the event did not come directly from the user agent, but was instead dispatched by other code. Another payment request is currently being processed, the current payment request is not currently being displayed to the user, or payment information is currently being updated.
 
 ## Examples
 

--- a/files/en-us/web/api/merchantvalidationevent/complete/index.md
+++ b/files/en-us/web/api/merchantvalidationevent/complete/index.md
@@ -42,7 +42,7 @@ complete(merchantSessionPromise)
 This exception may be passed into the rejection handler for the promise:
 
 - `InvalidStateError` {{domxref("DOMException")}}
-  - : Returned if the event did not come directly from the user agent, but was instead dispatched by other code. Another payment request is currently being processed, the current payment request is not currently being displayed to the user, or payment information is currently being updated.
+  - : Thrown if the event did not come directly from the user agent, but was instead dispatched by other code. Another payment request is currently being processed, the current payment request is not currently being displayed to the user, or payment information is currently being updated.
 
 ## Examples
 

--- a/files/en-us/web/api/merchantvalidationevent/merchantvalidationevent/index.md
+++ b/files/en-us/web/api/merchantvalidationevent/merchantvalidationevent/index.md
@@ -43,10 +43,10 @@ A newly-created {{domxref("MerchantValidationEvent")}} providing the information
 
 ### Exceptions
 
-- `TypeError`
-  - : The string specified as `validationURL` could not be parsed as a URL.
-- `RangeError`
-  - : The specified `methodName` does not correspond to a known and supported merchant or is not a well-formed standard payment method identifier.
+- {{jsxref("TypeError")}}
+  - : Thrown if the string specified as `validationURL` could not be parsed as a URL.
+- {{jsxref("RangeError")}}
+  - : Thrown if the specified `methodName` does not correspond to a known and supported merchant or is not a well-formed standard payment method identifier.
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/mouseevent/mouseevent/index.md
+++ b/files/en-us/web/api/mouseevent/mouseevent/index.md
@@ -81,7 +81,7 @@ new MouseEvent(typeArg, mouseEventInit);
       The absence of any affected hit region is represented with the `null` value.
 
     In some implementations, passing anything other than a number for the screen and
-    client fields will throw a `TypeError`.
+    client fields will throw a {{jsxref("TypeError")}}.
 
     > **Note:** The `MouseEventInit` dictionary also accepts fields from
     > {{domxref("UIEvent.UIEvent", "UIEventInit")}} and from {{domxref("Event.Event",

--- a/files/en-us/web/api/navigator/requestmediakeysystemaccess/index.md
+++ b/files/en-us/web/api/navigator/requestmediakeysystemaccess/index.md
@@ -62,12 +62,12 @@ fulfillment handler receives as input just one parameter:
 In case of an error, the returned {{jsxref('Promise')}} is rejected with a
 {{domxref('DOMException')}} whose name indicates what kind of error occurred.
 
-- `NotSupportedError`
+- `NotSupportedError` {{domxref("DOMException")}}
   - : Either the specified `keySystem` isn't supported by the platform or the
     browser, or none of the configurations specified by
     `supportedConfigurations` can be satisfied (if, for example, none of the
     `codecs` specified in `contentType` are available).
-- `TypeError`
+- {{jsxref("TypeError")}}`
   - : Either `keySystem` is an empty string or the
     `supportedConfigurations` array is empty.
 

--- a/files/en-us/web/api/navigator/share/index.md
+++ b/files/en-us/web/api/navigator/share/index.md
@@ -48,9 +48,9 @@ A {{jsxref("Promise")}} that resolves with `undefined`, or rejected with one of 
 
 The {{jsxref("Promise")}} may be rejected with one of the following `DOMException` values:
 
-- `NotAllowedError`
+- `NotAllowedError` {{domxref("DOMException")}}
   - : The [web-share](/en-US/docs/Web/HTTP/Headers/Feature-Policy/web-share) permission has not been granted, or the window does not have {{Glossary("transient activation")}}, or a file share is being blocked due to security considerations.
-- `TypeError`
+- {{jsxref("TypeError")}}
 
   - : The specified share data cannot be validated. Possible reasons include:
 
@@ -59,9 +59,9 @@ The {{jsxref("Promise")}} may be rejected with one of the following `DOMExceptio
     - Files are specified but the implementation does not support file sharing.
     - Sharing the specified data would be considered a "hostile share" by the user-agent.
 
-- `AbortError`
+- `AbortError` {{domxref("DOMException")}}
   - : The user canceled the share operation or there are no share targets available.
-- `DataError`
+- `DataError` {{domxref("DOMException")}}
   - : There was a problem starting the share target or transmitting the data.
 
 ## Shareable file types

--- a/files/en-us/web/api/nodelist/item/index.md
+++ b/files/en-us/web/api/nodelist/item/index.md
@@ -13,13 +13,20 @@ browser-compat: api.NodeList.item
 
 Returns a node from a [`NodeList`](/en-US/docs/Web/API/NodeList) by index. This method
 doesn't throw exceptions as long as you provide arguments. A value of `null`
-is returned if the index is out of range, and a `TypeError` is thrown if no
+is returned if the index is out of range, and a {{jsxref("TypeError")}} is thrown if no
 argument is provided.
 
 ## Syntax
 
 ```js
 item(index)
+```
+
+JavaScript also offers an array-like bracketed syntax for obtaining an item from a
+NodeList by index:
+
+```js
+nodeItem = nodeList[index]
 ```
 
 ### Parameters
@@ -30,15 +37,11 @@ item(index)
 
 The `index`th node in the `nodeList` returned by the `item` method.
 
-## Alternate Syntax
+### Exceptions
 
-JavaScript also offers an array-like bracketed syntax for obtaining an item from a
-NodeList by index:
-
-```js
-nodeItem = nodeList[index]
-```
-
+- {{jsxref("TypeError")}}
+  - : Thrown if no argument is provided.
+  
 ## Examples
 
 ```js

--- a/files/en-us/web/api/notification/notification/index.md
+++ b/files/en-us/web/api/notification/notification/index.md
@@ -106,7 +106,7 @@ function spawnNotification(body, icon, title) {
 
 Starting in Chrome 49, notifications don't work in incognito mode.
 
-Chrome for Android will throw a `TypeError` when calling the
+Chrome for Android will throw a {{jsxref("TypeError")}} when calling the
 `Notification` constructor. It only supports creating
 notifications from a service worker. See the
 [Chromium issue tracker](https://bugs.chromium.org/p/chromium/issues/detail?id=481856) for more details.

--- a/files/en-us/web/api/paintworklet/registerpaint/index.md
+++ b/files/en-us/web/api/paintworklet/registerpaint/index.md
@@ -34,9 +34,9 @@ image where a CSS property expects a file.
 
 ### Exceptions
 
-- TypeError
+- {{jsxref("TypeError")}}
   - : Thrown when one of the arguments is invalid or missing.
-- InvalidModificationError
+- `InvalidModificationError` {{domxref("DOMException")}}
   - : Thrown when the a worklet already exists with the specified name.
 
 ## Examples

--- a/files/en-us/web/api/pannernode/distancemodel/index.md
+++ b/files/en-us/web/api/pannernode/distancemodel/index.md
@@ -27,7 +27,7 @@ The possible values are:
 
 ## Value
 
-A enum — see [`DistanceModelType`](https://webaudio.github.io/web-audio-api/#idl-def-DistanceModelType).
+An enum — see [`DistanceModelType`](https://webaudio.github.io/web-audio-api/#idl-def-DistanceModelType).
 
 ## Examples
 

--- a/files/en-us/web/api/pannernode/maxdistance/index.md
+++ b/files/en-us/web/api/pannernode/maxdistance/index.md
@@ -22,8 +22,8 @@ A double. The default is `10000`, and non-positive values are not allowed.
 
 ### Exceptions
 
-- `RangeError`
-  - : The property has been given a value that is outside the accepted range.
+- {{jsxref("RangeError")}}
+  - : Thrown if the property has been given a value that is outside the accepted range.
 
 ## Examples
 

--- a/files/en-us/web/api/pannernode/pannernode/index.md
+++ b/files/en-us/web/api/pannernode/pannernode/index.md
@@ -62,7 +62,7 @@ A new {{domxref("PannerNode")}} object instance.
 
 ### Exceptions
 
-- `RangeError` {{domxref("DOMException")}}
+- {{jsxref("RangeError")}}
   - : Thrown if the `refDistance`, `maxDistance`, or `rolloffFactor` properties have been given a value that is outside the accepted range.
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the `coneOuterGain` property has been given a value outside the accepted range (0–1).

--- a/files/en-us/web/api/pannernode/refdistance/index.md
+++ b/files/en-us/web/api/pannernode/refdistance/index.md
@@ -18,12 +18,12 @@ The `refDistance` property's default value is `1`.
 
 ## Value
 
-A non-negative number. If the value is set to less than 0, a `RangeError` is thrown.
+A non-negative number. If the value is set to less than 0, a {{jsxref("RangeError")}} is thrown.
 
 ### Exceptions
 
-- `RangeError`
-  - : The property has been given a value that is outside the accepted range.
+- {{jsxref("RangeError")}}
+  - : Thrown if the property has been given a value that is outside the accepted range.
 
 ## Examples
 

--- a/files/en-us/web/api/pannernode/rollofffactor/index.md
+++ b/files/en-us/web/api/pannernode/rollofffactor/index.md
@@ -27,8 +27,8 @@ A number whose range depends on the {{ domxref("PannerNode.distanceModel", "dist
 
 ### Exceptions
 
-- `RangeError`
-  - : The property has been given a value that is outside the accepted range.
+- {{jsxref("RangeError")}}
+  - : Thrown if the property has been given a value that is outside the accepted range.
 
 ## Examples
 

--- a/files/en-us/web/api/performance/measure/index.md
+++ b/files/en-us/web/api/performance/measure/index.md
@@ -88,7 +88,7 @@ The returned _measure_ will have the following property values:
 
 ### Exceptions
 
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : This can be thrown in any case where the start, end or duration might be ambiguous:
 
     - Both `endMark` and `MeasureOptions` are specified.
@@ -106,7 +106,7 @@ The returned _measure_ will have the following property values:
 - `DataCloneError` {{domxref("DOMException")}}
   - : The `MeasureOptions.detail` value is non-`null` and cannot be serialized using the HTML "StructuredSerialize" algorithm.
 
-- `RangeError`
+- {{jsxref("RangeError")}}
   - : The `MeasureOptions.detail` value is non-`null` and memory cannot be allocated during serialization using the HTML "StructuredSerialize" algorithm.
 
 ## Examples

--- a/files/en-us/web/api/permissions/revoke/index.md
+++ b/files/en-us/web/api/permissions/revoke/index.md
@@ -59,7 +59,7 @@ A {{jsxref("Promise")}} that calls its fulfillment handler with a
 
 ### Exceptions
 
-- `TypeError`
+- {{jsxref("TypeError")}}
   - : Retrieving the `PermissionDescriptor` information failed in some way, or
     the permission doesn't exist or is currently unsupported (e.g. `midi`, or
     `push` with `userVisibleOnly`).

--- a/files/en-us/web/api/readablebytestreamcontroller/close/index.md
+++ b/files/en-us/web/api/readablebytestreamcontroller/close/index.md
@@ -35,8 +35,8 @@ None.
 
 ### Exceptions
 
-- TypeError
-  - : The source object is not a `ReadableByteStreamController`, or the stream
+- {{jsxref("TypeError")}}
+  - : Thrown if the source object is not a `ReadableByteStreamController`, or the stream
     is not readable for some other reason.
 
 ## Examples

--- a/files/en-us/web/api/readablebytestreamcontroller/enqueue/index.md
+++ b/files/en-us/web/api/readablebytestreamcontroller/enqueue/index.md
@@ -34,8 +34,8 @@ enqueue(chunk)
 
 ### Exceptions
 
-- TypeError
-  - : The source object is not a `ReadableByteStreamController`, or the stream
+- {{jsxref("TypeError")}}
+  - : Thrown if the source object is not a `ReadableByteStreamController`, or the stream
     cannot be read for some other reason, or the chunk is not an object, or the chunk's
     internal array buffer is non-existent or detached.
 

--- a/files/en-us/web/api/readablebytestreamcontroller/error/index.md
+++ b/files/en-us/web/api/readablebytestreamcontroller/error/index.md
@@ -34,8 +34,8 @@ error(e)
 
 ### Exceptions
 
-- TypeError
-  - : The source object is not a `ReadableByteStreamController`, or the stream
+- {{jsxref("TypeError")}}
+  - : Thrown if the source object is not a `ReadableByteStreamController`, or the stream
     is not readable for some other reason.
 
 ## Examples

--- a/files/en-us/web/api/readablestream/cancel/index.md
+++ b/files/en-us/web/api/readablestream/cancel/index.md
@@ -40,7 +40,7 @@ A {{jsxref("Promise")}}, which fulfills with the value given in the `reason` par
 
 ### Exceptions
 
-- `TypeError`
+- {{jsxref("TypeError")}}
   - : The stream you are trying to cancel is not a {{domxref("ReadableStream")}}, or it is locked.
 
 ## Examples

--- a/files/en-us/web/api/readablestream/getreader/index.md
+++ b/files/en-us/web/api/readablestream/getreader/index.md
@@ -38,10 +38,10 @@ A {{domxref("ReadableStreamDefaultReader")}} or {{domxref("ReadableStreamBYOBRea
 
 ### Exceptions
 
-- `RangeError`
-  - : The provided mode value is not `"byob"` or `undefined`.
-- `TypeError`
-  - : The stream you are trying to create a reader for is not a
+- {{jsxref("RangeeError")}}
+  - : Thrown if the provided mode value is not `"byob"` or `undefined`.
+- {{jsxref("TypeError")}}
+  - : Thrown if the stream you are trying to create a reader for is not a
     {{domxref("ReadableStream")}}.
 
 ## Examples

--- a/files/en-us/web/api/readablestream/pipethrough/index.md
+++ b/files/en-us/web/api/readablestream/pipethrough/index.md
@@ -67,8 +67,8 @@ The `readable` side of the `transformStream`.
 
 ### Exceptions
 
-- `TypeError`
-  - : The `writable` and/or `readable` property of `transformStream` are undefined.
+- {{jsxref("TypeError")}}
+  - : Thrown if the `writable` and/or `readable` property of `transformStream` are undefined.
 
 ## Examples
 

--- a/files/en-us/web/api/readablestream/pipeto/index.md
+++ b/files/en-us/web/api/readablestream/pipeto/index.md
@@ -49,7 +49,7 @@ A {{jsxref("Promise")}} that resolves when the piping process has completed.
 
 ### Exceptions
 
-- TypeError
+- {{jsxref("TypeError")}}
   - : The `writableStream` and/or `readableStream` objects are not a writable stream/readable stream, or one or both of the streams are locked.
 
 ## Examples

--- a/files/en-us/web/api/readablestream/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/readablestream/index.md
@@ -93,8 +93,8 @@ An instance of the {{domxref("ReadableStream")}} object.
 
 ### Exceptions
 
-- RangeError
-  - : The supplied type value is neither `"bytes"` nor `undefined`.
+- {{jsxref("RangeError")}}
+  - : Thrown if the supplied type value is neither `"bytes"` nor `undefined`.
 
 ## Examples
 

--- a/files/en-us/web/api/readablestream/tee/index.md
+++ b/files/en-us/web/api/readablestream/tee/index.md
@@ -42,8 +42,8 @@ An {{jsxref("Array")}} containing two {{domxref("ReadableStream")}} instances.
 
 ### Exceptions
 
-- `TypeError`
-  - : The source stream is not a `ReadableStream`.
+- {{jsxref("TypeError")}}
+  - : Thrown if the source stream is not a `ReadableStream`.
 
 ## Examples
 

--- a/files/en-us/web/api/readablestreambyobreader/cancel/index.md
+++ b/files/en-us/web/api/readablestreambyobreader/cancel/index.md
@@ -39,7 +39,7 @@ parameter.
 
 ### Exceptions
 
-- TypeError
+- {{jsxref("TypeError")}}
   - : The source object is not a `ReadableStreamBYOBReader`, or the stream has
     no owner.
 

--- a/files/en-us/web/api/readablestreambyobreader/read/index.md
+++ b/files/en-us/web/api/readablestreambyobreader/read/index.md
@@ -40,7 +40,7 @@ the stream. The following are possible:
 
 ### Exceptions
 
-- TypeError
+- {{jsxref("TypeError")}}
   - : The source object is not a `ReadableStreamBYOBReader`, the stream has no
     owner, the view is not an object or has become detached, or the view's length is 0.
 

--- a/files/en-us/web/api/readablestreambyobreader/readablestreambyobreader/index.md
+++ b/files/en-us/web/api/readablestreambyobreader/readablestreambyobreader/index.md
@@ -35,8 +35,8 @@ An instance of the {{domxref("ReadableStreamBYOBReader")}} object.
 
 ### Exceptions
 
-- TypeError
-  - : The supplied `stream` parameter is not a {{domxref("ReadableStream")}},
+- {{jsxref("TypeError")}}
+  - : Thrown if the supplied `stream` parameter is not a {{domxref("ReadableStream")}},
     or it is already locked for reading by another reader, or its stream controller is not
     a {{domxref("ReadableByteStreamController")}}.
 

--- a/files/en-us/web/api/readablestreambyobreader/releaselock/index.md
+++ b/files/en-us/web/api/readablestreambyobreader/releaselock/index.md
@@ -40,8 +40,8 @@ None.
 
 ### Exceptions
 
-- TypeError
-  - : The source object is not a `ReadableStreamBYOBReader`, or a read request
+- {{jsxref("TypeError")}}
+  - : Thrown if the source object is not a `ReadableStreamBYOBReader`, or a read request
     is pending.
 
 ## Examples

--- a/files/en-us/web/api/readablestreambyobrequest/respond/index.md
+++ b/files/en-us/web/api/readablestreambyobrequest/respond/index.md
@@ -33,8 +33,8 @@ Void.
 
 ### Exceptions
 
-- TypeError
-  - : The source object is not a `ReadableStreamBYOBRequest`, or there is no
+- {{jsxref("TypeError")}}
+  - : Thrown if the source object is not a `ReadableStreamBYOBRequest`, or there is no
     associated controller, or the associated internal array buffer is detached.
 
 ## Examples

--- a/files/en-us/web/api/readablestreambyobrequest/respondwithnewview/index.md
+++ b/files/en-us/web/api/readablestreambyobrequest/respondwithnewview/index.md
@@ -33,8 +33,8 @@ Void.
 
 ### Exceptions
 
-- TypeError
-  - : The source object is not a `ReadableStreamBYOBRequest`, or there is no
+- {{jsxref("TypeError")}}
+  - : Thrown if the source object is not a `ReadableStreamBYOBRequest`, or there is no
     associated controller, or the associated internal array buffer is non-existent or
     detached.
 

--- a/files/en-us/web/api/readablestreamdefaultcontroller/close/index.md
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/close/index.md
@@ -37,8 +37,8 @@ None.
 
 ### Exceptions
 
-- TypeError
-  - : The source object is not a `ReadableStreamDefaultController`.
+- {{jsxref("TypeError")}}
+  - : Thrown if the source object is not a `ReadableStreamDefaultController`.
 
 ## Examples
 

--- a/files/en-us/web/api/readablestreamdefaultcontroller/enqueue/index.md
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/enqueue/index.md
@@ -33,8 +33,8 @@ enqueue(chunk)
 
 ### Exceptions
 
-- TypeError
-  - : The source object is not a `ReadableStreamDefaultController`.
+- {{jsxref("TypeError")}}
+  - : Thrown if the source object is not a `ReadableStreamDefaultController`.
 
 ## Examples
 

--- a/files/en-us/web/api/readablestreamdefaultcontroller/error/index.md
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/error/index.md
@@ -36,8 +36,8 @@ error(e)
 
 ### Exceptions
 
-- TypeError
-  - : The source object is not a `ReadableStreamDefaultController`.
+- {{jsxref("TypeError")}}
+  - : Thrown if the source object is not a `ReadableStreamDefaultController`.
 
 ## Examples
 

--- a/files/en-us/web/api/readablestreamdefaultreader/cancel/index.md
+++ b/files/en-us/web/api/readablestreamdefaultreader/cancel/index.md
@@ -44,7 +44,7 @@ parameter.
 
 ### Exceptions
 
-- TypeError
+- {{jsxref("TypeError")}}
   - : The source object is not a `ReadableStreamDefaultReader`, or the stream
     has no owner.
 

--- a/files/en-us/web/api/readablestreamdefaultreader/read/index.md
+++ b/files/en-us/web/api/readablestreamdefaultreader/read/index.md
@@ -39,7 +39,7 @@ the stream. The different possibilities are as follows:
 
 ### Exceptions
 
-- TypeError
+- {{jsxref("TypeError")}}
   - : The source object is not a `ReadableStreamDefaultReader`, or the stream
     has no owner.
 

--- a/files/en-us/web/api/readablestreamdefaultreader/readablestreamdefaultreader/index.md
+++ b/files/en-us/web/api/readablestreamdefaultreader/readablestreamdefaultreader/index.md
@@ -35,8 +35,8 @@ An instance of the {{domxref("ReadableStreamDefaultReader")}} object.
 
 ### Exceptions
 
-- TypeError
-  - : The supplied `stream` parameter is not a {{domxref("ReadableStream")}},
+- {{jsxref("TypeError")}}
+  - : Thrown if the supplied `stream` parameter is not a {{domxref("ReadableStream")}},
     or it is already locked for reading by another reader.
 
 ## Examples

--- a/files/en-us/web/api/readablestreamdefaultreader/releaselock/index.md
+++ b/files/en-us/web/api/readablestreamdefaultreader/releaselock/index.md
@@ -39,8 +39,8 @@ None.
 
 ### Exceptions
 
-- TypeError
-  - : The source object is not a `ReadableStreamDefaultReader`, or a read
+- {{jsxref("TypeError")}}
+  - : Thrown if the source object is not a `ReadableStreamDefaultReader`, or a read
     request is pending.
 
 ## Examples

--- a/files/en-us/web/api/rtcdatachannel/send/index.md
+++ b/files/en-us/web/api/rtcdatachannel/send/index.md
@@ -58,7 +58,7 @@ send(data)
 - `NetworkError` {{domxref("DOMException")}}
   - : Thrown when the specified `data` would need to be buffered, and there isn't room for
     it in the buffer. In this scenario, the underlying transport is immediately closed.
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Thrown if the specified `data` is too large for the other peer to receive. Since
     there are multiple techniques for breaking up large data into smaller pieces for
     transfer, it's possible to encounter scenarios in which the other peer does not

--- a/files/en-us/web/api/rtcicecandidate/rtcicecandidate/index.md
+++ b/files/en-us/web/api/rtcicecandidate/rtcicecandidate/index.md
@@ -93,8 +93,6 @@ new RTCIceCandidate(candidateInfo)
 
         Additional information can be found in {{domxref("RTCIceCandidate.usernameFragment")}}.
 
-    The method will throw a `TypeError` exception if both `sdpMid` and `sdpMLineIndex` are `null`.
-
 ### Return value
 
 A newly-created {{domxref("RTCIceCandidate")}} object.
@@ -117,8 +115,8 @@ If `candidateInfo` is provided, the new `RTCIceCandidate` is initialized as foll
 
 ### Exceptions
 
-- `TypeError`
-  - : The specified `candidateInfo` has values of `null` in **both** the `sdpMid` and `sdpMLineIndex` properties.
+- {{jsxref("TypeError")}}
+  - : Thrown if the specified `candidateInfo` has values of `null` in **both** the `sdpMid` and `sdpMLineIndex` properties.
 
 ## Usage notes
 

--- a/files/en-us/web/api/rtcicecandidate/sdpmid/index.md
+++ b/files/en-us/web/api/rtcicecandidate/sdpmid/index.md
@@ -32,7 +32,7 @@ A {{domxref("DOMString")}} which uniquely identifies the source media component 
 which the candidate draws data, or `null` if no such association exists for the candidate.
 
 > **Note:** Attempting to add a candidate (using {{domxref("RTCPeerConnection.addIceCandidate", "addIceCandidate()")}}) that has a
-> value of `null` for both `sdpMid` and `sdpMLineIndex` will throw a `TypeError` exception.
+> value of `null` for both `sdpMid` and `sdpMLineIndex` will throw a {{jsxref("TypeError")}} exception.
 
 ## Examples
 

--- a/files/en-us/web/api/rtcicecandidate/sdpmlineindex/index.md
+++ b/files/en-us/web/api/rtcicecandidate/sdpmlineindex/index.md
@@ -33,7 +33,7 @@ indicating which media source is associated with the candidate, or `null` if no 
 > **Note:** Attempting to add a candidate (using
 > {{domxref("RTCPeerConnection.addIceCandidate", "addIceCandidate()")}}) that has a
 > value of `null` for either `sdpMid` or
-> `sdpMLineIndex` will throw a `TypeError` exception.
+> `sdpMLineIndex` will throw a {{jsxref("TypeError")}} exception.
 
 ## Examples
 

--- a/files/en-us/web/api/rtcpeerconnection/addicecandidate/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addicecandidate/index.md
@@ -100,7 +100,7 @@ addIceCandidate(candidate, successCallback, failureCallback) // deprecated
 
         Additional information can be found in {{domxref("RTCIceCandidate.usernameFragment")}}.
 
-    The method will throw a `TypeError` exception if both `sdpMid` and `sdpMLineIndex` are `null`.
+    The method will throw a {{jsxref("TypeError")}} exception if both `sdpMid` and `sdpMLineIndex` are `null`.
 
     The contents of the object should be constructed from a message received over the signaling channel, describing a newly received ICE candidate that's ready to be delivered to the local ICE agent.
 
@@ -137,7 +137,7 @@ When an error occurs while attempting to add the ICE candidate, the
 below as the {{domxref("DOMException.name", "name")}} attribute in the specified
 {{domxref("DOMException")}} object passed to the rejection handler.
 
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Returned if the specified candidate's {{domxref("RTCIceCandidate.sdpMid", "sdpMid")}} and
     {{domxref("RTCIceCandidate.sdpMLineIndex", "sdpMLineIndex")}} are both `null`.
 - `InvalidStateError` {{domxref("DOMException")}}

--- a/files/en-us/web/api/rtcpeerconnection/addtransceiver/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addtransceiver/index.md
@@ -50,8 +50,8 @@ addTransceiver(trackOrKind, init)
 
 ### Exceptions
 
-- `TypeError`
-  - : A string was specified as `trackOrKind` which is not valid. The string
+- {{jsxref("TypeError")}}
+  - : Thrown if an invalide string was specified as `trackOrKind`. The string
     must be either `"audio"` or `"video"`.
 
 ## Specifications

--- a/files/en-us/web/api/rtcpeerconnection/addtransceiver/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addtransceiver/index.md
@@ -51,8 +51,7 @@ addTransceiver(trackOrKind, init)
 ### Exceptions
 
 - {{jsxref("TypeError")}}
-  - : Thrown if an invalide string was specified as `trackOrKind`. The string
-    must be either `"audio"` or `"video"`.
+  - : Thrown if `trackOrKind` was not either `"audio"` or `"video"`.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcpeerconnection/createdatachannel/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/createdatachannel/index.md
@@ -99,7 +99,7 @@ included; otherwise, the defaults listed above are established.
 
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the {{domxref("RTCPeerConnection")}} is closed.
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Thrown in the following situations:
     - The label and/or protocol string is too long; these cannot be longer than 65,535
       bytes (bytes, rather than characters).

--- a/files/en-us/web/api/rtcpeerconnection/setremotedescription/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/setremotedescription/index.md
@@ -122,7 +122,7 @@ by `setRemoteDescription()`:
     {{Glossary("SDP")}} specified by {{domxref("RTCSessionDescription.sdp")}} is not valid. The
     error object's {{domxref("RTCError.sdpLineNumber", "sdpLineNumber")}} property
     indicates the line number within the SDP on which the syntax error was detected.
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Returned if the specified `RTCSessionDescriptionInit` or
     `RTCSessionDescription` object is missing the
     {{domxref("RTCSessionDescription.type", "type")}} property, or no description

--- a/files/en-us/web/api/rtcrtpencodingparameters/scaleresolutiondownby/index.md
+++ b/files/en-us/web/api/rtcrtpencodingparameters/scaleresolutiondownby/index.md
@@ -50,7 +50,7 @@ size.
 
 A value less than 1.0 would cause the video to get larger rather than smaller, which is
 not the intent of this property. Therefore, specifying a value less than 1.0 is not
-permitted and will cause a `RangeError` exception to be thrown by
+permitted and will cause a {{jsxref("RangeError")}} exception to be thrown by
 {{domxref("RTCPeerConnection.addTransceiver()")}} or
 {{domxref("RTCRtpSender.setParameters()")}}.
 

--- a/files/en-us/web/api/rtcrtpsender/replacetrack/index.md
+++ b/files/en-us/web/api/rtcrtpsender/replacetrack/index.md
@@ -68,7 +68,7 @@ rejection handler:
     would require negotiation.
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Returned if the track on which this method was called is stopped rather than running.
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Returned if the new track's `kind` doesn't match the original track.
 
 ## Usage notes

--- a/files/en-us/web/api/rtcrtpsender/setparameters/index.md
+++ b/files/en-us/web/api/rtcrtpsender/setparameters/index.md
@@ -80,7 +80,7 @@ from the list below.
     has no parameters to set.
 - `OperationError` {{domxref("DOMException")}}
   - : Returned if an error occurs that does not match the ones specified here.
-- `RangeError` {{domxref("DOMException")}}
+- {{jsxref("RangeError")}}
   - : Returned if the value specified for {{domxref("RTCRtpSendParameters.scaleResolutionDownBy",
     "scaleResolutionDownBy")}} is less than 1.0, which would result in scaling up rather
     than down, which is not allowed; or one or more of the specified encodings'

--- a/files/en-us/web/api/screenorientation/lock/index.md
+++ b/files/en-us/web/api/screenorientation/lock/index.md
@@ -72,7 +72,7 @@ The promise may be rejected with the following exceptions:
     For example, a browser may require that the top-level browsing context's `Document` is full screen.
     The promise may also be rejected with this error if the document has the sandboxed orientation lock browsing context flag set.
 
-- `TypeError`
+- {{jsxref("TypeError")}}
   - : The `orientation` argument was not supplied.
 
 ## Examples

--- a/files/en-us/web/api/sharedworker/sharedworker/index.md
+++ b/files/en-us/web/api/sharedworker/sharedworker/index.md
@@ -60,14 +60,15 @@ The created worker.
 
 ### Exceptions
 
-- A `SecurityError` is raised if the document is not allowed to start
-  workers, for example if the URL has an invalid syntax or if the same-origin policy is
-  violated.
-- A `NetworkError` is raised if the MIME type of the worker script is
-  incorrect. It should _always_ be `text/javascript` (for historical
-  reasons [other
-  JavaScript MIME types](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#javascript_types) may be accepted).
-- A `SyntaxError` is raised if _aURL_ cannot be parsed.
+- `SecurityError` {{domxref("DOMException")}}
+  - : Thrown if the document is not allowed to start workers,
+    for example if the URL has an invalid syntax or if the same-origin policy is violated.
+- `NetworkError`  {{domxref("DOMException")}}
+  - : Thrown if the MIME type of the worker script is incorrect.
+    It should _always_ be `text/javascript`
+    (for historical reasons [other JavaScript MIME types](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#javascript_types) may be accepted).
+- `SyntaxError`  {{domxref("DOMException")}}
+  - : Thrown if _aURL_ cannot be parsed.
 
 ## Examples
 

--- a/files/en-us/web/api/sourcebuffer/changetype/index.md
+++ b/files/en-us/web/api/sourcebuffer/changetype/index.md
@@ -45,7 +45,7 @@ None.
 
 ### Exceptions
 
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Thrown if the specified string is empty, rather than indicating a valid MIME type.
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the {{domxref("SourceBuffer")}} is not a member of the parent media source's

--- a/files/en-us/web/api/videodecoder/configure/index.md
+++ b/files/en-us/web/api/videodecoder/configure/index.md
@@ -69,7 +69,7 @@ None.
 
 ### Exceptions
 
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Thrown if the provided `config` is invalid.
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the {{domxref("VideoDecoder.state","state")}} is `"closed"`.

--- a/files/en-us/web/api/videoencoder/configure/index.md
+++ b/files/en-us/web/api/videoencoder/configure/index.md
@@ -63,7 +63,7 @@ None.
 
 ### Exceptions
 
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Thrown if the provided `config` is invalid.
 - `InvalidStateError` {{domxref("DOMException")}}
   - : Thrown if the {{domxref("VideoEncoder.state","state")}} is `"closed"`.

--- a/files/en-us/web/api/websocket/close/index.md
+++ b/files/en-us/web/api/websocket/close/index.md
@@ -44,7 +44,7 @@ close(code, reason)
 
 - `InvalidAccessError` {{domxref("DOMException")}}
   - : Thrown if [`code`](#code) is neither an integer equal to `1000` nor an integer in the range `3000`–`4999`.
-- `SyntaxError`  {{domxref("DOMException")}}
+- `SyntaxError` {{domxref("DOMException")}}
   - : Thrown if the UTF-8-encoded [`reason`](#reason) value is longer than 123 bytes.
 
 ## Specifications

--- a/files/en-us/web/api/worker/postmessage/index.md
+++ b/files/en-us/web/api/worker/postmessage/index.md
@@ -32,7 +32,7 @@ postMessage(message, transfer)
 
   - : The object to deliver to the worker; this will be in the `data` field in the event delivered to the {{domxref("DedicatedWorkerGlobalScope.message_event")}} event. This may be any value or JavaScript object handled by the [structured clone](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) algorithm, which includes cyclical references.
 
-    If the `message` parameter is _not_ provided, a `TypeError` will be thrown. If the data to be passed to the worker is unimportant, `null` or `undefined` can be passed explicitly.
+    If the `message` parameter is _not_ provided, a {{jsxref("SyntaxError")}} will be thrown by the parser. If the data to be passed to the worker is unimportant, `null` or `undefined` can be passed explicitly.
 
 - _transfer_ {{optional_inline}}
 

--- a/files/en-us/web/api/worker/worker/index.md
+++ b/files/en-us/web/api/worker/worker/index.md
@@ -35,9 +35,13 @@ new Worker(aURL, options);
 
 ### Exceptions
 
-- A `SecurityError` is raised if the document is not allowed to start workers, e.g. if the URL has an invalid syntax or if the same-origin policy is violated.
-- A `NetworkError` is raised if the MIME type of the worker script is incorrect. It _should_ always be `text/javascript` (for historical reasons [other JavaScript MIME types](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#JavaScript_types) may be accepted).
-- A `SyntaxError` is raised if _aURL_ cannot be parsed.
+- `SecurityError` {{domxref("DOMException")}}
+  - : Thrown if the document is not allowed to start workers, e.g. if the URL has an invalid syntax or if the same-origin policy is violated.
+- `NetworkError` {{domxref("DOMException")}}
+  - : Thrown if the MIME type of the worker script is incorrect. It _should_ always be `text/javascript` 
+    (for historical reasons [other JavaScript MIME types](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#JavaScript_types) may be accepted).
+- `SyntaxError` {{domxref("DOMException")}}
+  - : Thrown if _aURL_ cannot be parsed.
 
 ## Examples
 

--- a/files/en-us/web/api/worklet/addmodule/index.md
+++ b/files/en-us/web/api/worklet/addmodule/index.md
@@ -53,9 +53,9 @@ added. The promise doesn't return any value.
 If `addModule()` fails, it rejects the promise, delivering one of the
 following errors to the rejection handler.
 
-- `AbortError`
+- `AbortError` {{domxref("DOMException")}}
   - : The specified script is invalid or could not be loaded.
-- `SyntaxError`
+- `SyntaxError` {{domxref("DOMException")}}
   - : The specified `moduleURL` is invalid.
 
 ## Examples

--- a/files/en-us/web/api/xmlserializer/serializetostring/index.md
+++ b/files/en-us/web/api/xmlserializer/serializetostring/index.md
@@ -40,7 +40,7 @@ A {{domxref("DOMString")}} containing the XML representation of the specified DO
 
 ### Exceptions
 
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Thrown if the specified `rootNode` is not a compatible node type. The root node
     must be either {{domxref("Node")}} or {{domxref("Attr")}}.
 - `InvalidStateError` {{domxref("DOMException")}}
@@ -70,7 +70,7 @@ The following types are also permitted as descendants of the root node, in addit
 - {{domxref("ProcessingInstruction")}}
 - {{domxref("Attr")}}
 
-If any other type is encountered, a `TypeError` exception is thrown.
+If any other type is encountered, a {{jsxref("TypeError")}} exception is thrown.
 
 ### Notes on the resulting XML
 

--- a/files/en-us/web/api/xrframe/filljointradii/index.md
+++ b/files/en-us/web/api/xrframe/filljointradii/index.md
@@ -33,7 +33,8 @@ A boolean indicating if all of the spaces have a valid pose.
 
 ### Exceptions
 
-- Throws a `TypeError` if the length of `jointSpaces` is larger than the number of elements in `radii`.
+- {{jsxref("TypeError")}}
+  -: Thrown if the length of `jointSpaces` is larger than the number of elements in `radii`.
 
 ## Examples
 

--- a/files/en-us/web/api/xrframe/fillposes/index.md
+++ b/files/en-us/web/api/xrframe/fillposes/index.md
@@ -35,7 +35,8 @@ A boolean indicating if all of the spaces have a valid pose.
 
 ### Exceptions
 
-- Throws a `TypeError` if the length of `spaces` multiplied by 16 is larger than the number of elements in `transforms`.
+- {{jsxref("TypeError")}}
+  - : Thrown if the length of `spaces` multiplied by 16 is larger than the number of elements in `transforms`.
 
 ## Examples
 

--- a/files/en-us/web/api/xrray/xrray/index.md
+++ b/files/en-us/web/api/xrray/xrray/index.md
@@ -37,11 +37,11 @@ A newly-created {{domxref("XRRay")}} object.
 
 ### Exceptions
 
-A `TypeError` is thrown,
-
-- if all of `direction`'s `x`, `y`, and `z` coordinates are zero.
-- if `direction`'s `w` coordinate is not 0.0.
-- if `origin`'s `w` coordinate is not 1.0.
+- {{jsxref("TypeError")}}
+  - : Thrown if one of the following conditions is met:
+    - if all of `direction`'s `x`, `y`, and `z` coordinates are zero.
+    - if `direction`'s `w` coordinate is not 0.0.
+    - if `origin`'s `w` coordinate is not 1.0.
 
 ## Examples
 

--- a/files/en-us/web/api/xrray/xrray/index.md
+++ b/files/en-us/web/api/xrray/xrray/index.md
@@ -39,9 +39,9 @@ A newly-created {{domxref("XRRay")}} object.
 
 - {{jsxref("TypeError")}}
   - : Thrown if one of the following conditions is met:
-    - if all of `direction`'s `x`, `y`, and `z` coordinates are zero.
-    - if `direction`'s `w` coordinate is not 0.0.
-    - if `origin`'s `w` coordinate is not 1.0.
+    - all of `direction`'s `x`, `y`, and `z` coordinates are zero.
+    - `direction`'s `w` coordinate is not 0.0.
+    - `origin`'s `w` coordinate is not 1.0.
 
 ## Examples
 

--- a/files/en-us/web/api/xrrigidtransform/xrrigidtransform/index.md
+++ b/files/en-us/web/api/xrrigidtransform/xrrigidtransform/index.md
@@ -59,8 +59,8 @@ origin to the specified `position` and facing in the direction indicated by
 
 ### Exceptions
 
-- `TypeError`
-  - : The value of the `w` coordinate in the specified `position` is
+- {{jsxref("TypeError")}}
+  - : Thrown if the value of the `w` coordinate in the specified `position` is
     not 1.0.
 
 ## Examples

--- a/files/en-us/web/api/xrsession/updaterenderstate/index.md
+++ b/files/en-us/web/api/xrsession/updaterenderstate/index.md
@@ -53,7 +53,7 @@ None.
     - The `layers` option is used in a session that has been created without the `layers` feature.
     - Both the `baseLayer` and `layers` options are specified.
 
-- `TypeError` {{domxref("DOMException")}}
+- {{jsxref("TypeError")}}
   - : Thrown if the `layers` option contains duplicate instances.
 
 ## Examples


### PR DESCRIPTION
Most exceptions in web/API are `DOMException`s.

But there are three special cases:
-  `RangeError` and `TypeError` are JS exceptions; 
- `SyntaxError` can be both but is in 99% of the cases a `DOMException` in web/API (the JS exception is reserved for the use of the JS parser).

This PR fixes this. It is larger than what I initially expected, a kind of a rabbit hole here. Sorry.