### PR TITLE
Fix-sidebar-for-EME

### DIFF
--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -394,7 +394,7 @@
     "Encrypted Media Extensions": {
       "overview": ["Encrypted Media Extensions API"],
       "interfaces": [
-        "MediaKeySessionEvent",
+        "MediaKeyMessageEvent",
         "MediaKeys",
         "MediaKeySession",
         "MediaKeyStatusMap",
@@ -405,10 +405,11 @@
         "HTMLMediaElement.setMediaKeys()"
       ],
       "properties": [
-        "HTMLMediaElement.mediaKeys",
-        "HTMLMediaElement.onencrypted"
+        "HTMLMediaElement.mediaKeys"
       ],
-      "events": []
+      "events": [
+        "HTMLMediaElement: encrypted"
+      ]
     },
     "EyeDropper API": {
       "overview": ["EyeDropper API"],


### PR DESCRIPTION
There was a typo in (`MediaKeySessionEvent` -> `MediaKeyMessageEvent`, per both the spec and was is documented on MDN).

And a red link to `onencrypted` that I transformed into a red link to `HTMLMediaElement: encrypted`.