### PR TITLE
Fix Typo (css/user-select)

### DIFF
--- a/files/en-us/web/css/user-select/index.md
+++ b/files/en-us/web/css/user-select/index.md
@@ -71,7 +71,7 @@ user-select: unset;
 - `text`
   - : The text can be selected by the user.
 - `all`
-  - : The content of the element shall be selected atomically: If a selection would contain part of the element, then the selection must contain the entire element including all its descendants.  If a double-click or context-click occurred in sub-elements, the highest ancestor with this value will be selected.
+  - : The content of the element shall be selected automatically: If a selection would contain part of the element, then the selection must contain the entire element including all its descendants.  If a double-click or context-click occurred in sub-elements, the highest ancestor with this value will be selected.
 - `contain`
   - : Enables selection to start within the element; however, the selection will be contained by the bounds of that element.
 - `element`{{non-standard_inline}} (IE-specific alias)


### PR DESCRIPTION
#### Summary
Typo in CSS "user-select": `all` value description ... Replace "atomically" with "automatically"

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error