### PR TITLE
Remove the 5 last occurrences of {{Spec}} macro

### DIFF
--- a/files/en-us/glossary/mathml/index.md
+++ b/files/en-us/glossary/mathml/index.md
@@ -15,4 +15,4 @@ tags:
 - {{interwiki("wikipedia", "MathML", "MathML")}} on Wikipedia
 - [MathML](/en-US/docs/Web/MathML)
 - [Authoring MathML](/en-US/docs/Web/MathML/Authoring)
-- {{spec("http://www.w3.org/Math/whatIsMathML.html", "MathML", "REC")}}
+- [What is MathML](http://www.w3.org/Math/whatIsMathML.html)

--- a/files/en-us/web/api/blobbuilder/index.md
+++ b/files/en-us/web/api/blobbuilder/index.md
@@ -151,13 +151,15 @@ File getFile(
 
 A {{domxref("File")}} object.
 
+## Specifications
+
+This feature is not part of any specification anymore. It is no more on track to become a standard.
+
 ## Browser compatibility
 
 {{Compat}}
 
 ## See also
 
-- {{spec("http://dev.w3.org/2009/dap/file-system/file-writer.html#idl-def-BlobBuilder",
-    "File API Specification: BlobBuilder", "ED")}}
 - {{domxref("Blob")}}
 - {{domxref("File")}}

--- a/files/en-us/web/api/document/xmlencoding/index.md
+++ b/files/en-us/web/api/document/xmlencoding/index.md
@@ -28,8 +28,7 @@ However, Firefox 3.0 includes information on endianness (e.g., UTF-16BE for big 
 
 ## Specifications
 
-- [http://www.w3.org/TR/DOM-Level-3-Cor...ment3-encoding](https://www.w3.org/TR/DOM-Level-3-Core/core.html#Document3-encoding)
-- This has been removed from {{ spec("http://www.w3.org/TR/domcore/","DOM Core Level 4","WD") }}
+This feature is not part of any specification anymore. It is no more on track to become a standard.
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/document/xmlversion/index.md
+++ b/files/en-us/web/api/document/xmlversion/index.md
@@ -24,8 +24,7 @@ if (document.createElement("foo").tagName == "FOO") {
 
 ## Specifications
 
-- [http://www.w3.org/TR/DOM-Level-3-Cor...ument3-version](https://www.w3.org/TR/DOM-Level-3-Core/core.html#Document3-version)
-- This has been removed from {{ spec("http://www.w3.org/TR/domcore/","DOM Core Level 4","WD") }}
+This feature is not part of any specification anymore. It is no more on track to become a standard.
 
 ## Browser compatibility
 

--- a/files/en-us/web/css/ime-mode/index.md
+++ b/files/en-us/web/css/ime-mode/index.md
@@ -28,7 +28,7 @@ ime-mode: revert-layer;
 ime-mode: unset;
 ```
 
-The `ime-mode` property is only partially and inconsistently implemented in browsers. It was introduced by Microsoft with Internet Explorer 5 as a proprietary extension: {{spec("https://msdn.microsoft.com/library/ms530767(VS.85).aspx","-ms-ime-mode Attribute | imeMode Property")}}.
+The `ime-mode` property is only partially and inconsistently implemented in browsers. It was introduced by Microsoft with Internet Explorer 5 as a proprietary extension.
 
 > **Note:** In general, it's not appropriate for a public web site to change the IME mode. This property should only be used for private web applications or to undo the property if it was previously set by legacy code.
 


### PR DESCRIPTION
In another life (circa 2012), I created `{{Spec2}}` to get rid of `{{Spec}}`. The new one is long deprecated (and we are removing it little by little). 

So: time for its ancestor to go away! 🍾 🥳 
