### PR TITLE
Changing sidebar for data-* attributes in SVG

### DIFF
--- a/files/en-us/web/svg/attribute/data-_star_/index.md
+++ b/files/en-us/web/svg/attribute/data-_star_/index.md
@@ -6,7 +6,7 @@ tags:
   - SVG
 browser-compat: svg.attributes.data
 ---
-{{APIRef("SVG")}}
+{{SVGRef}}
 
 The **`data-*`** SVG attributes are called custom data attributes. They let SVG markup and its resulting DOM share information that standard attributes can't, usually for scripting purposes. Their custom data are available via the {{domxref("SVGElement")}} interface of the element the attributes belong to, with the {{domxref("SVGElement.dataset")}} property.
 


### PR DESCRIPTION
This is not an API, so `{{APIRef}}` was incorrect (creating red links and flaws). I set it to `{{SVGRef}}` like for other SVG attributes. (Coherence even if not a good sidebar, but let's avoid this rabbit hole for now.