### PR TITLE
Introduce block formatting context abbreviation

### DIFF
--- a/files/en-us/web/guide/css/block_formatting_context/index.md
+++ b/files/en-us/web/guide/css/block_formatting_context/index.md
@@ -11,7 +11,7 @@ tags:
 ---
 {{ CSSRef }}
 
-A **block formatting context** is a part of a visual CSS rendering of a web page. It's the region in which the layout of block boxes occurs and in which floats interact with other elements.
+A **block formatting context** (BFC) is a part of a visual CSS rendering of a web page. It's the region in which the layout of block boxes occurs and in which floats interact with other elements.
 
 A block formatting context is created by at least one of the following:
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Introduces a key abbreviation in the Block Formatting Context guide to improve content clarity further down the page.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I was reading the guide on block formatting context, and quickly started seeing the "BFC" abbreviation being heavily used. It took me a minute to process since the abbreviation was never introduced alongside the full term, i.e., "block formatting context".

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
