### PR TITLE
MV3 add the Action API

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/action/colorarray/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/colorarray/index.md
@@ -1,0 +1,66 @@
+---
+title: action.ColorArray
+slug: Mozilla/Add-ons/WebExtensions/API/action/ColorArray
+tags:
+  - API
+  - Add-ons
+  - ColorArray
+  - Extensions
+  - Non-standard
+  - Reference
+  - Type
+  - WebExtensions
+  - action
+browser-compat: webextensions.api.action.ColorArray
+---
+{{AddonSidebar()}}
+
+## Type
+
+An `array` of four integers in the range 0-255, defining an RGBA color. The four values specify the following channels:
+
+1. Red
+2. Green
+3. Blue
+4. Alpha (opacity).
+
+For example, opaque red is `[255, 0, 0, 255]`.
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
+
+> **Note:** This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#type-ColorArray) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+>
+> Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.
+
+<div class="hidden"><pre>// Copyright 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre></div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/disable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/disable/index.md
@@ -1,0 +1,94 @@
+---
+title: action.disable()
+slug: Mozilla/Add-ons/WebExtensions/API/action/disable
+tags:
+  - API
+  - Add-ons
+  - Extensions
+  - Method
+  - Non-standard
+  - Reference
+  - WebExtensions
+  - action
+  - disable
+browser-compat: webextensions.api.action.disable
+---
+{{AddonSidebar()}}
+
+Disables the browser action for a tab, meaning that it cannot be clicked when that tab is active.
+
+> **Note:** This API is available in Manifest V3 or higher.
+
+## Syntax
+
+```js
+browser.action.disable(
+  tabId // optional integer
+)
+```
+
+### Parameters
+
+- `tabId`{{optional_inline}}
+  - : `integer`. The id of the tab for which you want to disable the browser action.
+
+## Examples
+
+Disable the browser action when clicked, and re-enable it every time a new tab is opened:
+
+```js
+browser.tabs.onCreated.addListener(() => {
+  browser.action.enable();
+});
+
+browser.action.onClicked.addListener(() => {
+  browser.action.disable();
+});
+```
+
+Disable the browser action only for the active tab:
+
+```js
+browser.action.onClicked.addListener((tab) => {
+  browser.action.disable(tab.id);
+});
+```
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
+
+> **Note:** This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-disable) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+>
+> Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.
+
+<div class="hidden"><pre>// Copyright 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre></div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/enable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/enable/index.md
@@ -1,0 +1,86 @@
+---
+title: action.enable()
+slug: Mozilla/Add-ons/WebExtensions/API/action/enable
+tags:
+  - API
+  - Add-ons
+  - Enable
+  - Extensions
+  - Method
+  - Non-standard
+  - Reference
+  - WebExtensions
+  - action
+browser-compat: webextensions.api.action.enable
+---
+{{AddonSidebar()}}
+
+Enables the browser action for a tab. By default, browser actions are enabled for all tabs.
+
+> **Note:** This API is available in Manifest V3 or higher.
+
+## Syntax
+
+```js
+browser.action.enable(
+  tabId // optional integer
+)
+```
+
+### Parameters
+
+- `tabId`{{optional_inline}}
+  - : `integer`. The id of the tab for which you want to enable the browser action.
+
+## Examples
+
+Disable the browser action when clicked, and re-enable it every time a new tab is opened:
+
+```js
+browser.tabs.onCreated.addListener(() => {
+  browser.action.enable();
+});
+
+browser.action.onClicked.addListener(() => {
+  browser.action.disable();
+});
+```
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
+
+> **Note:** This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-enable) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+>
+> Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.
+
+<div class="hidden"><pre>// Copyright 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre></div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/getbadgebackgroundcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/getbadgebackgroundcolor/index.md
@@ -1,0 +1,105 @@
+---
+title: action.getBadgeBackgroundColor()
+slug: Mozilla/Add-ons/WebExtensions/API/action/getBadgeBackgroundColor
+tags:
+  - API
+  - Add-ons
+  - Extensions
+  - Method
+  - Non-standard
+  - Reference
+  - WebExtensions
+  - action
+  - getBadgeBackgroundColor
+browser-compat: webextensions.api.action.getBadgeBackgroundColor
+---
+{{AddonSidebar()}}
+
+Gets the background color of the browser action's badge.
+
+> **Note:** This API is available in Manifest V3 or higher.
+
+This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
+
+## Syntax
+
+```js
+browser.action.getBadgeBackgroundColor(
+  details // object
+)
+```
+
+### Parameters
+
+- `details`
+
+  - : An object with the following properties:
+
+    - `tabId`{{optional_inline}}
+      - : `integer`. Specifies the tab to get the badge background color from.
+    - `windowId`{{optional_inline}}
+      - : `integer`. Specifies the window from which to get the badge background color.
+
+<!---->
+
+- If `windowId` and `tabId` are both supplied, the function fails.
+- If `windowId` and `tabId` are both omitted, the global badge background color is returned.
+
+### Return value
+
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with the retrieved color as a {{WebExtAPIRef('action.ColorArray')}}.
+
+## Examples
+
+Log the badge's background color:
+
+```js
+function onGot(color) {
+  console.log(color);
+}
+
+function onFailure(error) {
+  console.log(error);
+}
+
+browser.action.getBadgeBackgroundColor({}).then(onGot, onFailure);
+```
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
+
+> **Note:** This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-getBadgeBackgroundColor) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+>
+> Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.
+
+<div class="hidden"><pre>// Copyright 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre></div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/getbadgetext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/getbadgetext/index.md
@@ -1,0 +1,102 @@
+---
+title: action.getBadgeText()
+slug: Mozilla/Add-ons/WebExtensions/API/action/getBadgeText
+tags:
+  - API
+  - Add-ons
+  - Extensions
+  - Method
+  - Non-standard
+  - Reference
+  - WebExtensions
+  - action
+  - getBadgeText
+browser-compat: webextensions.api.action.getBadgeText
+---
+{{AddonSidebar()}}
+
+Gets the browser action's badge text.
+
+> **Note:** This API is available in Manifest V3 or higher.
+
+This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
+
+## Syntax
+
+```js
+let gettingText = browser.action.getBadgeText(
+  details               // object
+)
+```
+
+### Parameters
+
+- `details`
+
+  - : An object with the following properties:
+
+    - `tabId`{{optional_inline}}
+      - : `integer`. Specifies the tab from which to get the badge text.
+    - `windowId`{{optional_inline}}
+      - : `integer`. Specifies the window from which to get the badge text.
+
+<!---->
+
+- If windowId and tabId are both supplied, the function fails.
+- If windowId and tabId are both omitted, the global badge text is returned.
+
+### Return value
+
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a string containing the badge text.
+
+## Examples
+
+Log the badge text:
+
+```js
+function gotBadgeText(text) {
+  console.log(text);
+}
+
+let gettingBadgeText = browser.action.getBadgeText({});
+gettingBadgeText.then(gotBadgeText);
+```
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
+
+> **Note:** This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-getBadgeText) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+>
+> Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.
+
+<div class="hidden"><pre>// Copyright 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre></div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/getbadgetextcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/getbadgetextcolor/index.md
@@ -1,0 +1,106 @@
+---
+title: action.getBadgeTextColor()
+slug: Mozilla/Add-ons/WebExtensions/API/action/getBadgeTextColor
+tags:
+  - API
+  - Add-ons
+  - Extensions
+  - Method
+  - Reference
+  - WebExtensions
+  - action
+  - getBadgeTextColor
+browser-compat: webextensions.api.action.getBadgeTextColor
+---
+{{AddonSidebar()}}
+
+Gets the text color for the browser action's badge.
+
+> **Note:** This API is available in Manifest V3 or higher.
+
+In Firefox, unless the badge text color is explicitly set using {{WebExtAPIRef("action.setBadgeTextColor()")}}, the badge text color is automatically set to black or white so as to maximize contrast with the specified badge background color. For example, if you set the badge background color to white, the default badge text color is set to black, and vice versa.
+
+Other browsers always use a white text color.
+
+This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
+
+## Syntax
+
+```js
+browser.action.getBadgeTextColor(
+  details // object
+)
+```
+
+### Parameters
+
+- `details`
+
+  - : `object`.
+
+    - `tabId`{{optional_inline}}
+      - : `integer`. Specifies the tab to get the badge text color from.
+    - `windowId`{{optional_inline}}
+      - : `integer`. Specifies the window from which to get the badge text color.
+
+<!---->
+
+- If `windowId` and `tabId` are both supplied, the function fails.
+- If `windowId` and `tabId` are both omitted, the global badge text color is returned.
+
+### Return value
+
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with the retrieved color as a {{WebExtAPIRef('action.ColorArray')}}.
+
+## Examples
+
+Log the badge's text color:
+
+```js
+function onGot(color) {
+  console.log(color);
+}
+
+function onFailure(error) {
+  console.log(error);
+}
+
+browser.action.getBadgeTextColor({}).then(onGot, onFailure);
+```
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
+
+> **Note:** This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-getBadgeBackgroundColor) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+
+<div class="hidden"><pre>// Copyright 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre></div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/getpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/getpopup/index.md
@@ -1,0 +1,102 @@
+---
+title: action.getPopup()
+slug: Mozilla/Add-ons/WebExtensions/API/action/getPopup
+tags:
+  - API
+  - Add-ons
+  - Extensions
+  - Method
+  - Non-standard
+  - Reference
+  - WebExtensions
+  - action
+  - getPopup
+browser-compat: webextensions.api.action.getPopup
+---
+{{AddonSidebar()}}
+
+Gets the HTML document set as the popup for this browser action.
+
+> **Note:** This API is available in Manifest V3 or higher.
+
+This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
+
+## Syntax
+
+```js
+let gettingPopup = browser.action.getPopup(
+  details               // object
+)
+```
+
+### Parameters
+
+- `details`
+
+  - : An object with the following properties:
+
+    - `tabId`{{optional_inline}}
+      - : `integer`. The tab whose popup to get.
+    - `windowId`{{optional_inline}}
+      - : `integer`. The windows whose popup to get.
+
+<!---->
+
+- If `windowId` and `tabId` are both supplied, the function fails.
+- If `windowId` and `tabId` are both omitted, the global popup is returned.
+
+### Return value
+
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a string containing the URL for the popup's document. This will be a fully qualified URL, such as `moz-extension://d1d8a2eb-fe60-f646-af30-a866c5b39942/popups/popup2.html`.
+
+## Examples
+
+Get the popup's URL:
+
+```js
+function gotPopup(popupURL) {
+  console.log(popupURL)
+}
+
+let gettingPopup = browser.action.getPopup({});
+gettingPopup.then(gotPopup);
+```
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
+
+> **Note:** This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-getPopup) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+>
+> Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.
+
+<div class="hidden"><pre>// Copyright 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre></div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/gettitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/gettitle/index.md
@@ -1,0 +1,110 @@
+---
+title: action.getTitle()
+slug: Mozilla/Add-ons/WebExtensions/API/action/getTitle
+tags:
+  - API
+  - Add-ons
+  - Extensions
+  - Method
+  - Non-standard
+  - Reference
+  - WebExtensions
+  - action
+  - getTitle
+browser-compat: webextensions.api.action.getTitle
+---
+{{AddonSidebar()}}
+
+Gets the browser action's title.
+
+> **Note:** This API is available in Manifest V3 or higher.
+
+Just as you can set the title on a per-tab basis using {{WebExtAPIRef("action.setTitle()")}}, so you can retrieve a tab-specific title by passing the tab's ID into this function.
+
+This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
+
+## Syntax
+
+```js
+let gettingTitle = browser.action.getTitle(
+  details               // object
+)
+```
+
+### Parameters
+
+- `details`
+
+  - : An object with the following properties:
+
+    - `tabId`{{optional_inline}}
+      - : `integer`. Specify the tab to get the title from.
+    - `windowId`{{optional_inline}}
+      - : `integer`. Specify the window to get the title from.
+
+<!---->
+
+- If `windowId` and `tabId` are both supplied, the function fails and the promise it returns is rejected.
+- If `windowId` and `tabId` are both omitted, the global title is returned.
+
+### Return value
+
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a string containing the browser action's title.
+
+## Examples
+
+This code switches the title between "this" and "that" each time the user clicks the browser action:
+
+```js
+function toggleTitle(title) {
+  if (title == "this") {
+    browser.action.setTitle({title: "that"});
+  } else {
+    browser.action.setTitle({title: "this"});
+  }
+}
+
+browser.action.onClicked.addListener(() => {
+  let gettingTitle = browser.action.getTitle({});
+  gettingTitle.then(toggleTitle);
+});
+```
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
+
+> **Note:** This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-getTitle) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+>
+> Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.
+
+<div class="hidden"><pre>// Copyright 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre></div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/imagedatatype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/imagedatatype/index.md
@@ -1,0 +1,61 @@
+---
+title: action.ImageDataType
+slug: Mozilla/Add-ons/WebExtensions/API/action/ImageDataType
+tags:
+  - API
+  - Add-ons
+  - Extensions
+  - ImageDataType
+  - Non-standard
+  - Reference
+  - Type
+  - WebExtensions
+  - action
+browser-compat: webextensions.api.action.ImageDataType
+---
+{{AddonSidebar()}}
+
+Pixel data for an image. Must be an [`ImageData`](/en-US/docs/Web/API/ImageData) object (for example, from a {{htmlelement("canvas")}} element).
+
+## Type
+
+An [`ImageData`](/en-US/docs/Web/API/ImageData) object.
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
+
+> **Note:** This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#type-ImageDataType) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+>
+> Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.
+
+<div class="hidden"><pre>// Copyright 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre></div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/index.md
@@ -1,0 +1,116 @@
+---
+title: action
+slug: Mozilla/Add-ons/WebExtensions/API/action
+tags:
+  - API
+  - Add-ons
+  - Extensions
+  - Interface
+  - Non-standard
+  - Reference
+  - WebExtensions
+  - action
+browser-compat: webextensions.api.action
+---
+{{AddonSidebar}}
+
+Adds a button to the browser's toolbar.
+
+> **Note:** This API is available in Manifest V3 or higher.
+
+A [browser action](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Browser_action) is a button in the browser's toolbar.
+
+You can associate a popup with the button. The popup is specified using HTML, CSS and JavaScript, just like a normal web page. JavaScript running in the popup gets access to all the same WebExtension APIs as your background scripts, but its global context is the popup, not the current page displayed in the browser. To affect web pages you need to communicate with them via [messages](/en-US/docs/Mozilla/Add-ons/WebExtensions/Modify_a_web_page#messaging).
+
+If you specify a popup, it will be shown — and the content will be loaded — when the user clicks the icon. If you do not specify a popup, then when the user clicks the icon an event is dispatched to your extension.
+
+You can define most of a browser action's properties declaratively using the [`browser_action`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action) key in the manifest.json.
+
+With the `action` API, you can:
+
+- use {{WebExtAPIRef("action.onClicked")}} to listen for clicks on the icon.
+- get and set the icon's properties — icon, title, popup, and so on. You can get and set these globally across all tabs, or for a specific tab by passing the tab ID as an additional argument.
+
+## Types
+
+- {{WebExtAPIRef("action.ColorArray")}}
+  - : An array of four integers in the range 0-255 defining an RGBA color.
+- {{WebExtAPIRef("action.ImageDataType")}}
+  - : Pixel data for an image. Must be an [`ImageData`](/en-US/docs/Web/API/ImageData) object (for example, from a {{htmlelement("canvas")}} element).
+
+## Functions
+
+- {{WebExtAPIRef("action.setTitle()")}}
+  - : Sets the browser action's title. This will be displayed in a tooltip.
+- {{WebExtAPIRef("action.getTitle()")}}
+  - : Gets the browser action's title.
+- {{WebExtAPIRef("action.setIcon()")}}
+  - : Sets the browser action's icon.
+- {{WebExtAPIRef("action.setPopup()")}}
+  - : Sets the HTML document to be opened as a popup when the user clicks on the browser action's icon.
+- {{WebExtAPIRef("action.getPopup()")}}
+  - : Gets the HTML document set as the browser action's popup.
+- {{WebExtAPIRef("action.openPopup()")}}
+  - : Open the browser action's popup.
+- {{WebExtAPIRef("action.setBadgeText()")}}
+  - : Sets the browser action's badge text. The badge is displayed on top of the icon.
+- {{WebExtAPIRef("action.getBadgeText()")}}
+  - : Gets the browser action's badge text.
+- {{WebExtAPIRef("action.setBadgeBackgroundColor()")}}
+  - : Sets the badge's background color.
+- {{WebExtAPIRef("action.getBadgeBackgroundColor()")}}
+  - : Gets the badge's background color.
+- {{WebExtAPIRef("action.setBadgeTextColor()")}}
+  - : Sets the badge's text color.
+- {{WebExtAPIRef("action.getBadgeTextColor()")}}
+  - : Gets the badge's text color.
+- {{WebExtAPIRef("action.enable()")}}
+  - : Enables the browser action for a tab. By default, browser actions are enabled for all tabs.
+- {{WebExtAPIRef("action.disable()")}}
+  - : Disables the browser action for a tab, meaning that it cannot be clicked when that tab is active.
+- {{WebExtAPIRef("action.isEnabled()")}}
+  - : Checks whether the browser action is enabled or not.
+
+## Events
+
+- {{WebExtAPIRef("action.onClicked")}}
+  - : Fired when a browser action icon is clicked. This event will not fire if the browser action has a popup.
+
+{{WebExtExamples("h2")}}
+
+## Browser compatibility
+
+{{Compat}}
+
+> **Note:** This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+>
+> Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.
+
+<div class="hidden"><pre>// Copyright 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre></div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/isenabled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/isenabled/index.md
@@ -1,0 +1,80 @@
+---
+title: action.isEnabled()
+slug: Mozilla/Add-ons/WebExtensions/API/action/isEnabled
+tags:
+  - API
+  - Add-ons
+  - Extensions
+  - Method
+  - Reference
+  - WebExtensions
+  - action
+  - isEnabled
+browser-compat: webextensions.api.action.isEnabled
+---
+{{AddonSidebar()}}
+
+Returns `true` if the browser action is enabled.
+
+> **Note:** This API is available in Manifest V3 or higher.
+
+This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
+
+## Syntax
+
+```js
+let gettingIsEnabled = browser.action.isEnabled(
+  details // object
+)
+```
+
+### Parameters
+
+- `details`
+
+  - : `object`. An object optionally containing the `tabId` or `windowId` to check.
+
+    - `tabId` {{optional_inline}}
+      - : `integer`. ID of a tab to check.
+    - `windowId` {{optional_inline}}
+      - : `integer`. ID of a window to check.
+
+<!---->
+
+- If windowId and tabId are both supplied, the function fails.
+- If windowId and tabId are both omitted, the global enabled/disabled status is returned.
+
+### Return value
+
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with `true` if the extension's browser action is enabled, and `false` otherwise.
+
+## Examples
+
+Check the global state:
+
+```js
+browser.action.isEnabled({}).then(result => {
+  console.log(result);
+});
+```
+
+Check the state of the currently active tab:
+
+```js
+async function enabledInActiveTab() {
+  let tabs = await browser.tabs.query({
+    currentWindow:true,
+    active: true
+  });
+  let enabled = await browser.action.isEnabled({
+    tabId: tabs[0].id
+  });
+  console.log(enabled);
+}
+```
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/onclicked/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/onclicked/index.md
@@ -1,0 +1,110 @@
+---
+title: action.onClicked
+slug: Mozilla/Add-ons/WebExtensions/API/action/onClicked
+tags:
+  - API
+  - Add-ons
+  - Event
+  - Extensions
+  - Non-standard
+  - Reference
+  - WebExtensions
+  - action
+  - onClicked
+browser-compat: webextensions.api.action.onClicked
+---
+{{AddonSidebar()}}
+
+Fired when a browser action icon is clicked. This event will not fire if the browser action has a popup.
+
+> **Note:** This API is available in Manifest V3 or higher.
+
+To define a right-click action, use the [`contextMenus`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/menus) API with the "browser_action" [context type](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/menus/ContextType).
+
+## Syntax
+
+```js
+browser.action.onClicked.addListener(listener)
+browser.action.onClicked.removeListener(listener)
+browser.action.onClicked.hasListener(listener)
+```
+
+Events have three functions:
+
+- `addListener(listener)`
+  - : Adds a listener to this event.
+- `removeListener(listener)`
+  - : Stop listening to this event. The `listener` argument is the listener to remove.
+- `hasListener(listener)`
+  - : Check whether `listener` is registered for this event. Returns `true` if it is listening, `false` otherwise.
+
+## addListener syntax
+
+### Parameters
+
+- `callback`
+
+  - : Function that will be called when this event occurs. The function will be passed the following arguments:
+
+    - `tab`
+      - : {{WebExtAPIRef('tabs.Tab')}}. The tab that was active when the icon was clicked.
+    - `OnClickData`
+
+      - : An object containing information about the click.
+
+        - `modifiers`
+          - : An `array`. The keyboard modifiers active at the time of the click, being one or more of `Shift`, `Alt`, `Command`, `Ctrl`, or `MacCtrl`.
+        - `button`
+          - : An `integer`. Indicates the button used to click the page action icon: `0` for a left-click or a click not associated with a mouse, such as one from the keyboard and `1` for a middle button or wheel click. Note that the right-click is not supported because Firefox consumes that click to display the context menu before this event is triggered.
+
+## Examples
+
+When the user clicks the icon, disable it for the active tab, and log the tab's URL:
+
+```js
+browser.action.onClicked.addListener((tab) => {
+  // disable the active tab
+  browser.action.disable(tab.id);
+  // requires the "tabs" or "activeTab" permission, or host permissions for the URL
+  console.log(tab.url);
+});
+```
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
+
+> **Note:** This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#event-onClicked) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+>
+> Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.
+
+<div class="hidden"><pre>// Copyright 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre></div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/openpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/openpopup/index.md
@@ -1,0 +1,58 @@
+---
+title: action.openPopup()
+slug: Mozilla/Add-ons/WebExtensions/API/action/openPopup
+tags:
+  - API
+  - Add-ons
+  - Extensions
+  - Method
+  - Non-standard
+  - Reference
+  - WebExtensions
+  - action
+  - openPopup
+browser-compat: webextensions.api.action.openPopup
+---
+{{AddonSidebar()}}
+
+Open the browser action's popup.
+
+> **Note:** This API is available in Manifest V3 or higher.
+
+You can only call this function from inside the handler for a [user action](/en-US/docs/Mozilla/Add-ons/WebExtensions/User_actions).
+
+## Syntax
+
+```js
+browser.action.openPopup()
+```
+
+### Parameters
+
+None.
+
+### Return value
+
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is resolved with no arguments.
+
+## Examples
+
+Open the popup when the user selects a context menu item:
+
+```js
+browser.menus.create({
+  id: "open-popup",
+  title: "open popup",
+  contexts: ["all"]
+});
+
+browser.menus.onClicked.addListener(() => {
+  browser.action.openPopup();
+});
+```
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgebackgroundcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgebackgroundcolor/index.md
@@ -1,0 +1,124 @@
+---
+title: action.setBadgeBackgroundColor()
+slug: Mozilla/Add-ons/WebExtensions/API/action/setBadgeBackgroundColor
+tags:
+  - API
+  - Add-ons
+  - Extensions
+  - Method
+  - Non-standard
+  - Reference
+  - WebExtensions
+  - action
+  - setBadgeBackgroundColor
+browser-compat: webextensions.api.action.setBadgeBackgroundColor
+---
+{{AddonSidebar()}}
+
+Sets the background color for the badge. Tabs without a specific badge background color will inherit the global badge background color, which defaults to `[217, 0, 0, 255]` in Firefox.
+
+> **Note:** This API is available in Manifest V3 or higher.
+
+In Firefox, unless the badge text color is explicitly set using {{WebExtAPIRef("action.setBadgeTextColor()")}}, then the badge text color iw automatically set to black or white to maximize contrast with the specified badge background color. For example, if you set the badge background color to white, the default badge text color is set to black, and vice versa.
+
+Other browsers always use a white text color, so setting a dark background may be preferable to ensure the text is readable.
+
+## Syntax
+
+```js
+browser.action.setBadgeBackgroundColor(
+  details // object
+)
+```
+
+### Parameters
+
+- `details`
+
+  - : An object with the following properties:
+
+    - `color`
+
+      - : The color, specified as one of:
+
+        - a string: any CSS [\<color>](/en-US/docs/Web/CSS/color_value) value, for example `"red"`, `"#FF0000"`, or `"rgb(255,0,0)"`. If the string is not a valid color, the returned promise will be rejected and the background color won't be altered.
+        - a `{{WebExtAPIRef('action.ColorArray')}}` object.
+        - `null`. If a `tabId` is specified, it removes the tab-specific badge background color so that the tab inherits the global badge background color. Otherwise it reverts the global badge background color to the default value.
+
+    - `tabId`{{optional_inline}}
+      - : `integer`. Sets the badge background color only for the given tab. The color is reset when the user navigates this tab to a new page.
+    - `windowId`{{optional_inline}}
+      - : `integer`. Sets the badge background color only for the given tab.
+
+<!---->
+
+- If `windowId` and `tabId` are both supplied, the function fails and the color is not set.
+- If `windowId` and `tabId` are both omitted, the global badge background color is set instead.
+
+## Examples
+
+A background color that starts off as red, and turns green when the browser action is clicked:
+
+```js
+browser.action.setBadgeText({text: "1234"});
+browser.action.setBadgeBackgroundColor({color: "red"});
+
+browser.action.onClicked.addListener(()=> {
+  browser.action.setBadgeBackgroundColor({color: "green"});
+});
+```
+
+Set the badge background color only for the active tab:
+
+```js
+browser.action.setBadgeText({text: "1234"});
+browser.action.setBadgeBackgroundColor({color: "red"});
+
+browser.action.onClicked.addListener((tab)=> {
+  browser.action.setBadgeBackgroundColor({
+    color: "green",
+    tabId: tab.id
+  });
+});
+```
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
+
+The default color in Firefox is: `[217, 0, 0, 255]`.
+
+> **Note:** This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-setBadgeBackgroundColor) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+>
+> Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.
+
+<div class="hidden"><pre>// Copyright 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre></div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgetext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgetext/index.md
@@ -1,0 +1,111 @@
+---
+title: action.setBadgeText()
+slug: Mozilla/Add-ons/WebExtensions/API/action/setBadgeText
+tags:
+  - API
+  - Add-ons
+  - Extensions
+  - Method
+  - Non-standard
+  - Reference
+  - WebExtensions
+  - action
+  - setBadgeText
+browser-compat: webextensions.api.action.setBadgeText
+---
+{{AddonSidebar()}}
+
+Sets the badge text for the browser action. The badge is displayed on top of the icon.
+
+> **Note:** This API is available in Manifest V3 or higher.
+
+Tabs without an specific badge text will inherit the global badge text, which is `""` by default.
+
+## Syntax
+
+```js
+browser.action.setBadgeText(
+  details // object
+)
+```
+
+This API is also available as `chrome.action.setBadgeText()`.
+
+### Parameters
+
+- `details`
+
+  - : An object with the following properties:
+
+    - `text`
+
+      - : `string` or `null`. Any number of characters can be passed, but only about four can fit in the space.
+
+        Use an empty string - `""` - if you don't want any badge.
+
+        If a `tabId` is specified, `null` removes the tab-specific badge text so that the tab inherits the global badge text. Otherwise it reverts the global badge text to `""`.
+
+        If a `windowId` is specified, `null` removes the window-specific badge text so that the tab inherits the global badge text. Otherwise it reverts the global badge text to `""`.
+
+    - `tabId`{{optional_inline}}
+      - : `integer`. Set the badge text only for the given tab. The text is reset when the user navigates this tab to a new page.
+    - `windowId`{{optional_inline}}
+      - : `integer`. Set the badge text for the given window.
+
+<!---->
+
+- If `windowId` and `tabId` are both supplied, the function fails.
+- If `windowId` and `tabId` are both omitted, the global badge is set.
+
+## Examples
+
+Add a badge indicating how many times the user clicked the button:
+
+```js
+let clicks = 0;
+
+function increment() {
+  browser.action.setBadgeText({text: (++clicks).toString()});
+}
+
+browser.action.onClicked.addListener(increment);
+```
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
+
+> **Note:** This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-setBadgeText) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+>
+> Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.
+
+<div class="hidden"><pre>// Copyright 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre></div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgetextcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgetextcolor/index.md
@@ -1,0 +1,115 @@
+---
+title: action.setBadgeTextColor()
+slug: Mozilla/Add-ons/WebExtensions/API/action/setBadgeTextColor
+tags:
+  - API
+  - Add-ons
+  - Extensions
+  - Method
+  - Reference
+  - WebExtensions
+  - action
+  - setBadgeTextColor
+browser-compat: webextensions.api.action.setBadgeTextColor
+---
+{{AddonSidebar()}}
+
+Sets the text color for the browser action's badge. Tabs without a specific badge text color will inherit the global badge text color.
+
+> **Note:** This API is available in Manifest V3 or higher.
+
+## Syntax
+
+```js
+browser.action.setBadgeTextColor(
+  details // object
+)
+```
+
+### Parameters
+
+- `details`
+
+  - : An object with the following properties:
+
+    - `color`
+
+      - : The color, specified as one of:
+
+        - a string: any CSS [\<color>](/en-US/docs/Web/CSS/color_value) value, for example `"red"`, `"#FF0000"`, or `"rgb(255,0,0)"`. If the string is not a valid color, the returned promise will be rejected and the text color won't be altered.
+        - a `{{WebExtAPIRef('action.ColorArray')}}` object.
+        - `null`. If a `tabId` is specified, it removes the tab-specific badge text color so that the tab inherits the global badge text color. Otherwise it reverts the global badge text color to the default value.
+
+    - `tabId`{{optional_inline}}
+      - : `integer`. Sets the badge text color only for the given tab. The color is reset when the user navigates this tab to a new page.
+    - `windowId`{{optional_inline}}
+      - : `integer`. Sets the badge text color only for the given tab.
+
+<!---->
+
+- If `windowId` and `tabId` are both supplied, the function fails and the color is not set.
+- If `windowId` and `tabId` are both omitted, the global badge text color is set instead.
+
+## Examples
+
+A badge text color that starts off as red, and turns green when the browser action is clicked:
+
+```js
+browser.action.setBadgeText({text: "1234"});
+browser.action.setBadgeTextColor({color: "red"});
+
+browser.action.onClicked.addListener(()=> {
+  browser.action.setBadgeTextColor({color: "green"});
+});
+```
+
+Set the badge text color only for the active tab:
+
+```js
+browser.action.setBadgeText({text: "1234"});
+browser.action.setBadgeTextColor({color: "red"});
+
+browser.action.onClicked.addListener((tab)=> {
+  browser.action.setBadgeTextColor({
+    color: "green",
+    tabId: tab.id
+  });
+});
+```
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
+
+> **Note:** This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-setBadgeBackgroundColor) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+
+<div class="hidden"><pre>// Copyright 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre></div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/seticon/index.md
@@ -1,0 +1,193 @@
+---
+title: action.setIcon()
+slug: Mozilla/Add-ons/WebExtensions/API/action/setIcon
+tags:
+  - API
+  - Add-ons
+  - Extensions
+  - Method
+  - Non-standard
+  - Reference
+  - WebExtensions
+  - action
+  - setIcon
+browser-compat: webextensions.api.action.setIcon
+---
+{{AddonSidebar()}}
+
+Sets the icon for the browser action.
+
+> **Note:** This API is available in Manifest V3 or higher.
+
+You can specify a single icon as either the path to an image file or a {{WebExtAPIRef('action.ImageDataType')}} object.
+
+You can specify multiple icons in different sizes by supplying a dictionary containing multiple paths or `ImageData` objects. This means the icon doesn't have to be scaled for a device with a different pixel density.
+
+Tabs without a specific icon will inherit the global icon, which defaults to the [`default_icon`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action) specified in the manifest.
+
+This is an asynchronous function that returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
+
+## Syntax
+
+```js
+let settingIcon = browser.action.setIcon(
+  details         // object
+)
+```
+
+### Parameters
+
+- `details`
+
+  - : `object`. An object containing either `imageData` or `path` properties, and optionally a `tabId` property.
+
+    - `imageData`{{optional_inline}}
+
+      - : `{{WebExtAPIRef('action.ImageDataType')}}` or `object`. This is either a single `ImageData` object or a dictionary object.
+
+        Use a dictionary object to specify multiple `ImageData` objects in different sizes, so the icon does not have to be scaled for a device with a different pixel density. If `imageData` is a dictionary, the value of each property is an `ImageData` object, and its name is its size, like this:
+
+        ```json
+        {
+          16: image16,
+          32: image32
+        }
+        ```
+
+        The browser will choose the image to use depending on the screen's pixel density. See [Choosing icon sizes](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action#choosing_icon_sizes) for more information on this.
+
+    - `path`{{optional_inline}}
+
+      - : `string` or `object`. This is either a relative path to an icon file or it is a dictionary object.
+
+        Use a dictionary object to specify multiple icon files in different sizes, so the icon does not have to be scaled for a device with a different pixel density. If `path` is a dictionary, the value of each property is a relative path, and its name is its size, like this:
+
+        ```json
+        {
+          16: "path/to/image16.jpg",
+          32: "path/to/image32.jpg"
+        }
+        ```
+
+        The browser will choose the image to use depending on the screen's pixel density. See [Choosing icon sizes](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action#choosing_icon_sizes) for more information on this.
+
+    - `tabId`{{optional_inline}}
+      - : `integer`. Sets the icon only for the given tab. The icon is reset when the user navigates this tab to a new page.
+    - `windowId`{{optional_inline}}
+      - : `integer`. Sets the icon for the given window.
+
+<!---->
+
+- If `windowId` and `tabId` are both supplied, the function fails and the icon is not set.
+- If `windowId` and `tabId` are both omitted, the global icon is set.
+
+If each one of `imageData` and `path` is one of `undefined`, `null` or empty object:
+
+- If `tabId` is specified, and the tab has a tab-specific icon set, then the tab will inherit the icon from the window to which it belongs.
+- If `windowId` is specified, and the window has a window-specific icon set, then the window will inherit the global icon.
+- Otherwise, the global icon will be reset to the manifest icon.
+
+### Return value
+
+A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with no arguments once the icon has been set.
+
+## Examples
+
+The code below uses a browser action to toggle a listener for {{WebExtAPIRef("webRequest.onHeadersReceived")}}, and uses `setIcon()` to indicate whether listening is on or off:
+
+```js
+function logResponseHeaders(requestDetails) {
+  console.log(requestDetails);
+}
+
+function startListening() {
+  browser.webRequest.onHeadersReceived.addListener(
+    logResponseHeaders,
+    {urls: ["<all_urls>"]},
+    ["responseHeaders"]
+  );
+  browser.action.setIcon({path: "icons/listening-on.svg"});
+}
+
+function stopListening() {
+  browser.webRequest.onHeadersReceived.removeListener(logResponseHeaders);
+  browser.action.setIcon({path: "icons/listening-off.svg"});
+}
+
+function toggleListener() {
+  if (browser.webRequest.onHeadersReceived.hasListener(logResponseHeaders)) {
+    stopListening();
+  } else {
+    startListening();
+  }
+}
+
+browser.action.onClicked.addListener(toggleListener);
+```
+
+The code below sets the icon using an [`ImageData`](/en-US/docs/Web/API/ImageData) object:
+
+```js
+function getImageData() {
+  let canvas = document.createElement("canvas");
+  let ctx = canvas.getContext("2d");
+
+  ctx.fillStyle = "green";
+  ctx.fillRect(10, 10, 100, 100);
+
+  return ctx.getImageData(50, 50, 100, 100);
+}
+
+browser.action.onClicked.addListener(() => {
+  browser.action.setIcon({imageData: getImageData()});
+});
+```
+
+The following snippet updates the icon when the user clicks it, but only for the active tab:
+
+```js
+browser.action.onClicked.addListener((tab) => {
+  browser.action.setIcon({
+    tabId: tab.id, path: "icons/updated-48.png"
+  });
+});
+```
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
+
+> **Note:** This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-setIcon) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+>
+> Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.
+
+<div class="hidden"><pre>// Copyright 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre></div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/setpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/setpopup/index.md
@@ -1,0 +1,134 @@
+---
+title: action.setPopup()
+slug: Mozilla/Add-ons/WebExtensions/API/action/setPopup
+tags:
+  - API
+  - Add-ons
+  - Extensions
+  - Method
+  - Non-standard
+  - Reference
+  - WebExtensions
+  - action
+  - setPopup
+browser-compat: webextensions.api.action.setPopup
+---
+{{AddonSidebar()}}
+
+Sets the HTML document that is opened as a popup when the user clicks on the browser action's icon. Tabs without a specific popup will inherit the global popup, which defaults to the [`default_popup`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action) specified in the manifest.
+
+> **Note:** This API is available in Manifest V3 or higher.
+
+## Syntax
+
+```js
+browser.action.setPopup(
+  details // object
+)
+```
+
+### Parameters
+
+- `details`
+
+  - : An object with the following properties:
+
+    - `tabId`{{optional_inline}}
+      - : `integer`. Sets the popup only for a specific tab. The popup is reset when the user navigates this tab to a new page.
+    - `windowId`{{optional_inline}}
+      - : `integer`. Sets the popup only for the specified window.
+    - `popup`
+
+      - : `string` or `null`. The HTML file to show in a popup, specified as a URL.
+
+        This can point to a file packaged within the extension (for example, created using {{WebExtAPIRef("extension.getURL")}}), or a remote document (e.g. `https://example.org/`).
+
+        If an empty string (`""`) is passed here, the popup is disabled, and the extension will receive {{WebExtAPIRef("action.onClicked")}} events.
+
+        If `popup` is `null`:
+
+        - If `tabId` is specified, removes the tab-specific popup so that the tab inherits the global popup.
+        - If `windowId` is specified, removes the window-specific popup so that the window inherits the global popup.
+        - If `tabId` and `windowId` are both omitted, reverts the global popup to the default value.
+
+<!---->
+
+- If `windowId` and `tabId` are both supplied, the function fails and the popup is not set.
+- If `windowId` and `tabId` are both omitted, the global popup is set.
+
+## Examples
+
+This code adds a pair of context menu items that you can use to switch between two popups. Note that you'll need the "contextMenus" [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) set in the extension's manifest to create context menu items.
+
+```js
+function onCreated() {
+  if (browser.runtime.lastError) {
+    console.log("error creating item:" + browser.runtime.lastError);
+  } else {
+    console.log("item created successfully");
+  }
+}
+
+browser.contextMenus.create({
+  id: "popup-1",
+  type: "radio",
+  title: "Popup 1",
+  contexts: ["all"],
+  checked: true
+}, onCreated);
+
+browser.contextMenus.create({
+  id: "popup-2",
+  type: "radio",
+  title: "Popup 2",
+  contexts: ["all"],
+  checked: false
+}, onCreated);
+
+browser.contextMenus.onClicked.addListener(function(info, tab) {
+  if (info.menuItemId == "popup-1") {
+    browser.action.setPopup({popup: "/popup/popup1.html"})
+  } else if (info.menuItemId == "popup-2") {
+    browser.action.setPopup({popup: "/popup/popup2.html"})
+  }
+});
+```
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
+
+> **Note:** This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-setPopup) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+>
+> Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.
+
+<div class="hidden"><pre>// Copyright 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre></div>

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/settitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/settitle/index.md
@@ -1,0 +1,113 @@
+---
+title: action.setTitle()
+slug: Mozilla/Add-ons/WebExtensions/API/action/setTitle
+tags:
+  - API
+  - Add-ons
+  - Extensions
+  - Method
+  - Reference
+  - WebExtensions
+  - action
+  - setTitle
+browser-compat: webextensions.api.action.setTitle
+---
+{{AddonSidebar}}
+
+Sets the browser action's title. The title is displayed in a tooltip over the browser action's icon. You can pass a `tabId` in or a `windowId` as an optional parameter — if you do this then the title is changed only for the specified tab or window. Tabs or windows without a specific title inherit the global title text, which defaults to the [`default_title`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action) or [`name`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/name) specified in the manifest.
+
+> **Note:** This API is available in Manifest V3 or higher.
+
+## Syntax
+
+```js
+browser.action.setTitle(
+  details // object
+)
+```
+
+### Parameters
+
+- `details`
+
+  - : `object`. The new title and optionally the ID of the tab or window to target.
+
+    - `title`
+
+      - : `string` or `null`. The string the browser action should display when moused over.
+
+        If `title` is an empty string, the used title will be the extension name, but {{WebExtAPIRef("action.getTitle")}} will still provide the empty string.
+
+        If `title` is `null`:
+
+        - If `tabId` is specified, and the tab has a tab-specific title set, then the tab will inherit the title from the window to which it belongs.
+        - if `windowId` is specified, and the window has a window-specific title set, then the window will inherit the global title.
+        - Otherwise, the global title will be reset to the manifest title.
+
+    - `tabId`{{Optional_Inline}}
+      - : `integer`. Sets the title only for the given tab.
+    - `windowId`{{Optional_Inline}}
+      - : `integer`. Sets the title for the given window.
+
+<!---->
+
+- If `windowId` and `tabId` are both supplied, the function fails and the title is not set.
+- If `windowId` and `tabId` are both omitted, the global title is set.
+
+## Examples
+
+This code switches the title between "this" and "that" each time the user clicks the browser action:
+
+```js
+function toggleTitle(title) {
+  if (title == "this") {
+    browser.action.setTitle({title: "that"});
+  } else {
+    browser.action.setTitle({title: "this"});
+  }
+}
+
+browser.action.onClicked.addListener(() => {
+  let gettingTitle = browser.action.getTitle({});
+  gettingTitle.then(toggleTitle);
+});
+```
+
+{{WebExtExamples}}
+
+## Browser compatibility
+
+{{Compat}}
+
+> **Note:** This API is based on Chromium's [`chrome.action`](https://developer.chrome.com/docs/extensions/reference/action/#method-setTitle) API. This documentation is derived from [`browser_action.json`](https://chromium.googlesource.com/chromium/src/+/master/chrome/common/extensions/api/browser_action.json) in the Chromium code.
+>
+> Microsoft Edge compatibility data is supplied by Microsoft Corporation and is included here under the Creative Commons Attribution 3.0 United States License.
+
+<div class="hidden"><pre>// Copyright 2015 The Chromium Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre></div>


### PR DESCRIPTION
** do not merge until all manifest V3 content is ready **

This content is a copy of the browserAction API content with the following changes:

- removed references to the Firefox version (63) in the action.setBadgeBackgroundColor() & action.getBadgeTextColor() notes about default colors
- moved compatibility data to the end of the content (to make examples more prominent)
- added a note about Manifest V3 support

#### Metadata

This PR…
- [x] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
