### PR TITLE
Rephrase the ordering of arguments of comparison

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
@@ -76,7 +76,7 @@ elements are sorted according to the return value of the compare function (all
 
 | `compareFunction(a, b)` return value | sort order                         |
 |--------------------------------------|------------------------------------|
-| > 0                                  | sort `b` before `a`                |
+| > 0                                  | sort `a` after `b`                 |
 | < 0                                  | sort `a` before `b`                |
 | === 0                                | keep original order of `a` and `b` |
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Rephrase the ordering of arguments of comparison to make it easier to understand. Now it reads like:

- If the result is greater than zero, it means `a` is greater than `b` and hence, `a` comes after `b`.
- If the result is less than zero, it means `a` is less than `b` and hence, `a` comes before `b`.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Improve readability.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
