### PR TITLE
Close CSS markdown in aria-errormessage docs

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-errormessage/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-errormessage/index.md
@@ -46,6 +46,7 @@ We use `aria-invalid="true"` to identify invalid objects:
 [aria-invalid="true"] ~ .errormessage {
   visibility: visible;
 }
+```
 
 When an object is invalid, we use JavaScript to add `aria-invalid="true"`. The above CSS makes the `.errormessage` following an invalid object become visible.
 


### PR DESCRIPTION
A CSS block in the page wasn't closed

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

Closed a CSS markdown block so that the page is formatted properly
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation

Readers may be confused by the unterminated CSS code and the `\`\`\`html` on one line in the code block.
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
N/A
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
N/A
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
