### PR TITLE
Remove long gone broken link

### DIFF
--- a/files/en-us/web/api/keyboardevent/keycode/index.md
+++ b/files/en-us/web/api/keyboardevent/keycode/index.md
@@ -21,7 +21,7 @@ This is usually the decimal ASCII ({{RFC(20)}}) or Windows 1252 code correspondi
 
 You should avoid using this if possible; it's been deprecated for some time. Instead, you should use {{domxref("KeyboardEvent.code")}}, if it's implemented. Unfortunately, some browsers still don't have it, so you'll have to be careful to make sure you use one which is supported on all target browsers.
 
-> **Note:** Web developers shouldn't use the `keyCode` attribute for printable characters when handling `keydown` and `keyup` events. As described above, the `keyCode` attribute is not useful for printable characters, especially those input with the <kbd>Shift</kbd> or <kbd>Alt</kbd> key pressed. When implementing a shortcut key handler, the {{event("keypress")}} event is usually better (at least when Gecko is the runtime in use). See [Gecko Keypress Event](/en-US/docs/Gecko_Keypress_Event) for details.
+> **Note:** Web developers shouldn't use the `keyCode` attribute for printable characters when handling `keydown` and `keyup` events. As described above, the `keyCode` attribute is not useful for printable characters, especially those input with the <kbd>Shift</kbd> or <kbd>Alt</kbd> key pressed. When implementing a shortcut key handler, the {{event("keypress")}} event is usually better (at least when Gecko is the runtime in use).
 
 ## Examples
 


### PR DESCRIPTION
This document was Gecko-specific, we have the main info in the note here, and it is long gone…

Let's remove the clause.