### PR TITLE
Fixing anchor links to HTTP headers page

### DIFF
--- a/files/en-us/web/http/connection_management_in_http_1.x/index.md
+++ b/files/en-us/web/http/connection_management_in_http_1.x/index.md
@@ -23,7 +23,7 @@ Two newer models were created in HTTP/1.1. The persistent-connection model keeps
 
 > **Note:** HTTP/2 adds additional models for connection management.
 
-It's important point to note that connection management in HTTP applies to the connection between two consecutive nodes, which is [hop-by-hop](/en-US/docs/Web/HTTP/Headers#hbh) and not [end-to-end](/en-US/docs/Web/HTTP/Headers#e2e). The model used in connections between a client and its first proxy may differ from the model between a proxy and the destination server (or any intermediate proxies). The HTTP headers involved in defining the connection model, like {{HTTPHeader("Connection")}} and {{HTTPHeader("Keep-Alive")}}, are [hop-by-hop](/en-US/docs/Web/HTTP/Headers#hbh) headers with their values able to be changed by intermediary nodes.
+It's important point to note that connection management in HTTP applies to the connection between two consecutive nodes, which is [hop-by-hop](/en-US/docs/Web/HTTP/Headers) and not [end-to-end](/en-US/docs/Web/HTTP/Headers). The model used in connections between a client and its first proxy may differ from the model between a proxy and the destination server (or any intermediate proxies). The HTTP headers involved in defining the connection model, like {{HTTPHeader("Connection")}} and {{HTTPHeader("Keep-Alive")}}, are [hop-by-hop](/en-US/docs/Web/HTTP/Headers) headers with their values able to be changed by intermediary nodes.
 
 A related topic is the concept of HTTP connection upgrades, wherein an HTTP/1.1 connection is upgraded to a different protocol, such as TLS/1.0, WebSocket, or even HTTP/2 in cleartext. This [protocol upgrade mechanism](/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism) is documented in more detail elsewhere.
 


### PR DESCRIPTION
#### Summary
I removed the anchors on the 'hop-by-hop' and 'end-to-end' links to the HTTP headers page. 

#### Motivation
The anchors currently linked to by the 'hop-by-hop' and 'end-to-end' links do not exist on the HTTP headers page. There were no closer anchors that I could find.

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error