### PR TITLE
Avoid using emoji as a collation example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/collation/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/collation/index.md
@@ -147,8 +147,8 @@ Like other locale subtags, the collation type can be added to the {{jsxref("Intl
 In the [Unicode locale string spec](https://www.unicode.org/reports/tr35/), collation types are locale key "extension subtags". These subtags add additional data about the locale, and are added to locale identifiers by using the `-u` extension. Thus, the collation type can be added to the initial locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Locale")}} constructor. To add the collation type, first add the `-u` extension to the string. Next, add the `-co` extension to indicate that you are adding a collation type. Finally, add the collation to the string.
 
 ```js
-let locale = new Intl.Locale("en-Latn-US-u-co-emoji");
-console.log(locale.collation); // Prints "emoji"
+let locale = new Intl.Locale("zh-Hant-u-co-zhuyin");
+console.log(locale.collation); // Prints "zhuyin"
 ```
 
 ### Adding a collation type via the configuration object argument
@@ -156,8 +156,8 @@ console.log(locale.collation); // Prints "emoji"
 The {{jsxref("Intl/Locale/Locale", "Intl.Locale")}} constructor has an optional configuration object argument, which can contain any of several extension types, including collation types. Set the `collation` property of the configuration object to your desired collation type, and then pass it into the constructor.
 
 ```js
-let locale = new Intl.Locale("en-Latn-US", { collation: "emoji" });
-console.log(locale.collation); // Prints "emoji"
+let locale = new Intl.Locale("zh-Hant", { collation: "zhuyin" });
+console.log(locale.collation); // Prints "zhuyin"
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Instead of using `emoji` as an example of an explicitly-requested collation type, use `zhuyin` instead.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

The `emoji` collation type is [intended for charts and emoji pickers](https://github.com/tc39/proposal-intl-locale-info/issues/33#issuecomment-1115123121) and that it combines with a language like English is incidental and works only because English is an alias for the root collation. Notably, it doesn't combine with languages that aren't aliases for the root.

The non-default collation types that have the most present-day use case relevance are probably `zhuyin` for Traditional Chinese and `phonebk` for German and of these, phonebooks are arguably more special-casey. Therefore, using `zhuyin` as the example.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://github.com/tc39/proposal-intl-locale-info/issues/33#issuecomment-1115123121

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
