### PR TITLE
DOMString -> string

### DIFF
--- a/files/en-us/web/api/html_drag_and_drop_api/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/index.md
@@ -187,7 +187,7 @@ For more information, see:
 
 ### Define the drag's data
 
-The application is free to include any number of data items in a drag operation. Each data item is a {{domxref("DOMString","string")}} of a particular `type` — typically a MIME type such as `text/html`.
+The application is free to include any number of data items in a drag operation. Each data item is a string of a particular `type` — typically a MIME type such as `text/html`.
 
 Each {{domxref("DragEvent","drag event")}} has a {{domxref("DragEvent.dataTransfer","dataTransfer")}} property that _holds_ the event's data. This property (which is a {{domxref("DataTransfer")}} object) also has methods to _manage_ drag data. The {{domxref("DataTransfer.setData","setData()")}} method is used to add an item to the drag data, as shown in the following example.
 

--- a/files/en-us/web/api/htmlslotelement/index.md
+++ b/files/en-us/web/api/htmlslotelement/index.md
@@ -18,7 +18,7 @@ The **`HTMLSlotElement`** interface of the [Shadow DOM API](/en-US/docs/Web/Web_
 ## Properties
 
 - {{domxref('HTMLSlotElement.name')}}
-  - : A {{domxref("DOMString","string")}} used to get and set the slot's name.
+  - : A string used to get and set the slot's name.
 
 ## Methods
 

--- a/files/en-us/web/api/imagedecoder/imagedecoder/index.md
+++ b/files/en-us/web/api/imagedecoder/imagedecoder/index.md
@@ -23,7 +23,7 @@ new ImageDecoder(init)
 - `init`
   - : An object containing the following members:
     - `type`
-      - : A {{domxref("DOMString","string")}} containing the MIME type of the image file to be decoded.
+      - : A string containing the MIME type of the image file to be decoded.
     - `data`
       - : A {{domxref("BufferSource")}} or {{domxref("ReadableStream")}} of bytes representing an encoded image type as described by `type`.
     - `premultiplyAlpha`{{Optional_Inline}}

--- a/files/en-us/web/api/interventionreportbody/id/index.md
+++ b/files/en-us/web/api/interventionreportbody/id/index.md
@@ -15,7 +15,7 @@ The **`id`** read-only property of the {{domxref("InterventionReportBody")}} int
 
 ## Value
 
-A {{domxref("DOMString","string")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/interventionreportbody/index.md
+++ b/files/en-us/web/api/interventionreportbody/index.md
@@ -29,15 +29,15 @@ An instance of `InterventionReportBody` is returned as the value of {{domxref("R
 This interface also inherits properties from {{domxref("ReportBody")}}.
 
 - {{domxref("InterventionReportBody.id")}}{{ReadOnlyInline}}
-  - : A {{domxref("DOMString","string")}} representing the intervention that generated the report. This can be used to group reports.
+  - : A string representing the intervention that generated the report. This can be used to group reports.
 - {{domxref("InterventionReportBody.message")}}{{ReadOnlyInline}}
-  - : A {{domxref("DOMString","string")}} containing a human-readable description of the intervention, including information such how the intervention could be avoided. This typically matches the message a browser will display in its DevTools console when an intervention is imposed, if one is available.
+  - : A string containing a human-readable description of the intervention, including information such how the intervention could be avoided. This typically matches the message a browser will display in its DevTools console when an intervention is imposed, if one is available.
 - {{domxref("InterventionReportBody.sourceFile")}}{{ReadOnlyInline}}
-  - : A {{domxref("DOMString","string")}} containing the path to the source file where the intervention occurred, if known, or `null` otherwise.
+  - : A string containing the path to the source file where the intervention occurred, if known, or `null` otherwise.
 - {{domxref("InterventionReportBody.lineNumber")}}{{ReadOnlyInline}}
-  - : A {{domxref("DOMString","string")}} representing the line in the source file in which the intervention occurred, if known, or `null` otherwise.
+  - : A string representing the line in the source file in which the intervention occurred, if known, or `null` otherwise.
 - {{domxref("InterventionReportBody.columnNumber")}}{{ReadOnlyInline}}
-  - : A {{domxref("DOMString","string")}} representing the column in the source file in which the intervention occurred, if known, or `null` otherwise.
+  - : A string representing the column in the source file in which the intervention occurred, if known, or `null` otherwise.
 
 ## Methods
 

--- a/files/en-us/web/api/interventionreportbody/message/index.md
+++ b/files/en-us/web/api/interventionreportbody/message/index.md
@@ -15,7 +15,7 @@ The **`message`** read-only property of the {{domxref("InterventionReportBody")}
 
 ## Value
 
-A {{domxref("DOMString","string")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/interventionreportbody/sourcefile/index.md
+++ b/files/en-us/web/api/interventionreportbody/sourcefile/index.md
@@ -17,7 +17,7 @@ The **`sourceFile`** read-only property of the {{domxref("InterventionReportBody
 
 ## Value
 
-A {{domxref("DOMString","string")}}, or `null` if the path is not known.
+A string, or `null` if the path is not known.
 
 ## Examples
 

--- a/files/en-us/web/api/largestcontentfulpaint/id/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/id/index.md
@@ -15,7 +15,7 @@ The **`id`** read-only property of the {{domxref("LargestContentfulPaint")}} int
 
 ## Value
 
-A {{domxref("DOMString","string")}} containing the ID of the element.
+A string containing the ID of the element.
 
 ## Examples
 

--- a/files/en-us/web/api/largestcontentfulpaint/url/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/url/index.md
@@ -15,7 +15,7 @@ The **`url`** read-only property of the {{domxref("LargestContentfulPaint")}} in
 
 ## Value
 
-A {{domxref("DOMString","string")}} containing a URL.
+A string containing a URL.
 
 ## Examples
 

--- a/files/en-us/web/api/midiport/connection/index.md
+++ b/files/en-us/web/api/midiport/connection/index.md
@@ -15,7 +15,7 @@ The **`connection`** property of the {{domxref("MIDIPort")}} interface returns t
 
 ## Value
 
-Returns a {{domxref("DOMString","string")}} containing the connection state of the port, one of:
+Returns a string containing the connection state of the port, one of:
 
 - `"open"`
   - : The device that this `MIDIPort` represents has been opened and is available.

--- a/files/en-us/web/api/midiport/id/index.md
+++ b/files/en-us/web/api/midiport/id/index.md
@@ -15,7 +15,7 @@ The **`id`** read-only property of the {{domxref("MIDIPort")}} interface returns
 
 ## Value
 
-A {{domxref("DOMString","string")}} containing an ID for the port.
+A string containing an ID for the port.
 
 ## Examples
 

--- a/files/en-us/web/api/midiport/index.md
+++ b/files/en-us/web/api/midiport/index.md
@@ -19,14 +19,14 @@ A `MIDIPort` instance is created when a new MIDI device is connected. Therefore 
 ## Properties
 
 - {{domxref("MIDIPort.id")}}{{ReadOnlyInline}}
-  - : Returns a {{domxref("DOMString","string")}} containing the unique ID of the port.
+  - : Returns a string containing the unique ID of the port.
 - {{domxref("MIDIPort.manufacturer")}}{{ReadOnlyInline}}
-  - : Returns a {{domxref("DOMString","string")}} containing the manufacturer of the port.
+  - : Returns a string containing the manufacturer of the port.
 - {{domxref("MIDIPort.name")}}{{ReadOnlyInline}}
-  - : Returns a {{domxref("DOMString","string")}} containing the system name of the port.
+  - : Returns a string containing the system name of the port.
 - {{domxref("MIDIPort.type")}}{{ReadOnlyInline}}
 
-  - : Returns a {{domxref("DOMString","string")}} containing the type of the port, one of:
+  - : Returns a string containing the type of the port, one of:
 
     - `"input"`
       - : The `MIDIPort` is an input port.
@@ -34,10 +34,10 @@ A `MIDIPort` instance is created when a new MIDI device is connected. Therefore 
       - : The `MIDIPort` is an output port.
 
 - {{domxref("MIDIPort.version")}}{{ReadOnlyInline}}
-  - : Returns a {{domxref("DOMString","string")}} containing the version of the port.
+  - : Returns a string containing the version of the port.
 - {{domxref("MIDIPort.state")}}{{ReadOnlyInline}}
 
-  - : Returns a {{domxref("DOMString","string")}} containing the state of the port, one of:
+  - : Returns a string containing the state of the port, one of:
 
     - `"disconnected"`
       - : The device that this `MIDIPort` represents is disconnected from the system.
@@ -46,7 +46,7 @@ A `MIDIPort` instance is created when a new MIDI device is connected. Therefore 
 
 - {{domxref("MIDIPort.connection")}}{{ReadOnlyInline}}
 
-  - : Returns a {{domxref("DOMString","string")}} containing the connection state of the port, one of:
+  - : Returns a string containing the connection state of the port, one of:
 
     - `"open"`
       - : The device that this `MIDIPort` represents has been opened and is available.

--- a/files/en-us/web/api/midiport/manufacturer/index.md
+++ b/files/en-us/web/api/midiport/manufacturer/index.md
@@ -15,7 +15,7 @@ The **`manufacturer`** read-only property of the {{domxref("MIDIPort")}} interfa
 
 ## Value
 
-A {{domxref("DOMString","string")}} containing the manufacturer of the port.
+A string containing the manufacturer of the port.
 
 ## Examples
 

--- a/files/en-us/web/api/midiport/name/index.md
+++ b/files/en-us/web/api/midiport/name/index.md
@@ -15,7 +15,7 @@ The **`name`** read-only property of the {{domxref("MIDIPort")}} interface retur
 
 ## Value
 
-A {{domxref("DOMString","string")}} containing the system name of the port.
+A string containing the system name of the port.
 
 ## Examples
 

--- a/files/en-us/web/api/midiport/state/index.md
+++ b/files/en-us/web/api/midiport/state/index.md
@@ -15,7 +15,7 @@ The **`state`** read-only property of the {{domxref("MIDIPort")}} interface retu
 
 ## Value
 
-A {{domxref("DOMString","string")}} containing the state of the port, one of:
+A string containing the state of the port, one of:
 
 - `"disconnected"`
   - : The device that this `MIDIPort` represents is disconnected from the system.

--- a/files/en-us/web/api/midiport/type/index.md
+++ b/files/en-us/web/api/midiport/type/index.md
@@ -15,7 +15,7 @@ The **`type`** read-only property of the {{domxref("MIDIPort")}} interface retur
 
 ## Value
 
-A {{domxref("DOMString","string")}} containing the type of the port, one of:
+A string containing the type of the port, one of:
 
 - `"input"`
   - : The `MIDIPort` is an input port.

--- a/files/en-us/web/api/midiport/version/index.md
+++ b/files/en-us/web/api/midiport/version/index.md
@@ -15,7 +15,7 @@ The **`version`** read-only property of the {{domxref("MIDIPort")}} interface re
 
 ## Value
 
-A {{domxref("DOMString","string")}} containing the version of the port.
+A string containing the version of the port.
 
 ## Examples
 

--- a/files/en-us/web/api/navigatoruadata/brands/index.md
+++ b/files/en-us/web/api/navigatoruadata/brands/index.md
@@ -18,9 +18,9 @@ The **`brands`** read-only property of the {{domxref("NavigatorUAData")}} interf
 An array containing the following information for each brand:
 
 - brand
-  - : A {{domxref("DOMString","string")}} containing the brand. For example, `"Google Chrome"`.
+  - : A string containing the brand. For example, `"Google Chrome"`.
 - version
-  - : A {{domxref("DOMString","string")}} containing the version. For example, `"91"`.
+  - : A string containing the version. For example, `"91"`.
 
 ## Examples
 

--- a/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.md
+++ b/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.md
@@ -42,15 +42,15 @@ getHighEntropyValues(hints)
 A {{jsxref("Promise")}} that resolves to an object containing some or all of the following values (based on the hints requested):
 
 - `architecture`
-  - : A {{domxref("DOMString","string")}} containing the platform architecture. For example, `"x86"`.
+  - : A string containing the platform architecture. For example, `"x86"`.
 - `bitness`
-  - : A {{domxref("DOMString","string")}} containing the architecture bitness. For example, `"64"`.
+  - : A string containing the architecture bitness. For example, `"64"`.
 - `model`
-  - : A {{domxref("DOMString","string")}} containing the device model. For example, `"Pixel 2XL"`.
+  - : A string containing the device model. For example, `"Pixel 2XL"`.
 - `platformVersion`
-  - : A {{domxref("DOMString","string")}} containing the platform version. For example, `"10.0"`.
+  - : A string containing the platform version. For example, `"10.0"`.
 - `uaFullVersion` {{deprecated_inline}}
-  - : A {{domxref("DOMString","string")}} containing the full browser version. For example, `"91.0.4472.124"`.
+  - : A string containing the full browser version. For example, `"91.0.4472.124"`.
 - `fullVersionList`
   - : An array of brand information containing the browser name and full version.
     For example, `"Chromium";v="91.0.4472.124","Google Chrome";v="91.0.4472.124"`.

--- a/files/en-us/web/api/navigatoruadata/platform/index.md
+++ b/files/en-us/web/api/navigatoruadata/platform/index.md
@@ -15,7 +15,7 @@ The **`platform`** read-only property of the {{domxref("NavigatorUAData")}} inte
 
 ## Value
 
-A {{domxref("DOMString","string")}} containing the platform brand.
+A string containing the platform brand.
 For example, `"Windows"`.
 
 ## Examples

--- a/files/en-us/web/api/otpcredential/code/index.md
+++ b/files/en-us/web/api/otpcredential/code/index.md
@@ -15,7 +15,7 @@ The **`code`** property of the {{domxref("OTPCredential")}} interface returns th
 
 ## Value
 
-A {{domxref("DOMString","string")}} containing the one-time password.
+A string containing the one-time password.
 
 ## Examples
 

--- a/files/en-us/web/api/performancenavigationtiming/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/index.md
@@ -59,7 +59,7 @@ The interface also supports the following properties:
 - {{domxref('PerformanceNavigationTiming.responseStart')}} {{readonlyInline}}
   - : A {{domxref("DOMHighResTimeStamp")}} representing the time immediately after the user agent's HTTP parser receives the first byte of the response from relevant application caches, or from local resources or from the server.
 - {{domxref('PerformanceNavigationTiming.type')}} {{readonlyInline}}
-  - : A {{domxref("DOMString","string")}} representing the navigation type. Must be: "`navigate`", "`reload`", "`back_forward`" or "`prerender`".
+  - : A string representing the navigation type. Must be: "`navigate`", "`reload`", "`back_forward`" or "`prerender`".
 - {{domxref('PerformanceNavigationTiming.unloadEventEnd')}} {{readonlyInline}}
   - : A {{domxref("DOMHighResTimeStamp")}} representing the time value equal to the time immediately after the user agent finishes the unload event of the previous document.
 - {{domxref('PerformanceNavigationTiming.unloadEventStart')}} {{readonlyInline}}

--- a/files/en-us/web/api/performancenavigationtiming/type/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/type/index.md
@@ -14,7 +14,7 @@ The **`type`** read-only property returns the type of navigation.
 
 ## Value
 
-A {{domxref("DOMString","string")}} containing one of the following values:
+A string containing one of the following values:
 
 - `"navigate"`
   - : Navigation started by clicking a link, entering the URL in the browser's address

--- a/files/en-us/web/api/performanceresourcetiming/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/index.md
@@ -34,9 +34,9 @@ This interface extends the following {{domxref("PerformanceEntry")}} properties 
 The interface also supports the following properties which are listed in the order in which they are recorded for the fetching of a single resource. An alphabetical listing is shown in the navigation, at left.
 
 - {{domxref('PerformanceResourceTiming.initiatorType')}}{{readonlyInline}}
-  - : A {{domxref("DOMString","string")}} representing the _type_ of resource that initiated the performance entry, as specified in {{domxref('PerformanceResourceTiming.initiatorType')}}.
+  - : A string representing the _type_ of resource that initiated the performance entry, as specified in {{domxref('PerformanceResourceTiming.initiatorType')}}.
 - {{domxref('PerformanceResourceTiming.nextHopProtocol')}}{{readonlyInline}}
-  - : A {{domxref("DOMString","string")}} representing the _network protocol_ used to fetch the resource, as identified by the [ALPN Protocol ID (RFC7301)](https://datatracker.ietf.org/doc/html/rfc7301).
+  - : A string representing the _network protocol_ used to fetch the resource, as identified by the [ALPN Protocol ID (RFC7301)](https://datatracker.ietf.org/doc/html/rfc7301).
 - {{domxref('PerformanceResourceTiming.workerStart')}}{{readonlyInline}}
   - : Returns a {{domxref("DOMHighResTimeStamp")}} immediately before dispatching the {{domxref("FetchEvent")}} if a Service Worker thread is already running, or immediately before starting the Service Worker thread if it is not already running. If the resource is not intercepted by a Service Worker the property will always return 0.
 - {{domxref('PerformanceResourceTiming.redirectStart')}}{{readonlyInline}}

--- a/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
@@ -11,7 +11,7 @@ browser-compat: api.PerformanceResourceTiming.initiatorType
 {{APIRef("Resource Timing API")}}
 
 The **`initiatorType`** read-only property is a
-{{domxref("DOMString","string")}} that represents the _type_ of resource that
+string that represents the _type_ of resource that
 initiated the performance event.
 
 The value of this string is as follows:
@@ -29,7 +29,7 @@ The value of this string is as follows:
 
 ## Value
 
-A {{domxref("DOMString","string")}} representing the _type_ of resource that
+A string representing the _type_ of resource that
 initiated the performance event, as specified above.
 
 ## Examples

--- a/files/en-us/web/api/performanceresourcetiming/nexthopprotocol/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/nexthopprotocol/index.md
@@ -12,7 +12,7 @@ browser-compat: api.PerformanceResourceTiming.nextHopProtocol
 {{APIRef("Resource Timing API")}}
 
 The **`nextHopProtocol`** read-only
-property is a {{domxref("DOMString","string")}} representing the _network
+property is a string representing the _network
 protocol_ used to fetch the resource, as identified by the [ALPN Protocol ID (RFC7301)](https://datatracker.ietf.org/doc/html/rfc7301).
 
 When a proxy is used, if a tunnel connection is established, this property returns the
@@ -23,7 +23,7 @@ Protocol ID of the first hop to the proxy.
 
 ## Value
 
-A {{domxref("DOMString","string")}} representing the _network protocol_ used to
+A string representing the _network protocol_ used to
 fetch the resource, as identified by the [ALPN Protocol ID (RFC7301)](https://datatracker.ietf.org/doc/html/rfc7301).
 
 ## Examples

--- a/files/en-us/web/api/texttrack/id/index.md
+++ b/files/en-us/web/api/texttrack/id/index.md
@@ -15,7 +15,7 @@ The **`id`** read-only property of the {{domxref("TextTrack")}} interface return
 
 ## Value
 
-A {{domxref("DOMString","string")}} containing the ID, or an empty string.
+A string containing the ID, or an empty string.
 
 ## Examples
 

--- a/files/en-us/web/api/texttrack/inbandmetadatatrackdispatchtype/index.md
+++ b/files/en-us/web/api/texttrack/inbandmetadatatrackdispatchtype/index.md
@@ -19,7 +19,7 @@ The value of this attribute could be used to attach these tracks to dedicated sc
 
 ## Value
 
-A {{domxref("DOMString","string")}} containing the `inBandMetadataTrackDispatchType`, or an empty string.
+A string containing the `inBandMetadataTrackDispatchType`, or an empty string.
 
 ## Examples
 

--- a/files/en-us/web/api/texttrack/kind/index.md
+++ b/files/en-us/web/api/texttrack/kind/index.md
@@ -15,7 +15,7 @@ The **`kind`** read-only property of the {{domxref("TextTrack")}} interface retu
 
 ## Value
 
-A {{domxref("DOMString","string")}}. One of:
+A string. One of:
 
 - `"subtitles"`
   - : The cues are overlaid on the video. Positioning of the cues is controlled using the properties of an object that inherits from {{domxref("TextTrackCue")}}, for example {{domxref("VTTCue")}}.

--- a/files/en-us/web/api/texttrack/label/index.md
+++ b/files/en-us/web/api/texttrack/label/index.md
@@ -15,7 +15,7 @@ The **`label`** read-only property of the {{domxref("TextTrack")}} interface ret
 
 ## Value
 
-A {{domxref("DOMString","string")}} containing the `label`, or an empty string.
+A string containing the `label`, or an empty string.
 
 ## Examples
 

--- a/files/en-us/web/api/texttrack/language/index.md
+++ b/files/en-us/web/api/texttrack/language/index.md
@@ -17,7 +17,7 @@ This uses the same values as the HTML {{htmlattrxref("lang")}} attribute. These 
 
 ## Value
 
-A {{domxref("DOMString","string")}} containing a language identifier. For example, `"en-US"` for United States English or `"pt-BR"` for Brazilian Portuguese.
+A string containing a language identifier. For example, `"en-US"` for United States English or `"pt-BR"` for Brazilian Portuguese.
 
 ## Examples
 

--- a/files/en-us/web/api/texttrackcue/id/index.md
+++ b/files/en-us/web/api/texttrackcue/id/index.md
@@ -15,7 +15,7 @@ The **`id`** property of the {{domxref("TextTrackCue")}} interface returns and s
 
 ## Value
 
-A {{domxref("DOMString","string")}} containing the ID of this cue.
+A string containing the ID of this cue.
 
 ## Examples
 

--- a/files/en-us/web/api/trustedhtml/index.md
+++ b/files/en-us/web/api/trustedhtml/index.md
@@ -19,7 +19,7 @@ The value of a **TrustedHTML** object is set when the object is created and cann
 - {{domxref("TrustedHTML.toJSON()")}}
   - : Returns a JSON representation of the stored data.
 - {{domxref("TrustedHTML.toString()")}}
-  - : A {{domxref("DOMString","string")}} containing the sanitized HTML.
+  - : A string containing the sanitized HTML.
 
 ## Examples
 

--- a/files/en-us/web/api/trustedhtml/tojson/index.md
+++ b/files/en-us/web/api/trustedhtml/tojson/index.md
@@ -25,7 +25,7 @@ None.
 
 ### Return value
 
-A {{domxref("DOMString","string")}} containing a JSON representation of the stored data.
+A string containing a JSON representation of the stored data.
 
 ## Examples
 

--- a/files/en-us/web/api/trustedhtml/tostring/index.md
+++ b/files/en-us/web/api/trustedhtml/tostring/index.md
@@ -25,7 +25,7 @@ None.
 
 ### Return value
 
-A {{domxref("DOMString","string")}} containing the sanitized HTML.
+A string containing the sanitized HTML.
 
 ## Examples
 

--- a/files/en-us/web/api/trustedscript/index.md
+++ b/files/en-us/web/api/trustedscript/index.md
@@ -19,7 +19,7 @@ The value of a **TrustedScript** object is set when the object is created and ca
 - {{domxref("TrustedScript.toJSON()")}}
   - : Returns a JSON representation of the stored data.
 - {{domxref("TrustedScript.toString()")}}
-  - : A {{domxref("DOMString","string")}} containing the sanitized script.
+  - : A string containing the sanitized script.
 
 ## Examples
 

--- a/files/en-us/web/api/trustedscript/tojson/index.md
+++ b/files/en-us/web/api/trustedscript/tojson/index.md
@@ -25,7 +25,7 @@ None.
 
 ### Return value
 
-A {{domxref("DOMString","string")}} containing a JSON representation of the stored data.
+A string containing a JSON representation of the stored data.
 
 ## Examples
 

--- a/files/en-us/web/api/trustedscript/tostring/index.md
+++ b/files/en-us/web/api/trustedscript/tostring/index.md
@@ -25,7 +25,7 @@ None.
 
 ### Return value
 
-A {{domxref("DOMString","string")}} containing the sanitized script.
+A string containing the sanitized script.
 
 ## Examples
 

--- a/files/en-us/web/api/trustedscripturl/tojson/index.md
+++ b/files/en-us/web/api/trustedscripturl/tojson/index.md
@@ -25,7 +25,7 @@ None.
 
 ### Return value
 
-A {{domxref("DOMString","string")}} containing a JSON representation of the stored data.
+A string containing a JSON representation of the stored data.
 
 ## Examples
 

--- a/files/en-us/web/api/trustedscripturl/tostring/index.md
+++ b/files/en-us/web/api/trustedscripturl/tostring/index.md
@@ -25,7 +25,7 @@ None.
 
 ### Return value
 
-A {{domxref("DOMString","string")}} containing the sanitized URL
+A string containing the sanitized URL
 
 ## Examples
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.md
@@ -24,17 +24,17 @@ getAttributeType(tagName, attribute, elementNS, attrNS)
 ### Parameters
 
 - `tagName`
-  - : A {{domxref("DOMString","string")}} containing the name of an HTML tag.
+  - : A string containing the name of an HTML tag.
 - `attribute`
-  - : A {{domxref("DOMString","string")}} containing an attribute.
+  - : A string containing an attribute.
 - `elementNS`{{optional_inline}}
-  - : A {{domxref("DOMString","string")}} containing a namespace, if empty defaults to the HTML namespace.
+  - : A string containing a namespace, if empty defaults to the HTML namespace.
 - `attrNS`{{optional_inline}}
-  - : A {{domxref("DOMString","string")}} containing a namespace, if empty defaults to null.
+  - : A string containing a namespace, if empty defaults to null.
 
 ### Return value
 
-A {{domxref("DOMString","string")}} with one of:
+A string with one of:
 
 - `"TrustedHTML"`
 - `"TrustedScript"`

--- a/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.md
@@ -23,15 +23,15 @@ getPropertyType(tagName, property, elementNS)
 ### Parameters
 
 - `tagName`
-  - : A {{domxref("DOMString","string")}} containing the name of an HTML tag.
+  - : A string containing the name of an HTML tag.
 - `property`
-  - : A {{domxref("DOMString","string")}} containing a property, for example `"innerHTML"`.
+  - : A string containing a property, for example `"innerHTML"`.
 - `elementNS`{{optional_inline}}
-  - : A {{domxref("DOMString","string")}} containing a namespace, if empty defaults to the HTML namespace.
+  - : A string containing a namespace, if empty defaults to the HTML namespace.
 
 ### Return value
 
-A {{domxref("DOMString","string")}} with one of:
+A string with one of:
 
 - `"TrustedHTML"`
 - `"TrustedScript"`

--- a/files/en-us/web/api/videodecoder/configure/index.md
+++ b/files/en-us/web/api/videodecoder/configure/index.md
@@ -24,7 +24,7 @@ configure(config)
 - `config`
   - : An object containing the following members:
     - `codec`
-      - : A {{domxref("DOMString","string")}} containing a [valid codec string](https://www.w3.org/TR/webcodecs-codec-registry/#audio-codec-registry).
+      - : A string containing a [valid codec string](https://www.w3.org/TR/webcodecs-codec-registry/#audio-codec-registry).
     - `description`{{Optional_Inline}}
       - : A {{domxref("BufferSource")}} containing a sequence of codec specific bytes, commonly known as extradata.
     - `codedWidth`{{Optional_Inline}}

--- a/files/en-us/web/api/videoencoder/configure/index.md
+++ b/files/en-us/web/api/videoencoder/configure/index.md
@@ -24,7 +24,7 @@ configure(config)
 - `config`
   - : A dictionary object containing the following members:
     - `codec`
-      - : A {{domxref("DOMString","string")}} containing a [valid codec string](https://www.w3.org/TR/webcodecs-codec-registry/#audio-codec-registry).
+      - : A string containing a [valid codec string](https://www.w3.org/TR/webcodecs-codec-registry/#audio-codec-registry).
     - `width`{{Optional_Inline}}
       - : An integer representing the width of each output {{domxref("EncodedVideoChunk")}} in pixels, before any ratio adjustments.
     - `height`{{Optional_Inline}}

--- a/files/en-us/web/api/videoencoder/videoencoder/index.md
+++ b/files/en-us/web/api/videoencoder/videoencoder/index.md
@@ -27,7 +27,7 @@ new VideoEncoder(init)
         - `decoderconfig` {{Optional_Inline}}
           - : An object containing:
             - `codec`
-              - : A {{domxref("DOMString","string")}} containing a [valid codec string](https://www.w3.org/TR/webcodecs-codec-registry/#video-codec-registry).
+              - : A string containing a [valid codec string](https://www.w3.org/TR/webcodecs-codec-registry/#video-codec-registry).
             - `description` {{Optional_Inline}}
               - : A {{domxref("BufferSource")}} containing a sequence of codec-specific bytes, commonly known as "extradata".
             - `codedWidth` {{Optional_Inline}}

--- a/files/en-us/web/api/videoframe/format/index.md
+++ b/files/en-us/web/api/videoframe/format/index.md
@@ -15,7 +15,7 @@ The **`format`** property of the {{domxref("VideoFrame")}} interface returns the
 
 ## Value
 
-A {{domxref("DOMString","string")}} containing a video pixel format, one of:
+A string containing a video pixel format, one of:
 
 - `"I420"`
   - : Also known as *Planar YUV 4:2:0*, this format is composed of three distinct planes, one plane of luma and two planes of chroma, denoted Y, U and V, and present in this order. The U an V planes are sub-sampled horizontally and vertically by a factor of 2 compared to the Y plane. Each sample in this format is 8 bits.

--- a/files/en-us/web/api/vttcue/align/index.md
+++ b/files/en-us/web/api/vttcue/align/index.md
@@ -15,7 +15,7 @@ The **`align`** property of the {{domxref("VTTCue")}} interface represents the a
 
 ## Value
 
-A {{domxref("DOMString","string")}} containing one of the following values:
+A string containing one of the following values:
 
 - `"start"`
   - : Start alignment.

--- a/files/en-us/web/api/vttcue/linealign/index.md
+++ b/files/en-us/web/api/vttcue/linealign/index.md
@@ -15,7 +15,7 @@ The **`lineAlign`** property of the {{domxref("VTTCue")}} interface represents t
 
 ## Value
 
-A {{domxref("DOMString","string")}} containing one of the following values:
+A string containing one of the following values:
 
 - `"start"`
   - : Start alignment.

--- a/files/en-us/web/api/vttcue/positionalign/index.md
+++ b/files/en-us/web/api/vttcue/positionalign/index.md
@@ -15,7 +15,7 @@ The **`positionAlign`** property of the {{domxref("VTTCue")}} interface is used 
 
 ## Value
 
-A {{domxref("DOMString","string")}} containing one of the following values:
+A string containing one of the following values:
 
 - `"line-left"`
   - : Line-left alignment.

--- a/files/en-us/web/api/vttcue/vertical/index.md
+++ b/files/en-us/web/api/vttcue/vertical/index.md
@@ -11,11 +11,11 @@ browser-compat: api.VTTCue.vertical
 ---
 {{APIRef("WebVTT")}}
 
-The **`vertical`** property of the {{domxref("VTTCue")}} interface is a {{domxref("DOMString","string")}} representing the cue's writing direction.
+The **`vertical`** property of the {{domxref("VTTCue")}} interface is a string representing the cue's writing direction.
 
 ## Value
 
-A {{domxref("DOMString","string")}} containing one of the following values:
+A string containing one of the following values:
 
 - `""` (an empty string)
   - : Represents a horizontal writing direction.


### PR DESCRIPTION
Continuing #15499 

### Summary
`DOMString` is not exposed by browsers to JavaScript. It is converted to `string`.[[ref](https://developer.mozilla.org/en-US/docs/Web/API/DOMString)]

Same is the case with `USVString` and `CSSOMString`.

### Metadata
- [x] Fixes a typo, bug, or other error
