### PR TITLE
Fix typo in Cascade

### DIFF
--- a/files/en-us/web/css/cascade/index.md
+++ b/files/en-us/web/css/cascade/index.md
@@ -149,7 +149,7 @@ Once again, there are four steps in the cascade algorithm, in order:
 The `1px` is for print media. Due to lack of _relevance_ based on it's media type. It is removed from consideration.
 
 No declaration is marked as `!important`, so the precedence order is author style sheets over user style sheets over user-agent stylesheet. Based on _origin and importance_,  the `1em` from the user stylesheet and the `10px` from the user-agent stylesheet are removed from consideration.
-Note that even though the user style on `.specific` of `1em` has a higher specificity, is it a normal declaration in a user style sheet. As such it is a lower precedence than any author styles, and gets removed by the origin and importance step of the algorithm before specificity even comes into play.
+Note that even though the user style on `.specific` of `1em` has a higher specificity, it's a normal declaration in a user style sheet. As such, it has a lower precedence than any author styles, and gets removed by the origin and importance step of the algorithm before specificity even comes into play.
 
 There are three declarations in author stylesheets:
 


### PR DESCRIPTION
Fix typo in en-us/web/css/cascade

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fixes two small typos: 
- `is it a normal declaration` to `it's a normal declaration` and,
- `As such it is a lower precedence` to `As such, it has a lower precendence`

#### Motivation
Given the context of the surrounding text, these two changes are better suited for the content.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
