### PR TITLE
Remove links from headings in OpenType fonts guide

### DIFF
--- a/files/en-us/web/css/css_fonts/opentype_fonts_guide/index.md
+++ b/files/en-us/web/css/css_fonts/opentype_fonts_guide/index.md
@@ -45,13 +45,17 @@ There are a number of different features to consider. They are grouped and expla
 
 > **Note:** The examples below show the properties and some example combinations, along with the lower-level syntax equivalents. They may not match exactly due to browser implementation inconsistencies, but in many cases, the first example will match the second. The typefaces shown are Playfair Display, Source Serif Pro, IBM Plex Serif, Dancing Script, and Kokoro (all available and free to use, most are on Google Fonts and other services).
 
-### Kerning ({{cssxref("font-kerning")}})
+### Kerning
+
+Associated CSS property: {{cssxref("font-kerning")}}
 
 This refers to the spacing between specific glyph pairings. This is generally on by default (as recommended by the OpenType specification). It should be noted that if {{cssxref("letter-spacing")}} is also set on your text, that is applied after kerning.
 
 {{EmbedGHLiveSample("css-examples/font-features/font-kerning.html", '100%', 520)}}
 
-### Alternates ({{cssxref("font-variant-alternates")}})
+### Alternates
+
+Associated CSS property: {{cssxref("font-variant-alternates")}}
 
 Fonts can supply a number of different alternatives for various glyphs, such as different styles of lower case 'a' or more or less elaborate swashes in a script typeface. This property can activate an entire set of alternates or just a specific one, depending on the values supplied. The example below is showing several different aspects of working with alternate characters. Fonts with alternate glyphs can make them available across the board or individually in separate stylistic sets, or even individual characters. In this example you can see two different typefaces, and the introduction of the {{cssxref("@font-feature-values")}} at-rule. This is used to define shortcuts or named options that can be defined per font family. This way you can create a named option that applies to only a single font, or one that is shared and can be applied more generally
 
@@ -78,7 +82,9 @@ and notice that the lower case 'a' reverts to its regular form and the lower cas
 - <https://www.w3.org/TR/css-fonts-4/#propdef-font-variant-alternates>
 - [https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-alternates](/en-US/docs/Web/CSS/font-variant-alternates)
 
-### Ligatures ({{cssxref("font-variant-ligatures")}})
+### Ligatures
+
+Associated CSS property: {{cssxref("font-variant-ligatures")}}
 
 Ligatures are glyphs that replace two or more separate glyphs in order to represent them more smoothly (from a spacing or aesthetic perspective). Some of the most common are letters like 'fi', 'fl', or 'ffl' — but there are many other possibilities. There are the most frequent ones (referred to as common ligatures), and there are also more specialized categories like 'discretionary ligatures', 'historical ligatures', and 'contextual alternates'. While these last ones are not technically ligatures, they are generally similar in that they replace specific combinations of letters when they appear together.
 
@@ -86,19 +92,25 @@ While more common in script typefaces, in the below example they are used to cre
 
 {{EmbedGHLiveSample("css-examples/font-features/font-variant-ligatures.html", '100%', 540)}}
 
-### Position ({{cssxref("font-variant-position")}})
+### Position
+
+Associated CSS property: {{cssxref("font-variant-position")}}
 
 Position variants are used to enable typographic superscript and subscript glyphs. These are designed to work with the surrounding text without altering the baseline or line spacing. This is one of the key benefits over using the {{htmlelement("sub")}} or {{htmlelement("sup")}} elements.
 
 {{EmbedGHLiveSample("css-examples/font-features/font-variant-position.html", '100%', 550)}}
 
-### Capitals ({{cssxref("font-variant-caps")}})
+### Capitals
+
+Associated CSS property: {{cssxref("font-variant-caps")}}
 
 One of the more common use cases for OpenType features is proper small caps. These are capital letters sized to fit better amongst lower case letters and are generally used for acronyms and abbreviations.
 
 {{EmbedGHLiveSample("css-examples/font-features/font-variant-caps.html", '100%', 620)}}
 
-### Numerals ({{cssxref("font-variant-numeric")}})
+### Numerals
+
+Associated CSS property: {{cssxref("font-variant-numeric")}}
 
 There are several different styles of numerals commonly included in fonts:
 
@@ -114,7 +126,7 @@ There are two types of fractions supported through this property:
 
 Ordinals are also supported (such as '1st' or '3rd'), as is a slashed zero if present in the font.
 
-#### Lining and Oldstyle figures
+#### Lining and old-style figures
 
 {{EmbedGHLiveSample("css-examples/font-features/font-variant-numeric.html", '100%', 560)}}
 
@@ -122,7 +134,9 @@ Ordinals are also supported (such as '1st' or '3rd'), as is a slashed zero if pr
 
 {{EmbedGHLiveSample("css-examples/font-features/font-variant-numeric-frac.html", '100%', 600)}}
 
-### East Asian ({{cssxref("font-variant-east-asian")}})
+### East Asian
+
+Associated CSS property: {{cssxref("font-variant-east-asian")}}
 
 This allows access to various alternate forms of glyphs within a font. The example below shows a string of glyphs with only the OpenType set 'jis78' enabled. Uncheck the box below and you'll see more characters displayed.
 
@@ -130,9 +144,9 @@ This allows access to various alternate forms of glyphs within a font. The examp
 
 > **Note:** these glyphs were copied out of a font sample and are not intended as prose.
 
-### Font variant shorthand ({{Cssxref("font-variant")}})
+### Font variant shorthand
 
-This is the shorthand syntax for defining all of the above. Setting a value of `normal` resets all properties to their initial value. Setting a value of `none` sets `font-variant-ligatures` to none and all other properties to their initial value. (Meaning that if kerning is on by default, it will still be on even with a value of `none` being supplied here.)
+The {{Cssxref("font-variant")}} property is the shorthand syntax for defining all of the above. Setting a value of `normal` resets all properties to their initial value. Setting a value of `none` sets `font-variant-ligatures` to none and all other properties to their initial value. (Meaning that if kerning is on by default, it will still be on even with a value of `none` being supplied here.)
 
 {{EmbedGHLiveSample("css-examples/font-features/font-variant.html", '100%', 600)}}
 


### PR DESCRIPTION
Our writing guide forbids having links in headings. This fixes it for the _OpenType fonts guide_.