### PR TITLE
domxref -> jsxref

### DIFF
--- a/files/en-us/mozilla/firefox/releases/11/index.md
+++ b/files/en-us/mozilla/firefox/releases/11/index.md
@@ -121,7 +121,7 @@ The following interfaces were implementation details that are no longer needed:
 
 ### Preference changes
 
-- {{Pref("ui.tooltipDelay")}}
+- `ui.tooltipDelay`
   - : Specifies the delay, in milliseconds, between the mouse cursor beginning to hover and the display of a tooltip.
 
 ### Build system changes

--- a/files/en-us/mozilla/firefox/releases/21/index.md
+++ b/files/en-us/mozilla/firefox/releases/21/index.md
@@ -30,7 +30,7 @@ Firefox 21 was released on May 14, 2013. This article lists key changes that are
 
 ### DOM
 
-- Support for {{domxref("RTCPeerConnection")}} (as `MozRTCPeerConnection`) is now enabled by default ({{bug(796463)}}). It can be disabled again if necessary by setting {{pref("media.peerconnection.enabled")}} to false.
+- Support for {{domxref("RTCPeerConnection")}} (as `MozRTCPeerConnection`) is now enabled by default ({{bug(796463)}}). It can be disabled again if necessary by setting `media.peerconnection.enabled` to false.
 - The `origin` property has been added to the {{domxref("window.location")}} ({{bug("828261")}}).
 - The `valueAsDate` and `valueAsNumber` methods have been added for `<input type="time">` ({{bug("781570")}}).
 - The `min` and `max` attributes now apply to `<input type="time">` too ({{bug("781572")}}).

--- a/files/en-us/mozilla/firefox/releases/38/index.md
+++ b/files/en-us/mozilla/firefox/releases/38/index.md
@@ -31,7 +31,7 @@ Highlights:
 - The {{cssxref(":unresolved")}} pseudo-class has been implemented for custom elements ({{bug(1111633)}}).
 - The predefined style {{cssxref("list-style-type", "ethiopic-numeric")}} now uses a space, instead of a dot, as the suffix to match a recent change to the spec ({{bug(1120721)}}).
 - CSS transitions on generated content (with {{cssxref("::before")}} and {{cssxref("::after")}}) on both an inline and the block that splits them now start as expected by the specification ({{bug(1110277)}}).
-- The implementation of CSS Logical Properties made big progress. The following properties are available behind the {{pref("layout.css.vertical-text.enabled")}} flag (`false` by default):
+- The implementation of CSS Logical Properties made big progress. The following properties are available behind the `layout.css.vertical-text.enabled` flag (`false` by default):
 
   - Direction-independent equivalents of {{cssxref("width")}} and {{cssxref("height")}}: {{cssxref("block-size")}} and {{cssxref("inline-size")}} ({{bug(1117983)}}).
   - Direction-independent equivalents of {{cssxref("min-width")}} and {{cssxref("min-height")}}: {{cssxref("min-block-size")}} and {{cssxref("min-inline-size")}} ({{bug(1117983)}}).
@@ -110,7 +110,7 @@ _No change._
 
 - In Firefox, the {{htmlattrxref("autocomplete", "input")}}`=false` attribute is now ignored when dealing with a login form ({{bug(1025703)}}). This is intended to encourage the use of more secure passwords by allowing password manager tools to work more reliably.
 - RC4 is now disabled when using TLS, except for a few specifically whitelisted Web sites. This whitelist is an interim measure until those sites are fixed ({{bug(1124039)}}). This fallback is controlled by the `security.tls.unrestricted_rc4_fallback` preference, `true` by default for the moment ({{bug(1138882)}}).
-- Web sites needing to fall back to an insecure version of TLS in order to work are now in a hardcoded whitelist which will shrink over time ({{bug(1114816)}}). The whitelist can be disabled by setting {{pref("security.tls.insecure_fallback_hosts.use_static_list")}}  to `false`.
+- Web sites needing to fall back to an insecure version of TLS in order to work are now in a hardcoded whitelist which will shrink over time ({{bug(1114816)}}). The whitelist can be disabled by setting `security.tls.insecure_fallback_hosts.use_static_list` to `false`.
 
 ## Changes for add-on and Mozilla developers
 

--- a/files/en-us/mozilla/firefox/releases/45/index.md
+++ b/files/en-us/mozilla/firefox/releases/45/index.md
@@ -112,7 +112,7 @@ _No change._
 
 ## HTTP
 
-- The `jar:` protocol has been disabled by default when accessed from Web content; you may enable this if necessary by setting the {{pref("network.jar.block-remote-files")}} preference to `false` ({{bug(1215235)}}).
+- The `jar:` protocol has been disabled by default when accessed from Web content; you may enable this if necessary by setting the `network.jar.block-remote-files` preference to `false` ({{bug(1215235)}}).
 
 ## Security
 

--- a/files/en-us/web/api/abortsignal/throwifaborted/index.md
+++ b/files/en-us/web/api/abortsignal/throwifaborted/index.md
@@ -64,7 +64,7 @@ If the signal is aborted, this will cause the `waitForCondition()` promise to be
 
 An API that needs to support aborting can accept an `AbortSignal` object, and use its state to trigger abort signal handling when needed.
 
-A {{domxref("Promise")}}-based API should respond to the abort signal by rejecting any unsettled promise with the `AbortSignal` abort {{domxref("AbortSignal.reason", "reason")}}.
+A {{jsxref("Promise")}}-based API should respond to the abort signal by rejecting any unsettled promise with the `AbortSignal` abort {{domxref("AbortSignal.reason", "reason")}}.
 For example, consider the following `myCoolPromiseAPI`, which takes a signal and returns a promise.
 The promise is rejected immediately if the signal is already aborted, or if the abort event is detected.
 Otherwise it completes normally and then resolves the promise.

--- a/files/en-us/web/api/element/dommousescroll_event/index.md
+++ b/files/en-us/web/api/element/dommousescroll_event/index.md
@@ -62,7 +62,7 @@ If the event represents scrolling up by a page, the value of `detail` is -32768.
 
 Trusted events are never fired with 0.
 
-> **Note:** If the platform's native mouse wheel events only provide scroll distance by pixels, or if the speed can be customized by the user, the value is computed using the line height of the nearest scrollable ancestor element of the event's target. If that element's font size is smaller than {{pref("mousewheel.min_line_scroll_amount")}}, that preference's value is used as the line height.
+> **Note:** If the platform's native mouse wheel events only provide scroll distance by pixels, or if the speed can be customized by the user, the value is computed using the line height of the nearest scrollable ancestor element of the event's target. If that element's font size is smaller than `mousewheel.min_line_scroll_amount`, that preference's value is used as the line height.
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/webvtt_api/index.md
+++ b/files/en-us/web/api/webvtt_api/index.md
@@ -804,6 +804,6 @@ Where p and a are the tags which are used in HTML for paragraph and link, respec
 
 Prior to Firefox 50, the `AlignSetting` enum (representing possible values for {{domxref("VTTCue.align")}}) incorrectly included the value `"middle"` instead of `"center"`. This has been corrected.
 
-WebVTT was implemented in Firefox 24 behind the preference {{pref("media.webvtt.enabled")}}, which is disabled by default; you can enable it by setting this preference to `true`. WebVTT is enabled by default starting in Firefox 31 and can be disabled by setting the preference to `false`.
+WebVTT was implemented in Firefox 24 behind the preference `media.webvtt.enabled`, which is disabled by default; you can enable it by setting this preference to `true`. WebVTT is enabled by default starting in Firefox 31 and can be disabled by setting the preference to `false`.
 
 Prior to Firefox 58, the `REGION` keyword was creating {{domxref("VTTRegion")}} objects, but they were not being used. Firefox 58 now fully supports `VTTRegion` and its use; however, this feature is disabled by default behind the preference `media.webvtt.regions.enabled`; set it to `true` to enable region support in Firefox 58. Regions are enabled by default starting in Firefox 59 (see bugs {{bug(1338030)}} and {{bug(1415805)}}).

--- a/files/en-us/web/api/window/requestfilesystem/index.md
+++ b/files/en-us/web/api/window/requestfilesystem/index.md
@@ -17,7 +17,7 @@ tags:
   - requestFileSystem
 browser-compat: api.Window.requestFileSystem
 ---
-{{APIRef("File System API")}} {{Deprecated_Header}} {{non-standard_header()}}
+{{APIRef("File and Directory Entries API")}} {{Deprecated_Header}} {{non-standard_header()}}
 
 The non-standard {{domxref("Window")}} method
 **`requestFileSystem()`** method is a Google Chrome-specific

--- a/files/en-us/web/api/window/requestfilesystem/index.md
+++ b/files/en-us/web/api/window/requestfilesystem/index.md
@@ -17,7 +17,7 @@ tags:
   - requestFileSystem
 browser-compat: api.Window.requestFileSystem
 ---
-{{APIRef("File and Directory Entries API")}} {{Deprecated_Header}} {{non-standard_header()}}
+{{APIRef("File System API")}} {{Deprecated_Header}} {{non-standard_header()}}
 
 The non-standard {{domxref("Window")}} method
 **`requestFileSystem()`** method is a Google Chrome-specific


### PR DESCRIPTION
To reach `Promise`, we need to use `{{jsxref}}` and not `{{domxref}}`