### PR TITLE
Clarify "ray casting" rather than "ray tracing"

### DIFF
--- a/files/en-us/web/api/canvas_api/index.md
+++ b/files/en-us/web/api/canvas_api/index.md
@@ -72,7 +72,7 @@ ctx.fillRect(10, 10, 150, 100);
 - [Canvas Handbook](https://bucephalus.org/text/CanvasHandbook/CanvasHandbook.html)
   - : A handy reference for the Canvas API.
 - [Demo: A basic ray-caster](/en-US/docs/Web/API/Canvas_API/A_basic_ray-caster)
-  - : A demo of ray-tracing animation using canvas.
+  - : A demo of ray-casting animation using canvas.
 - [Manipulating video using canvas](/en-US/docs/Web/API/Canvas_API/Manipulating_video_using_canvas)
   - : Combining {{HTMLElement("video")}} and {{HTMLElement("canvas")}} to manipulate video data in real time.
 


### PR DESCRIPTION
#### Summary

The original text, "ray tracing" isn't as accurate as "ray casting", which is the primary style of rendering shown in the tutorial.

#### Motivation

It's a minor tweak, but an improvement nonetheless and makes it easier to read the list of links without confusion about whether "casting" or "tracing" will be discussed.

#### Supporting details

See [wikipedia: ray tracing](https://en.wikipedia.org/wiki/Ray_tracing_(graphics)#Ray_casting_algorithm) and https://news.ycombinator.com/item?id=18667437 for some discussion of the distinction.

#### Metadata

This PR…

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
