### PR TITLE
Remove mention of dictionary PhotoCapabilities

### DIFF
--- a/files/en-us/web/api/mediastream_image_capture_api/index.md
+++ b/files/en-us/web/api/mediastream_image_capture_api/index.md
@@ -56,8 +56,6 @@ let imageCapture = new ImageCapture(track);
 
 - {{domxref("ImageCapture")}}
   - : An interface for capturing images from a photographic device referenced through a valid {{domxref("MediaStreamTrack")}}.
-- {{domxref("PhotoCapabilities")}}
-  - : Provides available configuration options for an attached photographic device. Retrieve a `PhotoCapabilities` object by calling {{domxref("ImageCapture.getPhotoCapabilities()")}}.
 
 ## Specifications
 
@@ -65,13 +63,7 @@ let imageCapture = new ImageCapture(track);
 
 ## Browser compatibility
 
-### `ImageCapture`
-
 {{Compat("api.ImageCapture")}}
-
-### `PhotoCapabilities`
-
-{{Compat("api.PhotoCapabilities")}}
 
 ## See also
 


### PR DESCRIPTION
`PhotoCapabilities` was a dictionary that we merged with the method using it long ago. There was some mentions and a broken compat table left. 

This PR cleans this.