### PR TITLE
Restructure Exception section

### DIFF
--- a/files/en-us/web/api/webgl_lose_context/restorecontext/index.md
+++ b/files/en-us/web/api/webgl_lose_context/restorecontext/index.md
@@ -26,10 +26,10 @@ None.
 
 ### Exceptions
 
-This method doesn't raise any exception, but an error can be notified using the {{domxref("WEBGLRenderingContext.getError", "getError()")}} method's return value:
+Browsers may not report WebGL errors by default. WebGL's error reporting works by calling {{domxref("WEBGLRenderingContext.getError", "getError()")}} and checking for errors. The following exceptions may be thrown:
 
-- `INVALID_OPERATION` (`0x0502`)
-  - : Set if the context was not lost.
+- `INVALID_OPERATION`
+  - : Thrown if the context was not lost.
 
 ## Examples
 

--- a/files/en-us/web/api/webgl_lose_context/restorecontext/index.md
+++ b/files/en-us/web/api/webgl_lose_context/restorecontext/index.md
@@ -26,7 +26,7 @@ None.
 
 ### Exceptions
 
-This method doesn't raise any exception, but an error can be notified by the {{domxref("WEBGLRenderingContext.getError", "getError()")}} method's return value:
+This method doesn't raise any exception, but an error can be notified using the {{domxref("WEBGLRenderingContext.getError", "getError()")}} method's return value:
 
 - `INVALID_OPERATION` (`0x0502`)
   - : Set if the context was not lost.

--- a/files/en-us/web/api/webgl_lose_context/restorecontext/index.md
+++ b/files/en-us/web/api/webgl_lose_context/restorecontext/index.md
@@ -24,9 +24,12 @@ restoreContext()
 
 None.
 
-### Errors thrown
+### Exceptions
 
-- `INVALID_OPERATION` if the context was not lost.
+This method doesn't raise any exception, but an error can be notified by the {{domxref("WEBGLRenderingContext.getError", "getError()")}} method's return value:
+
+- `INVALID_OPERATION` (`0x0502`)
+  - : Set if the context was not lost.
 
 ## Examples
 


### PR DESCRIPTION
WebGL methods raise very few exceptions and convey errors via the `getError()` method.

This PR is an attempt, for one method, to make this unusual way of returning problems works with the standard method template, which has an _Exceptions_ section.