### PR TITLE
Remove 10-year old broken example on Window.personalbar

### DIFF
--- a/files/en-us/web/api/window/personalbar/index.md
+++ b/files/en-us/web/api/window/personalbar/index.md
@@ -20,36 +20,6 @@ window.
 
 A `personalbar` object.
 
-## Examples
-
-{{todo('https://bugzilla.mozilla.org/show_bug.cgi?id=790023')}}
-
-{{deprecated_inline}} The following complete HTML example shows the way that the
-visible property of the various "bar" objects is used, and also the change to the
-privileges necessary to write to the visible property of any of the bars on an existing
-window. Due to [deprecation of
-enablePrivilege](/en-US/docs/Bypassing_Security_Restrictions_and_Signing_Code) this functionality can not be used in web pages. EnablePrivilege
-is disabled in Firefox 15 and will be removed in Firefox 17.
-
-```html
-<!DOCTYPE html>
-<html>
-<head>
-<title>Various DOM Tests</title>
-
-<script>
-// changing bar states on the existing window
-netscape.security.PrivilegeManager.enablePrivilege("UniversalBrowserWrite");
-window.personalbar.visible = !window.personalbar.visible;
-</script>
-
-</head>
-<body>
-  <p>Various DOM Tests</p>
-</body>
-</html>
-```
-
 ## Notes
 
 When you load the example page above, the browser displays the following dialog: ![](modify_any_open_window_dialog.png)


### PR DESCRIPTION
This example is broken for 10 years with a {{todo}} macro (that I missed as it has a parameter). Time to just remove the example.

(See https://bugzilla.mozilla.org/show_bug.cgi?id=790023 for the initial report of the problem)