### PR TITLE
{{event}} to {{domxref}} for pointer events

### DIFF
--- a/files/en-us/mozilla/firefox/releases/44/index.md
+++ b/files/en-us/mozilla/firefox/releases/44/index.md
@@ -104,7 +104,7 @@ Highlights:
 - The obsolete property `DocumentType.internalSubset` has been removed ({{bug(801545)}}).
 - For compatibility with existing sites, the properties {{domxref("Window.orientation")}} and {{domxref("Window.onorientationchange")}}, as well as the {{domxref("Window.orientationchange_event", "orientationchange")}} event have been implemented ({{bug(920734)}}).
 - An {{HTMLElement("iframe")}} with explicit fullscreen request should not exit fullscreen implicitly ({{bug(1187801)}}).
-- The events {{event("mouseover")}}, {{event("mouseout")}}, {{event("mouseenter")}}, {{event("mouseleave")}}, {{event("pointermove")}}, {{event("pointerover")}}, {{event("pointerout")}}, {{event("pointerenter")}} and {{event("pointerleave")}} are now triggered for disabled form elements ({{bug(218093)}}).
+- The events {{event("mouseover")}}, {{event("mouseout")}}, {{event("mouseenter")}}, {{event("mouseleave")}}, {{domxref("HTMLElement/pointermove_event", "pointermove")}}, {{domxref("HTMLElement/pointerover_event", "pointerover")}}, {{domxref("HTMLElement/pointerout_event", "pointerout")}}, {{domxref("HTMLElement/pointerenter_event", "pointerenter")}} and {{domxref("HTMLElement/pointerleave_event", "pointerleave")}} are now triggered for disabled form elements ({{bug(218093)}}).
 - The method {{domxref("Element.webkitMatchesSelector()")}} has been added ({{bug(1216193)}}) to improve interoperability.
 - To match the spec, the method {{domxref("Document.createAttribute()")}} now converts the input to lower case ({{bug(1176313)}}).
 - The non-standard `dialog` feature for {{domxref("Window.open()")}} is no longer available to Web content. It is still available to extensions and other code with chrome privileges ({{bug(1095236)}}.

--- a/files/en-us/web/api/document/pointercancel_event/index.md
+++ b/files/en-us/web/api/document/pointercancel_event/index.md
@@ -12,7 +12,7 @@ browser-compat: api.Document.pointercancel_event
 ---
 {{APIRef}}
 
-The **`pointercancel`** event is fired when the browser determines that there are unlikely to be any more pointer events, or if after the {{event("pointerdown")}} event is fired, the pointer is then used to manipulate the viewport by panning, zooming, or scrolling.
+The **`pointercancel`** event is fired when the browser determines that there are unlikely to be any more pointer events, or if after the {{domxref("Document/pointerdown_event", "pointerdown")}} event is fired, the pointer is then used to manipulate the viewport by panning, zooming, or scrolling.
 
 <table class="properties">
   <tbody>
@@ -44,7 +44,7 @@ Some examples of situations that will trigger a `pointercancel` event:
 - The browser decides that the user started pointer input accidentally. This can happen if, for example, the hardware supports palm rejection to prevent a hand resting on the display while using a stylus from accidentally triggering events.
 - The {{cssxref("touch-action")}} CSS property prevents the input from continuing.
 
-> **Note:** After the `pointercancel` event is fired, the browser will also send {{event("pointerout")}} followed by {{event("pointerleave")}}.
+> **Note:** After the `pointercancel` event is fired, the browser will also send {{domxref("Document/pointerout_event", "pointerout")}} followed by {{domxref("Document/pointerleave_event", "pointerleave")}}.
 
 ## Examples
 

--- a/files/en-us/web/api/globaleventhandlers/index.md
+++ b/files/en-us/web/api/globaleventhandlers/index.md
@@ -81,7 +81,7 @@ These event handlers are defined on the {{domxref("GlobalEventHandlers")}} mixin
 - {{domxref("GlobalEventHandlers.onformdata")}}
   - : An [event handler](/en-US/docs/Web/Events/Event_handlers) for processing {{domxref("HTMLFormElement/formdata_event", "formdata")}} events, fired after the entry list representing the form's data is constructed.
 - {{domxref("GlobalEventHandlers.ongotpointercapture")}}
-  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("gotpointercapture")}} event type is raised.
+  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("HTMLElement/gotpointercapture_event", "gotpointercapture")}} event type is raised.
 - {{domxref("GlobalEventHandlers.oninput")}}
   - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("input")}} event is raised.
 - {{domxref("GlobalEventHandlers.oninvalid")}}
@@ -103,7 +103,7 @@ These event handlers are defined on the {{domxref("GlobalEventHandlers")}} mixin
 - {{domxref("GlobalEventHandlers.onloadstart")}}
   - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("loadstart")}} event is raised (when progress has begun on the loading of a resource.)
 - {{domxref("GlobalEventHandlers.onlostpointercapture")}}
-  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("lostpointercapture")}} event type is raised.
+  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("HTMLElement/lostpointercapture_event", "lostpointercapture")}} event type is raised.
 - {{domxref("GlobalEventHandlers.onmousedown")}}
   - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("mousedown")}} event is raised.
 - {{domxref("GlobalEventHandlers.onmouseenter")}}
@@ -129,21 +129,21 @@ These event handlers are defined on the {{domxref("GlobalEventHandlers")}} mixin
 - {{domxref("GlobalEventHandlers.onplaying")}}
   - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("playing")}} event is raised.
 - {{domxref("GlobalEventHandlers.onpointerdown")}}
-  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("pointerdown")}} event is raised.
+  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("HTMLElement/pointerdown_event", "pointerdown")}} event is raised.
 - {{domxref("GlobalEventHandlers.onpointermove")}}
-  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("pointermove")}} event is raised.
+  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("HTMLElement/pointermove_event", "pointermove")}} event is raised.
 - {{domxref("GlobalEventHandlers.onpointerup")}}
-  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("pointerup")}} event is raised.
+  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("HTMLElement/pointerup_event", "pointerup")}} event is raised.
 - {{domxref("GlobalEventHandlers.onpointercancel")}}
-  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("pointercancel")}} event is raised.
+  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("HTMLElement/pointercancel_event", "pointercancel")}} event is raised.
 - {{domxref("GlobalEventHandlers.onpointerover")}}
-  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("pointerover")}} event is raised.
+  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("HTMLElement/pointerover_event", "pointerover")}} event is raised.
 - {{domxref("GlobalEventHandlers.onpointerout")}}
-  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("pointerout")}} event is raised.
+  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("HTMLElement/pointerout_event", "pointerout")}} event is raised.
 - {{domxref("GlobalEventHandlers.onpointerenter")}}
-  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("pointerenter")}} event is raised.
+  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("HTMLElement/pointerenter_event", "pointerenter")}} event is raised.
 - {{domxref("GlobalEventHandlers.onpointerleave")}}
-  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("pointerleave")}} event is raised.
+  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("HTMLElement/pointerleave_event", "pointerleave")}} event is raised.
 - {{domxref("GlobalEventHandlers.onpointerlockchange")}} {{experimental_inline}}
   - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("pointerlockchange")}} event is raised.
 - {{domxref("GlobalEventHandlers.onpointerlockerror")}} {{experimental_inline}}

--- a/files/en-us/web/api/globaleventhandlers/ongotpointercapture/index.md
+++ b/files/en-us/web/api/globaleventhandlers/ongotpointercapture/index.md
@@ -16,7 +16,7 @@ browser-compat: api.GlobalEventHandlers.ongotpointercapture
 
 The **`ongotpointercapture`** property of the
 {{domxref("GlobalEventHandlers")}} mixin is an [event handler](/en-US/docs/Web/Events/Event_handlers) that
-processes {{event("gotpointercapture")}} events.
+processes {{domxref("HTMLElement/gotpointercapture_event", "gotpointercapture")}} events.
 
 ## Syntax
 

--- a/files/en-us/web/api/globaleventhandlers/onlostpointercapture/index.md
+++ b/files/en-us/web/api/globaleventhandlers/onlostpointercapture/index.md
@@ -16,7 +16,7 @@ browser-compat: api.GlobalEventHandlers.onlostpointercapture
 
 The **`onlostpointercapture`** property of the
 {{domxref("GlobalEventHandlers")}} mixin is an [event handler](/en-US/docs/Web/Events/Event_handlers) that
-processes {{event("lostpointercapture")}} events.
+processes {{domxref("HTMLElement/lostpointercapture_event", "lostpointercapture")}} events.
 
 ## Syntax
 

--- a/files/en-us/web/api/globaleventhandlers/onpointercancel/index.md
+++ b/files/en-us/web/api/globaleventhandlers/onpointercancel/index.md
@@ -15,7 +15,7 @@ browser-compat: api.GlobalEventHandlers.onpointercancel
 
 The **`onpointercancel`** property of the
 {{domxref("GlobalEventHandlers")}} mixin is an [event handler](/en-US/docs/Web/Events/Event_handlers) that
-processes {{event("pointercancel")}} events.
+processes {{domxref("HTMLElement/pointercancel_event", "pointercancel")}} events.
 
 ## Syntax
 

--- a/files/en-us/web/api/globaleventhandlers/onpointerdown/index.md
+++ b/files/en-us/web/api/globaleventhandlers/onpointerdown/index.md
@@ -19,7 +19,7 @@ browser-compat: api.GlobalEventHandlers.onpointerdown
 
 The {{domxref("GlobalEventHandlers")}} event handler
 **`onpointerdown`** is used to specify the event handler for the
-{{event("pointerdown")}} event, which is fired when the pointing device is initially
+{{domxref("HTMLElement/pointerdown_event", "pointerdown")}} event, which is fired when the pointing device is initially
 pressed. This event can be sent to {{domxref("Window")}}, {{domxref("Document")}}, and
 {{domxref("Element")}} objects.
 
@@ -124,7 +124,7 @@ called to ensure that the `mousedown` event isn't triggered, potentially
 causing events to be handled twice if we had a handler for those events in case Pointer
 Event support is missing.
 
-We also have a handler for {{event("pointerup")}} events:
+We also have a handler for {{domxref("HTMLElement/pointerup_event", "pointerup")}} events:
 
 ```js
 targetBox.onpointerup = handleUp;

--- a/files/en-us/web/api/globaleventhandlers/onpointermove/index.md
+++ b/files/en-us/web/api/globaleventhandlers/onpointermove/index.md
@@ -15,7 +15,7 @@ browser-compat: api.GlobalEventHandlers.onpointermove
 
 The **`onpointermove`** property of the
 {{domxref("GlobalEventHandlers")}} mixin is an [event handler](/en-US/docs/Web/Events/Event_handlers) that
-processes {{event("pointermove")}} events.
+processes {{domxref("HTMLElement/pointermove_event", "pointermove")}} events.
 
 ## Syntax
 

--- a/files/en-us/web/api/globaleventhandlers/onpointerout/index.md
+++ b/files/en-us/web/api/globaleventhandlers/onpointerout/index.md
@@ -15,7 +15,7 @@ browser-compat: api.GlobalEventHandlers.onpointerout
 
 The **`onpointerout`** property of the
 {{domxref("GlobalEventHandlers")}} mixin is an [event handler](/en-US/docs/Web/Events/Event_handlers) that
-processes {{event("pointerout")}} events.
+processes {{domxref("HTMLElement/pointerout_event", "pointerout")}} events.
 
 ## Syntax
 

--- a/files/en-us/web/api/globaleventhandlers/onpointerover/index.md
+++ b/files/en-us/web/api/globaleventhandlers/onpointerover/index.md
@@ -15,7 +15,7 @@ browser-compat: api.GlobalEventHandlers.onpointerover
 
 The **`onpointerover`** property of the
 {{domxref("GlobalEventHandlers")}} mixin is an [event handler](/en-US/docs/Web/Events/Event_handlers) that
-processes {{event("pointerover")}} events.
+processes {{domxref("HTMLElement/pointerover_event", "pointerover")}} events.
 
 ## Syntax
 

--- a/files/en-us/web/api/globaleventhandlers/onpointerup/index.md
+++ b/files/en-us/web/api/globaleventhandlers/onpointerup/index.md
@@ -15,7 +15,7 @@ browser-compat: api.GlobalEventHandlers.onpointerup
 
 The **`onpointerup`** property of the
 {{domxref("GlobalEventHandlers")}} mixin is an [event handler](/en-US/docs/Web/Events/Event_handlers) that
-processes {{event("pointerup")}} events.
+processes {{domxref("HTMLElement/pointerup_event", "pointerup")}} events.
 
 ## Syntax
 

--- a/files/en-us/web/api/performanceeventtiming/index.md
+++ b/files/en-us/web/api/performanceeventtiming/index.md
@@ -37,15 +37,15 @@ The `PerformanceEventTiming` interface of the Event Timing API provides timing i
 - {{event("mouseout")}}
 - {{event("mouseover")}}
 - {{event("mouseup")}}
-- {{event("pointerover")}}
-- {{event("pointerenter")}}
-- {{event("pointerdown")}}
-- {{event("pointerup")}}
-- {{event("pointercancel")}}
-- {{event("pointerout")}}
-- {{event("pointerleave")}}
-- {{event("gotpointercapture")}}
-- {{event("lostpointercapture")}}
+- {{domxref("HTMLElement/pointerover_event", "pointerover")}}
+- {{domxref("HTMLElement/pointerenter_event", "pointerenter")}}
+- {{domxref("HTMLElement/pointerdown_event", "pointerdown")}}
+- {{domxref("HTMLElement/pointerup_event", "pointerup")}}
+- {{domxref("HTMLElement/pointercancel_event", "pointercancel")}}
+- {{domxref("HTMLElement/pointerout_event", "pointerout")}}
+- {{domxref("HTMLElement/pointerleave_event", "pointerleave")}}
+- {{domxref("HTMLElement/gotpointercapture_event", "gotpointercapture")}}
+- {{domxref("HTMLElement/lostpointercapture_event", "lostpointercapture")}}
 - {{event("touchstart")}}
 - {{event("touchend")}}
 - {{event("touchcancel")}}

--- a/files/en-us/web/api/pointer_events/index.md
+++ b/files/en-us/web/api/pointer_events/index.md
@@ -103,7 +103,7 @@ Below is a short description of each event type and its associated {{domxref("Gl
   </thead>
   <tbody>
     <tr>
-      <td>{{event('pointerover')}}</td>
+      <td>{{domxref('HTMLElement/pointerover_event', 'pointerover')}}</td>
       <td>
         {{domxref('GlobalEventHandlers.onpointerover','onpointerover')}}
       </td>
@@ -113,7 +113,7 @@ Below is a short description of each event type and its associated {{domxref("Gl
       </td>
     </tr>
     <tr>
-      <td>{{event('pointerenter')}}</td>
+      <td>{{domxref('HTMLElement/pointerenter_event', 'pointerenter')}}</td>
       <td>
         {{domxref('GlobalEventHandlers.onpointerenter','onpointerenter')}}
       </td>
@@ -125,14 +125,14 @@ Below is a short description of each event type and its associated {{domxref("Gl
       </td>
     </tr>
     <tr>
-      <td>{{event('pointerdown')}}</td>
+      <td>{{domxref('HTMLElement/pointerdown_event', 'pointerdown')}}</td>
       <td>
         {{domxref('GlobalEventHandlers.onpointerdown','onpointerdown')}}
       </td>
       <td>Fired when a pointer becomes <em>active buttons state</em>.</td>
     </tr>
     <tr>
-      <td>{{event('pointermove')}}</td>
+      <td>{{domxref('HTMLElement/pointermove_event', 'pointermove')}}</td>
       <td>
         {{domxref('GlobalEventHandlers.onpointermove','onpointermove')}}
       </td>
@@ -142,14 +142,14 @@ Below is a short description of each event type and its associated {{domxref("Gl
       </td>
     </tr>
     <tr>
-      <td>{{event('pointerup')}}</td>
+      <td>{{domxref('HTMLElement/pointerup_event', 'pointerup')}}</td>
       <td>
         {{domxref('GlobalEventHandlers.onpointerup','onpointerup')}}
       </td>
       <td>Fired when a pointer is no longer <em>active buttons state</em>.</td>
     </tr>
     <tr>
-      <td>{{event('pointercancel')}}</td>
+      <td>{{domxref('HTMLElement/pointercancel_event', 'pointercancel')}}</td>
       <td>
         {{domxref('GlobalEventHandlers.onpointercancel','onpointercancel')}}
       </td>
@@ -159,7 +159,7 @@ Below is a short description of each event type and its associated {{domxref("Gl
       </td>
     </tr>
     <tr>
-      <td>{{event('pointerout')}}</td>
+      <td>{{domxref('HTMLElement/pointerout_event', 'pointerout')}}</td>
       <td>
         {{domxref('GlobalEventHandlers.onpointerout','onpointerout')}}
       </td>
@@ -173,7 +173,7 @@ Below is a short description of each event type and its associated {{domxref("Gl
       </td>
     </tr>
     <tr>
-      <td>{{event('pointerleave')}}</td>
+      <td>{{domxref('HTMLElement/pointerleave_event', 'pointerleave')}}</td>
       <td>
         {{domxref('GlobalEventHandlers.onpointerleave','onpointerleave')}}
       </td>
@@ -185,14 +185,14 @@ Below is a short description of each event type and its associated {{domxref("Gl
       </td>
     </tr>
     <tr>
-      <td>{{event('gotpointercapture')}}</td>
+      <td>{{domxref('HTMLElement/gotpointercapture_event', 'gotpointercapture')}}</td>
       <td>
         {{domxref('GlobalEventHandlers.ongotpointercapture','ongotpointercapture')}}
       </td>
       <td>Fired when an element receives pointer capture.</td>
     </tr>
     <tr>
-      <td>{{event('lostpointercapture')}}</td>
+      <td>{{domxref('HTMLElement/lostpointercapture_event', 'lostpointercapture')}}</td>
       <td>
         {{domxref('GlobalEventHandlers.onlostpointercapture','onlostpointercapture')}}
       </td>
@@ -385,7 +385,7 @@ The following example shows pointer capture being set on an element.
 </html>
 ```
 
-The following example shows a pointer capture being released (when a {{event("pointercancel")}} event occurs. The browser does this automatically when a {{event("pointerup")}} or {{event("pointercancel")}} event occurs.
+The following example shows a pointer capture being released (when a {{domxref("HTMLElement/pointercancel_event", "pointercancel")}} event occurs. The browser does this automatically when a {{domxref("HTMLElement/pointerup_event", "pointerup")}} or {{domxref("HTMLElement/pointercancel_event", "pointercancel")}} event occurs.
 
 ```html
 <html>

--- a/files/en-us/web/api/pointer_events/multi-touch_interaction/index.md
+++ b/files/en-us/web/api/pointer_events/multi-touch_interaction/index.md
@@ -16,7 +16,7 @@ A _live_ version of this application is available on [GitHub](https://mdn.github
 
 ## Example
 
-This example demonstrates using pointer events' various event types ({{event("pointerdown")}}, {{event("pointermove")}}, {{event("pointerup")}} {{event("pointercancel")}}, etc.) for different multi-touch interactions.
+This example demonstrates using pointer events' various event types ({{domxref("HTMLElement/pointerdown_event", "pointerdown")}}, {{domxref("HTMLElement/pointermove_event", "pointermove")}}, {{domxref("HTMLElement/pointerup_event", "pointerup")}} {{domxref("HTMLElement/pointercancel_event", "pointercancel")}}, etc.) for different multi-touch interactions.
 
 ### Define touch targets
 
@@ -59,7 +59,7 @@ var evCache3 = new Array();
 
 ### Register event handlers
 
-Event handlers are registered for the following pointer events: {{event("pointerdown")}}, {{event("pointermove")}} and {{event("pointerup")}}. The handler for {{event("pointerup")}} is used for the {{event("pointercancel")}}, {{event("pointerout")}} and {{event("pointerleave")}} events, since these four events have the same semantics in this application.
+Event handlers are registered for the following pointer events: {{domxref("HTMLElement/pointerdown_event", "pointerdown")}}, {{domxref("HTMLElement/pointermove_event", "pointermove")}} and {{domxref("HTMLElement/pointerup_event", "pointerup")}}. The handler for {{domxref("HTMLElement/pointerup_event", "pointerup")}} is used for the {{domxref("HTMLElement/pointercancel_event", "pointercancel")}}, {{domxref("HTMLElement/pointerout_event", "pointerout")}} and {{domxref("HTMLElement/pointerleave_event", "pointerleave")}} events, since these four events have the same semantics in this application.
 
 ```js
 function set_handlers(name) {
@@ -85,7 +85,7 @@ function init() {
 
 ### Pointer down
 
-The {{event("pointerdown")}} event is fired when a pointer (mouse, pen/stylus or touch point on a touchscreen) makes contact with the _contact surface_. The event's state must be cached, in case this down event is part of a multi-touch interaction.
+The {{domxref("HTMLElement/pointerdown_event", "pointerdown")}} event is fired when a pointer (mouse, pen/stylus or touch point on a touchscreen) makes contact with the _contact surface_. The event's state must be cached, in case this down event is part of a multi-touch interaction.
 
 In this application, when a pointer is placed down on an element, the background color of the element changes, depending on the number of active touch points the element has. See the [`update_background`](#update_background_color) function for more details about the color changes.
 
@@ -102,7 +102,7 @@ function pointerdown_handler(ev) {
 
 ### Pointer move
 
-The {{event("pointermove")}} handler is called when the pointer moves. It may be called multiple times (for example, if the user moves the pointer) before a different event type is fired.
+The {{domxref("HTMLElement/pointermove_event", "pointermove")}} handler is called when the pointer moves. It may be called multiple times (for example, if the user moves the pointer) before a different event type is fired.
 
 In this application, a pointer move is represented by the target's border being set to `dashed` to provide a clear visual indication that the element has received this event.
 
@@ -121,9 +121,9 @@ function pointermove_handler(ev) {
 
 ### Pointer up
 
-The {{event("pointerup")}} event is fired when a pointer is raised from the _contact surface_. When this occurs, the event is removed from the associated event cache.
+The {{domxref("HTMLElement/pointerup_event", "pointerup")}} event is fired when a pointer is raised from the _contact surface_. When this occurs, the event is removed from the associated event cache.
 
-In this application, this handler is also used for {{event("pointercancel")}}, {{event("pointerleave")}} and {{event("pointerout")}} events.
+In this application, this handler is also used for {{domxref("HTMLElement/pointercancel_event", "pointercancel")}}, {{domxref("HTMLElement/pointerleave_event", "pointerleave")}} and {{domxref("HTMLElement/pointerout_event", "pointerout")}} events.
 
 ```js
 function pointerup_handler(ev) {

--- a/files/en-us/web/api/pointer_events/pinch_zoom_gestures/index.md
+++ b/files/en-us/web/api/pointer_events/pinch_zoom_gestures/index.md
@@ -47,7 +47,7 @@ var prevDiff = -1;
 
 ### Register event handlers
 
-Event handlers are registered for the following pointer events: {{event("pointerdown")}}, {{event("pointermove")}} and {{event("pointerup")}}. The handler for {{event("pointerup")}} is used for the {{event("pointercancel")}}, {{event("pointerout")}} and {{event("pointerleave")}} events since these four events have the same semantics in this application.
+Event handlers are registered for the following pointer events: {{domxref("HTMLElement/pointerdown_event", "pointerdown")}}, {{domxref("HTMLElement/pointermove_event", "pointermove")}} and {{domxref("HTMLElement/pointerup_event", "pointerup")}}. The handler for {{domxref("HTMLElement/pointerup_event", "pointerup")}} is used for the {{domxref("HTMLElement/pointercancel_event", "pointercancel")}}, {{domxref("HTMLElement/pointerout_event", "pointerout")}} and {{domxref("HTMLElement/pointerleave_event", "pointerleave")}} events since these four events have the same semantics in this application.
 
 ```js
 function init() {
@@ -67,7 +67,7 @@ function init() {
 
 ### Pointer down
 
-The {{event("pointerdown")}} event is fired when a pointer (mouse, pen/stylus or touch point on a touchscreen) makes contact with the _contact surface_. In this application, the event's state must be cached in case this down event is part of a two-pointer pinch/zoom gesture.
+The {{domxref("HTMLElement/pointerdown_event", "pointerdown")}} event is fired when a pointer (mouse, pen/stylus or touch point on a touchscreen) makes contact with the _contact surface_. In this application, the event's state must be cached in case this down event is part of a two-pointer pinch/zoom gesture.
 
 ```js
 function pointerdown_handler(ev) {
@@ -80,7 +80,7 @@ function pointerdown_handler(ev) {
 
 ### Pointer move
 
-The {{event("pointermove")}} event handler detects if a user is invoking a two-pointer pinch/zoom gesture. If two pointers are down, and the distance between the pointers is increasing (signifying a pinch out or zoom in), the element's background color is changed to `pink`, and if the distance between the pointers is decreasing (a pinch in or zoom out), the background color is changed to `lightblue`. In a more sophisticated application, pinch in or pinch out determination could be used to apply application-specific semantics.
+The {{domxref("HTMLElement/pointermove_event", "pointermove")}} event handler detects if a user is invoking a two-pointer pinch/zoom gesture. If two pointers are down, and the distance between the pointers is increasing (signifying a pinch out or zoom in), the element's background color is changed to `pink`, and if the distance between the pointers is decreasing (a pinch in or zoom out), the background color is changed to `lightblue`. In a more sophisticated application, pinch in or pinch out determination could be used to apply application-specific semantics.
 
 When this event is processed, the target's border is set to `dashed` to provide a clear visual indication the element has received a move event.
 
@@ -131,9 +131,9 @@ function pointermove_handler(ev) {
 
 ### Pointer up
 
-The {{event("pointerup")}} event is fired when a pointer is raised from the _contact surface_. When this occurs, the event is removed from the event cache and the target element's background color and border are restored to their original values.
+The {{domxref("HTMLElement/pointerup_event", "pointerup")}} event is fired when a pointer is raised from the _contact surface_. When this occurs, the event is removed from the event cache and the target element's background color and border are restored to their original values.
 
-In this application, this handler is also used for {{event("pointercancel")}}, {{event("pointerleave")}} and {{event("pointerout")}} events.
+In this application, this handler is also used for {{domxref("HTMLElement/pointercancel_event", "pointercancel")}}, {{domxref("HTMLElement/pointerleave_event", "pointerleave")}} and {{domxref("HTMLElement/pointerout_event", "pointerout")}} events.
 
 ```js
 function pointerup_handler(ev) {

--- a/files/en-us/web/api/pointer_events/using_pointer_events/index.md
+++ b/files/en-us/web/api/pointer_events/using_pointer_events/index.md
@@ -67,7 +67,7 @@ We'll keep track of the touches in-progress.
 var ongoingTouches = new Array();
 ```
 
-When a {{event("pointerdown")}} event occurs, indicating that a new touch on the surface has occurred, the `handleStart()` function below is called.
+When a {{domxref("HTMLElement/pointerdown_event", "pointerdown")}} event occurs, indicating that a new touch on the surface has occurred, the `handleStart()` function below is called.
 
 ```js
 function handleStart(evt) {
@@ -90,7 +90,7 @@ After storing some of the event's processing in the `ongoingTouches` for later p
 
 #### Drawing as the pointers move
 
-Each time one or more pointers moves, a {{event("pointermove")}} event is delivered, resulting in our `handleMove()` function being called. Its responsibility in this example is to update the cached touch information and to draw a line from the previous position to the current position of each touch.
+Each time one or more pointers moves, a {{domxref("HTMLElement/pointermove_event", "pointermove")}} event is delivered, resulting in our `handleMove()` function being called. Its responsibility in this example is to update the cached touch information and to draw a line from the previous position to the current position of each touch.
 
 ```js
 function handleMove(evt) {
@@ -126,7 +126,7 @@ After drawing the line, we call [`Array.splice()`](/en-US/docs/Web/JavaScript/Re
 
 #### Handling the end of a touch
 
-When the user lifts a finger off the surface, a {{event("pointerup")}} event is sent. We handle this event by calling the `handleEnd()` function below. Its job is to draw the last line segment for the touch that ended and remove the touch point from the ongoing touch list.
+When the user lifts a finger off the surface, a {{domxref("HTMLElement/pointerup_event", "pointerup")}} event is sent. We handle this event by calling the `handleEnd()` function below. Its job is to draw the last line segment for the touch that ended and remove the touch point from the ongoing touch list.
 
 ```js
 function handleEnd(evt) {
@@ -154,7 +154,7 @@ This is very similar to the previous function; the only real differences are tha
 
 #### Handling canceled touches
 
-If the user's finger wanders into browser UI, or the touch otherwise needs to be canceled, the {{event("pointercancel")}} event is sent, and we call the `handleCancel()` function below.
+If the user's finger wanders into browser UI, or the touch otherwise needs to be canceled, the {{domxref("HTMLElement/pointercancel_event", "pointercancel")}} event is sent, and we call the `handleCancel()` function below.
 
 ```js
 function handleCancel(evt) {

--- a/files/en-us/web/api/pointerevent/getcoalescedevents/index.md
+++ b/files/en-us/web/api/pointerevent/getcoalescedevents/index.md
@@ -15,7 +15,7 @@ browser-compat: api.PointerEvent.getCoalescedEvents
 The **`getCoalescedEvents()`** method of the
 {{domxref("PointerEvent")}} interface returns a sequence of all
 `PointerEvent` instances that were coalesced into the dispatched
-{{event('pointermove')}} event.
+{{domxref('HTMLElement/pointermove_event', 'pointermove')}} event.
 
 ## Syntax
 

--- a/files/en-us/web/api/pointerevent/index.md
+++ b/files/en-us/web/api/pointerevent/index.md
@@ -54,9 +54,9 @@ _This interface inherits properties from {{domxref("MouseEvent")}} and {{domxref
 ## Methods
 
 - {{DOMxRef('PointerEvent.getCoalescedEvents()')}} {{Experimental_Inline}}
-  - : Returns a sequence of all `PointerEvent` instances that were coalesced into the dispatched {{event("pointermove")}} event.
+  - : Returns a sequence of all `PointerEvent` instances that were coalesced into the dispatched {{domxref("HTMLElement/pointermove_event", "pointermove")}} event.
 - {{DOMxRef('PointerEvent.getPredictedEvents()')}} {{Experimental_Inline}}
-  - : Returns a sequence of `PointerEvent` instances that the browser predicts will follow the dispatched {{event("pointermove")}} event's coalesced events.
+  - : Returns a sequence of `PointerEvent` instances that the browser predicts will follow the dispatched {{domxref("HTMLElement/pointermove_event", "pointermove")}} event's coalesced events.
 
 ## Pointer event types
 
@@ -64,50 +64,50 @@ The `PointerEvent` interface has several event types. To determine which event f
 
 > **Note:** It's important to note that in many cases, both pointer and mouse events get sent (in order to let non-pointer-specific code still interact with the user). If you use pointer events, you should call {{ domxref("event.preventDefault()") }} to keep the mouse event from being sent as well.
 
-- {{event('pointerover')}}
+- {{domxref('HTMLElement/pointerover_event', 'pointerover')}}
   - : This event is fired when a pointing device is moved into an element's hit test boundaries.
-- {{event('pointerenter')}}
+- {{domxref('HTMLElement/pointerenter_event', 'pointerenter')}}
   - : This event is fired when a pointing device is moved into the hit test boundaries of an element or one of its descendants, including as a result of a `pointerdown` event from a device that does not support hover (see `pointerdown`). This event type is similar to `pointerover`, but differs in that it does not bubble.
-- {{event('pointerdown')}}
+- {{domxref('HTMLElement/pointerdown_event', 'pointerdown')}}
   - : The event is fired when a pointer becomes _active_. For mouse, it is fired when the device transitions from no buttons depressed to at least one button depressed. For touch, it is fired when physical contact is made with the digitizer. For pen, it is fired when the stylus makes physical contact with the digitizer.
 
   > **Note:** For touchscreen browsers that allow [direct manipulation](https://w3c.github.io/pointerevents/#dfn-direct-manipulation), a `pointerdown` event triggers [implicit pointer capture](https://w3c.github.io/pointerevents/#dfn-implicit-pointer-capture), which causes the target to capture all subsequent pointer events as if they were occurring over the capturing target. Accordingly, `pointerover`, `pointerenter`, `pointerleave`, and `pointerout` **will not fire** as long as this capture is set. The capture can be released manually by calling {{ domxref('element.releasePointerCapture') }} on the target element, or it will be implicitly released after a `pointerup` or `pointercancel` event.
 
-- {{event('pointermove')}}
+- {{domxref('HTMLElement/pointermove_event', 'pointermove')}}
   - : This event is fired when a pointer changes coordinates.
 - {{event('pointerrawupdate')}} {{Experimental_Inline}}
   - : This event is fired when any of a pointer's properties change.
-- {{event('pointerup')}}
+- {{domxref('HTMLElement/pointerup_event', 'pointerup')}}
   - : This event is fired when a pointer is no longer _active_.
-- {{event('pointercancel')}}
+- {{domxref('HTMLElement/pointercancel_event', 'pointercancel')}}
   - : A browser fires this event if it concludes the pointer will no longer be able to generate events (for example the related device is deactivated).
-- {{event('pointerout')}}
+- {{domxref('HTMLElement/pointerout_event', 'pointerout')}}
   - : This event is fired for several reasons including: pointing device is moved out of the hit test boundaries of an element; firing the `pointerup` event for a device that does not support hover (see `pointerup`); after firing the `pointercancel` event (see `pointercancel`); when a pen stylus leaves the hover range detectable by the digitizer.
-- {{event('pointerleave')}}
+- {{domxref('HTMLElement/pointerleave_event', 'pointerleave')}}
   - : This event is fired when a pointing device is moved out of the hit test boundaries of an element. For pen devices, this event is fired when the stylus leaves the hover range detectable by the digitizer.
-- {{event('gotpointercapture')}}
+- {{domxref('HTMLElement/gotpointercapture_event', 'gotpointercapture')}}
   - : This event is fired when an element receives pointer capture.
-- {{event('lostpointercapture')}}
+- {{domxref('HTMLElement/lostpointercapture_event', 'lostpointercapture')}}
   - : This event is fired after pointer capture is released for a pointer.
 
 ## GlobalEventHandlers
 
 - {{ domxref('GlobalEventHandlers.onpointerover') }}
-  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{event('pointerover')}} event.
+  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{domxref('HTMLElement/pointerover_event', 'pointerover')}} event.
 - {{ domxref('GlobalEventHandlers.onpointerenter') }}
-  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{event('pointerenter')}} event.
+  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{domxref('HTMLElement/pointerenter_event', 'pointerenter')}} event.
 - {{ domxref('GlobalEventHandlers.onpointerdown') }}
-  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{event('pointerdown')}} event.
+  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{domxref('HTMLElement/pointerdown_event', 'pointerdown')}} event.
 - {{ domxref('GlobalEventHandlers.onpointermove') }}
-  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{event('pointermove')}} event.
+  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{domxref('HTMLElement/pointermove_event', 'pointermove')}} event.
 - {{ domxref('GlobalEventHandlers.onpointerup') }}
-  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{event('pointerup')}} event.
+  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{domxref('HTMLElement/pointerup_event', 'pointerup')}} event.
 - {{ domxref('GlobalEventHandlers.onpointercancel') }}
-  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{event('pointercancel')}} event.
+  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{domxref('HTMLElement/pointercancel_event', 'pointercancel')}} event.
 - {{ domxref('GlobalEventHandlers.onpointerout') }}
-  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{event('pointerout')}} event.
+  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{domxref('HTMLElement/pointerout_event', 'pointerout')}} event.
 - {{ domxref('GlobalEventHandlers.onpointerleave') }}
-  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{event('pointerleave')}} event.
+  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{domxref('HTMLElement/pointerleave_event', 'pointerleave')}} event.
 
 ## Example
 

--- a/files/en-us/web/api/pointerevent/isprimary/index.md
+++ b/files/en-us/web/api/pointerevent/isprimary/index.md
@@ -26,9 +26,9 @@ can achieve that by ignoring non-primary pointers.
 
 A pointer is considered primary if the pointer represents a mouse device. A pointer
 representing pen input is considered the primary pen input if its
-{{event("pointerdown")}} event was dispatched when no other active pointers representing
+{{domxref("HTMLElement/pointerdown_event", "pointerdown")}} event was dispatched when no other active pointers representing
 pen input existed. A pointer representing touch input is considered the primary touch
-input if its {{event("pointerdown")}} event was dispatched when no other active pointers
+input if its {{domxref("HTMLElement/pointerdown_event", "pointerdown")}} event was dispatched when no other active pointers
 representing touch input existed.
 
 When two or more pointer device types are being used concurrently, multiple pointers

--- a/files/en-us/web/api/pointerevent/pointerid/index.md
+++ b/files/en-us/web/api/pointerevent/pointerid/index.md
@@ -25,7 +25,7 @@ A number.
 ## Examples
 
 The following code snippet compares a previously saved `pointerId` with the
-one of the {{event("pointerdown")}} event that was just fired.
+one of the {{domxref("HTMLElement/pointerdown_event", "pointerdown")}} event that was just fired.
 
 ```js
 let id; // Let's assume that this is a previously saved pointerId

--- a/files/en-us/web/api/pointerevent/pressure/index.md
+++ b/files/en-us/web/api/pointerevent/pressure/index.md
@@ -22,7 +22,7 @@ The normalized pressure of the pointer input in the range of `0` to `1`, inclusi
 
 ## Examples
 
-In this snippet, when a {{event("pointerdown")}} event is fired, different functions
+In this snippet, when a {{domxref("HTMLElement/pointerdown_event", "pointerdown")}} event is fired, different functions
 are called depending on the value of the event's `pressure` property.
 
 ```js

--- a/files/en-us/web/api/pointerevent/tangentialpressure/index.md
+++ b/files/en-us/web/api/pointerevent/tangentialpressure/index.md
@@ -29,7 +29,7 @@ be `0`.
 
 ## Examples
 
-In this snippet, when a {{event("pointerdown")}} event is fired, different functions
+In this snippet, when a {{domxref("HTMLElement/pointerdown_event", "pointerdown")}} event is fired, different functions
 are called depending on the value of the event's `tangentialPressure`
 property.
 

--- a/files/en-us/web/api/pointerevent/twist/index.md
+++ b/files/en-us/web/api/pointerevent/twist/index.md
@@ -26,7 +26,7 @@ inclusive. For devices that do not report `twist`, the value is
 
 ## Examples
 
-When a {{event("pointerdown")}} event is fired, different functions are called
+When a {{domxref("HTMLElement/pointerdown_event", "pointerdown")}} event is fired, different functions are called
 depending on the value of the event's `twist` property.
 
 ```js

--- a/files/en-us/web/api/range/commonancestorcontainer/index.md
+++ b/files/en-us/web/api/range/commonancestorcontainer/index.md
@@ -32,7 +32,7 @@ A {{domxref("Node")}} object.
 
 ## Examples
 
-In this example, we create an event listener to handle {{Event("pointerup")}} events on
+In this example, we create an event listener to handle {{domxref("Document/pointerup_event", "pointerup")}} events on
 a list. The listener gets the common ancestors of each piece of selected text, and
 triggers an animation to highlight them.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Replace {{event}} macros with {{domxref} for pointer events.
Note that I have mainly replaced with `HTMLElement/XXX_event` because they are mainly fired on `HTMLElement`.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
