### PR TITLE
Fix case of a CSS property

### DIFF
--- a/files/en-us/web/api/globaleventhandlers/onclick/index.md
+++ b/files/en-us/web/api/globaleventhandlers/onclick/index.md
@@ -61,7 +61,7 @@ This example changes the color of an element when it's clicked upon.
 document.getElementById('demo').onclick = function changeContent() {
 
    document.getElementById('demo').textContent = "Help me";
-   document.getElementById('demo').style = "Color: red";
+   document.getElementById('demo').style = "color: red";
 
 }
 ```


### PR DESCRIPTION
Lowercase CSS property .

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Minor case correction for CSS property => from `Color` to `color`

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
To ensure consistency with the MDN docs.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
The CSS `color` property should be lowercase as per the [docs](https://developer.mozilla.org/en-US/docs/Web/CSS/color).
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
N/A

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
