### PR TITLE
Use NodeJS v16 for workflows

### DIFF
--- a/.github/workflows/json-lint.yml
+++ b/.github/workflows/json-lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: "12"
+          node-version: "16"
           cache: yarn
 
       - name: Lint markdown files

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: "12"
+          node-version: "16"
           cache: yarn
 
       - name: Lint markdown files

--- a/.github/workflows/pr-check_redirects.yml
+++ b/.github/workflows/pr-check_redirects.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: "12"
+          node-version: "16"
           cache: yarn
 
       - name: Install all yarn packages

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: "12"
+          node-version: "16"
           cache: yarn
 
       - name: Install all yarn packages

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: "12"
+          node-version: "16"
           cache: yarn
 
       - name: Install all yarn packages


### PR DESCRIPTION
This PR updates all workflows to use NodeJS v16 rather than v12.  Required to land #15866.
