### PR TITLE
Change `/Data_URIs` links and mentions to `/Data_URLs`

### DIFF
--- a/files/en-us/glossary/base64/index.md
+++ b/files/en-us/glossary/base64/index.md
@@ -16,7 +16,7 @@ tags:
 
 Base64 encoding schemes are commonly used when there is a need to encode binary data that needs to be stored and transferred over media that are designed to deal with ASCII. This is to ensure that the data remain intact without modification during transport. Base64 is commonly used in a number of applications including email via [MIME](https://en.wikipedia.org/wiki/MIME), and storing complex data in [XML](/en-US/docs/Web/XML).
 
-One common application of Base64 encoding on the web is to encode binary data so it can be included in a [data: URL](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs).
+One common application of Base64 encoding on the web is to encode binary data so it can be included in a [data: URL](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs).
 
 In JavaScript there are two functions respectively for decoding and encoding Base64 strings:
 

--- a/files/en-us/learn/common_questions/what_is_a_url/index.md
+++ b/files/en-us/learn/common_questions/what_is_a_url/index.md
@@ -109,7 +109,7 @@ The {{Glossary("HTML")}} language — [which will be discussed later on](/en-US/
 - to display media such as images (with the {{HTMLElement("img")}} element), videos (with the {{HTMLElement("video")}} element), sounds and music (with the {{HTMLElement("audio")}} element), etc.;
 - to display other HTML documents with the {{HTMLElement("iframe")}} element.
 
-> **Note:** When specifying URLs to load resources as part of a page (such as when using the `<script>`, `<audio>`, `<img>`, `<video>`, and the like), you should generally only use HTTP and HTTPS URLs, with few exceptions (one notable one being `data:`; see [Data URLs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs)). Using FTP, for example, is not secure and is no longer supported by modern browsers.
+> **Note:** When specifying URLs to load resources as part of a page (such as when using the `<script>`, `<audio>`, `<img>`, `<video>`, and the like), you should generally only use HTTP and HTTPS URLs, with few exceptions (one notable one being `data:`; see [Data URLs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs)). Using FTP, for example, is not secure and is no longer supported by modern browsers.
 
 Other technologies, such as {{Glossary("CSS")}} or {{Glossary("JavaScript")}}, use URLs extensively, and these are really the heart of the Web.
 
@@ -210,4 +210,4 @@ Linguistic semantics are of course irrelevant to computers. You've probably ofte
 
 ## See also
 
-[Data URLs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) — Data URLs, URLs prefixed with the `data:` scheme, allow content creators to embed small files inline in documents.
+[Data URLs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) — Data URLs, URLs prefixed with the `data:` scheme, allow content creators to embed small files inline in documents.

--- a/files/en-us/mozilla/firefox/releases/10/index.md
+++ b/files/en-us/mozilla/firefox/releases/10/index.md
@@ -67,7 +67,7 @@ Firefox 10 shipped on January 31, 2012. This article provides information about 
 #### Web Workers
 
 - The attribute `XMLHttpRequest.responseType` and `XMLHttpRequest.response` are now available from inside [Workers](/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers#section_2).
-- The [`Worker()`](</en-US/docs/Web/API/Worker#worker()>) constructor now accepts [data URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs).
+- The [`Worker()`](</en-US/docs/Web/API/Worker#worker()>) constructor now accepts [data URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs).
 
 #### IndexedDB
 

--- a/files/en-us/mozilla/firefox/releases/10/index.md
+++ b/files/en-us/mozilla/firefox/releases/10/index.md
@@ -67,7 +67,7 @@ Firefox 10 shipped on January 31, 2012. This article provides information about 
 #### Web Workers
 
 - The attribute `XMLHttpRequest.responseType` and `XMLHttpRequest.response` are now available from inside [Workers](/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers#section_2).
-- The [`Worker()`](</en-US/docs/Web/API/Worker#worker()>) constructor now accepts [data URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs).
+- The [`Worker()`](</en-US/docs/Web/API/Worker#worker()>) constructor now accepts [data URLs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs).
 
 #### IndexedDB
 

--- a/files/en-us/mozilla/firefox/releases/12/index.md
+++ b/files/en-us/mozilla/firefox/releases/12/index.md
@@ -32,7 +32,7 @@ Firefox 12 was shipped on April 24, 2012. This page summarizes the changes in Fi
 
 - {{domxref("DOMParser")}} now supports parsing of HTML document fragments.
 - {{domxref("XMLHttpRequest")}} now supports timeouts using the `timeout` property and "timeout" event, as well as the `ontimeout` event handler on the {{domxref("XMLHttpRequestEventTarget")}} interface.
-- {{domxref("XMLHttpRequest")}} can now load from [`data:` URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs).
+- {{domxref("XMLHttpRequest")}} can now load from [`data:` URLs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs).
 - When downloading large amounts of data, {{domxref("XMLHttpRequest")}} progress event handlers are now called periodically with the `responseType` set to "moz-blob" and the response being a {{domxref("Blob")}} containing all of the data received so far. This lets progress handlers begin processing data without having to wait for it all to arrive.
 - Gecko now supports [multi-touch](/en-US/docs/Web/API/Touch_events) (instead of just single touches at a time) on Android.
 - While editing text using an IME, the `input` event is now sent whenever the contents of the element being edited have been changed; this happens after the `compositionupdate` event has been sent to indicate that the IME's text has been changed. You can use the `input` event handler, therefore, to monitor changes to the actual content of the element.

--- a/files/en-us/mozilla/firefox/releases/12/index.md
+++ b/files/en-us/mozilla/firefox/releases/12/index.md
@@ -32,7 +32,7 @@ Firefox 12 was shipped on April 24, 2012. This page summarizes the changes in Fi
 
 - {{domxref("DOMParser")}} now supports parsing of HTML document fragments.
 - {{domxref("XMLHttpRequest")}} now supports timeouts using the `timeout` property and "timeout" event, as well as the `ontimeout` event handler on the {{domxref("XMLHttpRequestEventTarget")}} interface.
-- {{domxref("XMLHttpRequest")}} can now load from [`data:` URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs).
+- {{domxref("XMLHttpRequest")}} can now load from [`data:` URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs).
 - When downloading large amounts of data, {{domxref("XMLHttpRequest")}} progress event handlers are now called periodically with the `responseType` set to "moz-blob" and the response being a {{domxref("Blob")}} containing all of the data received so far. This lets progress handlers begin processing data without having to wait for it all to arrive.
 - Gecko now supports [multi-touch](/en-US/docs/Web/API/Touch_events) (instead of just single touches at a time) on Android.
 - While editing text using an IME, the `input` event is now sent whenever the contents of the element being edited have been changed; this happens after the `compositionupdate` event has been sent to indicate that the IME's text has been changed. You can use the `input` event handler, therefore, to monitor changes to the actual content of the element.

--- a/files/en-us/mozilla/firefox/releases/6/index.md
+++ b/files/en-us/mozilla/firefox/releases/6/index.md
@@ -86,7 +86,7 @@ Firefox 6, based on Gecko 6.0, was released on August 16, 2011. This article pro
 ### SVG
 
 - The {{ SVGAttr("pathLength") }} attribute is now supported.
-- SVG patterns, gradients, and filters now work correctly when loaded from [`data:` URLs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs).
+- SVG patterns, gradients, and filters now work correctly when loaded from [`data:` URLs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs).
 
 ### MathML
 

--- a/files/en-us/web/api/atob/index.md
+++ b/files/en-us/web/api/atob/index.md
@@ -61,5 +61,5 @@ const decodedData = atob(encodedData); // decode the string
 ## See also
 
 - [A polyfill of `atob`](https://github.com/zloirock/core-js#base64-utility-methods) is available in [`core-js`](https://github.com/zloirock/core-js)
-- [`data` URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs)
+- [`data` URLs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs)
 - {{domxref("btoa","btoa()")}}

--- a/files/en-us/web/api/atob/index.md
+++ b/files/en-us/web/api/atob/index.md
@@ -61,5 +61,5 @@ const decodedData = atob(encodedData); // decode the string
 ## See also
 
 - [A polyfill of `atob`](https://github.com/zloirock/core-js#base64-utility-methods) is available in [`core-js`](https://github.com/zloirock/core-js)
-- [`data` URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs)
+- [`data` URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs)
 - {{domxref("btoa","btoa()")}}

--- a/files/en-us/web/api/btoa/index.md
+++ b/files/en-us/web/api/btoa/index.md
@@ -139,7 +139,7 @@ See also the example `utf8_to_b64` and `b64_to_utf8` functions in the [Solution 
 ## See also
 
 - [A polyfill of `btoa`](https://github.com/zloirock/core-js#base64-utility-methods) is available in [`core-js`](https://github.com/zloirock/core-js)
-- [`data` URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs)
+- [`data` URLs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs)
 - {{domxref("atob","atob()")}}
 - {{Glossary("Base64")}}
 - [Polyfill](https://github.com/MaxArt2501/base64-js/blob/master/base64.js)

--- a/files/en-us/web/api/btoa/index.md
+++ b/files/en-us/web/api/btoa/index.md
@@ -139,7 +139,7 @@ See also the example `utf8_to_b64` and `b64_to_utf8` functions in the [Solution 
 ## See also
 
 - [A polyfill of `btoa`](https://github.com/zloirock/core-js#base64-utility-methods) is available in [`core-js`](https://github.com/zloirock/core-js)
-- [`data` URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs)
+- [`data` URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs)
 - {{domxref("atob","atob()")}}
 - {{Glossary("Base64")}}
 - [Polyfill](https://github.com/MaxArt2501/base64-js/blob/master/base64.js)

--- a/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
@@ -302,7 +302,7 @@ Also see the source code — [HTML](https://github.com/mdn/dom-examples/blob/mas
 
 ## Saving images
 
-The {{domxref("HTMLCanvasElement")}} provides a `toDataURL()` method, which is useful when saving images. It returns a [data URI](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) containing a representation of the image in the format specified by the `type` parameter (defaults to [PNG](https://en.wikipedia.org/wiki/Portable_Network_Graphics)). The returned image is in a resolution of 96 dpi.
+The {{domxref("HTMLCanvasElement")}} provides a `toDataURL()` method, which is useful when saving images. It returns a [data URI](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) containing a representation of the image in the format specified by the `type` parameter (defaults to [PNG](https://en.wikipedia.org/wiki/Portable_Network_Graphics)). The returned image is in a resolution of 96 dpi.
 
 > **Note:** Be aware that if the canvas contains any pixels that were obtained from another {{Glossary("origin")}} without using CORS, the canvas is **tainted** and its contents can no longer be read and saved.
 > See {{SectionOnPage("/en-US/docs/Web/HTML/CORS_enabled_image", "Security and tainted canvases")}}

--- a/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
@@ -302,7 +302,7 @@ Also see the source code — [HTML](https://github.com/mdn/dom-examples/blob/mas
 
 ## Saving images
 
-The {{domxref("HTMLCanvasElement")}} provides a `toDataURL()` method, which is useful when saving images. It returns a [data URI](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) containing a representation of the image in the format specified by the `type` parameter (defaults to [PNG](https://en.wikipedia.org/wiki/Portable_Network_Graphics)). The returned image is in a resolution of 96 dpi.
+The {{domxref("HTMLCanvasElement")}} provides a `toDataURL()` method, which is useful when saving images. It returns a [data URL](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) containing a representation of the image in the format specified by the `type` parameter (defaults to [PNG](https://en.wikipedia.org/wiki/Portable_Network_Graphics)). The returned image is in a resolution of 96 dpi.
 
 > **Note:** Be aware that if the canvas contains any pixels that were obtained from another {{Glossary("origin")}} without using CORS, the canvas is **tainted** and its contents can no longer be read and saved.
 > See {{SectionOnPage("/en-US/docs/Web/HTML/CORS_enabled_image", "Security and tainted canvases")}}
@@ -312,7 +312,7 @@ The {{domxref("HTMLCanvasElement")}} provides a `toDataURL()` method, which is u
 - {{domxref("HTMLCanvasElement.toDataURL", "canvas.toDataURL('image/jpeg', quality)")}}
   - : Creates a JPG image. Optionally, you can provide a quality in the range from 0 to 1, with one being the best quality and with 0 almost not recognizable but small in file size.
 
-Once you have generated a data URI from you canvas, you are able to use it as the source of any {{HTMLElement("image")}} or put it into a hyper link with a [download attribute](/en-US/docs/Web/HTML/Element/a#attr-download) to save it to disc, for example.
+Once you have generated a data URL from your canvas, you are able to use it as the source of any {{HTMLElement("image")}} or put it into a hyper link with a [download attribute](/en-US/docs/Web/HTML/Element/a#attr-download) to save it to disc, for example.
 
 You can also create a {{domxref("Blob")}} from the canvas.
 

--- a/files/en-us/web/api/canvas_api/tutorial/using_images/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/using_images/index.md
@@ -79,7 +79,7 @@ If you're only using one external image this can be a good approach, but once yo
 
 ### Embedding an image via data: URL
 
-Another possible way to include images is via the [data: URL](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs). Data URLs allow you to completely define an image as a Base64 encoded string of characters directly in your code.
+Another possible way to include images is via the [data: URL](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs). Data URLs allow you to completely define an image as a Base64 encoded string of characters directly in your code.
 
 ```js
 var img = new Image();   // Create new img element

--- a/files/en-us/web/api/canvasrenderingcontext2d/drawwindow/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawwindow/index.md
@@ -22,7 +22,7 @@ scrolling.
 This API cannot be used by Web content. It is synchronous, and as such can't capture
 cross-origin (out of process) iframes with Fission.  If you're using it from an
 extension, you should switch to {{WebExtAPIRef('tabs.captureTab')}} to capture the
-tab's image as a [data: URL](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) and then render the captured image onto canvas using
+tab's image as a [data: URL](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) and then render the captured image onto canvas using
 {{domxref("CanvasRenderingContext2D.drawImage")}}. If you're writing chrome code,
 you probably want [WindowGlobalParent.drawSnapshot](https://searchfox.org/mozilla-central/rev/9b282b34b5/dom/chrome-webidl/WindowGlobalActors.webidl#81-98)
 from the parent process.

--- a/files/en-us/web/api/document/domain/index.md
+++ b/files/en-us/web/api/document/domain/index.md
@@ -36,7 +36,7 @@ The getter for this property returns the domain portion of the current document'
 origin. In most cases, this will be the hostname portion of the document's URL. However,
 there are some exceptions:
 
-- If the page has an opaque {{glossary("origin")}}, e.g. for a page with a [data URL](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs), then it will
+- If the page has an opaque {{glossary("origin")}}, e.g. for a page with a [data URL](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs), then it will
   return the empty string.
 - If the `document.domain` [setter](#setter) has been used, then
   it will return the value that was set.

--- a/files/en-us/web/api/filereader/readasdataurl/index.md
+++ b/files/en-us/web/api/filereader/readasdataurl/index.md
@@ -15,7 +15,7 @@ The `readAsDataURL` method is used to read the contents of the specified
 {{domxref("Blob")}} or {{domxref("File")}}. When the read operation is finished, the
 {{domxref("FileReader.readyState","readyState")}} becomes `DONE`, and the
 {{event("loadend")}} is triggered. At that time, the
-{{domxref("FileReader.result","result")}} attribute contains the data as a [data: URL](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) representing the
+{{domxref("FileReader.result","result")}} attribute contains the data as a [data: URL](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) representing the
 file's data as a base64 encoded string.
 
 > **Note:** The blob's {{domxref("FileReader.result","result")}} cannot be

--- a/files/en-us/web/api/html_drag_and_drop_api/recommended_drag_types/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/recommended_drag_types/index.md
@@ -135,7 +135,7 @@ You could use feature detection to determine which method is supported on `types
 
 ## Dragging Images
 
-Direct image dragging is not common. In fact, Mozilla does not support direct image dragging on Mac or Linux. Instead, images are usually dragged only by their URLs. To do this, use the `text/uri-list` type as with other URLs. The data should be the URL of the image, or a [`data:` URI](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) if the image is not stored on a web site or disk.
+Direct image dragging is not common. In fact, Mozilla does not support direct image dragging on Mac or Linux. Instead, images are usually dragged only by their URLs. To do this, use the `text/uri-list` type as with other URLs. The data should be the URL of the image, or a [`data:` URL](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) if the image is not stored on a web site or disk.
 
 As with links, the data for the `text/plain` type should also contain the URL. However, a `data:` URL is not usually useful in a text context, so you may wish to exclude the `text/plain` data in this situation.
 

--- a/files/en-us/web/api/html_drag_and_drop_api/recommended_drag_types/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/recommended_drag_types/index.md
@@ -135,7 +135,7 @@ You could use feature detection to determine which method is supported on `types
 
 ## Dragging Images
 
-Direct image dragging is not common. In fact, Mozilla does not support direct image dragging on Mac or Linux. Instead, images are usually dragged only by their URLs. To do this, use the `text/uri-list` type as with other URLs. The data should be the URL of the image, or a [`data:` URI](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) if the image is not stored on a web site or disk.
+Direct image dragging is not common. In fact, Mozilla does not support direct image dragging on Mac or Linux. Instead, images are usually dragged only by their URLs. To do this, use the `text/uri-list` type as with other URLs. The data should be the URL of the image, or a [`data:` URI](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) if the image is not stored on a web site or disk.
 
 As with links, the data for the `text/plain` type should also contain the URL. However, a `data:` URL is not usually useful in a text context, so you may wish to exclude the `text/plain` data in this situation.
 

--- a/files/en-us/web/api/htmlcanvaselement/todataurl/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/todataurl/index.md
@@ -11,7 +11,7 @@ browser-compat: api.HTMLCanvasElement.toDataURL
 ---
 {{APIRef("Canvas API")}}
 
-The **`HTMLCanvasElement.toDataURL()`** method returns a [data URI](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) containing a representation of the image in the format specified by the `type` parameter.
+The **`HTMLCanvasElement.toDataURL()`** method returns a [data URL](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) containing a representation of the image in the format specified by the `type` parameter.
 
 The desired file format and image quality may be specified.
 If the file format is not specified, or if the given format is not supported, then the data will be exported as `image/png`.
@@ -40,7 +40,7 @@ toDataURL(type, encoderOptions)
 
 ### Return value
 
-A string containing the requested [data URI](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs).
+A string containing the requested [data URL](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs).
 
 If the height or width of the canvas is `0` or larger than the [maximum canvas size](/en-US/docs/Web/HTML/Element/canvas#maximum_canvas_size), the string `"data:,"` is returned.
 
@@ -142,4 +142,4 @@ function removeColors() {
 
 ## See also
 
-- [Data URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) in the [HTTP](/en-US/docs/Web/HTTP) reference.
+- [Data URLs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) in the [HTTP](/en-US/docs/Web/HTTP) reference.

--- a/files/en-us/web/api/htmlcanvaselement/todataurl/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/todataurl/index.md
@@ -11,7 +11,7 @@ browser-compat: api.HTMLCanvasElement.toDataURL
 ---
 {{APIRef("Canvas API")}}
 
-The **`HTMLCanvasElement.toDataURL()`** method returns a [data URI](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) containing a representation of the image in the format specified by the `type` parameter.
+The **`HTMLCanvasElement.toDataURL()`** method returns a [data URI](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) containing a representation of the image in the format specified by the `type` parameter.
 
 The desired file format and image quality may be specified.
 If the file format is not specified, or if the given format is not supported, then the data will be exported as `image/png`.
@@ -40,7 +40,7 @@ toDataURL(type, encoderOptions)
 
 ### Return value
 
-A string containing the requested [data URI](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs).
+A string containing the requested [data URI](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs).
 
 If the height or width of the canvas is `0` or larger than the [maximum canvas size](/en-US/docs/Web/HTML/Element/canvas#maximum_canvas_size), the string `"data:,"` is returned.
 
@@ -142,4 +142,4 @@ function removeColors() {
 
 ## See also
 
-- [Data URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) in the [HTTP](/en-US/docs/Web/HTTP) reference.
+- [Data URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) in the [HTTP](/en-US/docs/Web/HTTP) reference.

--- a/files/en-us/web/api/xmlhttprequest/responsexml/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responsexml/index.md
@@ -32,7 +32,7 @@ Usually, the response is parsed as "`text/xml`". If the
 {{domxref("XMLHttpRequest.responseType", "responseType")}} is set to
 "`document`" and the request was made asynchronously, instead the response is
 parsed as "`text/html`". `responseXML` is `null` for
-any other types of data, as well as for [`data:` URLs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs).
+any other types of data, as well as for [`data:` URLs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs).
 
 If the server doesn't specify the {{HTTPHeader("Content-Type")}} as
 "`text/xml`" or "`application/xml`", you can use

--- a/files/en-us/web/html/element/a/index.md
+++ b/files/en-us/web/html/element/a/index.md
@@ -36,7 +36,7 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/G
 
       - The {{HTTPHeader("Content-Disposition")}} HTTP header
       - The final segment in the URL [path](/en-US/docs/Web/API/URL/pathname)
-      - The {{Glossary("MIME_type", "media type")}} (from the {{HTTPHeader("Content-Type")}} header, the start of a [`data:` URL](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs), or {{domxref("Blob.type")}} for a [`blob:` URL](/en-US/docs/Web/API/URL/createObjectURL))
+      - The {{Glossary("MIME_type", "media type")}} (from the {{HTTPHeader("Content-Type")}} header, the start of a [`data:` URL](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs), or {{domxref("Blob.type")}} for a [`blob:` URL](/en-US/docs/Web/API/URL/createObjectURL))
 
     - Defining a value suggests it as the filename. `/` and `\` characters are converted to underscores (`_`). Filesystems may forbid other characters in filenames, so browsers will adjust the suggested name if necessary.
 

--- a/files/en-us/web/http/basics_of_http/identifying_resources_on_the_web/index.md
+++ b/files/en-us/web/http/basics_of_http/identifying_resources_on_the_web/index.md
@@ -64,7 +64,7 @@ The two URNs correspond to
 
 | Scheme      | Description                                                          |
 | ----------- | -------------------------------------------------------------------- |
-| data        | [Data URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs)           |
+| data        | [Data URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs)           |
 | file        | Host-specific file names                                             |
 | ftp         | {{Glossary("FTP","File Transfer Protocol")}}         |
 | http/https  | [Hyper text transfer protocol (Secure)](/en-US/docs/Glossary/HTTP)   |

--- a/files/en-us/web/http/basics_of_http/identifying_resources_on_the_web/index.md
+++ b/files/en-us/web/http/basics_of_http/identifying_resources_on_the_web/index.md
@@ -64,7 +64,7 @@ The two URNs correspond to
 
 | Scheme      | Description                                                          |
 | ----------- | -------------------------------------------------------------------- |
-| data        | [Data URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs)           |
+| data        | [Data URLs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs)           |
 | file        | Host-specific file names                                             |
 | ftp         | {{Glossary("FTP","File Transfer Protocol")}}         |
 | http/https  | [Hyper text transfer protocol (Secure)](/en-US/docs/Glossary/HTTP)   |

--- a/files/en-us/web/http/basics_of_http/index.md
+++ b/files/en-us/web/http/basics_of_http/index.md
@@ -20,8 +20,8 @@ HTTP is an extensible protocol that relies on concepts like resources and Unifor
   - : A brief introduction to the concept of resources, identifiers, and locations on the web.
 - [Identifying resources on the Web](/en-US/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web)
   - : Describes how web resources are referenced and how to locate them.
-- [Data URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs)
-  - : A specific kind of URI that directly embeds the resource it represents. Data URIs are very convenient, but have some caveats.
+- [Data URLs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs)
+  - : A specific kind of URI that directly embeds the resource it represents. Data URLs are very convenient, but have some caveats.
 - [Resource URLs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Resource_URLs) {{Non-standard_Inline}}
   - : Resource URLs, those prefixed with the `resource` scheme are used by Firefox and Firefox browser extensions to load resources internally, but is also available to some sites the browser connects to as well.
 - [MIME types](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types)

--- a/files/en-us/web/http/basics_of_http/index.md
+++ b/files/en-us/web/http/basics_of_http/index.md
@@ -20,7 +20,7 @@ HTTP is an extensible protocol that relies on concepts like resources and Unifor
   - : A brief introduction to the concept of resources, identifiers, and locations on the web.
 - [Identifying resources on the Web](/en-US/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web)
   - : Describes how web resources are referenced and how to locate them.
-- [Data URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs)
+- [Data URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs)
   - : A specific kind of URI that directly embeds the resource it represents. Data URIs are very convenient, but have some caveats.
 - [Resource URLs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Resource_URLs) {{Non-standard_Inline}}
   - : Resource URLs, those prefixed with the `resource` scheme are used by Firefox and Firefox browser extensions to load resources internally, but is also available to some sites the browser connects to as well.

--- a/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.md
@@ -71,7 +71,7 @@ Content-Security-Policy: frame-ancestors <source> <source>;
 
   - : A scheme such as `http:` or `https:`. The colon is required and scheme should not be quoted. You can also specify data schemes (not recommended).
 
-    - `data:` Allows [`data:` URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) to be used as a content source. _This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts._
+    - `data:` Allows [`data:` URLs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) to be used as a content source. _This is insecure; an attacker can also inject arbitrary `data:` URLs. Use this sparingly and definitely not for scripts._
     - `mediastream:` Allows [`mediastream:` URIs](/en-US/docs/Web/API/Media_Streams_API) to be used as a content source.
     - `blob:` Allows [`blob:` URIs](/en-US/docs/Web/API/Blob) to be used as a content source.
     - `filesystem:` Allows [`filesystem:` URIs](/en-US/docs/Web/API/FileSystem) to be used as a content source.

--- a/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.md
@@ -71,7 +71,7 @@ Content-Security-Policy: frame-ancestors <source> <source>;
 
   - : A scheme such as `http:` or `https:`. The colon is required and scheme should not be quoted. You can also specify data schemes (not recommended).
 
-    - `data:` Allows [`data:` URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) to be used as a content source. _This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts._
+    - `data:` Allows [`data:` URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) to be used as a content source. _This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts._
     - `mediastream:` Allows [`mediastream:` URIs](/en-US/docs/Web/API/Media_Streams_API) to be used as a content source.
     - `blob:` Allows [`blob:` URIs](/en-US/docs/Web/API/Blob) to be used as a content source.
     - `filesystem:` Allows [`filesystem:` URIs](/en-US/docs/Web/API/FileSystem) to be used as a content source.

--- a/files/en-us/web/http/headers/content-security-policy/sources/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/sources/index.md
@@ -34,7 +34,7 @@ Relevant directives include the {{Glossary("fetch directive", "fetch directives"
     Unlike other values below, single quotes shouldn't be used.
     You can also specify data schemes (not recommended).
 
-    - `data:` Allows [`data:` URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs) to be used as a content source.
+    - `data:` Allows [`data:` URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) to be used as a content source.
       _This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts._
     - `mediastream:` Allows [`mediastream:` URIs](/en-US/docs/Web/API/Media_Streams_API) to be used as a content source.
     - `blob:` Allows [`blob:` URIs](/en-US/docs/Web/API/Blob) to be used as a content source.

--- a/files/en-us/web/http/headers/content-security-policy/sources/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/sources/index.md
@@ -34,8 +34,8 @@ Relevant directives include the {{Glossary("fetch directive", "fetch directives"
     Unlike other values below, single quotes shouldn't be used.
     You can also specify data schemes (not recommended).
 
-    - `data:` Allows [`data:` URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) to be used as a content source.
-      _This is insecure; an attacker can also inject arbitrary data: URIs. Use this sparingly and definitely not for scripts._
+    - `data:` Allows [`data:` URLs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) to be used as a content source.
+      _This is insecure; an attacker can also inject arbitrary `data:` URLs. Use this sparingly and definitely not for scripts._
     - `mediastream:` Allows [`mediastream:` URIs](/en-US/docs/Web/API/Media_Streams_API) to be used as a content source.
     - `blob:` Allows [`blob:` URIs](/en-US/docs/Web/API/Blob) to be used as a content source.
     - `filesystem:` Allows [`filesystem:` URIs](/en-US/docs/Web/API/FileSystem) to be used as a content source.

--- a/files/en-us/web/http/resources_and_uris/index.md
+++ b/files/en-us/web/http/resources_and_uris/index.md
@@ -18,8 +18,8 @@ HTTP allows a browser, or another {{Glossary("user agent")}}, to communicate wit
 
 - [Identifying resources on the Web](/en-US/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web)
   - : URIs and how to access resources on the Web.
-- [Data URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs)
-  - : A specific kind of URIs, data URIs, embed the resource itself inside the identifier.
+- [Data URLs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs)
+  - : A specific kind of URIs, data URLs, embed the resource itself inside the identifier.
 - [Choosing between www and non-www URLs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs)
   - : Advice on using a www-prefixed domain or not, this article explains the consequences of the choice as well as how to make it.
 - [MIME Types](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types)

--- a/files/en-us/web/http/resources_and_uris/index.md
+++ b/files/en-us/web/http/resources_and_uris/index.md
@@ -18,7 +18,7 @@ HTTP allows a browser, or another {{Glossary("user agent")}}, to communicate wit
 
 - [Identifying resources on the Web](/en-US/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web)
   - : URIs and how to access resources on the Web.
-- [Data URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs)
+- [Data URIs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs)
   - : A specific kind of URIs, data URIs, embed the resource itself inside the identifier.
 - [Choosing between www and non-www URLs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Choosing_between_www_and_non-www_URLs)
   - : Advice on using a www-prefixed domain or not, this article explains the consequences of the choice as well as how to make it.

--- a/files/en-us/web/opensearch/index.md
+++ b/files/en-us/web/opensearch/index.md
@@ -45,7 +45,7 @@ The XML file that describes a search engine follows the basic template below. Se
 
   - : URI of an icon for the search engine. When possible, include a 16×16 image of type `image/x-icon` (such as `/favicon.ico`) and a 64×64 image of type `image/jpeg` or `image/png`.
 
-    The URI may also use the [`data:` URI scheme](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URIs). (You can generate a `data:` URI from an icon file at [The `data:` URI kitchen](https://software.hixie.ch/utilities/cgi/data/data).)
+    The URI may also use the [`data:` URI scheme](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs). (You can generate a `data:` URI from an icon file at [The `data:` URI kitchen](https://software.hixie.ch/utilities/cgi/data/data).)
 
     ```xml
     <Image height="16" width="16" type="image/x-icon">https://example.com/favicon.ico</Image>

--- a/files/en-us/web/opensearch/index.md
+++ b/files/en-us/web/opensearch/index.md
@@ -45,7 +45,7 @@ The XML file that describes a search engine follows the basic template below. Se
 
   - : URI of an icon for the search engine. When possible, include a 16×16 image of type `image/x-icon` (such as `/favicon.ico`) and a 64×64 image of type `image/jpeg` or `image/png`.
 
-    The URI may also use the [`data:` URI scheme](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs). (You can generate a `data:` URI from an icon file at [The `data:` URI kitchen](https://software.hixie.ch/utilities/cgi/data/data).)
+    The URI may also use the [`data:` URL scheme](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs). (You can generate a `data:` URL from an icon file at [The `data:` URI kitchen](https://software.hixie.ch/utilities/cgi/data/data).)
 
     ```xml
     <Image height="16" width="16" type="image/x-icon">https://example.com/favicon.ico</Image>


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
- Changes `Web/HTTP/Basics_of_HTTP/Data_URIs` links to `Web/HTTP/Basics_of_HTTP/Data_URLs` after the page was renamed/redirected
- Changes affected link text/mentions to "data URL"

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Follow-up of #16031, avoids page redirection when these links are clicked.

#### Supporting details

Official specs: https://datatracker.ietf.org/doc/html/rfc2397

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
