### PR TITLE
Convert to normal links for `at-rule` etc.

### DIFF
--- a/files/en-us/glossary/descriptor_(css)/index.md
+++ b/files/en-us/glossary/descriptor_(css)/index.md
@@ -7,7 +7,7 @@ tags:
   - Glossary
   - NeedsContent
 ---
-A **CSS descriptor** defines the characteristics of an {{cssxref("at-rule")}}. At-rules may have one or multiple descriptors. Each descriptor has:
+A **CSS descriptor** defines the characteristics of an [at-rule](/en-US/docs/Web/CSS/At-rule). At-rules may have one or multiple descriptors. Each descriptor has:
 
 - A name
 - A value, which holds the component values

--- a/files/en-us/web/api/cssconditionrule/index.md
+++ b/files/en-us/web/api/cssconditionrule/index.md
@@ -10,7 +10,7 @@ browser-compat: api.CSSConditionRule
 ---
 {{ APIRef("CSSOM") }}
 
-An object implementing the **`CSSConditionRule`** interface represents a single condition CSS {{cssxref("at-rule")}}, which consists of a condition and a statement block.
+An object implementing the **`CSSConditionRule`** interface represents a single condition CSS [at-rule](/en-US/docs/Web/CSS/At-rule), which consists of a condition and a statement block.
 
 Two objects derive from `CSSConditionRule`: {{domxref("CSSMediaRule")}} and {{domxref("CSSSupportsRule")}}.
 

--- a/files/en-us/web/api/cssfontfacerule/index.md
+++ b/files/en-us/web/api/cssfontfacerule/index.md
@@ -11,7 +11,7 @@ browser-compat: api.CSSFontFaceRule
 ---
 {{APIRef("CSSOM")}}
 
-The **`CSSFontFaceRule`** interface represents an {{cssxref("@font-face")}} {{cssxref("at-rule")}}.
+The **`CSSFontFaceRule`** interface represents an {{cssxref("@font-face")}} [at-rule](/en-US/docs/Web/CSS/At-rule).
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/cssgroupingrule/index.md
+++ b/files/en-us/web/api/cssgroupingrule/index.md
@@ -10,7 +10,7 @@ browser-compat: api.CSSGroupingRule
 ---
 {{ APIRef("CSSOM") }}
 
-The **`CSSGroupingRule`** interface of the {{domxref("CSS Object Model")}} represents any CSS {{CSSXref("at-rule")}} that contains other rules nested within it.
+The **`CSSGroupingRule`** interface of the [CSS Object Model](/en-US/docs/Web/API/CSS_Object_Model) represents any CSS [at-rule](/en-US/docs/Web/CSS/At-rule) that contains other rules nested within it.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/cssimportrule/index.md
+++ b/files/en-us/web/api/cssimportrule/index.md
@@ -10,7 +10,7 @@ browser-compat: api.CSSImportRule
 ---
 {{APIRef("CSSOM")}}
 
-The **`CSSImportRule`** interface represents an {{cssxref("@import")}} {{cssxref("at-rule")}}.
+The **`CSSImportRule`** interface represents an {{cssxref("@import")}} [at-rule](/en-US/docs/Web/CSS/At-rule).
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/csskeyframerule/index.md
+++ b/files/en-us/web/api/csskeyframerule/index.md
@@ -11,7 +11,7 @@ browser-compat: api.CSSKeyframeRule
 ---
 {{APIRef("CSSOM")}}
 
-The **`CSSKeyframeRule`** interface describes an object representing a set of styles for a given keyframe. It corresponds to the contents of a single keyframe of a {{cssxref("@keyframes")}} {{cssxref("at-rule")}}.
+The **`CSSKeyframeRule`** interface describes an object representing a set of styles for a given keyframe. It corresponds to the contents of a single keyframe of a {{cssxref("@keyframes")}} [at-rule](/en-US/docs/Web/CSS/At-rule).
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/csskeyframesrule/cssrules/index.md
+++ b/files/en-us/web/api/csskeyframesrule/cssrules/index.md
@@ -12,7 +12,7 @@ browser-compat: api.CSSKeyframesRule.cssRules
 ---
 {{APIRef("CSSOM") }}
 
-The read-only **`cssRules`** property of the {{domxref("CSSKeyframeRule")}} interface returns a {{domxref("CSSRuleList")}} containing the rules in the keyframes {{cssxref("at-rule")}}.
+The read-only **`cssRules`** property of the {{domxref("CSSKeyframeRule")}} interface returns a {{domxref("CSSRuleList")}} containing the rules in the keyframes [at-rule](/en-US/docs/Web/CSS/At-rule).
 
 ## Value
 

--- a/files/en-us/web/api/csskeyframesrule/index.md
+++ b/files/en-us/web/api/csskeyframesrule/index.md
@@ -11,7 +11,7 @@ browser-compat: api.CSSKeyframesRule
 ---
 {{APIRef("CSSOM")}}
 
-The **`CSSKeyframesRule`** interface describes an object representing a complete set of keyframes for a CSS animation. It corresponds to the contents of a whole {{cssxref("@keyframes")}} {{cssxref("at-rule")}}.
+The **`CSSKeyframesRule`** interface describes an object representing a complete set of keyframes for a CSS animation. It corresponds to the contents of a whole {{cssxref("@keyframes")}} [at-rule](/en-US/docs/Web/CSS/At-rule).
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/cssnamespacerule/index.md
+++ b/files/en-us/web/api/cssnamespacerule/index.md
@@ -10,7 +10,7 @@ browser-compat: api.CSSNamespaceRule
 ---
 {{APIRef("CSSOM")}}
 
-The **`CSSNamespaceRule`** interface describes an object representing a single CSS {{ cssxref("@namespace") }} {{cssxref("at-rule")}}.
+The **`CSSNamespaceRule`** interface describes an object representing a single CSS {{ cssxref("@namespace") }} [at-rule](/en-US/docs/Web/CSS/At-rule).
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/csssupportsrule/index.md
+++ b/files/en-us/web/api/csssupportsrule/index.md
@@ -10,7 +10,7 @@ browser-compat: api.CSSSupportsRule
 ---
 {{APIRef("CSSOM")}}
 
-The **`CSSSupportsRule`** interface represents a single CSS {{cssxref("@supports")}} {{cssxref("at-rule")}}.
+The **`CSSSupportsRule`** interface represents a single CSS {{cssxref("@supports")}} [at-rule](/en-US/docs/Web/CSS/At-rule).
 
 {{InheritanceDiagram}}
 
@@ -24,7 +24,7 @@ _Inherits methods from its ancestors {{domxref("CSSConditionRule")}}, {{domxref(
 
 ## Examples
 
-The CSS includes a CSS feature query using the {{cssxref("@supports")}} {{cssxref("at-rule")}}, containing one style rule. This will be the first CSSRule returned by `document.styleSheets[0].cssRules`.
+The CSS includes a CSS feature query using the {{cssxref("@supports")}} [at-rule](/en-US/docs/Web/CSS/At-rule), containing one style rule. This will be the first CSSRule returned by `document.styleSheets[0].cssRules`.
 `myRules[0]` therefore returns a {{domxref("CSSSupportsRule")}} object.
 
 ```css

--- a/files/en-us/web/css/@color-profile/index.md
+++ b/files/en-us/web/css/@color-profile/index.md
@@ -13,7 +13,7 @@ browser-compat: css.at-rules.color-profile
 ---
 {{CSSRef}}
 
-The **`@color-profile`** [CSS](/en-US/docs/Web/CSS) {{cssxref("at-rule")}} defines and names a color profile which can later be used in the {{cssxref("color_value/color", "color()")}} function to specify a color.
+The **`@color-profile`** [CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CSS/At-rule) defines and names a color profile which can later be used in the {{cssxref("color_value/color", "color()")}} function to specify a color.
 
 ## Syntax
 

--- a/files/en-us/web/css/@property/index.md
+++ b/files/en-us/web/css/@property/index.md
@@ -13,7 +13,7 @@ browser-compat: css.at-rules.property
 ---
 {{CSSRef}}{{SeeCompatTable}}
 
-The **`@property`** [CSS](/en-US/docs/Web/CSS) {{cssxref("at-rule")}} is part of the [CSS Houdini](/en-US/docs/Web/Guide/Houdini) umbrella of APIs, it allows developers to explicitly define their {{cssxref('--*', 'CSS custom properties')}}, allowing for property type checking, setting default values, and define whether a property can inherit values or not.
+The **`@property`** [CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CSS/At-rule) is part of the [CSS Houdini](/en-US/docs/Web/Guide/Houdini) umbrella of APIs, it allows developers to explicitly define their {{cssxref('--*', 'CSS custom properties')}}, allowing for property type checking, setting default values, and define whether a property can inherit values or not.
 
 The `@property` rule represents a custom property registration directly in a stylesheet without having to run any JS. Valid `@property` rules result in a registered custom property, as if {{domxref('CSS.registerProperty')}} had been called with equivalent parameters.
 

--- a/files/en-us/web/css/@property/inherits/index.md
+++ b/files/en-us/web/css/@property/inherits/index.md
@@ -11,7 +11,7 @@ browser-compat: css.at-rules.property.inherits
 ---
 {{CSSRef}}{{SeeCompatTable}}
 
-The **`inherits`** [CSS](/en-US/docs/Web/CSS) descriptor is required when using the {{cssxref("@property")}} {{cssxref("at-rule")}} and controls whether the custom property registration specified by `@property` inherits by default.
+The **`inherits`** [CSS](/en-US/docs/Web/CSS) descriptor is required when using the {{cssxref("@property")}} [at-rule](/en-US/docs/Web/CSS/At-rule) and controls whether the custom property registration specified by `@property` inherits by default.
 
 ## Syntax
 

--- a/files/en-us/web/css/@property/initial-value/index.md
+++ b/files/en-us/web/css/@property/initial-value/index.md
@@ -11,7 +11,7 @@ browser-compat: css.at-rules.property.initial-value
 ---
 {{CSSRef}}{{SeeCompatTable}}
 
-The **`initial-value`** [CSS](/en-US/docs/Web/CSS) descriptor is required when using the {{cssxref("@property")}} {{cssxref("at-rule")}} unless the syntax accepts any valid token stream. It sets the initial-value for the property.
+The **`initial-value`** [CSS](/en-US/docs/Web/CSS) descriptor is required when using the {{cssxref("@property")}} [at-rule](/en-US/docs/Web/CSS/At-rule) unless the syntax accepts any valid token stream. It sets the initial-value for the property.
 
 The value chosen as the `initial-value` must parse correctly according to the syntax definition. Therefore, if syntax is `<color>` then the initial-value must be a valid {{cssxref("color")}} value.
 

--- a/files/en-us/web/css/@property/syntax/index.md
+++ b/files/en-us/web/css/@property/syntax/index.md
@@ -11,7 +11,7 @@ browser-compat: css.at-rules.property.syntax
 ---
 {{CSSRef}}{{SeeCompatTable}}
 
-The **`syntax`** [CSS](/en-US/docs/Web/CSS) descriptor is required when using the {{cssxref("@property")}} {{cssxref("at-rule")}} and describes the allowable syntax for the property.
+The **`syntax`** [CSS](/en-US/docs/Web/CSS) descriptor is required when using the {{cssxref("@property")}} [at-rule](/en-US/docs/Web/CSS/At-rule) and describes the allowable syntax for the property.
 
 ## Syntax
 

--- a/files/en-us/web/css/color_value/color/index.md
+++ b/files/en-us/web/css/color_value/color/index.md
@@ -16,7 +16,7 @@ The **`color()`** functional notation allows a color to be specified in a partic
 
 Support for a particular colorspace can be detected with the [`color-gamut`](/en-US/docs/Web/CSS/@media/color-gamut) CSS media feature.
 
-The [`@color-profile`](/en-US/docs/Web/CSS/@color-profile) [CSS](/en-US/docs/Web/CSS) {{cssxref("at-rule")}} can be used to define and names a color profile to be used in the `color()` function to specify a color.
+The [`@color-profile`](/en-US/docs/Web/CSS/@color-profile) [CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CSS/At-rule) can be used to define and names a color profile to be used in the `color()` function to specify a color.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Convert {{cssxref}}s to normal links for `at-rule` and `CSS Object Model` because they aren't a keyword in a code.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
