### PR TITLE
Remove inaccurate description of example

### DIFF
--- a/files/en-us/web/api/navigator/registerprotocolhandler/web-based_protocol_handlers/index.md
+++ b/files/en-us/web/api/navigator/registerprotocolhandler/web-based_protocol_handlers/index.md
@@ -40,7 +40,7 @@ When a browser executes this code, it should display a prompt to the user, askin
 
 > **Note:** The URL template supplied when registering **must** be of the same domain as the webpage attempting to perform the registration or the registration will fail. For example, `http://example.com/homepage.html` can register a protocol handler for `http://example.com/handle_mailto/%s`, but not for `http://example.org/handle_mailto/%s`.
 
-Registering the same protocol handler more than once will pop up a different notification, indicating that the protocol handler is already registered. Therefore, it is a good idea to guard your call to register the protocol handler with a check to see if it is already registered, such as in the example below.
+Registering the same protocol handler more than once will pop up a different notification, indicating that the protocol handler is already registered.
 
 ### Example
 


### PR DESCRIPTION
This removes an inaccurate description of an example from the Registration section of the web-based protocol handlers reference page.

#### Summary
Removes a sentence promising something about the example, which is not delivered in the example.

#### Motivation
The text about the content of the example does not match the content of the example. 

#### Questions
- I think it would be better to update the example to deliver on the promise, but I was not able to find any existing API for protocol handlers that would allow me to implement such a guard. As such, I've settled on updating the description. However, if anyone knows of an API that would allow us to implement the guard, that would be preferable. Can we update the example instead?
- If we do have to update the description, it may be worth removing both sentences. I'm not sure how accurate or helpful the remaining sentence: "Registering the same protocol handler more than once will pop up a different notification, indicating that the protocol handler is already registered." For accuracy, I do not have time to test in multiple browsers, but it's not accurate for Chrome. For helpfulness, if I'm right about the web API, there is nothing the developer can do in response to the information, so it doesn't seem extremely relevant. Should this sentence also be deleted?

#### Supporting details
As noted in the related issue below, the description and example haven't matched since the original commit: https://github.com/mdn/content/blob/main/files/en-us/web/api/navigator/registerprotocolhandler/web-based_protocol_handlers/index.md?plain=1

#### Related issues
Fixes https://github.com/mdn/content/issues/15870

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
