### PR TITLE
In the “Web app manifests” doc, replace manual spec table with inline link to spec (in the article intro)

### DIFF
--- a/files/en-us/web/manifest/index.md
+++ b/files/en-us/web/manifest/index.md
@@ -14,11 +14,11 @@ browser-compat: html.manifest
 
 **Web app manifests** are part of a collection of web technologies called [progressive web apps](/en-US/docs/Web/Progressive_web_apps) (PWAs), which are websites that can be installed to a device's homescreen without an app store. Unlike regular web apps with simple homescreen links or bookmarks, PWAs can be downloaded in advance and can work offline, as well as use regular [Web APIs](/en-US/docs/Web/API).
 
-The web app manifest provides information about a web application in a {{Glossary("JSON")}} text file, necessary for the web app to be downloaded and be presented to the user similarly to a native app (e.g., be installed on the homescreen of a device, providing users with quicker access and a richer experience). PWA manifests include its name, author, icon(s), version, description, and list of all the necessary resources (among other things).
+A web application manifest, as defined in the [Web Application Manifest](https://w3c.github.io/manifest/) specification, provides information about a web application in a {{Glossary("JSON")}} text file, necessary for the web app to be downloaded and be presented to the user similarly to a native app (e.g., be installed on the homescreen of a device, providing users with quicker access and a richer experience). PWA manifests include its name, author, icon(s), version, description, and list of all the necessary resources (among other things).
 
 ## Members
 
-Web manifests can contain the following keys. Click on each one to link through to more information about it:
+Web application manifests can contain the following keys. Click on each one to link through to more information about it:
 
 {{ListSubpages("/en-US/docs/Web/Manifest")}}
 
@@ -91,9 +91,7 @@ In some browsers (Chrome 47 and later, for example), a splash screen is displaye
 
 ## Specifications
 
-| Specification                                      |
-| -------------------------------------------------- |
-| [Web App Manifest](https://w3c.github.io/manifest/) |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/manifest/index.md
+++ b/files/en-us/web/manifest/index.md
@@ -89,10 +89,6 @@ In some browsers (Chrome 47 and later, for example), a splash screen is displaye
 - [`background_color`](/en-US/docs/Web/Manifest/background_color)
 - The icon in the [`icons`](/en-US/docs/Web/Manifest/icons) array that is closest to 128dpi for the device.
 
-## Specifications
-
-{{Specifications}}
-
 ## Browser compatibility
 
 {{Compat}}


### PR DESCRIPTION
Note that in BCD, `html.manifest` is a directory, not a file. Given that, there’s no way in BCD to associate a spec URL with the `html.manifest` feature. And anyway for the “Web app manifests” MDN article — which is an overview (non-reference) article — we don’t actually need a Specifications table. So this change replaces the table with an inline link to the spec (in the article intro).