### PR TITLE
Actions: Escape slashes in issue-regex-labeler.yml

### DIFF
--- a/.github/issue-regex-labeler.yml
+++ b/.github/issue-regex-labeler.yml
@@ -1,50 +1,50 @@
 Content:Accessibility:
-  - '/docs/Web/Accessibility'
+  - '\/docs\/Web\/Accessibility'
 Content:CSS:
-  - '/docs/Web/CSS'
+  - '\/docs\/Web\/CSS'
 Content:Events:
-  - '/docs/Web/Events'
+  - '\/docs\/Web\/Events'
 Content:Glossary:
-  - '/docs/Glossary'
+  - '\/docs\/Glossary'
 Content:HTML:
-  - '/docs/Web/HTML'
+  - '\/docs\/Web\/HTML'
 Content:HTTP:
-  - '/docs/Web/HTTP'
+  - '\/docs\/Web\/HTTP'
 Content:JS:
-  - '/docs/Web/JavaScript'
+  - '\/docs\/Web\/JavaScript'
 Content:Learn:
-  - '/docs/Learn/(Common|Front|Getting|Learning|Performance)'
+  - '\/docs\/Learn\/(Common|Front|Getting|Learning|Performance)'
 Content:Learn:Accessibility:
-  - '/docs/Learn/Accessibility'
+  - '\/docs\/Learn\/Accessibility'
 Content:Learn:Client-side:
-  - '/docs/Learn/Tools_and_testing/(Client-side|Understanding_client-side)'
+  - '\/docs\/Learn\/Tools_and_testing\/(Client-side|Understanding_client-side)'
 Content:Learn:Cross-Browser-Testing:
-  - '/docs/Learn/Tools_and_testing/Cross_browser_testing'
+  - '\/docs\/Learn\/Tools_and_testing\/Cross_browser_testing'
 Content:Learn:CSS:
-  - '/docs/Learn/CSS'
+  - '\/docs\/Learn\/CSS'
 Content:Learn:Django:
-  - '/docs/Learn/Server-side/Django'
+  - '\/docs\/Learn\/Server-side\/Django'
 Content:Learn:Forms:
-  - '/docs/Learn/Forms'
+  - '\/docs\/Learn\/Forms'
 Content:Learn:GitHub:
-  - '/docs/Learn/Tools_and_testing/GitHub'
+  - '\/docs\/Learn\/Tools_and_testing\/GitHub'
 Content:Learn:HTML:
-  - '/docs/Learn/HTML'
+  - '\/docs\/Learn\/HTML'
 Content:Learn:JavaScript:
-  - '/docs/Learn/JavaScript'
+  - '\/docs\/Learn\/JavaScript'
 Content:Manifest:
-  - '/docs/Web/Manifest'
+  - '\/docs\/Web\/Manifest'
 Content:Performance:
-  - '/docs/Web/Performance'
+  - '\/docs\/Web\/Performance'
 Content:Security:
-  - '/docs/Web/Security'
+  - '\/docs\/Web\/Security'
 Content:SVG:
-  - '/docs/Web/SVG'
+  - '\/docs\/Web\/SVG'
 Content:wasm:
-  - '/docs/WebAssembly'
+  - '\/docs\/WebAssembly'
 Content:WebAPI:
-  - '/docs/Web/API'
+  - '\/docs\/Web\/API'
 Content:WebDriver:
-  - '/docs/Web/WebDriver'
+  - '\/docs\/Web\/WebDriver'
 Content:WebExt:
-  - '/docs/Mozilla/Add-ons'
+  - '\/docs\/Mozilla\/Add-ons'


### PR DESCRIPTION
This change un-breaks our _“Label issues by MDN URL or other regex match in issue description”_ GitHub Action — which has been broken since May 14, when we upgraded our github/issue-labeler version from v2.0 to v4.1 in https://github.com/mdn/content/commit/fcaab4f.

Otherwise, without this change, when github/issue-labeler v4.1+ see slashes in the paths/slugs in our `issue-regex-labeler.yml` — for example, `'/docs/Web/Accessibility'` — the slashes don’t get parsed as literal slashes but instead are considered to be delimiters of the start and end of regex patterns. And that causes a failure with:

> Error: SyntaxError: Invalid flags supplied to RegExp constructor 'Accessibility'