### PR TITLE
Remove example inclusion for microdata attributes

### DIFF
--- a/files/en-us/web/html/global_attributes/itemid/index.md
+++ b/files/en-us/web/html/global_attributes/itemid/index.md
@@ -22,50 +22,59 @@ The exact meaning of an `itemtype`'s global identifier is provided by the defini
 
 > **Note:** The {{glossary("WHATWG")}} definition specifies that an `itemid` must be a {{glossary("URL")}}. However, the following example correctly illustrates that a {{glossary("URN")}} may also be used. This inconsistency may reflect the incomplete nature of the Microdata specification.
 
-## Example
+## Examples
 
-### HTML
+### Representing structured data for a book
 
-```html
-<dl itemscope
-    itemtype="http://vocab.example.net/book"
-    itemid="urn:isbn:0-330-34032-8">
-<dt>Title <dd itemprop="title">The Reality Dysfunction
-<dt>Author <dd itemprop="author">Peter F. Hamilton
-<dt>Publication date
-<dd><time itemprop="pubdate" datetime="1996-01-26">26 January 1996</time> </dl>
-```
-
-### Structured data
+This example uses microdata attributes to represent the following structured data:
 
 <table class="standard-table">
   <tbody>
     <tr>
       <td rowspan="4">itemscope</td>
       <td>itemtype: itemid</td>
-      <td colspan="2">http://vocab.example.net/book: urn:isbn:0-330-34032-8</td>
+      <td colspan="2">https://schema.org/Book: urn:isbn:0-374-22848-5</td>
     </tr>
     <tr>
       <td>itemprop</td>
       <td>title</td>
-      <td>The Reality Dysfunction</td>
+      <td>Owls of the Eastern Ice</td>
     </tr>
     <tr>
       <td>itemprop</td>
       <td>author</td>
-      <td>Peter F. Hamilton</td>
+      <td>Jonathan C Slaght</td>
     </tr>
     <tr>
       <td>itemprop</td>
-      <td>pubdate</td>
-      <td>1996-01-26</td>
+      <td>datePublished</td>
+      <td>2020-08-04</td>
     </tr>
   </tbody>
 </table>
 
-### Result
+#### HTML
 
-{{EmbedLiveSample('HTML', '', '', '', 'Web/HTML/Global_attributes/itemid')}}
+```html
+<dl itemscope
+  itemtype="https://schema.org/Book"
+  itemid="urn:isbn:0-374-22848-5<">
+ <dt>Title
+   <dd
+    itemprop="title">Owls of the Eastern Ice
+ <dt>Author
+   <dd
+     itemprop="author">Jonathan C Slaght
+ <dt>Publication date
+ <dd><time
+   itemprop="datePublished"
+   datetime="2020-08-04">August 4 2020</time>
+</dl>
+```
+
+#### Result
+
+{{EmbedLiveSample('Representing structured data for a book')}}
 
 ## Specifications
 

--- a/files/en-us/web/html/global_attributes/itemprop/index.md
+++ b/files/en-us/web/html/global_attributes/itemprop/index.md
@@ -389,28 +389,9 @@ And the following
 </div>
 ```
 
-## Other examples
+### Representing structured data for a book
 
-### HTML
-
-```html
-<dl itemscope
-  itemtype="https://schema.org/Book"
-  itemid="urn:isbn:0-374-22848-5<">
- <dt>Title
-   <dd
-    itemprop="title">Owls of the Eastern Ice
- <dt>Author
-   <dd
-     itemprop="author">Jonathan C Slaght
- <dt>Publication date
- <dd><time
-   itemprop="datePublished"
-   datetime="2020-08-04">August 4 2020</time>
-</dl>
-```
-
-### Structured data
+This example uses microdata attributes to represent the following structured data:
 
 <table class="standard-table">
   <tbody>
@@ -437,9 +418,28 @@ And the following
   </tbody>
 </table>
 
-### Result
+#### HTML
 
-{{EmbedLiveSample('HTML_2', '', '', '', 'Web/HTML/Global_attributes/itemprop')}}
+```html
+<dl itemscope
+  itemtype="https://schema.org/Book"
+  itemid="urn:isbn:0-374-22848-5<">
+ <dt>Title
+   <dd
+    itemprop="title">Owls of the Eastern Ice
+ <dt>Author
+   <dd
+     itemprop="author">Jonathan C Slaght
+ <dt>Publication date
+ <dd><time
+   itemprop="datePublished"
+   datetime="2020-08-04">August 4 2020</time>
+</dl>
+```
+
+#### Result
+
+{{EmbedLiveSample('Representing structured data for a book')}}
 
 ## Specifications
 

--- a/files/en-us/web/html/global_attributes/itemref/index.md
+++ b/files/en-us/web/html/global_attributes/itemref/index.md
@@ -21,23 +21,11 @@ The `itemref` attribute can only be specified on elements that have an `itemscop
 
 > **Note:** The `itemref` attribute is not part of the microdata data model. It is merely a syntactic construct to aid authors in adding annotations to pages where the data to be annotated does not follow a convenient tree structure. For example, it allows authors to mark up data in a table so that each column defines a separate item while keeping the properties in the cells.
 
-## Example
+## Examples
 
-### HTML
+### Representing structured data for a band
 
-```html
-<div itemscope id="amanda" itemref="a b"></div>
-<p id="a">Name: <span itemprop="name">Amanda</span> </p>
-<div id="b" itemprop="band" itemscope itemref="c"></div>
-<div id="c">
-    <p>Band: <span itemprop="name">Jazz Band</span> </p>
-    <p>Size: <span itemprop="size">12</span> players</p>
-</div>
-```
-
-### Structured data
-
-(in [JSON-LD](https://json-ld.org/) format)
+This example uses microdata attributes to represent the following structured data (in [JSON-LD](https://json-ld.org/) format):
 
 ```json
 {
@@ -51,9 +39,21 @@ The `itemref` attribute can only be specified on elements that have an `itemscop
 }
 ```
 
-### Result
+#### HTML
 
-{{EmbedLiveSample('Example', '', '', '', 'Web/HTML/Global_attributes/itemref')}}
+```html
+<div itemscope id="amanda" itemref="a b"></div>
+<p id="a">Name: <span itemprop="name">Amanda</span> </p>
+<div id="b" itemprop="band" itemscope itemref="c"></div>
+<div id="c">
+    <p>Band: <span itemprop="name">Jazz Band</span> </p>
+    <p>Size: <span itemprop="size">12</span> players</p>
+</div>
+```
+
+#### Result
+
+{{EmbedLiveSample('Representing structured data for a band')}}
 
 ## Specifications
 

--- a/files/en-us/web/html/global_attributes/itemscope/index.md
+++ b/files/en-us/web/html/global_attributes/itemscope/index.md
@@ -21,24 +21,15 @@ Every HTML element may have an `itemscope` attribute specified. An `itemscope` e
 
 > **Note:** Find more about `itemtype` attributes at <https://schema.org/Thing>
 
-### Simple example
+### itemscope id attributes
 
-#### HTML
+When you specify the `itemscope` attribute for an element, a new item is created. The item consists of a group of name-value pairs. For elements with an `itemscope` attribute and an `itemtype` attribute, you may also specify an {{htmlattrxref("id")}} attribute. You can use the `id` attribute to set a global identifier for the new item. A global identifier allows the item to relate to other items found on pages across the Web.
 
-The following example specifies the `itemscope` attribute. The example specifies the `itemtype` as "http\://schema.org/Movie", and specifies three related `itemprop` attributes.
+## Examples
 
-```html
-<div itemscope itemtype="https://schema.org/Movie">
-  <h1 itemprop="name">Avatar</h1>
-  <span>Director: <span itemprop="director">James Cameron</span> (born August 16, 1954)</span>
-  <span itemprop="genre">Science fiction</span>
-  <a href="https://youtu.be/0AY1XIkX7bY" itemprop="trailer">Trailer</a>
-</div>
-```
+### Representing structured data for a movie
 
-#### Structured data
-
-The following table shows the structured data from the preceding example.
+The following example specifies the `itemtype` as "http\://schema.org/Movie", and specifies four related `itemprop` attributes.
 
 <table class="standard-table">
   <tbody>
@@ -75,65 +66,18 @@ The following table shows the structured data from the preceding example.
   </tbody>
 </table>
 
-### itemscope id attributes
-
-When you specify the `itemscope` attribute for an element, a new item is created. The item consists of a group of name-value pairs. For elements with an `itemscope` attribute and an `itemtype` attribute, you may also specify an {{htmlattrxref("id")}} attribute. You can use the `id` attribute to set a global identifier for the new item. A global identifier allows the item to relate to other items found on pages across the Web.
-
-### Example
-
-There are four `itemscope` attributes in the following example. Each `itemscope` attribute sets the scope of its corresponding `itemtype` attribute. The `itemtype`s, `Recipe`, `AggregateRating`, and `NutritionInformation` in the following example are part of the [schema.org](www.schema.org) structured data for a recipe, as specified by the first `itemtype`, http\://schema.org/Recipe.
-
 ```html
-<div itemscope itemtype="https://schema.org/Recipe">
-  <h2 itemprop="name">Grandma's Holiday Apple Pie</h2>
-  <img itemprop="image" src="https://c1.staticflickr.com/1/30/42759561_8631e2f905_n.jpg" width="50" height="50" />
-  <p>
-    By <span itemprop="author" itemscope itemtype="https://schema.org/Person">
-      <span itemprop="name">Carol Smith</span>
-    </span>
-  </p>
-  <p>
-    Published: <time datetime="2009-11-05" itemprop="datePublished">November 5, 2009</time>
-  </p>
-  <span itemprop="description">This is my grandmother's apple pie recipe. I like to add a dash of nutmeg.</span>
-  <br>
-  <span itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating">
-    <span itemprop="ratingValue">4.0</span> stars based on <span itemprop="reviewCount">35</span> reviews
-  </span>
-  <br>
-  Prep time: <time datetime="PT30M" itemprop="prepTime">30 min</time><br>
-  Cook time: <time datetime="PT1H" itemprop="cookTime">1 hou</time>r<br>
-  Total time: <time datetime="PT1H30M" itemprop="totalTime">1 hour 30 min</time><br>
-  Yield: <span itemprop="recipeYield">1 9" pie (8 servings)</span><br>
-  <span itemprop="nutrition" itemscope itemtype="https://schema.org/NutritionInformation">
-    Serving size: <span itemprop="servingSize">1 medium slice</span><br>
-    Calories per serving: <span itemprop="calories">250 cal</span><br>
-    Fat per serving: <span itemprop="fatContent">12 g</span><br>
-  </span>
-  <p>
-    Ingredients:<br>
-    <span itemprop="recipeIngredient">Thinly-sliced apples: 6 cups<br></span>
-    <span itemprop="recipeIngredient">White sugar: 3/4 cup<br></span>
-    ...
-  </p>
-  Directions: <br>
-  <div itemprop="recipeInstructions">
-    1. Cut and peel apples<br>
-    2. Mix sugar and cinnamon. Use additional sugar for tart apples. <br>
-    ...
-  </div>
+<div itemscope itemtype="https://schema.org/Movie">
+  <h1 itemprop="name">Avatar</h1>
+  <span>Director: <span itemprop="director">James Cameron</span> (born August 16, 1954)</span>
+  <span itemprop="genre">Science fiction</span>
+  <a href="https://youtu.be/0AY1XIkX7bY" itemprop="trailer">Trailer</a>
 </div>
 ```
 
-### Results
+### Representing structured data for a recipe
 
-#### HTML
-
-The following is an example rendering of the preceding code example.
-
-{{EmbedLiveSample('Example', '500', '550', '', 'Web/HTML/Global_attributes/itemscope')}}
-
-#### Structured data
+There are four `itemscope` attributes in the following example. Each `itemscope` attribute sets the scope of its corresponding `itemtype` attribute. The `itemtype`s, `Recipe`, `AggregateRating`, and `NutritionInformation` in the following example are part of the [schema.org](www.schema.org) structured data for a recipe, as specified by the first `itemtype`, http\://schema.org/Recipe.
 
 <table class="standard-table">
   <tbody>
@@ -250,7 +194,55 @@ The following is an example rendering of the preceding code example.
   </tbody>
 </table>
 
-> **Note:** A handy tool for extracting microdata structures from HTML is Google's [Rich Results Testing Tool](https://search.google.com/test/rich-results). Try it on the HTML shown above.
+> **Note:** A handy tool for extracting microdata structures from HTML is Google's [Rich Results Testing Tool](https://search.google.com/test/rich-results). Try it on the HTML shown here.
+
+#### HTML
+
+```html
+<div itemscope itemtype="https://schema.org/Recipe">
+  <h2 itemprop="name">Grandma's Holiday Apple Pie</h2>
+  <img itemprop="image" src="https://c1.staticflickr.com/1/30/42759561_8631e2f905_n.jpg" width="50" height="50" />
+  <p>
+    By <span itemprop="author" itemscope itemtype="https://schema.org/Person">
+      <span itemprop="name">Carol Smith</span>
+    </span>
+  </p>
+  <p>
+    Published: <time datetime="2009-11-05" itemprop="datePublished">November 5, 2009</time>
+  </p>
+  <span itemprop="description">This is my grandmother's apple pie recipe. I like to add a dash of nutmeg.</span>
+  <br>
+  <span itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating">
+    <span itemprop="ratingValue">4.0</span> stars based on <span itemprop="reviewCount">35</span> reviews
+  </span>
+  <br>
+  Prep time: <time datetime="PT30M" itemprop="prepTime">30 min</time><br>
+  Cook time: <time datetime="PT1H" itemprop="cookTime">1 hou</time>r<br>
+  Total time: <time datetime="PT1H30M" itemprop="totalTime">1 hour 30 min</time><br>
+  Yield: <span itemprop="recipeYield">1 9" pie (8 servings)</span><br>
+  <span itemprop="nutrition" itemscope itemtype="https://schema.org/NutritionInformation">
+    Serving size: <span itemprop="servingSize">1 medium slice</span><br>
+    Calories per serving: <span itemprop="calories">250 cal</span><br>
+    Fat per serving: <span itemprop="fatContent">12 g</span><br>
+  </span>
+  <p>
+    Ingredients:<br>
+    <span itemprop="recipeIngredient">Thinly-sliced apples: 6 cups<br></span>
+    <span itemprop="recipeIngredient">White sugar: 3/4 cup<br></span>
+    ...
+  </p>
+  Directions: <br>
+  <div itemprop="recipeInstructions">
+    1. Cut and peel apples<br>
+    2. Mix sugar and cinnamon. Use additional sugar for tart apples. <br>
+    ...
+  </div>
+</div>
+```
+
+#### Result
+
+{{EmbedLiveSample('Representing structured data for a recipe', '', '550')}}
 
 ## Specifications
 

--- a/files/en-us/web/html/global_attributes/itemtype/index.md
+++ b/files/en-us/web/html/global_attributes/itemtype/index.md
@@ -27,89 +27,12 @@ Google and other major search engines support the [schema.org](https://schema.or
 - The itemid attribute can only be specified on elements which have both an itemscope attribute and an itemtype attribute specified. They must only be specified on elements with an itemscope attribute, whose itemtype attribute specifies a vocabulary not supporting global identifiers for items, as defined by that vocabulary's specification.
 - The exact meaning of a global identifier is determined by the vocabulary's specification. It is left to such specifications to define whether multiple items of the same global identifier (whether on the same page or different pages) are allowed to exist, and what processing rules for that vocabulary are, with respect to handling the case of multiple items with the same ID.
 
-### Simple example
+## Examples
 
-#### HTML
+### Representing structured data for a product
 
-```html
-<div itemscope itemtype="https://schema.org/Product">
-  <span itemprop="brand">ACME</span>
-  <span itemprop="name">Executive Anvil</span>
-</div>
-```
+This example uses microdata attributes to represent structured data for a product, as follows:
 
-#### Structured data
-
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <td rowspan="4">itemscope</td>
-      <td>itemtype</td>
-      <td colspan="2">schema.org Product</td>
-    </tr>
-    <tr>
-      <td>itemprop</td>
-      <td>name</td>
-      <td>Executive Anvil</td>
-    </tr>
-    <tr>
-      <td>itemprop</td>
-      <td colspan="2">brand [Thing]</td>
-    </tr>
-    <tr>
-      <td>itemprop</td>
-      <td>name</td>
-      <td>ACME</td>
-    </tr>
-  </tbody>
-</table>
-
-## Example
-
-### HTML
-
-```html
-<div itemscope itemtype="http://schema.org/Product">
-  <span itemprop="brand">ACME<br></span>
-  <span itemprop="name">Executive Anvil<br></span>
-  <img itemprop="image" src="https://pixabay.com/static/uploads/photo/2015/09/05/18/15/suitcase-924605_960_720.png" width="50" height="50" alt="Executive Anvil logo" /><br>
-
-<span itemprop="description">Sleeker than ACME's Classic Anvil, the
-    Executive Anvil is perfect for the business traveler
-    looking for something to drop from a height.
-  <br>
-</span>
-
-  Product #: <span itemprop="mpn">925872<br></span>
-  <span itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating">
-    Rating: <span itemprop="ratingValue">4.4</span> stars, based on <span itemprop="reviewCount">89
-      </span> reviews
-  </span><p>
-
-<span itemprop="offers" itemscope itemtype="http://schema.org/Offer">
-    Regular price: $179.99<br>
-    <meta itemprop="priceCurrency" content="USD" />
-    <span itemprop="price">Sale price: $119.99<br></span>
-    (Sale ends <time itemprop="priceValidUntil" datetime="2020-11-05">
-      5 November!</time>)<br>
-    Available from: <span itemprop="seller" itemscope itemtype="http://schema.org/Organization">
-                      <span itemprop="name">Executive Objects<br></span>
-                    </span>
-    Condition: <link itemprop="itemCondition" href="http://schema.org/UsedCondition"/>Previously owned,
-      in excellent condition<br>
-    <link itemprop="availability" href="http://schema.org/InStock"/>In stock! Order now!
-</span>
-
-</div>
-```
-
-### Result
-
-#### HTML
-
-{{EmbedLiveSample('HTML_2', '300', '400', '', 'Web/HTML/Global_attributes/itemtype')}}
-
-#### Structured data
 
 <table class="standard-table">
   <tbody>
@@ -213,7 +136,48 @@ Google and other major search engines support the [schema.org](https://schema.or
   </tbody>
 </table>
 
-> **Note:** A handy tool for extracting microdata structures from HTML is Google's [Structured Data Testing Tool](https://developers.google.com/search/docs/advanced/structured-data). Try it on the HTML shown above
+> **Note:** A handy tool for extracting microdata structures from HTML is Google's [Structured Data Testing Tool](https://developers.google.com/search/docs/advanced/structured-data). Try it on the HTML shown here.
+
+#### HTML
+
+```html
+<div itemscope itemtype="http://schema.org/Product">
+  <span itemprop="brand">ACME<br></span>
+  <span itemprop="name">Executive Anvil<br></span>
+  <img itemprop="image" src="https://pixabay.com/static/uploads/photo/2015/09/05/18/15/suitcase-924605_960_720.png" width="50" height="50" alt="Executive Anvil logo" /><br>
+
+<span itemprop="description">Sleeker than ACME's Classic Anvil, the
+    Executive Anvil is perfect for the business traveler
+    looking for something to drop from a height.
+  <br>
+</span>
+
+  Product #: <span itemprop="mpn">925872<br></span>
+  <span itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating">
+    Rating: <span itemprop="ratingValue">4.4</span> stars, based on <span itemprop="reviewCount">89
+      </span> reviews
+  </span><p>
+
+<span itemprop="offers" itemscope itemtype="http://schema.org/Offer">
+    Regular price: $179.99<br>
+    <meta itemprop="priceCurrency" content="USD" />
+    <span itemprop="price">Sale price: $119.99<br></span>
+    (Sale ends <time itemprop="priceValidUntil" datetime="2020-11-05">
+      5 November!</time>)<br>
+    Available from: <span itemprop="seller" itemscope itemtype="http://schema.org/Organization">
+                      <span itemprop="name">Executive Objects<br></span>
+                    </span>
+    Condition: <link itemprop="itemCondition" href="http://schema.org/UsedCondition"/>Previously owned,
+      in excellent condition<br>
+    <link itemprop="availability" href="http://schema.org/InStock"/>In stock! Order now!
+</span>
+
+</div>
+```
+
+#### Result
+
+{{EmbedLiveSample('Representing structured data for a product', '', '400')}}
 
 ## Specifications
 


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/15872.

Removes inclusion parameter for microdata attributes. Also does some general cleaning of these pages:

- using `## Examples` not `## Example`
- having a descriptive title for individual examples

It also applies https://github.com/mdn/content/pull/14488 to the `itemid` page. I can recommend "Owls of the Eastern Ice".