### PR TITLE
Fix internal link to baseVal

### DIFF
--- a/files/en-us/web/api/svganimatedstring/animval/index.md
+++ b/files/en-us/web/api/svganimatedstring/animval/index.md
@@ -5,7 +5,7 @@ browser-compat: api.SVGAnimatedString.animVal
 ---
 {{APIRef("SVG")}}
 
-AnimVal attribute or animVal property contains the same value as the [**baseVal**](/en-US/docs/new?slug=baseVal&parent=6389) property.If the given attribute or property is being animated, contains the current animated value of the attribute or property. If the given attribute or property is not currently being animated, then it contains the same value as baseVal
+AnimVal attribute or animVal property contains the same value as the {{domxref("SVGAnimatedString.baseVal")}} property. If the given attribute or property is being animated, contains the current animated value of the attribute or property. If the given attribute or property is not currently being animated, then it contains the same value as baseVal
 
 > **Note:** The **animVal** property is a read only property. Internet Explorer 9 supports script-based SVG animation but it does not support declarative-based SVG animation. As a result, the **animVal** property contains the same value as the **baseVal** property.
 


### PR DESCRIPTION
#### Summary
I replaced the internal link to the baseVal page with one conforming to the current style.

#### Motivation
The current link to baseVal is a superseded new page link. 

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
