### PR TITLE
Fixes en-us -> en-US

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/slice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/slice/index.md
@@ -11,7 +11,7 @@ browser-compat: javascript.builtins.Array.slice
 ---
 {{JSRef}}
 
-The **`slice()`** method returns a [shallow copy](/en-us/docs/Glossary/Shallow_copy) of a portion of
+The **`slice()`** method returns a [shallow copy](/en-US/docs/Glossary/Shallow_copy) of a portion of
 an array into a new array object selected from `start` to `end`
 (`end` not included) where `start` and `end` represent
 the index of items in that array. The original array will not be modified.
@@ -65,7 +65,7 @@ A new array containing the extracted elements.
 
 ## Description
 
-`slice` does not alter the original array. It returns a [shallow copy](/en-us/docs/Glossary/Shallow_copy) of
+`slice` does not alter the original array. It returns a [shallow copy](/en-US/docs/Glossary/Shallow_copy) of
 elements from the original array. Elements of the original array are copied into the
 returned array as follows:
 


### PR DESCRIPTION
en-US is the right way to do it (prevent a useless redirect and a flaw)