### PR TITLE
Remove example transclusion from datatransferitemlist/remove

### DIFF
--- a/files/en-us/web/api/datatransferitemlist/remove/index.md
+++ b/files/en-us/web/api/datatransferitemlist/remove/index.md
@@ -43,97 +43,113 @@ None ({{jsxref("undefined")}}).
 
 ## Examples
 
+### Dragging and dropping an element
+
 This example shows the use of the `remove()` method.
 
-### JavaScript
+#### HTML
+
+```html
+<div>
+ <p id="source" draggable="true">
+   Select this element, drag it to the Drop Zone
+   and then release the selection to move the element.</p>
+</div>
+<div id="target">Drop Zone</div>
+```
+
+#### CSS
+
+```css
+div {
+  margin: 0em;
+  padding: 2em;
+}
+
+#source {
+  color: blue;
+  border: 1px solid black;
+}
+
+#target {
+  border: 1px solid black;
+}
+```
+
+#### JavaScript
 
 ```js
 function dragstart_handler(ev) {
-  console.log("dragStart");
+  console.log('dragStart');
   // Add this element's id to the drag payload so the drop handler will
   // know which element to add to its tree
-  var dataList = ev.dataTransfer.items;
-  dataList.add(ev.target.id, "text/plain");
+  const dataList = ev.dataTransfer.items;
+  dataList.add(ev.target.id, 'text/plain');
   // Add some other items to the drag payload
-  dataList.add("<p>... paragraph ...</p>", "text/html");
-  dataList.add("http://www.example.org","text/uri-list");
+  dataList.add('<p>... paragraph ...</p>', 'text/html');
+  dataList.add('http://www.example.org','text/uri-list');
 }
 
 function drop_handler(ev) {
-  console.log("Drop");
+  console.log('Drop');
   ev.preventDefault();
-  var data = event.dataTransfer.items;
+  const data = event.dataTransfer.items;
   // Loop through the dropped items and log their data
-  for (var i = 0; i < data.length; i++) {
-    if ((data[i].kind == 'string') && (data[i].type.match('^text/plain'))) {
+  for (const item of data) {
+    if ((item.kind == 'string') &&
+        (item.type.match('^text/plain'))) {
       // This item is the target node
-      data[i].getAsString(function (s){
+      item.getAsString(function (s){
         ev.target.appendChild(document.getElementById(s));
       });
-    } else if ((data[i].kind == 'string') && (data[i].type.match('^text/html'))) {
+    } else if ((item.kind == 'string') &&
+               (item.type.match('^text/html'))) {
       // Drag data item is HTML
-      data[i].getAsString(function (s){
-        console.log("... Drop: HTML = " + s);
+      item.getAsString(function (s){
+        console.log('... Drop: HTML = ' + s);
       });
-    } else if ((data[i].kind == 'string') && (data[i].type.match('^text/uri-list'))) {
+    } else if ((item.kind == 'string') &&
+               (item.type.match('^text/uri-list'))) {
       // Drag data item is URI
-      data[i].getAsString(function (s){
-        console.log("... Drop: URI = " + s);
+      item.getAsString(function (s){
+        console.log('... Drop: URI = ' + s);
       });
     }
   }
 }
 
 function dragover_handler(ev) {
-  console.log("dragOver");
+  console.log('dragOver');
   ev.preventDefault();
   // Set the dropEffect to move
-  ev.dataTransfer.dropEffect = "move"
+  ev.dataTransfer.dropEffect = 'move'
 }
 
 function dragend_handler(ev) {
-  console.log("dragEnd");
-  var dataList = ev.dataTransfer.items;
-  // Clear all the files.  Iterate in reverse order to safely remove.
-  for (var i = dataList.length - 1; i >= 0; i--) {
-    if (dataList[i].kind === "file") {
+  console.log('dragEnd');
+  const dataList = ev.dataTransfer.items;
+  // Clear all the files. Iterate in reverse order to safely remove.
+  for (let i = dataList.length - 1; i >= 0; i--) {
+    if (dataList[i].kind === 'file') {
       dataList.remove(i);
     }
   }
   // Clear any remaining drag data
   dataList.clear();
 }
+
+const source = document.querySelector('#source');
+source.addEventListener('dragstart', dragstart_handler);
+source.addEventListener('dragend', dragend_handler);
+
+const target = document.querySelector('#target');
+target.addEventListener('drop', drop_handler);
+target.addEventListener('dragover', dragover_handler);
 ```
 
-### HTML
+#### Result
 
-```html
-<h1>Example uses of <code>DataTransferItemList</code> methods and property</h1>
- <div>
-   <p id="source" ondragstart="dragstart_handler(event);" ondragend="dragend_handler(event);" draggable="true">
-     Select this element, drag it to the Drop Zone and then release the selection to move the element.</p>
- </div>
- <div id="target" ondrop="drop_handler(event);" ondragover="dragover_handler(event);">Drop Zone</div>
-```
-
-### CSS
-
-```css
-  div {
-    margin: 0em;
-    padding: 2em;
-  }
-  #source {
-    color: blue;
-    border: 1px solid black;
-  }
-  #target {
-    border: 1px solid black;
-  }
-```
-
-{{ EmbedLiveSample('Examples', '300', '450', '', 'Web/API/DataTransferItemList/remove')
-  }}
+{{ EmbedLiveSample('Dragging and dropping an element', 100, '300px')}}
 
 ## Specifications
 

--- a/files/en-us/web/api/html_drag_and_drop_api/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/index.md
@@ -16,7 +16,7 @@ tags:
 
 The user may select _draggable_ elements with a mouse, drag those elements to a _droppable_ element, and drop them by releasing the mouse button. A translucent representation of the _draggable_ elements follows the pointer during the drag operation.
 
-For web sites, extensions, and XUL applications, you can customize which elements can become _draggable_, the type of feedback the _draggable_ elements produce, and the _droppable_ elements.
+You can customize which elements can become _draggable_, the type of feedback the _draggable_ elements produce, and the _droppable_ elements.
 
 This overview of HTML Drag and Drop includes a description of the interfaces, basic steps to add drag-and-drop support to an application, and an interoperability summary of the interfaces.
 


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/15872.

This is actually a bad example of `remove()` because it tries to show `remove()` by removing all the items one by one, then calls `clear()` which...removes all the items.

But fixing it would take a real overhaul of these docs, which seems like too deep a rathole.