### PR TITLE
DOMString -> string

### DIFF
--- a/files/en-us/web/api/window/message_event/index.md
+++ b/files/en-us/web/api/window/message_event/index.md
@@ -34,9 +34,9 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.data")}} {{readonlyInline}}
   - : The data sent by the message emitter.
 - {{domxref("MessageEvent.origin")}} {{readonlyInline}}
-  - : A {{domxref("USVString")}} representing the origin of the message emitter.
+  - : A string representing the origin of the message emitter.
 - {{domxref("MessageEvent.lastEventId")}} {{readonlyInline}}
-  - : A {{domxref("DOMString")}} representing a unique ID for the event.
+  - : A string representing a unique ID for the event.
 - {{domxref("MessageEvent.source")}} {{readonlyInline}}
   - : A `MessageEventSource` (which can be a {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
 - {{domxref("MessageEvent.ports")}} {{readonlyInline}}

--- a/files/en-us/web/api/window/messageerror_event/index.md
+++ b/files/en-us/web/api/window/messageerror_event/index.md
@@ -38,9 +38,9 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.data")}} {{readonlyInline}}
   - : The data sent by the message emitter.
 - {{domxref("MessageEvent.origin")}} {{readonlyInline}}
-  - : A {{domxref("USVString")}} representing the origin of the message emitter.
+  - : A string representing the origin of the message emitter.
 - {{domxref("MessageEvent.lastEventId")}} {{readonlyInline}}
-  - : A {{domxref("DOMString")}} representing a unique ID for the event.
+  - : A string representing a unique ID for the event.
 - {{domxref("MessageEvent.source")}} {{readonlyInline}}
   - : A `MessageEventSource` (which can be a {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
 - {{domxref("MessageEvent.ports")}} {{readonlyInline}}

--- a/files/en-us/web/api/window/sessionstorage/index.md
+++ b/files/en-us/web/api/window/sessionstorage/index.md
@@ -41,7 +41,7 @@ page**. In particular, data stored by a script on a site accessed with HTTP
 put in a different `sessionStorage` object from the same site accessed with
 HTTPS (e.g., <https://example.com>).
 
-The keys and the values are _always_ in the UTF-16 {{domxref("DOMString")}}
+The keys and the values are _always_ in the UTF-16 string
 format, which uses two bytes per character. As with objects, integer keys are
 automatically converted to strings.
 

--- a/files/en-us/web/api/window/storage_event/index.md
+++ b/files/en-us/web/api/window/storage_event/index.md
@@ -34,22 +34,22 @@ A {{domxref("StorageEvent")}}. Inherits from {{domxref("Event")}}.
 ## Event properties
 
 - {{domxref("StorageEvent.key", "key")}} {{ReadOnlyInline}}
-  - : Returns a {{DOMxRef("DOMString")}} that represents the key changed.
+  - : Returns a string that represents the key changed.
     The `key` attribute is {{jsxref("null")}}
     when the change is caused by the storage `clear()` method.
 - {{domxref("StorageEvent.newValue", "newValue")}} {{ReadOnlyInline}}
-  - : Returns a {{DOMxRef("DOMString")}} with the new value of the `key`.
+  - : Returns a string with the new value of the `key`.
     This value is `null`
     when the change has been invoked by storage `clear()` method,
     or the `key` has been removed from the storage.
 - {{domxref("StorageEvent.oldValue", "oldValue")}} {{ReadOnlyInline}}
-  - : Returns a {{DOMxRef("DOMString")}} with the original value of the `key`.
+  - : Returns a string with the original value of the `key`.
     This value is `null` when the `key` has been newly added
     and therefore doesn't have any previous value.
 - {{domxref("StorageEvent.storageArea", "storageArea")}} {{ReadOnlyInline}}
   - : Returns a {{DOMxRef("Storage")}} object that represents the storage that was affected.
 - {{domxref("StorageEvent.url", "url")}} {{ReadOnlyInline}}
-  - : Returns {{DOMxRef("DOMString")}} with the URL of the document whose `key` changed.
+  - : Returns string with the URL of the document whose `key` changed.
 
 ## Event handler aliases
 

--- a/files/en-us/web/api/windowclient/visibilitystate/index.md
+++ b/files/en-us/web/api/windowclient/visibilitystate/index.md
@@ -21,7 +21,7 @@ This value can be one of `"hidden"`, `"visible"`, or
 
 ## Value
 
-A {{domxref("DOMString")}} (See {{domxref("Document.visibilityState")}} for values).
+A string (See {{domxref("Document.visibilityState")}} for values).
 
 ## Examples
 

--- a/files/en-us/web/api/worker/message_event/index.md
+++ b/files/en-us/web/api/worker/message_event/index.md
@@ -38,9 +38,9 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.data")}} {{readonlyInline}}
   - : The data sent by the message emitter.
 - {{domxref("MessageEvent.origin")}} {{readonlyInline}}
-  - : A {{domxref("USVString")}} representing the origin of the message emitter.
+  - : A string representing the origin of the message emitter.
 - {{domxref("MessageEvent.lastEventId")}} {{readonlyInline}}
-  - : A {{domxref("DOMString")}} representing a unique ID for the event.
+  - : A string representing a unique ID for the event.
 - {{domxref("MessageEvent.source")}} {{readonlyInline}}
   - : A `MessageEventSource` (which can be a {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
 - {{domxref("MessageEvent.ports")}} {{readonlyInline}}

--- a/files/en-us/web/api/worker/messageerror_event/index.md
+++ b/files/en-us/web/api/worker/messageerror_event/index.md
@@ -38,9 +38,9 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 - {{domxref("MessageEvent.data")}} {{readonlyInline}}
   - : The data sent by the message emitter.
 - {{domxref("MessageEvent.origin")}} {{readonlyInline}}
-  - : A {{domxref("USVString")}} representing the origin of the message emitter.
+  - : A string representing the origin of the message emitter.
 - {{domxref("MessageEvent.lastEventId")}} {{readonlyInline}}
-  - : A {{domxref("DOMString")}} representing a unique ID for the event.
+  - : A string representing a unique ID for the event.
 - {{domxref("MessageEvent.source")}} {{readonlyInline}}
   - : A `MessageEventSource` (which can be a {{domxref("WindowProxy")}}, {{domxref("MessagePort")}}, or {{domxref("ServiceWorker")}} object) representing the message emitter.
 - {{domxref("MessageEvent.ports")}} {{readonlyInline}}

--- a/files/en-us/web/api/workerlocation/href/index.md
+++ b/files/en-us/web/api/workerlocation/href/index.md
@@ -11,7 +11,7 @@ browser-compat: api.WorkerLocation.href
 ---
 {{ApiRef("WorkerLocation")}}
 
-The **`href`** property of a {{domxref("WorkerLocation")}} object returns a {{domxref("USVString")}} containing the serialized {{domxref("URL")}} for the worker's location.
+The **`href`** property of a {{domxref("WorkerLocation")}} object returns a string containing the serialized {{domxref("URL")}} for the worker's location.
 
 ## Value
 

--- a/files/en-us/web/api/workerlocation/index.md
+++ b/files/en-us/web/api/workerlocation/index.md
@@ -16,7 +16,7 @@ This interface is only visible from inside a JavaScript script executed in the c
 ## Properties
 
 - {{domxref("WorkerLocation.href")}} {{readOnlyInline}}
-  - : Returns a {{domxref("USVString")}} containing the serialized {{domxref("URL")}} for the worker's location.
+  - : Returns a string containing the serialized {{domxref("URL")}} for the worker's location.
 - {{domxref("WorkerLocation.protocol")}} {{readOnlyInline}}
   - : Returns the {{domxref("URL.protocol", "protocol")}} part of the worker's location.
 - {{domxref("WorkerLocation.host")}} {{readOnlyInline}}
@@ -37,7 +37,7 @@ This interface is only visible from inside a JavaScript script executed in the c
 ## Methods
 
 - {{domxref("WorkerLocation.toString()")}}
-  - : Returns a {{domxref("USVString")}} containing the serialized {{domxref("URL")}} for the worker's location. It is a synonym for {{domxref("WorkerLocation.href")}}.
+  - : Returns a string containing the serialized {{domxref("URL")}} for the worker's location. It is a synonym for {{domxref("WorkerLocation.href")}}.
 
 ## Specifications
 

--- a/files/en-us/web/api/workernavigator/index.md
+++ b/files/en-us/web/api/workernavigator/index.md
@@ -30,9 +30,9 @@ _The `WorkerNavigator` interface doesn't inherit any property._
 - {{DOMxRef("WorkerNavigator.hardwareConcurrency")}}{{ReadOnlyInline}}
   - : Returns the number of logical processor cores available.
 - {{DOMxRef("WorkerNavigator.language")}} {{readonlyInline}}
-  - : Returns a {{domxref("DOMString")}} representing the preferred language of the user, usually the language of the browser UI. The `null` value is returned when this is unknown.
+  - : Returns a string representing the preferred language of the user, usually the language of the browser UI. The `null` value is returned when this is unknown.
 - {{DOMxRef("WorkerNavigator.languages")}} {{readonlyInline}} {{experimental_inline}}
-  - : Returns an array of {{domxref("DOMString")}} representing the languages known to the user, by order of preference.
+  - : Returns an array of strings representing the languages known to the user, by order of preference.
 - {{DOMxRef("WorkerNavigator.locks")}} {{Experimental_Inline}}{{ReadOnlyInline}}
   - : Returns a {{DOMxRef("LockManager")}} object which provides methods for requesting a new {{DOMxRef('Lock')}} object and querying for an existing `Lock` object.
 - {{DOMxRef("WorkerNavigator.onLine")}}{{ReadOnlyInline}}

--- a/files/en-us/web/api/workernavigator/language/index.md
+++ b/files/en-us/web/api/workernavigator/language/index.md
@@ -18,7 +18,7 @@ browser UI.
 
 ## Value
 
-A {{domxref("DOMString")}}. _`lang`_ stores a string representing the
+A string. _`lang`_ stores a string representing the
 language version as defined in {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}. Examples of valid language
 codes include "en", "en-US", "fr", "fr-FR", "es-ES", etc.
 

--- a/files/en-us/web/api/workernavigator/languages/index.md
+++ b/files/en-us/web/api/workernavigator/languages/index.md
@@ -14,7 +14,7 @@ browser-compat: api.WorkerNavigator.languages
 {{APIRef("HTML DOM")}}{{SeeCompatTable}}
 
 The **`WorkerNavigator.languages`** read-only property
-returns an array of {{domxref("DOMString")}}s representing the user's preferred
+returns an array of strings representing the user's preferred
 languages. The language is described using language tags according to
 {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}. In the returned
 array they are ordered by preference with the most preferred language first.

--- a/files/en-us/web/api/workernavigator/platform/index.md
+++ b/files/en-us/web/api/workernavigator/platform/index.md
@@ -19,7 +19,7 @@ reliable answer.
 
 ## Value
 
-A {{domxref("DOMString")}} identifying the platform on which the browser is running, or
+A string identifying the platform on which the browser is running, or
 an empty string if the browser declines to (or is unable to) identify the platform.
 `platform` is a string that must be an empty string or a string representing
 the platform on which the browser is executing.

--- a/files/en-us/web/api/workernavigator/useragent/index.md
+++ b/files/en-us/web/api/workernavigator/useragent/index.md
@@ -39,7 +39,7 @@ string is user configurable. For example:
 
 ## Value
 
-A {{domxref("DOMString")}} specifying the complete user agent string the browser
+A string specifying the complete user agent string the browser
 provides both in {{Glossary("HTTP")}} headers and in response to this and other related
 methods on the {{domxref("WorkerNavigator")}} object.
 

--- a/files/en-us/web/api/writablestream/writablestream/index.md
+++ b/files/en-us/web/api/writablestream/writablestream/index.md
@@ -61,7 +61,7 @@ new WritableStream(underlyingSink, queuingStrategy)
         `abort()` will be called even if writes are queued up — those chunks
         will be thrown away. If this process is asynchronous, it can return a promise to
         signal success or failure. The `reason` parameter contains a
-        {{domxref("DOMString")}} describing why the stream was aborted.
+        string describing why the stream was aborted.
 
 - `queuingStrategy` {{optional_inline}}
 

--- a/files/en-us/web/api/xmlhttprequest/index.md
+++ b/files/en-us/web/api/xmlhttprequest/index.md
@@ -39,9 +39,9 @@ _This interface also inherits properties of {{domxref("XMLHttpRequestEventTarget
 - {{domxref("XMLHttpRequest.readyState")}} {{readonlyinline}}
   - : Returns a number representing the state of the request.
 - {{domxref("XMLHttpRequest.response")}} {{readonlyinline}}
-  - : Returns an {{jsxref("ArrayBuffer")}}, {{domxref("Blob")}}, {{domxref("Document")}}, JavaScript object, or a {{domxref("DOMString")}}, depending on the value of {{domxref("XMLHttpRequest.responseType")}}, that contains the response entity body.
+  - : Returns an {{jsxref("ArrayBuffer")}}, {{domxref("Blob")}}, {{domxref("Document")}}, JavaScript object, or a string, depending on the value of {{domxref("XMLHttpRequest.responseType")}}, that contains the response entity body.
 - {{domxref("XMLHttpRequest.responseText")}} {{readonlyinline}}
-  - : Returns a {{domxref("DOMString")}} that contains the response to the request as text, or `null` if the request was unsuccessful or has not yet been sent.
+  - : Returns a string that contains the response to the request as text, or `null` if the request was unsuccessful or has not yet been sent.
 - {{domxref("XMLHttpRequest.responseType")}}
   - : Specifies the type of the response.
 - {{domxref("XMLHttpRequest.responseURL")}} {{readonlyinline}}
@@ -51,7 +51,7 @@ _This interface also inherits properties of {{domxref("XMLHttpRequestEventTarget
 - {{domxref("XMLHttpRequest.status")}} {{readonlyinline}}
   - : Returns the [HTTP response status code](/en-US/docs/Web/HTTP/Status) of the request.
 - {{domxref("XMLHttpRequest.statusText")}} {{readonlyinline}}
-  - : Returns a {{domxref("DOMString")}} containing the response string returned by the HTTP server. Unlike {{domxref("XMLHttpRequest.status")}}, this includes the entire text of the response message ("`OK`", for example).
+  - : Returns a string containing the response string returned by the HTTP server. Unlike {{domxref("XMLHttpRequest.status")}}, this includes the entire text of the response message ("`OK`", for example).
 
     > **Note:** According to the HTTP/2 specification {{RFC(7540, "Response Pseudo-Header Fields", "8.1.2.4")}}, HTTP/2 does not define a way to carry the version or reason phrase that is included in an HTTP/1.1 status line.
 

--- a/files/en-us/web/api/xmlhttprequest/index.md
+++ b/files/en-us/web/api/xmlhttprequest/index.md
@@ -39,7 +39,7 @@ _This interface also inherits properties of {{domxref("XMLHttpRequestEventTarget
 - {{domxref("XMLHttpRequest.readyState")}} {{readonlyinline}}
   - : Returns a number representing the state of the request.
 - {{domxref("XMLHttpRequest.response")}} {{readonlyinline}}
-  - : Returns an {{jsxref("ArrayBuffer")}}, {{domxref("Blob")}}, {{domxref("Document")}}, JavaScript object, or a string, depending on the value of {{domxref("XMLHttpRequest.responseType")}}, that contains the response entity body.
+  - : Returns an {{jsxref("ArrayBuffer")}}, a {{domxref("Blob")}}, a {{domxref("Document")}}, a JavaScript object, or a string, depending on the value of {{domxref("XMLHttpRequest.responseType")}}, that contains the response entity body.
 - {{domxref("XMLHttpRequest.responseText")}} {{readonlyinline}}
   - : Returns a string that contains the response to the request as text, or `null` if the request was unsuccessful or has not yet been sent.
 - {{domxref("XMLHttpRequest.responseType")}}

--- a/files/en-us/web/api/xmlhttprequest/response/index.md
+++ b/files/en-us/web/api/xmlhttprequest/response/index.md
@@ -20,8 +20,8 @@ browser-compat: api.XMLHttpRequest.response
 
 The {{domxref("XMLHttpRequest")}}
 **`response`** property returns the response's body content as
-an {{jsxref("ArrayBuffer")}}, {{domxref("Blob")}}, {{domxref("Document")}},
-JavaScript {{jsxref("Object")}}, or {{domxref("DOMString")}}, depending on the value
+an {{jsxref("ArrayBuffer")}}, a {{domxref("Blob")}}, a {{domxref("Document")}},
+an JavaScript {{jsxref("Object")}}, or a string, depending on the value
 of the request's {{domxref("XMLHttpRequest.responseType", "responseType")}}
 property.
 

--- a/files/en-us/web/api/xmlhttprequest/response/index.md
+++ b/files/en-us/web/api/xmlhttprequest/response/index.md
@@ -21,7 +21,7 @@ browser-compat: api.XMLHttpRequest.response
 The {{domxref("XMLHttpRequest")}}
 **`response`** property returns the response's body content as
 an {{jsxref("ArrayBuffer")}}, a {{domxref("Blob")}}, a {{domxref("Document")}},
-an JavaScript {{jsxref("Object")}}, or a string, depending on the value
+a JavaScript {{jsxref("Object")}}, or a string, depending on the value
 of the request's {{domxref("XMLHttpRequest.responseType", "responseType")}}
 property.
 

--- a/files/en-us/web/api/xmlhttprequest/responsetext/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responsetext/index.md
@@ -20,7 +20,7 @@ following a request being sent.
 
 ## Value
 
-A {{domxref("DOMString")}} which contains either the textual data received using the
+A string which contains either the textual data received using the
 `XMLHttpRequest` or `null` if the request failed or
 `""` if the request has not yet been sent by calling
 {{domxref("XMLHttpRequest.send", "send()")}}.

--- a/files/en-us/web/api/xmlhttprequest/responsetype/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responsetype/index.md
@@ -41,7 +41,7 @@ It can take the following values:
 - `"json"`
   - : The `response` is a JavaScript object created by parsing the contents of received data as {{Glossary("JSON")}}.
 - `"text"`
-  - : The `response` is a text in a {{domxref("DOMString")}} object.
+  - : The `response` is a text in a string.
 - `"ms-stream"` {{non-standard_inline}}
   - : The `response` is part of a streaming download; this response type is only allowed for download requests, and is only supported by Internet Explorer.
 

--- a/files/en-us/web/api/xmlserializer/serializetostring/index.md
+++ b/files/en-us/web/api/xmlserializer/serializetostring/index.md
@@ -36,7 +36,7 @@ xmlString = anXMLSerializer.serializeToString(rootNode);
 
 ### Return value
 
-A {{domxref("DOMString")}} containing the XML representation of the specified DOM tree.
+A string containing the XML representation of the specified DOM tree.
 
 ### Exceptions
 

--- a/files/en-us/web/api/xrinputsource/index.md
+++ b/files/en-us/web/api/xrinputsource/index.md
@@ -30,7 +30,7 @@ The [WebXR Device API's](/en-US/docs/Web/API/WebXR_Device_API) **`XRInputSource`
 - {{domxref('XRInputSource.hand', 'hand')}}{{readonlyInline}}
   - : An {{domxref("XRHand")}} object providing access to the underlying hand-tracking device.
 - {{domxref('XRInputSource.handedness', 'handedness')}}{{readonlyInline}}
-  - : A {{domxref("DOMString")}} that indicates which hand the device represented by this `XRInputSource` is being used in, if any. The value will be `left`, `right`, or `none`.
+  - : A string that indicates which hand the device represented by this `XRInputSource` is being used in, if any. The value will be `left`, `right`, or `none`.
 - {{domxref('XRInputSource.profiles', 'profiles')}}{{readonlyInline}}
   - : An array of `DOMString` objects, each specifying the name of an input profile describing the preferred visual representation and behavior of this input source.
 - {{domxref('XRInputSource.targetRayMode', 'targetRayMode')}}{{readonlyInline}}

--- a/files/en-us/web/guide/parsing_and_serializing_xml/index.md
+++ b/files/en-us/web/guide/parsing_and_serializing_xml/index.md
@@ -104,7 +104,7 @@ If the DOM you have is an HTML document, you can serialize using `serializeToStr
 const docInnerHtml = document.documentElement.innerHTML;
 ```
 
-As a result, `docInnerHtml` is a {{domxref("DOMString")}} containing the HTML of the contents of the document; that is, the {{HTMLElement("body")}} element's contents.
+As a result, `docInnerHtml` is a string containing the HTML of the contents of the document; that is, the {{HTMLElement("body")}} element's contents.
 
 You can get HTML corresponding to the `<body>` _and_ its descendants with this code:
 

--- a/files/en-us/web/html/element/input/button/index.md
+++ b/files/en-us/web/html/element/input/button/index.md
@@ -26,7 +26,7 @@ browser-compat: html.elements.input.input-button
   <tbody>
     <tr>
       <td><strong><a href="#value">Value</a></strong></td>
-      <td>A {{domxref("DOMString")}} used as the button's label</td>
+      <td>A string used as the button's label</td>
     </tr>
     <tr>
       <td><strong>Events</strong></td>
@@ -58,7 +58,7 @@ browser-compat: html.elements.input.input-button
 
 ### Button with a value
 
-An `<input type="button">` elements' {{htmlattrxref("value", "input")}} attribute contains a {{domxref("DOMString")}} that is used as the button's label.
+An `<input type="button">` elements' {{htmlattrxref("value", "input")}} attribute contains a string that is used as the button's label.
 
 ```html
 <input type="button" value="Click Me">

--- a/files/en-us/web/html/element/input/checkbox/index.md
+++ b/files/en-us/web/html/element/input/checkbox/index.md
@@ -26,7 +26,7 @@ browser-compat: html.elements.input.input-checkbox
     <tr>
       <td><strong><a href="#value">Value</a></strong></td>
       <td>
-        A {{domxref("DOMString")}} representing the value of the
+        A string representing the value of the
         checkbox.
       </td>
     </tr>
@@ -61,7 +61,7 @@ browser-compat: html.elements.input.input-checkbox
 
 ## Value
 
-A {{domxref("DOMString")}} representing the value of the checkbox. This is not displayed on the client-side, but on the server this is the `value` given to the data submitted with the checkbox's `name`. Take the following example:
+A string representing the value of the checkbox. This is not displayed on the client-side, but on the server this is the `value` given to the data submitted with the checkbox's `name`. Take the following example:
 
 ```html
 <form>

--- a/files/en-us/web/html/element/input/color/index.md
+++ b/files/en-us/web/html/element/input/color/index.md
@@ -30,7 +30,7 @@ The element's presentation may vary substantially from one browser and/or platfo
     <tr>
       <td><strong><a href="#value">Value</a></strong></td>
       <td>
-        A 7-character {{domxref("DOMString")}} specifying a
+        A 7-character string specifying a
         {{cssxref("&lt;color&gt;")}} in lower-case hexadecimal notation
       </td>
     </tr>
@@ -67,7 +67,7 @@ The element's presentation may vary substantially from one browser and/or platfo
 
 ## Value
 
-The {{htmlattrxref("value", "input")}} of an {{HTMLElement("input")}} element of type `color` is always a {{domxref("DOMString")}} which contains a 7-character string specifying an RGB color in hexadecimal format. While you can input the color in either upper- or lower-case, it will be stored in lower-case form. The value is never in any other form, and is never empty.
+The {{htmlattrxref("value", "input")}} of an {{HTMLElement("input")}} element of type `color` is always a string which contains a 7-character string specifying an RGB color in hexadecimal format. While you can input the color in either upper- or lower-case, it will be stored in lower-case form. The value is never in any other form, and is never empty.
 
 > **Note:** Setting the value to anything that isn't a valid, fully-opaque, RGB color _in hexadecimal notation_ will result in the value being set to `#000000`. In particular, you can't use CSS's standardized color names, or any CSS function syntax, to set the value. This makes sense when you keep in mind that HTML and CSS are separate languages and specifications. In addition, colors with an alpha channel are not supported; specifying a color in 9-character hexadecimal notation (e.g. `#009900aa`) will also result in the color being set to `#000000`.
 

--- a/files/en-us/web/html/element/input/date/index.md
+++ b/files/en-us/web/html/element/input/date/index.md
@@ -30,7 +30,7 @@ The input UI generally varies from browser to browser; see [Browser compatibilit
     <tr>
       <td><strong><a href="#value">Value</a></strong></td>
       <td>
-        A {{domxref("DOMString")}} representing a date in YYYY-MM-DD
+        A string representing a date in YYYY-MM-DD
         format, or empty
       </td>
     </tr>
@@ -74,7 +74,7 @@ The input UI generally varies from browser to browser; see [Browser compatibilit
 
 ## Value
 
-A {{domxref("DOMString")}} representing the date entered in the input. The date is formatted according to ISO8601, described in {{SectionOnPage("/en-US/docs/Web/HTML/Date_and_time_formats", "Format of a valid date string")}}.
+A string representing the date entered in the input. The date is formatted according to ISO8601, described in {{SectionOnPage("/en-US/docs/Web/HTML/Date_and_time_formats", "Format of a valid date string")}}.
 
 You can set a default value for the input with a date inside the {{htmlattrxref("value", "input")}} attribute, like so:
 

--- a/files/en-us/web/html/element/input/datetime-local/index.md
+++ b/files/en-us/web/html/element/input/datetime-local/index.md
@@ -36,7 +36,7 @@ Some browsers may resort to a text-only input element that validates that the re
     <tr>
       <td><strong><a href="#value">Value</a></strong></td>
       <td>
-        A {{domxref("DOMString")}} representing a date and time (in the
+        A string representing a date and time (in the
         local time zone), or empty.
       </td>
     </tr>
@@ -79,7 +79,7 @@ Some browsers may resort to a text-only input element that validates that the re
 
 ## Value
 
-A {{domxref("DOMString")}} representing the value of the date entered into the input. The format of the date and time value used by this input type is described in {{SectionOnPage("/en-US/docs/Web/HTML/Date_and_time_formats", "Local date and time strings")}}.
+A string representing the value of the date entered into the input. The format of the date and time value used by this input type is described in {{SectionOnPage("/en-US/docs/Web/HTML/Date_and_time_formats", "Local date and time strings")}}.
 
 You can set a default value for the input by including a date and time inside the {{htmlattrxref("value", "input")}} attribute, like so:
 

--- a/files/en-us/web/html/element/input/email/index.md
+++ b/files/en-us/web/html/element/input/email/index.md
@@ -26,7 +26,7 @@ On browsers that don't support inputs of type `email`, a `email` input falls bac
     <tr>
       <td><strong><a href="#value">Value</a></strong></td>
       <td>
-        A {{domxref("DOMString")}} representing an e-mail address, or
+        A string representing an e-mail address, or
         empty
       </td>
     </tr>
@@ -72,7 +72,7 @@ On browsers that don't support inputs of type `email`, a `email` input falls bac
 
 ## Value
 
-The {{HTMLElement("input")}} element's {{htmlattrxref("value", "input")}} attribute contains a {{domxref("DOMString")}} which is automatically validated as conforming to e-mail syntax. More specifically, there are three possible value formats that will pass validation:
+The {{HTMLElement("input")}} element's {{htmlattrxref("value", "input")}} attribute contains a string which is automatically validated as conforming to e-mail syntax. More specifically, there are three possible value formats that will pass validation:
 
 1. An empty string ("") indicating that the user did not enter a value or that the value was removed.
 2. A single properly-formed e-mail address. This doesn't necessarily mean the e-mail address exists, but it is at least formatted correctly. In simple terms, this means `username@domain` or `username@domain.tld`. There's more to it than that, of course; see [Validation](#validation) for a {{Glossary("regular expression")}} that matches the e-mail address validation algorithm.

--- a/files/en-us/web/html/element/input/file/index.md
+++ b/files/en-us/web/html/element/input/file/index.md
@@ -26,7 +26,7 @@ browser-compat: html.elements.input.input-file
     <tr>
       <td><strong><a href="#value">Value</a></strong></td>
       <td>
-        A {{domxref("DOMString")}} representing the path to the selected
+        A string representing the path to the selected
         file.
       </td>
     </tr>
@@ -68,7 +68,7 @@ browser-compat: html.elements.input.input-file
 
 ## Value
 
-A file input's {{htmlattrxref("value", "input")}} attribute contains a {{domxref("DOMString")}} that represents the path to the selected file(s). If the user selected multiple files, the `value` represents the first file in the list of files they selected. The other files can be identified using the input's `HTMLInputElement.files` property.
+A file input's {{htmlattrxref("value", "input")}} attribute contains a string that represents the path to the selected file(s). If the user selected multiple files, the `value` represents the first file in the list of files they selected. The other files can be identified using the input's `HTMLInputElement.files` property.
 
 > **Note:**
 >

--- a/files/en-us/web/html/element/input/hidden/index.md
+++ b/files/en-us/web/html/element/input/hidden/index.md
@@ -22,7 +22,7 @@ browser-compat: html.elements.input.input-hidden
     <tr>
       <td><strong><a href="#value">Value</a></strong></td>
       <td>
-        A {{domxref("DOMString")}} representing the value of the hidden
+        A string representing the value of the hidden
         data you want to pass back to the server.
       </td>
     </tr>
@@ -53,7 +53,7 @@ browser-compat: html.elements.input.input-hidden
 
 ## Value
 
-The {{HTMLElement("input")}} element's {{htmlattrxref("value", "input")}} attribute holds a {{domxref("DOMString")}} that contains the hidden data you want to include when the form is submitted to the server. This specifically can't be edited or seen by the user via the user interface, although you could edit the value via browser developer tools.
+The {{HTMLElement("input")}} element's {{htmlattrxref("value", "input")}} attribute holds a string that contains the hidden data you want to include when the form is submitted to the server. This specifically can't be edited or seen by the user via the user interface, although you could edit the value via browser developer tools.
 
 > **Warning:** While the value isn't displayed to the user in the page's content, it is visible—and can be edited—using any browser's developer tools or "View Source" functionality. Do not rely on `hidden` inputs as a form of security.
 

--- a/files/en-us/web/html/element/input/month/index.md
+++ b/files/en-us/web/html/element/input/month/index.md
@@ -42,7 +42,7 @@ The Microsoft Edge `month` control looks like this:
     <tr>
       <td><strong><a href="#value">Value</a></strong></td>
       <td>
-        A {{domxref("DOMString")}} representing a month and year, or
+        A string representing a month and year, or
         empty.
       </td>
     </tr>
@@ -83,7 +83,7 @@ The Microsoft Edge `month` control looks like this:
 
 ## Value
 
-A {{domxref("DOMString")}} representing the value of the month and year entered into the input, in the form YYYY-MM (four or more digit year, then a hyphen ("`-`"), followed by the two-digit month).
+A string representing the value of the month and year entered into the input, in the form YYYY-MM (four or more digit year, then a hyphen ("`-`"), followed by the two-digit month).
 The format of the month string used by this input type is described in {{SectionOnPage("/en-US/docs/Web/HTML/Date_and_time_formats", "Format of a valid local month string")}}.
 
 ### Setting a default value

--- a/files/en-us/web/html/element/input/password/index.md
+++ b/files/en-us/web/html/element/input/password/index.md
@@ -38,7 +38,7 @@ Both approaches help a user check that they entered the intended password, which
     <tr>
       <td><strong><a href="#value">Value</a></strong></td>
       <td>
-        A {{domxref("DOMString")}} representing a password, or empty
+        A string representing a password, or empty
       </td>
     </tr>
     <tr>
@@ -87,7 +87,7 @@ Both approaches help a user check that they entered the intended password, which
 
 ## Value
 
-The {{htmlattrxref("value", "input")}} attribute contains a {{domxref("DOMString")}} whose value is the current contents of the text editing control being used to enter the password. If the user hasn't entered anything yet, this value is an empty string (`""`). If the {{htmlattrxref("required")}} property is specified, then the password edit box must contain a value other than an empty string to be valid.
+The {{htmlattrxref("value", "input")}} attribute contains a string whose value is the current contents of the text editing control being used to enter the password. If the user hasn't entered anything yet, this value is an empty string (`""`). If the {{htmlattrxref("required")}} property is specified, then the password edit box must contain a value other than an empty string to be valid.
 
 If the {{htmlattrxref("pattern", "input")}} attribute is specified, the content of a `password` control is only considered valid if the value passes validation; see [Validation](#validation) for more information.
 

--- a/files/en-us/web/html/element/input/radio/index.md
+++ b/files/en-us/web/html/element/input/radio/index.md
@@ -40,7 +40,7 @@ They are called radio buttons because they look and operate in a similar manner 
     <tr>
       <td><strong><a href="#value">Value</a></strong></td>
       <td>
-        A {{domxref("DOMString")}} representing the value of the radio
+        A string representing the value of the radio
         button.
       </td>
     </tr>
@@ -77,7 +77,7 @@ They are called radio buttons because they look and operate in a similar manner 
 
 ## Value
 
-The `value` attribute is a {{domxref("DOMString")}} containing the radio button's value. The value is never shown to the user by their {{Glossary("user agent")}}. Instead, it's used to identify which radio button in a group is selected.
+The `value` attribute is a string containing the radio button's value. The value is never shown to the user by their {{Glossary("user agent")}}. Instead, it's used to identify which radio button in a group is selected.
 
 ### Defining a radio group
 

--- a/files/en-us/web/html/element/input/range/index.md
+++ b/files/en-us/web/html/element/input/range/index.md
@@ -30,7 +30,7 @@ If the user's browser doesn't support type `range`, it will fall back and treat 
     <tr>
       <td><strong><a href="#value">Value</a></strong></td>
       <td>
-        A {{domxref("DOMString")}} containing the string representation
+        A string containing the string representation
         of the selected numeric value; use
         {{domxref("HTMLInputElement.valueAsNumber", "valueAsNumber")}}
         to get the value as a number.
@@ -84,7 +84,7 @@ There is no pattern validation available; however, the following forms of automa
 
 ### Value
 
-The {{htmlattrxref("value", "input")}} attribute contains a {{domxref("DOMString")}} which contains a string representation of the selected number. The value is never an empty string (`""`). The default value is halfway between the specified minimum and maximum—unless the maximum is actually less than the minimum, in which case the default is set to the value of the `min` attribute. The algorithm for determining the default value is:
+The {{htmlattrxref("value", "input")}} attribute contains a string which contains a string representation of the selected number. The value is never an empty string (`""`). The default value is halfway between the specified minimum and maximum—unless the maximum is actually less than the minimum, in which case the default is set to the value of the `min` attribute. The algorithm for determining the default value is:
 
 ```js
 defaultValue = (rangeElem.max < rangeElem.min) ? rangeElem.min

--- a/files/en-us/web/html/element/input/reset/index.md
+++ b/files/en-us/web/html/element/input/reset/index.md
@@ -28,7 +28,7 @@ browser-compat: html.elements.input.input-reset
   <tbody>
     <tr>
       <td><strong><a href="#value">Value</a></strong></td>
-      <td>A {{domxref("DOMString")}} used as the button's label</td>
+      <td>A string used as the button's label</td>
     </tr>
     <tr>
       <td><strong>Events</strong></td>
@@ -58,7 +58,7 @@ browser-compat: html.elements.input.input-reset
 
 ## Value
 
-An `<input type="reset">` element's {{htmlattrxref("value", "input")}} attribute contains a {{domxref("DOMString")}} that is used as the button's label. Buttons such as `reset` don't have a value otherwise.
+An `<input type="reset">` element's {{htmlattrxref("value", "input")}} attribute contains a string that is used as the button's label. Buttons such as `reset` don't have a value otherwise.
 
 ### Setting the value attribute
 

--- a/files/en-us/web/html/element/input/search/index.md
+++ b/files/en-us/web/html/element/input/search/index.md
@@ -23,7 +23,7 @@ browser-compat: html.elements.input.input-search
     <tr>
       <td><strong><a href="#value">Value</a></strong></td>
       <td>
-        A {{domxref("DOMString")}} representing the value contained in
+        A string representing the value contained in
         the search field.
       </td>
     </tr>
@@ -68,7 +68,7 @@ browser-compat: html.elements.input.input-search
 
 ## Value
 
-The {{htmlattrxref("value", "input")}} attribute contains a {{domxref("DOMString")}} representing the value contained in the search field. You can retrieve this using the {{domxref("HTMLInputElement.value")}} property in JavaScript.
+The {{htmlattrxref("value", "input")}} attribute contains a string representing the value contained in the search field. You can retrieve this using the {{domxref("HTMLInputElement.value")}} property in JavaScript.
 
 ```js
 searchTerms = mySearch.value;

--- a/files/en-us/web/html/element/input/submit/index.md
+++ b/files/en-us/web/html/element/input/submit/index.md
@@ -26,7 +26,7 @@ browser-compat: html.elements.input.input-submit
   <tbody>
     <tr>
       <td><strong><a href="#value">Value</a></strong></td>
-      <td>A {{domxref("DOMString")}} used as the button's label</td>
+      <td>A string used as the button's label</td>
     </tr>
     <tr>
       <td><strong>Events</strong></td>
@@ -56,7 +56,7 @@ browser-compat: html.elements.input.input-submit
 
 ## Value
 
-An `<input type="submit">` element's {{htmlattrxref("value", "input")}} attribute contains a {{domxref("DOMString")}} which is displayed as the button's label. Buttons do not have a true value otherwise.
+An `<input type="submit">` element's {{htmlattrxref("value", "input")}} attribute contains a string which is displayed as the button's label. Buttons do not have a true value otherwise.
 
 ### Setting the value attribute
 

--- a/files/en-us/web/html/element/input/tel/index.md
+++ b/files/en-us/web/html/element/input/tel/index.md
@@ -31,7 +31,7 @@ Despite the fact that inputs of type `tel` are functionally identical to standar
     <tr>
       <td><strong><a href="#value">Value</a></strong></td>
       <td>
-        A {{domxref("DOMString")}} representing a telephone number, or
+        A string representing a telephone number, or
         empty
       </td>
     </tr>
@@ -80,7 +80,7 @@ Despite the fact that inputs of type `tel` are functionally identical to standar
 
 ## Value
 
-The {{HTMLElement("input")}} element's {{htmlattrxref("value", "input")}} attribute contains a {{domxref("DOMString")}} that either represents a telephone number or is an empty string (`""`).
+The {{HTMLElement("input")}} element's {{htmlattrxref("value", "input")}} attribute contains a string that either represents a telephone number or is an empty string (`""`).
 
 ## Additional attributes
 

--- a/files/en-us/web/html/element/input/text/index.md
+++ b/files/en-us/web/html/element/input/text/index.md
@@ -25,7 +25,7 @@ browser-compat: html.elements.input.input-text
     <tr>
       <td><strong><a href="#value">Value</a></strong></td>
       <td>
-        A {{domxref("DOMString")}} representing the text contained in
+        A string representing the text contained in
         the text field.
       </td>
     </tr>
@@ -72,7 +72,7 @@ browser-compat: html.elements.input.input-text
 
 ## Value
 
-The {{htmlattrxref("value", "input")}} attribute is a {{domxref("DOMString")}} that contains the current value of the text entered into the text field. You can retrieve this using the {{domxref("HTMLInputElement")}} `value` property in JavaScript.
+The {{htmlattrxref("value", "input")}} attribute is a string that contains the current value of the text entered into the text field. You can retrieve this using the {{domxref("HTMLInputElement")}} `value` property in JavaScript.
 
 ```js
 let theText = myTextInput.value;

--- a/files/en-us/web/html/element/input/time/index.md
+++ b/files/en-us/web/html/element/input/time/index.md
@@ -54,7 +54,7 @@ The Edge `time` control is somewhat more elaborate, opening up an hour and minut
   <tbody>
     <tr>
       <td><strong><a href="#value">Value</a></strong></td>
-      <td>A {{domxref("DOMString")}} representing a time, or empty.</td>
+      <td>A string representing a time, or empty.</td>
     </tr>
     <tr>
       <td><strong>Events</strong></td>

--- a/files/en-us/web/html/element/input/url/index.md
+++ b/files/en-us/web/html/element/input/url/index.md
@@ -32,7 +32,7 @@ On browsers that don't support inputs of type `url`, a `url` input falls back to
   <tbody>
     <tr>
       <td><strong><a href="#value">Value</a></strong></td>
-      <td>A {{domxref("DOMString")}} representing a URL, or empty</td>
+      <td>A string representing a URL, or empty</td>
     </tr>
     <tr>
       <td><strong>Events</strong></td>
@@ -80,7 +80,7 @@ On browsers that don't support inputs of type `url`, a `url` input falls back to
 
 ## Value
 
-The {{HTMLElement("input")}} element's {{htmlattrxref("value", "input")}} attribute contains a {{domxref("DOMString")}} which is automatically validated as conforming to URL syntax. More specifically, there are two possible value formats that will pass validation:
+The {{HTMLElement("input")}} element's {{htmlattrxref("value", "input")}} attribute contains a string which is automatically validated as conforming to URL syntax. More specifically, there are two possible value formats that will pass validation:
 
 1. An empty string ("") indicating that the user did not enter a value or that the value was removed.
 2. A single properly-formed absolute URL. This doesn't necessarily mean the URL address exists, but it is at least formatted correctly. In simple terms, this means `urlscheme://restofurl`.

--- a/files/en-us/web/html/element/input/week/index.md
+++ b/files/en-us/web/html/element/input/week/index.md
@@ -39,7 +39,7 @@ The Edge `week` control is somewhat more elaborate, opening up week and year pic
     <tr>
       <td><strong><a href="#value">Value</a></strong></td>
       <td>
-        A {{domxref("DOMString")}} representing a week and year, or
+        A string representing a week and year, or
         empty
       </td>
     </tr>
@@ -83,7 +83,7 @@ The Edge `week` control is somewhat more elaborate, opening up week and year pic
 
 ## Value
 
-A {{domxref("DOMString")}} representing the value of the week/year entered into the input. The format of the date and time value used by this input type is described in {{SectionOnPage("/en-US/docs/Web/HTML/Date_and_time_formats", "Format of a valid week string")}}.
+A string representing the value of the week/year entered into the input. The format of the date and time value used by this input type is described in {{SectionOnPage("/en-US/docs/Web/HTML/Date_and_time_formats", "Format of a valid week string")}}.
 
 You can set a default value for the input by including a value inside the {{htmlattrxref("value", "input")}} attribute, like so:
 

--- a/files/en-us/web/html/element/select/index.md
+++ b/files/en-us/web/html/element/select/index.md
@@ -32,7 +32,7 @@ For further examples, see [The native form widgets: Drop-down content](/en-US/do
 This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attributes).
 
 - {{htmlattrdef("autocomplete")}}
-  - : A {{domxref("DOMString")}} providing a hint for a {{Glossary("user agent", "user agent's")}} autocomplete feature. See [The HTML autocomplete attribute](/en-US/docs/Web/HTML/Attributes/autocomplete) for a complete list of values and details on how to use autocomplete.
+  - : A string providing a hint for a {{Glossary("user agent", "user agent's")}} autocomplete feature. See [The HTML autocomplete attribute](/en-US/docs/Web/HTML/Attributes/autocomplete) for a complete list of values and details on how to use autocomplete.
 - {{htmlattrdef("autofocus")}}
   - : This Boolean attribute lets you specify that a form control should have input focus when the page loads. Only one form element in a document can have the `autofocus` attribute.
 - {{htmlattrdef("disabled")}}

--- a/files/en-us/web/html/element/tr/index.md
+++ b/files/en-us/web/html/element/tr/index.md
@@ -34,7 +34,7 @@ The following attributes may still be implemented in browsers but are no longer 
 
 - {{HTMLAttrDef("align")}}{{deprecated_inline}}
 
-  - : A {{DOMxRef("DOMString")}} which specifies how the cell's context should be aligned horizontally within the cells in the row; this is shorthand for using `align` on every cell in the row individually. Possible values are:
+  - : A string which specifies how the cell's context should be aligned horizontally within the cells in the row; this is shorthand for using `align` on every cell in the row individually. Possible values are:
 
     - `left`
       - : Align the content of each cell at its left edge.
@@ -53,25 +53,25 @@ The following attributes may still be implemented in browsers but are no longer 
 
 - {{HTMLAttrDef("bgcolor")}}{{deprecated_inline}}
 
-  - : A {{DOMxRef("DOMString")}} specifying a color to apply to the backgrounds of each of the row's cells. This can be either an [hexadecimal `#RRGGBB` or `#RGB` value](</en-US/docs/Web/CSS/color_value#rgb()>) or a [color keyword](/en-US/docs/Web/CSS/color_value#color_keywords). Omitting the attribute or setting it to `null` in JavaScript causes the row's cells to inherit the row's parent element's background color.
+  - : A string specifying a color to apply to the backgrounds of each of the row's cells. This can be either an [hexadecimal `#RRGGBB` or `#RGB` value](</en-US/docs/Web/CSS/color_value#rgb()>) or a [color keyword](/en-US/docs/Web/CSS/color_value#color_keywords). Omitting the attribute or setting it to `null` in JavaScript causes the row's cells to inherit the row's parent element's background color.
 
     > **Note:** The {{HTMLElement("tr")}} element should be styled using [CSS](/en-US/docs/Web/CSS). To give a similar effect as the `bgcolor` attribute, use the [CSS](/en-US/docs/Web/CSS) property {{CSSxRef("background-color")}}.
 
 - {{HTMLAttrDef("char")}}{{deprecated_inline}}
 
-  - : A {{DOMxRef("DOMString")}} which sets the character to align the cells in each of the row's columns on (each row's centering that uses the same character gets aligned with others using the same character . Typical values for this include a period (`"."`) or comma (`","`) when attempting to align numbers or monetary values. If {{htmlattrxref("align", "tr")}} is not set to `char`, this attribute is ignored.
+  - : A string which sets the character to align the cells in each of the row's columns on (each row's centering that uses the same character gets aligned with others using the same character . Typical values for this include a period (`"."`) or comma (`","`) when attempting to align numbers or monetary values. If {{htmlattrxref("align", "tr")}} is not set to `char`, this attribute is ignored.
 
     > **Note:** This attribute is not only obsolete, but was rarely implemented anyway. To achieve the same effect as the {{htmlattrxref("char", "tr")}} attribute, set the CSS {{CSSxRef("text-align")}} property to the same string you would specify for the `char` property, such as `text-align: "."`.
 
 - {{HTMLAttrDef("charoff")}}{{deprecated_inline}}
 
-  - : A {{DOMxRef("DOMString")}} indicating the number of characters on the tail end of the column's data should be displayed after the alignment character specified by the `char` attribute. For example, when displaying money values for currencies that use hundredths of a unit (such as the dollar, which is divided into 100 cents), you would typically specify a value of 2, so that in tandem with `char` being set to `"."`, the values in a column would be cleanly aligned on the decimal points, with the number of cents properly displayed to the right of the decimal point.
+  - : A string indicating the number of characters on the tail end of the column's data should be displayed after the alignment character specified by the `char` attribute. For example, when displaying money values for currencies that use hundredths of a unit (such as the dollar, which is divided into 100 cents), you would typically specify a value of 2, so that in tandem with `char` being set to `"."`, the values in a column would be cleanly aligned on the decimal points, with the number of cents properly displayed to the right of the decimal point.
 
     > **Note:** This attribute is obsolete, and was never widely supported anyway.
 
 - {{HTMLAttrDef("valign")}}{{deprecated_inline}}
 
-  - : A {{DOMxRef("DOMString")}} specifying the vertical alignment of the text within each cell in the row. Possible values for this attribute are:
+  - : A string specifying the vertical alignment of the text within each cell in the row. Possible values for this attribute are:
 
     - `baseline`
       - : Aligns each cell's content text as closely as possible to the bottom of the cell, handling alignment of different fonts and font sizes by aligning the characters along the {{interwiki("wikipedia", "baseline")}} of the font(s) used in the row. If all of the characters in the row are the same size, the effect is the same as `bottom`.

--- a/files/en-us/web/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/web_components/using_custom_elements/index.md
@@ -20,7 +20,7 @@ The controller of custom elements on a web document is the {{domxref("CustomElem
 
 To register a custom element on the page, you use the {{domxref("CustomElementRegistry.define()")}} method. This takes as its arguments:
 
-- A {{domxref("DOMString")}} representing the name you are giving to the element. Note that custom element names [require a dash to be used in them](https://html.spec.whatwg.org/#valid-custom-element-name) (kebab-case); they can't be single words.
+- A string representing the name you are giving to the element. Note that custom element names [require a dash to be used in them](https://html.spec.whatwg.org/#valid-custom-element-name) (kebab-case); they can't be single words.
 - A [class](/en-US/docs/Web/JavaScript/Reference/Classes) object that defines the behavior of the element.
 - {{optional_inline}} An options object containing an `extends` property, which specifies the built-in element your element inherits from, if any (only relevant to customized built-in elements; see the definition below).
 


### PR DESCRIPTION
Continuing #15499 

### Summary
`DOMString` is not exposed by browsers to JavaScript. It is converted to `string`.[[ref](https://developer.mozilla.org/en-US/docs/Web/API/DOMString)]

Same is the case with `USVString` and `CSSOMString`.

### Metadata
- [x] Fixes a typo, bug, or other error
