### PR TITLE
`Forwarded` and `X-Forwarded-For` are not forbidden HTTP headers

### DIFF
--- a/files/en-us/web/http/headers/forwarded/index.md
+++ b/files/en-us/web/http/headers/forwarded/index.md
@@ -30,7 +30,7 @@ The alternative and de-facto standard versions of this header are the {{HTTPHead
     </tr>
     <tr>
       <th scope="row">{{Glossary("Forbidden header name")}}</th>
-      <td>yes</td>
+      <td>no</td>
     </tr>
   </tbody>
 </table>

--- a/files/en-us/web/http/headers/x-forwarded-for/index.md
+++ b/files/en-us/web/http/headers/x-forwarded-for/index.md
@@ -33,7 +33,7 @@ For detailed guidance on using this header, see the [Parsing](#parsing) and [Sel
     </tr>
     <tr>
       <th scope="row">{{Glossary("Forbidden header name")}}</th>
-      <td>yes</td>
+      <td>no</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Change documentation of `Forwarded` and `X-Forwarded-For` HTTP headers to say they are not [forbidden header names][MDN].

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
`Forwarded` and `X-Forwarded-For` are not listed as forbidden [in MDN][MDN] or [in the Fetch Standard][FETCH]. Major browsers do not treat them as forbidden, either.

[MDN]: https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name
[FETCH]: https://fetch.spec.whatwg.org/#forbidden-header-name

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
This issue was introduced by a02e7c5cb54e978eb907539ececc651afc1959d8 in #13838, but it’s unclear why they were regarded as forbidden.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
