### PR TITLE
Change width to height

### DIFF
--- a/files/en-us/learn/css/css_layout/flexbox/index.md
+++ b/files/en-us/learn/css/css_layout/flexbox/index.md
@@ -219,7 +219,7 @@ Refresh the page and you'll see that the buttons are now nicely centered horizon
 
 {{cssxref("align-items")}} controls where the flex items sit on the cross axis.
 
-- By default, the value is `stretch`, which stretches all flex items to fill the parent in the direction of the cross axis. If the parent doesn't have a fixed height in the cross axis direction, then all flex items will become as long as the longest flex item. This is how our first example had columns of equal height by default.
+- By default, the value is `stretch`, which stretches all flex items to fill the parent in the direction of the cross axis. If the parent doesn't have a fixed height in the cross axis direction, then all flex items will become as tall as the tallest flex item. This is how our first example had columns of equal height by default.
 - The `center` value that we used in our above code causes the items to maintain their intrinsic dimensions, but be centered along the cross axis. This is why our current example's buttons are centered vertically.
 - You can also have values like `flex-start` and `flex-end`, which will align all items at the start and end of the cross axis respectively. See {{cssxref("align-items")}} for the full details.
 

--- a/files/en-us/learn/css/css_layout/flexbox/index.md
+++ b/files/en-us/learn/css/css_layout/flexbox/index.md
@@ -219,7 +219,7 @@ Refresh the page and you'll see that the buttons are now nicely centered horizon
 
 {{cssxref("align-items")}} controls where the flex items sit on the cross axis.
 
-- By default, the value is `stretch`, which stretches all flex items to fill the parent in the direction of the cross axis. If the parent doesn't have a fixed width in the cross axis direction, then all flex items will become as long as the longest flex item. This is how our first example had columns of equal height by default.
+- By default, the value is `stretch`, which stretches all flex items to fill the parent in the direction of the cross axis. If the parent doesn't have a fixed height in the cross axis direction, then all flex items will become as long as the longest flex item. This is how our first example had columns of equal height by default.
 - The `center` value that we used in our above code causes the items to maintain their intrinsic dimensions, but be centered along the cross axis. This is why our current example's buttons are centered vertically.
 - You can also have values like `flex-start` and `flex-end`, which will align all items at the start and end of the cross axis respectively. See {{cssxref("align-items")}} for the full details.
 


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
```diff
-  By default, the value is stretch, which stretches all flex items to fill the parent in the direction of the cross axis. If the parent doesn't have a fixed width in the cross axis direction, then all flex items will become as long as the longest flex item.
+  By default, the value is stretch, which stretches all flex items to fill the parent in the direction of the cross axis. If the parent doesn't have a fixed height in the cross axis direction, then all flex items will become as long as the longest flex item.
```

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
If there is no fixed height. Flex items get stretched as much as long. But, In docs which are specified as fixed width. Width plays a role in the main axis, not in the cross axis.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://developer.mozilla.org/en-US/docs/Learn/CSS/CSS_layout/Flexbox#:~:text=If%20the%20parent%20doesn%27t%20have%20a%20fixed%20width%20in%20the%20cross%20axis%20direction
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Simple typo error

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
