### PR TITLE
Rumyra patch 1

### DIFF
--- a/files/en-us/mdn/index.md
+++ b/files/en-us/mdn/index.md
@@ -13,6 +13,6 @@ This is the landing page for the MDN project itself. Here you'll find guides on 
 
 And we invite anyone to help! If you are interested in improving this essential web developer resource, you are welcome to add and edit content. You don't need to be a programmer or know a lot about technology; there are many different tasks that need to be performed, from the simple (proof-reading and correcting typos) to the complex (writing API documentation).
 
-To find out how to help, visit our [Contributing to MDN](/en-US/docs/MDN/Contribute) page. If you want to talk to us and ask questions, join the discussion on the [MDN Web Docs chat room](https://chat.mozilla.org/#/room/#mdn:mozilla.org) on [Matrix](https://wiki.mozilla.org/Matrix).
+To find out how to help, visit https://developer.mozilla.org/en-US/docs/MDN/Contribute  page. If you want to talk to us and ask questions, join the discussion on the [MDN Web Docs chat room](https://chat.mozilla.org/#/room/#mdn:mozilla.org) on [Matrix](https://wiki.mozilla.org/Matrix).
 
 {{LandingPageListSubPages()}}

--- a/files/en-us/mdn/index.md
+++ b/files/en-us/mdn/index.md
@@ -13,6 +13,6 @@ This is the landing page for the MDN project itself. Here you'll find guides on 
 
 And we invite anyone to help! If you are interested in improving this essential web developer resource, you are welcome to add and edit content. You don't need to be a programmer or know a lot about technology; there are many different tasks that need to be performed, from the simple (proof-reading and correcting typos) to the complex (writing API documentation).
 
-To find out how to help, visit https://developer.mozilla.org/en-US/docs/MDN/Contribute  page. If you want to talk to us and ask questions, join the discussion on the [MDN Web Docs chat room](https://chat.mozilla.org/#/room/#mdn:mozilla.org) on [Matrix](https://wiki.mozilla.org/Matrix).
+To find out how to help, visit https://developer.mozilla.org/en-US/docs/MDN/Contribute mdn page. If you want to talk to us and ask questions, join the discussion on the [MDN Web Docs chat room](https://chat.mozilla.org/#/room/#mdn:mozilla.org) on [Matrix](https://wiki.mozilla.org/Matrix).
 
 {{LandingPageListSubPages()}}


### PR DESCRIPTION
Redirect link is  broken  
Change  made  for the  mdn contribution link page 


Direct users to the right mdn contribution page  
The page link provided is not found 

mdn contribution guide link 
https://developer.mozilla.org/en-US/docs/MDN/Contribute
