### PR TITLE
Remove comments about complex selector

### DIFF
--- a/files/en-us/web/css/_colon_not/index.md
+++ b/files/en-us/web/css/_colon_not/index.md
@@ -40,7 +40,7 @@ There are several unusual effects and outcomes when using `:not()` that you shou
 - This pseudo-class can increase the [specificity](/en-US/docs/Web/CSS/Specificity) of a rule. For example, `#foo:not(#bar)` will match the same element as the simpler `#foo`, but has a higher specificity.
 - `:not(.foo)` will match anything that isn't `.foo`, _including {{HTMLElement("html")}} and {{HTMLElement("body")}}._
 - This selector only applies to one element; you cannot use it to exclude all ancestors. For instance, `body :not(table) a` will still apply to links inside of a table, since {{HTMLElement("tr")}} will match with the `:not()` part of the selector.
-- Using two selectors at the same time might not be supported in all browsers. Example: `:not(.foo, .bar)`. For wider support you could use, `:not(.foo):not(.bar)`
+- You can negate several selectors at the same time. Example: `:not(.foo, .bar)` is equivalent to `:not(.foo):not(.bar)`.
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_not/index.md
+++ b/files/en-us/web/css/_colon_not/index.md
@@ -40,7 +40,7 @@ There are several unusual effects and outcomes when using `:not()` that you shou
 - This pseudo-class can increase the [specificity](/en-US/docs/Web/CSS/Specificity) of a rule. For example, `#foo:not(#bar)` will match the same element as the simpler `#foo`, but has a higher specificity.
 - `:not(.foo)` will match anything that isn't `.foo`, _including {{HTMLElement("html")}} and {{HTMLElement("body")}}._
 - This selector only applies to one element; you cannot use it to exclude all ancestors. For instance, `body :not(table) a` will still apply to links inside of a table, since {{HTMLElement("tr")}} will match with the `:not()` part of the selector.
-- Using two selectors at the same time is not yet supported in all browsers. Example: `:not(.foo, .bar)`. For wider support you could use, `:not(.foo):not(.bar)`
+- Using two selectors at the same time might not be supported in all browsers. Example: `:not(.foo, .bar)`. For wider support you could use, `:not(.foo):not(.bar)`
 
 ## Examples
 
@@ -81,13 +81,11 @@ body :not(div):not(span) {
 }
 
 /* Elements that are not <div>s or `.fancy` */
-/* Note that this syntax is not well supported yet. */
 body :not(div, .fancy) {
   text-decoration: overline underline;
 }
 
 /* Elements inside an <h2> that aren't a <span> with a class of foo. */
-/* Complex selectors such as an element with a class are not well supported yet. */
 h2 :not(span.foo) {
   color: red;
 }


### PR DESCRIPTION
I think it's time we could remove those comments, at least from the Example. According to [caniuse](https://caniuse.com/?search=not) it is pretty well supported.

As regarding the point in the description (i.e. _Using two selectors at the same time might not be supported in all browsers. Example: `:not(.foo, .bar)`. For wider support you could use, `:not(.foo):not(.bar)`_) 
I believe we can leave it for now, maybe changing it a bit to point out that for the browsers that still don't support it one could use the following syntax.
Would be happy to know other opinions.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
