### PR TITLE
{{event}} to {{domxref}} for "devicechange"

### DIFF
--- a/files/en-us/web/api/mediadevices/devicechange_event/index.md
+++ b/files/en-us/web/api/mediadevices/devicechange_event/index.md
@@ -207,7 +207,7 @@ parentheses, it's appended to the appropriate list by calling
 We call `updateDeviceList()` in two places. The first is in the
 {{domxref("MediaDevices.getUserMedia", "getUserMedia()")}} promise's fulfillment
 handler, to initially fill out the list when the stream is opened. The second is in the
-event handler for {{domxref("MediaDevices/devicechange_event", "devicechange")}}:
+event handler for this `devicechange` event:
 
 ```js
 navigator.mediaDevices.ondevicechange = event => {

--- a/files/en-us/web/api/mediadevices/devicechange_event/index.md
+++ b/files/en-us/web/api/mediadevices/devicechange_event/index.md
@@ -17,7 +17,7 @@ browser-compat: api.MediaDevices.devicechange_event
 
 A `devicechange` event is sent to a {{domxref("MediaDevices")}} instance whenever a media device such as a camera, microphone, or speaker is connected to or removed from the system.
 
-This device is not cancelable and does not bubble.
+This event is not cancelable and does not bubble.
 
 ## Syntax
 
@@ -207,7 +207,7 @@ parentheses, it's appended to the appropriate list by calling
 We call `updateDeviceList()` in two places. The first is in the
 {{domxref("MediaDevices.getUserMedia", "getUserMedia()")}} promise's fulfillment
 handler, to initially fill out the list when the stream is opened. The second is in the
-event handler for {{event("devicechange")}}:
+event handler for {{domxref("MediaDevices/devicechange_event", "devicechange")}}:
 
 ```js
 navigator.mediaDevices.ondevicechange = event => {

--- a/files/en-us/web/api/screen_capture_api/using_screen_capture/index.md
+++ b/files/en-us/web/api/screen_capture_api/using_screen_capture/index.md
@@ -88,7 +88,7 @@ For example, if you specify a {{domxref("MediaTrackConstraints.width", "width")}
 
 While display capture is in effect, the machine which is sharing screen contents will display some form of indicator so the user is aware that sharing is taking place.
 
-> **Note:** For privacy and security reasons, screen sharing sources are not enumerable using {{domxref("MediaDevices.enumerateDevices", "enumerateDevices()")}}. Related to this, the {{event("devicechange")}} event is never sent when there are changes to the sources available for `getDisplayMedia()`.
+> **Note:** For privacy and security reasons, screen sharing sources are not enumerable using {{domxref("MediaDevices.enumerateDevices", "enumerateDevices()")}}. Related to this, the {{domxref("MediaDevices/devicechange_event", "devicechange")}} event is never sent when there are changes to the sources available for `getDisplayMedia()`.
 
 ### Capturing shared audio
 

--- a/files/en-us/web/http/headers/feature-policy/xr-spatial-tracking/index.md
+++ b/files/en-us/web/http/headers/feature-policy/xr-spatial-tracking/index.md
@@ -39,7 +39,7 @@ The default allowlist is `'self'`.
 ## See also
 
 - [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API)
-- {{DOMxRef("XRSystem/requestSession","navigator.xr.requestSession()")}}, and {{DOMxRef("XRSystem/isSessionSupported","navigator.xr.isSessionSupported()")}} and {{Event("devicechange")}} event on {{DOMxRef("Navigator.xr","navigator.xr")}}
+- {{DOMxRef("XRSystem/requestSession","navigator.xr.requestSession()")}}, and {{DOMxRef("XRSystem/isSessionSupported","navigator.xr.isSessionSupported()")}} and {{domxref("XRSystem/devicechange_event", "devicechange")}} event on {{DOMxRef("Navigator.xr","navigator.xr")}}
 - {{HTTPHeader("Feature-Policy")}} header
 - [Feature Policy](/en-US/docs/Web/HTTP/Feature_Policy)
 - [Using Feature Policy](/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy)


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Replace {{event}} with {{domxref}} for "devicechange"s
Note that there are two types of events named "devicechange". Each macro is replaced as corresponding interface's event.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
