### PR TITLE
Remove links from headings in SVG's attribute type

### DIFF
--- a/files/en-us/web/svg/attribute/type/index.md
+++ b/files/en-us/web/svg/attribute/type/index.md
@@ -32,7 +32,9 @@ You can use this attribute with the following SVG elements:
 
 ## Usage context
 
-### For the {{SVGElement("animateTransform")}} elements
+### For the &lt;animateTransform&gt; elements
+
+SVG element: {{SVGElement("animateTransform")}}
 
 <table class="properties">
   <tbody>
@@ -63,7 +65,9 @@ You can use this attribute with the following SVG elements:
   </tbody>
 </table>
 
-### For the {{ SVGElement("feColorMatrix") }} element
+### For the &lt;feColorMatrix&gt; element
+
+SVG element: {{SVGElement("feColorMatrix")}}
 
 <table class="properties">
   <tbody>
@@ -95,7 +99,9 @@ You can use this attribute with the following SVG elements:
   </tbody>
 </table>
 
-### For the {{ SVGElement("feFuncR") }}, {{ SVGElement("feFuncG") }}, {{ SVGElement("feFuncB") }}, and {{ SVGElement("feFuncA") }} elements
+### For the &lt;feFuncR&gt;, &lt;feFuncG&gt;, &lt;feFuncB&gt;, and &lt;feFuncA&gt; elements
+
+SVG elements: {{SVGElement("feFuncR")}}, {{SVGElement("feFuncG")}}, {{SVGElement("feFuncB")}}, {{SVGElement("feFuncA")}}
 
 <table class="properties">
   <tbody>
@@ -127,7 +133,9 @@ You can use this attribute with the following SVG elements:
   </tbody>
 </table>
 
-### For the {{ SVGElement("feTurbulence") }} element
+### For the &lt;feTurbulence&gt; element
+
+SVG element: {{SVGElement("feTurbulence")}}
 
 <table class="properties">
   <tbody>
@@ -158,7 +166,9 @@ You can use this attribute with the following SVG elements:
   </tbody>
 </table>
 
-### For the {{ SVGElement("style") }} and {{SVGElement("script")}} elements
+### For the &lt;style&gt; and &lt;script&gt; elements
+
+SVG elements: {{SVGElement("style")}}, {{SVGElement("script")}}
 
 <table class="properties">
   <tbody>


### PR DESCRIPTION
This is against our convention, is unclickable, and leads to flaws.