### PR TITLE
newly created -> new

### DIFF
--- a/files/en-us/web/api/messagechannel/messagechannel/index.md
+++ b/files/en-us/web/api/messagechannel/messagechannel/index.md
@@ -74,5 +74,4 @@ too](https://mdn.github.io/dom-examples/channel-messaging-basic/)).
 
 ## See also
 
-- [Using
-  channel messaging](/en-US/docs/Web/API/Channel_Messaging_API/Using_channel_messaging)
+- [Using channel messaging](/en-US/docs/Web/API/Channel_Messaging_API/Using_channel_messaging)

--- a/files/en-us/web/api/messagechannel/messagechannel/index.md
+++ b/files/en-us/web/api/messagechannel/messagechannel/index.md
@@ -25,6 +25,10 @@ new MessageChannel()
 
 ### Parameters
 
+None ({{jsxref("undefined")}}).
+
+### Return value
+
 A new {{domxref("MessageChannel")}} object.
 
 ## Examples

--- a/files/en-us/web/api/messagechannel/messagechannel/index.md
+++ b/files/en-us/web/api/messagechannel/messagechannel/index.md
@@ -25,7 +25,7 @@ new MessageChannel()
 
 ### Parameters
 
-A newly created {{domxref("MessageChannel")}} object.
+A new {{domxref("MessageChannel")}} object.
 
 ## Examples
 

--- a/files/en-us/web/api/messagechannel/messagechannel/index.md
+++ b/files/en-us/web/api/messagechannel/messagechannel/index.md
@@ -60,9 +60,9 @@ function handleMessage(e) {
 }
 ```
 
-For a full working example, see our [channel
-messaging basic demo](https://github.com/mdn/dom-examples/tree/master/channel-messaging-basic) on GitHub ([run it live
-too](https://mdn.github.io/dom-examples/channel-messaging-basic/)).
+For a full working example,
+see our [channel messaging basic demo](https://github.com/mdn/dom-examples/tree/master/channel-messaging-basic)
+on GitHub ([run it live too](https://mdn.github.io/dom-examples/channel-messaging-basic/)).
 
 ## Specifications
 

--- a/files/en-us/web/api/messagechannel/messagechannel/index.md
+++ b/files/en-us/web/api/messagechannel/messagechannel/index.md
@@ -34,12 +34,12 @@ A new {{domxref("MessageChannel")}} object.
 ## Examples
 
 In the following code block, you can see a new channel being created using the
-{{domxref("MessageChannel()", "MessageChannel.MessageChannel")}} constructor. When the
-IFrame has loaded, we pass `port2` to the IFrame using
-{{domxref("MessagePort.postMessage")}} along with a message. The
-`handleMessage` handler then responds to a message being sent back from the
-IFrame (using {{domxref("MessagePort.message_event", "onmessage")}}), putting it into a paragraph.
-{{domxref("MessageChannel.port1")}} is listened to, to check when the message arrives.
+{{domxref("MessageChannel()", "MessageChannel.MessageChannel")}} constructor.
+When the {{HTMLElement("iframe")}} has loaded,
+we pass `port2` to the `<iframe>` using {{domxref("MessagePort.postMessage")}} along with a message.
+The `handleMessage` handler then responds to a message being sent back from the
+`<ifram>` (using {{domxref("MessagePort.message_event", "onmessage")}}), putting it into a paragraph.
+The {{domxref("MessageChannel.port1", "port1")}} is listened to, to check when the message arrives.
 
 ```js
 var channel = new MessageChannel();


### PR DESCRIPTION
_A new ..._ is easier to read, short, simpler, and means the same as _The newly created …_. This fixes it.

Did a bit of cleaning of structure at the same time.