### PR TITLE
Remove transclusion in mediatrackconstraints/facingmode

### DIFF
--- a/files/en-us/web/api/mediatrackconstraints/facingmode/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/facingmode/index.md
@@ -49,8 +49,22 @@ var constraints = {
 This indicates that only a user-facing camera is acceptable; if there is no user-facing
 camera, or the user declines permission to use that camera, the media request will fail.
 
-{{page("/en-US/docs/Web/API/MediaTrackSettings/facingMode", "VideoFacingModeEnum")}}
+The following strings are permitted values for the facing mode. These may represent
+separate cameras, or they may represent directions in which an adjustable camera can be
+pointed.
 
+- `"user"`
+  - : The video source is facing toward the user; this includes, for example, the
+    front-facing camera on a smartphone.
+- `"environment"`
+  - : The video source is facing away from the user, thereby viewing their environment.
+    This is the back camera on a smartphone.
+- `"left"`
+  - : The video source is facing toward the user but to their left, such as a camera aimed
+    toward the user but over their left shoulder.
+- `"right"`
+  - : The video source is facing toward the user but to their right, such as a camera
+    aimed toward the user but over their right shoulder.
 ## Examples
 
 See {{SectionOnPage("/en-US/docs/Web/API/Media_Streams_API/Constraints", "Example:


### PR DESCRIPTION
This is the last `{{page}}` in mdn/content ! (Some removals are still in open PRs, and once all are merged, I will create the last PR to remove the meta-docs about {{page}} and mark it as deprecated in yari).

This also helps remove MediaTrackSettings which is a dictionary that we want to get rid of. (Still, more work is needed for that).