### PR TITLE
Updating animatable properties' link

### DIFF
--- a/files/en-us/web/css/animation/index.md
+++ b/files/en-us/web/css/animation/index.md
@@ -27,7 +27,7 @@ animation: slidein 3s linear 1s;
 animation: slidein 3s;
 ```
 
-A [description of which properties are animatable](/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions#which_css_properties_are_animatable) is available; it's worth noting that this description is also valid for [CSS transitions](/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions).
+A [description of which properties are animatable](/en-US/docs/Web/CSS/CSS_animated_properties) is available; it's worth noting that this description is also valid for [CSS transitions](/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions).
 
 ## Constituent properties
 


### PR DESCRIPTION
I updated the link in the paragraph after the examples:

https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions#which_css_properties_are_animatable > https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_animated_properties