### PR TITLE
chore: Add Markdownlint cleanup job

### DIFF
--- a/.github/workflows/markdown-lint-fix.yml
+++ b/.github/workflows/markdown-lint-fix.yml
@@ -47,4 +47,4 @@ jobs:
           author: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
           body: |
             Auto-fix was run, but additional issues found.
-            Please review the last action run of https://github.com/mdn/content/actions/workflows/markdown-lint-fix.yml
+            Please review the run log: https://github.com/mdn/content/actions/runs/${GITHUB_RUN_ID}?check_suite_focus=true#step:5:1

--- a/.github/workflows/markdown-lint-fix.yml
+++ b/.github/workflows/markdown-lint-fix.yml
@@ -1,0 +1,50 @@
+name: Create Markdownlint auto-fix PR
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  fix:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: yarn
+
+      - name: Install all yarn packages
+        run: |
+          yarn --frozen-lockfile
+
+      - name: Lint markdown files
+        run: |
+          yarn lint:md
+
+      - name: Create PR with only fixable issues
+        if: success()
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: "chore: auto-fix Markdownlint issues"
+          branch: markdownlint-auto-cleanup
+          title: "Markdownlint auto-cleanup"
+          author: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
+          body: |
+            All issues auto-fixed
+
+      - name: Create PR with notice on unfixed issues
+        if: failure()
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: "chore: auto-fix Markdownlint issues"
+          branch: markdownlint-auto-cleanup
+          title: "Markdownlint auto-cleanup"
+          author: mdn-bot <108879845+mdn-bot@users.noreply.github.com>
+          body: |
+            Auto-fix was run, but additional issues found.
+            Please review the last action run of https://github.com/mdn/content/actions/workflows/markdown-lint-fix.yml


### PR DESCRIPTION
GitHub Action to create daily PR fixes for auto-fixable Markdownlint issues