### PR TITLE
fix: formatting of Quick_links

### DIFF
--- a/files/en-us/related/imsc/basics/index.md
+++ b/files/en-us/related/imsc/basics/index.md
@@ -236,4 +236,24 @@ The more expanded example below gives you an idea what you can do with IMSC afte
 
 That's it for your crash course in IMSC code basics! We've only really scratched the surface here, and you'll go much deeper into the above topics in subsequent articles.
 
-<section id="Quick_links"><ol><li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li><li class="toggle"><details open><summary>IMSC guides</summary><ol><li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li><li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li><li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li><li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li></ol></details></li></ol></section>
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
+    <li class="toggle">
+      <details open>
+        <summary>IMSC guides</summary>
+        <ol>
+          <li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a>
+          </li>
+          <li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li>
+        </ol>
+      </details>
+    </li>
+  </ol>
+</section>

--- a/files/en-us/related/imsc/imsc_and_other_standards/index.md
+++ b/files/en-us/related/imsc/imsc_and_other_standards/index.md
@@ -40,4 +40,24 @@ In summary, authors are encouraged to create IMSC 1.0.1 documents if possible an
 
 This document gives you all you need to know about IMSC and its relationship with other specifications.
 
-<section id="Quick_links"><ol><li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li><li class="toggle"><details open><summary>IMSC guides</summary><ol><li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li><li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li><li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li><li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li></ol></details></li></ol></section>
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
+    <li class="toggle">
+      <details open>
+        <summary>IMSC guides</summary>
+        <ol>
+          <li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a>
+          </li>
+          <li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li>
+        </ol>
+      </details>
+    </li>
+  </ol>
+</section>

--- a/files/en-us/related/imsc/index.md
+++ b/files/en-us/related/imsc/index.md
@@ -152,4 +152,24 @@ Team:
 
 If you want to get involved with documenting IMSC, please contact [Andreas Tai](mailto:tai@irt.de).
 
-<section id="Quick_links"><ol><li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li><li class="toggle"><details open><summary>IMSC guides</summary><ol><li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li><li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li><li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li><li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li></ol></details></li></ol></section>
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
+    <li class="toggle">
+      <details open>
+        <summary>IMSC guides</summary>
+        <ol>
+          <li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a>
+          </li>
+          <li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li>
+        </ol>
+      </details>
+    </li>
+  </ol>
+</section>

--- a/files/en-us/related/imsc/mapping_video_time_codes_to_imsc/index.md
+++ b/files/en-us/related/imsc/mapping_video_time_codes_to_imsc/index.md
@@ -59,4 +59,24 @@ This is saying that there are 24 frames in a second, and those are playing back 
 
 By describing this actual frame rate, you are now able to describe time expressions in frames, or f. This is the actual frame number that the event begins and ends. Here is the same example as above, where the event begins at 01:00:00:00, and ends one second later.
 
-<section id="Quick_links"><ol><li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li><li class="toggle"><details open><summary>IMSC guides</summary><ol><li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li><li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li><li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li><li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li></ol></details></li></ol></section>
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
+    <li class="toggle">
+      <details open>
+        <summary>IMSC guides</summary>
+        <ol>
+          <li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a>
+          </li>
+          <li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li>
+        </ol>
+      </details>
+    </li>
+  </ol>
+</section>

--- a/files/en-us/related/imsc/namespaces/index.md
+++ b/files/en-us/related/imsc/namespaces/index.md
@@ -134,4 +134,24 @@ Much more readable, isn't it?
 
 > **Note:** The namespace/prefix match is only a document-wide agreement. Theoretically you can use another prefix than `tts` to bind the styling namespace. It is completely legal to define `xmlns:foo="http://www.w3.org/ns/ttml#styling"` and then write `<p foo:color="yellow">`. But it makes your IMSC document much more readable if you use the official prefixes listed in [namespace section](https://www.w3.org/TR/ttml-imsc1.0.1/#namespaces) of the IMSC standard.
 
-<section id="Quick_links"><ol><li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li><li class="toggle"><details open><summary>IMSC guides</summary><ol><li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li><li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li><li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li><li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li></ol></details></li></ol></section>
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
+    <li class="toggle">
+      <details open>
+        <summary>IMSC guides</summary>
+        <ol>
+          <li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a>
+          </li>
+          <li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li>
+        </ol>
+      </details>
+    </li>
+  </ol>
+</section>

--- a/files/en-us/related/imsc/styling/index.md
+++ b/files/en-us/related/imsc/styling/index.md
@@ -160,4 +160,24 @@ Multiple styles can be also applied simultaneously on an element. For example, i
 <p style="s1 s2">Hello, I am Mork from Ork</p>
 ```
 
-<section id="Quick_links"><ol><li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li><li class="toggle"><details open><summary>IMSC guides</summary><ol><li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li><li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li><li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li><li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li></ol></details></li></ol></section>
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
+    <li class="toggle">
+      <details open>
+        <summary>IMSC guides</summary>
+        <ol>
+          <li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a>
+          </li>
+          <li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li>
+        </ol>
+      </details>
+    </li>
+  </ol>
+</section>

--- a/files/en-us/related/imsc/subtitle_placement/index.md
+++ b/files/en-us/related/imsc/subtitle_placement/index.md
@@ -33,4 +33,24 @@ The important items to consider here are:
 - `tts:textAlign` — the horizontal text justification. Like a word processor, this can be set to `left`, `center`, or `right`. `center` is the most common text justification for subtitles.
 - `tts:displayAlign` — the vertical alignment of the text. This can be set to `before`, `center`, or `after`. `before` means that the text will start from the very top of the region box, and flow downwards. `center` means the text will be vertically centered within the region box. After means that the text will start from the very bottom of the region box, and flow upwards.
 
-<section id="Quick_links"><ol><li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li><li class="toggle"><details open><summary>IMSC guides</summary><ol><li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li><li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li><li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li><li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li></ol></details></li></ol></section>
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
+    <li class="toggle">
+      <details open>
+        <summary>IMSC guides</summary>
+        <ol>
+          <li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a>
+          </li>
+          <li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li>
+        </ol>
+      </details>
+    </li>
+  </ol>
+</section>

--- a/files/en-us/related/imsc/timing_in_imsc/index.md
+++ b/files/en-us/related/imsc/timing_in_imsc/index.md
@@ -82,4 +82,24 @@ The advantage of using this method is that the time expression frame number is t
 
 > **Note:** You can find an additional explanation of these values in [Mapping video time codes to IMSC](/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC).
 
-<section id="Quick_links"><ol><li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li><li class="toggle"><details open><summary>IMSC guides</summary><ol><li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li><li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li><li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li><li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li></ol></details></li></ol></section>
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
+    <li class="toggle">
+      <details open>
+        <summary>IMSC guides</summary>
+        <ol>
+          <li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a>
+          </li>
+          <li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li>
+        </ol>
+      </details>
+    </li>
+  </ol>
+</section>

--- a/files/en-us/related/imsc/using_the_imscjs_polyfill/index.md
+++ b/files/en-us/related/imsc/using_the_imscjs_polyfill/index.md
@@ -280,4 +280,24 @@ The caption user interface problem is a bit harder to solve. Although we can lis
 
 the best solution is to building your own custom controls. Find out how in our [Creating a cross-browser video player](/en-US/docs/Web/Guide/Audio_and_video_delivery/cross_browser_video_player) tutorial.
 
-<section id="Quick_links"><ol><li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li><li class="toggle"><details open><summary>IMSC guides</summary><ol><li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li><li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li><li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li><li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a></li><li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li></ol></details></li></ol></section>
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Related/IMSC/"><strong>IMSC</strong></a></li>
+    <li class="toggle">
+      <details open>
+        <summary>IMSC guides</summary>
+        <ol>
+          <li><a href="/en-US/docs/Related/IMSC/Basics">IMSC basics</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Using_the_imscJS_polyfill">Using the imscJS polyfill</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Styling">Styling IMSC documents</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Subtitle_placement">Subtitle placement in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Namespaces">Namespaces in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Timing_in_IMSC">Timing in IMSC</a></li>
+          <li><a href="/en-US/docs/Related/IMSC/Mapping_video_time_codes_to_IMSC">Mapping video time codes to IMSC</a>
+          </li>
+          <li><a href="/en-US/docs/Related/IMSC/IMSC_and_other_standards">IMSC and other standards</a></li>
+        </ol>
+      </details>
+    </li>
+  </ol>
+</section>

--- a/files/en-us/web/accessibility/aria/roles/meter_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/meter_role/index.md
@@ -89,4 +89,9 @@ In the above scenario, when the `aria-valuenow` value updates, the width of the 
 - {{HTMLElement('meter')}}
 - {{HTMLElement('progress')}}
 
-<section id="Quick_links"><ol><li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li></ol></section>
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Web/Accessibility/ARIA/Roles"><strong>WAI-ARIA
+          roles</strong></a>{{ListSubpagesForSidebar("/en-US/docs/Web/Accessibility/ARIA/Roles")}}</li>
+  </ol>
+</section>

--- a/files/en-us/web/events/creating_and_triggering_events/index.md
+++ b/files/en-us/web/events/creating_and_triggering_events/index.md
@@ -148,4 +148,10 @@ function simulateClick() {
 - {{domxref("EventTarget.dispatchEvent()")}}
 - {{domxref("EventTarget.addEventListener()")}}
 
-<section id="Quick_links"><ul><li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a></li><li><a href="/en-US/docs/Web/Events/Event_handlers">Event handlers (overview)</a></li><li><a href="/en-US/docs/Web/Events">Event reference</a></li></ul></section>
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a></li>
+    <li><a href="/en-US/docs/Web/Events/Event_handlers">Event handlers (overview)</a></li>
+    <li><a href="/en-US/docs/Web/Events">Event reference</a></li>
+  </ol>
+</section>

--- a/files/en-us/web/events/detecting_device_orientation/index.md
+++ b/files/en-us/web/events/detecting_device_orientation/index.md
@@ -194,4 +194,14 @@ Finally, {{domxref("DeviceMotionEvent.interval","interval")}} represents the int
 - [Using deviceorientation in 3D Transforms](/en-US/docs/Web/Events/Using_device_orientation_with_3D_transforms)
 - [Cyber Orb: 2D maze game with device orientation](/en-US/docs/Games/Tutorials/HTML5_Gamedev_Phaser_Device_Orientation)
 
-<section id="Quick_links"><ul><li><a href="/en-US/docs/Web/Events/Orientation_and_motion_data_explained">Orientation and motion data explained</a></li><li>{{domxref("DeviceOrientationEvent")}}</li><li>{{domxref("DeviceMotionEvent")}}</li><li><a href="/en-US/docs/Web/Events/Using_device_orientation_with_3D_transforms">Using deviceorientation in 3D Transforms</a></li><li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a></li></ul></section>
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Web/Events/Orientation_and_motion_data_explained">Orientation and motion data explained</a>
+    </li>
+    <li>{{domxref("DeviceOrientationEvent")}}</li>
+    <li>{{domxref("DeviceMotionEvent")}}</li>
+    <li><a href="/en-US/docs/Web/Events/Using_device_orientation_with_3D_transforms">Using deviceorientation in 3D
+        Transforms</a></li>
+    <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a></li>
+  </ol>
+</section>

--- a/files/en-us/web/events/event_handlers/index.md
+++ b/files/en-us/web/events/event_handlers/index.md
@@ -85,4 +85,9 @@ Then the event handler created by the code above can be removed like this:
 controller.abort(); // removes any/all event handlers associated with this controller
 ```
 
-<section id="Quick_links"><ul><li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a></li><li><a href="/en-US/docs/Web/Events">Event reference</a></li></ul></section>
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a></li>
+    <li><a href="/en-US/docs/Web/Events">Event reference</a></li>
+  </ol>
+</section>

--- a/files/en-us/web/events/index.md
+++ b/files/en-us/web/events/index.md
@@ -1412,4 +1412,8 @@ This section lists events that have _their own_ reference pages on MDN. If you a
 | {{SpecName('HTML WHATWG', 'webappapis.html#event-handler-attributes', 'event handlers')}} | {{Spec2('HTML WHATWG')}} |         |
 | {{SpecName('HTML5 W3C', 'webappapis.html#event-handler-attributes', 'event handlers')}}     | {{Spec2('HTML5 W3C')}}     |         |
 
-<section id="Quick_links"><ul><li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a></li></ul>{{ListSubpages}}</section>
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a></li>
+  </ol>{{ListSubpages}}
+</section>

--- a/files/en-us/web/events/orientation_and_motion_data_explained/index.md
+++ b/files/en-us/web/events/orientation_and_motion_data_explained/index.md
@@ -64,4 +64,13 @@ Rotation around the y axis -- that is, tilting the device toward the left or rig
 
 The gamma angle is 0° when the device's left and right sides are the same distance from the surface of the Earth, and increases toward 90° as the device is tipped toward the right, and toward -90° as the device is tipped toward the left.
 
-<section id="Quick_links"><ul><li><a href="/en-US/docs/Web/Events/Detecting_device_orientation">Detecting device orientation</a></li><li>{{domxref("DeviceOrientationEvent")}}</li><li>{{domxref("DeviceMotionEvent")}}</li><li><a href="/en-US/docs/Web/Events/Using_device_orientation_with_3D_transforms">Using deviceorientation in 3D Transforms</a></li><li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a></li></ul></section>
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Web/Events/Detecting_device_orientation">Detecting device orientation</a></li>
+    <li>{{domxref("DeviceOrientationEvent")}}</li>
+    <li>{{domxref("DeviceMotionEvent")}}</li>
+    <li><a href="/en-US/docs/Web/Events/Using_device_orientation_with_3D_transforms">Using deviceorientation in 3D
+        Transforms</a></li>
+    <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a></li>
+  </ol>
+</section>

--- a/files/en-us/web/events/using_device_orientation_with_3d_transforms/index.md
+++ b/files/en-us/web/events/using_device_orientation_with_3d_transforms/index.md
@@ -83,4 +83,11 @@ function orient( aa ) {
 - [Using CSS transforms](/en-US/docs/Web/CSS/CSS_Transforms/Using_CSS_transforms)
 - [Detecting device orientation](/en-US/docs/Web/Events/Detecting_device_orientation)
 
-<section id="Quick_links"><ul><li><a href="/en-US/docs/Web/Events/Detecting_device_orientation">Detecting device orientation</a></li><li><a href="/en-US/docs/Web/CSS/CSS_Transforms/Using_CSS_transforms">Using CSS transforms</a></li><li>{{domxref("DeviceOrientationEvent")}}</li><li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a></li></ul></section>
+<section id="Quick_links">
+  <ol>
+    <li><a href="/en-US/docs/Web/Events/Detecting_device_orientation">Detecting device orientation</a></li>
+    <li><a href="/en-US/docs/Web/CSS/CSS_Transforms/Using_CSS_transforms">Using CSS transforms</a></li>
+    <li>{{domxref("DeviceOrientationEvent")}}</li>
+    <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a></li>
+  </ol>
+</section>

--- a/files/en-us/web/exslt/index.md
+++ b/files/en-us/web/exslt/index.md
@@ -85,4 +85,40 @@ The EXSLT Strings package provides functions that allow the manipulation of stri
 
 - [EXSLT web site](http://exslt.org/)
 
-<section id="Quick_links"><ol><li><strong><a href="/en-US/docs/Web/XSLT">XSLT</a></strong></li><li><strong><a href="/en-US/docs/Web/XPath">XPath</a></strong></li><li><strong><a href="/en-US/docs/Web/EXSLT">EXSLT</a></strong></li><li class="toggle"><details open><summary><a href="/en-US/docs/Web/EXSLT/exsl">Common (exsl)</a></summary>{{ListSubpagesForSidebar("/en-US/docs/Web/EXSLT/exsl", "", "", "exsl:", ")")}}</details></li><li class="toggle"><details open><summary><a href="/en-US/docs/Web/EXSLT/math">Math (math)</a></summary>{{ListSubpagesForSidebar("/en-US/docs/Web/EXSLT/math", "", "", "math:", ")")}}</details></li><li class="toggle"><details open><summary><a href="/en-US/docs/Web/EXSLT/regexp">Regular expressions (regexp)</a></summary>{{ListSubpagesForSidebar("/en-US/docs/Web/EXSLT/regexp", "", "", "regexp:", ")")}}</details></li><li class="toggle"><details open><summary><a href="/en-US/docs/Web/EXSLT/set">Sets (set)</a></summary>{{ListSubpagesForSidebar("/en-US/docs/Web/EXSLT/set", "", "", "set:", ")")}}</details></li><li class="toggle"><details open><summary><a href="/en-US/docs/Web/EXSLT/str">Strings (str)</a></summary>{{ListSubpagesForSidebar("/en-US/docs/Web/EXSLT/str", "", "", "str:", ")")}}</details></li></ol></section>
+<section id="Quick_links">
+  <ol>
+    <li><strong><a href="/en-US/docs/Web/XSLT">XSLT</a></strong></li>
+    <li><strong><a href="/en-US/docs/Web/XPath">XPath</a></strong></li>
+    <li><strong><a href="/en-US/docs/Web/EXSLT">EXSLT</a></strong></li>
+    <li class="toggle">
+      <details open>
+        <summary><a href="/en-US/docs/Web/EXSLT/exsl">Common (exsl)</a></summary>
+        {{ListSubpagesForSidebar("/en-US/docs/Web/EXSLT/exsl", "", "", "exsl:", ")")}}
+      </details>
+    </li>
+    <li class="toggle">
+      <details open>
+        <summary><a href="/en-US/docs/Web/EXSLT/math">Math (math)</a></summary>
+        {{ListSubpagesForSidebar("/en-US/docs/Web/EXSLT/math", "", "", "math:", ")")}}
+      </details>
+    </li>
+    <li class="toggle">
+      <details open>
+        <summary><a href="/en-US/docs/Web/EXSLT/regexp">Regular expressions (regexp)</a></summary>
+        {{ListSubpagesForSidebar("/en-US/docs/Web/EXSLT/regexp", "", "", "regexp:", ")")}}
+      </details>
+    </li>
+    <li class="toggle">
+      <details open>
+        <summary><a href="/en-US/docs/Web/EXSLT/set">Sets (set)</a></summary>
+        {{ListSubpagesForSidebar("/en-US/docs/Web/EXSLT/set", "", "", "set:", ")")}}
+      </details>
+    </li>
+    <li class="toggle">
+      <details open>
+        <summary><a href="/en-US/docs/Web/EXSLT/str">Strings (str)</a></summary>
+        {{ListSubpagesForSidebar("/en-US/docs/Web/EXSLT/str", "", "", "str:", ")")}}
+      </details>
+    </li>
+  </ol>
+</section>

--- a/files/en-us/web/xpath/comparison_with_css_selectors/index.md
+++ b/files/en-us/web/xpath/comparison_with_css_selectors/index.md
@@ -22,4 +22,32 @@ This article seeks to document the difference between CSS Selectors and XPath fo
 | [`following-sibling`](/en-US/docs/Web/XPath/Axes/following-sibling) axis                                                                                                     | [General sibling combinator](/en-US/docs/Web/CSS/General_sibling_combinator) or [adjacent sibling combinator](/en-US/docs/Web/CSS/Adjacent_sibling_combinator) |
 | [`self`](/en-US/docs/Web/XPath/Axes/self) axis                                                                                                                               | {{CSSxRef(":scope")}} or {{CSSxRef(":host")}} selector                                                                                          |
 
-<section id="Quick_links"><ol><li><strong><a href="/en-US/docs/Web/XSLT">XSLT</a></strong></li><li><strong><a href="/en-US/docs/Web/EXSLT">EXSLT</a></strong></li><li><strong><a href="/en-US/docs/Web/XPath">XPath</a></strong></li><li class="toggle"><details open><summary>Guides</summary><ol><li><a href="/en-US/docs/Web/XPath/Comparison_with_CSS_selectors">Comparison of CSS Selectors and XPath</a></li><li><a href="/en-US/docs/Web/XPath/Snippets">XPath snippets</a></li></ol></details></li><li class="toggle"><details open><summary><a href="/en-US/docs/Web/XPath/Axes">XPath Axes</a></summary>{{ListSubpagesForSidebar("/en-US/docs/Web/XPath/Axes")}}</details></li><li class="toggle"><details open><summary><a href="/en-US/docs/Web/XPath/Functions">XPath Functions</a></summary>{{ListSubpagesForSidebar("/en-US/docs/Web/XPath/Functions")}}</details></li></ol></section>
+<section id="Quick_links">
+  <ol>
+    <li><strong><a href="/en-US/docs/Web/XSLT">XSLT</a></strong></li>
+    <li><strong><a href="/en-US/docs/Web/EXSLT">EXSLT</a></strong></li>
+    <li><strong><a href="/en-US/docs/Web/XPath">XPath</a></strong></li>
+    <li class="toggle">
+      <details open>
+        <summary>Guides</summary>
+        <ol>
+          <li><a href="/en-US/docs/Web/XPath/Comparison_with_CSS_selectors">Comparison of CSS Selectors and XPath</a>
+          </li>
+          <li><a href="/en-US/docs/Web/XPath/Snippets">XPath snippets</a></li>
+        </ol>
+      </details>
+    </li>
+    <li class="toggle">
+      <details open>
+        <summary><a href="/en-US/docs/Web/XPath/Axes">XPath Axes</a></summary>
+        {{ListSubpagesForSidebar("/en-US/docs/Web/XPath/Axes")}}
+      </details>
+    </li>
+    <li class="toggle">
+      <details open>
+        <summary><a href="/en-US/docs/Web/XPath/Functions">XPath Functions</a></summary>
+        {{ListSubpagesForSidebar("/en-US/docs/Web/XPath/Functions")}}
+      </details>
+    </li>
+  </ol>
+</section>

--- a/files/en-us/web/xslt/index.md
+++ b/files/en-us/web/xslt/index.md
@@ -8,8 +8,6 @@ tags:
 ---
 {{XSLTRef}}
 
-<div id="Quick_links"><ol><li><strong><a href="/en-US/docs/Web/XSLT">XSLT</a></strong></li><li><strong><a href="/en-US/docs/Web/EXSLT">EXSLT</a></strong></li><li><strong><a href="/en-US/docs/Web/XPath">XPath</a></strong></li><li class="toggle"><details open><summary>Guides</summary><ol><li><a href="/en-US/docs/Web/XSLT/Common_errors">Common XSLT Errors</a></li><li><a href="/en-US/docs/Web/XSLT/PI_Parameters">PI Parameters</a></li><li><a href="/en-US/docs/Web/XSLT/XSLT_JS_interface_in_Gecko">The XSLT/JavaScript Interface in Gecko</a></li><li><a href="/en-US/docs/Web/XSLT/Transforming_XML_with_XSLT">Transforming XML with XSLT</a></li><li><a href="/en-US/docs/Web/XSLT/Using_the_Mozilla_JavaScript_interface_to_XSL_Transformations">Using the Mozilla JavaScript interface to XSL Transformations</a></li></ol></details></li><li class="toggle"><details open><summary><a href="/en-US/docs/XSLT/Element">XSLT Elements</a></summary>{{ListSubpagesForSidebar("/en-US/docs/Web/XSLT/Element", "", "", "&lt;xsl:", "&gt;")}}</details></li></ol></div>
-
 **Extensible Stylesheet Language Transformations (XSLT)** is an [XML](/en-US/docs/Web/XML/XML_introduction)-based language used, in conjunction with specialized processing software, for the transformation of XML documents.
 
 Although the process is referred to as "transformation," the original document is not changed; rather, a new XML document is created based on the content of an existing document. Then, the new document may be serialized (output) by the processor in standard XML syntax or in another format, such as [HTML](/en-US/docs/Web/HTML) or plain text.
@@ -36,3 +34,30 @@ XSLT is most often used to convert data between different XML schemas or to conv
 ## Related Topics
 
 - [XML](/en-US/docs/Web/XML/XML_introduction), [XPath](/en-US/docs/Web/XPath)
+
+<div id="Quick_links">
+  <ol>
+    <li><strong><a href="/en-US/docs/Web/XSLT">XSLT</a></strong></li>
+    <li><strong><a href="/en-US/docs/Web/EXSLT">EXSLT</a></strong></li>
+    <li><strong><a href="/en-US/docs/Web/XPath">XPath</a></strong></li>
+    <li class="toggle">
+      <details open>
+        <summary>Guides</summary>
+        <ol>
+          <li><a href="/en-US/docs/Web/XSLT/Common_errors">Common XSLT Errors</a></li>
+          <li><a href="/en-US/docs/Web/XSLT/PI_Parameters">PI Parameters</a></li>
+          <li><a href="/en-US/docs/Web/XSLT/XSLT_JS_interface_in_Gecko">The XSLT/JavaScript Interface in Gecko</a></li>
+          <li><a href="/en-US/docs/Web/XSLT/Transforming_XML_with_XSLT">Transforming XML with XSLT</a></li>
+          <li><a href="/en-US/docs/Web/XSLT/Using_the_Mozilla_JavaScript_interface_to_XSL_Transformations">Using the
+              Mozilla JavaScript interface to XSL Transformations</a></li>
+        </ol>
+      </details>
+    </li>
+    <li class="toggle">
+      <details open>
+        <summary><a href="/en-US/docs/XSLT/Element">XSLT Elements</a></summary>
+        {{ListSubpagesForSidebar("/en-US/docs/Web/XSLT/Element", "", "", "&lt;xsl:", "&gt;")}}
+      </details>
+    </li>
+  </ol>
+</div>


### PR DESCRIPTION
Noticed that some weren't indented so refomatted. A few were using UL, but the guidance says they are supposed to be OL, so converted them.

Don't think there is a better way to handle these in Markdown without getting into something like a cusom section/macro