### PR TITLE
`DOMString` -> `string`

### DIFF
--- a/files/en-us/web/api/compositionevent/compositionevent/index.md
+++ b/files/en-us/web/api/compositionevent/compositionevent/index.md
@@ -23,7 +23,7 @@ new CompositionEvent(typeArg, CompositionEventInit)
 ### Values
 
 - `typeArg`
-  - : Is a {{domxref("DOMString")}} representing the name of the event.
+  - : Is a string representing the name of the event.
 - `CompositionEventInit` {{optional_inline}}
 
   - : A `CompositionEventInit` dictionary object, which can contain the

--- a/files/en-us/web/api/compositionevent/data/index.md
+++ b/files/en-us/web/api/compositionevent/data/index.md
@@ -18,7 +18,7 @@ that generated the `CompositionEvent` object.
 
 ## Value
 
-A {{domxref("DOMString")}} representing the event data:
+A string representing the event data:
 
 - For `compositionstart` events, this is the currently selected text that
   will be replaced by the string being composed. This value doesn't change even if

--- a/files/en-us/web/api/compositionevent/locale/index.md
+++ b/files/en-us/web/api/compositionevent/locale/index.md
@@ -22,7 +22,7 @@ The **`locale`** read-only property of the
 
 ## Value
 
-A {{domxref("DOMString")}} representing the locale of current input method.
+A string representing the locale of current input method.
 
 ## Specifications
 

--- a/files/en-us/web/api/contentindexevent/contentindexevent/index.md
+++ b/files/en-us/web/api/contentindexevent/contentindexevent/index.md
@@ -27,7 +27,7 @@ new ContentIndexEvent(type, ContentIndexEventInit);
 ### Parameters
 
 - _type_
-  - : A {{domxref("DOMString")}} indicating the event which occurred. For
+  - : A string indicating the event which occurred. For
     `ContentIndexEvent`, this is always `delete`.
 - _eventInitDict_ {{optional_inline}}
 

--- a/files/en-us/web/api/cookiechangeevent/changed/index.md
+++ b/files/en-us/web/api/cookiechangeevent/changed/index.md
@@ -18,13 +18,13 @@ The **`changed`** read-only property of the {{domxref("CookieChangeEvent")}} int
 An array of objects containing the changed cookie(s). Each object contains the following properties:
 
 - `name`
-  - : A {{domxref("USVString")}} containing the name of the cookie.
+  - : A string containing the name of the cookie.
 - `value`
-  - : A {{domxref("USVString")}} containing the value of the cookie.
+  - : A string containing the value of the cookie.
 - `domain`
-  - : A {{domxref("USVString")}} containing the domain of the cookie.
+  - : A string containing the domain of the cookie.
 - `path`
-  - : A {{domxref("USVString")}} containing the path of the cookie.
+  - : A string containing the path of the cookie.
 - `expires`
   - : A {{domxref("DOMTimeStamp")}} containing the expiration date of the cookie.
 - `secure`

--- a/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.md
+++ b/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.md
@@ -23,7 +23,7 @@ new CookieChangeEvent(type,eventInitDict);
 ### Parameters
 
 - `type`
-  - : A {{domxref("DOMString")}} with the value `"changed"` or `"deleted"`.
+  - : A string with the value `"changed"` or `"deleted"`.
 - `eventInitDict`{{Optional_Inline}}
 
   - : An object containing:

--- a/files/en-us/web/api/cookiechangeevent/deleted/index.md
+++ b/files/en-us/web/api/cookiechangeevent/deleted/index.md
@@ -18,13 +18,13 @@ The **`deleted`** read-only property of the {{domxref("CookieChangeEvent")}} int
 An array of objects containing the deleted cookie(s). Each object contains the following properties:
 
 - `name`
-  - : A {{domxref("USVString")}} containing the name of the cookie.
+  - : A string containing the name of the cookie.
 - `value`
-  - : A {{domxref("USVString")}} containing the value of the cookie.
+  - : A string containing the value of the cookie.
 - `domain`
-  - : A {{domxref("USVString")}} containing the domain of the cookie.
+  - : A string containing the domain of the cookie.
 - `path`
-  - : A {{domxref("USVString")}} containing the path of the cookie.
+  - : A string containing the path of the cookie.
 - `expires`
   - : A {{domxref("DOMTimeStamp")}} containing the expiration date of the cookie.
 - `secure`

--- a/files/en-us/web/api/credential/id/index.md
+++ b/files/en-us/web/api/credential/id/index.md
@@ -14,13 +14,13 @@ browser-compat: api.Credential.id
 {{SeeCompatTable}}{{APIRef("Credential Management API")}}
 
 The **`id`** property of the
-{{domxref("Credential")}} interface returns a {{domxref("DOMString")}} containing the
+{{domxref("Credential")}} interface returns a string containing the
 credential's identifier. This might be any one of a GUID, username, or email
 address.
 
 ## Value
 
-A {{domxref("DOMString")}} containing the credential's identifier.
+A string containing the credential's identifier.
 
 ## Specifications
 

--- a/files/en-us/web/api/credential/index.md
+++ b/files/en-us/web/api/credential/index.md
@@ -24,9 +24,9 @@ The **`Credential`** interface of the [Credential Management API](/en-US/docs/We
 ## Properties
 
 - {{domxref("Credential.id")}} {{readonlyInline}}
-  - : Returns a {{domxref("DOMString")}} containing the credential's identifier. This might be any one of a GUID, username, or email address.
+  - : Returns a string containing the credential's identifier. This might be any one of a GUID, username, or email address.
 - {{domxref("Credential.type")}} {{readonlyInline}}
-  - : Returns a {{domxref("DOMString")}} containing the credential's type. Valid values are `password`, `federated` and `public-key`. (For {{domxref("PasswordCredential")}}, {{domxref("FederatedCredential")}} and {{domxref("PublicKeyCredential")}})
+  - : Returns a string containing the credential's type. Valid values are `password`, `federated` and `public-key`. (For {{domxref("PasswordCredential")}}, {{domxref("FederatedCredential")}} and {{domxref("PublicKeyCredential")}})
 
 ### Event handlers
 

--- a/files/en-us/web/api/credential/type/index.md
+++ b/files/en-us/web/api/credential/type/index.md
@@ -13,13 +13,13 @@ browser-compat: api.Credential.type
 {{SeeCompatTable}}{{APIRef("Credential Management API")}}
 
 The **`type`** property of the
-{{domxref("Credential")}} interface returns a {{domxref("DOMString")}} containing the
+{{domxref("Credential")}} interface returns a string containing the
 credential's type. Valid values are `password`, `federated` and
 `public-key`.
 
 ## Value
 
-A {{domxref("DOMString")}} contains a credential's given name.
+A string contains a credential's given name.
 
 ## Examples
 

--- a/files/en-us/web/api/cssanimation/animationname/index.md
+++ b/files/en-us/web/api/cssanimation/animationname/index.md
@@ -18,7 +18,7 @@ element.
 
 ## Value
 
-A {{domxref("CSSOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/cssanimation/index.md
+++ b/files/en-us/web/api/cssanimation/index.md
@@ -20,7 +20,7 @@ The **`CSSAnimation`** interface of the {{domxref('Web Animations API','','',' '
 Inherits methods from its ancestor {{domxref("Animation")}} and adds {{domxref("animationName")}}.
 
 - {{domxref("CSSAnimation.animationName")}}{{readonlyinline}}
-  - : Returns the animation name as a {{domxref("CSSOMString")}}.
+  - : Returns the animation name as a string.
 
 ### Event handlers
 

--- a/files/en-us/web/api/csscounterstylerule/additivesymbols/index.md
+++ b/files/en-us/web/api/csscounterstylerule/additivesymbols/index.md
@@ -15,7 +15,7 @@ The **`additiveSymbols`** property of the {{domxref("CSSCounterStyleRule")}} int
 
 ## Value
 
-A {{domxref("CSSOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/csscounterstylerule/fallback/index.md
+++ b/files/en-us/web/api/csscounterstylerule/fallback/index.md
@@ -15,7 +15,7 @@ The **`fallback`** property of the {{domxref("CSSCounterStyleRule")}} interface 
 
 ## Value
 
-A {{domxref("CSSOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/csscounterstylerule/index.md
+++ b/files/en-us/web/api/csscounterstylerule/index.md
@@ -19,27 +19,27 @@ The **`CSSCounterStyleRule`** interface represents an {{CSSxRef("@counter-style"
 _This interface also inherits properties from its parent {{DOMxRef("CSSRule")}}._
 
 - {{DOMxRef("CSSCounterStyleRule.name")}}
-  - : Is a {{DOMxRef("CSSOMString")}} object that contains the serialization of the {{CSSxRef("&lt;custom-ident&gt;")}} defined as the `name` for the associated rule.
+  - : Is a string object that contains the serialization of the {{CSSxRef("&lt;custom-ident&gt;")}} defined as the `name` for the associated rule.
 - {{DOMxRef("CSSCounterStyleRule.system")}}
-  - : Is a {{DOMxRef("CSSOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/system", "system")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
+  - : Is a string object that contains the serialization of the {{CSSxRef("@counter-style/system", "system")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
 - {{DOMxRef("CSSCounterStyleRule.symbols")}}
-  - : Is a {{DOMxRef("CSSOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/symbols", "symbols")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
+  - : Is a string object that contains the serialization of the {{CSSxRef("@counter-style/symbols", "symbols")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
 - {{DOMxRef("CSSCounterStyleRule.additiveSymbols")}}
-  - : Is a {{DOMxRef("CSSOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/additive-symbols", "additive-symbols")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
+  - : Is a string object that contains the serialization of the {{CSSxRef("@counter-style/additive-symbols", "additive-symbols")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
 - {{DOMxRef("CSSCounterStyleRule.negative")}}
-  - : Is a {{DOMxRef("CSSOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/negative", "negative")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
+  - : Is a string object that contains the serialization of the {{CSSxRef("@counter-style/negative", "negative")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
 - {{DOMxRef("CSSCounterStyleRule.prefix")}}
-  - : Is a {{DOMxRef("CSSOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/prefix", "prefix")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
+  - : Is a string object that contains the serialization of the {{CSSxRef("@counter-style/prefix", "prefix")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
 - {{DOMxRef("CSSCounterStyleRule.suffix")}}
-  - : Is a {{DOMxRef("CSSOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/suffix", "suffix")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
+  - : Is a string object that contains the serialization of the {{CSSxRef("@counter-style/suffix", "suffix")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
 - {{DOMxRef("CSSCounterStyleRule.range")}}
-  - : Is a {{DOMxRef("CSSOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/range", "range")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
+  - : Is a string object that contains the serialization of the {{CSSxRef("@counter-style/range", "range")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
 - {{DOMxRef("CSSCounterStyleRule.pad")}}
-  - : Is a {{DOMxRef("CSSOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/pad", "pad")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
+  - : Is a string object that contains the serialization of the {{CSSxRef("@counter-style/pad", "pad")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
 - {{DOMxRef("CSSCounterStyleRule.speakAs")}}
-  - : Is a {{DOMxRef("CSSOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/speak-as", "speak-as")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
+  - : Is a string object that contains the serialization of the {{CSSxRef("@counter-style/speak-as", "speak-as")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
 - {{DOMxRef("CSSCounterStyleRule.fallback")}}
-  - : Is a {{DOMxRef("CSSOMString")}} object that contains the serialization of the {{CSSxRef("@counter-style/fallback", "fallback")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
+  - : Is a string object that contains the serialization of the {{CSSxRef("@counter-style/fallback", "fallback")}} descriptor defined for the associated rule. If the descriptor was not specified in the associated rule, the attribute returns an empty string.
 
 ## Methods
 

--- a/files/en-us/web/api/csscounterstylerule/name/index.md
+++ b/files/en-us/web/api/csscounterstylerule/name/index.md
@@ -15,7 +15,7 @@ The **`name`** property of the {{domxref("CSSCounterStyleRule")}} interface gets
 
 ## Value
 
-A {{domxref("CSSOMString")}}
+A string
 
 ## Examples
 

--- a/files/en-us/web/api/csscounterstylerule/negative/index.md
+++ b/files/en-us/web/api/csscounterstylerule/negative/index.md
@@ -15,7 +15,7 @@ The **`negative`** property of the {{domxref("CSSCounterStyleRule")}} interface 
 
 ## Value
 
-A {{domxref("CSSOMString")}}
+A string
 
 ## Examples
 

--- a/files/en-us/web/api/csscounterstylerule/pad/index.md
+++ b/files/en-us/web/api/csscounterstylerule/pad/index.md
@@ -15,7 +15,7 @@ The **`pad`** property of the {{domxref("CSSCounterStyleRule")}} interface gets 
 
 ## Value
 
-A {{domxref("CSSOMString")}}
+A string
 
 ## Examples
 

--- a/files/en-us/web/api/csscounterstylerule/prefix/index.md
+++ b/files/en-us/web/api/csscounterstylerule/prefix/index.md
@@ -15,7 +15,7 @@ The **`prefix`** property of the {{domxref("CSSCounterStyleRule")}} interface ge
 
 ## Value
 
-A {{domxref("CSSOMString")}}
+A string
 
 ## Examples
 

--- a/files/en-us/web/api/csscounterstylerule/range/index.md
+++ b/files/en-us/web/api/csscounterstylerule/range/index.md
@@ -15,7 +15,7 @@ The **`range`** property of the {{domxref("CSSCounterStyleRule")}} interface get
 
 ## Value
 
-A {{domxref("CSSOMString")}}
+A string
 
 ## Examples
 

--- a/files/en-us/web/api/csscounterstylerule/speakas/index.md
+++ b/files/en-us/web/api/csscounterstylerule/speakas/index.md
@@ -15,7 +15,7 @@ The **`speakAs`** property of the {{domxref("CSSCounterStyleRule")}} interface g
 
 ## Value
 
-A {{domxref("CSSOMString")}}
+A string
 
 ## Examples
 

--- a/files/en-us/web/api/csscounterstylerule/suffix/index.md
+++ b/files/en-us/web/api/csscounterstylerule/suffix/index.md
@@ -15,7 +15,7 @@ The **`suffix`** property of the {{domxref("CSSCounterStyleRule")}} interface ge
 
 ## Value
 
-A {{domxref("CSSOMString")}}
+A string
 
 ## Examples
 

--- a/files/en-us/web/api/csscounterstylerule/symbols/index.md
+++ b/files/en-us/web/api/csscounterstylerule/symbols/index.md
@@ -15,7 +15,7 @@ The **`symbols`** property of the {{domxref("CSSCounterStyleRule")}} interface g
 
 ## Value
 
-A {{domxref("CSSOMString")}}
+A string
 
 ## Examples
 

--- a/files/en-us/web/api/csscounterstylerule/system/index.md
+++ b/files/en-us/web/api/csscounterstylerule/system/index.md
@@ -15,7 +15,7 @@ The **`system`** property of the {{domxref("CSSCounterStyleRule")}} interface ge
 
 ## Value
 
-A {{domxref("CSSOMString")}}
+A string
 
 ## Examples
 

--- a/files/en-us/web/api/cssimportrule/href/index.md
+++ b/files/en-us/web/api/cssimportrule/href/index.md
@@ -21,7 +21,7 @@ associated stylesheet.
 
 ## Value
 
-A {{domxref("USVString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/csskeyframesrule/index.md
+++ b/files/en-us/web/api/csskeyframesrule/index.md
@@ -29,11 +29,11 @@ _Inherits properties from its ancestor {{domxref("CSSRule")}}._
 _Inherits methods from its ancestor {{domxref("CSSRule")}}._
 
 - {{domxref("CSSKeyframesRule.appendRule()")}}
-  - : Inserts a new keyframe rule into the current CSSKeyframesRule. The parameter is a {{domxref("DOMString")}} containing a keyframe in the same format as an entry of a {{cssxref("@keyframes")}} at-rule. If it contains more than one keyframe rule, a {{domxref("DOMException")}} with a `SYNTAX_ERR` is thrown.
+  - : Inserts a new keyframe rule into the current CSSKeyframesRule. The parameter is a string containing a keyframe in the same format as an entry of a {{cssxref("@keyframes")}} at-rule. If it contains more than one keyframe rule, a {{domxref("DOMException")}} with a `SYNTAX_ERR` is thrown.
 - {{domxref("CSSKeyframesRule.deleteRule()")}}
-  - : Deletes a keyframe rule from the current CSSKeyframesRule. The parameter is the index of the keyframe to be deleted, expressed as a {{domxref("DOMString")}} resolving as a number between `0%` and `100%`.
+  - : Deletes a keyframe rule from the current CSSKeyframesRule. The parameter is the index of the keyframe to be deleted, expressed as a string resolving as a number between `0%` and `100%`.
 - {{domxref("CSSKeyframesRule.findRule()")}}
-  - : Returns a keyframe rule corresponding to the given key. The key is a {{domxref("DOMString")}} containing an index of the keyframe to be returned, resolving to a percentage between `0%` and `100%`. If no such keyframe exists, `findRule` returns `null`.
+  - : Returns a keyframe rule corresponding to the given key. The key is a string containing an index of the keyframe to be returned, resolving to a percentage between `0%` and `100%`. If no such keyframe exists, `findRule` returns `null`.
 
 ## Example
 

--- a/files/en-us/web/api/cssnamespacerule/namespaceuri/index.md
+++ b/files/en-us/web/api/cssnamespacerule/namespaceuri/index.md
@@ -12,11 +12,11 @@ browser-compat: api.CSSNamespaceRule.namespaceURI
 ---
 {{ APIRef("CSSOM") }}
 
-The read-only **`namespaceURI`** property of the {{domxref("CSSNamespaceRule")}} returns a {{domxref("DOMString")}} containing the text of the URI of the given namespace.
+The read-only **`namespaceURI`** property of the {{domxref("CSSNamespaceRule")}} returns a string containing the text of the URI of the given namespace.
 
 ## Value
 
-A {{domxref("DOMString")}} containing a URI.
+A string containing a URI.
 
 ## Examples
 

--- a/files/en-us/web/api/cssnamespacerule/prefix/index.md
+++ b/files/en-us/web/api/cssnamespacerule/prefix/index.md
@@ -12,11 +12,11 @@ browser-compat: api.CSSNamespaceRule.prefix
 ---
 {{ APIRef("CSSOM") }}
 
-The read-only **`prefix`** property of the {{domxref("CSSNamespaceRule")}} returns a {{domxref("DOMString")}} with the name of the prefix associated to this namespace. If there is no such prefix, it returns an empty string.
+The read-only **`prefix`** property of the {{domxref("CSSNamespaceRule")}} returns a string with the name of the prefix associated to this namespace. If there is no such prefix, it returns an empty string.
 
 ## Value
 
-A {{domxref("DOMString")}} containing the prefix associated to this namespace. If there is no prefix an empty string.
+A string containing the prefix associated to this namespace. If there is no prefix an empty string.
 
 ## Examples
 

--- a/files/en-us/web/api/csspropertyrule/initialvalue/index.md
+++ b/files/en-us/web/api/csspropertyrule/initialvalue/index.md
@@ -19,7 +19,7 @@ The read-only **`initialValue`** nullable property of the {{domxref("CSSProperty
 
 ## Value
 
-A {{domxref("USVString")}} which is a {{CSSXref("&lt;declaration-value&gt;")}} as
+A string which is a {{CSSXref("&lt;declaration-value&gt;")}} as
 defined in [CSS
 Syntax 3](https://www.w3.org/TR/css-syntax-3/#typedef-declaration-value).
 

--- a/files/en-us/web/api/csspropertyrule/name/index.md
+++ b/files/en-us/web/api/csspropertyrule/name/index.md
@@ -19,7 +19,7 @@ The read-only **`name`** property of the {{domxref("CSSPropertyRule")}} interfac
 
 ## Value
 
-A {{domxref("USVString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/csspropertyrule/syntax/index.md
+++ b/files/en-us/web/api/csspropertyrule/syntax/index.md
@@ -19,7 +19,7 @@ The read-only **`syntax`** property of the {{domxref("CSSPropertyRule")}} interf
 
 ## Value
 
-A {{domxref("USVString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/csstransformcomponent/index.md
+++ b/files/en-us/web/api/csstransformcomponent/index.md
@@ -27,7 +27,7 @@ The **`CSSTransformComponent`** interface of the {{domxref('CSS_Object_Model#css
   - : Returns a new {{domxref('DOMMatrix')}} object.
 - {{domxref("CSSTransformComponent.toString()")}}
 
-  - : A {{domxref("DOMString")}} in the form of a CSS {{cssxref("transform-function","Transforms function")}}.
+  - : A string in the form of a CSS {{cssxref("transform-function","Transforms function")}}.
 
     This will use the value of `is2D` to return either a 2D or 3D transform. For example if the component represents {{domxref("CSSRotate")}} and `is2D` is false then the string returned will be in the form of the CSS transformation [`rotate3D()`](</en-US/docs/Web/CSS/transform-function/rotate3d()>) function. If true the string returned will be in the form of the 2-dimensional [`rotate3D()`](</en-US/docs/Web/CSS/transform-function/rotate()>) function.
 

--- a/files/en-us/web/api/csstransition/index.md
+++ b/files/en-us/web/api/csstransition/index.md
@@ -20,7 +20,7 @@ The **`CSSTransition`** interface of the {{domxref('Web Animations API','','',' 
 Inherits methods from its ancestor {{domxref("Animation")}} and adds {{domxref("transitionProperty")}}.
 
 - {{domxref("CSSTransition.transitionProperty")}}{{readonlyinline}}
-  - : Returns the transition CSS property name as a {{domxref("CSSOMString")}}.
+  - : Returns the transition CSS property name as a string.
 
 ### Event handlers
 

--- a/files/en-us/web/api/csstransition/transitionproperty/index.md
+++ b/files/en-us/web/api/csstransition/transitionproperty/index.md
@@ -18,7 +18,7 @@ transition was generated.
 
 ## Value
 
-A {{domxref("CSSOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/cssvalue/csstext/index.md
+++ b/files/en-us/web/api/cssvalue/csstext/index.md
@@ -25,7 +25,7 @@ interface represents the current computed CSS property value.
 
 ## Value
 
-A {{domxref("DOMString")}} representing the current CSS property value.
+A string representing the current CSS property value.
 
 ## Examples
 

--- a/files/en-us/web/api/cssvalue/index.md
+++ b/files/en-us/web/api/cssvalue/index.md
@@ -26,7 +26,7 @@ The **`CSSValue`** interface represents the current computed value of a CSS prop
 ## Properties
 
 - {{DOMxRef("CSSValue.cssText")}}
-  - : A {{DOMxRef("DOMString")}} representing the current value.
+  - : A string representing the current value.
 - {{DOMxRef("CSSValue.cssValueType")}}{{ReadOnlyInline}}
 
   - : An `unsigned short` representing a code defining the type of the value. Possible values are:

--- a/files/en-us/web/api/datatransfer/dropeffect/index.md
+++ b/files/en-us/web/api/datatransfer/dropeffect/index.md
@@ -38,7 +38,7 @@ data being dragged should be removed from the source.
 
 ## Value
 
-A {{domxref("DOMString")}} representing the drag operation effect. The possible values
+A string representing the drag operation effect. The possible values
 are:
 
 - `copy`

--- a/files/en-us/web/api/datatransfer/effectallowed/index.md
+++ b/files/en-us/web/api/datatransfer/effectallowed/index.md
@@ -30,7 +30,7 @@ Assigning a value to `effectAllowed` in events other than
 
 ## Value
 
-A {{domxref("DOMString")}} representing the drag operation that is allowed. The
+A string representing the drag operation that is allowed. The
 possible values are:
 
 - none

--- a/files/en-us/web/api/datatransfer/mozcursor/index.md
+++ b/files/en-us/web/api/datatransfer/mozcursor/index.md
@@ -34,7 +34,7 @@ The possible values are:
 
 ## Value
 
-A {{domxref("DOMString")}} representing one of the values listed above.
+A string representing one of the values listed above.
 
 ## Examples
 

--- a/files/en-us/web/api/datatransferitem/kind/index.md
+++ b/files/en-us/web/api/datatransferitem/kind/index.md
@@ -20,7 +20,7 @@ or some file.
 
 ## Value
 
-A {{domxref("DOMString")}} representing the drag data item's kind. It must be one of
+A string representing the drag data item's kind. It must be one of
 the following values:
 
 - `'file'`

--- a/files/en-us/web/api/datatransferitem/type/index.md
+++ b/files/en-us/web/api/datatransferitem/type/index.md
@@ -23,7 +23,7 @@ Some example types are: `text/plain` and `text/html`.
 
 ## Value
 
-A {{domxref("DOMString")}} representing the drag data item's type.
+A string representing the drag data item's type.
 
 ## Examples
 

--- a/files/en-us/web/api/dedicatedworkerglobalscope/message_event/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/message_event/index.md
@@ -37,9 +37,9 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.data")}} {{readonlyInline}}
   - : The data sent by the message emitter.
 - {{domxref("MessageEvent.origin")}} {{readonlyInline}}
-  - : A {{domxref("USVString")}} representing the origin of the message emitter.
+  - : A string representing the origin of the message emitter.
 - {{domxref("MessageEvent.lastEventId")}} {{readonlyInline}}
-  - : A {{domxref("DOMString")}} representing a unique ID for the event.
+  - : A string representing a unique ID for the event.
 - {{domxref("MessageEvent.source")}} {{readonlyInline}}
   - : A `MessageEventSource` (which can be a {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
 - {{domxref("MessageEvent.ports")}} {{readonlyInline}}

--- a/files/en-us/web/api/dedicatedworkerglobalscope/messageerror_event/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/messageerror_event/index.md
@@ -38,9 +38,9 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.data")}} {{readonlyInline}}
   - : The data sent by the message emitter.
 - {{domxref("MessageEvent.origin")}} {{readonlyInline}}
-  - : A {{domxref("USVString")}} representing the origin of the message emitter.
+  - : A string representing the origin of the message emitter.
 - {{domxref("MessageEvent.lastEventId")}} {{readonlyInline}}
-  - : A {{domxref("DOMString")}} representing a unique ID for the event.
+  - : A string representing a unique ID for the event.
 - {{domxref("MessageEvent.source")}} {{readonlyInline}}
   - : A `MessageEventSource` (which can be a {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
 - {{domxref("MessageEvent.ports")}} {{readonlyInline}}

--- a/files/en-us/web/api/dedicatedworkerglobalscope/name/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/name/index.md
@@ -21,7 +21,7 @@ the {{domxref("DedicatedWorkerGlobalScope")}}.
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/devicemotionevent/devicemotionevent/index.md
+++ b/files/en-us/web/api/devicemotionevent/devicemotionevent/index.md
@@ -29,7 +29,7 @@ new DeviceMotionEvent(type, options)
 ### Parameters
 
 - `type`
-  - : A {{domxref("DOMString")}} representing the name of the event.
+  - : A string representing the name of the event.
 - `options`{{Optional_Inline}}
 
   - : Options are as follows:

--- a/files/en-us/web/api/document/dir/index.md
+++ b/files/en-us/web/api/document/dir/index.md
@@ -11,7 +11,7 @@ browser-compat: api.Document.dir
 ---
 {{ApiRef("HTML DOM")}}
 
-The **`Document.dir`** property is a {{domxref("DOMString")}}
+The **`Document.dir`** property is a string
 representing the directionality of the text of the document, whether left to right
 (default) or right to left. Possible values are `'rtl'`, right to left, and
 `'ltr'`, left to right.

--- a/files/en-us/web/api/document/index.md
+++ b/files/en-us/web/api/document/index.md
@@ -181,7 +181,7 @@ _This interface also inherits from the {{DOMxRef("Node")}} and {{DOMxRef("EventT
 - {{DOMxRef("Document.adoptNode()")}}
   - : Adopt node from an external document.
 - {{DOMxRef("Document.append()")}}
-  - : Inserts a set of {{domxref("Node")}} objects or {{domxref("DOMString")}} objects after the last child of the document.
+  - : Inserts a set of {{domxref("Node")}} objects or string objects after the last child of the document.
 - {{DOMxRef("Document.captureEvents()")}} {{Deprecated_Inline}}
   - : See {{DOMxRef("Window.captureEvents")}}.
 - {{DOMxRef("Document.caretPositionFromPoint()")}}
@@ -251,7 +251,7 @@ _This interface also inherits from the {{DOMxRef("Node")}} and {{DOMxRef("EventT
 - {{DOMxRef("Document.normalizeDocument()")}} {{deprecated_inline}}
   - : Replaces entities, normalizes text nodes, etc.
 - {{DOMxRef("Document.prepend()")}}
-  - : Inserts a set of {{domxref("Node")}} objects or {{domxref("DOMString")}} objects before the first child of the document.
+  - : Inserts a set of {{domxref("Node")}} objects or string objects before the first child of the document.
 - {{DOMxRef("Document.querySelector()")}}
   - : Returns the first Element node within the document, in document order, that matches the specified selectors.
 - {{DOMxRef("Document.querySelectorAll()")}}

--- a/files/en-us/web/api/document/location/index.md
+++ b/files/en-us/web/api/document/location/index.md
@@ -17,7 +17,7 @@ The **`Document.location`** read-only property returns a
 and provides methods for changing that URL and loading another URL.
 
 Though `Document.location` is a _read-only_ `Location`
-object, you can also assign a {{domxref("DOMString")}} to it. This means that you can
+object, you can also assign a string to it. This means that you can
 work with document.location as if it were a string in most cases:
 `document.location = 'http://www.example.com'` is a synonym of
 `document.location.href = 'http://www.example.com'`.If you assign another

--- a/files/en-us/web/api/documentfragment/index.md
+++ b/files/en-us/web/api/documentfragment/index.md
@@ -42,9 +42,9 @@ _This interface has no specific properties, but inherits those of its parent, {{
 _This interface inherits the methods of its parent, {{domxref("Node")}}._
 
 - {{DOMxRef("DocumentFragment.append()")}}
-  - : Inserts a set of {{domxref("Node")}} objects or {{domxref("DOMString")}} objects after the last child of the document fragment.
+  - : Inserts a set of {{domxref("Node")}} objects or string objects after the last child of the document fragment.
 - {{DOMxRef("DocumentFragment.prepend()")}}
-  - : Inserts a set of {{domxref("Node")}} objects or {{domxref("DOMString")}} objects before the first child of the document fragment.
+  - : Inserts a set of {{domxref("Node")}} objects or string objects before the first child of the document fragment.
 - {{domxref("DocumentFragment.querySelector()")}}
   - : Returns the first {{domxref("Element")}} node within the `DocumentFragment`, in document order, that matches the specified selectors.
 - {{domxref("DocumentFragment.querySelectorAll()")}}

--- a/files/en-us/web/api/documenttype/index.md
+++ b/files/en-us/web/api/documenttype/index.md
@@ -19,25 +19,25 @@ The **`DocumentType`** interface represents a {{domxref("Node")}} containing a d
 _Inherits properties from its parent, {{domxref("Node")}}._
 
 - {{domxref("DocumentType.internalSubset")}} {{readonlyInline}} {{deprecated_inline}}
-  - : A {{domxref("DOMString")}} of the internal subset, or `null` if there is none. Eg `"<!ELEMENT foo (bar)>"`.
+  - : A string of the internal subset, or `null` if there is none. Eg `"<!ELEMENT foo (bar)>"`.
 - {{domxref("DocumentType.name")}} {{readonlyInline}}
-  - : A {{domxref("DOMString")}}, eg `"html"` for `<!DOCTYPE HTML>`.
+  - : A string, eg `"html"` for `<!DOCTYPE HTML>`.
 - {{domxref("DocumentType.notations")}} {{readonlyInline}} {{deprecated_inline}}
   - : A {{domxref("NamedNodeMap")}} with notations declared in the DTD.
 - {{domxref("DocumentType.publicId")}} {{readonlyInline}}
-  - : A {{domxref("DOMString")}}, eg `"-//W3C//DTD HTML 4.01//EN"`, empty string for HTML5.
+  - : A string, eg `"-//W3C//DTD HTML 4.01//EN"`, empty string for HTML5.
 - {{domxref("DocumentType.systemId")}} {{readonlyInline}}
-  - : A {{domxref("DOMString")}}, eg `"http://www.w3.org/TR/html4/strict.dtd"`, empty string for HTML5.
+  - : A string, eg `"http://www.w3.org/TR/html4/strict.dtd"`, empty string for HTML5.
 
 ## Methods
 
 _Inherits methods from its parent, {{domxref("Node")}}._
 
 - {{domxref("DocumentType.after()")}}
-  - : Inserts a set of {{domxref("Node")}} or {{domxref("DOMString")}} objects in the children list of the
+  - : Inserts a set of {{domxref("Node")}} or string objects in the children list of the
     `DocumentType`'s parent, just after the `DocumentType` object.
 - {{domxref("DocumentType.before()")}}
-  - : Inserts a set of {{domxref("Node")}} or {{domxref("DOMString")}} objects in the children list of the
+  - : Inserts a set of {{domxref("Node")}} or string objects in the children list of the
     `DocumentType`'s parent, just before the `DocumentType` object.
 - {{domxref("DocumentType.remove()")}}
   - : Removes the object from its parent children list.

--- a/files/en-us/web/api/domexception/domexception/index.md
+++ b/files/en-us/web/api/domexception/domexception/index.md
@@ -28,7 +28,7 @@ new DOMException(message, name);
   - : A description of the exception. If not present, the empty string `''` is
     used.
 - `name` {{optional_inline}}
-  - : A {{domxref("DOMString")}}. If the specified name is a [standard error name](/en-US/docs/Web/API/DOMException#error_names), then getting the [`code`](/en-US/docs/Web/API/DOMException/code) property of the `DOMException` object will return the code number corresponding to the specified name.
+  - : A string. If the specified name is a [standard error name](/en-US/docs/Web/API/DOMException#error_names), then getting the [`code`](/en-US/docs/Web/API/DOMException/code) property of the `DOMException` object will return the code number corresponding to the specified name.
 
 ### Return value
 

--- a/files/en-us/web/api/domexception/index.md
+++ b/files/en-us/web/api/domexception/index.md
@@ -30,7 +30,7 @@ Each exception has a **name**, which is a short "PascalCase"-style string identi
 - {{domxref("DOMException.message")}} {{readOnlyInline}}
   - : Returns a {{ domxref("DOMString") }} representing a message or description associated with the given [error name](#error_names).
 - {{domxref("DOMException.name")}} {{readOnlyInline}}
-  - : Returns a {{domxref("DOMString")}} that contains one of the strings associated with an [error name](#error_names).
+  - : Returns a string that contains one of the strings associated with an [error name](#error_names).
 
 ## Error names
 

--- a/files/en-us/web/api/domexception/message/index.md
+++ b/files/en-us/web/api/domexception/message/index.md
@@ -17,7 +17,7 @@ a message or description associated with the given [error name](/en-US/docs/Web/
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Specifications
 

--- a/files/en-us/web/api/domexception/name/index.md
+++ b/files/en-us/web/api/domexception/name/index.md
@@ -13,12 +13,12 @@ browser-compat: api.DOMException.name
 {{ APIRef("DOM") }}
 
 The **`name`** read-only property of the
-{{domxref("DOMException")}} interface returns a {{domxref("DOMString")}} that contains
+{{domxref("DOMException")}} interface returns a string that contains
 one of the strings associated with an [error name](/en-US/docs/Web/API/DOMException#error_names).
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Specifications
 

--- a/files/en-us/web/api/dommatrixreadonly/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/index.md
@@ -76,7 +76,7 @@ _This interface doesn't inherit any methods. None of the following methods alter
   - : Returns a JSON representation of the `DOMMatrixReadOnly` object.
 - {{domxref("DOMMatrixReadOnly.toString()")}}
 
-  - : Creates and returns a {{domxref("DOMString")}} object which contains a string representation of the matrix in CSS matrix syntax, using the appropriate CSS matrix notation. See the {{cssxref("matrix", "matrix()")}} CSS function for details on this syntax.
+  - : Creates and returns a string object which contains a string representation of the matrix in CSS matrix syntax, using the appropriate CSS matrix notation. See the {{cssxref("matrix", "matrix()")}} CSS function for details on this syntax.
 
     For a 2D matrix, the elements `a` through `f` are listed, for a total of six values and the form `matrix(a, b, c, d, e, f)`.
 

--- a/files/en-us/web/api/domstringlist/index.md
+++ b/files/en-us/web/api/domstringlist/index.md
@@ -20,7 +20,7 @@ A type returned by some APIs which contains a list of [DOMString](/en-US/docs/We
 ## Methods
 
 - {{domxref("DOMStringList.item()")}}
-  - : Returns a {{domxref("DOMString")}}.
+  - : Returns a string.
 - {{domxref("DOMStringList.contains()")}}
   - : Returns a boolean value indicating if the given string is in the list
 

--- a/files/en-us/web/api/dragevent/dragevent/index.md
+++ b/files/en-us/web/api/dragevent/dragevent/index.md
@@ -27,10 +27,10 @@ This interface inherits properties from {{domxref("MouseEvent")}} and
 new DragEvent(type, DragEventInit);
 ```
 
-### Arguments
+### Parameters
 
 - _type_
-  - : Is a `string` representing the name of the event (see
+  - : Is a string representing the name of the event (see
     [DragEvent event types](/en-US/docs/Web/API/DragEvent#event_types)).
 - _DragEventInit_{{optional_inline}}
 

--- a/files/en-us/web/api/dragevent/dragevent/index.md
+++ b/files/en-us/web/api/dragevent/dragevent/index.md
@@ -30,7 +30,7 @@ new DragEvent(type, DragEventInit);
 ### Arguments
 
 - _type_
-  - : Is a `{{domxref("DOMString")}}` representing the name of the event (see
+  - : Is a `string` representing the name of the event (see
     [DragEvent event types](/en-US/docs/Web/API/DragEvent#event_types)).
 - _DragEventInit_{{optional_inline}}
 

--- a/files/en-us/web/api/dragevent/dragevent/index.md
+++ b/files/en-us/web/api/dragevent/dragevent/index.md
@@ -24,15 +24,15 @@ This interface inherits properties from {{domxref("MouseEvent")}} and
 ## Syntax
 
 ```js
-new DragEvent(type, DragEventInit);
+new DragEvent(type, dragEventInit)
 ```
 
 ### Parameters
 
-- _type_
+- `type`
   - : Is a string representing the name of the event (see
     [DragEvent event types](/en-US/docs/Web/API/DragEvent#event_types)).
-- _DragEventInit_{{optional_inline}}
+- `dragEventInit` {{optional_inline}}
 
   - : Is a `DragEventInit` dictionary, having the following fields:
 

--- a/files/en-us/web/api/ecdhkeyderiveparams/index.md
+++ b/files/en-us/web/api/ecdhkeyderiveparams/index.md
@@ -19,7 +19,7 @@ The parameters for ECDH `deriveKey()` therefore include the other entity's publi
 ## Properties
 
 - `name`
-  - : A {{domxref("DOMString")}}. This should be set to `ECDH`.
+  - : A string. This should be set to `ECDH`.
 - `public`
   - : A {{domxref("CryptoKey")}} object representing the public key of the other entity.
 

--- a/files/en-us/web/api/ecdsaparams/index.md
+++ b/files/en-us/web/api/ecdsaparams/index.md
@@ -15,10 +15,10 @@ The **`EcdsaParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web
 ## Properties
 
 - `name`
-  - : A {{domxref("DOMString")}}. This should be set to `ECDSA`.
+  - : A string. This should be set to `ECDSA`.
 - `hash`
 
-  - : A {{domxref("DOMString")}}. An identifier for the [digest algorithm](/en-US/docs/Web/API/SubtleCrypto/digest) to use. This should be one of the following:
+  - : A string. An identifier for the [digest algorithm](/en-US/docs/Web/API/SubtleCrypto/digest) to use. This should be one of the following:
 
     - `SHA-256`: selects the [SHA-256](/en-US/docs/Web/API/SubtleCrypto/digest#sha-256) algorithm.
     - `SHA-384`: selects the [SHA-384](/en-US/docs/Web/API/SubtleCrypto/digest#sha-384) algorithm.

--- a/files/en-us/web/api/eckeygenparams/index.md
+++ b/files/en-us/web/api/eckeygenparams/index.md
@@ -15,10 +15,10 @@ The **`EcKeyGenParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/
 ## Properties
 
 - `name`
-  - : A {{domxref("DOMString")}}. This should be set to `ECDSA` or `ECDH`, depending on the algorithm you want to use.
+  - : A string. This should be set to `ECDSA` or `ECDH`, depending on the algorithm you want to use.
 - `namedCurve`
 
-  - : A {{domxref("DOMString")}} representing the name of the elliptic curve to use. This may be any of the following names for [NIST](https://www.nist.gov/)-approved curves:
+  - : A string representing the name of the elliptic curve to use. This may be any of the following names for [NIST](https://www.nist.gov/)-approved curves:
 
     - `P-256`
     - `P-384`

--- a/files/en-us/web/api/eckeyimportparams/index.md
+++ b/files/en-us/web/api/eckeyimportparams/index.md
@@ -13,10 +13,10 @@ tags:
 ## Properties
 
 - `name`
-  - : A {{domxref("DOMString")}}. This should be set to `ECDSA` or `ECDH`, depending on the algorithm you want to use.
+  - : A string. This should be set to `ECDSA` or `ECDH`, depending on the algorithm you want to use.
 - `namedCurve`
 
-  - : A {{domxref("DOMString")}} representing the name of the elliptic curve to use. This may be any of the following names for [NIST](https://www.nist.gov/)-approved curves:
+  - : A string representing the name of the elliptic curve to use. This may be any of the following names for [NIST](https://www.nist.gov/)-approved curves:
 
     - `P-256`
     - `P-384`

--- a/files/en-us/web/api/element/ariaatomic/index.md
+++ b/files/en-us/web/api/element/ariaatomic/index.md
@@ -17,7 +17,7 @@ The **`ariaAtomic`** property of the {{domxref("Element")}} interface reflects t
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"false"`
   - : Assistive technologies will present only the changed node or nodes.


### PR DESCRIPTION
Continuing #15499 

### Summary
`DOMString` is not exposed by browsers to JavaScript. It is converted to `string`.[[ref](https://developer.mozilla.org/en-US/docs/Web/API/DOMString)]

Same is the case with `USVString` and `CSSOMString`.

### Metadata
- [x] Fixes a typo, bug, or other error
