### PR TITLE
Remove broken compat tables for dictionaries

### DIFF
--- a/files/en-us/web/api/web_authentication_api/index.md
+++ b/files/en-us/web/api/web_authentication_api/index.md
@@ -220,11 +220,3 @@ navigator.credentials.create(createCredentialDefaultArgs)
 ### AuthenticatorAssertionResponse
 
 {{Compat("api.AuthenticatorAssertionResponse")}}
-
-### PublicKeyCredentialCreationOptions
-
-{{Compat("api.PublicKeyCredentialCreationOptions")}}
-
-### PublicKeyCredentialRequestOptions
-
-{{Compat("api.PublicKeyCredentialRequestOptions")}}


### PR DESCRIPTION
Dictionaries are not considered features by themselves, they can't have a compat table. Removing these, as they will be forever broken.