### PR TITLE
Fix Device orientation and motion sidebar

### DIFF
--- a/files/en-us/web/api/devicemotionevent/acceleration/index.md
+++ b/files/en-us/web/api/devicemotionevent/acceleration/index.md
@@ -4,10 +4,8 @@ slug: Web/API/DeviceMotionEvent/acceleration
 tags:
   - API
   - Device Orientation
-  - Experimental
   - Mobile
   - Motion
-  - NeedsExample
   - Orientation
   - Property
   - Reference
@@ -15,11 +13,10 @@ browser-compat: api.DeviceMotionEvent.acceleration
 ---
 {{APIRef("Device Orientation Events")}}
 
-The `acceleration` property returns the amount of acceleration recorded by
-the device, in [meters
-per second squared (m/s²)](https://en.wikipedia.org/wiki/Meter_per_second_squared). The acceleration value does not include the effect of
-the gravity force, in contrast to
-{{DOMxRef("DeviceMotionEvent.accelerationIncludingGravity")}}.
+The **`acceleration`** property returns the amount of acceleration recorded by
+the device, in [meters per second squared (m/s²)](https://en.wikipedia.org/wiki/Meter_per_second_squared).
+The acceleration value does not include the effect of
+the gravity force, in contrast to {{DOMxRef("DeviceMotionEvent.accelerationIncludingGravity")}}.
 
 > **Note:** If the hardware doesn't know how to remove gravity from the
 > acceleration data, this value may not be present in the
@@ -53,7 +50,5 @@ acceleration on three axis. Each axis is represented with its own property:
 - {{DOMxRef("window.deviceorientation_event", "deviceorientation") }} event
 - {{DOMxRef("DeviceOrientationEvent")}}
 - {{DOMxRef("LinearAccelerationSensor")}}
-- [Detecting device
-  orientation](/en-US/docs/Web/Events/Detecting_device_orientation)
-- [Orientation and motion data
-  explained](/en-US/docs/Web/Events/Orientation_and_motion_data_explained)
+- [Detecting device orientation](/en-US/docs/Web/Events/Detecting_device_orientation)
+- [Orientation and motion data explained](/en-US/docs/Web/Events/Orientation_and_motion_data_explained)

--- a/files/en-us/web/api/devicemotionevent/accelerationincludinggravity/index.md
+++ b/files/en-us/web/api/devicemotionevent/accelerationincludinggravity/index.md
@@ -4,10 +4,8 @@ slug: Web/API/DeviceMotionEvent/accelerationIncludingGravity
 tags:
   - API
   - Device Orientation
-  - Experimental
   - Mobile
   - Motion
-  - NeedsExample
   - Orientation
   - Property
   - Reference
@@ -58,7 +56,5 @@ property:
 - {{DOMxRef("window.deviceorientation_event", "deviceorientation") }} event
 - {{DOMxRef("DeviceOrientationEvent")}}
 - {{DOMxRef("Accelerometer")}}
-- [Detecting device
-  orientation](/en-US/docs/Web/Events/Detecting_device_orientation)
-- [Orientation and motion data
-  explained](/en-US/docs/Web/Events/Orientation_and_motion_data_explained)
+- [Detecting device orientation](/en-US/docs/Web/Events/Detecting_device_orientation)
+- [Orientation and motion data explained](/en-US/docs/Web/Events/Orientation_and_motion_data_explained)

--- a/files/en-us/web/api/devicemotionevent/index.md
+++ b/files/en-us/web/api/devicemotionevent/index.md
@@ -12,9 +12,9 @@ tags:
   - Reference
 browser-compat: api.DeviceMotionEvent
 ---
-{{APIRef("Device Orientation Events")}}{{SeeCompatTable}}
+{{APIRef("Device Orientation Events")}}
 
-The `DeviceMotionEvent` provides web developers with information about the speed of changes for the device's position and orientation.
+The **`DeviceMotionEvent`** interface provides web developers with information about the speed of changes for the device's position and orientation.
 
 > **Warning:** Currently, Firefox and Chrome do not handle the coordinates the same way. Take care about this while using them.
 

--- a/files/en-us/web/api/devicemotionevent/interval/index.md
+++ b/files/en-us/web/api/devicemotionevent/interval/index.md
@@ -4,10 +4,8 @@ slug: Web/API/DeviceMotionEvent/interval
 tags:
   - API
   - Device Orientation
-  - Experimental
   - Mobile
   - Motion
-  - NeedsExample
   - Orientation
   - Property
   - Reference
@@ -15,7 +13,7 @@ browser-compat: api.DeviceMotionEvent.interval
 ---
 {{APIRef("Device Orientation Events")}}
 
-Returns the interval, in milliseconds, at which data is obtained from the underlying
+The **`DeviceMotionEvent.interval`** represents property returns the interval, in milliseconds, at which data is obtained from the underlying
 hardware. You can use this to determine the granularity of motion events.
 
 ## Value
@@ -36,7 +34,5 @@ A number representing the interval of time, in milliseconds.
 - {{DOMxRef("window.devicemotion_event", "devicemotion") }} event
 - {{DOMxRef("window.deviceorientation_event", "deviceorientation") }} event
 - {{DOMxRef("DeviceOrientationEvent")}}
-- [Detecting device
-  orientation](/en-US/docs/Web/API/Detecting_device_orientation)
-- [Orientation and motion data
-  explained](/en-US/docs/Web/Guide/Events/Orientation_and_motion_data_explained)
+- [Detecting device orientation](/en-US/docs/Web/Events/Detecting_device_orientation)
+- [Orientation and motion data explained](/en-US/docs/Web/Events/Orientation_and_motion_data_explained)

--- a/files/en-us/web/api/devicemotionevent/interval/index.md
+++ b/files/en-us/web/api/devicemotionevent/interval/index.md
@@ -13,7 +13,7 @@ browser-compat: api.DeviceMotionEvent.interval
 ---
 {{APIRef("Device Orientation Events")}}
 
-The **`DeviceMotionEvent.interval`** represents property returns the interval, in milliseconds, at which data is obtained from the underlying
+The **`DeviceMotionEvent.interval`** property returns the interval, in milliseconds, at which data is obtained from the underlying
 hardware. You can use this to determine the granularity of motion events.
 
 ## Value

--- a/files/en-us/web/api/devicemotionevent/rotationrate/index.md
+++ b/files/en-us/web/api/devicemotionevent/rotationrate/index.md
@@ -6,10 +6,8 @@ tags:
   - DOM
   - DOM Reference
   - Device Orientation
-  - Experimental
   - Mobile
   - Motion
-  - NeedsExample
   - Orientation
   - Property
   - Reference
@@ -17,7 +15,7 @@ browser-compat: api.DeviceMotionEvent.rotationRate
 ---
 {{APIRef("Device Orientation Events")}}
 
-Returns the rate at which the device is rotating around each of its axes in degrees per
+The **`DeviceMotionEvent.rotationRate`** read-only property returns the rate at which the device is rotating around each of its axes in degrees per
 second.
 
 > **Note:** If the hardware isn't capable of providing this
@@ -50,7 +48,5 @@ rates of the device around each of its axes:
 - {{DOMxRef("window.devicemotion_event", "devicemotion") }} event
 - {{DOMxRef("window.deviceorientation_event", "deviceorientation") }} event
 - {{DOMxRef("DeviceOrientationEvent") }}
-- [Detecting device
-  orientation](/en-US/docs/Web/API/Detecting_device_orientation)
-- [Orientation and motion data
-  explained](/en-US/docs/Web/Guide/Events/Orientation_and_motion_data_explained)
+- [Detecting device orientation](/en-US/docs/Web/API/Detecting_device_orientation)
+- [Orientation and motion data explained](/en-US/docs/Web/Guide/Events/Orientation_and_motion_data_explained)

--- a/files/en-us/web/api/devicemotioneventacceleration/index.md
+++ b/files/en-us/web/api/devicemotioneventacceleration/index.md
@@ -4,24 +4,22 @@ slug: Web/API/DeviceMotionEventAcceleration
 tags:
   - API
   - DeviceAcceleration
-  - Experimental
   - Interface
-  - NeedsExample
   - Reference
 browser-compat: api.DeviceMotionEventAcceleration
 ---
-{{securecontext_header}}{{ ApiRef("Device Orientation Events") }}{{SeeCompatTable}}
+{{securecontext_header}}{{ ApiRef("Device Orientation Events") }}
 
-A **`DeviceMotionEventAcceleration`** object provides information about the amount of acceleration the device is experiencing along all three axes.
+The **`DeviceMotionEventAcceleration`** object provides information about the amount of acceleration the device is experiencing along all three axes.
 
 ## Properties
 
 - {{domxref("DeviceMotionEventAcceleration.x")}} {{readonlyInline}}
-  - : The amount of acceleration along the X axis. **Read only.**
+  - : The amount of acceleration along the X axis.
 - {{domxref("DeviceMotionEventAcceleration.y")}} {{readonlyInline}}
-  - : The amount of acceleration along the Y axis. **Read only.**
+  - : The amount of acceleration along the Y axis.
 - {{domxref("DeviceMotionEventAcceleration.z")}} {{readonlyInline}}
-  - : The amount of acceleration along the Z axis. **Read only.**
+  - : The amount of acceleration along the Z axis.
 
 ## Specifications
 

--- a/files/en-us/web/api/devicemotioneventacceleration/x/index.md
+++ b/files/en-us/web/api/devicemotioneventacceleration/x/index.md
@@ -4,30 +4,20 @@ slug: Web/API/DeviceMotionEventAcceleration/x
 tags:
   - API
   - DeviceAcceleration
-  - NeedsExample
   - Property
   - Reference
 browser-compat: api.DeviceMotionEventAcceleration.x
 ---
 {{ APIRef("Device Orientation Events") }}
 
-## Summary
-
-This read-only property indicates the amount of acceleration that occurred along the X
+The **`DeviceMotionEventAcceleration.x`** read-only property indicates the amount of acceleration that occurred along the X
 axis in a [`DeviceMotionEventAcceleration`](/en-US/docs/Web/API/DeviceMotionEventAcceleration)
 object.
 
-## Syntax
+## Value
 
-```js
-var xAccel = DeviceMotionEventAcceleration.x;
-```
-
-### Return value
-
-- `x`
-  - : A `double` indicating the amount of acceleration along the X axis. See [Accelerometer values
-    explained](/en-US/docs/Web/API/Detecting_device_orientation) for details.
+A `double` indicating the amount of acceleration along the X axis.
+See [Accelerometer values explained](/en-US/docs/Web/Events/Detecting_device_orientation) for details.
 
 ## Specifications
 
@@ -39,5 +29,5 @@ var xAccel = DeviceMotionEventAcceleration.x;
 
 ## See also
 
-- [`DeviceMotionEventAcceleration.y`](/en-US/docs/Web/API/DeviceMotionEventAcceleration.y)
-- [`DeviceMotionEventAcceleration.z`](/en-US/docs/Web/API/DeviceMotionEventAcceleration.z)
+- [`DeviceMotionEventAcceleration.y`](/en-US/docs/Web/API/DeviceMotionEventAcceleration/y)
+- [`DeviceMotionEventAcceleration.z`](/en-US/docs/Web/API/DeviceMotionEventAcceleration/z)

--- a/files/en-us/web/api/devicemotioneventacceleration/y/index.md
+++ b/files/en-us/web/api/devicemotioneventacceleration/y/index.md
@@ -11,23 +11,14 @@ browser-compat: api.DeviceMotionEventAcceleration.y
 ---
 {{ APIRef("Device Orientation Events") }}
 
-## Summary
-
-This read-only property indicates the amount of acceleration that occurred along the Y
+The  **`DeviceMotionEventAcceleration.x`** read-only property indicates the amount of acceleration that occurred along the Y
 axis in a [`DeviceMotionEventAcceleration`](/en-US/docs/Web/API/DeviceMotionEventAcceleration)
 object.
 
-## Syntax
+## Value
 
-```js
-var yAccel = DeviceMotionEventAcceleration.y;
-```
-
-### Return value
-
-- `y`
-  - : A `double` indicating the amount of acceleration along the Y axis. See [Accelerometer values
-    explained](/en-US/docs/Web/API/Detecting_device_orientation) for details.
+A `double` indicating the amount of acceleration along the Y axis.
+See [Accelerometer values explained](/en-US/docs/Web/Events/Detecting_device_orientation) for details.
 
 ## Specifications
 
@@ -39,5 +30,5 @@ var yAccel = DeviceMotionEventAcceleration.y;
 
 ## See also
 
-- [`DeviceMotionEventAcceleration.x`](/en-US/docs/Web/API/DeviceMotionEventAcceleration.x)
-- [`DeviceMotionEventAcceleration.z`](/en-US/docs/Web/API/DeviceMotionEventAcceleration.z)
+- [`DeviceMotionEventAcceleration.x`](/en-US/docs/Web/API/DeviceMotionEventAcceleration/x)
+- [`DeviceMotionEventAcceleration.z`](/en-US/docs/Web/API/DeviceMotionEventAcceleration/z)

--- a/files/en-us/web/api/devicemotioneventacceleration/z/index.md
+++ b/files/en-us/web/api/devicemotioneventacceleration/z/index.md
@@ -4,30 +4,20 @@ slug: Web/API/DeviceMotionEventAcceleration/z
 tags:
   - API
   - DeviceAcceleration
-  - NeedsExample
   - Property
   - Reference
 browser-compat: api.DeviceMotionEventAcceleration.z
 ---
 {{ APIRef("Device Orientation Events") }}
 
-## Summary
-
-This read-only property indicates the amount of acceleration that occurred along the Z
+The **`DeviceMotionEventAcceleration.x`** read-only property indicates the amount of acceleration that occurred along the Z
 axis in a [`DeviceMotionEventAcceleration`](/en-US/docs/Web/API/DeviceMotionEventAcceleration)
 object.
 
-## Syntax
+## Value
 
-```js
-var zAccel = DeviceMotionEventAcceleration.z;
-```
-
-### Return value
-
-- `z`
-  - : A `double` indicating the amount of acceleration along the Z axis. See [Accelerometer values
-    explained](/en-US/docs/Web/API/Detecting_device_orientation) for details.
+A `double` indicating the amount of acceleration along the Z axis.
+See [Accelerometer values explained](/en-US/docs/Web/Events/Detecting_device_orientation) for details.
 
 ## Specifications
 
@@ -39,5 +29,5 @@ var zAccel = DeviceMotionEventAcceleration.z;
 
 ## See also
 
-- [`DeviceMotionEventAcceleration.x`](/en-US/docs/Web/API/DeviceMotionEventAcceleration.x)
-- [`DeviceMotionEventAcceleration.y`](/en-US/docs/Web/API/DeviceMotionEventAcceleration.y)
+- [`DeviceMotionEventAcceleration.x`](/en-US/docs/Web/API/DeviceMotionEventAcceleration/x)
+- [`DeviceMotionEventAcceleration.y`](/en-US/docs/Web/API/DeviceMotionEventAcceleration/y)

--- a/files/en-us/web/api/devicemotioneventrotationrate/alpha/index.md
+++ b/files/en-us/web/api/devicemotioneventrotationrate/alpha/index.md
@@ -4,7 +4,7 @@ slug: Web/API/DeviceMotionEventRotationRate/alpha
 tags:
   - API
   - Device Orientation
-  - Intermediate
+  - Property
   - Mobile
   - Motion
   - Orientation
@@ -13,23 +13,12 @@ browser-compat: api.DeviceMotionEventRotationRate.alpha
 ---
 {{ ApiRef("Device Orientation Events") }}
 
-This property indicates the rate of rotation around the Z axis -- in degrees per second
-\-- in a {{ domxref("DeviceMotionEventRotationRate") }} object.
+The **`DeviceMotionEventRotationRate.alpha`** read-only property indicates the rate of rotation around the Z axis, in degrees per second.
 
-## Syntax
+## Value
 
-```js
-var alpha = deviceRotationRate.alpha;
-```
-
-This property is read-only.
-
-### Return value
-
-- `alpha`
-  - : A `double` indicating the rate of rotation around the Z axis, in degrees
-    per second. See [Accelerometer
-    values explained](/en-US/docs/Web/API/Detecting_device_orientation#accelerometer_values_explained) for details.
+A `double` indicating the rate of rotation around the Z axis, in degrees per second.
+See [Accelerometer values explained](/en-US/docs/Web/Events/Detecting_device_orientation#accelerometer_values_explained) for details.
 
 ## Specifications
 

--- a/files/en-us/web/api/devicemotioneventrotationrate/beta/index.md
+++ b/files/en-us/web/api/devicemotioneventrotationrate/beta/index.md
@@ -4,7 +4,7 @@ slug: Web/API/DeviceMotionEventRotationRate/beta
 tags:
   - API
   - Device Orientation
-  - Intermediate
+  - Property
   - Mobile
   - Motion
   - Orientation
@@ -13,23 +13,12 @@ browser-compat: api.DeviceMotionEventRotationRate.beta
 ---
 {{ ApiRef("Device Orientation Events") }}
 
-This property indicates the rate of rotation around the X axis -- in degrees per second
-\-- in a {{ domxref("DeviceMotionEventRotationRate") }} object.
+The **`DeviceMotionEventRotationRate.alpha`** read-only property indicates the rate of rotation around the X axis, in degrees per second.
 
-## Syntax
+## Value
 
-```js
-var beta = deviceRotationRate.beta;
-```
-
-This property is read-only.
-
-### Return value
-
-- `beta`
-  - : A `double` indicating the rate of rotation around the X axis, in degrees
-    per second. See [Accelerometer
-    values explained](/en-US/docs/Web/API/Detecting_device_orientation#accelerometer_values_explained) for details.
+A `double` indicating the rate of rotation around the X axis, in degrees per second.
+See [Accelerometer values explained](/en-US/docs/Web/Events/Detecting_device_orientation#accelerometer_values_explained) for details.
 
 ## Specifications
 

--- a/files/en-us/web/api/devicemotioneventrotationrate/gamma/index.md
+++ b/files/en-us/web/api/devicemotioneventrotationrate/gamma/index.md
@@ -4,7 +4,7 @@ slug: Web/API/DeviceMotionEventRotationRate/gamma
 tags:
   - API
   - Device Orientation
-  - Intermediate
+  - Property
   - Mobile
   - Motion
   - Orientation
@@ -13,23 +13,12 @@ browser-compat: api.DeviceMotionEventRotationRate.gamma
 ---
 {{ ApiRef("Device Orientation Events") }}
 
-This property indicates the rate of rotation around the Y axis -- in degrees per second
-\-- in a {{ domxref("DeviceMotionEventRotationRate") }} object.
+This property indicates the rate of rotation around the Y axis, in degrees per second.
 
-## Syntax
+## Value
 
-```js
-var gamma = deviceRotationRate.gamma;
-```
-
-This property is read-only.
-
-### Return value
-
-- `gamma`
-  - : A `double` indicating the rate of rotation around the Y axis, in degrees
-    per second. See [Accelerometer
-    values explained](/en-US/docs/Web/API/Detecting_device_orientation#accelerometer_values_explained) for details.
+A `double` indicating the rate of rotation around the Y axis, in degrees per second.
+See [Accelerometer values explained](/en-US/docs/Web/Events/Detecting_device_orientation#accelerometer_values_explained) for details.
 
 ## Specifications
 

--- a/files/en-us/web/api/devicemotioneventrotationrate/index.md
+++ b/files/en-us/web/api/devicemotioneventrotationrate/index.md
@@ -5,11 +5,10 @@ tags:
   - API
   - DOM
   - DOM Reference
-  - Experimental
   - Reference
 browser-compat: api.DeviceMotionEventRotationRate
 ---
-{{securecontext_header}}{{ ApiRef("Device Orientation Events") }} {{SeeCompatTable}}
+{{securecontext_header}}{{ ApiRef("Device Orientation Events") }}
 
 A `DeviceMotionEventRotationRate` object provides information about the rate at which the device is rotating around all three axes.
 

--- a/files/en-us/web/api/deviceorientationevent/index.md
+++ b/files/en-us/web/api/deviceorientationevent/index.md
@@ -4,14 +4,12 @@ slug: Web/API/DeviceOrientationEvent
 tags:
   - API
   - Device Orientation API
-  - Experimental
   - Interface
   - Reference
 browser-compat: api.DeviceOrientationEvent
 ---
-{{apiref("Device Orientation Events")}}{{SeeCompatTable}}
-
-The `DeviceOrientationEvent` provides web developers with information from the physical orientation of the device running the web page.
+{{apiref("Device Orientation Events")}}
+The **`DeviceOrientationEvent`** object provides web developers with information from the physical orientation of the device running the web page.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/events/detecting_device_orientation/index.md
+++ b/files/en-us/web/events/detecting_device_orientation/index.md
@@ -10,7 +10,7 @@ tags:
   - Orientation
   - Reference
 ---
-{{SeeCompatTable}}
+{{DefaultAPISidebar("Device Orientation Events")}}
 
 Increasingly, web-enabled devices are capable of determining their **orientation**; that is, they can report data indicating changes to their orientation with relation to the pull of gravity. In particular, hand-held devices such as mobile phones can use this information to automatically rotate the display to remain upright, presenting a wide-screen view of the web content when the device is rotated so that its width is greater than its height.
 
@@ -189,19 +189,6 @@ Finally, {{domxref("DeviceMotionEvent.interval","interval")}} represents the int
 
 - {{domxref("DeviceOrientationEvent")}}
 - {{domxref("DeviceMotionEvent")}}
-- The legacy [`MozOrientation`](/en-US/docs/Web/Events/MozOrientation) event.
 - [Orientation and motion data explained](/en-US/docs/Web/Events/Orientation_and_motion_data_explained)
 - [Using deviceorientation in 3D Transforms](/en-US/docs/Web/Events/Using_device_orientation_with_3D_transforms)
 - [Cyber Orb: 2D maze game with device orientation](/en-US/docs/Games/Tutorials/HTML5_Gamedev_Phaser_Device_Orientation)
-
-<section id="Quick_links">
-  <ol>
-    <li><a href="/en-US/docs/Web/Events/Orientation_and_motion_data_explained">Orientation and motion data explained</a>
-    </li>
-    <li>{{domxref("DeviceOrientationEvent")}}</li>
-    <li>{{domxref("DeviceMotionEvent")}}</li>
-    <li><a href="/en-US/docs/Web/Events/Using_device_orientation_with_3D_transforms">Using deviceorientation in 3D
-        Transforms</a></li>
-    <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a></li>
-  </ol>
-</section>

--- a/files/en-us/web/events/orientation_and_motion_data_explained/index.md
+++ b/files/en-us/web/events/orientation_and_motion_data_explained/index.md
@@ -5,11 +5,12 @@ tags:
   - Intermediate
   - Mobile
   - Motion
-  - NeedsContent
   - Orientation
   - páginas_a_traducir
   - rotation
 ---
+{{DefaultAPISidebar("Device Orientation Events")}}
+
 When using orientation and motion events, it's important to understand what the values you're given by the browser mean. This article provides details about the coordinate systems at play and how you use them.
 
 ## About coordinate frames
@@ -63,14 +64,3 @@ Rotation around the y axis -- that is, tilting the device toward the left or rig
 ![](gamma.png)
 
 The gamma angle is 0° when the device's left and right sides are the same distance from the surface of the Earth, and increases toward 90° as the device is tipped toward the right, and toward -90° as the device is tipped toward the left.
-
-<section id="Quick_links">
-  <ol>
-    <li><a href="/en-US/docs/Web/Events/Detecting_device_orientation">Detecting device orientation</a></li>
-    <li>{{domxref("DeviceOrientationEvent")}}</li>
-    <li>{{domxref("DeviceMotionEvent")}}</li>
-    <li><a href="/en-US/docs/Web/Events/Using_device_orientation_with_3D_transforms">Using deviceorientation in 3D
-        Transforms</a></li>
-    <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a></li>
-  </ol>
-</section>

--- a/files/en-us/web/events/using_device_orientation_with_3d_transforms/index.md
+++ b/files/en-us/web/events/using_device_orientation_with_3d_transforms/index.md
@@ -5,20 +5,20 @@ tags:
   - Advanced
   - CSS
   - DOM
-  - NeedsUpdate
   - Orientation
   - Transforms
 ---
+{{DefaultAPISidebar("Device Orientation Events")}}
 This article provides tips on how to use device orientation information in tandem with CSS 3D transforms.
 
 ## Using orientation to rotate an element
 
-The easiest way to convert [orientation data](/en-US/docs/Web/API/Window.deviceorientation_event) to a [3D transform](/en-US/docs/Web/CSS/transform) is basically to use the alpha, gamma, and beta values as `rotateZ`, `rotateX` and `rotateY` values.
+The easiest way to convert [orientation data](/en-US/docs/Web/API/Window/deviceorientation_event) to a [3D transform](/en-US/docs/Web/CSS/transform) is basically to use the alpha, gamma, and beta values as `rotateZ`, `rotateX` and `rotateY` values.
 
 It is important to keep in mind, however, that the [Device Orientation coordinate system](/en-US/docs/Web/Events/Orientation_and_motion_data_explained) is different from the [CSS coordinate system](/en-US/docs/Web/CSS/CSSOM_View/Coordinate_systems). Namely, the former is {{interwiki("wikipedia", "Right-hand_rule", "right-handed")}} and its Y axis is positive upwards, while the latter is a left-handed coordinate system whose Y axis is positive to the bottom. Furthermore, the Device Orientation angle rotations should always be done in a Z - X' - Y'' order that does not match the order of some [CSS Transforms](/en-US/docs/Web/CSS/CSS_Transforms). These are some of the practical consequences of these differences:
 
 - The order of angle rotations matters, so make sure the alpha, beta and gamma rotations are applied in this order.
-- The [rotate3d()](</en-US/docs/Web/CSS/transform-function/rotate3d()>) CSS transformation, and the [DOMMatrixReadOnly.rotate()](/en-US/docs/Web/API/DOMMatrixReadOnly/rotate) and [DOMMatrix.rotateSelf()](/en-US/docs/Web/API/DOMMatrix/rotateSelf) functions apply angle rotations in a Z - Y' - X'' order, so it is not possible to apply the alpha, beta and gamma rotations in the right order with a single call to any of them. Instead, you should rotate each axis individually in the correct order.
+- The [rotate3d()](/en-US/docs/Web/CSS/transform-function/rotate3d) CSS transformation, and the [DOMMatrixReadOnly.rotate()](/en-US/docs/Web/API/DOMMatrixReadOnly/rotate) and [DOMMatrix.rotateSelf()](/en-US/docs/Web/API/DOMMatrix/rotateSelf) functions apply angle rotations in a Z - Y' - X'' order, so it is not possible to apply the alpha, beta and gamma rotations in the right order with a single call to any of them. Instead, you should rotate each axis individually in the correct order.
 - Due to the differences in coordinate systems outlined above, when looking towards the origin rotations are applied clockwise around in CSS and counter-clockwise in the Device Orientation spec. This means alpha and beta need to be inverted (the rotations around Z and X), but gamma (the rotation around Y) does not because they point to different directions in the two coordinate systems.
 
 Here's a simple code snippet to sum it up:
@@ -82,12 +82,3 @@ function orient( aa ) {
 
 - [Using CSS transforms](/en-US/docs/Web/CSS/CSS_Transforms/Using_CSS_transforms)
 - [Detecting device orientation](/en-US/docs/Web/Events/Detecting_device_orientation)
-
-<section id="Quick_links">
-  <ol>
-    <li><a href="/en-US/docs/Web/Events/Detecting_device_orientation">Detecting device orientation</a></li>
-    <li><a href="/en-US/docs/Web/CSS/CSS_Transforms/Using_CSS_transforms">Using CSS transforms</a></li>
-    <li>{{domxref("DeviceOrientationEvent")}}</li>
-    <li><a href="/en-US/docs/Learn/JavaScript/Building_blocks/Events">Introduction to events</a></li>
-  </ol>
-</section>

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -254,12 +254,16 @@
       ]
     },
     "Device Orientation Events": {
-      "guides": ["/docs/Web/API/Detecting_device_orientation"],
+      "guides": [
+          "/docs/Web/Events/Detecting_device_orientation",
+          "/docs/Web/Events/Orientation_and_motion_data_explained",
+          "/docs/Web/Events/Using_device_orientation_with_3D_transforms"
+        ],
       "interfaces": [
-        "DeviceAcceleration",
         "DeviceMotionEvent",
-        "DeviceOrientationEvent",
-        "DeviceRotationRate"
+        "DeviceMotionEventAcceleration",
+        "DeviceMotionEventRotationRate",
+        "DeviceOrientationEvent"
       ],
       "methods": [],
       "properties": [],


### PR DESCRIPTION
The sidebar was broken (generating flaws, missing redirects, missing guides!)

This fixes it and somewhat cleans the subpages (removed the experimental flags, modern structure).

There would be much more work. But I didn't go into the rabbit hole to add the missing overview page and transfer the guide pages beneath them. Also, I don't touch the constructor pages here as I have another PR fixing them in preparation.