### PR TITLE
Fix links for hidden attribute

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-hidden/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-hidden/index.md
@@ -41,7 +41,7 @@ On the surface, the `aria-hidden="true"` and the `role="presentation"` and its s
 
 `aria-hidden="true"` should not be added when:
 
-- The HTML {{htmlattrdef('hidden')}} attribute is present
+- The HTML [`hidden`](/en-US/docs/Web/HTML/Global_attributes/hidden) attribute is present
 - The element or the element's ancestor is hidden with [`display: none`](/en-US/docs/Web/CSS/display)
 - The element or the element's ancestor is hidden with [`visibility: hidden`](/en-US/docs/Web/CSS/visibility)
 
@@ -95,7 +95,7 @@ Used in **ALL** roles
 - [`aria-disabled`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-disabled)
 - [`aria-modal`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal)
 - [`aria-expanded`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded)
-- HTML {{htmlattrdef('hidden')}} attribute
+- HTML [`hidden`](/en-US/docs/Web/HTML/Global_attributes/hidden) attribute
 - CSS {{CSSXref('display')}} property
 - CSS {{CSSXref('visibility')}} property
 


### PR DESCRIPTION
links with {{htmlattrdef('hidden')}} don't seem to work as they link the same page (aria-hidden).