### PR TITLE
300 Status code message should be pluralized

### DIFF
--- a/files/en-us/web/http/status/index.md
+++ b/files/en-us/web/http/status/index.md
@@ -72,7 +72,7 @@ The below status codes are defined by [section 10 of RFC 2616](https://datatrack
 
 ## Redirection messages
 
-- {{HTTPStatus(300, "300 Multiple Choice")}}
+- {{HTTPStatus(300, "300 Multiple Choices")}}
   - : The request has more than one possible response. The user agent or user should choose one of them. (There is no standardized way of choosing one of the responses, but HTML links to the possibilities are recommended so the user can pick.)
 - {{HTTPStatus(301, "301 Moved Permanently")}}
   - : The URL of the requested resource has been changed permanently. The new URL is given in the response.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Pluralize status message for 300 response codes

#### Motivation
To fix a typo

#### Supporting details
It's plural in the RFC
https://datatracker.ietf.org/doc/html/rfc7231#section-6.4.1

#### Metadata
This PR…
- [ x] Fixes a typo, bug, or other error

