### PR TITLE
Update link to GitHub module examples

### DIFF
--- a/files/en-us/web/javascript/guide/modules/index.md
+++ b/files/en-us/web/javascript/guide/modules/index.md
@@ -34,7 +34,7 @@ Use of native JavaScript modules is dependent on the {{JSxRef("Statements/import
 
 ## Introducing an example
 
-To demonstrate usage of modules, we've created a [simple set of examples](https://github.com/mdn/js-examples/tree/master/modules) that you can find on GitHub. These examples demonstrate a simple set of modules that create a [`<canvas>`](/en-US/docs/Web/HTML/Element/canvas) element on a webpage, and then draw (and report information about) different shapes on the canvas.
+To demonstrate usage of modules, we've created a [simple set of examples](https://github.com/mdn/js-examples/tree/master/module-examples) that you can find on GitHub. These examples demonstrate a simple set of modules that create a [`<canvas>`](/en-US/docs/Web/HTML/Element/canvas) element on a webpage, and then draw (and report information about) different shapes on the canvas.
 
 These are fairly trivial, but have been kept deliberately simple to demonstrate modules clearly.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
The old url links to a path which doesn't exist anymore on that GitHub repo.
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The link on [JavaScript Modules - Introducing an example](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#introducing_an_example) pointed to a directory which doesn't exist anymore on the repo and this should help others not see a broken link.

Broken link:
> ...we've created a [simple set of examples](https://github.com/mdn/js-examples/tree/master/modules) that you can find...

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Just below  [JavaScript Modules - Introducing an example](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#introducing_an_example), in [JavaScript Modules - Basic example structure](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules#basic_example_structure), there was already a link to the correct directory in the repo:

> ...In our first example (see [basic-modules](https://github.com/mdn/js-examples/tree/master/module-examples/basic-modules)) we have a file structure...

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
