### PR TITLE
Fix spec-urls values for Web Crypto API docs

### DIFF
--- a/files/en-us/web/api/aescbcparams/index.md
+++ b/files/en-us/web/api/aescbcparams/index.md
@@ -7,7 +7,7 @@ tags:
   - Dictionary
   - Reference
   - Web Crypto API
-spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-AesCbcParams
+spec-urls: https://w3c.github.io/webcrypto/#dfn-AesCbcParams
 ---
 {{ APIRef("Web Crypto API") }}
 

--- a/files/en-us/web/api/aesctrparams/index.md
+++ b/files/en-us/web/api/aesctrparams/index.md
@@ -7,7 +7,7 @@ tags:
   - Dictionary
   - Reference
   - Web Crypto API
-spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-AesCtrParams
+spec-urls: https://w3c.github.io/webcrypto/#dfn-AesCtrParams
 ---
 {{ APIRef("Web Crypto API") }}
 

--- a/files/en-us/web/api/aesgcmparams/index.md
+++ b/files/en-us/web/api/aesgcmparams/index.md
@@ -7,7 +7,7 @@ tags:
   - Dictionary
   - Reference
   - Web Crypto API
-spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-AesGcmParams
+spec-urls: https://w3c.github.io/webcrypto/#dfn-AesGcmParams
 ---
 {{ APIRef("Web Crypto API") }}
 

--- a/files/en-us/web/api/aeskeygenparams/index.md
+++ b/files/en-us/web/api/aeskeygenparams/index.md
@@ -7,7 +7,7 @@ tags:
   - Dictionary
   - Reference
   - Web Crypto API
-spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-AesKeyGenParams
+spec-urls: https://w3c.github.io/webcrypto/#dfn-AesKeyGenParams
 ---
 {{ APIRef("Web Crypto API") }}The **`AesKeyGenParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed as the `algorithm` parameter into {{domxref("SubtleCrypto.generateKey()")}}, when generating an AES key: that is, when the algorithm is identified as any of [AES-CBC](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-cbc), [AES-CTR](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-ctr), [AES-GCM](/en-US/docs/Web/API/SubtleCrypto/encrypt#aes-gcm), or [AES-KW](/en-US/docs/Web/API/SubtleCrypto/wrapKey#aes-kw).
 

--- a/files/en-us/web/api/ecdhkeyderiveparams/index.md
+++ b/files/en-us/web/api/ecdhkeyderiveparams/index.md
@@ -7,7 +7,7 @@ tags:
   - EcdhKeyDeriveParams
   - Reference
   - Web Crypto API
-spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-EcdhKeyDeriveParams
+spec-urls: https://w3c.github.io/webcrypto/#dfn-EcdhKeyDeriveParams
 ---
 {{ APIRef("Web Crypto API") }}
 

--- a/files/en-us/web/api/ecdsaparams/index.md
+++ b/files/en-us/web/api/ecdsaparams/index.md
@@ -7,7 +7,7 @@ tags:
   - EcdsaParams
   - Reference
   - Web Crypto API
-spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-EcdsaParams
+spec-urls: https://w3c.github.io/webcrypto/#dfn-EcdsaParams
 ---
 {{ APIRef("Web Crypto API") }}
 

--- a/files/en-us/web/api/eckeygenparams/index.md
+++ b/files/en-us/web/api/eckeygenparams/index.md
@@ -7,7 +7,7 @@ tags:
   - EcKeyGenParams
   - Reference
   - Web Crypto API
-spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-EcKeyGenParams
+spec-urls: https://w3c.github.io/webcrypto/#dfn-EcKeyGenParams
 ---
 {{ APIRef("Web Crypto API") }}
 

--- a/files/en-us/web/api/eckeyimportparams/index.md
+++ b/files/en-us/web/api/eckeyimportparams/index.md
@@ -7,7 +7,7 @@ tags:
   - EcKeyImportParams
   - Reference
   - Web Crypto API
-spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-EcKeyImportParams
+spec-urls: https://w3c.github.io/webcrypto/#dfn-EcKeyImportParams
 ---
 {{ APIRef("Web Crypto API") }}The **`EcKeyImportParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed as the `algorithm` parameter into {{domxref("SubtleCrypto.importKey()")}} or {{domxref("SubtleCrypto.unwrapKey()")}}, when generating any elliptic-curve-based key pair: that is, when the algorithm is identified as either of [ECDSA](/en-US/docs/Web/API/SubtleCrypto/sign#ecdsa) or [ECDH](/en-US/docs/Web/API/SubtleCrypto/deriveKey#ecdh).
 

--- a/files/en-us/web/api/hkdfparams/index.md
+++ b/files/en-us/web/api/hkdfparams/index.md
@@ -7,7 +7,7 @@ tags:
   - HkdfParams
   - Reference
   - Web Crypto API
-spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-HkdfParams
+spec-urls: https://w3c.github.io/webcrypto/#dfn-HkdfParams
 ---
 {{ APIRef("Web Crypto API") }}The **`HkdfParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) represents the object that should be passed as the `algorithm` parameter into {{domxref("SubtleCrypto.deriveKey()")}}, when using the [HKDF](/en-US/docs/Web/API/SubtleCrypto/deriveKey#hkdf) algorithm.
 

--- a/files/en-us/web/api/hmacimportparams/index.md
+++ b/files/en-us/web/api/hmacimportparams/index.md
@@ -7,7 +7,7 @@ tags:
   - HmacImportParams
   - Reference
   - Web Crypto API
-spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-HmacImportParams
+spec-urls: https://w3c.github.io/webcrypto/#dfn-HmacImportParams
 ---
 {{ APIRef("Web Crypto API") }}
 

--- a/files/en-us/web/api/hmackeygenparams/index.md
+++ b/files/en-us/web/api/hmackeygenparams/index.md
@@ -7,7 +7,7 @@ tags:
   - HmacKeyGenParams
   - Reference
   - Web Crypto API
-spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-HmacKeyGenParams
+spec-urls: https://w3c.github.io/webcrypto/#dfn-HmacKeyGenParams
 ---
 {{ APIRef("Web Crypto API") }}
 

--- a/files/en-us/web/api/pbkdf2params/index.md
+++ b/files/en-us/web/api/pbkdf2params/index.md
@@ -7,7 +7,7 @@ tags:
   - Pbkdf2Params
   - Reference
   - Web Crypto API
-spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-Pbkdf2Params
+spec-urls: https://w3c.github.io/webcrypto/#dfn-Pbkdf2Params
 ---
 {{ APIRef("Web Crypto API") }}
 

--- a/files/en-us/web/api/rsahashedimportparams/index.md
+++ b/files/en-us/web/api/rsahashedimportparams/index.md
@@ -7,7 +7,7 @@ tags:
   - Reference
   - RsaHashedImportParams
   - Web Crypto API
-spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-RsaHashedImportParams
+spec-urls: https://w3c.github.io/webcrypto/#dfn-RsaHashedImportParams
 ---
 {{ APIRef("Web Crypto API") }}
 

--- a/files/en-us/web/api/rsahashedkeygenparams/index.md
+++ b/files/en-us/web/api/rsahashedkeygenparams/index.md
@@ -7,7 +7,7 @@ tags:
   - Reference
   - RsaHashedKeyGenParams
   - Web Crypto API
-spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-RsaHashedKeyGenParams
+spec-urls: https://w3c.github.io/webcrypto/#dfn-RsaHashedKeyGenParams
 ---
 {{ APIRef("Web Crypto API") }}
 

--- a/files/en-us/web/api/rsaoaepparams/index.md
+++ b/files/en-us/web/api/rsaoaepparams/index.md
@@ -7,7 +7,7 @@ tags:
   - Reference
   - RsaOaepParams
   - Web Crypto API
-spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-RsaOaepParams
+spec-urls: https://w3c.github.io/webcrypto/#dfn-RsaOaepParams
 ---
 {{ APIRef("Web Crypto API") }}
 

--- a/files/en-us/web/api/rsapssparams/index.md
+++ b/files/en-us/web/api/rsapssparams/index.md
@@ -7,7 +7,7 @@ tags:
   - Reference
   - RsaPssParams
   - Web Crypto API
-spec-urls: https://www.w3.org/TR/WebCryptoAPI/#dfn-RsaPssParams
+spec-urls: https://w3c.github.io/webcrypto/#dfn-RsaPssParams
 ---
 {{ APIRef("Web Crypto API") }}
 


### PR DESCRIPTION
These should be using https://w3c.github.io/webcrypto URLs rather than https://www.w3.org/TR/WebCryptoAPI URLs.