### PR TITLE
Add how to fire unmute with transceivers

### DIFF
--- a/files/en-us/web/api/mediastreamtrack/unmute_event/index.md
+++ b/files/en-us/web/api/mediastreamtrack/unmute_event/index.md
@@ -23,19 +23,6 @@ This ends the {{domxref("MediaStreamTrack.muted", "muted")}} state that began wi
 
 This event is not cancelable and does not bubble.
 
-## Unmute track
-
-```js
-const transceivers = peer.getTransceivers();
-
-const audioTrack = transceivers[0];
-audioTrack.direction = 'sendrecv';
-
-const videoTrack = transceivers[1];
-videoTrack.direction = 'sendrecv';
-```
-`transceivers` is an array of {{domxref("RTCRtpTransceiver")}} where you can find the audio or video track sent and received. More information about the behavior around modify {{domxref("RTCRtpTransceiver.direction", "direction")}}.
-
 ## Syntax
 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
@@ -78,7 +65,9 @@ musicTrack.mute = event = > {
 }
 ```
 
-## Full example
+### Unmute tracks through receivers
+
+The following example shows how to unmute tracks using receivers.
 
 ```js
 // Peer 1 (Receiver)
@@ -100,7 +89,7 @@ const videoTrack = transceivers[1];
 videoTrack.direction = 'sendrecv';
 ```
 
-> **Note:** In Safari < 14.1 exists an active bug which not fire the `unmute` event.
+`transceivers` is an array of {{domxref("RTCRtpTransceiver")}} where you can find the audio or video track sent and received. For more information, see the {{domxref("RTCRtpTransceiver.direction", "direction")}} article.
 
 ## Specifications
 

--- a/files/en-us/web/api/mediastreamtrack/unmute_event/index.md
+++ b/files/en-us/web/api/mediastreamtrack/unmute_event/index.md
@@ -23,6 +23,19 @@ This ends the {{domxref("MediaStreamTrack.muted", "muted")}} state that began wi
 
 This event is not cancelable and does not bubble.
 
+## Unmute track
+
+```js
+const transceivers = peer.getTransceivers();
+
+const audioTrack = transceivers[0];
+audioTrack.direction = 'sendrecv';
+
+const videoTrack = transceivers[1];
+videoTrack.direction = 'sendrecv';
+```
+`transceivers` is an array of {{domxref("RTCRtpTransceiver")}} where you can find the audio or video track sent and received. More information about the behavior around modify {{domxref("RTCRtpTransceiver.direction", "direction")}}.
+
 ## Syntax
 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
@@ -64,6 +77,30 @@ musicTrack.mute = event = > {
   document.getElementById("timeline-widget").style.backgroundColor = "#fff";
 }
 ```
+
+## Full example
+
+```js
+// Peer 1 (Receiver)
+audioTrack.addEventListener('unmute', event => {
+  // Do something in UI
+});
+
+videoTrack.addEventListener('unmute', event => {
+  // Do something in UI
+});
+
+// Peer 2 (Sender)
+const transceivers = peer.getTransceivers();
+
+const audioTrack = transceivers[0];
+audioTrack.direction = 'sendrecv';
+
+const videoTrack = transceivers[1];
+videoTrack.direction = 'sendrecv';
+```
+
+> **Note:** In Safari < 14.1 exists an active bug which not fire the `unmute` event.
 
 ## Specifications
 


### PR DESCRIPTION
I want to add how to unmute track through receivers which is the real way to fire the event on the peer.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
I want to add how to unmute track through receivers which is the real way to fire the event on the peer.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
There is no real example of how to fire this event so is really confusing for all developers.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
