### PR TITLE
Touch.* are no more experimental

### DIFF
--- a/files/en-us/web/api/touch/force/index.md
+++ b/files/en-us/web/api/touch/force/index.md
@@ -3,13 +3,12 @@ title: Touch.force
 slug: Web/API/Touch/force
 tags:
   - API
-  - Experimental
   - Property
   - Read-only
   - touch
 browser-compat: api.Touch.force
 ---
-{{ APIRef("Touch Events") }}{{SeeCompatTable}}
+{{ APIRef("Touch Events") }}
 
 The **`Touch.force`** read-only property returns the amount of
 pressure the user is applying to the touch surface for a {{ domxref("Touch") }} point.

--- a/files/en-us/web/api/touch/radiusx/index.md
+++ b/files/en-us/web/api/touch/radiusx/index.md
@@ -4,7 +4,6 @@ slug: Web/API/Touch/radiusX
 tags:
   - API
   - DOM
-  - Experimental
   - Mobile
   - Property
   - touch
@@ -12,13 +11,9 @@ browser-compat: api.Touch.radiusX
 ---
 {{ APIRef("Touch Events") }}
 
-## Summary
-
-Returns the X radius of the ellipse that most closely circumscribes the area of contact with the touch surface. The value is in CSS pixels of the same scale as {{ domxref("Touch.screenX") }}.
+The **`radiusX`** read-only property of the {{domxref("Touch")}} interface returns the X radius of the ellipse that most closely circumscribes the area of contact with the touch surface. The value is in CSS pixels of the same scale as {{ domxref("Touch.screenX") }}.
 
 This value, in combination with {{ domxref("Touch.radiusY") }} and {{ domxref("Touch.rotationAngle") }} constructs an ellipse that approximates the size and shape of the area of contact between the user and the screen. This may be a relatively large ellipse representing the contact between a fingertip and the screen or a small area representing the tip of a stylus, for example.
-
-> **Note:** This attribute has _not_ been formally standardized. It is specified in the {{SpecName('Touch Events 2')}} {{Spec2('Touch Events 2')}} specification and not in {{SpecName('Touch Events')}} {{Spec2('Touch Events')}}. This attribute is not widely implemented.
 
 ## Value
 

--- a/files/en-us/web/api/touch/radiusy/index.md
+++ b/files/en-us/web/api/touch/radiusy/index.md
@@ -4,7 +4,6 @@ slug: Web/API/Touch/radiusY
 tags:
   - API
   - DOM
-  - Experimental
   - Mobile
   - Property
   - touch
@@ -12,13 +11,9 @@ browser-compat: api.Touch.radiusY
 ---
 {{ APIRef("Touch Events") }}
 
-## Summary
-
-Returns the Y radius of the ellipse that most closely circumscribes the area of contact with the touch surface. The value is in CSS pixels of the same scale as {{ domxref("Touch.screenX") }}.
+The **`radiusX`** read-only property of the {{domxref("Touch")}} interface returns the Y radius of the ellipse that most closely circumscribes the area of contact with the touch surface. The value is in CSS pixels of the same scale as {{ domxref("Touch.screenX") }}.
 
 This value, in combination with {{ domxref("Touch.radiusX") }} and {{ domxref("Touch.rotationAngle") }} constructs an ellipse that approximates the size and shape of the area of contact between the user and the screen. This may be a large ellipse representing the contact between a fingertip and the screen or a small one representing the tip of a stylus, for example.
-
-> **Note:** This attribute has _not_ been formally standardized. It is specified in the {{SpecName('Touch Events 2')}} {{Spec2('Touch Events 2')}} specification and not in {{SpecName('Touch Events')}} {{Spec2('Touch Events')}}. This attribute is not widely implemented.
 
 ## Value
 

--- a/files/en-us/web/api/touch/rotationangle/index.md
+++ b/files/en-us/web/api/touch/rotationangle/index.md
@@ -4,7 +4,6 @@ slug: Web/API/Touch/rotationAngle
 tags:
   - API
   - DOM
-  - Experimental
   - Mobile
   - Property
   - touch
@@ -12,11 +11,7 @@ browser-compat: api.Touch.rotationAngle
 ---
 {{ APIRef("Touch Events") }}
 
-## Summary
-
-Returns the rotation angle, in degrees, of the contact area ellipse defined by {{ domxref("Touch.radiusX") }} and {{ domxref("Touch.radiusY") }}. The value may be between 0 and 90. Together, these three values describe an ellipse that approximates the size and shape of the area of contact between the user and the screen. This may be a relatively large ellipse representing the contact between a fingertip and the screen or a small area representing the tip of a stylus, for example.
-
-> **Note:** This attribute has _not_ been formally standardized. It is specified in the {{SpecName('Touch Events 2')}} {{Spec2('Touch Events 2')}} specification and not in {{SpecName('Touch Events')}} {{Spec2('Touch Events')}}. This attribute is not widely implemented.
+The **`radiusX`** read-only property of the {{domxref("Touch")}} interface returns the rotation angle, in degrees, of the contact area ellipse defined by {{ domxref("Touch.radiusX") }} and {{ domxref("Touch.radiusY") }}. The value may be between 0 and 90. Together, these three values describe an ellipse that approximates the size and shape of the area of contact between the user and the screen. This may be a relatively large ellipse representing the contact between a fingertip and the screen or a small area representing the tip of a stylus, for example.
 
 ## Value
 

--- a/files/en-us/web/api/touch/touch/index.md
+++ b/files/en-us/web/api/touch/touch/index.md
@@ -4,26 +4,25 @@ slug: Web/API/Touch/Touch
 tags:
   - API
   - Constructor
-  - Experimental
   - Reference
   - touch
 browser-compat: api.Touch.Touch
 ---
-{{APIRef("Touch Events")}} {{SeeCompatTable}}
+{{APIRef("Touch Events")}}
 
 The **`Touch()`** constructor creates a new {{domxref("Touch")}} object.
 
 ## Syntax
 
 ```js
-new Touch(touchInit)
+new Touch(options)
 ```
 
 ### Parameters
 
 - `touchInit`
 
-  - : A `TouchInit` dictionary, having the following fields:
+  - : An object with the following fields:
 
     - `identifier`
       - : A `long` value, that is the identification number for the touch point.


### PR DESCRIPTION
`Touch.radiusX`, `Touch.radiusY`, `Touch.rotationAngle`, `Touch.force` and `Touch()` are no more experimental.

This PR removes the different mentions and updates the pages to the modern structure.