### PR TITLE
Fix example title numbering for WebVTT API

### DIFF
--- a/files/en-us/web/api/webvtt_api/index.md
+++ b/files/en-us/web/api/webvtt_api/index.md
@@ -627,7 +627,7 @@ There are a number of tags, such as `<bold>`, that can be used. However, if the 
 
   - The timestamp must be greater that the cue's start timestamp, greater than any previous timestamp in the cue payload, and less than the cue's end timestamp. The *active text* is the text between the timestamp and the next timestamp or to the end of the payload if there is not another timestamp in the payload. Any text before the *active text* in the payload is *previous text* . Any text beyond the *active text* is *future text* . This enables karaoke style captions.
 
-  ##### Example 12 - Karaoke style text
+  ##### Example 14 - Karaoke style text
 
   ```plain
   1
@@ -649,7 +649,7 @@ The following tags are the HTML tags allowed in a cue and require opening and cl
 
   - Style the contained text using a CSS class.
 
-  ##### Example 14 - Class tag
+  ##### Example 15 - Class tag
 
   ```html
   <c.classname>text</c>
@@ -659,7 +659,7 @@ The following tags are the HTML tags allowed in a cue and require opening and cl
 
   - Italicize the contained text.
 
-  ##### Example 15 - Italics tag
+  ##### Example 16 - Italics tag
 
   ```html
   <i>text</i>
@@ -669,7 +669,7 @@ The following tags are the HTML tags allowed in a cue and require opening and cl
 
   - Bold the contained text.
 
-  ##### Example 16 - Bold tag
+  ##### Example 17 - Bold tag
 
   ```html
   <b>text</b>
@@ -679,7 +679,7 @@ The following tags are the HTML tags allowed in a cue and require opening and cl
 
   - Underline the contained text.
 
-  ##### Example 17 - Underline tag
+  ##### Example 18 - Underline tag
 
   ```html
   <u>text</u>
@@ -689,7 +689,7 @@ The following tags are the HTML tags allowed in a cue and require opening and cl
 
   - Used with ruby text tags to display [ruby characters](https://en.wikipedia.org/wiki/Ruby_character) (i.e., small annotative characters above other characters).
 
-  ##### Example 18 - Ruby tag
+  ##### Example 19 - Ruby tag
 
   ```html
   <ruby>WWW<rt>World Wide Web</rt>oui<rt>yes</rt></ruby>
@@ -699,7 +699,7 @@ The following tags are the HTML tags allowed in a cue and require opening and cl
 
   - Used with ruby tags to display [ruby characters](https://en.wikipedia.org/wiki/Ruby_character) (i.e., small annotative characters above other characters).
 
-  ##### Example 19 - Ruby text tag
+  ##### Example 20 - Ruby text tag
 
   ```html
   <ruby>WWW<rt>World Wide Web</rt>oui<rt>yes</rt></ruby>
@@ -709,7 +709,7 @@ The following tags are the HTML tags allowed in a cue and require opening and cl
 
   - Similar to class tag, also used to style the contained text using CSS.
 
-  ##### Example 20 - Voice tag
+  ##### Example 21 - Voice tag
 
   ```html
   <v Bob>text</v>


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Changes/updates example numbers in their titles

- e.g. the first title that was modified here (Example 14 - Karaoke style text) follows "Example 13 - Cue setting examples". Previously the "karaoke text" example was "Example 12".

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
A few numbers were skipped or repeated and didn't seem to follow the correct/expected order. I wasn't sure if this was done intentionally, but I couldn't really find reasons for the examples to be numbered that way.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
