### PR TITLE
Remove uses of {{exception}} macro

### DIFF
--- a/files/en-us/mdn/contribute/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.md
+++ b/files/en-us/mdn/contribute/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.md
@@ -247,7 +247,7 @@ If the keyword `readonly` is present, the property can't be modified. It must be
 
 In some cases, like when some values are illegal, setting a new value can lead to an exception being raised. This is marked using the `[SetterThrows]` annotation. When this happens, the Syntax section of the property page _must_ have an Exceptions subsection. The list of exceptions and the conditions to have them thrown are listed, as textual information, in the specification of that API.
 
-Note that some exceptions are not explicitly marked but are defined by the JavaScript bindings. [Trying to set an illegal enumerated value](https://heycam.github.io/webidl/#es-enumeration) (mapped to a JavaScript {{jsxref('String')}}) raises a {{exception('TypeError')}} exception. This must be documented, but is only implicitly marked in the WebIDL document.
+Note that some exceptions are not explicitly marked but are defined by the JavaScript bindings. [Trying to set an illegal enumerated value](https://heycam.github.io/webidl/#es-enumeration) (mapped to a JavaScript {{jsxref('String')}}) raises a {{jsxref('TypeError')}} exception. This must be documented, but is only implicitly marked in the WebIDL document.
 
 It is uncommon to have getters throwing exceptions, though it happens in a few cases. In this case the `[GetterThrows]` annotation is used. Here also, the Syntax section of the property page _must_ have an Exceptions subsection.
 
@@ -372,7 +372,7 @@ The keyword `void` means that there is no return value. It is not a return value
 
 Some methods can throw exceptions. This is marked using the `[Throws]` annotation. When this happens, the Syntax section of the method page _must_ have an Exceptions subsection. The list of exceptions and the conditions to have them thrown are listed, as textual information, in the specification of that API.
 
-Note that some exceptions are not explicitly marked but are defined by the JavaScript bindings. [Trying to set an illegal enumerated value](https://heycam.github.io/webidl/#es-enumeration) (mapped to a JavaScript {{jsxref('String')}}) as a parameter will raise a {{exception('TypeError')}} exception. This must be documented, but it is only implicitly marked in the WebIDL document.
+Note that some exceptions are not explicitly marked but are defined by the JavaScript bindings. [Trying to set an illegal enumerated value](https://heycam.github.io/webidl/#es-enumeration) (mapped to a JavaScript {{jsxref('String')}}) as a parameter will raise a {{jsxref('TypeError')}} exception. This must be documented, but it is only implicitly marked in the WebIDL document.
 
 Have a look at one of these [_Exceptions_ sections](/en-US/docs/Web/API/SubtleCrypto/importKey#exceptions).
 

--- a/files/en-us/mozilla/firefox/releases/38/index.md
+++ b/files/en-us/mozilla/firefox/releases/38/index.md
@@ -83,7 +83,7 @@ Highlights:
 - Constants of {{domxref("KeyboardEvent.location")}}, `DOM_KEY_LOCATION_MOBILE` and DOM_KEY_LOCATION_JOYSTICK, have been removed, since they were removed from the DOM Level 3 Spec ({{bug(936313)}}.
 - {{domxref("KeyboardEvent.code")}} is now available; previously it was only available in prerelease builds. ({{bug(1126673)}})
 - {{domxref("KeyboardEvent.code")}} now supports special keys on Sun keyboards on Linux, Android, and Firefox OS. ({{bug(1020139)}})
-- The {{domxref("TextEncoder.TextEncoder", "TextEncoder()")}} constructor has been changed to match the spec: when an invalid parameter is passed, the {{exception("RangeError")}} exception is now raised, rather than the erroneous {{exception("TypeError")}} ({{bug(1125766)}}).
+- The {{domxref("TextEncoder.TextEncoder", "TextEncoder()")}} constructor has been changed to match the spec: when an invalid parameter is passed, the `RangeError` {{domxref("DOMException")}} is now raised, rather than the erroneous {{jsxref("TypeError")}} ({{bug(1125766)}}).
 - The User Timing API, adding {{domxref("Performance.mark()")}}, {{domxref("Performance.clearMarks()")}}, {{domxref("Performance.measure()")}}, and {{domxref("Performance.clearMeasures()")}} has been implemented ({{bug(782751)}}).
 - The prefixed version of {{domxref("indexedDB")}}, `mozIndexedDB` has been removed ({{bug(975699)}}).
 - The {{event("DOMContentLoaded")}} event is no longer cancelable ({{bug(1134559)}}).

--- a/files/en-us/mozilla/firefox/releases/43/index.md
+++ b/files/en-us/mozilla/firefox/releases/43/index.md
@@ -84,7 +84,7 @@ _No change._
 - Experimental support for {{domxref("Selection")}} events {{event("selectionchange")}} and {{event("selectstart")}}, as well as the {{domxref("GlobalEventHandlers/onselectionchange", "Document.onselectionchange")}} and {{domxref("GlobalEventHandlers.onselectstart")}} event handlers property has been added ({{bug(571294)}}). The `selectionchange` event is fired on the {{domxref("Document")}} if the associated `Selection` object is concerned, or on the specific {{domxref("HTMLInputElement")}} or {{domxref("HTMLTextAreaElement")}} ({{bug(1196479)}}). This feature is controlled by the `dom.select_events.enabled` preference, that defaults to `false`, except on Nightly.
 - Support for {{domxref("MouseEvent.offsetX")}} and {{domxref("MouseEvent.offsetY")}} have been activated on Firefox for Android and Firefox OS ({{bug(1204841)}}).
 - The {{domxref("HTMLCanvasElement.mozFetchAsStream()")}} method has been removed ({{bug(1206030)}}).
-- The constructor {{domxref("Request.Request", "Request()")}} as well as {{domxref("fetch()")}} will now raise a {{exception("TypeError")}} exception when used with a URL containing a username and password ({{bug(1195820)}}).
+- The constructor {{domxref("Request.Request", "Request()")}} as well as {{domxref("fetch()")}} will now raise a {{jsxref("TypeError")}} exception when used with a URL containing a username and password ({{bug(1195820)}}).
 
 ### MathML
 

--- a/files/en-us/web/api/crypto/getrandomvalues/index.md
+++ b/files/en-us/web/api/crypto/getrandomvalues/index.md
@@ -37,8 +37,10 @@ getRandomValues(typedArray)
 ### Parameters
 
 - `typedArray`
-  - : An integer-based {{jsxref("TypedArray")}}, that is one of: {{jsxref("Int8Array")}}, {{jsxref("Uint8Array")}}, {{jsxref("Uint8ClampedArray")}}, {{jsxref("Int16Array")}}, {{jsxref("Uint16Array")}},
-    {{jsxref("Int32Array")}}, {{jsxref("Uint32Array")}}, {{jsxref("BigInt64Array")}}, {{jsxref("BigUint64Array")}} (but **not** `Float32Array` nor `Float64Array`).
+  - : An integer-based {{jsxref("TypedArray")}}, that is one of: {{jsxref("Int8Array")}}, {{jsxref("Uint8Array")}}, 
+    {{jsxref("Uint8ClampedArray")}}, {{jsxref("Int16Array")}}, {{jsxref("Uint16Array")}},
+    {{jsxref("Int32Array")}}, {{jsxref("Uint32Array")}}, {{jsxref("BigInt64Array")}}, 
+    {{jsxref("BigUint64Array")}} (but **not** `Float32Array` nor `Float64Array`).
     All elements in the array are overwritten with random numbers.
 
 ### Return value
@@ -48,10 +50,8 @@ Note that `typedArray` is modified in-place, and no copy is made.
 
 ### Exceptions
 
-This method can throw an exception under error conditions.
-
-- {{domxref("DOMException")}} (name: {{exception("QuotaExceededError")}})
-  - : The requested length exceeds 65,536 bytes.
+- `QuotaExceededError`{{domxref("DOMException")}} 
+  - : Thrown if the requested length exceeds 65,536 bytes.
 
 ## Usage notes
 

--- a/files/en-us/web/api/element/closest/index.md
+++ b/files/en-us/web/api/element/closest/index.md
@@ -26,19 +26,18 @@ closest(selectors)
 
 ### Parameters
 
-- `selectors` is a string containing a
-  selector list.
-  ex: `p:hover, .toto + q`
+- `selectors`
+  - : A string containing a selector list, e.g.: `p:hover, .toto + q`.
 
 ### Return value
 
-- `closestElement` is the {{domxref("Element")}} which is the
-  closest ancestor of the selected element. It may be `null`.
+The {{domxref("Element")}} which is the closest ancestor of the selected element,
+or `null` if there are no ancestors.
 
 ### Exceptions
 
-- {{exception("SyntaxError")}} is thrown if the `selectors` is
-  not a valid selector list string.
+- `SyntaxError` {{domxref("DOMException")}}
+  - : Thrown if the `selectors` is not a valid selector list string.
 
 ## Examples
 

--- a/files/en-us/web/api/idbtransaction/abort/index.md
+++ b/files/en-us/web/api/idbtransaction/abort/index.md
@@ -19,7 +19,7 @@ interface rolls back all the changes to objects in the database associated with 
 transaction.
 
 All pending {{domxref("IDBRequest")}} objects created during this transaction have
-their {{domxref("IDBRequest.error")}} attribute set to {{exception("AbortError")}}.
+their {{domxref("IDBRequest.error")}} attribute set to an `AbortError` {{domxref("DOMException")}}.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/idbtransaction/commit/index.md
+++ b/files/en-us/web/api/idbtransaction/commit/index.md
@@ -16,7 +16,7 @@ The **`commit()`** method of the {{domxref("IDBTransaction")}} interface commits
 
 Note that `commit()` doesn't normally _have_ to be called — a transaction will automatically commit when all outstanding requests have been satisfied and no new requests have been made. `commit()` can be used to start the commit process without waiting for events from outstanding requests to be dispatched.
 
-If it is called on a transaction that is not active, it throws an {{exception("InvalidStateError")}} `DOMException`.
+If it is called on a transaction that is not active, it throws an `InvalidStateError` {{domxref("DOMException")}}.
 
 {{AvailableInWorkers}}
 

--- a/files/en-us/web/api/idbtransaction/error/index.md
+++ b/files/en-us/web/api/idbtransaction/error/index.md
@@ -14,24 +14,20 @@ browser-compat: api.IDBTransaction.error
 ---
 {{ APIRef("IndexedDB") }}
 
-The **`IDBTransaction.error`** property of the
-{{domxref("IDBTransaction")}} interface returns one of several types of error when
-there is an unsuccessful transaction.
+The **`IDBTransaction.error`** property of the {{domxref("IDBTransaction")}} interface
+returns the type of error when there is an unsuccessful transaction.
 
 {{AvailableInWorkers}}
 
 ## Value
 
-A {{domxref("DOMError")}} containing the relevant error. In Chrome 48+/Firefox 58+ this
-property returns a {{domxref("DOMException")}} because `DOMError` has been
-removed from the DOM standard. The exact error is one of several possibilities. It can
-be a reference to the same error as the request object that raised it, or a transaction
-failure (for example {{exception("QuotaExceededError")}} or
-{{exception("UnknownError")}}).
+A {{domxref("DOMException")}} containing the relevant error, or `null` if there are none.
 
-This property is `null` if the transaction is not finished, is finished and
-successfully committed, or was aborted with the {{domxref("IDBTransaction.abort")}}
-method.
+It can be a reference to the same error as the request object that raised it, or a transaction
+failure (for example `QuotaExceededError`).
+
+This property is `null` if the transaction is not finished, or is finished and
+was successfully committed.
 
 ## Examples
 

--- a/files/en-us/web/api/offlineaudiocontext/resume/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/resume/index.md
@@ -16,9 +16,7 @@ browser-compat: api.OfflineAudioContext.resume
 The **`resume()`** method of the
 {{domxref("OfflineAudioContext")}} interface resumes the progression of time in an audio
 context that has been suspended. The promise resolves immediately because the
-`OfflineAudioContext` does not require the audio hardware. If the context is
-not currently suspended or the rendering has not started, the promise is rejected with
-{{exception("InvalidStateError")}}.
+`OfflineAudioContext` does not require the audio hardware.
 
 ## Syntax
 

--- a/files/en-us/web/http/headers/feature-policy/payment/index.md
+++ b/files/en-us/web/http/headers/feature-policy/payment/index.md
@@ -14,7 +14,7 @@ browser-compat: http.headers.Feature-Policy.payment
 ---
 {{HTTPSidebar}} {{SeeCompatTable}}
 
-The HTTP {{HTTPHeader("Feature-Policy")}} header field's `payment` directive controls whether the current document is allowed to use the [Payment Request API](/en-US/docs/Web/API/Payment_Request_API). When this policy is disabled, the {{DOMxRef("PaymentRequest()")}} constructor will throw a {{exception("SyntaxError")}}.
+The HTTP {{HTTPHeader("Feature-Policy")}} header field's `payment` directive controls whether the current document is allowed to use the [Payment Request API](/en-US/docs/Web/API/Payment_Request_API). When this policy is disabled, the {{DOMxRef("PaymentRequest()")}} constructor will throw a `SyntaxError` {{domxref("DOMException")}}.
 
 ## Syntax
 


### PR DESCRIPTION
This removes the last occurrences of the `{{exception}}` macro.

We use now `` `ExceptionName` {{domxref("DOMException")}}``  for non-JS exceptions and `{{jsxref}}` for JavaScript ones like `TypeError`.

I will update mdn/yari and notify mdn/translated-content