### PR TITLE
'prefers-contrast': Remove experimental banner and add 'custom' value

### DIFF
--- a/files/en-us/web/css/@media/prefers-contrast/index.md
+++ b/files/en-us/web/css/@media/prefers-contrast/index.md
@@ -14,11 +14,13 @@ The **`prefers-contrast`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/doc
 ## Syntax
 
 - `no-preference`
-  - : Indicates that the user has made no preference known to the system. This keyword value evaluates as false in a Boolean context.
+  - : Indicates that the user has made no preference known to the system. This keyword value evaluates as false in the Boolean context.
 - `more`
   - : Indicates that user has notified the system that they prefer an interface that has a higher level of contrast.
 - `less`
   - : Indicates that user has notified the system that they prefer an interface that has a lower level of contrast.
+- `custom`
+  - : Indicates that user has notified the system for using a specific set of colors, and the contrast implied by these colors matches neither `more` nor `less`. This value will match the color palette specified by users of [`forced-colors: active`](/en-US/docs/Web/CSS/@media/forced-colors).
 
 ## User preferences
 

--- a/files/en-us/web/css/@media/prefers-contrast/index.md
+++ b/files/en-us/web/css/@media/prefers-contrast/index.md
@@ -7,9 +7,9 @@ tags:
   - media feature
 browser-compat: css.at-rules.media.prefers-contrast
 ---
-{{CSSRef}}{{SeeCompatTable}}
+{{CSSRef}}
 
-The **`prefers-contrast`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#media_features) is used to detect if the user has requested that the web content is presented with a higher (or lower) contrast.
+The **`prefers-contrast`** [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#media_features) is used to detect whether the user has requested the web content to be presented with a lower or higher contrast.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
In FF101, the `layout.css.prefers-contrast.enabled` flag is set to true by default.

The [`prefers-contrast`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-contrast) feature is already documented.

This PR:
- removes the experimental banner
- updates the feature with the new `custom` value

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

- https://bugzilla.mozilla.org/show_bug.cgi?id=1656363
- https://drafts.csswg.org/mediaqueries-5/#prefers-contrast

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Doc issue tracking this update: https://github.com/mdn/content/issues/15466

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
