### PR TITLE
FF101 RelNote: RTCRtpEncodingParameters.maxFramerate

### DIFF
--- a/files/en-us/mozilla/firefox/releases/101/index.md
+++ b/files/en-us/mozilla/firefox/releases/101/index.md
@@ -49,7 +49,7 @@ This article provides information about the changes in Firefox 101 that will aff
 
 
 - [`RTCRtpEncodingParameters.maxFramerate`](/en-US/docs/Web/API/RTCRtpEncodingParameters/maxFramerate) is now supported for setting the maximum framerate that can be used to send an encoding (in {{domxref("RTCPeerConnection.addTransceiver()")}} and {{domxref("RTCRtpSender.setParameters()")}}).
-  Note that zero if a valid value, but is interpreted by Firefox as "no frame rate limit".
+  Note that zero if a valid frame rate value, but is interpreted by Firefox as "no frame rate limit".
   For more information see {{bug(1611957)}}.
   
 

--- a/files/en-us/mozilla/firefox/releases/101/index.md
+++ b/files/en-us/mozilla/firefox/releases/101/index.md
@@ -48,6 +48,11 @@ This article provides information about the changes in Firefox 101 that will aff
 - [`DOMException`](/en-US/docs/Web/API/DOMException) is now a {{Glossary("serializable object")}}, so it can be cloned with {{domxref("structuredClone()")}} or copied between [workers](/en-US/docs/Web/API/Worker) using {{domxref("Worker.postMessage()", "postMessage()")}} ({{bug(1561357)}}).
 
 
+- [`RTCRtpEncodingParameters.maxFramerate`](/en-US/docs/Web/API/RTCRtpEncodingParameters/maxFramerate) is now supported for setting the maximum framerate that can be used to send an encoding (in {{domxref("RTCPeerConnection.addTransceiver()")}} and {{domxref("RTCRtpSender.setParameters()")}}).
+  Note that zero if a valid value, but is interpreted by Firefox as "no frame rate limit".
+  For more information see {{bug(1611957)}}.
+  
+
 #### Media, WebRTC, and Web Audio
 
 #### Removals


### PR DESCRIPTION
This adds FF101 release note for [`RTCRtpEncodingParameters.maxFramerate`](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpEncodingParameters/maxFramerate).
Note this is slightly off spec due to an upstream bug. There is no issue posted for that bug as far as I can tell, so I have just linked to the original but which mentions the issue in a comment.

Other docs work for this tracked in #15470