### PR TITLE
Add missing sidebar + fix link to API

### DIFF
--- a/files/en-us/web/api/audioencoder/index.md
+++ b/files/en-us/web/api/audioencoder/index.md
@@ -8,7 +8,8 @@ tags:
   - AudioEncoder
 browser-compat: api.AudioEncoder
 ---
-The **`AudioEncoder`** interface of the {{domxref('WebCodecs API','','','true')}} encodes {{domxref("AudioData")}} objects.
+{{APIRef("WebCodecs API")}}
+The **`AudioEncoder`** interface of the [WebCodecs API](/en-US/docs/Web/API/WebCodecs_API) encodes {{domxref("AudioData")}} objects.
 
 ## Constructor
 


### PR DESCRIPTION
The sidebar was missing + the link to the API was using `domxref` when not needed