### PR TITLE
Remove mentions of IDL dictionaries

### DIFF
--- a/files/en-us/web/api/blob/blob/index.md
+++ b/files/en-us/web/api/blob/blob/index.md
@@ -30,10 +30,7 @@ new Blob(array, options)
     objects, that will be put inside the {{domxref("Blob")}}. `USVString`
     objects are encoded as UTF-8.
 - `options` {{optional_inline}}
-
-  - : An optional object of type {{domxref("BlobPropertyBag")}} which may specify any of
-    the following properties:
-
+  - : An object which may specify any of the following properties:
     - `type` {{optional_inline}}
       - : The {{Glossary("MIME type")}} of the data that will be stored into the blob. The
         default value is the empty string, (`""`).

--- a/files/en-us/web/api/channelmergernode/channelmergernode/index.md
+++ b/files/en-us/web/api/channelmergernode/channelmergernode/index.md
@@ -26,27 +26,23 @@ new ChannelMergerNode(context, options)
 - `context`
   - : A {{domxref("BaseAudioContext")}} representing the audio context you want the node to be associated with.
 - `options` {{optional_inline}}
-
-  - : A [`ChannelMergerOptions`](https://webaudio.github.io/web-audio-api/#idl-def-ChannelMergerOptions) dictionary object defining the properties you want the `ChannelMergerNode` to have:
-
-    - `numberOfInputs`
+  - : An object defining the properties you want the `ChannelMergerNode` to have:
+    - `numberOfInputs` {{optional_inline}}
       - : A number defining the number of inputs the {{domxref("ChannelMergerNode")}} should have. If not specified, the default value used is 6.
-    - `channelCount`
-      - : Represents an integer used to determine how many channels are used when [up-mixing
-        and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing) connections to any inputs to the node. (See
-        {{domxref("AudioNode.channelCount")}} for more information.) Its usage and precise
-        definition depend on the value of `channelCountMode`.
-    - `channelCountMode`
-      - : Represents an enumerated value describing the way channels must be matched between
+    - `channelCount`  {{optional_inline}}
+      - : An integer used to determine how many channels are used when [up-mixing and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing) connections to any inputs to the node.
+        (See {{domxref("AudioNode.channelCount")}} for more information.)
+        Its usage and precise definition depend on the value of `channelCountMode`.
+    - `channelCountMode` {{optional_inline}}
+      - : A string describing the way channels must be matched between
         the node's inputs and outputs. (See {{domxref("AudioNode.channelCountMode")}} for more
         information including default values.)
-    - `channelInterpretation`
-      - : Represents an enumerated value describing the meaning of the channels. This
-        interpretation will define how audio [up- `mixing`
-        and down- `mixing`    ](/en- `US`    /docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up- `mixing`    and_down- `mixing`    ) will happen.
-        The possible values are `"speakers"` or `"discrete"`. (See
-        {{domxref("AudioNode.channelCountMode")}} for more information including default
-        values.)
+    - `channelInterpretation` {{optional_inline}}
+      - : A string describing the meaning of the channels.
+        This interpretation will define how audio
+        [up-mixing and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down_mixing) will happen.
+        The possible values are `"speakers"` or `"discrete"`.
+        (See {{domxref("AudioNode.channelCountMode")}} for more information including default values.)
 
 ### Return value
 

--- a/files/en-us/web/api/channelsplitternode/channelsplitternode/index.md
+++ b/files/en-us/web/api/channelsplitternode/channelsplitternode/index.md
@@ -29,26 +29,21 @@ new ChannelSpitterNode(context, options)
   - : A {{domxref("BaseAudioContext")}} representing the audio context you want the node to be associated with.
 - `options` {{optional_inline}}
 
-  - : A [`ChannelSplitterOptions`](https://webaudio.github.io/web-audio-api/#idl-def-ChannelSplitterOptions) dictionary object defining the properties you want the `ChannelSplitterNode` to have:
-
-    - `numberOfOutputs`
+  - : An object defining the properties you want the `ChannelSplitterNode` to have:
+    - `numberOfOutputs` {{optional_inline}}
       - : A number defining the number of inputs the {{domxref("ChannelSplitterNode")}} should have. If not specified, the default value used is 6.
-    - `channelCount`
-      - : Represents an integer used to determine how many channels are used when [up-mixing
-        and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing) connections to any inputs to the node. (See
-        {{domxref("AudioNode.channelCount")}} for more information.) Its usage and precise
-        definition depend on the value of `channelCountMode`.
-    - `channelCountMode`
-      - : Represents an enumerated value describing the way channels must be matched between
-        the node's inputs and outputs. (See {{domxref("AudioNode.channelCountMode")}} for more
-        information including default values.)
-    - `channelInterpretation`
-      - : Represents an enumerated value describing the meaning of the channels. This
-        interpretation will define how audio [up-mixing
-        and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing) will happen.
-        The possible values are `"speakers"` or `"discrete"`. (See
-        {{domxref("AudioNode.channelCountMode")}} for more information including default
-        values.)
+    - `channelCount` {{optional_inline}}
+      - : An integer used to determine how many channels are used when [up-mixing and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing) connections to any inputs to the node.
+        (See {{domxref("AudioNode.channelCount")}} for more information.)
+        Its usage and precise definition depend on the value of `channelCountMode`.
+    - `channelCountMode` {{optional_inline}}
+      - : A string describing the way channels must be matched between the node's inputs and outputs.
+        (See {{domxref("AudioNode.channelCountMode")}} for more information including default values.)
+    - `channelInterpretation` {{optional_inline}}
+      - : A string describing the meaning of the channels.
+        This interpretation will define how audio [up-mixing and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing) will happen.
+        The possible values are `"speakers"` or `"discrete"`.
+        (See {{domxref("AudioNode.channelCountMode")}} for more information including default values.)
 
 ### Return value
 

--- a/files/en-us/web/api/clipboarditem/clipboarditem/index.md
+++ b/files/en-us/web/api/clipboarditem/clipboarditem/index.md
@@ -33,7 +33,7 @@ new ClipboardItem(data, options)
 - `options` {{optional_inline}}
   - : An object with the following properties:
     - `presentationStyle` {{optional_inline}}
-      - : One of the 3 strings: `unspecified`, `inline` or `attachment`. The default is `unspecified`.
+      - : One of the three strings: `unspecified`, `inline` or `attachment`. The default is `unspecified`.
 
 > **Note:** You can also work with text via the {{domxref("Clipboard.readText()")}} and {{domxref("Clipboard.writeText()")}} methods of the {{domxref("Clipboard")}}
 > interface.

--- a/files/en-us/web/api/clipboarditem/clipboarditem/index.md
+++ b/files/en-us/web/api/clipboarditem/clipboarditem/index.md
@@ -22,19 +22,18 @@ The **`ClipboardItem()`** constructor of the {{domxref("Clipboard API")}} create
 ## Syntax
 
 ```js
-new ClipboardItem(clipboardItemData)
-new ClipboardItem(clipboardItemData, clipboardItemOptions)
+new ClipboardItem(data)
+new ClipboardItem(data, options)
 ```
 
 ### Parameters
 
-- `clipboardItemData`
+- `data`
   - : An {{jsxref("Object")}} with the {{Glossary("MIME type")}} as the key and data as the value. The data can be represented as a {{domxref("Blob")}}, a {{jsxref("String")}} or a {{jsxref("Promise")}} which resolves to either a blob or string.
-- `clipboardItemOptions` {{optional_inline}}
-
-  - : An {{jsxref("Object")}} with the following properties:
-
-    - **`presentationStyle`**: One of `"unspecified"`, `"inline"` or `"attachment"`. The default is `"unspecified"`.
+- `options` {{optional_inline}}
+  - : An object with the following properties:
+    - `presentationStyle` {{optional_inline}}
+      - : One of the 3 strings: `unspecified`, `inline` or `attachment`. The default is `unspecified`.
 
 > **Note:** You can also work with text via the {{domxref("Clipboard.readText()")}} and {{domxref("Clipboard.writeText()")}} methods of the {{domxref("Clipboard")}}
 > interface.

--- a/files/en-us/web/api/documenttimeline/documenttimeline/index.md
+++ b/files/en-us/web/api/documenttimeline/documenttimeline/index.md
@@ -25,7 +25,11 @@ new DocumentTimeline(options)
 ### Parameters
 
 - `options`
-  - : An object specifying options for the new timeline. Currently the only supported option is the `originTime` member which specifies the zero time for the `documentTimeline` as a real number of milliseconds relative to the {{domxref("PerformanceTiming.navigationStart","navigationStart")}} moment of the active document for the current browsing context.
+  - : An object specifying options for the new timeline. The following properties are available:
+    - `originTime`
+      - : A number which specifies the zero time for the `documentTimeline`
+        as a real number of milliseconds relative to the {{domxref("PerformanceTiming.navigationStart","navigationStart")}} moment of the active document
+        for the current browsing context.
 
 ## Examples
 

--- a/files/en-us/web/api/documenttimeline/documenttimeline/index.md
+++ b/files/en-us/web/api/documenttimeline/documenttimeline/index.md
@@ -27,8 +27,8 @@ new DocumentTimeline(options)
 - `options`
   - : An object specifying options for the new timeline. The following properties are available:
     - `originTime`
-      - : A number which specifies the zero time for the `documentTimeline`
-        as a real number of milliseconds relative to the {{domxref("PerformanceTiming.navigationStart","navigationStart")}} moment of the active document
+      - : A number that specifies the zero time for the `documentTimeline`
+        as a real number of milliseconds relative to the {{domxref("PerformanceTiming.navigationStart","navigationStart")}} time of the active document
         for the current browsing context.
 
 ## Examples

--- a/files/en-us/web/api/encodedaudiochunk/encodedaudiochunk/index.md
+++ b/files/en-us/web/api/encodedaudiochunk/encodedaudiochunk/index.md
@@ -15,12 +15,12 @@ The **`EncodedAudioChunk()`** constructor creates a new {{domxref("EncodedAudioC
 ## Syntax
 
 ```js
-new EncodedAudioChunk(init)
+new EncodedAudioChunk(options)
 ```
 
 ### Parameters
 
-- `init`
+- `options`
   - : An object containing the following members:
     - `type`
       - : Indicates if the chunk is a key chunk that does not rely on other frames for encoding. One of:

--- a/files/en-us/web/api/encodedvideochunk/encodedvideochunk/index.md
+++ b/files/en-us/web/api/encodedvideochunk/encodedvideochunk/index.md
@@ -15,12 +15,12 @@ The **`EncodedVideoChunk()`** constructor creates a new {{domxref("EncodedVideoC
 ## Syntax
 
 ```js
-new EncodedVideoChunk(init)
+new EncodedVideoChunk(options)
 ```
 
 ### Parameters
 
-- `init`
+- `options`
   - : An object containing the following members:
     - `type`
       - : Indicates if the chunk is a key chunk that does not rely on other frames for encoding. One of:

--- a/files/en-us/web/api/eventsource/eventsource/index.md
+++ b/files/en-us/web/api/eventsource/eventsource/index.md
@@ -19,7 +19,7 @@ remote resource.
 
 ```js
 new EventSource(url)
-new EventSource(url, configuration)
+new EventSource(url, options)
 ```
 
 ### Parameters
@@ -27,12 +27,13 @@ new EventSource(url, configuration)
 - `url`
   - : A string that represents the location of the remote resource
     serving the events/messages.
-- `configuration` {{optional_inline}}
+- `options` {{optional_inline}}
 
   - : Provides options to configure the new connection. The possible entries are:
 
-    - `withCredentials`, defaulting to `false`, indicating if
-      CORS should be set to `include` credentials.
+    - `withCredentials` {{optional_inline}}
+      - : A boolean value, defaulting to `false`, indicating
+        if CORS should be set to `include` credentials.
 
 ## Examples
 

--- a/files/en-us/web/api/mediaelementaudiosourcenode/mediaelementaudiosourcenode/index.md
+++ b/files/en-us/web/api/mediaelementaudiosourcenode/mediaelementaudiosourcenode/index.md
@@ -25,22 +25,20 @@ new MediaElementAudioSourceNode(context, options)
 - `context`
   - : An {{domxref("AudioContext")}} representing the audio context you want the node to be associated with.
 - `options`
-
-  - : A `MediaElementAudioSourceOptions` dictionary object defining the properties you want the `MediaElementAudioSourceNode` to have:
-
+  - : An object defining the properties you want the `MediaElementAudioSourceNode` to have:
     - `mediaElement`
       - : An {{domxref("HTMLMediaElement")}} that will be used as the source for the audio.
     - `channelCount`
-      - : Represents an integer used to determine how many channels are used when [up-mixing
+      - : An integer used to determine how many channels are used when [up-mixing
         and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing) connections to any inputs to the node. (See
         {{domxref("AudioNode.channelCount")}} for more information.) Its usage and precise
         definition depend on the value of `channelCountMode`.
     - `channelCountMode`
-      - : Represents an enumerated value describing the way channels must be matched between
+      - : A string describing the way channels must be matched between
         the node's inputs and outputs. (See {{domxref("AudioNode.channelCountMode")}} for more
         information including default values.)
     - `channelInterpretation`
-      - : Represents an enumerated value describing the meaning of the channels. This
+      - : A string describing the meaning of the channels. This
         interpretation will define how audio [up-mixing
         and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing) will happen.
         The possible values are `"speakers"` or `"discrete"`. (See

--- a/files/en-us/web/api/mediastreamaudiodestinationnode/mediastreamaudiodestinationnode/index.md
+++ b/files/en-us/web/api/mediastreamaudiodestinationnode/mediastreamaudiodestinationnode/index.md
@@ -30,16 +30,16 @@ new MediaStreamAudioDestinationNode(context, options)
   - : An object defining the properties you want the `MediaStreamAudioDestinationNode` to have:
 
     - `channelCount`
-      - : Represents an integer used to determine how many channels are used when [up-mixing
+      - : An integer used to determine how many channels are used when [up-mixing
         and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing) connections to any inputs to the node. (See
         {{domxref("AudioNode.channelCount")}} for more information.) Its usage and precise
         definition depend on the value of `channelCountMode`.
     - `channelCountMode`
-      - : Represents an enumerated value describing the way channels must be matched between
+      - : A string describing the way channels must be matched between
         the node's inputs and outputs. (See {{domxref("AudioNode.channelCountMode")}} for more
         information including default values.)
     - `channelInterpretation`
-      - : Represents an enumerated value describing the meaning of the channels. This
+      - : A string describing the meaning of the channels. This
         interpretation will define how audio [up-mixing
         and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing) will happen.
         The possible values are `"speakers"` or `"discrete"`. (See

--- a/files/en-us/web/api/mediastreamaudiosourcenode/mediastreamaudiosourcenode/index.md
+++ b/files/en-us/web/api/mediastreamaudiosourcenode/mediastreamaudiosourcenode/index.md
@@ -35,8 +35,7 @@ new MediaStreamAudioSourceNode(context, options)
     be associated with.
 - `options`
 
-  - : An object defining the properties you
-    want the `MediaStreamAudioSourceNode` to have:
+  - : An object defining the properties you want the `MediaStreamAudioSourceNode` to have:
 
     - `mediaStream`
       - : A required property which specifies the {{domxref("MediaStream")}} from which to obtain audio for the node.


### PR DESCRIPTION
Remove the mention of the names of the IDL dictionaries.

These names are not available in debuggers and doesn't bring anything to the reader.