### PR TITLE
Move key pages and register as guides

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -8499,6 +8499,8 @@
 /en-US/docs/Web/API/KeyboardEvent.metaKey	/en-US/docs/Web/API/KeyboardEvent/metaKey
 /en-US/docs/Web/API/KeyboardEvent.shiftKey	/en-US/docs/Web/API/KeyboardEvent/shiftKey
 /en-US/docs/Web/API/KeyboardEvent.which	/en-US/docs/Web/API/UIEvent/which
+/en-US/docs/Web/API/KeyboardEvent/code/code_values	/en-US/docs/Web/API/UI_Events/Keyboard_event_code_values
+/en-US/docs/Web/API/KeyboardEvent/key/Key_Values	/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values
 /en-US/docs/Web/API/KeyboardEvent/which	/en-US/docs/Web/API/UIEvent/which
 /en-US/docs/Web/API/KeyframeEffect/KeyframeEffect.getKeyframes()	/en-US/docs/Web/API/KeyframeEffect/getKeyframes
 /en-US/docs/Web/API/KeyframeEffect/getFrames	/en-US/docs/Web/API/KeyframeEffect/getKeyframes

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -54271,13 +54271,6 @@
       "kscarfone"
     ]
   },
-  "Web/API/KeyboardEvent/code/code_values": {
-    "modified": "2019-11-18T13:07:24.231Z",
-    "contributors": [
-      "LeonFrempong",
-      "irenesmith"
-    ]
-  },
   "Web/API/KeyboardEvent/ctrlKey": {
     "modified": "2020-10-15T21:31:53.854Z",
     "contributors": [
@@ -54381,27 +54374,6 @@
       "jscape",
       "johndrinkwater",
       "ishita"
-    ]
-  },
-  "Web/API/KeyboardEvent/key/Key_Values": {
-    "modified": "2020-10-27T11:23:58.174Z",
-    "contributors": [
-      "ksam",
-      "Zearin_Galaurum",
-      "wbamberg",
-      "HiEv",
-      "mwallnoefer",
-      "SphinxKnight",
-      "Sheppy",
-      "tuespetre",
-      "nikparo",
-      "chrisdavidmills",
-      "CaptainJKoB",
-      "darkfrog26",
-      "Speich",
-      "cactus1",
-      "Nimelrian",
-      "stephaniehobson"
     ]
   },
   "Web/API/KeyboardEvent/keyCode": {
@@ -75996,6 +75968,34 @@
       "Shaver",
       "JesseW",
       "cbiesinger"
+    ]
+  },
+  "Web/API/UI_Events/Keyboard_event_code_values": {
+    "modified": "2019-11-18T13:07:24.231Z",
+    "contributors": [
+      "LeonFrempong",
+      "irenesmith"
+    ]
+  },
+  "Web/API/UI_Events/Keyboard_event_key_values": {
+    "modified": "2020-10-27T11:23:58.174Z",
+    "contributors": [
+      "ksam",
+      "Zearin_Galaurum",
+      "wbamberg",
+      "HiEv",
+      "mwallnoefer",
+      "SphinxKnight",
+      "Sheppy",
+      "tuespetre",
+      "nikparo",
+      "chrisdavidmills",
+      "CaptainJKoB",
+      "darkfrog26",
+      "Speich",
+      "cactus1",
+      "Nimelrian",
+      "stephaniehobson"
     ]
   },
   "Web/API/URL": {

--- a/files/en-us/web/api/ui_events/keyboard_event_code_values/index.md
+++ b/files/en-us/web/api/ui_events/keyboard_event_code_values/index.md
@@ -1,8 +1,9 @@
 ---
-title: 'KeyboardEvent: code values'
-slug: Web/API/KeyboardEvent/code/code_values
+title: 'Code values for keyboard events'
+slug: Web/API/UI_Events/Keyboard_event_code_values
 ---
-{{APIRef("UI Events")}}
+{{DefaultAPISidebar("UI Events")}}
+
 The following tables show what code values are used for each native scancode or virtual keycode on major platforms. The reason is that some browsers choose to interpret physical keys differently, there are some differences in which keys map to which codes. These tables show those variations when known.
 
 ## Code values on Windows

--- a/files/en-us/web/api/ui_events/keyboard_event_key_values/index.md
+++ b/files/en-us/web/api/ui_events/keyboard_event_key_values/index.md
@@ -1,6 +1,6 @@
 ---
-title: Key Values
-slug: Web/API/KeyboardEvent/key/Key_Values
+title: Key values for keyboard events
+slug: Web/API/UI_Events/Keyboard_event_key_values
 tags:
   - Characters
   - DOM
@@ -20,7 +20,8 @@ tags:
   - keyboard
   - keys
 ---
-{{APIRef("UI Events")}}
+{{DefaultAPISidebar("UI Events")}}
+
 The tables below list the standard key values in various categories of key, with an explanation of what the key is typically used for. Corresponding virtual keycodes for common platforms are included where available.
 
 > **Callout:**

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -1406,6 +1406,10 @@
     },
     "UI Events": {
       "overview": ["UI Events"],
+      "guides": [
+        "/docs/Web/API/UI_Events/Keyboard_event_code_values",
+        "/docs/Web/API/UI_Events/Keyboard_event_key_values"
+      ],
       "interfaces": [
         "CompositionEvent",
         "FocusEvent",


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/13761.

This covers the last bits of 
https://github.com/mdn/content/issues/13761#issuecomment-1119826020, except adding guides to `APIRef`, which I think we should do separately.

- moves the "codes" and "keys" pages under "UI Events"
- retitles them
- adds them to GroupData as guides, so they will appear in the UI Events sidebar
