### PR TITLE
Remove links in headings in Mozilla CSS extensions

### DIFF
--- a/files/en-us/web/css/mozilla_extensions/index.md
+++ b/files/en-us/web/css/mozilla_extensions/index.md
@@ -167,7 +167,9 @@ Mozilla applications such as Firefox support a number of special **Mozilla exten
 
 - {{CSSxRef("initial","-moz-initial")}}
 
-### {{CSSxRef("-moz-appearance")}}
+### -moz-appearance
+
+Property: {{CSSxRef("-moz-appearance")}}
 
 - `button`
 - `button-arrow-down`
@@ -254,7 +256,9 @@ Mozilla applications such as Firefox support a number of special **Mozilla exten
 - `treeview`
 - `window`
 
-### {{CSSxRef("background-image")}}
+### background-image
+
+Property: {{CSSxRef("background-image")}}
 
 #### Gradients
 
@@ -269,17 +273,23 @@ Mozilla applications such as Firefox support a number of special **Mozilla exten
 
 - {{CSSxRef("-moz-image-rect")}}
 
-### {{CSSxRef("border-color")}}
+### border-color
+
+Property: {{CSSxRef("border-color")}}
 
 - `-moz-use-text-color`{{deprecated_inline}} (removed in {{bug(1306214)}}); use {{CSSxRef("color_value#currentColor_keyword","currentcolor")}} instead.
 
-### {{CSSxRef("border-style")}} and {{CSSxRef("outline-style")}}
+### order-style and outline-style
+
+Properties: {{CSSxRef("border-style")}} and {{CSSxRef("outline-style")}}
 
 - `-moz-bg-inset` {{deprecated_inline}}
 - `-moz-bg-outset` {{deprecated_inline}}
 - `-moz-bg-solid` {{deprecated_inline}}
 
-### {{CSSxRef("&lt;color&gt;")}} keywords
+### &lt;color&gt; keywords
+
+Type: {{CSSxRef("&lt;color&gt;")}}
 
 - `-moz-activehyperlinktext`
 - `-moz-hyperlinktext`
@@ -315,7 +325,9 @@ Mozilla applications such as Firefox support a number of special **Mozilla exten
 - `-moz-win-mediatext`
 - `-moz-nativehyperlinktext`
 
-### {{CSSxRef("display")}}
+### display
+
+Property: {{CSSxRef("display")}}
 
 - `-moz-box` {{deprecated_inline}}
 - `-moz-inline-block` {{deprecated_inline}}
@@ -332,11 +344,15 @@ Mozilla applications such as Firefox support a number of special **Mozilla exten
 - `-moz-stack` {{deprecated_inline}}
 - `-moz-marker` {{deprecated_inline}}
 
-### {{CSSxRef("empty-cells")}}
+### empty-cells
+
+Property: {{CSSxRef("empty-cells")}}
 
 - `-moz-show-background` (default value in quirks mode)
 
-### {{CSSxRef("font")}}
+### font
+
+Property: {{CSSxRef("font")}}
 
 - `-moz-button`
 - `-moz-info`
@@ -349,19 +365,27 @@ Mozilla applications such as Firefox support a number of special **Mozilla exten
 - `-moz-pull-down-menu`
 - `-moz-field` (also a color)
 
-### {{CSSxRef("font-family")}}
+### font-family
+
+Property: {{CSSxRef("font-family")}}
 
 - `-moz-fixed`
 
-### {{CSSxRef("image-rendering")}}
+### image-rendering
+
+Property: {{CSSxRef("image-rendering")}}
 
 - {{CSSxRef("image-rendering","-moz-crisp-edges")}}
 
-### {{CSSxRef("&lt;length&gt;")}}
+### &lt;length&gt;
+
+Type: {{CSSxRef("&lt;length&gt;")}}
 
 - {{CSSxRef("-moz-calc")}}
 
-### {{CSSxRef("list-style-type")}}
+### list-style-type
+
+Property: {{CSSxRef("list-style-type")}}
 
 - `-moz-arabic-indic`
 - `-moz-bengali`
@@ -395,29 +419,39 @@ Mozilla applications such as Firefox support a number of special **Mozilla exten
 - `-moz-trad-chinese-informal`
 - `-moz-urdu`
 
-### {{CSSxRef("overflow")}}
+### overflow
+
+Property: {{CSSxRef("overflow")}}
 
 - {{CSSxRef("-moz-scrollbars-none")}} {{deprecated_inline}}
 - {{CSSxRef("-moz-scrollbars-horizontal")}} {{Deprecated_Inline}}
 - {{CSSxRef("-moz-scrollbars-vertical")}} {{Deprecated_Inline}}
 - {{CSSxRef("-moz-hidden-unscrollable")}}
 
-### {{CSSxRef("text-align")}}
+### text-align
+
+Property: {{CSSxRef("text-align")}}
 
 - `-moz-center`
 - `-moz-left`
 - `-moz-right`
 
-### {{CSSxRef("text-decoration")}}
+### text-decoration
+
+Property: {{CSSxRef("text-decoration")}}
 
 - `-moz-anchor-decoration`
 
-### {{CSSxRef("-moz-user-select")}}
+### -moz-user-select
+
+Property: {{CSSxRef("-moz-user-select")}}
 
 - `-moz-all`
 - `-moz-none`
 
-### {{CSSxRef("width")}}, {{CSSxRef("min-width")}}, and {{CSSxRef("max-width")}}
+### width, min-width, and max-width
+
+Properties: {{CSSxRef("width")}}, {{CSSxRef("min-width")}}, and {{CSSxRef("max-width")}}
 
 - `-moz-min-content`
 - `-moz-fit-content`


### PR DESCRIPTION
Our writing guides (enforced by yari) prohibit links in the headings (they are inaccessible anyway). This fixes the one in the _Mozilla CSS extensions_ pages, one of the two left with such links.