### PR TITLE
Fix live samples (inadvertently broken)

### DIFF
--- a/files/en-us/web/api/characterdata/replacewith/index.md
+++ b/files/en-us/web/api/characterdata/replacewith/index.md
@@ -49,7 +49,7 @@ em.textContent = "Italic text";
 text.replaceWith(em); // Replace `Some text` by `Italic text`
 ```
 
-{{EmbedLiveSample("Example", "100%", 30)}}
+{{EmbedLiveSample("Examples", "100%", 30)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/document/createdocumentfragment/index.md
+++ b/files/en-us/web/api/document/createdocumentfragment/index.md
@@ -77,7 +77,7 @@ element.appendChild(fragment);
 
 ### Result
 
-{{EmbedLiveSample("Example", 600, 140)}}
+{{EmbedLiveSample("Examples", 600, 140)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/document/hasfocus/index.md
+++ b/files/en-us/web/api/document/hasfocus/index.md
@@ -71,7 +71,7 @@ setInterval(checkPageFocus, 300);
 
 ### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Examples")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/element/insertadjacenthtml/index.md
+++ b/files/en-us/web/api/element/insertadjacenthtml/index.md
@@ -126,7 +126,7 @@ reset.addEventListener('click', () => {
 
 #### Result
 
-{{EmbedLiveSample("Example", 100, 100)}}
+{{EmbedLiveSample("Examples", 100, 100)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/element/releasepointercapture/index.md
+++ b/files/en-us/web/api/element/releasepointercapture/index.md
@@ -92,7 +92,7 @@ slider.onpointerup = stopSliding;
 
 ### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Examples")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/element/setpointercapture/index.md
+++ b/files/en-us/web/api/element/setpointercapture/index.md
@@ -106,7 +106,7 @@ slider.onpointerup = stopSliding;
 
 ### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Examples")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/filereader/readasdataurl/index.md
+++ b/files/en-us/web/api/filereader/readasdataurl/index.md
@@ -64,7 +64,7 @@ function previewFile() {
 
 ### Live Result
 
-{{EmbedLiveSample("Example", "100%", 240)}}
+{{EmbedLiveSample("Examples", "100%", 240)}}
 
 ## Example reading multiple files
 

--- a/files/en-us/web/api/filereader/readastext/index.md
+++ b/files/en-us/web/api/filereader/readastext/index.md
@@ -61,7 +61,7 @@ function previewFile() {
 
 ### Result
 
-{{EmbedLiveSample("Example", "100%", 240)}}
+{{EmbedLiveSample("Examples", "100%", 240)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlinputelement/select/index.md
+++ b/files/en-us/web/api/htmlinputelement/select/index.md
@@ -46,7 +46,7 @@ function selectText() {
 
 ### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Examples")}}
 
 ## Notes
 

--- a/files/en-us/web/api/htmlinputelement/setrangetext/index.md
+++ b/files/en-us/web/api/htmlinputelement/setrangetext/index.md
@@ -71,7 +71,7 @@ function selectText() {
 
 ### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Examples")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlinputelement/setselectionrange/index.md
+++ b/files/en-us/web/api/htmlinputelement/setselectionrange/index.md
@@ -87,7 +87,7 @@ function selectText() {
 
 ### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Examples")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlinputelement/showpicker/index.md
+++ b/files/en-us/web/api/htmlinputelement/showpicker/index.md
@@ -67,7 +67,7 @@ button.addEventListener("click", () => {
 
 ### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Examples")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlinputelement/stepdown/index.md
+++ b/files/en-us/web/api/htmlinputelement/stepdown/index.md
@@ -174,7 +174,7 @@ input:invalid {
 
 ### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Examples")}}
 
 Note if you don't pass a parameter to the `stepDown()` method, it defaults
 to 1. Any other value is a multiplier of the `step` attribute value, which in

--- a/files/en-us/web/api/htmlinputelement/stepup/index.md
+++ b/files/en-us/web/api/htmlinputelement/stepup/index.md
@@ -180,7 +180,7 @@ input:invalid {
 
 ### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Examples")}}
 
 Note if you don't pass a parameter to the `stepUp` method, it defaults to
 `1`. Any other value is a multiplier of the `step` attribute

--- a/files/en-us/web/api/htmltableelement/createcaption/index.md
+++ b/files/en-us/web/api/htmltableelement/createcaption/index.md
@@ -55,7 +55,7 @@ caption.textContent = 'This caption was created by JavaScript!';
 
 ### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Examples")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmltableelement/deletecaption/index.md
+++ b/files/en-us/web/api/htmltableelement/deletecaption/index.md
@@ -46,7 +46,7 @@ table.deleteCaption();
 
 ### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Examples")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmltableelement/deleterow/index.md
+++ b/files/en-us/web/api/htmltableelement/deleterow/index.md
@@ -62,7 +62,7 @@ table.deleteRow(1);
 
 ### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Examples")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmltableelement/deletetfoot/index.md
+++ b/files/en-us/web/api/htmltableelement/deletetfoot/index.md
@@ -45,7 +45,7 @@ table.deleteTFoot();
 
 ### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Examples")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmltableelement/deletethead/index.md
+++ b/files/en-us/web/api/htmltableelement/deletethead/index.md
@@ -44,7 +44,7 @@ table.deleteTHead();
 
 ### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Examples")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmltableelement/insertrow/index.md
+++ b/files/en-us/web/api/htmltableelement/insertrow/index.md
@@ -100,7 +100,7 @@ addRow('my-table');
 
 ### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Examples")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/htmltablerowelement/insertcell/index.md
+++ b/files/en-us/web/api/htmltablerowelement/insertcell/index.md
@@ -93,7 +93,7 @@ addRow('my-table');
 
 ### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Examples")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/range/getboundingclientrect/index.md
+++ b/files/en-us/web/api/range/getboundingclientrect/index.md
@@ -66,7 +66,7 @@ highlight.style.height = `${clientRect.height}px`;
 
 ### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Examples")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/range/surroundcontents/index.md
+++ b/files/en-us/web/api/range/surroundcontents/index.md
@@ -55,7 +55,7 @@ range.surroundContents(newParent);
 
 ### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Examples")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/range/tostring/index.md
+++ b/files/en-us/web/api/range/tostring/index.md
@@ -49,7 +49,7 @@ document.getElementById('log').textContent = range.toString();
 
 ### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Examples")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/selection/addrange/index.md
+++ b/files/en-us/web/api/selection/addrange/index.md
@@ -61,7 +61,7 @@ button.addEventListener('click', function () {
 
 ### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Examples")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/selection/deletefromdocument/index.md
+++ b/files/en-us/web/api/selection/deletefromdocument/index.md
@@ -53,7 +53,7 @@ function deleteSelection() {
 
 ### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Examples")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/selection/modify/index.md
+++ b/files/en-us/web/api/selection/modify/index.md
@@ -96,7 +96,7 @@ function modify() {
 
 ### Result
 
-{{EmbedLiveSample("Example", 700, 200)}}
+{{EmbedLiveSample("Examples", 700, 200)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/selection/selectallchildren/index.md
+++ b/files/en-us/web/api/selection/selectallchildren/index.md
@@ -55,7 +55,7 @@ button.addEventListener('click', (e) => {
 
 ### Result
 
-{{EmbedLiveSample("Example", 700, 200)}}
+{{EmbedLiveSample("Examples", 700, 200)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/speechsynthesis/getvoices/index.md
+++ b/files/en-us/web/api/speechsynthesis/getvoices/index.md
@@ -71,7 +71,7 @@ if (typeof speechSynthesis !== 'undefined' && speechSynthesis.onvoiceschanged !=
 <select id="voiceSelect"></select>
 ```
 
-{{EmbedLiveSample("Example", 400, 25)}}
+{{EmbedLiveSample("Examples", 400, 25)}}
 
 ## Specifications
 

--- a/files/en-us/web/api/svggeometryelement/ispointinfill/index.md
+++ b/files/en-us/web/api/svggeometryelement/ispointinfill/index.md
@@ -63,7 +63,7 @@ console.log('Point at 40,30:', circle.isPointInFill(new DOMPoint(40, 30)));
 
 ### Result
 
-{{EmbedLiveSample("Example", "150", "150")}}
+{{EmbedLiveSample("Examples", "150", "150")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/svggeometryelement/ispointinstroke/index.md
+++ b/files/en-us/web/api/svggeometryelement/ispointinstroke/index.md
@@ -68,7 +68,7 @@ console.log('Point at 83,17:', circle.isPointInStroke(new DOMPoint(83, 17)));
 
 ### Result
 
-{{EmbedLiveSample("Example", "150", "150")}}
+{{EmbedLiveSample("Examples", "150", "150")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/textdecoder/decode/index.md
+++ b/files/en-us/web/api/textdecoder/decode/index.md
@@ -68,7 +68,7 @@ document.getElementById('decoded-value').textContent = str;
 
 ### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Examples")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/window/find/index.md
+++ b/files/en-us/web/api/window/find/index.md
@@ -68,7 +68,7 @@ function findString(text) {
 
 ### Result
 
-{{EmbedLiveSample("Example")}}
+{{EmbedLiveSample("Examples")}}
 
 ## Notes
 


### PR DESCRIPTION
When updating methods to the modern structure, we renamed a lot of sections from _Example_ to _Examples_.

But in some cases the `{{EmbedLiveSample}}` macro was linking to the fragment _Example_ and got broken.

This PR fixes this.