### PR TITLE
Add RTCRtpEncodingParameters.maxFramerate - supported in FF101

### DIFF
--- a/files/en-us/web/api/rtcpeerconnection/addtransceiver/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addtransceiver/index.md
@@ -57,6 +57,9 @@ None ({{jsxref("undefined")}}).
 - {{jsxref("TypeError")}}
   - : Thrown if `trackOrKind` was not either `"audio"` or `"video"`.
 
+- {{jsxref("RangeError")}}
+  - : Thrown if any of the `sendEncodings` encodings have a {{domxref("RTCRtpEncodingParameters.maxFramerate", "maxFramerate")}} value less than 0.0.
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/rtcrtpencodingparameters/index.md
+++ b/files/en-us/web/api/rtcrtpencodingparameters/index.md
@@ -33,7 +33,7 @@ This dictionary is used in the {{domxref("RTCRtpSendParameters")}} describing th
 - {{domxref("RTCRtpEncodingParameters.maxBitrate", "maxBitrate")}}
   - : An unsigned long integer indicating the maximum number of bits per second to allow for this encoding. Other parameters may further constrain the bit rate, such as the value of `maxFramerate` or transport or physical network limitations.
 - {{domxref("RTCRtpEncodingParameters.maxFramerate", "maxFramerate")}}
-  - : A double-precision floating-point value specifying the maximum number of frames per second to allow for this encoding.
+  - : A value specifying the maximum number of frames per second to allow for this encoding.
 - {{domxref("RTCRtpEncodingParameters.ptime", "ptime")}}
   - : An unsigned long integer value indicating the preferred duration of a media packet in milliseconds. This is typically only relevant for audio encodings. The user agent will try to match this as well as it can, but there is no guarantee.
 - {{domxref("RTCRtpEncodingParameters.rid", "rid")}}

--- a/files/en-us/web/api/rtcrtpencodingparameters/maxframerate/index.md
+++ b/files/en-us/web/api/rtcrtpencodingparameters/maxframerate/index.md
@@ -1,0 +1,44 @@
+---
+title: RTCRtpEncodingParameters.maxFramerate
+slug: Web/API/RTCRtpEncodingParameters/maxFramerate
+tags:
+  - API
+  - BPS
+  - Bandwidth
+  - Bit Rate
+  - Codec
+  - Encoding
+  - Property
+  - RTCRtpEncodingParameters
+  - Reference
+  - Settings
+  - WebRTC
+  - WebRTC API
+  - maxFramerate
+  - parameters
+browser-compat: api.RTCRtpEncodingParameters.maxFramerate
+---
+{{APIRef("WebRTC")}}
+
+The **`maxFramerate`** property of the {{domxref("RTCRtpEncodingParameters")}} dictionary specifies the maximum framerate that can be used to send the encoding, in frames per second.
+
+The user agent is free to allocate bandwidth between the encodings, as long as the `maxFramerate` value is not exceeded.
+
+The frame rate is a positive real number ({{domxref("RTCPeerConnection.addTransceiver()")}} and {{domxref("RTCRtpSender.setParameters()")}} will throw a {{jsxref("RangeError")}} exception if the value is less than 0.0).
+Setting the maximum frame rate to zero using {{domxref("RTCRtpSender.setParameters()")}} has the effect of freezing the video on the next frame.
+
+## Value
+
+A positive real number indicating the maximum frame rate for the specified encoding, in frames per second.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("RTCRtpEncodingParameters.maxBitrate")}}

--- a/files/en-us/web/api/rtcrtpsender/setparameters/index.md
+++ b/files/en-us/web/api/rtcrtpsender/setparameters/index.md
@@ -81,15 +81,9 @@ from the list below.
 - `OperationError` {{domxref("DOMException")}}
   - : Returned if an error occurs that does not match the ones specified here.
 - {{jsxref("RangeError")}}
-  - : Returned if the value specified for {{domxref("RTCRtpSendParameters.scaleResolutionDownBy",
-    "scaleResolutionDownBy")}} is less than 1.0, which would result in scaling up rather
-    than down, which is not allowed; or one or more of the specified encodings'
-    {{domxref("RTCRtpEncodingParameters.maxFramerate", "maxFramerate")}} values is less
-    than 0.0.
+  - : Returned if the value specified for {{domxref("RTCRtpSendParameters.scaleResolutionDownBy", "scaleResolutionDownBy")}} is less than 1.0, which would result in scaling up rather than down, which is not allowed; or one or more of the specified `encodings` {{domxref("RTCRtpEncodingParameters.maxFramerate", "maxFramerate")}} values is less than 0.0.
 
-In addition, if a WebRTC error occurs while configuring or accessing the media, an
-{{domxref("RTCError")}} is thrown with its {{domxref("RTCError.errorDetail",
-  "errorDetail")}} set to `hardware-encoder-error`.
+In addition, if a WebRTC error occurs while configuring or accessing the media, an {{domxref("RTCError")}} is thrown with its {{domxref("RTCError.errorDetail", "errorDetail")}} set to `hardware-encoder-error`.
 
 ## Description
 

--- a/files/en-us/web/api/rtcrtpsender/setparameters/index.md
+++ b/files/en-us/web/api/rtcrtpsender/setparameters/index.md
@@ -81,7 +81,7 @@ from the list below.
 - `OperationError` {{domxref("DOMException")}}
   - : Returned if an error occurs that does not match the ones specified here.
 - {{jsxref("RangeError")}}
-  - : Returned if the value specified for {{domxref("RTCRtpSendParameters.scaleResolutionDownBy", "scaleResolutionDownBy")}} is less than 1.0, which would result in scaling up rather than down, which is not allowed; or one or more of the specified `encodings` {{domxref("RTCRtpEncodingParameters.maxFramerate", "maxFramerate")}} values is less than 0.0.
+  - : Returned if the value specified for {{domxref("RTCRtpSendParameters.scaleResolutionDownBy", "scaleResolutionDownBy")}} is less than 1.0 — which would result in scaling up rather than down, which is not allowed; or if one or more of the specified `encodings` {{domxref("RTCRtpEncodingParameters.maxFramerate", "maxFramerate")}} values is less than 0.0.
 
 In addition, if a WebRTC error occurs while configuring or accessing the media, an {{domxref("RTCError")}} is thrown with its {{domxref("RTCError.errorDetail", "errorDetail")}} set to `hardware-encoder-error`.
 


### PR DESCRIPTION
`RTCRtpEncodingParameters.maxFramerate` is supported in FF101 by https://bugzilla.mozilla.org/show_bug.cgi?id=1611957

This adds a page for the dictionary according to spec. The BCD also updated.

Note, I am aware that we don't do dictionaries in this way any more. Do I need to integrate for this now. Kind of bigger job than I want to do for this right now.

Other docs work tracked in https://github.com/mdn/content/issues/15470