### PR TITLE
Reflect spec update of HTMLCanvasElement.getContext()

### DIFF
--- a/files/en-us/web/api/htmlcanvaselement/getcontext/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/getcontext/index.md
@@ -77,16 +77,11 @@ getContext(contextType, contextAttributes)
     - **`desynchronized`**: Boolean that hints the user agent
       to reduce the latency by desynchronizing the canvas paint cycle from the event
       loop
-    - {{non-standard_inline}} (Gecko only)
-      **`willReadFrequently`**: Boolean that indicates whether
+    - **`willReadFrequently`**: Boolean that indicates whether
       or not a lot of read-back operations are planned. This will force the use of a
       software (instead of hardware accelerated) 2D canvas and can save memory when
       calling {{domxref("CanvasRenderingContext2D.getImageData", "getImageData()")}}
-      frequently. This option is only available, if the flag
-      `gfx.canvas.willReadFrequently.enable` is set to `true`
-      (which, by default, is only the case for B2G/Firefox OS).
-    - {{non-standard_inline}} (Blink only) **`storage`**:
-      String that indicates which storage is used ("persistent" by default).
+      frequently.
 
     WebGL context attributes:
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Removes `{{non-standard_inline}}` macro and Gecko-specific descriptions from `willReadFrequently`'s description.

#### Motivation
- `willReadFrequently` is no longer a Gecko-specific attribute.
- Also removes `storage`: Can't find anything about it from my search, and the result of `canvas.getContext('2d', { storage: 'persistent' }).getContextAttributes()` contains no `storage` key in Chrome (Blink).

#### Supporting details
https://github.com/whatwg/html/issues/5614
https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-will-read-frequently

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->