### PR TITLE
MV3 Content security policy

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/content_security_policy/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/content_security_policy/index.md
@@ -71,7 +71,7 @@ Under the default CSP you may only load [\<script>](/en-US/docs/Web/HTML/Element
 This will no longer load the requested resource: it will fail silently, and any object which you expected to be present from the resource will not be found. There are two main solutions to this:
 
 - download the resource, package it in your extension, and refer to this version of the resource
-- use the [`content_security_policy`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_security_policy) key to allow the remote origin you need.
+- use the [`content_security_policy`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_security_policy) key or in Manifest V3 the `content_scripts` property, to allow the remote origin you need.
 
 ### eval() and friends
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.md
@@ -72,15 +72,6 @@ In Manifest V3, the `content_security_policy` key is an object that may have any
   </thead>
   <tbody>
     <tr>
-      <td>
-        <code>content_scripts</code>
-      </td>
-      <td><code>String</code></td>
-      <td>
-        The content security policy used for content pages.
-      </td>
-    </tr>
-    <tr>
       <td><code>extension_pages</code></td>
       <td><code>String</code></td>
       <td>
@@ -92,14 +83,7 @@ In Manifest V3, the `content_security_policy` key is an object that may have any
         </ul>
       </td>
     </tr>
-    <tr>
-      <td><code>isolated_world</code></td>
-      <td><code>String</code></td>
-      <td>
-        An alias for <code>content_scripts</code> to provide Chrome compatibility. In Firefox, if both `isolated_world` and `content_scripts` are specified, the value from `content_scripts` is used.
-      </td>
-    </tr>
-    <tr>
+   <tr>
       <td><code>sandbox</code></td>
       <td><code>String</code></td>
       <td>
@@ -118,7 +102,6 @@ In Manifest V3, the `content_security_policy` key is an object that may have any
 
 Require that all types of content should be packaged with the extension:
 
-Allow remote scripts from "https://example.com":
 
 **Manifest V2**
 
@@ -130,11 +113,11 @@ Allow remote scripts from "https://example.com":
 
 ```json
 "content_security_policy": {
-  "content_scripts": "default-src 'self'"
+  "extension_page": "default-src 'self'"
 } 
 ```
 
-Allow remote scripts from any subdomain of "jquery.com":
+Allow remote scripts from "https://example.com":
 
 **Manifest V2**
 
@@ -146,32 +129,72 @@ Allow remote scripts from any subdomain of "jquery.com":
 
 ```json
 "content_security_policy": {
-  "content_scripts": "script-src 'self' https://example.com; object-src 'self'"
+  "extension_page": "script-src 'self' https://example.com; object-src 'self'"
 } 
 ```
 
+Allow remote scripts from any subdomain of "jquery.com":
 
+**Manifest V2**
 
 ```json
 "content_security_policy": "script-src 'self' https://*.jquery.com; object-src 'self'"
 ```
 
+**Manifest V3**
+
+```json
+"content_security_policy": {
+  "extension_page": "script-src 'self' https://*.jquery.com; object-src 'self'"
+} 
+```
+
 Allow [`eval()` and friends](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_Security_Policy#eval%28%29_and_friends):
+
+**Manifest V2**
 
 ```json
 "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self';"
 ```
 
+**Manifest V3**
+
+```json
+"content_security_policy": {
+  "extension_page": "script-src 'self' 'unsafe-eval'; object-src 'self';"
+} 
+```
+
 Allow the inline script: `"<script>alert('Hello, world.');</script>"`:
+
+**Manifest V2**
 
 ```json
 "content_security_policy": "script-src 'self' 'sha256-qznLcsROx4GACP2dm0UCKCzCG+HiZ1guq6ZZDob/Tng='; object-src 'self'"
 ```
 
+**Manifest V3**
+
+```json
+"content_security_policy": {
+  "extension_page": "script-src 'self' 'sha256-qznLcsROx4GACP2dm0UCKCzCG+HiZ1guq6ZZDob/Tng='; object-src 'self'"
+} 
+```
+
 Keep the rest of the policy, but also require that images should be packaged with the extension:
+
+**Manifest V2**
 
 ```json
 "content_security_policy": "script-src 'self'; object-src 'self'; img-src 'self'"
+```
+
+**Manifest V3**
+
+```json
+"content_security_policy": {
+  "extension_page": "script-src 'self'; object-src 'self'; img-src 'self'"
+} 
 ```
 
 ### Invalid examples

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.md
@@ -50,6 +50,65 @@ There are restrictions on the policy you can specify here:
 - The only permitted schemes for sources are: `blob:`, `filesystem:`, `moz-extension:`, `https:`, and `wss:`.
 - The only permitted [keywords](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/default-src#sources) are: `'none'`, `'self'`, and `'unsafe-eval'`.
 
+## Manifest V2 syntax
+
+In Manifest V2 there is one content security policy specified against the key, like this:
+
+```json
+"content_security_policy": "default-src 'self'"
+```
+
+## Manifest V2 syntax
+
+In Manifest V3, the `content_security_policy` key is an object that may have any of the following properties, all optional:
+
+<table class="fullwidth-table standard-table">
+  <thead>
+    <tr>
+      <th scope="col">Name</th>
+      <th scope="col">Type</th>
+      <th scope="col">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>
+        <code>content_scripts</code>
+      </td>
+      <td><code>String</code></td>
+      <td>
+        The content security policy used for content pages.
+      </td>
+    </tr>
+    <tr>
+      <td><code>extension_pages</code></td>
+      <td><code>String</code></td>
+      <td>
+        The content security policy used for extension pages. The <code>script-src</code>, <code>object-src</code>, and <code>worker-src</code> directives may only have these values:
+        <ul>
+          <li><code>self</code></li>
+          <li><code>none</code></li>
+          <li>Any localhost source, (<code>http://localhost</code>, <code>http://127.0.0.1</code>, or any port on those domains.)</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td><code>isolated_world</code></td>
+      <td><code>String</code></td>
+      <td>
+        An alias for <code>content_scripts</code> to provide Chrome compatibility. In Firefox, if both `isolated_world` and `content_scripts` are specified, the value from `content_scripts` is used.
+      </td>
+    </tr>
+    <tr>
+      <td><code>sandbox</code></td>
+      <td><code>String</code></td>
+      <td>
+        The content security policy used for sandboxed extension pages.
+      </td>
+    </tr>
+  </tbody>
+</table>
+
 ## Example
 
 ### Valid examples
@@ -59,17 +118,39 @@ There are restrictions on the policy you can specify here:
 
 Require that all types of content should be packaged with the extension:
 
+Allow remote scripts from "https\://example.com":
+
+**Manifest V2**
+
 ```json
 "content_security_policy": "default-src 'self'"
 ```
 
-Allow remote scripts from "https\://example.com":
+**Manifest V3**
+
+```json
+"content_security_policy": {
+  "content_scripts": "default-src 'self'"
+} 
+```
+
+Allow remote scripts from any subdomain of "jquery.com":
+
+**Manifest V2**
 
 ```json
 "content_security_policy": "script-src 'self' https://example.com; object-src 'self'"
 ```
 
-Allow remote scripts from any subdomain of "jquery.com":
+**Manifest V3**
+
+```json
+"content_security_policy": {
+  "content_scripts": "script-src 'self' https://example.com; object-src 'self'"
+} 
+```
+
+
 
 ```json
 "content_security_policy": "script-src 'self' https://*.jquery.com; object-src 'self'"

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.md
@@ -118,7 +118,7 @@ In Manifest V3, the `content_security_policy` key is an object that may have any
 
 Require that all types of content should be packaged with the extension:
 
-Allow remote scripts from "https\://example.com":
+Allow remote scripts from "https://example.com":
 
 **Manifest V2**
 


### PR DESCRIPTION
#### Summary
Updates to document the Manifest V3 changes to the content_security_policy manifest key along with related changes to the content security policy article.

#### Metadata

This PR…

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
