### PR TITLE
setHTML and config option fixes

### DIFF
--- a/files/en-us/web/api/element/sethtml/index.md
+++ b/files/en-us/web/api/element/sethtml/index.md
@@ -34,8 +34,8 @@ setHTML(input, options)
   - : A options object with the following optional parameters:
 
      - `sanitizer`
-       - : A {{domxref("Sanitizer")}} object, which defines what elements of the input will be sanitized.
-         If not specified the default {{domxref("Sanitizer")}} object is used. 
+       - : A {{domxref("Sanitizer")}} object which defines what elements of the input will be sanitized.
+         If not specified, the default {{domxref("Sanitizer")}} object is used. 
 
 ### Return value
 

--- a/files/en-us/web/api/element/sethtml/index.md
+++ b/files/en-us/web/api/element/sethtml/index.md
@@ -31,7 +31,7 @@ setHTML(input, options)
 - `input`
   - : A string defining HTML to be sanitized.
 - `options` {{optional_inline}}
-  - : A options object with the following optional parameters.
+  - : A options object with the following optional parameters:
 
      - `sanitizer`
        - : A {{domxref("Sanitizer")}} object, which defines what elements of the input will be sanitized.

--- a/files/en-us/web/api/element/sethtml/index.md
+++ b/files/en-us/web/api/element/sethtml/index.md
@@ -23,19 +23,23 @@ The sanitizer configuration may be customized using {{domxref("Sanitizer.Sanitiz
 ## Syntax
 
 ```js
-setHTML(input, sanitizer)
+setHTML(input, options)
 ```
 
 ### Parameters
 
 - `input`
   - : A string defining HTML to be sanitized.
-- `sanitizer`
-  - : A {{domxref("Sanitizer")}} object, which defines what elements of the input will be sanitized.
+- `options` {{optional_inline}}
+  - : A options object with the following optional parameters.
+
+     - `sanitizer`
+       - : A {{domxref("Sanitizer")}} object, which defines what elements of the input will be sanitized.
+         If not specified the default {{domxref("Sanitizer")}} object is used. 
 
 ### Return value
 
-`undefined`
+None (`undefined`).
 
 ### Exceptions
 
@@ -47,10 +51,10 @@ The code below demonstrates how to sanitize a string of HTML and insert it into 
 
 ```js
 const unsanitized_string = "abc <script>alert(1)</script> def";  // Unsanitized string of HTML
-const sanitizer = new Sanitizer();  // Default sanitizer;
+const sanitizer1 = new Sanitizer();  // Default sanitizer;
 
 // Get the Element with id "target" and set it with the sanitized string.
-document.getElementById("target").setHTML(unsanitized_string, sanitizer);
+document.getElementById("target").setHTML(unsanitized_string, {sanitizer: sanitizer1});
 
 // Result (as a string): "abc  def"
 ```

--- a/files/en-us/web/api/html_sanitizer_api/index.md
+++ b/files/en-us/web/api/html_sanitizer_api/index.md
@@ -25,7 +25,8 @@ Creating a {{domxref("Sanitizer.Sanitizer", "Sanitizer()")}} with a custom confi
 
 The API has three main methods for sanitizing data:
 
-1. {{domxref('Element.setHTML()')}} parses and sanitizes a string of HTML and immediately inserts it into the DOM as a child of the current element. This is essentially a "safe" version of {{domxref('Element.innerHTML')}}, and should be used instead of `innerHTML` when inserting untrusted data.
+1. {{domxref('Element.setHTML()')}} parses and sanitizes a string of HTML and immediately inserts it into the DOM as a child of the current element.
+   This is essentially a "safe" version of {{domxref('Element.innerHTML')}}, and should be used instead of `innerHTML` when inserting untrusted data.
 2. {{domxref('Sanitizer.sanitizeFor()')}} parses and sanitizes a string of HTML for later insertion into the DOM. This might be used when the target element for the string is not always ready/available for update.
 3. {{domxref('Sanitizer.sanitize()')}} sanitizes data that is in a {{domxref('Document')}} or {{domxref('DocumentFragment')}}. It might be used, for example, to sanitize a {{domxref('Document')}} instance in a frame.
 
@@ -79,7 +80,7 @@ const sanitizer = new Sanitizer();  // Default sanitizer;
 
 // Get the Element with id "target" and set it with the sanitized string.
 const target = document.getElementById("target");
-target.setHTML(unsanitized_string, sanitizer);
+target.setHTML(unsanitized_string, {sanitizer: sanitizer});
 
 console.log(target.innerHTML);
 // "abc  def"

--- a/files/en-us/web/api/sanitizer/sanitizer/index.md
+++ b/files/en-us/web/api/sanitizer/sanitizer/index.md
@@ -13,7 +13,7 @@ browser-compat: api.Sanitizer.Sanitizer
 The **`Sanitizer()`** constructor creates a new {{domxref("Sanitizer")}} object, which can be used to sanitize untrusted strings of HTML, or untrusted {{domxref("Document")}} or {{domxref("DocumentFragment")}} objects, making them safe for insertion into a document's DOM.
 
 The default `Sanitizer()` configuration causes sanitizer operations to strip out XSS-relevant input by default, including {{HTMLElement("script")}} tags, custom elements, and comments.
-The constructor options shown below can be used to customize the sanitizer behavior.
+The constructor `config` option can be used to customize the sanitizer behavior.
 
 ## Syntax
 
@@ -24,38 +24,39 @@ new Sanitizer(config)
 
 ### Parameters
 
-> **Note:** The custom configuration options described here are not yet supported (because at time of writing the sanitizer configuration object is still being defined).
-
 - `config` {{optional_inline}}
 
   - : A sanitizer configuration object with the following options (referred to as `SanitizerConfig` in the specification):
 
     - `allowElements` {{optional_inline}}
-      - : An {{jsxref('Array')}} of {{jsxref('String','strings')}} indicating elements the sanitizer should not remove.
+      - : An {{jsxref('Array')}} of {{jsxref('String','strings')}} indicating elements that the sanitizer should not remove.
     - `blockElements` {{optional_inline}}
-      - : An {{jsxref('Array')}} of {{jsxref('String','strings')}} indicating elements the sanitizer should remove, keeping their child elements.
-        Child elements are retained.
+      - : An {{jsxref('Array')}} of {{jsxref('String','strings')}} indicating elements that the sanitizer should remove, but keeping their child elements.
     - `dropElements` {{optional_inline}}
-      - : An {{jsxref('Array')}} of {{jsxref('String','strings')}} indicating elements the sanitizer should remove, along with their child elements.
+      - : An {{jsxref('Array')}} of {{jsxref('String','strings')}} indicating elements (including nested elements) that the sanitizer should remove.
     - `allowAttributes` {{optional_inline}}
-      - : An {{jsxref('Array')}} of {{jsxref('String','strings')}} indicating attributes the sanitizer should not remove.
+      - : An {{jsxref('Array')}} of {{jsxref('String','strings')}} indicating the attributes on an element that the sanitizer should not remove.
     - `dropAttributes` {{optional_inline}}
-      - : An {{jsxref('Array')}} of {{jsxref('String','strings')}} indicating attributes the sanitizer should remove.
+      - : An {{jsxref('Array')}} of {{jsxref('String','strings')}} indicating attributes that the sanitizer should remove.
     - `allowCustomElements` {{optional_inline}}
       - : A {{jsxref('Boolean')}} value set to `false` (default) to remove custom elements and their children.
-        Set to `true` to ensure sanitize custom elements using build-in and custom configuration checks.
+        If set to `true`, custom elements will be subject to built-in and custom configuration checks (and will be retained or dropped based on those checks).
     - `allowComments` {{optional_inline}}
       - : A {{jsxref('Boolean')}} value set to `false` (default) to remove HTML comments.
-        Set to `true` ensures that comments are retained.
+        Set to `true` in order to keep comments.
+
 
 ## Examples
 
-The example below shows a sanitization operation using the {{domxref("Sanitizer.sanitizeFor()")}} method.
+The examples below show a sanitization operation using the {{domxref("Sanitizer.sanitizeFor()")}} method.
 This method takes as inputs a string of HTML to sanitize and the context (tag) in which it is sanitized, and returns a sanitized node object for the specified tag.
 To simplify the presentation the result that is shown is actually the _innerHTML_ of the returned object.
 
 > **Note:** The API _only_ sanitizes HTML in strings in the context of a particular element/tag.
 > For more information see {{domxref('HTML Sanitizer API')}} (and {{domxref("Sanitizer.sanitizeFor()")}}).
+
+
+### Using the default sanitizer
 
 This example shows the result of sanitizing a string with disallowed `script` element using the default sanitizer (in a `div` context).
 


### PR DESCRIPTION
Fixes #15414

[`Element.setHTML()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/setHTML) takes an options object that contains a reference to a sanitizer, rather than taking a sanitizer directly according to the spec. This updates to match the spec.

NOTE in practice a sanitizer object can be passed directly, and that appears in some spec examples. I will ask for correction/clarification in the spec repo.

In addition, the spec now states that the config options are supported (when I updated the docs in FF84 this was still marked as "still being worked out". What I have done is removed that comment and made sure the config options are correct. 
BUT I have not gone through and updated examples to set the configuration. I'll create an issue for that. 

EDITED:
- Also added https://github.com/mdn/browser-compat-data/pull/16063 to track related incorrect FF and Chrome support statements
- Follow on required actions in #15500