### PR TITLE
Fix exceptions section in Navigator.registerProtocolHandler()

### DIFF
--- a/files/en-us/web/api/navigator/registerprotocolhandler/index.md
+++ b/files/en-us/web/api/navigator/registerprotocolhandler/index.md
@@ -55,7 +55,7 @@ None ({{jsxref("undefined")}}).
 
 ### Exceptions
 
-- {{Exception("SecurityError")}}
+- `SecurityError` {{domxref("DOMException")}}
   - : The user agent blocked the registration.
     This might happen if:
 
@@ -64,7 +64,7 @@ None ({{jsxref("undefined")}}).
     - The browser requires that this function is called from a secure context.
     - The browser requires that the handler's URL be over HTTPS.
 
-- {{Exception("SyntaxError")}}
+- `SyntaxError`{{domxref("DOMException")}}
   - : The `%s` placeholder is missing from the handler URL.
 
 ## Permitted schemes


### PR DESCRIPTION
We deprecated `{{exception}}` and these new flaws appeared. (We missed them because of the unusual capitalization).

This fixes it.