### PR TITLE
List exception in Exceptions section

### DIFF
--- a/files/en-us/web/api/canvasgradient/addcolorstop/index.md
+++ b/files/en-us/web/api/canvasgradient/addcolorstop/index.md
@@ -12,10 +12,8 @@ browser-compat: api.CanvasGradient.addColorStop
 ---
 {{APIRef("Canvas API")}}
 
-The
-**`CanvasGradient.addColorStop()`**
-method adds a new color stop, defined by an `offset` and a
-`color`, to a given canvas gradient.
+The **`CanvasGradient.addColorStop()`** method adds a new color stop,
+defined by an `offset` and a `color`, to a given canvas gradient.
 
 ## Syntax
 
@@ -28,16 +26,21 @@ addColorStop(offset, color)
 - `offset`
   - : A number between `0` and `1`, inclusive, representing the
     position of the color stop. `0` represents the start of the gradient and
-    `1` represents the end; an `INDEX_SIZE_ERR` is raised if the
-    number is outside that range.
+    `1` represents the end.
 - `color`
   - : A [CSS](/en-US/docs/Web/CSS) {{cssxref("&lt;color&gt;")}} value
-    representing the color of the stop. A `SYNTAX_ERR` is raised if the value
-    cannot be parsed as a CSS `<color>` value.
+    representing the color of the stop.
 
 ### Return value
 
 None ({{jsxref("undefined")}}).
+
+### Exceptions
+
+- `IndexSizeError` {{domxref("DOMException")}}
+  - : Thrown if `offset` is not between 0 and 1 (both included).
+- `SyntaxError`{{domxref("DOMException")}}
+  - : Thrown if `color` cannot be parsed as a CSS {{cssxref("&lt;color&gt;")}} value.
 
 ## Examples
 

--- a/files/en-us/web/api/canvasgradient/index.md
+++ b/files/en-us/web/api/canvasgradient/index.md
@@ -10,6 +10,8 @@ tags:
   - Reference
 browser-compat: api.CanvasGradient
 ---
+{{APIRef("Canvas API")}}
+
 The **`CanvasGradient`** interface represents an [opaque object](https://en.wikipedia.org/wiki/Opaque_data_type) describing a gradient. It is returned by the methods {{domxref("CanvasRenderingContext2D.createLinearGradient()")}}, {{domxref("CanvasRenderingContext2D.createConicGradient()")}} or {{domxref("CanvasRenderingContext2D.createRadialGradient()")}}.
 
 It can be used as a {{domxref("CanvasRenderingContext2D.fillStyle", "fillStyle")}} or {{domxref("CanvasRenderingContext2D.strokeStyle", "strokeStyle")}}.
@@ -21,7 +23,7 @@ _As an opaque object, there is no exposed property._
 ## Methods
 
 - {{domxref("CanvasGradient.addColorStop()")}}
-  - : Adds a new stop, defined by an `offset` and a `color`, to the gradient. If the offset is not between `0` and `1`, inclusive, an `INDEX_SIZE_ERR` is raised; if the color can't be parsed as a CSS {{cssxref("&lt;color&gt;")}}, a `SYNTAX_ERR` is raised.
+  - : Adds a new stop, defined by an `offset` and a `color`, to the gradient.
 
 ## Specifications
 
@@ -35,5 +37,3 @@ _As an opaque object, there is no exposed property._
 
 - Creator methods in {{domxref("CanvasRenderingContext2D")}}.
 - The {{HTMLElement("canvas")}} element and its associated interface, {{domxref("HTMLCanvasElement")}}.
-
-{{APIRef("Canvas API")}}


### PR DESCRIPTION
In `CanvasGradient`, exceptions were listed using deprecated constants and inside the prose.

This PR removes them from the text, and add them in a new _Exceptions_ sections (modern structure).