### PR TITLE
Follow-up of #15145

### DIFF
--- a/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.md
@@ -98,11 +98,13 @@ Fill in a syntax box, according to the guidance in our [syntax sections](/en-US/
 - `parameter2`
   - : etc.
 
+> **Note:** This section is mandatory. If there aren't any parameter, put "None." instead of the definition list. 
+
 ### Return value
 
 Include a description of the method's return value, including data type and what it represents.
 
-If the method doesn't return anything, just put "{{jsxref('undefined')}}.".
+If the method doesn't return anything, just put "None {{jsxref('undefined')}}.".
 
 ### Exceptions
 


### PR DESCRIPTION
@hamishwillee @wbamberg What we discussed in #15145 (The _Return value_ section syntax when there is no returned value) was documented on a second page. This updates the second occurrence. (We should clean all these meta-docs at some point, but let's wait until the reorg is done)