### PR TITLE
Fix IndexedDB sidebar

### DIFF
--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -781,7 +781,6 @@
         "IDBCursor",
         "IDBCursorWithValue",
         "IDBDatabase",
-        "IDBEnvironment",
         "IDBFactory",
         "IDBIndex",
         "IDBKeyRange",
@@ -789,8 +788,7 @@
         "IDBOpenDBRequest",
         "IDBRequest",
         "IDBTransaction",
-        "IDBVersionChangeEvent",
-        "IDBVersionChangeRequest"
+        "IDBVersionChangeEvent"
       ],
       "methods": [],
       "properties": [],


### PR DESCRIPTION
`IDBEnvironment` and `IDBVersionChangeRequest` are:
- non-standard
- not implemented (nothing in bcd…)
- not documented.

This PR removes them from the IndexedDB sidebar.