### PR TITLE
Remove link to MDN 404 page

### DIFF
--- a/files/en-us/web/http/status/404/index.md
+++ b/files/en-us/web/http/status/404/index.md
@@ -30,7 +30,7 @@ You can display a custom 404 page to be more helpful to a user and provide guida
 ErrorDocument 404 /notfound.html
 ```
 
-For an example of a custom 404 page, see [MDN's 404 page](/en-US/404).
+For an example of a custom 404 page, see this [404 page](https://konmari.com/404).
 
 > **Note:** Custom design is a good thing, in moderation. Feel free to make your 404 page humorous and human, but don't confuse your users.
 


### PR DESCRIPTION
We want to show an example of a customized 404 page. Unfortunately here, linking to a non-existent MDN page has the additional effect to show a red _broken_ link, which is not what we want.

So I linked to another 404 page.