### PR TITLE
Fix internal links to subpages

### DIFF
--- a/files/en-us/web/css/transform-function/index.md
+++ b/files/en-us/web/css/transform-function/index.md
@@ -20,62 +20,62 @@ The `<transform-function>` data type is specified using one of the transformatio
 
 ### Matrix transformation
 
-- [`matrix()`](/en-US/docs/Web/CSS/transform-function/matrix())
+- [`matrix()`](/en-US/docs/Web/CSS/transform-function/matrix)
   - : Describes a homogeneous 2D transformation matrix.
-- [`matrix3d()`](/en-US/docs/Web/CSS/transform-function/matrix3d())
+- [`matrix3d()`](/en-US/docs/Web/CSS/transform-function/matrix3d)
   - : Describes a 3D transformation as a 4×4 homogeneous matrix.
 
 ### Perspective
 
-- [`perspective()`](/en-US/docs/Web/CSS/transform-function/perspective())
+- [`perspective()`](/en-US/docs/Web/CSS/transform-function/perspective)
   - : Sets the distance between the user and the z=0 plane.
 
 ### Rotation
 
-- [`rotate()`](/en-US/docs/Web/CSS/transform-function/rotate())
+- [`rotate()`](/en-US/docs/Web/CSS/transform-function/rotate)
   - : Rotates an element around a fixed point on the 2D plane.
-- [`rotate3d()`](/en-US/docs/Web/CSS/transform-function/rotate3d())
+- [`rotate3d()`](/en-US/docs/Web/CSS/transform-function/rotate3d)
   - : Rotates an element around a fixed axis in 3D space.
-- [`rotateX()`](/en-US/docs/Web/CSS/transform-function/rotateX())
+- [`rotateX()`](/en-US/docs/Web/CSS/transform-function/rotateX)
   - : Rotates an element around the horizontal axis.
-- [`rotateY()`](/en-US/docs/Web/CSS/transform-function/rotateY())
+- [`rotateY()`](/en-US/docs/Web/CSS/transform-function/rotateY)
   - : Rotates an element around the vertical axis.
-- [`rotateZ()`](/en-US/docs/Web/CSS/transform-function/rotateZ())
+- [`rotateZ()`](/en-US/docs/Web/CSS/transform-function/rotateZ)
   - : Rotates an element around the z-axis.
 
 ### Scaling (resizing)
 
-- [`scale()`](/en-US/docs/Web/CSS/transform-function/scale())
+- [`scale()`](/en-US/docs/Web/CSS/transform-function/scale)
   - : Scales an element up or down on the 2D plane.
-- [`scale3d()`](/en-US/docs/Web/CSS/transform-function/scale3d())
+- [`scale3d()`](/en-US/docs/Web/CSS/transform-function/scale3d)
   - : Scales an element up or down in 3D space.
-- [`scaleX()`](/en-US/docs/Web/CSS/transform-function/scaleX())
+- [`scaleX()`](/en-US/docs/Web/CSS/transform-function/scaleX)
   - : Scales an element up or down horizontally.
-- [`scaleY()`](/en-US/docs/Web/CSS/transform-function/scaleY())
+- [`scaleY()`](/en-US/docs/Web/CSS/transform-function/scaleY)
   - : Scales an element up or down vertically.
-- [`scaleZ()`](/en-US/docs/Web/CSS/transform-function/scaleZ())
+- [`scaleZ()`](/en-US/docs/Web/CSS/transform-function/scaleZ)
   - : Scales an element up or down along the z-axis.
 
 ### Skewing (distortion)
 
-- [`skew()`](/en-US/docs/Web/CSS/transform-function/skew())
+- [`skew()`](/en-US/docs/Web/CSS/transform-function/skew)
   - : Skews an element on the 2D plane.
-- [`skewX()`](/en-US/docs/Web/CSS/transform-function/skewX())
+- [`skewX()`](/en-US/docs/Web/CSS/transform-function/skewX)
   - : Skews an element in the horizontal direction.
-- [`skewY()`](/en-US/docs/Web/CSS/transform-function/skewY())
+- [`skewY()`](/en-US/docs/Web/CSS/transform-function/skewY)
   - : Skews an element in the vertical direction.
 
 ### Translation (moving)
 
-- [`translate()`](/en-US/docs/Web/CSS/transform-function/translate())
+- [`translate()`](/en-US/docs/Web/CSS/transform-function/translate)
   - : Translates an element on the 2D plane.
-- [`translate3d()`](/en-US/docs/Web/CSS/transform-function/translate3d())
+- [`translate3d()`](/en-US/docs/Web/CSS/transform-function/translate3d)
   - : Translates an element in 3D space.
-- [`translateX()`](/en-US/docs/Web/CSS/transform-function/translateX())
+- [`translateX()`](/en-US/docs/Web/CSS/transform-function/translateX)
   - : Translates an element horizontally.
-- [`translateY()`](/en-US/docs/Web/CSS/transform-function/translateY())
+- [`translateY()`](/en-US/docs/Web/CSS/transform-function/translateY)
   - : Translates an element vertically.
-- [`translateZ()`](/en-US/docs/Web/CSS/transform-function/translateZ())
+- [`translateZ()`](/en-US/docs/Web/CSS/transform-function/translateZ)
   - : Translates an element along the z-axis.
 
 ## Description


### PR DESCRIPTION
The sub-pages have been renamed (getting rid of the parenthesis in the slug). This fixes the links to them.