### PR TITLE
More guidance about examples

### DIFF
--- a/files/en-us/mdn/structures/code_examples/index.md
+++ b/files/en-us/mdn/structures/code_examples/index.md
@@ -80,7 +80,7 @@ If you're not using a particular language type (for example if you are not using
 For example:
 
 ````
-
+## Examples
 ### Styling a paragraph
 
 In this example we're using CSS to style paragraphs which have the `fancy` class set.

--- a/files/en-us/mdn/structures/code_examples/index.md
+++ b/files/en-us/mdn/structures/code_examples/index.md
@@ -75,7 +75,7 @@ If you write a live sample in the "Examples" section, provide a descriptive H3 h
 - Result
 Write the code blocks in the respective subsections listed above.
 In the **Result** subsection, add the call to the [`EmbedLiveSample` macro](/en-US/docs/MDN/Structures/Live_samples#live_sample_macros). Preferably, include some more prose in this subsection to describe the result.
-If you're not using a particular language type (for example if you are not using JavaScript), or if you are hiding it, then you should omit the corresponding heading.
+If you're not using a particular language type (for example, if you are not using JavaScript) or if you are hiding it, then you should omit the corresponding heading.
 
 For example:
 
@@ -83,7 +83,7 @@ For example:
 ## Examples
 ### Styling a paragraph
 
-In this example we're using CSS to style paragraphs which have the `fancy` class set.
+In this example, we're using CSS to style paragraphs that have the `fancy` class set.
 
 #### HTML
 
@@ -105,7 +105,7 @@ p.fancy {
 
 \{{EmbedLiveSample("Styling a paragraph")}}
 
-Optionally, you can include some more prose here describing the result.
+Only the `<p>` element with `class="fancy"` will get styled `red`.
 
 ````
 

--- a/files/en-us/mdn/structures/code_examples/index.md
+++ b/files/en-us/mdn/structures/code_examples/index.md
@@ -67,7 +67,7 @@ Traditional live samples are inserted into the page using the [`EmbedLiveSample`
 
 ### Formatting live samples
 
-If you write a live sample in the "Examples" section, provide a descriptive H3 heading for this live sample example. Ideally, write a short description of the example explaining the scenario and what you are hoping to demonstrate. Then add subsections with following H4 headings, in the order listed:
+If you write a live sample in the "Examples" section, provide a descriptive H3 heading (`###`) for this live sample example. Ideally, write a short description of the example explaining the scenario and what you are hoping to demonstrate. Then add subsections with following H4 headings (`####`), in the order listed:
 
 - HTML
 - CSS

--- a/files/en-us/mdn/structures/code_examples/index.md
+++ b/files/en-us/mdn/structures/code_examples/index.md
@@ -67,7 +67,7 @@ Traditional live samples are inserted into the page using the [`EmbedLiveSample`
 
 ### Formatting live samples
 
-If you write a live sample, you should give it a descriptive heading, then optionally a short prose description of the example, then the following subheadings, in the following order:
+If you write a live sample in the "Examples" section, provide a descriptive H3 heading for this live sample example. Ideally, write a short description of the example explaining the scenario and what you are hoping to demonstrate. Then add subsections with following H4 headings, in the order listed:
 
 - **HTML** containing HTML code blocks
 - **CSS** containing CSS code blocks

--- a/files/en-us/mdn/structures/code_examples/index.md
+++ b/files/en-us/mdn/structures/code_examples/index.md
@@ -81,6 +81,7 @@ For example:
 
 ````
 ## Examples
+
 ### Styling a paragraph
 
 In this example, we're using CSS to style paragraphs that have the `fancy` class set.

--- a/files/en-us/mdn/structures/code_examples/index.md
+++ b/files/en-us/mdn/structures/code_examples/index.md
@@ -69,10 +69,10 @@ Traditional live samples are inserted into the page using the [`EmbedLiveSample`
 
 If you write a live sample in the "Examples" section, provide a descriptive H3 heading for this live sample example. Ideally, write a short description of the example explaining the scenario and what you are hoping to demonstrate. Then add subsections with following H4 headings, in the order listed:
 
-- **HTML** containing HTML code blocks
-- **CSS** containing CSS code blocks
-- **JavaScript** containing JavaScript code blocks
-- **Result** containing the `EmbedLiveSample` macro call itself.
+- HTML
+- CSS
+- JavaScript
+- Result
 Write the code blocks in the respective subsections listed above.
 In the **Result** subsection, add the call to the [`EmbedLiveSample` macro](/en-US/docs/MDN/Structures/Live_samples#live_sample_macros). Preferably, include some more prose in this subsection to describe the result.
 If you're not using a particular language type (for example if you are not using JavaScript), or if you are hiding it, then you should omit the corresponding heading.

--- a/files/en-us/mdn/structures/code_examples/index.md
+++ b/files/en-us/mdn/structures/code_examples/index.md
@@ -65,6 +65,49 @@ Optionally, you might want to show a static image of the code's resulting output
 
 Traditional live samples are inserted into the page using the [`EmbedLiveSample`](https://github.com/mdn/yari/blob/main/kumascript/macros/EmbedLiveSample.ejs) macro. An \\{{EmbedLiveSample}} call dynamically grabs the code blocks in the same document section as itself and puts them into a document, which it then inserts into the page inside an {{htmlelement("iframe")}}. See our [Live samples guide](/en-US/docs/MDN/Structures/Live_samples) for more information.
 
+### Formatting live samples
+
+If you write a live sample, you should give it a descriptive heading, then optionally a short prose description of the example, then the following subheadings, in the following order:
+
+- **HTML** containing HTML code blocks
+- **CSS** containing CSS code blocks
+- **JavaScript** containing JavaScript code blocks
+- **Result** containing the `EmbedLiveSample` macro call itself.
+
+If you're not using a particular language type (for example if you are not using JavaScript), or if you are hiding it, then you should omit the corresponding heading.
+
+For example:
+
+````
+
+### Styling a paragraph
+
+In this example we're using CSS to style paragraphs which have the `fancy` class set.
+
+#### HTML
+
+```html
+<p>I'm not fancy.</p>
+
+<p class="fancy">But I am!</p>
+```
+
+#### CSS
+
+```css
+p.fancy {
+  color: red;
+}
+```
+
+#### Result
+
+\{{EmbedLiveSample("Styling a paragraph")}}
+
+Optionally, you can include some more prose here describing the result.
+
+````
+
 ## GitHub live samples
 
 GitHub live samples are inserted into the page using the [`EmbedGHLiveSample`](https://github.com/mdn/yari/blob/main/kumascript/macros/EmbedGHLiveSample.ejs) macro. An \\{{EmbedGHLiveSample}} call dynamically grabs the document at a specified URL (which has to be inside the **mdn** GitHub organization), and inserts into the page inside an {{htmlelement("iframe")}}.

--- a/files/en-us/mdn/structures/code_examples/index.md
+++ b/files/en-us/mdn/structures/code_examples/index.md
@@ -73,7 +73,8 @@ If you write a live sample in the "Examples" section, provide a descriptive H3 h
 - **CSS** containing CSS code blocks
 - **JavaScript** containing JavaScript code blocks
 - **Result** containing the `EmbedLiveSample` macro call itself.
-
+Write the code blocks in the respective subsections listed above.
+In the **Result** subsection, add the call to the [`EmbedLiveSample` macro](/en-US/docs/MDN/Structures/Live_samples#live_sample_macros). Preferably, include some more prose in this subsection to describe the result.
 If you're not using a particular language type (for example if you are not using JavaScript), or if you are hiding it, then you should omit the corresponding heading.
 
 For example:

--- a/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.md
@@ -121,7 +121,8 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 
 > **Note:** Sometimes you will want to link to examples given on another page.
 >
-> If you have some examples in this page and some more examples on another page, then include an H3 heading for each example in this page, then a final H3 heading with the text "More examples", under which you can link to the extra examples. For example:
+> Scenario 1: If you have some examples on this page and some more examples on another page
+> Include an H3 heading for each example on this page and then a final H3 heading with the text "More examples", under which you can link to the examples on other pages. For example:
 >
 >  ```md
 >  ## Examples
@@ -130,10 +131,11 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 >  ... example of Fetch
 >
 >  ### More examples
->  ...links to further examples
+>  ...links to more examples on other pages
 >  ```
 >
-> If you _only_ have examples on another page, then you should not provide any H3 headings, but just add the links directly under the "Examples" H2. For example:
+> Scenario 2: If you _only_ have examples on another page and none on this page
+Don't add any H3 headings; just add the links directly under the H2 heading "Examples". For example:
 >
 >  ```md
 >   ## Examples

--- a/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.md
@@ -119,6 +119,28 @@ Each example must have an H3 heading naming the example. The heading should be d
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 
+> **Note:** Sometimes you will want to link to examples given on another page.
+>
+> If you have some examples in this page and some more examples on another page, then include an H3 heading for each example in this page, then a final H3 heading with the text "More examples", under which you can link to the extra examples. For example:
+>
+>  ```md
+>  ## Examples
+>
+>  ### Using the fetch API
+>  ... example of Fetch
+>
+>  ### More examples
+>  ...links to further examples
+>  ```
+>
+> If you _only_ have examples on another page, then you should not provide any H3 headings, but just add the links directly under the "Examples" H2. For example:
+>
+>  ```md
+>   ## Examples
+>
+>   For examples of this API, see [the page on fetch()](https://example.org).
+>
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.md
@@ -115,7 +115,7 @@ This is normally just "An instance of the {{domxref("NameOfTheParentInterface")}
 
 ### A descriptive heading
 
-Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing - don't put "A simple example". The heading should be concise: for a longer description use a paragraph after the heading.
+Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 

--- a/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.md
@@ -113,17 +113,11 @@ This is normally just "An instance of the {{domxref("NameOfTheParentInterface")}
 
 ## Examples
 
-Fill in a simple example that nicely shows a typical usage of the constructor, then perhaps some more complex examples (see our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information).
+### A descriptive heading
 
-```js
-my code block
-```
+Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing - don't put "A simple example". The heading should be concise: for a longer description use a paragraph after the heading.
 
-And/or include a list of links to useful code samples that live elsewhere:
-
-- x
-- y
-- z
+See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 
 ## Specifications
 

--- a/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.md
@@ -144,7 +144,7 @@ which can provide more information.
 
 ### A descriptive heading
 
-Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing - don't put "A simple example". The heading should be concise: for a longer description use a paragraph after the heading.
+Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 

--- a/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.md
@@ -144,7 +144,7 @@ which can provide more information.
 
 ### A descriptive heading
 
-Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
+Each example must have an H3 heading (`###`) naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 

--- a/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.md
@@ -142,7 +142,7 @@ which can provide more information.
 
 ## Examples
 
-### Listening for key presses
+### A descriptive heading
 
 Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing - don't put "A simple example". The heading should be concise: for a longer description use a paragraph after the heading.
 

--- a/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.md
@@ -142,17 +142,11 @@ which can provide more information.
 
 ## Examples
 
-Fill in a simple example that nicely shows a typical usage of the event, then perhaps some more complex examples (see our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information). You should show how to use the event with both, {{domxref("EventTarget.addEventListener", "addEventListener()")}} and with the event handler property.
+### Listening for key presses
 
-```js
-my code block
-```
+Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing - don't put "A simple example". The heading should be concise: for a longer description use a paragraph after the heading.
 
-And/or include a list of links to useful code samples that live elsewhere:
-
-- x
-- y
-- z
+See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 
 ## Specifications
 

--- a/files/en-us/mdn/structures/page_types/api_landing_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_landing_page_template/index.md
@@ -135,7 +135,7 @@ The _name of interface_ extends the following APIs, adding the listed features.
 
 ### A descriptive heading
 
-Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing - don't put "A simple example". The heading should be concise: for a longer description use a paragraph after the heading.
+Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 

--- a/files/en-us/mdn/structures/page_types/api_landing_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_landing_page_template/index.md
@@ -133,21 +133,11 @@ The _name of interface_ extends the following APIs, adding the listed features.
 
 ## Examples
 
-Fill in a simple example that nicely shows a typical usage of the API, then perhaps some more complex examples (see our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information).
+### A descriptive heading
 
-This text should be replaced with a brief description of what the example demonstrates.
+Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing - don't put "A simple example". The heading should be concise: for a longer description use a paragraph after the heading.
 
-```js
-my code block
-```
-
-If you've included an example directly in the page as shown above, and that example is longer than 4-5 lines or so, consider following the example with a step-by-step explanation of what it's doing, so that new programmers can learn more easily, and to help smooth the learning curve for complicated subjects.
-
-And/or include a list of links to useful code samples that live elsewhere:
-
-- x
-- y
-- z
+See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 
 ## Specifications
 

--- a/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.md
@@ -104,7 +104,7 @@ Fill in a syntax box, according to the guidance in our [syntax sections](/en-US/
 
 Include a description of the method's return value, including data type and what it represents.
 
-If the method doesn't return anything, just put "None {{jsxref('undefined')}}.".
+If the method doesn't return anything, just put "None ({{jsxref('undefined')}}).".
 
 ### Exceptions
 
@@ -127,17 +127,13 @@ Here is an example where a method can raise a `DOMException` with a name of `Ind
 - {{jsxref("TypeError")}}
   - : Thrown …
 
-Fill in a simple example that nicely shows a typical usage of the method, then perhaps some more complex examples (see our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information).
+## Examples
 
-```js
-my code block
-```
+### A descriptive heading
 
-And/or include a list of links to useful code samples that live elsewhere:
+Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing - don't put "A simple example". The heading should be concise: for a longer description use a paragraph after the heading.
 
-- x
-- y
-- z
+See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 
 ## Specifications
 

--- a/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.md
@@ -131,7 +131,7 @@ Here is an example where a method can raise a `DOMException` with a name of `Ind
 
 ### A descriptive heading
 
-Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing - don't put "A simple example". The heading should be concise: for a longer description use a paragraph after the heading.
+Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 

--- a/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.md
@@ -95,7 +95,7 @@ Include a description of the property's value, including data type and what it r
 
 ### A descriptive heading
 
-Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
+Each example must have an H3 heading (`###`) naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 

--- a/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.md
@@ -95,7 +95,7 @@ Include a description of the property's value, including data type and what it r
 
 ### A descriptive heading
 
-Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing - don't put "A simple example". The heading should be concise: for a longer description use a paragraph after the heading.
+Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 

--- a/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.md
@@ -93,17 +93,11 @@ Include a description of the property's value, including data type and what it r
 
 ## Examples
 
-Fill in a simple example that nicely shows a typical usage of the property, then perhaps some more complex examples (see our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information).
+### A descriptive heading
 
-```js
-my code block
-```
+Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing - don't put "A simple example". The heading should be concise: for a longer description use a paragraph after the heading.
 
-And/or include a list of links to useful code samples that live elsewhere:
-
-- x
-- y
-- z
+See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 
 ## Specifications
 

--- a/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
@@ -102,17 +102,12 @@ Listen to these events using [`addEventListener()`](/en-US/docs/Web/API/EventTar
 
 ## Examples
 
-Fill in a simple example that nicely shows a typical usage of the interfaces, then perhaps some more complex examples (see our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information).
+### A descriptive heading
 
-```js
-my code block
-```
+Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing - don't put "A simple example". The heading should be concise: for a longer description use a paragraph after the heading.
 
-And/or include a list of links to useful code samples that live elsewhere:
+See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 
-- x
-- y
-- z
 
 ## Specifications
 

--- a/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
@@ -104,7 +104,7 @@ Listen to these events using [`addEventListener()`](/en-US/docs/Web/API/EventTar
 
 ### A descriptive heading
 
-Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing - don't put "A simple example". The heading should be concise: for a longer description use a paragraph after the heading.
+Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 

--- a/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
@@ -104,7 +104,7 @@ Listen to these events using [`addEventListener()`](/en-US/docs/Web/API/EventTar
 
 ### A descriptive heading
 
-Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
+Each example must have an H3 heading (`###`) naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 

--- a/files/en-us/mdn/structures/page_types/aria_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/aria_page_template/index.md
@@ -74,7 +74,7 @@ Include a complete description of the attribute or role.
 
 ### A descriptive heading
 
-Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing - don't put "A simple example". The heading should be concise: for a longer description use a paragraph after the heading.
+Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 

--- a/files/en-us/mdn/structures/page_types/aria_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/aria_page_template/index.md
@@ -72,17 +72,11 @@ Include a complete description of the attribute or role.
 
 ## Examples
 
-Fill in a simple example that shows a typical usage of the property, then perhaps some more complex examples. For more information, see our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples).
+### A descriptive heading
 
-```html
-my code block
-```
+Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing - don't put "A simple example". The heading should be concise: for a longer description use a paragraph after the heading.
 
-And/or include a list of links to useful code samples that live elsewhere:
-
-- x
-- y
-- z
+See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 
 ## Accessibility concerns
 

--- a/files/en-us/mdn/structures/page_types/aria_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/aria_page_template/index.md
@@ -74,7 +74,7 @@ Include a complete description of the attribute or role.
 
 ### A descriptive heading
 
-Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
+Each example must have an H3 heading (`###`) naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 

--- a/files/en-us/mdn/structures/page_types/css_property_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/css_property_page_template/index.md
@@ -112,7 +112,7 @@ Include a description of the property and what component subvalues make up a com
 
 ### A descriptive heading
 
-Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing - don't put "A simple example". The heading should be concise: for a longer description use a paragraph after the heading.
+Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 

--- a/files/en-us/mdn/structures/page_types/css_property_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/css_property_page_template/index.md
@@ -112,7 +112,7 @@ Include a description of the property and what component subvalues make up a com
 
 ### A descriptive heading
 
-Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
+Each example must have an H3 heading (`###`) naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 

--- a/files/en-us/mdn/structures/page_types/css_property_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/css_property_page_template/index.md
@@ -110,17 +110,11 @@ Include a description of the property and what component subvalues make up a com
 
 ## Examples
 
-Fill in a simple example that nicely shows a typical usage of the property, then perhaps some more complex examples (see our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information).
+### A descriptive heading
 
-```css
-my code block
-```
+Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing - don't put "A simple example". The heading should be concise: for a longer description use a paragraph after the heading.
 
-And/or include a list of links to useful code samples that live elsewhere:
-
-- x
-- y
-- z
+See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 
 ## Accessibility concerns
 

--- a/files/en-us/mdn/structures/page_types/css_selector_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/css_selector_page_template/index.md
@@ -93,17 +93,11 @@ The summary paragraph — start by naming the selector and saying what it does. 
 
 ## Examples
 
-Fill in a simple example that nicely shows a typical usage of the selector, then perhaps some more complex examples (see our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information).
+### Selecting every third child
 
-```css
-my code block
-```
+Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing - don't put "A simple example". The heading should be concise: for a longer description use a paragraph after the heading.
 
-And/or include a list of links to useful code samples that live elsewhere:
-
-- x
-- y
-- z
+See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 
 ## Accessibility concerns
 

--- a/files/en-us/mdn/structures/page_types/css_selector_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/css_selector_page_template/index.md
@@ -95,7 +95,7 @@ The summary paragraph — start by naming the selector and saying what it does. 
 
 ### A descriptive heading
 
-Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing - don't put "A simple example". The heading should be concise: for a longer description use a paragraph after the heading.
+Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 

--- a/files/en-us/mdn/structures/page_types/css_selector_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/css_selector_page_template/index.md
@@ -93,7 +93,7 @@ The summary paragraph — start by naming the selector and saying what it does. 
 
 ## Examples
 
-### Selecting every third child
+### A descriptive heading
 
 Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing - don't put "A simple example". The heading should be concise: for a longer description use a paragraph after the heading.
 

--- a/files/en-us/mdn/structures/page_types/css_selector_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/css_selector_page_template/index.md
@@ -95,7 +95,7 @@ The summary paragraph — start by naming the selector and saying what it does. 
 
 ### A descriptive heading
 
-Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
+Each example must have an H3 heading (`###`) naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 

--- a/files/en-us/mdn/structures/page_types/html_element_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/html_element_page_template/index.md
@@ -109,7 +109,7 @@ Include a table of the events fired on this type of element, if any.
 
 ### A descriptive heading
 
-Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing - don't put "A simple example". The heading should be concise: for a longer description use a paragraph after the heading.
+Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 

--- a/files/en-us/mdn/structures/page_types/html_element_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/html_element_page_template/index.md
@@ -109,7 +109,7 @@ Include a table of the events fired on this type of element, if any.
 
 ### A descriptive heading
 
-Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
+Each example must have an H3 heading (`###`) naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 

--- a/files/en-us/mdn/structures/page_types/html_element_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/html_element_page_template/index.md
@@ -107,17 +107,11 @@ Include a table of the events fired on this type of element, if any.
 
 ## Examples
 
-Fill in a simple example that nicely shows a typical usage of the element, then perhaps some more complex examples (see our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information).
+### A descriptive heading
 
-```html
-my code block
-```
+Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing - don't put "A simple example". The heading should be concise: for a longer description use a paragraph after the heading.
 
-And/or include a list of links to useful code samples that live elsewhere:
-
-- x
-- y
-- z
+See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 
 ## Accessibility concerns
 

--- a/files/en-us/mdn/structures/page_types/http_header_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/http_header_page_template/index.md
@@ -127,7 +127,7 @@ If the header has a lot of available directives, feel free to include multiple d
 
 ### A descriptive heading
 
-Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
+Each example must have an H3 heading (`###`) naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 

--- a/files/en-us/mdn/structures/page_types/http_header_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/http_header_page_template/index.md
@@ -125,17 +125,11 @@ If the header has a lot of available directives, feel free to include multiple d
 
 ## Examples
 
-Fill in a some examples that show common use cases of the HTTP header (for example, a typical request and response sequence).
+### A descriptive heading
 
-```http
-my HTTP header example
-```
+Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing - don't put "A simple example". The heading should be concise: for a longer description use a paragraph after the heading.
 
-And/or include a list of links to useful code samples that live elsewhere:
-
-- x
-- y
-- z
+See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 
 ## Specifications
 

--- a/files/en-us/mdn/structures/page_types/http_header_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/http_header_page_template/index.md
@@ -127,7 +127,7 @@ If the header has a lot of available directives, feel free to include multiple d
 
 ### A descriptive heading
 
-Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing - don't put "A simple example". The heading should be concise: for a longer description use a paragraph after the heading.
+Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 

--- a/files/en-us/mdn/structures/page_types/svg_element_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/svg_element_page_template/index.md
@@ -113,7 +113,7 @@ This element implements the {{domxref("NameOfSVGDOMElement")}} interface.
 
 ### A descriptive heading
 
-Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing - don't put "A simple example". The heading should be concise: for a longer description use a paragraph after the heading.
+Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 

--- a/files/en-us/mdn/structures/page_types/svg_element_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/svg_element_page_template/index.md
@@ -113,7 +113,7 @@ This element implements the {{domxref("NameOfSVGDOMElement")}} interface.
 
 ### A descriptive heading
 
-Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
+Each example must have an H3 heading (`###`) naming the example. The heading should be descriptive of what the example is doing. For example, "A simple example" does not say anything about the example and therefore, not a good heading. The heading should be concise. For a longer description, use the paragraph after the heading.
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 

--- a/files/en-us/mdn/structures/page_types/svg_element_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/svg_element_page_template/index.md
@@ -111,17 +111,11 @@ This element implements the {{domxref("NameOfSVGDOMElement")}} interface.
 
 ## Examples
 
-Fill in a simple example that nicely shows a typical usage of the element, then perhaps some more complex examples (see our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information).
+### A descriptive heading
 
-```svg
-my code block
-```
+Each example must have an H3 heading naming the example. The heading should be descriptive of what the example is doing - don't put "A simple example". The heading should be concise: for a longer description use a paragraph after the heading.
 
-And/or include a list of links to useful code samples that live elsewhere:
-
-- x
-- y
-- z
+See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 
 ## Specifications
 


### PR DESCRIPTION
@dipikabh , @teoli2003 , here's an attempt to update the meta-docs to be more prescriptive about examples.

In particular, I want to:

- require a descriptive heading for each example
- require a consistent organization for live samples

I removed the bit about linking to examples that live elsewhere, but maybe should put it back as it is probably legitimate sometimes. But I'm not sure how to work that into this structure. An H3 `### More examples`? But what if there are _only_ examples that live elsewhere?

Maybe:
- if there are only linked examples, put them right under `## Examples`, with no H3s
- if there are some in-page examples and some linked ones, put the linked ones last, under an H3 `### More examples`

?