### PR TITLE
Change sidebar of Window.requestFileSystem

### DIFF
--- a/files/en-us/web/api/window/requestfilesystem/index.md
+++ b/files/en-us/web/api/window/requestfilesystem/index.md
@@ -67,5 +67,4 @@ As this method was removed from the [File and Directory Entries API](https://wic
 
 ## See also
 
-- [File
-  and Directory Entries API support in Firefox](/en-US/docs/Web/API/File_and_Directory_Entries_API/Firefox_support)
+- [File and Directory Entries API support in Firefox](/en-US/docs/Web/API/File_and_Directory_Entries_API/Firefox_support)


### PR DESCRIPTION
As mentioned on this very same page, this is a (non-standard) method of File and Directory Entries API and not of File System API.

This fixes it (as well as a drive by fix).

There would be much more to fix on this page, but I'm not going down this rabbit hole now.