### PR TITLE
`DOMString` -> `string`

### DIFF
--- a/files/en-us/web/api/element/ariaautocomplete/index.md
+++ b/files/en-us/web/api/element/ariaautocomplete/index.md
@@ -17,7 +17,7 @@ The **`ariaAutoComplete`** property of the {{domxref("Element")}} interface refl
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"inline"`
   - : When a user is providing input, text suggesting one way to complete the provided input may be dynamically inserted after the caret.

--- a/files/en-us/web/api/element/ariabusy/index.md
+++ b/files/en-us/web/api/element/ariabusy/index.md
@@ -17,7 +17,7 @@ The **`ariaBusy`** property of the {{domxref("Element")}} interface reflects the
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"true"`
   - : The element is being updated.

--- a/files/en-us/web/api/element/ariachecked/index.md
+++ b/files/en-us/web/api/element/ariachecked/index.md
@@ -19,7 +19,7 @@ The **`ariaChecked`** property of the {{domxref("Element")}} interface reflects 
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"true"`
   - : The element is checked.

--- a/files/en-us/web/api/element/ariacolcount/index.md
+++ b/files/en-us/web/api/element/ariacolcount/index.md
@@ -17,7 +17,7 @@ The **`ariaColCount`** property of the {{domxref("Element")}} interface reflects
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/element/ariacolindex/index.md
+++ b/files/en-us/web/api/element/ariacolindex/index.md
@@ -17,7 +17,7 @@ The **`ariaColIndex`** property of the {{domxref("Element")}} interface reflects
 
 ## Value
 
-A {{domxref("DOMString")}} which contains an integer.
+A string which contains an integer.
 
 ## Examples
 

--- a/files/en-us/web/api/element/ariacolindextext/index.md
+++ b/files/en-us/web/api/element/ariacolindextext/index.md
@@ -17,7 +17,7 @@ The **`ariaColIndexText`** property of the {{domxref("Element")}} interface refl
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/element/ariacolspan/index.md
+++ b/files/en-us/web/api/element/ariacolspan/index.md
@@ -17,7 +17,7 @@ The **`ariaColSpan`** property of the {{domxref("Element")}} interface reflects 
 
 ## Value
 
-A {{domxref("DOMString")}} which contains an integer.
+A string which contains an integer.
 
 ## Examples
 

--- a/files/en-us/web/api/element/ariacurrent/index.md
+++ b/files/en-us/web/api/element/ariacurrent/index.md
@@ -17,7 +17,7 @@ The **`ariaCurrent`** property of the {{domxref("Element")}} interface reflects 
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"page"`
   - : Represents the current page within a set of pages.

--- a/files/en-us/web/api/element/ariadescription/index.md
+++ b/files/en-us/web/api/element/ariadescription/index.md
@@ -17,7 +17,7 @@ The **`ariaDescription`** property of the {{domxref("Element")}} interface refle
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/element/ariadisabled/index.md
+++ b/files/en-us/web/api/element/ariadisabled/index.md
@@ -19,7 +19,7 @@ The **`ariaDisabled`** property of the {{domxref("Element")}} interface reflects
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"true"`
   - : The element and all focusable descendants are disabled, but perceivable, and their values cannot be changed by the user.

--- a/files/en-us/web/api/element/ariaexpanded/index.md
+++ b/files/en-us/web/api/element/ariaexpanded/index.md
@@ -17,7 +17,7 @@ The **`ariaExpanded`** property of the {{domxref("Element")}} interface reflects
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"true"`
   - : The grouping element this element owns or controls is expanded.

--- a/files/en-us/web/api/element/ariahaspopup/index.md
+++ b/files/en-us/web/api/element/ariahaspopup/index.md
@@ -17,7 +17,7 @@ The **`ariaHasPopup`** property of the {{domxref("Element")}} interface reflects
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"false"`
   - : The element does not have a popup.

--- a/files/en-us/web/api/element/ariahidden/index.md
+++ b/files/en-us/web/api/element/ariahidden/index.md
@@ -17,7 +17,7 @@ The **`ariaHidden`** property of the {{domxref("Element")}} interface reflects t
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"true"`
   - : The element is hidden from the accessibility API.

--- a/files/en-us/web/api/element/ariakeyshortcuts/index.md
+++ b/files/en-us/web/api/element/ariakeyshortcuts/index.md
@@ -17,7 +17,7 @@ The **`ariaKeyShortcuts`** property of the {{domxref("Element")}} interface refl
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/element/arialabel/index.md
+++ b/files/en-us/web/api/element/arialabel/index.md
@@ -17,7 +17,7 @@ The **`ariaLabel`** property of the {{domxref("Element")}} interface reflects th
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/element/arialevel/index.md
+++ b/files/en-us/web/api/element/arialevel/index.md
@@ -19,7 +19,7 @@ The **`ariaLevel`** property of the {{domxref("Element")}} interface reflects th
 
 ## Value
 
-A {{domxref("DOMString")}} containing an integer.
+A string containing an integer.
 
 ## Examples
 

--- a/files/en-us/web/api/element/arialive/index.md
+++ b/files/en-us/web/api/element/arialive/index.md
@@ -16,7 +16,7 @@ The **`ariaLive`** property of the {{domxref("Element")}} interface reflects the
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"assertive"`
   - : Indicates that updates to the region have the highest priority and should be presented the user immediately.

--- a/files/en-us/web/api/element/ariamodal/index.md
+++ b/files/en-us/web/api/element/ariamodal/index.md
@@ -17,7 +17,7 @@ The **`ariaModal`** property of the {{domxref("Element")}} interface reflects th
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"true"`
   - : The element is modal.

--- a/files/en-us/web/api/element/ariamultiline/index.md
+++ b/files/en-us/web/api/element/ariamultiline/index.md
@@ -19,7 +19,7 @@ The **`ariaMultiline`** property of the {{domxref("Element")}} interface reflect
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"true"`
   - : This is a multi-line text box.

--- a/files/en-us/web/api/element/ariamultiselectable/index.md
+++ b/files/en-us/web/api/element/ariamultiselectable/index.md
@@ -19,7 +19,7 @@ The **`ariaMultiSelectable`** property of the {{domxref("Element")}} interface r
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"true"`
   - : More than one item may be selected at a time.

--- a/files/en-us/web/api/element/ariaorientation/index.md
+++ b/files/en-us/web/api/element/ariaorientation/index.md
@@ -17,7 +17,7 @@ The **`ariaOrientation`** property of the {{domxref("Element")}} interface refle
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"horizontal"`
   - : The element is horizontal.

--- a/files/en-us/web/api/element/ariaplaceholder/index.md
+++ b/files/en-us/web/api/element/ariaplaceholder/index.md
@@ -19,7 +19,7 @@ The **`ariaPlaceholder`** property of the {{domxref("Element")}} interface refle
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/element/ariaposinset/index.md
+++ b/files/en-us/web/api/element/ariaposinset/index.md
@@ -17,7 +17,7 @@ The **`ariaPosInSet`** property of the {{domxref("Element")}} interface reflects
 
 ## Value
 
-A {{domxref("DOMString")}} containing an integer.
+A string containing an integer.
 
 ## Examples
 

--- a/files/en-us/web/api/element/ariapressed/index.md
+++ b/files/en-us/web/api/element/ariapressed/index.md
@@ -19,7 +19,7 @@ The **`ariaPressed`** property of the {{domxref("Element")}} interface reflects 
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"true"`
   - : The element is pressed.

--- a/files/en-us/web/api/element/ariareadonly/index.md
+++ b/files/en-us/web/api/element/ariareadonly/index.md
@@ -19,7 +19,7 @@ The **`ariaReadOnly`** property of the {{domxref("Element")}} interface reflects
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"true"`
   - : The user cannot change the value of the element.

--- a/files/en-us/web/api/element/ariarelevant/index.md
+++ b/files/en-us/web/api/element/ariarelevant/index.md
@@ -17,7 +17,7 @@ The **`ariaRelevant`** property of the {{domxref("Element")}} interface reflects
 
 ## Value
 
-A {{domxref("DOMString")}} containing one or more of the following values, space separated:
+A string containing one or more of the following values, space separated:
 
 - `"additions"`
   - : Additions of Element Nodes within the live region should be considered relevant.

--- a/files/en-us/web/api/element/ariarequired/index.md
+++ b/files/en-us/web/api/element/ariarequired/index.md
@@ -19,7 +19,7 @@ The **`ariaRequired`** property of the {{domxref("Element")}} interface reflects
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"true"`
   - : Users need to provide input on an element before a form is submitted.

--- a/files/en-us/web/api/element/ariaroledescription/index.md
+++ b/files/en-us/web/api/element/ariaroledescription/index.md
@@ -17,7 +17,7 @@ The **`ariaRoleDescription`** property of the {{domxref("Element")}} interface r
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/element/ariarowcount/index.md
+++ b/files/en-us/web/api/element/ariarowcount/index.md
@@ -17,7 +17,7 @@ The **`ariaRowCount`** property of the {{domxref("Element")}} interface reflects
 
 ## Value
 
-A {{domxref("DOMString")}} which contains an integer.
+A string which contains an integer.
 
 ## Examples
 

--- a/files/en-us/web/api/element/ariarowindex/index.md
+++ b/files/en-us/web/api/element/ariarowindex/index.md
@@ -17,7 +17,7 @@ The **`ariaRowIndex`** property of the {{domxref("Element")}} interface reflects
 
 ## Value
 
-A {{domxref("DOMString")}} which contains an integer.
+A string which contains an integer.
 
 ## Examples
 

--- a/files/en-us/web/api/element/ariarowindextext/index.md
+++ b/files/en-us/web/api/element/ariarowindextext/index.md
@@ -17,7 +17,7 @@ The **`ariaRowIndexText`** property of the {{domxref("Element")}} interface refl
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/element/ariarowspan/index.md
+++ b/files/en-us/web/api/element/ariarowspan/index.md
@@ -17,7 +17,7 @@ The **`ariaRowSpan`** property of the {{domxref("Element")}} interface reflects 
 
 ## Value
 
-A {{domxref("DOMString")}} which contains an integer.
+A string which contains an integer.
 
 ## Examples
 

--- a/files/en-us/web/api/element/ariaselected/index.md
+++ b/files/en-us/web/api/element/ariaselected/index.md
@@ -17,7 +17,7 @@ The **`ariaSelected`** property of the {{domxref("Element")}} interface reflects
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"true"`
   - : The item is selected.

--- a/files/en-us/web/api/element/ariasetsize/index.md
+++ b/files/en-us/web/api/element/ariasetsize/index.md
@@ -17,7 +17,7 @@ The **`ariaSetSize`** property of the {{domxref("Element")}} interface reflects 
 
 ## Value
 
-A {{domxref("DOMString")}} containing an integer.
+A string containing an integer.
 
 ## Examples
 

--- a/files/en-us/web/api/element/ariasort/index.md
+++ b/files/en-us/web/api/element/ariasort/index.md
@@ -17,7 +17,7 @@ The **`ariaSort`** property of the {{domxref("Element")}} interface reflects the
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"ascending"`
   - : Items are sorted in ascending order by this column.

--- a/files/en-us/web/api/element/ariavaluemax/index.md
+++ b/files/en-us/web/api/element/ariavaluemax/index.md
@@ -17,7 +17,7 @@ The **`ariaValueMax`** property of the {{domxref("Element")}} interface reflects
 
 ## Value
 
-A {{domxref("DOMString")}} which contains a number.
+A string which contains a number.
 
 ## Examples
 

--- a/files/en-us/web/api/element/ariavaluemin/index.md
+++ b/files/en-us/web/api/element/ariavaluemin/index.md
@@ -17,7 +17,7 @@ The **`ariaValueMin`** property of the {{domxref("Element")}} interface reflects
 
 ## Value
 
-A {{domxref("DOMString")}} which contains a number.
+A string which contains a number.
 
 ## Examples
 

--- a/files/en-us/web/api/element/ariavaluenow/index.md
+++ b/files/en-us/web/api/element/ariavaluenow/index.md
@@ -17,7 +17,7 @@ The **`ariaValueNow`** property of the {{domxref("Element")}} interface reflects
 
 ## Value
 
-A {{domxref("DOMString")}} which contains a number.
+A string which contains a number.
 
 ## Examples
 

--- a/files/en-us/web/api/element/ariavaluetext/index.md
+++ b/files/en-us/web/api/element/ariavaluetext/index.md
@@ -17,7 +17,7 @@ The **`ariaValueText`** property of the {{domxref("Element")}} interface reflect
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/element/index.md
+++ b/files/en-us/web/api/element/index.md
@@ -36,7 +36,7 @@ _`Element` inherits properties from its parent interface, {{DOMxRef("Node")}}, a
 - {{DOMxRef("Element.classList")}} {{readOnlyInline}}
   - : Returns a {{DOMxRef("DOMTokenList")}} containing the list of class attributes.
 - {{DOMxRef("Element.className")}}
-  - : Is a {{DOMxRef("DOMString")}} representing the class of the element.
+  - : Is a string representing the class of the element.
 - {{DOMxRef("Element.clientHeight")}} {{readOnlyInline}}
   - : Returns a number representing the inner height of the element.
 - {{DOMxRef("Element.clientLeft")}} {{readOnlyInline}}
@@ -48,13 +48,13 @@ _`Element` inherits properties from its parent interface, {{DOMxRef("Node")}}, a
 - {{domxref("Element.firstElementChild")}} {{readonlyInline}}
   - : Returns the first child element of this element.
 - {{DOMxRef("Element.id")}}
-  - : Is a {{DOMxRef("DOMString")}} representing the id of the element.
+  - : Is a string representing the id of the element.
 - {{DOMxRef("Element.innerHTML")}}
-  - : Is a {{DOMxRef("DOMString")}} representing the markup of the element's content.
+  - : Is a string representing the markup of the element's content.
 - {{domxref("Element.lastElementChild")}} {{readonlyInline}}
   - : Returns the last child element of this element.
 - {{DOMxRef("Element.localName")}} {{readOnlyInline}}
-  - : A {{DOMxRef("DOMString")}} representing the local part of the qualified name of the element.
+  - : A string representing the local part of the qualified name of the element.
 - {{DOMxRef("Element.namespaceURI")}} {{readonlyInline}}
 
   - : The namespace URI of the element, or `null` if it is no namespace.
@@ -64,13 +64,13 @@ _`Element` inherits properties from its parent interface, {{DOMxRef("Node")}}, a
 - {{DOMxRef("Element.nextElementSibling")}} {{readOnlyInline}}
   - : Is an {{DOMxRef("Element")}}, the element immediately following the given one in the tree, or `null` if there's no sibling node.
 - {{DOMxRef("Element.outerHTML")}}
-  - : Is a {{DOMxRef("DOMString")}} representing the markup of the element including its content. When used as a setter, replaces the element with nodes parsed from the given string.
+  - : Is a string representing the markup of the element including its content. When used as a setter, replaces the element with nodes parsed from the given string.
 - {{DOMxRef("Element.openOrClosedShadowRoot")}} {{Non-standard_Inline}}{{readOnlyInline}}
   - : Returns the shadow root that is hosted by the element, regardless if its open or closed. **Only available to [WebExtensions](/en-US/docs/Mozilla/Add-ons/WebExtensions).**
 - {{DOMxRef("Element.part")}}
   - : Represents the part identifier(s) of the element (i.e. set using the `part` attribute), returned as a {{domxref("DOMTokenList")}}.
 - {{DOMxRef("Element.prefix")}} {{readOnlyInline}}
-  - : A {{DOMxRef("DOMString")}} representing the namespace prefix of the element, or `null` if no prefix is specified.
+  - : A string representing the namespace prefix of the element, or `null` if no prefix is specified.
 - {{DOMxRef("Element.previousElementSibling")}} {{readOnlyInline}}
   - : An {{DOMxRef("Element")}}, the element immediately preceding the given one in the tree, or `null` if there is no sibling element.
 - {{DOMxRef("Element.scrollHeight")}} {{readOnlyInline}}
@@ -97,85 +97,85 @@ _`Element` inherits properties from its parent interface, {{DOMxRef("Node")}}, a
 _The `Element` interface includes the following properties, defined on the `ARIAMixin` mixin._
 
 - {{domxref("Element.ariaAtomic")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-atomic`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic) attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant) attribute.
+  - : Is a string reflecting the [`aria-atomic`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic) attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant) attribute.
 - {{domxref("Element.ariaAutoComplete")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-autocomplete`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-autocomplete) attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.
+  - : Is a string reflecting the [`aria-autocomplete`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-autocomplete) attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.
 - {{domxref("Element.ariaBusy")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-busy`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-busy) attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.
+  - : Is a string reflecting the [`aria-busy`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-busy) attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.
 - {{domxref("Element.ariaChecked")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.
+  - : Is a string reflecting the [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.
 - {{domxref("Element.ariaColCount")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colcount) attribute, which defines the number of columns in a table, grid, or treegrid.
+  - : Is a string reflecting the [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colcount) attribute, which defines the number of columns in a table, grid, or treegrid.
 - {{domxref("Element.ariaColIndex")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindex) attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
+  - : Is a string reflecting the [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindex) attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
 - {{domxref("Element.ariaColIndexText")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-colindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindextext) attribute, which defines a human readable text alternative of aria-colindex.
+  - : Is a string reflecting the [`aria-colindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindextext) attribute, which defines a human readable text alternative of aria-colindex.
 - {{domxref("Element.ariaColSpan")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-colspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colspan) attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
+  - : Is a string reflecting the [`aria-colspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colspan) attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
 - {{domxref("Element.ariaCurrent")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-current`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current) attribute, which indicates the element that represents the current item within a container or set of related elements.
+  - : Is a string reflecting the [`aria-current`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current) attribute, which indicates the element that represents the current item within a container or set of related elements.
 - {{domxref("Element.ariaDescription")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-description`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-description) attribute, which defines a string value that describes or annotates the current element.
+  - : Is a string reflecting the [`aria-description`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-description) attribute, which defines a string value that describes or annotates the current element.
 - {{domxref("Element.ariaDisabled")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-disabled`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled) attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
+  - : Is a string reflecting the [`aria-disabled`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled) attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
 - {{domxref("Element.ariaExpanded")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-expanded`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded) attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.
+  - : Is a string reflecting the [`aria-expanded`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded) attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.
 - {{domxref("Element.ariaHasPopup")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-haspopup`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup) attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.
+  - : Is a string reflecting the [`aria-haspopup`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup) attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.
 - {{domxref("Element.ariaHidden")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-hidden`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden) attribute, which indicates whether the element is exposed to an accessibility API.
+  - : Is a string reflecting the [`aria-hidden`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden) attribute, which indicates whether the element is exposed to an accessibility API.
 - {{domxref("Element.ariaKeyShortcuts")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-keyshortcuts`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-keyshortcuts) attribute, which indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.
+  - : Is a string reflecting the [`aria-keyshortcuts`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-keyshortcuts) attribute, which indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.
 - {{domxref("Element.ariaLabel")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) attribute, which defines a string value that labels the current element.
+  - : Is a string reflecting the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) attribute, which defines a string value that labels the current element.
 - {{domxref("Element.ariaLevel")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-level`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-level) attribute, which defines the hierarchical level of an element within a structure.
+  - : Is a string reflecting the [`aria-level`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-level) attribute, which defines the hierarchical level of an element within a structure.
 - {{domxref("Element.ariaLive")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-live`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live) attribute, which indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
+  - : Is a string reflecting the [`aria-live`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live) attribute, which indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 - {{domxref("Element.ariaModal")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-modal`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal) attribute, which indicates whether an element is modal when displayed.
+  - : Is a string reflecting the [`aria-modal`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal) attribute, which indicates whether an element is modal when displayed.
 - {{domxref("Element.ariaMultiline")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-multiline`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiline) attribute, which indicates whether a text box accepts multiple lines of input or only a single line.
+  - : Is a string reflecting the [`aria-multiline`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiline) attribute, which indicates whether a text box accepts multiple lines of input or only a single line.
 - {{domxref("Element.ariaMultiSelectable")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-multiselectable`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiselectable) attribute, which indicates that the user may select more than one item from the current selectable descendants.
+  - : Is a string reflecting the [`aria-multiselectable`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiselectable) attribute, which indicates that the user may select more than one item from the current selectable descendants.
 - {{domxref("Element.ariaOrientation")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-orientation`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-orientation) attribute, which indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.
+  - : Is a string reflecting the [`aria-orientation`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-orientation) attribute, which indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.
 - {{domxref("Element.ariaPlaceholder")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-placeholder`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-placeholder) attribute, which defines a short hint intended to aid the user with data entry when the control has no value.
+  - : Is a string reflecting the [`aria-placeholder`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-placeholder) attribute, which defines a short hint intended to aid the user with data entry when the control has no value.
 - {{domxref("Element.ariaPosInSet")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-posinset`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-posinset) attribute, which defines an element's number or position in the current set of listitems or treeitems.
+  - : Is a string reflecting the [`aria-posinset`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-posinset) attribute, which defines an element's number or position in the current set of listitems or treeitems.
 - {{domxref("Element.ariaPressed")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed) attribute, which indicates the current "pressed" state of toggle buttons.
+  - : Is a string reflecting the [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed) attribute, which indicates the current "pressed" state of toggle buttons.
 - {{domxref("Element.ariaReadOnly")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-readonly`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-readonly) attribute, which indicates that the element is not editable, but is otherwise operable.
+  - : Is a string reflecting the [`aria-readonly`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-readonly) attribute, which indicates that the element is not editable, but is otherwise operable.
 - {{domxref("Element.ariaRelevant")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant) attribute, which indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. This is used to describe what changes in an `aria-live` region are relevant and should be announced.
+  - : Is a string reflecting the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant) attribute, which indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. This is used to describe what changes in an `aria-live` region are relevant and should be announced.
 - {{domxref("Element.ariaRequired")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-required`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) attribute, which indicates that user input is required on the element before a form may be submitted.
+  - : Is a string reflecting the [`aria-required`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) attribute, which indicates that user input is required on the element before a form may be submitted.
 - {{domxref("Element.ariaRoleDescription")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-roledescription`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-roledescription) attribute, which defines a human-readable, author-localized description for the role of an element.
+  - : Is a string reflecting the [`aria-roledescription`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-roledescription) attribute, which defines a human-readable, author-localized description for the role of an element.
 - {{domxref("Element.ariaRowCount")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-rowcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowcount) attribute, which defines the total number of rows in a table, grid, or treegrid.
+  - : Is a string reflecting the [`aria-rowcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowcount) attribute, which defines the total number of rows in a table, grid, or treegrid.
 - {{domxref("Element.ariaRowIndex")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindex) attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
+  - : Is a string reflecting the [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindex) attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
 - {{domxref("Element.ariaRowIndexText")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindextext) attribute, which defines a human readable text alternative of aria-rowindex.
+  - : Is a string reflecting the [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindextext) attribute, which defines a human readable text alternative of aria-rowindex.
 - {{domxref("Element.ariaRowSpan")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-rowspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowspan) attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
+  - : Is a string reflecting the [`aria-rowspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowspan) attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
 - {{domxref("Element.ariaSelected")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected) attribute, which indicates the current "selected" state of elements that have a selected state.
+  - : Is a string reflecting the [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected) attribute, which indicates the current "selected" state of elements that have a selected state.
 - {{domxref("Element.ariaSetSize")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-setsize`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-setsize) attribute, which defines the number of items in the current set of listitems or treeitems.
+  - : Is a string reflecting the [`aria-setsize`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-setsize) attribute, which defines the number of items in the current set of listitems or treeitems.
 - {{domxref("Element.ariaSort")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-sort`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-sort) attribute, which indicates if items in a table or grid are sorted in ascending or descending order.
+  - : Is a string reflecting the [`aria-sort`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-sort) attribute, which indicates if items in a table or grid are sorted in ascending or descending order.
 - {{domxref("Element.ariaValueMax")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-valueMax`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemax) attribute, which defines the maximum allowed value for a range widget.
+  - : Is a string reflecting the [`aria-valueMax`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemax) attribute, which defines the maximum allowed value for a range widget.
 - {{domxref("Element.ariaValueMin")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-valueMin`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemin) attribute, which defines the minimum allowed value for a range widget.
+  - : Is a string reflecting the [`aria-valueMin`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemin) attribute, which defines the minimum allowed value for a range widget.
 - {{domxref("Element.ariaValueNow")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-valueNow`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuenow) attribute, which defines the current value for a range widget.
+  - : Is a string reflecting the [`aria-valueNow`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuenow) attribute, which defines the current value for a range widget.
 - {{domxref("Element.ariaValueText")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-valuetext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuetext) attribute, which defines the human readable text alternative of aria-valuenow for a range widget.
+  - : Is a string reflecting the [`aria-valuetext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuetext) attribute, which defines the human readable text alternative of aria-valuenow for a range widget.
 
 ## Methods
 
@@ -184,15 +184,15 @@ _`Element` inherits methods from its parents {{DOMxRef("Node")}}, and its own pa
 - {{DOMxRef("EventTarget.addEventListener()")}}
   - : Registers an event handler to a specific event type on the element.
 - {{DOMxRef("Element.after()")}}
-  - : Inserts a set of {{domxref("Node")}} or {{domxref("DOMString")}} objects in the children list of the `Element`'s parent, just after the `Element`.
+  - : Inserts a set of {{domxref("Node")}} or string objects in the children list of the `Element`'s parent, just after the `Element`.
 - {{DOMxRef("Element.attachShadow()")}}
   - : Attaches a shadow DOM tree to the specified element and returns a reference to its {{DOMxRef("ShadowRoot")}}.
 - {{DOMxRef("Element.animate()")}} {{Experimental_Inline}}
   - : A shortcut method to create and run an animation on an element. Returns the created Animation object instance.
 - {{DOMxRef("Element.append()")}}
-  - : Inserts a set of {{domxref("Node")}} objects or {{domxref("DOMString")}} objects after the last child of the element.
+  - : Inserts a set of {{domxref("Node")}} objects or string objects after the last child of the element.
 - {{DOMxRef("Element.before()")}}
-  - : Inserts a set of {{domxref("Node")}} or {{domxref("DOMString")}} objects in the children list of the `Element`'s parent, just before the `Element`.
+  - : Inserts a set of {{domxref("Node")}} or string objects in the children list of the `Element`'s parent, just before the `Element`.
 - {{DOMxRef("Element.closest()")}}
   - : Returns the {{DOMxRef("Element")}} which is the closest ancestor of the current element (or the current element itself) which matches the selectors given in parameter.
 - {{DOMxRef("Element.createShadowRoot()")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
@@ -242,7 +242,7 @@ _`Element` inherits methods from its parents {{DOMxRef("Node")}}, and its own pa
 - {{DOMxRef("Element.matches()")}}
   - : Returns a boolean value indicating whether or not the element would be selected by the specified selector string.
 - {{DOMxRef("Element.prepend()")}}
-  - : Inserts a set of {{domxref("Node")}} objects or {{domxref("DOMString")}} objects before the first child of the element.
+  - : Inserts a set of {{domxref("Node")}} objects or string objects before the first child of the element.
 - {{DOMxRef("Element.querySelector()")}}
   - : Returns the first {{DOMxRef("Node")}} which matches the specified selector string relative to the element.
 - {{DOMxRef("Element.querySelectorAll()")}}
@@ -262,7 +262,7 @@ _`Element` inherits methods from its parents {{DOMxRef("Node")}}, and its own pa
 - {{DOMxRef("Element.replaceChildren()")}}
   - : Replaces the existing children of a {{domxref("Node")}} with a specified new set of children.
 - {{DOMxRef("Element.replaceWith()")}}
-  - : Replaces the element in the children list of its parent with a set of {{domxref("Node")}} or {{domxref("DOMString")}} objects.
+  - : Replaces the element in the children list of its parent with a set of {{domxref("Node")}} or string objects.
 - {{DOMxRef("Element.requestFullscreen()")}} {{Experimental_Inline}}
   - : Asynchronously asks the browser to make the element fullscreen.
 - {{DOMxRef("Element.requestPointerLock()")}} {{Experimental_Inline}}

--- a/files/en-us/web/api/element/index.md
+++ b/files/en-us/web/api/element/index.md
@@ -184,15 +184,15 @@ _`Element` inherits methods from its parents {{DOMxRef("Node")}}, and its own pa
 - {{DOMxRef("EventTarget.addEventListener()")}}
   - : Registers an event handler to a specific event type on the element.
 - {{DOMxRef("Element.after()")}}
-  - : Inserts a set of {{domxref("Node")}} or string objects in the children list of the `Element`'s parent, just after the `Element`.
+  - : Inserts a set of {{domxref("Node")}} objects or strings in the children list of the `Element`'s parent, just after the `Element`.
 - {{DOMxRef("Element.attachShadow()")}}
   - : Attaches a shadow DOM tree to the specified element and returns a reference to its {{DOMxRef("ShadowRoot")}}.
 - {{DOMxRef("Element.animate()")}} {{Experimental_Inline}}
   - : A shortcut method to create and run an animation on an element. Returns the created Animation object instance.
 - {{DOMxRef("Element.append()")}}
-  - : Inserts a set of {{domxref("Node")}} objects or string objects after the last child of the element.
+  - : Inserts a set of {{domxref("Node")}} objects or strings after the last child of the element.
 - {{DOMxRef("Element.before()")}}
-  - : Inserts a set of {{domxref("Node")}} or string objects in the children list of the `Element`'s parent, just before the `Element`.
+  - : Inserts a set of {{domxref("Node")}} objects or strings in the children list of the `Element`'s parent, just before the `Element`.
 - {{DOMxRef("Element.closest()")}}
   - : Returns the {{DOMxRef("Element")}} which is the closest ancestor of the current element (or the current element itself) which matches the selectors given in parameter.
 - {{DOMxRef("Element.createShadowRoot()")}} {{Non-standard_Inline}} {{Deprecated_Inline}}
@@ -242,7 +242,7 @@ _`Element` inherits methods from its parents {{DOMxRef("Node")}}, and its own pa
 - {{DOMxRef("Element.matches()")}}
   - : Returns a boolean value indicating whether or not the element would be selected by the specified selector string.
 - {{DOMxRef("Element.prepend()")}}
-  - : Inserts a set of {{domxref("Node")}} objects or string objects before the first child of the element.
+  - : Inserts a set of {{domxref("Node")}} objects or strings before the first child of the element.
 - {{DOMxRef("Element.querySelector()")}}
   - : Returns the first {{DOMxRef("Node")}} which matches the specified selector string relative to the element.
 - {{DOMxRef("Element.querySelectorAll()")}}
@@ -262,7 +262,7 @@ _`Element` inherits methods from its parents {{DOMxRef("Node")}}, and its own pa
 - {{DOMxRef("Element.replaceChildren()")}}
   - : Replaces the existing children of a {{domxref("Node")}} with a specified new set of children.
 - {{DOMxRef("Element.replaceWith()")}}
-  - : Replaces the element in the children list of its parent with a set of {{domxref("Node")}} or string objects.
+  - : Replaces the element in the children list of its parent with a set of {{domxref("Node")}} objects or strings.
 - {{DOMxRef("Element.requestFullscreen()")}} {{Experimental_Inline}}
   - : Asynchronously asks the browser to make the element fullscreen.
 - {{DOMxRef("Element.requestPointerLock()")}} {{Experimental_Inline}}

--- a/files/en-us/web/api/element/innerhtml/index.md
+++ b/files/en-us/web/api/element/innerhtml/index.md
@@ -23,7 +23,7 @@ use the method {{domxref("Element.insertAdjacentHTML", "insertAdjacentHTML()")}}
 
 ## Value
 
-A {{domxref("DOMString")}} containing the HTML serialization of the element's
+A string containing the HTML serialization of the element's
 descendants. Setting the value of `innerHTML` removes all of the element's
 descendants and replaces them with nodes constructed by parsing the HTML given in the
 string _htmlString_.

--- a/files/en-us/web/api/element/localname/index.md
+++ b/files/en-us/web/api/element/localname/index.md
@@ -17,7 +17,7 @@ local part of the qualified name of an element.
 
 ## Value
 
-A {{domxref("DOMString")}} representing the local part of the element's qualified name.
+A string representing the local part of the element's qualified name.
 
 ## Examples
 

--- a/files/en-us/web/api/element/outerhtml/index.md
+++ b/files/en-us/web/api/element/outerhtml/index.md
@@ -28,7 +28,7 @@ instead.
 
 ## Value
 
-Reading the value of `outerHTML` returns a {{domxref("DOMString")}}
+Reading the value of `outerHTML` returns a string
 containing an HTML serialization of the `element` and its descendants.
 Setting the value of `outerHTML` replaces the element and all of its
 descendants with a new DOM tree constructed by parsing the specified

--- a/files/en-us/web/api/element/slot/index.md
+++ b/files/en-us/web/api/element/slot/index.md
@@ -21,7 +21,7 @@ slots](/en-US/docs/Web/Web_Components/Using_templates_and_slots) for more inform
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/elementinternals/ariaatomic/index.md
+++ b/files/en-us/web/api/elementinternals/ariaatomic/index.md
@@ -19,7 +19,7 @@ The **`ariaAtomic`** property of the {{domxref("ElementInternals")}} interface r
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"false"`
   - : Assistive technologies will present only the changed node or nodes.

--- a/files/en-us/web/api/elementinternals/ariaautocomplete/index.md
+++ b/files/en-us/web/api/elementinternals/ariaautocomplete/index.md
@@ -19,7 +19,7 @@ The **`ariaAutoComplete`** property of the {{domxref("ElementInternals")}} inter
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"inline"`
   - : When a user is providing input, text suggesting one way to complete the provided input may be dynamically inserted after the caret.

--- a/files/en-us/web/api/elementinternals/ariabusy/index.md
+++ b/files/en-us/web/api/elementinternals/ariabusy/index.md
@@ -19,7 +19,7 @@ The **`ariaBusy`** property of the {{domxref("ElementInternals")}} interface ref
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"true"`
   - : The element is being updated.

--- a/files/en-us/web/api/elementinternals/ariachecked/index.md
+++ b/files/en-us/web/api/elementinternals/ariachecked/index.md
@@ -19,7 +19,7 @@ The **`ariaChecked`** property of the {{domxref("ElementInternals")}} interface 
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"true"`
   - : The element is checked.

--- a/files/en-us/web/api/elementinternals/ariacolcount/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolcount/index.md
@@ -19,7 +19,7 @@ The **`ariaColCount`** property of the {{domxref("ElementInternals")}} interface
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/elementinternals/ariacolindex/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolindex/index.md
@@ -19,7 +19,7 @@ The **`ariaColIndex`** property of the {{domxref("ElementInternals")}} interface
 
 ## Value
 
-A {{domxref("DOMString")}} which contains an integer.
+A string which contains an integer.
 
 ## Examples
 

--- a/files/en-us/web/api/elementinternals/ariacolindextext/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolindextext/index.md
@@ -19,7 +19,7 @@ The **`ariaColIndexText`** property of the {{domxref("ElementInternals")}} inter
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/elementinternals/ariacolspan/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolspan/index.md
@@ -19,7 +19,7 @@ The **`ariaColSpan`** property of the {{domxref("ElementInternals")}} interface 
 
 ## Value
 
-A {{domxref("DOMString")}} which contains an integer.
+A string which contains an integer.
 
 ## Examples
 

--- a/files/en-us/web/api/elementinternals/ariacurrent/index.md
+++ b/files/en-us/web/api/elementinternals/ariacurrent/index.md
@@ -19,7 +19,7 @@ The **`ariaCurrent`** property of the {{domxref("ElementInternals")}} interface 
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"page"`
   - : Represents the current page within a set of pages.

--- a/files/en-us/web/api/elementinternals/ariadescription/index.md
+++ b/files/en-us/web/api/elementinternals/ariadescription/index.md
@@ -19,7 +19,7 @@ The **`ariaDescription`** property of the {{domxref("ElementInternals")}} interf
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/elementinternals/ariadisabled/index.md
+++ b/files/en-us/web/api/elementinternals/ariadisabled/index.md
@@ -19,7 +19,7 @@ The **`ariaDisabled`** property of the {{domxref("ElementInternals")}} interface
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"true"`
   - : The element and all focusable descendants are disabled, but perceivable, and their values cannot be changed by the user.

--- a/files/en-us/web/api/elementinternals/ariaexpanded/index.md
+++ b/files/en-us/web/api/elementinternals/ariaexpanded/index.md
@@ -19,7 +19,7 @@ The **`ariaExpanded`** property of the {{domxref("ElementInternals")}} interface
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"true"`
   - : The grouping element this element owns or controls is expanded.

--- a/files/en-us/web/api/elementinternals/ariahaspopup/index.md
+++ b/files/en-us/web/api/elementinternals/ariahaspopup/index.md
@@ -19,7 +19,7 @@ The **`ariaHasPopup`** property of the {{domxref("ElementInternals")}} interface
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"false"`
   - : The element does not have a popup.

--- a/files/en-us/web/api/elementinternals/ariahidden/index.md
+++ b/files/en-us/web/api/elementinternals/ariahidden/index.md
@@ -19,7 +19,7 @@ The **`ariaHidden`** property of the {{domxref("ElementInternals")}} interface r
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"true"`
   - : The element is hidden from the accessibility API.

--- a/files/en-us/web/api/elementinternals/ariakeyshortcuts/index.md
+++ b/files/en-us/web/api/elementinternals/ariakeyshortcuts/index.md
@@ -19,7 +19,7 @@ The **`ariaKeyShortcuts`** property of the {{domxref("ElementInternals")}} inter
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/elementinternals/arialabel/index.md
+++ b/files/en-us/web/api/elementinternals/arialabel/index.md
@@ -19,7 +19,7 @@ The **`ariaLabel`** property of the {{domxref("ElementInternals")}} interface re
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/elementinternals/arialevel/index.md
+++ b/files/en-us/web/api/elementinternals/arialevel/index.md
@@ -19,7 +19,7 @@ The **`ariaLevel`** property of the {{domxref("ElementInternals")}} interface re
 
 ## Value
 
-A {{domxref("DOMString")}} containing an integer.
+A string containing an integer.
 
 ## Examples
 

--- a/files/en-us/web/api/elementinternals/arialive/index.md
+++ b/files/en-us/web/api/elementinternals/arialive/index.md
@@ -18,7 +18,7 @@ The **`ariaLive`** property of the {{domxref("ElementInternals")}} interface ref
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"assertive"`
   - : Indicates that updates to the region have the highest priority and should be presented the user immediately.


### PR DESCRIPTION
Continuing #15499 

### Summary
`DOMString` is not exposed by browsers to JavaScript. It is converted to `string`.[[ref](https://developer.mozilla.org/en-US/docs/Web/API/DOMString)]

Same is the case with `USVString` and `CSSOMString`.

### Metadata
- [x] Fixes a typo, bug, or other error
