### PR TITLE
Fix CSS Painting API sidebar

### DIFF
--- a/files/en-us/web/api/css/index.md
+++ b/files/en-us/web/api/css/index.md
@@ -52,6 +52,3 @@ _No inherited static methods_.
 
 {{Compat}}
 
-## See also
-
-- [Components.utils.importGlobalProperties](/en-US/docs/Components.utils.importGlobalProperties)

--- a/files/en-us/web/api/css/paintworklet/index.md
+++ b/files/en-us/web/api/css/paintworklet/index.md
@@ -16,8 +16,7 @@ browser-compat: api.CSS.paintWorklet
 ---
 {{APIRef("CSSOM")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
-**`paintWorklet`** is a static,
-read-only property of the {{DOMxRef("CSS")}} interface that provides access to the
+The static, read-only **`paintWorklet`**  property of the {{DOMxRef("CSS")}} interface provides access to the
 {{DOMxRef("PaintWorklet")}}, which programmatically generates an image where a CSS
 property expects a file.
 
@@ -49,5 +48,4 @@ file and does so by feature detection.
 ## See also
 
 - [CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API)
-- [Houdini APIs](/en-US/docs/Web/Houdini)
-- [Houdini overview](/en-US/docs/Web/Houdini/learn)
+- [Houdini APIs](/en-US/docs/Web/Guide/Houdini)

--- a/files/en-us/web/api/css_painting_api/guide/index.md
+++ b/files/en-us/web/api/css_painting_api/guide/index.md
@@ -8,7 +8,8 @@ tags:
   - Houdini
   - Learn
 ---
-The CSS Paint API is designed to enable developers to programmatically define images which can then be used anywhere a CSS image can be invoked, such as CSS [`background-image`](/en-US/docs/Web/CSS/background-image), [`border-image`](/en-US/docs/Web/CSS/border-image-source), [`mask-image`](/en-US/docs/Web/CSS/mask-image), etc.
+{{DefaultAPISidebar("CSS Painting API")}}
+The [CSS Paint API](/en-US/docs/Web/API/CSS_Painting_API) is designed to enable developers to programmatically define images which can then be used anywhere a CSS image can be invoked, such as CSS [`background-image`](/en-US/docs/Web/CSS/background-image), [`border-image`](/en-US/docs/Web/CSS/border-image-source), [`mask-image`](/en-US/docs/Web/CSS/mask-image), etc.
 
 To programmatically create an image used by a CSS stylesheet we need to work through a few steps:
 

--- a/files/en-us/web/api/css_painting_api/index.md
+++ b/files/en-us/web/api/css_painting_api/index.md
@@ -11,7 +11,7 @@ tags:
 ---
 {{DefaultAPISidebar("CSS Painting API")}}
 
-The CSS Painting API — part of the [CSS Houdini](/en-US/docs/Web/Houdini) umbrella of APIs — allows developers to write JavaScript functions that can draw directly into an element's background, border, or content.
+The CSS Painting API — part of the [CSS Houdini](/en-US/docs/Web/Guide/Houdini) umbrella of APIs — allows developers to write JavaScript functions that can draw directly into an element's background, border, or content.
 
 ## Concepts and usage
 
@@ -154,4 +154,4 @@ See the browser compatibility data for each CSS Painting API Interface.
 
 - [Using the CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API/Guide)
 - [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Typed_OM_API)
-- [CSS Houdini](/en-US/docs/Web/Houdini)
+- [CSS Houdini](/en-US/docs/Web/Guide/Houdini)

--- a/files/en-us/web/api/paintworklet/devicepixelratio/index.md
+++ b/files/en-us/web/api/paintworklet/devicepixelratio/index.md
@@ -37,6 +37,5 @@ A double-precision integer.
 - [CSS.paintWorklet](/en-US/docs/Web/API/CSS/paintWorklet)
 - [Worklet](/en-US/docs/Web/API/Worklet)
 - [CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API)
-- [Houdini APIs](/en-US/docs/Web/Houdini)
-- [Houdini overview](/en-US/docs/Web/Houdini/learn)
+- [Houdini APIs](/en-US/docs/Web/Guide/Houdini)
 - [window.devicePixelRatio](/en-US/docs/Web/API/Window/devicePixelRatio)

--- a/files/en-us/web/api/paintworklet/index.md
+++ b/files/en-us/web/api/paintworklet/index.md
@@ -39,7 +39,7 @@ _This interface inherits methods from {{domxref('Worklet')}}._
 
 - {{domxref('PaintWorklet.registerPaint()')}}
   - : Registers a class programmatically generate an image where a CSS property expects a file.
-- {{domxref('Worklet.addModule', 'CSS.PaintWorklet.addModule()')}}
+- {{domxref('Worklet.addModule', 'PaintWorklet.addModule()')}}
   - : The [`addModule()`](/en-US/docs/Web/API/Worklet/addModule) method, inherited from the _{{domxref('Worklet')}}_ interface loads the module in the given JavaScript file and adds it to the current PaintWorklet.
 
 ## Examples
@@ -117,4 +117,4 @@ You can also use the {{cssxref('@supports')}} at-rule.
 ## See also
 
 - [CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API)
-- [Houdini APIs](/en-US/docs/Web/Houdini)
+- [Houdini APIs](/en-US/docs/Web/Guide/Houdini)

--- a/files/en-us/web/api/paintworklet/registerpaint/index.md
+++ b/files/en-us/web/api/paintworklet/registerpaint/index.md
@@ -101,5 +101,4 @@ li {
 ## See also
 
 - [CSS Painting API](/en-US/docs/Web/API/CSS_Painting_API)
-- [Houdini APIs](/en-US/docs/Web/Houdini)
-- [Houdini overview](/en-US/docs/Web/Houdini/learn)
+- [Houdini APIs](/en-US/docs/Web/Guide/Houdini)

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -181,12 +181,14 @@
     },
     "CSS Painting API": {
       "overview": ["CSS Painting API"],
+      "guides": ["/docs/Web/API/CSS_Painting_API/Guide"],
       "interfaces": [
+        "PaintWorklet",
         "PaintWorkletGlobalScope",
         "PaintRenderingContext2D",
         "PaintSize"
       ],
-      "methods": ["PaintWorklet.registerPaint()"],
+      "methods": ["CSS.paintWorklet"],
       "properties": [],
       "events": []
     },


### PR DESCRIPTION
This fixes the Houdini's CSS Painting API sidebar.

Note that there are a few red links left (but they don't generate flaws and are actually missing documentation)

I also fixed:
- Broken links to the Houdini overview page.
- Broken links to the non-existing Houdini/learn page (removed).
- A broken link to some XUL pages (removed).