### PR TITLE
Document.createAttributeNS

### DIFF
--- a/files/en-us/web/api/document/createattribute/index.md
+++ b/files/en-us/web/api/document/createattribute/index.md
@@ -11,7 +11,7 @@ browser-compat: api.Document.createAttribute
 {{ ApiRef("DOM") }}
 
 The **`Document.createAttribute()`** method creates a new
-attribute node, and returns it. The object created a node implementing the
+attribute node, and returns it. The object created is a node implementing the
 {{domxref("Attr")}} interface. The DOM does not enforce what sort of attributes can be
 added to a particular element in this manner.
 
@@ -56,4 +56,7 @@ console.log(node.getAttribute("my_attrib")); // "newVal"
 
 ## See also
 
+- {{domxref("Document.createAttributeNS()")}}
 - {{domxref("Document.createElement()")}}
+- {{domxref("Element.setAttribute()")}}
+- {{domxref("Element.setAttributeNode()")}}

--- a/files/en-us/web/api/document/createattributens/index.md
+++ b/files/en-us/web/api/document/createattributens/index.md
@@ -1,0 +1,83 @@
+---
+title: Document.createAttributeNS()
+slug: Web/API/Document/createAttributeNS
+tags:
+  - API
+  - DOM
+  - Method
+  - Reference
+browser-compat: api.Document.createAttributeNS
+---
+{{ ApiRef("DOM") }}
+
+The **`Document.createAttributeNS()`** method creates a new attribute node
+with the specified namespace URI and qualified name, and returns it.
+The object created is a node implementing the
+{{domxref("Attr")}} interface. The DOM does not enforce what sort of attributes can be
+added to a particular element in this manner.
+
+## Syntax
+
+```js
+createAttributeNS(namespaceURI, qualifiedName)
+```
+
+### Parameters
+
+- _namespaceURI_
+  - : A string that specifies the [namespace URI](https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/glossary.html#dt-namespaceURI) to associate with the attribute.
+    The {{DOMxRef("attribute.namespaceURI", "namespaceURI")}} property of the created attribute is initialized with the value of _namespaceURI_.
+    See [Valid Namespace URIs](#important_namespace_uris).
+- _qualifiedName_
+  - : A string that specifies the name of attribute to be created.
+    The {{DOMxRef("attribute.name", "name")}} property of the created attribute is initialized with the value of _qualifiedName_.
+
+### Return value
+
+The new {{domxref("Attr")}} node.
+
+### Exceptions
+
+- `NamespaceError` {{domxref("DOMException")}}
+  - : Thrown if the [`namespaceURI`](#namespaceuri) value is not a valid [namespace URI](https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/glossary.html#dt-namespaceURI)
+- `InvalidCharacterError` {{domxref("DOMException")}}
+  - : Thrown if the [`qualifiedName`](#qualifiedName) value is not a valid [XML name](https://www.w3.org/TR/REC-xml/#dt-name); for example, it starts with a number, hyphen, or period, or contains characters other than alphanumeric characters, underscores, hyphens, or periods.
+
+## Important Namespace URIs
+
+- [HTML](/en-US/docs/Web/HTML)
+  - : `http://www.w3.org/1999/xhtml`
+- [SVG](/en-US/docs/Web/SVG)
+  - : `http://www.w3.org/2000/svg`
+- [MathML](/en-US/docs/Web/MathML)
+  - : `http://www.w3.org/1998/Math/MathML`
+- [XUL](/en-US/docs/Mozilla/Tech/XUL) {{Non-standard_Inline}}
+  - : `http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul`
+- [XBL](/en-US/docs/Mozilla/Tech/XBL) {{Non-standard_Inline}} {{Deprecated_Inline}}
+  - : `http://www.mozilla.org/xbl`
+
+## Examples
+
+```js
+var node = document.getElementById("svg");
+var a = document.createAttributeNS("http://www.w3.org/2000/svg", "viewBox");
+a.value = "0 0 100 100";
+node.setAttributeNode(a);
+console.log(node.getAttribute("viewBox")); // "0 0 100 100"
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("Document.createAttribute()")}}
+- {{domxref("Document.createElementNS()")}}
+- {{domxref("Element.setAttributeNS()")}}
+- {{domxref("Element.setAttributeNode()")}}
+- {{domxref("Element.setAttributeNodeNS()")}}

--- a/files/en-us/web/api/document/createattributens/index.md
+++ b/files/en-us/web/api/document/createattributens/index.md
@@ -24,13 +24,13 @@ createAttributeNS(namespaceURI, qualifiedName)
 
 ### Parameters
 
-- _namespaceURI_
+- `namespaceURI`
   - : A string that specifies the [namespace URI](https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/glossary.html#dt-namespaceURI) to associate with the attribute.
-    The {{DOMxRef("attribute.namespaceURI", "namespaceURI")}} property of the created attribute is initialized with the value of _namespaceURI_.
+    The {{DOMxRef("attribute.namespaceURI", "namespaceURI")}} property of the created attribute is initialized with the value of `namespaceURI`.
     See [Valid Namespace URIs](#important_namespace_uris).
-- _qualifiedName_
+- `qualifiedName`
   - : A string that specifies the name of attribute to be created.
-    The {{DOMxRef("attribute.name", "name")}} property of the created attribute is initialized with the value of _qualifiedName_.
+    The {{DOMxRef("attribute.name", "name")}} property of the created attribute is initialized with the value of `qualifiedName`.
 
 ### Return value
 
@@ -51,10 +51,6 @@ The new {{domxref("Attr")}} node.
   - : `http://www.w3.org/2000/svg`
 - [MathML](/en-US/docs/Web/MathML)
   - : `http://www.w3.org/1998/Math/MathML`
-- [XUL](/en-US/docs/Mozilla/Tech/XUL) {{Non-standard_Inline}}
-  - : `http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul`
-- [XBL](/en-US/docs/Mozilla/Tech/XBL) {{Non-standard_Inline}} {{Deprecated_Inline}}
-  - : `http://www.mozilla.org/xbl`
 
 ## Examples
 

--- a/files/en-us/web/api/document/createelementns/index.md
+++ b/files/en-us/web/api/document/createelementns/index.md
@@ -30,7 +30,7 @@ createElementNS(namespaceURI, qualifiedName, options)
     See [Valid Namespace URIs](#important_namespace_uris).
 - _qualifiedName_
   - : A string that specifies the type of element to be created.
-    The {{DOMxRef("element.nodeName", "nodeName")}} property of the created element is initialized with the value of _qualifiedName_.
+    The {{DOMxRef("node.nodeName", "nodeName")}} property of the created element is initialized with the value of _qualifiedName_.
 - _options_{{Optional_Inline}}
 
   - : An optional `ElementCreationOptions` object containing a single property named `is`, whose value is the tag name for a custom element previously defined using `customElements.define()`.
@@ -43,6 +43,13 @@ createElementNS(namespaceURI, qualifiedName, options)
 ### Return value
 
 The new {{DOMxRef("Element")}}.
+
+### Exceptions
+
+- `NamespaceError` {{domxref("DOMException")}}
+  - : Thrown if the [`namespaceURI`](#namespaceuri) value is not a valid [namespace URI](https://www.w3.org/TR/2004/REC-DOM-Level-3-Core-20040407/glossary.html#dt-namespaceURI)
+- `InvalidCharacterError` {{domxref("DOMException")}}
+  - : Thrown if the [`qualifiedName`](#qualifiedName) value is not a valid [XML name](https://www.w3.org/TR/REC-xml/#dt-name); for example, it starts with a number, hyphen, or period, or contains characters other than alphanumeric characters, underscores, hyphens, or periods.
 
 ## Important Namespace URIs
 

--- a/files/en-us/web/api/element/setattributenode/index.md
+++ b/files/en-us/web/api/element/setattributenode/index.md
@@ -69,3 +69,7 @@ used to change element's attributes.
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("Document.createAttribute()")}}

--- a/files/en-us/web/api/element/setattributenodens/index.md
+++ b/files/en-us/web/api/element/setattributenodens/index.md
@@ -57,3 +57,8 @@ Note that if you try to set without cloning the node, Mozilla gives an NS_ERROR_
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("Document.createAttribute()")}}
+- {{domxref("Document.createAttributeNS()")}}


### PR DESCRIPTION
#### Summary
* Adds documentation for the `Document.createAttributeNS` DOM interface (and "see also" links)
* Small grammar fix in [`Document.createAttribute`](https://developer.mozilla.org/en-US/docs/Web/API/Document/createAttribute)
* Small improvements to [`Document.createElementNS`](https://developer.mozilla.org/en-US/docs/Web/API/Document/createElementNS): fix broken link (I hope) and add possible exceptions.

#### Motivation
Though I guess rarely used over [`Element.setAttributeNS`](https://developer.mozilla.org/en-US/docs/Web/API/Element/setAttributeNS), this seems to be a core part of the DOM spec, [defined with `createAttribute`](https://dom.spec.whatwg.org/#dom-document-createattribute).

#### Supporting details
Based on the existing documentation for [`Document.createAttribute`](https://developer.mozilla.org/en-US/docs/Web/API/Document/createAttribute) and [`Document.createElementNS`](https://developer.mozilla.org/en-US/docs/Web/API/Document/createElementNS).

I've never created a page before, so I'm not sure whether I need to do something to get the Specifications or Browser compatibility to work. Or to get a crosslink back from the DOM spec.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
- [x] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

