### PR TITLE
Deprecated notice for "track" RTCStatsType

### DIFF
--- a/files/en-us/web/api/rtcstatstype/index.md
+++ b/files/en-us/web/api/rtcstatstype/index.md
@@ -53,8 +53,9 @@ This type determines which of the {{domxref("RTCStats")}}-based dictionaries the
   - : An object containing statistics about the {{domxref("RTCRtpSender")}} for a stream on the {{domxref("RTCPeerConnection")}}. If {{domxref("RTCStats.kind", "kind")}} is `"audio"`, this object is of type {{domxref("RTCAudioSenderStats")}}; if `kind` is `"video"`, this is an {{domxref("RTCVideoSenderStats")}} object.
 - `stream`
   - : An object of type {{domxref("RTCMediaStreamStats")}}, providing statistics and information about a {{domxref("MediaStream")}} which is part of the {{domxref("RTCPeerConnection")}}.
-- `track`
+- `track` {{deprecated_inline}}
   - : The object is one of the types based on {{domxref("RTCMediaHandlerStats")}}: for audio tracks, the type is {{domxref("RTCSenderAudioTrackAttachmentStats")}} and for video tracks, the type is {{domxref("RTCSenderVideoTrackAttachmentStats")}}. The data within provides statistics related to a particular {{domxref("MediaStreamTrack")}}'s attachment to an {{domxref("RTCRtpSender")}}; also included are the media level metrics that go along with the track.
+> **Note:** All "track" stats have been made obsolete. The relevant metrics have been moved to "media-source", "sender", "outbound-rtp", "receiver" and "inbound-rtp" stats.
 - `transport`
   - : An object that contains statistics related to a transport for an `RTCPeerConnection`. The object is of type {{domxref("RTCTransportStats")}}.
 

--- a/files/en-us/web/api/rtcstatstype/index.md
+++ b/files/en-us/web/api/rtcstatstype/index.md
@@ -51,7 +51,7 @@ This type determines which of the {{domxref("RTCStats")}}-based dictionaries the
   - : The report is an {{domxref("RTCRemoteOutboundRtpStreamStats")}} object that contains statistics about your inbound RTP (`inbound-rtp`) stream, but from the perspective of the remote peer.
 - `sender`
   - : An object containing statistics about the {{domxref("RTCRtpSender")}} for a stream on the {{domxref("RTCPeerConnection")}}. If {{domxref("RTCStats.kind", "kind")}} is `"audio"`, this object is of type {{domxref("RTCAudioSenderStats")}}; if `kind` is `"video"`, this is an {{domxref("RTCVideoSenderStats")}} object.
-- `stream`
+- `stream` {{deprecated_inline}}
   - : An object of type {{domxref("RTCMediaStreamStats")}}, providing statistics and information about a {{domxref("MediaStream")}} which is part of the {{domxref("RTCPeerConnection")}}.
 - `track` {{deprecated_inline}}
   - : The object is one of the types based on {{domxref("RTCMediaHandlerStats")}}: for audio tracks, the type is {{domxref("RTCSenderAudioTrackAttachmentStats")}} and for video tracks, the type is {{domxref("RTCSenderVideoTrackAttachmentStats")}}. The data within provides statistics related to a particular {{domxref("MediaStreamTrack")}}'s attachment to an {{domxref("RTCRtpSender")}}; also included are the media level metrics that go along with the track.


### PR DESCRIPTION
Ref: https://www.w3.org/TR/webrtc-stats/#dom-rtcstatstype-track

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Notice to developers the `track` RTCStatsType is deprecated and moved to `media-source`, `sender`, `outbound-rtp`, `receiver`, and `inbound-rtp`.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Because can confuse devs and they could use this `RTCStatsType` in production which is not recommended.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://www.w3.org/TR/webrtc-stats/#dom-rtcstatstype-track

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
