### PR TITLE
Fixes sidebar for AudioData interface

### DIFF
--- a/files/en-us/web/api/audiodata/index.md
+++ b/files/en-us/web/api/audiodata/index.md
@@ -8,9 +8,9 @@ tags:
   - AudioData
 browser-compat: api.AudioData
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}
 
-The **`AudioData`** interface of the {{domxref('WebCodecs API')}} represents an audio sample.
+The **`AudioData`** interface of the [WebCodecs API](/en-US/docs/Web/API/WebCodecs_API) represents an audio sample.
 
 `AudioData` is a {{glossary("Transferable objects","transferable object")}}.
 


### PR DESCRIPTION
Put the `APIRef` sidebar on this page, as well as fixed the typograph of _WebCodecs API_.