### PR TITLE
Fixes en-us -> en-US

### DIFF
--- a/files/en-us/web/accessibility/aria/annotations/index.md
+++ b/files/en-us/web/accessibility/aria/annotations/index.md
@@ -192,7 +192,7 @@ We've used `role="comment"` to mark this up as a comment. To associate the comme
 </div>
 ```
 
-> **Note:** If for some reason you can't use the {{HTMLElement('mark')}} element in your application, you could also use [`<span role="mark"></span>`](/en-us/docs/web/accessibility/aria/roles/mark_role).
+> **Note:** If for some reason you can't use the {{HTMLElement('mark')}} element in your application, you could also use [`<span role="mark"></span>`](/en-US/docs/web/accessibility/aria/roles/mark_role).
 
 Since `aria-details` can now accept multiple IDs, we can associate multiple comments with the same annotation, like so:
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-sort/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-sort/index.md
@@ -55,7 +55,7 @@ This table loads with the last name column sorted in ascending order.
 </table>
 ```
 
-If a user clicks on the _Last Name_ button, [`aria-pressed="true"`](/en-us/web/accessibility/aria/attributes/aria-pressed) would be added to the {{HTMLElement('button')}} element and the `aria-sort` value would be toggled to `"descending"` with JavaScript. If the user clicks on a different header button, the `aria-sort` would be removed from the _Last Name_ header to be placed on the clicked button's {{HTMLElement('th')}} parent.
+If a user clicks on the _Last Name_ button, [`aria-pressed="true"`](/en-US/web/accessibility/aria/attributes/aria-pressed) would be added to the {{HTMLElement('button')}} element and the `aria-sort` value would be toggled to `"descending"` with JavaScript. If the user clicks on a different header button, the `aria-sort` would be removed from the _Last Name_ header to be placed on the clicked button's {{HTMLElement('th')}} parent.
 
 We provided instructions in the caption for assistive technology who may not see the down arrows that we would add with CSS targeting the `th[aria-sort="ascending"]` and `th[aria-sort="descending"]` selectors.
 

--- a/files/en-us/web/javascript/reference/global_objects/array/concat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/concat/index.md
@@ -32,7 +32,7 @@ concat(value0, value1, ... , valueN)
 - `valueN` {{optional_inline}}
   - : Arrays and/or values to concatenate into a new array. If all
     `valueN` parameters are omitted, `concat` returns a
-    [shallow copy](/en-us/docs/Glossary/Shallow_copy) of the existing array on which it is called. See the description below
+    [shallow copy](/en-US/docs/Glossary/Shallow_copy) of the existing array on which it is called. See the description below
     for more details.
 
 ### Return value
@@ -47,7 +47,7 @@ that argument (if the argument is an array) or the argument itself (if the argum
 not an array). It does not recurse into nested array arguments.
 
 The `concat` method does not alter `this` or any of the arrays
-provided as arguments but instead returns a [shallow copy](/en-us/docs/Glossary/Shallow_copy) that contains copies of the
+provided as arguments but instead returns a [shallow copy](/en-US/docs/Glossary/Shallow_copy) that contains copies of the
 same elements combined from the original arrays. Elements of the original arrays are
 copied into the new array as follows:
 

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcdate/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcdate/index.md
@@ -27,7 +27,7 @@ getUTCDate()
 A `number`.
 If the `Date` object represents a valid date, an integer number ranging from 1 to 31
 representing day of month for the given date, according to universal time.
-Otherwise, [`NaN`](/en-us/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN)
+Otherwise, [`NaN`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN)
 if the `Date` object doesn't represent a valid date.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcday/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcday/index.md
@@ -28,7 +28,7 @@ A `number`.
 If the `Date` object represents a valid date, an integer number corresponding to the day
 of the week for the given date, according to universal time: 0 for Sunday, 1 for Monday,
 2 for Tuesday, and so on.
-Otherwise, [`NaN`](/en-us/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN)
+Otherwise, [`NaN`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN)
 if the `Date` object doesn't represent a valid date.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcfullyear/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcfullyear/index.md
@@ -27,7 +27,7 @@ getUTCFullYear()
 A `number`.
 If the `Date` object represents a valid date, an integer representing the year in the given date
 according to universal time.
-Otherwise, [`NaN`](/en-us/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN)
+Otherwise, [`NaN`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN)
 if the `Date` object doesn't represent a valid date.
 
 ## Description

--- a/files/en-us/web/javascript/reference/global_objects/date/getutchours/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutchours/index.md
@@ -27,7 +27,7 @@ getUTCHours()
 A `number`.
 If the `Date` object represents a valid date, an integer between 0 and 23, representing the hours in the given date according
 to Coordinated Universal Time.
-Otherwise, [`NaN`](/en-us/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN)
+Otherwise, [`NaN`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN)
 if the `Date` object doesn't represent a valid date.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcmilliseconds/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcmilliseconds/index.md
@@ -27,7 +27,7 @@ getUTCMilliseconds()
 A `number`.
 If the `Date` object represents a valid date, an integer between 0 and 999, representing
 the milliseconds portion of the given `Date` object according to universal time.
-Otherwise, [`NaN`](/en-us/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN)
+Otherwise, [`NaN`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN)
 if the `Date` object doesn't represent a valid date.
 
 Not to be confused with Unix epoch time. To get the total milliseconds since 1970/01/01,

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcminutes/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcminutes/index.md
@@ -27,7 +27,7 @@ getUTCMinutes()
 A `number`.
 If the `Date` object represents a valid date, an integer between 0 and 59,
 representing the minutes in the given date according to universal time.
-Otherwise, [`NaN`](/en-us/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN)
+Otherwise, [`NaN`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN)
 if the `Date` object doesn't represent a valid date.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcmonth/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcmonth/index.md
@@ -27,7 +27,7 @@ getUTCMonth()
 
 A `number`. If the `Date` object represents a valid date, an integer number, between 0 and 11,
 corresponding to the month of the given date according to universal time. 0 for January,
-1 for February, 2 for March, and so on. Otherwise, [`NaN`](/en-us/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN)
+1 for February, 2 for March, and so on. Otherwise, [`NaN`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN)
 if the `Date` object doesn't represent a valid date.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/date/getutcseconds/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/getutcseconds/index.md
@@ -27,7 +27,7 @@ getUTCSeconds()
 A `number`.
 If the `Date` object represents a valid date, an integer between 0 and 59, representing
 the seconds in the given date according to universal time.
-Otherwise, [`NaN`](/en-us/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN)
+Otherwise, [`NaN`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/NaN)
 if the `Date` object doesn't represent a valid date.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/object/assign/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/assign/index.md
@@ -77,7 +77,7 @@ console.log(copy); // { a: 1 }
 
 ### Warning for Deep Clone
 
-For [deep cloning](/en-us/docs/Glossary/Deep_copy), we need to use alternatives, because `Object.assign()`
+For [deep cloning](/en-US/docs/Glossary/Deep_copy), we need to use alternatives, because `Object.assign()`
 copies property values.
 
 If the source value is a reference to an object, it only copies the reference value.

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/slice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/slice/index.md
@@ -61,7 +61,7 @@ A new typed array containing the extracted elements.
 
 ## Description
 
-The `slice` method does not alter the original typed array, but instead returns a copy of a portion of the original typed array. As typed arrays only store primitive values, the copy the `slice` method returns is always a [shallow copy](/en-us/docs/Glossary/Shallow_copy).
+The `slice` method does not alter the original typed array, but instead returns a copy of a portion of the original typed array. As typed arrays only store primitive values, the copy the `slice` method returns is always a [shallow copy](/en-US/docs/Glossary/Shallow_copy).
 
 If an element is changed in either typed array, the other typed array is not affected.
 


### PR DESCRIPTION
Extends #15854

> en-US is the right way to do it (prevent a useless redirect and a flaw)

#### Metadata
- [x] Fixes a typo, bug, or other error
