### PR TITLE
Replace external broken link to the link to the original source

### DIFF
--- a/files/en-us/web/guide/api/webrtc/peer-to-peer_communications_with_webrtc/index.md
+++ b/files/en-us/web/guide/api/webrtc/peer-to-peer_communications_with_webrtc/index.md
@@ -26,7 +26,7 @@ A high-level description of what happens in an `RTCPeerConnection` was shown in 
 ## Resources
 
 - A good tutorial on basic features in WebRTC is at [HTML5 Rocks](https://www.html5rocks.com/en/tutorials/webrtc/basics/).   A collection of basic test pages to support development are at [webrtc-landing](https://mozilla.github.io/webrtc-landing/).
-- You can make simple person-to-person calls (including to people using Chrome) at [apprtc.appspot.com](https://apprtc.appspot.com/).
+- You can make simple person-to-person calls using [apprtc](https://github.com/webrtc/apprtc).
 - A high-level description of what happens in an `RTCPeerConnection` was shown in the [Mozilla Hacks](https://hacks.mozilla.org/category/webrtc/) blog article [Embedding WebRTC video chat](https://hacks.mozilla.org/2013/05/embedding-webrtc-video-chat-right-into-your-website/).
 
 ## Specifications


### PR DESCRIPTION
Fixes #16188

(I don't think there is a live, and free, demo available (all demos I found are collecting data)