### PR TITLE
Function repeat example

### DIFF
--- a/files/en-us/web/css/repeat/index.md
+++ b/files/en-us/web/css/repeat/index.md
@@ -15,6 +15,8 @@ browser-compat: css.properties.grid-template-columns.repeat
 
 The **`repeat()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) represents a repeated fragment of the track list, allowing a large number of columns or rows that exhibit a recurring pattern to be written in a more compact form.
 
+{{EmbedInteractiveExample("pages/css/function-repeat.html")}}
+
 This function can be used in the CSS Grid properties {{cssxref("grid-template-columns")}} and {{cssxref("grid-template-rows")}}.
 
 ```css

--- a/files/en-us/web/css/repeat/index.md
+++ b/files/en-us/web/css/repeat/index.md
@@ -19,6 +19,8 @@ The **`repeat()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS
 
 This function can be used in the CSS Grid properties {{cssxref("grid-template-columns")}} and {{cssxref("grid-template-rows")}}.
 
+## Syntax
+
 ```css
 /* <track-repeat> values */
 repeat(4, 1fr)
@@ -49,8 +51,6 @@ repeat(4, [col-start] minmax(100px, 1fr) [col-end])
 repeat(4, [col-start] fit-content(200px) [col-end])
 repeat(4, 10px [col-start] 30% [col-middle] 400px [col-end])
 ```
-
-## Syntax
 
 ### Values
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
I have noticed unused example for [repeat](https://developer.mozilla.org/en-US/docs/Web/CSS/repeat) function which looks alright. Similar functions [minmax](https://developer.mozilla.org/en-US/docs/Web/CSS/minmax) & f[it-content](https://developer.mozilla.org/en-US/docs/Web/CSS/fit-content_function) are shown, so I don't see any reason not to add it.
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
