### PR TITLE
DOMException serializable - relnote and tidy

### DIFF
--- a/files/en-us/glossary/serializable_object/index.md
+++ b/files/en-us/glossary/serializable_object/index.md
@@ -22,6 +22,7 @@ Objects that can be transferred are called {{Glossary("Transferable objects")}}.
 
 ## Supported objects
 
+All primitive values are serializable.
 Not all objects are serializable objects.
 The objects that can be serialized are listed in: [The structured clone algorithm > Supported types](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm#supported_types)
 

--- a/files/en-us/mozilla/firefox/releases/101/index.md
+++ b/files/en-us/mozilla/firefox/releases/101/index.md
@@ -45,6 +45,8 @@ This article provides information about the changes in Firefox 101 that will aff
 
 - [`HTMLInputElement.showPicker()`](/en-US/docs/Web/API/HTMLInputElement/showPicker) is now supported, allowing the picker for an input element to be displayed when a user interacts with some other element, such as a button ({{bug(1745005)}}).
 
+- [`DOMException`](/en-US/docs/Web/API/DOMException) is now a {{Glossary("serializable object")}}, so it can be cloned with {{domxref("structuredClone()")}} or copied between [workers](/en-US/docs/Web/API/Worker) using {{domxref("Worker.postMessage()", "postMessage()")}} ({{bug(1561357)}}).
+
 
 #### Media, WebRTC, and Web Audio
 

--- a/files/en-us/web/api/domexception/code/index.md
+++ b/files/en-us/web/api/domexception/code/index.md
@@ -7,20 +7,18 @@ tags:
   - DOMException
   - Property
   - Reference
+  - deprecated
 browser-compat: api.DOMException.code
 ---
-{{ APIRef("DOM") }}
+{{ APIRef("DOM") }} {{deprecated_header}}
 
-The **`code`** read-only property of the
-{{domxref("DOMException")}} interface returns a `short` that contains one of
-the [error code constants](/en-US/docs/Web/API/DOMException#error_names), or
-`0` if none match. This field is used for historical reasons. New DOM
-exceptions don't use this anymore: they put this info in the
-{{domxref("DOMException.name")}} attribute.
+The **`code`** read-only property of the {{domxref("DOMException")}} interface returns one of the legacy [error code constants](/en-US/docs/Web/API/DOMException#error_names), or `0` if none match.
+
+This field is used for historical reasons. New DOM exceptions don't use this anymore: they put this info in the {{domxref("DOMException.name")}} attribute.
 
 ## Value
 
-A short number.
+One of the [error code constants](/en-US/docs/Web/API/DOMException#error_names), or `0` if none match.
 
 ## Specifications
 

--- a/files/en-us/web/api/domexception/index.md
+++ b/files/en-us/web/api/domexception/index.md
@@ -28,9 +28,9 @@ Each exception has a **name**, which is a short "PascalCase"-style string identi
 ## Properties
 
 - {{domxref("DOMException.code")}} {{deprecated_inline}} {{readOnlyInline}}
-  - : Returns a `short` that contains one of the error code constants, or `0` if none match. This field is used for historical reasons. New DOM exceptions don't use this anymore: they put this info in the {{domxref("DOMException.name")}} attribute.
+  - : Returns one of the legacy error code constants, or `0` if none match.
 - {{domxref("DOMException.message")}} {{readOnlyInline}}
-  - : Returns a {{ domxref("DOMString") }} representing a message or description associated with the given [error name](#error_names).
+  - : Returns a string representing a message or description associated with the given [error name](#error_names).
 - {{domxref("DOMException.name")}} {{readOnlyInline}}
   - : Returns a string that contains one of the strings associated with an [error name](#error_names).
 


### PR DESCRIPTION
[DOMException](https://developer.mozilla.org/en-US/docs/Web/API/DOMException) is serializable in FF101 following https://bugzilla.mozilla.org/show_bug.cgi?id=1561357. 

This add a release note.
It also marks [`DOMException.code`](https://developer.mozilla.org/en-US/docs/Web/API/DOMException) as deprecated in the sub doc to match the same BCD update. 

This is part of #15638