### PR TITLE
Remove broken links to B2G, FirefoxOS and Plugin API

### DIFF
--- a/files/en-us/mozilla/firefox/releases/52/index.md
+++ b/files/en-us/mozilla/firefox/releases/52/index.md
@@ -100,7 +100,7 @@ Firefox 52 was released on March 7, 2017. This article lists key changes that ar
 
 - The [Selection API](/en-US/docs/Web/API/Selection) has fully shipped, including the new {{Event("selectstart")}} and {{Event("selectionchange")}} events (see also {{domxref("GlobalEventHandlers.onselectstart")}} and {{domxref("GlobalEventHandlers.onselectionchange")}}) ({{bug(1309612)}}).
 - The property {{domxref("Event.composed")}} is now supported; this Boolean value indicates whether or not the event can bubble through the shadow root into the standard DOM ({{bug(1292063)}}).
-- Only HTML elements, plus the {{HTMLElement("svg")}} and {{HTMLElement("math")}} elements, can be put into full-screen mode by calling {{domxref("Element.requestFullscreen()")}} ({{bug(1305928)}}).
+- Only HTML elements, plus the {{SVGElement("svg")}} and {{MathMLElement("math")}} elements, can be put into full-screen mode by calling {{domxref("Element.requestFullscreen()")}} ({{bug(1305928)}}).
 - [Touch events](/en-US/docs/Web/API/Touch_events) have been reenabled on Windows desktop platforms — see {{bug(1244402)}}. (They were disabled in Firefox 24 because they broke a number of major sites; see {{bug(888304)}}.)
 - The {{event("focusin")}} and {{event("focusout")}} events are now implemented ({{bug("687787")}}).
 - The {{domxref("isSecureContext")}} property has been implemented (see {{bug(1269052)}}).
@@ -118,10 +118,10 @@ Firefox 52 was released on March 7, 2017. This article lists key changes that ar
 
 - The Firefox OS APIs that deal with managing phone calls (Contacts, MobileConnection, Icc, etc.) have been removed ({{bug(1311206)}}).
 - The Firefox OS `Identity` interface has been removed ({{bug(1309030)}}).
-- The Firefox OS Voicemail API [`MozVoicemail`](/en-US/docs/Archive/B2G_OS/API/MozVoicemail), [`MozVoicemailEvent`](/en-US/docs/Archive/B2G_OS/API/MozVoicemailEvent), [`MozVoicemailStatus`](/en-US/docs/Archive/B2G_OS/API/MozVoicemailStatus), [`Navigator.mozVoicemail`](/en-US/docs/Archive/B2G_OS/API/Navigator/mozVoicemail)) has been removed ({{bug(1309723)}}).
+- The Firefox OS Voicemail API (`MozVoicemail`, `MozVoicemailEvent`, `MozVoicemailStatus`, `Navigator.mozVoicemail`) has been removed ({{bug(1309723)}}).
 - The Firefox OS Cell Broadcast API (`MozCellBroadcast`, `MozCellBroadcastEvent`, `MozCellBroadcastMessage`, `Navigator.mozCellBroadcast`) has been removed ({{bug(1306772)}}).
 - The Firefox OS TV broadcast-related APIs have been removed ({{bug(1306778)}}).
-- The Firefox OS FM Radio API ([`FMRadio`](/en-US/docs/Archive/B2G_OS/API/FMRadio), [`Navigator.mozFMRadio`](/en-US/docs/Archive/B2G_OS/API/Navigator/mozFMRadio)) has been removed ({{bug(1306779)}}).
+- The Firefox OS FM Radio API (`FMRadio`, `Navigator.mozFMRadio`) has been removed ({{bug(1306779)}}).
 
 ### Service Workers and Fetch
 
@@ -146,9 +146,9 @@ Firefox 52 was released on March 7, 2017. This article lists key changes that ar
 ### Other APIs
 
 - The method {{domxref("FileSystemFileEntry.createWriter()")}}, which was added (but always returned an error) in Firefox 50 has been removed ({{bug(1315185)}}.
-- The proprietary Firefox OS [Apps installation/management APIs](/en-US/docs/Archive/Marketplace/API/App_installation_and_management_APIs) have been removed from the platform (see {{bug(1261019)}}).
-- The proprietary Firefox OS [Web Telephony API](/en-US/docs/Archive/Firefox_OS/Web_Telephony_API) has been removed from the platform (see {{bug(1309719)}}).
-- The proprietary Firefox OS [Web Bluetooth API](/en-US/docs/Archive/Firefox_OS/Bluetooth_API) has been removed from the platform (see {{bug(1310020)}}).
+- The proprietary Firefox OS `Apps installation/management APIs` have been removed from the platform (see {{bug(1261019)}}).
+- The proprietary Firefox OS `Web Telephony API` has been removed from the platform (see {{bug(1309719)}}).
+- The proprietary Firefox OS `Web Bluetooth API` has been removed from the platform (see {{bug(1310020)}}).
 - The [Battery Status API](/en-US/docs/Web/API/Battery_Status_API) is now available only to chrome/privileged code (see {{bug(1313580)}}).
 - `ImageBitmapRenderingContext.transferImageBitmap()` has been renamed to {{domxref("ImageBitmapRenderingContext.transferFromImageBitmap()")}} (see {{bug(1304767)}}).
 - The `mozDash` and `mozDashOffset` members have been removed from {{domxref("CanvasRenderingContext2D")}} (see {{bug(931389)}}).
@@ -172,7 +172,7 @@ Firefox 52 was released on March 7, 2017. This article lists key changes that ar
 
 ## Plugins
 
-All NPAPI [plugin](/en-US/docs/Mozilla/Add-ons/Plugins) support except Flash has been dropped. Flash usage is also set to be phased out in the future.
+All NPAPI plugin support except Flash has been dropped. Flash usage is also set to be phased out in the future.
 
 ## Changes for add-on and Mozilla developers
 


### PR DESCRIPTION
Links to B2G, FirefoxOS, and Plugin API are long gone. This removes it and fixes two erroneous `HTMLElement` macros.