### PR TITLE
Remove misleading statement about setters

### DIFF
--- a/files/en-us/web/javascript/reference/operators/spread_syntax/index.md
+++ b/files/en-us/web/javascript/reference/operators/spread_syntax/index.md
@@ -277,8 +277,7 @@ let mergedObj = { ...obj1, ...obj2 };
 // Object { foo: "baz", x: 42, y: 13 }
 ```
 
-Note that {{jsxref("Object.assign()")}} triggers {{jsxref("Functions/set",
-   "setters")}}, whereas spread syntax doesn't.
+Note that {{jsxref("Object.assign()")}} can be used to mutate an object, whereas spread syntax can't.
 
 Note that you cannot replace or mimic the {{jsxref("Object.assign()")}} function:
 


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

The remark made it seem like `Object.assign({}, objectWithSetters)` copies property descriptors. That is not true and thus the real reason setters are not involved is because the object is never mutated. The next example after this that references Object.assign is also kind of strange but decided not to touch it.

#### Motivation

the comment made me worry that changing spread syntax from being transpiled to Object.assign to native spread can cause behavioral changes, which it cannot.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
