### PR TITLE
Added wasm parametric instructions

### DIFF
--- a/files/en-us/webassembly/reference/control_flow/drop/index.md
+++ b/files/en-us/webassembly/reference/control_flow/drop/index.md
@@ -9,14 +9,14 @@ tags:
 ---
 {{WebAssemblySidebar}}
 
-The **`drop`** instruction, drops the top value from the stack.
+The **`drop`** instruction, pops a value from the stack, and discards it.
 
 {{EmbedInteractiveExample("pages/wat/drop.html", "tabbed-taller")}}
 
 ## Syntax
 
 ```wasm
-;; load multiple values onto the stack
+;; push multiple values onto the stack
 i32.const 1
 i32.const 2
 i32.const 3

--- a/files/en-us/webassembly/reference/control_flow/drop/index.md
+++ b/files/en-us/webassembly/reference/control_flow/drop/index.md
@@ -1,0 +1,32 @@
+---
+title: Drop
+slug: WebAssembly/Reference/Control_flow/Drop
+tags:
+  - WebAssembly
+  - wasm
+  - Reference
+  - Control flow
+---
+{{WebAssemblySidebar}}
+
+The **`drop`** instruction, drops the top value from the stack.
+
+{{EmbedInteractiveExample("pages/wat/drop.html", "tabbed-taller")}}
+
+## Syntax
+
+```wasm
+;; load multiple values onto the stack
+i32.const 1
+i32.const 2
+i32.const 3
+
+;; drop the top item from the stack (`3`)
+drop
+
+;; the top item on the stack will now be `2`
+```
+
+| Instruction | Binary opcode |
+| ----------- | ------------- |
+| `drop`      | `0x1a`        |

--- a/files/en-us/webassembly/reference/control_flow/index.md
+++ b/files/en-us/webassembly/reference/control_flow/index.md
@@ -15,42 +15,32 @@ WebAssembly control flow operators.
 - [`block`](/en-US/docs/WebAssembly/Reference/Control_flow/block)
   - : Creates a label that can later be branched out of with a [`br`](/en-US/docs/WebAssembly/Reference/Control_flow/br).
 
-<!---->
-
 - [`br`](/en-US/docs/WebAssembly/Reference/Control_flow/br)
   - : Branches to a loop or block.
-
-<!---->
 
 - [`call`](/en-US/docs/WebAssembly/Reference/Control_flow/call)
   - : Calls a function.
 
-<!---->
+- [`drop`](/en-US/docs/WebAssembly/Reference/Control_flow/drop)
+  - : Drops a value from the stack.
 
 - [`end`](/en-US/docs/WebAssembly/Reference/Control_flow/end)
   - : Can be used to end a `block`, `loop`, `if`, or `else`.
 
-<!---->
-
 - [`if...else`](/en-US/docs/WebAssembly/Reference/Control_flow/if...else)
   - : Executes a statement if the last item on the stack is true (`1`).
-
-<!---->
 
 - [`loop`](/en-US/docs/WebAssembly/Reference/Control_flow/loop)
   - : Creates a label that can later be branched to with a [`br`](/en-US/docs/WebAssembly/Reference/Control_flow/br).
 
-<!---->
-
 - [`nop`](/en-US/docs/WebAssembly/Reference/Control_flow/nop)
   - : Does nothing.
-
-<!---->
 
 - [`return`](/en-US/docs/WebAssembly/Reference/Control_flow/return)
   - : Returns from a function.
 
-<!---->
+- [`select`](/en-US/docs/WebAssembly/Reference/Control_flow/select)
+  - : Selects one of its first two operands based on a boolean condition.
 
 - [`unreachable`](/en-US/docs/WebAssembly/Reference/Control_flow/unreachable)
   - : Denotes a point in code that should not be reachable.

--- a/files/en-us/webassembly/reference/control_flow/index.md
+++ b/files/en-us/webassembly/reference/control_flow/index.md
@@ -22,7 +22,7 @@ WebAssembly control flow operators.
   - : Calls a function.
 
 - [`drop`](/en-US/docs/WebAssembly/Reference/Control_flow/drop)
-  - : Drops a value from the stack.
+  - : Pops a value from the stack, and discards it.
 
 - [`end`](/en-US/docs/WebAssembly/Reference/Control_flow/end)
   - : Can be used to end a `block`, `loop`, `if`, or `else`.

--- a/files/en-us/webassembly/reference/control_flow/select/index.md
+++ b/files/en-us/webassembly/reference/control_flow/select/index.md
@@ -1,0 +1,31 @@
+---
+title: Select
+slug: WebAssembly/Reference/Control_flow/Select
+tags:
+  - WebAssembly
+  - wasm
+  - Reference
+  - Control flow
+---
+{{WebAssemblySidebar}}
+
+The **`select`** instruction, selects one of its first two operands based on whether its third operand is zero or not, it shares some similarities with the ternary operator in other languages (e.g. `false ? 10 : 20`).
+
+{{EmbedInteractiveExample("pages/wat/select.html", "tabbed-taller")}}
+
+## Syntax
+
+```wasm
+;; load two values onto the stack
+i32.const 10
+i32.const 20
+
+;; change to `1` (true) to get the first value (`10`)
+i32.const 0
+select
+```
+
+| Instruction | Binary opcode |
+| ----------- | ------------- |
+| `select`    | `0x1b`        |
+| `select t`  | `0x1c`        |

--- a/files/en-us/webassembly/reference/control_flow/select/index.md
+++ b/files/en-us/webassembly/reference/control_flow/select/index.md
@@ -9,14 +9,14 @@ tags:
 ---
 {{WebAssemblySidebar}}
 
-The **`select`** instruction, selects one of its first two operands based on whether its third operand is zero or not, it shares some similarities with the ternary operator in other languages (e.g. `false ? 10 : 20`).
+The **`select`** instruction, selects one of its first two operands based on whether its third operand is zero or not. It shares some similarities with the ternary operator in other languages (e.g. `false ? 10 : 20`), but doesn't [short-circuit](https://en.wikipedia.org/wiki/Short-circuit_evaluation).
 
 {{EmbedInteractiveExample("pages/wat/select.html", "tabbed-taller")}}
 
 ## Syntax
 
 ```wasm
-;; load two values onto the stack
+;; push two values onto the stack
 i32.const 10
 i32.const 20
 

--- a/files/en-us/webassembly/reference/index.md
+++ b/files/en-us/webassembly/reference/index.md
@@ -19,8 +19,6 @@ WebAssembly instructions.
 
 - [`Reference Instructions`](/en-US/docs/WebAssembly/Reference/Reference)
 
-- [`Parametric Instructions`](/en-US/docs/WebAssembly/Reference/Parametric)
-
 - [`Variable Instructions`](/en-US/docs/WebAssembly/Reference/Variables)
   - : Setting and getting local and global variables.
 


### PR DESCRIPTION
**Warning**: This should not be merged without mdn/interactive-examples/pull/2126

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Added WebAssembly parametric instructions (select and drop).

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
I've decided to put the parametric instructions under control flow instead of having a separate section for it like in the spec, as I think control flow is where most users would go looking for these instructions.

(I just couldn't figure out what `select t` does, or how to use it, so I didn't add any details about it)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->


#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->

@sunfishcode please review whenever you get a chance, thanks!



