### PR TITLE
Remove non-existent ScreenLuminance from sidebars

### DIFF
--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -758,7 +758,6 @@
       ],
       "interfaces": [
         "MediaCapabilities",
-        "ScreenLuminance",
         "Screen"
       ],
       "methods": [


### PR DESCRIPTION
It is not documented, not in the relevant spec, and no mention found elsewhere. Let's remove this red link from the sidebars.
