### PR TITLE
Fix some links (using macros) in HTML DOM API

### DIFF
--- a/files/en-us/web/api/html_dom_api/index.md
+++ b/files/en-us/web/api/html_dom_api/index.md
@@ -53,7 +53,7 @@ Among the things added to `Document` by the HTML standard are:
 - Access to lists of elements in the document's {{HTMLElement("head")}} block and {{DOMxRef("Document/body", "body", "", "1")}}, as well as lists of the {{DOMxRef("Document/images", "images", "", "1")}}, {{DOMxRef("Document/links", "links", "", "1")}}, {{DOMxRef("Document/scripts", "scripts", "", "1")}}, etc. contained in the document.
 - Support for interacting with the user by examining {{DOMxRef("Document/hasFocus", "focus", "", "1")}} and by executing commands on [editable content](/en-US/docs/Web/HTML/Global_attributes/contenteditable).
 - Event handlers for document {{DOMxRef("GlobalEventHandlers", "events defined by the HTML standard", "", "1")}} to allow access to {{DOMxRef("MouseEvent", "mouse", "", "1")}} and {{DOMxRef("KeyboardEvent", "keyboard", "", "1")}} events, {{DOMxRef("HTML_Drag_and_Drop_API", "drag and drop", "", "1")}}, {{DOMxRef("HTMLMediaElement", "media control", "", "1")}}, and more.
-- Event handlers for events that can be delivered to both elements and documents; these presently include only {{DOMxRef("HTMLElement/oncopy", "copy", "", "1")}}, {{DOMxRef("HTMLElement/oncut", "cut", "", "1")}}, and {{DOMxRef("HTMLElement/onpaste", "paste", "", "1")}} actions.
+- Event handlers for events that can be delivered to both elements and documents; these presently include only {{DOMxRef("HTMLElement/copy_event", "copy", "", "1")}}, {{DOMxRef("HTMLElement/cut_event", "cut", "", "1")}}, and {{DOMxRef("HTMLElement/paste_event", "paste", "", "1")}} actions.
 
 ### HTML element interfaces
 
@@ -291,7 +291,7 @@ These interfaces are used by the {{DOMxRef("Web_Workers_API", "", "", "1")}} bot
 - {{DOMxRef("Worker")}}
 - {{DOMxRef("WorkerGlobalScope")}}
 - {{DOMxRef("WorkerLocation")}}
-- {{DOMxRef("WorkerNavigator ")}}
+- {{DOMxRef("WorkerNavigator")}}
 
 #### WebSocket interfaces
 
@@ -308,7 +308,7 @@ The {{domxref("EventSource")}} interface represents the source which sent or is 
 
 ## Examples
 
-In this example, an {{HTMLElement("input")}} element's {{domxref("HTMLInputElement.input_event", "input")}} event is monitored in order to update the state of a form's "submit" button based on whether or not a given field currently has a value.
+In this example, an {{HTMLElement("input")}} element's {{domxref("HTMLElement/input_event", "input")}} event is monitored in order to update the state of a form's "submit" button based on whether or not a given field currently has a value.
 
 #### JavaScript
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fix some links (using macros) in HTML DOM API
- HTMLElement/onXXX to HTMLElement/XXX_event
- Trim the last space of WorkerNavigator
- HTMLInputEvent/input_event to HTMLElement/input_event

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
