### PR TITLE
Remove redundant backticks

### DIFF
--- a/files/en-us/learn/getting_started_with_the_web/javascript_basics/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/javascript_basics/index.md
@@ -63,9 +63,9 @@ However, getting comfortable with JavaScript is more challenging than getting co
 
 ### What happened?
 
-The heading text changed to _Hello world!_ using JavaScript. You did this by using a function called `{{domxref("Document.querySelector", "querySelector()")}}` to grab a reference to your heading, and then store it in a variable called `myHeading`. This is similar to what we did using CSS selectors. When you want to do something to an element, you need to select it first.
+The heading text changed to _Hello world!_ using JavaScript. You did this by using a function called {{domxref("Document.querySelector", "querySelector()")}} to grab a reference to your heading, and then store it in a variable called `myHeading`. This is similar to what we did using CSS selectors. When you want to do something to an element, you need to select it first.
 
-Following that, the code set the value of the `myHeading` variable's `{{domxref("Node.textContent", "textContent")}}` property (which represents the content of the heading) to _Hello world!_.
+Following that, the code set the value of the `myHeading` variable's {{domxref("Node.textContent", "textContent")}} property (which represents the content of the heading) to _Hello world!_.
 
 > **Note:** Both of the features you used in this exercise are parts of the [Document Object Model (DOM) API](/en-US/docs/Web/API/Document_Object_Model), which has the capability to manipulate documents.
 

--- a/files/en-us/mozilla/firefox/releases/70/index.md
+++ b/files/en-us/mozilla/firefox/releases/70/index.md
@@ -84,7 +84,7 @@ This article provides information about the changes in Firefox 70 that will affe
 
 #### DOM
 
-- The {{domxref("History.back","back()")}}, {{domxref("History.forward","forward()")}}, and {{domxref("History.go","go()")}} methods are now asynchronous. Add a listener to the `{{domxref("Window/popstate_event", "popstate")}}` event to get notification that navigation has completed {{Bug(1563587)}}.
+- The {{domxref("History.back","back()")}}, {{domxref("History.forward","forward()")}}, and {{domxref("History.go","go()")}} methods are now asynchronous. Add a listener to the {{domxref("Window/popstate_event", "popstate")}} event to get notification that navigation has completed {{Bug(1563587)}}.
 - We've added support {{DOMxRef("DOMMatrix")}}, {{DOMxRef("DOMPoint")}}, etc. in web workers ({{bug(1420580)}}).
 - A few more members have been moved from {{domxref("HTMLDocument")}} to {{domxref("Document")}}, including {{domxref("Document.all")}}, {{domxref("Document.clear")}}, {{domxref("Document.captureEvents")}}, and {{domxref("Document.clearEvents")}} ({{bug(1558570)}}, {{bug(1558571)}}).
 - [Notification](/en-US/docs/Web/API/Notifications_API) permission can no longer be requested from inside a cross-origin {{htmlelement("iframe")}} ({{bug(1560741)}}).

--- a/files/en-us/web/api/animationplaybackevent/animationplaybackevent/index.md
+++ b/files/en-us/web/api/animationplaybackevent/animationplaybackevent/index.md
@@ -26,7 +26,7 @@ new AnimationPlaybackEvent(type, eventInitDict)
 
 ### Parameters
 
-- `{{domxref("Event.type", "type")}}`
+- {{domxref("Event.type", "type")}}
   - : A [`DOMString`](/en-US/docs/Web/API/DOMString) representing the name of the event.
 - `eventInitDict` {{optional_inline}}
 

--- a/files/en-us/web/api/element/index.md
+++ b/files/en-us/web/api/element/index.md
@@ -365,13 +365,13 @@ Listen to these events using `addEventListener()` or by assigning an event liste
 
 ### Keyboard events
 
-- `{{domxref("Element/keydown_event", "keydown")}}`
+- {{domxref("Element/keydown_event", "keydown")}}
   - : Fired when a key is pressed.
     Also available via the {{domxref("GlobalEventHandlers/onkeydown", "onkeydown")}} property.
-- `{{domxref("Element/keypress_event", "keypress")}}`  {{deprecated_inline}}
+- {{domxref("Element/keypress_event", "keypress")}}  {{deprecated_inline}}
   - : Fired when a key that produces a character value is pressed down.
     Also available via the {{domxref("GlobalEventHandlers/onkeypress", "onkeypress")}} property.
-- `{{domxref("Element/keyup_event", "keyup")}}`
+- {{domxref("Element/keyup_event", "keyup")}}
   - : Fired when a key is released.
     Also available via the {{domxref("GlobalEventHandlers/onkeyup", "onkeyup")}} property.
 

--- a/files/en-us/web/api/formdataentryvalue/index.md
+++ b/files/en-us/web/api/formdataentryvalue/index.md
@@ -8,6 +8,6 @@ tags:
 
 A `string` or {{domxref("File")}} that represents a single value from a set of {{domxref("FormData")}} key-value pairs.
 
-This type is returned by the `{{domxref("FormData.get()")}}` and `{{domxref("FormData.getAll()")}}` methods. The `{{domxref("FormData.get()")}}` method returns a single value while `{{domxref("FormData.getAll()")}}` returns an array of `FormDataEntryValue`s.
+This type is returned by the {{domxref("FormData.get()")}} and {{domxref("FormData.getAll()")}} methods. The {{domxref("FormData.get()")}} method returns a single value while {{domxref("FormData.getAll()")}} returns an array of `FormDataEntryValue`s.
 
 Note that the {{domxref("FormData.append()")}} and {{domxref("FormData.set()")}} methods allow passing a {{domxref("Blob")}} value, which is converted to a `File` in the process.

--- a/files/en-us/web/api/html_drag_and_drop_api/drag_operations/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/drag_operations/index.md
@@ -42,7 +42,7 @@ The `{{htmlattrxref("draggable")}}` attribute may be used on any element, includ
 
 ## Starting a Drag Operation
 
-In this example, a listener is added for the {{event("dragstart")}} event by using the `{{domxref("GlobalEventHandlers.ondragstart","ondragstart")}}` attribute.
+In this example, a listener is added for the {{event("dragstart")}} event by using the {{domxref("GlobalEventHandlers.ondragstart","ondragstart")}} attribute.
 
 ```html
 <p draggable="true" ondragstart="event.dataTransfer.setData('text/plain', 'This text may be dragged')">
@@ -247,7 +247,7 @@ If the mouse is released over an element that is a valid drop target, that is, o
 
 During the `{{event("drop")}}` event, you should retrieve that data that was dropped from the event and insert it at the drop location. You can use the {{domxref("DataTransfer.dropEffect","dropEffect")}} property to determine which drag operation was desired.
 
-As with all drag-related events, the event's `{{domxref("DataTransfer","dataTransfer")}}` property will hold the data that is being dragged. The {{domxref("DataTransfer.getData","getData()")}} method may be used to retrieve the data again.
+As with all drag-related events, the event's {{domxref("DataTransfer","dataTransfer")}} property will hold the data that is being dragged. The {{domxref("DataTransfer.getData","getData()")}} method may be used to retrieve the data again.
 
 ```js
 function onDrop(event) {

--- a/files/en-us/web/api/html_drag_and_drop_api/recommended_drag_types/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/recommended_drag_types/index.md
@@ -70,7 +70,7 @@ Example
 
 ## Dragging HTML and XML
 
-HTML content may use the `text/html` type. The data for this type should be serialized HTML source code. For example, it would be suitable to set its data to the value of the `{{domxref("Element.innerHTML","innerHTML")}}` property of an element.
+HTML content may use the `text/html` type. The data for this type should be serialized HTML source code. For example, it would be suitable to set its data to the value of the {{domxref("Element.innerHTML","innerHTML")}} property of an element.
 
 XML content may use the `text/xml` type, but ensure that the data is well-formed XML.
 

--- a/files/en-us/web/api/keyframeeffect/getkeyframes/index.md
+++ b/files/en-us/web/api/keyframeeffect/getkeyframes/index.md
@@ -34,9 +34,9 @@ Returns a sequence of objects with the following format:
 - property value pairs
   - : As many property value pairs as are contained in each keyframe of the animation.
 - offset
-  - : The offset of the keyframe specified as a number between `0.0` and `1.0` inclusive or `null`. This is equivalent to specifying start and end states in percentages in CSS stylesheets using `@keyframes`. This will be `null` if the keyframe is automatically spaced using `{{domxref("KeyframeEffect.spacing")}}`.
+  - : The offset of the keyframe specified as a number between `0.0` and `1.0` inclusive or `null`. This is equivalent to specifying start and end states in percentages in CSS stylesheets using `@keyframes`. This will be `null` if the keyframe is automatically spaced using {{domxref("KeyframeEffect.spacing")}}.
 - computedOffset
-  - : The computed offset for this keyframe, calculated when the list of computed keyframes was produced according to `{{domxref("KeyframeEffect.spacing")}}`. Unlike **`offset`,** above, the **`computedOffset`** is never `null`.
+  - : The computed offset for this keyframe, calculated when the list of computed keyframes was produced according to {{domxref("KeyframeEffect.spacing")}}. Unlike **`offset`,** above, the **`computedOffset`** is never `null`.
 - easing
   - : The [easing function](/en-US/docs/Web/CSS/easing-function) used from this keyframe until the next keyframe in the series.
 - composite

--- a/files/en-us/web/api/mediastream_recording_api/using_the_mediastream_recording_api/index.md
+++ b/files/en-us/web/api/mediastream_recording_api/using_the_mediastream_recording_api/index.md
@@ -272,5 +272,5 @@ Finally, we set an `onclick` handler on the delete button to be a function that 
 ## See also
 
 - [MediaRecorder API](/en-US/docs/Web/API/MediaStream_Recording_API) landing page
-- `{{domxref("Navigator.getUserMedia()")}}`
+- {{domxref("Navigator.getUserMedia()")}}
 - [MediaRecorder API now supported by 65% of your website users](https://addpipe.com/blog/media-recorder-api-is-now-supported-by-65-of-all-desktop-internet-users/)

--- a/files/en-us/web/api/mediatracksettings/index.md
+++ b/files/en-us/web/api/mediatracksettings/index.md
@@ -29,36 +29,36 @@ Some or all of the following will be included in the object, either because it's
 ### Properties of all media tracks
 
 - {{domxref("MediaTrackSettings.deviceId", "deviceId")}}
-  - : A {{domxref("DOMString")}} indicating the current value of the `{{domxref("MediaTrackConstraints.deviceId", "deviceId")}}` property. The device ID is a origin-unique string identifying the source of the track; this is usually a {{Glossary("GUID")}}. This value is specific to the source of the track's data and is not usable for setting constraints; it can, however, be used for initially selecting media when calling {{domxref("MediaDevices.getUserMedia()")}}.
+  - : A {{domxref("DOMString")}} indicating the current value of the {{domxref("MediaTrackConstraints.deviceId", "deviceId")}} property. The device ID is a origin-unique string identifying the source of the track; this is usually a {{Glossary("GUID")}}. This value is specific to the source of the track's data and is not usable for setting constraints; it can, however, be used for initially selecting media when calling {{domxref("MediaDevices.getUserMedia()")}}.
 - {{domxref("MediaTrackSettings.groupId", "groupId")}}
-  - : A {{domxref("DOMString")}} indicating the current value of the `{{domxref("MediaTrackConstraints.groupId", "groupId")}}` property. The group ID is a browsing session-unique string identifying the source group of the track. Two devices (as identified by the {{domxref("MediaTrackSettings.deviceId", "deviceId")}}) are considered part of the same group if they are from the same physical device. For instance, the audio input and output devices for the speaker and microphone built into a phone would share the same group ID, since they're part of the same physical device. The microphone on a headset would have a different ID, though. This value is specific to the source of the track's data and is not usable for setting constraints; it can, however, be used for initially selecting media when calling {{domxref("MediaDevices.getUserMedia()")}}.
+  - : A {{domxref("DOMString")}} indicating the current value of the {{domxref("MediaTrackConstraints.groupId", "groupId")}} property. The group ID is a browsing session-unique string identifying the source group of the track. Two devices (as identified by the {{domxref("MediaTrackSettings.deviceId", "deviceId")}}) are considered part of the same group if they are from the same physical device. For instance, the audio input and output devices for the speaker and microphone built into a phone would share the same group ID, since they're part of the same physical device. The microphone on a headset would have a different ID, though. This value is specific to the source of the track's data and is not usable for setting constraints; it can, however, be used for initially selecting media when calling {{domxref("MediaDevices.getUserMedia()")}}.
 
 ### Properties of audio tracks
 
 - {{domxref("MediaTrackSettings.autoGainControl", "autoGainControl")}}
   - : A Boolean which indicates the current value of the {{domxref("MediaTrackConstraints.autoGainControl", "autoGainControl")}} property, which is `true` if automatic gain control is enabled and is `false` otherwise.
 - {{domxref("MediaTrackSettings.channelCount", "channelCount")}}
-  - : A long integer value indicating the current value of the `{{domxref("MediaTrackConstraints.channelCount", "channelCount")}}` property, specifying the number of audio channels present on the track (therefore indicating how many audio samples exist in each audio frame). This is 1 for mono, 2 for stereo, and so forth.
+  - : A long integer value indicating the current value of the {{domxref("MediaTrackConstraints.channelCount", "channelCount")}} property, specifying the number of audio channels present on the track (therefore indicating how many audio samples exist in each audio frame). This is 1 for mono, 2 for stereo, and so forth.
 - {{domxref("MediaTrackSettings.echoCancellation", "echoCancellation")}}
-  - : A Boolean indicating the current value of the `{{domxref("MediaTrackConstraints.echoCancellation", "echoCancellation")}}` property, specifying `true` if echo cancellation is enabled, otherwise `false`.
+  - : A Boolean indicating the current value of the {{domxref("MediaTrackConstraints.echoCancellation", "echoCancellation")}} property, specifying `true` if echo cancellation is enabled, otherwise `false`.
 - {{domxref("MediaTrackSettings.latency", "latency")}}
-  - : A double-precision floating point value indicating the current value of the `{{domxref("MediaTrackConstraints.latency", "latency")}}` property, specifying the audio latency, in seconds. Latency is the amount of time which elapses between the start of processing the audio and the data being available to the next stop in the audio utilization process. This value is a target value; actual latency may vary to some extent for various reasons.
+  - : A double-precision floating point value indicating the current value of the {{domxref("MediaTrackConstraints.latency", "latency")}} property, specifying the audio latency, in seconds. Latency is the amount of time which elapses between the start of processing the audio and the data being available to the next stop in the audio utilization process. This value is a target value; actual latency may vary to some extent for various reasons.
 - {{domxref("MediaTrackSettings.noiseSuppression", "noiseSuppression")}}
   - : A Boolean which indicates the current value of the {{domxref("MediaTrackConstraints.noiseSuppression", "noiseSuppression")}} property, which is `true` if noise suppression is enabled and is `false` otherwise.
 - {{domxref("MediaTrackSettings.sampleRate", "sampleRate")}}
-  - : A long integer value indicating the current value of the `{{domxref("MediaTrackConstraints.sampleRate", "sampleRate")}}` property, specifying the sample rate in samples per second of the audio data. Standard CD-quality audio, for example, has a sample rate of 41,000 samples per second.
+  - : A long integer value indicating the current value of the {{domxref("MediaTrackConstraints.sampleRate", "sampleRate")}} property, specifying the sample rate in samples per second of the audio data. Standard CD-quality audio, for example, has a sample rate of 41,000 samples per second.
 - {{domxref("MediaTrackSettings.sampleSize", "sampleSize")}}
-  - : A long integer value indicating the current value of the `{{domxref("MediaTrackConstraints.sampleSize", "sampleSize")}}` property, specifying the linear size, in bits, of each audio sample. CD-quality audio, for example, is 16-bit, so this value would be 16 in that case.
+  - : A long integer value indicating the current value of the {{domxref("MediaTrackConstraints.sampleSize", "sampleSize")}} property, specifying the linear size, in bits, of each audio sample. CD-quality audio, for example, is 16-bit, so this value would be 16 in that case.
 - {{domxref("MediaTrackSettings.volume", "volume")}}
-  - : A double-precision floating point value indicating the current value of the `{{domxref("MediaTrackConstraints.volume", "volume")}}` property, specifying the volume level of the track. This value will be between 0.0 (silent) to 1.0 (maximum supported volume).
+  - : A double-precision floating point value indicating the current value of the {{domxref("MediaTrackConstraints.volume", "volume")}} property, specifying the volume level of the track. This value will be between 0.0 (silent) to 1.0 (maximum supported volume).
 
 ### Properties of video tracks
 
 - {{domxref("MediaTrackSettings.aspectRatio", "aspectRatio")}}
-  - : A double-precision floating point value indicating the current value of the `{{domxref("MediaTrackConstraints.aspectRatio", "aspectRatio")}}` property, specified precisely to 10 decimal places. This is the width of the image in pixels divided by its height in pixels. Common values include 1.3333333333 (for the classic television 4:3 "standard" aspect ratio, also used on tablets such as Apple's iPad), 1.7777777778 (for the 16:9 high-definition widescreen aspect ratio), and 1.6 (for the 16:10 aspect ratio common among widescreen computers and tablets).
+  - : A double-precision floating point value indicating the current value of the {{domxref("MediaTrackConstraints.aspectRatio", "aspectRatio")}} property, specified precisely to 10 decimal places. This is the width of the image in pixels divided by its height in pixels. Common values include 1.3333333333 (for the classic television 4:3 "standard" aspect ratio, also used on tablets such as Apple's iPad), 1.7777777778 (for the 16:9 high-definition widescreen aspect ratio), and 1.6 (for the 16:10 aspect ratio common among widescreen computers and tablets).
 - {{domxref("MediaTrackSettings.facingMode", "facingMode")}}
 
-  - : A {{domxref("DOMString")}} indicating the current value of the `{{domxref("MediaTrackConstraints.facingMode", "facingMode")}}` property, specifying the direction the camera is facing. The value will be one of:
+  - : A {{domxref("DOMString")}} indicating the current value of the {{domxref("MediaTrackConstraints.facingMode", "facingMode")}} property, specifying the direction the camera is facing. The value will be one of:
 
     - `"user"`
       - : A camera facing the user (commonly known as a "selfie cam"), used for self-portraiture and video calling.
@@ -70,14 +70,14 @@ Some or all of the following will be included in the object, either because it's
       - : A camera facing toward the environment to the user's right.
 
 - {{domxref("MediaTrackSettings.frameRate", "frameRate")}}
-  - : A double-precision floating point value indicating the current value of the `{{domxref("MediaTrackConstraints.frameRate", "frameRate")}}` property, specifying how many frames of video per second the track includes. If the value can't be determined for any reason, the value will match the vertical sync rate of the device the user agent is running on.
+  - : A double-precision floating point value indicating the current value of the {{domxref("MediaTrackConstraints.frameRate", "frameRate")}} property, specifying how many frames of video per second the track includes. If the value can't be determined for any reason, the value will match the vertical sync rate of the device the user agent is running on.
 - {{domxref("MediaTrackSettings.height", "height")}}
-  - : A long integer value indicating the current value of the `{{domxref("MediaTrackConstraints.height", "height")}}` property, specifying the height of the track's video data in pixels.
+  - : A long integer value indicating the current value of the {{domxref("MediaTrackConstraints.height", "height")}} property, specifying the height of the track's video data in pixels.
 - {{domxref("MediaTrackSettings.width", "width")}}
   - : A long integer value indicating the current value of the {{domxref("MediaTrackSettings.width", "width")}} property, specifying the width of the track's video data in pixels.
 - {{domxref("MediaTrackSettings.resizeMode", "resizeMode")}}
 
-  - : A {{domxref("DOMString")}} indicating the current value of the `{{domxref("MediaTrackConstraints.resizeMode", "resizeMode")}}` property, specifying the mode used by the user agent to derive the resolution of the track. The value will be one of:
+  - : A {{domxref("DOMString")}} indicating the current value of the {{domxref("MediaTrackConstraints.resizeMode", "resizeMode")}} property, specifying the mode used by the user agent to derive the resolution of the track. The value will be one of:
 
     - `"none"`
       - : The track has the resolution offered by the camera, its driver or the OS.

--- a/files/en-us/web/api/request/clone/index.md
+++ b/files/en-us/web/api/request/clone/index.md
@@ -34,7 +34,7 @@ A {{domxref("Request")}} object, which is an exact copy of the `Request` that `c
 
 ## Examples
 
-In the following snippet, we create a new request using the `{{domxref("Request.Request", "Request()")}}` constructor (for an image file in the same directory as the script), then clone the request.
+In the following snippet, we create a new request using the {{domxref("Request.Request", "Request()")}} constructor (for an image file in the same directory as the script), then clone the request.
 
 ```js
 var myRequest = new Request('flowers.jpg');

--- a/files/en-us/web/api/service_worker_api/using_service_workers/index.md
+++ b/files/en-us/web/api/service_worker_api/using_service_workers/index.md
@@ -185,7 +185,7 @@ self.addEventListener('fetch', (event) => {
 
 Let's look at a few other options we have when defining our magic (see our [Fetch API documentation](/en-US/docs/Web/API/Fetch_API) for more information about {{domxref("Request")}} and {{domxref("Response")}} objects.)
 
-1. The `{{domxref("Response.Response","Response()")}}` constructor allows you to create a custom response. In this case, we are just returning a simple text string:
+1. The {{domxref("Response.Response","Response()")}} constructor allows you to create a custom response. In this case, we are just returning a simple text string:
 
     ```js
     new Response('Hello from your friendly neighborhood service worker!');

--- a/files/en-us/web/api/settimeout/index.md
+++ b/files/en-us/web/api/settimeout/index.md
@@ -225,7 +225,7 @@ setTimeout(function() {
 }, 500);
 ```
 
-A string passed to `{{domxref("setTimeout()")}}` is evaluated in the global context, so local symbols in the context where `{{domxref("setTimeout()")}}` was called will not be available when the string is evaluated as code.
+A string passed to {{domxref("setTimeout()")}} is evaluated in the global context, so local symbols in the context where {{domxref("setTimeout()")}} was called will not be available when the string is evaluated as code.
 
 ### Reasons for delays longer than specified
 

--- a/files/en-us/web/api/wakelock/index.md
+++ b/files/en-us/web/api/wakelock/index.md
@@ -18,7 +18,7 @@ The system wake lock is exposed through the global {{domxref('Navigator.wakeLock
 
 ## Methods
 
-- `{{domxref("WakeLock.request", "request()")}}`
+- {{domxref("WakeLock.request", "request()")}}
   - : Requests a {{domxref("WakeLockSentinel")}} object, which returns a {{jsxref("Promise")}} that resolves with a {{domxref("WakeLockSentinel")}} object.
 
 ## Examples

--- a/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.md
@@ -147,7 +147,7 @@ back to an integer in the vertex shader (e.g. `(int) floatNumber`), or use
 The vertex shader code may include a number of attributes, but we don't need to specify
 the values for each attribute. Instead, we can supply a default value that will be
 identical for all vertices. We can call
-`{{domxref("WebGLRenderingContext.disableVertexAttribArray()", "gl.disableVertexAttribArray()")}}`
+{{domxref("WebGLRenderingContext.disableVertexAttribArray()", "gl.disableVertexAttribArray()")}}
 to tell WebGL to use the default value, while calling
 {{domxref("WebGLRenderingContext.enableVertexAttribArray()",
   "gl.enableVertexAttribArray()")}} will read the values from the array buffer as
@@ -161,7 +161,7 @@ value.
 
 The default value is `vec4(0.0, 0.0, 0.0, 1.0)` by default but we can
 specify a different default value with
-`{{domxref("WebGLRenderingContext.vertexAttrib()", "gl.vertexAttrib[1234]f[v]()")}}`.
+{{domxref("WebGLRenderingContext.vertexAttrib()", "gl.vertexAttrib[1234]f[v]()")}}.
 
 For example, your vertex shader may be using a position and a color attribute. Most
 meshes have the color specified at a per-vertex level, but some meshes are of a uniform

--- a/files/en-us/web/api/webrtc_api/taking_still_photos/index.md
+++ b/files/en-us/web/api/webrtc_api/taking_still_photos/index.md
@@ -193,7 +193,7 @@ Clearing the photo box involves creating an image, then converting it into a for
 
 We start by getting a reference to the hidden {{HTMLElement("canvas")}} element that we use for offscreen rendering. Next we set the `fillStyle` to `#AAA` (a fairly light grey), and fill the entire canvas with that color by calling {{domxref("CanvasRenderingContext2D.fillRect()","fillRect()")}}.
 
-Last in this function, we convert the canvas into a PNG image and call `{{domxref("Element.setAttribute", "photo.setAttribute()")}}` to make our captured still box display the image.
+Last in this function, we convert the canvas into a PNG image and call {{domxref("Element.setAttribute", "photo.setAttribute()")}} to make our captured still box display the image.
 
 ### Capturing a frame from the stream
 


### PR DESCRIPTION
Adding to #15795
After using wider search pattern found more cases.

### Summary
The `domxref` macro already uses code highlighting. So, we don't have to surround the macro with backticks.
This PR fixes such redundant use of backticks.

#### Metadata
- [x] Fixes a typo, bug, or other error
