### PR TITLE
Fix sidebars for Canvas, Channel Messaging, File System & Directory API, and Fullscreen

### DIFF
--- a/files/en-us/web/api/channel_messaging_api/index.md
+++ b/files/en-us/web/api/channel_messaging_api/index.md
@@ -32,9 +32,7 @@ Find out more about how to use this API in [Using channel messaging](/en-US/docs
   - : Creates a new message channel to send messages across.
 - {{domxref("MessagePort")}}
   - : Controls the ports on the message channel, allowing sending of messages from one port and listening out for them arriving at the other.
-- {{domxref("PortCollection")}}
-  - : An array of `MessagePort`s; an experimental solution to allow broadcasting of a message to multiple ports simultaneously.
-
+  
 ## Examples
 
 - We have published a [channel messaging basic demo](https://github.com/mdn/dom-examples/tree/master/channel-messaging-basic) on GitHub ([run it live too](https://mdn.github.io/dom-examples/channel-messaging-basic/)), which shows a really simple single message transfer between a page and an embedded {{htmlelement("iframe")}}.

--- a/files/en-us/web/api/eyedropper/index.md
+++ b/files/en-us/web/api/eyedropper/index.md
@@ -22,7 +22,7 @@ The **`EyeDropper`** interface represents an instance of an eyedropper tool that
 
 _The `EyeDropper` interface doesn't inherit any methods_.
 
-- {{DOMxRef("EyeDropper.prototype.open()")}}
+- {{DOMxRef("EyeDropper.open()")}}
   - : Returns a promise that resolves to an object that gives access to the selected color.
 
 ## Examples

--- a/files/en-us/web/api/eyedropper/open/index.md
+++ b/files/en-us/web/api/eyedropper/open/index.md
@@ -1,5 +1,5 @@
 ---
-title: EyeDropper.prototype.open()
+title: EyeDropper.open()
 slug: Web/API/EyeDropper/open
 tags:
   - API
@@ -11,7 +11,7 @@ browser-compat: api.EyeDropper.open
 ---
 {{APIRef("EyeDropper API")}}{{SeeCompatTable}}
 
-The **`EyeDropper.prototype.open()`** method starts the eyedropper mode, returning a promise which is fulfilled once the user has either selected a color or dismissed the eyedropper mode.
+The **`EyeDropper.open()`** method starts the eyedropper mode, returning a promise which is fulfilled once the user has either selected a color or dismissed the eyedropper mode.
 
 ## Syntax
 

--- a/files/en-us/web/api/eyedropper_api/index.md
+++ b/files/en-us/web/api/eyedropper_api/index.md
@@ -34,9 +34,7 @@ To prevent malicious websites from getting pixel data from a user's screen witho
 
 ## Specifications
 
-| Specification                    | Status                       | Comment             |
-| -------------------------------- | ---------------------------- | ------------------- |
-| {{SpecName("EyeDropper")}}       | {{Spec2("EyeDropper")}}      | Initial definition. |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -87,7 +87,6 @@
         "CanvasRenderingContext2D",
         "HTMLCanvasElement",
         "ImageBitmap",
-        "ImageBitmapFactories",
         "ImageBitmapRenderingContext",
         "ImageData",
         "OffscreenCanvas",
@@ -101,7 +100,10 @@
     "Channel Messaging API": {
       "overview": ["Channel Messaging API"],
       "guides": ["/docs/Web/API/Channel_Messaging_API/Using_channel_messaging"],
-      "interfaces": ["MessageChannel", "MessagePort", "PortCollection"],
+      "interfaces": [
+        "MessageChannel",
+        "MessagePort"
+      ],
       "methods": [],
       "properties": [],
       "events": []
@@ -455,7 +457,6 @@
         "FileSystemDirectoryReader",
         "FileSystemEntry",
         "FileSystemFileEntry",
-        "FileSystemFlags",
         "FileSystem"
       ],
       "methods": [],
@@ -504,15 +505,10 @@
       "overview": ["Fullscreen API"],
       "guides": ["/docs/Web/API/Fullscreen_API/Guide"],
       "interfaces": [],
-      "dictionaries": ["FullscreenOptions"],
       "methods": ["Document.exitFullscreen()", "Element.requestFullscreen()"],
       "properties": [
         "Document.fullscreen",
-        "DocumentOrShadowRoot.fullscreenElement",
-        "Document.onfullscreenchange",
-        "Document.onfullscreenerror",
-        "Element.onfullscreenchange",
-        "Element.onfullscreenerror"
+        "Document.fullscreenElement"
       ],
       "events": [
         "Document: fullscreenchange",


### PR DESCRIPTION
Fixes sidebars for Canvas, Channel Messaging, File System Directory API, and Fullscreen API (note that on Fullscreen, this is a consequence of the event work done last Quarter)


Also removed `prototype` on EyeDropper pages.