### PR TITLE
Fix prism errors in HTTP & Security sections

### DIFF
--- a/files/en-us/web/http/authentication/index.md
+++ b/files/en-us/web/http/authentication/index.md
@@ -153,7 +153,7 @@ location /status {
 
 Many clients also let you avoid the login prompt by using an encoded URL containing the username and the password like this:
 
-```example-bad
+```plain example-bad
 https://username:password@www.example.com/
 ```
 

--- a/files/en-us/web/http/headers/authorization/index.md
+++ b/files/en-us/web/http/headers/authorization/index.md
@@ -124,7 +124,7 @@ Generally you will need to check the relevant specifications for these (keys for
 
 For `"Basic"` authentication the credentials are constructed by first combining the username and the password with a colon (`aladdin:opensesame`), and then by encoding the resulting string in [`base64`](/en-US/docs/Glossary/Base64) (`YWxhZGRpbjpvcGVuc2VzYW1l`).
 
-```https
+```http
 Authorization: Basic YWxhZGRpbjpvcGVuc2VzYW1l
 ```
 

--- a/files/en-us/web/http/headers/link/index.md
+++ b/files/en-us/web/http/headers/link/index.md
@@ -33,11 +33,11 @@ The link header contains parameters, which are separated with `;` and are equiva
 
 The URI (absolute or relative) must be enclosed between `<` and `>`:
 
-```example-good
+```http example-good
 Link: <https://example.com>; rel="preconnect"
 ```
 
-```example-bad
+```http example-bad
 Link: https://bad.example; rel="preconnect"
 ```
 

--- a/files/en-us/web/http/headers/set-cookie/samesite/index.md
+++ b/files/en-us/web/http/headers/set-cookie/samesite/index.md
@@ -54,13 +54,13 @@ This Set-Cookie was blocked because it had the "SameSite=None" attribute but did
 
 The warning appears because any cookie that requests `SameSite=None` but is not marked `Secure` will be rejected.
 
-```example-bad
+```http example-bad
 Set-Cookie: flavor=choco; SameSite=None
 ```
 
 To fix this, you will have to add the `Secure` attribute to your `SameSite=None` cookies.
 
-```example-good
+```http example-good
 Set-Cookie: flavor=choco; SameSite=None; Secure
 ```
 
@@ -82,13 +82,13 @@ Cookie "myCookie" has "SameSite" policy set to "Lax" because it is missing a "Sa
 
 The warning appears because the `SameSite` policy for a cookie was not explicitly specified:
 
-```example-bad
+```http example-bad
 Set-Cookie: flavor=choco
 ```
 
 You should explicitly communicate the intended `SameSite` policy for your cookie (rather than relying on browsers to apply `SameSite=Lax` automatically). This will also improve the experience across browsers as not all of them default to `Lax` yet.
 
-```example-good
+```http example-good
 Set-Cookie: flavor=choco; SameSite=Lax
 ```
 

--- a/files/en-us/web/security/subresource_integrity/index.md
+++ b/files/en-us/web/security/subresource_integrity/index.md
@@ -60,7 +60,7 @@ shasum -b -a 384 FILENAME.js | awk '{ print $1 }' | xxd -r -p | base64
 
 In a Windows environment, you can create a tool for generating SRI hashes with the following code:
 
-```bat
+```bash
 @echo off
 set bits=384
 openssl dgst -sha%bits% -binary %1% | openssl base64 -A > tmp


### PR DESCRIPTION
There were a few Prism errors logged when bulding the site:

```
Unable to find a Prism grammar for 'example-bad' found in /en-US/docs/Web/HTTP/Authentication
Unable to find a Prism grammar for 'https' found in /en-US/docs/Web/HTTP/Headers/Authorization
Unable to find a Prism grammar for 'example-good' found in /en-US/docs/Web/HTTP/Headers/Link
Unable to find a Prism grammar for 'example-bad' found in /en-US/docs/Web/HTTP/Headers/Link
Unable to find a Prism grammar for 'example-bad' found in /en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
Unable to find a Prism grammar for 'example-good' found in /en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
Unable to find a Prism grammar for 'example-bad' found in /en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
Unable to find a Prism grammar for 'example-good' found in /en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
Unable to find a Prism grammar for 'https' found in /en-US/docs/Web/HTTP/Headers/WWW-Authenticate
Unable to find a Prism grammar for 'bat' found in /en-US/docs/Web/Security/Subresource_Integrity
```

This PR fixes these.