### PR TITLE
Switch "things" to "properties"

### DIFF
--- a/files/en-us/glossary/accessibility_tree/index.md
+++ b/files/en-us/glossary/accessibility_tree/index.md
@@ -12,7 +12,7 @@ The **accessibility tree** contains {{Glossary("accessibility")}}-related inform
 
 Browsers convert markup into an internal representation called the _[DOM tree](/en-US/docs/Web/API/Document_object_model/How_to_create_a_DOM_tree)_. The DOM tree contains objects representing all the markup's elements, attributes, and text nodes. Browsers then create an accessibility tree based on the DOM tree, which is used by platform-specific Accessibility APIs to provide a representation that can be understood by assistive technologies, such as screen readers.
 
-There are four things in an accessibility tree object:
+There are four properties in an accessibility tree object:
 
 - **name**
   - : How can we refer to this thing? For instance, a link with the text "Read more" will have "Read more" as its name (find more on how names are computed in the [Accessible Name and Description Computation spec](https://www.w3.org/TR/accname-1.1/)).


### PR DESCRIPTION
#### Summary
The word, "properties" is more applicable in the context of an object.

#### Motivation
To make the categorization more recognizable from a programming perspective.

#### Supporting details
[Property (programming)](https://en.wikipedia.org/wiki/Property_(programming)#:~:text=A%20property%2C%20in%20some%20object,value%20of%20a%20private%20field.)

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error