### PR TITLE
`DOMString` -> `string`

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/index.md
+++ b/files/en-us/web/api/htmlmediaelement/index.md
@@ -40,9 +40,9 @@ _This interface also inherits properties from its ancestors {{domxref("HTMLEleme
 - {{domxref("HTMLMediaElement.controlsList")}} {{readonlyinline}}
   - : Returns a {{domxref("DOMTokenList")}} that helps the user agent select what controls to show on the media element whenever the user agent shows its own set of controls. The `DOMTokenList` takes one or more of three possible values: `nodownload`, `nofullscreen`, and `noremoteplayback`.
 - {{domxref("HTMLMediaElement.crossOrigin")}}
-  - : A {{domxref("DOMString")}} indicating the [CORS setting](/en-US/docs/Web/HTML/Attributes/crossorigin) for this media element.
+  - : A string indicating the [CORS setting](/en-US/docs/Web/HTML/Attributes/crossorigin) for this media element.
 - {{domxref("HTMLMediaElement.currentSrc")}} {{readonlyinline}}
-  - : Returns a {{domxref("DOMString")}} with the absolute URL of the chosen media resource.
+  - : Returns a string with the absolute URL of the chosen media resource.
 - {{domxref("HTMLMediaElement.currentTime")}}
   - : A double-precision floating-point value indicating the current playback time in seconds; if the media has not started to play and has not been seeked, this value is the media's initial playback time. Setting this value seeks the media to the new time. The time is specified relative to the media's timeline.
 - {{domxref("HTMLMediaElement.defaultMuted")}}
@@ -72,7 +72,7 @@ _This interface also inherits properties from its ancestors {{domxref("HTMLEleme
 - {{domxref("HTMLMediaElement.played")}} {{readonlyinline}}
   - : Returns a {{domxref('TimeRanges')}} object that contains the ranges of the media source that the browser has played, if any.
 - {{domxref("HTMLMediaElement.preload")}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("preload", "video")}} HTML attribute, indicating what data should be preloaded, if any. Possible values are: `none`, `metadata`, `auto`.
+  - : Is a string that reflects the {{htmlattrxref("preload", "video")}} HTML attribute, indicating what data should be preloaded, if any. Possible values are: `none`, `metadata`, `auto`.
 - {{domxref("HTMLMediaElement.preservesPitch")}}
   - : Is a boolean value that determines if the pitch of the sound will be preserved. If set to `false`, the pitch will adjust to the speed of the audio.
 - {{domxref("HTMLMediaElement.readyState")}} {{readonlyinline}}
@@ -82,9 +82,9 @@ _This interface also inherits properties from its ancestors {{domxref("HTMLEleme
 - {{domxref("HTMLMediaElement.seeking")}} {{readonlyinline}}
   - : Returns a {{jsxref('Boolean')}} that indicates whether the media is in the process of seeking to a new position.
 - {{domxref("HTMLMediaElement.sinkId")}} {{readonlyinline}} {{experimental_inline}}
-  - : Returns a {{domxref("DOMString")}} that is the unique ID of the audio device delivering output, or an empty string if it is using the user agent default. This ID should be one of the `MediaDeviceInfo.deviceid` values returned from {{domxref("MediaDevices.enumerateDevices()")}}, `id-multimedia`, or `id-communications`.
+  - : Returns a string that is the unique ID of the audio device delivering output, or an empty string if it is using the user agent default. This ID should be one of the `MediaDeviceInfo.deviceid` values returned from {{domxref("MediaDevices.enumerateDevices()")}}, `id-multimedia`, or `id-communications`.
 - {{domxref("HTMLMediaElement.src")}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("src", "video")}} HTML attribute, which contains the URL of a media resource to use.
+  - : Is a string that reflects the {{htmlattrxref("src", "video")}} HTML attribute, which contains the URL of a media resource to use.
 - {{domxref("HTMLMediaElement.srcObject")}}
   - : Is a {{domxref('MediaStream')}} representing the media to play or that has played in the current `HTMLMediaElement`, or `null` if not assigned.
 - {{domxref("HTMLMediaElement.textTracks")}} {{readonlyinline}}
@@ -108,7 +108,7 @@ These properties are obsolete and should not be used, even if a browser still su
 - {{domxref("HTMLMediaElement.controller")}} {{deprecated_inline}}
   - : Is a {{domxref("MediaController")}} object that represents the media controller assigned to the element, or `null` if none is assigned.
 - {{domxref("HTMLMediaElement.mediaGroup")}} {{deprecated_inline}}
-  - : A {{domxref("DOMString")}} that reflects the {{ htmlattrxref("mediagroup", "video")}} HTML attribute, which indicates the name of the group of elements it belongs to. A group of media elements shares a common {{domxref('MediaController')}}.
+  - : A string that reflects the {{ htmlattrxref("mediagroup", "video")}} HTML attribute, which indicates the name of the group of elements it belongs to. A group of media elements shares a common {{domxref('MediaController')}}.
 - {{domxref("HTMLMediaElement.mozAudioCaptured")}} {{readonlyinline}} {{non-standard_inline}} {{deprecated_inline}}
   - : Returns a {{jsxref('Boolean')}}. Related to audio stream capture.
 - {{domxref("HTMLMediaElement.mozFragmentEnd")}} {{non-standard_inline}} {{deprecated_inline}}

--- a/files/en-us/web/api/htmlmediaelement/mediagroup/index.md
+++ b/files/en-us/web/api/htmlmediaelement/mediagroup/index.md
@@ -16,7 +16,7 @@ The **`HTMLMediaElement.mediaGroup`** property reflects the {{htmlattrxref("medi
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlmediaelement/sinkid/index.md
+++ b/files/en-us/web/api/htmlmediaelement/sinkid/index.md
@@ -15,7 +15,7 @@ browser-compat: api.HTMLMediaElement.sinkId
 {{SeeCompatTable}}{{APIRef("HTML DOM")}}
 
 The **`HTMLMediaElement.sinkId`** read-only property returns a
-{{domxref("DOMString")}} that is the unique ID of the audio device delivering output. If
+string that is the unique ID of the audio device delivering output. If
 it is using the user agent default, it returns an empty string. This ID should be one of
 the {{domxref("MediaDeviceInfo.deviceId")}} values returned from
 {{domxref("MediaDevices.enumerateDevices()")}}, `id-multimedia`, or

--- a/files/en-us/web/api/htmlmediaelement/src/index.md
+++ b/files/en-us/web/api/htmlmediaelement/src/index.md
@@ -25,7 +25,7 @@ resource to use in the element.
 
 ## Value
 
-A {{domxref("USVString")}} object containing the URL of a media resource to use in the
+A string object containing the URL of a media resource to use in the
 element; this property reflects the value of the HTML element's `src`
 attribute.
 

--- a/files/en-us/web/api/htmlmetaelement/index.md
+++ b/files/en-us/web/api/htmlmetaelement/index.md
@@ -20,10 +20,10 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 | Name                                  | Type                             | Description                                                                            |
 | ------------------------------------- | -------------------------------- | -------------------------------------------------------------------------------------- |
-| `content`                             | {{domxref("DOMString")}} | Gets or sets the value of meta-data property.                                          |
-| `httpEquiv`                           | {{domxref("DOMString")}} | Gets or sets the name of an HTTP response header to define for a document.             |
-| `name`                                | {{domxref("DOMString")}} | Gets or sets the name of a meta-data property to define for a document.                |
-| `scheme` {{deprecated_inline}} | {{domxref("DOMString")}} | Gets or sets the name of a scheme used to interpret the value of a meta-data property. |
+| `content`                             | string | Gets or sets the value of meta-data property.                                          |
+| `httpEquiv`                           | string | Gets or sets the name of an HTTP response header to define for a document.             |
+| `name`                                | string | Gets or sets the name of a meta-data property to define for a document.                |
+| `scheme` {{deprecated_inline}} | string | Gets or sets the name of a scheme used to interpret the value of a meta-data property. |
 
 ## Methods
 

--- a/files/en-us/web/api/htmlmodelement/index.md
+++ b/files/en-us/web/api/htmlmodelement/index.md
@@ -19,9 +19,9 @@ The **`HTMLModElement`** interface provides special properties (beyond the regul
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLModElement.cite")}}
-  - : Is a {{domxref("DOMString")}} reflecting the {{htmlattrxref("cite", "del")}} HTML attribute, containing a URI of a resource explaining the change.
+  - : Is a string reflecting the {{htmlattrxref("cite", "del")}} HTML attribute, containing a URI of a resource explaining the change.
 - {{domxref("HTMLModElement.dateTime")}}
-  - : Is a {{domxref("DOMString")}} reflecting the {{htmlattrxref("datetime", "del")}} HTML attribute, containing a date-and-time string representing a timestamp for the change.
+  - : Is a string reflecting the {{htmlattrxref("datetime", "del")}} HTML attribute, containing a date-and-time string representing a timestamp for the change.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlobjectelement/data/index.md
+++ b/files/en-us/web/api/htmlobjectelement/data/index.md
@@ -14,7 +14,7 @@ browser-compat: api.HTMLObjectElement.data
 {{APIRef("HTML DOM")}}
 
 The **`data`** property of the
-{{domxref("HTMLObjectElement")}} interface returns a {{domxref("DOMString")}} that
+{{domxref("HTMLObjectElement")}} interface returns a string that
 reflects the {{htmlattrxref("data", "object")}} HTML attribute, specifying the address
 of a resource's data.
 

--- a/files/en-us/web/api/htmlobjectelement/height/index.md
+++ b/files/en-us/web/api/htmlobjectelement/height/index.md
@@ -14,7 +14,7 @@ browser-compat: api.HTMLObjectElement.height
 {{APIRef("HTML DOM")}}
 
 The **`height`** property of the
-{{domxref("HTMLObjectElement")}} interface Returns a {{domxref("DOMString")}} that
+{{domxref("HTMLObjectElement")}} interface Returns a string that
 reflects the {{htmlattrxref("height", "object")}} HTML attribute, specifying the
 displayed height of the resource in CSS pixels.
 

--- a/files/en-us/web/api/htmlobjectelement/index.md
+++ b/files/en-us/web/api/htmlobjectelement/index.md
@@ -19,47 +19,47 @@ The **`HTMLObjectElement`** interface provides special properties and methods (b
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLObjectElement.align")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} representing an enumerated property indicating alignment of the element's contents with respect to the surrounding context. The possible values are `"left"`, `"right"`, `"justify"`, and `"center"`.
+  - : Is a string representing an enumerated property indicating alignment of the element's contents with respect to the surrounding context. The possible values are `"left"`, `"right"`, `"justify"`, and `"center"`.
 - {{domxref("HTMLObjectElement.archive")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("archive", "object")}} HTML attribute, containing a list of archives for resources for this object.
+  - : Is a string that reflects the {{htmlattrxref("archive", "object")}} HTML attribute, containing a list of archives for resources for this object.
 - {{domxref("HTMLObjectElement.border")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("border", "object")}} HTML attribute, specifying the width of a border around the object.
+  - : Is a string that reflects the {{htmlattrxref("border", "object")}} HTML attribute, specifying the width of a border around the object.
 - {{domxref("HTMLObjectElement.code")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} representing the name of an applet class file, containing either the applet's subclass, or the path to get to the class, including the class file itself.
+  - : Is a string representing the name of an applet class file, containing either the applet's subclass, or the path to get to the class, including the class file itself.
 - {{domxref("HTMLObjectElement.codeBase")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("codebase", "object")}} HTML attribute, specifying the base path to use to resolve relative URIs.
+  - : Is a string that reflects the {{htmlattrxref("codebase", "object")}} HTML attribute, specifying the base path to use to resolve relative URIs.
 - {{domxref("HTMLObjectElement.codeType")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("codetype", "object")}} HTML attribute, specifying the content type of the data.
+  - : Is a string that reflects the {{htmlattrxref("codetype", "object")}} HTML attribute, specifying the content type of the data.
 - {{domxref("HTMLObjectElement.contentDocument")}} {{readonlyInline}}
   - : Returns a {{domxref("Document")}} representing the active document of the object element's nested browsing context, if any; otherwise `null`.
 - {{domxref("HTMLObjectElement.contentWindow")}} {{readonlyInline}}
   - : Returns a {{domxref("WindowProxy")}} representing the window proxy of the object element's nested browsing context, if any; otherwise `null`.
 - {{domxref("HTMLObjectElement.data")}}
-  - : Returns a {{domxref("DOMString")}} that reflects the {{htmlattrxref("data", "object")}} HTML attribute, specifying the address of a resource's data.
+  - : Returns a string that reflects the {{htmlattrxref("data", "object")}} HTML attribute, specifying the address of a resource's data.
 - {{domxref("HTMLObjectElement.declare")}} {{deprecated_inline}}
   - : Is a boolean value that reflects the {{htmlattrxref("declare", "object")}} HTML attribute, indicating that this is a declaration, not an instantiation, of the object.
 - {{domxref("HTMLObjectElement.form")}} {{readonlyInline}}
   - : Returns a {{domxref("HTMLFormElement")}} representing the object element's form owner, or null if there isn't one.
 - {{domxref("HTMLObjectElement.height")}}
-  - : Returns a {{domxref("DOMString")}} that reflects the {{htmlattrxref("height", "object")}} HTML attribute, specifying the displayed height of the resource in CSS pixels.
+  - : Returns a string that reflects the {{htmlattrxref("height", "object")}} HTML attribute, specifying the displayed height of the resource in CSS pixels.
 - {{domxref("HTMLObjectElement.hspace")}} {{deprecated_inline}}
   - : Is a `long` representing the horizontal space in pixels around the control.
 - {{domxref("HTMLObjectElement.name")}}
-  - : Returns a {{domxref("DOMString")}} that reflects the {{htmlattrxref("name", "object")}} HTML attribute, specifying the name of the browsing context.
+  - : Returns a string that reflects the {{htmlattrxref("name", "object")}} HTML attribute, specifying the name of the browsing context.
 - {{domxref("HTMLObjectElement.standby")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("standby", "object")}} HTML attribute, specifying a message to display while the object loads.
+  - : Is a string that reflects the {{htmlattrxref("standby", "object")}} HTML attribute, specifying a message to display while the object loads.
 - {{domxref("HTMLObjectElement.type")}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("type", "object")}} HTML attribute, specifying the MIME type of the resource.
+  - : Is a string that reflects the {{htmlattrxref("type", "object")}} HTML attribute, specifying the MIME type of the resource.
 - {{domxref("HTMLObjectElement.useMap")}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("usemap", "object")}} HTML attribute, specifying a {{HTMLElement("map")}} element to use.
+  - : Is a string that reflects the {{htmlattrxref("usemap", "object")}} HTML attribute, specifying a {{HTMLElement("map")}} element to use.
 - {{domxref("HTMLObjectElement.validationMessage")}} {{readonlyInline}}
-  - : Returns a {{domxref("DOMString")}} representing a localized message that describes the validation constraints that the control does not satisfy (if any). This is the empty string if the control is not a candidate for constraint validation (`willValidate` is `false`), or it satisfies its constraints.
+  - : Returns a string representing a localized message that describes the validation constraints that the control does not satisfy (if any). This is the empty string if the control is not a candidate for constraint validation (`willValidate` is `false`), or it satisfies its constraints.
 - {{domxref("HTMLObjectElement.validity")}} {{readonlyInline}}
   - : Returns a {{domxref("ValidityState")}} with the validity states that this element is in.
 - {{domxref("HTMLObjectElement.vspace")}} {{deprecated_inline}}
   - : Is a `long` representing the horizontal space in pixels around the control.
 - {{domxref("HTMLObjectElement.width")}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("width", "object")}} HTML attribute, specifying the displayed width of the resource in CSS pixels.
+  - : Is a string that reflects the {{htmlattrxref("width", "object")}} HTML attribute, specifying the displayed width of the resource in CSS pixels.
 - {{domxref("HTMLObjectElement.willValidate")}} {{readonlyInline}}
   - : Returns a boolean value that indicates whether the element is a candidate for constraint validation. Always `false` for `HTMLObjectElement` objects.
 

--- a/files/en-us/web/api/htmlobjectelement/name/index.md
+++ b/files/en-us/web/api/htmlobjectelement/name/index.md
@@ -14,7 +14,7 @@ browser-compat: api.HTMLObjectElement.name
 {{APIRef("HTML DOM")}}
 
 The **`name`** property of the
-{{domxref("HTMLObjectElement")}} interface returns a {{domxref("DOMString")}} that
+{{domxref("HTMLObjectElement")}} interface returns a string that
 reflects the {{htmlattrxref("name", "object")}} HTML attribute, specifying the name of
 the browsing context.
 

--- a/files/en-us/web/api/htmlobjectelement/type/index.md
+++ b/files/en-us/web/api/htmlobjectelement/type/index.md
@@ -14,7 +14,7 @@ browser-compat: api.HTMLObjectElement.type
 {{APIRef("HTML DOM")}}
 
 The **`type`** property of the
-{{domxref("HTMLObjectElement")}} interface returns a {{domxref("DOMString")}} that
+{{domxref("HTMLObjectElement")}} interface returns a string that
 reflects the {{htmlattrxref("type", "object")}} HTML attribute, specifying the MIME type
 of the resource.
 

--- a/files/en-us/web/api/htmlobjectelement/usemap/index.md
+++ b/files/en-us/web/api/htmlobjectelement/usemap/index.md
@@ -14,7 +14,7 @@ browser-compat: api.HTMLObjectElement.useMap
 {{APIRef("HTML DOM")}}
 
 The **`useMap`** property of the
-{{domxref("HTMLObjectElement")}} interface returns a {{domxref("DOMString")}} that
+{{domxref("HTMLObjectElement")}} interface returns a string that
 reflects the {{htmlattrxref("usemap", "object")}} HTML attribute, specifying a
 {{HTMLElement("map")}} element to use.
 

--- a/files/en-us/web/api/htmlobjectelement/validationmessage/index.md
+++ b/files/en-us/web/api/htmlobjectelement/validationmessage/index.md
@@ -14,7 +14,7 @@ browser-compat: api.HTMLObjectElement.validationMessage
 {{APIRef("HTML DOM")}}
 
 The **`validationMessage`** read-only property
-of the {{domxref("HTMLObjectElement")}} interface returns a {{domxref("DOMString")}}
+of the {{domxref("HTMLObjectElement")}} interface returns a string
 representing a localized message that describes the validation constraints that the
 control does not satisfy (if any). This is the empty string if the control is not a
 candidate for constraint validation (willValidate is false), or it satisfies its

--- a/files/en-us/web/api/htmlobjectelement/width/index.md
+++ b/files/en-us/web/api/htmlobjectelement/width/index.md
@@ -14,13 +14,13 @@ browser-compat: api.HTMLObjectElement.width
 {{APIRef("HTML DOM")}}
 
 The **`width`** property of the
-{{domxref("HTMLObjectElement")}} interface returns a {{domxref("DOMString")}} that
+{{domxref("HTMLObjectElement")}} interface returns a string that
 reflects the {{htmlattrxref("width", "object")}} HTML attribute, specifying the
 displayed width of the resource in CSS pixels.
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmlolistelement/index.md
+++ b/files/en-us/web/api/htmlolistelement/index.md
@@ -24,7 +24,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
   - : Is a `long` value reflecting the {{htmlattrxref("start", "ol")}} and defining the value of the first number of the first element of the list.
 - {{domxref("HTMLOListElement.type")}}
 
-  - : Is a {{domxref("DOMString")}} value reflecting the {{htmlattrxref("type", "ol")}} and defining the kind of marker to be used to display. It can have the following values:
+  - : Is a string value reflecting the {{htmlattrxref("type", "ol")}} and defining the kind of marker to be used to display. It can have the following values:
 
     - `'1'` meaning that decimal numbers are used: `1`, `2`, `3`, `4`, `5`, …
     - `'a'` meaning that the lowercase latin alphabet is used:  `a`, `b`, `c`, `d`, `e`, …

--- a/files/en-us/web/api/htmloptgroupelement/index.md
+++ b/files/en-us/web/api/htmloptgroupelement/index.md
@@ -23,7 +23,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 - {{domxref("HTMLOptGroupElement.disabled")}}
   - : Is a boolean value representing whether or not the whole list of children {{HTMLElement("option")}} is disabled (true) or not (false).
 - {{domxref("HTMLOptGroupElement.label")}}
-  - : Is a {{domxref("DOMString")}} representing the label for the group.
+  - : Is a string representing the label for the group.
 
 ## Methods
 

--- a/files/en-us/web/api/htmloptionelement/index.md
+++ b/files/en-us/web/api/htmloptionelement/index.md
@@ -33,13 +33,13 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 - {{domxref("HTMLOptionElement.index")}} {{readonlyInline}}
   - : Is a `long` representing the position of the option within the list of options it belongs to, in tree-order. If the option is not part of a list of options, like when it is part of the {{HTMLElement("datalist")}} element, the value is `0`.
 - {{domxref("HTMLOptionElement.label")}} {{readonlyInline}}
-  - : Is a {{domxref("DOMString")}} that reflects the value of the {{htmlattrxref("label", "option")}} HTML attribute, which provides a label for the option. If this attribute isn't specifically set, reading it returns the element's text content.
+  - : Is a string that reflects the value of the {{htmlattrxref("label", "option")}} HTML attribute, which provides a label for the option. If this attribute isn't specifically set, reading it returns the element's text content.
 - {{domxref("HTMLOptionElement.selected")}}
   - : Has a value of either `true` or `false` that indicates whether the option is currently selected.
 - {{domxref("HTMLOptionElement.text")}}
-  - : Is a {{domxref("DOMString")}} that contains the text content of the element.
+  - : Is a string that contains the text content of the element.
 - {{domxref("HTMLOptionElement.value")}}
-  - : Is a {{domxref("DOMString")}} that reflects the value of the {{htmlattrxref("value", "option")}} HTML attribute, if it exists; otherwise reflects value of the {{domxref("Node.textContent")}} property.
+  - : Is a string that reflects the value of the {{htmlattrxref("value", "option")}} HTML attribute, if it exists; otherwise reflects value of the {{domxref("Node.textContent")}} property.
 
 ## Methods
 

--- a/files/en-us/web/api/htmloptionelement/option/index.md
+++ b/files/en-us/web/api/htmloptionelement/option/index.md
@@ -30,11 +30,11 @@ new Option(text, value, defaultSelected, selected)
 ### Parameters
 
 - `text` {{optional_inline}}
-  - : A {{domxref("DOMString")}} representing the content of the element, i.e. the
+  - : A string representing the content of the element, i.e. the
     displayed text. If this is not specified, a default value of "" (empty string) is
     used.
 - `value` {{optional_inline}}
-  - : A {{domxref("DOMString")}} representing the value of the
+  - : A string representing the value of the
     {{domxref("HTMLOptionElement")}}, i.e. the value attribute of the equivalent
     {{htmlelement("option")}}. If this is not specified, the value of text is used as the
     value, e.g. for the associated {{htmlelement("select")}} element's value when the form

--- a/files/en-us/web/api/htmloutputelement/index.md
+++ b/files/en-us/web/api/htmloutputelement/index.md
@@ -19,7 +19,7 @@ The **`HTMLOutputElement`** interface provides properties and methods (beyond th
 _This interface also inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLOutputElement.defaultValue")}}
-  - : A {{domxref("DOMString")}} representing the default value of the element, initially the empty string.
+  - : A string representing the default value of the element, initially the empty string.
 - {{domxref("HTMLOutputElement.form")}}{{ReadOnlyInline}}
   - : An {{domxref("HTMLFormElement")}} indicating the form associated with the control, reflecting the {{htmlattrxref("form", "output")}} HTML attribute if it is defined.
 - {{domxref("HTMLOutputElement.htmlFor")}}{{ReadOnlyInline}}
@@ -27,15 +27,15 @@ _This interface also inherits properties from its parent, {{domxref("HTMLElement
 - {{domxref("HTMLOutputElement.labels")}}{{ReadOnlyInline}}
   - : A {{domxref("NodeList")}} of {{HTMLElement("label")}} elements associated with the element.
 - {{domxref("HTMLOutputElement.name")}}
-  - : A {{domxref("DOMString")}} reflecting the {{htmlattrxref("name", "output")}} HTML attribute, containing the name for the control that is submitted with form data.
+  - : A string reflecting the {{htmlattrxref("name", "output")}} HTML attribute, containing the name for the control that is submitted with form data.
 - {{domxref("HTMLOutputElement.type")}}{{ReadOnlyInline}}
-  - : The {{domxref("DOMString")}} "`output`".
+  - : The string "`output`".
 - {{domxref("HTMLOutputElement.validationMessage")}}{{ReadOnlyInline}}
-  - : A {{domxref("DOMString")}} representing a localized message that describes the validation constraints that the control does not satisfy (if any). This is the empty string if the control is not a candidate for constraint validation (`willValidate` is `false`), or it satisfies its constraints.
+  - : A string representing a localized message that describes the validation constraints that the control does not satisfy (if any). This is the empty string if the control is not a candidate for constraint validation (`willValidate` is `false`), or it satisfies its constraints.
 - {{domxref("HTMLOutputElement.validity")}}{{ReadOnlyInline}}
   - : A {{domxref("ValidityState")}} representing the validity states that this element is in.
 - {{domxref("HTMLOutputElement.value")}}
-  - : A {{domxref("DOMString")}} representing the value of the contents of the elements. Behaves like the {{domxref("Node.textContent")}} property.
+  - : A string representing the value of the contents of the elements. Behaves like the {{domxref("Node.textContent")}} property.
 - {{domxref("HTMLOutputElement.willValidate")}}{{ReadOnlyInline}}
   - : A boolean value indicating whether the element is a candidate for constraint validation.
 

--- a/files/en-us/web/api/htmlparagraphelement/index.md
+++ b/files/en-us/web/api/htmlparagraphelement/index.md
@@ -19,7 +19,7 @@ The **`HTMLParagraphElement`** interface provides special properties (beyond tho
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLParagraphElement.align")}} {{deprecated_inline}}
-  - : A {{domxref("DOMString")}} representing an enumerated property indicating alignment of the element's contents with respect to the surrounding context. The possible values are `"left"`, `"right"`, `"justify"`, and `"center"`.
+  - : A string representing an enumerated property indicating alignment of the element's contents with respect to the surrounding context. The possible values are `"left"`, `"right"`, `"justify"`, and `"center"`.
 
 ## Methods
 

--- a/files/en-us/web/api/htmlparamelement/index.md
+++ b/files/en-us/web/api/htmlparamelement/index.md
@@ -20,13 +20,13 @@ The **`HTMLParamElement`** interface provides special properties (beyond those o
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLParamElement.name")}}
-  - : Is a {{domxref("DOMString")}} representing the name of the parameter. It reflects the {{htmlattrxref("name", "param")}} attribute.
+  - : Is a string representing the name of the parameter. It reflects the {{htmlattrxref("name", "param")}} attribute.
 - {{domxref("HTMLParamElement.value")}}
-  - : Is a {{domxref("DOMString")}} representing the value associated to the parameter. It reflects the {{htmlattrxref("value", "param")}} attribute.
+  - : Is a string representing the value associated to the parameter. It reflects the {{htmlattrxref("value", "param")}} attribute.
 - {{domxref("HTMLParamElement.type")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} containing the type of the parameter when `valueType` has the `"ref"` value. It reflects the {{htmlattrxref("type", "param")}} attribute.
+  - : Is a string containing the type of the parameter when `valueType` has the `"ref"` value. It reflects the {{htmlattrxref("type", "param")}} attribute.
 - {{domxref("HTMLParamElement.valueType")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} containing the type of the `value`. It reflects the {{htmlattrxref("<code>valuetype</code>", "param")}} attribute and has one of the values: `"data"`, `"ref"`, or `"object"`.
+  - : Is a string containing the type of the `value`. It reflects the {{htmlattrxref("<code>valuetype</code>", "param")}} attribute and has one of the values: `"data"`, `"ref"`, or `"object"`.
 
 ## Methods
 

--- a/files/en-us/web/api/htmlquoteelement/index.md
+++ b/files/en-us/web/api/htmlquoteelement/index.md
@@ -19,7 +19,7 @@ The **`HTMLQuoteElement`** interface provides special properties and methods (be
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLQuoteElement.cite")}}
-  - : Is a {{domxref("DOMString")}} reflecting the {{htmlattrxref("cite", "blockquote")}} HTML attribute, containing a URL for the source of the quotation.
+  - : Is a string reflecting the {{htmlattrxref("cite", "blockquote")}} HTML attribute, containing a URL for the source of the quotation.
 
 ## Methods
 

--- a/files/en-us/web/api/htmlscriptelement/referrerpolicy/index.md
+++ b/files/en-us/web/api/htmlscriptelement/referrerpolicy/index.md
@@ -18,7 +18,7 @@ fetches made by that script, defining which referrer is sent when fetching the r
 
 ## Value
 
-A {{domxref("DOMString")}}; one of the following:
+A string; one of the following:
 
 - no-referrer
   - : The {{HTTPHeader("Referer")}} header will be omitted entirely. No referrer

--- a/files/en-us/web/api/htmlselectelement/index.md
+++ b/files/en-us/web/api/htmlselectelement/index.md
@@ -32,7 +32,7 @@ _This interface inherits the properties of {{domxref("HTMLElement")}}, and of {{
 - {{domxref("HTMLSelectElement.multiple")}}
   - : A boolean value reflecting the {{htmlattrxref("multiple", "select")}} HTML attribute, which indicates whether multiple items can be selected.
 - {{domxref("HTMLSelectElement.name")}}
-  - : A {{domxref("DOMString")}} reflecting the {{htmlattrxref("name", "select")}} HTML attribute, containing the name of this control used by servers and DOM search functions.
+  - : A string reflecting the {{htmlattrxref("name", "select")}} HTML attribute, containing the name of this control used by servers and DOM search functions.
 - {{domxref("HTMLSelectElement.options")}}{{ReadOnlyInline}}
   - : An {{domxref("HTMLOptionsCollection")}} representing the set of {{HTMLElement("option")}} ({{domxref("HTMLOptionElement")}}) elements contained by this element.
 - {{domxref("HTMLSelectElement.required")}}
@@ -44,13 +44,13 @@ _This interface inherits the properties of {{domxref("HTMLElement")}}, and of {{
 - {{domxref("HTMLSelectElement.size")}}
   - : A `long` reflecting the {{htmlattrxref("size", "select")}} HTML attribute, which contains the number of visible items in the control. The default is 1, unless `multiple` is `true`, in which case it is 4.
 - {{domxref("HTMLSelectElement.type")}}{{ReadOnlyInline}}
-  - : A {{domxref("DOMString")}} representing the form control's type. When `multiple` is `true`, it returns `"select-multiple"`; otherwise, it returns `"select-one"`.
+  - : A string representing the form control's type. When `multiple` is `true`, it returns `"select-multiple"`; otherwise, it returns `"select-one"`.
 - {{domxref("HTMLSelectElement.validationMessage")}}{{ReadOnlyInline}}
-  - : A {{domxref("DOMString")}} representing a localized message that describes the validation constraints that the control does not satisfy (if any). This attribute is the empty string if the control is not a candidate for constraint validation (`willValidate` is false), or it satisfies its constraints.
+  - : A string representing a localized message that describes the validation constraints that the control does not satisfy (if any). This attribute is the empty string if the control is not a candidate for constraint validation (`willValidate` is false), or it satisfies its constraints.
 - {{domxref("HTMLSelectElement.validity")}}{{ReadOnlyInline}}
   - : A {{domxref("ValidityState")}} reflecting the validity state that this control is in.
 - {{domxref("HTMLSelectElement.value")}}
-  - : A {{domxref("DOMString")}} reflecting the value of the form control. Returns the `value` property of the first selected option element if there is one, otherwise the empty string.
+  - : A string reflecting the value of the form control. Returns the `value` property of the first selected option element if there is one, otherwise the empty string.
 - {{domxref("HTMLSelectElement.willValidate")}}{{ReadOnlyInline}}
   - : A boolean value that indicates whether the button is a candidate for constraint validation. It is `false` if any conditions bar it from constraint validation.
 

--- a/files/en-us/web/api/htmlsourceelement/index.md
+++ b/files/en-us/web/api/htmlsourceelement/index.md
@@ -19,19 +19,19 @@ The **`HTMLSourceElement`** interface provides special properties (beyond the re
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLSourceElement.media")}}
-  - : Is a {{domxref("DOMString")}} reflecting the {{ htmlattrxref("media", "source") }} HTML attribute, containing the intended type of the media resource.
+  - : Is a string reflecting the {{ htmlattrxref("media", "source") }} HTML attribute, containing the intended type of the media resource.
 - {{domxref("HTMLSourceElement.sizes")}} {{experimental_inline}}
-  - : Is a {{domxref("DOMString")}} representing image sizes between breakpoints
+  - : Is a string representing image sizes between breakpoints
 - {{domxref("HTMLSourceElement.src")}}
 
-  - : Is a {{domxref("DOMString")}} reflecting the {{ htmlattrxref("src", "source") }} HTML attribute, containing the URL for the media resource. The {{domxref("HTMLSourceElement.src")}} property has a meaning only when the associated {{HTMLElement("source")}} element is nested in a media element that is a {{htmlelement("video")}} or an {{htmlelement("audio")}} element. It has no meaning and is ignored when it is nested in a {{HTMLElement("picture")}} element.
+  - : Is a string reflecting the {{ htmlattrxref("src", "source") }} HTML attribute, containing the URL for the media resource. The {{domxref("HTMLSourceElement.src")}} property has a meaning only when the associated {{HTMLElement("source")}} element is nested in a media element that is a {{htmlelement("video")}} or an {{htmlelement("audio")}} element. It has no meaning and is ignored when it is nested in a {{HTMLElement("picture")}} element.
 
     > **Note:** If the `src` property is updated (along with any siblings), the parent {{domxref("HTMLMediaElement")}}'s `load` method should be called when done, since `<source>` elements are not re-scanned automatically.
 
 - {{domxref("HTMLSourceElement.srcset")}} {{experimental_inline}}
-  - : Is a {{domxref("DOMString")}} reflecting the {{ htmlattrxref("srcset", "source") }} HTML attribute, containing a list of candidate images, separated by a comma (`',', U+002C COMMA`). A candidate image is a URL followed by a `'w'` with the width of the images, or an `'x'` followed by the pixel density.
+  - : Is a string reflecting the {{ htmlattrxref("srcset", "source") }} HTML attribute, containing a list of candidate images, separated by a comma (`',', U+002C COMMA`). A candidate image is a URL followed by a `'w'` with the width of the images, or an `'x'` followed by the pixel density.
 - {{domxref("HTMLSourceElement.type")}}
-  - : Is a {{domxref("DOMString")}} reflecting the {{ htmlattrxref("type", "source") }} HTML attribute, containing the type of the media resource.
+  - : Is a string reflecting the {{ htmlattrxref("type", "source") }} HTML attribute, containing the type of the media resource.
 
 ## Methods
 

--- a/files/en-us/web/api/htmlstyleelement/index.md
+++ b/files/en-us/web/api/htmlstyleelement/index.md
@@ -22,9 +22,9 @@ This interface doesn't allow to manipulate the CSS it contains (in most case). T
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLStyleElement.media")}}
-  - : Is a {{domxref("DOMString")}} reflecting the HTML attribute representing the intended destination medium for style information.
+  - : Is a string reflecting the HTML attribute representing the intended destination medium for style information.
 - {{domxref("HTMLStyleElement.type")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} reflecting the HTML attribute representing the type of style being applied by this statement.
+  - : Is a string reflecting the HTML attribute representing the type of style being applied by this statement.
 - {{domxref("HTMLStyleElement.disabled")}}
   - : Is a boolean value reflecting the HTML attribute representing whether or not the stylesheet is disabled (true) or not (false).
 - {{domxref("HTMLStyleElement.sheet")}} {{readonlyInline}}

--- a/files/en-us/web/api/htmltablecaptionelement/index.md
+++ b/files/en-us/web/api/htmltablecaptionelement/index.md
@@ -19,7 +19,7 @@ The **`HTMLTableCaptionElement`** interface provides special properties (beyond 
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLTableCaptionElement.align")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} which represents an enumerated attribute indicating alignment of the caption with respect to the table.
+  - : Is a string which represents an enumerated attribute indicating alignment of the caption with respect to the table.
 
 ## Methods
 

--- a/files/en-us/web/api/htmltablecolelement/index.md
+++ b/files/en-us/web/api/htmltablecolelement/index.md
@@ -20,17 +20,17 @@ The **`HTMLTableColElement`** interface provides properties for manipulating sin
 _Inherits properties from its parent, {{domxref("HTMLElement")}}_.
 
 - {{domxref("HTMLTableColElement.align")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} that indicates the horizontal alignment of the cell data in the column.
+  - : Is a string that indicates the horizontal alignment of the cell data in the column.
 - {{domxref("HTMLTableColElement.ch")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} representing the alignment character for cell data.
+  - : Is a string representing the alignment character for cell data.
 - {{domxref("HTMLTableColElement.chOff")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} representing the offset for the alignment character.
+  - : Is a string representing the offset for the alignment character.
 - {{domxref("HTMLTableColElement.span")}}
   - : Is an `unsigned long` that reflects the {{htmlattrxref("span", "col")}} HTML attribute, indicating the number of columns to apply this object's attributes to. Must be a positive integer.
 - {{domxref("HTMLTableColElement.vAlign")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} that indicates the vertical alignment of the cell data in the column.
+  - : Is a string that indicates the vertical alignment of the cell data in the column.
 - {{domxref("HTMLTableColElement.width")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} representing the default column width.
+  - : Is a string representing the default column width.
 
 ## Methods
 

--- a/files/en-us/web/api/htmltableelement/cellspacing/index.md
+++ b/files/en-us/web/api/htmltableelement/cellspacing/index.md
@@ -23,7 +23,7 @@ representing a table's cells. Any two cells are separated by the sum of the
 
 ## Value
 
-A {{domxref("DOMString")}} which is either a number of pixels (such as
+A string which is either a number of pixels (such as
 `"10"`) or a percentage value (like `"10%"`).
 
 ## Examples

--- a/files/en-us/web/api/htmltableelement/index.md
+++ b/files/en-us/web/api/htmltableelement/index.md
@@ -34,23 +34,23 @@ _Inherits properties from its parent, {{DOMxRef("HTMLElement")}}._
 > **Warning:** The following properties are obsolete.  You should avoid using them.
 
 - {{DOMxRef("HTMLTableElement.align")}} {{deprecated_inline}}
-  - : Is a {{DOMxRef("DOMString")}} containing an enumerated value reflecting the {{HTMLAttrxRef("align", "table")}} attribute. It indicates the alignment of the element's contents with respect to the surrounding context. The possible values are `"left"`, `"right"`, and `"center"`.
+  - : Is a string containing an enumerated value reflecting the {{HTMLAttrxRef("align", "table")}} attribute. It indicates the alignment of the element's contents with respect to the surrounding context. The possible values are `"left"`, `"right"`, and `"center"`.
 - {{DOMxRef("HTMLTableElement.bgColor")}} {{deprecated_inline}}
-  - : Is a {{DOMxRef("DOMString")}} containing the background color of the cells. It reflects the obsolete {{HTMLAttrxRef("bgColor", "table")}} attribute.
+  - : Is a string containing the background color of the cells. It reflects the obsolete {{HTMLAttrxRef("bgColor", "table")}} attribute.
 - {{DOMxRef("HTMLTableElement.border")}} {{deprecated_inline}}
-  - : Is a {{DOMxRef("DOMString")}} containing the width in pixels of the border of the table. It reflects the obsolete {{HTMLAttrxRef("border", "table")}} attribute.
+  - : Is a string containing the width in pixels of the border of the table. It reflects the obsolete {{HTMLAttrxRef("border", "table")}} attribute.
 - {{DOMxRef("HTMLTableElement.cellPadding")}} {{deprecated_inline}}
-  - : Is a {{DOMxRef("DOMString")}} containing the width in pixels of the horizontal and vertical space between cell content and cell borders. It reflects the obsolete {{HTMLAttrxRef("cellpadding", "table")}} attribute.
+  - : Is a string containing the width in pixels of the horizontal and vertical space between cell content and cell borders. It reflects the obsolete {{HTMLAttrxRef("cellpadding", "table")}} attribute.
 - {{DOMxRef("HTMLTableElement.cellSpacing")}} {{deprecated_inline}}
-  - : Is a {{DOMxRef("DOMString")}} containing the width in pixels of the horizontal and vertical separation between cells. It reflects the obsolete {{HTMLAttrxRef("cellspacing", "table")}} attribute.
+  - : Is a string containing the width in pixels of the horizontal and vertical separation between cells. It reflects the obsolete {{HTMLAttrxRef("cellspacing", "table")}} attribute.
 - {{DOMxRef("HTMLTableElement.frame")}} {{deprecated_inline}}
-  - : Is a {{DOMxRef("DOMString")}} containing the type of the external borders of the table. It reflects the obsolete {{HTMLAttrxRef("frame", "table")}} attribute and can take one of the following values: `"void"`, `"above"`, `"below"`, `"hsides"`, `"vsides"`, `"lhs"`, `"rhs"`, `"box"`, or `"border"`.
+  - : Is a string containing the type of the external borders of the table. It reflects the obsolete {{HTMLAttrxRef("frame", "table")}} attribute and can take one of the following values: `"void"`, `"above"`, `"below"`, `"hsides"`, `"vsides"`, `"lhs"`, `"rhs"`, `"box"`, or `"border"`.
 - {{DOMxRef("HTMLTableElement.rules")}} {{deprecated_inline}}
-  - : Is a {{DOMxRef("DOMString")}} containing the type of the internal borders of the table. It reflects the obsolete {{HTMLAttrxRef("rules", "table")}} attribute and can take one of the following values: `"none"`, `"groups"`, `"rows"`, `"cols"`, or `"all"`.
+  - : Is a string containing the type of the internal borders of the table. It reflects the obsolete {{HTMLAttrxRef("rules", "table")}} attribute and can take one of the following values: `"none"`, `"groups"`, `"rows"`, `"cols"`, or `"all"`.
 - {{DOMxRef("HTMLTableElement.summary")}} {{deprecated_inline}}
-  - : Is a {{DOMxRef("DOMString")}} containing a description of the purpose or the structure of the table. It reflects the obsolete {{HTMLAttrxRef("summary", "table")}} attribute.
+  - : Is a string containing a description of the purpose or the structure of the table. It reflects the obsolete {{HTMLAttrxRef("summary", "table")}} attribute.
 - {{DOMxRef("HTMLTableElement.width")}} {{deprecated_inline}}
-  - : Is a {{DOMxRef("DOMString")}} containing the length in pixels or in percentage of the desired width fo the entire table. It reflects the obsolete {{HTMLAttrxRef("width", "table")}} attribute.
+  - : Is a string containing the length in pixels or in percentage of the desired width fo the entire table. It reflects the obsolete {{HTMLAttrxRef("width", "table")}} attribute.
 
 ## Methods
 

--- a/files/en-us/web/api/htmltablerowelement/index.md
+++ b/files/en-us/web/api/htmltablerowelement/index.md
@@ -39,15 +39,15 @@ _Inherits methods from its parent, {{domxref("HTMLElement")}}_.
 > **Warning:** These properties have been {{Glossary("deprecated")}} and should no longer be used. They are documented primarily to help understand older code bases.
 
 - {{domxref("HTMLTableRowElement.align")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} containing an enumerated value reflecting the {{htmlattrxref("align", "tr")}} attribute. It indicates the alignment of the element's contents with respect to the surrounding context. The possible values are `"left"`, `"right"`, and `"center"`.
+  - : Is a string containing an enumerated value reflecting the {{htmlattrxref("align", "tr")}} attribute. It indicates the alignment of the element's contents with respect to the surrounding context. The possible values are `"left"`, `"right"`, and `"center"`.
 - {{domxref("HTMLTableRowElement.bgColor")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} containing the background color of the cells. It reflects the obsolete {{htmlattrxref("bgColor", "tr")}} attribute.
+  - : Is a string containing the background color of the cells. It reflects the obsolete {{htmlattrxref("bgColor", "tr")}} attribute.
 - {{domxref("HTMLTableRowElement.ch")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} containing one single character. This character is the one to align all the cell of a column on. It reflects the {{htmlattrxref("char", "tr")}} and default to the decimal points associated with the language, e.g. `'.'` for English, or `','` for French. This property was optional and was not very well supported.
+  - : Is a string containing one single character. This character is the one to align all the cell of a column on. It reflects the {{htmlattrxref("char", "tr")}} and default to the decimal points associated with the language, e.g. `'.'` for English, or `','` for French. This property was optional and was not very well supported.
 - {{domxref("HTMLTableRowElement.chOff")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} containing a integer indicating how many characters must be left at the right (for left-to-right scripts; or at the left for right-to-left scripts) of the character defined by `HTMLTableRowElement.ch`. This property was optional and was not very well supported.
+  - : Is a string containing a integer indicating how many characters must be left at the right (for left-to-right scripts; or at the left for right-to-left scripts) of the character defined by `HTMLTableRowElement.ch`. This property was optional and was not very well supported.
 - {{domxref("HTMLTableRowElement.vAlign")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} representing an enumerated value indicating how the content of the cell must be vertically aligned. It reflects the {{htmlattrxref("valign", "tr")}} attribute and can have one of the following values: `"top"`, `"middle"`, `"bottom"`, or `"baseline"`.
+  - : Is a string representing an enumerated value indicating how the content of the cell must be vertically aligned. It reflects the {{htmlattrxref("valign", "tr")}} attribute and can have one of the following values: `"top"`, `"middle"`, `"bottom"`, or `"baseline"`.
 
 ## Specifications
 

--- a/files/en-us/web/api/htmltablesectionelement/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/index.md
@@ -19,15 +19,15 @@ The **`HTMLTableSectionElement`** interface provides special properties and meth
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLTableSectionElement.align")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} containing an enumerated value reflecting the {{htmlattrxref("align", "tr")}} attribute. It indicates the alignment of the element's contents with respect to the surrounding context. The possible values are `"left"`, `"right"`, and `"center"`.
+  - : Is a string containing an enumerated value reflecting the {{htmlattrxref("align", "tr")}} attribute. It indicates the alignment of the element's contents with respect to the surrounding context. The possible values are `"left"`, `"right"`, and `"center"`.
 - {{domxref("HTMLTableSectionElement.rows")}} {{readonlyInline}}
   - : Returns a live {{domxref("HTMLCollection")}} containing the rows in the section. The `HTMLCollection` is live and is automatically updated when rows are added or removed.
 - {{domxref("HTMLTableSectionElement.ch")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} containing one single character. This character is the one to align all the cell of a column on. It reflects the {{htmlattrxref("char", "tr")}} and default to the decimal points associated with the language, e.g. `'.'` for English, or `','` for French. This property was optional and was not very well supported.
+  - : Is a string containing one single character. This character is the one to align all the cell of a column on. It reflects the {{htmlattrxref("char", "tr")}} and default to the decimal points associated with the language, e.g. `'.'` for English, or `','` for French. This property was optional and was not very well supported.
 - {{domxref("HTMLTableSectionElement.chOff")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} containing a integer indicating how many characters must be left at the right (for left-to-right scripts; or at the left for right-to-left scripts) of the character defined by `HTMLTableRowElement.ch`. This property was optional and was not very well supported.
+  - : Is a string containing a integer indicating how many characters must be left at the right (for left-to-right scripts; or at the left for right-to-left scripts) of the character defined by `HTMLTableRowElement.ch`. This property was optional and was not very well supported.
 - {{domxref("HTMLTableSectionElement.vAlign")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} representing an enumerated value indicating how the content of the cell must be vertically aligned. It reflects the {{htmlattrxref("valign", "tr")}} attribute and can have one of the following values: `"top"`, `"middle"`, `"bottom"`, or `"baseline"`.
+  - : Is a string representing an enumerated value indicating how the content of the cell must be vertically aligned. It reflects the {{htmlattrxref("valign", "tr")}} attribute and can have one of the following values: `"top"`, `"middle"`, `"bottom"`, or `"baseline"`.
 
 ## Methods
 

--- a/files/en-us/web/api/htmltimeelement/datetime/index.md
+++ b/files/en-us/web/api/htmltimeelement/datetime/index.md
@@ -13,7 +13,7 @@ browser-compat: api.HTMLTimeElement.dateTime
 
 The
 **`HTMLTimeElement.dateTime`**
-property is a {{domxref("DOMString")}} that reflects the {{ htmlattrxref("datetime",
+property is a string that reflects the {{ htmlattrxref("datetime",
   "time") }} HTML attribute, containing a machine-readable form of the element's date and
 time value.
 

--- a/files/en-us/web/api/htmltimeelement/index.md
+++ b/files/en-us/web/api/htmltimeelement/index.md
@@ -19,7 +19,7 @@ The **`HTMLTimeElement`** interface provides special properties (beyond the regu
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLTimeElement.dateTime")}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{ htmlattrxref("datetime", "time") }} HTML attribute, containing a machine-readable form of the element's date and time value.
+  - : Is a string that reflects the {{ htmlattrxref("datetime", "time") }} HTML attribute, containing a machine-readable form of the element's date and time value.
 
 ## Methods
 

--- a/files/en-us/web/api/htmltitleelement/index.md
+++ b/files/en-us/web/api/htmltitleelement/index.md
@@ -19,7 +19,7 @@ The **`HTMLTitleElement`** interface contains the title for a document. This ele
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLTitleElement.text")}}
-  - : Is a {{domxref("DOMString")}} representing the text of the document's title, and only the text part. For example, consider this:
+  - : Is a string representing the text of the document's title, and only the text part. For example, consider this:
 
 ```html
 <!doctype html>

--- a/files/en-us/web/api/htmltrackelement/index.md
+++ b/files/en-us/web/api/htmltrackelement/index.md
@@ -21,13 +21,13 @@ The **`HTMLTrackElement`** interface represents an {{Glossary("HTML")}} {{HTMLEl
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLTrackElement.kind")}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("kind", "track")}} HTML attribute, indicating how the text track is meant to be used. Possible values are: `subtitles`, `captions`, `descriptions`, `chapters`, or `metadata`.
+  - : Is a string that reflects the {{htmlattrxref("kind", "track")}} HTML attribute, indicating how the text track is meant to be used. Possible values are: `subtitles`, `captions`, `descriptions`, `chapters`, or `metadata`.
 - {{domxref("HTMLTrackElement.src")}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("src", "track")}} HTML attribute, indicating the address of the text track data.
+  - : Is a string that reflects the {{htmlattrxref("src", "track")}} HTML attribute, indicating the address of the text track data.
 - {{domxref("HTMLTrackElement.srclang")}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("srclang", "track")}} HTML attribute, indicating the language of the text track data.
+  - : Is a string that reflects the {{htmlattrxref("srclang", "track")}} HTML attribute, indicating the language of the text track data.
 - {{domxref("HTMLTrackElement.label")}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("label", "track")}} HTML attribute, indicating a user-readable title for the track.
+  - : Is a string that reflects the {{htmlattrxref("label", "track")}} HTML attribute, indicating a user-readable title for the track.
 - {{domxref("HTMLTrackElement.default")}}
   - : A boolean value reflecting the {{htmlattrxref("default", "track")}} attribute, indicating that the track is to be enabled if the user's preferences do not indicate that another track would be more appropriate.
 - {{domxref("HTMLTrackElement.readyState")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/htmltrackelement/src/index.md
+++ b/files/en-us/web/api/htmltrackelement/src/index.md
@@ -20,7 +20,7 @@ indicates the URL of the text track's data.
 
 ## Value
 
-A {{domxref("DOMString")}} object containing the URL of the text track data.
+A string object containing the URL of the text track data.
 
 ## Example
 

--- a/files/en-us/web/api/htmlulistelement/index.md
+++ b/files/en-us/web/api/htmlulistelement/index.md
@@ -19,7 +19,7 @@ The **`HTMLUListElement`** interface provides special properties (beyond those d
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLUListElement.type")}} {{deprecated_inline}}
-  - : Is a {{domxref("DOMString")}} value reflecting the {{htmlattrxref("type", "ul")}} and defining the kind of marker to be used to display. The values are browser dependent and have never been standardized.
+  - : Is a string value reflecting the {{htmlattrxref("type", "ul")}} and defining the kind of marker to be used to display. The values are browser dependent and have never been standardized.
 - {{domxref("HTMLUListElement.compact")}} {{deprecated_inline}}
   - : Is a boolean value indicating that spacing between list items should be reduced. This property reflects the {{htmlattrxref("compact", "ul")}} attribute only, it doesn't consider the {{cssxref("line-height")}} CSS property used for that behavior in modern pages.
 

--- a/files/en-us/web/api/htmlvideoelement/index.md
+++ b/files/en-us/web/api/htmlvideoelement/index.md
@@ -23,15 +23,15 @@ The list of [supported media formats](/en-US/docs/Web/Media/Formats) varies from
 _Inherits properties from its ancestor interfaces, {{domxref("HTMLMediaElement")}}, and {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLVideoElement.height")}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("height", "video")}} HTML attribute, which specifies the height of the display area, in CSS pixels.
+  - : Is a string that reflects the {{htmlattrxref("height", "video")}} HTML attribute, which specifies the height of the display area, in CSS pixels.
 - {{domxref("HTMLVideoElement.poster")}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("poster", "video")}} HTML attribute, which specifies an image to show while no video data is available.
+  - : Is a string that reflects the {{htmlattrxref("poster", "video")}} HTML attribute, which specifies an image to show while no video data is available.
 - {{domxref("HTMLVideoElement.videoHeight")}} {{readonlyInline}}
   - : Returns an unsigned integer value indicating the intrinsic height of the resource in CSS pixels, or 0 if no media is available yet.
 - {{domxref("HTMLVideoElement.videoWidth")}} {{readonlyInline}}
   - : Returns an unsigned integer value indicating the intrinsic width of the resource in CSS pixels, or 0 if no media is available yet.
 - {{domxref("HTMLVideoElement.width")}}
-  - : Is a {{domxref("DOMString")}} that reflects the {{htmlattrxref("width", "video")}} HTML attribute, which specifies the width of the display area, in CSS pixels.
+  - : Is a string that reflects the {{htmlattrxref("width", "video")}} HTML attribute, which specifies the width of the display area, in CSS pixels.
 - {{DOMxRef("HTMLVideoElement.autoPictureInPicture")}}
   - : The `autoPictureInPicture` attribute will automatically enter and leave the picture-in-picture mode for a video element when the user switches tab and/or applications
 - {{DOMxRef("HTMLVideoElement.disablePictureInPicture")}}

--- a/files/en-us/web/api/idbcursor/direction/index.md
+++ b/files/en-us/web/api/idbcursor/direction/index.md
@@ -15,7 +15,7 @@ browser-compat: api.IDBCursor.direction
 {{ APIRef("IndexedDB") }}
 
 The **`direction`** read-only property of the
-{{domxref("IDBCursor")}} interface is a {{domxref("DOMString")}} that returns the
+{{domxref("IDBCursor")}} interface is a string that returns the
 direction of traversal of the cursor (set using
 {{domxref("IDBObjectStore.openCursor")}} for example). See the [Values](#values)
 section below for possible values.

--- a/files/en-us/web/api/idbindex/locale/index.md
+++ b/files/en-us/web/api/idbindex/locale/index.md
@@ -19,7 +19,7 @@ The **`locale`** read-only property of the {{domxref("IDBIndex")}} interface ret
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/idbindex/name/index.md
+++ b/files/en-us/web/api/idbindex/name/index.md
@@ -21,7 +21,7 @@ interface contains a string which names the index.
 
 ## Value
 
-A {{domxref("DOMString")}} specifying a name for the index.
+A string specifying a name for the index.
 
 ### Exceptions
 

--- a/files/en-us/web/api/idbobjectstore/name/index.md
+++ b/files/en-us/web/api/idbobjectstore/name/index.md
@@ -21,7 +21,7 @@ interface indicates the name of this object store.
 
 ## Value
 
-A {{domxref("DOMString")}} containing the object
+A string containing the object
 store's name.
 
 ### Exceptions

--- a/files/en-us/web/api/idbversionchangeevent/idbversionchangeevent/index.md
+++ b/files/en-us/web/api/idbversionchangeevent/idbversionchangeevent/index.md
@@ -28,7 +28,7 @@ new IDBVersionChangeEvent(type, eventInitDict)
 ### Parameters
 
 - `type`
-  - : A {{domxref("DOMString")}} indicating the event which occurred. For
+  - : A string indicating the event which occurred. For
     `IDBVersionChangeEvent` this is `versionchange`.
 - `eventInitDict` {{optional_inline}}
 

--- a/files/en-us/web/api/inputevent/data/index.md
+++ b/files/en-us/web/api/inputevent/data/index.md
@@ -16,13 +16,13 @@ browser-compat: api.InputEvent.data
 {{APIRef("DOM Events")}}
 
 The **`data`** read-only property of the
-{{domxref("InputEvent")}} interface returns a {{domxref("DOMString")}} with inserted
+{{domxref("InputEvent")}} interface returns a string with inserted
 characters. This may be an empty string if the change doesn't insert text, such as when
 characters are deleted.
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/inputevent/index.md
+++ b/files/en-us/web/api/inputevent/index.md
@@ -27,7 +27,7 @@ The **`InputEvent`** interface represents an event notifying the user of editabl
 _This interface inherits properties from its parents, {{DOMxRef("UIEvent")}} and {{DOMxRef("Event")}}._
 
 - {{DOMxRef("InputEvent.data")}}{{ReadOnlyInline}}
-  - : Returns a {{DOMxRef("DOMString")}} with the inserted characters. This may be an empty string if the change doesn't insert text (such as when deleting characters, for example).
+  - : Returns a string with the inserted characters. This may be an empty string if the change doesn't insert text (such as when deleting characters, for example).
 - {{DOMxRef("InputEvent.dataTransfer")}}{{ReadOnlyInline}}
   - : Returns a {{DOMxRef("DataTransfer")}} object containing information about richtext or plaintext data being added to or removed from editable content.
 - {{DOMxRef("InputEvent.inputType")}}{{ReadOnlyInline}}

--- a/files/en-us/web/api/inputevent/inputevent/index.md
+++ b/files/en-us/web/api/inputevent/inputevent/index.md
@@ -16,7 +16,7 @@ browser-compat: api.InputEvent.InputEvent
 {{APIRef("DOM Events")}}
 
 The **`InputEvent()`** constructor creates a new
-{{domxref("InputEvent")}}.
+{{domxref("InputEvent")}}. 
 
 ## Syntax
 
@@ -28,7 +28,7 @@ new InputEvent(typeArg, inputEventInit)
 ### Parameters
 
 - `typeArg`
-  - : Is a {{domxref("DOMString")}} representing the name of the event.
+  - : Is a string representing the name of the event.
 - `inputEventInit` {{optional_inline}}
 
   - : Is a `InputEventInit` dictionary, having the following fields:

--- a/files/en-us/web/api/inputevent/inputtype/index.md
+++ b/files/en-us/web/api/inputevent/inputtype/index.md
@@ -21,7 +21,7 @@ Possible changes include for example inserting, deleting, and formatting text.
 
 ## Value
 
-A {{domxref("DOMString")}} containing the type of input that was made. There are many
+A string containing the type of input that was made. There are many
 possible values, such as `insertText`, `deleteContentBackward`,
 `insertFromPaste`, and `formatBold`. For a complete list of the
 available input types, see the [Attributes

--- a/files/en-us/web/api/keyboardevent/index.md
+++ b/files/en-us/web/api/keyboardevent/index.md
@@ -125,7 +125,7 @@ _This interface also inherits properties of its parents, {{domxref("UIEvent")}} 
 
 - {{domxref("KeyboardEvent.code")}} {{Readonlyinline}}
 
-  - : Returns a {{domxref("DOMString")}} with the code value of the physical key represented by the event.
+  - : Returns a string with the code value of the physical key represented by the event.
 
     > **Warning:** This ignores the user's keyboard layout, so that if the user presses the key at the "Y" position in a QWERTY keyboard layout (near the middle of the row above the home row), this will always return "KeyY", even if the user has a QWERTZ keyboard (which would mean the user expects a "Z" and all the other properties would indicate a "Z") or a Dvorak keyboard layout (where the user would expect an "F"). If you want to display the correct keystrokes to the user, you can use {{domxref("Keyboard.getLayoutMap()")}}.
 
@@ -136,10 +136,10 @@ _This interface also inherits properties of its parents, {{domxref("UIEvent")}} 
 - {{domxref("KeyboardEvent.isComposing")}} {{Readonlyinline}}
   - : Returns a boolean value that is `true` if the event is fired between after `compositionstart` and before `compositionend`.
 - {{domxref("KeyboardEvent.key")}} {{Readonlyinline}}
-  - : Returns a {{domxref("DOMString")}} representing the key value of the key represented by the event.
+  - : Returns a string representing the key value of the key represented by the event.
 - {{domxref("KeyboardEvent.locale")}} {{Readonlyinline}}
 
-  - : Returns a {{domxref("DOMString")}} representing a locale string indicating the locale the keyboard is configured for. This may be the empty string if the browser or device doesn't know the keyboard's locale.
+  - : Returns a string representing a locale string indicating the locale the keyboard is configured for. This may be the empty string if the browser or device doesn't know the keyboard's locale.
 
     > **Note:** This does not describe the locale of the data being entered. A user may be using one keyboard layout while typing text in a different language.
 
@@ -174,7 +174,7 @@ _This interface also inherits methods of its parents, {{domxref("UIEvent")}} and
 
 - {{domxref("KeyboardEvent.char")}} {{Non-standard_inline}}{{Deprecated_inline}}{{Readonlyinline}}
 
-  - : Returns a {{domxref("DOMString")}} representing the character value of the key. If the key corresponds to a printable character, this value is a non-empty Unicode string containing that character. If the key doesn't have a printable representation, this is an empty string.
+  - : Returns a string representing the character value of the key. If the key corresponds to a printable character, this value is a non-empty Unicode string containing that character. If the key doesn't have a printable representation, this is an empty string.
 
     > **Note:** If the key is used as a macro that inserts multiple characters, this attribute's value is the entire string, not just the first character.
 

--- a/files/en-us/web/api/keyboardevent/keyboardevent/index.md
+++ b/files/en-us/web/api/keyboardevent/keyboardevent/index.md
@@ -12,7 +12,7 @@ browser-compat: api.KeyboardEvent.KeyboardEvent
 {{APIRef("DOM Events")}}
 
 The **`KeyboardEvent()`** constructor creates a new
-{{domxref("KeyboardEvent")}}.
+{{domxref("KeyboardEvent")}}. 
 
 ## Syntax
 
@@ -24,14 +24,14 @@ new KeyboardEvent(typeArg, keyboardEventInit)
 ### Parameters
 
 - `typeArg`
-  - : Is a {{domxref("DOMString")}} representing the name of the event.
+  - : Is a string representing the name of the event.
 - `keyboardEventInit` {{optional_inline}}
 
   - : Is a `KeyboardEventInit` dictionary, having the following fields:
 
-    - `"key"`, optional {{domxref("DOMString")}}, defaulting to `""`,
+    - `"key"`, optional string, defaulting to `""`,
       that sets the value of {{domxref("KeyboardEvent.key")}}.
-    - `"code"`, optional {{domxref("DOMString")}}, defaulting to `""`,
+    - `"code"`, optional string, defaulting to `""`,
       that sets the value of {{domxref("KeyboardEvent.code")}}.
     - `"location"`, optional `unsigned long`, defaulting to `0`,
       that sets the value of {{domxref("KeyboardEvent.location")}}.


### PR DESCRIPTION
Continuing #15499 

### Summary
`DOMString` is not exposed by browsers to JavaScript. It is converted to `string`.[[ref](https://developer.mozilla.org/en-US/docs/Web/API/DOMString)]

Same is the case with `USVString` and `CSSOMString`.

### Metadata
- [x] Fixes a typo, bug, or other error
