### PR TITLE
Remove calls to {{property_prefix}} macro

### DIFF
--- a/files/en-us/mozilla/firefox/releases/53/index.md
+++ b/files/en-us/mozilla/firefox/releases/53/index.md
@@ -130,9 +130,9 @@ Firefox 53 was released on April 19, 2017. This article lists key changes that a
 
 ### CSS
 
-- Removed {{property_prefix("-moz")}} prefixed variant of {{cssxref(":dir", ":dir()")}} pseudo-class ({{bug(1270406)}}).
+- Removed `-moz` prefixed variant of {{cssxref(":dir", ":dir()")}} pseudo-class ({{bug(1270406)}}).
 - The `-moz` prefixed version of {{cssxref("text-align-last")}} got removed ({{bug(1276808)}}).
-- Removed {{property_prefix("-moz")}} prefixed variant of {{cssxref("calc", "calc()")}} method ({{bug(1331296)}}).
+- Removed `-moz` prefixed variant of {{cssxref("calc", "calc()")}} method ({{bug(1331296)}}).
 - The proprietary `-moz-samplesize` media fragment (added to aid in delivery of downsampled images to low memory Firefox OS devices; see {{bug(854795)}}) has been removed ({{bug(1311246)}}).
 
 ### JavaScript


### PR DESCRIPTION
This PR removes the remaining two calls to the `{{property_prefix}}` macro, so that we may deprecate it and completely remove it in the near future.
