### PR TITLE
Fix CSS animation examples

### DIFF
--- a/files/en-us/web/css/animation-delay/index.md
+++ b/files/en-us/web/css/animation-delay/index.md
@@ -58,7 +58,9 @@ animation-delay: unset;
 
 ## Examples
 
-### The animation has a delay of 2 seconds
+### Setting an animation delay
+
+This animation has a delay of 2 seconds.
 
 #### HTML
 
@@ -74,6 +76,9 @@ animation-delay: unset;
   border-radius: 10px;
   width: 100px;
   height: 100px;
+}
+
+.box:hover {
   animation-name: rotate;
   animation-duration: 0.7s;
   animation-delay: 2s;
@@ -91,7 +96,7 @@ animation-delay: unset;
 
 #### Result
 
-{{EmbedLiveSample("Examples","100%","250")}}
+{{EmbedLiveSample("Setting an animation delay","100%","250")}}
 
 See [CSS animations](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations) for examples.
 

--- a/files/en-us/web/css/animation-delay/index.md
+++ b/files/en-us/web/css/animation-delay/index.md
@@ -96,6 +96,8 @@ This animation has a delay of 2 seconds.
 
 #### Result
 
+Hover over the rectangle to start the animation.
+
 {{EmbedLiveSample("Setting an animation delay","100%","250")}}
 
 See [CSS animations](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations) for examples.

--- a/files/en-us/web/css/animation-direction/index.md
+++ b/files/en-us/web/css/animation-direction/index.md
@@ -61,7 +61,7 @@ animation-direction: unset;
 
 ## Examples
 
-### The animation is playing reversed
+### Reversing the animation direction
 
 #### HTML
 
@@ -77,6 +77,9 @@ animation-direction: unset;
   border-radius: 10px;
   width: 100px;
   height: 100px;
+}
+
+.box:hover {
   animation-name: rotate;
   animation-duration: 0.7s;
   animation-direction: reverse;
@@ -94,7 +97,7 @@ animation-direction: unset;
 
 #### Result
 
-{{EmbedLiveSample("Examples","100%","250")}}
+{{EmbedLiveSample("Reversing the animation direction","100%","250")}}
 
 See [CSS animations](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations) for examples.
 

--- a/files/en-us/web/css/animation-duration/index.md
+++ b/files/en-us/web/css/animation-duration/index.md
@@ -55,7 +55,9 @@ animation-duration: unset;
 
 ## Examples
 
-### The animation has an animation-duration of 0.7 seconds
+### Setting animation duration
+
+This animation has an animation-duration of 0.7 seconds.
 
 #### HTML
 
@@ -71,6 +73,9 @@ animation-duration: unset;
   border-radius: 10px;
   width: 100px;
   height: 100px;
+}
+
+.box:hover {
   animation-name: rotate;
   animation-duration: 0.7s;
 }
@@ -87,7 +92,7 @@ animation-duration: unset;
 
 #### Result
 
-{{EmbedLiveSample("Examples","100%","250")}}
+{{EmbedLiveSample("Setting animation duration","100%","250")}}
 
 See [CSS animations](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations) for more examples.
 

--- a/files/en-us/web/css/animation-duration/index.md
+++ b/files/en-us/web/css/animation-duration/index.md
@@ -92,6 +92,8 @@ This animation has an animation-duration of 0.7 seconds.
 
 #### Result
 
+Hover over the rectangle to start the animation.
+
 {{EmbedLiveSample("Setting animation duration","100%","250")}}
 
 See [CSS animations](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations) for more examples.

--- a/files/en-us/web/css/animation-fill-mode/index.md
+++ b/files/en-us/web/css/animation-fill-mode/index.md
@@ -79,9 +79,11 @@ animation-fill-mode: unset;
 
 ## Examples
 
+### Setting fill mode
+
 You can see the effect of `animation-fill-mode` in the following example. It demonstrates how, for an animation that runs for an infinite time, you can cause it to remain in its final state rather than reverting to the original state (which is the default).
 
-### HTML
+#### HTML
 
 ```html
 <p>Move your mouse over the gray box!</p>
@@ -91,7 +93,7 @@ You can see the effect of `animation-fill-mode` in the following example. It dem
 </div>
 ```
 
-### CSS
+#### CSS
 
 ```css
 .demo {
@@ -116,9 +118,9 @@ You can see the effect of `animation-fill-mode` in the following example. It dem
 }
 ```
 
-### Result
+#### Result
 
-{{EmbedLiveSample('Examples',700,300)}}
+{{EmbedLiveSample('Setting fill mode',700,300)}}
 
 See [CSS animations](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations) for more examples.
 

--- a/files/en-us/web/css/animation-iteration-count/index.md
+++ b/files/en-us/web/css/animation-iteration-count/index.md
@@ -59,7 +59,9 @@ The **`animation-iteration-count`** property is specified as one or more comma-s
 
 ## Examples
 
-### The animation will run 10 times.
+### Setting iteration count
+
+This animation will run 10 times.
 
 #### HTML
 
@@ -75,6 +77,9 @@ The **`animation-iteration-count`** property is specified as one or more comma-s
   border-radius: 10px;
   width: 100px;
   height: 100px;
+}
+
+.box:hover {
   animation-name: rotate;
   animation-duration: 0.7s;
   animation-iteration-count: 10;
@@ -92,7 +97,7 @@ The **`animation-iteration-count`** property is specified as one or more comma-s
 
 #### Result
 
-{{EmbedLiveSample("Examples","100%","250")}}
+{{EmbedLiveSample("Setting iteration count","100%","250")}}
 
 See [CSS animations](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations) for examples.
 

--- a/files/en-us/web/css/animation-iteration-count/index.md
+++ b/files/en-us/web/css/animation-iteration-count/index.md
@@ -97,6 +97,8 @@ This animation will run 10 times.
 
 #### Result
 
+Hover over the rectangle to start the animation.
+
 {{EmbedLiveSample("Setting iteration count","100%","250")}}
 
 See [CSS animations](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations) for examples.

--- a/files/en-us/web/css/animation-name/index.md
+++ b/files/en-us/web/css/animation-name/index.md
@@ -57,7 +57,9 @@ animation-name: unset;
 
 ## Examples
 
-### The animation has an animation-name of rotate
+### Naming an animation
+
+This animation has an `animation-name` of `rotate`.
 
 #### HTML
 
@@ -73,6 +75,9 @@ animation-name: unset;
   border-radius: 10px;
   width: 100px;
   height: 100px;
+}
+
+.box:hover {
   animation-name: rotate;
   animation-duration: 0.7s;
 }
@@ -89,7 +94,7 @@ animation-name: unset;
 
 #### Result
 
-{{EmbedLiveSample("Examples","100%","250")}}
+{{EmbedLiveSample("Naming an animation","100%","250")}}
 
 See [CSS animations](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations) for examples.
 

--- a/files/en-us/web/css/animation-name/index.md
+++ b/files/en-us/web/css/animation-name/index.md
@@ -94,6 +94,8 @@ This animation has an `animation-name` of `rotate`.
 
 #### Result
 
+Hover over the rectangle to start the animation.
+
 {{EmbedLiveSample("Naming an animation","100%","250")}}
 
 See [CSS animations](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations) for examples.

--- a/files/en-us/web/css/animation-play-state/index.md
+++ b/files/en-us/web/css/animation-play-state/index.md
@@ -94,7 +94,7 @@ This animation is paused, but runs when you hover over it.
 
 #### Result
 
-Hover over the rectangle to start the animation.
+Hover over the rectangle to play the animation.
 
 {{EmbedLiveSample("Pausing an animation","100%","250")}}
 

--- a/files/en-us/web/css/animation-play-state/index.md
+++ b/files/en-us/web/css/animation-play-state/index.md
@@ -94,6 +94,8 @@ This animation is paused, but runs when you hover over it.
 
 #### Result
 
+Hover over the rectangle to start the animation.
+
 {{EmbedLiveSample("Pausing an animation","100%","250")}}
 
 See [CSS animations](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations) for examples.

--- a/files/en-us/web/css/animation-play-state/index.md
+++ b/files/en-us/web/css/animation-play-state/index.md
@@ -54,7 +54,9 @@ animation-play-state: unset;
 
 ## Examples
 
-### The animation is paused
+### Pausing an animation
+
+This animation is paused, but runs when you hover over it.
 
 #### HTML
 
@@ -72,7 +74,12 @@ animation-play-state: unset;
   height: 100px;
   animation-name: rotate;
   animation-duration: 0.7s;
+  animation-iteration-count: infinite;
   animation-play-state: paused;
+}
+
+.box:hover {
+  animation-play-state: running;
 }
 
 @keyframes rotate {
@@ -87,7 +94,7 @@ animation-play-state: unset;
 
 #### Result
 
-{{EmbedLiveSample("Examples","100%","250")}}
+{{EmbedLiveSample("Pausing an animation","100%","250")}}
 
 See [CSS animations](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations) for examples.
 

--- a/files/en-us/web/css/animation-timeline/index.md
+++ b/files/en-us/web/css/animation-timeline/index.md
@@ -57,7 +57,7 @@ animation-timeline: unset;
 
 ## Examples
 
-### Simple example
+### Setting a scroll timeline
 
 A scroll timeline named `squareTimeline` is declared and applied to the `#square` element using `animation-timeline: squareTimeline`.
 
@@ -104,7 +104,7 @@ A scroll timeline named `squareTimeline` is declared and applied to the `#square
 
 #### Result
 
-{{EmbedLiveSample("Simple example")}}
+{{EmbedLiveSample("Setting a scroll timeline")}}
 
 ## Specifications
 

--- a/files/en-us/web/css/animation-timeline/index.md
+++ b/files/en-us/web/css/animation-timeline/index.md
@@ -104,6 +104,8 @@ A scroll timeline named `squareTimeline` is declared and applied to the `#square
 
 #### Result
 
+Scroll to see the animation.
+
 {{EmbedLiveSample("Setting a scroll timeline")}}
 
 ## Specifications


### PR DESCRIPTION
The examples for our CSS animation properties play on page load, so they are done by the time you see them.

This PR makes them play on hover instead, so you can see them when you are ready.

I've also given them more titley titles.