### PR TITLE
USVString -> string

### DIFF
--- a/files/en-us/web/api/cssunitvalue/index.md
+++ b/files/en-us/web/api/cssunitvalue/index.md
@@ -27,7 +27,7 @@ The **`CSSUnitValue`** interface of the {{domxref('CSS_Object_Model#css_typed_ob
 - {{domxref('CSSUnitValue.value')}}
   - : Returns a double indicating the number of units.
 - {{domxref('CSSUnitValue.unit')}}
-  - : Returns a {{jsxref('USVString')}} indicating the type of unit.
+  - : Returns a string indicating the type of unit.
 
 ### Event handlers
 


### PR DESCRIPTION
We are replacing `USVString` with _string_. This one was also using the incorrect `{{jsxref}}` macro, hence a red link.

This fixed it.