### PR TITLE
Remove experimental tag + fix sidebar of SecurityPolicyViolationEvent.*

### DIFF
--- a/files/en-us/web/api/securitypolicyviolationevent/blockeduri/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/blockeduri/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SecurityPolicyViolationEvent/blockedURI
 tags:
   - API
   - CSP
-  - Experimental
   - HTTP
   - Property
   - Reference
@@ -12,15 +11,15 @@ tags:
   - SecurityPolicyViolationEvent
 browser-compat: api.SecurityPolicyViolationEvent.blockedURI
 ---
-{{APIRef("{{HTTPSidebar}}")}}{{ SeeCompatTable() }}
+{{HTTPSidebar}}
 
 The **`blockedURI`** read-only property of the
-{{domxref("SecurityPolicyViolationEvent")}} interface is a {{domxref("USVString")}}
+{{domxref("SecurityPolicyViolationEvent")}} interface is a string
 representing the URI of the resource that was blocked because it violates a policy.
 
 ## Value
 
-A {{domxref("USVString")}} representing the URI of the blocked resource.
+A string representing the URI of the blocked resource.
 
 ## Examples
 

--- a/files/en-us/web/api/securitypolicyviolationevent/columnnumber/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/columnnumber/index.md
@@ -13,7 +13,7 @@ tags:
   - columnNumber
 browser-compat: api.SecurityPolicyViolationEvent.columnNumber
 ---
-{{APIRef("{{HTTPSidebar}}")}}{{ SeeCompatTable() }}
+{{HTTPSidebar}}"
 
 The **`columnNumber`** read-only property of the
 {{domxref("SecurityPolicyViolationEvent")}} interface is the column number in the

--- a/files/en-us/web/api/securitypolicyviolationevent/disposition/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/disposition/index.md
@@ -5,7 +5,6 @@ tags:
   - API
   - CSP
   - Disposition
-  - Experimental
   - HTTP
   - Property
   - Reference
@@ -13,7 +12,7 @@ tags:
   - SecurityPolicyViolationEvent
 browser-compat: api.SecurityPolicyViolationEvent.disposition
 ---
-{{APIRef("{{HTTPSidebar}}")}}{{ SeeCompatTable() }}
+{{HTTPSidebar}}")}}
 
 The **`disposition`** read-only property of the
 {{domxref("SecurityPolicyViolationEvent")}} interface indicates how the violated policy
@@ -21,9 +20,8 @@ is configured to be treated by the user agent.
 
 ## Value
 
-A value defined in the [SecurityPolicyViolationEventDisposition
-enum](https://w3c.github.io/webappsec-csp/#enumdef-securitypolicyviolationeventdisposition) representing the URI of the blocked resource. Possible values are
-`"enforce"` or `"report"`
+A value defined in the [SecurityPolicyViolationEventDisposition enum](https://w3c.github.io/webappsec-csp/#enumdef-securitypolicyviolationeventdisposition)
+representing the URI of the blocked resource. Possible values are `"enforce"` or `"report"`
 
 ## Examples
 

--- a/files/en-us/web/api/securitypolicyviolationevent/documenturi/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/documenturi/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SecurityPolicyViolationEvent/documentURI
 tags:
   - API
   - CSP
-  - Experimental
   - HTTP
   - Property
   - Reference
@@ -13,15 +12,15 @@ tags:
   - documentURI
 browser-compat: api.SecurityPolicyViolationEvent.documentURI
 ---
-{{APIRef("{{HTTPSidebar}}")}}{{ SeeCompatTable() }}
+{{HTTPSidebar}}
 
 The **`documentURI`** read-only property of the
-{{domxref("SecurityPolicyViolationEvent")}} interface is a {{domxref("USVString")}}
+{{domxref("SecurityPolicyViolationEvent")}} interface is a string
 representing the URI of the document or worker in which the violation was found.
 
 ## Value
 
-A {{domxref("USVString")}} representing the URI of the document or worker in which the
+A string representing the URI of the document or worker in which the
 violation was found.
 
 ## Examples

--- a/files/en-us/web/api/securitypolicyviolationevent/effectivedirective/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/effectivedirective/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SecurityPolicyViolationEvent/effectiveDirective
 tags:
   - API
   - CSP
-  - Experimental
   - HTTP
   - Property
   - Reference
@@ -13,15 +12,15 @@ tags:
   - effectiveDirective
 browser-compat: api.SecurityPolicyViolationEvent.effectiveDirective
 ---
-{{APIRef("{{HTTPSidebar}}")}}{{ SeeCompatTable() }}
+{{HTTPSidebar}}
 
 The **`effectiveDirective`** read-only property of the
-{{domxref("SecurityPolicyViolationEvent")}} interface is a {{domxref("DOMString")}}
+{{domxref("SecurityPolicyViolationEvent")}} interface is a string
 representing the directive whose enforcement uncovered the violation.
 
 ## Value
 
-A {{domxref("DOMString")}} representing the directive whose enforcement uncovered the
+A string representing the directive whose enforcement uncovered the
 violation.
 
 ## Examples

--- a/files/en-us/web/api/securitypolicyviolationevent/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SecurityPolicyViolationEvent
 tags:
   - API
   - CSP
-  - Experimental
   - HTTP
   - Interface
   - Reference
@@ -12,7 +11,7 @@ tags:
   - SecurityPolicyViolationEvent
 browser-compat: api.SecurityPolicyViolationEvent
 ---
-{{APIRef("{{HTTPSidebar}}")}}{{ SeeCompatTable() }}
+{{HTTPSidebar}}
 
 The **`SecurityPolicyViolationEvent`** interface inherits from {{domxref("Event")}}, and represents the event object of an event sent on a document or worker when its content security policy is violated.
 
@@ -26,29 +25,29 @@ The **`SecurityPolicyViolationEvent`** interface inherits from {{domxref("Event"
 ## Properties
 
 - {{domxref("SecurityPolicyViolationEvent.blockedURI")}}{{readonlyInline}}
-  - : A {{domxref("USVString")}} representing the URI of the resource that was blocked because it violates a policy.
+  - : A string representing the URI of the resource that was blocked because it violates a policy.
 - {{domxref("SecurityPolicyViolationEvent.columnNumber")}}{{readonlyInline}}
   - : The column number in the document or worker at which the violation occurred.
 - {{domxref("SecurityPolicyViolationEvent.disposition")}}{{readonlyInline}}
   - : Indicates how the violated policy is configured to be treated by the user agent. This will be `"enforce"` or `"report"`.
 - {{domxref("SecurityPolicyViolationEvent.documentURI")}}{{readonlyInline}}
-  - : A {{domxref("USVString")}} representing the URI of the document or worker in which the violation was found.
+  - : A string representing the URI of the document or worker in which the violation was found.
 - {{domxref("SecurityPolicyViolationEvent.effectiveDirective")}}{{readonlyInline}}
-  - : A {{domxref("DOMString")}} representing the directive whose enforcement uncovered the violation.
+  - : A string representing the directive whose enforcement uncovered the violation.
 - {{domxref("SecurityPolicyViolationEvent.lineNumber")}}{{readonlyInline}}
   - : The line number in the document or worker at which the violation occurred.
 - {{domxref("SecurityPolicyViolationEvent.originalPolicy")}}{{readonlyInline}}
-  - : A {{domxref("DOMString")}} containing the policy whose enforcement uncovered the violation.
+  - : A string containing the policy whose enforcement uncovered the violation.
 - {{domxref("SecurityPolicyViolationEvent.referrer")}}{{readonlyInline}}
-  - : A {{domxref("USVString")}} representing the referrer of the resources whose policy was violated. This will be a URL or `null`.
+  - : A string representing the referrer of the resources whose policy was violated. This will be a URL or `null`.
 - {{domxref("SecurityPolicyViolationEvent.sample")}}{{readonlyInline}}
-  - : A {{domxref("DOMString")}} representing a sample of the resource that caused the violation, usually the first 40 characters. This will only be populated if the resource is an inline script, event handler, or style — external resources causing a violation will not generate a sample.
+  - : A string representing a sample of the resource that caused the violation, usually the first 40 characters. This will only be populated if the resource is an inline script, event handler, or style — external resources causing a violation will not generate a sample.
 - {{domxref("SecurityPolicyViolationEvent.sourceFile")}}{{readonlyInline}}
-  - : A {{domxref("USVString")}} representing the URI of the document or worker in which the violation was found.
+  - : A string representing the URI of the document or worker in which the violation was found.
 - {{domxref("SecurityPolicyViolationEvent.statusCode")}}{{readonlyInline}}
   - : A number representing the HTTP status code of the document or worker in which the violation occurred.
 - {{domxref("SecurityPolicyViolationEvent.violatedDirective")}}{{readonlyInline}}
-  - : A {{domxref("DOMString")}} representing the directive whose enforcement uncovered the violation.
+  - : A string representing the directive whose enforcement uncovered the violation.
 
 ## Examples
 

--- a/files/en-us/web/api/securitypolicyviolationevent/linenumber/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/linenumber/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SecurityPolicyViolationEvent/lineNumber
 tags:
   - API
   - CSP
-  - Experimental
   - HTTP
   - Property
   - Reference
@@ -13,7 +12,7 @@ tags:
   - lineNumber
 browser-compat: api.SecurityPolicyViolationEvent.lineNumber
 ---
-{{APIRef("{{HTTPSidebar}}")}}{{ SeeCompatTable() }}
+{{HTTPSidebar}}")}}
 
 The **`lineNumber`** read-only property of the
 {{domxref("SecurityPolicyViolationEvent")}} interface is the line number in the document

--- a/files/en-us/web/api/securitypolicyviolationevent/originalpolicy/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/originalpolicy/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SecurityPolicyViolationEvent/originalPolicy
 tags:
   - API
   - CSP
-  - Experimental
   - HTTP
   - Property
   - Reference
@@ -13,15 +12,15 @@ tags:
   - originalPolicy
 browser-compat: api.SecurityPolicyViolationEvent.originalPolicy
 ---
-{{APIRef("{{HTTPSidebar}}")}}{{ SeeCompatTable() }}
+{{HTTPSidebar}}
 
 The **`originalPolicy`** read-only property of the
-{{domxref("SecurityPolicyViolationEvent")}} interface is a {{domxref("DOMString")}}
+{{domxref("SecurityPolicyViolationEvent")}} interface is a string
 containing the policy whose enforcement uncovered the violation.
 
 ## Value
 
-A {{domxref("DOMString")}} representing the policy whose enforcement uncovered the
+A string representing the policy whose enforcement uncovered the
 violation.
 
 ## Examples

--- a/files/en-us/web/api/securitypolicyviolationevent/referrer/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/referrer/index.md
@@ -13,16 +13,16 @@ tags:
   - referrer
 browser-compat: api.SecurityPolicyViolationEvent.referrer
 ---
-{{APIRef("{{HTTPSidebar}}")}}{{ SeeCompatTable() }}
+{{HTTPSidebar}}
 
 The **`referrer`** read-only property of the
-{{domxref("SecurityPolicyViolationEvent")}} interface is a {{domxref("USVString")}}
+{{domxref("SecurityPolicyViolationEvent")}} interface is a string
 representing the referrer of the resources whose policy was violated. This will be a URL
 or `null`.
 
 ## Value
 
-A {{domxref("USVString")}} representing the URL of the referrer of the violating
+A string representing the URL of the referrer of the violating
 resources.
 
 ## Examples

--- a/files/en-us/web/api/securitypolicyviolationevent/sample/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/sample/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SecurityPolicyViolationEvent/sample
 tags:
   - API
   - CSP
-  - Experimental
   - HTTP
   - Property
   - Reference
@@ -13,15 +12,15 @@ tags:
   - SecurityPolicyViolationEvent
 browser-compat: api.SecurityPolicyViolationEvent.sample
 ---
-{{APIRef("{{HTTPSidebar}}")}}{{ SeeCompatTable() }}
+{{HTTPSidebar}}
 
 The **`sample`** read-only property of the
-{{domxref("SecurityPolicyViolationEvent")}} interface is a {{domxref("DOMString")}}
+{{domxref("SecurityPolicyViolationEvent")}} interface is a string
 representing a sample of the resource that caused the violation.
 
 ## Value
 
-A {{domxref("DOMString")}} containing a sample of the resource that caused the
+A string containing a sample of the resource that caused the
 violation, usually the first 40 characters. This will only be populated if the resource
 is an inline script, event handler, or style — external resources causing a violation
 will not generate a sample.

--- a/files/en-us/web/api/securitypolicyviolationevent/securitypolicyviolationevent/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/securitypolicyviolationevent/index.md
@@ -5,14 +5,13 @@ tags:
   - API
   - CSP
   - Constructor
-  - Experimental
   - HTTP
   - Reference
   - Security
   - SecurityPolicyViolationEvent
 browser-compat: api.SecurityPolicyViolationEvent.SecurityPolicyViolationEvent
 ---
-{{APIRef("{{HTTPSidebar}}")}}{{ SeeCompatTable() }}
+{{HTTPSidebar}}
 
 The **`SecurityPolicyViolationEvent`** constructor creates a
 new `SecurityPolicyViolationEvent` object instance.

--- a/files/en-us/web/api/securitypolicyviolationevent/sourcefile/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/sourcefile/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SecurityPolicyViolationEvent/sourceFile
 tags:
   - API
   - CSP
-  - Experimental
   - HTTP
   - Property
   - Reference
@@ -13,15 +12,15 @@ tags:
   - sourceFile
 browser-compat: api.SecurityPolicyViolationEvent.sourceFile
 ---
-{{APIRef("{{HTTPSidebar}}")}}{{ SeeCompatTable() }}
+{{HTTPSidebar}}
 
 The **`sourceFile`** read-only property of the
-{{domxref("SecurityPolicyViolationEvent")}} interface is a {{domxref("USVString")}}
+{{domxref("SecurityPolicyViolationEvent")}} interface is a string
 representing the URI of the document or worker in which the violation was found.
 
 ## Value
 
-A {{domxref("USVString")}} representing the URI of the document or worker in which the
+A string representing the URI of the document or worker in which the
 violation was found.
 
 ## Examples

--- a/files/en-us/web/api/securitypolicyviolationevent/statuscode/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/statuscode/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SecurityPolicyViolationEvent/statusCode
 tags:
   - API
   - CSP
-  - Experimental
   - HTTP
   - Property
   - Reference
@@ -13,7 +12,7 @@ tags:
   - statusCode
 browser-compat: api.SecurityPolicyViolationEvent.statusCode
 ---
-{{APIRef("{{HTTPSidebar}}")}}{{ SeeCompatTable() }}
+{{HTTPSidebar}}
 
 The **`statusCode`** read-only property of the
 {{domxref("SecurityPolicyViolationEvent")}} interface is a number representing the HTTP

--- a/files/en-us/web/api/securitypolicyviolationevent/violateddirective/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/violateddirective/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SecurityPolicyViolationEvent/violatedDirective
 tags:
   - API
   - CSP
-  - Experimental
   - HTTP
   - Property
   - Reference
@@ -13,15 +12,15 @@ tags:
   - violatedDirective
 browser-compat: api.SecurityPolicyViolationEvent.violatedDirective
 ---
-{{APIRef("{{HTTPSidebar}}")}}{{ SeeCompatTable() }}
+{{HTTPSidebar}}
 
 The **`violatedDirective`** read-only property of the
-{{domxref("SecurityPolicyViolationEvent")}} interface is a {{domxref("DOMString")}}
+{{domxref("SecurityPolicyViolationEvent")}} interface is a string
 representing the directive whose enforcement uncovered the violation.
 
 ## Value
 
-A {{domxref("DOMString")}} representing the directive whose enforcement uncovered the
+A string representing the directive whose enforcement uncovered the
 violation.
 
 ## Examples


### PR DESCRIPTION
- No more experimental in mdn/browser-compat-data (and supported by 3 browser engines).
- Sidebar was wrong (the parameter of `APIRef` was the right sidebar).
- Removed mentions of WebIDL types `DOMString` and `USVString`.