### PR TITLE
Remove extraneous code Markdown marks in Performance API

### DIFF
--- a/files/en-us/web/api/performance_api/index.md
+++ b/files/en-us/web/api/performance_api/index.md
@@ -30,7 +30,7 @@ The {{domxref("Performance.toJSON","toJSON()")}} method returns a serialization 
 
 The {{domxref("Performance")}} interface has two properties. The {{domxref("Performance.timing","timing")}} property returns a {{domxref("PerformanceTiming")}} object containing latency-related performance information such as the start of navigation time, start and end times for redirects, start and end times for responses, etc.
 
-The `{{domxref("Performance.navigation","navigation")}}` property returns a {{domxref("PerformanceNavigation")}} object representing the type of navigation that occurs in the given browsing context, such as the page was navigated to from history, the page was navigated to by following a link, etc.
+The {{domxref("Performance.navigation","navigation")}} property returns a {{domxref("PerformanceNavigation")}} object representing the type of navigation that occurs in the given browsing context, such as the page was navigated to from history, the page was navigated to by following a link, etc.
 
 ## Interfaces
 
@@ -39,11 +39,11 @@ The `{{domxref("Performance.navigation","navigation")}}` property returns a {{do
 - {{domxref('PerformanceEntry')}}
   - : Provides methods and properties the encapsulate a single performance metric that is part of the performance timeline.
 - {{domxref('PerformanceMark')}}
-  - : An abstract interface for [`performance entries`](/en-US/docs/Web/API/PerformanceEntry) with an [`entry type`](/en-US/docs/Web/API/PerformanceEntry/entryType) of "`mark`". Entries of this type are created by calling [`performance.mark()`](/en-US/docs/Web/API/Performance/mark) to add a named [`DOMHighResTimeStamp`](/en-US/docs/Web/API/DOMHighResTimeStamp) (the mark) to the browser's performance timeline.
+  - : An abstract interface for [performance entries](/en-US/docs/Web/API/PerformanceEntry) with an [entry type](/en-US/docs/Web/API/PerformanceEntry/entryType) of "`mark`". Entries of this type are created by calling [`performance.mark()`](/en-US/docs/Web/API/Performance/mark) to add a named [`DOMHighResTimeStamp`](/en-US/docs/Web/API/DOMHighResTimeStamp) (the mark) to the browser's performance timeline.
 - {{domxref('PerformanceMeasure')}}
-  - : An abstract interface for [`performance entries`](/en-US/docs/Web/API/PerformanceEntry) with an [`entry type`](/en-US/docs/Web/API/PerformanceEntry/entryType) of "`measure`". Entries of this type are created by calling [`performance.measure()`](/en-US/docs/Web/API/Performance/measure) to add a named[`DOMHighResTimeStamp`](/en-US/docs/Web/API/DOMHighResTimeStamp) (the measure) between two marks to the browser's performance timeline.
+  - : An abstract interface for [performance entries](/en-US/docs/Web/API/PerformanceEntry) with an [entry type](/en-US/docs/Web/API/PerformanceEntry/entryType) of "`measure`". Entries of this type are created by calling [`performance.measure()`](/en-US/docs/Web/API/Performance/measure) to add a named [`DOMHighResTimeStamp`](/en-US/docs/Web/API/DOMHighResTimeStamp) (the measure) between two marks to the browser's performance timeline.
 - {{domxref('PerformanceNavigationTiming')}}
-  - : Provides methods and properties to store and retrieve [`high resolution timestamps`](/en-US/docs/Web/API/DOMHighResTimeStamp) or metrics regarding the browser's document navigation events.
+  - : Provides methods and properties to store and retrieve [high resolution timestamps](/en-US/docs/Web/API/DOMHighResTimeStamp) or metrics regarding the browser's document navigation events.
 - {{domxref('PerformanceObserver')}}
   - : Provides methods and properties used to observe performance measurement events and be notified of new [performance entries](/en-US/docs/Web/API/PerformanceEntry) as they are recorded in the browser's performance timeline.
 - {{domxref('PerformanceResourceTiming')}}


### PR DESCRIPTION
There were a few incorrect ticks.