### PR TITLE
Drop Specifications table from ALPN glossary entry

### DIFF
--- a/files/en-us/glossary/alpn/index.md
+++ b/files/en-us/glossary/alpn/index.md
@@ -8,19 +8,13 @@ tags:
   - NeedsContent
   - TLS
 ---
-**Application-Layer {{Glossary("Protocol")}} Negotiation** (**ALPN**) is a {{Glossary("TLS")}} extension which indicates what application layer protocol is negotiating the encrypted connection without requiring additional round trips.
+**Application-Layer Protocol Negotiation** (**ALPN**) is a {{Glossary("TLS")}} extension (defined in [RFC 7301](https://www.rfc-editor.org/rfc/rfc7301)) for identifying what application-layer protocol is negotiating the encrypted connection, without requiring additional round trips to do so.
 
 | Protocol                                       | Identification sequence                                |
 | ---------------------------------------------- | ------------------------------------------------------ |
-| {{Glossary("HTTP")}}/1.1               | `0x68 0x74 0x74 0x70 0x2F 0x31 0x2E 0x31` ("http/1.1") |
+| {{Glossary("HTTP", "HTTP/1.1")}}               | `0x68 0x74 0x74 0x70 0x2F 0x31 0x2E 0x31` ("http/1.1") |
 | {{Glossary("HTTP 2", "HTTP/2")}}   | `0x68 0x32` ("h2")                                     |
 | HTTP/2 over cleartext {{Glossary("TCP")}} | `0x68 0x32 0x63` ("h2c")                               |
-
-## Specifications
-
-| Specification    | Status   | Notes               |
-| ---------------- | -------- | ------------------- |
-| {{RFC(7301)}} | IETF RFC | Initial definition. |
 
 ## See also
 


### PR DESCRIPTION
The ALPN glossary entry is the only entry in the Glossary with a Specifications
section/table. It’s really not necessary for a glossary entry to have a spec
table, so this change replaces the table with a simple inline hyperlink to
the spec. The change also makes a couple other minor fixes.