### PR TITLE
Replace non-existent {{compat}} with standard text

### DIFF
--- a/files/en-us/web/api/deprecationreportbody/sourcefile/index.md
+++ b/files/en-us/web/api/deprecationreportbody/sourcefile/index.md
@@ -43,4 +43,4 @@ let observer = new ReportingObserver(function(reports, observer) {
 
 ## Browser compatibility
 
-{{Compat}}
+This feature is not yet available by default in any released browser. It can be activated in Firefox by setting `dom_reporting_enabled` to `true` and in Chrome if you [enable this experimental feature](https://web.dev/reporting-api/#use-devtools).


### PR DESCRIPTION
Not implemented in any browser -> no bcd entry yet