### PR TITLE
Fix bcd and spec tables of WebRTC Statistics API

### DIFF
--- a/files/en-us/web/api/webrtc_statistics_api/index.md
+++ b/files/en-us/web/api/webrtc_statistics_api/index.md
@@ -12,6 +12,7 @@ tags:
   - Stats
   - WebRTC
   - WebRTC Statistics API
+browser-compat: api.RTCStatsReport
 ---
 {{DefaultAPISidebar("WebRTC")}}
 
@@ -529,11 +530,8 @@ The {{domxref("RTCStatsReport")}} object contains a map of named objects based o
 
 ## Specifications
 
-| Specification                                                                                                                |
-| ---------------------------------------------------------------------------------------------------------------------------- |
-| [WebRTC: Real-Time Communication Between Browsers # dom-rtcstatsreport](https://w3c.github.io/webrtc-pc/#dom-rtcstatsreport) |
-| [Identifiers for WebRTC's Statistics API](https://w3c.github.io/webrtc-stats/)                                               |
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.RTCStatsType")}}
+{{Compat}}


### PR DESCRIPTION
`RTCStatsType` is an enum and they don't have their own bcd key anymore. This actually use the main interface to generation both the specifications and compat tables.