### PR TITLE
Remove Arg in parameter names

### DIFF
--- a/files/en-us/web/api/compositionevent/initcompositionevent/index.md
+++ b/files/en-us/web/api/compositionevent/initcompositionevent/index.md
@@ -22,25 +22,25 @@ method of the {{domxref("CompositionEvent")}} interface initializes the attribut
 ## Syntax
 
 ```js
-initCompositionEvent(typeArg, canBubbleArg, cancelableArg, viewArg, dataArg, localeArg)
+initCompositionEvent(type, canBubble, cancelable, view, data, locale)
 ```
 
 ### Parameters
 
-- `typeArg`
+- `type`
   - : A string representing the type of composition event; this will be
     one of `compositionstart`, `compositionupdate`, or
     `compositionend`.
-- `canBubbleArg`
+- `canBubble`
   - : A boolean value specifying whether or not the event can bubble.
-- `cancelableArg`
+- `cancelable`
   - : A boolean value indicating whether or not the event can be canceled.
-- `viewArg`
+- `view`
   - : The {{domxref("Window")}} object from which the event was generated.
-- `dataArg`
+- `data`
   - : A string representing the value of the `data`
     attribute.
-- `localeArg`
+- `locale`
   - : A string representing the value of the `locale`
     attribute.
 

--- a/files/en-us/web/api/focusevent/focusevent/index.md
+++ b/files/en-us/web/api/focusevent/focusevent/index.md
@@ -33,7 +33,7 @@ _The `FocusEvent()` constructor also inherits arguments from
   - : A string with the name of the event.
     It is case-sensitive and browsers set it to `blur`, `focus`, `focusin`, or `focusout`.
 - `options` {{optional_inline}}
-  - : n object that, _in addition of the properties defined in {{domxref("UIEvent/UIEvent", "UIEvent()")}}_, can have the following properties:
+  - : An object that, in addition of the properties defined in {{domxref("UIEvent/UIEvent", "UIEvent()")}}, can have the following properties:
     - `relatedTarget` {{optional_inline}}
       - : An {{domxref("EventTarget")}} representing the secondary target of a {{domxref("FocusEvent")}}. It defaults to `null`.
 

--- a/files/en-us/web/api/focusevent/focusevent/index.md
+++ b/files/en-us/web/api/focusevent/focusevent/index.md
@@ -19,8 +19,8 @@ set to the other target.
 ## Syntax
 
 ```js
-new FocusEvent(typeArg)
-new FocusEvent(typeArg, focusEventInit)
+new FocusEvent(type)
+new FocusEvent(type, options)
 ```
 
 ### Parameters
@@ -29,19 +29,13 @@ _The `FocusEvent()` constructor also inherits arguments from
 {{domxref("UIEvent.UIEvent", "UIEvent()")}} and from {{domxref("Event.Event",
     "Event()")}}._
 
-- `typeArg`
-  - : A string representing the name of the event.
-- `focusEventInit` {{optional_inline}}
-
-  - : A `FocusEventInit` dictionary, having the following fields:
-
-    - `"relatedTarget"`, optional and defaulting to `null`, is
-      an {{domxref("EventTarget")}} representing the secondary target of a
-      {{domxref("FocusEvent")}}.
-
-    > **Note:** The `FocusEventInit` dictionary also accepts fields from the
-    > {{domxref("UIEvent.UIEvent", "UIEventInit")}} and {{domxref("Event.Event",
-        "EventInit")}} dictionaries.
+- `type`
+  - : A string with the name of the event.
+    It is case-sensitive and browsers set it to `blur`, `focus`, `focusin`, or `focusout`.
+- `options` {{optional_inline}}
+  - : n object that, _in addition of the properties defined in {{domxref("UIEvent/UIEvent", "UIEvent()")}}_, can have the following properties:
+    - `relatedTarget` {{optional_inline}}
+      - : An {{domxref("EventTarget")}} representing the secondary target of a {{domxref("FocusEvent")}}. It defaults to `null`.
 
 ## Specifications
 

--- a/files/en-us/web/api/keyboardevent/getmodifierstate/index.md
+++ b/files/en-us/web/api/keyboardevent/getmodifierstate/index.md
@@ -19,12 +19,12 @@ current state of the specified modifier key: `true` if the modifier is active
 ## Syntax
 
 ```js
-getModifierState(keyArg)
+getModifierState(key)
 ```
 
 ### Parameters
 
-- _`keyArg`_
+- `key`
   - : A modifier key value. The value must be one of the {{domxref("KeyboardEvent.key")}}
     values which represent modifier keys, or the string `"Accel"`
     {{deprecated_inline}}. This is case-sensitive.

--- a/files/en-us/web/api/keyboardevent/initkeyboardevent/index.md
+++ b/files/en-us/web/api/keyboardevent/initkeyboardevent/index.md
@@ -31,9 +31,9 @@ initKeyboardEvent(type, canBubble, cancelable,
   - : The type of keyboard event; browsers always set it to one of `keydown`,
     `keypress`, or `keyup`.
 - `canBubble` {{optional_inline}}
-  - : Whether or not the event can bubble. Defaults to `false`.
+  - : Indicates whether or not the event can bubble. Defaults to `false`.
 - `cancelable` {{optional_inline}}
-  - : Whether or not the event can be canceled. Defaults to `false`.
+  - : Indicates whether or not the event can be canceled. Defaults to `false`.
 - `view` {{optional_inline}}
   - : The {{domxref("WindowProxy")}} it is associated to. Defaults to `null`.
 - `key` {{optional_inline}}
@@ -41,13 +41,13 @@ initKeyboardEvent(type, canBubble, cancelable,
 - `location` {{optional_inline}}
   - : The value of the location attribute. Defaults to `0`.
 - `ctrlKey` {{optional_inline}}
-  - : Whether the Control key modifier is active. Defaults to `false`.
+  - : Indicates whether the control key modifier is active. Defaults to `false`.
 - `altKey` {{optional_inline}}
-  - : Whether the Alt key modifier is active. Defaults to `false`.
+  - : Indicates whether the alt key modifier is active. Defaults to `false`.
 - `shiftKey` {{optional_inline}}
-  - : Whether the Shift key modifier is active. Defaults to `false`.
+  - : Indicates whether the shift key modifier is active. Defaults to `false`.
 - `metaKey` {{optional_inline}}
-  - : Whether the Meta key modifier is active. Defaults to `false`.
+  - : Indicates whether the meta key modifier is active. Defaults to `false`.
 
 ### Return value
 

--- a/files/en-us/web/api/keyboardevent/initkeyboardevent/index.md
+++ b/files/en-us/web/api/keyboardevent/initkeyboardevent/index.md
@@ -20,34 +20,34 @@ Web applications should use constructor instead of this if it's available.
 ## Syntax
 
 ```js
-initKeyboardEvent(typeArg, canBubbleArg, cancelableArg,
-                           viewArg, charArg, keyArg,
-                           locationArg, modifiersListArg, repeat)
+initKeyboardEvent(type, canBubble, cancelable,
+                  view,  key, location, ctrlKey,
+                  altKey, shiftKey, metaKey)
 ```
 
 ### Parameters
 
-- _`typeArg`_
-  - : The type of keyboard event; this will be one of `keydown`,
+- `type`
+  - : The type of keyboard event; browsers always set it to one of `keydown`,
     `keypress`, or `keyup`.
-- _`canBubbleArg`_
-  - : Whether or not the event can bubble.
-- _`cancelableArg`_
-  - : Whether or not the event can be canceled.
-- _`viewArg`_
-  - : The {{domxref("WindowProxy")}} it is associated to.
-- _`keyArg`_
-  - : The value of the key attribute.
-- _`locationArg`_
-  - : The value of the location attribute.
-- _`ctrlKey`_
-  - : Whether the Control key modifier is active.
-- _`altKey`_
-  - : Whether the Alt key modifier is active.
-- _`shiftKey`_
-  - : Whether the Shift key modifier is active.
-- _`metaKey`_
-  - : Whether the Meta key modifier is active.
+- `canBubble` {{optional_inline}}
+  - : Whether or not the event can bubble. Defaults to `false`.
+- `cancelable` {{optional_inline}}
+  - : Whether or not the event can be canceled. Defaults to `false`.
+- `view` {{optional_inline}}
+  - : The {{domxref("WindowProxy")}} it is associated to. Defaults to `null`.
+- `key` {{optional_inline}}
+  - : The value of the key attribute. Defaults to `""`.
+- `location` {{optional_inline}}
+  - : The value of the location attribute. Defaults to `0`.
+- `ctrlKey` {{optional_inline}}
+  - : Whether the Control key modifier is active. Defaults to `false`.
+- `altKey` {{optional_inline}}
+  - : Whether the Alt key modifier is active. Defaults to `false`.
+- `shiftKey` {{optional_inline}}
+  - : Whether the Shift key modifier is active. Defaults to `false`.
+- `metaKey` {{optional_inline}}
+  - : Whether the Meta key modifier is active. Defaults to `false`.
 
 ### Return value
 

--- a/files/en-us/web/api/keyboardevent/initkeyevent/index.md
+++ b/files/en-us/web/api/keyboardevent/initkeyevent/index.md
@@ -59,7 +59,7 @@ initKeyEvent (type, bubbles, cancelable, view,
     generated is a combination of keys containing the <kbd>Meta</kbd> key.
 - `keyCode`
   - : An `unsigned long` representing the virtual key code value of the key
-    which was depressed, otherwise `0`. See {{ domxref("KeyboardEvent.keyCode")
+    which was pressed, otherwise `0`. See {{ domxref("KeyboardEvent.keyCode")
     }} for the list of key codes.
 - `charCode`
   - : An `unsigned long` representing the Unicode character associated with

--- a/files/en-us/web/api/keyboardevent/initkeyevent/index.md
+++ b/files/en-us/web/api/keyboardevent/initkeyevent/index.md
@@ -29,64 +29,40 @@ this way must have been created with the
 ## Syntax
 
 ```js
-initKeyEvent (type, bubbles, cancelable, viewArg,
-                    ctrlKeyArg, altKeyArg, shiftKeyArg, metaKeyArg,
-                    keyCodeArg, charCodeArg)
+initKeyEvent (type, bubbles, cancelable, view,
+                    ctrlKey, altKey, shiftKey, metaKey,
+                    keyCode, charCode)
 ```
 
 ### Parameters
 
-- _`type`_
+- `type`
   - : A string representing the type of event.
-- _`bubbles`_
+- `bubbles`
   - : A boolean value indicating whether the event should bubble up through the
     event chain or not (see [bubbles](/en-US/docs/Web/API/Event/bubbles)).
-- _`cancelable`_
+- `cancelable`
   - : A boolean value indicating whether the event can be canceled (see [cancelable](/en-US/docs/Web/API/Event/cancelable)).
-- _`viewArg`_
+- `view`
   - : Specifies the {{domxref("UIEvent.view")}}; this value may be `null`.
-- _`ctrlKeyArg`_
-
+- `ctrlKey`
   - : A boolean value that is `true` if the virtual key to be
-    generated is a combination of keys containing the
-
-    <kbd>Ctrl</kbd>
-
-    key.
-
-- _`altKeyArg`_
-
+    generated is a combination of keys containing the <kbd>Ctrl</kbd> key.
+- `altKey`
   - : A boolean value that is `true` if the virtual key to be
-    generated is a combination of keys containing the
-
-    <kbd>Alt</kbd>
-
-    key.
-
-- _`shiftKeyArg`_
-
+    generated is a combination of keys containing the <kbd>Alt</kbd> key.
+- `shiftKey`
   - : A boolean value that is `true` if the virtual key to be generated
-    is a combination of keys containing the
-
-    <kbd>Shift</kbd>
-
-    key.
-
-- _`metaKeyArg`_
-
+    is a combination of keys containing the <kbd>Shift</kbd>key.
+- `metaKey`
   - : A boolean value that is `true` if the virtual key to be
-    generated is a combination of keys containing the
-
-    <kbd>Meta</kbd>
-
-    key.
-
-- _`keyCodeArg`_
-  - : A `unsigned long` representing the virtual key code value of the key
+    generated is a combination of keys containing the <kbd>Meta</kbd> key.
+- `keyCode`
+  - : An `unsigned long` representing the virtual key code value of the key
     which was depressed, otherwise `0`. See {{ domxref("KeyboardEvent.keyCode")
     }} for the list of key codes.
-- _`charCodeArg`_
-  - : A `unsigned long` representing the Unicode character associated with
+- `charCode`
+  - : An `unsigned long` representing the Unicode character associated with
     the depressed key otherwise `0`.
 
 ### Return value

--- a/files/en-us/web/api/mouseevent/getmodifierstate/index.md
+++ b/files/en-us/web/api/mouseevent/getmodifierstate/index.md
@@ -20,12 +20,12 @@ See {{domxref("KeyboardEvent.getModifierState","KeyboardEvent.getModifierState()
 ## Syntax
 
 ```js
-getModifierState(keyArg)
+getModifierState(key)
 ```
 
 ### Parameters
 
-- _`keyArg`_
+- _`key`_
   - : A modifier key value.
     The value must be one of the {{domxref("KeyboardEvent.key")}} values which represent modifier keys or `"Accel"`{{deprecated_inline}}.
     This is case-sensitive.

--- a/files/en-us/web/api/progressevent/initprogressevent/index.md
+++ b/files/en-us/web/api/progressevent/initprogressevent/index.md
@@ -25,31 +25,21 @@ an animation event created using the deprecated {{domxref("Document.createEvent(
 ## Syntax
 
 ```js
-initProgressEvent(typeArg, canBubbleArg, cancelableArg, lengthComputable, loaded, total)
+initProgressEvent(type, canBubble, cancelable, lengthComputable, loaded, total)
 ```
 
 ### Parameters
 
-- `typeArg`
+- `type`
 
   - : A string identifying the specific type of animation event that
-    occurred. The following values are allowed:
-
-    | Value       | Meaning                                          |
-    | ----------- | ------------------------------------------------ |
-    | `loadstart` | The operation has started.                       |
-    | `progress`  | The operation still is in progress.              |
-    | `error`     | The operation failed and didn't complete.        |
-    | `abort`     | The operation was cancelled and didn't complete. |
-    | `load`      | The operation completed.                         |
-    | `loadend`   | The operation stopped.                           |
-
-- `canBubbleArg`
+    occurred. Browsers set it to one of the following values: `loadstart`, `progress`, `error`, `abort`, `load`, or `loadend`.
+- `canBubble`
   - : A boolean flag indicating if the event can bubble
-    (`true`) or not (`false)`.
-- `cancelableArg`
+    (`true`) or not (`false`).
+- `cancelable`
   - : A boolean flag indicating if the event associated action can be
-    avoided (`true`) or not (`false)`.
+    avoided (`true`) or not (`false`).
 - `lengthComputable`
   - : A boolean flag indicating if the total work to be done, and the
     amount of work already done, by the underlying process is calculable. In other words,

--- a/files/en-us/web/api/progressevent/initprogressevent/index.md
+++ b/files/en-us/web/api/progressevent/initprogressevent/index.md
@@ -33,7 +33,7 @@ initProgressEvent(type, canBubble, cancelable, lengthComputable, loaded, total)
 - `type`
 
   - : A string identifying the specific type of animation event that
-    occurred. Browsers set it to one of the following values: `loadstart`, `progress`, `error`, `abort`, `load`, or `loadend`.
+    occurred. Possible values are: `loadstart`, `progress`, `error`, `abort`, `load`, or `loadend`.
 - `canBubble`
   - : A boolean flag indicating if the event can bubble
     (`true`) or not (`false`).

--- a/files/en-us/web/api/settimeout/index.md
+++ b/files/en-us/web/api/settimeout/index.md
@@ -26,9 +26,9 @@ setTimeout(code, delay)
 
 setTimeout(functionRef)
 setTimeout(functionRef, delay)
-setTimeout(functionRef, delay, arg1)
-setTimeout(functionRef, delay, arg1, arg2)
-setTimeout(functionRef, delay, arg1, arg2, /* ... ,*/ argN)
+setTimeout(functionRef, delay, param1)
+setTimeout(functionRef, delay, param1, param2)
+setTimeout(functionRef, delay, param1, param2, /* ... ,*/ paramN)
 ```
 
 ### Parameters
@@ -47,9 +47,9 @@ setTimeout(functionRef, delay, arg1, arg2, /* ... ,*/ argN)
 
     Note that in either case, the actual delay may be longer than intended; see [Reasons for delays longer than specified](#reasons_for_delays_longer_than_specified) below.
 
-    Also note that if the value isn’t a number, implicit [type coercion](/en-US/docs/Glossary/Type_coercion) is silently done on the value to convert it to a number — which can lead to unexpected and surprising results; see [Non-number delay values are silently coerced into numbers](#non-number_delay_values_are_silently_coerced_into_numbers) for an example.
+    Also note that if the value isn't a number, implicit [type coercion](/en-US/docs/Glossary/Type_coercion) is silently done on the value to convert it to a number — which can lead to unexpected and surprising results; see [Non-number delay values are silently coerced into numbers](#non-number_delay_values_are_silently_coerced_into_numbers) for an example.
 
-- `arg1`, …, argN` {{optional_inline}}
+- `param1`, …, `paramN` {{optional_inline}}
 
   - : Additional arguments which are passed through to the function specified by
     `function`.

--- a/files/en-us/web/api/transitionevent/inittransitionevent/index.md
+++ b/files/en-us/web/api/transitionevent/inittransitionevent/index.md
@@ -31,31 +31,25 @@ method.
 ## Syntax
 
 ```js
-initTransitionEvent(typeArg, canBubbleArg, cancelableArg, transitionNameArg, elapsedTimeArg)
+initTransitionEvent(type, canBubble, cancelable, transitionName, elapsedTime)
 ```
 
 ### Parameters
 
-- `typeArg`
-
+- `type`
   - : A string identifying the specific type of transition event that
-    occurred. The following value is allowed:
-
-    | Value           | Meaning                   |
-    | --------------- | ------------------------- |
-    | `transitionend` | The transition completed. |
-
-- `canBubbleArg`
+    occurred. Browsers always set it up to `transitionend`.
+- `canBubble`
   - : A boolean flag indicating if the event can bubble
-    (`true`) or not (`false)`.
-- `cancelableArg`
+    (`true`) or not (`false`).
+- `cancelable`
   - : A boolean flag indicating if the event associated action can be
-    avoided (`true`) or not (`false)`.
-- `transitionNameArg`
+    avoided (`true`) or not (`false`).
+- `transitionName`
   - : A string containing the name of the CSS property associated
     with the transition. This value is not affected by the {{cssxref("transition-delay")}}
     property.
-- `elapsedTimeArg`
+- `elapsedTime`
   - : Is `float` giving the amount of time the transition has been running, in
     seconds, when this event fired.
 


### PR DESCRIPTION
This PR renames parameters name of the form xxxArg (except those called thisArg as I don't have a good name for it):
- We don't use the word argument on MDN but use parameter instead (we don't make the subtle distinction between both terms).
- `blablaArg` is more complex to read than `blabla`.
- The context is obvious, so no need to stress they are parameters/arguments.