### PR TITLE
Update GroupData.json for Geometry Interfaces sidebar

### DIFF
--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -550,7 +550,12 @@
       "events": []
     },
     "Geometry Interfaces": {
-      "interfaces": ["CSSMatrix", "DOMMatrix", "DOMMatrixReadOnly", "DOMRect", "DOMRectReadOnly", "Point"],
+      "interfaces": [
+        "DOMMatrix",
+        "DOMMatrixReadOnly",
+        "DOMRect",
+        "DOMRectReadOnly"
+      ],
       "methods": [],
       "properties": [],
       "events": []


### PR DESCRIPTION
`CSSMatrix` and `Point` don't exist anymore (they are aliases or long removed).

We don't want them in the sidebar (and they create 2 flaws on each article about Geometry API.