### PR TITLE
Update window resize_event documentation

### DIFF
--- a/files/en-us/web/api/window/resize_event/index.md
+++ b/files/en-us/web/api/window/resize_event/index.md
@@ -39,7 +39,7 @@ The **`resize`** event fires when the document view (window) has been resized.
 
 In some earlier browsers it was possible to register `resize` event handlers on any HTML element. It is still possible to set `onresize` attributes or use {{domxref("EventTarget.addEventListener", "addEventListener()")}} to set a handler on any element. However, `resize` events are only fired on the {{domxref("Window", "window")}} object (i.e. returned by {{domxref("document.defaultView")}}). Only handlers registered on the `window` object will receive `resize` events.
 
-While the `resize` event fires only for the window nowadays, this can now be accomplished for other elements by using the [ResizeObserver.](/en-US/docs/Web/API/ResizeObserver)
+While the `resize` event fires only for the window nowadays, you can get resize notifications for other elements using the [ResizeObserver](/en-US/docs/Web/API/ResizeObserver) API.
 
 If the resize event is triggered too many times for your application, see [Optimizing window.onresize](https://bencentra.com/code/2015/02/27/optimizing-window-resize.html) to control the time after which the event fires.
 

--- a/files/en-us/web/api/window/resize_event/index.md
+++ b/files/en-us/web/api/window/resize_event/index.md
@@ -39,7 +39,7 @@ The **`resize`** event fires when the document view (window) has been resized.
 
 In some earlier browsers it was possible to register `resize` event handlers on any HTML element. It is still possible to set `onresize` attributes or use {{domxref("EventTarget.addEventListener", "addEventListener()")}} to set a handler on any element. However, `resize` events are only fired on the {{domxref("Window", "window")}} object (i.e. returned by {{domxref("document.defaultView")}}). Only handlers registered on the `window` object will receive `resize` events.
 
-There is a proposal to allow all elements to be notified of resize changes. See [Resize Observer](https://wicg.github.io/ResizeObserver/) to read the draft document, and [GitHub issues](https://github.com/WICG/resize-observer/issues) to read the on-going discussions.
+While the `resize` event fires only for the window nowadays, this can now be accomplished for other elements by using the [ResizeObserver.](/en-US/docs/Web/API/ResizeObserver)
 
 If the resize event is triggered too many times for your application, see [Optimizing window.onresize](https://bencentra.com/code/2015/02/27/optimizing-window-resize.html) to control the time after which the event fires.
 


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Update resize_event documentation to link to the now standard `ResizeObserver`

#### Motivation
The copy is outdated as it mentioned the `ResizeObserver` as only a proposal

#### Supporting details
https://www.w3.org/TR/resize-observer-1/
https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
