### PR TITLE
Add warning about browser details of MouseEvent

### DIFF
--- a/files/en-us/web/api/mouseevent/movementx/index.md
+++ b/files/en-us/web/api/mouseevent/movementx/index.md
@@ -19,6 +19,10 @@ browser-compat: api.MouseEvent.movementX
 The **`movementX`** read-only property of the {{domxref("MouseEvent")}} interface provides the difference in the X coordinate of the mouse pointer between the given event and the previous {{domxref("Element/mousemove_event", "mousemove")}} event.
 In other words, the value of the property is computed like this: `currentEvent.movementX = currentEvent.screenX - previousEvent.screenX`.
 
+> **Warning:** Different from the description in the specification, browsers may use different units for `movementX` and {{domxref("MouseEvent.screenX", "screenX")}}. The unit of `movementX` may be physical pixel of the screen, logical pixel from the operating system, or CSS pixel from the browser.
+>
+> See also [Issue #42 - w3c/pointerlock](https://github.com/w3c/pointerlock/issues/42)
+
 ## Value
 
 A number.

--- a/files/en-us/web/api/mouseevent/movementx/index.md
+++ b/files/en-us/web/api/mouseevent/movementx/index.md
@@ -19,9 +19,7 @@ browser-compat: api.MouseEvent.movementX
 The **`movementX`** read-only property of the {{domxref("MouseEvent")}} interface provides the difference in the X coordinate of the mouse pointer between the given event and the previous {{domxref("Element/mousemove_event", "mousemove")}} event.
 In other words, the value of the property is computed like this: `currentEvent.movementX = currentEvent.screenX - previousEvent.screenX`.
 
-> **Warning:** Different from the description in the specification, browsers may use different units for `movementX` and {{domxref("MouseEvent.screenX", "screenX")}}. The unit of `movementX` may be physical pixel of the screen, logical pixel from the operating system, or CSS pixel from the browser.
->
-> See also [Issue #42 - w3c/pointerlock](https://github.com/w3c/pointerlock/issues/42)
+> **Warning:** Browsers [use different units for `movementX` and {{domxref("MouseEvent.screenX", "screenX")}}](https://github.com/w3c/pointerlock/issues/42) than what the specification defines. Depending on the browser and operating system, the `movementX` units may be a physical pixel, a logical pixel, or a CSS pixel.
 
 ## Value
 

--- a/files/en-us/web/api/mouseevent/movementy/index.md
+++ b/files/en-us/web/api/mouseevent/movementy/index.md
@@ -19,9 +19,7 @@ browser-compat: api.MouseEvent.movementY
 The **`movementY`** read-only property of the {{domxref("MouseEvent")}} interface provides the difference in the Y coordinate of the mouse pointer between the given event and the previous {{domxref("Element/mousemove_event", "mousemove")}} event.
 In other words, the value of the property is computed like this: `currentEvent.movementY = currentEvent.screenY - previousEvent.screenY`.
 
-> **Warning:** Different from the description in the specification, browsers may use different units for `movementY` and {{domxref("MouseEvent.screenY", "screenY")}}. The unit of `movementY` may be physical pixel of the screen, logical pixel from the operating system, or CSS pixel from the browser.
->
-> See also [Issue #42 - w3c/pointerlock](https://github.com/w3c/pointerlock/issues/42)
+> **Warning:** Browsers [use different units for `movementY` and {{domxref("MouseEvent.screenY", "screenY")}}](https://github.com/w3c/pointerlock/issues/42) than what the specification defines. Depending on the browser and operating system, the `movementY` units may be a physical pixel, a logical pixel, or a CSS pixel.
 
 ## Value
 

--- a/files/en-us/web/api/mouseevent/movementy/index.md
+++ b/files/en-us/web/api/mouseevent/movementy/index.md
@@ -19,6 +19,10 @@ browser-compat: api.MouseEvent.movementY
 The **`movementY`** read-only property of the {{domxref("MouseEvent")}} interface provides the difference in the Y coordinate of the mouse pointer between the given event and the previous {{domxref("Element/mousemove_event", "mousemove")}} event.
 In other words, the value of the property is computed like this: `currentEvent.movementY = currentEvent.screenY - previousEvent.screenY`.
 
+> **Warning:** Different from the description in the specification, browsers may use different units for `movementY` and {{domxref("MouseEvent.screenY", "screenY")}}. The unit of `movementY` may be physical pixel of the screen, logical pixel from the operating system, or CSS pixel from the browser.
+>
+> See also [Issue #42 - w3c/pointerlock](https://github.com/w3c/pointerlock/issues/42)
+
 ## Value
 
 A number.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The usual browser implementation of MouseEvent.movementX/movementy is different from the specification description. A warning is added to get attention to this difference.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Developers may get confused that the `movementX` property is not as expected and different from the description in the document.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
See this issue in w3c/pointerlock: https://github.com/w3c/pointerlock/issues/42#issue-423956482

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #11707

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
