### PR TITLE
DOMString -> string (last PR)

### DIFF
--- a/files/en-us/mdn/contribute/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.md
+++ b/files/en-us/mdn/contribute/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.md
@@ -498,7 +498,7 @@ Some IDL members indicate special behaviors that should be noted on appropriate 
 
 ### Stringifiers
 
-In addition to adding the `toString()` method to an interface as described in [toString() and toJSON()](#tostring_and_tojson), stringifiers also indicate that an object instance, when used as a string, returns a `DOMString` other than the default. (The default is usually a JSON representation of the object). Exactly how depends on the way it is specified in the IDL. Regardless of the how, the non-default behavior should be described on the interface page.
+In addition to adding the `toString()` method to an interface as described in [toString() and toJSON()](#tostring_and_tojson), stringifiers also indicate that an object instance, when used as a string, returns a string other than the default. (The default is usually a JSON representation of the object). Exactly how depends on the way it is specified in the IDL. Regardless of the how, the non-default behavior should be described on the interface page.
 
 When the `stringifier` keyword accompanies an attribute name, referencing the object name has the same result as referencing the attribute name. Consider the following IDL:
 

--- a/files/en-us/web/api/cssconditionrule/conditiontext/index.md
+++ b/files/en-us/web/api/cssconditionrule/conditiontext/index.md
@@ -17,7 +17,7 @@ rule.
 
 ## Value
 
-A {{domxref('CSSOMString')}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/csskeyframerule/keytext/index.md
+++ b/files/en-us/web/api/csskeyframerule/keytext/index.md
@@ -16,7 +16,7 @@ The **`keyText`** property of the {{domxref("CSSKeyframeRule")}} interface repre
 
 ## Value
 
-A {{domxref('CSSOMString')}}.
+A string.
 
 ### Exceptions
 

--- a/files/en-us/web/api/csskeyframesrule/name/index.md
+++ b/files/en-us/web/api/csskeyframesrule/name/index.md
@@ -16,7 +16,7 @@ The **`name`** property of the {{domxref("CSSKeyframeRule")}} interface gets and
 
 ## Value
 
-A {{domxref('CSSOMString')}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/csskeywordvalue/value/index.md
+++ b/files/en-us/web/api/csskeywordvalue/value/index.md
@@ -20,7 +20,7 @@ The **`value`** property of the
 
 ## Value
 
-A {{domxref('USVString')}}.
+A string.
 
 ### Exceptions
 

--- a/files/en-us/web/api/csspagerule/selectortext/index.md
+++ b/files/en-us/web/api/csspagerule/selectortext/index.md
@@ -15,7 +15,7 @@ The **`selectorText`** property of the {{domxref("CSSPageRule")}} interface gets
 
 ## Value
 
-A {{domxref('CSSOMString')}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/csspseudoelement/index.md
+++ b/files/en-us/web/api/csspseudoelement/index.md
@@ -21,7 +21,7 @@ The **`CSSPseudoElement`** interface represents a pseudo-element that may be the
 - {{DOMxRef('CSSPseudoElement.element')}} {{Experimental_Inline}} {{readOnlyInline}}
   - : Returns the originating/parent {{DOMxRef('Element')}} of the pseudo-element.
 - {{DOMxRef('CSSPseudoElement.type')}} {{Experimental_Inline}} {{readOnlyInline}}
-  - : Returns the pseudo-element selector as a {{DOMxRef('CSSOMString')}}.
+  - : Returns the pseudo-element selector as a string.
 
 ## Methods
 

--- a/files/en-us/web/api/csspseudoelement/type/index.md
+++ b/files/en-us/web/api/csspseudoelement/type/index.md
@@ -18,7 +18,7 @@ string, represented in the form of a [CSS selector](/en-US/docs/Web/CSS/CSS_Sele
 
 ## Value
 
-A {{DOMxRef('CSSOMString')}} containing one of the following values:
+A string containing one of the following values:
 
 - {{CSSxRef('::before', '"::before"')}}
 - {{CSSxRef('::after', '"::after"')}}

--- a/files/en-us/web/api/cssstyledeclaration/cssfloat/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/cssfloat/index.md
@@ -23,7 +23,7 @@ CSSStyleDeclaration.cssFloat = "right"
 
 ### Value
 
-A {{domxref('CSSOMString')}}.
+A string.
 
 ## Example
 

--- a/files/en-us/web/api/cssstylerule/selectortext/index.md
+++ b/files/en-us/web/api/cssstylerule/selectortext/index.md
@@ -15,7 +15,7 @@ The **`selectorText`** property of the {{domxref("CSSStyleRule")}} interface get
 
 ## Value
 
-A {{domxref('CSSOMString')}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/cssstylesheet/replace/index.md
+++ b/files/en-us/web/api/cssstylesheet/replace/index.md
@@ -24,7 +24,7 @@ replace(text)
 ### Parameters
 
 - `text`
-  - : A {{domxref("USVString","string")}} containing the style rules to replace the content of the stylesheet. If the string does not contain a parseable list of rules, then the value will be set to an empty string.
+  - : A string containing the style rules to replace the content of the stylesheet. If the string does not contain a parseable list of rules, then the value will be set to an empty string.
 
 > **Note:** If any of the rules passed in `text` are an external stylesheet imported with the {{cssxref("@import")}} rule, those rules will be removed, and a warning printed to the console.
 

--- a/files/en-us/web/api/cssstylesheet/replacesync/index.md
+++ b/files/en-us/web/api/cssstylesheet/replacesync/index.md
@@ -24,7 +24,7 @@ replaceSync(text)
 ### Parameters
 
 - `text`
-  - : A {{domxref("USVString","string")}} containing the style rules to replace the content of the stylesheet. If the string does not contain a parseable list of rules, then the value will be set to an empty string.
+  - : A string containing the style rules to replace the content of the stylesheet. If the string does not contain a parseable list of rules, then the value will be set to an empty string.
 
 > **Note:** If any of the rules passed in `text` are an external stylesheet imported with the {{cssxref("@import")}} rule, those rules will be removed, and a warning printed to the console.
 

--- a/files/en-us/web/api/cssunitvalue/unit/index.md
+++ b/files/en-us/web/api/cssunitvalue/unit/index.md
@@ -15,12 +15,12 @@ browser-compat: api.CSSUnitValue.unit
 {{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}
 
 The **`CSSUnitValue.unit`** read-only property
-of the {{domxref("CSSUnitValue")}} interface returns a {{jsxref('USVString')}}
+of the {{domxref("CSSUnitValue")}} interface returns a string
 indicating the type of unit.
 
 ## Value
 
-A {{jsxref('USVString')}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/cssvariablereferencevalue/variable/index.md
+++ b/files/en-us/web/api/cssvariablereferencevalue/variable/index.md
@@ -20,7 +20,7 @@ The **`variable`** property of the
 
 ## Value
 
-A {{domxref('USVString')}} beginning with `--` (that is, a [custom property name](/en-US/docs/Web/CSS/--*)).
+A string beginning with `--` (that is, a [custom property name](/en-US/docs/Web/CSS/--*)).
 
 ## Specifications
 

--- a/files/en-us/web/api/datatransfer/moztypesat/index.md
+++ b/files/en-us/web/api/datatransfer/moztypesat/index.md
@@ -35,7 +35,7 @@ mozTypesAt(index)
 ### Return value
 
 - `nsIVariant`
-  - : A list of data formats (which are {{domxref("DOMString","strings")}}). If the index
+  - : A list of data formats (which are strings). If the index
     is not in the range from 0 to the number of items minus one, an empty string list is
     returned.
 

--- a/files/en-us/web/api/datatransfer/types/index.md
+++ b/files/en-us/web/api/datatransfer/types/index.md
@@ -12,7 +12,7 @@ browser-compat: api.DataTransfer.types
 {{APIRef("HTML Drag and Drop API")}}
 
 The **`DataTransfer.types`** read-only property returns an
-array of the drag data formats (as {{domxref("DOMString","strings")}}) that were set in
+array of the drag data formats (as strings) that were set in
 the {{event("dragstart")}} event. The order of the formats is the same order as the data
 included in the drag operation.
 

--- a/files/en-us/web/api/datatransferitemlist/index.md
+++ b/files/en-us/web/api/datatransferitemlist/index.md
@@ -27,7 +27,7 @@ This interface has no constructor.
 ## Methods
 
 - {{domxref("DataTransferItemList.add()")}}
-  - : Adds an item (either a {{domxref("File")}} object or a {{domxref("DOMString","string")}}) to the drag item list and returns a {{domxref("DataTransferItem")}} object for the new item.
+  - : Adds an item (either a {{domxref("File")}} object or a string) to the drag item list and returns a {{domxref("DataTransferItem")}} object for the new item.
 - {{domxref("DataTransferItemList.remove()")}}
   - : Removes the drag item from the list at the given index.
 - {{domxref("DataTransferItemList.clear()")}}

--- a/files/en-us/web/api/deprecationreportbody/id/index.md
+++ b/files/en-us/web/api/deprecationreportbody/id/index.md
@@ -15,7 +15,7 @@ The **`id`** read-only property of the {{domxref("DeprecationReportBody")}} inte
 
 ## Value
 
-A {{domxref("DOMString","string")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/deprecationreportbody/message/index.md
+++ b/files/en-us/web/api/deprecationreportbody/message/index.md
@@ -15,7 +15,7 @@ The **`message`** read-only property of the {{domxref("DeprecationReportBody")}}
 
 ## Value
 
-A {{domxref("DOMString","string")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/deprecationreportbody/sourcefile/index.md
+++ b/files/en-us/web/api/deprecationreportbody/sourcefile/index.md
@@ -17,7 +17,7 @@ The **`sourceFile`** read-only property of the {{domxref("DeprecationReportBody"
 
 ## Value
 
-A {{domxref("DOMString","string")}}, or `null` if the path is not known.
+A string, or `null` if the path is not known.
 
 ## Examples
 

--- a/files/en-us/web/api/element/animate/index.md
+++ b/files/en-us/web/api/element/animate/index.md
@@ -37,7 +37,7 @@ animate(keyframes, options)
     milliseconds), **or** an Object containing one or more timing properties described in the [`KeyframeEffect()` options parameter](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect#parameters) and/or the following options:
 
     - `id`{{optional_inline}}
-      - : A property unique to `animate()`: a [`DOMString`](/en-US/docs/Web/API/DOMString)
+      - : A property unique to `animate()`: a string
         with which to reference the animation.
 
 ### Return value

--- a/files/en-us/web/api/elementinternals/index.md
+++ b/files/en-us/web/api/elementinternals/index.md
@@ -30,7 +30,7 @@ This interface has no constructor. An `ElementInternals` object is returned when
 - {{domxref("ElementInternals.validity")}}{{ReadOnlyInline}}
   - : Returns a {{domxref("ValidityState")}} object which represents the different validity states the element can be in, with respect to constraint validation.
 - {{domxref("ElementInternals.validationMessage")}}{{ReadOnlyInline}}
-  - : A {{domxref("DOMString","string")}} containing the validation message of this element.
+  - : A string containing the validation message of this element.
 - {{domxref("ElementInternals.labels")}}{{ReadOnlyInline}}
   - : Returns a {{domxref("NodeList")}} of all of the label elements associated with this element.
 

--- a/files/en-us/web/api/elementinternals/setformvalue/index.md
+++ b/files/en-us/web/api/elementinternals/setformvalue/index.md
@@ -23,9 +23,9 @@ setFormValue(value, state)
 ### Parameters
 
 - `value`
-  - : A {{domxref("File")}}, or a {{domxref("USVString","string")}}, or {{domxref("FormData")}} as the value to be submitted to the server.
+  - : A {{domxref("File")}}, or a string, or a {{domxref("FormData")}} as the value to be submitted to the server.
 - `state`{{Optional_Inline}}
-  - : A {{domxref("File")}}, or a {{domxref("USVString","string")}}, or {{domxref("FormData")}} representing the input made by the user.
+  - : A {{domxref("File")}}, or a {{domxref("USVString","string")}}, or a {{domxref("FormData")}} representing the input made by the user.
     This allows the application to re-display the information that the user submitted, in the form that they submitted it, if required.
 
 > **Note:** In general, `state` is used to pass information specified by a user, the `value` is suitable for submission to a server, post sanitization.

--- a/files/en-us/web/api/elementinternals/setvalidity/index.md
+++ b/files/en-us/web/api/elementinternals/setvalidity/index.md
@@ -23,7 +23,7 @@ setValidity(flags, message, anchor)
 
 ### Parameters
 
-- `flags`{{Optional_Inline}}
+- `flags` {{Optional_Inline}}
 
   - : A dictionary object containing one or more flags indicating the validity state of the element:
 
@@ -50,9 +50,9 @@ setValidity(flags, message, anchor)
 
     > **Note:** To set all flags to `false`, indicating that this element passes all constraints validation, pass in an empty object `{}`. In this case, you do not need to also pass a `message`.
 
-- `message`{{Optional_Inline}}
-  - : A {{domxref("DOMString","string")}} containing a message, which will be set if any `flags` are `true`. This parameter is only optional if all `flags` are `false`.
-- `anchor`{{Optional_Inline}}
+- `message` {{Optional_Inline}}
+  - : A string containing a message, which will be set if any `flags` are `true`. This parameter is only optional if all `flags` are `false`.
+- `anchor` {{Optional_Inline}}
   - : An {{domxref("HTMLElement")}} which can be used by the user agent to report problems with this form submission.
 
 ### Return value

--- a/files/en-us/web/api/elementinternals/validationmessage/index.md
+++ b/files/en-us/web/api/elementinternals/validationmessage/index.md
@@ -15,7 +15,7 @@ The **`validationMessage`** read-only property of the {{domxref("ElementInternal
 
 ## Value
 
-A {{domxref("DOMString","string")}} containing the validation message of this element.
+A string containing the validation message of this element.
 
 ## Examples
 

--- a/files/en-us/web/api/file_system_access_api/index.md
+++ b/files/en-us/web/api/file_system_access_api/index.md
@@ -27,7 +27,7 @@ These handles represent the file or directory on the user's system. You must fir
 
 The handle provides its own functionality and there are a few differences depending on whether a file or directory was selected (see the [interfaces](#interfaces) section for specific details). You then can access file data, or information (including children) of the directory selected.
 
-There is also "save" functionality, using the {{domxref('FilesystemWritableFileStream')}} interface. Once the data you'd like to save is in a format of {{domxref('Blob')}}, {{domxref('USVString')}} or {{jsxref('ArrayBuffer', 'buffer')}}, you can open a stream and save the data to a file. This can be the existing file or a new file.
+There is also "save" functionality, using the {{domxref('FilesystemWritableFileStream')}} interface. Once the data you'd like to save is in a format of {{domxref('Blob')}}, {{jsxref("String")}} object, string literal or {{jsxref('ArrayBuffer', 'buffer')}}, you can open a stream and save the data to a file. This can be the existing file or a new file.
 
 This API opens up potential functionality the web has been lacking. Still, security has been of utmost concern when designing the API, and access to file/directory data is disallowed unless the user specifically permits it.
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/getdirectoryhandle/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/getdirectoryhandle/index.md
@@ -26,7 +26,7 @@ var FileSystemDirectoryHandle = FileSystemDirectoryHandle.getDirectoryHandle();
 ### Parameters
 
 - _name_
-  - : A {{domxref('USVString')}} representing the {{domxref('FileSystemHandle.name')}} of
+  - : A string representing the {{domxref('FileSystemHandle.name')}} of
     the subdirectory you wish to retrieve.
 - _options_ {{optional_inline}}
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/getfilehandle/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/getfilehandle/index.md
@@ -25,7 +25,7 @@ var FileSystemFileHandle = FileSystemDirectoryHandle.getFileHandle(name);
 ### Parameters
 
 - _name_
-  - : A {{domxref('USVString')}} representing the {{domxref('FileSystemHandle.name')}} of
+  - : A string representing the {{domxref('FileSystemHandle.name')}} of
     the file you wish to retrieve.
 - _options_ {{optional_inline}}
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/removeentry/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/removeentry/index.md
@@ -24,7 +24,7 @@ FileSystemDirectoryHandle.removeEntry(name).then...
 ### Parameters
 
 - _name_
-  - : A {{domxref('USVString')}} representing the {{domxref('FileSystemHandle.name')}} of
+  - : A string representing the {{domxref('FileSystemHandle.name')}} of
     the entry you wish to remove.
 - _options_ {{optional_inline}}
 

--- a/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.md
@@ -31,7 +31,7 @@ var pathArr = FileSystemDirectoryHandle.resolve(possibleDescendant);
 ### Return value
 
 A {{jsxref('Promise')}} which resolves with an {{jsxref('Array')}} of
-{{jsxref('USVString','strings')}}, or `null` if `possibleDescendant` is not a descendant of this {{domxref('FileSystemDirectoryHandle')}}.
+strings, or `null` if `possibleDescendant` is not a descendant of this {{domxref('FileSystemDirectoryHandle')}}.
 
 ### Exceptions
 

--- a/files/en-us/web/api/filesystemhandle/name/index.md
+++ b/files/en-us/web/api/filesystemhandle/name/index.md
@@ -18,7 +18,7 @@ handle.
 
 ## Value
 
-{{domxref('USVString')}}
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/filesystemwritablefilestream/write/index.md
+++ b/files/en-us/web/api/filesystemwritablefilestream/write/index.md
@@ -25,7 +25,7 @@ file contains.
 ## Syntax
 
 ```js
-FileSystemWritableFileStream.write(data).then(...);
+write(data)
 ```
 
 ### Parameters
@@ -33,14 +33,14 @@ FileSystemWritableFileStream.write(data).then(...);
 - `data`
 
   - : Can be either the file data to write, in the form of a {{domxref('BufferSource')}},
-    {{domxref('Blob')}} or {{domxref('USVString')}}. Or an object containing the following
+    {{domxref('Blob')}} or string. Or an object containing the following
     properties:
 
     - **`type`**: One of `'write'`,
       `'seek'` or `'truncate'`. This is required if the object is
       passed into the `write()` method.
     - **`data`**: The file data to write. Can be a
-      {{domxref('BufferSource')}}, {{domxref('Blob')}} or {{domxref('USVString')}}. This
+      {{domxref('BufferSource')}}, a {{domxref('Blob')}}, a {{jsxref("String")}} object, or a string literal. This
       is required if the `type` is set to `'write'`.
     - **`position`**: The byte position the current file
       cursor should move to if type `'seek'` is used. Can also be set with

--- a/files/en-us/web/api/fontface/ascentoverride/index.md
+++ b/files/en-us/web/api/fontface/ascentoverride/index.md
@@ -15,7 +15,7 @@ The **`ascentOverride`** property of the {{domxref("FontFace")}} interface retur
 
 ## Value
 
-A {{domxref("CSSOMString","string")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/fontface/descentoverride/index.md
+++ b/files/en-us/web/api/fontface/descentoverride/index.md
@@ -15,7 +15,7 @@ The **`descentOverride`** property of the {{domxref("FontFace")}} interface retu
 
 ## Value
 
-A {{domxref("CSSOMString","string")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/fontface/featuresettings/index.md
+++ b/files/en-us/web/api/fontface/featuresettings/index.md
@@ -21,7 +21,7 @@ are not available from a font's variant properties. It is equivalent to the
 
 ## Value
 
-A {{domxref('CSSOMString')}} containing a descriptor.
+A string containing a descriptor.
 
 ## Specifications
 

--- a/files/en-us/web/api/fontface/linegapoverride/index.md
+++ b/files/en-us/web/api/fontface/linegapoverride/index.md
@@ -15,7 +15,7 @@ The **`lineGapOverride`** property of the {{domxref("FontFace")}} interface retu
 
 ## Value
 
-A {{domxref("CSSOMString","string")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/fontface/stretch/index.md
+++ b/files/en-us/web/api/fontface/stretch/index.md
@@ -20,7 +20,7 @@ equivalent to the {{cssxref("@font-face/font-stretch", "font-stretch")}} descrip
 
 ## Value
 
-A {{domxref('CSSOMString')}} containing a descriptor as it would be defined in a style
+A string containing a descriptor as it would be defined in a style
 sheet's `@font-face` rule.
 
 ## Specifications

--- a/files/en-us/web/api/fontface/style/index.md
+++ b/files/en-us/web/api/fontface/style/index.md
@@ -20,7 +20,7 @@ to the {{cssxref("@font-face/font-style", "font-style")}} descriptor.
 
 ## Value
 
-A {{domxref('CSSOMString')}} containing the descriptors defined in the style sheet's
+A string containing the descriptors defined in the style sheet's
 `@font-face` rule.
 
 ## Specifications

--- a/files/en-us/web/api/fontface/unicoderange/index.md
+++ b/files/en-us/web/api/fontface/unicoderange/index.md
@@ -21,7 +21,7 @@ encompassing the font. It is equivalent to the {{cssxref("@font-face/unicode-ran
 
 ## Value
 
-A {{domxref('CSSOMString')}} containing a descriptor as it would appear in a style
+A string containing a descriptor as it would appear in a style
 sheet's `@font-face` rule.
 
 ## Specifications

--- a/files/en-us/web/api/fontface/variant/index.md
+++ b/files/en-us/web/api/fontface/variant/index.md
@@ -21,7 +21,7 @@ descriptor.
 
 ## Value
 
-A {{domxref('CSSOMString')}} containing a descriptor as it would be defined in a style
+A string containing a descriptor as it would be defined in a style
 sheet's `@font-face` rule.
 
 ## Specifications

--- a/files/en-us/web/api/fontface/variationsettings/index.md
+++ b/files/en-us/web/api/fontface/variationsettings/index.md
@@ -21,7 +21,7 @@ It is equivalent to the
 
 ## Value
 
-A {{domxref('CSSOMString')}} containing a descriptor.
+A string containing a descriptor.
 
 ## Specifications
 

--- a/files/en-us/web/api/fontface/weight/index.md
+++ b/files/en-us/web/api/fontface/weight/index.md
@@ -20,7 +20,7 @@ equivalent to the {{cssxref("@font-face/font-weight", "font-weight")}} descripto
 
 ## Value
 
-A {{domxref('CSSOMString')}} containing a descriptor as it would be defined in a style
+A string containing a descriptor as it would be defined in a style
 sheet's `@font-face` rule.
 
 ## Specifications

--- a/files/en-us/web/api/hiddevice/index.md
+++ b/files/en-us/web/api/hiddevice/index.md
@@ -25,7 +25,7 @@ This interface also inherits properties from {{domxref("EventTarget")}}.
 - {{domxref("HIDDevice.productId")}}{{ReadOnlyInline}}
   - : Returns the productID of the HID device.
 - {{domxref("HIDDevice.productName")}}{{ReadOnlyInline}}
-  - : Returns a {{domxref("DOMString","string")}} containing the product name of the HID device.
+  - : Returns a string containing the product name of the HID device.
 - {{domxref("HIDDevice.collections")}}{{ReadOnlyInline}}
   - : Returns an array of report formats for the HID device.
 

--- a/files/en-us/web/api/hiddevice/productname/index.md
+++ b/files/en-us/web/api/hiddevice/productname/index.md
@@ -15,7 +15,7 @@ The **`productName`** read-only property of the {{domxref("HIDDevice")}} interfa
 
 ## Value
 
-A {{domxref("DOMString","string")}}.
+A string.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlelement/enterkeyhint/index.md
+++ b/files/en-us/web/api/htmlelement/enterkeyhint/index.md
@@ -16,7 +16,7 @@ The **`enterKeyHint`** property is an enumerated property defining
 what action label (or icon) to present for the enter key on virtual keyboards.
 It reflects the [`enterkeyhint`](/en-US/docs/Web/HTML/Global_attributes/enterkeyhint)
 HTML global attribute and is an enumerated property, only accepting the following values
-as a [`DOMString`](/en-US/docs/Web/API/DOMString):
+as a string:
 
 - `'enter'` typically indicating inserting a new line.
 - `'done'` typically meaning there is nothing more to input and the input method editor (IME) will be closed.

--- a/files/en-us/web/api/idbdatabase/name/index.md
+++ b/files/en-us/web/api/idbdatabase/name/index.md
@@ -15,14 +15,14 @@ browser-compat: api.IDBDatabase.name
 {{ APIRef("IndexedDB") }}
 
 The **`name`** read-only property of the
-`IDBDatabase` interface is a {{ domxref("DOMString")}} that contains the
+`IDBDatabase` interface is a string that contains the
 name of the connected database.
 
 {{AvailableInWorkers}}
 
 ## Value
 
-A {{ domxref("DOMString")}} containing the name of the connected database.
+A string containing the name of the connected database.
 
 ## Examples
 

--- a/files/en-us/web/api/mscaching/index.md
+++ b/files/en-us/web/api/mscaching/index.md
@@ -20,7 +20,7 @@ This proprietary method is specific to Internet Explorer and Microsoft Edge.
 
 ### Values
 
-Type: DOMString
+Type: string
 
 | Property value | Description                                    |
 | -------------- | ---------------------------------------------- |

--- a/files/en-us/web/api/navigator/requestmediakeysystemaccess/index.md
+++ b/files/en-us/web/api/navigator/requestmediakeysystemaccess/index.md
@@ -41,7 +41,7 @@ requestMediaKeySystemAccess(keySystem, supportedConfigurations)
 ### Parameters
 
 - `keySystem`
-  - : A {{domxref('DOMString')}} identifying the key system. For example
+  - : A string identifying the key system. For example
     `com.example.somesystem` or `org.w3.clearkey`.
 - `supportedConfigurations`
   - : A non-empty {{jsxref('Array')}} of objects conforming to the object returned by {{domxref("MediaKeySystemAccess.getConfiguration")}}. The first element with a satisfiable configuration will be used.

--- a/files/en-us/web/api/notification/badge/index.md
+++ b/files/en-us/web/api/notification/badge/index.md
@@ -19,7 +19,7 @@ not enough space to display the notification itself.
 
 ## Value
 
-A {{domxref('USVString')}} containing a URL.
+A string containing a URL.
 
 ## Specifications
 

--- a/files/en-us/web/api/paymentrequestevent/paymentrequestorigin/index.md
+++ b/files/en-us/web/api/paymentrequestevent/paymentrequestorigin/index.md
@@ -19,7 +19,7 @@ The **`paymentRequestOrigin`** read-only property of the
 
 ## Value
 
-A USVString.
+A string.
 
 ## Specifications
 

--- a/files/en-us/web/api/paymentrequestevent/toporigin/index.md
+++ b/files/en-us/web/api/paymentrequestevent/toporigin/index.md
@@ -19,7 +19,7 @@ the {{domxref("PaymentRequest")}} object was initialized.
 
 ## Value
 
-A USVString
+A string
 
 ## Specifications
 

--- a/files/en-us/web/api/request/request/index.md
+++ b/files/en-us/web/api/request/request/index.md
@@ -52,9 +52,9 @@ new Request(input, options)
         {{jsxref("String")}} values.
     - `body`
       - : Any body that you want to add to your request: this can be a
-        {{domxref("Blob")}}, {{domxref("BufferSource")}}, {{domxref("FormData")}},
-        {{domxref("URLSearchParams")}}, {{domxref("USVString")}}, or
-        {{domxref("ReadableStream")}} object. Note that a request using the
+        {{domxref("Blob")}}, a {{domxref("BufferSource")}}, a {{domxref("FormData")}},
+        a {{domxref("URLSearchParams")}}, a string, or
+        a {{domxref("ReadableStream")}} object. Note that a request using the
         `GET` or `HEAD` method cannot have a body.
     - `mode`
       - : The mode you want to use for the request, e.g.,

--- a/files/en-us/web/api/screen/lockorientation/index.md
+++ b/files/en-us/web/api/screen/lockorientation/index.md
@@ -86,7 +86,7 @@ doesn't indicate that the screen orientation is indeed locked: there may be a de
 
 ## Examples
 
-### Usage with a `DOMString` argument
+### Usage with a string argument
 
 ```js
 screen.lockOrientationUniversal = screen.lockOrientation || screen.mozLockOrientation || screen.msLockOrientation;

--- a/files/en-us/web/api/trustedscripturl/index.md
+++ b/files/en-us/web/api/trustedscripturl/index.md
@@ -19,7 +19,7 @@ The value of a **TrustedScriptURL** object is set when the object is created and
 - {{domxref("TrustedScriptURL.toJSON()")}}
   - : Returns a JSON representation of the stored data.
 - {{domxref("TrustedScriptURL.toString()")}}
-  - : A {{domxref("USVString","string")}} containing the sanitized URL.
+  - : A string containing the sanitized URL.
 
 ## Examples
 

--- a/files/en-us/web/api/url/url/index.md
+++ b/files/en-us/web/api/url/url/index.md
@@ -41,7 +41,7 @@ new URL(url, base)
 
 > **Note:** The `url` and `base` arguments will
 > each be stringified from whatever value you pass, just like with other Web APIs
-> that accept {{domxref("USVString")}}. In particular, you can use an existing
+> that accept a string. In particular, you can use an existing
 > {{domxref("URL")}} object for either argument, and it will stringify to the
 > object's {{domxref("URL.href", "href")}} property.
 

--- a/files/en-us/web/api/usbdevice/manufacturername/index.md
+++ b/files/en-us/web/api/usbdevice/manufacturername/index.md
@@ -20,7 +20,7 @@ device.
 
 ## Value
 
-A {{jsxref("DOMString")}}.
+A string.
 
 ## Specifications
 

--- a/files/en-us/web/api/videoencoder/configure/index.md
+++ b/files/en-us/web/api/videoencoder/configure/index.md
@@ -47,7 +47,7 @@ configure(config)
         - `"discard"` (default)
         - `"keep"`
     - `scalabilityMode`
-      - : A {{domxref("DOMString", "string")}} containing an encoding scalability mode identifier as defined in [WebRTC](https://w3c.github.io/webrtc-svc/#scalabilitymodes*).
+      - : A string containing an encoding scalability mode identifier as defined in [WebRTC](https://w3c.github.io/webrtc-svc/#scalabilitymodes*).
     - `bitrateMode`
       - : A string containing a bitrate mode. One of:
         - `"constant"`

--- a/files/en-us/web/api/websocket/protocol/index.md
+++ b/files/en-us/web/api/websocket/protocol/index.md
@@ -18,7 +18,7 @@ object, or the empty string if no connection is established.
 
 ## Value
 
-A [`DOMString`](/en-US/docs/Web/API/DOMString).
+A string.
 
 ## Specifications
 

--- a/files/en-us/web/api/websocket/url/index.md
+++ b/files/en-us/web/api/websocket/url/index.md
@@ -16,7 +16,7 @@ URL of the {{domxref("WebSocket")}} as resolved by the constructor.
 
 ## Value
 
-A [`DOMString`](/en-US/docs/Web/API/DOMString).
+A string.
 
 ## Specifications
 

--- a/files/en-us/web/api/xpathresult/index.md
+++ b/files/en-us/web/api/xpathresult/index.md
@@ -31,7 +31,7 @@ Since XPath expressions can result in a variety of result types, this interface 
 - {{domxref("XPathResult.snapshotLength")}}{{readonlyInline}}
   - : The number of nodes in the result snapshot.
 - {{domxref("XPathResult.stringValue")}}{{readonlyInline}}
-  - : A {{domxref("DOMString", "string")}} representing the value of the result if `resultType` is `STRING_TYPE`.
+  - : A string representing the value of the result if `resultType` is `STRING_TYPE`.
 
 ## Methods
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/global/global/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/global/global/index.md
@@ -25,7 +25,7 @@ new WebAssembly.Global(descriptor, value)
 
   - : A `GlobalDescriptor` dictionary object, which contains two properties:
 
-    - `value`: A [`USVString`](/en-US/docs/Web/API/USVString) representing the
+    - `value`: A string representing the
       data type of the global. This can be any one of:
       - `i32`: A 32-bit integer.
       - `i64`: A 64-bit integer.


### PR DESCRIPTION
Continuing #15499 

All DOMString, USVString, and CSSOMString have been updated in relevant places. This is the last PR in the series. 🥳

***
### Summary
`DOMString` is not exposed by browsers to JavaScript. It is converted to `string`.[[ref](https://developer.mozilla.org/en-US/docs/Web/API/DOMString)]
Same is the case with `USVString` and `CSSOMString`.

### Metadata
- [x] Fixes a typo, bug, or other error
