### PR TITLE
Remove links in headings in WebGL/Constants

### DIFF
--- a/files/en-us/web/api/webgl_api/constants/index.md
+++ b/files/en-us/web/api/webgl_api/constants/index.md
@@ -1740,27 +1740,33 @@ Constants passed to {{domxref("WebGLRenderingContext.texParameter", "WebGLRender
 
 ## Constants defined in WebGL extensions
 
-### {{domxref("ANGLE_instanced_arrays")}}
+### ANGLE_instanced_arrays
 
 | Constant name                       | Value  | Description                                                   |
 | ----------------------------------- | ------ | ------------------------------------------------------------- |
 | `VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE` | 0x88FE | Describes the frequency divisor used for instanced rendering. |
 
-### {{domxref("WEBGL_debug_renderer_info")}}
+For more information, see {{domxref("ANGLE_instanced_arrays")}}.
+
+### WEBGL_debug_renderer_info
 
 | Constant name             | Value  | Description                                                                 |
 | ------------------------- | ------ | --------------------------------------------------------------------------- |
 | `UNMASKED_VENDOR_WEBGL`   | 0x9245 | Passed to `getParameter` to get the vendor string of the graphics driver.   |
 | `UNMASKED_RENDERER_WEBGL` | 0x9246 | Passed to `getParameter` to get the renderer string of the graphics driver. |
 
-### {{domxref("EXT_texture_filter_anisotropic")}}
+For more information, see {{domxref("WEBGL_debug_renderer_info")}}.
+
+### EXT_texture_filter_anisotropic
 
 | Constant name                    | Value  | Description                                                                   |
 | -------------------------------- | ------ | ----------------------------------------------------------------------------- |
 | `MAX_TEXTURE_MAX_ANISOTROPY_EXT` | 0x84FF | Returns the maximum available anisotropy.                                     |
 | `TEXTURE_MAX_ANISOTROPY_EXT`     | 0x84FE | Passed to `texParameter` to set the desired maximum anisotropy for a texture. |
 
-### {{domxref("WEBGL_compressed_texture_s3tc")}}
+For more information, see {{domxref("EXT_texture_filter_anisotropic")}}.
+
+### WEBGL_compressed_texture_s3tc
 
 <table class="no-markdown">
   <thead>
@@ -1804,7 +1810,9 @@ Constants passed to {{domxref("WebGLRenderingContext.texParameter", "WebGLRender
   </tbody>
 </table>
 
-### {{domxref("WEBGL_compressed_texture_etc")}}
+For more information, see {{domxref("WEBGL_compressed_texture_s3tc")}}.
+
+### WEBGL_compressed_texture_etc
 
 <table class="no-markdown">
   <thead>
@@ -1880,7 +1888,9 @@ Constants passed to {{domxref("WebGLRenderingContext.texParameter", "WebGLRender
   </tbody>
 </table>
 
-### {{domxref("WEBGL_compressed_texture_pvrtc")}}
+For more information, see {{domxref("WEBGL_compressed_texture_etc")}}.
+
+### WEBGL_compressed_texture_pvrtc
 
 | Constant name                      | Value  | Description                                                    |
 | ---------------------------------- | ------ | -------------------------------------------------------------- |
@@ -1889,25 +1899,33 @@ Constants passed to {{domxref("WebGLRenderingContext.texParameter", "WebGLRender
 | `COMPRESSED_RGB_PVRTC_2BPPV1_IMG`  | 0x8C01 | RGB compression in 2-bit mode. One block for each 8×4 pixels.  |
 | `COMPRESSED_RGBA_PVRTC_2BPPV1_IMG` | 0x8C03 | RGBA compression in 2-bit mode. One block for each 8×4 pixe    |
 
-### {{domxref("WEBGL_compressed_texture_etc1")}}
+For more information, see {{domxref("WEBGL_compressed_texture_pvrtc")}}.
+
+### WEBGL_compressed_texture_etc1
 
 | Constant name               | Value  | Description                                       |
 | --------------------------- | ------ | ------------------------------------------------- |
 | `COMPRESSED_RGB_ETC1_WEBGL` | 0x8D64 | Compresses 24-bit RGB data with no alpha channel. |
 
-### {{domxref("WEBGL_depth_texture")}}
+For more information, see {{domxref("WEBGL_compressed_texture_etc1")}}.
+
+### WEBGL_depth_texture
 
 | Constant name             | Value  | Description                                          |
 | ------------------------- | ------ | ---------------------------------------------------- |
 | `UNSIGNED_INT_24_8_WEBGL` | 0x84FA | Unsigned integer type for 24-bit depth texture data. |
 
-### {{domxref("OES_texture_half_float")}}
+For more information, see {{domxref("WEBGL_depth_texture")}}.
+
+### OES_texture_half_float
 
 | Constant name    | Value  | Description                        |
 | ---------------- | ------ | ---------------------------------- |
 | `HALF_FLOAT_OES` | 0x8D61 | Half floating-point type (16-bit). |
 
-### {{domxref("WEBGL_color_buffer_float")}}
+For more information, see {{domxref("OES_texture_half_float")}}.
+
+### WEBGL_color_buffer_float
 
 | Constant name                               | Value  | Description                                         |
 | ------------------------------------------- | ------ | --------------------------------------------------- |
@@ -1916,14 +1934,18 @@ Constants passed to {{domxref("WebGLRenderingContext.texParameter", "WebGLRender
 | `FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT` | 0x8211 |                                                     |
 | `UNSIGNED_NORMALIZED_EXT`                   | 0x8C17 |                                                     |
 
-### {{domxref("EXT_blend_minmax")}}
+For more information, see {{domxref("WEBGL_color_buffer_float")}}.
+
+### EXT_blend_minmax
 
 | Constant name | Value  | Description                                                                 |
 | ------------- | ------ | --------------------------------------------------------------------------- |
 | `MIN_EXT`     | 0x8007 | Produces the minimum color components of the source and destination colors. |
 | `MAX_EXT`     | 0x8008 | Produces the maximum color components of the source and destination colors. |
 
-### {{domxref("EXT_sRGB")}}
+For more information, see {{domxref("EXT_blend_minmax")}}.
+
+### EXT_sRGB
 
 | Constant name                               | Value  | Description                                                     |
 | ------------------------------------------- | ------ | --------------------------------------------------------------- |
@@ -1932,7 +1954,9 @@ Constants passed to {{domxref("WebGLRenderingContext.texParameter", "WebGLRender
 | `SRGB8_ALPHA8_EXT`                          | 0x8C43 | Sized (8-bit) sRGB and alpha formats.                           |
 | `FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING_EXT` | 0x8210 | Returns the framebuffer color encoding.                         |
 
-### {{domxref("OES_standard_derivatives")}}
+For more information, see {{domxref("EXT_sRGB")}}.
+
+### OES_standard_derivatives
 
 <table class="no-markdown">
   <thead>
@@ -1955,7 +1979,9 @@ Constants passed to {{domxref("WebGLRenderingContext.texParameter", "WebGLRender
   </tbody>
 </table>
 
-### {{domxref("WEBGL_draw_buffers")}}
+For more information, see {{domxref("OES_standard_derivatives")}}.
+
+### WEBGL_draw_buffers
 
 | Constant name                 | Value  | Description                                           |
 | ----------------------------- | ------ | ----------------------------------------------------- |
@@ -1994,13 +2020,17 @@ Constants passed to {{domxref("WebGLRenderingContext.texParameter", "WebGLRender
 | `MAX_COLOR_ATTACHMENTS_WEBGL` | 0x8CDF | Maximum number of framebuffer color attachment points |
 | `MAX_DRAW_BUFFERS_WEBGL`      | 0x8824 | Maximum number of draw buffers                        |
 
-### {{domxref("OES_vertex_array_object")}}
+For more information, see {{domxref("WEBGL_draw_buffers")}}.
+
+### OES_vertex_array_object
 
 | Constant name              | Value  | Description                          |
 | -------------------------- | ------ | ------------------------------------ |
 | `VERTEX_ARRAY_BINDING_OES` | 0x85B5 | The bound vertex array object (VAO). |
 
-### {{domxref("EXT_disjoint_timer_query")}}
+For more information, see {{domxref("OES_vertex_array_object")}}.
+
+### EXT_disjoint_timer_query
 
 | Constant name                | Value  | Description                                                                   |
 | ---------------------------- | ------ | ----------------------------------------------------------------------------- |
@@ -2011,6 +2041,8 @@ Constants passed to {{domxref("WebGLRenderingContext.texParameter", "WebGLRender
 | `TIME_ELAPSED_EXT`           | 0x88BF | Elapsed time (in nanoseconds).                                                |
 | `TIMESTAMP_EXT`              | 0x8E28 | The current time.                                                             |
 | `GPU_DISJOINT_EXT`           | 0x8FBB | A Boolean indicating whether or not the GPU performed any disjoint operation. |
+
+For more information, see {{domxref("EXT_disjoint_timer_query")}}.
 
 ## Specifications
 


### PR DESCRIPTION
Such links are against our convention and raising flaws (and not discoverable).