### PR TITLE
The properties aren't represented as Unix time

### DIFF
--- a/files/en-us/web/api/performancetiming/index.md
+++ b/files/en-us/web/api/performancetiming/index.md
@@ -27,7 +27,7 @@ _The `PerformanceTiming` interface doesn't inherit any properties._
 
 These properties each describe the time at which a particular point in the page loading process was reached. Some correspond to DOM events; others describe the time at which internal browser operations of interest took place.
 
-Each time is provided as a {{interwiki("wikipedia", "Unix_time", "Unix time")}} (`unsigned long long`) representing the moment, in milliseconds since the UNIX epoch.
+Each time is provided as a 64-bit unsigned integer (`unsigned long long`) representing the moment, in milliseconds since the UNIX epoch.
 
 These properties are listed in the order in which they occur during the navigation process.
 

--- a/files/en-us/web/api/performancetiming/index.md
+++ b/files/en-us/web/api/performancetiming/index.md
@@ -27,7 +27,7 @@ _The `PerformanceTiming` interface doesn't inherit any properties._
 
 These properties each describe the time at which a particular point in the page loading process was reached. Some correspond to DOM events; others describe the time at which internal browser operations of interest took place.
 
-Each time is provided as a 64-bit unsigned integer (`unsigned long long`) representing the moment, in milliseconds since the UNIX epoch.
+Each time is provided as a number representing the moment, in milliseconds since the UNIX epoch.
 
 These properties are listed in the order in which they occur during the navigation process.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
The properties aren't represented as Unix time, Unix time is in seconds, but these are in milliseconds.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
