### PR TITLE
In the “Certificate Transparency” doc, replace manual spec table with inline link to the spec (in the article intro)

### DIFF
--- a/files/en-us/web/security/certificate_transparency/index.md
+++ b/files/en-us/web/security/certificate_transparency/index.md
@@ -40,7 +40,3 @@ Apple [requires](https://support.apple.com/en-gb/HT205280) a varying number of S
 Firefox [does not](https://bugzilla.mozilla.org/show_bug.cgi?id=1281469) currently check or require the use of CT logs for sites that users visit.
 
 The [Expect-CT header](/en-US/docs/Web/HTTP/Headers/Expect-CT) can be used to request that a browser _always_ enforces the requirement for certificate transparency (e.g. in Chrome, even if the certificate was issued with a notBefore date prior to April).
-
-## Specifications
-
-{{Specifications}}

--- a/files/en-us/web/security/certificate_transparency/index.md
+++ b/files/en-us/web/security/certificate_transparency/index.md
@@ -5,7 +5,7 @@ tags:
   - Security
   - Web
 ---
-**Certificate Transparency** is an open framework designed to protect against and monitor for certificate mis-issuances. Newly issued certificates are 'logged' to publicly run, often independent CT logs which maintain an append-only, cryptographically assured record of issued TLS certificates.
+**Certificate Transparency** is an open framework designed to protect against and monitor for certificate mis-issuances. It's defined in [RFC 9162](https://www.rfc-editor.org/rfc/rfc9162). With certificate transparency, newly-issued certificates are 'logged' to publicly-run, often independent _CT logs_ — which maintain an append-only, cryptographically-assured record of issued TLS certificates.
 
 In this way, certificate authorities (CAs) can be subject to much greater public scrutiny and oversight. Potentially malicious certificates, such as those that violate the CA/B Forum _Baseline Requirements_, can be detected and revoked much more quickly. Browser vendors and root store maintainers are also empowered to make more informed decisions regarding problematic CAs that they may decide to distrust.
 
@@ -43,6 +43,4 @@ The [Expect-CT header](/en-US/docs/Web/HTTP/Headers/Expect-CT) can be used to re
 
 ## Specifications
 
-| Specification                                                             | Status   | Comment |
-| ------------------------------------------------------------------------- | -------- | ------- |
-| [Certificate Transparency](https://datatracker.ietf.org/doc/html/rfc6962) | IETF RFC |         |
+{{Specifications}}


### PR DESCRIPTION
This change replaces the manual spec table in the “Certificate Transparency” overview (non-reference) article with an inline link to the Certificate Transparency spec (in the article intro).

(And note also that the Certificate Transparency spec isn’t in browser-specs — so if we wanted to instead use `spec-urls` for it (rather than an inline link as this PR does), we’d also need to add it to the `SpecData.json` file.)