### PR TITLE
Improving accuracy of `:nth-child()` example text

### DIFF
--- a/files/en-us/web/css/_colon_nth-child/index.md
+++ b/files/en-us/web/css/_colon_nth-child/index.md
@@ -15,7 +15,7 @@ browser-compat: css.selectors.nth-child
 The **`:nth-child()`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) matches elements based on their position among a group of siblings.
 
 ```css
-/* Selects the second <li> element in a list */
+/* Selects the second element in a list IF that element is a <li> */
 li:nth-child(2) {
   color: lime;
 }
@@ -26,6 +26,8 @@ li:nth-child(2) {
   color: lime;
 }
 ```
+
+Note that, in the `element:nth-child()` syntax, the child count includes children of any element type; but it is only considered a match if the element *at that child position* is the type of element specified.
 
 ## Syntax
 

--- a/files/en-us/web/css/_colon_nth-child/index.md
+++ b/files/en-us/web/css/_colon_nth-child/index.md
@@ -27,7 +27,7 @@ li:nth-child(2) {
 }
 ```
 
-Note that, in the `element:nth-child()` syntax, the child count includes children of any element type; but it is only considered a match if the element *at that child position* is the type of element specified.
+Note that, in the `element:nth-child()` syntax, the child count includes children of any element type; but it is considered a match only if the element *at that child position* is of the specified element type.
 
 ## Syntax
 

--- a/files/en-us/web/css/_colon_nth-child/index.md
+++ b/files/en-us/web/css/_colon_nth-child/index.md
@@ -15,7 +15,7 @@ browser-compat: css.selectors.nth-child
 The **`:nth-child()`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) matches elements based on their position among a group of siblings.
 
 ```css
-/* Selects the second element in a list IF that element is a <li> */
+/* Selects the second element in a list if that element is a <li> */
 li:nth-child(2) {
   color: lime;
 }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

The current example text makes it sound like, in a situation where there were multiple sibling elements of different types, the second *list* element would be selected; when actually, if there were multiple types of elements at the same level and the second one was *not* a `<li>`, then nothing would be selected. I attempted to make the comment in the example more accurate in respect to this, and added a note on the point below.

This is a subtle, but potentially frustrating if misunderstood, aspect of `:nth-child()`. I'm not actually sure that this is even sufficient; one could potentially include a full example with an interactive code snippet. However, that might be overemphasizing the point, and I don't know how to include interactive code snippets! :sweat_smile: I think that this at least puts the idea in the careful reader's head.

If you feel a full interactive code example would be warranted, please feel free to include one, or direct me to an example I can follow and I can try to do it.

#### Motivation
Honestly, I had a bug due to this misunderstanding, consulted the MDN docs, and concluded that my initial understanding was correct, as they seemed to support it. (i.e., That only elements of the same type were included in the child count.) Having learned that I was not correct, I'd like to correct the MDN docs so that future readers won't have the same issue.

#### Supporting details
Here's a codepen demonstrating the behavior: 
https://codepen.io/runawaytrike/pen/LYQpqjq

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
