### PR TITLE
Update experimental status of pseudo-elements

### DIFF
--- a/files/en-us/web/css/_doublecolon_part/index.md
+++ b/files/en-us/web/css/_doublecolon_part/index.md
@@ -5,7 +5,6 @@ tags:
   - '::part'
   - CSS
   - Draft
-  - NeedsBrowserCompatibility
   - NeedsExample
   - Pseudo-element
   - Reference

--- a/files/en-us/web/css/pseudo-elements/index.md
+++ b/files/en-us/web/css/pseudo-elements/index.md
@@ -46,7 +46,7 @@ A
 
 B
 
-- {{CSSxRef("::backdrop")}} {{Experimental_Inline}}
+- {{CSSxRef("::backdrop")}}
 - {{CSSxRef("::before", "::before (:before)")}}
 
 C
@@ -66,12 +66,12 @@ G
 
 M
 
-- {{CSSxRef("::marker")}} {{Experimental_Inline}}
+- {{CSSxRef("::marker")}}
 
 P
 
-- {{CSSxRef("::part", "::part()")}} {{Experimental_Inline}}
-- {{CSSxRef("::placeholder")}} {{Experimental_Inline}}
+- {{CSSxRef("::part", "::part()")}}
+- {{CSSxRef("::placeholder")}}
 
 S
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Removes `{{experimental_inline}}` from some pseudo-elements.

#### Motivation
They are not experimental in BCD, nor tagged with `Experimental`.

I didn't remove the macro from `::grammar-error` and `::spelling-error` because no browsers have implemented them. I think BCD should mark them as experimental?

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
