### PR TITLE
Add the Digest Headers spec to SpecData.json

### DIFF
--- a/files/en-us/web/http/headers/digest/index.md
+++ b/files/en-us/web/http/headers/digest/index.md
@@ -58,7 +58,7 @@ Digest: sha-256=X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=,unixsum=30637
 
 ## Specifications
 
-{{Specifications("http.headers.Digest")}}
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/http/headers/want-digest/index.md
+++ b/files/en-us/web/http/headers/want-digest/index.md
@@ -120,7 +120,7 @@ Want-Digest: sha-256, sha-512
 
 ## Specifications
 
-{{Specifications("http.headers.Want-Digest")}}
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/jsondata/SpecData.json
+++ b/files/jsondata/SpecData.json
@@ -704,6 +704,11 @@
     "url": "https://w3c.github.io/deviceorientation/",
     "status": "ED"
   },
+  "Digest Headers": {
+    "name": "Digest Headers",
+    "url": "https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-digest-headers-05",
+    "status": "Draft"
+  },
   "DOM Parsing": {
     "name": "DOM Parsing and Serialization",
     "url": "https://w3c.github.io/DOM-Parsing/",


### PR DESCRIPTION
The Digest Headers spec isn’t in browser-specs, and may not be for a long time yet (see https://github.com/w3c/browser-specs/issues/339) — so this change adds it to `SpecData.json`.

Otherwise, without this change, it shows up as “Unknown specification” in https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Digest and https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Want-Digest

The change also drops the unnecessary arguments from the `{{Specifications}}` macro calls in the above articles; the arguments aren’t needed because the articles have `browser-compat` keys which the spec URLs can be picked up from.