### PR TITLE
DOMString -> string

### DIFF
--- a/files/en-us/web/api/messageevent/index.md
+++ b/files/en-us/web/api/messageevent/index.md
@@ -43,9 +43,9 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.data")}} {{readonlyInline}}
   - : The data sent by the message emitter.
 - {{domxref("MessageEvent.origin")}} {{readonlyInline}}
-  - : A {{domxref("USVString")}} representing the origin of the message emitter.
+  - : A string representing the origin of the message emitter.
 - {{domxref("MessageEvent.lastEventId")}} {{readonlyInline}}
-  - : A {{domxref("DOMString")}} representing a unique ID for the event.
+  - : A string representing a unique ID for the event.
 - {{domxref("MessageEvent.source")}} {{readonlyInline}}
   - : A `MessageEventSource` (which can be a {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
 - {{domxref("MessageEvent.ports")}} {{readonlyInline}}

--- a/files/en-us/web/api/messageport/message_event/index.md
+++ b/files/en-us/web/api/messageport/message_event/index.md
@@ -34,9 +34,9 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.data")}} {{readonlyInline}}
   - : The data sent by the message emitter.
 - {{domxref("MessageEvent.origin")}} {{readonlyInline}}
-  - : A {{domxref("USVString")}} representing the origin of the message emitter.
+  - : A string representing the origin of the message emitter.
 - {{domxref("MessageEvent.lastEventId")}} {{readonlyInline}}
-  - : A {{domxref("DOMString")}} representing a unique ID for the event.
+  - : A string representing a unique ID for the event.
 - {{domxref("MessageEvent.source")}} {{readonlyInline}}
   - : A `MessageEventSource` (which can be a {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
 - {{domxref("MessageEvent.ports")}} {{readonlyInline}}

--- a/files/en-us/web/api/messageport/messageerror_event/index.md
+++ b/files/en-us/web/api/messageport/messageerror_event/index.md
@@ -34,9 +34,9 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.data")}} {{readonlyInline}}
   - : The data sent by the message emitter.
 - {{domxref("MessageEvent.origin")}} {{readonlyInline}}
-  - : A {{domxref("USVString")}} representing the origin of the message emitter.
+  - : A string representing the origin of the message emitter.
 - {{domxref("MessageEvent.lastEventId")}} {{readonlyInline}}
-  - : A {{domxref("DOMString")}} representing a unique ID for the event.
+  - : A string representing a unique ID for the event.
 - {{domxref("MessageEvent.source")}} {{readonlyInline}}
   - : A `MessageEventSource` (which can be a {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
 - {{domxref("MessageEvent.ports")}} {{readonlyInline}}

--- a/files/en-us/web/api/midiconnectionevent/midiconnectionevent/index.md
+++ b/files/en-us/web/api/midiconnectionevent/midiconnectionevent/index.md
@@ -22,7 +22,7 @@ new MIDIConnectionEvent(type, midiConnectionEventInit)
 ### Parameters
 
 - `type`
-  - : A {{domxref("DOMString")}} with one of `"connect"` or `"disconnect"`.
+  - : A string with one of `"connect"` or `"disconnect"`.
 - `midiConnectionEventInit`{{Optional_Inline}}
 
   - : A dictionary including the following fields:

--- a/files/en-us/web/api/mouseevent/region/index.md
+++ b/files/en-us/web/api/mouseevent/region/index.md
@@ -18,7 +18,7 @@ If no hit region is affected, `null` is returned.
 
 ## Value
 
-A {{domxref("DOMString")}} representing the id of the hit region.
+A string representing the id of the hit region.
 
 ## Examples
 

--- a/files/en-us/web/api/navigator/index.md
+++ b/files/en-us/web/api/navigator/index.md
@@ -42,9 +42,9 @@ _Doesn't inherit any properties._
 - {{domxref('Navigator.keyboard')}} {{readonlyinline}} {{experimental_inline}}
   - : Returns a {{domxref('Keyboard')}} object which provides access to functions that retrieve keyboard layout maps and toggle capturing of key presses from the physical keyboard.
 - {{domxref("Navigator.language")}} {{readonlyInline}}
-  - : Returns a {{domxref("DOMString")}} representing the preferred language of the user, usually the language of the browser UI. The `null` value is returned when this is unknown.
+  - : Returns a string representing the preferred language of the user, usually the language of the browser UI. The `null` value is returned when this is unknown.
 - {{domxref("Navigator.languages")}} {{readonlyInline}} {{experimental_inline}}
-  - : Returns an array of {{domxref("DOMString")}} representing the languages known to the user, by order of preference.
+  - : Returns an array of strings representing the languages known to the user, by order of preference.
 - {{domxref("Navigator.locks")}} {{readonlyinline}} {{experimental_inline}}
   - : Returns a {{domxref("LockManager")}} object that provides methods for requesting a new {{domxref('Lock')}} object and querying for an existing {{domxref('Lock')}} object.
 - {{domxref("Navigator.maxTouchPoints")}} {{readonlyInline}}
@@ -100,7 +100,7 @@ _Doesn't inherit any properties._
 - {{domxref("Navigator.appName")}} {{readonlyInline}} {{deprecated_inline}}
   - : Always returns `'Netscape'`, in any browser.
 - {{domxref("Navigator.appVersion")}} {{readonlyInline}} {{deprecated_inline}}
-  - : Returns the version of the browser as a {{domxref("DOMString")}}. Do not rely on this property to return the correct value.
+  - : Returns the version of the browser as a string. Do not rely on this property to return the correct value.
 - {{domxref("Navigator.activeVRDisplays")}} {{readonlyInline}} {{deprecated_inline}}
   - : Returns an array containing every {{domxref("VRDisplay")}} object that is currently presenting ({{domxref("VRDisplay.ispresenting")}} is `true`).
 - {{domxref("Navigator.battery")}} {{readonlyInline}} {{deprecated_inline}}

--- a/files/en-us/web/api/navigator/language/index.md
+++ b/files/en-us/web/api/navigator/language/index.md
@@ -18,7 +18,7 @@ browser UI.
 
 ## Value
 
-A {{domxref("DOMString")}}. _`lang`_ stores a string representing the
+A string. _`lang`_ stores a string representing the
 language version as defined in {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}. Examples of valid language
 codes include "en", "en-US", "fr", "fr-FR", "es-ES", etc.
 

--- a/files/en-us/web/api/navigator/languages/index.md
+++ b/files/en-us/web/api/navigator/languages/index.md
@@ -14,7 +14,7 @@ browser-compat: api.Navigator.languages
 {{APIRef("HTML DOM")}}{{SeeCompatTable}}
 
 The **`Navigator.languages`** read-only property
-returns an array of {{domxref("DOMString")}}s representing the user's preferred
+returns an array of strings representing the user's preferred
 languages. The language is described using language tags according to
 {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}. In the returned
 array they are ordered by preference with the most preferred language first.

--- a/files/en-us/web/api/navigator/oscpu/index.md
+++ b/files/en-us/web/api/navigator/oscpu/index.md
@@ -16,7 +16,7 @@ The **`Navigator.oscpu`** property returns a string that identifies the current 
 
 ## Value
 
-A {{domxref("DOMString")}} providing a string which identifies the operating system on which the browser is running.
+A string providing a string which identifies the operating system on which the browser is running.
 
 | Operating system              | `oscpuInfo` string format                         |
 | ----------------------------- | ------------------------------------------------- |

--- a/files/en-us/web/api/navigator/share/index.md
+++ b/files/en-us/web/api/navigator/share/index.md
@@ -35,9 +35,9 @@ navigator.share(data)
 
     Possible values are:
 
-    - `url`: A {{domxref("USVString")}} representing a URL to be shared.
-    - `text`: A {{domxref("USVString")}} representing text to be shared.
-    - `title`: A {{domxref("USVString")}} representing a title to be shared. May be ignored by the target.
+    - `url`: A string representing a URL to be shared.
+    - `text`: A string representing text to be shared.
+    - `title`: A string representing a title to be shared. May be ignored by the target.
     - `files`: An array of {{domxref("File")}} objects representing files to be shared. See [below](#shareable_file_types) for shareable file types.
 
 ### Return value

--- a/files/en-us/web/api/navigator/useragent/index.md
+++ b/files/en-us/web/api/navigator/useragent/index.md
@@ -39,7 +39,7 @@ string is user configurable. For example:
 
 ## Value
 
-A {{domxref("DOMString")}} specifying the complete user agent string the browser
+A string specifying the complete user agent string the browser
 provides both in {{Glossary("HTTP")}} headers and in response to this and other related
 methods on the {{domxref("Navigator")}} object.
 

--- a/files/en-us/web/api/ndefreader/write/index.md
+++ b/files/en-us/web/api/ndefreader/write/index.md
@@ -23,7 +23,7 @@ NDEFReader.write(message);
 
 - `message`
 
-  - : The message to be written, one of {{DOMxRef("DOMString")}},
+  - : The message to be written, one of string,
     {{DOMxRef("BufferSource")}}, or an array of records. A record has the following members:
 
     - `data` {{optional_inline}}
@@ -92,7 +92,7 @@ following:
 
 ### Write a text string
 
-The following example shows how to write a {{DOMxRef("DOMString")}} to an NFC tag and process any errors that occur.
+The following example shows how to write a string to an NFC tag and process any errors that occur.
 
 ```js
 const ndef = new NDEFReader();

--- a/files/en-us/web/api/ndefrecord/encoding/index.md
+++ b/files/en-us/web/api/ndefrecord/encoding/index.md
@@ -22,7 +22,7 @@ NDEFRecord.encoding
 
 ### Value
 
-A {{DOMxRef("USVString")}} which can be one of the following: `"utf-8"`,
+A string which can be one of the following: `"utf-8"`,
 `"utf-16"`, `"utf-16le"`, or `"utf-16be"`.
 
 ## Specifications

--- a/files/en-us/web/api/ndefrecord/id/index.md
+++ b/files/en-us/web/api/ndefrecord/id/index.md
@@ -27,7 +27,7 @@ NDEFRecord.id
 
 ### Value
 
-A {{DOMxRef("USVString")}}.
+A string.
 
 ## Specifications
 

--- a/files/en-us/web/api/ndefrecord/lang/index.md
+++ b/files/en-us/web/api/ndefrecord/lang/index.md
@@ -24,7 +24,7 @@ NDEFRecord.lang
 
 ### Value
 
-A {{DOMxRef("USVString")}}.
+A string.
 
 ## Specifications
 

--- a/files/en-us/web/api/ndefrecord/mediatype/index.md
+++ b/files/en-us/web/api/ndefrecord/mediatype/index.md
@@ -20,7 +20,7 @@ NDEFRecord.mediaType
 
 ### Value
 
-A {{DOMxRef("USVString")}}, containing the {{Glossary("MIME type")}} of the record
+A string, containing the {{Glossary("MIME type")}} of the record
 payload.
 
 ## Examples

--- a/files/en-us/web/api/ndefrecord/recordtype/index.md
+++ b/files/en-us/web/api/ndefrecord/recordtype/index.md
@@ -20,7 +20,7 @@ NDEFRecord.recordType
 
 ### Value
 
-A {{DOMxRef("USVString")}} which can be one of the following:
+A string which can be one of the following:
 
 - `"empty"`
   - : An empty NDEF record.

--- a/files/en-us/web/api/node/index.md
+++ b/files/en-us/web/api/node/index.md
@@ -135,7 +135,7 @@ parent, {{DOMxRef("EventTarget")}}._
   - : Returns a boolean value indicating whether or not the two nodes are
     the same (that is, they reference the same object).
 - {{DOMxRef("Node.lookupPrefix()")}}
-  - : Returns a {{DOMxRef("DOMString")}} containing the prefix for a given namespace URI,
+  - : Returns a string containing the prefix for a given namespace URI,
     if present, and `null` if not. When multiple prefixes are possible, the
     result is implementation-dependent.
 - {{DOMxRef("Node.lookupNamespaceURI()")}}

--- a/files/en-us/web/api/notification/actions/index.md
+++ b/files/en-us/web/api/notification/actions/index.md
@@ -23,9 +23,9 @@ The actions are set using the `actions` option of the second argument for the [`
 
 A read-only array of actions. Each element in the array is an object with the following members:
 
-- action: A {{domxref("DOMString")}} identifying a user action to be displayed on the notification.
-- title: A {{domxref("DOMString")}} containing action text to be shown to the user.
-- icon: A {{domxref("USVString")}} containing the URL of an icon to display with the action.
+- action: A string identifying a user action to be displayed on the notification.
+- title: A string containing action text to be shown to the user.
+- icon: A string containing the URL of an icon to display with the action.
 
 ## Specifications
 

--- a/files/en-us/web/api/notification/body/index.md
+++ b/files/en-us/web/api/notification/body/index.md
@@ -20,7 +20,7 @@ specified in the `body` option of the
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/notification/dir/index.md
+++ b/files/en-us/web/api/notification/dir/index.md
@@ -17,7 +17,7 @@ The `dir` read-only property of the {{domxref("Notification")}} interface indica
 
 ## Value
 
-A {{domxref("DOMString")}} specifying the text direction. Possible values are:
+A string specifying the text direction. Possible values are:
 
 - `auto`: adopts the browser's language setting behavior (the default.)
 - `ltr`: left to right.

--- a/files/en-us/web/api/notification/icon/index.md
+++ b/files/en-us/web/api/notification/icon/index.md
@@ -20,7 +20,7 @@ part of the notification, as specified in the `icon` option of the
 
 ## Value
 
-A {{domxref("USVString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/notification/image/index.md
+++ b/files/en-us/web/api/notification/image/index.md
@@ -20,7 +20,7 @@ part of the notification, as specified in the `image` option of the
 
 ## Value
 
-A {{domxref("USVString")}}.
+A string.
 
 ## Specifications
 

--- a/files/en-us/web/api/notification/lang/index.md
+++ b/files/en-us/web/api/notification/lang/index.md
@@ -17,13 +17,13 @@ The **`lang`** read-only property of the
 as specified in the `lang` option of the
 {{domxref("Notification.Notification","Notification()")}} constructor.
 
-The language itself is specified using a {{domxref("DOMString")}} representing a language tag according to {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}.
+The language itself is specified using a string representing a language tag according to {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}.
 See the Sitepoint [ISO 2
 letter language codes](https://www.sitepoint.com/iso-2-letter-language-codes/) page for a simple reference.
 
 ## Value
 
-A {{domxref("DOMString")}} specifying the language tag.
+A string specifying the language tag.
 
 ## Examples
 

--- a/files/en-us/web/api/notification/permission/index.md
+++ b/files/en-us/web/api/notification/permission/index.md
@@ -18,7 +18,7 @@ display web notifications.
 
 ## Value
 
-A {{domxref("DOMString")}} representing the current permission. The value can be:
+A string representing the current permission. The value can be:
 
 - `granted`: The user has explicitly granted permission for the current
   origin to display system notifications.

--- a/files/en-us/web/api/notification/tag/index.md
+++ b/files/en-us/web/api/notification/tag/index.md
@@ -25,7 +25,7 @@ notifications.
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/notification/title/index.md
+++ b/files/en-us/web/api/notification/title/index.md
@@ -20,7 +20,7 @@ specified in the `title` parameter of the
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/origin/index.md
+++ b/files/en-us/web/api/origin/index.md
@@ -19,7 +19,7 @@ scope, serialized as a string.
 
 ## Value
 
-A {{domxref("USVString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/oscillatornode/type/index.md
+++ b/files/en-us/web/api/oscillatornode/type/index.md
@@ -20,7 +20,7 @@ tone that is produced.
 
 ## Value
 
-A {{domxref("DOMString")}} specifying the shape of oscillator wave. The different
+A string specifying the shape of oscillator wave. The different
 available values are:
 
 - `sine`

--- a/files/en-us/web/api/page_visibility_api/index.md
+++ b/files/en-us/web/api/page_visibility_api/index.md
@@ -119,7 +119,7 @@ The Page Visibility API adds the following properties to the {{domxref("Document
   - : Returns `true` if the page is in a state considered to be hidden to the user, and `false` otherwise.
 - {{domxref("Document.visibilityState")}} {{ReadOnlyInline}}
 
-  - : A {{domxref("DOMString")}} indicating the document's current visibility state. Possible values are:
+  - : A string indicating the document's current visibility state. Possible values are:
 
     - `visible`
       - : The page content may be at least partially visible. In practice this means that the page is the foreground tab of a non-minimized window.

--- a/files/en-us/web/api/passwordcredential/iconurl/index.md
+++ b/files/en-us/web/api/passwordcredential/iconurl/index.md
@@ -14,13 +14,13 @@ browser-compat: api.PasswordCredential.iconURL
 {{SeeCompatTable}}{{APIRef("Credential Management API")}}
 
 The **`iconURL`** read-only property
-of the {{domxref("PasswordCredential")}} interface returns a {{domxref("USVString")}}
+of the {{domxref("PasswordCredential")}} interface returns a string
 containing a URL pointing to an image for an icon. This image is intended for display
 in a credential chooser. The URL must be accessible without authentication.
 
 ## Value
 
-A {{domxref("USVString")}} containing a URL.
+A string containing a URL.
 
 ## Specifications
 

--- a/files/en-us/web/api/passwordcredential/index.md
+++ b/files/en-us/web/api/passwordcredential/index.md
@@ -30,7 +30,7 @@ _Inherits properties from its ancestor, {{domxref("Credential")}}._
 - {{domxref("PasswordCredential.iconURL")}} {{readonlyinline}}{{securecontext_inline}}
   - : A string containing a URL pointing to an image for an icon. This image is intended for display in a credential chooser. The URL must be accessible without authentication.
 - {{domxref("PasswordCredential.name")}} {{readonlyinline}}{{securecontext_inline}}
-  - : A string containing a human-readable public name for display in a credential chooser.
+  - : A human-readable string that provides public name for display in a credential chooser.
 - {{domxref("PasswordCredential.password")}}{{readonlyinline}}{{securecontext_inline}}
   - : A string containing the password of the credential.
 

--- a/files/en-us/web/api/passwordcredential/index.md
+++ b/files/en-us/web/api/passwordcredential/index.md
@@ -28,11 +28,11 @@ The interface of the [Credential Management API](/en-US/docs/Web/API/Credential_
 _Inherits properties from its ancestor, {{domxref("Credential")}}._
 
 - {{domxref("PasswordCredential.iconURL")}} {{readonlyinline}}{{securecontext_inline}}
-  - : A {{domxref("USVString")}} containing a URL pointing to an image for an icon. This image is intended for display in a credential chooser. The URL must be accessible without authentication.
+  - : A string containing a URL pointing to an image for an icon. This image is intended for display in a credential chooser. The URL must be accessible without authentication.
 - {{domxref("PasswordCredential.name")}} {{readonlyinline}}{{securecontext_inline}}
-  - : A {{domxref("USVString")}} containing a human-readable public name for display in a credential chooser.
+  - : A string containing a human-readable public name for display in a credential chooser.
 - {{domxref("PasswordCredential.password")}}{{readonlyinline}}{{securecontext_inline}}
-  - : A {{domxref("USVString")}} containing the password of the credential.
+  - : A string containing the password of the credential.
 
 ### Event handlers
 

--- a/files/en-us/web/api/passwordcredential/name/index.md
+++ b/files/en-us/web/api/passwordcredential/name/index.md
@@ -14,12 +14,12 @@ browser-compat: api.PasswordCredential.name
 {{SeeCompatTable}}{{APIRef("Credential Management API")}}
 
 The **`name`** read-only property of
-the {{domxref("PasswordCredential")}} interface returns a {{domxref("USVString")}}
+the {{domxref("PasswordCredential")}} interface returns a string
 containing a human-readable public name for display in a credential chooser.
 
 ## Value
 
-A {{domxref("USVString")}} containing a name.
+A string containing a name.
 
 ## Specifications
 

--- a/files/en-us/web/api/passwordcredential/password/index.md
+++ b/files/en-us/web/api/passwordcredential/password/index.md
@@ -14,12 +14,12 @@ browser-compat: api.PasswordCredential.password
 {{SeeCompatTable}}{{APIRef("Credential Management API")}}
 
 The **`password`** read-only property
-of the {{domxref("PasswordCredential")}} interface returns a {{domxref("USVString")}}
+of the {{domxref("PasswordCredential")}} interface returns a string
 containing the password of the credential.
 
 ## Value
 
-A {{domxref("USVString")}} containing a password.
+A string containing a password.
 
 ## Specifications
 

--- a/files/en-us/web/api/paymentaddress/addressline/index.md
+++ b/files/en-us/web/api/paymentaddress/addressline/index.md
@@ -18,7 +18,7 @@ browser-compat: api.PaymentAddress.addressLine
 
 The **`addressLine`** read-only
 property of the {{domxref('PaymentAddress')}} interface is an array of
-{{domxref("DOMString")}} objects, each specifying a line of the address that is not
+string objects, each specifying a line of the address that is not
 covered by one of the other properties of `PaymentAddress`.
 
 These
@@ -27,7 +27,7 @@ descriptive instructions, or post office box.
 
 ## Value
 
-An array of {{domxref("DOMString")}} objects, each containing one line of the address.
+An array of string objects, each containing one line of the address.
 For example, the `addressLine` array for the Mozilla Space in London would
 have the following entries:
 

--- a/files/en-us/web/api/paymentaddress/addressline/index.md
+++ b/files/en-us/web/api/paymentaddress/addressline/index.md
@@ -18,7 +18,7 @@ browser-compat: api.PaymentAddress.addressLine
 
 The **`addressLine`** read-only
 property of the {{domxref('PaymentAddress')}} interface is an array of
-string objects, each specifying a line of the address that is not
+strings, each specifying a line of the address that is not
 covered by one of the other properties of `PaymentAddress`.
 
 These
@@ -27,7 +27,7 @@ descriptive instructions, or post office box.
 
 ## Value
 
-An array of string objects, each containing one line of the address.
+An array of strings, each containing one line of the address.
 For example, the `addressLine` array for the Mozilla Space in London would
 have the following entries:
 

--- a/files/en-us/web/api/paymentaddress/city/index.md
+++ b/files/en-us/web/api/paymentaddress/city/index.md
@@ -25,7 +25,7 @@ town portion of the address.
 
 ## Value
 
-A {{domxref("DOMString")}} indicating the city or town portion of the address described
+A string indicating the city or town portion of the address described
 by the {{domxref("PaymentAddress")}} object.
 
 ## Browser compatibility

--- a/files/en-us/web/api/paymentaddress/country/index.md
+++ b/files/en-us/web/api/paymentaddress/country/index.md
@@ -26,7 +26,7 @@ Some examples of valid `country` values: `"US"`,
 
 ## Value
 
-A {{domxref("DOMString")}} which contains the ISO3166-1 alpha-2 code identifying the
+A string which contains the ISO3166-1 alpha-2 code identifying the
 country in which the address is located, or an empty string if no country is available,
 which frequently can be assumed to mean "same country as the site owner."
 

--- a/files/en-us/web/api/paymentaddress/dependentlocality/index.md
+++ b/files/en-us/web/api/paymentaddress/dependentlocality/index.md
@@ -21,7 +21,7 @@ town_.
 
 ## Value
 
-A {{domxref("DOMString")}} indicating the sublocality portion of the address. This may
+A string indicating the sublocality portion of the address. This may
 be an empty string if no sublocality is available or required. It's used to provide
 disambiguation when a city may include areas that duplicate street names
 

--- a/files/en-us/web/api/paymentaddress/index.md
+++ b/files/en-us/web/api/paymentaddress/index.md
@@ -20,7 +20,7 @@ It may be useful to refer to the Universal Postal Union web site's [Addressing S
 ## Properties
 
 - {{domxref('PaymentAddress.addressLine')}} {{readonlyinline}}{{deprecated_inline}}
-  - : An array of string objects providing each line of the address not included among the other properties. The exact size and content varies by country or location and can include, for example, a street name, house number, apartment number, rural delivery route, descriptive instructions, or post office box number.
+  - : An array of strings providing each line of the address not included among the other properties. The exact size and content varies by country or location and can include, for example, a street name, house number, apartment number, rural delivery route, descriptive instructions, or post office box number.
 - {{domxref('PaymentAddress.country')}} {{readonlyinline}}{{deprecated_inline}}
   - : A string specifying the country in which the address is located, using the {{interwiki("wikipedia", "ISO-3166-1 alpha-2")}} standard. The string is always given in its canonical upper-case form. Some examples of valid `country` values: `"US"`, `"GB"`, `"CN"`, or `"JP"`.
 - {{domxref('PaymentAddress.city')}} {{readonlyinline}}{{deprecated_inline}}

--- a/files/en-us/web/api/paymentaddress/index.md
+++ b/files/en-us/web/api/paymentaddress/index.md
@@ -20,25 +20,25 @@ It may be useful to refer to the Universal Postal Union web site's [Addressing S
 ## Properties
 
 - {{domxref('PaymentAddress.addressLine')}} {{readonlyinline}}{{deprecated_inline}}
-  - : An array of {{domxref("DOMString")}} objects providing each line of the address not included among the other properties. The exact size and content varies by country or location and can include, for example, a street name, house number, apartment number, rural delivery route, descriptive instructions, or post office box number.
+  - : An array of string objects providing each line of the address not included among the other properties. The exact size and content varies by country or location and can include, for example, a street name, house number, apartment number, rural delivery route, descriptive instructions, or post office box number.
 - {{domxref('PaymentAddress.country')}} {{readonlyinline}}{{deprecated_inline}}
-  - : A {{domxref("DOMString")}} specifying the country in which the address is located, using the {{interwiki("wikipedia", "ISO-3166-1 alpha-2")}} standard. The string is always given in its canonical upper-case form. Some examples of valid `country` values: `"US"`, `"GB"`, `"CN"`, or `"JP"`.
+  - : A string specifying the country in which the address is located, using the {{interwiki("wikipedia", "ISO-3166-1 alpha-2")}} standard. The string is always given in its canonical upper-case form. Some examples of valid `country` values: `"US"`, `"GB"`, `"CN"`, or `"JP"`.
 - {{domxref('PaymentAddress.city')}} {{readonlyinline}}{{deprecated_inline}}
-  - : A {{domxref("DOMString")}} which contains the city or town portion of the address.
+  - : A string which contains the city or town portion of the address.
 - {{domxref('PaymentAddress.dependentLocality')}} {{readonlyinline}}{{deprecated_inline}}
-  - : A {{domxref("DOMString")}} giving the dependent locality or sublocality within a city, for example, a neighborhood, borough, district, or UK dependent locality.
+  - : A string giving the dependent locality or sublocality within a city, for example, a neighborhood, borough, district, or UK dependent locality.
 - {{domxref('PaymentAddress.organization')}} {{readonlyinline}}{{deprecated_inline}}
-  - : A {{domxref("DOMString")}} specifying the name of the organization, firm, company, or institution at the payment address.
+  - : A string specifying the name of the organization, firm, company, or institution at the payment address.
 - {{domxref('PaymentAddress.phone')}} {{readonlyinline}}{{deprecated_inline}}
-  - : A {{domxref("DOMString")}} specifying the telephone number of the recipient or contact person.
+  - : A string specifying the telephone number of the recipient or contact person.
 - {{domxref('PaymentAddress.postalCode')}} {{readonlyinline}}{{deprecated_inline}}
-  - : A {{domxref("DOMString")}} specifying a code used by a jurisdiction for mail routing, for example, the ZIP code in the United States or the PIN code in India.
+  - : A string specifying a code used by a jurisdiction for mail routing, for example, the ZIP code in the United States or the PIN code in India.
 - {{domxref('PaymentAddress.recipient')}} {{readonlyinline}}{{deprecated_inline}}
-  - : A {{domxref("DOMString")}} giving the name of the recipient, purchaser, or contact person at the payment address.
+  - : A string giving the name of the recipient, purchaser, or contact person at the payment address.
 - {{domxref('PaymentAddress.region')}} {{readonlyinline}}{{deprecated_inline}}
-  - : A {{domxref("DOMString")}} containing the top level administrative subdivision of the country, for example a state, province, oblast, or prefecture.
+  - : A string containing the top level administrative subdivision of the country, for example a state, province, oblast, or prefecture.
 - {{domxref('PaymentAddress.sortingCode')}} {{readonlyinline}}{{deprecated_inline}}
-  - : A {{domxref("DOMString")}} providing a postal sorting code such as is used in France.
+  - : A string providing a postal sorting code such as is used in France.
 
 > **Note:** Properties for which values were not specified contain empty strings.
 
@@ -47,7 +47,7 @@ It may be useful to refer to the Universal Postal Union web site's [Addressing S
 The following properties are obsolete and should no longer be used, but may still be present in some browser versions.
 
 - {{domxref("PaymentAddress.languageCode")}} {{ReadOnlyInline}} {{deprecated_inline}}
-  - : A {{domxref("DOMString")}} indicating the language code of the address. This identifies the language in which the address is given, and is intended to aid in localization of the display of the address.
+  - : A string indicating the language code of the address. This identifies the language in which the address is given, and is intended to aid in localization of the display of the address.
 
 ## Methods
 

--- a/files/en-us/web/api/paymentaddress/languagecode/index.md
+++ b/files/en-us/web/api/paymentaddress/languagecode/index.md
@@ -37,7 +37,7 @@ var paymentLanguageCode = PaymentAddress.languageCode;
 
 ### Value
 
-A {{domxref("DOMString")}} providing the {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}
+A string providing the {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}
 format language code indicating
 the language the address was written in, such as `"en-US"`,
 `"pt-BR"`, or `"ja-JP"`.

--- a/files/en-us/web/api/paymentaddress/organization/index.md
+++ b/files/en-us/web/api/paymentaddress/organization/index.md
@@ -25,7 +25,7 @@ the name of the organization, firm, company, or institution at the address.
 
 ## Value
 
-A {{domxref("DOMString")}} whose value is the name of the organization or company
+A string whose value is the name of the organization or company
 located at the address described by the `PaymentAddress` object. This should
 be the name of the organization that is to receive the shipment for shipping addresses,
 or which is responsible for payment addresses.

--- a/files/en-us/web/api/paymentaddress/phone/index.md
+++ b/files/en-us/web/api/paymentaddress/phone/index.md
@@ -25,7 +25,7 @@ of the recipient or contact person.
 
 ## Value
 
-A {{domxref("DOMString")}} containing the telephone number for the recipient of the
+A string containing the telephone number for the recipient of the
 shipment or of the responsible party for payment. If no phone number is available, this
 value is an empty string.
 

--- a/files/en-us/web/api/paymentaddress/postalcode/index.md
+++ b/files/en-us/web/api/paymentaddress/postalcode/index.md
@@ -31,7 +31,7 @@ in India.
 
 ## Value
 
-A {{domxref("DOMString")}} which contains the postal code portion of the address. A
+A string which contains the postal code portion of the address. A
 postal code is a string (either numeric or alphanumeric) which is used by a postal
 service to optimize mail routing and delivery.
 

--- a/files/en-us/web/api/paymentaddress/recipient/index.md
+++ b/files/en-us/web/api/paymentaddress/recipient/index.md
@@ -19,7 +19,7 @@ recipient, purchaser, or contact person at the payment address.
 
 ## Value
 
-A {{domxref("DOMString")}} giving the name of the person receiving or paying for the
+A string giving the name of the person receiving or paying for the
 purchase, or the name of a contact person in other contexts. If no name is available,
 this string is empty.
 

--- a/files/en-us/web/api/paymentaddress/region/index.md
+++ b/files/en-us/web/api/paymentaddress/region/index.md
@@ -28,7 +28,7 @@ this may be a state, province, oblast, or prefecture.
 
 ## Value
 
-A {{domxref("DOMString")}} specifying the top-level administrative subdivision within
+A string specifying the top-level administrative subdivision within
 the country in which the address is located. This region has different names in
 different countries, such as: state, province, oblast, prefecture, or county.
 

--- a/files/en-us/web/api/paymentaddress/sortingcode/index.md
+++ b/files/en-us/web/api/paymentaddress/sortingcode/index.md
@@ -23,7 +23,7 @@ code such as is used in France.
 
 ## Value
 
-A {{domxref("DOMString")}} containing the sorting code portion of the address.
+A string containing the sorting code portion of the address.
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/paymentmethodchangeevent/index.md
+++ b/files/en-us/web/api/paymentmethodchangeevent/index.md
@@ -31,7 +31,7 @@ _In addition to the properties below, this interface includes properties inherit
 - {{domxref("PaymentMethodChangeEvent.methodDetails", "methodDetails")}} {{ReadOnlyInline}} {{securecontext_inline}}
   - : An object containing payment method-specific data useful when handling a payment method change. If no such information is available, this value is `null`.
 - {{domxref("PaymentMethodChangeEvent.methodName", "methodName")}} {{ReadOnlyInline}} {{securecontext_inline}}
-  - : A {{domxref("DOMString")}} containing the payment method identifier, a string which uniquely identifies a particular payment method. This identifier is usually a URL used during the payment process, but may be a standardized non-URL string as well, such as `basic-card`. The default value is the empty string, `""`.
+  - : A string containing the payment method identifier, a string which uniquely identifies a particular payment method. This identifier is usually a URL used during the payment process, but may be a standardized non-URL string as well, such as `basic-card`. The default value is the empty string, `""`.
 
 ## Methods
 

--- a/files/en-us/web/api/paymentmethodchangeevent/methodname/index.md
+++ b/files/en-us/web/api/paymentmethodchangeevent/methodname/index.md
@@ -25,7 +25,7 @@ within the payment handler are described by the `PaymentMethodChangeEvent`.
 
 ## Value
 
-A {{domxref("DOMString")}} which uniquely identifies the currently-selected payment
+A string which uniquely identifies the currently-selected payment
 handler. This may be a string chosen from the list of standardized payment method
 identifiers, or a URL used by the payment processing service. See
 {{SectionOnPage("/en-US/docs/Web/API/Payment_Request_API", "Payment method

--- a/files/en-us/web/api/paymentrequest/merchantvalidation_event/index.md
+++ b/files/en-us/web/api/paymentrequest/merchantvalidation_event/index.md
@@ -44,9 +44,9 @@ An {{domxref("MerchantValidationEvent")}}. Inherits from {{domxref("Event")}}.
 ## Event properties
 
 - {{domxref("MerchantValidationEvent.methodName")}} {{securecontext_inline}}
-  - : A {{domxref("DOMString")}} providing a unique payment method identifier for the payment handler that's requiring validation. This may be either one of the standard payment method identifier strings or a URL that both identifies and handles requests for the payment handler, such as `https://apple.com/apple-pay`.
+  - : A string providing a unique payment method identifier for the payment handler that's requiring validation. This may be either one of the standard payment method identifier strings or a URL that both identifies and handles requests for the payment handler, such as `https://apple.com/apple-pay`.
 - {{domxref("MerchantValidationEvent.validationURL")}} {{securecontext_inline}}
-  - : A {{domxref("USVString")}} specifying a URL from which the site or app can fetch payment handler specific validation information. Once this data is retrieved, the data (or a promise resolving to the validation data) should be passed into {{domxref("MerchantValidationEvent.complete", "complete()")}} to validate that the payment request is coming from an authorized merchant.
+  - : A string specifying a URL from which the site or app can fetch payment handler specific validation information. Once this data is retrieved, the data (or a promise resolving to the validation data) should be passed into {{domxref("MerchantValidationEvent.complete", "complete()")}} to validate that the payment request is coming from an authorized merchant.
 
 ## Examples
 


### PR DESCRIPTION
Continuing #15499 

### Summary
`DOMString` is not exposed by browsers to JavaScript. It is converted to `string`.[[ref](https://developer.mozilla.org/en-US/docs/Web/API/DOMString)]

Same is the case with `USVString` and `CSSOMString`.

### Metadata
- [x] Fixes a typo, bug, or other error
