### PR TITLE
Order of returned array from document.elementsFromPoint

### DIFF
--- a/files/en-us/web/api/document/elementsfrompoint/index.md
+++ b/files/en-us/web/api/document/elementsfrompoint/index.md
@@ -14,7 +14,7 @@ browser-compat: api.Document.elementsFromPoint
 The **`elementsFromPoint()`** method
 of the {{domxref("Document")}} interface returns an array of all elements
 at the specified coordinates (relative to the viewport).
-The elements are ordered from topmost to bottommost.
+The elements are ordered from the topmost to the bottommost box of the viewport.
 
 It operates in a similar way to the {{domxref("Document.elementFromPoint",
   "elementFromPoint()")}} method.
@@ -34,7 +34,7 @@ elementsFromPoint(x, y)
 
 ### Return value
 
-An array of {{domxref('Element')}} objects.
+An array of {{domxref('Element')}} objects, ordered from the topmost to the bottommost box of the viewport.
 
 ## Examples
 

--- a/files/en-us/web/api/document/elementsfrompoint/index.md
+++ b/files/en-us/web/api/document/elementsfrompoint/index.md
@@ -14,6 +14,7 @@ browser-compat: api.Document.elementsFromPoint
 The **`elementsFromPoint()`** method
 of the {{domxref("Document")}} interface returns an array of all elements
 at the specified coordinates (relative to the viewport).
+The elements are ordered from topmost to bottommost.
 
 It operates in a similar way to the {{domxref("Document.elementFromPoint",
   "elementFromPoint()")}} method.
@@ -33,7 +34,7 @@ elementsFromPoint(x, y)
 
 ### Return value
 
-An array of {{domxref('element')}} objects.
+An array of {{domxref('Element')}} objects.
 
 ## Examples
 


### PR DESCRIPTION
#### Summary
Describe the order of the returned array from `document.elementsFromPoint`: from topmost element to bottommost.

#### Motivation
The example and the linked standard make the order clear, but it wasn't explicitly
mentioned in the text. There are two natural orders, and only one is correct.

#### Supporting details
The [spec](https://drafts.csswg.org/cssom-view/#dom-document-elementsfrompoint) says (emphasis added):
> For each [box](https://drafts.csswg.org/css-display-3/#box) in the [viewport](https://drafts.csswg.org/css2/#viewport%E2%91%A0), in paint order, ***starting with the topmost box***, that would be a target for hit testing at coordinates x,y even if nothing would be overlapping it, when applying the [transforms](https://drafts.csswg.org/cssom-view/#transforms) that apply to the descendants of the viewport, append the associated element to sequence.

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

