### PR TITLE
Syntax_sections: fix escape characters

### DIFF
--- a/files/en-us/mdn/structures/syntax_sections/index.md
+++ b/files/en-us/mdn/structures/syntax_sections/index.md
@@ -170,7 +170,7 @@ Next, include a "Return value" subsection, which explains what the return value 
 
 If there is no return value, use the following text:
 
-None (\{\{jsxref("undefined")}}).
+None (\\{{jsxref("undefined")}}).
 
 #### Exceptions section
 


### PR DESCRIPTION
### Summary
On page https://developer.mozilla.org/en-US/docs/MDN/Structures/Syntax_sections
in the "Return Value" section, the macro text has not properly been escaped. It is showing random characters:
> None ({{��ky��u���}}).

Using `\\{{jsxref("undefined")}}` fixes the issue.

#### Metadata
- [x] Fixes a typo, bug, or other error
