### PR TITLE
Fix tagged template literal syntax

### DIFF
--- a/files/en-us/web/javascript/reference/template_literals/index.md
+++ b/files/en-us/web/javascript/reference/template_literals/index.md
@@ -35,7 +35,7 @@ const templateFn = expression => `string text ${expression} string text`;
 
 // Tagged, this calls the function "example" with the template as the
 // first argument and substitution values as subsequent arguments:
-example`string text ${expression} string text`
+templateFn`string text ${expression} string text`
 ```
 
 ## Description

--- a/files/en-us/web/javascript/reference/template_literals/index.md
+++ b/files/en-us/web/javascript/reference/template_literals/index.md
@@ -30,12 +30,9 @@ Template literals are sometimes informally called _template strings_, because th
 
 `string text ${expression} string text`
 
-// Re-usable template:
-const templateFn = expression => `string text ${expression} string text`;
-
-// Tagged, this calls the function "example" with the template as the
+// Tagged, this calls the function "tagFunction" with the template as the
 // first argument and substitution values as subsequent arguments:
-templateFn`string text ${expression} string text`
+tagFunction`string text ${expression} string text`
 ```
 
 ## Description


### PR DESCRIPTION
Fix tagged template literal syntax

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fixed a typo calling to example instead of templateFn

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Very confusing in addition to the syntax that doesn't use ()

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
