### PR TITLE
Add how to fire mute with transceivers

### DIFF
--- a/files/en-us/web/api/mediastreamtrack/mute_event/index.md
+++ b/files/en-us/web/api/mediastreamtrack/mute_event/index.md
@@ -25,6 +25,19 @@ During the time between the `mute` event and the `unmute` event, the value of th
 
 This event is not cancelable and does not bubble.
 
+## Mute track
+
+```js
+const transceivers = peer.getTransceivers();
+
+const audioTrack = transceivers[0];
+audioTrack.direction = 'recvonly';
+
+const videoTrack = transceivers[1];
+videoTrack.direction = 'recvonly';
+```
+`transceivers` is an array of {{domxref("RTCRtpTransceiver")}} where you can find the audio or video track sent and received. More information about the behavior around modify {{domxref("RTCRtpTransceiver.direction", "direction")}}.
+
 ## Syntax
 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
@@ -66,6 +79,30 @@ musicTrack.onunmute = event = > {
   document.getElementById("timeline-widget").style.backgroundColor = "#fff";
 }
 ```
+
+## Full example
+
+```js
+// Peer 1 (Receiver)
+audioTrack.addEventListener('mute', event => {
+  // Do something in UI
+});
+
+videoTrack.addEventListener('mute', event => {
+  // Do something in UI
+});
+
+// Peer 2 (Sender)
+const transceivers = peer.getTransceivers();
+
+const audioTrack = transceivers[0];
+audioTrack.direction = 'recvonly';
+
+const videoTrack = transceivers[1];
+videoTrack.direction = 'recvonly';
+```
+
+> **Note:** In Safari < 14.1 exists an active bug which not fire the `mute` event.
 
 ## Specifications
 

--- a/files/en-us/web/api/mediastreamtrack/mute_event/index.md
+++ b/files/en-us/web/api/mediastreamtrack/mute_event/index.md
@@ -25,19 +25,6 @@ During the time between the `mute` event and the `unmute` event, the value of th
 
 This event is not cancelable and does not bubble.
 
-## Mute track
-
-```js
-const transceivers = peer.getTransceivers();
-
-const audioTrack = transceivers[0];
-audioTrack.direction = 'recvonly';
-
-const videoTrack = transceivers[1];
-videoTrack.direction = 'recvonly';
-```
-`transceivers` is an array of {{domxref("RTCRtpTransceiver")}} where you can find the audio or video track sent and received. More information about the behavior around modify {{domxref("RTCRtpTransceiver.direction", "direction")}}.
-
 ## Syntax
 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
@@ -80,7 +67,9 @@ musicTrack.onunmute = event = > {
 }
 ```
 
-## Full example
+### Mute tracks through receivers
+
+The following example shows how to mute tracks using receivers.
 
 ```js
 // Peer 1 (Receiver)
@@ -102,7 +91,7 @@ const videoTrack = transceivers[1];
 videoTrack.direction = 'recvonly';
 ```
 
-> **Note:** In Safari < 14.1 exists an active bug which not fire the `mute` event.
+`transceivers` is an array of {{domxref("RTCRtpTransceiver")}} where you can find the audio or video track sent and received. For more information, see the {{domxref("RTCRtpTransceiver.direction", "direction")}} article.
 
 ## Specifications
 
@@ -115,3 +104,4 @@ videoTrack.direction = 'recvonly';
 ## See also
 
 - {{domxref("MediaStreamTrack/unmute_event", "unmute")}} event
+- {{domxref("RTCRtpTransceiver.direction", "direction")}}


### PR DESCRIPTION
I want to add how to mute track through receivers which is the real way to fire the event on the peer.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
How to mute track through receivers which is the real way to fire the event on the peer.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
There is no real example of how to fire this event so is really confusing for all developers.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->


#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
