### PR TITLE
Fixed a typo

### DIFF
--- a/files/en-us/web/http/headers/authorization/index.md
+++ b/files/en-us/web/http/headers/authorization/index.md
@@ -116,7 +116,7 @@ Generally you will need to check the relevant specifications for these (keys for
   - : Nonce count. The hexadecimal count of requests in which the client has sent the current `cnonce` value (including the current request).
     The server can use duplicate `nc` values to recognize replay requests.
 - **`userhash`** {{optional_inline}}
-  - : `"true` if the username has been hashed. `"false"` by default.
+  - : `"true"` if the username has been hashed. `"false"` by default.
 
 ## Examples
 


### PR DESCRIPTION
#### Summary
It should be `"true"` instead of `"true`.

#### Motivation
There was a typo in the page so I thought fixing the typo would make the page look better.

#### Supporting details
None

#### Related issues
None

#### Metadata

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
