### PR TITLE
Fixed internal links to HTML data-* attr page

### DIFF
--- a/files/en-us/web/api/svgelement/index.md
+++ b/files/en-us/web/api/svgelement/index.md
@@ -24,7 +24,7 @@ _Also inherits properties from: {{DOMxRef("DocumentAndElementEventHandlers")}}, 
 - {{DOMxRef("SVGElement.attributeStyleMap")}}{{ReadOnlyInline}}
   - : A {{DOMxRef("StylePropertyMap")}} representing the declarations of the element's {{SVGAttr("style")}} attribute.
 - {{DOMxRef("SVGElement.dataset")}}{{ReadOnlyInline}}
-  - : A {{DOMxRef("DOMStringMap")}} object which provides a list of key/value pairs of named data attributes which correspond to [custom data attributes](/en-US/docs/Web/Guide/HTML/Using_data_attributes) attached to the element. These can also be defined in SVG using attributes of the form {{SVGAttr("data-*")}}, where `*` is the key name for the pair. This works just like HTML's {{DOMxRef("HTMLElement.dataset")}} property and HTML's {{HTMLAttrxRef("data-*")}} global attribute.
+  - : A {{DOMxRef("DOMStringMap")}} object which provides a list of key/value pairs of named data attributes which correspond to [custom data attributes](/en-US/docs/Web/Guide/HTML/Using_data_attributes) attached to the element. These can also be defined in SVG using attributes of the form {{SVGAttr("data-*")}}, where `*` is the key name for the pair. This works just like HTML's {{DOMxRef("HTMLElement.dataset")}} property and HTML's [`data-*`](/en-US/docs/Web/HTML/Global_attributes/data-*) global attribute.
 - {{DOMxRef("SVGElement.className")}} {{Deprecated_Inline}}{{ReadOnlyInline}}
   - : An {{DOMxRef("SVGAnimatedString")}} that reflects the value of the {{SVGAttr("class")}} attribute on the given element, or the empty string if `class` is not present. This attribute is deprecated and may be removed in a future version of this specification. Authors are advised to use {{DOMxRef("Element.classList")}} instead.
 - {{DOMxRef("SVGElement.nonce")}}
@@ -74,6 +74,6 @@ Listen to these events using [`addEventListener()`](/en-US/docs/Web/API/EventTar
 
 ## See also
 
-- HTML {{HTMLAttrxRef("data-*")}} attribute
+- HTML [`data-*`](/en-US/docs/Web/HTML/Global_attributes/data-*) attribute
 - SVG {{SVGAttr("data-*")}} attribute
 - [Using custom data attributes in HTML](/en-US/docs/Web/Guide/HTML/Using_data_attributes)


### PR DESCRIPTION
#### Summary
I changed the internal link for HTML data-* attr to /en-US/docs/Web/HTML/Global_attributes/data-* .

#### Motivation
The current HTMLAttrxRef link to data-* attr links to a non-existent anchor. 

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
