### PR TITLE
Typo: fix capitalization of parameter name

### DIFF
--- a/files/en-us/web/api/bluetoothremotegattserver/getprimaryservice/index.md
+++ b/files/en-us/web/api/bluetoothremotegattserver/getprimaryservice/index.md
@@ -26,7 +26,7 @@ getPrimaryService(bluetoothServiceUUID)
 
 ### Parameters
 
-- `BluetoothServiceUUID`
+- `bluetoothServiceUUID`
   - : A Bluetooth service universally unique identifier for a specified device.
 
 ### Return value


### PR DESCRIPTION
BluetoothUUID -> bluetoothUUID to match the parameter name in the syntax box (and coherence with the rest of MDN, parameters starts with a lower-case letter)