### PR TITLE
WebAPI: Update Method pages to modern structure (part 25)

### DIFF
--- a/files/en-us/web/api/baseaudiocontext/creategain/index.md
+++ b/files/en-us/web/api/baseaudiocontext/creategain/index.md
@@ -30,6 +30,10 @@ overall gain (or volume) of the audio graph.
 createGain()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("GainNode")}} which takes as input one or more audio sources and outputs

--- a/files/en-us/web/api/baseaudiocontext/createoscillator/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createoscillator/index.md
@@ -27,6 +27,10 @@ waveform. It basically generates a constant tone.
 createOscillator()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 An {{domxref("OscillatorNode")}}.

--- a/files/en-us/web/api/baseaudiocontext/createpanner/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createpanner/index.md
@@ -32,6 +32,10 @@ audio.
 createPanner()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("PannerNode")}}.

--- a/files/en-us/web/api/baseaudiocontext/createstereopanner/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createstereopanner/index.md
@@ -28,6 +28,10 @@ It positions an incoming audio stream in a stereo image using a [low-cost pannin
 createStereoPanner()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("StereoPannerNode")}}.

--- a/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.md
@@ -27,6 +27,10 @@ distortion. It is used to apply distortion effects to your audio.
 createWaveShaper()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("WaveShaperNode")}}.

--- a/files/en-us/web/api/blob/arraybuffer/index.md
+++ b/files/en-us/web/api/blob/arraybuffer/index.md
@@ -21,6 +21,10 @@ binary data contained in an {{jsxref("ArrayBuffer")}}.
 arrayBuffer()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A promise that resolves with an {{jsxref("ArrayBuffer")}} that contains the blob's

--- a/files/en-us/web/api/blob/stream/index.md
+++ b/files/en-us/web/api/blob/stream/index.md
@@ -21,6 +21,10 @@ which upon reading returns the data contained within the `Blob`.
 stream()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("ReadableStream")}} which, upon reading, returns the contents of the

--- a/files/en-us/web/api/blob/text/index.md
+++ b/files/en-us/web/api/blob/text/index.md
@@ -21,6 +21,10 @@ string containing the contents of the blob, interpreted as UTF-8.
 text()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A promise that resolves with a string which contains the blob's data

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptor/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptor/index.md
@@ -24,6 +24,10 @@ first {{domxref("BluetoothRemoteGATTDescriptor")}} for a given descriptor UUID.
 getDescriptor(bluetoothDescriptorUUID)
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{jsxref("Promise")}} that resolves to the

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptors/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptors/index.md
@@ -24,6 +24,10 @@ returns a {{jsxref("Promise")}} that resolves to an {{jsxref("Array")}} of all
 getDescriptors(bluetoothDescriptorUUID)
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{jsxref("Promise")}} that resolves to an {{jsxref("Array")}}

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/readvalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/readvalue/index.md
@@ -25,6 +25,10 @@ it throws an error.
 readValue()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{jsxref("Promise")}} that resolves to an {{jsxref("DataView")}}.

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/startnotifications/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/startnotifications/index.md
@@ -24,6 +24,10 @@ there is an active notification on it.
 startNotifications()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{jsxref("Promise")}} to the BluetoothRemoteGATTCharacteristic instance.

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/stopnotifications/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/stopnotifications/index.md
@@ -24,6 +24,10 @@ there is no longer an active notification on it.
 stopNotifications()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{jsxref("Promise")}}.

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/readvalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/readvalue/index.md
@@ -27,6 +27,10 @@ it is available and supported. Otherwise it throws an error.
 readValue()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{jsxref("Promise")}} that resolves to an {{jsxref("ArrayBuffer")}}.

--- a/files/en-us/web/api/canvasrenderingcontext2d/beginpath/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/beginpath/index.md
@@ -25,6 +25,10 @@ this method when you want to create a new path.
 beginPath()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ### Creating distinct paths

--- a/files/en-us/web/api/canvasrenderingcontext2d/closepath/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/closepath/index.md
@@ -27,6 +27,10 @@ the {{domxref("CanvasRenderingContext2D.stroke()", "stroke()")}} or
 closePath()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ### Closing a triangle

--- a/files/en-us/web/api/canvasrenderingcontext2d/getcontextattributes/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getcontextattributes/index.md
@@ -24,6 +24,10 @@ on context creation.
 getContextAttributes()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A `CanvasRenderingContext2DSettings` object that contains the actual context

--- a/files/en-us/web/api/canvasrenderingcontext2d/getlinedash/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getlinedash/index.md
@@ -20,6 +20,10 @@ The **`getLineDash()`** method of the Canvas 2D API's
 getLineDash()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 An {{jsxref("Array")}} of numbers that specify distances to alternately draw a line and

--- a/files/en-us/web/api/canvasrenderingcontext2d/restore/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/restore/index.md
@@ -26,6 +26,10 @@ state](/en-US/docs/Web/API/CanvasRenderingContext2D/save#drawing_state), see {{d
 restore()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ### Restoring a saved state

--- a/files/en-us/web/api/canvasrenderingcontext2d/save/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/save/index.md
@@ -50,6 +50,10 @@ The drawing state that gets saved onto a stack consists of:
 save()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ### Saving the drawing state

--- a/files/en-us/web/api/console/clear/index.md
+++ b/files/en-us/web/api/console/clear/index.md
@@ -21,6 +21,10 @@ environment allows it.
 clear()
 ```
 
+### Parameters
+
+None.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/cookiestoremanager/getsubscriptions/index.md
+++ b/files/en-us/web/api/cookiestoremanager/getsubscriptions/index.md
@@ -19,6 +19,10 @@ The **`getSubscriptions()`** method of the {{domxref("CookieStoreManager")}} int
 getSubscriptions()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{jsxref("promise")}} that resolves with a list of objects, each containing:

--- a/files/en-us/web/api/crypto/randomuuid/index.md
+++ b/files/en-us/web/api/crypto/randomuuid/index.md
@@ -22,6 +22,10 @@ The **`randomUUID()`** method of the {{domxref("Crypto")}} interface is used to 
 randomUUID()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A string containing a randomly generated, 36 character long v4 UUID.

--- a/files/en-us/web/api/cssprimitivevalue/getcountervalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/getcountervalue/index.md
@@ -32,6 +32,10 @@ is raised. Modification to the corresponding style property can be achieved usin
 getCounterValue()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("Counter")}} object representing the counter value.

--- a/files/en-us/web/api/cssprimitivevalue/getrectvalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/getrectvalue/index.md
@@ -31,6 +31,10 @@ Modification to the corresponding style property can be achieved using the
 getRectValue()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("Rect")}} object representing the rect value.

--- a/files/en-us/web/api/cssprimitivevalue/getrgbcolorvalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/getrgbcolorvalue/index.md
@@ -31,6 +31,10 @@ Modification to the corresponding style property can be achieved using the
 getRGBColorValue()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 An {{domxref("RGBColor")}} object representing the color value.

--- a/files/en-us/web/api/cssprimitivevalue/getstringvalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/getstringvalue/index.md
@@ -29,6 +29,10 @@ value doesn't contain a string value, a {{domxref("DOMException")}} is raised.
 getStringValue()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A `string` value.

--- a/files/en-us/web/api/customstateset/keys/index.md
+++ b/files/en-us/web/api/customstateset/keys/index.md
@@ -19,6 +19,10 @@ The **`keys()`** method of the {{domxref("CustomStateSet")}} interface is an ali
 keys()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A new iterator object containing the values for each element in the given `CustomStateSet`, in insertion order.

--- a/files/en-us/web/api/customstateset/values/index.md
+++ b/files/en-us/web/api/customstateset/values/index.md
@@ -19,6 +19,10 @@ The **`values()`** method of the {{domxref("CustomStateSet")}} interface returns
 values()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A new iterator object containing the values for each element in the given `CustomStateSet`, in insertion order.

--- a/files/en-us/web/api/dedicatedworkerglobalscope/close/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/close/index.md
@@ -21,6 +21,10 @@ The **`close()`** method of the {{domxref("DedicatedWorkerGlobalScope")}} interf
 close()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 If you want to close your worker instance from inside the worker itself, you can call the following:

--- a/files/en-us/web/api/document/clear/index.md
+++ b/files/en-us/web/api/document/clear/index.md
@@ -20,6 +20,10 @@ The **`Document.clear()`** method does nothing, but doesn't raise any error.
 clear()
 ```
 
+### Parameters
+
+None.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/document/close/index.md
+++ b/files/en-us/web/api/document/close/index.md
@@ -20,6 +20,10 @@ document, opened with {{domxref("Document.open()")}}.
 close()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/document/createdocumentfragment/index.md
+++ b/files/en-us/web/api/document/createdocumentfragment/index.md
@@ -21,6 +21,10 @@ DOM nodes can be added to build an offscreen DOM tree.
 createDocumentFragment()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A newly created, empty, {{domxref("DocumentFragment")}} object, which is ready to have

--- a/files/en-us/web/api/document/createnodeiterator/index.md
+++ b/files/en-us/web/api/document/createnodeiterator/index.md
@@ -21,6 +21,10 @@ createNodeIterator(root, whatToShow)
 createNodeIterator(root, whatToShow, filter)
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 - `root`

--- a/files/en-us/web/api/document/createrange/index.md
+++ b/files/en-us/web/api/document/createrange/index.md
@@ -22,7 +22,13 @@ The **`Document.createRange()`** method returns a new
 createRange()
 ```
 
-_range_ is the created {{domxref("Range")}} object.
+### Parameters
+
+None.
+
+### Return value
+
+The created {{domxref("Range")}} object.
 
 ## Examples
 

--- a/files/en-us/web/api/document/exitpointerlock/index.md
+++ b/files/en-us/web/api/document/exitpointerlock/index.md
@@ -23,6 +23,10 @@ To track the success or failure of the request, it is necessary to listen for th
 exitPointerLock()
 ```
 
+### Parameters
+
+None.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/document/hasfocus/index.md
+++ b/files/en-us/web/api/document/hasfocus/index.md
@@ -26,6 +26,10 @@ active element in a document has focus.
 hasFocus()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 `false` if the active element in the document has no focus;

--- a/files/en-us/web/api/documenttype/remove/index.md
+++ b/files/en-us/web/api/documenttype/remove/index.md
@@ -24,6 +24,10 @@ The **`DocumentType.remove()`** method removes a document's `doctype`.
 remove()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ### Using `remove()`

--- a/files/en-us/web/api/element/getattributenames/index.md
+++ b/files/en-us/web/api/element/getattributenames/index.md
@@ -29,6 +29,10 @@ The names returned by **`getAttributeNames()`** are _qualified_ attribute names,
 getAttributeNames()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 The following example shows how:

--- a/files/en-us/web/api/element/getboundingclientrect/index.md
+++ b/files/en-us/web/api/element/getboundingclientrect/index.md
@@ -36,6 +36,10 @@ position relative to the [viewport](/en-US/docs/Glossary/Viewport).
 getBoundingClientRect()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 The returned value is a {{domxref("DOMRect")}} object which is the smallest rectangle

--- a/files/en-us/web/api/element/getclientrects/index.md
+++ b/files/en-us/web/api/element/getclientrects/index.md
@@ -30,6 +30,10 @@ Most elements only have one border box each, but a multiline [inline element](/e
 getClientRects()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 The returned value is a collection of {{DOMxRef("DOMRect")}} objects, one for each CSS

--- a/files/en-us/web/api/element/hasattributes/index.md
+++ b/files/en-us/web/api/element/hasattributes/index.md
@@ -21,6 +21,10 @@ attributes or not.
 hasAttributes()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A boolean.

--- a/files/en-us/web/api/element/remove/index.md
+++ b/files/en-us/web/api/element/remove/index.md
@@ -18,6 +18,10 @@ The **`Element.remove()`** method removes the element from the DOM.
 remove()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ### Using `remove()`

--- a/files/en-us/web/api/element/requestpointerlock/index.md
+++ b/files/en-us/web/api/element/requestpointerlock/index.md
@@ -27,6 +27,10 @@ To track the success or failure of the request, it is necessary to listen for th
 requestPointerLock()
 ```
 
+### Parameters
+
+None.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/element/setcapture/index.md
+++ b/files/en-us/web/api/element/setcapture/index.md
@@ -27,6 +27,8 @@ to this element until the mouse button is released or {{
 setCapture(retargetToElement)
 ```
 
+### Parameters
+
 - `retargetToElement`
   - : If `true`, all events are targeted directly to this element; if
     `false`, events can also fire at descendants of this element.

--- a/files/en-us/web/api/filereader/abort/index.md
+++ b/files/en-us/web/api/filereader/abort/index.md
@@ -22,6 +22,10 @@ the {{domxref("FileReader.readyState","readyState")}} will be `DONE`.
 abort()
 ```
 
+### Parameters
+
+None.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/fontfaceset/keys/index.md
+++ b/files/en-us/web/api/fontfaceset/keys/index.md
@@ -19,6 +19,10 @@ The **`keys()`** method of the {{domxref("FontFaceSet")}} interface is an alias 
 keys()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A new iterator object containing the values for each element in the given `FontFaceSet`, in insertion order.

--- a/files/en-us/web/api/fontfaceset/values/index.md
+++ b/files/en-us/web/api/fontfaceset/values/index.md
@@ -19,6 +19,10 @@ The **`values()`** method of the {{domxref("FontFaceSet")}} interface returns a 
 values()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A new iterator object containing the values for each element in the given `FontFaceSet`, in insertion order.

--- a/files/en-us/web/api/formdata/entries/index.md
+++ b/files/en-us/web/api/formdata/entries/index.md
@@ -25,6 +25,10 @@ object; the value either a string, or a {{domxref("Blob")}}.
 entries()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 Returns an {{jsxref("Iteration_protocols","iterator")}}.

--- a/files/en-us/web/api/formdata/keys/index.md
+++ b/files/en-us/web/api/formdata/keys/index.md
@@ -24,6 +24,10 @@ in this object. The keys are string objects.
 keys()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 Returns an {{jsxref("Iteration_protocols","iterator")}}.

--- a/files/en-us/web/api/formdata/values/index.md
+++ b/files/en-us/web/api/formdata/values/index.md
@@ -25,6 +25,10 @@ contained in this object. The values are string or
 values()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 Returns an {{jsxref("Iteration_protocols","iterator")}}.

--- a/files/en-us/web/api/headers/entries/index.md
+++ b/files/en-us/web/api/headers/entries/index.md
@@ -24,6 +24,10 @@ contained in this object. The both the key and value of each pairs are
 entries()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 Returns an {{jsxref("Iteration_protocols","iterator")}}.

--- a/files/en-us/web/api/headers/keys/index.md
+++ b/files/en-us/web/api/headers/keys/index.md
@@ -23,6 +23,10 @@ in this object. The keys are {{jsxref("String")}} objects.
 keys()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 Returns an {{jsxref("Iteration_protocols","iterator")}}.

--- a/files/en-us/web/api/headers/values/index.md
+++ b/files/en-us/web/api/headers/values/index.md
@@ -23,6 +23,10 @@ in this object. The values are {{jsxref("String")}} objects.
 values()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 Returns an {{jsxref("Iteration_protocols","iterator")}}.

--- a/files/en-us/web/api/history/back/index.md
+++ b/files/en-us/web/api/history/back/index.md
@@ -29,6 +29,10 @@ This method is {{glossary("asynchronous")}}. Add a listener for the
 back()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 The following short example causes a button on the page to navigate back one entry in

--- a/files/en-us/web/api/history/forward/index.md
+++ b/files/en-us/web/api/history/forward/index.md
@@ -25,6 +25,10 @@ This method is {{glossary("asynchronous")}}. Add a listener for the
 forward()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 The following examples create a button that moves forward one step in the session

--- a/files/en-us/web/api/htmlanchorelement/tostring/index.md
+++ b/files/en-us/web/api/htmlanchorelement/tostring/index.md
@@ -20,6 +20,10 @@ version of {{domxref("HTMLAnchorElement.href")}}.
 toString()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ### Calling toString on an anchor element

--- a/files/en-us/web/api/htmlareaelement/tostring/index.md
+++ b/files/en-us/web/api/htmlareaelement/tostring/index.md
@@ -20,6 +20,10 @@ version of {{domxref("HTMLAreaElement.href")}}.
 toString()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ### Calling toString on an area element

--- a/files/en-us/web/api/htmlcanvaselement/transfercontroltooffscreen/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/transfercontroltooffscreen/index.md
@@ -23,6 +23,10 @@ thread or on a worker.
 transferControlToOffscreen()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 An {{domxref("OffscreenCanvas")}} object.

--- a/files/en-us/web/api/htmlelement/blur/index.md
+++ b/files/en-us/web/api/htmlelement/blur/index.md
@@ -20,6 +20,10 @@ removes keyboard focus from the current element.
 blur()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ### Remove focus from a text input

--- a/files/en-us/web/api/htmlelement/click/index.md
+++ b/files/en-us/web/api/htmlelement/click/index.md
@@ -25,6 +25,10 @@ events.
 click()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 Simulate a mouse-click when moving the mouse pointer over a checkbox:

--- a/files/en-us/web/api/htmlformelement/reset/index.md
+++ b/files/en-us/web/api/htmlformelement/reset/index.md
@@ -32,6 +32,10 @@ whatever value the {{domxref("Element.setAttribute", "setAttribute()")}} call se
 reset()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/htmlformelement/submit/index.md
+++ b/files/en-us/web/api/htmlformelement/submit/index.md
@@ -39,6 +39,10 @@ submitted when you do it with original HTML form submit.
 submit()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/htmlinputelement/checkvalidity/index.md
+++ b/files/en-us/web/api/htmlinputelement/checkvalidity/index.md
@@ -22,6 +22,10 @@ The **`HTMLInputElement.checkValidity()`** method returns a boolean value which 
 checkValidity()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 Returns `true` if the value of the element has no validity problems; otherwise returns `false`.

--- a/files/en-us/web/api/htmlinputelement/reportvalidity/index.md
+++ b/files/en-us/web/api/htmlinputelement/reportvalidity/index.md
@@ -22,6 +22,10 @@ The **`reportValidity()`** method of the {{domxref('HTMLInputElement')}} interfa
 reportValidity()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 Returns `true` if the element's value has no validity problems; otherwise, returns `false`.

--- a/files/en-us/web/api/htmlinputelement/select/index.md
+++ b/files/en-us/web/api/htmlinputelement/select/index.md
@@ -22,6 +22,10 @@ that includes a text field.
 select()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 Click the button in this example to select all the text in the

--- a/files/en-us/web/api/htmlinputelement/showpicker/index.md
+++ b/files/en-us/web/api/htmlinputelement/showpicker/index.md
@@ -37,6 +37,10 @@ can also be prepopulated with items from a {{htmlelement("datalist")}} element o
 showPicker()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 Click the button in this example to show a color picker.

--- a/files/en-us/web/api/htmlmediaelement/seektonextframe/index.md
+++ b/files/en-us/web/api/htmlmediaelement/seektonextframe/index.md
@@ -43,6 +43,10 @@ happens.
 seekToNextFrame()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{jsxref("Promise")}} which is fulfilled once the seek operation has completed.

--- a/files/en-us/web/api/htmlselectelement/checkvalidity/index.md
+++ b/files/en-us/web/api/htmlselectelement/checkvalidity/index.md
@@ -23,6 +23,10 @@ element, and then returns `false`.
 checkValidity()
 ```
 
+### Parameters
+
+None.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/htmltableelement/createcaption/index.md
+++ b/files/en-us/web/api/htmltableelement/createcaption/index.md
@@ -28,6 +28,10 @@ it, and then returns it.
 createCaption()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 {{domxref("HTMLTableCaptionElement")}}

--- a/files/en-us/web/api/htmltableelement/createtbody/index.md
+++ b/files/en-us/web/api/htmltableelement/createtbody/index.md
@@ -28,6 +28,10 @@ The **`createTBody()`** method of
 createTBody()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 {{domxref("HTMLTableSectionElement")}}

--- a/files/en-us/web/api/htmltableelement/createtfoot/index.md
+++ b/files/en-us/web/api/htmltableelement/createtfoot/index.md
@@ -28,6 +28,10 @@ method creates it, and then returns it.
 createTFoot()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 {{domxref("HTMLTableSectionElement")}}

--- a/files/en-us/web/api/htmltableelement/createthead/index.md
+++ b/files/en-us/web/api/htmltableelement/createthead/index.md
@@ -28,6 +28,10 @@ method creates it, and then returns it.
 createTHead()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 {{domxref("HTMLTableSectionElement")}}

--- a/files/en-us/web/api/htmltableelement/deletecaption/index.md
+++ b/files/en-us/web/api/htmltableelement/deletecaption/index.md
@@ -23,6 +23,10 @@ nothing.
 deleteCaption()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 This example uses JavaScript to delete a table's caption.

--- a/files/en-us/web/api/htmltableelement/deletetfoot/index.md
+++ b/files/en-us/web/api/htmltableelement/deletetfoot/index.md
@@ -21,6 +21,10 @@ The **`HTMLTableElement.deleteTFoot()`** method removes the
 deleteTFoot()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 This example uses JavaScript to delete a table's footer.

--- a/files/en-us/web/api/htmltableelement/deletethead/index.md
+++ b/files/en-us/web/api/htmltableelement/deletethead/index.md
@@ -21,6 +21,10 @@ The **`HTMLTableElement.deleteTHead()`** removes the
 deleteTHead()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 This example uses JavaScript to delete a table's header.

--- a/files/en-us/web/api/htmlvideoelement/getvideoplaybackquality/index.md
+++ b/files/en-us/web/api/htmlvideoelement/getvideoplaybackquality/index.md
@@ -34,6 +34,10 @@ The data returned can be used to evaluate the quality of the video stream.
 getVideoPlaybackQuality()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("VideoPlaybackQuality")}} object providing information about the video

--- a/files/en-us/web/api/htmlvideoelement/requestpictureinpicture/index.md
+++ b/files/en-us/web/api/htmlvideoelement/requestpictureinpicture/index.md
@@ -32,6 +32,10 @@ video will receive a {{domxref("HTMLVideoElement.enterpictureinpicture_event",
 requestPictureInPicture()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{jsxref("Promise")}} that will resolve to a {{domxref("PictureInPictureWindow")}}

--- a/files/en-us/web/api/idbcursor/delete/index.md
+++ b/files/en-us/web/api/idbcursor/delete/index.md
@@ -32,6 +32,10 @@ Be aware that you can't call `delete()` (or
 delete()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 An {{domxref("IDBRequest")}} object on which subsequent events related to this

--- a/files/en-us/web/api/idbdatabase/close/index.md
+++ b/files/en-us/web/api/idbdatabase/close/index.md
@@ -29,6 +29,10 @@ operation is pending.
 close()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/idbmutablefile/getfile/index.md
+++ b/files/en-us/web/api/idbmutablefile/getfile/index.md
@@ -22,6 +22,10 @@ file in the form of a {{domxref("File")}} object.
 getFile()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("DOMRequest")}} object. In case of success, the request's

--- a/files/en-us/web/api/idbobjectstore/clear/index.md
+++ b/files/en-us/web/api/idbobjectstore/clear/index.md
@@ -32,6 +32,10 @@ or {{domxref("IDBKeyRange")}}.
 clear()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 An {{domxref("IDBRequest")}} object on which subsequent events related to this

--- a/files/en-us/web/api/idbtransaction/abort/index.md
+++ b/files/en-us/web/api/idbtransaction/abort/index.md
@@ -29,6 +29,10 @@ their {{domxref("IDBRequest.error")}} attribute set to {{exception("AbortError")
 abort()
 ```
 
+### Parameters
+
+None.
+
 ### Exceptions
 
 - `InvalidStateError` {{domxref("DOMException")}}

--- a/files/en-us/web/api/idledeadline/timeremaining/index.md
+++ b/files/en-us/web/api/idledeadline/timeremaining/index.md
@@ -30,6 +30,10 @@ should return control to the user agent's event loop.
 timeRemaining()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("DOMHighResTimeStamp")}} value (which is a floating-point number)

--- a/files/en-us/web/api/imagebitmap/close/index.md
+++ b/files/en-us/web/api/imagebitmap/close/index.md
@@ -21,6 +21,10 @@ method disposes of all graphical resources associated with an `ImageBitmap`.
 close()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/imagecapture/getphotocapabilities/index.md
+++ b/files/en-us/web/api/imagecapture/getphotocapabilities/index.md
@@ -27,6 +27,10 @@ available configuration options.
 getPhotoCapabilities()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{jsxref("Promise")}} that resolves with an object containing the following properties:

--- a/files/en-us/web/api/imagecapture/getphotosettings/index.md
+++ b/files/en-us/web/api/imagecapture/getphotosettings/index.md
@@ -27,6 +27,10 @@ configuration settings.
 getPhotoSettings()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{jsxref("Promise")}} that resolves with a {{domxref("PhotoSettings")}} object

--- a/files/en-us/web/api/imagecapture/grabframe/index.md
+++ b/files/en-us/web/api/imagecapture/grabframe/index.md
@@ -27,6 +27,10 @@ a {{domxref("ImageBitmap")}} containing the snapshot.
 grabFrame()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{jsxref("Promise")}} that resolves to an {{domxref("ImageBitmap")}} object.

--- a/files/en-us/web/api/location/reload/index.md
+++ b/files/en-us/web/api/location/reload/index.md
@@ -25,7 +25,11 @@ information.
 reload()
 ```
 
-## location.reload() has no parameter
+### Parameters
+
+None.
+
+#### location.reload() has no parameter
 
 Firefox supports a non-standard [`forceGet` boolean parameter](https://searchfox.org/mozilla-central/source/dom/base/Location.cpp#551) for `location.reload()`, to tell Firefox to bypass its cache and force-reload the current document. However, in all other browsers, any parameter you specify in a `location.reload()` call will be ignored and have no effect of any kind.
 

--- a/files/en-us/web/api/location/reload/index.md
+++ b/files/en-us/web/api/location/reload/index.md
@@ -29,8 +29,6 @@ reload()
 
 None.
 
-#### location.reload() has no parameter
-
 > **Note:** Firefox supports a non-standard [`forceGet` boolean parameter](https://searchfox.org/mozilla-central/source/dom/base/Location.cpp#551) for `location.reload()`, to tell Firefox to bypass its cache and force-reload the current document. However, in all other browsers, any parameter you specify in a `location.reload()` call will be ignored and have no effect of any kind.
 
 You may, though, come across instances of `location.reload(true)` in existing code that was written with the assumption the force-reload effect occurs in all browsers. A GitHub "`location.reload(true)`" search returns [several hundred thousand results](https://github.com/search?q=%22location.reload%28true%29%22&type=code). So there's a lot of existing code which has it.

--- a/files/en-us/web/api/location/reload/index.md
+++ b/files/en-us/web/api/location/reload/index.md
@@ -31,7 +31,7 @@ None.
 
 #### location.reload() has no parameter
 
-Firefox supports a non-standard [`forceGet` boolean parameter](https://searchfox.org/mozilla-central/source/dom/base/Location.cpp#551) for `location.reload()`, to tell Firefox to bypass its cache and force-reload the current document. However, in all other browsers, any parameter you specify in a `location.reload()` call will be ignored and have no effect of any kind.
+> **Note:** Firefox supports a non-standard [`forceGet` boolean parameter](https://searchfox.org/mozilla-central/source/dom/base/Location.cpp#551) for `location.reload()`, to tell Firefox to bypass its cache and force-reload the current document. However, in all other browsers, any parameter you specify in a `location.reload()` call will be ignored and have no effect of any kind.
 
 You may, though, come across instances of `location.reload(true)` in existing code that was written with the assumption the force-reload effect occurs in all browsers. A GitHub "`location.reload(true)`" search returns [several hundred thousand results](https://github.com/search?q=%22location.reload%28true%29%22&type=code). So there's a lot of existing code which has it.
 

--- a/files/en-us/web/api/location/tostring/index.md
+++ b/files/en-us/web/api/location/tostring/index.md
@@ -21,6 +21,10 @@ whole URL. It is a read-only version of {{domxref("Location.href")}}.
 toString()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/lockedfile/abort/index.md
+++ b/files/en-us/web/api/lockedfile/abort/index.md
@@ -27,6 +27,10 @@ The `abort` method is used to release the lock on the
 abort()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("FileRequest")}} object to handle the success or failure of the operation.

--- a/files/en-us/web/api/lockedfile/flush/index.md
+++ b/files/en-us/web/api/lockedfile/flush/index.md
@@ -28,6 +28,10 @@ lost. To avoid that, it's possible to force a write onto the disk by calling the
 flush()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("FileRequest")}} object to handle the success or failure of the operation.

--- a/files/en-us/web/api/mediadevices/enumeratedevices/index.md
+++ b/files/en-us/web/api/mediadevices/enumeratedevices/index.md
@@ -23,6 +23,10 @@ The list of returned devices will omit any devices for which the corresponding p
 enumerateDevices()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{ jsxref("Promise") }} that receives an array of {{domxref("MediaDeviceInfo")}} objects when the promise is fulfilled.

--- a/files/en-us/web/api/mediakeysession/remove/index.md
+++ b/files/en-us/web/api/mediakeysession/remove/index.md
@@ -22,6 +22,10 @@ The `MediaKeySession.remove()` method returns a {{jsxref('Promise')}} after remo
 remove()
 ```
 
+### Parameters
+
+None.
+
 ## Return value
 
 A {{jsxref('Promise')}} that resolves to a boolean indicating whether the load succeeded or failed.

--- a/files/en-us/web/api/mediakeysystemaccess/createmediakeys/index.md
+++ b/files/en-us/web/api/mediakeysystemaccess/createmediakeys/index.md
@@ -25,6 +25,10 @@ The `MediaKeySystemAccess.createMediaKeys()` method returns a
 createMediaKeys()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{jsxref('Promise')}}.

--- a/files/en-us/web/api/mediakeysystemaccess/getconfiguration/index.md
+++ b/files/en-us/web/api/mediakeysystemaccess/getconfiguration/index.md
@@ -36,6 +36,10 @@ the following configuration options:
 getConfiguration()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 An object.

--- a/files/en-us/web/api/mediarecorder/pause/index.md
+++ b/files/en-us/web/api/mediarecorder/pause/index.md
@@ -34,6 +34,10 @@ browser queues a task that runs the below steps:
 pause()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 `undefined`.

--- a/files/en-us/web/api/mediarecorder/requestdata/index.md
+++ b/files/en-us/web/api/mediarecorder/requestdata/index.md
@@ -40,6 +40,10 @@ runs the following steps:
 requestData()
 ```
 
+### Parameters
+
+None.
+
 ### Errors
 
 An `InvalidState` error is raised if the `requestData()` method

--- a/files/en-us/web/api/mediarecorder/resume/index.md
+++ b/files/en-us/web/api/mediarecorder/resume/index.md
@@ -34,6 +34,10 @@ the following steps:
 resume()
 ```
 
+### Parameters
+
+None.
+
 ### Errors
 
 An `InvalidState` error is raised if the `resume()` method is

--- a/files/en-us/web/api/mediarecorder/stop/index.md
+++ b/files/en-us/web/api/mediarecorder/stop/index.md
@@ -34,6 +34,10 @@ following steps:
 stop()
 ```
 
+### Parameters
+
+None.
+
 ### Errors
 
 An `InvalidState` error is raised if the `stop()` method is

--- a/files/en-us/web/api/mediastreamtrack/clone/index.md
+++ b/files/en-us/web/api/mediastreamtrack/clone/index.md
@@ -24,6 +24,10 @@ interface creates a duplicate of the `MediaStreamTrack`. This new
 clone()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A new {{domxref("MediaStreamTrack")}} instance which is identical to the one

--- a/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
+++ b/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
@@ -30,6 +30,10 @@ and settings](/en-US/docs/Web/API/Media_Streams_API/Constraints) for details on 
 getCapabilities()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref('MediaTrackCapabilities')}} object which specifies the value or range of values which are supported for each of the user agent's supported constrainable properties.

--- a/files/en-us/web/api/mediastreamtrack/getconstraints/index.md
+++ b/files/en-us/web/api/mediastreamtrack/getconstraints/index.md
@@ -33,6 +33,10 @@ and settings](/en-US/docs/Web/API/Media_Streams_API/Constraints) for details on 
 getConstraints()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref('MediaTrackConstraints')}} object which indicates the constrainable

--- a/files/en-us/web/api/mediastreamtrack/getsettings/index.md
+++ b/files/en-us/web/api/mediastreamtrack/getsettings/index.md
@@ -26,6 +26,10 @@ and settings](/en-US/docs/Web/API/Media_Streams_API/Constraints) for details on 
 getSettings()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("MediaTrackSettings")}} object describing the current configuration of the

--- a/files/en-us/web/api/mediastreamtrack/stop/index.md
+++ b/files/en-us/web/api/mediastreamtrack/stop/index.md
@@ -24,6 +24,10 @@ The **`MediaStreamTrack.stop()`** method stops the track.
 stop()
 ```
 
+### Parameters
+
+None.
+
 ## Description
 
 Calling `stop()` tells the {{glossary("user agent")}} that the track's

--- a/files/en-us/web/api/navigationpreloadmanager/disable/index.md
+++ b/files/en-us/web/api/navigationpreloadmanager/disable/index.md
@@ -23,6 +23,10 @@ The method may be called in the service worker's `activate` event handler (befor
 disable()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{jsxref("Promise")}} that resolves with {{jsxref('undefined')}}.

--- a/files/en-us/web/api/navigationpreloadmanager/enable/index.md
+++ b/files/en-us/web/api/navigationpreloadmanager/enable/index.md
@@ -23,6 +23,10 @@ The method should be called in the service worker's `activate` event handler, wh
 enable()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{jsxref("Promise")}} that resolves with {{jsxref('undefined')}}.

--- a/files/en-us/web/api/navigationpreloadmanager/getstate/index.md
+++ b/files/en-us/web/api/navigationpreloadmanager/getstate/index.md
@@ -19,6 +19,10 @@ The **`getState()`** method of the {{domxref("NavigationPreloadManager")}} inter
 getState()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{jsxref("Promise")}} that resolves with an object that has the following properties:

--- a/files/en-us/web/api/navigator/getbattery/index.md
+++ b/files/en-us/web/api/navigator/getbattery/index.md
@@ -27,6 +27,10 @@ documentation for additional details, a guide to using the API, and sample code.
 getBattery()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{JSxRef("Promise")}} which, when resolved, calls its fulfillment handler with a

--- a/files/en-us/web/api/navigator/getgamepads/index.md
+++ b/files/en-us/web/api/navigator/getgamepads/index.md
@@ -27,6 +27,10 @@ Calls to this method will throw a `SecurityError` {{domxref('DOMException')}} if
 getGamepads()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/navigator/javaenabled/index.md
+++ b/files/en-us/web/api/navigator/javaenabled/index.md
@@ -18,6 +18,10 @@ This method always returns false.
 javaEnabled()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 The boolean value `false`.

--- a/files/en-us/web/api/navigator/taintenabled/index.md
+++ b/files/en-us/web/api/navigator/taintenabled/index.md
@@ -24,6 +24,10 @@ method only stays for maintaining compatibility with very old scripts.
 taintEnabled()
 ```
 
+### Parameters
+
+None.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/nodeiterator/detach/index.md
+++ b/files/en-us/web/api/nodeiterator/detach/index.md
@@ -25,6 +25,10 @@ iterates, releasing any resources used by the set and setting the iterator's sta
 detach()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/nodeiterator/nextnode/index.md
+++ b/files/en-us/web/api/nodeiterator/nextnode/index.md
@@ -28,6 +28,10 @@ throw.
 nextNode()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/nodeiterator/previousnode/index.md
+++ b/files/en-us/web/api/nodeiterator/previousnode/index.md
@@ -28,6 +28,10 @@ throw.
 previousNode()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/offscreencanvas/transfertoimagebitmap/index.md
+++ b/files/en-us/web/api/offscreencanvas/transfertoimagebitmap/index.md
@@ -22,6 +22,10 @@ the `OffscreenCanvas`.
 transferToImageBitmap()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 An {{domxref("ImageBitmap")}}.

--- a/files/en-us/web/api/performance/clearresourcetimings/index.md
+++ b/files/en-us/web/api/performance/clearresourcetimings/index.md
@@ -25,6 +25,10 @@ to zero. To set the size of the browser's performance data buffer, use the
 clearResourceTimings()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 none

--- a/files/en-us/web/api/performance/getentries/index.md
+++ b/files/en-us/web/api/performance/getentries/index.md
@@ -27,6 +27,10 @@ certain types or that have certain names, see {{domxref("Performance.getEntriesB
 getEntries()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 - entries

--- a/files/en-us/web/api/performance/now/index.md
+++ b/files/en-us/web/api/performance/now/index.md
@@ -41,6 +41,10 @@ are alleviated through other means.
 now()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/performance/tojson/index.md
+++ b/files/en-us/web/api/performance/tojson/index.md
@@ -22,6 +22,10 @@ object's properties.
 toJSON()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A JSON object that is the serialization of the {{domxref("Performance")}} object.

--- a/files/en-us/web/api/performanceelementtiming/tojson/index.md
+++ b/files/en-us/web/api/performanceelementtiming/tojson/index.md
@@ -19,6 +19,10 @@ The **`toJSON()`** method of the {{domxref("PerformanceElementTiming")}} interfa
 toJSON()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 - json

--- a/files/en-us/web/api/performanceentry/tojson/index.md
+++ b/files/en-us/web/api/performanceentry/tojson/index.md
@@ -21,6 +21,10 @@ a JSON representation of the {{domxref("PerformanceEntry","performance entry")}}
 toJSON()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A JSON object that is the serialization of the {{domxref("PerformanceEntry")}} object.

--- a/files/en-us/web/api/performanceobserver/disconnect/index.md
+++ b/files/en-us/web/api/performanceobserver/disconnect/index.md
@@ -25,6 +25,10 @@ events.
 disconnect()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/presentationconnection/close/index.md
+++ b/files/en-us/web/api/presentationconnection/close/index.md
@@ -22,6 +22,10 @@ When the `close()` method is called on a {{domxref("PresentationConnection")}}, 
 close()
 ```
 
+### Parameters
+
+None.
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/presentationconnection/terminate/index.md
+++ b/files/en-us/web/api/presentationconnection/terminate/index.md
@@ -24,6 +24,10 @@ When the `terminate()` method is called on a {{domxref("PresentationConnection")
 terminate()
 ```
 
+### Parameters
+
+None.
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/pushmanager/register/index.md
+++ b/files/en-us/web/api/pushmanager/register/index.md
@@ -22,6 +22,10 @@ a new endpoint for notifications.
 register()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("DOMRequest")}} object to handle the success or failure of the method call.

--- a/files/en-us/web/api/pushmanager/registrations/index.md
+++ b/files/en-us/web/api/pushmanager/registrations/index.md
@@ -22,6 +22,10 @@ existing push endpoint registrations.
 registrations()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("DOMRequest")}} object to handle the success or failure of the method call.

--- a/files/en-us/web/api/range/clonecontents/index.md
+++ b/files/en-us/web/api/range/clonecontents/index.md
@@ -28,6 +28,10 @@ fragment valid.
 cloneContents()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("DocumentFragment") }} object.

--- a/files/en-us/web/api/range/clonerange/index.md
+++ b/files/en-us/web/api/range/clonerange/index.md
@@ -23,6 +23,10 @@ The returned clone is copied by value, not reference, so a change in either
 cloneRange()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/range/deletecontents/index.md
+++ b/files/en-us/web/api/range/deletecontents/index.md
@@ -22,6 +22,10 @@ Unlike {{ domxref("Range.extractContents()") }}, this method does not return a
 deleteContents()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/range/detach/index.md
+++ b/files/en-us/web/api/range/detach/index.md
@@ -20,6 +20,10 @@ resources. The method has been kept for compatibility.
 detach()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/range/extractcontents/index.md
+++ b/files/en-us/web/api/range/extractcontents/index.md
@@ -28,6 +28,10 @@ document fragment valid.
 extractContents()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ### Basic example

--- a/files/en-us/web/api/range/getboundingclientrect/index.md
+++ b/files/en-us/web/api/range/getboundingclientrect/index.md
@@ -26,6 +26,10 @@ details on the returned value.
 getBoundingClientRect()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ### HTML

--- a/files/en-us/web/api/range/getclientrects/index.md
+++ b/files/en-us/web/api/range/getclientrects/index.md
@@ -22,6 +22,10 @@ The **`Range.getClientRects()`** method returns a list of {{
 getClientRects()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/range/tostring/index.md
+++ b/files/en-us/web/api/range/tostring/index.md
@@ -24,6 +24,10 @@ ineffective.
 toString()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A string.

--- a/files/en-us/web/api/reportingobserver/disconnect/index.md
+++ b/files/en-us/web/api/reportingobserver/disconnect/index.md
@@ -28,6 +28,10 @@ callback will return any reports. The associated observer will no longer be acti
 disconnect()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/reportingobserver/observe/index.md
+++ b/files/en-us/web/api/reportingobserver/observe/index.md
@@ -23,6 +23,10 @@ collecting reports in its report queue.
 observe()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/reportingobserver/takerecords/index.md
+++ b/files/en-us/web/api/reportingobserver/takerecords/index.md
@@ -22,6 +22,10 @@ in the observer's report queue, and empties the queue.
 takeRecords()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 An array of {{domxref("Report")}} objects.

--- a/files/en-us/web/api/rtcicecandidate/tojson/index.md
+++ b/files/en-us/web/api/rtcicecandidate/tojson/index.md
@@ -27,6 +27,10 @@ A stringified version of the object can then be obtained by calling {{jsxref("JS
 toJSON()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 <!-- RTCIceCandidateInit in spec -->

--- a/files/en-us/web/api/rtcrtpreceiver/getstats/index.md
+++ b/files/en-us/web/api/rtcrtpreceiver/getstats/index.md
@@ -28,6 +28,10 @@ results are available.
 getStats()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A JavaScript {{jsxref("Promise")}} which is fulfilled once the statistics are

--- a/files/en-us/web/api/rtcrtpsender/getstats/index.md
+++ b/files/en-us/web/api/rtcrtpsender/getstats/index.md
@@ -27,6 +27,10 @@ available.
 getStats()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A JavaScript {{jsxref("Promise")}} which is fulfilled once the statistics are

--- a/files/en-us/web/api/screen/unlockorientation/index.md
+++ b/files/en-us/web/api/screen/unlockorientation/index.md
@@ -27,6 +27,10 @@ method should be used instead.
 unlockOrientation()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 Returns `true` if the orientation was successfully unlocked or

--- a/files/en-us/web/api/selection/tostring/index.md
+++ b/files/en-us/web/api/selection/tostring/index.md
@@ -20,6 +20,10 @@ currently being represented by the selection object, i.e. the currently selected
 toString()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A string representing the selection.

--- a/files/en-us/web/api/serial/getports/index.md
+++ b/files/en-us/web/api/serial/getports/index.md
@@ -19,6 +19,10 @@ The **`getPorts()`** method of the {{domxref("Serial")}} interface returns a {{j
 getPorts()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{jsxref("Promise")}} that resolves with an array of {{domxref("SerialPort")}} objects.

--- a/files/en-us/web/api/serviceworkerglobalscope/skipwaiting/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/skipwaiting/index.md
@@ -23,6 +23,10 @@ Use this method with {{domxref("Clients.claim()")}} to ensure that updates to th
 skipWaiting()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{jsxref("Promise")}} that immediately resolves with `undefined`.

--- a/files/en-us/web/api/sharedworkerglobalscope/close/index.md
+++ b/files/en-us/web/api/sharedworkerglobalscope/close/index.md
@@ -21,6 +21,10 @@ The **`close()`** method of the {{domxref("SharedWorkerGlobalScope")}} interface
 close()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 If you want to close your worker instance from inside the worker itself, you can call the following:

--- a/files/en-us/web/api/storage/clear/index.md
+++ b/files/en-us/web/api/storage/clear/index.md
@@ -20,6 +20,10 @@ interface clears all keys stored in a given `Storage` object.
 clear()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 {{jsxref("undefined")}}.

--- a/files/en-us/web/api/svggeometryelement/gettotallength/index.md
+++ b/files/en-us/web/api/svggeometryelement/gettotallength/index.md
@@ -22,6 +22,10 @@ the user agent's computed value for the total length of the path in user units.
 getTotalLength()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A float indicating the total length of the path in user units.

--- a/files/en-us/web/api/svgpointlist/appenditem/index.md
+++ b/files/en-us/web/api/svgpointlist/appenditem/index.md
@@ -19,6 +19,8 @@ The **`appendItem()`** method of the {{domxref("SVGPointList")}} interface adds 
 appendItem(obj)
 ```
 
+### Parameters
+
 - `obj`
   - : An {{domxref("SVGPoint")}} object containing the coordinates of the point to be appended.
 

--- a/files/en-us/web/api/treewalker/firstchild/index.md
+++ b/files/en-us/web/api/treewalker/firstchild/index.md
@@ -22,6 +22,10 @@ returns `null` and the current node is not changed.
 firstChild()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("Node")}} object or `null`.

--- a/files/en-us/web/api/treewalker/lastchild/index.md
+++ b/files/en-us/web/api/treewalker/lastchild/index.md
@@ -22,6 +22,10 @@ returns `null` and the current node is not changed.
 lastChild()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("Node")}} object or `null`.

--- a/files/en-us/web/api/treewalker/nextnode/index.md
+++ b/files/en-us/web/api/treewalker/nextnode/index.md
@@ -22,6 +22,10 @@ returns `null` and the current node is not changed.
 nextNode()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("Node")}} object or `null`.

--- a/files/en-us/web/api/treewalker/nextsibling/index.md
+++ b/files/en-us/web/api/treewalker/nextsibling/index.md
@@ -21,6 +21,10 @@ is no such node, return `null` and the current node is not changed.
 nextSibling()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("Node")}} object or `null`.

--- a/files/en-us/web/api/treewalker/parentnode/index.md
+++ b/files/en-us/web/api/treewalker/parentnode/index.md
@@ -23,6 +23,10 @@ node is not changed.
 parentNode()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("Node")}} object or `null`.

--- a/files/en-us/web/api/treewalker/previousnode/index.md
+++ b/files/en-us/web/api/treewalker/previousnode/index.md
@@ -23,6 +23,10 @@ construction, returns `null` and the current node is not changed.
 previousNode()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("Node")}} object or `null`.

--- a/files/en-us/web/api/treewalker/previoussibling/index.md
+++ b/files/en-us/web/api/treewalker/previoussibling/index.md
@@ -23,6 +23,10 @@ there is no such node, return `null` and the current node is not changed.
 previousSibling()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("Node")}} object or `null`.

--- a/files/en-us/web/api/trustedhtml/tojson/index.md
+++ b/files/en-us/web/api/trustedhtml/tojson/index.md
@@ -19,6 +19,10 @@ The **`toJSON()`** method of the {{domxref("TrustedHTML")}} interface returns a 
 toJSON()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("DOMString","string")}} containing a JSON representation of the stored data.

--- a/files/en-us/web/api/trustedhtml/tostring/index.md
+++ b/files/en-us/web/api/trustedhtml/tostring/index.md
@@ -19,6 +19,10 @@ The **`toString()`** method of the {{domxref("TrustedHTML")}} interface returns 
 toString()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("DOMString","string")}} containing the sanitized HTML.

--- a/files/en-us/web/api/trustedscript/tojson/index.md
+++ b/files/en-us/web/api/trustedscript/tojson/index.md
@@ -19,6 +19,10 @@ The **`toJSON()`** method of the {{domxref("TrustedScript")}} interface returns 
 toJSON()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("DOMString","string")}} containing a JSON representation of the stored data.

--- a/files/en-us/web/api/trustedscript/tostring/index.md
+++ b/files/en-us/web/api/trustedscript/tostring/index.md
@@ -19,6 +19,10 @@ The **`toString()`** method of the {{domxref("TrustedScript")}} interface return
 toString()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("DOMString","string")}} containing the sanitized script.

--- a/files/en-us/web/api/trustedscripturl/tojson/index.md
+++ b/files/en-us/web/api/trustedscripturl/tojson/index.md
@@ -19,6 +19,10 @@ The **`toJSON()`** method of the {{domxref("TrustedScriptURL")}} interface retur
 toJSON()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("DOMString","string")}} containing a JSON representation of the stored data.

--- a/files/en-us/web/api/trustedscripturl/tostring/index.md
+++ b/files/en-us/web/api/trustedscripturl/tostring/index.md
@@ -19,6 +19,10 @@ The **`toString()`** method of the {{domxref("TrustedScriptURL")}} interface ret
 toString()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("DOMString","string")}} containing the sanitized URL

--- a/files/en-us/web/api/url/tojson/index.md
+++ b/files/en-us/web/api/url/tojson/index.md
@@ -25,6 +25,10 @@ although in practice it seems to have the same effect as
 toJSON()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A string.

--- a/files/en-us/web/api/url/tostring/index.md
+++ b/files/en-us/web/api/url/tostring/index.md
@@ -24,6 +24,10 @@ of {{domxref("URL.href")}}.
 toString()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A string.

--- a/files/en-us/web/api/webgl2renderingcontext/pausetransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/pausetransformfeedback/index.md
@@ -21,6 +21,10 @@ feedback operation.
 pauseTransformFeedback()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 None.

--- a/files/en-us/web/api/webgl2renderingcontext/resumetransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/resumetransformfeedback/index.md
@@ -21,6 +21,10 @@ transform feedback operation.
 resumeTransformFeedback()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 None.

--- a/files/en-us/web/api/webgl_compressed_texture_astc/getsupportedprofiles/index.md
+++ b/files/en-us/web/api/webgl_compressed_texture_astc/getsupportedprofiles/index.md
@@ -22,6 +22,10 @@ by the implementation.
 getSupportedProfiles()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 An {{jsxref("Array")}} of string elements indicating which ASTC

--- a/files/en-us/web/api/webgl_lose_context/losecontext/index.md
+++ b/files/en-us/web/api/webgl_lose_context/losecontext/index.md
@@ -24,6 +24,10 @@ called.
 loseContext()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 With this method, you can simulate the

--- a/files/en-us/web/api/webgl_lose_context/restorecontext/index.md
+++ b/files/en-us/web/api/webgl_lose_context/restorecontext/index.md
@@ -20,6 +20,10 @@ restoring the context of a {{domxref("WebGLRenderingContext")}} object.
 restoreContext()
 ```
 
+### Parameters
+
+None.
+
 ### Errors thrown
 
 - `INVALID_OPERATION` if the context was not lost.

--- a/files/en-us/web/api/webglrenderingcontext/commit/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/commit/index.md
@@ -23,6 +23,10 @@ context is not directly fixed to a specific canvas.
 commit()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 `undefined`.

--- a/files/en-us/web/api/webglrenderingcontext/getcontextattributes/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getcontextattributes/index.md
@@ -21,6 +21,10 @@ parameters. Might return {{jsxref("null")}}, if the context is lost.
 getContextAttributes()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A `WebGLContextAttributes` object that contains the actual context

--- a/files/en-us/web/api/webglrenderingcontext/getsupportedextensions/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getsupportedextensions/index.md
@@ -21,6 +21,10 @@ extensions.
 getSupportedExtensions()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 An {{jsxref("Array")}} of strings with all the supported WebGL extensions.

--- a/files/en-us/web/api/webglrenderingcontext/iscontextlost/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/iscontextlost/index.md
@@ -25,6 +25,10 @@ must be re-established before rendering can resume.
 isContextLost()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A boolean value which is `true` if the context is lost, or

--- a/files/en-us/web/api/window/blur/index.md
+++ b/files/en-us/web/api/window/blur/index.md
@@ -18,6 +18,10 @@ Shifts focus away from the window.
 blur()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 `undefined`.

--- a/files/en-us/web/api/window/close/index.md
+++ b/files/en-us/web/api/window/close/index.md
@@ -30,6 +30,10 @@ objects returned by
 close()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ### Closing a window opened with `window.open()`

--- a/files/en-us/web/api/window/focus/index.md
+++ b/files/en-us/web/api/window/focus/index.md
@@ -19,6 +19,10 @@ Makes a request to bring the window to the front. It may fail due to user settin
 focus()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/window/getselection/index.md
+++ b/files/en-us/web/api/window/getselection/index.md
@@ -23,6 +23,10 @@ the current position of the caret.
 getSelection()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("Selection")}} object.

--- a/files/en-us/web/api/window/print/index.md
+++ b/files/en-us/web/api/window/print/index.md
@@ -23,6 +23,10 @@ This method will block while the print dialog is open.
 print()
 ```
 
+### Parameters
+
+None.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/window/sizetocontent/index.md
+++ b/files/en-us/web/api/window/sizetocontent/index.md
@@ -25,6 +25,10 @@ being too small for the user to interact with.
 sizeToContent()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/window/stop/index.md
+++ b/files/en-us/web/api/window/stop/index.md
@@ -26,6 +26,10 @@ objects.
 stop()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/windowcontrolsoverlay/gettitlebararearect/index.md
+++ b/files/en-us/web/api/windowcontrolsoverlay/gettitlebararearect/index.md
@@ -21,6 +21,10 @@ This only applies to Progressive Web Apps installed on desktop operating systems
 getTitlebarAreaRect()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 A {{domxref("DOMRect")}} that provides the coordinates and size of the title bar area within the app's content.

--- a/files/en-us/web/api/workerlocation/tostring/index.md
+++ b/files/en-us/web/api/workerlocation/tostring/index.md
@@ -19,6 +19,10 @@ The **`toString()`** {{Glossary("stringifier")}} method of a {{domxref("WorkerLo
 toString()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/xmldocument/load/index.md
+++ b/files/en-us/web/api/xmldocument/load/index.md
@@ -21,6 +21,10 @@ browser-compat: api.XMLDocument.load
 load()
 ```
 
+### Parameters
+
+None.
+
 ## Examples
 
 ```js

--- a/files/en-us/web/api/xpathresult/iteratenext/index.md
+++ b/files/en-us/web/api/xpathresult/iteratenext/index.md
@@ -22,6 +22,10 @@ next node from it or `null` if there are no more nodes.
 iterateNext()
 ```
 
+### Parameters
+
+None.
+
 ### Return value
 
 The next {{domxref("Node")}} within the node set of the `XPathResult`.


### PR DESCRIPTION
### Summary
Adding missing empty `### Parameters` sections as per the decision made here #15145.

The empty `### Return value` sections will be added after the parameters sections are done.

#### Metadata
- [x] Fixes a typo, bug, or other error