### PR TITLE
"log" missing from table of Math methods

### DIFF
--- a/files/en-us/web/javascript/guide/numbers_and_dates/index.md
+++ b/files/en-us/web/javascript/guide/numbers_and_dates/index.md
@@ -205,6 +205,7 @@ The following table summarizes the `Math` object's methods.
           {{jsxref("Math.pow", "pow()")}},
           {{jsxref("Math.exp", "exp()")}},
           {{jsxref("Math.expm1", "expm1()")}},
+          {{jsxref("Math.log", "log()")}},
           {{jsxref("Math.log10", "log10()")}},
           {{jsxref("Math.log1p", "log1p()")}},
           {{jsxref("Math.log2", "log2()")}}


### PR DESCRIPTION
#### Summary
Added Math.log to Math methods table.

#### Motivation
The log function was missing from the table.

#### Supporting details
(https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log)

#### Related issues

#### Metadata

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

