### PR TITLE
Fixing the bug in display_genre

### DIFF
--- a/files/en-us/learn/server-side/django/admin_site/index.md
+++ b/files/en-us/learn/server-side/django/admin_site/index.md
@@ -218,9 +218,9 @@ Unfortunately we can't directly specify the `genre` field in `list_display` beca
 Add the following code into your `Book` model (**models.py**). This creates a string from the first three values of the `genre` field (if they exist) and creates a `short_description` that can be used in the admin site for this method.
 
 ```python
-def display_genre(self):
+def display_genre(self, book):
     """Create a string for the Genre. This is required to display genre in Admin."""
-    return ', '.join(genre.name for genre in self.genre.all()[:3])
+    return ', '.join(genre.name for genre in book.genre.all()[:3])
 
 display_genre.short_description = 'Genre'
 ```


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The function **display_genre** in class **BookAdmin** should take the argument **book** in addition to the **self** argument.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
It is a bug in a code snippet. The code from the snippet doesn't work as it is. It works after making the change proposed in this pull request.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- ✅ Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
