### PR TITLE
Add `resolvedOptions()` into `Intl.ListFormat` page

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/listformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/listformat/index.md
@@ -35,6 +35,8 @@ The **`Intl.ListFormat`** object enables language-sensitive list formatting.
   - : Returns a language-specific formatted string representing the elements of the list.
 - {{jsxref("Intl/ListFormat/formatToParts", "Intl.ListFormat.prototype.formatToParts()")}}
   - : Returns an array of objects representing the different components that can be used to format a list of values in a locale-aware fashion.
+- {{jsxref("Intl/ListFormat/resolvedOptions", "Intl.ListFormat.prototype.resolvedOptions()")}}
+  - : Returns a new object with properties reflecting the locale and style formatting options computed during the construction of the current {{jsxref("Intl.ListFormat")}} object.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Add `resolvedOptions()` into `Intl.ListFormat` page.
This method is valid, but isn't written in the `Intl.ListFormat` page.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
