### PR TITLE
Remove ChromeWorker from GroupData

### DIFF
--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -2018,7 +2018,6 @@
         "/docs/Web/API/Web_Workers_API/Structured_clone_algorithm"
       ],
       "interfaces": [
-        "ChromeWorker",
         "DedicatedWorkerGlobalScope",
         "ServiceWorker",
         "SharedWorker",


### PR DESCRIPTION
`ChromeWorker` was an old attempt, long forgotten. Let's remove it from the sidebar (red link anyway)