### PR TITLE
Remove example transclusion from BatteryManager.level

### DIFF
--- a/files/en-us/web/api/batterymanager/level/index.md
+++ b/files/en-us/web/api/batterymanager/level/index.md
@@ -22,23 +22,36 @@ A number.
 
 ## Examples
 
-### HTML Content
+### Getting the battery level
+
+#### HTML
 
 ```html
-<div id="level">(battery level unknown)</div>
+<button id="get-level">Get battery level</button>
+<div id="output"></div>
 ```
 
-### JavaScript Content
+#### JavaScript
 
 ```js
-navigator.getBattery().then(battery => {
-    const level = battery.level;
+const getLevel = document.querySelector('#get-level');
+const output = document.querySelector('#output');
 
-    document.querySelector('#level').textContent = level;
+getLevel.addEventListener('click', async () => {
+  if (!navigator.getBattery) {
+    output.textContent = 'Battery manager is unsupported';
+  } else {
+    const manager = await navigator.getBattery();
+    const level = manager.level;
+    output.textContent = `Battery level: ${level}`;
+  }
 });
+
 ```
 
-{{ EmbedLiveSample('Example', '100%', 30, '', 'Web/API/BatteryManager/level') }}
+#### Result
+
+{{ EmbedLiveSample('Getting the battery level') }}
 
 ## Specifications
 


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/15872. Removes transclusion and generally makes it work.