### PR TITLE
HTMLInputElement.showPicker() doc improvements

### DIFF
--- a/files/en-us/web/api/htmlinputelement/showpicker/index.md
+++ b/files/en-us/web/api/htmlinputelement/showpicker/index.md
@@ -6,30 +6,34 @@ tags:
   - HTML DOM
   - HTMLInputElement
   - Method
-  - NeedsCompatTable
   - Reference
 browser-compat: api.HTMLInputElement.showPicker
 ---
 {{ APIRef("HTML DOM") }}
 
-The **`HTMLInputElement.showPicker()`** method shows a browser picker to the
-user.
+The **`HTMLInputElement.showPicker()`** method displays the browser picker for an `input` element.
 
-A browser picker is shown when the element is one of these types: `"date"`,
-`"month"`, `"week"`, `"time"`, `"datetime-local"`, `"color"`, or `"file"`. It
-can also be prepopulated with items from a {{htmlelement("datalist")}} element or [`autocomplete`](/en-US/docs/Web/HTML/Attributes/autocomplete) attribute.
+This is the same picker that would normally be displayed when the element is selected, but can be triggered from a button press or other user interaction.
+
+Commonly browsers implement it for inputs of these types: `"date"`, `"month"`, `"week"`, `"time"`, `"datetime-local"`, `"color"`, or `"file"`.
+It can also be prepopulated with items from a {{htmlelement("datalist")}} element or [`autocomplete`](/en-US/docs/Web/HTML/Attributes/autocomplete) attribute.
+
+More generally, this method should ideally display the picker for any input element on the platform that has a picker.
+
 
 ### Return value
 
-{{jsxref("undefined")}}.
+None ({{jsxref("undefined")}}).
 
 ### Exceptions
 
+- `InvalidStateError` {{domxref("DOMException")}}
+  - : Thrown if the element is not mutable, meaning that the user cannot modify it and/or that it cannot be automatically prefilled.
 - `NotAllowedError` {{domxref("DOMException")}}
-  - : Thrown if not called in response to a user gesture such as a touch gesture
-    or mouse click.
+  - : Thrown if not explicitly triggered by a user action such as a touch gesture or mouse click (the picker requires {{Glossary("Transient activation")}}).
 - `SecurityError` {{domxref("DOMException")}}
-  - : Thrown if called in a cross-origin iframe.
+  - : Thrown if called in a cross-origin iframe, except for file and color pickers (exempt for historical reasons).
+
 
 ## Syntax
 
@@ -43,35 +47,161 @@ None.
 
 ## Examples
 
-Click the button in this example to show a color picker.
+### Feature Detection
 
-### HTML
-
-```html
-<input type="color">
-<button>Show the color picker</button>
-```
-
-### JavaScript
+The code below shows how to check if `showPicker()` is supported:
 
 ```js
-const button = document.querySelector("button");
-const colorInput = document.querySelector("input");
+if ('showPicker' in HTMLInputElement.prototype) {
+  // showPicker() is supported.
+}
+```
 
-button.addEventListener("click", () => {
-  try {
-    colorInput.showPicker();
-    // A color picker is shown.
-  } catch (error) {
-    window.alert(error);
-    // Use external library when this fails.
-  }
+### Showing the normal pickers
+
+This example shows how the picker can be launched for each of the inputs that normally support this feature. 
+
+#### HTML
+
+```html
+<p>
+<input type="color">
+<button id ="color">Show the color picker</button>
+</p>
+
+<p>
+<input type="date">
+<button id ="date">Show the date picker</button>
+</p>
+
+<p>
+<input type="datetime-local">
+<button id ="datetime-local">Show the datetime-local picker</button>
+</p>
+
+<p>
+<input type="file">
+<button id ="file">Show the file picker</button>
+</p>
+
+<p>
+<input type="month">
+<button id ="month">Show the month picker</button>
+</p>
+
+<p>
+<input type="time">
+<button id ="time">Show the time picker</button>
+</p>
+
+<p>
+<input type="week">
+<button id ="week">Show the week picker</button>
+</p>
+```
+
+#### JavaScript
+
+The code simply gets the previous element of the selected button and calls `showPicker()` on it.
+
+```js
+document.querySelectorAll("button").forEach((button) => {
+  button.addEventListener("click", () => {
+    const input = event.srcElement.previousElementSibling;
+    try {
+      input.showPicker();
+    } catch(error) {
+      window.alert(error);
+    }
+  });
 });
 ```
 
-### Result
+#### Result
 
-{{EmbedLiveSample("Examples")}}
+Click the button next to each input type to show its picker.
+
+{{EmbedLiveSample("Showing the normal pickers","600px", "350px")}}
+
+
+### showPicker() for a datalist input
+
+This example shows how to show the picker for a input that specifes a text-based [`<datalist>`](/en-US/docs/Web/HTML/Element/datalist) (the same approach would work for other lists).
+
+#### HTML
+
+Here we define a `<datalist>` in HTML consisting of a number of internet browsers.
+```html
+<datalist id="browsers">
+  <option value="Chrome">
+  <option value="Firefox">
+  <option value="Internet Explorer">
+  <option value="Opera">
+  <option value="Safari">
+  <option value="Microsoft Edge">
+</datalist>
+<input type="text" list="browsers">
+<button>Select browser</button>
+```
+
+#### JavaScript
+
+The code below shows the picker for the input when the button is clicked.
+```js
+  const button = document.querySelector("button");
+  const browserInput = document.querySelector("input");
+
+  button.addEventListener("click", () => {
+    try {
+      browserInput.showPicker();
+    } catch (error) {
+      // Fall back to another picker mechanism
+    }
+  });
+```
+
+#### Result
+
+Click the button to show the picker for the "browser options" input:
+
+{{EmbedLiveSample("showPicker() for a datalist input","600px", "50px")}}
+
+
+### showPicker() for autocomplete
+
+This example shows how to show the picker for an [`autocomplete`](/en-US/docs/Web/HTML/Attributes/autocomplete) input.
+
+#### HTML
+
+Here we define an input that takes an autocomplete option of "name".
+
+```html
+<input autocomplete="name">
+<button>Show autocomplete options</button>
+```
+
+#### JavaScript
+
+The code below shows the picker for the input when the button is clicked.
+```js
+  const button = document.querySelector("button");
+  const browserInput = document.querySelector("input");
+
+  button.addEventListener("click", () => {
+    try {
+      browserInput.showPicker();
+    } catch (error) {
+      // Fall back to another picker mechanism
+    }
+  });
+```
+
+#### Result
+
+Click the button to show the picker for the "name" autocomplete input:
+
+{{EmbedLiveSample("showPicker() for autocomplete","600px", "50px")}}
+
 
 ## Specifications
 
@@ -85,3 +215,5 @@ button.addEventListener("click", () => {
 
 - {{ HTMLElement("input") }}
 - {{ domxref("HTMLInputElement") }}
+- {{htmlelement("datalist")}}
+- [`autocomplete`](/en-US/docs/Web/HTML/Attributes/autocomplete)


### PR DESCRIPTION
FF101 supports [HTMLInputElement.showPicker()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/showPicker) - added in https://bugzilla.mozilla.org/show_bug.cgi?id=1745005

This updates the existing doc to reflect some points that I felt were not clear:
1. The input types that are supported depends on the browser - it is desirably "all inputs that normally have a picker also work with showpicker" but this is not guaranteed.
2. Make it clear that this allows you to programmatically trigger an existing picker for an input via user interaction from some other control like a button.
3. Add the exception for the mutable case.
4. Add examples for autocomplete and datalist
5. Add live examples for each of the types to make it much easier to test which are supported on particular platforms.

Other docs work tracked in #15407