### PR TITLE
Replace incorrect variable name

### DIFF
--- a/files/en-us/web/api/globaleventhandlers/onselectionchange/index.md
+++ b/files/en-us/web/api/globaleventhandlers/onselectionchange/index.md
@@ -70,9 +70,9 @@ It uses {{domxref("HTMLTextAreaElement")}} properties `selectionStart`, `selecti
 const myinput = document.getElementById("mytext");
 
 myinput.addEventListener("selectionchange", () => {
-  document.getElementById("start").textContent = mytext.selectionStart;
-  document.getElementById("end").textContent = mytext.selectionEnd;
-  document.getElementById("direction").textContent = mytext.selectionDirection;
+  document.getElementById("start").textContent = myinput.selectionStart;
+  document.getElementById("end").textContent = myinput.selectionEnd;
+  document.getElementById("direction").textContent = myinput.selectionDirection;
 });
 ```
 


### PR DESCRIPTION
#### Summary
Replaced variable "mytext" with "myinput"

#### Motivation
The demo code used an incorrect variable name, "mytext", instead of the proper variable name, "myinput".

#### Supporting details

#### Related issues

#### Metadata
This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error
