### PR TITLE
Move {{Optional_Inline}} out of code span

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.md
@@ -54,7 +54,7 @@ let setting = browser.cookies.set(
 
     - `path`{{optional_inline}}
       - : A `string` representing the path of the cookie. If omitted, this defaults to the path portion of the URL parameter.
-    - `sameSite{{optional_inline}}`
+    - `sameSite`{{optional_inline}}
       - : A {{WebExtAPIRef("cookies.SameSiteStatus")}} value that indicates the SameSite state of the cookie. If omitted, it defaults to 0, 'no_restriction'.
     - `secure`{{optional_inline}}
       - : A `boolean` that specifies whether the cookie should be marked as secure (`true`), or not (false). If omitted, it defaults to false.

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.md
@@ -32,7 +32,7 @@ let uninstalling = browser.management.uninstall(
 
 - `id`
   - : `string`. ID of the add-on to uninstall.
-- `options{{optional_inline}}`
+- `options`{{optional_inline}}
   - : `object`. Object which may contain a single property, `showConfirmDialog`. If `showConfirmDialog` is `true`, the browser will show a dialog asking the user to confirm that the add-on should be uninstalled.
 
 <!---->

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstallself/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstallself/index.md
@@ -29,13 +29,13 @@ let uninstallingSelf = browser.management.uninstallSelf(
 
 ### Parameters
 
-- `options{{optional_inline}}`
+- `options`{{optional_inline}}
 
   - : `object`. Object which may two properties, both optional:
 
-    - `showConfirmDialog{{optional_inline}}`
+    - `showConfirmDialog`{{optional_inline}}
       - : Boolean. If `showConfirmDialog` is `true`, the browser will show a dialog asking the user to confirm that the add-on should be uninstalled. Defaults to `false`.
-    - `dialogMessage{{optional_inline}}`
+    - `dialogMessage`{{optional_inline}}
       - : String. An extra message that will be displayed in the confirmation dialog.
 
 ### Return value

--- a/files/en-us/web/api/element/animate/index.md
+++ b/files/en-us/web/api/element/animate/index.md
@@ -36,7 +36,7 @@ animate(keyframes, options)
   - : Either an **integer representing the animation's duration** (in
     milliseconds), **or** an Object containing one or more timing properties described in the [`KeyframeEffect()` options parameter](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect#parameters) and/or the following options:
 
-    - `id {{optional_inline}}`
+    - `id`{{optional_inline}}
       - : A property unique to `animate()`: a [`DOMString`](/en-US/docs/Web/API/DOMString)
         with which to reference the animation.
 

--- a/files/en-us/web/api/element/getanimations/index.md
+++ b/files/en-us/web/api/element/getanimations/index.md
@@ -37,7 +37,7 @@ getAnimations(options)
 
 ### Parameters
 
-- `options {{optional_inline}}`
+- `options`{{optional_inline}}
 
   - : An options object containing the following property:
 

--- a/files/en-us/web/exslt/regexp/match/index.md
+++ b/files/en-us/web/exslt/regexp/match/index.md
@@ -22,7 +22,7 @@ regexp:match(targetString, regExpString[, flagsString])
   - : The string to perform regular expression matching upon.
 - `regExpString`
   - : The JavaScript style regular expression to evaluate.
-- `flagsString{{Optional_Inline}}`
+- `flagsString`{{Optional_Inline}}
   - : An optional string containing character flags.
 
 The character flags are:


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Move the `{{Optional_Inline}}` macros out of their corresponding code spans.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
As shown by the [`sameSite` parameter in this page](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies/set#samesiteoptional), this macro is styled inconsistently in a code span.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
