### PR TITLE
Fix broken link to aria-haspopup

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/combobox_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/combobox_role/index.md
@@ -52,7 +52,7 @@ Every `combobox` must have an accessible name. If using an {{HTMLElement('input'
 
 - [`aria-expanded`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-expanded)
   - : Required. Identifies whether the combobox is open (`true`) or closed (`false`).
-- [`aria-haspopup`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-)
+- [`aria-haspopup`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-haspopup)
   - : Implied. If omitted, defaults to `listbox`. Also supports `tree`, `grid`, or `dialog`. Identifies the combobox has having a popout, and indicates the type.
 
 ### Keyboard interactions


### PR DESCRIPTION
Fixes a broken link to aria-haspopup

#### Summary
This PR fixes a broken link to aria-haspopup documentation

#### Motivation
It was an issue that needed to be fixed

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
