### PR TITLE
Add deprecated header and tag to CSSPrimitiveValue.primitiveType

### DIFF
--- a/files/en-us/web/api/cssprimitivevalue/primitivetype/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/primitivetype/index.md
@@ -7,10 +7,11 @@ tags:
   - Property
   - Read-only
   - Reference
+  - Deprecated
   - primitiveValue
 browser-compat: api.CSSPrimitiveValue.primitiveType
 ---
-{{APIRef("CSSOM")}}
+{{APIRef("CSSOM")}}{{deprecated_header}}
 
 The **`primitiveType`** read-only property of the
 {{domxref("CSSPrimitiveValue")}} interface represents the type of a CSS value.


### PR DESCRIPTION
This is deprecated (see bcd). All the other methods and properties of this interface, as well as the interface itself, are correctly tagged.

This fixes this oddity.