### PR TITLE
Adapt specifications table for Web Crypto params dicts to new format

### DIFF
--- a/files/en-us/web/api/aescbcparams/index.md
+++ b/files/en-us/web/api/aescbcparams/index.md
@@ -7,6 +7,7 @@ tags:
   - Dictionary
   - Reference
   - Web Crypto API
+spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-AesCbcParams
 ---
 {{ APIRef("Web Crypto API") }}
 
@@ -25,22 +26,7 @@ See the examples for {{domxref("SubtleCrypto.encrypt()")}} and {{domxref("Subtle
 
 ## Specifications
 
-<table class="no-markdown">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{ SpecName('Web Crypto API', '#dfn-AesCbcParams', 'SubtleCrypto.AesCbcParams') }}
-      </td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/aesctrparams/index.md
+++ b/files/en-us/web/api/aesctrparams/index.md
@@ -7,6 +7,7 @@ tags:
   - Dictionary
   - Reference
   - Web Crypto API
+spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-AesCtrParams
 ---
 {{ APIRef("Web Crypto API") }}
 
@@ -43,22 +44,7 @@ See the examples for {{domxref("SubtleCrypto.encrypt()")}} and {{domxref("Subtle
 
 ## Specifications
 
-<table class="no-markdown">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{ SpecName('Web Crypto API', '#dfn-AesCtrParams', 'SubtleCrypto.AesCtrParams') }}
-      </td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/aesgcmparams/index.md
+++ b/files/en-us/web/api/aesgcmparams/index.md
@@ -7,6 +7,7 @@ tags:
   - Dictionary
   - Reference
   - Web Crypto API
+spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-AesGcmParams
 ---
 {{ APIRef("Web Crypto API") }}
 
@@ -42,22 +43,7 @@ See the examples for {{domxref("SubtleCrypto.encrypt()")}} and {{domxref("Subtle
 
 ## Specifications
 
-<table class="no-markdown">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{ SpecName('Web Crypto API', '#dfn-AesGcmParams', 'SubtleCrypto.AesGcmParams') }}
-      </td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/aeskeygenparams/index.md
+++ b/files/en-us/web/api/aeskeygenparams/index.md
@@ -7,6 +7,7 @@ tags:
   - Dictionary
   - Reference
   - Web Crypto API
+spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-AesKeyGenParams
 ---
 {{ APIRef("Web Crypto API") }}The **`AesKeyGenParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed as the `algorithm` parameter into {{domxref("SubtleCrypto.generateKey()")}}, when generating an AES key: that is, when the algorithm is identified as any of [AES-CBC](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-cbc), [AES-CTR](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-ctr), [AES-GCM](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-gcm), or [AES-KW](/en-US/docs/Web/API/SubtleCrypto/wrapKey#aes-kw).
 
@@ -23,22 +24,7 @@ See the examples for {{domxref("SubtleCrypto.generateKey()")}}.
 
 ## Specifications
 
-<table class="no-markdown">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{ SpecName('Web Crypto API', '#dfn-AesKeyGenParams', 'SubtleCrypto.AesKeyGenParams') }}
-      </td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/ecdhkeyderiveparams/index.md
+++ b/files/en-us/web/api/ecdhkeyderiveparams/index.md
@@ -7,6 +7,7 @@ tags:
   - EcdhKeyDeriveParams
   - Reference
   - Web Crypto API
+spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-EcdhKeyDeriveParams
 ---
 {{ APIRef("Web Crypto API") }}
 
@@ -29,22 +30,7 @@ See the examples for {{domxref("SubtleCrypto.deriveKey()")}}.
 
 ## Specifications
 
-<table class="no-markdown">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{ SpecName('Web Crypto API', '#dfn-EcdhKeyDeriveParams', 'SubtleCrypto.EcdhKeyDeriveParams') }}
-      </td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/ecdsaparams/index.md
+++ b/files/en-us/web/api/ecdsaparams/index.md
@@ -7,6 +7,7 @@ tags:
   - EcdsaParams
   - Reference
   - Web Crypto API
+spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-EcdsaParams
 ---
 {{ APIRef("Web Crypto API") }}
 
@@ -32,22 +33,7 @@ See the examples for {{domxref("SubtleCrypto.sign()")}} or {{domxref("SubtleCryp
 
 ## Specifications
 
-<table class="no-markdown">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{ SpecName('Web Crypto API', '#dfn-EcdsaParams', 'SubtleCrypto.EcdsaParams') }}
-      </td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/eckeygenparams/index.md
+++ b/files/en-us/web/api/eckeygenparams/index.md
@@ -7,6 +7,7 @@ tags:
   - EcKeyGenParams
   - Reference
   - Web Crypto API
+spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-EcKeyGenParams
 ---
 {{ APIRef("Web Crypto API") }}
 
@@ -30,22 +31,7 @@ See the examples for {{domxref("SubtleCrypto.generateKey()")}}.
 
 ## Specifications
 
-<table class="no-markdown">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{ SpecName('Web Crypto API', '#dfn-EcKeyGenParams', 'SubtleCrypto.EcKeyGenParams') }}
-      </td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/eckeyimportparams/index.md
+++ b/files/en-us/web/api/eckeyimportparams/index.md
@@ -7,6 +7,7 @@ tags:
   - EcKeyImportParams
   - Reference
   - Web Crypto API
+spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-EcKeyImportParams
 ---
 {{ APIRef("Web Crypto API") }}The **`EcKeyImportParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed as the `algorithm` parameter into {{domxref("SubtleCrypto.importKey()")}} or {{domxref("SubtleCrypto.unwrapKey()")}}, when generating any elliptic-curve-based key pair: that is, when the algorithm is identified as either of [ECDSA](/en-US/docs/Web/API/SubtleCrypto/sign#ecdsa) or [ECDH](/en-US/docs/Web/API/SubtleCrypto/deriveKey#ecdh).
 
@@ -28,22 +29,7 @@ See the examples for {{domxref("SubtleCrypto.importKey()")}}.
 
 ## Specifications
 
-<table class="no-markdown">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{ SpecName('Web Crypto API', '#dfn-EcKeyImportParams', 'SubtleCrypto.EcKeyImportParams') }}
-      </td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/hkdfparams/index.md
+++ b/files/en-us/web/api/hkdfparams/index.md
@@ -7,6 +7,7 @@ tags:
   - HkdfParams
   - Reference
   - Web Crypto API
+spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-HkdfParams
 ---
 {{ APIRef("Web Crypto API") }}The **`HkdfParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed as the `algorithm` parameter into {{domxref("SubtleCrypto.deriveKey()")}}, when using the [HKDF](/en-US/docs/Web/API/SubtleCrypto/deriveKey#hkdf) algorithm.
 
@@ -34,22 +35,7 @@ See the examples for {{domxref("SubtleCrypto.deriveKey()")}}.
 
 ## Specifications
 
-<table class="no-markdown">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{ SpecName('Web Crypto API', '#dfn-HkdfParams', 'SubtleCrypto.HkdfParams') }}
-      </td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/hmacimportparams/index.md
+++ b/files/en-us/web/api/hmacimportparams/index.md
@@ -7,6 +7,7 @@ tags:
   - HmacImportParams
   - Reference
   - Web Crypto API
+spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-HmacImportParams
 ---
 {{ APIRef("Web Crypto API") }}
 
@@ -31,22 +32,7 @@ See the examples for {{domxref("SubtleCrypto.importKey()")}}.
 
 ## Specifications
 
-<table class="no-markdown">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{ SpecName('Web Crypto API', '#dfn-HmacImportParams', 'SubtleCrypto.HmacImportParams') }}
-      </td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/hmackeygenparams/index.md
+++ b/files/en-us/web/api/hmackeygenparams/index.md
@@ -7,6 +7,7 @@ tags:
   - HmacKeyGenParams
   - Reference
   - Web Crypto API
+spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-HmacKeyGenParams
 ---
 {{ APIRef("Web Crypto API") }}
 
@@ -27,22 +28,7 @@ See the examples for {{domxref("SubtleCrypto.generateKey()")}}.
 
 ## Specifications
 
-<table class="no-markdown">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{ SpecName('Web Crypto API', '#dfn-HmacKeyGenParams', 'SubtleCrypto.HmacKeyGenParams') }}
-      </td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/pbkdf2params/index.md
+++ b/files/en-us/web/api/pbkdf2params/index.md
@@ -7,6 +7,7 @@ tags:
   - Pbkdf2Params
   - Reference
   - Web Crypto API
+spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-Pbkdf2Params
 ---
 {{ APIRef("Web Crypto API") }}
 
@@ -38,22 +39,7 @@ See the examples for {{domxref("SubtleCrypto.deriveKey()")}}.
 
 ## Specifications
 
-<table class="no-markdown">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{ SpecName('Web Crypto API', '#dfn-Pbkdf2Params', 'SubtleCrypto.Pbkdf2Params') }}
-      </td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/rsahashedimportparams/index.md
+++ b/files/en-us/web/api/rsahashedimportparams/index.md
@@ -7,6 +7,7 @@ tags:
   - Reference
   - RsaHashedImportParams
   - Web Crypto API
+spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-RsaHashedImportParams
 ---
 {{ APIRef("Web Crypto API") }}
 
@@ -28,22 +29,7 @@ See the examples for {{domxref("SubtleCrypto.importKey()")}}.
 
 ## Specifications
 
-<table class="no-markdown">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{ SpecName('Web Crypto API', '#dfn-RsaHashedImportParams', 'SubtleCrypto.RsaHashedImportParams') }}
-      </td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/rsahashedkeygenparams/index.md
+++ b/files/en-us/web/api/rsahashedkeygenparams/index.md
@@ -7,6 +7,7 @@ tags:
   - Reference
   - RsaHashedKeyGenParams
   - Web Crypto API
+spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-RsaHashedKeyGenParams
 ---
 {{ APIRef("Web Crypto API") }}
 
@@ -32,22 +33,7 @@ See the examples for {{domxref("SubtleCrypto.generateKey()")}}.
 
 ## Specifications
 
-<table class="no-markdown">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{ SpecName('Web Crypto API', '#dfn-RsaHashedKeyGenParams', 'SubtleCrypto.RsaHashedKeyGenParams') }}
-      </td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/rsaoaepparams/index.md
+++ b/files/en-us/web/api/rsaoaepparams/index.md
@@ -7,6 +7,7 @@ tags:
   - Reference
   - RsaOaepParams
   - Web Crypto API
+spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-RsaOaepParams
 ---
 {{ APIRef("Web Crypto API") }}
 
@@ -28,22 +29,7 @@ See the examples for {{domxref("SubtleCrypto.encrypt()")}} and {{domxref("Subtle
 
 ## Specifications
 
-<table class="no-markdown">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{ SpecName('Web Crypto API', '#dfn-RsaOaepParams', 'SubtleCrypto.RsaOaepParams') }}
-      </td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/rsapssparams/index.md
+++ b/files/en-us/web/api/rsapssparams/index.md
@@ -7,6 +7,7 @@ tags:
   - Reference
   - RsaPssParams
   - Web Crypto API
+spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-RsaPssParams
 ---
 {{ APIRef("Web Crypto API") }}
 
@@ -36,22 +37,7 @@ See the examples for {{domxref("SubtleCrypto.sign()")}} and {{domxref("SubtleCry
 
 ## Specifications
 
-<table class="no-markdown">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{ SpecName('Web Crypto API', '#dfn-RsaPssParams', 'SubtleCrypto.RsaPssParams') }}
-      </td>
-      <td>{{ Spec2('Web Crypto API') }}</td>
-      <td></td>
-    </tr>
-  </tbody>
-</table>
+{{Specifications}}
 
 ## Browser compatibility
 


### PR DESCRIPTION
This PR adapts the specification tables in the pages for the Web Crypto params dictionaries to the new format.  Part of work for #13126.
