### PR TITLE
follow-up of https://github.com/mdn/yari/pull/6183 - Node version bump - GH Actions failing

### DIFF
--- a/.github/workflows/json-lint.yml
+++ b/.github/workflows/json-lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: "12"
+          node-version: "14"
           cache: yarn
 
       - name: Lint markdown files

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: "12"
+          node-version: "14"
           cache: yarn
 
       - name: Lint markdown files

--- a/.github/workflows/pr-check_redirects.yml
+++ b/.github/workflows/pr-check_redirects.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: "12"
+          node-version: "14"
           cache: yarn
 
       - name: Install all yarn packages

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: "12"
+          node-version: "14"
           cache: yarn
 
       - name: Install all yarn packages

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: "12"
+          node-version: "14"
           cache: yarn
 
       - name: Install all yarn packages


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
GitHub actions seem to fail because of Node version prerequisite. This intends to follow https://github.com/mdn/yari/pull/6183

#### Motivation

https://github.com/mdn/content/runs/6353422641?check_suite_focus=true

#### Supporting details

https://github.com/mdn/content/runs/6353422641?check_suite_focus=true

#### Related issues

Not an issue but https://github.com/mdn/translated-content/pull/5520

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

None of the above: CI / pipeline / tooling related PR 