### PR TITLE
HTTP: Replace the last remaining manual spec tables

### DIFF
--- a/files/en-us/web/http/headers/accept-post/index.md
+++ b/files/en-us/web/http/headers/accept-post/index.md
@@ -6,6 +6,7 @@ tags:
   - HTTP
   - HTTP Header
   - Response Header
+spec-urls: https://www.w3.org/TR/ldp/#header-accept-post
 ---
 {{HTTPSidebar}}
 
@@ -54,9 +55,7 @@ Accept-Post: */*
 
 ## Specifications
 
-| Specification                                                                                                           | Title       |
-| ----------------------------------------------------------------------------------------------------------------------- | ----------- |
-| [Linked Data Platform 1.0, Section 7.1: The Accept-Post Response Header](https://www.w3.org/TR/ldp/#header-accept-post) | ACCEPT POST |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/http/headers/expect-ct/index.md
+++ b/files/en-us/web/http/headers/expect-ct/index.md
@@ -82,9 +82,7 @@ Builds of Chrome are designed to stop enforcing the `Expect-CT` policy 10 weeks 
 
 ## Specifications
 
-| Specification                                                                           | Title                        |
-| --------------------------------------------------------------------------------------- | ---------------------------- |
-| [Internet Draft](https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-expect-ct-08) | Expect-CT Extension for HTTP |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/http/headers/proxy-authorization/index.md
+++ b/files/en-us/web/http/headers/proxy-authorization/index.md
@@ -7,6 +7,7 @@ tags:
   - Reference
   - Request header
   - header
+spec-urls: https://httpwg.org/specs/rfc7235.html#header.proxy-authorization
 ---
 {{HTTPSidebar}}
 
@@ -63,9 +64,7 @@ Proxy-Authorization: Basic YWxhZGRpbjpvcGVuc2VzYW1l
 
 ## Specifications
 
-| Specification                                                                                                 |
-| ------------------------------------------------------------------------------------------------------------- |
-| [RFC 7235<br/># header.proxy-authorization](https://httpwg.org/specs/rfc7235.html#header.proxy-authorization) |
+{{Specifications}}
 
 ## See also
 

--- a/files/en-us/web/http/headers/sourcemap/index.md
+++ b/files/en-us/web/http/headers/sourcemap/index.md
@@ -46,9 +46,7 @@ SourceMap: /path/to/file.js.map
 
 ## Specifications
 
-| Specification                                       | Title                          |
-| --------------------------------------------------- | ------------------------------ |
-| [Draft document](https://sourcemaps.info/spec.html) | Source Map Revision 3 Proposal |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/http/network_error_logging/index.md
+++ b/files/en-us/web/http/network_error_logging/index.md
@@ -6,6 +6,7 @@ tags:
   - HTTP
   - Network Error Logging
   - Reference
+browser-compat: http.headers.NEL
 ---
 {{HTTPSidebar}}{{SeeCompatTable}}
 
@@ -137,10 +138,8 @@ The type of the network error may be one of the following pre-defined values fro
 
 ## Specifications
 
-| Specification                                                                      |
-| ---------------------------------------------------------------------------------- |
-| [Network Error Logging](https://w3c.github.io/network-error-logging/#introduction) |
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("http.headers.NEL")}}
+{{Compat}}

--- a/files/jsondata/SpecData.json
+++ b/files/jsondata/SpecData.json
@@ -849,6 +849,11 @@
     "url": "https://wicg.github.io/eyedropper-api/",
     "status": "Draft"
   },
+  "Expect-CT": {
+    "name": "Expect-CT Extension for HTTP",
+    "url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-expect-ct-08",
+    "status": "Draft"
+  },
   "Feature Policy": {
     "name": "Permissions Policy",
     "url": "https://w3c.github.io/webappsec-permissions-policy/",
@@ -1083,6 +1088,11 @@
     "name": "Legacy RegExp features in JavaScript",
     "url": "https://github.com/tc39/proposal-regexp-legacy-features/",
     "status": "Draft"
+  },
+  "Linked Data Platform": {
+    "name": "Linked Data Platform",
+    "url": "https://www.w3.org/TR/ldp/",
+    "status": "REC"
   },
   "Local Font Access API": {
     "name": "Local Font Access API",
@@ -1513,6 +1523,11 @@
     "name": "Accelerated Shape Detection in Images",
     "url": "https://wicg.github.io/shape-detection-api/",
     "status": "Draft"
+  },
+  "Source Map": {
+    "name": "Source Map",
+    "url": "https://sourcemaps.info/spec.html",
+    "status": "Standard"
   },
   "Static Range": {
     "name": "Static Range",


### PR DESCRIPTION
A few articles in the HTTP tree with manual spec tables didn’t get changed in the initial round of conversions. This change replaces those last manual spec tables with {{Specifications}} macro calls.

Because some of the relevant specs aren’t in browser-specs, this change adds them to the SpecData.json file. And in the case of the `SourceMap` header, the spec probably *should* be in browser-specs, so see https://github.com/w3c/browser-specs/issues/618 for that.

Related BCD PR: https://github.com/mdn/browser-compat-data/pull/16361