### PR TITLE
inform people that DataTransfer.files has data only during drop events

### DIFF
--- a/files/en-us/web/api/datatransfer/files/index.md
+++ b/files/en-us/web/api/datatransfer/files/index.md
@@ -17,6 +17,8 @@ includes no files, the list is empty.
 
 This feature can be used to drag files from a user's _desktop_ to the browser.
 
+> **Note:** `DataTransfer.files` can only be accessed from within the `drop` event. For all other events `DataTransfer.files` will be empty because its underlying data store will be in a [protected mode](<https://html.spec.whatwg.org/multipage/dnd.html#the-drag-data-store>).
+
 ## Value
 
 A {{domxref("FileList","list")}} of the files in a drag operation, one list item for

--- a/files/en-us/web/api/datatransfer/files/index.md
+++ b/files/en-us/web/api/datatransfer/files/index.md
@@ -11,13 +11,11 @@ browser-compat: api.DataTransfer.files
 ---
 {{APIRef("HTML Drag and Drop API")}}
 
-The **`DataTransfer.files`** property is a
-{{domxref("FileList","list of the files")}} in the drag operation. If the operation
-includes no files, the list is empty.
+The **`files`** property of [`DataTransfer`](/en-US/docs/Web/API/DataTransfer) objects is a {{domxref("FileList","list of the files")}} in the drag operation. If the operation includes no files, the list is empty.
 
-This feature can be used to drag files from a user's _desktop_ to the browser.
+This feature can be used to drag files from a user's desktop to the browser.
 
-> **Note:** `DataTransfer.files` can only be accessed from within the `drop` event. For all other events `DataTransfer.files` will be empty because its underlying data store will be in a [protected mode](<https://html.spec.whatwg.org/multipage/dnd.html#the-drag-data-store>).
+> **Note:** The `files` property of [`DataTransfer`](/en-US/docs/Web/API/DataTransfer) objects can only be accessed from within the `drop` event. For all other events, the `files` property will be empty — because its underlying data store will be in a [protected mode](<https://html.spec.whatwg.org/multipage/dnd.html#the-drag-data-store>).
 
 ## Value
 


### PR DESCRIPTION
I added a note to inform people that `DataTransfer.files` has data only during `drop` events.

#### Motivation
Thanks to https://stackoverflow.com/a/33488949/5760141 I finally learned why `DataTransfer.files` was always empty when I tried to use it in `dragover` and `dragenter` event handlers, and so hopefully this note will save other people a lot of time and trouble.

#### Supporting details
https://stackoverflow.com/a/33488949/5760141
https://html.spec.whatwg.org/multipage/dnd.html#the-drag-data-store
https://html.spec.whatwg.org/multipage/dnd.html#concept-dnd-p