### PR TITLE
Tags of few offset & scroll-margin properties

### DIFF
--- a/files/en-us/web/css/offset-anchor/index.md
+++ b/files/en-us/web/css/offset-anchor/index.md
@@ -4,7 +4,7 @@ slug: Web/CSS/offset-anchor
 tags:
   - CSS
   - CSS Motion Path
-  - Experimental
+  - CSS Property
   - Motion Path
   - Reference
   - offset-anchor

--- a/files/en-us/web/css/offset-path/index.md
+++ b/files/en-us/web/css/offset-path/index.md
@@ -4,7 +4,7 @@ slug: Web/CSS/offset-path
 tags:
   - CSS
   - CSS Motion Path
-  - Experimental
+  - CSS Property
   - Motion Path
   - Reference
   - motion-path

--- a/files/en-us/web/css/scroll-margin-block-end/index.md
+++ b/files/en-us/web/css/scroll-margin-block-end/index.md
@@ -3,7 +3,11 @@ title: scroll-margin-block-end
 slug: Web/CSS/scroll-margin-block-end
 tags:
   - CSS
+  - CSS Property
+  - Reference
+  - Web
   - recipe:css-property
+  - scroll-margin-block
   - scroll-margin-block-end
 browser-compat: css.properties.scroll-margin-block-end
 ---

--- a/files/en-us/web/css/scroll-margin-block-start/index.md
+++ b/files/en-us/web/css/scroll-margin-block-start/index.md
@@ -2,10 +2,12 @@
 title: scroll-margin-block-start
 slug: Web/CSS/scroll-margin-block-start
 tags:
-  - Beginner
   - CSS
-  - Example
+  - CSS Property
+  - Reference
+  - Web
   - recipe:css-property
+  - scroll-margin-block
   - scroll-margin-block-start
 browser-compat: css.properties.scroll-margin-block-start
 ---

--- a/files/en-us/web/css/scroll-margin-block/index.md
+++ b/files/en-us/web/css/scroll-margin-block/index.md
@@ -3,7 +3,11 @@ title: scroll-margin-block
 slug: Web/CSS/scroll-margin-block
 tags:
   - CSS
+  - CSS Property
+  - Reference
+  - Web
   - recipe:css-shorthand-property
+  - scroll-margin
   - scroll-margin-block
 browser-compat: css.properties.scroll-margin-block
 ---

--- a/files/en-us/web/css/scroll-margin-inline-end/index.md
+++ b/files/en-us/web/css/scroll-margin-inline-end/index.md
@@ -2,10 +2,13 @@
 title: scroll-margin-inline-end
 slug: Web/CSS/scroll-margin-inline-end
 tags:
-  - Advanced
   - CSS
+  - CSS Property
   - Reference
+  - Web
   - recipe:css-property
+  - scroll-margin-inline
+  - scroll-margin-inline-end
 browser-compat: css.properties.scroll-margin-inline-end
 ---
 {{CSSRef}}

--- a/files/en-us/web/css/scroll-margin/index.md
+++ b/files/en-us/web/css/scroll-margin/index.md
@@ -3,7 +3,7 @@ title: scroll-margin
 slug: Web/CSS/scroll-margin
 tags:
   - CSS
-  - Property
+  - CSS Property
   - Reference
   - margin
   - recipe:css-shorthand-property

--- a/files/en-us/web/css/scroll-padding-right/index.md
+++ b/files/en-us/web/css/scroll-padding-right/index.md
@@ -3,6 +3,7 @@ title: scroll-padding-right
 slug: Web/CSS/scroll-padding-right
 tags:
   - CSS
+  - CSS Property
   - Reference
   - Web
   - recipe:css-property

--- a/files/en-us/web/css/scroll-padding-top/index.md
+++ b/files/en-us/web/css/scroll-padding-top/index.md
@@ -3,6 +3,7 @@ title: scroll-padding-top
 slug: Web/CSS/scroll-padding-top
 tags:
   - CSS
+  - CSS Property
   - Reference
   - Web
   - recipe:css-property


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
[Offset-path](https://developer.mozilla.org/en-US/docs/Web/CSS/offset-path) & [offset-anchor](https://developer.mozilla.org/en-US/docs/Web/CSS/offset-anchor) were not present in CSS properties side menu, so I added CSS Property tag to them. Browser compatibility table of those properties doesn't have experimental flag, so I removed Experimental tag too.
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
