### PR TITLE
fix livesample in HTMLSelectElement.selectedIndex

### DIFF
--- a/files/en-us/web/api/htmlselectelement/selectedindex/index.md
+++ b/files/en-us/web/api/htmlselectelement/selectedindex/index.md
@@ -51,7 +51,7 @@ selectElem.addEventListener('change', function() {
 })
 ```
 
-{{EmbedLiveSample("Example", "200px", "80px")}}
+{{EmbedLiveSample("Examples", "200px", "120px")}}
 
 ## Specifications
 


### PR DESCRIPTION
#### Summary

fix livesample error in HTMLSelectElement.selectedIndex

#### Motivation

The id is not match with which filled in `{{EmbedLiveSample}}`

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
