### PR TITLE
Removing mentions of B2G and Firefox OS

### DIFF
--- a/files/en-us/web/api/css_object_model/managing_screen_orientation/index.md
+++ b/files/en-us/web/api/css_object_model/managing_screen_orientation/index.md
@@ -10,7 +10,7 @@ tags:
 ---
 {{DefaultAPISidebar("Screen Orientation API")}}{{SeeCompatTable}}
 
-Screen orientation is something slightly different than [device orientation](/en-US/docs/Web/API/Detecting_device_orientation). Even if a device doesn't have the capacity to detect its own orientation, a screen always has one. And if a device is able to know its orientation, it's good to have the ability to control the screen orientation in order to preserve or adapt the interface of a web application.
+Screen orientation is something slightly different than [device orientation](/en-US/docs/Web/API/Events/Detecting_device_orientation). Even if a device doesn't have the capacity to detect its own orientation, a screen always has one. And if a device is able to know its orientation, it's good to have the ability to control the screen orientation in order to preserve or adapt the interface of a web application.
 
 There are several ways to handle screen orientation, both with CSS and JavaScript. The first is the [orientation media query](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#orientation). This lets content adjust its layout using CSS, based on whether the browser window is in landscape mode (that is, its width is greater than its height) or portrait mode (its height is greater than its width).
 
@@ -135,13 +135,11 @@ And here's the result
 
 ## Locking the screen orientation
 
-> **Warning:** This API is experimental and currently available on [Firefox OS](/en-US/docs/Mozilla/Firefox_OS) and [Firefox for Android](/en-US/docs/Mozilla/Firefox_for_Android) with a `moz` prefix, and for Internet Explorer on Windows 8.1 and above with a `ms` prefix.
-
 Some devices (mainly mobile devices) can dynamically change the orientation of the screen based on their own orientation, ensuring that the user will always be able to read what's on the screen. While this behavior is perfectly suited for text content, there is some content that can be negatively affected by such a change. For example, games based on the orientation of the device could be messed up by such a change of the orientation.
 
 The Screen Orientation API is made to prevent or handle such a change.
 
-### Listening orientation change
+### Listening to orientation changes
 
 The {{domxref("Window.orientationchange_event", "orientationchange")}} event is triggered each time the device change the orientation of the screen and the orientation itself can be read with the {{domxref("Screen.orientation")}} property.
 
@@ -164,14 +162,6 @@ screen.lockOrientation('landscape');
 > **Note:** A screen lock is web application dependent. If application A is locked to `landscape` and application B is locked to `portrait`, switching from application A to B or B to A will not fire an {{domxref("Window.orientationchange_event", "orientationchange")}} event because both applications will keep the orientation they had.
 >
 > However, locking the orientation can fire an {{domxref("Window.orientationchange_event", "orientationchange")}} event if the orientation had to be changed to satisfy the lock requirements.
-
-## Firefox OS and Android: Orientation lock using the manifest
-
-For a Firefox OS and Firefox Android (soon to work on Firefox desktop too) specific way to lock orientation, you can set the [orientation](/en-US/docs/Web/Apps/Build/Manifest#orientation) field in app's your manifest file, for example:
-
-```json
-"orientation": "portrait"
-```
 
 ## See also
 


### PR DESCRIPTION
The API exists in all browsers, although some features only prefixed in some of them.

No need to mention/restrict this to Firefox OS and B2G OS.