### PR TITLE
Remove {{page}} in WebGL_API/extensions

### DIFF
--- a/files/en-us/web/api/webgl_api/using_extensions/index.md
+++ b/files/en-us/web/api/webgl_api/using_extensions/index.md
@@ -56,7 +56,44 @@ The {{domxref("WebGLRenderingContext.getSupportedExtensions()")}} method returns
 
 The current extensions are:
 
-{{page("en-US/docs/Web/API/WebGL_API", "Extensions")}}
+### Extensions
+
+- {{domxref("ANGLE_instanced_arrays")}}
+- {{domxref("EXT_blend_minmax")}}
+- {{domxref("EXT_color_buffer_float")}}
+- {{domxref("EXT_color_buffer_half_float")}}
+- {{domxref("EXT_disjoint_timer_query")}}
+- {{domxref("EXT_float_blend")}} {{experimental_inline}}
+- {{domxref("EXT_frag_depth")}}
+- {{domxref("EXT_shader_texture_lod")}}
+- {{domxref("EXT_sRGB")}}
+- {{domxref("EXT_texture_compression_bptc")}}
+- {{domxref("EXT_texture_compression_rgtc")}}
+- {{domxref("EXT_texture_filter_anisotropic")}}
+- {{domxref("EXT_texture_norm16")}}
+- {{domxref("KHR_parallel_shader_compile")}}
+- {{domxref("OES_element_index_uint")}}
+- {{domxref("OES_fbo_render_mipmap")}}
+- {{domxref("OES_standard_derivatives")}}
+- {{domxref("OES_texture_float")}}
+- {{domxref("OES_texture_float_linear")}}
+- {{domxref("OES_texture_half_float")}}
+- {{domxref("OES_texture_half_float_linear")}}
+- {{domxref("OES_vertex_array_object")}}
+- {{domxref("OVR_multiview2")}}
+- {{domxref("WEBGL_color_buffer_float")}}
+- {{domxref("WEBGL_compressed_texture_astc")}}
+- {{domxref("WEBGL_compressed_texture_etc")}}
+- {{domxref("WEBGL_compressed_texture_etc1")}}
+- {{domxref("WEBGL_compressed_texture_pvrtc")}}
+- {{domxref("WEBGL_compressed_texture_s3tc")}}
+- {{domxref("WEBGL_compressed_texture_s3tc_srgb")}}
+- {{domxref("WEBGL_debug_renderer_info")}}
+- {{domxref("WEBGL_debug_shaders")}}
+- {{domxref("WEBGL_depth_texture")}}
+- {{domxref("WEBGL_draw_buffers")}}
+- {{domxref("WEBGL_lose_context")}}
+- {{domxref("WEBGL_multi_draw")}}
 
 ## Enabling an extension
 


### PR DESCRIPTION
This list varies extremely rarely, no need for a transclusion (that we want to get rid of)