### PR TITLE
Remove Navigator.battery from sidebars

### DIFF
--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -30,7 +30,7 @@
       ],
       "interfaces": ["BatteryManager"],
       "methods": ["Navigator.getBattery()"],
-      "properties": ["Navigator.battery"],
+      "properties": [],
       "events": []
     },
     "Barcode Detection API": {


### PR DESCRIPTION
We deleted this page yesterday (not implemented in any release browsers for almost a decade).

We also need to remove it from the sidebars.