### PR TITLE
Clarifies what is "requested length" in Crypto.getRandomValues()

### DIFF
--- a/files/en-us/web/api/crypto/getrandomvalues/index.md
+++ b/files/en-us/web/api/crypto/getrandomvalues/index.md
@@ -24,7 +24,6 @@ The array given as the parameter is filled with random numbers (random in its cr
 
 To guarantee enough performance, implementations are not using a truly random number generator, but they are using a pseudo-random number generator _seeded_ with a value with enough entropy.
 The pseudo-random number generator algorithm (PRNG) may vary across {{Glossary("user agent", "user agents")}}, but is suitable for cryptographic purposes.
-Implementations are required to use a seed with enough entropy, like a system-level entropy source.
 
 `getRandomValues()` is the only member of the `Crypto` interface which can be used from an insecure context.
 
@@ -41,7 +40,7 @@ getRandomValues(typedArray)
     {{jsxref("Uint8ClampedArray")}}, {{jsxref("Int16Array")}}, {{jsxref("Uint16Array")}},
     {{jsxref("Int32Array")}}, {{jsxref("Uint32Array")}}, {{jsxref("BigInt64Array")}},
     {{jsxref("BigUint64Array")}} (but **not** `Float32Array` nor `Float64Array`).
-    All elements in the array are overwritten with random numbers.
+    All elements in the array will be overwritten with random numbers.
 
 ### Return value
 
@@ -51,7 +50,7 @@ Note that `typedArray` is modified in-place, and no copy is made.
 ### Exceptions
 
 - `QuotaExceededError` {{domxref("DOMException")}}
-  - : Thrown if the requested length exceeds 65,536 bytes.
+  - : Thrown if the {{jsxref("TypedArray.byteLength", "byteLength")}} of `typedArray` exceeds 65,536.
 
 ## Usage notes
 
@@ -68,14 +67,12 @@ the Unix `/dev/urandom` device, or other source of random or pseudorandom data.
 ## Examples
 
 ```js
-/* Assuming that window.crypto.getRandomValues is available */
-
-var array = new Uint32Array(10);
+const array = new Uint32Array(10);
 self.crypto.getRandomValues(array);
 
 console.log("Your lucky numbers:");
-for (var i = 0; i < array.length; i++) {
-  console.log(array[i]);
+for (const num of array) {
+  console.log(num);
 }
 ```
 
@@ -90,5 +87,5 @@ for (var i = 0; i < array.length; i++) {
 ## See also
 
 - [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API)
-- {{ domxref("crypto_property", "crypto") }} to get a {{domxref("Crypto")}} object.
+- {{domxref("crypto_property", "crypto")}} to get a {{domxref("Crypto")}} object.
 - {{jsxref("Math.random")}}, a non-cryptographic source of random numbers.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Changes "requested length" to `TypedArray.prototype.byteLength`.

#### Motivation

`byteLength` should be easier to understand than "requested length". It's how the spec is written as well.

> Implementations are required to use a seed with enough entropy, like a system-level entropy source.

⬆️ In my opinion this is redundant in the summary. There's a note about it in its "Usage notes" section as well.

#### Supporting details
https://w3c.github.io/webcrypto/#Crypto-method-getRandomValues

> If the `byteLength` of *array* is greater than 65536, throw...

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
