### PR TITLE
Fix rendering of the tbody element in HTML

### DIFF
--- a/files/en-us/web/html/element/tbody/index.md
+++ b/files/en-us/web/html/element/tbody/index.md
@@ -39,7 +39,7 @@ The `<tbody>` element, along with its cousins {{HTMLElement("thead")}} and {{HTM
     <tr>
       <th scope="row">Tag omission</th>
       <td>
-        The `<tbody>` element is not a required child element for a parent {{ HTMLElement("table") }} element to graphically render. However, it must be present, if the parent {{ HTMLElement("table") }} element has a {{HTMLElement("thead")}}, a {{HTMLElement("tfoot")}} or another {{HTMLElement("tbody")}} element as a child. If the `<tbody>` element starts with a {{HTMLElement("tbody")}} element, and is not following a non-closed `<tbody>` element, its opening tag can be omitted.
+        The <code>&#x3C;tbody></code> element is not a required child element for a parent {{ HTMLElement("table") }} element to graphically render. However, it must be present, if the parent {{ HTMLElement("table") }} element has a {{HTMLElement("thead")}}, a {{HTMLElement("tfoot")}} or another {{HTMLElement("tbody")}} element as a child. If the <code>&#x3C;tbody></code> element starts with a {{HTMLElement("tbody")}} element, and is not following a non-closed <code>&#x3C;tbody></code> element, its opening tag can be omitted.
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Fix rendering of the `tbody` element in the [tbody docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody) by using `<code>&#x3C;tbody></code>` (which was previously used) instead of \`\<tbody\>\`. The issue resolved is likely due to the fact that the markdown inline code is rendered incorrectly when wrapped in HTML.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The `<tbody>` code snippet is incorrectly rendered on https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tbody
![image](https://user-images.githubusercontent.com/41845017/166427493-d5f51ff7-1bd1-43c7-bc31-861fbaecdb2d.png)


#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
