### PR TITLE
Fix return value of createHTMLDocument()

### DIFF
--- a/files/en-us/web/api/domimplementation/createhtmldocument/index.md
+++ b/files/en-us/web/api/domimplementation/createhtmldocument/index.md
@@ -30,7 +30,7 @@ createHTMLDocument(title)
 
 ### Return value
 
-None ({{jsxref("undefined")}}).
+A new HTML {{domxref("Document")}} object.
 
 ## Examples
 


### PR DESCRIPTION
Fixes #15957

This factory method obviously returns an object.
