### PR TITLE
FF101 RelNote: HTMLInputElement.showPicker() supported

### DIFF
--- a/files/en-us/mozilla/firefox/releases/101/index.md
+++ b/files/en-us/mozilla/firefox/releases/101/index.md
@@ -39,6 +39,8 @@ This article provides information about the changes in Firefox 101 that will aff
 
 #### DOM
 
+- [`HTMLInputElement.showPicker()`](/en-US/docs/Web/API/HTMLInputElement/showPicker) is now supported, allowing the picker for an input element to be displayed when a user interacts with some other element, such as a button ({{bug(1745005)}}).
+
 #### Media, WebRTC, and Web Audio
 
 #### Removals


### PR DESCRIPTION
This is the release note for FF101 support of [`HTMLInputElement.showPicker()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/showPicker), added in https://bugzilla.mozilla.org/show_bug.cgi?id=1745005

Related docs work can be tracked in #15407