### PR TITLE
Noting fallback technique for xlink:href to support older browsers

### DIFF
--- a/files/en-us/web/svg/attribute/href/index.md
+++ b/files/en-us/web/svg/attribute/href/index.md
@@ -10,7 +10,7 @@ browser-compat: svg.attributes.href
 
 The **`href`** attribute defines a link to a resource as a reference [URL](/en-US/docs/Web/SVG/Content_type#url). The exact meaning of that link depends on the context of each element using it.
 
-> **Note:** Specifications before SVG 2 defined an {{SVGAttr("xlink:href")}} attribute, which is now rendered obsolete by the `href` attribute.
+> **Note:** Specifications before SVG 2 defined an {{SVGAttr("xlink:href")}} attribute, which is now rendered obsolete by the `href` attribute. If you need to support older browsers, you may include an `xlink:href` fallback in addition to `href`, e.g. `<use href="some-id" xlink:href="some-id x="5" y="5" />`.
 
 You can use this attribute with the following SVG elements:
 

--- a/files/en-us/web/svg/attribute/href/index.md
+++ b/files/en-us/web/svg/attribute/href/index.md
@@ -10,7 +10,7 @@ browser-compat: svg.attributes.href
 
 The **`href`** attribute defines a link to a resource as a reference [URL](/en-US/docs/Web/SVG/Content_type#url). The exact meaning of that link depends on the context of each element using it.
 
-> **Note:** Specifications before SVG 2 defined an {{SVGAttr("xlink:href")}} attribute, which is now rendered obsolete by the `href` attribute. If you need to support older browsers, you may include an `xlink:href` fallback in addition to `href`, e.g. `<use href="some-id" xlink:href="some-id x="5" y="5" />`.
+> **Note:** Specifications before SVG 2 defined an {{SVGAttr("xlink:href")}} attribute, which is now rendered obsolete by the `href` attribute. If you need to support earlier browser versions, the deprecated `xlink:href` attribute can be used as a fallback in addition to the `href` attribute, e.g. `<use href="some-id" xlink:href="some-id x="5" y="5" />`.
 
 You can use this attribute with the following SVG elements:
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Added a note that `xlink:href` may be included in addition to `href` to support older browsers.

#### Motivation
We recently tried removing `xlink:href` from an svg sprite we use for our site, and found that it broke the sprite for users on Safari < 12.1, as specified by the browser support table. Looking at our analytics, this only comprises a portion of a single percent of our users - but this is still over a thousand users a week. Therefore, it seems worthwhile to note that both attributes may be included, which allows rendering on Safari < 12.1, but also future-proofs against browsers dropping support for `xlink:href`.

#### Supporting details
Note that this is supported in the W3 SVG2 spec [here](https://www.w3.org/TR/SVG2/linking.html#XLinkRefAttrs): 

> When the ‘href’ attribute is present in both the XLink namespace and without a namespace, the value of the attribute without a namespace shall be used. The attribute in the XLink namespace shall be ignored.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
