### PR TITLE
Fix incorrect browser-compat Yaml entry

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/segmenter/segmenter/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/segmenter/segmenter/index.md
@@ -9,7 +9,7 @@ tags:
   - JavaScript
   - Localization
   - Reference
-browser-compat: javascript.builtins.Intl.Segmenter.constructor
+browser-compat: javascript.builtins.Intl.Segmenter.Segmenter
 ---
 
 The **`Intl.Segmenter()`** constructor creates [`Intl.Segmenter`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Segmenter) objects that enable locale-sensitive text segmentation.


### PR DESCRIPTION
We don't use _constructor_ as a key in a bcd entry, but we duplicate the interface/class name.

This fixes one occurrence of this error (have not found any other).
