### PR TITLE
fix: maxStateObjectSize to new default value

### DIFF
--- a/files/en-us/web/api/history/pushstate/index.md
+++ b/files/en-us/web/api/history/pushstate/index.md
@@ -40,7 +40,7 @@ pushState(state, unused, url)
 
     The `state` object can be anything that can be serialized. Because
     Firefox saves `state` objects to the user's disk so they can be restored
-    after the user restarts the browser, we impose a size limit of 2 MiB on the
+    after the user restarts the browser, we impose a size limit of 16 MiB on the
     serialized representation of a `state` object. If you pass a
     `state` object whose serialized representation is larger than this
     to `pushState()`, the method will throw an exception. If you need more


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

The `browser.history.maxStateObjectSize` in Firefox has been changed to 16 MiB (see https://bugzilla.mozilla.org/show_bug.cgi?id=1742168)

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The documentation is not reflecting the current application settings.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://bugzilla.mozilla.org/show_bug.cgi?id=1742168

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
