### PR TITLE
Remove useless mention of XUL and XBL

### DIFF
--- a/files/en-us/web/xml/xml_introduction/index.md
+++ b/files/en-us/web/xml/xml_introduction/index.md
@@ -9,7 +9,7 @@ tags:
 ---
 XML (Extensible Markup Language) is a markup language similar to {{Glossary("HTML")}}, but without predefined tags to use. Instead, you define your own tags designed specifically for your needs. This is a powerful way to store data in a format that can be stored, searched, and shared. Most importantly, since the fundamental format of XML is standardized, if you share or transmit XML across systems or platforms, either locally or over the internet, the recipient can still parse the data due to the standardized XML syntax.
 
-There are many languages based on XML, including [XHTML](/en-US/docs/Glossary/XHTML), [MathML](/en-US/docs/Web/MathML), [SVG](/en-US/docs/Web/SVG), [XUL](/en-US/docs/Mozilla/Tech/XUL), [XBL](/en-US/docs/Mozilla/Tech/XBL), [RSS](/en-US/docs/Web/RSS), and [RDF](/en-US/docs/Web/RDF). You can also define your own.
+There are many languages based on XML, including [XHTML](/en-US/docs/Glossary/XHTML), [MathML](/en-US/docs/Web/MathML), [SVG](/en-US/docs/Web/SVG), [RSS](/en-US/docs/Glossary/RSS), and [RDF](/en-US/docs/Glossary/RDF). You can also define your own.
 
 ## Structure of an XML document
 


### PR DESCRIPTION
XUL and XBL are gone, not standard, and were adding more complexity here than helping comprehensions.

Also fixed broken links to RSS and RDF.