### PR TITLE
Fix 15872: stop including example sources from different pages: drag …

### DIFF
--- a/files/en-us/web/api/document/drag_event/index.md
+++ b/files/en-us/web/api/document/drag_event/index.md
@@ -46,22 +46,20 @@ The `drag` event is fired every few hundred milliseconds as an element or text s
 
 ## Examples
 
-See this code in a [JSFiddle demo](https://jsfiddle.net/radonirinamaminiaina/zfnj5rv4/) or interact with it below.
+### Drag and drop example
 
-### HTML
+#### HTML
 
 ```html
 <div class="dropzone">
-  <div id="draggable" draggable="true" ondragstart="event.dataTransfer.setData('text/plain',null)">
+  <div id="draggable" draggable="true">
     This div is draggable
   </div>
 </div>
 <div class="dropzone"></div>
-<div class="dropzone"></div>
-<div class="dropzone"></div>
 ```
 
-### CSS
+#### CSS
 
 ```css
 body {
@@ -70,8 +68,6 @@ body {
 }
 
 #draggable {
-  width: 200px;
-  height: 20px;
   text-align: center;
   background: white;
 }
@@ -80,68 +76,76 @@ body {
   width: 200px;
   height: 20px;
   background: blueviolet;
-  margin-bottom: 10px;
+  margin: 10px;
   padding: 10px;
+}
+
+.dropzone.dragover {
+  background-color: purple;
+}
+
+.dragging {
+  opacity: .5;
 }
 ```
 
-### JavaScript
+#### JavaScript
 
 ```js
-var dragged;
+let dragged;
 
 /* events fired on the draggable target */
-document.addEventListener("drag", function(event) {
+document.addEventListener("drag", event => {
+  console.log("dragging");
+});
 
-}, false);
-
-document.addEventListener("dragstart", function(event) {
+document.addEventListener("dragstart", event => {
   // store a ref. on the dragged elem
   dragged = event.target;
   // make it half transparent
-  event.target.style.opacity = .5;
-}, false);
+  event.target.classList.add("dragging");
+});
 
-document.addEventListener("dragend", function(event) {
+document.addEventListener("dragend", event => {
   // reset the transparency
-  event.target.style.opacity = "";
-}, false);
+  event.target.classList.remove("dragging");
+});
 
 /* events fired on the drop targets */
-document.addEventListener("dragover", function(event) {
+document.addEventListener("dragover", event => {
   // prevent default to allow drop
   event.preventDefault();
 }, false);
 
-document.addEventListener("dragenter", function(event) {
+document.addEventListener("dragenter", event => {
   // highlight potential drop target when the draggable element enters it
-  if (event.target.className == "dropzone") {
-    event.target.style.background = "purple";
+  if (event.target.classList.contains("dropzone")) {
+    event.target.classList.add("dragover");
   }
+});
 
-}, false);
-
-document.addEventListener("dragleave", function(event) {
+document.addEventListener("dragleave", event => {
   // reset background of potential drop target when the draggable element leaves it
-  if (event.target.className == "dropzone") {
-    event.target.style.background = "";
+  if (event.target.classList.contains("dropzone")) {
+    event.target.classList.remove("dragover");
   }
+});
 
-}, false);
-
-document.addEventListener("drop", function(event) {
+document.addEventListener("drop", event => {
   // prevent default action (open as link for some elements)
   event.preventDefault();
-  // move dragged elem to the selected drop target
-  if (event.target.className == "dropzone") {
-    event.target.style.background = "";
-    dragged.parentNode.removeChild( dragged );
-    event.target.appendChild( dragged );
+  // move dragged element to the selected drop target
+  if (event.target.classList.contains("dropzone")) {
+    event.target.classList.remove("dragover");
+    dragged.parentNode.removeChild(dragged);
+    event.target.appendChild(dragged);
   }
-}, false);
+});
 ```
 
-{{EmbedLiveSample('Examples', '300', '200', '')}}
+#### Result
+
+{{EmbedLiveSample('Drag and drop example')}}
 
 ## Specifications
 

--- a/files/en-us/web/api/document/dragend_event/index.md
+++ b/files/en-us/web/api/document/dragend_event/index.md
@@ -46,9 +46,67 @@ The `dragend` event is fired when a drag operation is being ended (by releasing 
 
 ## Examples
 
-See the [drag](/en-US/docs/Web/API/Document/drag_event) event for example code or this [JSFiddle demo](https://jsfiddle.net/radonirinamaminiaina/zfnj5rv4/).
+### Resetting opacity on drag end
 
-{{EmbedLiveSample('Examples', '300', '200', '', 'Web/API/Document/drag_event')}}
+In this example we have a draggable element inside a container. Try grabbing the element, dragging it, and then releasing it.
+
+We make the element half transparent while it is being dragged, and listen for the `dragend` event to reset the element's opacity when it is released.
+
+For a more complete example of drag and drop, see the page for the [drag](/en-US/docs/Web/API/Document/drag_event) event.
+
+#### HTML
+
+```html
+<div id="container">
+  <div id="draggable" draggable="true">
+    This div is draggable
+  </div>
+</div>
+<div class="dropzone"></div>
+```
+
+#### CSS
+
+```css
+body {
+  /* Prevent the user selecting text in the example */
+  user-select: none;
+}
+
+#draggable {
+  text-align: center;
+  background: white;
+}
+
+#container {
+  width: 200px;
+  height: 20px;
+  background: blueviolet;
+  padding: 10px;
+}
+
+.dragging {
+  opacity: .5;
+}
+```
+
+#### JavaScript
+
+```js
+document.addEventListener("dragstart", event => {
+  // make it half transparent
+  event.target.classList.add("dragging");
+});
+
+document.addEventListener("dragend", event => {
+  // reset the transparency
+  event.target.classList.remove("dragging");
+});
+```
+
+#### Result
+
+{{EmbedLiveSample('Resetting opacity on drag end')}}
 
 ## Specifications
 

--- a/files/en-us/web/api/document/dragend_event/index.md
+++ b/files/en-us/web/api/document/dragend_event/index.md
@@ -52,7 +52,7 @@ In this example we have a draggable element inside a container. Try grabbing the
 
 We make the element half transparent while it is being dragged, and listen for the `dragend` event to reset the element's opacity when it is released.
 
-For a more complete example of drag and drop, see the page for the [drag](/en-US/docs/Web/API/Document/drag_event) event.
+For a more complete example of drag and drop, see the page for the [`drag`](/en-US/docs/Web/API/Document/drag_event) event.
 
 #### HTML
 

--- a/files/en-us/web/api/document/dragend_event/index.md
+++ b/files/en-us/web/api/document/dragend_event/index.md
@@ -50,7 +50,7 @@ The `dragend` event is fired when a drag operation is being ended (by releasing 
 
 In this example, we have a draggable element inside a container. Try grabbing the element, dragging it, and then releasing it.
 
-We make the element half transparent while it is being dragged, and listen for the `dragend` event to reset the element's opacity when it is released.
+We make the element half-transparent while it is being dragged, and listen for the `dragend` event to reset the element's opacity when it is released.
 
 For a more complete example of drag and drop, see the page for the [`drag`](/en-US/docs/Web/API/Document/drag_event) event.
 

--- a/files/en-us/web/api/document/dragend_event/index.md
+++ b/files/en-us/web/api/document/dragend_event/index.md
@@ -48,7 +48,7 @@ The `dragend` event is fired when a drag operation is being ended (by releasing 
 
 ### Resetting opacity on drag end
 
-In this example we have a draggable element inside a container. Try grabbing the element, dragging it, and then releasing it.
+In this example, we have a draggable element inside a container. Try grabbing the element, dragging it, and then releasing it.
 
 We make the element half transparent while it is being dragged, and listen for the `dragend` event to reset the element's opacity when it is released.
 

--- a/files/en-us/web/api/document/dragenter_event/index.md
+++ b/files/en-us/web/api/document/dragenter_event/index.md
@@ -48,9 +48,72 @@ The target object is the _immediate user selection_ (the element directly indica
 
 ## Examples
 
-See the [drag event](/en-US/docs/Web/API/Document/drag_event) for example code or this [JSFiddle demo](https://jsfiddle.net/radonirinamaminiaina/zfnj5rv4/).
+### Styling drop zones on dragenter
 
-{{EmbedLiveSample('Examples', '300', '200', '', 'Web/API/Document/drag_event')}}
+In this example we have a draggable element inside a container. Try grabbing the element, dragging it over the other container, and then releasing it.
+
+We listen for the `dragenter` event to give the other container a purple background while the draggable element is over it, to signal that the draggable element could be dropped on to the container.
+
+Note though that in this partial example we haven't implemented dropping: for a complete example of drag and drop, see the page for the [drag](/en-US/docs/Web/API/Document/drag_event) event.
+
+#### HTML
+
+```html
+<div class="dropzone">
+  <div id="draggable" draggable="true">
+    This div is draggable
+  </div>
+</div>
+<div class="dropzone"></div>
+```
+
+#### CSS
+
+```css
+body {
+  /* Prevent the user selecting text in the example */
+  user-select: none;
+}
+
+#draggable {
+  text-align: center;
+  background: white;
+}
+
+.dropzone {
+  width: 200px;
+  height: 20px;
+  background: blueviolet;
+  margin: 10px;
+  padding: 10px;
+}
+
+.dropzone.dragover {
+  background-color: purple;
+}
+```
+
+#### JavaScript
+
+```js
+document.addEventListener("dragenter", event => {
+  // highlight potential drop target when the draggable element enters it
+  if (event.target.classList.contains("dropzone")) {
+    event.target.classList.add("dragover");
+  }
+});
+
+document.addEventListener("dragleave", event => {
+  // reset background of potential drop target when the draggable element leaves it
+  if (event.target.classList.contains("dropzone")) {
+    event.target.classList.remove("dragover");
+  }
+});
+```
+
+#### Result
+
+{{EmbedLiveSample('Styling drop zones on dragenter')}}
 
 ## Specifications
 

--- a/files/en-us/web/api/document/dragenter_event/index.md
+++ b/files/en-us/web/api/document/dragenter_event/index.md
@@ -54,7 +54,7 @@ In this example we have a draggable element inside a container. Try grabbing the
 
 We listen for the `dragenter` event to give the other container a purple background while the draggable element is over it, to signal that the draggable element could be dropped on to the container.
 
-Note though that in this partial example we haven't implemented dropping: for a complete example of drag and drop, see the page for the [drag](/en-US/docs/Web/API/Document/drag_event) event.
+Note though that in this partial example we haven't implemented dropping: for a complete example of drag and drop, see the page for the [`drag`](/en-US/docs/Web/API/Document/drag_event) event.
 
 #### HTML
 

--- a/files/en-us/web/api/document/dragenter_event/index.md
+++ b/files/en-us/web/api/document/dragenter_event/index.md
@@ -50,7 +50,7 @@ The target object is the _immediate user selection_ (the element directly indica
 
 ### Styling drop zones on dragenter
 
-In this example we have a draggable element inside a container. Try grabbing the element, dragging it over the other container, and then releasing it.
+In this example, we have a draggable element inside a container. Try grabbing the element, dragging it over the other container, and then releasing it.
 
 We listen for the `dragenter` event to give the other container a purple background while the draggable element is over it, to signal that the draggable element could be dropped on to the container.
 

--- a/files/en-us/web/api/document/dragleave_event/index.md
+++ b/files/en-us/web/api/document/dragleave_event/index.md
@@ -48,7 +48,7 @@ The `dragleave` event is fired when a dragged element or text selection leaves a
 
 ### Resetting drop zone styles on dragleave
 
-In this example we have a draggable element inside a container. Try grabbing the element, dragging it over the other container, and then releasing it.
+In this example, we have a draggable element inside a container. Try grabbing the element, dragging it over the other container, and then releasing it.
 
 We give the other container a purple background while the draggable element is over it, to signal that the draggable element could be dropped on to the container. We listen for the `dragleave` event to reset the container background when the draggable element is dragged off the container.
 

--- a/files/en-us/web/api/document/dragleave_event/index.md
+++ b/files/en-us/web/api/document/dragleave_event/index.md
@@ -46,9 +46,72 @@ The `dragleave` event is fired when a dragged element or text selection leaves a
 
 ## Examples
 
-See the [drag event](/en-US/docs/Web/API/Document/drag_event) for example code or this [JSFiddle demo](https://jsfiddle.net/radonirinamaminiaina/zfnj5rv4/).
+### Resetting drop zone styles on dragleave
 
-{{EmbedLiveSample('Examples', '300', '200', '', 'Web/API/Document/drag_event')}}
+In this example we have a draggable element inside a container. Try grabbing the element, dragging it over the other container, and then releasing it.
+
+We give the other container a purple background while the draggable element is over it, to signal that the draggable element could be dropped on to the container. We listen for the `dragleave` event to reset the container background when the draggable element is dragged off the container.
+
+Note though that in this partial example we haven't implemented dropping: for a complete example of drag and drop, see the page for the [drag](/en-US/docs/Web/API/Document/drag_event) event.
+
+#### HTML
+
+```html
+<div class="dropzone">
+  <div id="draggable" draggable="true">
+    This div is draggable
+  </div>
+</div>
+<div class="dropzone"></div>
+```
+
+#### CSS
+
+```css
+body {
+  /* Prevent the user selecting text in the example */
+  user-select: none;
+}
+
+#draggable {
+  text-align: center;
+  background: white;
+}
+
+.dropzone {
+  width: 200px;
+  height: 20px;
+  background: blueviolet;
+  margin: 10px;
+  padding: 10px;
+}
+
+.dropzone.dragover {
+  background-color: purple;
+}
+```
+
+#### JavaScript
+
+```js
+document.addEventListener("dragenter", event => {
+  // highlight potential drop target when the draggable element enters it
+  if (event.target.classList.contains("dropzone")) {
+    event.target.classList.add("dragover");
+  }
+});
+
+document.addEventListener("dragleave", event => {
+  // reset background of potential drop target when the draggable element leaves it
+  if (event.target.classList.contains("dropzone")) {
+    event.target.classList.remove("dragover");
+  }
+});
+```
+
+#### Result
+
+{{EmbedLiveSample('Resetting drop zone styles on dragleave')}}
 
 ## Specifications
 

--- a/files/en-us/web/api/document/dragleave_event/index.md
+++ b/files/en-us/web/api/document/dragleave_event/index.md
@@ -52,7 +52,7 @@ In this example we have a draggable element inside a container. Try grabbing the
 
 We give the other container a purple background while the draggable element is over it, to signal that the draggable element could be dropped on to the container. We listen for the `dragleave` event to reset the container background when the draggable element is dragged off the container.
 
-Note though that in this partial example we haven't implemented dropping: for a complete example of drag and drop, see the page for the [drag](/en-US/docs/Web/API/Document/drag_event) event.
+Note though that in this partial example we haven't implemented dropping: for a complete example of drag and drop, see the page for the [`drag`](/en-US/docs/Web/API/Document/drag_event) event.
 
 #### HTML
 

--- a/files/en-us/web/api/document/dragover_event/index.md
+++ b/files/en-us/web/api/document/dragover_event/index.md
@@ -53,9 +53,9 @@ In this example, we have a draggable element inside a container. Try grabbing th
 
 We use three event handlers here:
 
-- in the `dragstart` event handler we get a reference to the element that the user dragged
-- in the `dragover` event handler for the target container we call `event.preventDefault()`, which enables it to receive `drop` events.
-- in the `drop` event handler for the drop zone we handle moving the draggable element from the original container to the drop zone.
+- in the `dragstart` event handler, we get a reference to the element that the user dragged
+- in the `dragover` event handler for the target container, we call `event.preventDefault()`, which enables it to receive `drop` events.
+- in the `drop` event handler for the drop zone, we handle moving the draggable element from the original container to the drop zone.
 
 For a more complete example of drag and drop, see the page for the [`drag`](/en-US/docs/Web/API/Document/drag_event) event.
 

--- a/files/en-us/web/api/document/dragover_event/index.md
+++ b/files/en-us/web/api/document/dragover_event/index.md
@@ -49,7 +49,7 @@ The event is fired on the drop target(s).
 
 ### A minimal drag and drop example
 
-In this example we have a draggable element inside a container. Try grabbing the element, dragging it over the other container, and then releasing it.
+In this example, we have a draggable element inside a container. Try grabbing the element, dragging it over the other container, and then releasing it.
 
 We use three event handlers here:
 

--- a/files/en-us/web/api/document/dragover_event/index.md
+++ b/files/en-us/web/api/document/dragover_event/index.md
@@ -57,7 +57,7 @@ We use three event handlers here:
 - in the `dragover` event handler for the target container we call `event.preventDefault()`, which enables it to receive `drop` events.
 - in the `drop` event handler for the drop zone we handle moving the draggable element from the original container to the drop zone.
 
-For a more complete example of drag and drop, see the page for the [drag](/en-US/docs/Web/API/Document/drag_event) event.
+For a more complete example of drag and drop, see the page for the [`drag`](/en-US/docs/Web/API/Document/drag_event) event.
 
 #### HTML
 
@@ -117,6 +117,10 @@ document.addEventListener("drop", event => {
   }
 });
 ```
+
+#### Result
+
+{{EmbedLiveSample('A minimal drag and drop example')}}
 
 ## Specifications
 

--- a/files/en-us/web/api/document/dragover_event/index.md
+++ b/files/en-us/web/api/document/dragover_event/index.md
@@ -47,9 +47,76 @@ The event is fired on the drop target(s).
 
 ## Examples
 
-See the [drag event](/en-US/docs/Web/API/Document/drag_event) for example code or this [JSFiddle demo](https://jsfiddle.net/radonirinamaminiaina/zfnj5rv4/).
+### A minimal drag and drop example
 
-{{EmbedLiveSample('Examples', '300', '200', '', 'Web/API/Document/drag_event')}}
+In this example we have a draggable element inside a container. Try grabbing the element, dragging it over the other container, and then releasing it.
+
+We use three event handlers here:
+
+- in the `dragstart` event handler we get a reference to the element that the user dragged
+- in the `dragover` event handler for the target container we call `event.preventDefault()`, which enables it to receive `drop` events.
+- in the `drop` event handler for the drop zone we handle moving the draggable element from the original container to the drop zone.
+
+For a more complete example of drag and drop, see the page for the [drag](/en-US/docs/Web/API/Document/drag_event) event.
+
+#### HTML
+
+```html
+<div class="dropzone">
+  <div id="draggable" draggable="true">
+    This div is draggable
+  </div>
+</div>
+<div class="dropzone"></div>
+```
+
+#### CSS
+
+```css
+body {
+  /* Prevent the user selecting text in the example */
+  user-select: none;
+}
+
+#draggable {
+  text-align: center;
+  background: white;
+}
+
+.dropzone {
+  width: 200px;
+  height: 20px;
+  background: blueviolet;
+  margin: 10px;
+  padding: 10px;
+}
+```
+
+#### JavaScript
+
+```js
+let dragged = null;
+
+document.addEventListener("dragstart", event => {
+  // store a ref. on the dragged elem
+  dragged = event.target;
+});
+
+document.addEventListener("dragover", event => {
+  // prevent default to allow drop
+  event.preventDefault();
+});
+
+document.addEventListener("drop", event => {
+  // prevent default action (open as link for some elements)
+  event.preventDefault();
+  // move dragged element to the selected drop target
+  if (event.target.className == "dropzone") {
+    dragged.parentNode.removeChild(dragged);
+    event.target.appendChild(dragged);
+  }
+});
+```
 
 ## Specifications
 

--- a/files/en-us/web/api/document/dragstart_event/index.md
+++ b/files/en-us/web/api/document/dragstart_event/index.md
@@ -47,7 +47,7 @@ In this example we have a draggable element inside a container. Try grabbing the
 
 We listen for the `dragstart` event to make the element half transparent while it is being dragged.
 
-For a more complete example of drag and drop, see the page for the [drag](/en-US/docs/Web/API/Document/drag_event) event.
+For a more complete example of drag and drop, see the page for the [`drag`](/en-US/docs/Web/API/Document/drag_event) event.
 
 #### HTML
 

--- a/files/en-us/web/api/document/dragstart_event/index.md
+++ b/files/en-us/web/api/document/dragstart_event/index.md
@@ -43,7 +43,7 @@ The `dragstart` event is fired when the user starts dragging an element or text 
 
 ### Setting opacity on drag start
 
-In this example we have a draggable element inside a container. Try grabbing the element, dragging it, and then releasing it.
+In this example, we have a draggable element inside a container. Try grabbing the element, dragging it, and then releasing it.
 
 We listen for the `dragstart` event to make the element half transparent while it is being dragged.
 

--- a/files/en-us/web/api/document/dragstart_event/index.md
+++ b/files/en-us/web/api/document/dragstart_event/index.md
@@ -41,9 +41,67 @@ The `dragstart` event is fired when the user starts dragging an element or text 
 
 ## Examples
 
-See the [drag event](/en-US/docs/Web/API/Document/drag_event) for example code or this [JSFiddle demo](https://jsfiddle.net/radonirinamaminiaina/zfnj5rv4/).
+### Setting opacity on drag start
 
-{{EmbedLiveSample('Examples', '300', '200', '', 'Web/API/Document/drag_event')}}
+In this example we have a draggable element inside a container. Try grabbing the element, dragging it, and then releasing it.
+
+We listen for the `dragstart` event to make the element half transparent while it is being dragged.
+
+For a more complete example of drag and drop, see the page for the [drag](/en-US/docs/Web/API/Document/drag_event) event.
+
+#### HTML
+
+```html
+<div id="container">
+  <div id="draggable" draggable="true">
+    This div is draggable
+  </div>
+</div>
+<div class="dropzone"></div>
+```
+
+#### CSS
+
+```css
+body {
+  /* Prevent the user selecting text in the example */
+  user-select: none;
+}
+
+#draggable {
+  text-align: center;
+  background: white;
+}
+
+#container {
+  width: 200px;
+  height: 20px;
+  background: blueviolet;
+  padding: 10px;
+}
+
+.dragging {
+  opacity: .5;
+}
+```
+
+#### JavaScript
+
+```js
+document.addEventListener("dragstart", event => {
+  // make it half transparent
+  event.target.classList.add("dragging");
+});
+
+document.addEventListener("dragend", event => {
+  // reset the transparency
+  event.target.classList.remove("dragging");
+});
+```
+
+#### Result
+
+{{EmbedLiveSample('Setting opacity on drag start')}}
 
 ## Specifications
 

--- a/files/en-us/web/api/document/drop_event/index.md
+++ b/files/en-us/web/api/document/drop_event/index.md
@@ -50,9 +50,9 @@ In this example, we have a draggable element inside a container. Try grabbing th
 
 We use three event handlers here:
 
-- in the `dragstart` event handler we get a reference to the element that the user dragged
-- in the `dragover` event handler for the target container we call `event.preventDefault()`, which enables it to receive `drop` events.
-- in the `drop` event handler for the drop zone we handle moving the draggable element from the original container to the drop zone.
+- in the `dragstart` event handler, we get a reference to the element that the user dragged
+- in the `dragover` event handler for the target container, we call `event.preventDefault()`, which enables it to receive `drop` events.
+- in the `drop` event handler for the drop zone, we handle moving the draggable element from the original container to the drop zone.
 
 For a more complete example of drag and drop, see the page for the [`drag`](/en-US/docs/Web/API/Document/drag_event) event.
 

--- a/files/en-us/web/api/document/drop_event/index.md
+++ b/files/en-us/web/api/document/drop_event/index.md
@@ -54,7 +54,7 @@ We use three event handlers here:
 - in the `dragover` event handler for the target container we call `event.preventDefault()`, which enables it to receive `drop` events.
 - in the `drop` event handler for the drop zone we handle moving the draggable element from the original container to the drop zone.
 
-For a more complete example of drag and drop, see the page for the [drag](/en-US/docs/Web/API/Document/drag_event) event.
+For a more complete example of drag and drop, see the page for the [`drag`](/en-US/docs/Web/API/Document/drag_event) event.
 
 #### HTML
 

--- a/files/en-us/web/api/document/drop_event/index.md
+++ b/files/en-us/web/api/document/drop_event/index.md
@@ -44,9 +44,80 @@ The **`drop`** event is fired when an element or text selection is dropped on a 
 
 ## Examples
 
-See the [drag event](/en-US/docs/Web/API/Document/drag_event) for example code or this [JSFiddle demo](https://jsfiddle.net/radonirinamaminiaina/zfnj5rv4/).
+### A minimal drag and drop example
 
-{{EmbedLiveSample('Examples', '300', '200', '', 'Web/API/Document/drag_event')}}
+In this example we have a draggable element inside a container. Try grabbing the element, dragging it over the other container, and then releasing it.
+
+We use three event handlers here:
+
+- in the `dragstart` event handler we get a reference to the element that the user dragged
+- in the `dragover` event handler for the target container we call `event.preventDefault()`, which enables it to receive `drop` events.
+- in the `drop` event handler for the drop zone we handle moving the draggable element from the original container to the drop zone.
+
+For a more complete example of drag and drop, see the page for the [drag](/en-US/docs/Web/API/Document/drag_event) event.
+
+#### HTML
+
+```html
+<div class="dropzone">
+  <div id="draggable" draggable="true">
+    This div is draggable
+  </div>
+</div>
+<div class="dropzone"></div>
+```
+
+#### CSS
+
+```css
+body {
+  /* Prevent the user selecting text in the example */
+  user-select: none;
+}
+
+#draggable {
+  text-align: center;
+  background: white;
+}
+
+.dropzone {
+  width: 200px;
+  height: 20px;
+  background: blueviolet;
+  margin: 10px;
+  padding: 10px;
+}
+```
+
+#### JavaScript
+
+```js
+let dragged = null;
+
+document.addEventListener("dragstart", event => {
+  // store a ref. on the dragged elem
+  dragged = event.target;
+});
+
+document.addEventListener("dragover", event => {
+  // prevent default to allow drop
+  event.preventDefault();
+});
+
+document.addEventListener("drop", event => {
+  // prevent default action (open as link for some elements)
+  event.preventDefault();
+  // move dragged element to the selected drop target
+  if (event.target.className == "dropzone") {
+    dragged.parentNode.removeChild(dragged);
+    event.target.appendChild(dragged);
+  }
+});
+```
+
+#### Result
+
+{{EmbedLiveSample('A minimal drag and drop example')}}
 
 ## Specifications
 

--- a/files/en-us/web/api/document/drop_event/index.md
+++ b/files/en-us/web/api/document/drop_event/index.md
@@ -46,7 +46,7 @@ The **`drop`** event is fired when an element or text selection is dropped on a 
 
 ### A minimal drag and drop example
 
-In this example we have a draggable element inside a container. Try grabbing the element, dragging it over the other container, and then releasing it.
+In this example, we have a draggable element inside a container. Try grabbing the element, dragging it over the other container, and then releasing it.
 
 We use three event handlers here:
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/15872 : this is the last set of pages that used transclusion for live samples.

This is for drag events. Currently there's a single complete example that uses all the drag events, at https://developer.mozilla.org/en-US/docs/Web/API/Document/drag_event, and the other drag events transclude it.

I think it's nice to see a complete example but also useful to see minimal examples, so I have made minimal examples for the different events, and linked back to https://developer.mozilla.org/en-US/docs/Web/API/Document/drag_event for a complete example.
