### PR TITLE
Add a missing semicolon

### DIFF
--- a/files/en-us/learn/css/css_layout/floats/index.md
+++ b/files/en-us/learn/css/css_layout/floats/index.md
@@ -74,7 +74,7 @@ body {
   width: 90%;
   max-width: 900px;
   margin: 0 auto;
-  font: .9em/1.2 Arial, Helvetica, sans-serif
+  font: .9em/1.2 Arial, Helvetica, sans-serif;
 }
 
 .box {
@@ -157,7 +157,7 @@ body {
   width: 90%;
   max-width: 900px;
   margin: 0 auto;
-  font: .9em/1.2 Arial, Helvetica, sans-serif
+  font: .9em/1.2 Arial, Helvetica, sans-serif;
 }
 
 .box {
@@ -210,7 +210,7 @@ body {
   width: 90%;
   max-width: 900px;
   margin: 0 auto;
-  font: .9em/1.2 Arial, Helvetica, sans-serif
+  font: .9em/1.2 Arial, Helvetica, sans-serif;
 }
 
 .box {


### PR DESCRIPTION
One is missing at the end of the last declaration of the body's CSS styling.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
This was jus a minor hiccup, so it is meant to aid readability. The code works either way. 

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [✅] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
