### PR TITLE
typo fix ("If now" > "If not")

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/tablist_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/tablist_role/index.md
@@ -32,7 +32,7 @@ When creating a multi-selectable tablist, include [`aria-multiselectable="true"`
 
 The `tab` elements not the `tablist`, have the [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected) attribute. Set to `aria-selected="true"` for the tabs associated with each visible tabpanel. The tabs associated with hidden tabpanel elements have their `aria-selected` attributes set to `false`.
 
-If the tab list has a visible label, set [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) to the `id` of the labelling element. If now, use [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) to provide a label.
+If the tab list has a visible label, set [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) to the `id` of the labelling element. If not, use [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) to provide a label.
 
 To be keyboard accessible, focus must be managed for the descendants of this role.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Teensy typo, ninth paragraph of [Description section of this page](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Tablist_Role#description):
"If now" should be "If not":
![image](https://user-images.githubusercontent.com/2660348/167495016-2a6c2e3a-2ee2-42e2-9933-0d0a8da28276.png)


#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
See link + screenshot in "Summary" above.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
