### PR TITLE
FF102 IDBMutableFile, IDBFileHandle, IDBFileRequest behind pref

### DIFF
--- a/files/en-us/web/api/idbdatabase/index.md
+++ b/files/en-us/web/api/idbdatabase/index.md
@@ -39,7 +39,7 @@ Inherits from: [EventTarget](/en-US/docs/Web/API/EventTarget)
 
 - {{domxref("IDBDatabase.close()")}}
   - : Returns immediately and closes the connection to a database in a separate thread.
-- {{domxref("IDBDatabase.createMutableFile()")}}
+- `IDBDatabase.createMutableFile()` {{deprecated_inline}}{{Non-standard_Inline}}
   - : Creates a file handle, allowing files to be stored inside an IndexedDB database.
 - {{domxref("IDBDatabase.createObjectStore()")}}
   - : Creates and returns a new object store or index.

--- a/files/en-us/web/api/idbfilehandle/abort/index.md
+++ b/files/en-us/web/api/idbfilehandle/abort/index.md
@@ -5,12 +5,16 @@ tags:
   - API
   - Files
   - Method
-  - Non-standard
   - Reference
   - WebAPI
+  - Non-standard
+  - Deprecated
 browser-compat: api.IDBFileHandle.abort
 ---
-{{APIRef("IndexedDB")}}{{non-standard_header}}
+{{APIRef("IndexedDB")}}{{deprecated_header}}
+
+> **Note:** The three non-standard interfaces {{domxref("IDBMutableFile")}}, {{domxref("IDBFileHandle")}}, and {{domxref("IDBFileRequest")}} are [disabled by default](#browser_compatibility).
+> Consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 The **`abort()`** method of the {{domxref("IDBFileHandle")}} interface
 release the lock on the object, making it inactive:
@@ -21,9 +25,6 @@ release the lock on the object, making it inactive:
 > database transaction), therefore the file can be corrupted if the
 > canceled operation was performing some writing.
 
-> **Note:** The three interfaces `IDBMutableFile`, `IDBFileHandle`, and `IDBFileRequest` are deprecated and only implemented
-> for backward compatibility in Firefox. _Do not use them anymore_:
-> consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Syntax
 
@@ -45,7 +46,8 @@ This feature is not part of any current specification. It is no longer on track 
 
 ## Browser compatibility
 
-{{Compat}}
+This method is not supported by any current browser.
+From Firefox 102 it is behind the preference `dom.fileHandle.enabled`.
 
 ## See also
 

--- a/files/en-us/web/api/idbfilehandle/abort_event/index.md
+++ b/files/en-us/web/api/idbfilehandle/abort_event/index.md
@@ -4,21 +4,21 @@ slug: Web/API/IDBFileHandle/abort_event
 tags:
   - API
   - Files
-  - Non-standard
   - Event
   - Reference
   - WebAPI
+  - Non-standard
+  - Deprecated
 browser-compat: api.IDBFileHandle.abort_event
 ---
-{{APIRef("IndexedDB")}}{{ non-standard_header }}
+{{APIRef("IndexedDB")}}{{deprecated_header}}
+
+> **Note:** The three non-standard interfaces {{domxref("IDBMutableFile")}}, {{domxref("IDBFileHandle")}}, and {{domxref("IDBFileRequest")}} are [disabled by default](#browser_compatibility).
+> Consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 The **`abort`** is fired when the associated file has been aborted with the {{domxref("IDBFileHandle.abort()")}} method.
 
 This event is not cancelable and does not bubble.
-
-> **Note:** The three interfaces `IDBMutableFile`, `IDBFileHandle`, and `IDBFileRequest` are deprecated and only implemented
-> for backward compatibility in Firefox. _Do not use them anymore_:
-> consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Syntax
 
@@ -39,7 +39,8 @@ This feature is not part of any current specification. It is no longer on track 
 
 ## Browser compatibility
 
-{{Compat}}
+This event is not supported by any current browser.
+From Firefox 102 it is behind the preference `dom.fileHandle.enabled`.
 
 ## See also
 

--- a/files/en-us/web/api/idbfilehandle/active/index.md
+++ b/files/en-us/web/api/idbfilehandle/active/index.md
@@ -4,23 +4,23 @@ slug: Web/API/IDBFileHandle/active
 tags:
   - API
   - Files
-  - Non-standard
   - Property
   - Reference
   - WebAPI
+  - Non-standard
+  - Deprecated
 browser-compat: api.IDBFileHandle.abort
 ---
-{{APIRef("IndexedDB")}} {{non-standard_header}}
+{{APIRef("IndexedDB")}}{{deprecated_header}}
+
+> **Note:** The three non-standard interfaces {{domxref("IDBMutableFile")}}, {{domxref("IDBFileHandle")}}, and {{domxref("IDBFileRequest")}} are [disabled by default](#browser_compatibility).
+> Consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 The read-only **`active`** property of the {{domxref("IDBFileHandle")}} interface
 indicates if the object is still usable (`true`), or not (`false`). If the object is inactive then it is impossible to perform any
 read or write operation with it.
 Typically, an {{domxref("IDBFileHandle")}} object becomes inactive when the {{domxref("IDBFileHandle.abort()")}} method is called,
 or if an error occurs.
-
-> **Note:** The three interfaces `IDBMutableFile`, `IDBFileHandle`, and `IDBFileRequest` are deprecated and only implemented
-> for backward compatibility in Firefox. _Do not use them anymore_:
-> consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Value
 
@@ -32,7 +32,8 @@ This feature is not part of any current specification. It is no longer on track 
 
 ## Browser compatibility
 
-{{Compat}}
+This property is not supported by any current browser.
+From Firefox 102 it is behind the preference `dom.fileHandle.enabled`.
 
 ## See also
 

--- a/files/en-us/web/api/idbfilehandle/append/index.md
+++ b/files/en-us/web/api/idbfilehandle/append/index.md
@@ -5,12 +5,16 @@ tags:
   - API
   - Files
   - Method
-  - Non-standard
   - Reference
   - WebAPI
+  - Non-standard
+  - Deprecated
 browser-compat: api.IDBFileHandle.append
 ---
-{{APIRef("IndexedDB")}}{{non-standard_header}}
+{{APIRef("IndexedDB")}}{{deprecated_header}}
+
+> **Note:** The three non-standard interfaces {{domxref("IDBMutableFile")}}, {{domxref("IDBFileHandle")}}, and {{domxref("IDBFileRequest")}} are [disabled by default](#browser_compatibility).
+> Consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 The **`append()`** method of the {{domxref("IDBFileHandle")}} interface
 write additional data at the end of the file.
@@ -18,10 +22,6 @@ write additional data at the end of the file.
 The write operation is performed at the end of the file,
 regardless of the {{domxref("IDBFilehandle.location")}} value,
 and actually sets the value of this property to `null`.
-
-> **Note:** The three interfaces `IDBMutableFile`, `IDBFileHandle`, and `IDBFileRequest` are deprecated and only implemented
-> for backward compatibility in Firefox. _Do not use them anymore_:
-> consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Syntax
 
@@ -44,7 +44,8 @@ This feature is not part of any current specification. It is no longer on track 
 
 ## Browser compatibility
 
-{{Compat}}
+This method is not supported by any current browser.
+From Firefox 102 it is behind the preference `dom.fileHandle.enabled`.
 
 ## See also
 

--- a/files/en-us/web/api/idbfilehandle/complete_event/index.md
+++ b/files/en-us/web/api/idbfilehandle/complete_event/index.md
@@ -4,21 +4,21 @@ slug: Web/API/IDBFileHandle/complete_event
 tags:
   - API
   - Files
-  - Non-standard
   - Event
   - Reference
   - WebAPI
+  - Non-standard
+  - Deprecated
 browser-compat: api.IDBFileHandle.complete_event
 ---
-{{APIRef("IndexedDB")}}{{ non-standard_header }}
+{{APIRef("IndexedDB")}}{{deprecated_header}}
+
+> **Note:** The three non-standard interfaces {{domxref("IDBMutableFile")}}, {{domxref("IDBFileHandle")}}, and {{domxref("IDBFileRequest")}} are [disabled by default](#browser_compatibility).
+> Consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 The **`complete`** is fired when a read or write operation is successful.
 
 This event is not cancelable and does not bubble.
-
-> **Note:** The three interfaces `IDBMutableFile`, `IDBFileHandle`, and `IDBFileRequest` are deprecated and only implemented
-> for backward compatibility in Firefox. _Do not use them anymore_:
-> consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Syntax
 
@@ -39,7 +39,8 @@ This feature is not part of any current specification. It is no longer on track 
 
 ## Browser compatibility
 
-{{Compat}}
+This event is not supported by any current browser.
+From Firefox 102 it is behind the preference `dom.fileHandle.enabled`.
 
 ## See also
 

--- a/files/en-us/web/api/idbfilehandle/error_event/index.md
+++ b/files/en-us/web/api/idbfilehandle/error_event/index.md
@@ -4,21 +4,22 @@ slug: Web/API/IDBFileHandle/error_event
 tags:
   - API
   - Files
-  - Non-standard
   - Event
   - Reference
   - WebAPI
+  - Non-standard
+  - Deprecated
 browser-compat: api.IDBFileHandle.error_event
 ---
-{{APIRef("IndexedDB")}}{{ non-standard_header }}
+{{APIRef("IndexedDB")}}{{deprecated_header}}
+
+> **Note:** The three non-standard interfaces {{domxref("IDBMutableFile")}}, {{domxref("IDBFileHandle")}}, and {{domxref("IDBFileRequest")}} are [disabled by default](#browser_compatibility).
+> Consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 The **`error`** is fired when something goes wrong with the {{domxref("IDBFileHandle")}} object.
 
 This event is not cancelable and does not bubble.
 
-> **Note:** The three interfaces `IDBMutableFile`, `IDBFileHandle`, and `IDBFileRequest` are deprecated and only implemented
-> for backward compatibility in Firefox. _Do not use them anymore_:
-> consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Syntax
 
@@ -39,7 +40,8 @@ This feature is not part of any current specification. It is no longer on track 
 
 ## Browser compatibility
 
-{{Compat}}
+This event is not supported by any current browser.
+From Firefox 102 it is behind the preference `dom.fileHandle.enabled`.
 
 ## See also
 

--- a/files/en-us/web/api/idbfilehandle/filehandle/index.md
+++ b/files/en-us/web/api/idbfilehandle/filehandle/index.md
@@ -4,20 +4,21 @@ slug: Web/API/IDBFileHandle/fileHandle
 tags:
   - API
   - Files
-  - Non-standard
   - Property
   - Reference
   - WebAPI
+  - Non-standard
+  - Deprecated
 browser-compat: api.IDBFileHandle.fileHandle
 ---
-{{APIRef("IndexedDB")}}{{non-standard_header}}
+{{APIRef("IndexedDB")}}{{deprecated_header}}
+
+> **Note:** The three non-standard interfaces {{domxref("IDBMutableFile")}}, {{domxref("IDBFileHandle")}}, and {{domxref("IDBFileRequest")}} are [disabled by default](#browser_compatibility).
+> Consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 The read-only **`fileHandle`** property of the {{domxref("IDBFileHandle")}} interface
 returns the {{domxref("IDBMutableFile")}} object that produced this object.
 
-> **Note:** The three interfaces `IDBMutableFile`, `IDBFileHandle`, and `IDBFileRequest` are deprecated and only implemented
-> for backward compatibility in Firefox. _Do not use them anymore_:
-> consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Value
 
@@ -29,7 +30,8 @@ This feature is not part of any current specification. It is no longer on track 
 
 ## Browser compatibility
 
-{{Compat}}
+This property is not supported by any current browser.
+From Firefox 102 it is behind the preference `dom.fileHandle.enabled`.
 
 ## See also
 

--- a/files/en-us/web/api/idbfilehandle/flush/index.md
+++ b/files/en-us/web/api/idbfilehandle/flush/index.md
@@ -5,12 +5,16 @@ tags:
   - API
   - Files
   - Method
-  - Non-standard
   - Reference
   - WebAPI
+  - Non-standard
+  - Deprecated
 browser-compat: api.IDBFileHandle.flush
 ---
-{{APIRef("IndexedDB")}}{{non-standard_header}}
+{{APIRef("IndexedDB")}}{{deprecated_header}}
+
+> **Note:** The three non-standard interfaces {{domxref("IDBMutableFile")}}, {{domxref("IDBFileHandle")}}, and {{domxref("IDBFileRequest")}} are [disabled by default](#browser_compatibility).
+> Consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 The **`flush()`** method of the {{domxref("IDBFileHandle")}} interface
 ensures any change made to a file is properly written on disk.
@@ -20,10 +24,6 @@ This allows fast writing and reading operations.
 Periodically, the data are written onto disk.
 However, if something goes wrong before that, some operations can be lost.
 To avoid that, it's possible to force a write onto the disk by calling the `flush()` method.
-
-> **Note:** The three interfaces `IDBMutableFile`, `IDBFileHandle`, and `IDBFileRequest` are deprecated and only implemented
-> for backward compatibility in Firefox. _Do not use them anymore_:
-> consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Syntax
 
@@ -45,7 +45,8 @@ This feature is not part of any current specification. It is no longer on track 
 
 ## Browser compatibility
 
-{{Compat}}
+This method is not supported by any current browser.
+From Firefox 102 it is behind the preference `dom.fileHandle.enabled`.
 
 ## See also
 

--- a/files/en-us/web/api/idbfilehandle/getmetadata/index.md
+++ b/files/en-us/web/api/idbfilehandle/getmetadata/index.md
@@ -5,18 +5,19 @@ tags:
   - API
   - Files
   - Method
-  - Non-standard
   - Reference
   - WebAPI
+  - Non-standard
+  - Deprecated
 browser-compat: api.IDBFileHandle.getMetadata
 ---
-{{APIRef("IndexedDB")}}{{non-standard_header}}
+{{APIRef("IndexedDB")}}{{deprecated_header}}
+
+> **Note:** The three non-standard interfaces {{domxref("IDBMutableFile")}}, {{domxref("IDBFileHandle")}}, and {{domxref("IDBFileRequest")}} are [disabled by default](#browser_compatibility).
+> Consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 The **`getMetadata()`** method of the {{domxref("IDBFileHandle")}} allows retrieving some metadata about the file.
 
-> **Note:** The three interfaces `IDBMutableFile`, `IDBFileHandle`, and `IDBFileRequest` are deprecated and only implemented
-> for backward compatibility in Firefox. _Do not use them anymore_:
-> consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Syntax
 
@@ -51,7 +52,8 @@ This feature is not part of any current specification. It is no longer on track 
 
 ## Browser compatibility
 
-{{Compat}}
+This method is not supported by any current browser.
+From Firefox 102 it is behind the preference `dom.fileHandle.enabled`.
 
 ## See also
 

--- a/files/en-us/web/api/idbfilehandle/index.md
+++ b/files/en-us/web/api/idbfilehandle/index.md
@@ -4,19 +4,19 @@ slug: Web/API/IDBFileHandle
 tags:
   - API
   - Files
-  - Non-standard
   - Interface
   - Reference
   - WebAPI
+  - Non-standard
+  - Deprecated
 browser-compat: api.IDBFileHandle
 ---
-{{APIRef("IndexedDB")}} {{non-standard_header}}
+{{APIRef("IndexedDB")}}{{deprecated_header}}
+
+> **Note:** The three non-standard interfaces {{domxref("IDBMutableFile")}}, {{domxref("IDBFileHandle")}}, and {{domxref("IDBFileRequest")}} are [disabled by default](#browser_compatibility).
+> Consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 The **`IDBFileHandle`** interface provides tools to deal with a given file with all the necessary locks.
-
-> **Note:** The three interfaces `IDBMutableFile`, `IDBFileHandle`, and `IDBFileRequest` are deprecated and only implemented
-> for backward compatibility in Firefox. _Do not use them anymore_:
-> consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Properties
 
@@ -63,7 +63,8 @@ This feature is not part of any current specification. It is no longer on track 
 
 ## Browser compatibility
 
-{{Compat}}
+This interface is not supported by any current browser.
+From Firefox 102 it is behind the preference `dom.fileHandle.enabled`.
 
 ## See also
 

--- a/files/en-us/web/api/idbfilehandle/location/index.md
+++ b/files/en-us/web/api/idbfilehandle/location/index.md
@@ -4,13 +4,17 @@ slug: Web/API/IDBFileHandle/location
 tags:
   - API
   - Files
-  - Non-standard
   - Property
   - Reference
   - WebAPI
+  - Non-standard
+  - Deprecated
 browser-compat: api.IDBFileHandle.location
 ---
-{{APIRef("IndexedDB")}}{{non-standard_header}}
+{{APIRef("IndexedDB")}}{{deprecated_header}}
+
+> **Note:** The three non-standard interfaces {{domxref("IDBMutableFile")}}, {{domxref("IDBFileHandle")}}, and {{domxref("IDBFileRequest")}} are [disabled by default](#browser_compatibility).
+> Consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 The **`location`** property of the {{domxref("IDBFileHandle")}} is a zero-based index
 representing the position of the read/write pointer within the file.
@@ -20,10 +24,6 @@ This value is changed automatically after every read and write operation. The sp
 value `null` means end-of-file.
 
 This property can be changed at will.
-
-> **Note:** The three interfaces `IDBMutableFile`, `IDBFileHandle`, and `IDBFileRequest` are deprecated and only implemented
-> for backward compatibility in Firefox. _Do not use them anymore_:
-> consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Value
 
@@ -35,7 +35,8 @@ This feature is not part of any current specification. It is no longer on track 
 
 ## Browser compatibility
 
-{{Compat}}
+This property is not supported by any current browser.
+From Firefox 102 it is behind the preference `dom.fileHandle.enabled`.
 
 ## See also
 

--- a/files/en-us/web/api/idbfilehandle/mode/index.md
+++ b/files/en-us/web/api/idbfilehandle/mode/index.md
@@ -4,20 +4,20 @@ slug: Web/API/IDBFileHandle/mode
 tags:
   - API
   - Files
-  - Non-standard
   - Property
   - Reference
   - WebAPI
+  - Non-standard
+  - Deprecated
 browser-compat: api.IDBFileHandle.mode
 ---
-{{APIRef("IndexedDB")}}{{non-standard_header}}
+{{APIRef("IndexedDB")}}{{deprecated_header}}
+
+> **Note:** The three non-standard interfaces {{domxref("IDBMutableFile")}}, {{domxref("IDBFileHandle")}}, and {{domxref("IDBFileRequest")}} are [disabled by default](#browser_compatibility).
+> Consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 The **`mode`** read-only property of the {{domxref("IDBFileHandle")}} interface
 provides the read/write status of the file.
-
-> **Note:** The three interfaces `IDBMutableFile`, `IDBFileHandle`, and `IDBFileRequest` are deprecated and only implemented
-> for backward compatibility in Firefox. _Do not use them anymore_:
-> consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Value
 
@@ -29,7 +29,8 @@ This feature is not part of any current specification. It is no longer on track 
 
 ## Browser compatibility
 
-{{Compat}}
+This interface is not supported by any current browser.
+From Firefox 102 it is behind the preference `dom.fileHandle.enabled`.
 
 ## See also
 

--- a/files/en-us/web/api/idbfilehandle/readasarraybuffer/index.md
+++ b/files/en-us/web/api/idbfilehandle/readasarraybuffer/index.md
@@ -5,12 +5,16 @@ tags:
   - API
   - Files
   - Method
-  - Non-standard
   - Reference
   - WebAPI
+  - Non-standard
+  - Deprecated
 browser-compat: api.IDBFileHandle.readAsArrayBuffer
 ---
-{{APIRef("IndexedDB")}}{{non-standard_header}}
+{{APIRef("IndexedDB")}}{{deprecated_header}}
+
+> **Note:** The three non-standard interfaces {{domxref("IDBMutableFile")}}, {{domxref("IDBFileHandle")}}, and {{domxref("IDBFileRequest")}} are [disabled by default](#browser_compatibility).
+> Consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 The **`readAsArrayBuffer()`** method of the {{domxref("IDBFileHandle")}} interface
 reads the content of the associated file into an {{jsxref("ArrayBuffer")}}.
@@ -19,9 +23,6 @@ In many ways, it performs like the {{domxref("FileReader.readAsArrayBuffer()")}}
 The reading operation starts at the position given by the
 {{domxref("IDBFileHandle.location", "location")}} property.
 
-> **Note:** The three interfaces `IDBMutableFile`, `IDBFileHandle`, and `IDBFileRequest` are deprecated and only implemented
-> for backward compatibility in Firefox. _Do not use them anymore_:
-> consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Syntax
 
@@ -46,7 +47,8 @@ This feature is not part of any current specification. It is no longer on track 
 
 ## Browser compatibility
 
-{{Compat}}
+This method is not supported by any current browser.
+From Firefox 102 it is behind the preference `dom.fileHandle.enabled`.
 
 ## See also
 

--- a/files/en-us/web/api/idbfilehandle/readastext/index.md
+++ b/files/en-us/web/api/idbfilehandle/readastext/index.md
@@ -5,12 +5,16 @@ tags:
   - API
   - Files
   - Method
-  - Non-standard
   - Reference
   - WebAPI
+  - Non-standard
+  - Deprecated
 browser-compat: api.IDBFileHandle.readAsText
 ---
-{{APIRef("IndexedDB")}}{{non-standard_header}}
+{{APIRef("IndexedDB")}}{{deprecated_header}}
+
+> **Note:** The three non-standard interfaces {{domxref("IDBMutableFile")}}, {{domxref("IDBFileHandle")}}, and {{domxref("IDBFileRequest")}} are [disabled by default](#browser_compatibility).
+> Consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 The **`readAsText()`** method of the {{domxref("IDBFileHandle")}} interface
 reads the content of the associated file
@@ -19,10 +23,6 @@ In many ways, it performs like the {{domxref("FileReader.readAsText()")}} method
 
 The reading operation starts at the position given by the
 {{domxref("IDBFileHandle.location", "location")}} property.
-
-> **Note:** The three interfaces `IDBMutableFile`, `IDBFileHandle`, and `IDBFileRequest` are deprecated and only implemented
-> for backward compatibility in Firefox. _Do not use them anymore_:
-> consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Syntax
 
@@ -51,7 +51,8 @@ This feature is not part of any current specification. It is no longer on track 
 
 ## Browser compatibility
 
-{{Compat}}
+This method is not supported by any current browser.
+From Firefox 102 it is behind the preference `dom.fileHandle.enabled`.
 
 ## See also
 

--- a/files/en-us/web/api/idbfilehandle/truncate/index.md
+++ b/files/en-us/web/api/idbfilehandle/truncate/index.md
@@ -5,12 +5,16 @@ tags:
   - API
   - Files
   - Method
-  - Non Standard
   - Reference
   - WebAPI
+  - Non-standard
+  - Deprecated
 browser-compat: api.IDBFileHandle.truncate
 ---
-{{APIRef("IndexedDB")}}{{non-standard_header}}
+{{APIRef("IndexedDB")}}{{deprecated_header}}
+
+> **Note:** The three non-standard interfaces {{domxref("IDBMutableFile")}}, {{domxref("IDBFileHandle")}}, and {{domxref("IDBFileRequest")}} are [disabled by default](#browser_compatibility).
+> Consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 The **`truncate`** method of the {{domxref("IDBFileHandle")}} interface
 removes some data within the file.
@@ -22,9 +26,6 @@ If the method is called with an argument, the operation removes all the bytes st
 at the index corresponding to the parameter and regardless of the value of
 {{domxref("IDBFileHandle.location", "location")}}.
 
-> **Note:** The three interfaces `IDBMutableFile`, `IDBFileHandle`, and `IDBFileRequest` are deprecated and only implemented
-> for backward compatibility in Firefox. _Do not use them anymore_:
-> consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Syntax
 
@@ -48,7 +49,8 @@ This feature is not part of any current specification. It is no longer on track 
 
 ## Browser compatibility
 
-{{Compat}}
+This method is not supported by any current browser.
+From Firefox 102 it is behind the preference `dom.fileHandle.enabled`.
 
 ## See also
 

--- a/files/en-us/web/api/idbfilehandle/write/index.md
+++ b/files/en-us/web/api/idbfilehandle/write/index.md
@@ -5,12 +5,16 @@ tags:
   - API
   - Files
   - Method
-  - Non-standard
   - Reference
   - WebAPI
+  - Non-standard
+  - Deprecated
 browser-compat: api.IDBFileHandle.write
 ---
-{{APIRef("IndexedDB")}}{{non-standard_header}}
+{{APIRef("IndexedDB")}}{{deprecated_header}}
+
+> **Note:** The three non-standard interfaces {{domxref("IDBMutableFile")}}, {{domxref("IDBFileHandle")}}, and {{domxref("IDBFileRequest")}} are [disabled by default](#browser_compatibility).
+> Consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 The **`write()`** method of the {{domxref("IDBFileHandle")}} interface
 writes some data into the file.
@@ -18,9 +22,6 @@ writes some data into the file.
 The write starts at the position set in {{domxref("IDBFileHandle.location", "location")}} and moves
 that position by the number of written bytes.
 
-> **Note:** The three interfaces `IDBMutableFile`, `IDBFileHandle`, and `IDBFileRequest` are deprecated and only implemented
-> for backward compatibility in Firefox. _Do not use them anymore_:
-> consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Syntax
 
@@ -44,7 +45,8 @@ This feature is not part of any current specification. It is no longer on track 
 
 ## Browser compatibility
 
-{{Compat}}
+This method is not supported by any current browser.
+From Firefox 102 it is behind the preference `dom.fileHandle.enabled`.
 
 ## See also
 

--- a/files/en-us/web/api/idbfilerequest/index.md
+++ b/files/en-us/web/api/idbfilerequest/index.md
@@ -6,17 +6,17 @@ tags:
   - DOM
   - Files
   - Interface
-  - Non-standard
   - Reference
+  - Non-standard
+  - Deprecated
 browser-compat: api.IDBFileRequest
 ---
-{{APIRef("IndexedDB")}} {{non-standard_header}}
+{{APIRef("IndexedDB")}}{{deprecated_header}}
+
+> **Note:** The three non-standard interfaces {{domxref("IDBMutableFile")}}, {{domxref("IDBFileHandle")}}, and {{domxref("IDBFileRequest")}} are [disabled by default](#browser_compatibility).
+> Consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 The **`IDBFileRequest`** interface provides some extra properties necessary for the {{domxref("IDBFileHandle")}} objects.
-
-> **Note:** The three interfaces `IDBMutableFile`, `IDBFileHandle`, and `IDBFileRequest` are deprecated and only implemented
-> for backward compatibility in Firefox. _Do not use them anymore_:
-> consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Properties
 
@@ -42,7 +42,8 @@ This feature is not part of any current specification. It is no longer on track 
 
 ## Browser compatibility
 
-{{Compat}}
+This interface is not supported by any current browser.
+From Firefox 102 it is behind the preference `dom.fileHandle.enabled`.
 
 ## See also
 

--- a/files/en-us/web/api/idbfilerequest/lockedfile/index.md
+++ b/files/en-us/web/api/idbfilerequest/lockedfile/index.md
@@ -5,20 +5,20 @@ tags:
   - API
   - DOM
   - Files
-  - Non-standard
   - Property
   - Reference
   - WebAPI
+  - Non-standard
+  - Deprecated
 browser-compat: api.IDBFileRequest.lockedFile
 ---
-{{APIRef("IndexedDB")}} {{non-standard_header}}
+{{APIRef("IndexedDB")}}{{deprecated_header}}
+
+> **Note:** The three non-standard interfaces {{domxref("IDBMutableFile")}}, {{domxref("IDBFileHandle")}}, and {{domxref("IDBFileRequest")}} are [disabled by default](#browser_compatibility).
+> Consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 The **`lockedFile`** read-only property returns the {{domxref("IDBFileHandle")}} object
 from which the request was started.
-
-> **Note:** The three interfaces `IDBMutableFile`, `IDBFileHandle`, and `IDBFileRequest` are deprecated and only implemented
-> for backward compatibility in Firefox. _Do not use them anymore_:
-> consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Value
 
@@ -30,7 +30,8 @@ This feature is not part of any current specification. It is no longer on track 
 
 ## Browser compatibility
 
-{{Compat}}
+This property is not supported by any current browser.
+From Firefox 102 it is behind the preference `dom.fileHandle.enabled`.
 
 ## See also
 

--- a/files/en-us/web/api/idbfilerequest/progress_event/index.md
+++ b/files/en-us/web/api/idbfilerequest/progress_event/index.md
@@ -5,21 +5,21 @@ tags:
   - API
   - DOM
   - Files
-  - Non-standard
   - Event
   - Reference
   - WebAPI
+  - Non-standard
+  - Deprecated
 browser-compat: api.IDBFileRequest.progress_event
 ---
-{{APIRef("IndexedDB")}} {{non-standard_header}}
+{{APIRef("IndexedDB")}}{{deprecated_header}}
+
+> **Note:** The three non-standard interfaces {{domxref("IDBMutableFile")}}, {{domxref("IDBFileHandle")}}, and {{domxref("IDBFileRequest")}} are [disabled by default](#browser_compatibility).
+> Consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 The **`progress`** is fired periodically when the request in progress.
 
 This event is not cancelable and does not bubble.
-
-> **Note:** The three interfaces `IDBMutableFile`, `IDBFileHandle`, and `IDBFileRequest` are deprecated and only implemented
-> for backward compatibility in Firefox. _Do not use them anymore_:
-> consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Syntax
 
@@ -58,7 +58,8 @@ Not part of any current specification.
 
 ## Browser compatibility
 
-{{Compat}}
+This event is not supported by any current browser.
+From Firefox 102 it is behind the preference `dom.fileHandle.enabled`.
 
 ## See also
 

--- a/files/en-us/web/api/idbmutablefile/abort_event/index.md
+++ b/files/en-us/web/api/idbmutablefile/abort_event/index.md
@@ -4,21 +4,22 @@ slug: Web/API/IDBMutableFile/abort_event
 tags:
   - API
   - Files
-  - Non-standard
   - Event
   - Reference
   - WebAPI
+  - Non-standard
+  - Deprecated
 browser-compat: api.IDBMutableFile.abort_event
 ---
-{{APIRef("IndexedDB")}}{{ non-standard_header }}
+{{APIRef("IndexedDB")}}{{deprecated_header}}
+
+> **Note:** The three non-standard interfaces {{domxref("IDBMutableFile")}}, {{domxref("IDBFileHandle")}}, and {{domxref("IDBFileRequest")}} are [disabled by default](#browser_compatibility).
+> Consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 The **'abort'** event is fired when the associated locked file has been aborted with the {{domxref("IDBFileHandle.abort()")}} method.
 
 This event is not cancelable and does not bubble.
 
-> **Note:** The three interfaces `IDBMutableFile`, `IDBFileHandle`, and `IDBFileRequest` are deprecated and only implemented
-> for backward compatibility in Firefox. _Do not use them anymore_:
-> consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Syntax
 
@@ -39,7 +40,8 @@ This feature is not part of any current specification. It is no longer on track 
 
 ## Browser compatibility
 
-{{Compat}}
+This event is not supported by any current browser.
+From Firefox 102 it is behind the preference `dom.fileHandle.enabled`.
 
 ## See also
 

--- a/files/en-us/web/api/idbmutablefile/error_event/index.md
+++ b/files/en-us/web/api/idbmutablefile/error_event/index.md
@@ -4,21 +4,21 @@ slug: Web/API/IDBMutableFile/error_event
 tags:
   - API
   - Files
-  - Non-standard
   - Event
   - Reference
   - WebAPI
+  - Non-standard
+  - Deprecated
 browser-compat: api.IDBMutableFile.error_event
 ---
-{{APIRef("IndexedDB")}}{{ non-standard_header }}
+{{APIRef("IndexedDB")}}{{deprecated_header}}
+
+> **Note:** The three non-standard interfaces {{domxref("IDBMutableFile")}}, {{domxref("IDBFileHandle")}}, and {{domxref("IDBFileRequest")}} are [disabled by default](#browser_compatibility).
+> Consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 The **'error'** event is fired when something goes wrong.
 
 This event is not cancelable and does not bubble.
-
-> **Note:** The three interfaces `IDBMutableFile`, `IDBFileHandle`, and `IDBFileRequest` are deprecated and only implemented
-> for backward compatibility in Firefox. _Do not use them anymore_:
-> consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Syntax
 
@@ -39,7 +39,8 @@ This feature is not part of any current specification. It is no longer on track 
 
 ## Browser compatibility
 
-{{Compat}}
+This event is not supported by any current browser.
+From Firefox 102 it is behind the preference `dom.fileHandle.enabled`.
 
 ## See also
 

--- a/files/en-us/web/api/idbmutablefile/index.md
+++ b/files/en-us/web/api/idbmutablefile/index.md
@@ -6,19 +6,19 @@ tags:
   - DOM
   - Files
   - Reference
-  - Non-standard
   - Interface
+  - Deprecated
+  - Non-standard
 browser-compat: api.IDBMutableFile
 ---
-{{APIRef("IndexedDB")}}{{non-standard_header}}
+{{APIRef("IndexedDB")}}{{deprecated_header}}
+
+> **Note:** The three non-standard interfaces {{domxref("IDBMutableFile")}}, {{domxref("IDBFileHandle")}}, and {{domxref("IDBFileRequest")}} are [disabled by default](#browser_compatibility).
+> Consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 The **`IDBMutableFile`** interface provides access in read or write mode to a file, dealing with all the necessary locks.
 
-As `IDBMutableFile` objects are bound to a fake file system built using IndexedDB, such an object is created using the {{domxref("IDBDatabase.createMutableFile()")}} method.
-
-> **Note:** The three interfaces `IDBMutableFile`, `IDBFileHandle`, and `IDBFileRequest` are deprecated and only implemented
-> for backward compatibility in Firefox. _Do not use them anymore_:
-> consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
+As `IDBMutableFile` objects are bound to a fake file system built using `IndexedDB`, such an object is created using the [`IDBDatabase.createMutableFile()`](/en-US/docs/Web/API/IDBDatabase#idbdatabase.createmutablefile) method.
 
 ## Properties
 
@@ -45,7 +45,8 @@ This feature is not part of any current specification. It is no longer on track 
 
 ## Browser compatibility
 
-{{Compat}}
+This interface is not supported by any current browser.
+From Firefox 102 it is behind the preference `dom.fileHandle.enabled`.
 
 ## See also
 

--- a/files/en-us/web/api/idbmutablefile/name/index.md
+++ b/files/en-us/web/api/idbmutablefile/name/index.md
@@ -4,19 +4,19 @@ slug: Web/API/IDBMutableFile/name
 tags:
   - API
   - Files
-  - Non-standard
   - Property
   - Reference
   - WebAPI
+  - Non-standard
+  - deprecated
 browser-compat: api.IDBMutableFile.name
 ---
-{{APIRef("IDBMutableFile")}}{{non-standard_header}}
+{{APIRef("IDBMutableFile")}}{{deprecated_header}}
+
+> **Note:** The three non-standard interfaces {{domxref("IDBMutableFile")}}, {{domxref("IDBFileHandle")}}, and {{domxref("IDBFileRequest")}} are [disabled by default](#browser_compatibility).
+> Consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 The read-only **`name`** property of the {{domxref("IDBMutableFile")}} interface provides the name of the file.
-
-> **Note:** The three interfaces `IDBMutableFile`, `IDBFileHandle`, and `IDBFileRequest` are deprecated and only implemented
-> for backward compatibility in Firefox. _Do not use them anymore_:
-> consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Value
 
@@ -28,7 +28,8 @@ This feature is not part of any current specification. It is no longer on track 
 
 ## Browser compatibility
 
-{{Compat}}
+This property is not supported by any current browser.
+From Firefox 102 it is behind the preference `dom.fileHandle.enabled`.
 
 ## See also
 

--- a/files/en-us/web/api/idbmutablefile/open/index.md
+++ b/files/en-us/web/api/idbmutablefile/open/index.md
@@ -5,20 +5,21 @@ tags:
   - API
   - Files
   - Method
-  - Non-standard
   - Reference
   - WebAPI
+  - Non-standard
+  - Deprecated
 browser-compat: api.IDBMutableFile.open
 ---
-{{APIRef("IndexedDB")}}{{non-standard_header}}
+{{APIRef("IndexedDB")}}{{deprecated_header}}
+
+> **Note:** The three non-standard interfaces {{domxref("IDBMutableFile")}}, {{domxref("IDBFileHandle")}}, and {{domxref("IDBFileRequest")}} are [disabled by default](#browser_compatibility).
+> Consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 The **`open()`** method of the {{domxref("IDBMutableFile")}}
 returns an {{domxref("IDBFileHandle")}} object
 that allows to safely write in the file.
 
-> **Note:** The three interfaces `IDBMutableFile`, `IDBFileHandle`, and `IDBFileRequest` are deprecated and only implemented
-> for backward compatibility in Firefox. _Do not use them anymore_:
-> consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Syntax
 
@@ -41,7 +42,8 @@ This feature is not part of any current specification. It is no longer on track 
 
 ## Browser compatibility
 
-{{Compat}}
+This method is not supported by any current browser.
+From Firefox 102 it is behind the preference `dom.fileHandle.enabled`.
 
 ## See also
 

--- a/files/en-us/web/api/idbmutablefile/type/index.md
+++ b/files/en-us/web/api/idbmutablefile/type/index.md
@@ -4,20 +4,19 @@ slug: Web/API/IDBMutableFile/type
 tags:
   - API
   - Files
-  - Non-standard
   - Property
   - Reference
   - WebAPI
+  - Non-standard
+  - Deprecated
 browser-compat: api.IDBMutableFile.type
 ---
-{{APIRef("IndexedDB")}}{{non-standard_header}}
+{{APIRef("IndexedDB")}}{{deprecated_header}}
 
-The read-only **`type`** property of the {{domxref("IDBMutableFile")}} interface
-returns the MIME type of the file.
+> **Note:** The three non-standard interfaces {{domxref("IDBMutableFile")}}, {{domxref("IDBFileHandle")}}, and {{domxref("IDBFileRequest")}} are [disabled by default](#browser_compatibility).
+> Consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
-> **Note:** The three interfaces `IDBMutableFile`, `IDBFileHandle`, and `IDBFileRequest` are deprecated and only implemented
-> for backward compatibility in Firefox. _Do not use them anymore_:
-> consider using the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
+The read-only **`type`** property of the {{domxref("IDBMutableFile")}} interface returns the MIME type of the file.
 
 ## Value
 
@@ -29,7 +28,8 @@ This feature is not part of any current specification. It is no longer on track 
 
 ## Browser compatibility
 
-{{Compat}}
+This property is not supported by any current browser.
+From Firefox 102 it is behind the preference `dom.fileHandle.enabled`.
 
 ## See also
 


### PR DESCRIPTION
FF102 puts [IDBMutableFile](https://developer.mozilla.org/en-US/docs/Web/API/IDBMutableFile), [IDBFileHandle](https://developer.mozilla.org/en-US/docs/Web/API/IDBFileHandle) , [IDBFileRequest](https://developer.mozilla.org/en-US/docs/Web/API/IDBFileRequest) and the method [IDBDatabase.createMutableFile()](https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase#idbdatabase.createmutablefile) behind the preference `dom.fileHandle.enabled` - on the path for removal.

They aren't in BCD and [IDBDatabase.createMutableFile()](https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase#idbdatabase.createmutablefile) isn't documented.

There is no point in doing BCD for something FF-only that is being removed. So I have marked all affected items with this header:
![image](https://user-images.githubusercontent.com/5368500/169451408-ba8a1fbd-14df-4f32-a613-0a4101b5b3b9.png)

And this compatibility section:
![image](https://user-images.githubusercontent.com/5368500/169451462-dcdf7a1a-2146-4bf0-8cd2-3ee223054db9.png)

Other docs work can be tracked in #16151