### PR TITLE
Sanitizer API: Makes code work in `<script>` tag

### DIFF
--- a/files/en-us/web/api/element/sethtml/index.md
+++ b/files/en-us/web/api/element/sethtml/index.md
@@ -50,7 +50,7 @@ None.
 The code below demonstrates how to sanitize a string of HTML and insert it into the `Element` with an id of `target`.
 
 ```js
-const unsanitized_string = "abc <script>alert(1)</script> def";  // Unsanitized string of HTML
+const unsanitized_string = "abc <script>alert(1)<" + "/script> def";  // Unsanitized string of HTML
 const sanitizer1 = new Sanitizer();  // Default sanitizer;
 
 // Get the Element with id "target" and set it with the sanitized string.

--- a/files/en-us/web/api/html_sanitizer_api/index.md
+++ b/files/en-us/web/api/html_sanitizer_api/index.md
@@ -74,7 +74,7 @@ The code below demonstrates how {{domxref('Element/setHTML','Element.setHTML()')
 The `script` element is disallowed by the default sanitizer so the alert is removed.
 
 ```js
-const unsanitized_string = "abc <script>alert(1)</script> def";  // Unsanitized string of HTML
+const unsanitized_string = "abc <script>alert(1)<" + "/script> def";  // Unsanitized string of HTML
 
 const sanitizer = new Sanitizer();  // Default sanitizer;
 
@@ -91,7 +91,7 @@ console.log(target.innerHTML);
 The example below shows the same sanitization operation using the {{domxref("Sanitizer.sanitizeFor()")}} method, with the intent of later inserting the returned element into a `<div>` element:
 
 ```js
-const unsanitized_string = "abc <script>alert(1)</script> def";  // Unsanitized string of HTML
+8const unsanitized_string = "abc <script>alert(1)<" + "/script> def";  // Unsanitized string of HTML
 const sanitizer = new Sanitizer();  // Default sanitizer;
 
 // Sanitize the string
@@ -114,7 +114,7 @@ document.querySelector("div#target").replaceChildren(sanitizedDiv.children);
 > but you must remember to use the correct context when the string is applied:
 >
 > ```js
-> const unsanitized_string = "abc <script>alert(1)</script> def";
+> const unsanitized_string = "abc <script>alert(1)<" + "/script> def";
 > let sanitizedString = new Sanitizer().sanitizeFor("div", unsanitized_string).innerHTML;
 > ```
 

--- a/files/en-us/web/api/html_sanitizer_api/index.md
+++ b/files/en-us/web/api/html_sanitizer_api/index.md
@@ -91,7 +91,7 @@ console.log(target.innerHTML);
 The example below shows the same sanitization operation using the {{domxref("Sanitizer.sanitizeFor()")}} method, with the intent of later inserting the returned element into a `<div>` element:
 
 ```js
-8const unsanitized_string = "abc <script>alert(1)<" + "/script> def";  // Unsanitized string of HTML
+const unsanitized_string = "abc <script>alert(1)<" + "/script> def";  // Unsanitized string of HTML
 const sanitizer = new Sanitizer();  // Default sanitizer;
 
 // Sanitize the string

--- a/files/en-us/web/api/sanitizer/sanitizefor/index.md
+++ b/files/en-us/web/api/sanitizer/sanitizefor/index.md
@@ -52,7 +52,7 @@ None.
 The code below demonstrates how to sanitize a string of HTML into a `div` element.
 
 ```js
-const unsanitized_string = "abc <script>alert(1)</script> def";  // Unsanitized string of HTML
+const unsanitized_string = "abc <script>alert(1)<" + "/script> def";  // Unsanitized string of HTML
 const sanitizer = new Sanitizer();  // Default sanitizer;
 
 // Sanitize the string

--- a/files/en-us/web/api/sanitizer/sanitizer/index.md
+++ b/files/en-us/web/api/sanitizer/sanitizer/index.md
@@ -59,7 +59,7 @@ To simplify the presentation the result that is shown is actually the _innerHTML
 This example shows the result of sanitizing a string with disallowed `script` element using the default sanitizer (in a `div` context).
 
 ```js
-let unsanitized = "abc <script>alert(1)</script> def"
+const unsanitized = "abc <script>alert(1)<" + "/script> def";
 const sanitized =  new Sanitizer().sanitizeFor("div", unsanitized);
 // Result (innerHTML of 'sanitized'): script will be removed: "abc alert(1) def"
 ```


### PR DESCRIPTION
### Summary

The code doesn't work in `<script>` tag:
```html
<script>
    const unsanitized_string = "abc <script>alert(1)</script> def";
                                                    ^ the <script> tag gets closed here.
</script>
```
Splitting the closing tag makes it work:
```js
const unsanitized_string = "abc <script>alert(1)<" + "/script> def";
```