### PR TITLE
Change CSS for nested `kbd` sample.

### DIFF
--- a/files/en-us/web/html/element/kbd/index.md
+++ b/files/en-us/web/html/element/kbd/index.md
@@ -141,10 +141,10 @@ We can make more sense of this by adding some CSS:
 
 ##### CSS
 
-We add a new style for `<kbd>` elements, `key`, which we can apply when rendering keyboard keys:
+We add a new selector for nested `<kbd>` elements, `kbd>kbd`, which we can apply when rendering keyboard keys:
 
 ```css
-kbd.key {
+kbd>kbd {
   border-radius: 3px;
   padding: 1px 2px 0;
   border: 1px solid black;
@@ -156,7 +156,7 @@ kbd.key {
 Then we update the HTML to use this class on the keys in the output to be presented:
 
 ```html
-<p>You can also create a new document by pressing <kbd><kbd class="key">Ctrl</kbd>+<kbd class="key">N</kbd></kbd>.</p>
+<p>You can also create a new document by pressing <kbd><kbd>Ctrl</kbd>+<kbd>N</kbd></kbd>.</p>
 ```
 
 ##### Result


### PR DESCRIPTION
Currently, a class is used to target the nested `<kbd>` elements. I think this defeats the purpose of nesting.

Instead, I have removed the class and changed the selector to `kbd>kbd` which is more in keeping with nesting.

Can someone tell me what to do about updating the sample result?

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
