### PR TITLE
Delete empty getCandidateWindowClientRect page

### DIFF
--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -87919,12 +87919,6 @@
       "kscarfone"
     ]
   },
-  "Web/API/getCandidateWindowClientRect": {
-    "modified": "2019-01-17T03:16:44.967Z",
-    "contributors": [
-      "mattwojo"
-    ]
-  },
   "Web/API/indexedDB": {
     "modified": "2020-10-15T21:25:18.475Z",
     "contributors": [

--- a/files/en-us/web/api/getcandidatewindowclientrect/index.md
+++ b/files/en-us/web/api/getcandidatewindowclientrect/index.md
@@ -1,8 +1,0 @@
----
-title: getCandidateWindowClientRect
-slug: Web/API/getCandidateWindowClientRect
-tags:
-  - Reference
-  - Deprecated
----
-{{deprecated_header}}


### PR DESCRIPTION
This page is virtually empty and not in the right place anyway.