### PR TITLE
Fix issue 15872: remove live sample inclusions in CSS

### DIFF
--- a/files/en-us/web/css/@counter-style/negative/index.md
+++ b/files/en-us/web/css/@counter-style/negative/index.md
@@ -72,7 +72,7 @@ If the counter value is negative, the symbol provided as value for the descripto
 
 #### Result
 
-{{ EmbedLiveSample('Rendering_negative_counters', '', '', '', 'Web/CSS/@counter-style/negative') }}
+{{ EmbedLiveSample('Rendering negative counters') }}
 
 ## Specifications
 

--- a/files/en-us/web/css/@counter-style/pad/index.md
+++ b/files/en-us/web/css/@counter-style/pad/index.md
@@ -69,7 +69,7 @@ If a marker representation is smaller than the specified pad length, then the ma
 
 #### Result
 
-{{ EmbedLiveSample('Padding_a_counter', '', '', '', 'Web/CSS/@counter-style/pad') }}
+{{ EmbedLiveSample('Padding a counter') }}
 
 ## Specifications
 

--- a/files/en-us/web/css/_colon_-moz-list-bullet/index.md
+++ b/files/en-us/web/css/_colon_-moz-list-bullet/index.md
@@ -22,7 +22,9 @@ li::-moz-list-bullet
 
 ## Examples
 
-### HTML
+### Styling list item markers
+
+#### HTML
 
 ```html
 <ul>
@@ -32,7 +34,7 @@ li::-moz-list-bullet
 </ul>
 ```
 
-### CSS
+#### CSS
 
 ```css
 ::-moz-list-bullet {
@@ -41,9 +43,9 @@ li::-moz-list-bullet
 }
 ```
 
-### Result
+#### Result
 
-{{ EmbedLiveSample('Examples', '', '', '', 'Web/CSS/:-moz-list-bullet') }}
+{{ EmbedLiveSample('Styling list item markers') }}
 
 ## Specifications
 

--- a/files/en-us/web/css/box-orient/index.md
+++ b/files/en-us/web/css/box-orient/index.md
@@ -88,7 +88,7 @@ div.example {
 
 #### Result
 
-{{ EmbedLiveSample('Setting_horizontal_box_orientation', 600, 50, '', 'Web/CSS/box-orient') }}
+{{ EmbedLiveSample('Setting horizontal box orientation', '', 100) }}
 
 ## Specifications
 

--- a/files/en-us/web/css/css_positioning/understanding_z_index/stacking_context_example_1/index.md
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/stacking_context_example_1/index.md
@@ -112,7 +112,7 @@ In terms of stacking contexts, DIV #1 and DIV #3 are assimilated into the root e
 
 ### Result
 
-{{ EmbedLiveSample('Example', '', '', '', 'Web/CSS/CSS_Positioning/Understanding_z_index/Stacking_context_example_1') }}
+{{ EmbedLiveSample('Example', '', '300px') }}
 
 ## See also
 

--- a/files/en-us/web/css/css_positioning/understanding_z_index/stacking_context_example_1/index.md
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/stacking_context_example_1/index.md
@@ -100,7 +100,7 @@ In terms of stacking contexts, DIV #1 and DIV #3 are assimilated into the root e
     z-index: 2;
     position: absolute;
     width: 200px;
-    height: 70px;
+    height: 80px;
     top: 65px;
     left: 50px;
     border: 1px dashed #000099;

--- a/files/en-us/web/css/css_positioning/understanding_z_index/stacking_context_example_1/index.md
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/stacking_context_example_1/index.md
@@ -112,7 +112,7 @@ In terms of stacking contexts, DIV #1 and DIV #3 are assimilated into the root e
 
 ### Result
 
-{{ EmbedLiveSample('Example', '', '300px') }}
+{{ EmbedLiveSample('Example', '', '300') }}
 
 ## See also
 

--- a/files/en-us/web/css/flex-grow/index.md
+++ b/files/en-us/web/css/flex-grow/index.md
@@ -99,7 +99,7 @@ The remaining space is the size of the flex container minus the size of all flex
 
 #### Result
 
-{{EmbedLiveSample('Setting_flex_item_grow_factor', '700px', '300px', '', 'Web/CSS/flex-grow')}}
+{{EmbedLiveSample('Setting flex item grow factor')}}
 
 ## Specifications
 

--- a/files/en-us/web/css/flex-wrap/index.md
+++ b/files/en-us/web/css/flex-wrap/index.md
@@ -127,7 +127,7 @@ The following values are accepted:
 
 #### Results
 
-{{ EmbedLiveSample('Setting flex container wrap values', '', '700px') }}
+{{ EmbedLiveSample('Setting flex container wrap values', '', '700') }}
 
 ## Specifications
 

--- a/files/en-us/web/css/flex-wrap/index.md
+++ b/files/en-us/web/css/flex-wrap/index.md
@@ -127,7 +127,7 @@ The following values are accepted:
 
 #### Results
 
-{{ EmbedLiveSample('Setting_flex_container_wrap_values', '700px', '700px', '', 'Web/CSS/flex-wrap') }}
+{{ EmbedLiveSample('Setting flex container wrap values', '', '700px') }}
 
 ## Specifications
 

--- a/files/en-us/web/css/font-language-override/index.md
+++ b/files/en-us/web/css/font-language-override/index.md
@@ -79,7 +79,7 @@ p.para2 {
 
 #### Result
 
-{{ EmbedLiveSample('Using_Danish_glyphs', '600', '', '', 'Web/CSS/font-language-override') }}
+{{ EmbedLiveSample('Using Danish glyphs') }}
 
 ## Specifications
 

--- a/files/en-us/web/css/font-variant-alternates/index.md
+++ b/files/en-us/web/css/font-variant-alternates/index.md
@@ -77,14 +77,16 @@ This property may take one of two forms:
 
 ## Examples
 
-### HTML
+### Enabling swash gyphs
+
+#### HTML
 
 ```html
 <p>Firefox rocks!</p>
 <p class="variant">Firefox rocks!</p>
 ```
 
-### CSS
+#### CSS
 
 ```css
 @font-feature-values "Leitura Display Swashes" {
@@ -101,11 +103,11 @@ p {
 }
 ```
 
-### Result
+#### Result
 
 > **Note:** You need to install the OpenType font _Leitura Display Swashes_ for this example to work. You can find a few free versions for testing purposes, for example from [fontsgeek.com](https://fontsgeek.com/fonts/Leitura-Display-Swashes).
 
-{{ EmbedLiveSample('Examples', '', '', '', 'Web/CSS/font-variant-alternates') }}
+{{ EmbedLiveSample('Enabling swash gyphs') }}
 
 ## Specifications
 

--- a/files/en-us/web/css/font-variant-ligatures/index.md
+++ b/files/en-us/web/css/font-variant-ligatures/index.md
@@ -189,7 +189,7 @@ p {
 
 #### Result
 
-{{ EmbedLiveSample('Setting_font_ligatures_and_contextual_forms', '', '700', '', 'Web/CSS/font-variant-ligatures') }}
+{{ EmbedLiveSample('Setting font ligatures and contextual forms', '', '700') }}
 
 ## Specifications
 

--- a/files/en-us/web/css/font-variant/index.md
+++ b/files/en-us/web/css/font-variant/index.md
@@ -90,7 +90,7 @@ p.small {
 
 #### Result
 
-{{ EmbedLiveSample('Setting_the_small-caps_font_variant', '', '', '', 'Web/CSS/font-variant') }}
+{{ EmbedLiveSample('Setting the small-caps font variant') }}
 
 ## Specifications
 


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/15872 : this removes the transclusion parameter from all `EmbedLiveSample` calls in the CSS docs.