### PR TITLE
Remove mention of WEBGL_compressed_texture_atc

### DIFF
--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -1747,7 +1747,6 @@
         "WebGL2RenderingContext",
         "WEBGL_compressed_texture_s3tc",
         "WEBGL_compressed_texture_s3tc_srgb",
-        "WEBGL_compressed_texture_atc",
         "WEBGL_compressed_texture_etc1",
         "WEBGL_compressed_texture_pvrtc",
         "WEBGL_debug_renderer_info",


### PR DESCRIPTION
As it was not implemented in any browsers, we removed the docs for WEBGL_compressed_texture_atc.

We also need to remove it from GroupData.json, or we have a useless red link in each WebGL sidebar.

This PR fixes it.