### PR TITLE
FF101 DOMException [Serializable]

### DIFF
--- a/files/en-us/glossary/serializable_object/index.md
+++ b/files/en-us/glossary/serializable_object/index.md
@@ -14,15 +14,15 @@ This allows them to, for example, be stored on disk and later restored, or clone
 The serialization may not include all the properties and other aspects of the the original object.
 For example, a serialization of a {{domxref("DOMException")}} must include the `name` and `message` properties, but whether it includes other properties is implementation dependent.
 As a result, a deserialized object may not be an identical clone/copy of the original object.
-The new object will however be a {{glossary("deep copy")}}, so any properties that were serialized will reference their own independent copies of any sub-objects.
+The new deserialized object will however be a {{glossary("deep copy")}}, so any properties that were serialized from the original object and then deseserialized into the new object will share no references with the original object.
 
-In some cases when serializing and deserializing an object it makes sense to transfer some resources rather than creating a copy.
+In some cases when serializing and deserializing an object, it makes sense to transfer some resources rather than creating a copy.
 Objects that can be transfered are called {{Glossary("Transferable objects")}}.
 
 
 ## Supported objects
 
 Not all objects are serializable objects.
-The object that can be serialized are listed in: [The structured clone algorithm > Supported types](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types)
+The objects that can be serialized are listed in: [The structured clone algorithm > Supported types](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types)
 
 > **Note:** Serializable objects are marked up in [Web IDL files](https://github.com/w3c/webref/tree/main/ed/idl) with the attribute `[Serializable]`.

--- a/files/en-us/glossary/serializable_object/index.md
+++ b/files/en-us/glossary/serializable_object/index.md
@@ -23,6 +23,6 @@ Objects that can be transfered are called {{Glossary("Transferable objects")}}.
 ## Supported objects
 
 Not all objects are serializable objects.
-The objects that can be serialized are listed in: [The structured clone algorithm > Supported types](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types)
+The objects that can be serialized are listed in: [The structured clone algorithm > Supported types](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types)
 
 > **Note:** Serializable objects are marked up in [Web IDL files](https://github.com/w3c/webref/tree/main/ed/idl) with the attribute `[Serializable]`.

--- a/files/en-us/glossary/serializable_object/index.md
+++ b/files/en-us/glossary/serializable_object/index.md
@@ -1,0 +1,28 @@
+---
+title: Serializable object
+slug: Glossary/Serializable_object
+tags:
+  - Serializable
+  - Transferable
+  - Structured clone
+  - Workers
+---
+
+**Serializable objects** are objects that can be serialized and later deserialized in any JavaScript environment ("realm").
+This allows them to, for example, be stored on disk and later restored, or cloned with {{domxref("structuredClone()")}}, or shared between workers using {{domxref("DedicatedWorkerGlobalScope.postMessage()")}}.
+
+The serialization may not include all the properties and other aspects of the the original object.
+For example, a serialization of a {{domxref("DOMException")}} must include the `name` and `message` properties, but whether it includes other properties is implementation dependent.
+As a result, a deserialized object may not be an identical clone/copy of the original object.
+The new object will however be a {{glossary("deep copy")}}, so any properties that were serialized will reference their own independent copies of any sub-objects.
+
+In some cases when serializing and deserializing an object it makes sense to transfer some resources rather than creating a copy.
+Objects that can be transfered are called {{Glossary("Transferable objects")}}.
+
+
+## Supported objects
+
+Not all objects are serializable objects.
+The object that can be serialized are listed in: [The structured clone algorithm > Supported types](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types)
+
+> **Note:** Serializable objects are marked up in [Web IDL files](https://github.com/w3c/webref/tree/main/ed/idl) with the attribute `[Serializable]`.

--- a/files/en-us/glossary/transferable_objects/index.md
+++ b/files/en-us/glossary/transferable_objects/index.md
@@ -3,6 +3,8 @@ title: Transferable objects
 slug: Glossary/Transferable_objects
 tags:
   - Transferable
+  - Serializable
+  - Structured clone
   - Workers
 ---
 
@@ -43,7 +45,7 @@ worker.postMessage(uInt8Array, [uInt8Array.buffer]);
 console.log(uInt8Array.byteLength);  // 0
 ```
 
-> **Note:** [Typed arrays](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) like {{jsxref("Int32Array")}} and {{jsxref("Uint8Array")}}, are serializable, but not transferable.
+> **Note:** [Typed arrays](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray) like {{jsxref("Int32Array")}} and {{jsxref("Uint8Array")}}, are {{Glossary("serializable object","serializable")}}, but not transferable.
 > However their underlying buffer is an {{jsxref("ArrayBuffer")}}, which is a transferable object.
 > We could have sent `uInt8Array.buffer` in the data parameter, but not `uInt8Array` in the transfer array.
 
@@ -87,7 +89,7 @@ The items that can be _transferred_ are:
 - {{domxref("OffscreenCanvas")}}
 - {{domxref("RTCDataChannel")}}
 
-> **Note:** Transferrable objects are marked up in [Web IDL files](https://github.com/w3c/webref/tree/main/ed/idl) with the attribute `Transferrable`.
+> **Note:** Transferrable objects are marked up in [Web IDL files](https://github.com/w3c/webref/tree/main/ed/idl) with the attribute `[Transferrable]`.
 
 ## See also
 

--- a/files/en-us/web/api/audiodata/index.md
+++ b/files/en-us/web/api/audiodata/index.md
@@ -12,6 +12,8 @@ browser-compat: api.AudioData
 
 The **`AudioData`** interface of the {{domxref('WebCodecs API')}} represents an audio sample.
 
+`AudioData` is a {{glossary("Transferable objects","transferable object")}}.
+
 ## Description
 
 An audio track consists of a stream of audio samples, each sample representing a captured moment of sound. An `AudioData` object is a representation of such a sample. Working alongside the interfaces of the [Insertable Streams API](/en-US/docs/Web/API/Insertable_Streams_for_MediaStreamTrack_API), you can break a stream into individual `AudioData` objects with {{domxref("MediaStreamTrackProcessor")}}, or construct an audio track from a stream of frames with {{domxref("MediaStreamTrackGenerator")}}.

--- a/files/en-us/web/api/domexception/index.md
+++ b/files/en-us/web/api/domexception/index.md
@@ -18,6 +18,8 @@ The **`DOMException`** interface represents an abnormal event (called an **excep
 
 Each exception has a **name**, which is a short "PascalCase"-style string identifying the error or abnormal condition.
 
+`DOMException` is a {{Glossary("Serializable object")}}, so it can be cloned with {{domxref("structuredClone()")}} or copied between [Workers](/en-US/docs/Web/API/Worker) using {{domxref("Worker.postMessage()", "postMessage()")}}.
+
 ## Constructor
 
 - {{domxref("DOMException.DOMException()", "DOMException()")}} {{experimental_inline}}

--- a/files/en-us/web/api/imagebitmap/index.md
+++ b/files/en-us/web/api/imagebitmap/index.md
@@ -13,6 +13,8 @@ browser-compat: api.ImageBitmap
 
 The **`ImageBitmap`** interface represents a bitmap image which can be drawn to a {{HTMLElement("canvas")}} without undue latency. It can be created from a variety of source objects using the {{domxref("createImageBitmap()")}} factory method. `ImageBitmap` provides an asynchronous and resource efficient pathway to prepare textures for rendering in WebGL.
 
+`ImageBitmap` is a {{glossary("Transferable objects","transferable object")}}.
+
 ## Properties
 
 - {{domxref("ImageBitmap.height")}} {{readonlyInline}}

--- a/files/en-us/web/api/messageport/index.md
+++ b/files/en-us/web/api/messageport/index.md
@@ -14,6 +14,8 @@ browser-compat: api.MessagePort
 
 The **`MessagePort`** interface of the [Channel Messaging API](/en-US/docs/Web/API/Channel_Messaging_API) represents one of the two ports of a {{domxref("MessageChannel")}}, allowing messages to be sent from one port and listening out for them arriving at the other.
 
+`MessagePort` is a {{glossary("Transferable objects","transferable object")}}.
+
 {{AvailableInWorkers}}
 
 {{InheritanceDiagram}}

--- a/files/en-us/web/api/offscreencanvas/index.md
+++ b/files/en-us/web/api/offscreencanvas/index.md
@@ -13,6 +13,8 @@ browser-compat: api.OffscreenCanvas
 
 The **`OffscreenCanvas`** interface provides a canvas that can be rendered off screen. It is available in both the window and [worker](/en-US/docs/Web/API/Web_Workers_API) contexts.
 
+`OffscreenCanvas` is a {{glossary("Transferable objects","transferable object")}}.
+
 {{AvailableInWorkers}}
 
 {{InheritanceDiagram}}

--- a/files/en-us/web/api/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/index.md
@@ -19,6 +19,8 @@ browser-compat: api.ReadableStream
 
 The `ReadableStream` interface of the [Streams API](/en-US/docs/Web/API/Streams_API) represents a readable stream of byte data. The [Fetch API](/en-US/docs/Web/API/Fetch_API) offers a concrete instance of a `ReadableStream` through the {{domxref("Response.body", "body")}} property of a {{domxref("Response")}} object.
 
+`ReadableStream` is a {{glossary("Transferable objects","transferable object")}}.
+
 ## Constructor
 
 - {{domxref("ReadableStream.ReadableStream", "ReadableStream()")}}

--- a/files/en-us/web/api/rtcdatachannel/index.md
+++ b/files/en-us/web/api/rtcdatachannel/index.md
@@ -21,6 +21,8 @@ The **`RTCDataChannel`** interface represents a network channel which can be use
 
 To create a data channel and ask a remote peer to join you, call the {{DOMxRef("RTCPeerConnection")}}'s {{DOMxRef("RTCPeerConnection.createDataChannel", "createDataChannel()")}} method. The peer being invited to exchange data receives a {{DOMxRef("RTCPeerConnection.datachannel_event", "datachannel")}} event (which has type {{DOMxRef("RTCDataChannelEvent")}}) to let it know the data channel has been added to the connection.
 
+`RTCDataChannel` is a {{glossary("Transferable objects","transferable object")}}.
+
 {{InheritanceDiagram}}
 
 ## Properties

--- a/files/en-us/web/api/transformstream/index.md
+++ b/files/en-us/web/api/transformstream/index.md
@@ -9,6 +9,8 @@ browser-compat: api.TransformStream
 
 The `TransformStream` interface of the [Streams API](/en-US/docs/Web/API/Streams_API) represents a set of transformable data.
 
+`TransformStream` is a {{glossary("Transferable objects","transferable object")}}.
+
 ## Constructor
 
 - {{domxref("TransformStream.TransformStream", "TransformStream()")}}

--- a/files/en-us/web/api/videoframe/index.md
+++ b/files/en-us/web/api/videoframe/index.md
@@ -12,6 +12,8 @@ browser-compat: api.VideoFrame
 
 The **`VideoFrame`** interface of the {{domxref('Web Codecs API','','',' ')}} represents a frame of a video.
 
+`VideoFrame` is a {{glossary("Transferable objects","transferable object")}}.
+
 ## Description
 
 A `VideoFrame` object can be created or accessed in a number of ways. The {{domxref("MediaStreamTrackProcessor")}} breaks a media track into individual `VideoFrame` objects.

--- a/files/en-us/web/api/web_workers_api/structured_clone_algorithm/index.md
+++ b/files/en-us/web/api/web_workers_api/structured_clone_algorithm/index.md
@@ -24,7 +24,8 @@ It clones by recursing through the input object while maintaining a map of previ
     For example, if an object is marked readonly with a [property descriptor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor), it will be read/write in the duplicate, since that's the default.
   - The prototype chain is not walked or duplicated.
 
-> **Note:** Native {{jsxref("Error")}} types can be cloned in Chrome, and Firefox is [working on it](https://bugzilla.mozilla.org/show_bug.cgi?id=1556604).
+> **Note:** Native {{jsxref("Error")}} types can be cloned in Chrome.
+> Firefox can clone {{domxref("DOMException")}}, and is [working on the other error types](https://bugzilla.mozilla.org/show_bug.cgi?id=1556604).
 
 ## Supported types
 
@@ -103,6 +104,10 @@ It clones by recursing through the input object while maintaining a map of previ
     <tr>
       <td>{{jsxref("Set")}}</td>
       <td></td>
+    </tr>
+    <tr>
+      <td>{{domxref("DOMException")}}</td>
+      <td>Most browsers only clone the propertes {{domxref("DOMException.name","name")}} and {{domxref("DOMException.message","message")}} (in theory stack traces and other attributes may also be cloned).</td>
     </tr>
   </tbody>
 </table>

--- a/files/en-us/web/api/writablestream/index.md
+++ b/files/en-us/web/api/writablestream/index.md
@@ -14,6 +14,8 @@ browser-compat: api.WritableStream
 The **`WritableStream`** interface of the [Streams API](/en-US/docs/Web/API/Streams_API) provides a standard abstraction for writing streaming data to a destination, known as a sink.
 This object comes with built-in backpressure and queuing.
 
+`WritableStream` is a {{glossary("Transferable objects","transferable object")}}.
+
 ## Constructor
 
 - {{domxref("WritableStream.WritableStream", "WritableStream()")}}

--- a/files/en-us/web/javascript/reference/global_objects/arraybuffer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/arraybuffer/index.md
@@ -18,6 +18,8 @@ It is an array of bytes, often referred to in other languages as a "byte array".
 
 The [`ArrayBuffer()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer/ArrayBuffer) constructor creates a new `ArrayBuffer` of the given length in bytes. You can also get an array buffer from existing data, for example, from a [Base64](/en-US/docs/Glossary/Base64) string or [from a local file](/en-US/docs/Web/API/FileReader/readAsArrayBuffer).
 
+`ArrayBuffer` is a {{glossary("Transferable objects","transferable object")}}.
+
 ## Constructor
 
 - {{jsxref("ArrayBuffer.ArrayBuffer", "ArrayBuffer()")}}


### PR DESCRIPTION
[DOMException](https://developer.mozilla.org/en-US/docs/Web/API/DOMException) is serializable in FF101 following https://bugzilla.mozilla.org/show_bug.cgi?id=1561357. 

For this I have specifically marked up DOMException as being serializable, and hence being able to be cloned and postmessaged :-). I also added it to the list of things that can be used in the structuredClone algorithm. 

To do this I thought it necessary to define what Serializable means for JavaScript - essentially a deep copy of some subset of the object. The definition is entwined with [Transferable objects](https://developer.mozilla.org/en-US/docs/Glossary/Transferable_objects) in the `structuredClone()`. I THINK they are orthogonal/complementary. I.e. you can serialize an object and it (or some part of it might be transferable) as well. So the top level object is serializable then you can create a copy of the original object or transfer the original object (depending on whether that object is transferrable).

Then I decided that it was worth adding a comment to the transferable items that they are transferrable. If this gets through I will probably to the same for serializable. 

Other docs work being done in https://github.com/mdn/content/issues/15638

@sideshowbarker FYI
