### PR TITLE
Reference color_scheme setting for theme manifest

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/theme/index.md
@@ -1395,6 +1395,19 @@ Additionally, this key accepts various properties that are aliases for one of th
     </tr>
   </thead>
   <tbody>
+        <tr>
+      <td><code>color_scheme</code></td>
+      <td>
+        <p><code>String</code></p>
+      </td>
+      <td>
+        <p>Optional.</p>
+        <p>
+          The color scheme to use for Firefox overlays like contextual menu and all other ones, if they're not overriden by the color settings.
+        </p>
+        <p>Possible values: <code>"light"</code> / <code>"dark"</code></p>
+      </td>
+    </tr>
     <tr>
       <td><code>additional_backgrounds_alignment</code></td>
       <td>


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Adding new color_scheme property available since Firefox 100

#### Motivation
This is just missing from the doc

#### Supporting details
This feature is referenced here: https://blog.nightly.mozilla.org/2022/04/11/these-weeks-in-firefox-issue-113/

#### Related issues
https://bugzilla.mozilla.org/show_bug.cgi?id=1750932
https://bugzilla.mozilla.org/show_bug.cgi?id=1749837

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
