### PR TITLE
DOMString -> string

### DIFF
--- a/files/en-us/web/api/audiodecoder/configure/index.md
+++ b/files/en-us/web/api/audiodecoder/configure/index.md
@@ -24,7 +24,7 @@ configure(config)
 - `config`
   - : A dictionary object containing the following members:
     - `codec`
-      - : A {{domxref("DOMString","string")}} containing a [valid codec string](https://www.w3.org/TR/webcodecs-codec-registry/#audio-codec-registry).
+      - : A string containing a [valid codec string](https://www.w3.org/TR/webcodecs-codec-registry/#audio-codec-registry).
     - `sampleRate`
       - : An integer representing the number of frame samples per second.
     - `numberOfChannels`

--- a/files/en-us/web/api/audioencoder/audioencoder/index.md
+++ b/files/en-us/web/api/audioencoder/audioencoder/index.md
@@ -25,7 +25,7 @@ new AudioEncoder(init)
     - `output`
       - : A callback which takes a {{domxref("EncodedAudioChunk")}} object as the first argument, and an optional metadata object as the second. The metadata object has one member, `decoderConfig` which has an object as its value containing:
         - `codec`
-          - : A {{domxref("DOMString","string")}} containing a [valid codec string](https://www.w3.org/TR/webcodecs-codec-registry/#audio-codec-registry).
+          - : A string containing a [valid codec string](https://www.w3.org/TR/webcodecs-codec-registry/#audio-codec-registry).
         - `sampleRate`
           - : An integer representing the number of frame samples per second.
         - `numberOfChannels`

--- a/files/en-us/web/api/audioencoder/configure/index.md
+++ b/files/en-us/web/api/audioencoder/configure/index.md
@@ -24,7 +24,7 @@ configure(config)
 - `config`
   - : A dictionary object containing the following members:
     - `codec`
-      - : A {{domxref("DOMString","string")}} containing a [valid codec string](https://www.w3.org/TR/webcodecs-codec-registry/#audio-codec-registry).
+      - : A string containing a [valid codec string](https://www.w3.org/TR/webcodecs-codec-registry/#audio-codec-registry).
     - `sampleRate`{{Optional_Inline}}
       - : An integer representing the number of frame samples per second.
     - `numberOfChannels`{{Optional_Inline}}

--- a/files/en-us/web/api/backgroundfetchregistration/id/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/id/index.md
@@ -15,7 +15,7 @@ The **`id`** read-only property of the {{domxref("BackgroundFetchRegistration")}
 
 ## Value
 
-A {{domxref("DOMString","string")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/backgroundfetchregistration/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/index.md
@@ -21,7 +21,7 @@ A `BackgroundFetchRegistration` instance is returned by the {{domxref("Backgroun
 The following properties are available synchronously, as convenience properties copied from those in the `BackgroundFetchRegistration` instance.
 
 - {{domxref("BackgroundFetchRegistration.id")}}{{ReadOnlyInline}}
-  - : A {{domxref("DOMString","string")}} containing the background fetch's ID.
+  - : A string containing the background fetch's ID.
 - {{domxref("BackgroundFetchRegistration.uploadTotal")}}{{ReadOnlyInline}}
   - : A {{jsxref("number")}} containing the total number of bytes to be uploaded.
 - {{domxref("BackgroundFetchRegistration.uploaded")}}{{ReadOnlyInline}}

--- a/files/en-us/web/api/backgroundfetchupdateuievent/updateui/index.md
+++ b/files/en-us/web/api/backgroundfetchupdateuievent/updateui/index.md
@@ -32,13 +32,13 @@ updateUI(options)
       - : A list of one or more image resources, containing icons for use in the user interface. An image resource is an object containing:
 
         - `src`
-          - : A {{domxref("DOMString","string")}} which is a URL of an image.
+          - : A string which is a URL of an image.
         - `sizes`{{optional_inline}}
-          - : A {{domxref("DOMString","string")}} which is equivalent to a {{htmlelement("link")}} `sizes` attribute.
+          - : A string which is equivalent to a {{htmlelement("link")}} `sizes` attribute.
         - `type`{{optional_inline}}
-          - : A {{domxref("DOMString","string")}} containing an image MIME type.
+          - : A string containing an image MIME type.
         - `label`{{optional_inline}}
-          - : A {{domxref("DOMString","string")}} providing a name for the associated image.
+          - : A string providing a name for the associated image.
 
     - `title`{{optional_inline}}
       - : A {{domxref("DOMString", "string")}} containing text to update the title of the user interface.

--- a/files/en-us/web/api/bluetoothuuid/canonicaluuid/index.md
+++ b/files/en-us/web/api/bluetoothuuid/canonicaluuid/index.md
@@ -23,7 +23,7 @@ canonicalUUID(alias)
 ### Parameters
 
 - `alias`
-  - : A {{domxref("DOMString","string")}} containing a 16- or 32- bit UUID alias.
+  - : A string containing a 16- or 32- bit UUID alias.
 
 ### Return value
 

--- a/files/en-us/web/api/bluetoothuuid/getcharacteristic/index.md
+++ b/files/en-us/web/api/bluetoothuuid/getcharacteristic/index.md
@@ -23,7 +23,7 @@ getCharacteristic(name)
 ### Parameters
 
 - `name`
-  - : A {{domxref("DOMString","string")}} containing the name of the characteristic.
+  - : A string containing the name of the characteristic.
 
 ### Return value
 

--- a/files/en-us/web/api/bluetoothuuid/getdescriptor/index.md
+++ b/files/en-us/web/api/bluetoothuuid/getdescriptor/index.md
@@ -23,7 +23,7 @@ getDescriptor(name)
 ### Parameters
 
 - `name`
-  - : A {{domxref("DOMString","string")}} containing the name of the descriptor.
+  - : A string containing the name of the descriptor.
 
 ### Return value
 

--- a/files/en-us/web/api/bluetoothuuid/getservice/index.md
+++ b/files/en-us/web/api/bluetoothuuid/getservice/index.md
@@ -23,7 +23,7 @@ getService(name)
 ### Parameters
 
 - `name`
-  - : A {{domxref("DOMString","string")}} containing the name of the service.
+  - : A string containing the name of the service.
 
 ### Return value
 

--- a/files/en-us/web/api/closeevent/reason/index.md
+++ b/files/en-us/web/api/closeevent/reason/index.md
@@ -14,7 +14,7 @@ The **`reason`** read-only property of the {{domxref("CloseEvent")}} interface r
 
 ## Value
 
-A {{domxref("DOMString","string")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/cssnamespacerule/index.md
+++ b/files/en-us/web/api/cssnamespacerule/index.md
@@ -19,9 +19,9 @@ The **`CSSNamespaceRule`** interface describes an object representing a single C
 _Inherits methods from its ancestor {{domxref("CSSRule")}}._
 
 - {{domxref("CSSNamespaceRule.namespaceURI")}}
-  - : Returns a {{ domxref("DOMString") }} containing the text of the URI of the given namespace.
+  - : Returns a string containing the text of the URI of the given namespace.
 - {{domxref("CSSNamespaceRule.prefix")}}
-  - : Returns a {{ domxref("DOMString") }} with the name of the prefix associated to this namespace. If there is no such prefix, returns an empty string.
+  - : Returns a string with the name of the prefix associated to this namespace. If there is no such prefix, returns an empty string.
 
 ## Methods
 

--- a/files/en-us/web/api/cssstylesheet/cssstylesheet/index.md
+++ b/files/en-us/web/api/cssstylesheet/cssstylesheet/index.md
@@ -28,9 +28,9 @@ new CSSStyleSheet(options)
   - : An object containing the following:
 
     - `baseURL`{{optional_inline}}
-      - : A {{domxref("DOMString","string")}} containing the `baseURL` used to resolve relative URLs in the stylesheet.
+      - : A string containing the `baseURL` used to resolve relative URLs in the stylesheet.
     - `media`{{optional_inline}}
-      - : A {{domxref("MediaList")}} containing a list of media rules, or a {{domxref("DOMString","string")}} containing a single rule.
+      - : A {{domxref("MediaList")}} containing a list of media rules, or a string containing a single rule.
     - `disabled`{{optional_inline}}
       - : A {{jsxref("Boolean")}} indicating whether the stylesheet is disabled. False by default.
 

--- a/files/en-us/web/api/datatransfer/cleardata/index.md
+++ b/files/en-us/web/api/datatransfer/cleardata/index.md
@@ -18,7 +18,7 @@ operation's {{domxref("DataTransfer","drag data")}} for the given type. If data 
 given type does not exist, this method does nothing.
 
 If this method is called with no arguments or the format is an empty
-{{domxref("DOMString","string")}}, the data of all types will be removed.
+string, the data of all types will be removed.
 
 This method does _not_ remove files from the drag operation, so it's possible
 for there still to be an entry with the type `"Files"` left in the object's
@@ -37,7 +37,7 @@ clearData(format)
 ### Parameters
 
 - `format` {{optional_inline}}
-  - : A {{domxref("DOMString","string")}} which specifies the type of data to remove. If
+  - : A string which specifies the type of data to remove. If
     this parameter is an empty string or is not provided, the data for all types is
     removed.
 

--- a/files/en-us/web/api/datatransfer/mozcleardataat/index.md
+++ b/files/en-us/web/api/datatransfer/mozcleardataat/index.md
@@ -38,7 +38,7 @@ mozClearDataAt(type, index)
 ### Parameters
 
 - _type_
-  - : A {{domxref("DOMString","string")}} representing the type of the drag data to remove
+  - : A string representing the type of the drag data to remove
     from the {{domxref("DataTransfer","drag data object")}}.
 - _index_
   - : A `unsigned long` representing the index of the data to remove.

--- a/files/en-us/web/api/datatransfer/mozgetdataat/index.md
+++ b/files/en-us/web/api/datatransfer/mozgetdataat/index.md
@@ -32,7 +32,7 @@ mozGetDataAt(type, index)
 ### Parameters
 
 - _type_
-  - : A {{domxref("DOMString","string")}} representing the type of the drag data to
+  - : A string representing the type of the drag data to
     retrieve from the {{domxref("DataTransfer","drag data object")}}.
 - _index_
   - : A `unsigned long` representing the index of the data to retrieve.

--- a/files/en-us/web/api/datatransfer/mozsetdataat/index.md
+++ b/files/en-us/web/api/datatransfer/mozsetdataat/index.md
@@ -29,7 +29,7 @@ Data should be added in order of preference, with the most specific format added
 and the least specific format added last. If data of the given format already exists, it
 is replaced in the same position as the old data.
 
-The data should be either a {{domxref("DOMString","string")}}, a boolean value
+The data should be either a string, a boolean value
 or number type (which will be converted into a string) or an `nsISupports`.
 
 > **Note:** This method is Firefox-specific.
@@ -44,7 +44,7 @@ mozSetDataAt(type, data, index)
 ### Parameters
 
 - _type_
-  - : A {{domxref("DOMString","string")}} representing the type of the drag data to add to
+  - : A string representing the type of the drag data to add to
     the {{domxref("DataTransfer","drag data object")}}.
 - _data_
   - : A `nsIVariant` representing the data to add to the

--- a/files/en-us/web/api/datatransfer/types/index.md
+++ b/files/en-us/web/api/datatransfer/types/index.md
@@ -22,7 +22,7 @@ by a MIME type. Some values that are not MIME types are special-cased for legacy
 
 ## Value
 
-An array of the data formats used in the drag operation. Each format is
+An array of the data formats used in the drag operation. Each format is a 
 string. If the drag operation included no data, this list
 will be empty. If any files are included in the drag operation, then one of the types
 will be the string `Files`.

--- a/files/en-us/web/api/datatransfer/types/index.md
+++ b/files/en-us/web/api/datatransfer/types/index.md
@@ -23,7 +23,7 @@ by a MIME type. Some values that are not MIME types are special-cased for legacy
 ## Value
 
 An array of the data formats used in the drag operation. Each format is
-{{domxref("DOMString","string")}}. If the drag operation included no data, this list
+string. If the drag operation included no data, this list
 will be empty. If any files are included in the drag operation, then one of the types
 will be the string `Files`.
 

--- a/files/en-us/web/api/datatransferitemlist/add/index.md
+++ b/files/en-us/web/api/datatransferitemlist/add/index.md
@@ -16,7 +16,7 @@ browser-compat: api.DataTransferItemList.add
 
 The **`DataTransferItemList.add()`** method creates a new
 {{domxref("DataTransferItem")}} using the specified data and adds it to the drag data
-list. The item may be a {{domxref("File")}} or a {{domxref("DOMString","string")}} of a
+list. The item may be a {{domxref("File")}} or a string of a
 given type. If the item is successfully added to the list, the newly-created
 {{domxref("DataTransferItem")}} object is returned.
 
@@ -30,9 +30,9 @@ add(file)
 ### Parameters
 
 - `data`
-  - : A {{domxref("DOMstring","string")}} representing the drag item's data.
+  - : A string representing the drag item's data.
 - `type`
-  - : A {{domxref("DOMstring","string")}} of the drag item's type. Some example types are
+  - : A string of the drag item's type. Some example types are
     `text/html` and `text/plain`.
 - `file`
   - : A {{domxref("File")}} object. No type needs to be given in this case.

--- a/files/en-us/web/api/domerror/index.md
+++ b/files/en-us/web/api/domerror/index.md
@@ -17,9 +17,9 @@ The **`DOMError`** interface describes an error object that contains an error na
 ## Properties
 
 - {{domxref("DOMError.name")}} {{readOnlyInline}}
-  - : Returns a {{ domxref("DOMString") }} representing one of the error type names (see below).
+  - : Returns a string representing one of the error type names (see below).
 - {{domxref("DOMError.message")}} {{readOnlyInline}}
-  - : Returns a {{ domxref("DOMString") }} representing a message or description associated with the given error type name.
+  - : Returns a string representing a message or description associated with the given error type name.
 
 ## Error types
 

--- a/files/en-us/web/api/domexception/message/index.md
+++ b/files/en-us/web/api/domexception/message/index.md
@@ -12,7 +12,7 @@ browser-compat: api.DOMException.message
 {{ APIRef("DOM") }}
 
 The **`message`** read-only property of the
-{{domxref("DOMException")}} interface returns a {{ domxref("DOMString") }} representing
+{{domxref("DOMException")}} interface returns a string representing
 a message or description associated with the given [error name](/en-US/docs/Web/API/DOMException#error_names).
 
 ## Value

--- a/files/en-us/web/api/htmlbodyelement/index.md
+++ b/files/en-us/web/api/htmlbodyelement/index.md
@@ -20,17 +20,17 @@ The **`HTMLBodyElement`** interface provides special properties (beyond those in
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLBodyElement.aLink")}} {{deprecated_inline}}
-  - : A {{ domxref("DOMString") }} that represents the color of active hyperlinks.
+  - : A string that represents the color of active hyperlinks.
 - {{domxref("HTMLBodyElement.background")}} {{deprecated_inline}}
-  - : A {{ domxref("DOMString") }} that represents the description of the location of the background image resource. Note that this is not an URI, though some older version of some browsers do expect it.
+  - : A string that represents the description of the location of the background image resource. Note that this is not an URI, though some older version of some browsers do expect it.
 - {{domxref("HTMLBodyElement.bgColor")}} {{deprecated_inline}}
-  - : A {{ domxref("DOMString") }} that represents the background color for the document.
+  - : A string that represents the background color for the document.
 - {{domxref("HTMLBodyElement.link")}} {{deprecated_inline}}
-  - : A {{ domxref("DOMString") }} that represents the color of unvisited links.
+  - : A string that represents the color of unvisited links.
 - {{domxref("HTMLBodyElement.text")}} {{deprecated_inline}}
-  - : A {{ domxref("DOMString") }} that represents the foreground color of text.
+  - : A string that represents the foreground color of text.
 - {{domxref("HTMLBodyElement.vLink")}} {{deprecated_inline}}
-  - : A {{ domxref("DOMString") }} that represents the color of visited links.
+  - : A string that represents the color of visited links.
 
 ## Methods
 

--- a/files/en-us/web/api/htmliframeelement/index.md
+++ b/files/en-us/web/api/htmliframeelement/index.md
@@ -33,7 +33,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}_.
 - {{domxref("HTMLIFrameElement.csp")}}
   - : Specifies the Content Security Policy that an embedded document must agree to enforce upon itself.
 - {{domxref("HTMLIFrameElement.fetchPriority")}}
-  - : An optional {{domxref("DOMString")}} representing a hint given to the browser on how it should prioritize fetching of the iframe document relative to other iframe documents. If this value is provided, it must be one of the possible permitted values: `high` to fetch at a high priority, `low` to fetch at a low priority, or `auto` to indicate no preference (which is the default).
+  - : An optional string representing a hint given to the browser on how it should prioritize fetching of the iframe document relative to other iframe documents. If this value is provided, it must be one of the possible permitted values: `high` to fetch at a high priority, `low` to fetch at a low priority, or `auto` to indicate no preference (which is the default).
 - {{domxref("HTMLIFrameElement.frameBorder")}} {{deprecated_inline}}
   - : A string that indicates whether to create borders between frames.
 - {{domxref("HTMLIFrameElement.height")}}

--- a/files/en-us/web/api/htmlimageelement/index.md
+++ b/files/en-us/web/api/htmlimageelement/index.md
@@ -30,37 +30,37 @@ The **`HTMLImageElement`** interface represents an HTML {{HTMLElement("img")}} e
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLImageElement.alt")}}
-  - : A {{domxref("DOMString")}} that reflects the {{htmlattrxref("alt", "img")}} HTML attribute, thus indicating the alternate fallback content to be displayed if the image has not been loaded.
+  - : A string that reflects the {{htmlattrxref("alt", "img")}} HTML attribute, thus indicating the alternate fallback content to be displayed if the image has not been loaded.
 - {{domxref("HTMLImageElement.complete")}} {{readonlyInline}}
   - : Returns a boolean value that is `true` if the browser has finished fetching the image, whether successful or not. That means this value is also `true` if the image has no {{domxref("HTMLImageElement.src", "src")}} value indicating an image to load.
 - {{domxref("HTMLImageElement.crossOrigin")}}
-  - : A {{domxref("DOMString")}} specifying the CORS setting for this image element. See [CORS settings attributes](/en-US/docs/Web/HTML/Attributes/crossorigin) for further details. This may be `null` if CORS is not used.
+  - : A string specifying the CORS setting for this image element. See [CORS settings attributes](/en-US/docs/Web/HTML/Attributes/crossorigin) for further details. This may be `null` if CORS is not used.
 - {{domxref("HTMLImageElement.currentSrc")}} {{readonlyInline}}
-  - : Returns a {{domxref("USVString")}} representing the URL from which the currently displayed image was loaded. This may change as the image is adjusted due to changing conditions, as directed by any [media queries](/en-US/docs/Web/CSS/Media_Queries) which are in place.
+  - : Returns a string representing the URL from which the currently displayed image was loaded. This may change as the image is adjusted due to changing conditions, as directed by any [media queries](/en-US/docs/Web/CSS/Media_Queries) which are in place.
 - {{domxref("HTMLImageElement.decoding")}}
-  - : An optional {{domxref("DOMString")}} representing a hint given to the browser on how it should decode the image. If this value is provided, it must be one of the possible permitted values: `sync` to decode the image synchronously, `async` to decode it asynchronously, or `auto` to indicate no preference (which is the default). Read the {{domxref("HTMLImageElement.decoding", "decoding")}} page for details on the implications of this property's values.
+  - : An optional string representing a hint given to the browser on how it should decode the image. If this value is provided, it must be one of the possible permitted values: `sync` to decode the image synchronously, `async` to decode it asynchronously, or `auto` to indicate no preference (which is the default). Read the {{domxref("HTMLImageElement.decoding", "decoding")}} page for details on the implications of this property's values.
 - {{domxref("HTMLImageElement.fetchPriority")}}
-  - : An optional {{domxref("DOMString")}} representing a hint given to the browser on how it should prioritize fetching of the image relative to other images. If this value is provided, it must be one of the possible permitted values: `high` to fetch at a high priority, `low` to fetch at a low priority, or `auto` to indicate no preference (which is the default).
+  - : An optional string representing a hint given to the browser on how it should prioritize fetching of the image relative to other images. If this value is provided, it must be one of the possible permitted values: `high` to fetch at a high priority, `low` to fetch at a low priority, or `auto` to indicate no preference (which is the default).
 - {{domxref("HTMLImageElement.height")}}
   - : An integer value that reflects the {{htmlattrxref("height", "img")}} HTML attribute, indicating the rendered height of the image in CSS pixels.
 - {{domxref("HTMLImageElement.isMap")}}
   - : A boolean value that reflects the {{htmlattrxref("ismap", "img")}} HTML attribute, indicating that the image is part of a server-side image map. This is different from a client-side image map, specified using an `<img>` element and a corresponding {{HTMLElement("map")}} which contains {{HTMLElement("area")}} elements indicating the clickable areas in the image. The image _must_ be contained within an {{HTMLElement("a")}} element; see the `ismap` page for details.
 - {{domxref("HTMLImageElement.loading")}}
-  - : A {{domxref("DOMString")}} providing a hint to the browser used to optimize loading the document by determining whether to load the image immediately (`eager`) or on an as-needed basis (`lazy`).
+  - : A string providing a hint to the browser used to optimize loading the document by determining whether to load the image immediately (`eager`) or on an as-needed basis (`lazy`).
 - {{domxref("HTMLImageElement.naturalHeight")}} {{readonlyInline}}
   - : Returns an integer value representing the intrinsic height of the image in CSS pixels, if it is available; else, it shows `0`. This is the height the image would be if it were rendered at its natural full size.
 - {{domxref("HTMLImageElement.naturalWidth")}} {{readonlyInline}}
   - : An integer value representing the intrinsic width of the image in CSS pixels, if it is available; otherwise, it will show `0`. This is the width the image would be if it were rendered at its natural full size.
 - {{domxref("HTMLImageElement.referrerPolicy")}}
-  - : A {{domxref("DOMString")}} that reflects the {{htmlattrxref("referrerpolicy", "img")}} HTML attribute, which tells the {{Glossary("user agent")}} how to decide which referrer to use in order to fetch the image. Read this article for details on the possible values of this string.
+  - : A string that reflects the {{htmlattrxref("referrerpolicy", "img")}} HTML attribute, which tells the {{Glossary("user agent")}} how to decide which referrer to use in order to fetch the image. Read this article for details on the possible values of this string.
 - {{domxref("HTMLImageElement.sizes")}}
-  - : A {{domxref("DOMString")}} reflecting the {{htmlattrxref("sizes", "img")}} HTML attribute. This string specifies a list of comma-separated conditional sizes for the image; that is, for a given viewport size, a particular image size is to be used. Read the documentation on the {{domxref("HTMLImageElement.sizes", "sizes")}} page for details on the format of this string.
+  - : A string reflecting the {{htmlattrxref("sizes", "img")}} HTML attribute. This string specifies a list of comma-separated conditional sizes for the image; that is, for a given viewport size, a particular image size is to be used. Read the documentation on the {{domxref("HTMLImageElement.sizes", "sizes")}} page for details on the format of this string.
 - {{domxref("HTMLImageElement.src")}}
-  - : A {{domxref("USVString")}} that reflects the {{htmlattrxref("src", "img")}} HTML attribute, which contains the full URL of the image including base URI. You can load a different image into the element by changing the URL in the `src` attribute.
+  - : A string that reflects the {{htmlattrxref("src", "img")}} HTML attribute, which contains the full URL of the image including base URI. You can load a different image into the element by changing the URL in the `src` attribute.
 - {{domxref("HTMLImageElement.srcset")}}
-  - : A {{domxref("USVString")}} reflecting the {{htmlattrxref("srcset", "img")}} HTML attribute. This specifies a list of candidate images, separated by commas (`',', U+002C COMMA`). Each candidate image is a URL followed by a space, followed by a specially-formatted string indicating the size of the image. The size may be specified either the width or a size multiple. Read the {{domxref("HTMLImageElement.srcset", "srcset")}} page for specifics on the format of the size substring.
+  - : A string reflecting the {{htmlattrxref("srcset", "img")}} HTML attribute. This specifies a list of candidate images, separated by commas (`',', U+002C COMMA`). Each candidate image is a URL followed by a space, followed by a specially-formatted string indicating the size of the image. The size may be specified either the width or a size multiple. Read the {{domxref("HTMLImageElement.srcset", "srcset")}} page for specifics on the format of the size substring.
 - {{domxref("HTMLImageElement.useMap")}}
-  - : A {{domxref("DOMString")}} reflecting the {{htmlattrxref("usemap", "img")}} HTML attribute, containing the page-local URL of the {{HTMLElement("map")}} element describing the image map to use. The page-local URL is a pound (hash) symbol (`#`) followed by the ID of the `<map>` element, such as `#my-map-element`. The `<map>` in turn contains {{HTMLElement("area")}} elements indicating the clickable areas in the image.
+  - : A string reflecting the {{htmlattrxref("usemap", "img")}} HTML attribute, containing the page-local URL of the {{HTMLElement("map")}} element describing the image map to use. The page-local URL is a pound (hash) symbol (`#`) followed by the ID of the `<map>` element, such as `#my-map-element`. The `<map>` in turn contains {{HTMLElement("area")}} elements indicating the clickable areas in the image.
 - {{domxref("HTMLImageElement.width")}}
   - : An integer value that reflects the {{htmlattrxref("width", "img")}} HTML attribute, indicating the rendered width of the image in CSS pixels.
 - {{domxref("HTMLImageElement.x")}} {{ReadOnlyInline}}
@@ -71,15 +71,15 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 ## Obsolete properties
 
 - {{domxref("HTMLImageElement.align")}} {{deprecated_inline}}
-  - : A {{domxref("DOMString")}} indicating the alignment of the image with respect to the surrounding context. The possible values are `"left"`, `"right"`, `"justify"`, and `"center"`. This is obsolete; you should instead use CSS (such as {{cssxref("text-align")}}, which works with images despite its name) to specify the alignment.
+  - : A string indicating the alignment of the image with respect to the surrounding context. The possible values are `"left"`, `"right"`, `"justify"`, and `"center"`. This is obsolete; you should instead use CSS (such as {{cssxref("text-align")}}, which works with images despite its name) to specify the alignment.
 - {{domxref("HTMLImageElement.border")}} {{deprecated_inline}}
-  - : A {{domxref("DOMString")}} which defines the width of the border surrounding the image. This is deprecated; use the CSS {{cssxref("border")}} property instead.
+  - : A string which defines the width of the border surrounding the image. This is deprecated; use the CSS {{cssxref("border")}} property instead.
 - {{domxref("HTMLImageElement.hspace")}} {{deprecated_inline}}
   - : An integer value which specifies the amount of space (in pixels) to leave empty on the left and right sides of the image.
 - {{domxref("HTMLImageElement.longDesc")}} {{deprecated_inline}}
-  - : A {{domxref("USVString")}} specifying the URL at which a long description of the image's contents may be found. This is used to turn the image into a hyperlink automatically. Modern HTML should instead place an `<img>` inside an {{HTMLElement("a")}} element defining the hyperlink.
+  - : A string specifying the URL at which a long description of the image's contents may be found. This is used to turn the image into a hyperlink automatically. Modern HTML should instead place an `<img>` inside an {{HTMLElement("a")}} element defining the hyperlink.
 - {{domxref("HTMLImageElement.name")}} {{deprecated_inline}}
-  - : A {{domxref("DOMString")}} representing the name of the element.
+  - : A string representing the name of the element.
 - {{domxref("HTMLImageElement.vspace")}} {{deprecated_inline}}
   - : An integer value specifying the amount of empty space, in pixels, to leave above and below the image.
 

--- a/files/en-us/web/api/htmllinkelement/index.md
+++ b/files/en-us/web/api/htmllinkelement/index.md
@@ -26,7 +26,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 - {{domxref("HTMLLinkElement.disabled")}}
   - : A boolean value which represents whether the link is disabled; currently only used with style sheet links.
 - {{domxref("HTMLLinkElement.fetchPriority")}}
-  - : An optional {{domxref("DOMString")}} representing a hint given to the browser on how it should prioritize fetching of a preload relative to other resources of the same type. If this value is provided, it must be one of the possible permitted values: `high` to fetch at a higher priority, `low` to fetch at a lower priority, or `auto` to indicate no preference (which is the default).
+  - : An optional string representing a hint given to the browser on how it should prioritize fetching of a preload relative to other resources of the same type. If this value is provided, it must be one of the possible permitted values: `high` to fetch at a higher priority, `low` to fetch at a lower priority, or `auto` to indicate no preference (which is the default).
 - {{domxref("HTMLLinkElement.href")}}
   - : A string representing the URI for the target resource.
 - {{domxref("HTMLLinkElement.hreflang")}}

--- a/files/en-us/web/api/htmlscriptelement/index.md
+++ b/files/en-us/web/api/htmlscriptelement/index.md
@@ -22,13 +22,13 @@ JavaScript files should be served with the `application/javascript` [MIME type](
 _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 
 - {{domxref("HTMLScriptElement.type")}}
-  - : A {{domxref("DOMString")}} representing the MIME type of the script. It reflects the {{htmlattrxref("type","script")}} attribute.
+  - : A string representing the MIME type of the script. It reflects the {{htmlattrxref("type","script")}} attribute.
 - {{domxref("HTMLScriptElement.src")}}
-  - : A {{domxref("DOMString")}} representing the URL of an external script. It reflects the {{htmlattrxref("src","script")}} attribute.
+  - : A string representing the URL of an external script. It reflects the {{htmlattrxref("src","script")}} attribute.
 - {{domxref("HTMLScriptElement.event")}} {{deprecated_inline}}
-  - : A {{domxref("DOMString")}}; an obsolete way of registering event handlers on elements in an HTML document.
+  - : A string; an obsolete way of registering event handlers on elements in an HTML document.
 - {{domxref("HTMLScriptElement.charset")}} {{deprecated_inline}}
-  - : A {{domxref("DOMString")}} representing the character encoding of an external script. It reflects the {{htmlattrxref("charset","script")}} attribute.
+  - : A string representing the character encoding of an external script. It reflects the {{htmlattrxref("charset","script")}} attribute.
 - {{domxref("HTMLScriptElement.async")}}, {{domxref("HTMLScriptElement.defer")}}
 
   - : The `async` and `defer` attributes are boolean attributes that control how the script should be executed. **The `defer` and `async` attributes must not be specified if the `src` attribute is absent.**
@@ -44,19 +44,19 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
     > **Note:** The exact processing details for these attributes are complex, involving many different aspects of HTML, and therefore are scattered throughout the specification. [These algorithms](https://html.spec.whatwg.org/multipage/scripting.html) describe the core ideas, but they rely on the parsing rules for {{HTMLElement("script")}} [start](https://html.spec.whatwg.org/multipage/syntax.html) and [end](https://html.spec.whatwg.org/multipage/syntax.html) tags in HTML, [in foreign content](https://html.spec.whatwg.org/multipage/syntax.html), and [in XML](https://html.spec.whatwg.org/multipage/xhtml.html); the rules for the [`document.write()`](/en-US/docs/Web/API/Document/write) method; the handling of [scripting](https://html.spec.whatwg.org/multipage/webappapis.html); and so on.
 
 - {{domxref("HTMLScriptElement.crossOrigin")}} {{experimental_inline}}
-  - : A {{domxref("DOMString")}} reflecting the [CORS setting](/en-US/docs/Web/HTML/Attributes/crossorigin) for the script element. For scripts from other [origins](/en-US/docs/Glossary/Origin), this controls if error information will be exposed.
+  - : A string reflecting the [CORS setting](/en-US/docs/Web/HTML/Attributes/crossorigin) for the script element. For scripts from other [origins](/en-US/docs/Glossary/Origin), this controls if error information will be exposed.
 - {{domxref("HTMLScriptElement.text")}}
 
-  - : A {{domxref("DOMString")}} that joins and returns the contents of all [`Text` nodes](/en-US/docs/Web/API/Text) inside the {{HTMLElement("script")}} element (ignoring other nodes like comments) in tree order. On setting, it acts the same way as the [`textContent`](/en-US/docs/Web/API/Node/textContent) IDL attribute.
+  - : A string that joins and returns the contents of all [`Text` nodes](/en-US/docs/Web/API/Text) inside the {{HTMLElement("script")}} element (ignoring other nodes like comments) in tree order. On setting, it acts the same way as the [`textContent`](/en-US/docs/Web/API/Node/textContent) IDL attribute.
 
     > **Note:** When inserted using the [`document.write()`](/en-US/docs/Web/API/Document/write) method, {{HTMLElement("script")}} elements execute (typically synchronously), but when inserted using [`innerHTML`](/en-US/docs/Web/API/Element/innerHTML) or [`outerHTML`](/en-US/docs/Web/API/Element/outerHTML), they do not execute at all.
 
 - {{domxref("HTMLScriptElement.fetchPriority")}}
-  - : An optional {{domxref("DOMString")}} representing a hint given to the browser on how it should prioritize fetching of an external script relative to other external scripts. If this value is provided, it must be one of the possible permitted values: `high` to fetch at a high priority, `low` to fetch at a low priority, or `auto` to indicate no preference (which is the default).
+  - : An optional string representing a hint given to the browser on how it should prioritize fetching of an external script relative to other external scripts. If this value is provided, it must be one of the possible permitted values: `high` to fetch at a high priority, `low` to fetch at a low priority, or `auto` to indicate no preference (which is the default).
 - {{domxref("HTMLScriptElement.noModule")}}
   - : A boolean value that if true, stops the script's execution in browsers that support [ES2015 modules](https://hacks.mozilla.org/2015/08/es6-in-depth-modules/) — used to run fallback scripts in older browsers that do _not_ support JavaScript modules.
 - {{domxref("HTMLScriptElement.referrerPolicy")}}
-  - : A {{domxref("DOMString")}} that reflects the {{htmlattrxref("referrerPolicy", "script")}} HTML attribute indicating which referrer to use when fetching the script, and fetches done by that script.
+  - : A string that reflects the {{htmlattrxref("referrerPolicy", "script")}} HTML attribute indicating which referrer to use when fetching the script, and fetches done by that script.
 
 ## Static methods
 

--- a/files/en-us/web/api/idbdatabase/index.md
+++ b/files/en-us/web/api/idbdatabase/index.md
@@ -27,7 +27,7 @@ The **`IDBDatabase`** interface of the IndexedDB API provides a [connection to a
 ## Properties
 
 - {{domxref("IDBDatabase.name")}} {{readonlyInline}}
-  - : A {{ domxref("DOMString") }} that contains the name of the connected database.
+  - : A string that contains the name of the connected database.
 - {{domxref("IDBDatabase.version")}} {{readonlyInline}}
   - : A 64-bit integer that contains the version of the connected database. When a database is first created, this attribute is an empty string.
 - {{domxref("IDBDatabase.objectStoreNames")}} {{readonlyInline}}

--- a/files/en-us/web/api/location/index.md
+++ b/files/en-us/web/api/location/index.md
@@ -57,23 +57,23 @@ document.body.addEventListener('click', function (evt) {
 - {{domxref("Location.ancestorOrigins")}}
   - : A static {{domxref("DOMStringList")}} containing, in reverse order, the origins of all ancestor browsing contexts of the document associated with the given `Location` object.
 - {{domxref("Location.href")}}
-  - : A {{Glossary("stringifier")}} that returns a {{domxref("USVString")}} containing the entire URL. If changed, the associated document navigates to the new page. It can be set from a different origin than the associated document.
+  - : A {{Glossary("stringifier")}} that returns a string containing the entire URL. If changed, the associated document navigates to the new page. It can be set from a different origin than the associated document.
 - {{domxref("Location.protocol")}}
-  - : A {{domxref("USVString")}} containing the protocol scheme of the URL, including the final `':'`.
+  - : A string containing the protocol scheme of the URL, including the final `':'`.
 - {{domxref("Location.host")}}
-  - : A {{domxref("USVString")}} containing the host, that is the _hostname_, a `':'`, and the _port_ of the URL.
+  - : A string containing the host, that is the _hostname_, a `':'`, and the _port_ of the URL.
 - {{domxref("Location.hostname")}}
-  - : A {{domxref("USVString")}} containing the domain of the URL.
+  - : A string containing the domain of the URL.
 - {{domxref("Location.port")}}
-  - : A {{domxref("USVString")}} containing the port number of the URL.
+  - : A string containing the port number of the URL.
 - {{domxref("Location.pathname")}}
-  - : A {{domxref("USVString")}} containing an initial `'/'` followed by the path of the URL, not including the query string or fragment.
+  - : A string containing an initial `'/'` followed by the path of the URL, not including the query string or fragment.
 - {{domxref("Location.search")}}
-  - : A {{domxref("USVString")}} containing a `'?'` followed by the parameters or "querystring" of the URL. Modern browsers provide [URLSearchParams](/en-US/docs/Web/API/URLSearchParams/get#example) and [URL.searchParams](/en-US/docs/Web/API/URL/searchParams#example) to make it easy to parse out the parameters from the querystring.
+  - : A string containing a `'?'` followed by the parameters or "querystring" of the URL. Modern browsers provide [URLSearchParams](/en-US/docs/Web/API/URLSearchParams/get#example) and [URL.searchParams](/en-US/docs/Web/API/URL/searchParams#example) to make it easy to parse out the parameters from the querystring.
 - {{domxref("Location.hash")}}
-  - : A {{domxref("USVString")}} containing a `'#'` followed by the fragment identifier of the URL.
+  - : A string containing a `'#'` followed by the fragment identifier of the URL.
 - {{domxref("Location.origin")}} {{readOnlyInline}}
-  - : Returns a {{domxref("USVString")}} containing the canonical form of the origin of the specific location.
+  - : Returns a string containing the canonical form of the origin of the specific location.
 
 ## Methods
 
@@ -84,7 +84,7 @@ document.body.addEventListener('click', function (evt) {
 - {{domxref("Location.replace()")}}
   - : Replaces the current resource with the one at the provided URL (redirects to the provided URL). The difference from the `assign()` method and setting the `href` property is that after using `replace()` the current page will not be saved in session {{domxref("History")}}, meaning the user won't be able to use the _back_ button to navigate to it.
 - {{domxref("Location.toString()")}}
-  - : Returns a {{domxref("USVString")}} containing the whole URL. It is a synonym for {{domxref("Location.href")}}, though it can't be used to modify the value.
+  - : Returns a string containing the whole URL. It is a synonym for {{domxref("Location.href")}}, though it can't be used to modify the value.
 
 ## Examples
 

--- a/files/en-us/web/api/notification/notification/index.md
+++ b/files/en-us/web/api/notification/notification/index.md
@@ -39,25 +39,25 @@ new Notification(title, options)
         and `rtl` (although most browsers seem to ignore these settings.)
     - `lang`
       - : The notification's language, as specified using a
-        {{domxref("DOMString")}} representing a language tag
+        string representing a language tag
         according to {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}.
         See the Sitepoint [ISO
         2 letter language codes](https://www.sitepoint.com/iso-2-letter-language-codes/) page for a simple reference.
     - `badge`
-      - : A {{domxref("USVString")}} containing the URL of the image
+      - : A string containing the URL of the image
         used to represent the notification when there isn't enough space to display the
         notification itself.
     - `body`
-      - : A {{domxref("DOMString")}} representing the body text of the
+      - : A string representing the body text of the
         notification, which is displayed below the title.
     - `tag`
-      - : A {{domxref("DOMString")}} representing an identifying tag for
+      - : A string representing an identifying tag for
         the notification.
     - `icon`
-      - : A {{domxref("USVString")}} containing the URL of an icon to
+      - : A string containing the URL of an icon to
         be displayed in the notification.
     - `image`
-      - : a {{domxref("USVString")}} containing the URL of an image to
+      - : a string containing the URL of an image to
         be displayed in the notification.
     - `data`
       - : Arbitrary data that you want associated with the
@@ -76,9 +76,9 @@ new Notification(title, options)
     - `actions`
       - : An array of actions to display in the notification. Each element in the array is an object with the following members:
 
-        - `action`:  A {{domxref("DOMString")}} identifying a user action to be displayed on the notification.
-        - `title`:  A {{domxref("DOMString")}} containing action text to be shown to the user.
-        - `icon`:  A {{domxref("USVString")}} containing the URL of an icon to display with the action.
+        - `action`:  A string identifying a user action to be displayed on the notification.
+        - `title`:  A string containing action text to be shown to the user.
+        - `icon`:  A string containing the URL of an icon to display with the action.
 
         Appropriate responses are built using `event.action` within the
         {{domxref("ServiceWorkerGlobalScope.notificationclick_event", "notificationclick")}} event.

--- a/files/en-us/web/api/request/request/index.md
+++ b/files/en-us/web/api/request/request/index.md
@@ -27,7 +27,7 @@ new Request(input, options)
 
   - : Defines the resource that you wish to fetch. This can either be:
 
-    - A {{domxref("USVString")}} containing the direct URL of the resource you want to
+    - A string containing the direct URL of the resource you want to
       fetch.
     - A {{domxref("Request")}} object, effectively creating a copy. Note the following
       behavioral updates to retain security while making the constructor less likely to
@@ -71,7 +71,7 @@ new Request(input, options)
       - : The redirect mode to use: `follow`,
         `error`, or `manual`. The default is `follow`.
     - `referrer`
-      - : A {{domxref("USVString")}} specifying
+      - : A string specifying
         `no-referrer`, `client`, or a URL. The default is
         `about:client`.
     - `integrity`

--- a/files/en-us/web/api/sharedworker/sharedworker/index.md
+++ b/files/en-us/web/api/sharedworker/sharedworker/index.md
@@ -32,10 +32,10 @@ new SharedWorker(aURL, options)
 ### Parameters
 
 - `aURL`
-  - : A {{domxref("DOMString")}} representing the URL of the script the worker will
+  - : A string representing the URL of the script the worker will
     execute. It must obey the same-origin policy.
 - `name` {{optional_inline}}
-  - : A {{domxref("DOMString")}} specifying an identifying name for the
+  - : A string specifying an identifying name for the
     {{domxref("SharedWorkerGlobalScope")}} representing the scope of the worker, which is
     mainly useful for debugging purposes.
 - `options` {{optional_inline}}
@@ -44,17 +44,17 @@ new SharedWorker(aURL, options)
     instance. Available properties are as follows:
 
     - `type`
-      - : A {{domxref("DOMString")}} specifying the type of worker to
+      - : A string specifying the type of worker to
         create. The value can be `classic` or `module`. If not
         specified, the default used is `classic`.
     - `credentials`
-      - : A {{domxref("DOMString")}} specifying the type of
+      - : A string specifying the type of
         credentials to use for the worker. The value can be `omit`,
         `same-origin`, or _`include`. If not
         specified, or if type is `classic`, the default used is
         `omit` (no credentials required)._
     - `name`
-      - : A {{domxref("DOMString")}} specifying an
+      - : A string specifying an
         identifying name for the {{domxref("SharedWorkerGlobalScope")}} representing the
         scope of the worker, which is mainly useful for debugging purposes.
 

--- a/files/en-us/web/api/svgaelement/index.md
+++ b/files/en-us/web/api/svgaelement/index.md
@@ -23,9 +23,9 @@ _This interface also inherits properties from its parent, {{domxref("SVGGraphics
 - {{domxref("SVGAElement.href")}} {{ReadOnlyInline}}
   - : An {{domxref("SVGAnimatedString")}} that reflects the {{SVGAttr("href")}} or {{SVGAttr("xlink:href")}} attribute.
 - {{domxref("SVGAElement.hreflang")}}
-  - : A {{domxref("DOMString")}} that reflects the `hreflang` attribute, indicating the language of the linked resource.
+  - : A string that reflects the `hreflang` attribute, indicating the language of the linked resource.
 - {{domxref("SVGAElement.ping")}}
-  - : A {{domxref("DOMString")}} that reflects the ping attribute, containing a space-separated list of URLs to which, when the hyperlink is followed, {{HTTPMethod("POST")}} requests with the body `PING` will be sent by the browser (in the background). Typically used for tracking.
+  - : A string that reflects the ping attribute, containing a space-separated list of URLs to which, when the hyperlink is followed, {{HTTPMethod("POST")}} requests with the body `PING` will be sent by the browser (in the background). Typically used for tracking.
 - {{domxref("SVGAElement.referrerPolicy")}}
   - : See {{domxref("HTMLAnchorElement.referrerPolicy")}}.
 - {{domxref("SVGAElement.rel")}}
@@ -35,9 +35,9 @@ _This interface also inherits properties from its parent, {{domxref("SVGGraphics
 - {{domxref("SVGAElement.target")}} {{readonlyInline}}
   - : It corresponds to the {{SVGAttr("target")}} attribute of the given element.
 - {{domxref("SVGAElement.text")}}
-  - : A {{domxref("DOMString")}} being a synonym for the {{domxref("Node.textContent")}} property.
+  - : A string being a synonym for the {{domxref("Node.textContent")}} property.
 - {{domxref("SVGAElement.type")}}
-  - : A {{domxref("DOMString")}} that reflects the `type` attribute, indicating the MIME type of the linked resource.
+  - : A string that reflects the `type` attribute, indicating the MIME type of the linked resource.
 
 ## Methods
 

--- a/files/en-us/web/api/svglength/index.md
+++ b/files/en-us/web/api/svglength/index.md
@@ -53,7 +53,7 @@ An `SVGLength` object can be designated as read only, which means that attempts 
           <li>float <code>value</code></li>
           <li>float <code>valueInSpecifiedUnits</code></li>
           <li>
-            {{ domxref("DOMString") }} <code>valueAsString</code>
+            string <code>valueAsString</code>
           </li>
         </ul>
       </td>
@@ -265,7 +265,7 @@ value: 26.66666603088379, valueInSpecifiedUnits 8: 0.277777761220932, valueAsStr
     </tr>
     <tr>
       <td><code>valueAsString</code></td>
-      <td>{{ domxref("DOMString") }}</td>
+      <td>string</td>
       <td>
         <p>
           The value as a string value, in the units expressed by

--- a/files/en-us/web/api/textdecoder/textdecoder/index.md
+++ b/files/en-us/web/api/textdecoder/textdecoder/index.md
@@ -30,7 +30,7 @@ new TextDecoder(utfLabel, options)
 ### Parameters
 
 - `utfLabel`{{Optional_Inline}}
-  - : A {{DOMxRef("DOMString")}}, defaulting to `"utf-8"`, containing the
+  - : A string, defaulting to `"utf-8"`, containing the
     _label_ of the encoder. This may be [any valid label](/en-US/docs/Web/API/Encoding_API/Encodings).
 - `options`{{Optional_Inline}}
 

--- a/files/en-us/web/api/transitionevent/index.md
+++ b/files/en-us/web/api/transitionevent/index.md
@@ -26,11 +26,11 @@ The **`TransitionEvent`** interface represents events providing information rela
 _Also inherits properties from its parent {{domxref("Event")}}_.
 
 - {{domxref("TransitionEvent.propertyName")}} {{readonlyInline}}
-  - : A {{domxref("DOMString")}} containing the name CSS property associated with the transition.
+  - : A string containing the name CSS property associated with the transition.
 - {{domxref("TransitionEvent.elapsedTime")}} {{readonlyInline}}
   - : A `float` giving the amount of time the transition has been running, in seconds, when this event fired. This value is not affected by the {{cssxref("transition-delay")}} property.
 - {{domxref("TransitionEvent.pseudoElement")}} {{readonlyInline}}
-  - : A {{domxref("DOMString")}}, starting with `::`, containing the name of the [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements) the animation runs on. If the transition doesn't run on a pseudo-element but on the element, an empty string: `''`.
+  - : A string, starting with `::`, containing the name of the [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements) the animation runs on. If the transition doesn't run on a pseudo-element but on the element, an empty string: `''`.
 
 ## Types of `TransitionEvent`
 

--- a/files/en-us/web/api/url/index.md
+++ b/files/en-us/web/api/url/index.md
@@ -37,41 +37,41 @@ If a browser doesn't yet support the {{domxref("URL.URL", "URL()")}} constructor
 ## Properties
 
 - {{domxref("URL.hash", "hash")}}
-  - : A {{domxref("USVString")}} containing a `'#'` followed by the fragment identifier of the URL.
+  - : A string containing a `'#'` followed by the fragment identifier of the URL.
 - {{domxref("URL.host", "host")}}
-  - : A {{domxref("USVString")}} containing the domain (that is the _hostname_) followed by (if a port was specified) a `':'` and the _port_ of the URL.
+  - : A string containing the domain (that is the _hostname_) followed by (if a port was specified) a `':'` and the _port_ of the URL.
 - {{domxref("URL.hostname", "hostname")}}
-  - : A {{domxref("USVString")}} containing the domain of the URL.
+  - : A string containing the domain of the URL.
 - {{domxref("URL.href", "href")}}
-  - : A {{Glossary("stringifier")}} that returns a {{domxref("USVString")}} containing the whole URL.
+  - : A {{Glossary("stringifier")}} that returns a string containing the whole URL.
 - {{domxref("URL.origin", "origin")}} {{readonlyInline}}
-  - : Returns a {{domxref("USVString")}} containing the origin of the URL, that is its scheme, its domain and its port.
+  - : Returns a string containing the origin of the URL, that is its scheme, its domain and its port.
 - {{domxref("URL.password", "password")}}
-  - : A {{domxref("USVString")}} containing the password specified before the domain name.
+  - : A string containing the password specified before the domain name.
 - {{domxref("URL.pathname", "pathname")}}
-  - : A {{domxref("USVString")}} containing an initial `'/'` followed by the path of the URL, not including the query string or fragment.
+  - : A string containing an initial `'/'` followed by the path of the URL, not including the query string or fragment.
 - {{domxref("URL.port", "port")}}
-  - : A {{domxref("USVString")}} containing the port number of the URL.
+  - : A string containing the port number of the URL.
 - {{domxref("URL.protocol", "protocol")}}
-  - : A {{domxref("USVString")}} containing the protocol scheme of the URL, including the final `':'`.
+  - : A string containing the protocol scheme of the URL, including the final `':'`.
 - {{domxref("URL.search", "search")}}
-  - : A {{domxref("USVString")}} indicating the URL's parameter string; if any parameters are provided, this string includes all of them, beginning with the leading `?` character.
+  - : A string indicating the URL's parameter string; if any parameters are provided, this string includes all of them, beginning with the leading `?` character.
 - {{domxref("URL.searchParams", "searchParams")}} {{readonlyInline}}
   - : A {{domxref("URLSearchParams")}} object which can be used to access the individual query parameters found in `search`.
 - {{domxref("URL.username","username")}}
-  - : A {{domxref("USVString")}} containing the username specified before the domain name.
+  - : A string containing the username specified before the domain name.
 
 ## Methods
 
 - {{domxref("URL.toString", "toString()")}}
-  - : Returns a {{domxref("USVString")}} containing the whole URL. It is a synonym for {{domxref("URL.href")}}, though it can't be used to modify the value.
+  - : Returns a string containing the whole URL. It is a synonym for {{domxref("URL.href")}}, though it can't be used to modify the value.
 - {{domxref("URL.toJSON", "toJSON()")}}
-  - : Returns a {{domxref("USVString")}} containing the whole URL. It returns the same string as the `href` property.
+  - : Returns a string containing the whole URL. It returns the same string as the `href` property.
 
 ## Static methods
 
 - {{domxref("URL.createObjectURL", "createObjectURL()")}}
-  - : Returns a {{domxref("DOMString")}} containing a unique blob URL, that is a URL with `blob:` as its scheme, followed by an opaque string uniquely identifying the object in the browser.
+  - : Returns a string containing a unique blob URL, that is a URL with `blob:` as its scheme, followed by an opaque string uniquely identifying the object in the browser.
 - {{domxref("URL.revokeObjectURL", "revokeObjectURL()")}}
   - : Revokes an object URL previously created using {{domxref("URL.createObjectURL()")}}.
 

--- a/files/en-us/web/api/windowcontrolsoverlaygeometrychangeevent/windowcontrolsoverlaygeometrychangeevent/index.md
+++ b/files/en-us/web/api/windowcontrolsoverlaygeometrychangeevent/windowcontrolsoverlaygeometrychangeevent/index.md
@@ -25,7 +25,7 @@ _The `WindowControlsOverlayGeometryChangeEvent()` constructor also inherits argu
 {{domxref("Event.Event", "Event()")}}._
 
 - `type`
-  - : A {{domxref("DOMString")}} indicating the event type. Its value must be `geometrychange` and is case-sensitive.
+  - : A string indicating the event type. Its value must be `geometrychange` and is case-sensitive.
 - `options`
   - : An object with the following properties:
     - `visible`

--- a/files/en-us/web/api/worker/worker/index.md
+++ b/files/en-us/web/api/worker/worker/index.md
@@ -25,17 +25,17 @@ new Worker(aURL, options)
 ### Parameters
 
 - `aURL`
-  - : A {{domxref("USVString")}} representing the URL of the script the worker will execute. It must obey the same-origin policy.
+  - : A string representing the URL of the script the worker will execute. It must obey the same-origin policy.
 - `options` {{optional_inline}}
 
   - : An object containing option properties that can be set when creating the object instance. Available properties are as follows:
 
     - `type`
-      - : A {{domxref("DOMString")}} specifying the type of worker to create. The value can be `classic` or `module`. If not specified, the default used is `classic`.
+      - : A string specifying the type of worker to create. The value can be `classic` or `module`. If not specified, the default used is `classic`.
     - `credentials`
-      - : A {{domxref("DOMString")}} specifying the type of credentials to use for the worker. The value can be `omit`, `same-origin`, or _`include`. If not specified, or if type is `classic`, the default used is `omit` (no credentials required)._
+      - : A string specifying the type of credentials to use for the worker. The value can be `omit`, `same-origin`, or _`include`. If not specified, or if type is `classic`, the default used is `omit` (no credentials required)._
     - `name`
-      - : A {{domxref("DOMString")}} specifying an identifying name for the {{domxref("DedicatedWorkerGlobalScope")}} representing the scope of the worker, which is mainly useful for debugging purposes.
+      - : A string specifying an identifying name for the {{domxref("DedicatedWorkerGlobalScope")}} representing the scope of the worker, which is mainly useful for debugging purposes.
 
 ### Exceptions
 


### PR DESCRIPTION
Continuing #15499 

### Summary
`DOMString` is not exposed by browsers to JavaScript. It is converted to `string`.[[ref](https://developer.mozilla.org/en-US/docs/Web/API/DOMString)]

Same is the case with `USVString` and `CSSOMString`.

### Metadata
- [x] Fixes a typo, bug, or other error
