### PR TITLE
Corrected Javascript Garden URL

### DIFF
--- a/files/en-us/web/guide/introduction_to_web_development/index.md
+++ b/files/en-us/web/guide/introduction_to_web_development/index.md
@@ -52,7 +52,7 @@ For another (overlapping) set of links to learning resources, see the [MDN Learn
 
 - [Learning advanced JavaScript](https://johnresig.com/apps/learn/) — John Resig's guide to advanced JavaScript
 - [Crockford on Advanced JavaScript](https://uk.screen.yahoo.com/watch/111585/1027823) — a three part video series on advanced JavaScript concepts
-- [JavaScript Garden](https://bonsaiden.github.com/JavaScript-Garden/) — Documentation of the most quirky parts of JavaScript.
+- [JavaScript Garden](https://bonsaiden.github.io/JavaScript-Garden/) — Documentation of the most quirky parts of JavaScript.
 
 ## Resources
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Javascript Garden URL was pointing to github.com, corrected 

#### Motivation
URL not working due to github domain changes

#### Supporting details
Working URL - https://bonsaiden.github.io/JavaScript-Garden/ 
Existing URL -  https://bonsaiden.github.com/JavaScript-Garden/ 

#### Related issues
NA

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
