### PR TITLE
Remove bold from interface name

### DIFF
--- a/files/en-us/web/api/rtcicetransport/gatheringstate/index.md
+++ b/files/en-us/web/api/rtcicetransport/gatheringstate/index.md
@@ -16,13 +16,11 @@ browser-compat: api.RTCIceTransport.gatheringState
 ---
 {{APIRef("WebRTC")}}
 
-The read-only **{{domxref("RTCIceTransport")}}** property **`gatheringState`** returns a string that indicates the current gathering state of the ICE agent: `"new"`, `"gathering"`, or `"complete"`.
+The read-only property **`gatheringState`** property of the {{domxref("RTCIceTransport")}} interface returns a string that indicates the current gathering state of the ICE agent: `"new"`, `"gathering"`, or `"complete"`.
 
 ## Value
 
 A string that indicates the current state of the ICE agent's candidate gathering process:
-
-<!-- RTCIceGathererState enum-->
 
 - `"new"`
   - : The {{domxref("RTCIceTransport")}} is newly created and has not yet started to gather ICE candidates.


### PR DESCRIPTION
In the first sentence, the interface name was in bold which was confusing. This fixes it.