### PR TITLE
IDBRequest.error returns a DOMException or null, no more a DOMError

### DIFF
--- a/files/en-us/web/api/idbrequest/error/index.md
+++ b/files/en-us/web/api/idbrequest/error/index.md
@@ -22,10 +22,10 @@ request.
 
 ## Value
 
-A {{domxref("DOMError")}} containing the relevant error. In Chrome 48+/Firefox 58+ this
-property returns a {{domxref("DOMException")}} because `DOMError` has been
-removed from the DOM standard. The following error codes are returned under certain
-conditions:
+A {{domxref("DOMError")}} containing the relevant error, or `null` if there was no error.
+In Chrome 48+/Firefox 58+ this property returns a {{domxref("DOMException")}} because 
+`DOMError` has been removed from the DOM standard. The following error codes are returned
+under certain conditions:
 
 <table class="no-markdown">
   <thead>

--- a/files/en-us/web/api/idbrequest/error/index.md
+++ b/files/en-us/web/api/idbrequest/error/index.md
@@ -22,10 +22,8 @@ request.
 
 ## Value
 
-A {{domxref("DOMError")}} containing the relevant error, or `null` if there was no error.
-In Chrome 48+/Firefox 58+ this property returns a {{domxref("DOMException")}} because 
-`DOMError` has been removed from the DOM standard. The following error codes are returned
-under certain conditions:
+A {{domxref("DOMException")}} or `null` if there is no error. The following error names are returned
+in the exception object:
 
 <table class="no-markdown">
   <thead>


### PR DESCRIPTION
This matches what v3 of the spec says. I'm not sure what the `NoError` DomException is for. Is this from v2 of the spec?

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
