### PR TITLE
Remove XDomain group

### DIFF
--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -2149,12 +2149,6 @@
       "properties": ["Navigator.windowControlsOverlay"],
       "events": []
     },
-    "XDomain": {
-      "interfaces": ["XDomainRequest"],
-      "methods": [],
-      "properties": [],
-      "events": []
-    },
     "XMLHttpRequest": {
       "overview": ["XMLHttpRequest"],
       "guides": [


### PR DESCRIPTION
Remove the XDomain group from GroupData.json.

This is not used anymore (for a long time) on MDN. Time to clean this up.