### PR TITLE
Deprecate live sample transclusion

### DIFF
--- a/files/en-us/mdn/structures/live_samples/index.md
+++ b/files/en-us/mdn/structures/live_samples/index.md
@@ -60,7 +60,7 @@ In many cases, you may be able to add the `EmbedLiveSample` or `LiveSampleLink` 
 
   - : The slug of the page containing the sample; this is optional, and if it's not provided, the sample is pulled from the same page on which the macro is used.
 
-    > **Warning:** To show a live sample from one code-containing page in a different, target page, the code-containing page must itself use the [`EmbedLiveSample`](https://github.com/mdn/yari/blob/main/kumascript/macros/EmbedLiveSample.ejs) macro to embed a live sample in its own page. Otherwise, if the code-containing page doesn't itself use the [`EmbedLiveSample`](https://github.com/mdn/yari/blob/main/kumascript/macros/EmbedLiveSample.ejs) macro its own page, the live sample will fail to display at all on the target page. (See [Yari issue #2243](https://github.com/mdn/yari/issues/2243).)
+    > **Warning:** This parameter is deprecated. Don't use it in new examples, and remove it from existing examples if you see it. We're actively removing usages of it, and when it is no longer used we will remove support for it.
 
 #### LiveSampleLink macro
 


### PR DESCRIPTION
Also part of https://github.com/mdn/content/issues/15872: this asks people to stop using the `page_slug` argument to the live sample macro.