### PR TITLE
Fix extra semicolon breaks replaceSync example

### DIFF
--- a/files/en-us/web/api/cssstylesheet/replace/index.md
+++ b/files/en-us/web/api/cssstylesheet/replace/index.md
@@ -47,11 +47,12 @@ In the following example a new stylesheet is created and two CSS rules are added
 const stylesheet = new CSSStyleSheet();
 
 stylesheet.replace('body { font-size: 1.4em; } p { color: red; }')
-  .then(() => { console.log(stylesheet.cssRules[0].cssText);
-})
-.catch(err => {
-  console.error('Failed to replace styles:', err);
-});
+  .then(() => {
+    console.log(stylesheet.cssRules[0].cssText);
+  })
+  .catch(err => {
+    console.error('Failed to replace styles:', err);
+  });
 ```
 
 ## Specifications

--- a/files/en-us/web/api/cssstylesheet/replace/index.md
+++ b/files/en-us/web/api/cssstylesheet/replace/index.md
@@ -41,13 +41,13 @@ A {{jsxref("Promise")}} that resolves with a {{domxref("CSSStyleSheet")}}.
 
 ## Examples
 
-In the following example a new stylesheet is created and two CSS rules are added using `replace()`. The first rule is then printed to the console, which will return: `body { font-size: 1.4em };`
+In the following example a new stylesheet is created and two CSS rules are added using `replace()`. The first rule is then printed to the console, which will return: `body { font-size: 1.4em; }`
 
 ```js
-let stylesheet = new CSSStyleSheet();
+const stylesheet = new CSSStyleSheet();
 
-stylesheet.replace('body { font-size: 1.4em };p { color: red; }')
-  .then(() => {   console.log(stylesheet.cssRules[0].cssText);
+stylesheet.replace('body { font-size: 1.4em; } p { color: red; }')
+  .then(() => { console.log(stylesheet.cssRules[0].cssText);
 })
 .catch(err => {
   console.error('Failed to replace styles:', err);

--- a/files/en-us/web/api/cssstylesheet/replacesync/index.md
+++ b/files/en-us/web/api/cssstylesheet/replacesync/index.md
@@ -42,9 +42,9 @@ Undefined.
 In the following example a new stylesheet is created and two CSS rules are added using `replaceSync`.
 
 ```js
-let stylesheet = new CSSStyleSheet();
+const stylesheet = new CSSStyleSheet();
 
-stylesheet.replaceSync('body { font-size: 1.4em } p { color: red; }');
+stylesheet.replaceSync('body { font-size: 1.4em; } p { color: red; }');
 ```
 
 ## Specifications

--- a/files/en-us/web/api/cssstylesheet/replacesync/index.md
+++ b/files/en-us/web/api/cssstylesheet/replacesync/index.md
@@ -44,7 +44,7 @@ In the following example a new stylesheet is created and two CSS rules are added
 ```js
 let stylesheet = new CSSStyleSheet();
 
-stylesheet.replaceSync('body { font-size: 1.4em };p { color: red; }');
+stylesheet.replaceSync('body { font-size: 1.4em } p { color: red; }');
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Just removing a semicolon that breaks replaceSync. The second rule won't get parsed because of the semicolon.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Testing out CSSOM api. Example didn't work. Upon further investigation the CSS was incorrect.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
