### PR TITLE
Typo fix, removed extraneous "the"

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-placeholder/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-placeholder/index.md
@@ -23,7 +23,7 @@ If you are creating a `textbox` using any other element, `placeholder` is not su
 <div contenteditable role="textbox" aria-labelledby="date-of-birth" aria-placeholder="MM-DD-YYYY">MM-DD-YYYY</div>
 ```
 
-The placeholder hint should be shown to the user whenever the control's value is the empty, including when a value is deleted.
+The placeholder hint should be shown to the user whenever the control's value is empty, including when a value is deleted.
 
 > **Note:** ARIA is only modify the accessibility tree for an element and therefore how assistive technology presents the content to your users. ARIA doesn't change anything about an elements function or behavior. When not using semantic HTML elements for their intended purpose and default functionality, you must use JavaScript to manage behavior.
 


### PR DESCRIPTION
"The placeholder hint should be shown to the user whenever the control's value is THE empty, including when a value is deleted." changed to "The placeholder hint should be shown to the user whenever the control's value is empty, including when a value is deleted."

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
