### PR TITLE
Minor grammar fix

### DIFF
--- a/files/en-us/web/css/css_positioning/understanding_z_index/the_stacking_context/index.md
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/the_stacking_context/index.md
@@ -23,7 +23,7 @@ A stacking context is formed, anywhere in the document, by any element in the fo
 - Element with a {{cssxref("position")}} value `fixed` or `sticky` (sticky for all mobile browsers, but not older desktop).
 - Element that is a child of a [flex](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox) container, with {{cssxref("z-index")}} value other than `auto`.
 - Element that is a child of a {{cssxref("grid")}} container, with {{cssxref("z-index")}} value other than `auto`.
-- Element with a {{cssxref("opacity")}} value less than `1` (See [the specification for opacity](https://www.w3.org/TR/css-color-3/#transparency)).
+- Element with an {{cssxref("opacity")}} value less than `1` (See [the specification for opacity](https://www.w3.org/TR/css-color-3/#transparency)).
 - Element with a {{cssxref("mix-blend-mode")}} value other than `normal`.
 - Element with any of the following properties with value other than `none`:
 
@@ -34,7 +34,7 @@ A stacking context is formed, anywhere in the document, by any element in the fo
   - {{cssxref("clip-path")}}
   - {{cssxref("mask")}} / {{cssxref("mask-image")}} / {{cssxref("mask-border")}}
 
-- Element with a {{cssxref("isolation")}} value `isolate`.
+- Element with an {{cssxref("isolation")}} value `isolate`.
 - Element with a {{cssxref("will-change")}} value specifying any property that would create a stacking context on non-initial value (see [this post](https://dev.opera.com/articles/css-will-change-property/)).
 - Element with a {{cssxref("contain")}} value of `layout`, or `paint`, or a composite value that includes either of them (i.e. `contain: strict`, `contain: content`).
 


### PR DESCRIPTION
Updates two instances of word "a" to the word "an", following proper English grammar conventions

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
This is a minor fix on grammatical usage of "a" vs "an" that I noticed while referencing MDN's "The stacking context" page.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I thought this would be an simple grammar update which generally improves the reading experience on MDN.  Usage of "a" vs "an" does serve a minor function in the English language towards making a sentence's flow of speech smoother and more understandable.  I often read aloud when studying as a reinforcement technique and stumble on minor errors like "a apple" instead of "an apple", which takes away from the reading experience.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Online resource detailing grammatical usage of "a" vs "an", from a website referenced in the MDN writing style guide page: https://brians.wsu.edu/2016/05/16/aan/

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
