### PR TITLE
FF102 Window.sidebar deprecation relnote and tidy

### DIFF
--- a/files/en-us/mozilla/firefox/releases/102/index.md
+++ b/files/en-us/mozilla/firefox/releases/102/index.md
@@ -39,6 +39,8 @@ This article provides information about the changes in Firefox 102 that will aff
 
 #### DOM
 
+- The Firefox-only property {{domxref("Window.sidebar")}} has been moved behind a preference, and is planned for removal ({{bug(1768486)}}).
+
 #### Media, WebRTC, and Web Audio
 
 #### Removals

--- a/files/en-us/web/api/window/external/index.md
+++ b/files/en-us/web/api/window/external/index.md
@@ -3,9 +3,10 @@ title: Window.external
 slug: Web/API/Window/external
 tags:
   - API
-  - Deprecated
+  - property
   - Window
   - external
+  - Deprecated
 browser-compat: api.Window.external
 ---
 {{APIRef}} {{deprecated_header}}

--- a/files/en-us/web/api/window/index.md
+++ b/files/en-us/web/api/window/index.md
@@ -67,6 +67,8 @@ Note that properties which are objects (e.g., for overriding the prototype of bu
   - : Returns a reference to the document that the window contains.
 - {{domxref("Window.event")}} {{deprecated_inline}} {{readOnlyInline}}
   - : Returns the **current event**, which is the event currently being handled by the JavaScript code's context, or `undefined` if no event is currently being handled. The {{domxref("Event")}} object passed directly to event handlers should be used instead whenever possible.
+- {{domxref("Window.external")}} {{deprecated_inline}} {{readOnlyInline}}
+  - : Returns an object with functions for adding external search providers to the browser.
 - {{domxref("Window.frameElement")}} {{readOnlyInline}}
   - : Returns the element in which the window is embedded, or null if the window is not embedded.
 - {{domxref("Window.frames")}} {{readOnlyInline}}

--- a/files/en-us/web/api/window/sidebar/index.md
+++ b/files/en-us/web/api/window/sidebar/index.md
@@ -3,13 +3,15 @@ title: Window.sidebar
 slug: Web/API/Window/sidebar
 tags:
   - HTML DOM
-  - Non-standard
   - Property
   - Reference
   - Window
-browser-compat: api.Window.sidebar
+  - Non-standard
+  - Deprecated
 ---
-{{APIRef}} {{Deprecated_Header}} {{Non-standard_header}}
+{{APIRef}} {{Deprecated_Header}}
+
+> **Warning:** This non-standard Firefox-only alias of the [`window.external`](/en-US/docs/Web/API/Window/external) property [has been removed](#browser_compatibility).
 
 Returns a sidebar object which contains several methods for registering add-ons with the browser.
 
@@ -98,4 +100,5 @@ Mozilla-specific. Not part of any standard.
 
 ## Browser compatibility
 
-{{Compat}}
+Moved behind preference in Firefox 102.
+For more information see Firefox compatibity information in [`window.external`](/en-US/docs/Web/API/Window/external#browser_compatibility).


### PR DESCRIPTION
FF102 puts  [`Window.sidebar`](https://developer.mozilla.org/en-US/docs/Web/API/Window/sidebar) behind a preference in preparation for removal. 
This property is an FF only alias for an (also deprecated) property: [`Window.external`](https://developer.mozilla.org/en-US/docs/Web/API/Window/external).

What this does is 
- add a release note for the removal.
- add a more clear header and compatibility section for window.sidebar
- Tidy window.external and add to `window` page (just normal cleanup)

Other docs work can be tracked in #16149