### PR TITLE
Replace `Number` object with `Number` primitive

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/bigint/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/tostring/index.md
@@ -75,7 +75,7 @@ complement of the `bigIntObj`.
 
 There is no negative-zero `BigInt` as there are no negative zeros in
 integers. `-0.0` is an IEEE floating-point concept that only appears in the
-JavaScript {{jsxref("Number")}} type.
+JavaScript [`Number`](/en-US/docs/Web/JavaScript/Data_structures#number_type) type.
 
 ```js
 (-0n).toString();      // '0'


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Replace `Number` object with `Number` primitive

#### Motivation
In this context, `Number` type is a primitive, but {{jsxref("Number")}} produces a link to "Number" wrapper object.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
