### PR TITLE
Remove prototype from title

### DIFF
--- a/files/en-us/web/api/worker/postmessage/index.md
+++ b/files/en-us/web/api/worker/postmessage/index.md
@@ -1,5 +1,5 @@
 ---
-title: Worker.prototype.postMessage()
+title: Worker.postMessage()
 slug: Web/API/Worker/postMessage
 tags:
   - API


### PR DESCRIPTION
In web/api we don't put the word `prototype` like in web/javascript. This PR fixes one occurrence of it.