### PR TITLE
MV3 Manifest keys updates

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/action/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/action/index.md
@@ -1,11 +1,11 @@
 ---
-title: browser_action
-slug: Mozilla/Add-ons/WebExtensions/manifest.json/browser_action
+title: action
+slug: Mozilla/Add-ons/WebExtensions/manifest.json/action
 tags:
   - Add-ons
   - Extensions
   - WebExtensions
-browser-compat: webextensions.manifest.browser_action
+browser-compat: webextensions.manifest.action
 ---
 {{AddonSidebar}}
 
@@ -21,13 +21,13 @@ browser-compat: webextensions.manifest.browser_action
     </tr>
     <tr>
       <th scope="row">Manifest version</th>
-      <td>2</td>
+      <td>3 or higher</td>
     </tr>
     <tr>
       <th scope="row">Example</th>
       <td>
         <pre class="brush: json">
-"browser_action": {
+"action": {
   "browser_style": true,
   "default_icon": {
     "16": "button/geo-16.png",
@@ -51,17 +51,17 @@ browser-compat: webextensions.manifest.browser_action
   </tbody>
 </table>
 
-A browser action is a button that your extension adds to the browser's toolbar. The button has an icon, and may optionally have a popup whose content is specified using HTML, CSS, and JavaScript.
+An action is a button that your extension adds to the browser's toolbar. The button has an icon, and may optionally have a popup whose content is specified using HTML, CSS, and JavaScript.
 
-This key is replaced by [`action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action) in Manifest V3 extensions.
+This key replaces [`browser_action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action) in Manifest V3 extensions.
 
-If you supply a popup, then the popup is opened when the user clicks the button, and your JavaScript running in the popup can handle the user's interaction with it. If you don't supply a popup, then a click event is dispatched to your extension's [background scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/Anatomy_of_a_WebExtension#background_scripts) when the user clicks the button.
+If you supply a popup, then the popup is opened when the user clicks the button, and your JavaScript running in the popup can handle the user's interaction with it. If you don't supply a popup, then a click event is dispatched to your extension's [background scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/Background_scripts) when the user clicks the button.
 
-You can also create and manipulate browser actions programmatically using the [browserAction API](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction).
+You can also create and manipulate actions programmatically using the {{WebExtAPIRef("action")}} .
 
 ## Syntax
 
-The `browser_action` key is an object that may have any of the following properties, all optional:
+The `action` key is an object that may have any of these properties, all optional:
 
 <table class="fullwidth-table standard-table">
   <thead>
@@ -178,7 +178,7 @@ The `browser_action` key is an object that may have any of the following propert
       <td><code>Object</code> or <code>String</code></td>
       <td>
         <p>
-          Use this to specify one or more icons for the browser action. The icon
+          Use this to specify one or more icons for the action. The icon
           is shown in the browser toolbar by default.
         </p>
         <p>
@@ -200,7 +200,7 @@ The `browser_action` key is an object that may have any of the following propert
         <p>
           You cannot specify multiple icons of the same sizes.<br /><br />See
           <a
-            href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action#choosing_icon_sizes"
+            href="/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action#choosing_icon_sizes"
             >Choosing icon sizes</a
           >
           for more guidance on this.
@@ -321,7 +321,7 @@ The `browser_action` key is an object that may have any of the following propert
 
 ## Choosing icon sizes
 
-The browser action's icon may need to be displayed in different sizes in different contexts:
+The action's icon may need to be displayed in different sizes in different contexts:
 
 - The icon is displayed in the browser toolbar. Older versions of Firefox supported the option of placing the icon in the browser's menu panel (the panel that opens when the user clicks the "hamburger" icon). In those versions of Firefox the icon in the menu panel was larger than the icon in the toolbar.
 - On a high-density display like a Retina screen, icons needs to be twice as big.
@@ -356,7 +356,7 @@ If Firefox can't find an exact match for the size it wants, then it will pick th
 ## Example
 
 ```json
-"browser_action": {
+"action": {
   "default_icon": {
     "16": "button/geo-16.png",
     "32": "button/geo-32.png"
@@ -364,14 +364,14 @@ If Firefox can't find an exact match for the size it wants, then it will pick th
 }
 ```
 
-A browser action with just an icon, specified in 2 different sizes. The extension's background scripts can receive click events when the user clicks the icon using code like this:
+An action with just an icon, specified in 2 sizes. The extension's background scripts can receive click events when the user clicks the icon using code like this:
 
 ```js
- browser.browserAction.onClicked.addListener(handleClick);
+ browser.Action.onClicked.addListener(handleClick);
 ```
 
 ```json
-"browser_action": {
+"action": {
   "default_icon": {
     "16": "button/geo-16.png",
     "32": "button/geo-32.png"
@@ -381,16 +381,8 @@ A browser action with just an icon, specified in 2 different sizes. The extensio
 }
 ```
 
-A browser action with an icon, a title, and a popup. The popup will be shown when the user clicks the button.
-
-For a simple, but complete, extension that uses a browser action, see the [walkthrough tutorial](/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_second_WebExtension).
+An action with an icon, a title, and a popup. The popup is shown when the user clicks the button.
 
 ## Browser compatibility
 
 {{Compat}}
-
-## See also
-
-- [`page_action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action)
-- [`sidebar_action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action)
-- [Browser styles](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_styles)

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/author/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/author/index.md
@@ -20,6 +20,10 @@ browser-compat: webextensions.manifest.author
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td><pre class="brush: json">"author": "Walt Whitman"</pre></td>
     </tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.md
@@ -22,6 +22,10 @@ browser-compat: webextensions.manifest.background
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td>
         <pre class="brush: json">

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/chrome_settings_overrides/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/chrome_settings_overrides/index.md
@@ -21,6 +21,11 @@ browser-compat: webextensions.manifest.chrome_settings_overrides
       <th scope="row">Mandatory</th>
       <td>No</td>
     </tr>
+    <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+
   <tr>
       <th scope="row">Example</th>
       <td><pre class="brush:json">
@@ -139,8 +144,10 @@ The `chrome_settings_overrides` key is an object that may have the following pro
           </dd>
           <dt><code>favicon_url {{optional_inline}}</code></dt>
           <dd>
-            String: URL pointing to an icon for the search engine. This must be
-            a absolute HTTP or HTTPS URL.
+            String: URL pointing to an icon for the search engine. In Manifest V2,
+            this must be an absolute HTTP or HTTPS URL. In Manifest V3, this must 
+            reference an icon provided in the extension as a path relative to the 
+            extension's root.
           </dd>
           <dt><code>image_url {{optional_inline}}</code></dt>
           <dd>String: URL used for image search.</dd>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/chrome_url_overrides/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/chrome_url_overrides/index.md
@@ -20,6 +20,10 @@ browser-compat: webextensions.manifest.chrome_url_overrides
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td>
         <pre class="brush: json">

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/commands/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/commands/index.md
@@ -21,6 +21,10 @@ browser-compat: webextensions.manifest.commands
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td>
         <pre class="brush: json">

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_scripts/index.md
@@ -20,6 +20,10 @@ browser-compat: webextensions.manifest.content_scripts
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td>
         <pre class="brush: json">

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.md
@@ -20,6 +20,10 @@ browser-compat: webextensions.manifest.content_security_policy
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td>
         <pre class="brush: json">

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/description/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/description/index.md
@@ -20,6 +20,10 @@ browser-compat: webextensions.manifest.description
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td>
         <pre class="brush: json">

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/developer/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/developer/index.md
@@ -20,6 +20,10 @@ browser-compat: webextensions.manifest.developer
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td>
         <pre class="brush: json">

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/devtools_page/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/devtools_page/index.md
@@ -24,6 +24,10 @@ browser-compat: webextensions.manifest.devtools_page
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td>
         <pre class="brush: json">"devtools_page": "devtools/my-page.html"</pre>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/dictionaries/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/dictionaries/index.md
@@ -21,6 +21,10 @@ browser-compat: webextensions.manifest.dictionaries
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td>
         <pre class="brush: json">

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/externally_connectable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/externally_connectable/index.md
@@ -20,6 +20,10 @@ browser-compat: webextensions.manifest.externally_connectable
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td>
         <pre>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/homepage_url/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/homepage_url/index.md
@@ -20,6 +20,10 @@ browser-compat: webextensions.manifest.homepage_url
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td>
         <pre class="brush: json">

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/icons/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/icons/index.md
@@ -20,6 +20,10 @@ browser-compat: webextensions.manifest.icons
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td>
         <pre class="brush: json">

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/incognito/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/incognito/index.md
@@ -21,6 +21,10 @@ browser-compat: webextensions.manifest.incognito
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td>
         <pre class="brush: json">"incognito": "spanning"</pre>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/index.md
@@ -58,7 +58,7 @@ These are the `manifest.json` keys and the manifest versions they are supported 
 - [storage](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/storage) (Manifest V2 and above)
 - [theme](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme) (Manifest V2 and above)
 - [theme_experiment](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme_experiment) (Manifest V2 and above)
-- [user_scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/user_scripts) (Manifest V2 and above)
+- [user_scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/user_scripts) (Manifest V2)
 - [version](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version) (Manifest V2 and above)
 - [version_name](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version_name) (Manifest V2 and above)
 - [web_accessible_resources](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources) (Manifest V2 and above)

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/index.md
@@ -21,9 +21,47 @@ It is a [JSON](/en-US/docs/Glossary/JSON)-formatted file, with one exception: it
 
 ## List of manifest.json keys
 
-`manifest.json` keys are listed below:
+These are the `manifest.json` keys and the manifest versions they are supported in:
 
-{{ListSubpages("/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json")}}
+- [action](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action) (Manifest V3 and above)
+- [author](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/author) (Manifest V2 and above)
+- [background](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/background) (Manifest V2 and above)
+- [browser_action](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action) (Manifest V2)
+- [browser_specific_settings](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) (Manifest V2 and above)
+- [chrome_settings_overrides](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides) (Manifest V2 and above)
+- [chrome_url_overrides](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_url_overrides) (Manifest V2 and above)
+- [commands](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/commands) (Manifest V2 and above)
+- [content_scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) (Manifest V2 and above)
+- [content_security_policy](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_security_policy) (Manifest V2 and above)
+- [default_locale](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/default_locale) (Manifest V2 and above)
+- [description](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/description) (Manifest V2 and above)
+- [developer](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/developer) (Manifest V2 and above)
+- [devtools_page](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/devtools_page) (Manifest V2 and above)
+- [dictionaries](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/dictionaries) (Manifest V2 and above)
+- [externally_connectable](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/externally_connectable) (Manifest V2 and above)
+- [homepage_url](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/homepage_url) (Manifest V2 and above)
+- [host_permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/host_permissions) (Manifest V3 and above)
+- [icons](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/icons) (Manifest V2 and above)
+- [incognito](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/incognito) (Manifest V2 and above)
+- [manifest_version](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/manifest_version) (Manifest V2 and above)
+- [name](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/name) (Manifest V2 and above)
+- [offline_enabled](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/offline_enabled) (Manifest V2 and above)
+- [omnibox](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/omnibox) (Manifest V2 and above)
+- [optional_permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/optional_permissions) (Manifest V2 and above)
+- [options_page](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_page) (Manifest V2 and above)
+- [options_ui](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui) (Manifest V2 and above)
+- [page_action](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action) (Manifest V2)
+- [permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) (Manifest V2 and above)
+- [protocol_handlers](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/protocol_handlers) (Manifest V2 and above)
+- [short_name](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/short_name) (Manifest V2 and above)
+- [sidebar_action](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action) (Manifest V2 and above)
+- [storage](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/storage) (Manifest V2 and above)
+- [theme](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme) (Manifest V2 and above)
+- [theme_experiment](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme_experiment) (Manifest V2 and above)
+- [user_scripts](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/user_scripts) (Manifest V2 and above)
+- [version](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version) (Manifest V2 and above)
+- [version_name](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version_name) (Manifest V2 and above)
+- [web_accessible_resources](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources) (Manifest V2 and above)
 
 ### Notes about manifest.json keys
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/offline_enabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/offline_enabled/index.md
@@ -25,7 +25,7 @@ browser-compat: webextensions.manifest.offline_enabled
     </tr>
     <tr>
       <th scope="row">Manifest version</th>
-      <td>2 or higher</td>
+      <td>2</td>
     </tr>
     <tr>
       <th scope="row">Example</th>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/offline_enabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/offline_enabled/index.md
@@ -24,6 +24,10 @@ browser-compat: webextensions.manifest.offline_enabled
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td><pre class="brush: json">"offline_enabled": true</pre></td>
     </tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/omnibox/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/omnibox/index.md
@@ -20,6 +20,10 @@ browser-compat: webextensions.manifest.omnibox
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td>
         <pre class="brush: json">

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/options_page/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/options_page/index.md
@@ -24,6 +24,10 @@ browser-compat: webextensions.manifest.options_page
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td>
         <pre class="brush: json;">"options_page": "options/options.html"</pre>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/options_ui/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/options_ui/index.md
@@ -25,6 +25,10 @@ browser-compat: webextensions.manifest.options_ui
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td>
         <pre class="brush: json;">

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/page_action/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/page_action/index.md
@@ -20,6 +20,10 @@ browser-compat: webextensions.manifest.page_action
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td>
         <pre class="brush: json">

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/protocol_handlers/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/protocol_handlers/index.md
@@ -21,6 +21,10 @@ browser-compat: webextensions.manifest.protocol_handlers
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td>
         <pre class="brush: json">

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/short_name/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/short_name/index.md
@@ -20,6 +20,10 @@ browser-compat: webextensions.manifest.short_name
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td><pre class="brush: json">"short_name": "My Extension"</pre></td>
     </tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/sidebar_action/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/sidebar_action/index.md
@@ -18,6 +18,10 @@ browser-compat: webextensions.manifest.sidebar_action
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td>
         <pre class="brush: json">

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/storage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/storage/index.md
@@ -22,6 +22,10 @@ browser-compat: webextensions.manifest.storage
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td>
         <pre class="brush: json">

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme/index.md
@@ -26,6 +26,10 @@ browser-compat: webextensions.manifest.theme
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td>
         <pre class="brush: json">

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme_experiment/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme_experiment/index.md
@@ -26,6 +26,10 @@ browser-compat: webextensions.manifest.theme_experiment
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td>
         <pre class="brush: json">

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/user_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/user_scripts/index.md
@@ -23,7 +23,7 @@ browser-compat: webextensions.manifest.user_scripts
     </tr>
     <tr>
       <th scope="row">Manifest version</th>
-      <td>2 or higher</td>
+      <td>2</td>
     </tr>
     <tr>
       <th scope="row">Example</th>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/user_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/user_scripts/index.md
@@ -22,6 +22,10 @@ browser-compat: webextensions.manifest.user_scripts
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td>
         <pre class="brush: json">

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/version_name/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/version_name/index.md
@@ -20,6 +20,10 @@ browser-compat: webextensions.manifest.version_name
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td><pre class="brush: json">"version_name": "0.1 beta"</pre></td>
     </tr>

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.md
@@ -20,6 +20,10 @@ browser-compat: webextensions.manifest.web_accessible_resources
       <td>No</td>
     </tr>
     <tr>
+      <th scope="row">Manifest version</th>
+      <td>2 or higher</td>
+    </tr>
+    <tr>
       <th scope="row">Example</th>
       <td>
         <pre class="brush: json">


### PR DESCRIPTION
#### Summary
Changes to the manifest keys for Manifest V3 support in the developer preview, including:

- update to the keys list on the overview page to add details of supported manifest versions
- addition of a "Manifest version" line into the overview table of every manifest key page
- addition of the `action` key (as a copy of the `browser_action` key) with cross-reference information between the two
- update to `favicon_url` of the  [chrome_settings_overrides](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides) manifest key that a local URL must be provided in MV3.  

#### Metadata

This PR…

- [x] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
