### PR TITLE
Migrate to {{Specifications}}

### DIFF
--- a/files/en-us/web/api/decompressionstream/writable/index.md
+++ b/files/en-us/web/api/decompressionstream/writable/index.md
@@ -26,22 +26,9 @@ let stream = new DecompressionStream('gzip');
 console.log(stream.writeable); //a WritableStream
 ```
 
-<table class="no-markdown">
-  <tbody>
-    <tr>
-      <th scope="col">Specification</th>
-      <th scope="col">Status</th>
-      <th scope="col">Comment</th>
-    </tr>
-    <tr>
-      <td>
-        {{SpecName('Streams','#dom-generictransformstream-writable','writable')}}
-      </td>
-      <td>{{Spec2('Streams')}}</td>
-      <td>Initial definition.</td>
-    </tr>
-  </tbody>
-</table>
+## Specifications
+
+{{Specifications}}
 
 ## Browser compatibility
 


### PR DESCRIPTION
This page had no `## Specifications` section so the migration script missed it.

This PR fixes this.