### PR TITLE
Remove hyphen

### DIFF
--- a/files/en-us/web/api/usbdevice/claiminterface/index.md
+++ b/files/en-us/web/api/usbdevice/claiminterface/index.md
@@ -28,7 +28,7 @@ claimInterface(interfaceNumber)
 
 - `interfaceNumber`
   - : The index of one of the interfaces supported by the device. Interfaces are
-    device-specific.
+    device specific.
 
 ### Return value
 


### PR DESCRIPTION
The adjective phrase is after the verb, therefore no hyphen (If I've understood correctly)