### PR TITLE
FF102 RelNote: IDBMutableFile, IDBFileHandle , IDBFileRequest disabled

### DIFF
--- a/files/en-us/mozilla/firefox/releases/102/index.md
+++ b/files/en-us/mozilla/firefox/releases/102/index.md
@@ -37,6 +37,8 @@ This article provides information about the changes in Firefox 102 that will aff
 
 ### APIs
 
+- The Non-standard interfaces [IDBMutableFile](/en-US/docs/Web/API/IDBMutableFile), [IDBFileHandle](/en-US/docs/Web/API/IDBFileHandle), [IDBFileRequest](/en-US/docs/Web/API/IDBFileRequest), and the method [IDBDatabase.createMutableFile()](/en-US/docs/Web/API/IDBDatabase#idbdatabase.createmutablefile), have been disabled by default, in preparation for removal in a future release ({{bug(1764771)}}).
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio


### PR DESCRIPTION
FF102 puts [IDBMutableFile](https://developer.mozilla.org/en-US/docs/Web/API/IDBMutableFile), [IDBFileHandle](https://developer.mozilla.org/en-US/docs/Web/API/IDBFileHandle) , [IDBFileRequest](https://developer.mozilla.org/en-US/docs/Web/API/IDBFileRequest) and the method [IDBDatabase.createMutableFile()](https://developer.mozilla.org/en-US/docs/Web/API/IDBDatabase#idbdatabase.createmutablefile) behind the preference `dom.fileHandle.enabled` - on the path for removal.

This adds a release note.

Other docs work can be tracked in #16151