### PR TITLE
Remove {{page}} from event pages

### DIFF
--- a/files/en-us/web/api/audiotracklist/addtrack_event/index.md
+++ b/files/en-us/web/api/audiotracklist/addtrack_event/index.md
@@ -39,7 +39,10 @@ An {{domxref("TrackEvent")}}. Inherits from {{domxref("Event")}}.
 
 ## Event properties
 
-{{page("/en-us/docs/Web/API/TrackEvent", "Properties")}}
+_`TrackEvent` is based on {{domxref("Event")}}, so properties of `Event` are also available on `TrackEvent` objects._
+
+- {{domxref("TrackEvent.track", "track")}} {{ReadOnlyInline}}
+  - : The DOM track object the event is in reference to. If not `null`, this is always an object of one of the media track types: {{domxref("AudioTrack")}}, {{domxref("VideoTrack")}}, or {{domxref("TextTrack")}}).
 
 ## Description
 

--- a/files/en-us/web/api/audiotracklist/removetrack_event/index.md
+++ b/files/en-us/web/api/audiotracklist/removetrack_event/index.md
@@ -40,7 +40,10 @@ An {{domxref("TrackEvent")}}. Inherits from {{domxref("Event")}}.
 
 ## Event properties
 
-{{page("/en-us/docs/Web/API/TrackEvent", "Properties")}}
+_`TrackEvent` is based on {{domxref("Event")}}, so properties of `Event` are also available on `TrackEvent` objects._
+
+- {{domxref("TrackEvent.track", "track")}} {{ReadOnlyInline}}
+  - : The DOM track object the event is in reference to. If not `null`, this is always an object of one of the media track types: {{domxref("AudioTrack")}}, {{domxref("VideoTrack")}}, or {{domxref("TextTrack")}}).
 
 ## Description
 

--- a/files/en-us/web/api/filereader/abort_event/index.md
+++ b/files/en-us/web/api/filereader/abort_event/index.md
@@ -35,7 +35,14 @@ An {{domxref("ProgressEvent")}}. Inherits from {{domxref("Event")}}.
 
 ## Event properties
 
-{{page("/en-US/docs/Web/API/ProgressEvent", "Properties")}}
+_Also inherits properties from its parent {{domxref("Event")}}_.
+
+- {{domxref("ProgressEvent.lengthComputable")}} {{readonlyInline}}
+  - : A boolean flag indicating if the total work to be done, and the amount of work already done, by the underlying process is calculable. In other words, it tells if the progress is measurable or not.
+- {{domxref("ProgressEvent.loaded")}} {{readonlyInline}}
+  - : A 64-bit unsigned integer value indicating the amount of work already performed by the underlying process. The ratio of work done can be calculated by dividing `total` by the value of this property. When downloading a resource using HTTP, this only counts the body of the HTTP message, and doesn't include headers and other overhead.
+- {{domxref("ProgressEvent.total")}} {{readonlyInline}}
+  - : A 64-bit unsigned integer representing the total amount of work that the underlying process is in the progress of performing. When downloading a resource using HTTP, this is the `Content-Length` (the size of the body of the message), and doesn't include the headers and other overhead.
 
 ## Examples
 

--- a/files/en-us/web/api/filereader/error_event/index.md
+++ b/files/en-us/web/api/filereader/error_event/index.md
@@ -36,7 +36,14 @@ An {{domxref("ProgressEvent")}}. Inherits from {{domxref("Event")}}.
 
 ## Event properties
 
-{{page("/en-US/docs/Web/API/ProgressEvent", "Properties")}}
+_Also inherits properties from its parent {{domxref("Event")}}_.
+
+- {{domxref("ProgressEvent.lengthComputable")}} {{readonlyInline}}
+  - : A boolean flag indicating if the total work to be done, and the amount of work already done, by the underlying process is calculable. In other words, it tells if the progress is measurable or not.
+- {{domxref("ProgressEvent.loaded")}} {{readonlyInline}}
+  - : A 64-bit unsigned integer value indicating the amount of work already performed by the underlying process. The ratio of work done can be calculated by dividing `total` by the value of this property. When downloading a resource using HTTP, this only counts the body of the HTTP message, and doesn't include headers and other overhead.
+- {{domxref("ProgressEvent.total")}} {{readonlyInline}}
+  - : A 64-bit unsigned integer representing the total amount of work that the underlying process is in the progress of performing. When downloading a resource using HTTP, this is the `Content-Length` (the size of the body of the message), and doesn't include the headers and other overhead.
 
 ## Examples
 

--- a/files/en-us/web/api/filereader/load_event/index.md
+++ b/files/en-us/web/api/filereader/load_event/index.md
@@ -33,7 +33,14 @@ An {{domxref("ProgressEvent")}}. Inherits from {{domxref("Event")}}.
 
 ## Event properties
 
-{{page("/en-US/docs/Web/API/ProgressEvent", "Properties")}}
+_Also inherits properties from its parent {{domxref("Event")}}_.
+
+- {{domxref("ProgressEvent.lengthComputable")}} {{readonlyInline}}
+  - : A boolean flag indicating if the total work to be done, and the amount of work already done, by the underlying process is calculable. In other words, it tells if the progress is measurable or not.
+- {{domxref("ProgressEvent.loaded")}} {{readonlyInline}}
+  - : A 64-bit unsigned integer value indicating the amount of work already performed by the underlying process. The ratio of work done can be calculated by dividing `total` by the value of this property. When downloading a resource using HTTP, this only counts the body of the HTTP message, and doesn't include headers and other overhead.
+- {{domxref("ProgressEvent.total")}} {{readonlyInline}}
+  - : A 64-bit unsigned integer representing the total amount of work that the underlying process is in the progress of performing. When downloading a resource using HTTP, this is the `Content-Length` (the size of the body of the message), and doesn't include the headers and other overhead.
 
 ## Examples
 

--- a/files/en-us/web/api/filereader/loadend_event/index.md
+++ b/files/en-us/web/api/filereader/loadend_event/index.md
@@ -34,7 +34,14 @@ An {{domxref("ProgressEvent")}}. Inherits from {{domxref("Event")}}.
 
 ## Event properties
 
-{{page("/en-US/docs/Web/API/ProgressEvent", "Properties")}}
+_Also inherits properties from its parent {{domxref("Event")}}_.
+
+- {{domxref("ProgressEvent.lengthComputable")}} {{readonlyInline}}
+  - : A boolean flag indicating if the total work to be done, and the amount of work already done, by the underlying process is calculable. In other words, it tells if the progress is measurable or not.
+- {{domxref("ProgressEvent.loaded")}} {{readonlyInline}}
+  - : A 64-bit unsigned integer value indicating the amount of work already performed by the underlying process. The ratio of work done can be calculated by dividing `total` by the value of this property. When downloading a resource using HTTP, this only counts the body of the HTTP message, and doesn't include headers and other overhead.
+- {{domxref("ProgressEvent.total")}} {{readonlyInline}}
+  - : A 64-bit unsigned integer representing the total amount of work that the underlying process is in the progress of performing. When downloading a resource using HTTP, this is the `Content-Length` (the size of the body of the message), and doesn't include the headers and other overhead.
 
 ## Examples
 

--- a/files/en-us/web/api/filereader/loadstart_event/index.md
+++ b/files/en-us/web/api/filereader/loadstart_event/index.md
@@ -34,7 +34,14 @@ An {{domxref("ProgressEvent")}}. Inherits from {{domxref("Event")}}.
 
 ## Event properties
 
-{{page("/en-US/docs/Web/API/ProgressEvent", "Properties")}}
+_Also inherits properties from its parent {{domxref("Event")}}_.
+
+- {{domxref("ProgressEvent.lengthComputable")}} {{readonlyInline}}
+  - : A boolean flag indicating if the total work to be done, and the amount of work already done, by the underlying process is calculable. In other words, it tells if the progress is measurable or not.
+- {{domxref("ProgressEvent.loaded")}} {{readonlyInline}}
+  - : A 64-bit unsigned integer value indicating the amount of work already performed by the underlying process. The ratio of work done can be calculated by dividing `total` by the value of this property. When downloading a resource using HTTP, this only counts the body of the HTTP message, and doesn't include headers and other overhead.
+- {{domxref("ProgressEvent.total")}} {{readonlyInline}}
+  - : A 64-bit unsigned integer representing the total amount of work that the underlying process is in the progress of performing. When downloading a resource using HTTP, this is the `Content-Length` (the size of the body of the message), and doesn't include the headers and other overhead.
 
 ## Examples
 

--- a/files/en-us/web/api/filereader/progress_event/index.md
+++ b/files/en-us/web/api/filereader/progress_event/index.md
@@ -35,7 +35,14 @@ An {{domxref("ProgressEvent")}}. Inherits from {{domxref("Event")}}.
 
 ## Event properties
 
-{{page("/en-US/docs/Web/API/ProgressEvent", "Properties")}}
+_Also inherits properties from its parent {{domxref("Event")}}_.
+
+- {{domxref("ProgressEvent.lengthComputable")}} {{readonlyInline}}
+  - : A boolean flag indicating if the total work to be done, and the amount of work already done, by the underlying process is calculable. In other words, it tells if the progress is measurable or not.
+- {{domxref("ProgressEvent.loaded")}} {{readonlyInline}}
+  - : A 64-bit unsigned integer value indicating the amount of work already performed by the underlying process. The ratio of work done can be calculated by dividing `total` by the value of this property. When downloading a resource using HTTP, this only counts the body of the HTTP message, and doesn't include headers and other overhead.
+- {{domxref("ProgressEvent.total")}} {{readonlyInline}}
+  - : A 64-bit unsigned integer representing the total amount of work that the underlying process is in the progress of performing. When downloading a resource using HTTP, this is the `Content-Length` (the size of the body of the message), and doesn't include the headers and other overhead.
 
 ## Examples
 

--- a/files/en-us/web/api/hiddevice/inputreport_event/index.md
+++ b/files/en-us/web/api/hiddevice/inputreport_event/index.md
@@ -31,7 +31,14 @@ An {{domxref("HIDInputReportEvent")}}. Inherits from {{domxref("Event")}}.
 
 ## Event properties
 
-{{page("/en-US/docs/Web/API/HIDInputReportEvent", "Properties")}}
+_This interface also inherits properties from {{domxref("Event")}}._
+
+- {{domxref("HIDInputReportEvent.data")}}{{readonlyinline}}
+  - : A {{jsxref("DataView")}} containing the data from the input report, excluding the `reportId` if the HID interface uses report IDs.
+- {{domxref("HIDInputReportEvent.device")}}{{readonlyinline}}
+  - : The {{domxref("HIDDevice")}} instance that represents the HID interface that sent the input report.
+- {{domxref("HIDInputReportEvent.reportId")}}{{readonlyinline}}
+  - : The one-byte identification prefix for this report, or 0 if the HID interface does not use report IDs.
 
 ## Example
 

--- a/files/en-us/web/api/mediakeysession/keystatuseschange_event/index.md
+++ b/files/en-us/web/api/mediakeysession/keystatuseschange_event/index.md
@@ -31,7 +31,7 @@ An {{domxref("ExtendableEvent")}}. Inherits from {{domxref("Event")}}.
 
 ## Event properties
 
-{{page("/en-US/docs/Web/API/ExtendableEvent", "Properties")}}
+_Doesn't implement any specific properties, but inherits properties from its parent, {{domxref("Event")}}._
 
 ## Specifications
 

--- a/files/en-us/web/api/mediakeysession/message_event/index.md
+++ b/files/en-us/web/api/mediakeysession/message_event/index.md
@@ -33,8 +33,11 @@ An {{domxref("MediaKeyMessageEvent")}}. Inherits from {{domxref("Event")}}.
 
 ## Event properties
 
-{{page("/en-US/docs/Web/API/MediaKeyMessageEvent", "Properties")}}
-
+- {{domxref("MediaKeyMessageEvent.message")}} {{readonlyinline}}
+  - : Returns an {{jsxref("ArrayBuffer")}} with a message from the content decryption module. Messages vary by key system.
+- {{domxref("MediaKeyMessageEvent.messageType")}} {{readonlyinline}}
+  - : Indicates the type of message. May be one of `license-request`, `license-renewal`, `license-release`, or `individualization-request`.
+  
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/offlineaudiocontext/complete_event/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/complete_event/index.md
@@ -34,7 +34,10 @@ An {{domxref("OfflineAudioCompletionEvent")}}. Inherits from {{domxref("Event")}
 
 ## Event properties
 
-{{page("/en-US/docs/Web/API/OfflineAudioCompletionEvent", "Properties")}}
+_Also inherits properties from its parent, {{domxref("Event")}}_.
+
+- {{domxref("OfflineAudioCompletionEvent.renderedBuffer")}} {{readonlyinline}}
+  - : An {{domxref("AudioBuffer")}} containing the result of processing an {{domxref("OfflineAudioContext")}}.
 
 ## Examples
 


### PR DESCRIPTION
When we redesigned the event page in Q1, we settled not to use the `{{page}}` transclusion macro.

Some pages (among the first to be migrated) were merged with some occurrences of this macro.

This PR fixes this.