### PR TITLE
`DOMString` -> `string`

### DIFF
--- a/files/en-us/web/api/htmlbasefontelement/index.md
+++ b/files/en-us/web/api/htmlbasefontelement/index.md
@@ -22,11 +22,11 @@ The `<basefont>` element has been deprecated in HTML4 and removed in HTML5. This
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - `HTMLBaseFontElement.color`
-  - : Is a {{domxref("DOMString")}} representing the text color using either a named color or a color specified in the hexadecimal `#RRGGBB` format.
+  - : Is a string representing the text color using either a named color or a color specified in the hexadecimal `#RRGGBB` format.
 - `HTMLBaseFontElement.face`
-  - : Is a {{domxref("DOMString")}} representing a list of one or more font names. The document text in the default style is rendered in the first font face that the client's browser supports. If no font listed is installed on the local system, the browser typically defaults to the proportional or fixed-width font for that system.
+  - : Is a string representing a list of one or more font names. The document text in the default style is rendered in the first font face that the client's browser supports. If no font listed is installed on the local system, the browser typically defaults to the proportional or fixed-width font for that system.
 - `HTMLBaseFontElement.size`
-  - : Is a {{domxref("DOMString")}} representing the font size as either a numeric or relative value. Numeric values range from `1` to `7` with `1` being the smallest and `3` the default. Relative value starts with a `'+'` or a `'-`'.
+  - : Is a string representing the font size as either a numeric or relative value. Numeric values range from `1` to `7` with `1` being the smallest and `3` the default. Relative value starts with a `'+'` or a `'-`'.
 
 ## Methods
 

--- a/files/en-us/web/api/htmlbrelement/index.md
+++ b/files/en-us/web/api/htmlbrelement/index.md
@@ -19,7 +19,7 @@ The **`HTMLBRElement`** interface represents an HTML line break element ({{htmle
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLBRElement.clear")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} indicating the flow of text around floating objects.
+  - : Is a string indicating the flow of text around floating objects.
 
 ## Methods
 

--- a/files/en-us/web/api/htmlbuttonelement/index.md
+++ b/files/en-us/web/api/htmlbuttonelement/index.md
@@ -20,7 +20,7 @@ The **`HTMLButtonElement`** interface provides properties and methods (beyond th
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLButtonElement.accessKey")}}
-  - : Is a {{domxref("DOMString")}} indicating the single-character keyboard key to give access to the button.
+  - : Is a string indicating the single-character keyboard key to give access to the button.
 - {{domxref("HTMLButtonElement.autofocus")}}
   - : Is a boolean value indicating whether or not the control should have input focus when the page loads, unless the user overrides it, for example by typing in a different control. Only one form-associated element in a document can have this attribute specified.
 - {{domxref("HTMLButtonElement.disabled")}}
@@ -29,26 +29,26 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
   - : Is an {{domxref("HTMLFormElement")}} reflecting the form that this button is associated with. If the button is a descendant of a form element, then this attribute is a reference to that form's associated `HTMLFormElement`.
     If the button is not a descendant of a form element, then the attribute can be a reference to any `HTMLFormElement` element in the same document it is related to, or the `null` value if none matches.
 - {{domxref("HTMLButtonElement.formAction")}}
-  - : Is a {{domxref("DOMString")}} reflecting the URI of a resource that processes information submitted by the button. If specified, this attribute overrides the {{htmlattrxref("action", "form")}} attribute of the {{HTMLElement("form")}} element that owns this element.
+  - : Is a string reflecting the URI of a resource that processes information submitted by the button. If specified, this attribute overrides the {{htmlattrxref("action", "form")}} attribute of the {{HTMLElement("form")}} element that owns this element.
 - {{domxref("HTMLButtonElement.formEnctype")}}
-  - : Is a {{domxref("DOMString")}} reflecting the type of content that is used to submit the form to the server. If specified, this attribute overrides the {{htmlattrxref("enctype", "form")}} attribute of the {{HTMLElement("form")}} element that owns this element.
+  - : Is a string reflecting the type of content that is used to submit the form to the server. If specified, this attribute overrides the {{htmlattrxref("enctype", "form")}} attribute of the {{HTMLElement("form")}} element that owns this element.
 - {{domxref("HTMLButtonElement.formMethod")}}
-  - : Is a {{domxref("DOMString")}} reflecting the HTTP method that the browser uses to submit the form. If specified, this attribute overrides the {{htmlattrxref("method", "form")}} attribute of the {{HTMLElement("form")}} element that owns this element.
+  - : Is a string reflecting the HTTP method that the browser uses to submit the form. If specified, this attribute overrides the {{htmlattrxref("method", "form")}} attribute of the {{HTMLElement("form")}} element that owns this element.
 - {{domxref("HTMLButtonElement.formNoValidate")}}
   - : Is a boolean value indicating that the form is not to be validated when it is submitted. If specified, this attribute overrides the {{htmlattrxref("novalidate", "form")}} attribute of the {{HTMLElement("form")}} element that owns this element.
 - {{domxref("HTMLButtonElement.formTarget")}}
-  - : Is a {{domxref("DOMString")}} reflecting a name or keyword indicating where to display the response that is received after submitting the form. If specified, this attribute overrides the {{htmlattrxref("target", "form")}} attribute of the {{HTMLElement("form")}} element that owns this element.
+  - : Is a string reflecting a name or keyword indicating where to display the response that is received after submitting the form. If specified, this attribute overrides the {{htmlattrxref("target", "form")}} attribute of the {{HTMLElement("form")}} element that owns this element.
 - {{domxref("HTMLButtonElement.labels")}} {{readonlyInline}}
   - : Is a {{domxref("NodeList")}} that represents a list of {{HTMLElement("label")}} elements that are labels for this button.
 - {{domxref("HTMLButtonElement.menu")}} {{experimental_inline}}
   - : Is a {{domxref("HTMLMenuElement")}} representing the menu element to be displayed if the button is clicked and is of `type="menu"`.
 - {{domxref("HTMLButtonElement.name")}}
-  - : Is a {{domxref("DOMString")}} representing the name of the object when submitted with a form. If specified, it must not be the empty string.
+  - : Is a string representing the name of the object when submitted with a form. If specified, it must not be the empty string.
 - {{domxref("HTMLButtonElement.tabIndex")}}
   - : Is a `long` that represents this element's position in the tabbing order.
 - {{domxref("HTMLButtonElement.type")}}
 
-  - : Is a {{domxref("DOMString")}} indicating the behavior of the button. This is an enumerated attribute with the following possible values:
+  - : Is a string indicating the behavior of the button. This is an enumerated attribute with the following possible values:
 
     - `submit`: The button submits the form. This is the default value if the attribute is not specified, or if it is dynamically changed to an empty or invalid value.
     - `reset`: The button resets the form.
@@ -58,11 +58,11 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 - {{domxref("HTMLButtonElement.willValidate")}} {{readonlyInline}}
   - : Is a boolean value indicating whether the button is a candidate for constraint validation. It is `false` if any conditions bar it from constraint validation, including: its `type` property is `reset` or `button`; it has a {{HTMLElement("datalist")}} ancestor; or the `disabled` property is set to `true`.
 - {{domxref("HTMLButtonElement.validationMessage")}} {{readonlyInline}}
-  - : Is a {{domxref("DOMString")}} representing the localized message that describes the validation constraints that the control does not satisfy (if any). This attribute is the empty string if the control is not a candidate for constraint validation (`willValidate` is `false`), or it satisfies its constraints.
+  - : Is a string representing the localized message that describes the validation constraints that the control does not satisfy (if any). This attribute is the empty string if the control is not a candidate for constraint validation (`willValidate` is `false`), or it satisfies its constraints.
 - {{domxref("HTMLButtonElement.validity")}} {{readonlyInline}}
   - : Is a {{domxref("ValidityState")}} representing the validity states that this button is in.
 - {{domxref("HTMLButtonElement.value")}}
-  - : Is a {{domxref("DOMString")}} representing the current form control value of the button.
+  - : Is a string representing the current form control value of the button.
 
 ## Methods
 

--- a/files/en-us/web/api/htmlcontentelement/index.md
+++ b/files/en-us/web/api/htmlcontentelement/index.md
@@ -20,7 +20,7 @@ The **`HTMLContentElement`** interface represents a {{HTMLElement("content")}} H
 _This interface inherits the properties of {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLContentElement.select")}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{ htmlattrxref("select", "content") }} HTML attribute. The value is a comma-separated list of CSS selectors that select the content to insert in place of the `<content>` element.
+  - : Is a string that reflects the {{ htmlattrxref("select", "content") }} HTML attribute. The value is a comma-separated list of CSS selectors that select the content to insert in place of the `<content>` element.
 
 ## Methods
 

--- a/files/en-us/web/api/htmlcontentelement/select/index.md
+++ b/files/en-us/web/api/htmlcontentelement/select/index.md
@@ -13,7 +13,7 @@ browser-compat: api.HTMLContentElement.select
 {{ APIRef("Web Components") }}{{Deprecated_header}}
 
 The **`HTMLContentElement.select`** property reflects the
-`select` attribute. It is a {{domxref("DOMString")}} containing a
+`select` attribute. It is a string containing a
 space-separated list of CSS selectors that select the content to insert in place of the
 \<content> element.
 

--- a/files/en-us/web/api/htmldataelement/index.md
+++ b/files/en-us/web/api/htmldataelement/index.md
@@ -21,7 +21,7 @@ The **`HTMLDataElement`** interface provides special properties (beyond the regu
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLDataElement.value")}}
-  - : Is a {{domxref("DOMString")}} reflecting the {{htmlattrxref("value", "data")}} HTML attribute, containing a machine-readable form of the element's value.
+  - : Is a string reflecting the {{htmlattrxref("value", "data")}} HTML attribute, containing a machine-readable form of the element's value.
 
 ## Methods
 

--- a/files/en-us/web/api/htmldataelement/value/index.md
+++ b/files/en-us/web/api/htmldataelement/value/index.md
@@ -14,12 +14,12 @@ browser-compat: api.HTMLDataElement.value
 {{APIRef("HTML DOM")}}
 
 The **`value`** property of the {{domxref("HTMLDataElement")}}
-interface returns a {{domxref("DOMString")}} reflecting the {{htmlattrxref("value",
+interface returns a string reflecting the {{htmlattrxref("value",
   "data")}} HTML attribute.
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmldialogelement/index.md
+++ b/files/en-us/web/api/htmldialogelement/index.md
@@ -23,14 +23,14 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 - {{domxref("HTMLDialogElement.open")}}
   - : A boolean value reflecting the {{htmlattrxref("open", "dialog")}} HTML attribute, indicating whether the dialog is available for interaction.
 - {{domxref("HTMLDialogElement.returnValue")}}
-  - : A {{domxref("DOMString")}} that sets or returns the return value for the dialog.
+  - : A string that sets or returns the return value for the dialog.
 
 ## Methods
 
 _Inherits methods from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLDialogElement.close()")}}
-  - : Closes the dialog. An optional {{domxref("DOMString")}} may be passed as an argument, updating the `returnValue` of the dialog.
+  - : Closes the dialog. An optional string may be passed as an argument, updating the `returnValue` of the dialog.
 - {{domxref("HTMLDialogElement.show()")}}
   - : Displays the dialog modelessly, i.e. still allowing interaction with content outside of the dialog.
 - {{domxref("HTMLDialogElement.showModal()")}}

--- a/files/en-us/web/api/htmldialogelement/returnvalue/index.md
+++ b/files/en-us/web/api/htmldialogelement/returnvalue/index.md
@@ -22,7 +22,7 @@ close it.
 
 ## Value
 
-A {{domxref("DOMString")}} representing the `returnValue` of the dialog.
+A string representing the `returnValue` of the dialog.
 
 ## Examples
 

--- a/files/en-us/web/api/htmldivelement/index.md
+++ b/files/en-us/web/api/htmldivelement/index.md
@@ -20,7 +20,7 @@ The **`HTMLDivElement`** interface provides special properties (beyond the regul
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLDivElement.align")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} representing an enumerated property indicating alignment of the element's contents with respect to the surrounding context. The possible values are `"left"`, `"right"`, `"justify"`, and `"center"`.
+  - : Is a string representing an enumerated property indicating alignment of the element's contents with respect to the surrounding context. The possible values are `"left"`, `"right"`, `"justify"`, and `"center"`.
 
 ## Methods
 

--- a/files/en-us/web/api/htmlelement/innertext/index.md
+++ b/files/en-us/web/api/htmlelement/innertext/index.md
@@ -21,7 +21,7 @@ As a setter this will replace the element's children with the given value, conve
 
 ## Value
 
-A {{domxref("DOMString")}} representing the rendered text content of an element.
+A string representing the rendered text content of an element.
 
 If the element itself is not [being rendered](https://html.spec.whatwg.org/multipage/rendering.html#being-rendered) (for example, is detached from the document or is hidden from view), the returned value is the same as the {{domxref("Node.textContent")}} property.
 

--- a/files/en-us/web/api/htmlelement/outertext/index.md
+++ b/files/en-us/web/api/htmlelement/outertext/index.md
@@ -18,7 +18,7 @@ See {{domxref("HTMLElement.innerText")}} for more information and examples showi
 
 ## Value
 
-A {{domxref("DOMString")}} representing the rendered text content of an element and its descendants.
+A string representing the rendered text content of an element and its descendants.
 
 If the element itself is not [being rendered](https://html.spec.whatwg.org/multipage/rendering.html#being-rendered) (for example, is detached from the document or is hidden from view), the returned value is the same as the {{domxref("Node.textContent")}} property.
 

--- a/files/en-us/web/api/htmlembedelement/index.md
+++ b/files/en-us/web/api/htmlembedelement/index.md
@@ -22,17 +22,17 @@ The **`HTMLEmbedElement`** interface provides special properties (beyond the reg
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLEmbedElement.align")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} representing an enumerated property indicating alignment of the element's contents with respect to the surrounding context. The possible values are `"left"`, `"right"`, `"center"`, and `"justify"`.
+  - : Is a string representing an enumerated property indicating alignment of the element's contents with respect to the surrounding context. The possible values are `"left"`, `"right"`, `"center"`, and `"justify"`.
 - {{domxref("HTMLEmbedElement.height")}}
-  - : Is a {{domxref("DOMString")}} reflecting the {{htmlattrxref("height", "embed")}} HTML attribute, containing the displayed height of the resource.
+  - : Is a string reflecting the {{htmlattrxref("height", "embed")}} HTML attribute, containing the displayed height of the resource.
 - {{domxref("HTMLEmbedElement.name")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} representing the name of the embedded object.
+  - : Is a string representing the name of the embedded object.
 - {{domxref("HTMLEmbedElement.src")}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("src", "embed")}} HTML attribute, containing the address of the resource.
+  - : Is a string that reflects the {{htmlattrxref("src", "embed")}} HTML attribute, containing the address of the resource.
 - {{domxref("HTMLEmbedElement.type")}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("type", "embed")}} HTML attribute, containing the type of the resource.
+  - : Is a string that reflects the {{htmlattrxref("type", "embed")}} HTML attribute, containing the type of the resource.
 - {{domxref("HTMLEmbedElement.width")}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("width", "embed")}} HTML attribute, containing the displayed width of the resource.
+  - : Is a string that reflects the {{htmlattrxref("width", "embed")}} HTML attribute, containing the displayed width of the resource.
 
 ## Methods
 

--- a/files/en-us/web/api/htmlfieldsetelement/index.md
+++ b/files/en-us/web/api/htmlfieldsetelement/index.md
@@ -26,11 +26,11 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
   - : An {{domxref("HTMLFormControlsCollection")}} or {{domxref("HTMLCollection")}} referencing the containing form element, if this element is in a form.
     If the field set is not a descendant of a form element, then the attribute can be the ID of any form element in the same document it is related to, or the `null` value if none matches.
 - {{domxref("HTMLFieldSetElement.name")}}
-  - : A {{domxref("DOMString")}} reflecting the {{htmlattrxref("name", "fieldset")}} HTML attribute, containing the name of the field set. This can be used when accessing the field set in JavaScript. It is _not_ part of the data which is sent to the server.
+  - : A string reflecting the {{htmlattrxref("name", "fieldset")}} HTML attribute, containing the name of the field set. This can be used when accessing the field set in JavaScript. It is _not_ part of the data which is sent to the server.
 - {{domxref("HTMLFieldSetElement.type")}}{{ReadOnlyInline}}
-  - : The {{domxref("DOMString")}} "`fieldset`".
+  - : The string "`fieldset`".
 - {{domxref("HTMLFieldSetElement.validationMessage")}}
-  - : A {{domxref("DOMString")}} representing a localized message that describes the validation constraints that the element does not satisfy (if any). This is the empty string if the element is not a candidate for constraint validation (`willValidate` is `false`), or it satisfies its constraints.
+  - : A string representing a localized message that describes the validation constraints that the element does not satisfy (if any). This is the empty string if the element is not a candidate for constraint validation (`willValidate` is `false`), or it satisfies its constraints.
 - {{domxref("HTMLFieldSetElement.validity")}}
   - : A {{domxref("ValidityState")}} representing the validity states that this element is in.
 - {{domxref("HTMLFieldSetElement.willValidate")}}

--- a/files/en-us/web/api/htmlfontelement/color/index.md
+++ b/files/en-us/web/api/htmlfontelement/color/index.md
@@ -14,7 +14,7 @@ browser-compat: api.HTMLFontElement.color
 
 The obsolete
 **`HTMLFontElement.color`**
-property is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("color",
+property is a string that reflects the {{htmlattrxref("color",
     "font")}} HTML attribute, containing either a named color or a color specified in the
 hexadecimal #RRGGBB format.
 

--- a/files/en-us/web/api/htmlfontelement/face/index.md
+++ b/files/en-us/web/api/htmlfontelement/face/index.md
@@ -14,7 +14,7 @@ browser-compat: api.HTMLFontElement.face
 
 The obsolete
 **`HTMLFontElement.face`**
-property is a {{domxref("DOMString")}} that reflects the {{ htmlattrxref("face",
+property is a string that reflects the {{ htmlattrxref("face",
     "font") }} HTML attribute, containing a comma-separated list of one or more font
 names.
 

--- a/files/en-us/web/api/htmlfontelement/index.md
+++ b/files/en-us/web/api/htmlfontelement/index.md
@@ -20,11 +20,11 @@ Implements the document object model (DOM) representation of the font element. T
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLFontElement.color")}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("color", "font")}} HTML attribute, containing either a named color or a color specified in the hexadecimal #RRGGBB format.
+  - : Is a string that reflects the {{htmlattrxref("color", "font")}} HTML attribute, containing either a named color or a color specified in the hexadecimal #RRGGBB format.
 - {{domxref("HTMLFontElement.face")}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("face", "font")}} HTML attribute, containing a comma-separated list of one or more font names.
+  - : Is a string that reflects the {{htmlattrxref("face", "font")}} HTML attribute, containing a comma-separated list of one or more font names.
 - {{domxref("HTMLFontElement.size")}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("size", "font")}} HTML attribute, containing either a font size number ranging from 1 to 7 or a relative size to the {{htmlattrxref("size", "basefont")}} attribute of the {{HTMLElement("basefont")}} element, for example -2 or +1.
+  - : Is a string that reflects the {{htmlattrxref("size", "font")}} HTML attribute, containing either a font size number ranging from 1 to 7 or a relative size to the {{htmlattrxref("size", "basefont")}} attribute of the {{HTMLElement("basefont")}} element, for example -2 or +1.
 
 ## Methods
 

--- a/files/en-us/web/api/htmlfontelement/size/index.md
+++ b/files/en-us/web/api/htmlfontelement/size/index.md
@@ -14,7 +14,7 @@ browser-compat: api.HTMLFontElement.size
 
 The obsolete
 **`HTMLFontElement.size`** property is a
-{{domxref("DOMString")}} that reflects the {{ htmlattrxref("size", "font") }} HTML
+string that reflects the {{ htmlattrxref("size", "font") }} HTML
 attribute. It contains either an integer number in the range of 1-7 or a relative
 value to increase/decrease the value of the {{htmlattrxref("size", "basefont")}}
 attribute of the {{HTMLElement("basefont")}} element.

--- a/files/en-us/web/api/htmlformelement/index.md
+++ b/files/en-us/web/api/htmlformelement/index.md
@@ -27,19 +27,19 @@ _This interface also inherits properties from its parent, {{domxref("HTMLElement
 - {{domxref("HTMLFormElement.length")}}{{ReadOnlyInline}}
   - : A `long` reflecting the number of controls in the form.
 - {{domxref("HTMLFormElement.name")}}
-  - : A {{domxref("DOMString")}} reflecting the value of the form's {{ htmlattrxref("name", "form") }} HTML attribute, containing the name of the form.
+  - : A string reflecting the value of the form's {{ htmlattrxref("name", "form") }} HTML attribute, containing the name of the form.
 - {{domxref("HTMLFormElement.method")}}
-  - : A {{domxref("DOMString")}} reflecting the value of the form's {{ htmlattrxref("method", "form") }} HTML attribute, indicating the HTTP method used to submit the form. Only specified values can be set.
+  - : A string reflecting the value of the form's {{ htmlattrxref("method", "form") }} HTML attribute, indicating the HTTP method used to submit the form. Only specified values can be set.
 - {{domxref("HTMLFormElement.target")}}
-  - : A {{domxref("DOMString")}} reflecting the value of the form's {{ htmlattrxref("target", "form") }} HTML attribute, indicating where to display the results received from submitting the form.
+  - : A string reflecting the value of the form's {{ htmlattrxref("target", "form") }} HTML attribute, indicating where to display the results received from submitting the form.
 - {{domxref("HTMLFormElement.action")}}
-  - : A {{domxref("DOMString")}} reflecting the value of the form's {{ htmlattrxref("action", "form") }} HTML attribute, containing the URI of a program that processes the information submitted by the form.
+  - : A string reflecting the value of the form's {{ htmlattrxref("action", "form") }} HTML attribute, containing the URI of a program that processes the information submitted by the form.
 - {{domxref("HTMLFormElement.encoding")}} or {{domxref("HTMLFormElement.enctype")}}
-  - : A {{domxref("DOMString")}} reflecting the value of the form's {{ htmlattrxref("enctype", "form") }} HTML attribute, indicating the type of content that is used to transmit the form to the server. Only specified values can be set. The two properties are synonyms.
+  - : A string reflecting the value of the form's {{ htmlattrxref("enctype", "form") }} HTML attribute, indicating the type of content that is used to transmit the form to the server. Only specified values can be set. The two properties are synonyms.
 - {{domxref("HTMLFormElement.acceptCharset")}}
-  - : A {{domxref("DOMString")}} reflecting the value of the form's {{ htmlattrxref("accept-charset", "form") }} HTML attribute, representing the character encoding that the server accepts.
+  - : A string reflecting the value of the form's {{ htmlattrxref("accept-charset", "form") }} HTML attribute, representing the character encoding that the server accepts.
 - {{domxref("HTMLFormElement.autocomplete")}}
-  - : A {{domxref("DOMString")}} reflecting the value of the form's {{ htmlattrxref("autocomplete", "form") }} HTML attribute, indicating whether the controls in this form can have their values automatically populated by the browser.
+  - : A string reflecting the value of the form's {{ htmlattrxref("autocomplete", "form") }} HTML attribute, indicating whether the controls in this form can have their values automatically populated by the browser.
 - {{domxref("HTMLFormElement.noValidate")}}
   - : A boolean value reflecting the value of the form's {{ htmlattrxref("novalidate", "form") }} HTML attribute, indicating whether the form should not be validated.
 

--- a/files/en-us/web/api/htmlframesetelement/index.md
+++ b/files/en-us/web/api/htmlframesetelement/index.md
@@ -21,9 +21,9 @@ The **`HTMLFrameSetElement`** interface provides special properties (beyond thos
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLFrameSetElement.cols")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} structured as a comma-separated list specifying the width of each column inside a frameset.
+  - : Is a string structured as a comma-separated list specifying the width of each column inside a frameset.
 - {{domxref("HTMLFrameSetElement.rows")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} structured as a comma-separated list specifying the height of each column inside a frameset.
+  - : Is a string structured as a comma-separated list specifying the height of each column inside a frameset.
 
 ## Methods
 

--- a/files/en-us/web/api/htmlheadelement/index.md
+++ b/files/en-us/web/api/htmlheadelement/index.md
@@ -19,7 +19,7 @@ The **`HTMLHeadElement`** interface contains the descriptive information, or met
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLHeadElement.profile")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} representing the URIs of one or more metadata profiles (white space separated).
+  - : Is a string representing the URIs of one or more metadata profiles (white space separated).
 
 ## Methods
 

--- a/files/en-us/web/api/htmlheadingelement/index.md
+++ b/files/en-us/web/api/htmlheadingelement/index.md
@@ -20,7 +20,7 @@ The **`HTMLHeadingElement`** interface represents the different heading elements
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLHeadingElement.align")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} representing an enumerated attribute indicating alignment of the heading with respect to the surrounding context. The possible values are `"left"`, `"right"`, `"justify"`, and `"center"`.
+  - : Is a string representing an enumerated attribute indicating alignment of the heading with respect to the surrounding context. The possible values are `"left"`, `"right"`, `"justify"`, and `"center"`.
 
 ## Methods
 

--- a/files/en-us/web/api/htmlhrelement/index.md
+++ b/files/en-us/web/api/htmlhrelement/index.md
@@ -20,15 +20,15 @@ The **`HTMLHRElement`** interface provides special properties (beyond those of t
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLHRElement.align")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}}, an enumerated attribute indicating alignment of the rule with respect to the surrounding context.
+  - : Is a string, an enumerated attribute indicating alignment of the rule with respect to the surrounding context.
 - {{domxref("HTMLHRElement.color")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} representing the name of the color of the rule.
+  - : Is a string representing the name of the color of the rule.
 - {{domxref("HTMLHRElement.noshade")}} {{deprecated_inline}}
   - : Is a boolean value that sets the rule to have no shading.
 - {{domxref("HTMLHRElement.size")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} representing the height of the rule.
+  - : Is a string representing the height of the rule.
 - {{domxref("HTMLHRElement.width")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} representing the width of the rule on the page.
+  - : Is a string representing the width of the rule on the page.
 
 ## Methods
 

--- a/files/en-us/web/api/htmlhtmlelement/index.md
+++ b/files/en-us/web/api/htmlhtmlelement/index.md
@@ -22,7 +22,7 @@ You can retrieve the `HTMLHtmlElement` object for a given document by reading th
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLHtmlElement.version")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} representing the version of the HTML Document Type Definition (DTD) that governs this document. This property should not be used any more as it is non-conforming. Omit it.
+  - : Is a string representing the version of the HTML Document Type Definition (DTD) that governs this document. This property should not be used any more as it is non-conforming. Omit it.
 
 ## Methods
 

--- a/files/en-us/web/api/htmliframeelement/fetchpriority/index.md
+++ b/files/en-us/web/api/htmliframeelement/fetchpriority/index.md
@@ -19,7 +19,7 @@ to other iframe documents.
 
 ## Value
 
-A {{domxref("DOMString")}} representing the priority hint. Possible values are:
+A string representing the priority hint. Possible values are:
 
 - **`high`**: Fetch the iframe document at a high priority relative to other
   iframe documents.

--- a/files/en-us/web/api/htmlimageelement/align/index.md
+++ b/files/en-us/web/api/htmlimageelement/align/index.md
@@ -32,7 +32,7 @@ content attribute.
 
 ## Value
 
-A {{domxref("DOMString")}} specifying one of the following strings which set the
+A string specifying one of the following strings which set the
 alignment mode for the image.
 
 #### Baseline alignment

--- a/files/en-us/web/api/htmlimageelement/alt/index.md
+++ b/files/en-us/web/api/htmlimageelement/alt/index.md
@@ -40,7 +40,7 @@ to take the place of the image _without altering the meaning of the page_.
 
 ## Value
 
-A {{domxref("DOMString")}} which contains the alternate text to display when the image
+A string which contains the alternate text to display when the image
 is not loaded or for use by assistive devices.
 
 The `alt` attribute is officially mandatory; it's meant to always be

--- a/files/en-us/web/api/htmlimageelement/border/index.md
+++ b/files/en-us/web/api/htmlimageelement/border/index.md
@@ -37,7 +37,7 @@ For compatibility (or perhaps other) reasons, you can use the older properties i
 
 ## Value
 
-A {{domxref("DOMString")}} containing an integer value specifying the thickness of the
+A string containing an integer value specifying the thickness of the
 border that should surround the image, in CSS pixels. A value of `0`, or an
 empty string, indicates that there should be no border drawn. The default value of
 `border` is `0`

--- a/files/en-us/web/api/htmlimageelement/crossorigin/index.md
+++ b/files/en-us/web/api/htmlimageelement/crossorigin/index.md
@@ -24,7 +24,7 @@ retrieving the image.
 
 ## Value
 
-A {{domxref("DOMString")}} of a keyword specifying the CORS mode to use when fetching
+A string of a keyword specifying the CORS mode to use when fetching
 the image resource. If you don't specify `crossOrigin`, the image is fetched
 without CORS (the fetch `no-cors` mode).
 

--- a/files/en-us/web/api/htmlimageelement/currentsrc/index.md
+++ b/files/en-us/web/api/htmlimageelement/currentsrc/index.md
@@ -20,7 +20,7 @@ currently presented in the {{HTMLElement("img")}} element it represents.
 
 ## Value
 
-A {{domxref("USVString")}} indicating the full URL of the image currently visible in
+A string indicating the full URL of the image currently visible in
 the {{HTMLElement("img")}} element represented by the `HTMLImageElement`.
 This is useful when you provide multiple image options using the
 {{domxref("HTMLImageElement.sizes", "sizes")}} and/or

--- a/files/en-us/web/api/htmlimageelement/decoding/index.md
+++ b/files/en-us/web/api/htmlimageelement/decoding/index.md
@@ -18,7 +18,7 @@ it should decode the image.
 
 ## Value
 
-A {{domxref("DOMString")}} representing the decoding hint. Possible values are:
+A string representing the decoding hint. Possible values are:
 
 - **`sync`**: Decode the image synchronously for atomic
   presentation with other content.

--- a/files/en-us/web/api/htmlimageelement/fetchpriority/index.md
+++ b/files/en-us/web/api/htmlimageelement/fetchpriority/index.md
@@ -18,7 +18,7 @@ it should prioritize the fetch of the image relative to other images.
 
 ## Value
 
-A {{domxref("DOMString")}} representing the priority hint. Possible values are:
+A string representing the priority hint. Possible values are:
 
 - **`high`**: Fetch the image at a high priority relative to other images.
 - **`low`**: Fetch the image at a low priority relative to other images.

--- a/files/en-us/web/api/htmlimageelement/loading/index.md
+++ b/files/en-us/web/api/htmlimageelement/loading/index.md
@@ -34,7 +34,7 @@ it's expected to be needed, rather than immediately during the initial page load
 
 ## Value
 
-A {{domxref("DOMString")}} providing a hint to the user agent as to how to best
+A string providing a hint to the user agent as to how to best
 schedule the loading of the image to optimize page performance. The possible values are:
 
 - `eager`

--- a/files/en-us/web/api/htmlimageelement/longdesc/index.md
+++ b/files/en-us/web/api/htmlimageelement/longdesc/index.md
@@ -25,7 +25,7 @@ provide optional added details beyond the short description provided in the
 
 ## Value
 
-A {{domxref("DOMString")}} which may be either an empty string (indicating that no long
+A string which may be either an empty string (indicating that no long
 description is available) or the URL of a file containing a long form description of the
 image's contents.
 

--- a/files/en-us/web/api/htmlimageelement/name/index.md
+++ b/files/en-us/web/api/htmlimageelement/name/index.md
@@ -23,7 +23,7 @@ property available on all elements.
 
 ## Value
 
-A {{domxref("DOMString")}} providing a name by which the image can be referenced.
+A string providing a name by which the image can be referenced.
 
 > **Warning:** This property is deprecated and is only in the
 > specification still for backward compatibility purposes. Since it functions

--- a/files/en-us/web/api/htmlimageelement/referrerpolicy/index.md
+++ b/files/en-us/web/api/htmlimageelement/referrerpolicy/index.md
@@ -19,7 +19,7 @@ resource.
 
 ## Value
 
-A {{domxref("DOMString")}}; one of the following:
+A string; one of the following:
 
 - no-referrer
   - : The {{HTTPHeader("Referer")}} header will be omitted entirely. No referrer

--- a/files/en-us/web/api/htmlimageelement/sizes/index.md
+++ b/files/en-us/web/api/htmlimageelement/sizes/index.md
@@ -29,7 +29,7 @@ by [media queries](/en-US/docs/Web/CSS/Media_Queries).
 
 ## Value
 
-A {{domxref("USVString")}} containing a comma-separated list of source size descriptors
+A string containing a comma-separated list of source size descriptors
 followed by an optional fallback size. Each **source size descriptor** is
 comprised of a media condition, then at least one whitespace character, then the
 **source size value** to use for the image when the media condition

--- a/files/en-us/web/api/htmlimageelement/src/index.md
+++ b/files/en-us/web/api/htmlimageelement/src/index.md
@@ -33,7 +33,7 @@ let src = htmlImageElement.src;
 
 When providing only a single image, rather than a set of images from which the browser
 selects the best match for the viewport size and display pixel density, the
-`src` attribute is a {{domxref("USVString")}} specifying the URL of the
+`src` attribute is a string specifying the URL of the
 desired image. This can be set either within the HTML itself using the
 {{htmlattrxref("src", "img")}} content attribute, or programmatically by setting the
 element's `src` property.

--- a/files/en-us/web/api/htmlimageelement/srcset/index.md
+++ b/files/en-us/web/api/htmlimageelement/srcset/index.md
@@ -35,7 +35,7 @@ situation.
 
 ## Value
 
-A {{domxref("USVString")}} containing a comma-separated list of one or more image
+A string containing a comma-separated list of one or more image
 candidate strings to be used when determining which image resource to present inside the
 {{HTMLElement("img")}} element represented by the
 `HTMLImageElement`.

--- a/files/en-us/web/api/htmlimageelement/usemap/index.md
+++ b/files/en-us/web/api/htmlimageelement/usemap/index.md
@@ -25,7 +25,7 @@ providing the name of the client-side image map to apply to the image.
 
 ## Value
 
-A {{domxref("USVString")}} providing the page-local URL (that is, a URL that begins
+A string providing the page-local URL (that is, a URL that begins
 with the hash or pound symbol, "`#`") of the {{HTMLElement("map")}} element
 which defines the image map to apply to the image.
 

--- a/files/en-us/web/api/htmllabelelement/htmlfor/index.md
+++ b/files/en-us/web/api/htmllabelelement/htmlfor/index.md
@@ -26,7 +26,7 @@ HTMLLabelElement.htmlFor = newId
 
 ### Value
 
-A {{domxref("DOMString")}} which contains the ID string of the element which is
+A string which contains the ID string of the element which is
 associated with the control.
 
 > **Note:** If this property has a value, the {{domxref("HTMLLabelElement.control")}} property

--- a/files/en-us/web/api/htmllegendelement/index.md
+++ b/files/en-us/web/api/htmllegendelement/index.md
@@ -22,9 +22,9 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 - {{domxref("HTMLLegendElement.form")}} {{readonlyInline}}
   - : Is a {{domxref("HTMLFormElement")}} representing the form that this legend belongs to. If the legend has a fieldset element as its parent, then this attribute returns the same value as the **form** attribute on the parent fieldset element. Otherwise, it returns null.
 - {{domxref("HTMLLegendElement.accessKey")}}
-  - : Is a {{domxref("DOMString")}} representing a single-character access key to give access to the element.
+  - : Is a string representing a single-character access key to give access to the element.
 - {{domxref("HTMLLegendElement.align")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} representing the alignment relative to the form set
+  - : Is a string representing the alignment relative to the form set
 
 ## Methods
 

--- a/files/en-us/web/api/htmllielement/index.md
+++ b/files/en-us/web/api/htmllielement/index.md
@@ -20,7 +20,7 @@ The **`HTMLLIElement`** interface exposes specific properties and methods (beyon
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLLIElement.type")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} representing the type of the bullets, `"disc"`, `"square"` or `"circle"`. As the standard way of defining the list type is via the CSS {{cssxref("list-style-type")}} property, use the CSSOM methods to set it via a script.
+  - : Is a string representing the type of the bullets, `"disc"`, `"square"` or `"circle"`. As the standard way of defining the list type is via the CSS {{cssxref("list-style-type")}} property, use the CSSOM methods to set it via a script.
 - {{domxref("HTMLLIElement.value")}}
   - : Is a `long` indicating the ordinal position of the _list element_ inside a given {{HTMLElement("ol")}}. It reflects the {{htmlattrxref("value", "li")}} attribute of the HTML {{HTMLElement("li")}} element, and can be smaller than `0`. If the {{HTMLElement("li")}} element is not a child of an {{HTMLElement("ol")}} element, the property has no meaning.
 

--- a/files/en-us/web/api/htmllinkelement/as/index.md
+++ b/files/en-us/web/api/htmllinkelement/as/index.md
@@ -15,14 +15,14 @@ browser-compat: api.HTMLLinkElement.as
 {{SeeCompatTable}}{{APIRef("HTML DOM")}}
 
 The **`as`** property of the {{domxref("HTMLLinkElement")}}
-interface returns a {{domxref("DOMString")}} representing the type of content being
+interface returns a string representing the type of content being
 loaded by the HTML link, one of `"script"`, `"style"`,
 `"image"`, `"video"`, `"audio"`, `"track"`,
 `"font"`, `"fetch"`.
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmllinkelement/fetchpriority/index.md
+++ b/files/en-us/web/api/htmllinkelement/fetchpriority/index.md
@@ -21,7 +21,7 @@ resources of the same type.
 
 ## Value
 
-A {{domxref("DOMString")}} representing the priority hint. Possible values are:
+A string representing the priority hint. Possible values are:
 
 - **`high`**: Fetch the preload at a high priority relative to other resources
   of the same type.

--- a/files/en-us/web/api/htmllinkelement/referrerpolicy/index.md
+++ b/files/en-us/web/api/htmllinkelement/referrerpolicy/index.md
@@ -21,7 +21,7 @@ See the HTTP {{HTTPHeader("Referrer-Policy")}} header for details.
 
 ## Value
 
-A {{domxref("DOMString")}}; one of the following:
+A string; one of the following:
 
 - no-referrer
   - : The {{HTTPHeader("Referer")}} header will be omitted entirely. No referrer

--- a/files/en-us/web/api/htmllinkelement/rel/index.md
+++ b/files/en-us/web/api/htmllinkelement/rel/index.md
@@ -12,7 +12,7 @@ browser-compat: api.HTMLLinkElement.rel
 {{ APIRef("HTML DOM") }}
 
 The **`HTMLLinkElement.rel`** property reflects the
-{{htmlattrxref("rel", "link")}} attribute. It is a {{domxref("DOMString")}} containing a
+{{htmlattrxref("rel", "link")}} attribute. It is a string containing a
 space-separated list of [link types](/en-US/docs/Web/HTML/Link_types)
 indicating the relationship between the resource represented by the
 {{HTMLElement("link")}} element and the current document.

--- a/files/en-us/web/api/htmllinkelement/rellist/index.md
+++ b/files/en-us/web/api/htmllinkelement/rellist/index.md
@@ -53,5 +53,5 @@ for (var i = 0; i < length; i++) {
 
 - The equivalent property on {{HTMLElement("a")}} and {{HTMLElement("area")}},
   {{domxref("HTMLAnchorElement.relList")}} and {{domxref("HTMLAreaElement.relList")}}.
-- The very same list but as a space-separated tokens in a {{domxref("DOMString")}}:
+- The very same list but as a space-separated tokens in a string:
   {{domxref("HTMLLinkElement.rel")}}

--- a/files/en-us/web/api/htmlmapelement/index.md
+++ b/files/en-us/web/api/htmlmapelement/index.md
@@ -19,7 +19,7 @@ The **`HTMLMapElement`** interface provides special properties and methods (beyo
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLMapElement.name")}}
-  - : Is a {{domxref("DOMString")}} representing the {{HTMLElement("map")}} element for referencing it other context. If the `id` attribute is set, this must have the same value; and it cannot be `null` or empty.
+  - : Is a string representing the {{HTMLElement("map")}} element for referencing it other context. If the `id` attribute is set, this must have the same value; and it cannot be `null` or empty.
 - {{domxref("HTMLMapElement.areas")}} {{readonlyInline}}
   - : Is a live {{domxref("HTMLCollection")}} representing the {{HTMLElement("area")}} elements associated to this {{HTMLElement("map")}}.
 

--- a/files/en-us/web/api/htmlmediaelement/currentsrc/index.md
+++ b/files/en-us/web/api/htmlmediaelement/currentsrc/index.md
@@ -19,7 +19,7 @@ is an empty string if the `networkState` property is `EMPTY`.
 
 ## Value
 
-A {{domxref("DOMString")}} object containing the absolute URL of the chosen media
+A string object containing the absolute URL of the chosen media
 source; this may be an empty string if `networkState` is `EMPTY`;
 otherwise, it will be one of the resources listed by the
 {{domxref("HTMLSourceElement")}} contained within the media element, or the value or src


### PR DESCRIPTION
Continuing #15499 

### Summary
`DOMString` is not exposed by browsers to JavaScript. It is converted to `string`.[[ref](https://developer.mozilla.org/en-US/docs/Web/API/DOMString)]

Same is the case with `USVString` and `CSSOMString`.

### Metadata
- [x] Fixes a typo, bug, or other error
