### PR TITLE
Changed `different absolute` to `different relative`

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/update/index.md
@@ -78,7 +78,7 @@ let updating = browser.tabs.update(
         - file: URLs (i.e., files on the filesystem. However, to use a file packaged inside the extension, see below)
         - privileged about: URLs (for example, `about:config`, `about:addons`, `about:debugging`, `about:newtab`). Non-privileged URLs (e.g., `about:blank`) are allowed.
 
-        To load a page that's packaged with your extension, specify an absolute URL starting at the extension's manifest.json file. For example: '/path/to/my-page.html'. If you omit the leading '/', the URL is treated as a relative URL, and different browsers may construct different absolute URLs.
+        To load a page that's packaged with your extension, specify an absolute URL starting at the extension's manifest.json file. For example: '/path/to/my-page.html'. If you omit the leading '/', the URL is treated as a relative URL, and different browsers may construct different relative URLs.
 
 ### Return value
 


### PR DESCRIPTION
#### Summary
One-word change at line 81: "... construct different **absolute** URLs ..." to "... construct different **relative** URLs ...".

#### Motivation
I was reading through the docs and this seemed odd. The instructions say to specify an absolute URL and warn that if you specify a relative URL, "different browsers may construct different *absolute* URLs"? I think it's supposed to be "different browsers may construct different *relative* URLs", based on the wording and context alone.

I don't know if browsers construct different absolute URLs or relative URLs, so I might be wrong! It just seems weird from a linguistic perspective.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
It seems that the https://github.com/mdn/content/commit/cbe151a06d6e5b4d1fbb46081bd16e69ef4c1630 initial commit already had this issue.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Unknown.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
