### PR TITLE
Change browser-compat for individual input types

### DIFF
--- a/files/en-us/web/html/element/input/button/index.md
+++ b/files/en-us/web/html/element/input/button/index.md
@@ -11,7 +11,7 @@ tags:
   - Input Type
   - Reference
   - button
-browser-compat: html.elements.input.input-button
+browser-compat: html.elements.input.type_button
 ---
 
 {{HTMLRef("Input_types")}}

--- a/files/en-us/web/html/element/input/checkbox/index.md
+++ b/files/en-us/web/html/element/input/checkbox/index.md
@@ -10,7 +10,7 @@ tags:
   - Reference
   - checkbox
   - form
-browser-compat: html.elements.input.input-checkbox
+browser-compat: html.elements.input.type_checkbox
 ---
 
 {{HTMLRef}}

--- a/files/en-us/web/html/element/input/color/index.md
+++ b/files/en-us/web/html/element/input/color/index.md
@@ -12,7 +12,7 @@ tags:
   - Input
   - Reference
   - color
-browser-compat: html.elements.input.input-color
+browser-compat: html.elements.input.type_color
 ---
 
 {{HTMLRef}}

--- a/files/en-us/web/html/element/input/date/index.md
+++ b/files/en-us/web/html/element/input/date/index.md
@@ -12,7 +12,7 @@ tags:
   - Input Element
   - Input Type
   - Reference
-browser-compat: html.elements.input.input-date
+browser-compat: html.elements.input.type_date
 ---
 
 {{HTMLRef}}

--- a/files/en-us/web/html/element/input/datetime-local/index.md
+++ b/files/en-us/web/html/element/input/datetime-local/index.md
@@ -14,7 +14,7 @@ tags:
   - Reference
   - Time
   - datetime-local
-browser-compat: html.elements.input.input-datetime-local
+browser-compat: html.elements.input.type_datetime-local
 ---
 
 {{HTMLRef("Input_types")}}

--- a/files/en-us/web/html/element/input/email/index.md
+++ b/files/en-us/web/html/element/input/email/index.md
@@ -8,7 +8,7 @@ tags:
   - HTML forms
   - Input Type
   - Reference
-browser-compat: html.elements.input.input-email
+browser-compat: html.elements.input.type_email
 ---
 
 {{HTMLRef}}

--- a/files/en-us/web/html/element/input/file/index.md
+++ b/files/en-us/web/html/element/input/file/index.md
@@ -12,7 +12,7 @@ tags:
   - Input Type
   - Reference
   - Type
-browser-compat: html.elements.input.input-file
+browser-compat: html.elements.input.type_file
 ---
 
 {{HTMLRef("Input_types")}}

--- a/files/en-us/web/html/element/input/hidden/index.md
+++ b/files/en-us/web/html/element/input/hidden/index.md
@@ -10,7 +10,7 @@ tags:
   - Input Types
   - Reference
   - hidden
-browser-compat: html.elements.input.input-hidden
+browser-compat: html.elements.input.type_hidden
 ---
 
 {{HTMLRef}}

--- a/files/en-us/web/html/element/input/image/index.md
+++ b/files/en-us/web/html/element/input/image/index.md
@@ -14,7 +14,7 @@ tags:
   - Input Type
   - Number
   - Reference
-browser-compat: html.elements.input.input-image
+browser-compat: html.elements.input.type_image
 ---
 
 {{HTMLRef}}

--- a/files/en-us/web/html/element/input/month/index.md
+++ b/files/en-us/web/html/element/input/month/index.md
@@ -15,7 +15,7 @@ tags:
   - Number
   - Reference
   - month
-browser-compat: html.elements.input.input-month
+browser-compat: html.elements.input.type_month
 ---
 
 {{HTMLRef("Input_types")}}

--- a/files/en-us/web/html/element/input/number/index.md
+++ b/files/en-us/web/html/element/input/number/index.md
@@ -11,7 +11,7 @@ tags:
   - Input Type
   - Number
   - Reference
-browser-compat: html.elements.input.input-number
+browser-compat: html.elements.input.type_number
 ---
 
 {{HTMLRef("Input_types")}}

--- a/files/en-us/web/html/element/input/password/index.md
+++ b/files/en-us/web/html/element/input/password/index.md
@@ -14,7 +14,7 @@ tags:
   - Reference
   - Web
   - password
-browser-compat: html.elements.input.input-password
+browser-compat: html.elements.input.type_password
 ---
 
 {{HTMLRef("Input_types")}}

--- a/files/en-us/web/html/element/input/radio/index.md
+++ b/files/en-us/web/html/element/input/radio/index.md
@@ -18,7 +18,7 @@ tags:
   - form
   - radio
   - radio button
-browser-compat: html.elements.input.input-radio
+browser-compat: html.elements.input.type_radio
 ---
 
 {{HTMLRef("Input_types")}}

--- a/files/en-us/web/html/element/input/range/index.md
+++ b/files/en-us/web/html/element/input/range/index.md
@@ -12,7 +12,7 @@ tags:
   - Reference
   - Web
   - slider
-browser-compat: html.elements.input.input-range
+browser-compat: html.elements.input.type_range
 ---
 
 {{HTMLRef("Input_types")}}

--- a/files/en-us/web/html/element/input/reset/index.md
+++ b/files/en-us/web/html/element/input/reset/index.md
@@ -13,7 +13,7 @@ tags:
   - Reference
   - Reset Button
   - reset
-browser-compat: html.elements.input.input-reset
+browser-compat: html.elements.input.type_reset
 ---
 
 {{HTMLRef("Input_types")}}

--- a/files/en-us/web/html/element/input/search/index.md
+++ b/files/en-us/web/html/element/input/search/index.md
@@ -9,7 +9,7 @@ tags:
   - Input Type
   - Reference
   - Search
-browser-compat: html.elements.input.input-search
+browser-compat: html.elements.input.type_search
 ---
 
 {{HTMLRef("Input_types")}}

--- a/files/en-us/web/html/element/input/submit/index.md
+++ b/files/en-us/web/html/element/input/submit/index.md
@@ -15,7 +15,7 @@ tags:
   - form
   - submit
   - submit button
-browser-compat: html.elements.input.input-submit
+browser-compat: html.elements.input.type_submit
 ---
 
 {{HTMLRef("Input_types")}}

--- a/files/en-us/web/html/element/input/tel/index.md
+++ b/files/en-us/web/html/element/input/tel/index.md
@@ -13,7 +13,7 @@ tags:
   - Input Type
   - Phone Numbers
   - Reference
-browser-compat: html.elements.input.input-tel
+browser-compat: html.elements.input.type_tel
 ---
 
 {{HTMLRef("Input_types")}}

--- a/files/en-us/web/html/element/input/text/index.md
+++ b/files/en-us/web/html/element/input/text/index.md
@@ -12,7 +12,7 @@ tags:
   - Text
   - text entry
   - text input
-browser-compat: html.elements.input.input-text
+browser-compat: html.elements.input.type_text
 ---
 {{HTMLRef("Input_types")}}
 

--- a/files/en-us/web/html/element/input/time/index.md
+++ b/files/en-us/web/html/element/input/time/index.md
@@ -13,7 +13,7 @@ tags:
   - Input Type
   - Reference
   - Time
-browser-compat: html.elements.input.input-time
+browser-compat: html.elements.input.type_time
 ---
 
 {{HTMLRef("Input_types")}}

--- a/files/en-us/web/html/element/input/url/index.md
+++ b/files/en-us/web/html/element/input/url/index.md
@@ -15,7 +15,7 @@ tags:
   - Text
   - URL
   - control
-browser-compat: html.elements.input.input-url
+browser-compat: html.elements.input.type_url
 ---
 
 {{HTMLRef("Input_types")}}

--- a/files/en-us/web/html/element/input/week/index.md
+++ b/files/en-us/web/html/element/input/week/index.md
@@ -15,7 +15,7 @@ tags:
   - Reference
   - Week
   - Weeks
-browser-compat: html.elements.input.input-week
+browser-compat: html.elements.input.type_week
 ---
 
 {{HTMLRef("Input_types")}}


### PR DESCRIPTION
This PR updates the BCD keys for the individual input types of the `<input>` HTML element to match the changes in https://github.com/mdn/browser-compat-data/pull/16295.
