### PR TITLE
Remove prefers-contrast from experimental features and add to release notes

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -389,48 +389,6 @@ Adds support for a [masonry-style layout](/en-US/docs/Web/CSS/CSS_Grid_Layout/Ma
   </tbody>
 </table>
 
-### Media feature: prefers-contrast
-
-The [`prefers-contrast`](/en-US/docs/Web/CSS/@media/prefers-contrast) media feature is used to detect whether the user has specified a preference for higher (or lower) contrast in the presentation of web content. Refer to {{bug("1506364")}} for more details.
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>80</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>80</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>80</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>80</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2">
-        <p><code>layout.css.prefers-contrast.enabled</code></p>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ### Property: math-style
 
 The {{cssxref("math-style")}} property indicates whether MathML equations should render with normal or compact height. (See {{bug(1665975)}} for more details.)

--- a/files/en-us/mozilla/firefox/releases/101/index.md
+++ b/files/en-us/mozilla/firefox/releases/101/index.md
@@ -21,7 +21,7 @@ This article provides information about the changes in Firefox 101 that will aff
 
 ### CSS
 
-The [`prefers-contrast`](/en-US/docs/Web/CSS/@media/prefers-contrast) media feature that is used to detect whether the user has specified a preference for higher (or lower) contrast in the presentation of web content is now available by default ({{bug(1656363)}}).
+The [`prefers-contrast`](/en-US/docs/Web/CSS/@media/prefers-contrast) media feature that is used to detect whether the user has specified a preference for higher (`more`)  or lower (`less`) contrast in the presentation of web content is now available by default. This feature now also lets users specify a set of colors to use for the contrast through the new `custom` value ({{bug(1656363)}}).
 
 #### Removals
 

--- a/files/en-us/mozilla/firefox/releases/101/index.md
+++ b/files/en-us/mozilla/firefox/releases/101/index.md
@@ -21,6 +21,8 @@ This article provides information about the changes in Firefox 101 that will aff
 
 ### CSS
 
+The [`prefers-contrast`](/en-US/docs/Web/CSS/@media/prefers-contrast) media feature that is used to detect whether the user has specified a preference for higher (or lower) contrast in the presentation of web content is now available by default ({{bug(1656363)}}).
+
 #### Removals
 
 ### JavaScript


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

In FF101, the `layout.css.prefers-contrast.enabled` flag is set to true by default.

- [Experimental Features](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Experimental_features): Removed "Media feature: prefers-contrast" entry from the CSS section.
- [Release Notes](https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Releases/101): Added entry about `prefers-contrast` to the CSS section plus also mentioned the new `custom` value.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://bugzilla.mozilla.org/show_bug.cgi?id=1656363

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Doc issue tracking this update: https://github.com/mdn/content/issues/15466
Other related doc PR: https://github.com/mdn/content/pull/16109

