### PR TITLE
Double NOT reference anchor

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/boolean/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/boolean/index.md
@@ -36,7 +36,7 @@ if (x) {
 }
 ```
 
-Do not use a `Boolean` object to convert a non-boolean value to a boolean value. To perform this task, instead, use `Boolean` as a function, or a [double NOT operator](/en-US/docs/Web/JavaScript/Reference/Operators/Logical_NOT):
+Do not use a `Boolean` object to convert a non-boolean value to a boolean value. To perform this task, instead, use `Boolean` as a function, or a [double NOT operator](/en-US/docs/Web/JavaScript/Reference/Operators/Logical_NOT#double_not_!!):
 
 ```js
 var x = Boolean(expression);     // use this...


### PR DESCRIPTION
#### Summary

Improves outbound link from `Boolean` section to the correct heading of `Logical NOT` page.

#### Motivation

`Boolean` page shows `!!(typecasting)` referencing `Logical NOT` description. While the link to the whole `!` topic might give some intro context, not linking to the actual `!!` section might make the actual example of `!!(expression)` hard to grasp mentally.

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
