### PR TITLE
Add sentence about degenerate case

### DIFF
--- a/files/en-us/web/api/cleartimeout/index.md
+++ b/files/en-us/web/api/cleartimeout/index.md
@@ -14,6 +14,9 @@ browser-compat: api.clearTimeout
 The global **`clearTimeout()`** method cancels a timeout previously established
 by calling {{domxref("setTimeout()")}}.
 
+If the parameter provided does not identify a previously established action,
+this method does nothing.
+
 ## Syntax
 
 ```js
@@ -86,4 +89,3 @@ exception is thrown.
 - {{domxref("setInterval()")}}
 - {{domxref("clearInterval()")}}
 - {{domxref("Window.requestAnimationFrame()")}}
-- [_Daemons_ management](/en-US/docs/JavaScript/Timers/Daemons)


### PR DESCRIPTION
We recently explained this for `clearInterval()` in #15942.

This also makes sense in `clearTimeout()`. Let's add it.

I also removed a red link to an article deleted long ago.