### PR TITLE
`DOMString` -> `string`

### DIFF
--- a/files/en-us/web/api/elementinternals/ariamodal/index.md
+++ b/files/en-us/web/api/elementinternals/ariamodal/index.md
@@ -19,7 +19,7 @@ The **`ariaModal`** property of the {{domxref("ElementInternals")}} interface re
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"true"`
   - : The element is modal.

--- a/files/en-us/web/api/elementinternals/ariamultiline/index.md
+++ b/files/en-us/web/api/elementinternals/ariamultiline/index.md
@@ -19,7 +19,7 @@ The **`ariaMultiline`** property of the {{domxref("ElementInternals")}} interfac
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"true"`
   - : This is a multi-line text box.

--- a/files/en-us/web/api/elementinternals/ariamultiselectable/index.md
+++ b/files/en-us/web/api/elementinternals/ariamultiselectable/index.md
@@ -19,7 +19,7 @@ The **`ariaMultiSelectable`** property of the {{domxref("ElementInternals")}} in
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"true"`
   - : More than one item may be selected at a time.

--- a/files/en-us/web/api/elementinternals/ariaorientation/index.md
+++ b/files/en-us/web/api/elementinternals/ariaorientation/index.md
@@ -19,7 +19,7 @@ The **`ariaOrientation`** property of the {{domxref("ElementInternals")}} interf
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"horizontal"`
   - : The element is horizontal.

--- a/files/en-us/web/api/elementinternals/ariaplaceholder/index.md
+++ b/files/en-us/web/api/elementinternals/ariaplaceholder/index.md
@@ -19,7 +19,7 @@ The **`ariaPlaceholder`** property of the {{domxref("ElementInternals")}} interf
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/elementinternals/ariaposinset/index.md
+++ b/files/en-us/web/api/elementinternals/ariaposinset/index.md
@@ -19,7 +19,7 @@ The **`ariaPosInSet`** property of the {{domxref("ElementInternals")}} interface
 
 ## Value
 
-A {{domxref("DOMString")}} containing an integer.
+A string containing an integer.
 
 ## Examples
 

--- a/files/en-us/web/api/elementinternals/ariapressed/index.md
+++ b/files/en-us/web/api/elementinternals/ariapressed/index.md
@@ -19,7 +19,7 @@ The **`ariaPressed`** property of the {{domxref("ElementInternals")}} interface 
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"true"`
   - : The element is pressed.

--- a/files/en-us/web/api/elementinternals/ariareadonly/index.md
+++ b/files/en-us/web/api/elementinternals/ariareadonly/index.md
@@ -19,7 +19,7 @@ The **`ariaReadOnly`** property of the {{domxref("ElementInternals")}} interface
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"true"`
   - : The user cannot change the value of the element.

--- a/files/en-us/web/api/elementinternals/ariarelevant/index.md
+++ b/files/en-us/web/api/elementinternals/ariarelevant/index.md
@@ -19,7 +19,7 @@ The **`ariaRelevant`** property of the {{domxref("ElementInternals")}} interface
 
 ## Value
 
-A {{domxref("DOMString")}} containing one or more of the following values, space separated:
+A string containing one or more of the following values, space separated:
 
 - "additions"
   - : Additions of Element Nodes within the live region should be considered relevant.

--- a/files/en-us/web/api/elementinternals/ariarequired/index.md
+++ b/files/en-us/web/api/elementinternals/ariarequired/index.md
@@ -19,7 +19,7 @@ The **`ariaRequired`** property of the {{domxref("Element")}} interface reflects
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"true"`
   - : Users need to provide input on an element before a form is submitted.

--- a/files/en-us/web/api/elementinternals/ariaroledescription/index.md
+++ b/files/en-us/web/api/elementinternals/ariaroledescription/index.md
@@ -19,7 +19,7 @@ The **`ariaRoleDescription`** property of the {{domxref("Element")}} interface r
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/elementinternals/ariarowcount/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowcount/index.md
@@ -19,7 +19,7 @@ The **`ariaRowCount`** property of the {{domxref("ElementInternals")}} interface
 
 ## Value
 
-A {{domxref("DOMString")}} which contains an integer.
+A string which contains an integer.
 
 ## Examples
 

--- a/files/en-us/web/api/elementinternals/ariarowindex/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowindex/index.md
@@ -19,7 +19,7 @@ The **`ariaRowIndex`** property of the {{domxref("ElementInternals")}} interface
 
 ## Value
 
-A {{domxref("DOMString")}} which contains an integer.
+A string which contains an integer.
 
 ## Examples
 

--- a/files/en-us/web/api/elementinternals/ariarowindextext/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowindextext/index.md
@@ -19,7 +19,7 @@ The **`ariaRowIndexText`** property of the {{domxref("ElementInternals")}} inter
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/elementinternals/ariarowspan/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowspan/index.md
@@ -19,7 +19,7 @@ The **`ariaRowSpan`** property of the {{domxref("ElementInternals")}} interface 
 
 ## Value
 
-A {{domxref("DOMString")}} which contains an integer.
+A string which contains an integer.
 
 ## Examples
 

--- a/files/en-us/web/api/elementinternals/ariaselected/index.md
+++ b/files/en-us/web/api/elementinternals/ariaselected/index.md
@@ -19,7 +19,7 @@ The **`ariaSelected`** property of the {{domxref("ElementInternals")}} interface
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"true"`
   - : The item is selected.

--- a/files/en-us/web/api/elementinternals/ariasetsize/index.md
+++ b/files/en-us/web/api/elementinternals/ariasetsize/index.md
@@ -19,7 +19,7 @@ The **`ariaSetSize`** property of the {{domxref("ElementInternals")}} interface 
 
 ## Value
 
-A {{domxref("DOMString")}} containing an integer.
+A string containing an integer.
 
 ## Examples
 

--- a/files/en-us/web/api/elementinternals/ariasort/index.md
+++ b/files/en-us/web/api/elementinternals/ariasort/index.md
@@ -19,7 +19,7 @@ The **`ariaSort`** property of the {{domxref("ElementInternals")}} interface ref
 
 ## Value
 
-A {{domxref("DOMString")}} with one of the following values:
+A string with one of the following values:
 
 - `"ascending"`
   - : Items are sorted in ascending order by this column.

--- a/files/en-us/web/api/elementinternals/ariavaluemax/index.md
+++ b/files/en-us/web/api/elementinternals/ariavaluemax/index.md
@@ -19,7 +19,7 @@ The **`ariaValueMax`** property of the {{domxref("ElementInternals")}} interface
 
 ## Value
 
-A {{domxref("DOMString")}} which contains a number.
+A string which contains a number.
 
 ## Examples
 

--- a/files/en-us/web/api/elementinternals/ariavaluemin/index.md
+++ b/files/en-us/web/api/elementinternals/ariavaluemin/index.md
@@ -19,7 +19,7 @@ The **`ariaValueMin`** property of the {{domxref("ElementInternals")}} interface
 
 ## Value
 
-A {{domxref("DOMString")}} which contains a number.
+A string which contains a number.
 
 ## Examples
 

--- a/files/en-us/web/api/elementinternals/ariavaluenow/index.md
+++ b/files/en-us/web/api/elementinternals/ariavaluenow/index.md
@@ -19,7 +19,7 @@ The **`ariaValueNow`** property of the {{domxref("ElementInternals")}} interface
 
 ## Value
 
-A {{domxref("DOMString")}} which contains a number.
+A string which contains a number.
 
 ## Examples
 

--- a/files/en-us/web/api/elementinternals/ariavaluetext/index.md
+++ b/files/en-us/web/api/elementinternals/ariavaluetext/index.md
@@ -19,7 +19,7 @@ The **`ariaValueText`** property of the {{domxref("ElementInternals")}} interfac
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/elementinternals/index.md
+++ b/files/en-us/web/api/elementinternals/index.md
@@ -41,85 +41,85 @@ The `ElementInternals` interface includes the following properties, defined on t
 > **Note:** These are included in order that default accessibility semantics can be defined on a custom element. These may be overwritten by author-defined attributes, but ensure that default semantics are retained should the author delete those attributes, or fail to add them at all. For more information see the [Accessibility Object Model explainer](https://wicg.github.io/aom/explainer.html#default-semantics-for-custom-elements-via-the-elementinternals-object).
 
 - {{domxref("ElementInternals.ariaAtomic")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-atomic`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic) attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant) attribute.
+  - : Is a string reflecting the [`aria-atomic`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic) attribute, which indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant) attribute.
 - {{domxref("ElementInternals.ariaAutoComplete")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-autocomplete`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-autocomplete) attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.
+  - : Is a string reflecting the [`aria-autocomplete`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-autocomplete) attribute, which indicates whether inputting text could trigger display of one or more predictions of the user's intended value for a combobox, searchbox, or textbox and specifies how predictions would be presented if they were made.
 - {{domxref("ElementInternals.ariaBusy")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-busy`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-busy) attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.
+  - : Is a string reflecting the [`aria-busy`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-busy) attribute, which indicates whether an element is being modified, as assistive technologies may want to wait until the modifications are complete before exposing them to the user.
 - {{domxref("ElementInternals.ariaChecked")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.
+  - : Is a string reflecting the [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) attribute, which indicates the current "checked" state of checkboxes, radio buttons, and other widgets that have a checked state.
 - {{domxref("ElementInternals.ariaColCount")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colcount) attribute, which defines the number of columns in a table, grid, or treegrid.
+  - : Is a string reflecting the [`aria-colcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colcount) attribute, which defines the number of columns in a table, grid, or treegrid.
 - {{domxref("ElementInternals.ariaColIndex")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindex) attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
+  - : Is a string reflecting the [`aria-colindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindex) attribute, which defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
 - {{domxref("ElementInternals.ariaColIndexText")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-colindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindextext) attribute, which defines a human readable text alternative of aria-colindex.
+  - : Is a string reflecting the [`aria-colindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colindextext) attribute, which defines a human readable text alternative of aria-colindex.
 - {{domxref("ElementInternals.ariaColSpan")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-colspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colspan) attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
+  - : Is a string reflecting the [`aria-colspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-colspan) attribute, which defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
 - {{domxref("ElementInternals.ariaCurrent")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-current`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current) attribute, which indicates the element that represents the current item within a container or set of related elements.
+  - : Is a string reflecting the [`aria-current`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current) attribute, which indicates the element that represents the current item within a container or set of related elements.
 - {{domxref("ElementInternals.ariaDescription")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-description`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-description) attribute, which defines a string value that describes or annotates the current ElementInternals.
+  - : Is a string reflecting the [`aria-description`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-description) attribute, which defines a string value that describes or annotates the current ElementInternals.
 - {{domxref("ElementInternals.ariaDisabled")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-disabled`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled) attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
+  - : Is a string reflecting the [`aria-disabled`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled) attribute, which indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
 - {{domxref("ElementInternals.ariaExpanded")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-expanded`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded) attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.
+  - : Is a string reflecting the [`aria-expanded`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded) attribute, which indicates whether a grouping element owned or controlled by this element is expanded or collapsed.
 - {{domxref("ElementInternals.ariaHasPopup")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-haspopup`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup) attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an ElementInternals.
+  - : Is a string reflecting the [`aria-haspopup`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup) attribute, which indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an ElementInternals.
 - {{domxref("ElementInternals.ariaHidden")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-hidden`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden) attribute, which indicates whether the element is exposed to an accessibility API.
+  - : Is a string reflecting the [`aria-hidden`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden) attribute, which indicates whether the element is exposed to an accessibility API.
 - {{domxref("ElementInternals.ariaKeyShortcuts")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-keyshortcuts`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-keyshortcuts) attribute, which indicates keyboard shortcuts that an author has implemented to activate or give focus to an ElementInternals.
+  - : Is a string reflecting the [`aria-keyshortcuts`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-keyshortcuts) attribute, which indicates keyboard shortcuts that an author has implemented to activate or give focus to an ElementInternals.
 - {{domxref("ElementInternals.ariaLabel")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) attribute, which defines a string value that labels the current ElementInternals.
+  - : Is a string reflecting the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) attribute, which defines a string value that labels the current ElementInternals.
 - {{domxref("ElementInternals.ariaLevel")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-level`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-level) attribute, which defines the hierarchical level of an element within a structure.
+  - : Is a string reflecting the [`aria-level`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-level) attribute, which defines the hierarchical level of an element within a structure.
 - {{domxref("ElementInternals.ariaLive")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-live`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live) attribute, which indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
+  - : Is a string reflecting the [`aria-live`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-live) attribute, which indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
 - {{domxref("ElementInternals.ariaModal")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-modal`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal) attribute, which indicates whether an element is modal when displayed.
+  - : Is a string reflecting the [`aria-modal`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal) attribute, which indicates whether an element is modal when displayed.
 - {{domxref("ElementInternals.ariaMultiline")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-multiline`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiline) attribute, which indicates whether a text box accepts multiple lines of input or only a single line.
+  - : Is a string reflecting the [`aria-multiline`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiline) attribute, which indicates whether a text box accepts multiple lines of input or only a single line.
 - {{domxref("ElementInternals.ariaMultiSelectable")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-multiselectable`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiselectable) attribute, which indicates that the user may select more than one item from the current selectable descendants.
+  - : Is a string reflecting the [`aria-multiselectable`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-multiselectable) attribute, which indicates that the user may select more than one item from the current selectable descendants.
 - {{domxref("ElementInternals.ariaOrientation")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-orientation`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-orientation) attribute, which indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.
+  - : Is a string reflecting the [`aria-orientation`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-orientation) attribute, which indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.
 - {{domxref("ElementInternals.ariaPlaceholder")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-placeholder`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-placeholder) attribute, which defines a short hint intended to aid the user with data entry when the control has no value.
+  - : Is a string reflecting the [`aria-placeholder`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-placeholder) attribute, which defines a short hint intended to aid the user with data entry when the control has no value.
 - {{domxref("ElementInternals.ariaPosInSet")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-posinset`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-posinset) attribute, which defines an element's number or position in the current set of listitems or treeitems.
+  - : Is a string reflecting the [`aria-posinset`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-posinset) attribute, which defines an element's number or position in the current set of listitems or treeitems.
 - {{domxref("ElementInternals.ariaPressed")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed) attribute, which indicates the current "pressed" state of toggle buttons.
+  - : Is a string reflecting the [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed) attribute, which indicates the current "pressed" state of toggle buttons.
 - {{domxref("ElementInternals.ariaReadOnly")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-readonly`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-readonly) attribute, which indicates that the element is not editable, but is otherwise operable.
+  - : Is a string reflecting the [`aria-readonly`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-readonly) attribute, which indicates that the element is not editable, but is otherwise operable.
 - {{domxref("ElementInternals.ariaRelevant")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant) attribute, which indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. This is used to describe what changes in an `aria-live` region are relevant and should be announced.
+  - : Is a string reflecting the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant) attribute, which indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. This is used to describe what changes in an `aria-live` region are relevant and should be announced.
 - {{domxref("ElementInternals.ariaRequired")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-required`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) attribute, which indicates that user input is required on the element before a form may be submitted.
+  - : Is a string reflecting the [`aria-required`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) attribute, which indicates that user input is required on the element before a form may be submitted.
 - {{domxref("ElementInternals.ariaRoleDescription")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-roledescription`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-roledescription) attribute, which defines a human-readable, author-localized description for the role of an Element.
+  - : Is a string reflecting the [`aria-roledescription`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-roledescription) attribute, which defines a human-readable, author-localized description for the role of an Element.
 - {{domxref("ElementInternals.ariaRowCount")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-rowcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowcount) attribute, which defines the total number of rows in a table, grid, or treegrid.
+  - : Is a string reflecting the [`aria-rowcount`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowcount) attribute, which defines the total number of rows in a table, grid, or treegrid.
 - {{domxref("ElementInternals.ariaRowIndex")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindex) attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
+  - : Is a string reflecting the [`aria-rowindex`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindex) attribute, which defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
 - {{domxref("ElementInternals.ariaRowIndexText")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindextext) attribute, which defines a human readable text alternative of aria-rowindex.
+  - : Is a string reflecting the [`aria-rowindextext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowindextext) attribute, which defines a human readable text alternative of aria-rowindex.
 - {{domxref("ElementInternals.ariaRowSpan")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-rowspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowspan) attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
+  - : Is a string reflecting the [`aria-rowspan`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-rowspan) attribute, which defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
 - {{domxref("ElementInternals.ariaSelected")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected) attribute, which indicates the current "selected" state of elements that have a selected state.
+  - : Is a string reflecting the [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected) attribute, which indicates the current "selected" state of elements that have a selected state.
 - {{domxref("ElementInternals.ariaSetSize")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-setsize`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-setsize) attribute, which defines the number of items in the current set of listitems or treeitems.
+  - : Is a string reflecting the [`aria-setsize`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-setsize) attribute, which defines the number of items in the current set of listitems or treeitems.
 - {{domxref("ElementInternals.ariaSort")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-sort`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-sort) attribute, which indicates if items in a table or grid are sorted in ascending or descending order.
+  - : Is a string reflecting the [`aria-sort`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-sort) attribute, which indicates if items in a table or grid are sorted in ascending or descending order.
 - {{domxref("ElementInternals.ariaValueMax")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-valueMax`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valueMax) attribute, which defines the maximum allowed value for a range widget.
+  - : Is a string reflecting the [`aria-valueMax`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valueMax) attribute, which defines the maximum allowed value for a range widget.
 - {{domxref("ElementInternals.ariaValueMin")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-valueMin`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valueMin) attribute, which defines the minimum allowed value for a range widget.
+  - : Is a string reflecting the [`aria-valueMin`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valueMin) attribute, which defines the minimum allowed value for a range widget.
 - {{domxref("ElementInternals.ariaValueNow")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-valueNow`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valueNow) attribute, which defines the current value for a range widget.
+  - : Is a string reflecting the [`aria-valueNow`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valueNow) attribute, which defines the current value for a range widget.
 - {{domxref("ElementInternals.ariaValueText")}}
-  - : Is a {{domxref("DOMString")}} reflecting the [`aria-valuetext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuetext) attribute, which defines the human readable text alternative of aria-valuenow for a range widget.
+  - : Is a string reflecting the [`aria-valuetext`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuetext) attribute, which defines the human readable text alternative of aria-valuenow for a range widget.
 
 ## Methods
 

--- a/files/en-us/web/api/elementinternals/role/index.md
+++ b/files/en-us/web/api/elementinternals/role/index.md
@@ -15,7 +15,7 @@ The **`role`** read-only property of the {{domxref("ElementInternals")}} interfa
 
 ## Value
 
-A {{domxref("DOMString")}} which contains an ARIA role. A full list of ARIA roles can be found on the [ARIA techniques page](/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques).
+A string which contains an ARIA role. A full list of ARIA roles can be found on the [ARIA techniques page](/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques).
 
 ## Examples
 

--- a/files/en-us/web/api/errorevent/index.md
+++ b/files/en-us/web/api/errorevent/index.md
@@ -18,9 +18,9 @@ The **`ErrorEvent`** interface represents events providing information related t
 _Also inherits properties from its parent {{domxref("Event")}}_.
 
 - {{domxref("ErrorEvent.message")}} {{readonlyInline}}
-  - : Is a {{domxref("DOMString")}} containing a human-readable error message describing the problem.
+  - : Is a string containing a human-readable error message describing the problem.
 - {{domxref("ErrorEvent.filename")}} {{readonlyInline}}
-  - : Is a {{domxref("DOMString")}} containing the name of the script file in which the error occurred.
+  - : Is a string containing the name of the script file in which the error occurred.
 - {{domxref("ErrorEvent.lineno")}} {{readonlyInline}}
   - : Is an `integer` containing the line number of the script file on which the error occurred.
 - {{domxref("ErrorEvent.colno")}} {{readonlyInline}}

--- a/files/en-us/web/api/eventsource/eventsource/index.md
+++ b/files/en-us/web/api/eventsource/eventsource/index.md
@@ -24,7 +24,7 @@ new EventSource(url, configuration);
 ### Parameters
 
 - `url`
-  - : A {{domxref("USVString")}} that represents the location of the remote resource
+  - : A string that represents the location of the remote resource
     serving the events/messages.
 - `configuration` {{optional_inline}}
 

--- a/files/en-us/web/api/eventsource/index.md
+++ b/files/en-us/web/api/eventsource/index.md
@@ -38,7 +38,7 @@ _This interface also inherits properties from its parent, {{domxref("EventTarget
 - {{domxref("EventSource.readyState")}} {{readonlyinline}}
   - : A number representing the state of the connection. Possible values are `CONNECTING` (`0`), `OPEN` (`1`), or `CLOSED` (`2`).
 - {{domxref("EventSource.url")}} {{readonlyinline}}
-  - : A {{domxref("DOMString")}} representing the URL of the source.
+  - : A string representing the URL of the source.
 - {{domxref("EventSource.withCredentials")}} {{readonlyinline}}
   - : A boolean value indicating whether the `EventSource` object was instantiated with cross-origin ([CORS](/en-US/docs/Web/HTTP/CORS)) credentials set (`true`), or not (`false`, the default).
 

--- a/files/en-us/web/api/eventsource/message_event/index.md
+++ b/files/en-us/web/api/eventsource/message_event/index.md
@@ -38,9 +38,9 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.data")}} {{readonlyInline}}
   - : The data sent by the message emitter.
 - {{domxref("MessageEvent.origin")}} {{readonlyInline}}
-  - : A {{domxref("USVString")}} representing the origin of the message emitter.
+  - : A string representing the origin of the message emitter.
 - {{domxref("MessageEvent.lastEventId")}} {{readonlyInline}}
-  - : A {{domxref("DOMString")}} representing a unique ID for the event.
+  - : A string representing a unique ID for the event.
 - {{domxref("MessageEvent.source")}} {{readonlyInline}}
   - : A `MessageEventSource` (which can be a {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
 - {{domxref("MessageEvent.ports")}} {{readonlyInline}}

--- a/files/en-us/web/api/eventsource/url/index.md
+++ b/files/en-us/web/api/eventsource/url/index.md
@@ -13,12 +13,12 @@ browser-compat: api.EventSource.url
 {{APIRef('WebSockets API')}}
 
 The **`url`** read-only property of the
-{{domxref("EventSource")}} interface returns a {{domxref("DOMString")}} representing the
+{{domxref("EventSource")}} interface returns a string representing the
 URL of the source.
 
 ## Value
 
-A {{domxref("DOMString")}} representing the URL of the source.
+A string representing the URL of the source.
 
 ## Examples
 

--- a/files/en-us/web/api/extendablecookiechangeevent/changed/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/changed/index.md
@@ -18,13 +18,13 @@ The **`changed`** read-only property of the {{domxref("ExtendableCookieChangeEve
 An array of objects containing the changed cookie(s). Each object contains the following properties:
 
 - `name`
-  - : A {{domxref("USVString")}} containing the name of the cookie.
+  - : A string containing the name of the cookie.
 - `value`
-  - : A {{domxref("USVString")}} containing the value of the cookie.
+  - : A string containing the value of the cookie.
 - `domain`
-  - : A {{domxref("USVString")}} containing the domain of the cookie.
+  - : A string containing the domain of the cookie.
 - `path`
-  - : A {{domxref("USVString")}} containing the path of the cookie.
+  - : A string containing the path of the cookie.
 - `expires`
   - : A {{domxref("DOMTimeStamp")}} containing the expiration date of the cookie.
 - `secure`

--- a/files/en-us/web/api/extendablecookiechangeevent/deleted/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/deleted/index.md
@@ -18,13 +18,13 @@ The **`deleted`** read-only property of the {{domxref("ExtendableCookieChangeEve
 An array of objects containing the deleted cookie(s). Each object contains the following properties:
 
 - `name`
-  - : A {{domxref("USVString")}} containing the name of the cookie.
+  - : A string containing the name of the cookie.
 - `value`
-  - : A {{domxref("USVString")}} containing the value of the cookie.
+  - : A string containing the value of the cookie.
 - `domain`
-  - : A {{domxref("USVString")}} containing the domain of the cookie.
+  - : A string containing the domain of the cookie.
 - `path`
-  - : A {{domxref("USVString")}} containing the path of the cookie.
+  - : A string containing the path of the cookie.
 - `expires`
   - : A {{domxref("DOMTimeStamp")}} containing the expiration date of the cookie.
 - `secure`

--- a/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.md
@@ -24,7 +24,7 @@ new ExtendableCookieChangeEvent(type, eventInitDict);
 ### Parameters
 
 - `type`
-  - : A {{domxref("DOMString")}} with the value `"changed"` or `"deleted"`.
+  - : A string with the value `"changed"` or `"deleted"`.
 - `eventInitDict`{{Optional_Inline}}
 
   - : An object containing:

--- a/files/en-us/web/api/extendablemessageevent/extendablemessageevent/index.md
+++ b/files/en-us/web/api/extendablemessageevent/extendablemessageevent/index.md
@@ -25,15 +25,15 @@ new ExtendableMessageEvent(type, init);
 ### Parameters
 
 - type
-  - : A {{domxref("DOMString")}} that defines the type of the message event being created.
+  - : A string that defines the type of the message event being created.
 - init {{optional_inline}}
 
   - : An initialization object, which should contain the following parameters:
 
     - `data`: The event's data — this can be any data type.
-    - `origin`: A {{domxref("DOMString")}} that defines the origin of the
+    - `origin`: A string that defines the origin of the
       corresponding service worker's environment settings object.
-    - `lastEventId`: A {{domxref("DOMString")}} that defines the last event
+    - `lastEventId`: A string that defines the last event
       ID of the event source.
     - `source`: The {{domxref("Client")}}, {{domxref("ServiceWorker")}} or
       {{domxref("MessagePort")}} that sent the message.

--- a/files/en-us/web/api/extendablemessageevent/lasteventid/index.md
+++ b/files/en-us/web/api/extendablemessageevent/lasteventid/index.md
@@ -19,7 +19,7 @@ events](/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events), the la
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/extendablemessageevent/origin/index.md
+++ b/files/en-us/web/api/extendablemessageevent/origin/index.md
@@ -19,7 +19,7 @@ The **`origin`** read-only property of the
 
 ## Value
 
-A {{domxref("USVString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/federatedcredential/federatedcredential/index.md
+++ b/files/en-us/web/api/federatedcredential/federatedcredential/index.md
@@ -30,7 +30,7 @@ new FederatedCredential(init)
 
   - : Options are:
 
-    - `provider`: A {{domxref("USVString")}}; identifying the credential
+    - `provider`: A string; identifying the credential
       provider.
 
 ## Specifications

--- a/files/en-us/web/api/federatedcredential/index.md
+++ b/files/en-us/web/api/federatedcredential/index.md
@@ -28,9 +28,9 @@ In browsers that support it, an instance of this interface may be passed in the 
 _Inherits properties from its ancestor, {{domxref("Credential")}}._
 
 - {{domxref("FederatedCredential.provider")}} {{readonlyInline}}
-  - : Returns a {{domxref("USVString")}} containing a credential's federated identity provider.
+  - : Returns a string containing a credential's federated identity provider.
 - {{domxref("FederatedCredential.protocol")}} {{readonlyInline}}
-  - : Returns a {{domxref("DOMString")}} containing a credential's federated identity protocol.
+  - : Returns a string containing a credential's federated identity protocol.
 
 ### Event handlers
 

--- a/files/en-us/web/api/federatedcredential/protocol/index.md
+++ b/files/en-us/web/api/federatedcredential/protocol/index.md
@@ -16,13 +16,13 @@ browser-compat: api.FederatedCredential.protocol
 
 The **`protocol`** property of the
 {{domxref("FederatedCredential")}} interface returns a read-only
-{{domxref("DOMString")}} containing a credential's federated identity protocol. If this
+string containing a credential's federated identity protocol. If this
 property is {{jsxref("null")}}, the protocol may be inferred from the
 {{domxref("FederatedCredential.provider")}} property.
 
 ## Value
 
-A {{domxref("DOMString")}} containing a credential's federated identity protocol (e.g.
+A string containing a credential's federated identity protocol (e.g.
 `openidconnect`).
 
 ## Examples

--- a/files/en-us/web/api/federatedcredential/provider/index.md
+++ b/files/en-us/web/api/federatedcredential/provider/index.md
@@ -14,12 +14,12 @@ browser-compat: api.FederatedCredential.provider
 {{SeeCompatTable}}{{APIRef("Credential Management API")}}
 
 The **`provider`** property of the
-{{domxref("FederatedCredential")}} interface returns a {{domxref("USVString")}}
+{{domxref("FederatedCredential")}} interface returns a string
 containing a credential's federated identity provider.
 
 ## Value
 
-A {{domxref("USVString")}} containing a credential's federated identity provider.
+A string containing a credential's federated identity provider.
 
 ## Examples
 

--- a/files/en-us/web/api/fetchevent/clientid/index.md
+++ b/files/en-us/web/api/fetchevent/clientid/index.md
@@ -22,7 +22,7 @@ associated client.
 
 ## Value
 
-A {{domxref("DOMString")}} that represents the client ID.
+A string that represents the client ID.
 
 ## Examples
 

--- a/files/en-us/web/api/fetchevent/fetchevent/index.md
+++ b/files/en-us/web/api/fetchevent/fetchevent/index.md
@@ -27,7 +27,7 @@ new FetchEvent(type, init);
 ### Parameters
 
 - `type`
-  - : A {{domxref("DOMString")}} object specifying which event the object represents. This
+  - : A string object specifying which event the object represents. This
     is always `fetch` for Fetch events.
 - `init` {{optional_inline}}
 
@@ -46,10 +46,10 @@ new FetchEvent(type, init);
       - : A {{jsxref("Promise")}} which returns a previously-loaded response to the
         client.
     - `replacesClientId` {{ReadOnlyInline}}
-      - : A {{domxref("DOMString")}} which identifies the client which is being replaced
+      - : A string which identifies the client which is being replaced
         by `resultingClientId`.
     - `resultingClientId` {{ReadOnlyInline}}
-      - : A {{domxref("DOMString")}} containing the new `clientId` if the
+      - : A string containing the new `clientId` if the
         client changes as a result of the page load.
     - `request` {{ReadOnlyInline}}
       - : The {{domxref("Request")}} object that would have triggered the event handler.

--- a/files/en-us/web/api/fetchevent/replacesclientid/index.md
+++ b/files/en-us/web/api/fetchevent/replacesclientid/index.md
@@ -29,7 +29,7 @@ imminently be replaced, right before a navigation.
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/fetchevent/resultingclientid/index.md
+++ b/files/en-us/web/api/fetchevent/resultingclientid/index.md
@@ -28,7 +28,7 @@ If the fetch request is a subresource request or the request's
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/file/file/index.md
+++ b/files/en-us/web/api/file/file/index.md
@@ -24,17 +24,17 @@ new File(bits, name, options);
 
 - `bits`
   - : An {{jsxref("Array")}} of {{jsxref("ArrayBuffer")}}, {{domxref("ArrayBufferView")}},
-    {{domxref("Blob")}}, {{domxref("USVString")}} objects, or a mix of any of such
+    {{domxref("Blob")}}, string objects, or a mix of any of such
     objects, that will be put inside the {{domxref("File")}}. `USVString`
     objects are encoded as UTF-8.
 - `name`
-  - : A {{domxref("USVString")}} representing the file name or the path to the file.
+  - : A string representing the file name or the path to the file.
 - `options` {{optional_inline}}
 
   - : An options object containing optional attributes for the file. Available options are
     as follows:
 
-    - `type`: A {{domxref("DOMString")}} representing the MIME type of the
+    - `type`: A string representing the MIME type of the
       content that will be put into the file. Defaults to a value of `"".`
     - `lastModified`: A number representing the number of milliseconds
       between the Unix time epoch and when the file was last modified. Defaults to a

--- a/files/en-us/web/api/file/index.md
+++ b/files/en-us/web/api/file/index.md
@@ -53,7 +53,7 @@ _The `File` interface doesn't define any methods, but inherits methods from the 
 - {{DOMxRef("Blob.prototype.stream()")}}
   - : Transforms the `File` into a {{DOMxRef("ReadableStream")}} that can be used to read the `File` contents.
 - {{DOMxRef("Blob.prototype.text()")}}
-  - : Transforms the `File` into a stream and reads it to completion. It returns a promise that resolves with a {{DOMxRef("USVString")}} (text).
+  - : Transforms the `File` into a stream and reads it to completion. It returns a promise that resolves with a string (text).
 - {{DOMxRef("Blob.prototype.arrayBuffer()")}}
   - : Transforms the `File` into a stream and reads it to completion. It returns a promise that resolves with an {{jsxref("ArrayBuffer")}}.
 

--- a/files/en-us/web/api/file/webkitrelativepath/index.md
+++ b/files/en-us/web/api/file/webkitrelativepath/index.md
@@ -17,13 +17,13 @@ browser-compat: api.File.webkitRelativePath
 {{APIRef("File API")}}{{non-standard_header}}
 
 The **`File.webkitRelativePath`** is a read-only property that
-contains a {{domxref("USVString")}} which specifies the file's path relative to the
+contains a string which specifies the file's path relative to the
 directory selected by the user in an {{HTMLElement("input")}} element with its
 {{htmlattrxref("webkitdirectory", "input")}} attribute set.
 
 ## Value
 
-A {{domxref("USVString")}} containing the path of the file relative to the ancestor
+A string containing the path of the file relative to the ancestor
 directory the user selected.
 
 ## Example

--- a/files/en-us/web/api/filereadersync/index.md
+++ b/files/en-us/web/api/filereadersync/index.md
@@ -23,11 +23,11 @@ This interface does not have any properties.
 - {{DOMxRef("FileReaderSync.readAsArrayBuffer","FileReaderSync.readAsArrayBuffer()")}}
   - : This method converts a specified {{DOMxRef("Blob")}} or a {{DOMxRef("File")}} into an {{jsxref("ArrayBuffer")}} representing the input data as a binary string.
 - {{DOMxRef("FileReaderSync.readAsBinaryString","FileReaderSync.readAsBinaryString()")}} {{deprecated_inline}}
-  - : This method converts a specified {{DOMxRef("Blob")}} or a {{DOMxRef("File")}} into a {{DOMxRef("DOMString")}} representing the input data as a binary string. This method is deprecated, consider using `readAsArrayBuffer()` instead.
+  - : This method converts a specified {{DOMxRef("Blob")}} or a {{DOMxRef("File")}} into a string representing the input data as a binary string. This method is deprecated, consider using `readAsArrayBuffer()` instead.
 - {{DOMxRef("FileReaderSync.readAsText","FileReaderSync.readAsText()")}}
-  - : This method converts a specified {{DOMxRef("Blob")}} or a {{DOMxRef("File")}} into a {{DOMxRef("DOMString")}} representing the input data as a text string. The optional **`encoding`** parameter indicates the encoding to be used (e.g., iso-8859-1 or UTF-8). If not present, the method will apply a detection algorithm for it.
+  - : This method converts a specified {{DOMxRef("Blob")}} or a {{DOMxRef("File")}} into a string representing the input data as a text string. The optional **`encoding`** parameter indicates the encoding to be used (e.g., iso-8859-1 or UTF-8). If not present, the method will apply a detection algorithm for it.
 - {{DOMxRef("FileReaderSync.readAsDataURL","FileReaderSync.readAsDataURL()")}}
-  - : This method converts a specified {{DOMxRef("Blob")}} or a {{DOMxRef("File")}} into a {{DOMxRef("DOMString")}} representing the input data as a data URL.
+  - : This method converts a specified {{DOMxRef("Blob")}} or a {{DOMxRef("File")}} into a string representing the input data as a data URL.
 
 ## Specifications
 

--- a/files/en-us/web/api/filereadersync/readasbinarystring/index.md
+++ b/files/en-us/web/api/filereadersync/readasbinarystring/index.md
@@ -10,7 +10,7 @@ browser-compat: api.FileReaderSync.readAsBinaryString
 
 > **Note:** This method is deprecated in favor of {{DOMxRef("FileReaderSync.readAsArrayBuffer","readAsArrayBuffer()")}}.
 
-The `readAsBinaryString()` method of the {{DOMxRef("FileReaderSync")}} interface allows to read {{DOMxRef("File")}} or {{DOMxRef("Blob")}} objects in a synchronous way into an {{DOMxRef("DOMString")}}. This interface is [only available](/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers) in [workers](/en-US/docs/Web/API/Worker) as it enables synchronous I/O that could potentially block.
+The `readAsBinaryString()` method of the {{DOMxRef("FileReaderSync")}} interface allows to read {{DOMxRef("File")}} or {{DOMxRef("Blob")}} objects in a synchronous way into a string. This interface is [only available](/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers) in [workers](/en-US/docs/Web/API/Worker) as it enables synchronous I/O that could potentially block.
 
 ## Syntax
 
@@ -26,7 +26,7 @@ readAsBinaryString(Blob);
 
 ### Return value
 
-A {{DOMxRef("DOMString")}} representing the input data.
+A string representing the input data.
 
 ## Exceptions
 

--- a/files/en-us/web/api/filereadersync/readasdataurl/index.md
+++ b/files/en-us/web/api/filereadersync/readasdataurl/index.md
@@ -5,7 +5,7 @@ browser-compat: api.FileReaderSync.readAsDataURL
 ---
 {{APIRef("File API")}}
 
-The `readAsDataURL()` method of the {{DOMxRef("FileReaderSync")}} interface allows to read {{DOMxRef("File")}} or {{DOMxRef("Blob")}} objects in a synchronous way into an {{DOMxRef("DOMString")}} representing a data URL. This interface is [only available](/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers) in [workers](/en-US/docs/Web/API/Worker) as it enables synchronous I/O that could potentially block.
+The `readAsDataURL()` method of the {{DOMxRef("FileReaderSync")}} interface allows to read {{DOMxRef("File")}} or {{DOMxRef("Blob")}} objects in a synchronous way into a string representing a data URL. This interface is [only available](/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers) in [workers](/en-US/docs/Web/API/Worker) as it enables synchronous I/O that could potentially block.
 
 ## Syntax
 
@@ -21,7 +21,7 @@ readAsDataURL(Blob);
 
 ### Return value
 
-A {{DOMxRef("DOMString")}} representing the input data as a data URL.
+A string representing the input data as a data URL.
 
 ## Exceptions
 

--- a/files/en-us/web/api/filereadersync/readastext/index.md
+++ b/files/en-us/web/api/filereadersync/readastext/index.md
@@ -5,7 +5,7 @@ browser-compat: api.FileReaderSync.readAsText
 ---
 {{APIRef("File API")}}
 
-The `readAsText()` method of the {{DOMxRef("FileReaderSync")}} interface allows to read {{DOMxRef("File")}} or {{DOMxRef("Blob")}} objects in a synchronous way into an {{DOMxRef("DOMString")}}. This interface is [only available](/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers) in [workers](/en-US/docs/Web/API/Worker) as it enables synchronous I/O that could potentially block.
+The `readAsText()` method of the {{DOMxRef("FileReaderSync")}} interface allows to read {{DOMxRef("File")}} or {{DOMxRef("Blob")}} objects in a synchronous way into a string. This interface is [only available](/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers) in [workers](/en-US/docs/Web/API/Worker) as it enables synchronous I/O that could potentially block.
 
 ## Syntax
 
@@ -25,7 +25,7 @@ readAsText(Blob, encoding);
 
 ### Return value
 
-A {{DOMxRef("DOMString")}} representing the input data.
+A string representing the input data.
 
 ## Exceptions
 

--- a/files/en-us/web/api/filesystem/index.md
+++ b/files/en-us/web/api/filesystem/index.md
@@ -26,7 +26,7 @@ There are two ways to get access to a `FileSystem` object:
 ## Properties
 
 - {{domxref("FileSystem.name")}} {{ReadOnlyInline}}
-  - : A {{domxref("USVString")}} representing the file system's name. This name is unique among the entire list of exposed file systems.
+  - : A string representing the file system's name. This name is unique among the entire list of exposed file systems.
 - {{domxref("FileSystem.root")}} {{ReadOnlyInline}}
   - : A {{domxref("FileSystemDirectoryEntry")}} object which represents the file system's root directory. Through this object, you can gain access to all files and directories in the file system.
 

--- a/files/en-us/web/api/filesystem/name/index.md
+++ b/files/en-us/web/api/filesystem/name/index.md
@@ -16,12 +16,12 @@ browser-compat: api.FileSystem.name
 
 The read-only **`name`** property of the
 {{domxref("FileSystem")}} interface indicates the file system's name. This
-{{domxref("USVString")}} is unique among all file systems currently exposed by the [File and Directory Entries
+string is unique among all file systems currently exposed by the [File and Directory Entries
 API](/en-US/docs/Web/API/File_and_Directory_Entries_API).
 
 ## Value
 
-A {{domxref("USVString")}} representing the file system's name.
+A string representing the file system's name.
 
 ## Examples
 


### PR DESCRIPTION
Continuing #15499 

### Summary
`DOMString` is not exposed by browsers to JavaScript. It is converted to `string`.[[ref](https://developer.mozilla.org/en-US/docs/Web/API/DOMString)]

Same is the case with `USVString` and `CSSOMString`.

### Metadata
- [x] Fixes a typo, bug, or other error
