### PR TITLE
Fix sidebars in Bluetooth API

### DIFF
--- a/files/en-us/web/api/bluetoothdevice/index.md
+++ b/files/en-us/web/api/bluetoothdevice/index.md
@@ -13,8 +13,7 @@ browser-compat: api.BluetoothDevice
 ---
 {{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
-The BluetoothDevice interface of the [Web Bluetooth
-API](/en-US/docs/Web/API/Web_Bluetooth_API) represents a Bluetooth device inside a particular script execution
+The BluetoothDevice interface of the [Web Bluetooth API](/en-US/docs/Web/API/Web_Bluetooth_API) represents a Bluetooth device inside a particular script execution
 environment.
 
 {{InheritanceDiagram}}

--- a/files/en-us/web/api/bluetoothdevice/name/index.md
+++ b/files/en-us/web/api/bluetoothdevice/name/index.md
@@ -17,11 +17,6 @@ browser-compat: api.BluetoothDevice.name
 The **`BluetoothDevice.name`** read-only property returns a
 string that provides a human-readable name for the device.
 
-> **Note:** This page describes the W3C Community Group BluetoothDevice.name property. For the
-> Firefox OS property of the same name, see
-> {{DOMxRef("BluetoothDevice_%28Firefox_OS%29/name", "BluetoothDevice.name
-    (Firefox OS)")}}.
-
 ## Value
 
 A string.

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptor/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptor/index.md
@@ -12,7 +12,7 @@ tags:
   - getDescriptor()
 browser-compat: api.BluetoothRemoteGATTCharacteristic.getDescriptor
 ---
-{{SeeCompatTable}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`BluetoothRemoteGATTCharacteristic.getDescriptor()`** method
 returns a {{jsxref("Promise")}} that resolves to the

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptors/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/getdescriptors/index.md
@@ -12,7 +12,7 @@ tags:
   - getDescriptors()
 browser-compat: api.BluetoothRemoteGATTCharacteristic.getDescriptors
 ---
-{{SeeCompatTable}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`BluetoothRemoteGATTCharacteristic.getDescriptors()`** method
 returns a {{jsxref("Promise")}} that resolves to an {{jsxref("Array")}} of all

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/properties/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/properties/index.md
@@ -12,7 +12,7 @@ tags:
   - properties
 browser-compat: api.BluetoothRemoteGATTCharacteristic.properties
 ---
-{{SeeCompatTable}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`BluetoothRemoteGATTCharacteristic.properties`**
 read-only property returns a {{domxref('BluetoothCharacteristicProperties')}} instance

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/readvalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/readvalue/index.md
@@ -12,7 +12,7 @@ tags:
   - readValue
 browser-compat: api.BluetoothRemoteGATTCharacteristic.readValue
 ---
-{{SeeCompatTable}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`BluetoothRemoteGATTCharacteristic.readValue()`** method
 returns a {{jsxref("Promise")}} that resolves to a {{jsxref("DataView")}} holding a

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/service/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/service/index.md
@@ -12,7 +12,7 @@ tags:
   - Web Bluetooth API
 browser-compat: api.BluetoothRemoteGATTCharacteristic.service
 ---
-{{SeeCompatTable}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`BluetoothRemoteGATTCharacteristic.service`** read-only
 property returns the {{domxref("BluetoothRemoteGATTService")}} this characteristic belongs to.

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/startnotifications/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/startnotifications/index.md
@@ -12,7 +12,7 @@ tags:
   - startNotifications()
 browser-compat: api.BluetoothRemoteGATTCharacteristic.startNotifications
 ---
-{{SeeCompatTable}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`BluetoothRemoteGATTCharacteristic.startNotifications()`** method
 returns a {{jsxref("Promise")}} to the BluetoothRemoteGATTCharacteristic instance when

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/stopnotifications/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/stopnotifications/index.md
@@ -12,7 +12,7 @@ tags:
   - stopNotifications
 browser-compat: api.BluetoothRemoteGATTCharacteristic.stopNotifications
 ---
-{{SeeCompatTable}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`BluetoothRemoteGATTCharacteristic.stopNotifications()`** method
 returns a {{jsxref("Promise")}} to the BluetoothRemoteGATTCharacteristic instance when

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/uuid/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/uuid/index.md
@@ -13,7 +13,7 @@ tags:
   - uuid
 browser-compat: api.BluetoothRemoteGATTCharacteristic.uuid
 ---
-{{SeeCompatTable}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`BluetoothRemoteGATTCharacteristic.uuid`** read-only
 property returns a string containing the UUID of the characteristic, for

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/value/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/value/index.md
@@ -12,7 +12,7 @@ tags:
   - value
 browser-compat: api.BluetoothRemoteGATTCharacteristic.value
 ---
-{{SeeCompatTable}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`BluetoothRemoteGATTCharacteristic.value`** read-only
 property returns currently cached characteristic value. This value gets updated when the

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevalue/index.md
@@ -12,7 +12,7 @@ tags:
   - writeValue
 browser-compat: api.BluetoothRemoteGATTCharacteristic.writeValue
 ---
-{{Deprecated_header}}
+{{APIRef("Bluetooth API")}}{{Deprecated_header}}
 
 Use {{DOMxRef("BluetoothRemoteGATTCharacteristic.writeValueWithResponse()")}} and {{DOMxRef("BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse()")}} instead.
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithoutresponse/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithoutresponse/index.md
@@ -12,6 +12,8 @@ tags:
   - writeValueWithoutResponse
 browser-compat: api.BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse
 ---
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
+
 The **`BluetoothRemoteGATTCharacteristic.writeValueWithoutResponse()`** method sets a {{domxref("BluetoothRemoteGATTCharacteristic")}} object's `value` property to the bytes contained in a given {{JSxRef("ArrayBuffer")}}, calls [`WriteCharacteristicValue`(_this_=`this`, _value=value_, _response_=`"never"`)](https://webbluetoothcg.github.io/web-bluetooth/#writecharacteristicvalue), and returns the resulting {{JSxRef("Promise")}}.
 
 ## Syntax

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithresponse/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithresponse/index.md
@@ -12,6 +12,8 @@ tags:
   - writeValueWithResponse
 browser-compat: api.BluetoothRemoteGATTCharacteristic.writeValueWithResponse
 ---
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
+
 The **`BluetoothRemoteGATTCharacteristic.writeValueWithResponse()`** method sets a {{domxref("BluetoothRemoteGATTCharacteristic")}} object's `value` property to the bytes contained in a given {{JSxRef("ArrayBuffer")}}, calls [`WriteCharacteristicValue`(_this_=`this`, _value=value_, _response_=`"required"`)](https://webbluetoothcg.github.io/web-bluetooth/#writecharacteristicvalue), and returns the resulting {{JSxRef("Promise")}}.
 
 ## Syntax

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/characteristic/index.md
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/characteristic/index.md
@@ -13,7 +13,7 @@ tags:
   - characteristic
 browser-compat: api.BluetoothRemoteGATTDescriptor.characteristic
 ---
-{{APIRef("Web Bluetooth API")}}{{SeeCompatTable}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`BluetoothRemoteGATTDescriptor.characteristic`**
 read-only property returns the {{domxref("BluetoothRemoteGATTCharacteristic")}} this

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/index.md
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/index.md
@@ -16,10 +16,6 @@ browser-compat: api.BluetoothRemoteGATTDescriptor
 The `BluetoothRemoteGATTDescriptor` interface of the [Web Bluetooth API](/en-US/docs/Web/API/Web_Bluetooth_API) provides a GATT Descriptor,
 which provides further information about a characteristic's value.
 
-> **Note:** This page describes the W3C Community Group Web Bluetooth API. For the Firefox OS
-> Bluetooth API, see [`BluetoothGattDescriptor`
-> (Firefox OS)](/en-US/docs/Archive/B2G_OS/API/BluetoothGattDescriptor).
-
 ## Properties
 
 - {{DOMxRef("BluetoothRemoteGATTDescriptor.characteristic")}}{{ReadOnlyInline}}

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/readvalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/readvalue/index.md
@@ -13,7 +13,7 @@ tags:
   - readValue()
 browser-compat: api.BluetoothRemoteGATTDescriptor.readValue
 ---
-{{APIRef("Web Bluetooth API")}}{{SeeCompatTable}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The
 **`BluetoothRemoteGATTDescriptor.readValue()`**

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/uuid/index.md
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/uuid/index.md
@@ -12,7 +12,7 @@ tags:
   - uuid
 browser-compat: api.BluetoothRemoteGATTDescriptor.uuid
 ---
-{{APIRef("Web Bluetooth API")}}{{SeeCompatTable}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`BluetoothRemoteGATTDescriptor.uuid`** read-only property returns the {{Glossary("UUID")}} of the characteristic descriptor.
 For example '`00002902-0000-1000-8000-00805f9b34fb`' for theClient Characteristic Configuration descriptor.

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/value/index.md
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/value/index.md
@@ -13,7 +13,7 @@ tags:
   - value
 browser-compat: api.BluetoothRemoteGATTDescriptor.value
 ---
-{{APIRef("Web Bluetooth API")}}{{SeeCompatTable}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`BluetoothRemoteGATTDescriptor.value`**
 read-only property returns an {{jsxref("ArrayBuffer")}} containing the currently cached

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/writevalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/writevalue/index.md
@@ -13,7 +13,7 @@ tags:
   - writeValue()
 browser-compat: api.BluetoothRemoteGATTDescriptor.writeValue
 ---
-{{APIRef("Web Bluetooth API")}}{{SeeCompatTable}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`BluetoothRemoteGATTDescriptor.writeValue()`**
 method sets the value property to the bytes contained in

--- a/files/en-us/web/api/bluetoothremotegattserver/connect/index.md
+++ b/files/en-us/web/api/bluetoothremotegattserver/connect/index.md
@@ -12,7 +12,7 @@ tags:
   - connect()
 browser-compat: api.BluetoothRemoteGATTServer.connect
 ---
-{{SeeCompatTable}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The
 **`BluetoothRemoteGATTServer.connect()`** method causes the

--- a/files/en-us/web/api/bluetoothremotegattserver/connected/index.md
+++ b/files/en-us/web/api/bluetoothremotegattserver/connected/index.md
@@ -11,7 +11,7 @@ tags:
   - Web Bluetooth API
 browser-compat: api.BluetoothRemoteGATTServer.connected
 ---
-{{SeeCompatTable}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`BluetoothRemoteGATTServer.connected`** read-only
 property returns a boolean value that returns true while this script execution

--- a/files/en-us/web/api/bluetoothremotegattserver/device/index.md
+++ b/files/en-us/web/api/bluetoothremotegattserver/device/index.md
@@ -10,7 +10,7 @@ tags:
   - Reference
 browser-compat: api.BluetoothRemoteGATTServer.device
 ---
-{{SeeCompatTable}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`BluetoothRemoteGATTServer.device`** read-only property
 returns a reference to the {{domxref("BluetoothDevice")}} running the server.

--- a/files/en-us/web/api/bluetoothremotegattserver/disconnect/index.md
+++ b/files/en-us/web/api/bluetoothremotegattserver/disconnect/index.md
@@ -12,7 +12,7 @@ tags:
   - disconnect()
 browser-compat: api.BluetoothRemoteGATTServer.disconnect
 ---
-{{SeeCompatTable}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`BluetoothRemoteGATTServer.disconnect()`** method causes
 the script execution environment to disconnect from `this.device`.

--- a/files/en-us/web/api/bluetoothremotegattserver/getprimaryservice/index.md
+++ b/files/en-us/web/api/bluetoothremotegattserver/getprimaryservice/index.md
@@ -12,7 +12,7 @@ tags:
   - getPrimaryService()
 browser-compat: api.BluetoothRemoteGATTServer.getPrimaryService
 ---
-{{SeeCompatTable}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`BluetoothRemoteGATTServer.getPrimaryService()`** method
 returns a promise to the primary {{domxref("BluetoothRemoteGATTService")}} offered by the

--- a/files/en-us/web/api/bluetoothremotegattserver/getprimaryservices/index.md
+++ b/files/en-us/web/api/bluetoothremotegattserver/getprimaryservices/index.md
@@ -12,7 +12,7 @@ tags:
   - getPrimaryServices()
 browser-compat: api.BluetoothRemoteGATTServer.getPrimaryServices
 ---
-{{SeeCompatTable}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **BluetoothRemoteGATTServer.getPrimaryServices()** method returns a
 promise to a list of primary {{domxref("BluetoothRemoteGATTService")}} objects offered by the
@@ -31,7 +31,7 @@ objects.
 
 ### Parameters
 
-- `BluetoothServiceUUID`
+- `bluetoothServiceUUID`
   - : A Bluetooth service universally unique identifier for a specified device.
 
 ## Specifications

--- a/files/en-us/web/api/bluetoothremotegattserver/index.md
+++ b/files/en-us/web/api/bluetoothremotegattserver/index.md
@@ -16,10 +16,6 @@ browser-compat: api.BluetoothRemoteGATTServer
 The **`BluetoothRemoteGATTServer`** interface of the [Web Bluetooth API](/en-US/docs/Web/API/Web_Bluetooth_API) represents a GATT
 Server on a remote device.
 
-> **Note:** This page describes the W3C Community Group Web Bluetooth API. For the Firefox OS
-> Bluetooth API, see [`BluetoothGattServer`
-> (Firefox OS)](/en-US/docs/Archive/B2G_OS/API/BluetoothGattServer).
-
 ## Properties
 
 - {{DOMxRef("BluetoothRemoteGATTServer.connected")}}{{ReadOnlyInline}}

--- a/files/en-us/web/api/bluetoothremotegattservice/device/index.md
+++ b/files/en-us/web/api/bluetoothremotegattservice/device/index.md
@@ -12,7 +12,7 @@ tags:
   - Web Bluetooth API
 browser-compat: api.BluetoothRemoteGATTService.device
 ---
-{{SeeCompatTable}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`BluetoothGATTService.device`** read-only property
 returns information about a Bluetooth device through an instance of

--- a/files/en-us/web/api/bluetoothremotegattservice/getcharacteristic/index.md
+++ b/files/en-us/web/api/bluetoothremotegattservice/getcharacteristic/index.md
@@ -12,7 +12,7 @@ tags:
   - getCharacteristic()
 browser-compat: api.BluetoothRemoteGATTService.getCharacteristic
 ---
-{{SeeCompatTable}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`BluetoothGATTService.getCharacteristic()`** method
 returns a {{jsxref("Promise")}} to an instance of

--- a/files/en-us/web/api/bluetoothremotegattservice/getcharacteristics/index.md
+++ b/files/en-us/web/api/bluetoothremotegattservice/getcharacteristics/index.md
@@ -12,7 +12,7 @@ tags:
   - getCharacteristics()
 browser-compat: api.BluetoothRemoteGATTService.getCharacteristics
 ---
-{{SeeCompatTable}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`BluetoothGATTService.getCharacteristics()`** method
 returns a {{jsxref("Promise")}} to a list of {{domxref("BluetoothRemoteGATTCharacteristic")}}
@@ -31,7 +31,7 @@ A {{jsxref("Promise")}} to an
 
 ### Parameters
 
-- characteristic
+- characteristics
   - : The UUID of a characteristic, for
     example `'00002a37-0000-1000-8000-00805f9b34fb'` for the Heart Rate
     Measurement characteristic.

--- a/files/en-us/web/api/bluetoothremotegattservice/index.md
+++ b/files/en-us/web/api/bluetoothremotegattservice/index.md
@@ -12,11 +12,7 @@ tags:
   - Web Bluetooth API
 browser-compat: api.BluetoothRemoteGATTService
 ---
-{{SeeCompatTable}}
-
-> **Note:** This page describes the W3C Community Group BluetoothRemoteGATTService, formerly
-> called BluetoothGATTService. For the Firefox OS interface of the same name,
-> see [`BluetoothGattService`](/en-US/docs/Archive/B2G_OS/API/BluetoothGattService).
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The `BluetoothRemoteGATTService` interface of the [Web Bluetooth API](/en-US/docs/Web/API/Web_Bluetooth_API) represents a
 service provided by a GATT server, including a device, a list of referenced services,
@@ -42,7 +38,7 @@ and a list of the characteristics of this service.
     {{domxref("BluetoothRemoteGATTCharacteristic")}} for a given universally unique identifier
     (UUID).
 - {{domxref("BluetoothRemoteGATTService.getCharacteristics()")}}
-  - : Returns a {{jsxref("Promise")}} to an {{domxref("Array")}} of
+  - : Returns a {{jsxref("Promise")}} to an {{jsxref("Array")}} of
     {{domxref("BluetoothRemoteGATTCharacteristic")}} instances for an optional universally
     unique identifier (UUID).
 

--- a/files/en-us/web/api/bluetoothremotegattservice/isprimary/index.md
+++ b/files/en-us/web/api/bluetoothremotegattservice/isprimary/index.md
@@ -12,7 +12,7 @@ tags:
   - isPrimary
 browser-compat: api.BluetoothRemoteGATTService.isPrimary
 ---
-{{SeeCompatTable}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`BluetoothGATTService.isPrimary`** read-only property
 returns a boolean value that indicates whether this is a primary service. If it

--- a/files/en-us/web/api/bluetoothremotegattservice/uuid/index.md
+++ b/files/en-us/web/api/bluetoothremotegattservice/uuid/index.md
@@ -12,7 +12,7 @@ tags:
   - uuid
 browser-compat: api.BluetoothRemoteGATTService.uuid
 ---
-{{SeeCompatTable}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`BluetoothGATTService.uuid`** read-only property
 returns a string representing the UUID of this service.

--- a/files/en-us/web/api/bluetoothuuid/canonicaluuid/index.md
+++ b/files/en-us/web/api/bluetoothuuid/canonicaluuid/index.md
@@ -5,11 +5,12 @@ tags:
   - API
   - Method
   - Reference
+  - Experimental
   - canonicalUUID()
   - BluetoothUUID
 browser-compat: api.BluetoothUUID.canonicalUUID
 ---
-{{APIRef("Bluetooth API")}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`canonicalUUID()`**  method of the {{domxref("BluetoothUUID")}} interface returns the 128-bit UUID when passed a 16- or 32-bit UUID alias.
 

--- a/files/en-us/web/api/bluetoothuuid/getcharacteristic/index.md
+++ b/files/en-us/web/api/bluetoothuuid/getcharacteristic/index.md
@@ -5,11 +5,12 @@ tags:
   - API
   - Method
   - Reference
+  - Experimental
   - getCharacteristic
   - BluetoothUUID
 browser-compat: api.BluetoothUUID.getCharacteristic
 ---
-{{APIRef("Bluetooth API")}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`getCharacteristic()`**  method of the {{domxref("BluetoothUUID")}} interface returns a UUID representing a registered characteristic when passed a name or the 16- or 32-bit UUID alias.
 

--- a/files/en-us/web/api/bluetoothuuid/getdescriptor/index.md
+++ b/files/en-us/web/api/bluetoothuuid/getdescriptor/index.md
@@ -6,10 +6,11 @@ tags:
   - Method
   - Reference
   - getDescriptor
+  - Experimental
   - BluetoothUUID
 browser-compat: api.BluetoothUUID.getDescriptor
 ---
-{{APIRef("Bluetooth API")}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`getDescriptor()`**  method of the {{domxref("BluetoothUUID")}} interface returns a UUID representing a registered descriptor when passed a name or the 16- or 32-bit UUID alias.
 

--- a/files/en-us/web/api/bluetoothuuid/getservice/index.md
+++ b/files/en-us/web/api/bluetoothuuid/getservice/index.md
@@ -6,10 +6,11 @@ tags:
   - Method
   - Reference
   - getService
+  - Experimental
   - BluetoothUUID
 browser-compat: api.BluetoothUUID.getService
 ---
-{{APIRef("Bluetooth API")}}
+{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`getService()`**  method of the {{domxref("BluetoothUUID")}} interface returns a UUID representing a registered service when passed a name or the 16- or 32-bit UUID alias.
 

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -62,12 +62,11 @@
     "Bluetooth API": {
       "overview": ["Web Bluetooth API"],
       "interfaces": [
-        "BluetoothAdvertisingData",
         "BluetoothDevice",
-        "BluetoothGATTCharacteristic",
-        "BluetoothGATTDescriptor",
-        "BluetoothGATTRemoteServer",
-        "BluetoothGATTService"
+        "BluetoothRemoteGATTCharacteristic",
+        "BluetoothRemoteGATTServer",
+        "BluetoothRemoteGATTService",
+        "BluetoothUUID"
       ],
       "methods": [],
       "properties": [],


### PR DESCRIPTION
Sidebars in Bluetooth API are a mess. This is fixing it.
- The interface names were the ones from the old Firefox OS Bluetooth API (with redirections). This was creating 4-5 flaws per page.
- The sidebar was not displayed on each page
- Some parts were not labeled as _Experimental_
- There were notes about Firefox OS (now gone!)
- One interface (`BluetoothUUID`) is documented, but not listed in the sidebar.

There will be some fix in browser-compat-data too as some spec links and mdn links are missing (nothing big).