### PR TITLE
Fix link to dynamic-range & video-dynamic-range

### DIFF
--- a/files/en-us/mozilla/firefox/releases/100/index.md
+++ b/files/en-us/mozilla/firefox/releases/100/index.md
@@ -19,7 +19,7 @@ No notable changes.
 
 ### CSS
 
-- CSS media features for [`dynamic-range`](en-US/docs/Web/CSS/@media/dynamic-range) and [`video-dynamic-range`](en-US/docs/Web/CSS/@media/video-dynamic-range) are now supported. You can now test whether a user agent or an output device supports the combination of brightness, contrast ratio, and color depth by using `dynamic-range` and in the video plane by using `video-dynamic-range` ({{bug(1751217)}}).
+- CSS media features for [`dynamic-range`](/en-US/docs/Web/CSS/@media/dynamic-range) and [`video-dynamic-range`](/en-US/docs/Web/CSS/@media/video-dynamic-range) are now supported. You can now test whether a user agent or an output device supports the combination of brightness, contrast ratio, and color depth by using `dynamic-range` and in the video plane by using `video-dynamic-range` ({{bug(1751217)}}).
 
 ### JavaScript
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Links to [dynamic-range](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/dynamic-range) and [video-dynamic-range](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/video-dynamic-range) had incorrect path in [Release Notes 100](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/100).
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
