### PR TITLE
Clarify "Converting mistakes into errors" example

### DIFF
--- a/files/en-us/web/javascript/reference/strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/strict_mode/index.md
@@ -84,7 +84,7 @@ let mistypeVariable;
                       
 mistypeVarible = 17;  // Assuming no global variable mistypeVarible exists
                       // this line throws a ReferenceError due to the
-                      // misspelling of "Variable" word
+                      // misspelling of "mistypeVariable" (lack of an "a")
 ```
 
 Second, strict mode makes assignments which would otherwise silently fail to throw an exception. For example, `NaN` is a non-writable global variable. In normal code assigning to `NaN` does nothing; the developer receives no failure feedback. In strict mode assigning to `NaN` throws an exception. Any assignment that silently fails in normal code (assignment to a non-writable global or property, assignment to a getter-only property, assignment to a new property on a [non-extensible](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions) object) will throw in strict mode:

--- a/files/en-us/web/javascript/reference/strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/strict_mode/index.md
@@ -84,7 +84,7 @@ let mistypeVariable;
                       
 mistypeVarible = 17;  // Assuming no global variable mistypeVarible exists
                       // this line throws a ReferenceError due to the
-                      // misspelling of variable name
+                      // misspelling of "Variable" word
 ```
 
 Second, strict mode makes assignments which would otherwise silently fail to throw an exception. For example, `NaN` is a non-writable global variable. In normal code assigning to `NaN` does nothing; the developer receives no failure feedback. In strict mode assigning to `NaN` throws an exception. Any assignment that silently fails in normal code (assignment to a non-writable global or property, assignment to a getter-only property, assignment to a new property on a [non-extensible](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions) object) will throw in strict mode:

--- a/files/en-us/web/javascript/reference/strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/strict_mode/index.md
@@ -80,7 +80,7 @@ First, strict mode makes it impossible to accidentally create global variables. 
 
 ```js
 'use strict';
-var mistypeVariable;
+let mistypeVariable;
                       
 mistypeVarible = 17;  // Assuming no global variable mistypeVarible exists
                       // this line throws a ReferenceError due to the

--- a/files/en-us/web/javascript/reference/strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/strict_mode/index.md
@@ -80,9 +80,11 @@ First, strict mode makes it impossible to accidentally create global variables. 
 
 ```js
 'use strict';
-                       // Assuming no global variable mistypeVariable exists
-mistypeVariable = 17;  // this line throws a ReferenceError due to the
-                       // misspelling of variable
+var mistypeVariable;
+                      
+mistypeVarible = 17;  // Assuming no global variable mistypeVarible exists
+                      // this line throws a ReferenceError due to the
+                      // misspelling of variable name
 ```
 
 Second, strict mode makes assignments which would otherwise silently fail to throw an exception. For example, `NaN` is a non-writable global variable. In normal code assigning to `NaN` does nothing; the developer receives no failure feedback. In strict mode assigning to `NaN` throws an exception. Any assignment that silently fails in normal code (assignment to a non-writable global or property, assignment to a getter-only property, assignment to a new property on a [non-extensible](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions) object) will throw in strict mode:


### PR DESCRIPTION
#### Summary
I updated the example of how strict mode handles 'accidental' global variable initialization. The previous example mentioned a 'misspelled variable,' but there was none present in the example. This PR _adds_ a variable declaration that is then misspelled to generate the strict mode error, which clarifies the example.

#### Motivation
These changes clarify the code example. Now, the example matches the content in the relevant paragraph.

#### Supporting details
None

#### Related issues
N/A

#### Metadata
This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

Thanks for your awesome resources!
