### PR TITLE
domxref -> jsxref

### DIFF
--- a/files/en-us/web/api/abortsignal/throwifaborted/index.md
+++ b/files/en-us/web/api/abortsignal/throwifaborted/index.md
@@ -64,7 +64,7 @@ If the signal is aborted, this will cause the `waitForCondition()` promise to be
 
 An API that needs to support aborting can accept an `AbortSignal` object, and use its state to trigger abort signal handling when needed.
 
-A {{domxref("Promise")}}-based API should respond to the abort signal by rejecting any unsettled promise with the `AbortSignal` abort {{domxref("AbortSignal.reason", "reason")}}.
+A {{jsxref("Promise")}}-based API should respond to the abort signal by rejecting any unsettled promise with the `AbortSignal` abort {{domxref("AbortSignal.reason", "reason")}}.
 For example, consider the following `myCoolPromiseAPI`, which takes a signal and returns a promise.
 The promise is rejected immediately if the signal is already aborted, or if the abort event is detected.
 Otherwise it completes normally and then resolves the promise.


### PR DESCRIPTION
To reach `Promise`, we need to use `{{jsxref}}` and not `{{domxref}}`.