### PR TITLE
Typo in macro name

### DIFF
--- a/files/en-us/web/api/writablestream/abort/index.md
+++ b/files/en-us/web/api/writablestream/abort/index.md
@@ -31,7 +31,7 @@ A {{jsxref("Promise")}}, which fulfills with the value given in the `reason` par
 
 ### Exceptions
 
-- {{jsxsref("TypeError")}}
+- {{jsxref("TypeError")}}
   - : The stream you are trying to abort is not a {{domxref("WritableStream")}}, or it is locked.
 
 ## Examples

--- a/files/en-us/web/api/writablestream/getwriter/index.md
+++ b/files/en-us/web/api/writablestream/getwriter/index.md
@@ -31,7 +31,7 @@ A {{domxref("WritableStreamDefaultWriter")}} object instance.
 
 ### Exceptions
 
-- {{jsxsref("TypeError")}}
+- {{jsxref("TypeError")}}
   - : The stream you are trying to create a writer for is not a {{domxref("WritableStream")}}.
 
 ## Examples

--- a/files/en-us/web/api/writablestreamdefaultcontroller/error/index.md
+++ b/files/en-us/web/api/writablestreamdefaultcontroller/error/index.md
@@ -39,7 +39,7 @@ error(e)
 
 ### Exceptions
 
-- {{jsxsref("TypeError")}}
+- {{jsxref("TypeError")}}
   - : The stream you are trying to error is not a {{domxref("WritableStream")}}.
 
 ## Examples

--- a/files/en-us/web/api/writablestreamdefaultwriter/abort/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/abort/index.md
@@ -41,7 +41,7 @@ parameter.
 
 ### Exceptions
 
-- {{jsxsref("TypeError")}}
+- {{jsxref("TypeError")}}
   - : The stream you are trying to abort is not a {{domxref("WritableStream")}}, or it is
     locked.
 

--- a/files/en-us/web/api/writablestreamdefaultwriter/close/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/close/index.md
@@ -39,7 +39,7 @@ a problem was encountered during the process.
 
 ### Exceptions
 
-- {{jsxsref("TypeError")}}
+- {{jsxref("TypeError")}}
   - : The stream you are trying to close is not a {{domxref("WritableStream")}}.
 
 ## Examples

--- a/files/en-us/web/api/writablestreamdefaultwriter/desiredsize/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/desiredsize/index.md
@@ -27,7 +27,7 @@ closed.
 
 ### Exceptions
 
-- {{jsxsref("TypeError")}}
+- {{jsxref("TypeError")}}
   - : The writer's lock is released.
 
 ## Examples

--- a/files/en-us/web/api/writablestreamdefaultwriter/writablestreamdefaultwriter/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/writablestreamdefaultwriter/index.md
@@ -35,7 +35,7 @@ An instance of the {{domxref("WritableStreamDefaultWriter")}} object.
 
 ### Exceptions
 
-- {{jsxsref("TypeError")}}
+- {{jsxref("TypeError")}}
   - : The provided `stream` value is not a {{domxref("WritableStream")}}, or it
     is locked to another writer already.
 

--- a/files/en-us/web/api/writablestreamdefaultwriter/write/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/write/index.md
@@ -42,7 +42,7 @@ writing process is initiated.
 
 ### Exceptions
 
-- {{jsxsref("TypeError")}}
+- {{jsxref("TypeError")}}
   - : The target stream is not a writable stream, or it does not have an owner.
 
 ## Examples


### PR DESCRIPTION
`jsxsref` instead of `jsxref`

(Detected thanks to the flaws dashboard (normally we have 0 `MacroNotFoundError` flaws, but suddenly we got 8)