### PR TITLE
FF101 HTMLMediaElement.preservesPitch updates

### DIFF
--- a/files/en-us/mozilla/firefox/releases/101/index.md
+++ b/files/en-us/mozilla/firefox/releases/101/index.md
@@ -39,6 +39,11 @@ This article provides information about the changes in Firefox 101 that will aff
 
 #### DOM
 
+- [`HTMLMediaElement.preservesPitch`](/en-US/docs/Web/API/HTMLMediaElement/preservesPitch) is now supported without the `moz` prefix.
+  `mozPreservesPitch` is now an alias of `preservesPitch`, but is deprecated, and may be removed in future releases.
+  ({{bug(1652950)}}).
+  
+
 #### Media, WebRTC, and Web Audio
 
 #### Removals

--- a/files/en-us/web/api/htmlmediaelement/preservespitch/index.md
+++ b/files/en-us/web/api/htmlmediaelement/preservespitch/index.md
@@ -52,8 +52,12 @@ rate.addEventListener('input', () => audio.playbackRate = rate.value );
 
 const pitch = document.querySelector('#pitch');
 pitch.addEventListener('change', () => {
-  audio.mozPreservesPitch = pitch.checked;
-  audio.preservesPitch = pitch.checked;
+  if ('preservesPitch' in audio) {
+    audio.preservesPitch = pitch.checked;
+  }
+  else if ('mozPreservesPitch' in audio) { //deprecated
+    audio.mozPreservesPitch = pitch.checked;
+  } 
 });
 ```
 


### PR DESCRIPTION
FF101 now supports the unprefixed [`HTMLMediaElement.preservesPitch`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/preservesPitch). `mozPreservesPitch` is a deprecated alias. See https://bugzilla.mozilla.org/show_bug.cgi?id=1652950

This adds a release note and also updates the example to use `preservesPitch` if it has been defined, and try `mozPreservesPitch` if not. This is a little more robust/cross-platform than the existing code.

Other docs work can be tracked in #15462