### PR TITLE
Add more information about collation types

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/collator/collator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/collator/collator/index.md
@@ -45,22 +45,23 @@ new Intl.Collator(locales, options)
 
     - `co`
       - : Variant collations for certain locales. Possible values include:
-        - `big5han`
-        - `compat`
-        - `dict`
-        - `direct`
-        - `ducet`
-        - `eor`
-        - `gb2312`
-        - `phonebk`(only supported in German)
-        - `phonetic`
-        - `pinyin`
-        - `reformed`
-        - `searchjl`
-        - `stroke`
+        - `big5han` (Chinese; not available in Chrome or Edge)
+        - `compat` (Arabic)
+        - `dict` (Sinhala)
+        - `direct` (deprecated, do not use)
+        - `ducet` (not available, do not use)
+        - `emoji` (root)
+        - `eor` (root)
+        - `gb2312` (Chinese; not available in Chrome or Edge)
+        - `phonebk`(German)
+        - `phonetic` (Lingala)
+        - `pinyin` (Chinese)
+        - `reformed` (Swedish; do not specify explicitly as this is the default for Swedish)
+        - `searchjl` (Korean; do not use for sorting)
+        - `stroke` (Chinese)
         - `trad`
-        - `unihan`
-        - `zhuyin`
+        - `unihan` (Chinese, Japanese, and Korean; not available in Chrome or Edge)
+        - `zhuyin` (Chinese)
         > **Note:**  This option can be also be set through the `options` property "`collation`".
     - `kn`
       - : Whether numeric collation should be used, such that "1" < "2" <
@@ -136,22 +137,23 @@ new Intl.Collator(locales, options)
 
     - `collation`
       - : Variant collations for certain locales. Possible values include:
-        - `big5han`
-        - `compat`
-        - `dict`
-        - `direct`
-        - `ducet`
-        - `eor`
-        - `gb2312`
-        - `phonebk`(only supported in German)
-        - `phonetic`
-        - `pinyin`
-        - `reformed`
-        - `searchjl`
-        - `stroke`
+        - `big5han` (Chinese; not available in Chrome or Edge)
+        - `compat` (Arabic)
+        - `dict` (Sinhala)
+        - `direct` (deprecated, do not use)
+        - `ducet` (not available, do not use)
+        - `emoji` (root)
+        - `eor` (root)
+        - `gb2312` (Chinese; not available in Chrome or Edge)
+        - `phonebk`(German)
+        - `phonetic` (Lingala)
+        - `pinyin` (Chinese)
+        - `reformed` (Swedish; do not specify explicitly as this is the default for Swedish)
+        - `searchjl` (Korean; do not use for sorting)
+        - `stroke` (Chinese)
         - `trad`
-        - `unihan`
-        - `zhuyin`
+        - `unihan` (Chinese, Japanese, and Korean; not available in Chrome or Edge)
+        - `zhuyin` (Chinese)
         > **Note:** This option can also be set through the `co` Unicode
         > extension key; if both are provided, this `options`
         > property takes precedence.

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/collation/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/collation/index.md
@@ -67,7 +67,7 @@ Below is a table with the available collation types, adapted from the [Unicode c
     </tr>
     <tr>
       <td>ducet</td>
-      <td>The default Unicode collation element table order</td>
+      <td>The default Unicode collation element table order
         <div class="notecard warning">
           <p>
             <strong>Warning:</strong> The `ducet` collation type is
@@ -76,6 +76,7 @@ Below is a table with the available collation types, adapted from the [Unicode c
             to DUCET.
           </p>
         </div>
+      </td>
     </tr>
     <tr>
       <td>emoji</td>

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/collation/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/collation/index.md
@@ -20,7 +20,7 @@ The **`Intl.Locale.prototype.collation`** property is an accessor property that 
 
 Collation is the process of ordering strings of characters. It is used whenever strings must be sorted and placed into a certain order, from search query results to ordering records in a database. While the idea of placing strings in order might seem trivial, the idea of order can vary from region to region and language to language. The `collation` property helps to make it easier for JavaScript programmers to access the collation type used by a particular locale.
 
-Below is a table with the available collation types, taken from the [Unicode collation specification](https://github.com/unicode-org/cldr/blob/2dd06669d833823e26872f249aa304bc9d9d2a90/common/bcp47/collation.xml).
+Below is a table with the available collation types, adapted from the [Unicode collation specification](https://github.com/unicode-org/cldr/blob/2dd06669d833823e26872f249aa304bc9d9d2a90/common/bcp47/collation.xml).
 
 ### Valid collation types
 
@@ -36,16 +36,22 @@ Below is a table with the available collation types, taken from the [Unicode col
       <td>big5han</td>
       <td>
         Pinyin ordering for Latin, big5 charset ordering for CJK characters
-        (used in Chinese)
+        (for Chinese)
+        <div class="notecard">
+          <p>
+            <strong>Note:</strong> The `big5han` collation type is
+            not available in Chrome or Edge.
+          </p>
+        </div>
       </td>
     </tr>
     <tr>
       <td>compat</td>
-      <td>A previous version of the ordering, for compatibility</td>
+      <td>A previous version of the ordering, for compatibility (for Arabic)</td>
     </tr>
     <tr>
       <td>dict</td>
-      <td>Dictionary style ordering (such as in Sinhala)</td>
+      <td>Dictionary style ordering (for Sinhala)</td>
     </tr>
     <tr>
       <td>
@@ -57,48 +63,79 @@ Below is a table with the available collation types, taken from the [Unicode col
         </div>
         <p>direct</p>
       </td>
-      <td>Binary code point order (used in Hindi)</td>
+      <td>Binary code point order</td>
     </tr>
     <tr>
       <td>ducet</td>
       <td>The default Unicode collation element table order</td>
+        <div class="notecard warning">
+          <p>
+            <strong>Warning:</strong> The `ducet` collation type is
+            not available to the Web. Use the `und` locale without a collation
+            type specifier instead. `und` is the collation that is the closest
+            to DUCET.
+          </p>
+        </div>
     </tr>
     <tr>
       <td>emoji</td>
-      <td>Recommended ordering for emoji characters</td>
+      <td>Recommended ordering for emoji characters (for the `und` locale)</td>
     </tr>
     <tr>
       <td>eor</td>
-      <td>European ordering rules</td>
+      <td>European ordering rules (for the `und` locale)</td>
     </tr>
     <tr>
       <td>gb2312</td>
       <td>
         Pinyin ordering for Latin, gb2312han charset ordering for CJK characters
-        (used in Chinese)
+        (for Chinese)
+        <div class="notecard">
+          <p>
+            <strong>Note:</strong> The <code>gb2313</code> collation type is
+            not available in Chrome or Edge.
+          </p>
+        </div>
       </td>
     </tr>
     <tr>
       <td>phonebk</td>
-      <td>Phonebook style ordering (such as in German)</td>
+      <td>Phonebook style ordering (for German)</td>
     </tr>
     <tr>
       <td>phonetic</td>
-      <td>Phonetic ordering (sorting based on pronunciation)</td>
+      <td>Phonetic ordering (sorting based on pronunciation; for Lingala)</td>
     </tr>
     <tr>
       <td>pinyin</td>
       <td>
-        Pinyin ordering for Latin and for CJK characters (used in Chinese)
+        Pinyin ordering for Latin and for CJK characters (for Chinese)
       </td>
     </tr>
     <tr>
       <td>reformed</td>
-      <td>Reformed ordering (such as in Swedish)</td>
+      <td>Reformed ordering (for Swedish)
+        <div class="notecard">
+          <p>
+            <strong>Note:</strong> This is the default ordering for Swedish
+            whose collation naming is unusual as of May 2022. Since this is
+            the default, request `sv` instead of requesting `sv-u-co-reformed`.
+          </p>
+        </div>
+      </td>
     </tr>
     <tr>
       <td>search</td>
-      <td>Special collation type for string search</td>
+      <td>Special collation type for string search
+        <div class="notecard warning">
+          <p>
+            <strong>Warning:</strong> Do not use. In <code>Intl.Collator</code> this
+            collation is activated via the `search` value for the `usage` option.
+            Furthermore, there is currently no API for actually using the collator
+            for search.
+          </p>
+        </div>
+      </td>
     </tr>
     <tr>
       <td>searchjl</td>
@@ -106,12 +143,21 @@ Below is a table with the available collation types, taken from the [Unicode col
     </tr>
     <tr>
       <td>standard</td>
-      <td>Default ordering for each language</td>
+      <td>Default ordering for each language, except Chinese and, as of May 2022, Swedish
+        <div class="notecard warning">
+          <p>
+            <strong>Warning:</strong> Do not use explicitly. In general, it's unnecessary
+            to specify this explicitly and specifying this for Swedish is problematic in
+            case the naming of the Swedish collations is changed to be consistent with
+            other languages in the future.
+          </p>
+        </div>
+      </td>
     </tr>
     <tr>
       <td>stroke</td>
       <td>
-        Pinyin ordering for Latin, stroke order for CJK characters (used in
+        Pinyin ordering for Latin, stroke order for CJK characters (for
         Chinese)
       </td>
     </tr>
@@ -122,8 +168,14 @@ Below is a table with the available collation types, taken from the [Unicode col
     <tr>
       <td>unihan</td>
       <td>
-        Pinyin ordering for Latin, Unihan radical-stroke ordering for CJK
-        characters (used in Chinese)
+        Radical-stroke ordering for Han characters (for Chinese, Japanese, and Korean).
+        Pinyin ordering for Latin in the case of Chinese.
+        <div class="notecard">
+          <p>
+            <strong>Note:</strong> The <code>unihan</code> collation type is
+            not available in Chrome or Edge.
+          </p>
+        </div>
       </td>
     </tr>
     <tr>
@@ -131,7 +183,7 @@ Below is a table with the available collation types, taken from the [Unicode col
       <td>
         <p>
           Pinyin ordering for Latin, zhuyin order for Bopomofo and CJK
-          characters (used in Chinese)
+          characters (for Chinese)
         </p>
       </td>
     </tr>


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Document what languages various collation types apply to (at present). Document which ones Chrome and Edge exclude. (I didn't test if there are other Chromium-based browsers that undo the exclusions.) Give advice against using types that are unavailable, already defaults, or problematic in the case of unusual naming for Swedish.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

My main motivation is preparation for Swedish [renaming](https://unicode-org.atlassian.net/browse/CLDR-15603) and preparation for [aligning Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1630920) with the exclusions that Chrome already makes.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

The language applicability comes from searching CLDR source.

Chrome and Edge exclusions can be seen in the [source](https://source.chromium.org/chromium/chromium/src/+/main:third_party/icu/filters/common.json;l=1308-1311;drc=d2858cb5ee4335a08ae35c9779ab8bed67e89ef5) and verified by a [demo](https://hsivonen.com/test/moz/zh-collations.html).

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
