### PR TITLE
Remove link to archived then delete page

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/allsettled/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/allsettled/index.md
@@ -109,7 +109,6 @@ console.log(values)
 ## See also
 
 - [Polyfill of `Promise.allSettled` in `core-js`](https://github.com/zloirock/core-js#ecmascript-promise)
-- [Promises](/en-US/docs/Archive/Add-ons/Techniques/Promises)
 - [Using promises](/en-US/docs/Web/JavaScript/Guide/Using_promises)
 - [Graceful asynchronous programming with promises](/en-US/docs/Learn/JavaScript/Asynchronous/Promises)
 - {{jsxref("Promise")}}


### PR DESCRIPTION
The article is deleted and other articles linked from this page are enough.

Removing this entry from the _See also_ section.