### PR TITLE
Autoboxing and JS primitives

### DIFF
--- a/files/en-us/glossary/primitive/index.md
+++ b/files/en-us/glossary/primitive/index.md
@@ -58,7 +58,7 @@ bar = bar.toUpperCase();
 console.log(bar);               // BAZ
 
 // By contrast, using an array method mutates the array
-var foo = [];
+let foo = [];
 console.log(foo);               // []
 foo.push("plugh");
 console.log(foo);               // ["plugh"]

--- a/files/en-us/glossary/primitive/index.md
+++ b/files/en-us/glossary/primitive/index.md
@@ -6,39 +6,30 @@ tags:
   - Glossary
   - JavaScript
 ---
-In {{Glossary("JavaScript")}}, a **primitive** (primitive value, primitive data type) is data that is not an {{Glossary("object")}} and has no {{glossary("method","methods")}}. There are 7 primitive data types: {{Glossary("string")}}, {{Glossary("number")}}, {{Glossary("bigint")}}, {{Glossary("boolean")}}, {{Glossary("undefined")}}, {{Glossary("symbol")}}, and {{Glossary("null")}}.
+In {{Glossary("JavaScript")}}, a **primitive** (primitive value, primitive data type) is data that is not an {{Glossary("object")}} and has no {{glossary("method","methods")}} or [properties](/en-US/docs/Glossary/property/JavaScript). There are 7 primitive data types: {{Glossary("string")}}, {{Glossary("number")}}, {{Glossary("bigint")}}, {{Glossary("boolean")}}, {{Glossary("undefined")}}, {{Glossary("symbol")}}, and {{Glossary("null")}}.
 
 Most of the time, a primitive value is represented directly at the lowest level of the language implementation.
 
 All primitives are **immutable**, i.e., they cannot be altered. It is important not to confuse a primitive itself with a variable assigned a primitive value. The variable may be reassigned a new value, but the existing value can not be changed in the ways that objects, arrays, and functions can be altered.
 
+
 ## Example
 
-This example will help you understand that primitive values are **immutable.**
+### Autoboxing: primitive wrapper objects in JavaScript
 
-### JavaScript
+Due to a feature known as "autoboxing", JavaScript primitives _appear_ to have methods and properties.
+For example, below it looks like `toUpperCase()` and `length` are methods and properties of the string primitive.
 
 ```js
-// Using a string method doesn't mutate the string
-var bar = "baz";
-console.log(bar);               // baz
-bar.toUpperCase();
-console.log(bar);               // baz
-
-// Using an array method mutates the array
-var foo = [];
-console.log(foo);               // []
-foo.push("plugh");
-console.log(foo);               // ["plugh"]
-
-// Assignment gives the primitive a new (not a mutated) value
-bar = bar.toUpperCase();       // BAZ
+let mystring = "lower case string";
+mystring.toUpperCase();
+console.log(mystring);
+// 'LOWER CASE STRING'
+console.log(mystring.length)
+// 17
 ```
 
-A primitive can be replaced, but it can't be directly altered.
-
-## Primitive wrapper objects in JavaScript
-
+What actually happens is that a wrapper object associated with the primitive is automatically accessed instead. 
 Except for `null` and `undefined`, all primitive values have object equivalents that wrap around the primitive values:
 
 - {{jsxref("String")}} for the string primitive.
@@ -48,6 +39,31 @@ Except for `null` and `undefined`, all primitive values have object equivalents 
 - {{jsxref("Symbol")}} for the symbol primitive.
 
 The wrapper's [`valueOf()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/valueOf) method returns the primitive value.
+
+
+### Primitives are immutable
+
+This example will help you understand that primitive values are **immutable**.
+A primitive can be replaced, but it can't be directly altered.
+
+```js
+// Using a string method doesn't mutate the string
+let bar = "baz";
+console.log(bar);               // baz
+bar.toUpperCase();
+console.log(bar);               // baz
+
+// Assignment gives the primitive a new (not a mutated) value
+bar = bar.toUpperCase();       
+console.log(bar);               // BAZ
+
+// By contrast, using an array method mutates the array
+var foo = [];
+console.log(foo);               // []
+foo.push("plugh");
+console.log(foo);               // ["plugh"]
+```
+
 
 ## See also
 


### PR DESCRIPTION
Fixes #15744

JS primitives do not have methods or properties, but "appear to" due to the feature known as autoboxing where the methods/properties are automatically accessed from a wrapper object. We mention the wrapper objects in the glossary [Primitive](https://developer.mozilla.org/en-US/docs/Glossary/Primitive) but not autoboxing/what they do.

This fixes the glossary item to explicitly mention the purpose of the wrappers.

Note, the glossary term is linked in [Grammar_and_types > data types](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#data_types). I was in two minds if it was worth extending that section to at least mention that primitives are immutable basic types but decided not to.
