### PR TITLE
DOMString -> string

### DIFF
--- a/files/en-us/web/api/rtcstats/index.md
+++ b/files/en-us/web/api/rtcstats/index.md
@@ -22,11 +22,11 @@ Specific classes of statistic are defined as dictionaries based on `RTCStats`. F
 ## Properties
 
 - {{domxref("RTCStats.id", "id")}}
-  - : A {{domxref("DOMString")}} which uniquely identifies the object which was inspected to produce this object based on `RTCStats`.
+  - : A string which uniquely identifies the object which was inspected to produce this object based on `RTCStats`.
 - {{domxref("RTCStats.timestamp", "timestamp")}}
   - : A {{domxref("DOMHighResTimeStamp")}} object indicating the time at which the sample was taken for this statistics object.
 - {{domxref("RTCStats.type", "type")}}
-  - : A {{domxref("DOMString")}} indicating the type of statistics the object contains, taken from the enum type {{domxref("RTCStatsType")}}.
+  - : A string indicating the type of statistics the object contains, taken from the enum type {{domxref("RTCStatsType")}}.
 
 ## The statistics type hierarchy
 

--- a/files/en-us/web/api/rtcstats/type/index.md
+++ b/files/en-us/web/api/rtcstats/type/index.md
@@ -26,7 +26,7 @@ The string can be used to determine which of the
 
 ## Value
 
-A {{domxref("DOMString")}} which specifies which type of statistic is represented by
+A string which specifies which type of statistic is represented by
 the object. The string comes from the {{domxref("RTCStatsType")}} enum and corresponds to
 one of the {{domxref("RTCStats")}}-based statistic object types.
 

--- a/files/en-us/web/api/screen/orientation/index.md
+++ b/files/en-us/web/api/screen/orientation/index.md
@@ -21,7 +21,7 @@ The **`orientation`** read-only property of the
 An instance of {{DOMxRef("ScreenOrientation")}} representing the orientation of the
 screen.
 
-Note that older, prefixed versions returned a {{DOMxRef("DOMString")}} equivalent to
+Note that older, prefixed versions returned a string equivalent to
 {{DOMxRef("ScreenOrientation.type")}}.
 
 ## Examples

--- a/files/en-us/web/api/selection/index.md
+++ b/files/en-us/web/api/selection/index.md
@@ -31,7 +31,7 @@ A user may make a selection from left to right (in document order) or right to l
 - {{DOMxRef("Selection.rangeCount")}}{{ReadOnlyInline}}
   - : Returns the number of ranges in the selection.
 - {{DOMxRef("Selection.type")}}{{ReadOnlyInline}}
-  - : Returns a {{DOMxRef("DOMString")}} describing the type of the current selection.
+  - : Returns a string describing the type of the current selection.
 
 ## Methods
 

--- a/files/en-us/web/api/selection/type/index.md
+++ b/files/en-us/web/api/selection/type/index.md
@@ -12,12 +12,12 @@ browser-compat: api.Selection.type
 {{APIRef("DOM")}}
 
 The **`type`** read-only property of the
-{{domxref("Selection")}} interface returns a {{domxref("DOMString")}} describing the
+{{domxref("Selection")}} interface returns a string describing the
 type of the current selection.
 
 ## Value
 
-A {{domxref("DOMString")}} describing the type of the current selection. Possible
+A string describing the type of the current selection. Possible
 values are:
 
 - `None`: No selection has currently been made.

--- a/files/en-us/web/api/serviceworker/scripturl/index.md
+++ b/files/en-us/web/api/serviceworker/scripturl/index.md
@@ -18,8 +18,7 @@ Must be on the same origin as the document that registers the
 
 ## Value
 
-A {{domxref("USVString")}} (see the [WebIDL definition of
-USVString](https://heycam.github.io/webidl/#idl-USVString).)
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/serviceworkercontainer/message_event/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/message_event/index.md
@@ -37,9 +37,9 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.data")}} {{readonlyInline}}
   - : The data sent by the message emitter.
 - {{domxref("MessageEvent.origin")}} {{readonlyInline}}
-  - : A {{domxref("USVString")}} representing the origin of the message emitter.
+  - : A string representing the origin of the message emitter.
 - {{domxref("MessageEvent.lastEventId")}} {{readonlyInline}}
-  - : A {{domxref("DOMString")}} representing a unique ID for the event.
+  - : A string representing a unique ID for the event.
 - {{domxref("MessageEvent.source")}} {{readonlyInline}}
   - : A `MessageEventSource` (which can be a {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
 - {{domxref("MessageEvent.ports")}} {{readonlyInline}}

--- a/files/en-us/web/api/shadowroot/innerhtml/index.md
+++ b/files/en-us/web/api/shadowroot/innerhtml/index.md
@@ -18,7 +18,7 @@ interface sets or returns a reference to the DOM tree inside the
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/sharedworkerglobalscope/connect_event/index.md
+++ b/files/en-us/web/api/sharedworkerglobalscope/connect_event/index.md
@@ -39,9 +39,9 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.data")}} {{readonlyInline}}
   - : The data sent by the message emitter.
 - {{domxref("MessageEvent.origin")}} {{readonlyInline}}
-  - : A {{domxref("USVString")}} representing the origin of the message emitter.
+  - : A string representing the origin of the message emitter.
 - {{domxref("MessageEvent.lastEventId")}} {{readonlyInline}}
-  - : A {{domxref("DOMString")}} representing a unique ID for the event.
+  - : A string representing a unique ID for the event.
 - {{domxref("MessageEvent.source")}} {{readonlyInline}}
   - : A `MessageEventSource` (which can be a {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
 - {{domxref("MessageEvent.ports")}} {{readonlyInline}}

--- a/files/en-us/web/api/sharedworkerglobalscope/name/index.md
+++ b/files/en-us/web/api/sharedworkerglobalscope/name/index.md
@@ -20,7 +20,7 @@ to get a reference to the {{domxref("SharedWorkerGlobalScope")}}.
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/sourcebuffer/mode/index.md
+++ b/files/en-us/web/api/sourcebuffer/mode/index.md
@@ -46,7 +46,7 @@ processing either an {{domxref("SourceBuffer.appendBuffer","appendBuffer()")}} o
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ### Exceptions
 

--- a/files/en-us/web/api/speechgrammar/src/index.md
+++ b/files/en-us/web/api/speechgrammar/src/index.md
@@ -21,7 +21,7 @@ interface sets and returns a string containing the grammar from within in the
 
 ## Value
 
-A {{domxref("DOMString")}} representing the grammar.
+A string representing the grammar.
 
 ## Examples
 

--- a/files/en-us/web/api/speechgrammarlist/index.md
+++ b/files/en-us/web/api/speechgrammarlist/index.md
@@ -35,7 +35,7 @@ Grammar is defined using [JSpeech Grammar Format](https://www.w3.org/TR/jsgf/) (
 - {{domxref("SpeechGrammarList.addFromURI()")}}
   - : Takes a grammar present at a specific URI and adds it to the `SpeechGrammarList` as a new {{domxref("SpeechGrammar")}} object.
 - {{domxref("SpeechGrammarList.addFromString()")}}
-  - : Takes a grammar present in a specific {{domxref("DOMString")}} within the code base (e.g. stored in a variable) and adds it to the `SpeechGrammarList` as a new {{domxref("SpeechGrammar")}} object.
+  - : Adds a grammar in a string to the `SpeechGrammarList` as a new {{domxref("SpeechGrammar")}} object.
 
 ## Examples
 

--- a/files/en-us/web/api/speechrecognition/lang/index.md
+++ b/files/en-us/web/api/speechrecognition/lang/index.md
@@ -20,7 +20,7 @@ value, or the user agent's language setting if that isn't set either.
 
 ## Value
 
-A {{domxref("DOMString")}} representing the BCP 47 language tag for the current `SpeechRecognition`.
+A string representing the BCP 47 language tag for the current `SpeechRecognition`.
 
 ## Examples
 

--- a/files/en-us/web/api/speechrecognitionerror/error/index.md
+++ b/files/en-us/web/api/speechrecognitionerror/error/index.md
@@ -23,7 +23,7 @@ The **`error`** read-only property of the
 
 ## Value
 
-A {{domxref("DOMString")}} naming the type of error. The possible error types are:
+A string naming the type of error. The possible error types are:
 
 - no-speech
   - : No speech was detected.

--- a/files/en-us/web/api/speechrecognitionerror/message/index.md
+++ b/files/en-us/web/api/speechrecognitionerror/message/index.md
@@ -24,7 +24,7 @@ in more detail.
 
 ## Value
 
-A {{domxref("DOMString")}} containing more details about the error that was raised.
+A string containing more details about the error that was raised.
 Note that the spec does not define the exact wording of these messages — this is up to
 the implementors to decide upon.
 

--- a/files/en-us/web/api/speechrecognitionerrorevent/error/index.md
+++ b/files/en-us/web/api/speechrecognitionerrorevent/error/index.md
@@ -20,7 +20,7 @@ The **`error`** read-only property of the
 
 ## Value
 
-A {{domxref("DOMString")}} naming the type of error. The possible error types are:
+A string naming the type of error. The possible error types are:
 
 - no-speech
   - : No speech was detected.

--- a/files/en-us/web/api/speechrecognitionerrorevent/message/index.md
+++ b/files/en-us/web/api/speechrecognitionerrorevent/message/index.md
@@ -21,7 +21,7 @@ error in more detail.
 
 ## Value
 
-A {{domxref("DOMString")}} containing more details about the error that was raised.
+A string containing more details about the error that was raised.
 Note that the spec does not define the exact wording of these messages — this is up to
 the implementors to decide upon.
 

--- a/files/en-us/web/api/speechsynthesiserrorevent/error/index.md
+++ b/files/en-us/web/api/speechsynthesiserrorevent/error/index.md
@@ -19,7 +19,7 @@ The **`error`** property of the
 
 ## Value
 
-A {{domxref("DOMString")}} containing an error code. Possible codes are:
+A string containing an error code. Possible codes are:
 
 - `canceled`
   - : A {{domxref("SpeechSynthesis.cancel")}} method call caused the

--- a/files/en-us/web/api/speechsynthesisevent/name/index.md
+++ b/files/en-us/web/api/speechsynthesisevent/name/index.md
@@ -19,7 +19,7 @@ the name of the [SSML](https://www.w3.org/TR/speech-synthesis/#S3.3.2) marker re
 
 ## Value
 
-A {{domxref("DOMString")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/speechsynthesisutterance/lang/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/lang/index.md
@@ -20,7 +20,7 @@ If unset, the app's (i.e. the {{htmlelement("html")}} {{htmlattrxref("lang", "ht
 
 ## Value
 
-A {{domxref("DOMString")}} representing a BCP 47 language tag.
+A string representing a BCP 47 language tag.
 
 ## Examples
 

--- a/files/en-us/web/api/speechsynthesisutterance/speechsynthesisutterance/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/speechsynthesisutterance/index.md
@@ -24,7 +24,7 @@ new SpeechSynthesisUtterance(text)
 ### Parameters
 
 - `text`
-  - : A {{domxref("DOMString")}} containing the text that will be synthesized when the utterance is spoken.
+  - : A string containing the text that will be synthesized when the utterance is spoken.
 
 ## Examples
 

--- a/files/en-us/web/api/speechsynthesisutterance/text/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/text/index.md
@@ -22,7 +22,7 @@ The SSML tags will be stripped away by devices that don't support SSML.
 
 ## Value
 
-A {{domxref("DOMString")}} representing the text to the synthesized.
+A string representing the text to the synthesized.
 The maximum length of the text that can be spoken in each utterance is 32,767 characters.
 
 ## Examples

--- a/files/en-us/web/api/speechsynthesisvoice/lang/index.md
+++ b/files/en-us/web/api/speechsynthesisvoice/lang/index.md
@@ -18,7 +18,7 @@ The **`lang`** read-only property of the {{domxref("SpeechSynthesisVoice")}} int
 
 ## Value
 
-A {{domxref("DOMString")}} representing the language of the device.
+A string representing the language of the device.
 
 ## Examples
 

--- a/files/en-us/web/api/speechsynthesisvoice/name/index.md
+++ b/files/en-us/web/api/speechsynthesisvoice/name/index.md
@@ -20,7 +20,7 @@ represents the voice.
 
 ## Value
 
-A {{domxref("DOMString")}} representing the name of the voice.
+A string representing the name of the voice.
 
 ## Examples
 

--- a/files/en-us/web/api/speechsynthesisvoice/voiceuri/index.md
+++ b/files/en-us/web/api/speechsynthesisvoice/voiceuri/index.md
@@ -20,7 +20,7 @@ the speech synthesis service for this voice.
 
 ## Value
 
-A {{domxref("DOMString")}} representing the URI of the voice. This is a generic URI and
+A string representing the URI of the voice. This is a generic URI and
 can point to local or remote services, e.g. it could be a proprietary system URN or a URL to a remote service.
 
 ## Examples

--- a/files/en-us/web/api/storageevent/index.md
+++ b/files/en-us/web/api/storageevent/index.md
@@ -27,22 +27,22 @@ when a storage area the window has access to is changed within the context of an
 _In addition to the properties listed below, this interface inherits the properties of its parent interface, {{domxref("Event")}}._
 
 - {{domxref("StorageEvent.key", "key")}} {{ReadOnlyInline}}
-  - : Returns a {{DOMxRef("DOMString")}} that represents the key changed.
+  - : Returns a string that represents the key changed.
     The `key` attribute is {{jsxref("null")}}
     when the change is caused by the storage `clear()` method.
 - {{domxref("StorageEvent.newValue", "newValue")}} {{ReadOnlyInline}}
-  - : Returns a {{DOMxRef("DOMString")}} with the new value of the `key`.
+  - : Returns a string with the new value of the `key`.
     This value is `null`
     when the change has been invoked by storage `clear()` method,
     or the `key` has been removed from the storage.
 - {{domxref("StorageEvent.oldValue", "oldValue")}} {{ReadOnlyInline}}
-  - : Returns a {{DOMxRef("DOMString")}} with the original value of the `key`.
+  - : Returns a string with the original value of the `key`.
     This value is `null` when the `key` has been newly added
     and therefore doesn't have any previous value.
 - {{domxref("StorageEvent.storageArea", "storageArea")}} {{ReadOnlyInline}}
   - : Returns a {{DOMxRef("Storage")}} object that represents the storage that was affected.
 - {{domxref("StorageEvent.url", "url")}} {{ReadOnlyInline}}
-  - : Returns {{DOMxRef("DOMString")}} with the URL of the document whose `key` changed.
+  - : Returns string with the URL of the document whose `key` changed.
 
 ## Methods
 

--- a/files/en-us/web/api/stylesheet/index.md
+++ b/files/en-us/web/api/stylesheet/index.md
@@ -20,7 +20,7 @@ An object implementing the `StyleSheet` interface represents a single style shee
 - {{domxref("StyleSheet.disabled")}}
   - : A boolean value representing whether the current stylesheet has been applied or not.
 - {{domxref("StyleSheet.href")}} {{readonlyInline}}
-  - : Returns a {{domxref("DOMString")}} representing the location of the stylesheet.
+  - : Returns a string representing the location of the stylesheet.
 - {{domxref("StyleSheet.media")}} {{readonlyInline}}
   - : Returns a {{domxref("MediaList")}} representing the intended destination medium for style information.
 - {{domxref("StyleSheet.ownerNode")}} {{readonlyInline}}
@@ -28,9 +28,9 @@ An object implementing the `StyleSheet` interface represents a single style shee
 - {{domxref("StyleSheet.parentStyleSheet")}} {{readonlyInline}}
   - : Returns a {{domxref("StyleSheet")}} including this one, if any; returns `null` if there aren't any.
 - {{domxref("StyleSheet.title")}} {{readonlyInline}}
-  - : Returns a {{domxref("DOMString")}} representing the advisory title of the current style sheet.
+  - : Returns a string representing the advisory title of the current style sheet.
 - {{domxref("StyleSheet.type")}}{{readonlyInline}}
-  - : Returns a {{domxref("DOMString")}} representing the style sheet language for this style sheet.
+  - : Returns a string representing the style sheet language for this style sheet.
 
 ## Specifications
 

--- a/files/en-us/web/api/svgaltglyphelement/format/index.md
+++ b/files/en-us/web/api/svgaltglyphelement/format/index.md
@@ -8,7 +8,7 @@ browser-compat: api.SVGAltGlyphElement.format
 {{Deprecated_header}}
 
 The **`SVGAltGlyphElement.format`** property is a
-{{domxref("DOMString")}} that defines the format of the given font. It has the same
+string that defines the format of the given font. It has the same
 meaning as the 'format' property of {{domxref("SVGGlyphRefElement")}} property. If the
 font is in one of the formats listed in [CSS2(\[CSS2\],
 section15.3.5)](https://www.w3.org/TR/2008/REC-CSS2-20080411/fonts.html#referencing), then its value is the corresponding \<string> parameter

--- a/files/en-us/web/api/svgaltglyphelement/glyphref/index.md
+++ b/files/en-us/web/api/svgaltglyphelement/glyphref/index.md
@@ -16,7 +16,7 @@ browser-compat: api.SVGAltGlyphElement.glyphRef
 {{Deprecated_header}}
 
 The **`SVGAltGlyphElement.glyphRef`** property is a
-{{domxref("DOMString")}} representing a glyph identifier. It has the same meaning as the
+string representing a glyph identifier. It has the same meaning as the
 'glyphRef' property on the {{domxref("SVGGlyphRefElement")}} interface of the
 {{SVGElement("glyphRef")}} element.
 

--- a/files/en-us/web/api/svgangle/index.md
+++ b/files/en-us/web/api/svgangle/index.md
@@ -52,7 +52,7 @@ Every `SVGAngle` object operates in one of two modes:
 
 - `valueAsString`
 
-  - : The value as a {{domxref("DOMString")}} value, in the units expressed by `unitType`. Setting this attribute will cause `value`, `valueInSpecifiedUnits`, and `unitType` to be updated automatically to reflect this setting.
+  - : The value as a string value, in the units expressed by `unitType`. Setting this attribute will cause `value`, `valueInSpecifiedUnits`, and `unitType` to be updated automatically to reflect this setting.
 
     **Exceptions on setting:**
 

--- a/files/en-us/web/api/svganimatedstring/index.md
+++ b/files/en-us/web/api/svganimatedstring/index.md
@@ -16,9 +16,9 @@ The **`SVGAnimatedString`** interface represents string attributes which can be 
 ## Properties
 
 - {{domxref("SVGAnimatedString.animVal")}} {{readonlyInline}}
-  - : This is a {{domxref("DOMString")}} representing the animation value. If the given attribute or property is being animated it contains the current animated value of the attribute or property. If the given attribute or property is not currently being animated, it contains the same value as baseVal.
+  - : This is a string representing the animation value. If the given attribute or property is being animated it contains the current animated value of the attribute or property. If the given attribute or property is not currently being animated, it contains the same value as baseVal.
 - {{domxref("SVGAnimatedString.baseVal")}}
-  - : This is a {{domxref("DOMString")}} representing the base value. The base value of the given attribute before applying any animations. Setter throws DOMException.
+  - : This is a string representing the base value. The base value of the given attribute before applying any animations. Setter throws DOMException.
 
 ## Methods
 

--- a/files/en-us/web/api/svgevent/index.md
+++ b/files/en-us/web/api/svgevent/index.md
@@ -16,6 +16,6 @@ The {{domxref("SVGEvent")}} interface represents the event object for most SVG-r
 | Property                              | Type                                 | Description                                            |
 | ------------------------------------- | ------------------------------------ | ------------------------------------------------------ |
 | `target` {{readonlyInline}}     | {{domxref("EventTarget")}} | The event target (the topmost target in the DOM tree). |
-| `type` {{readonlyInline}}       | {{domxref("DOMString")}}     | The type of event.                                     |
+| `type` {{readonlyInline}}       | string     | The type of event.                                     |
 | `bubbles` {{readonlyInline}}    | A boolean value                      | Whether the event normally bubbles or not.             |
 | `cancelable` {{readonlyInline}} | A boolean value                      | Whether the event is cancellable or not.               |

--- a/files/en-us/web/api/svgglyphrefelement/index.md
+++ b/files/en-us/web/api/svgglyphrefelement/index.md
@@ -20,9 +20,9 @@ The **`SVGGlyphRefElement`** interface corresponds to the {{SVGElement("glyphRef
 _This interface also inherits properties from its parent, {{domxref("SVGElement")}}._
 
 - {{domxref("SVGGlyphRefElement.glyphRef")}}
-  - : A {{domxref("DOMString")}} corresponding to the {{SVGAttr("glyphRef")}} attribute of the given element.
+  - : A string corresponding to the {{SVGAttr("glyphRef")}} attribute of the given element.
 - {{domxref("SVGGlyphRefElement.format")}}
-  - : A {{domxref("DOMString")}} corresponding to the {{SVGAttr("format")}} attribute of the given element.
+  - : A string corresponding to the {{SVGAttr("format")}} attribute of the given element.
 - {{domxref("SVGGlyphRefElement.x")}}
   - : A float corresponding to the {{SVGAttr("x")}} attribute of the given element.
 - {{domxref("SVGGlyphRefElement.y")}}

--- a/files/en-us/web/api/svgimageelement/decoding/index.md
+++ b/files/en-us/web/api/svgimageelement/decoding/index.md
@@ -20,7 +20,7 @@ it should decode the image.
 
 ## Value
 
-A {{domxref("DOMString")}} representing the decoding hint. Possible values are:
+A string representing the decoding hint. Possible values are:
 
 - **`sync`**: Decode the image synchronously for atomic
   presentation with other content.

--- a/files/en-us/web/api/svgimageelement/index.md
+++ b/files/en-us/web/api/svgimageelement/index.md
@@ -25,9 +25,9 @@ _This interface also inherits properties from its parent, {{domxref("SVGGraphics
 - {{domxref("SVGImageElement.href")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedString")}} corresponding to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} attribute of the given {{SVGElement("image")}} element.
 - {{domxref("SVGImageElement.crossOrigin")}}
-  - : A {{domxref("DOMString")}} corresponding to the {{SVGAttr("crossorigin")}} attribute of the given {{SVGElement("image")}} element.
+  - : A string corresponding to the {{SVGAttr("crossorigin")}} attribute of the given {{SVGElement("image")}} element.
 - {{domxref("SVGImageElement.decoding")}}
-  - : A {{domxref("DOMString")}} representing a hint given to the browser on how it should decode the image.
+  - : A string representing a hint given to the browser on how it should decode the image.
 - {{domxref("SVGImageElement.height")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedLength")}} corresponding to the {{SVGAttr("height")}} attribute of the given {{SVGElement("image")}} element.
 - {{domxref("SVGImageElement.preserveAspectRatio")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/svgscriptelement/index.md
+++ b/files/en-us/web/api/svgscriptelement/index.md
@@ -20,9 +20,9 @@ The **`SVGScriptElement`** interface corresponds to the SVG {{SVGElement("script
 - {{domxref("SVGScriptElement.href")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedString")}} corresponding to the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} attribute of the given {{SVGElement("script")}} element.
 - {{domxref("SVGScriptElement.type")}} {{ReadOnlyInline}}
-  - : A {{domxref("DOMString")}} corresponding to the {{SVGAttr("type")}} attribute of the given {{SVGElement("script")}} element. A {{domxref("DOMException")}} is raised with the code `NO_MODIFICATION_ALLOWED_ERR` on an attempt to change the value of a read only attribute.
+  - : A string corresponding to the {{SVGAttr("type")}} attribute of the given {{SVGElement("script")}} element. A {{domxref("DOMException")}} is raised with the code `NO_MODIFICATION_ALLOWED_ERR` on an attempt to change the value of a read only attribute.
 - {{domxref("SVGScriptElement.crossOrigin")}} {{ReadOnlyInline}}
-  - : A {{domxref("DOMString")}} corresponding to the {{SVGAttr("crossorigin")}} attribute of the given {{SVGElement("script")}} element.
+  - : A string corresponding to the {{SVGAttr("crossorigin")}} attribute of the given {{SVGElement("script")}} element.
 
 ## Methods
 

--- a/files/en-us/web/api/svgstyleelement/index.md
+++ b/files/en-us/web/api/svgstyleelement/index.md
@@ -23,19 +23,19 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 
 - {{domxref("SVGStyleElement.type")}}
 
-  - : A {{domxref("DOMString")}} corresponding to the {{SVGAttr("type")}} attribute of the given element.
+  - : A string corresponding to the {{SVGAttr("type")}} attribute of the given element.
 
     SVG 1.1 defined that a {{domxref("DOMException")}} is raised with code `NO_MODIFICATION_ALLOWED_ERR` on an attempt to change the value of a read-only attribute. This restriction was removed in SVG 2.
 
 - {{domxref("SVGStyleElement.media")}}
 
-  - : A {{domxref("DOMString")}} corresponding to the {{SVGAttr("media")}} attribute of the given element.
+  - : A string corresponding to the {{SVGAttr("media")}} attribute of the given element.
 
     SVG 1.1 defined that a {{domxref("DOMException")}} is raised with code `NO_MODIFICATION_ALLOWED_ERR` on an attempt to change the value of a read-only attribute. This restriction was removed in SVG 2.
 
 - {{domxref("SVGStyleElement.title")}}
 
-  - : A {{domxref("DOMString")}} corresponding to the {{SVGAttr("title")}} attribute of the given element.
+  - : A string corresponding to the {{SVGAttr("title")}} attribute of the given element.
 
     SVG 1.1 defined that a {{domxref("DOMException")}} is raised with code `NO_MODIFICATION_ALLOWED_ERR` on an attempt to change the value of a read-only attribute. This restriction was removed in SVG 2.
 

--- a/files/en-us/web/api/svgviewelement/index.md
+++ b/files/en-us/web/api/svgviewelement/index.md
@@ -20,7 +20,7 @@ The **`SVGViewElement`** interface provides access to the properties of {{SVGEle
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
 - {{domxref("SVGViewElement.viewTarget")}} {{deprecated_inline}}
-  - : An {{domxref("SVGStringList")}} corresponding to the {{SVGAttr("viewTarget")}} attribute of the given {{SVGElement("view")}} element. A list of {{domxref("DOMString")}} values which contain the names listed in the {{SVGAttr("viewTarget")}} attribute. Each of the `DOMString` values can be associated with the corresponding element using the {{domxref("Document.getElementById()", "getElementById()")}} method call.
+  - : An {{domxref("SVGStringList")}} corresponding to the {{SVGAttr("viewTarget")}} attribute of the given {{SVGElement("view")}} element. A list of string values which contain the names listed in the {{SVGAttr("viewTarget")}} attribute. Each of the `DOMString` values can be associated with the corresponding element using the {{domxref("Document.getElementById()", "getElementById()")}} method call.
 
 ## Methods
 

--- a/files/en-us/web/api/taskattributiontiming/containerid/index.md
+++ b/files/en-us/web/api/taskattributiontiming/containerid/index.md
@@ -19,7 +19,7 @@ the whole, for a long task.
 
 ## Value
 
-A {{domxref("DOMString")}} containing the containers `id` attribute.
+A string containing the containers `id` attribute.
 
 ## Specifications
 

--- a/files/en-us/web/api/taskattributiontiming/containername/index.md
+++ b/files/en-us/web/api/taskattributiontiming/containername/index.md
@@ -19,7 +19,7 @@ the whole, for a long task.
 
 ## Value
 
-A {{domxref("DOMString")}} containing the container's `name` attribute.
+A string containing the container's `name` attribute.
 
 ## Specifications
 

--- a/files/en-us/web/api/taskattributiontiming/containersrc/index.md
+++ b/files/en-us/web/api/taskattributiontiming/containersrc/index.md
@@ -19,7 +19,7 @@ the whole, for a long task.
 
 ## Value
 
-A {{domxref("DOMString")}} containing the container's `src` attribute.
+A string containing the container's `src` attribute.
 
 ## Specifications
 

--- a/files/en-us/web/api/taskattributiontiming/containertype/index.md
+++ b/files/en-us/web/api/taskattributiontiming/containertype/index.md
@@ -18,7 +18,7 @@ of `iframe`, `embed`, or `object`.
 
 ## Value
 
-A {{domxref("DOMString")}} containing the container's type, one of `iframe`,
+A string containing the container's type, one of `iframe`,
 `embed`, or `object`.
 
 ## Specifications

--- a/files/en-us/web/api/text/index.md
+++ b/files/en-us/web/api/text/index.md
@@ -40,7 +40,7 @@ _Inherits properties from its parents, {{domxref("CharacterData")}}, {{domxref("
 - {{domxref("Text.assignedSlot")}} {{readonlyInline}}
   - : Returns a {{domxref("HTMLSlotElement")}} representing the {{htmlelement("slot")}} the node is inserted in.
 - {{domxref("Text.wholeText")}} {{readonlyInline}}
-  - : Returns a {{domxref("DOMString")}} containing the text of all `Text` nodes logically adjacent to this {{domxref("Node")}}, concatenated in document order.
+  - : Returns a string containing the text of all `Text` nodes logically adjacent to this {{domxref("Node")}}, concatenated in document order.
 
 ## Methods
 

--- a/files/en-us/web/api/textdecoder/encoding/index.md
+++ b/files/en-us/web/api/textdecoder/encoding/index.md
@@ -13,7 +13,7 @@ browser-compat: api.TextDecoder.encoding
 {{APIRef("Encoding API")}}{{SeeCompatTable}}
 
 The **`TextDecoder.encoding`** read-only property
-returns a {{DOMxRef("DOMString")}} containing the name of the decoding algorithm used by
+returns a string containing the name of the decoding algorithm used by
 the specific decoder.
 
 It can be one of the following values:

--- a/files/en-us/web/api/textdecoder/index.md
+++ b/files/en-us/web/api/textdecoder/index.md
@@ -59,7 +59,7 @@ console.log(win1251decoder.decode(bytes)); // Привет, мир!
 _The `TextDecoder` interface doesn't inherit any properties._
 
 - {{DOMxRef("TextDecoder.encoding")}}{{ReadOnlyInline}}
-  - : A {{DOMxRef("DOMString")}} containing the name of the decoder, that is a string describing the method the `TextDecoder` will use.
+  - : A string containing the name of the decoder, that is a string describing the method the `TextDecoder` will use.
 - {{DOMxRef("TextDecoder.fatal")}}{{ReadOnlyInline}}
   - : A {{jsxref('Boolean')}} indicating whether the error mode is fatal.
 - {{DOMxRef("TextDecoder.ignoreBOM")}}{{ReadOnlyInline}}
@@ -70,7 +70,7 @@ _The `TextDecoder` interface doesn't inherit any properties._
 _The `TextDecoder` interface doesn't inherit any method_.
 
 - {{DOMxRef("TextDecoder.decode()")}}
-  - : Returns a {{DOMxRef("DOMString")}} containing the text decoded with the method of the specific `TextDecoder` object.
+  - : Returns a string containing the text decoded with the method of the specific `TextDecoder` object.
 
 ## Specifications
 

--- a/files/en-us/web/api/textdecoderstream/encoding/index.md
+++ b/files/en-us/web/api/textdecoderstream/encoding/index.md
@@ -11,11 +11,11 @@ browser-compat: api.TextDecoderStream.encoding
 ---
 {{APIRef("Encoding API")}}
 
-The **`encoding`** read-only property of the {{domxref("TextDecoderStream")}} interface returns a {{DOMxRef("DOMString")}} containing the name of the encoding algorithm used by the specific encoder.
+The **`encoding`** read-only property of the {{domxref("TextDecoderStream")}} interface returns a string containing the name of the encoding algorithm used by the specific encoder.
 
 ## Value
 
-A {{DOMxRef("DOMString")}}, ASCII lowercased.
+A string, ASCII lowercased.
 
 ## Examples
 

--- a/files/en-us/web/api/textdecoderstream/textdecoderstream/index.md
+++ b/files/en-us/web/api/textdecoderstream/textdecoderstream/index.md
@@ -22,7 +22,7 @@ new TextDecoderStream(label, options)
 ### Parameters
 
 - `label`
-  - : A {{domxref("DOMString")}} defaulting to `utf-8`. This may be [any valid label](/en-US/docs/Web/API/Encoding_API/Encodings).
+  - : A string defaulting to `utf-8`. This may be [any valid label](/en-US/docs/Web/API/Encoding_API/Encodings).
 - `options` {{optional_inline}}
 
   - : A `TextDecoderOptions` dictionary with the property:

--- a/files/en-us/web/api/textencoder/encoding/index.md
+++ b/files/en-us/web/api/textencoder/encoding/index.md
@@ -13,7 +13,7 @@ browser-compat: api.TextEncoder.encoding
 {{APIRef("Encoding API")}}
 
 The **`TextEncoder.encoding`** read-only property returns a
-{{DOMxRef("DOMString")}} containing the name of the encoding algorithm used by the
+string containing the name of the encoding algorithm used by the
 specific encoder.
 
 It can only have the following value `utf-8`.

--- a/files/en-us/web/api/textencoder/index.md
+++ b/files/en-us/web/api/textencoder/index.md
@@ -41,9 +41,9 @@ _The `TextEncoder` interface doesn't inherit any property._
 _The `TextEncoder` interface doesn't inherit any method_.
 
 - {{DOMxRef("TextEncoder.encode()")}}
-  - : Takes a {{domxref("USVString")}} as input, and returns a {{jsxref("Uint8Array")}} containing UTF-8 encoded text.
+  - : Takes a string as input, and returns a {{jsxref("Uint8Array")}} containing UTF-8 encoded text.
 - {{DOMxRef("TextEncoder.encodeInto()")}}
-  - : Takes a {{domxref("USVString")}} to encode and a destination {{jsxref("Uint8Array")}} to put resulting UTF-8 encoded text into, and returns a dictionary object indicating the progress of the encoding. This is potentially more performant than the older `encode()` method.
+  - : Takes a string to encode and a destination {{jsxref("Uint8Array")}} to put resulting UTF-8 encoded text into, and returns a dictionary object indicating the progress of the encoding. This is potentially more performant than the older `encode()` method.
 
 ## Specifications
 


### PR DESCRIPTION
Continuing #15499 

### Summary
`DOMString` is not exposed by browsers to JavaScript. It is converted to `string`.[[ref](https://developer.mozilla.org/en-US/docs/Web/API/DOMString)]

Same is the case with `USVString` and `CSSOMString`.

### Metadata
- [x] Fixes a typo, bug, or other error
