### PR TITLE
Fix definition list

### DIFF
--- a/files/en-us/web/api/audioprocessingevent/index.md
+++ b/files/en-us/web/api/audioprocessingevent/index.md
@@ -22,7 +22,7 @@ The [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) `AudioProcessingEvent` re
 
 _Also implements the properties inherited from its parent, {{domxref("Event")}}_.
 
-- `playbackTime` {{ReadOnlyInline}}</td>
+- `playbackTime` {{ReadOnlyInline}}
   - : A double representing the time when the audio will be played,
    as defined by the time of {{domxref("BaseAudioContext/currentTime", "AudioContext.currentTime")}}.
 - `inputBuffer` {{ReadOnlyInline}}

--- a/files/en-us/web/api/audioprocessingevent/index.md
+++ b/files/en-us/web/api/audioprocessingevent/index.md
@@ -23,7 +23,7 @@ The [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) `AudioProcessingEvent` re
 _Also implements the properties inherited from its parent, {{domxref("Event")}}_.
 
 - `playbackTime` {{ReadOnlyInline}}</td>
-- : A double representing the time when the audio will be played,
+  - : A double representing the time when the audio will be played,
    as defined by the time of {{domxref("BaseAudioContext/currentTime", "AudioContext.currentTime")}}.
 - `inputBuffer` {{ReadOnlyInline}}
   - : An {{domxref("AudioBuffer")}} that is the buffer containing the input audio data to be processed.

--- a/files/en-us/web/api/audioprocessingevent/index.md
+++ b/files/en-us/web/api/audioprocessingevent/index.md
@@ -24,7 +24,7 @@ _Also implements the properties inherited from its parent, {{domxref("Event")}}_
 
 - `playbackTime` {{ReadOnlyInline}}
   - : A double representing the time when the audio will be played,
-   as defined by the time of {{domxref("BaseAudioContext/currentTime", "AudioContext.currentTime")}}.
+    as defined by the time of {{domxref("BaseAudioContext/currentTime", "AudioContext.currentTime")}}.
 - `inputBuffer` {{ReadOnlyInline}}
   - : An {{domxref("AudioBuffer")}} that is the buffer containing the input audio data to be processed.
     The number of channels is defined as a parameter `numberOfInputChannels`,


### PR DESCRIPTION
The definition list of `AudioProcessingEvent` was broken due to an incorrect indentation.