### PR TITLE
WebAPI: Update Method pages to modern structure (part 34)

### DIFF
--- a/files/en-us/web/api/baseaudiocontext/createperiodicwave/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createperiodicwave/index.md
@@ -26,10 +26,6 @@ createPeriodicWave(real, imag)
 createPeriodicWave(real, imag, constraints)
 ```
 
-### Return value
-
-A {{domxref("PeriodicWave")}}.
-
 ### Parameters
 
 - `real`
@@ -50,6 +46,10 @@ otherwise an error is thrown.
       `false`.
 
 > **Note:** If normalized, the resulting wave will have a maximum absolute peak value of 1.
+
+### Return value
+
+A {{domxref("PeriodicWave")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/bluetooth/requestdevice/index.md
+++ b/files/en-us/web/api/bluetooth/requestdevice/index.md
@@ -24,16 +24,10 @@ requestDevice()
 requestDevice(options)
 ```
 
-### Return value
-
-A {{jsxref("Promise")}} to a {{domxref("BluetoothDevice")}} object.
-
 ### Parameters
 
-- options {{optional_inline}}
-
+- `options` {{optional_inline}}
   - : An object that sets options for the device request. The available options are:
-
     - `filters[]`: An array of `BluetoothScanFilters`. This
       filter consists of an array of `BluetoothServiceUUID`s, a
       `name` parameter, and a `namePrefix` parameter.
@@ -41,6 +35,10 @@ A {{jsxref("Promise")}} to a {{domxref("BluetoothDevice")}} object.
     - `acceptAllDevices`: A boolean value indicating that the
       requesting script can accept all Bluetooth devices. The default is
       `false`.
+
+### Return value
+
+A {{jsxref("Promise")}} to a {{domxref("BluetoothDevice")}} object.
 
 ### Exceptions
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevalue/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevalue/index.md
@@ -24,14 +24,14 @@ The **`BluetoothRemoteGATTCharacteristic.writeValue()`** method sets a {{domxref
 writeValue(value)
 ```
 
+### Parameters
+
+- `value`
+  - : An {{jsxref("ArrayBuffer")}}.
+
 ### Return value
 
 A {{jsxref("Promise")}}.
-
-### Parameters
-
-- value
-  - : An {{jsxref("ArrayBuffer")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithresponse/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/writevaluewithresponse/index.md
@@ -22,14 +22,14 @@ The **`BluetoothRemoteGATTCharacteristic.writeValueWithResponse()`** method sets
 writeValueWithResponse(value)
 ```
 
+### Parameters
+
+- `value`
+  - : An {{jsxref("ArrayBuffer")}}.
+
 ### Return value
 
 A {{jsxref("Promise")}}.
-
-### Parameters
-
-- value
-  - : An {{jsxref("ArrayBuffer")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/bluetoothremotegattserver/connect/index.md
+++ b/files/en-us/web/api/bluetoothremotegattserver/connect/index.md
@@ -24,13 +24,13 @@ script execution environment to connect to `this.device`.
 connect()
 ```
 
-### Return value
-
-A {{jsxref("Promise")}} that resolves to a {{domxref("BluetoothRemoteGATTServer")}}.
-
 ### Parameters
 
 None.
+
+### Return value
+
+A {{jsxref("Promise")}} that resolves to a {{domxref("BluetoothRemoteGATTServer")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/bluetoothremotegattserver/getprimaryservice/index.md
+++ b/files/en-us/web/api/bluetoothremotegattserver/getprimaryservice/index.md
@@ -24,14 +24,14 @@ Bluetooth device for a specified {{domxref("BluetoothServiceUUID")}}.
 getPrimaryService(bluetoothServiceUUID)
 ```
 
-### Return value
-
-A {{jsxref("Promise")}} that resolves to a {{domxref("BluetoothRemoteGATTService")}} object.
-
 ### Parameters
 
 - `BluetoothServiceUUID`
   - : A Bluetooth service universally unique identifier for a specified device.
+
+### Return value
+
+A {{jsxref("Promise")}} that resolves to a {{domxref("BluetoothRemoteGATTService")}} object.
 
 ## Specifications
 

--- a/files/en-us/web/api/bluetoothremotegattserver/getprimaryservices/index.md
+++ b/files/en-us/web/api/bluetoothremotegattserver/getprimaryservices/index.md
@@ -24,15 +24,15 @@ Bluetooth device for a specified `BluetoothServiceUUID`.
 getPrimaryServices(bluetoothServiceUUID)
 ```
 
-### Return value
-
-A {{jsxref("Promise")}} that resolves to a list of {{domxref("BluetoothRemoteGATTService")}}
-objects.
-
 ### Parameters
 
 - `bluetoothServiceUUID`
   - : A Bluetooth service universally unique identifier for a specified device.
+
+### Return value
+
+A {{jsxref("Promise")}} that resolves to a list of {{domxref("BluetoothRemoteGATTService")}}
+objects.
 
 ## Specifications
 

--- a/files/en-us/web/api/bluetoothremotegattservice/getcharacteristic/index.md
+++ b/files/en-us/web/api/bluetoothremotegattservice/getcharacteristic/index.md
@@ -25,16 +25,16 @@ returns a {{jsxref("Promise")}} to an instance of
 getCharacteristic(characteristic)
 ```
 
-### Return value
-
-A {{jsxref("Promise")}} to an instance of {{domxref("BluetoothRemoteGATTCharacteristic")}}
-
 ### Parameters
 
-- characteristic
+- `characteristic`
   - : The UUID of a characteristic, for
     example `'00002a37-0000-1000-8000-00805f9b34fb'` for the Heart Rate
     Measurement characteristic.
+
+### Return value
+
+A {{jsxref("Promise")}} to an instance of {{domxref("BluetoothRemoteGATTCharacteristic")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/bluetoothremotegattservice/getcharacteristics/index.md
+++ b/files/en-us/web/api/bluetoothremotegattservice/getcharacteristics/index.md
@@ -24,17 +24,17 @@ instances for a given universally unique identifier (UUID).
 getCharacteristics(characteristics)
 ```
 
+### Parameters
+
+- `characteristics`
+  - : The UUID of a characteristic, for
+    example `'00002a37-0000-1000-8000-00805f9b34fb'` for the Heart Rate
+    Measurement characteristic.
+
 ### Return value
 
 A {{jsxref("Promise")}} to an
 {{jsxref("Array")}} of {{domxref("BluetoothRemoteGATTCharacteristic")}} instances.
-
-### Parameters
-
-- characteristics
-  - : The UUID of a characteristic, for
-    example `'00002a37-0000-1000-8000-00805f9b34fb'` for the Heart Rate
-    Measurement characteristic.
 
 ## Specifications
 

--- a/files/en-us/web/api/document/execcommand/index.md
+++ b/files/en-us/web/api/document/execcommand/index.md
@@ -33,16 +33,6 @@ The [Clipboard API](/en-US/docs/Web/API/Clipboard_API) can be used instead of `e
 execCommand(aCommandName, aShowDefaultUI, aValueArgument)
 ```
 
-### Return value
-
-A boolean value that is `false` if the command is unsupported or
-disabled.
-
-> **Note:** `document.execCommand()` only returns
-> `true` if it is invoked as part of a user interaction. You can't use it to
-> verify browser support before calling a command. From Firefox 82, nested
-> `document.execCommand()` calls will always return `false`.
-
 ### Parameters
 
 - `aCommandName`
@@ -56,7 +46,7 @@ disabled.
     providing that information. For example, `insertImage` requires the URL of
     the image to insert. Specify `null` if no argument is needed.
 
-### Commands
+#### Commands
 
 - `backColor`
   - : Changes the document background color. In `styleWithCss` mode, it affects
@@ -217,6 +207,16 @@ disabled.
 
 - `AutoUrlDetect`
   - : Changes the browser auto-link behavior (Internet Explorer only)
+
+### Return value
+
+A boolean value that is `false` if the command is unsupported or
+disabled.
+
+> **Note:** `document.execCommand()` only returns
+> `true` if it is invoked as part of a user interaction. You can't use it to
+> verify browser support before calling a command. From Firefox 82, nested
+> `document.execCommand()` calls will always return `false`.
 
 ## Examples
 

--- a/files/en-us/web/api/document/execcommand/index.md
+++ b/files/en-us/web/api/document/execcommand/index.md
@@ -36,182 +36,117 @@ execCommand(aCommandName, aShowDefaultUI, aValueArgument)
 ### Parameters
 
 - `aCommandName`
-  - : A string specifying the name of the command to execute. See
-    [Commands](#commands) for a list of possible commands.
+  - : A string specifying the name of the command to execute.
+    - `backColor` 
+      - : Changes the document background color. In `styleWithCss` mode, it affects the background color of the containing block instead. This requires a {{cssxref("&lt;color&gt;")}} value string to be passed in as a value argument. Note that Internet Explorer uses this to set the text background color.
+    - `bold`
+      - : Toggles bold on/off for the selection or at the insertion point. Internet Explorer uses the {{HTMLElement("strong")}} tag instead of {{HTMLElement("b")}}.
+    - `ClearAuthenticationCache`
+      - : Clears all authentication credentials from the cache.
+    - `contentReadOnly`
+      - : Makes the content document either read-only or editable. This requires a boolean true/false as the value argument. (Not supported by Internet Explorer.)
+    - `copy`
+      - : Copies the current selection to the clipboard. Conditions of having this behavior enabled vary from one browser to another, and have evolved over time. Check the compatibility table to determine if you can use it in your case.
+    - `createLink`
+      - : Creates an hyperlink from the selection, but only if there is a selection. Requires a {{Glossary("URI")}} string as a value argument for the hyperlink's `href`. The URI must contain at least a single character, which may be whitespace. (Internet Explorer will create a link with a `null` value.)
+    - `cut`
+      - : Removes the current selection and copies it to the clipboard. When this behavior is enabled varies between browsers, and its conditions have evolved over time. Check [the compatibility table](#browser_compatibility) for usage details.
+    - `decreaseFontSize`
+      - : Adds a {{HTMLElement("small")}} tag around the selection or at the insertion point. (Not supported by Internet Explorer.)
+    - `defaultParagraphSeparator`
+      - : Changes the paragraph separator used when new paragraphs are created in editable text regions.See [Differences in markup generation](/en-US/docs/Web/Guide/HTML/Editable_content#differences_in_markup_generation) for more details.
+    - `delete`
+      - : Deletes the current selection.
+    - `enableAbsolutePositionEditor`
+      - : Enables or disables the grabber that allows absolutely-positioned elements to be moved around. The grabber is disabled by default since Firefox 64 ({{bug(1490641)}}).
+    - `enableInlineTableEditing`
+      - : Enables or disables the table row/column insertion and deletion controls. The controls are disabled by default since Firefox 64 ({{bug(1490641)}}).
+    - `enableObjectResizing`
+      - : Enables or disables the resize handles on images, tables, and absolutely-positioned elements and other resizable objects. The handles are disabled by default since Firefox 64 ({{bug(1490641)}}).
+    - `fontName`
+      - : Changes the font name for the selection or at the insertion point. This requires a font name string (like `"Arial"`) as a value argument.
+    - `fontSize`
+      - : Changes the font size for the selection or at the insertion point. This requires an integer from `1`-`7` as a value argument.
+    - `foreColor`
+      - : Changes a font color for the selection or at the insertion point. This requires a hexadecimal color value string as a value argument.
+    - `formatBlock`
+      - : Adds an HTML block-level element around the line containing the current selection, replacing the block element containing the line if one exists (in Firefox, {{HTMLElement("blockquote")}} is the exception — it will wrap any containing block element). Requires a tag-name string as a value argument. Virtually all block-level elements can be used. (Internet Explorer and Edge support only heading tags `H1`–`H6`, `ADDRESS`, and `PRE`, which must be wrapped in angle brackets, such as `"<H1>"`.)
+    - `forwardDelete`
+      - : Deletes the character ahead of the [cursor](https://en.wikipedia.org/wiki/Cursor_%28computers%29)'s position, identical to hitting the Delete key on a Windows keyboard.
+    - `heading`
+      - : Adds a heading element around a selection or insertion point line. Requires the tag-name string as a value argument (i.e. `"H1"`, `"H6"`). (Not supported by Internet Explorer and Safari.)
+    - `hiliteColor`
+      - : Changes the background color for the selection or at the insertion point. Requires a color value string as a value argument. `useCSS` must be `true` for this to function. (Not supported by Internet Explorer.)
+    - `increaseFontSize`
+      - : Adds a {{HTMLElement("big")}} tag around the selection or at the insertion point. (Not supported by Internet Explorer.)
+    - `indent`
+      - : Indents the line containing the selection or insertion point. In Firefox, if the selection spans multiple lines at different levels of indentation, only the least indented lines in the selection will be indented.
+    - `insertBrOnReturn`
+      - : Controls whether the Enter key inserts a {{HTMLElement("br")}} element, or splits the current block element into two. (Not supported by Internet Explorer.)
+    - `insertHorizontalRule`
+      - : Inserts a {{HTMLElement("hr")}} element at the insertion point, or replaces the selection with it.
+    - `insertHTML`
+      - : Inserts an HTML string at the insertion point (deletes selection). Requires a valid HTML string as a value argument. (Not supported by Internet Explorer.)
+    - `insertImage`
+      - : Inserts an image at the insertion point (deletes selection). Requires a URL string for the image's `src` as a value argument. The requirements for this string are the same as `createLink`.
+    - `insertOrderedList`
+      - : Creates a [numbered ordered list](/en-US/docs/Web/HTML/Element/ol) for the selection or at the insertion point.
+    - `insertUnorderedList`
+      - : Creates a [bulleted unordered list](/en-US/docs/Web/HTML/Element/ul) for the selection or at the insertion point.
+    - `insertParagraph`
+      - : Inserts a [paragraph](/en-US/docs/Web/HTML/Element/p) around the selection or the current line. (Internet Explorer inserts a paragraph at the insertion point and deletes the selection.)
+    - `insertText`
+      - : Inserts the given plain text at the insertion point (deletes selection).
+    - `italic`
+      - : Toggles italics on/off for the selection or at the insertion point. (Internet Explorer uses the {{HTMLElement("em")}} element instead of {{HTMLElement("i")}}.)
+    - `justifyCenter`
+      - : Centers the selection or insertion point.
+    - `justifyFull`
+      - : Justifies the selection or insertion point.
+    - `justifyLeft`
+      - : Justifies the selection or insertion point to the left.
+    - `justifyRight`
+      - : Right-justifies the selection or the insertion point.
+    - `outdent`
+      - : Outdents the line containing the selection or insertion point.
+    - `paste`
+      - : Pastes the clipboard contents at the insertion point (replaces current selection). Disabled for web content.
+    - `redo`
+      - : Redoes the previous undo command.
+    - `removeFormat`
+      - : Removes all formatting from the current selection.
+    - `selectAll`
+      - : Selects all of the content of the editable region.
+    - `strikeThrough`
+      - : Toggles strikethrough on/off for the selection or at the insertion point.
+    - `subscript`
+      - : Toggles [subscript](/en-US/docs/Web/HTML/Element/sub) on/off for the selection or at the insertion point.
+    - `superscript`
+      - : Toggles [superscript](/en-US/docs/Web/HTML/Element/sup) on/off for the selection or at the insertion point.
+    - `underline`
+      - : Toggles [underline](/en-US/docs/Web/HTML/Element/u) on/off for the selection or at the insertion point.
+    - `undo`
+      - : Undoes the last executed command.
+    - `unlink`
+      - : Removes the [anchor element](/en-US/docs/Web/HTML/Element/a) from a selected hyperlink.
+    - `useCSS` {{Deprecated_inline}}
+      - : Toggles the use of HTML tags or CSS for the generated markup. Requires a boolean true/false as a value argument.
+        > **Note:** This argument is logically backwards (i.e. use `false` to use CSS,
+        > `true` to use HTML) and unsupported by Internet Explorer. This has been
+        > deprecated in favor of `styleWithCSS`.
+    - `styleWithCSS`
+      - : Replaces the `useCSS` command. `true` modifies/generates `style` attributes in markup, false generates presentational elements.
+    - `AutoUrlDetect`
+      - : Changes the browser auto-link behavior (Internet Explorer only)
+
 - `aShowDefaultUI`
-  - : A boolean value indicating whether the default user interface should be
-    shown. This is not implemented in Mozilla.
+    - : A boolean value indicating whether the default user interface should be shown. This is not implemented in Mozilla.
 - `aValueArgument`
-  - : For commands which require an input argument, is a string
-    providing that information. For example, `insertImage` requires the URL of
-    the image to insert. Specify `null` if no argument is needed.
-
-#### Commands
-
-- `backColor`
-  - : Changes the document background color. In `styleWithCss` mode, it affects
-    the background color of the containing block instead. This requires a
-    {{cssxref("&lt;color&gt;")}} value string to be passed in as a value argument. Note
-    that Internet Explorer uses this to set the text background color.
-- `bold`
-  - : Toggles bold on/off for the selection or at the insertion point. Internet Explorer
-    uses the {{HTMLElement("strong")}} tag instead of {{HTMLElement("b")}}.
-- `ClearAuthenticationCache`
-  - : Clears all authentication credentials from the cache.
-- `contentReadOnly`
-  - : Makes the content document either read-only or editable. This requires a boolean
-    true/false as the value argument. (Not supported by Internet Explorer.)
-- `copy`
-  - : Copies the current selection to the clipboard. Conditions of having this behavior
-    enabled vary from one browser to another, and have evolved over time. Check the
-    compatibility table to determine if you can use it in your case.
-- `createLink`
-  - : Creates an hyperlink from the selection, but only if there is a selection. Requires
-    a {{Glossary("URI")}} string as a value
-    argument for the hyperlink's `href`. The URI must contain at least a single
-    character, which may be whitespace. (Internet Explorer will create a link with a
-    `null` value.)
-- `cut`
-  - : Removes the current selection and copies it to the clipboard. When this behavior is
-    enabled varies between browsers, and its conditions have evolved over time. Check [the compatibility table](#browser_compatibility) for usage details.
-- `decreaseFontSize`
-  - : Adds a {{HTMLElement("small")}} tag around the selection or at the insertion point.
-    (Not supported by Internet Explorer.)
-- `defaultParagraphSeparator`
-  - : Changes the paragraph separator used when new paragraphs are created in editable
-    text regions. See [Differences
-    in markup generation](/en-US/docs/Web/Guide/HTML/Editable_content#differences_in_markup_generation) for more details.
-- `delete`
-  - : Deletes the current selection.
-- `enableAbsolutePositionEditor`
-  - : Enables or disables the grabber that allows absolutely-positioned elements to be
-    moved around. The grabber is disabled by default since Firefox 64 ({{bug(1490641)}}).
-- `enableInlineTableEditing`
-  - : Enables or disables the table row/column insertion and deletion controls. The
-    controls are disabled by default since Firefox 64 ({{bug(1490641)}}).
-- `enableObjectResizing`
-  - : Enables or disables the resize handles on images, tables, and absolutely-positioned
-    elements and other resizable objects. The handles are disabled by default since
-    Firefox 64 ({{bug(1490641)}}).
-- `fontName`
-  - : Changes the font name for the selection or at the insertion point. This requires a
-    font name string (like `"Arial"`) as a value argument.
-- `fontSize`
-  - : Changes the font size for the selection or at the insertion point. This requires an
-    integer from `1`-`7` as a value argument.
-- `foreColor`
-  - : Changes a font color for the selection or at the insertion point. This requires a
-    hexadecimal color value string as a value argument.
-- `formatBlock`
-  - : Adds an HTML block-level element around the line containing the current selection,
-    replacing the block element containing the line if one exists (in Firefox,
-    {{HTMLElement("blockquote")}} is the exception — it will wrap any containing block
-    element). Requires a tag-name string as a value argument. Virtually all block-level
-    elements can be used. (Internet Explorer and Edge support only heading tags
-    `H1`–`H6`, `ADDRESS`, and `PRE`, which
-    must be wrapped in angle brackets, such as `"<H1>"`.)
-- `forwardDelete`
-  - : Deletes the character ahead of the [cursor](https://en.wikipedia.org/wiki/Cursor_%28computers%29)'s position,
-    identical to hitting the Delete key on a Windows keyboard.
-- `heading`
-  - : Adds a heading element around a selection or insertion point line. Requires the
-    tag-name string as a value argument (i.e. `"H1"`, `"H6"`). (Not
-    supported by Internet Explorer and Safari.)
-- `hiliteColor`
-  - : Changes the background color for the selection or at the insertion point. Requires a
-    color value string as a value argument. `useCSS` must be `true`
-    for this to function. (Not supported by Internet Explorer.)
-- `increaseFontSize`
-  - : Adds a {{HTMLElement("big")}} tag around the selection or at the insertion point.
-    (Not supported by Internet Explorer.)
-- `indent`
-  - : Indents the line containing the selection or insertion point. In Firefox, if the
-    selection spans multiple lines at different levels of indentation, only the least
-    indented lines in the selection will be indented.
-- `insertBrOnReturn`
-  - : Controls whether the Enter key inserts a {{HTMLElement("br")}} element, or splits
-    the current block element into two. (Not supported by Internet Explorer.)
-- `insertHorizontalRule`
-  - : Inserts a {{HTMLElement("hr")}} element at the insertion point, or replaces the
-    selection with it.
-- `insertHTML`
-  - : Inserts an HTML string at the insertion point (deletes selection). Requires a valid
-    HTML string as a value argument. (Not supported by Internet Explorer.)
-- `insertImage`
-  - : Inserts an image at the insertion point (deletes selection). Requires a URL string
-    for the image's `src` as a value argument. The requirements for this string
-    are the same as `createLink`.
-- `insertOrderedList`
-  - : Creates a [numbered ordered list](/en-US/docs/Web/HTML/Element/ol) for
-    the selection or at the insertion point.
-- `insertUnorderedList`
-  - : Creates a [bulleted unordered list](/en-US/docs/Web/HTML/Element/ul) for
-    the selection or at the insertion point.
-- `insertParagraph`
-  - : Inserts a [paragraph](/en-US/docs/Web/HTML/Element/p) around the
-    selection or the current line. (Internet Explorer inserts a paragraph at the insertion
-    point and deletes the selection.)
-- `insertText`
-  - : Inserts the given plain text at the insertion point (deletes selection).
-- `italic`
-  - : Toggles italics on/off for the selection or at the insertion point. (Internet
-    Explorer uses the {{HTMLElement("em")}} element instead of {{HTMLElement("i")}}.)
-- `justifyCenter`
-  - : Centers the selection or insertion point.
-- `justifyFull`
-  - : Justifies the selection or insertion point.
-- `justifyLeft`
-  - : Justifies the selection or insertion point to the left.
-- `justifyRight`
-  - : Right-justifies the selection or the insertion point.
-- `outdent`
-  - : Outdents the line containing the selection or insertion point.
-- `paste`
-  - : Pastes the clipboard contents at the insertion point (replaces current selection).
-    Disabled for web content.
-- `redo`
-  - : Redoes the previous undo command.
-- `removeFormat`
-  - : Removes all formatting from the current selection.
-- `selectAll`
-  - : Selects all of the content of the editable region.
-- `strikeThrough`
-  - : Toggles strikethrough on/off for the selection or at the insertion point.
-- `subscript`
-  - : Toggles [subscript](/en-US/docs/Web/HTML/Element/sub) on/off for the
-    selection or at the insertion point.
-- `superscript`
-  - : Toggles [superscript](/en-US/docs/Web/HTML/Element/sup) on/off for the
-    selection or at the insertion point.
-- `underline`
-  - : Toggles [underline](/en-US/docs/Web/HTML/Element/u) on/off for the
-    selection or at the insertion point.
-- `undo`
-  - : Undoes the last executed command.
-- `unlink`
-  - : Removes the [anchor element](/en-US/docs/Web/HTML/Element/a) from a
-    selected hyperlink.
-- `useCSS` {{Deprecated_inline}}
-
-  - : Toggles the use of HTML tags or CSS for the generated markup. Requires a boolean
-    true/false as a value argument.
-
-    > **Note:** This argument is logically backwards (i.e. use `false` to use CSS,
-    > `true` to use HTML) and unsupported by Internet Explorer. This has been
-    > deprecated in favor of `styleWithCSS`.
-
-- `styleWithCSS`
-
-  - : Replaces the `useCSS` command. `true` modifies/generates
-    `style` attributes in markup, false generates presentational elements.
-
-- `AutoUrlDetect`
-  - : Changes the browser auto-link behavior (Internet Explorer only)
+    - : For commands which require an input argument, is a string providing that information. For example, `insertImage` requires the URL of the image to insert. Specify `null` if no argument is needed.
 
 ### Return value
 
-A boolean value that is `false` if the command is unsupported or
-disabled.
+A boolean value that is `false` if the command is unsupported or disabled.
 
 > **Note:** `document.execCommand()` only returns
 > `true` if it is invoked as part of a user interaction. You can't use it to

--- a/files/en-us/web/api/document/execcommand/index.md
+++ b/files/en-us/web/api/document/execcommand/index.md
@@ -36,7 +36,7 @@ execCommand(aCommandName, aShowDefaultUI, aValueArgument)
 ### Parameters
 
 - `aCommandName`
-  - : A string specifying the name of the command to execute.
+  - : A string specifying the name of the command to execute. The following commands are specified:
     - `backColor` 
       - : Changes the document background color. In `styleWithCss` mode, it affects the background color of the containing block instead. This requires a {{cssxref("&lt;color&gt;")}} value string to be passed in as a value argument. Note that Internet Explorer uses this to set the text background color.
     - `bold`

--- a/files/en-us/web/api/fontfaceset/check/index.md
+++ b/files/en-us/web/api/fontfaceset/check/index.md
@@ -22,16 +22,16 @@ check(font)
 check(font, text)
 ```
 
-### Return value
-
-A {{jsxref("Boolean")}} value that is `true` if the font list is available.
-
 ### Parameters
 
 - `font`
   - : a font specification using the [CSS value syntax](/en-US/docs/), for example `"italic bold 16px Roboto"`
 - `text`
   - : limit the font faces to those whose Unicode range contains at least one of the characters in text. This [does not check for individual glyph coverage](https://lists.w3.org/Archives/Public/www-style/2015Aug/0330.html).
+
+### Return value
+
+A {{jsxref("Boolean")}} value that is `true` if the font list is available.
 
 ## Examples
 

--- a/files/en-us/web/api/fontfaceset/load/index.md
+++ b/files/en-us/web/api/fontfaceset/load/index.md
@@ -22,18 +22,18 @@ load(font)
 load(font, text)
 ```
 
-### Return value
-
-A {{jsxref("Promise")}} of an {{jsxref("Array")}} of {{jsxref("FontFace")}} loaded. The
-promise is fulfilled when all the fonts are loaded; it is rejected if one of the fonts
-failed to load.
-
 ### Parameters
 
 - `font`
   - : a font specification using the [CSS value syntax](/en-US/docs/), e.g. "italic bold 16px Roboto"
 - `text`
   - : limit the font faces to those whose Unicode range contains at least one of the characters in text. This [does not check for individual glyph coverage](https://lists.w3.org/Archives/Public/www-style/2015Aug/0330.html).
+
+### Return value
+
+A {{jsxref("Promise")}} of an {{jsxref("Array")}} of {{jsxref("FontFace")}} loaded. The
+promise is fulfilled when all the fonts are loaded; it is rejected if one of the fonts
+failed to load.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlinputelement/showpicker/index.md
+++ b/files/en-us/web/api/htmlinputelement/showpicker/index.md
@@ -19,6 +19,16 @@ A browser picker is shown when the element is one of these types: `"date"`,
 `"month"`, `"week"`, `"time"`, `"datetime-local"`, `"color"`, or `"file"`. It
 can also be prepopulated with items from a {{htmlelement("datalist")}} element or [`autocomplete`](/en-US/docs/Web/HTML/Attributes/autocomplete) attribute.
 
+## Syntax
+
+```js
+showPicker()
+```
+
+### Parameters
+
+None.
+
 ### Return value
 
 None ({{jsxref("undefined")}}).
@@ -30,16 +40,6 @@ None ({{jsxref("undefined")}}).
     or mouse click.
 - `SecurityError` {{domxref("DOMException")}}
   - : Thrown if called in a cross-origin iframe.
-
-## Syntax
-
-```js
-showPicker()
-```
-
-### Parameters
-
-None.
 
 ## Examples
 

--- a/files/en-us/web/api/keyboardevent/getmodifierstate/index.md
+++ b/files/en-us/web/api/keyboardevent/getmodifierstate/index.md
@@ -22,16 +22,16 @@ current state of the specified modifier key: `true` if the modifier is active
 getModifierState(keyArg)
 ```
 
-### Return value
-
-A boolean value
-
 ### Parameters
 
 - _`keyArg`_
   - : A modifier key value. The value must be one of the {{domxref("KeyboardEvent.key")}}
     values which represent modifier keys, or the string `"Accel"`
     {{deprecated_inline}}. This is case-sensitive.
+
+### Return value
+
+A boolean.
 
 ## Modifier keys on Internet Explorer
 

--- a/files/en-us/web/api/webglrenderingcontext/linewidth/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/linewidth/index.md
@@ -36,7 +36,7 @@ lineWidth(width)
 
 ### Return value
 
-None.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/linkprogram/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/linkprogram/index.md
@@ -29,7 +29,7 @@ linkProgram(program)
 
 ### Return value
 
-None.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/pixelstorei/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/pixelstorei/index.md
@@ -30,7 +30,7 @@ pixelStorei(pname, param)
 
 ### Return value
 
-None.
+None ({{jsxref("undefined")}}).
 
 ## Pixel storage parameters
 

--- a/files/en-us/web/api/webglrenderingcontext/polygonoffset/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/polygonoffset/index.md
@@ -36,7 +36,7 @@ polygonOffset(factor, units)
 
 ### Return value
 
-None.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/readpixels/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/readpixels/index.md
@@ -96,7 +96,7 @@ readPixels(x, y, width, height, format, type, pixels, dstOffset)
 
 ### Return value
 
-None.
+None ({{jsxref("undefined")}}).
 
 ### Exceptions
 

--- a/files/en-us/web/api/webglrenderingcontext/renderbufferstorage/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/renderbufferstorage/index.md
@@ -102,7 +102,7 @@ renderbufferStorage(target, internalFormat, width, height)
 
 ### Return value
 
-None.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/samplecoverage/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/samplecoverage/index.md
@@ -32,7 +32,7 @@ sampleCoverage(value, invert)
 
 ### Return value
 
-None.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/scissor/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/scissor/index.md
@@ -37,7 +37,7 @@ scissor(x, y, width, height)
 
 ### Return value
 
-None.
+None ({{jsxref("undefined")}}).
 
 ### Exceptions
 

--- a/files/en-us/web/api/webglrenderingcontext/shadersource/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/shadersource/index.md
@@ -29,7 +29,7 @@ shaderSource(shader, source)
 
 ### Return value
 
-None.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/stencilfunc/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilfunc/index.md
@@ -55,7 +55,7 @@ stencilFunc(func, ref, mask)
 
 ### Return value
 
-None.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/stencilfuncseparate/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilfuncseparate/index.md
@@ -65,7 +65,7 @@ stencilFuncSeparate(face, func, ref, mask)
 
 ### Return value
 
-None.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/stencilmask/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilmask/index.md
@@ -31,7 +31,7 @@ stencilMask(mask)
 
 ### Return value
 
-None.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/stencilmaskseparate/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilmaskseparate/index.md
@@ -41,7 +41,7 @@ stencilMaskSeparate(face, mask)
 
 ### Return value
 
-None.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/stencilop/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilop/index.md
@@ -37,7 +37,7 @@ All three parameters accept all constants listed below.
 
 ### Return value
 
-None.
+None ({{jsxref("undefined")}}).
 
 ## Constants
 

--- a/files/en-us/web/api/webglrenderingcontext/stencilopseparate/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilopseparate/index.md
@@ -48,7 +48,7 @@ constants listed below.
 
 ### Return value
 
-None.
+None ({{jsxref("undefined")}}).
 
 ## Constants
 

--- a/files/en-us/web/api/webglrenderingcontext/teximage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/teximage2d/index.md
@@ -837,7 +837,7 @@ texImage2D(target, level, internalformat, width, height, border, format, type, s
 
 ### Return value
 
-None.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/texparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/texparameter/index.md
@@ -152,7 +152,7 @@ texParameteri(target, GLenum pname, GLint param)
 
 ### Return value
 
-None.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/texsubimage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/texsubimage2d/index.md
@@ -154,7 +154,7 @@ texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixe
 
 ### Return value
 
-None.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/uniform/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/uniform/index.md
@@ -65,7 +65,7 @@ uniform4iv(location, value)
 
 ### Return value
 
-None.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/uniformmatrix/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/uniformmatrix/index.md
@@ -51,7 +51,7 @@ uniformMatrix4fv(location, transpose, value)
 
 ### Return value
 
-`undefined`
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/useprogram/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/useprogram/index.md
@@ -27,7 +27,7 @@ useProgram(program)
 
 ### Return value
 
-None.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/validateprogram/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/validateprogram/index.md
@@ -29,7 +29,7 @@ validateProgram(program)
 
 ### Return value
 
-None.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/vertexattrib/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattrib/index.md
@@ -41,7 +41,7 @@ vertexAttrib4fv(index, value)
 
 ### Return value
 
-None.
+None ({{jsxref("undefined")}}).
 
 ## Description
 

--- a/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.md
@@ -72,7 +72,7 @@ vertexAttribPointer(index, size, type, normalized, stride, offset)
 
 ### Return value
 
-None.
+None ({{jsxref("undefined")}}).
 
 ### Exceptions
 

--- a/files/en-us/web/api/webglrenderingcontext/viewport/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/viewport/index.md
@@ -38,7 +38,7 @@ viewport(x, y, width, height)
 
 ### Return value
 
-None.
+None ({{jsxref("undefined")}}).
 
 ### Errors thrown
 

--- a/files/en-us/web/api/window/alert/index.md
+++ b/files/en-us/web/api/window/alert/index.md
@@ -31,7 +31,7 @@ alert(message)
 
 ### Return value
 
-`undefined`.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/window/back/index.md
+++ b/files/en-us/web/api/window/back/index.md
@@ -32,7 +32,7 @@ None.
 
 ### Return value
 
-`undefined`.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/window/blur/index.md
+++ b/files/en-us/web/api/window/blur/index.md
@@ -24,7 +24,7 @@ None.
 
 ### Return value
 
-`undefined`.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/window/cancelidlecallback/index.md
+++ b/files/en-us/web/api/window/cancelidlecallback/index.md
@@ -33,7 +33,7 @@ cancelIdleCallback(handle)
 
 ### Return value
 
-`undefined`.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/window/forward/index.md
+++ b/files/en-us/web/api/window/forward/index.md
@@ -30,7 +30,7 @@ None.
 
 ### Return value
 
-`undefined`.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/window/postmessage/index.md
+++ b/files/en-us/web/api/window/postmessage/index.md
@@ -62,7 +62,7 @@ postMessage(message, targetOrigin, transfer)
 
 ### Return value
 
-`undefined`
+None ({{jsxref("undefined")}}).
 
 ## The dispatched event
 

--- a/files/en-us/web/api/window/requestfilesystem/index.md
+++ b/files/en-us/web/api/window/requestfilesystem/index.md
@@ -55,7 +55,7 @@ requestFileSystem(type, size, successCallback, errorCallback)
 
 ### Return value
 
-`undefined`
+None ({{jsxref("undefined")}}).
 
 ## Specifications
 

--- a/files/en-us/web/api/worker/postmessage/index.md
+++ b/files/en-us/web/api/worker/postmessage/index.md
@@ -42,7 +42,7 @@ postMessage(message, transfer)
 
 ### Return value
 
-{{jsxref('undefined')}}.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/worker/terminate/index.md
+++ b/files/en-us/web/api/worker/terminate/index.md
@@ -26,7 +26,7 @@ None.
 
 ### Return value
 
-{{jsxref('undefined')}}.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/workerglobalscope/importscripts/index.md
+++ b/files/en-us/web/api/workerglobalscope/importscripts/index.md
@@ -28,7 +28,7 @@ A comma-separated list of string objects representing the scripts to be imported
 
 ### Return value
 
-_None._
+None ({{jsxref("undefined")}}).
 
 ### Exceptions
 

--- a/files/en-us/web/api/writablestreamdefaultcontroller/error/index.md
+++ b/files/en-us/web/api/writablestreamdefaultcontroller/error/index.md
@@ -35,7 +35,7 @@ error(e)
 
 ### Return value
 
-`undefined`.
+None ({{jsxref("undefined")}}).
 
 ### Exceptions
 

--- a/files/en-us/web/api/writablestreamdefaultwriter/releaselock/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/releaselock/index.md
@@ -31,7 +31,7 @@ None.
 
 ### Return value
 
-`undefined`.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/xmlhttprequest/abort/index.md
+++ b/files/en-us/web/api/xmlhttprequest/abort/index.md
@@ -38,7 +38,7 @@ None.
 
 ### Return value
 
-`undefined`
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/xmlhttprequest/overridemimetype/index.md
+++ b/files/en-us/web/api/xmlhttprequest/overridemimetype/index.md
@@ -40,7 +40,7 @@ overrideMimeType(mimeType)
 
 ### Return value
 
-`undefined`.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/xmlhttprequest/send/index.md
+++ b/files/en-us/web/api/xmlhttprequest/send/index.md
@@ -62,7 +62,7 @@ The best way to send binary content (e.g. in file uploads) is by using an
 
 ### Return value
 
-`undefined`.
+None ({{jsxref("undefined")}}).
 
 ### Exceptions
 

--- a/files/en-us/web/api/xmlhttprequest/setrequestheader/index.md
+++ b/files/en-us/web/api/xmlhttprequest/setrequestheader/index.md
@@ -58,7 +58,7 @@ setRequestHeader(header, value)
 
 ### Return value
 
-`undefined`.
+None ({{jsxref("undefined")}}).
 
 ## Specifications
 

--- a/files/en-us/web/api/xranchor/delete/index.md
+++ b/files/en-us/web/api/xranchor/delete/index.md
@@ -27,7 +27,7 @@ None.
 
 ### Return value
 
-Returns {{jsxref("undefined")}}.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/xrcompositionlayer/destroy/index.md
+++ b/files/en-us/web/api/xrcompositionlayer/destroy/index.md
@@ -27,7 +27,7 @@ None.
 
 ### Return value
 
-Returns {{jsxref("undefined")}}.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/xrhittestsource/cancel/index.md
+++ b/files/en-us/web/api/xrhittestsource/cancel/index.md
@@ -27,7 +27,7 @@ None.
 
 ### Return value
 
-Returns {{jsxref("undefined")}}.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/xrsession/cancelanimationframe/index.md
+++ b/files/en-us/web/api/xrsession/cancelanimationframe/index.md
@@ -38,7 +38,7 @@ cancelAnimationFrame(handle)
 
 ### Return value
 
-None.
+None ({{jsxref("undefined")}}).
 
 ## Usage notes
 

--- a/files/en-us/web/api/xrsession/updaterenderstate/index.md
+++ b/files/en-us/web/api/xrsession/updaterenderstate/index.md
@@ -38,7 +38,7 @@ updateRenderState(state)
 
 ### Return value
 
-None.
+None ({{jsxref("undefined")}}).
 
 ### Exceptions
 

--- a/files/en-us/web/api/xrtransientinputhittestsource/cancel/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestsource/cancel/index.md
@@ -27,7 +27,7 @@ None.
 
 ### Return value
 
-Returns {{jsxref("undefined")}}.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/xrview/requestviewportscale/index.md
+++ b/files/en-us/web/api/xrview/requestviewportscale/index.md
@@ -28,7 +28,7 @@ requestViewportScale(scale)
 
 ### Return value
 
-Returns {{jsxref("undefined")}}.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 


### PR DESCRIPTION
### Summary
Updates empty `### Return value` sections.
And puts `Return value` section after `Parameters` section, where it is not.

#### Metadata
- [x] Fixes a typo, bug, or other error