### PR TITLE
Drop `0` from fractionalSecondDigits values spec.

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
@@ -234,7 +234,6 @@ new Intl.DateTimeFormat(locales, options)
       - : The number of digits used to represent fractions of a second (any
         additional digits are truncated). Possible values are:
 
-        - `0` (Fractional part dropped.)
         - `1` (Fractional part represented as 1 digit. For
           example, 736 is formatted as `7`.)
         - `2` (Fractional part represented as 2 digits. For


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Drop `0` from fractionalSecondDigits values spec.
Because it is incorrect with Intl API Spec.


#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Actually web browsers does not implement to allow 0 for fractionalSecondDigits, and throws RangeError when using `fractionalSecondDigits: 0`.
I confirmed with Chrome v101, Safari v15.4, Firefox v99 and Node.js v16,v17.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
`fractionalSecondDigits` does not allow `0` in ECMAScript® 2021 Internationalization API Specification.
https://402.ecma-international.org/8.0/#sec-datetimeformat-abstracts

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
https://github.com/tc39/ecma402/issues/590

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
