### PR TITLE
Remove the outdated comment about `:has`

### DIFF
--- a/files/en-us/web/css/_colon_has/index.md
+++ b/files/en-us/web/css/_colon_has/index.md
@@ -16,7 +16,6 @@ The **`:has()`** CSS [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represen
 
 ```css
 /* Selects any <a>, as long as it has an <img> element directly inside it  */
-/* Note that this is not supported in any browser yet */
 let test = document.querySelector('a:has(> img)');
 ```
 


### PR DESCRIPTION
#### Summary
Safari supports `:has` which I just tested it and other browsers will come soon most likely so let's remove this not needed comment.

#### Motivation
As the comment was a bit misleading to me given the support is also indicated in the same page for Safari 15.4 so to me it felt this is a `querySelector` specific behavior even in supported browser which wasn't, `querySelector` does support `:has` in a supported browser.

#### Supporting details
Table below https://developer.mozilla.org/en-US/docs/Web/CSS/:has

#### Related issues
Probably there isn't

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
