### PR TITLE
Correcting grammar

### DIFF
--- a/files/en-us/learn/html/introduction_to_html/html_text_fundamentals/index.md
+++ b/files/en-us/learn/html/introduction_to_html/html_text_fundamentals/index.md
@@ -252,7 +252,7 @@ On the other hand, you could make any element _look_ like a top level heading. C
 <span style="font-size: 32px; margin: 21px 0; display: block;">Is this a top level heading?</span>
 ```
 
-This is a {{htmlelement("span")}} element. It has no semantics. You use it to wrap content when you want to apply CSS to it (or do something to it with JavaScript) without giving it any extra meaning. (You'll find out more about these later on in the course.) We've applied some CSS to it to make it look like a top level heading, but since it has no semantic value, it will not get any of the extra benefits described above. It is a good idea to use the relevant HTML element for the job.
+This is a {{htmlelement("span")}} element. It has no semantics. You use it to wrap content when you want to apply CSS to it (or do something to it with JavaScript) without giving it any extra meaning (You'll find out more about these later on in the course). We've applied some CSS to it to make it look like a top level heading, but since it has no semantic value, it will not get any of the extra benefits described above. It is a good idea to use the relevant HTML element for the job.
 
 ## Lists
 


### PR DESCRIPTION
#### Summary
Correcting grammar in the **HTML text fundamentals** page.

#### Motivation
This change fixes a very minor grammatical error in the page. The place of the "." is removed from inside a bracket thereby avoiding it's usage twice in the same sentence.

#### Supporting details

#### Related issues

#### Metadata
This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error


