### PR TITLE
Drop SeeCompatTable macro from “Using the Permissions API”

### DIFF
--- a/files/en-us/web/api/permissions_api/using_the_permissions_api/index.md
+++ b/files/en-us/web/api/permissions_api/using_the_permissions_api/index.md
@@ -8,7 +8,7 @@ tags:
   - Guide
   - Permissions
 ---
-{{DefaultAPISidebar("Permissions API")}}{{SeeCompatTable}}
+{{DefaultAPISidebar("Permissions API")}}
 
 This article provides a basic guide to using the W3C Permissions API, which provides a programmatic way to query the status of API permissions attributed to the current context.
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/15690