### PR TITLE
Update syntax sections of CustomElementRegistry methods

### DIFF
--- a/files/en-us/web/api/customelementregistry/define/index.md
+++ b/files/en-us/web/api/customelementregistry/define/index.md
@@ -26,6 +26,7 @@ There are two types of custom elements you can create:
 ## Syntax
 
 ```js
+define(name, constructor)
 define(name, constructor, options)
 ```
 
@@ -46,7 +47,7 @@ define(name, constructor, options)
 
 ### Return value
 
-Void.
+None ({{jsxref("undefined")}}).
 
 ### Exceptions
 

--- a/files/en-us/web/api/customelementregistry/get/index.md
+++ b/files/en-us/web/api/customelementregistry/get/index.md
@@ -31,7 +31,7 @@ get(name)
 
 ### Return value
 
-The constructor for the named custom element, or {{jsxref("undefined")}} if there is no custom element were defined with the name.
+The constructor for the named custom element, or {{jsxref("undefined")}} if there is no custom element defined with the name.
 
 ## Examples
 

--- a/files/en-us/web/api/customelementregistry/get/index.md
+++ b/files/en-us/web/api/customelementregistry/get/index.md
@@ -26,13 +26,12 @@ get(name)
 
 ### Parameters
 
-- name
-  - : The name of the custom element whose constructor you want to return a reference to.
+- `name`
+  - : The name of the custom element.
 
 ### Return value
 
-The constructor for the named custom element, or `undefined` if there is no
-custom element definition with that name.
+The constructor for the named custom element, or {{jsxref("undefined")}} if there is no custom element were defined with the name.
 
 ## Examples
 

--- a/files/en-us/web/api/customelementregistry/upgrade/index.md
+++ b/files/en-us/web/api/customelementregistry/upgrade/index.md
@@ -27,18 +27,16 @@ upgrade(root)
 ### Parameters
 
 - `root`
-  - : A {{domxref("Node")}} instance with shadow-containing descendant elements that are
-    to be upgraded. If there are no descendant elements that can be upgraded, no error is
+  - : A {{domxref("Node")}} instance with shadow-containing descendant elements to upgrade. If there are no descendant elements that can be upgraded, no error is
     thrown.
 
 ### Return value
 
-Void.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 
-Taken from the [HTML
-spec](https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-upgrade):
+Taken from the [HTML spec](https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-upgrade):
 
 ```js
 const el = document.createElement("spider-man");

--- a/files/en-us/web/api/customelementregistry/whendefined/index.md
+++ b/files/en-us/web/api/customelementregistry/whendefined/index.md
@@ -25,37 +25,14 @@ whenDefined(name)
 
 ### Parameters
 
-- name
-  - : Custom element name.
+- `name`
+  - : The name of the custom element.
 
 ### Return value
 
-A {{jsxref("Promise")}} that will be fulfilled with the [custom element](/en-US/docs/Web/API/Window/customElements)'s constructor when a [custom element](/en-US/docs/Web/API/Window/customElements) becomes defined with the
-given name. (If such a [custom element](/en-US/docs/Web/API/Window/customElements) is already defined, the
-returned promise will be immediately fulfilled.)
+A {{jsxref("Promise")}} that fulfills with the [custom element](/en-US/docs/Web/Web_Components/Using_custom_elements)'s constructor when a custom element becomes defined with the given name. If a custom element has already been defined with the name, the promise will immediately fulfill.
 
-### Exceptions
-
-<table class="no-markdown">
-  <thead>
-    <tr>
-      <th scope="col">Exception</th>
-      <th scope="col">Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>SyntaxError</code></td>
-      <td>
-        If the provided name is not a
-        <a
-          href="https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name"
-          >valid custom element name</a
-        >, the promise rejects with a <code>SyntaxError</code>.
-      </td>
-    </tr>
-  </tbody>
-</table>
+The promise is rejected with a `SyntaxError` {{domxref("DOMException")}} if the name is not a [valid custom element name]((https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name)).
 
 ## Examples
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Makes "Return value" sections follow the guideline.

#### Motivation
Used `None ({{jsxref("undefined")}}).` for void returning methods as specified in the guideline.

Also for the `whenDefined()`, removed its "Exceptions" section because the method itself won't throw. It's the promise that might reject.

#### Supporting details
https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-whendefined

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->