### PR TITLE
Remove mention of .oncontentdelete in GroupData

### DIFF
--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -137,8 +137,7 @@
       "interfaces": ["ContentIndex", "ContentIndexEvent"],
       "methods": [],
       "properties": [
-        "ServiceWorkerRegistration.index",
-        "ServiceWorkerGlobalScope.oncontentdelete"
+        "ServiceWorkerRegistration.index"
       ],
       "events": ["ServiceWorkerGlobalScope: contentdelete"]
     },


### PR DESCRIPTION
We don't have these pages anymore. Should not be in a sidebar.