### PR TITLE
image-resolution: no browser supports it

### DIFF
--- a/files/en-us/web/css/image-resolution/index.md
+++ b/files/en-us/web/css/image-resolution/index.md
@@ -8,7 +8,7 @@ tags:
   - Experimental
   - Reference
   - image-resolution
-browser-compat: css.properties.image-resolution
+spec-url: https://drafts.csswg.org/css-images-4/#the-image-resolution
 ---
 {{CSSRef}}{{SeeCompatTable}}
 
@@ -81,7 +81,7 @@ Uses the resolution from the image. If the image does not have a resolution, use
 
 ## Browser compatibility
 
-{{Compat}}
+No browser currently supports this property.
 
 ## See also
 


### PR DESCRIPTION
The two spec/browser compat tables were broken: as nobody implements this feature, it has no bcd entry.

This PR:
- use `spec-url` in Yaml to link to the spec
- remove the `{{Compat}}` and replace it with a text instead of the broken table message.