### PR TITLE
Replace most remaining manual spec tables in API tree

### DIFF
--- a/files/en-us/web/api/background_fetch_api/index.md
+++ b/files/en-us/web/api/background_fetch_api/index.md
@@ -69,9 +69,7 @@ You can find a demo application which implements Background Fetch [here](https:/
 
 ## Specifications
 
-| Specification                                                |
-| ------------------------------------------------------------ |
-| [Background Fetch](https://wicg.github.io/background-fetch/) |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/barcode_detection_api/index.md
+++ b/files/en-us/web/api/barcode_detection_api/index.md
@@ -9,6 +9,7 @@ tags:
   - barcode detection
   - shape detection
   - Experimental
+browser-compat: api.BarcodeDetector
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Barcode Detection API")}} {{AvailableInWorkers}} {{SeeCompatTable}}
 
@@ -272,13 +273,11 @@ This example uses the `detect()` method to detect the barcodes within the given 
 
 ## Specifications
 
-| Specification                                                                                                                      |
-| ---------------------------------------------------------------------------------------------------------------------------------- |
-| [Accelerated Shape Detection in Images # barcode-detection-api](https://wicg.github.io/shape-detection-api/#barcode-detection-api) |
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.BarcodeDetector")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/css_object_model/index.md
+++ b/files/en-us/web/api/css_object_model/index.md
@@ -6,6 +6,10 @@ tags:
   - CSSOM
   - Overview
   - Reference
+spec-urls:
+  - https://drafts.csswg.org/cssom/
+  - https://drafts.csswg.org/cssom-view/
+  - https://drafts.css-houdini.org/css-typed-om/
 ---
 {{DefaultAPISidebar("CSSOM")}}
 
@@ -102,18 +106,7 @@ Several other interfaces are also extended by the CSSOM-related specifications: 
 
 ## Specifications
 
-| Specification                                                                                               |
-| ----------------------------------------------------------------------------------------------------------- |
-| [CSS Object Model (CSSOM)](https://drafts.csswg.org/cssom/)                                                 |
-| [CSSOM View Module](https://drafts.csswg.org/cssom-view/)                                                   |
-| [CSS Fonts Module # object-model](https://drafts.csswg.org/css-fonts/#object-model)                         |
-| [CSS Animations # interface-dom](https://drafts.csswg.org/css-animations/#interface-dom)                    |
-| [CSS Conditional Rules Module # APIs](https://drafts.csswg.org/css-conditional/#apis)                       |
-| [CSS Custom Properties for Cascading Variables Module # APIs](https://drafts.csswg.org/css-variables/#apis) |
-| [CSS Counter Styles # APIs](https://drafts.csswg.org/css-counter-styles/#apis)                              |
-| [CSS Device Adaptation Module # cssom](https://drafts.csswg.org/css-device-adapt/#cssom)                    |
-| [CSS Painting API # paint-worklet](https://drafts.css-houdini.org/css-paint-api/#paint-worklet)             |
-| [CSS Typed OM](https://drafts.css-houdini.org/css-typed-om/)                                                |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/document_object_model/index.md
+++ b/files/en-us/web/api/document_object_model/index.md
@@ -10,6 +10,7 @@ tags:
   - Overview
   - Reference
   - Web
+spec-urls: https://dom.spec.whatwg.org/
 ---
 {{DefaultAPISidebar("DOM")}}
 
@@ -271,9 +272,7 @@ Here are the DOM APIs for data types used in the definitions of SVG properties a
 
 ## Specifications
 
-| Specification                                       |
-| --------------------------------------------------- |
-| [DOM Living Standard](https://dom.spec.whatwg.org/) |
+{{Specifications}}
 
 ## See also
 

--- a/files/en-us/web/api/document_object_model/introduction/index.md
+++ b/files/en-us/web/api/document_object_model/introduction/index.md
@@ -9,6 +9,7 @@ tags:
   - HTML DOM
   - Introduction
   - Tutorial
+spec-urls: https://dom.spec.whatwg.org/
 ---
 {{DefaultAPISidebar("DOM")}}
 
@@ -309,6 +310,4 @@ The following simple example illustrates using the DOM {{domxref("Document")}} A
 
 ## Specifications
 
-| Specification                                       |
-| --------------------------------------------------- |
-| [DOM Living Standard](https://dom.spec.whatwg.org/) |
+{{Specifications}}

--- a/files/en-us/web/api/indexeddb_api/index.md
+++ b/files/en-us/web/api/indexeddb_api/index.md
@@ -9,6 +9,7 @@ tags:
   - Landing
   - Reference
   - Storage
+spec-urls: https://w3c.github.io/IndexedDB/
 ---
 {{DefaultAPISidebar("IndexedDB")}}
 
@@ -81,9 +82,7 @@ This specification fires events with the following custom interface:
 
 ## Specifications
 
-| Specification                                            |
-| -------------------------------------------------------- |
-| [Indexed Database API](https://w3c.github.io/IndexedDB/) |
+{{Specifications}}
 
 ## See also
 

--- a/files/en-us/web/api/navigation_timing_api/index.md
+++ b/files/en-us/web/api/navigation_timing_api/index.md
@@ -11,6 +11,8 @@ tags:
   - Timing
   - Web
   - Web Performance
+browser-compat:
+  - api.PerformanceNavigationTiming
 ---
 {{DefaultAPISidebar("Navigation Timing")}}
 
@@ -72,12 +74,8 @@ This is obtained by starting with the time at which loading of the DOM and its d
 
 ## Specifications
 
-| Specification                                                 |
-| ------------------------------------------------------------- |
-| [Navigation Timing](https://w3c.github.io/navigation-timing/) |
+{{Specifications}}
 
 ## Browser compatibility
 
-### `Window.performance.timing`
-
-{{Compat("api.PerformanceTiming")}}
+{{Compat}}

--- a/files/en-us/web/api/notifications_api/index.md
+++ b/files/en-us/web/api/notifications_api/index.md
@@ -7,6 +7,7 @@ tags:
   - Notifications API
   - permission
   - system
+browser-compat: api.Notification
 ---
 {{DefaultAPISidebar("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 
@@ -55,13 +56,11 @@ In addition, the Notifications API spec specifies a number of additions to the [
 
 ## Specifications
 
-| Specification                                                               |
-| --------------------------------------------------------------------------- |
-| [Notifications API Living Standard](https://notifications.spec.whatwg.org/) |
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.Notification")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/page_visibility_api/index.md
+++ b/files/en-us/web/api/page_visibility_api/index.md
@@ -14,6 +14,7 @@ tags:
   - Tutorials
   - Visibility
   - Visible Pages
+browser-compat: api.Document.visibilityState
 ---
 {{DefaultAPISidebar("Page Visibility API")}}
 
@@ -159,12 +160,8 @@ document.addEventListener("visibilitychange", handleVisibilityChange, false);
 
 ## Specifications
 
-| Specification                                             |
-| --------------------------------------------------------- |
-| [Page Visibility](https://w3c.github.io/page-visibility/) |
+{{Specifications}}
 
 ## Browser compatibility
 
-### `Document.visibilityState`
-
-{{Compat("api.Document.visibilityState")}}
+{{Compat}}

--- a/files/en-us/web/api/payment_request_api/index.md
+++ b/files/en-us/web/api/payment_request_api/index.md
@@ -14,6 +14,7 @@ tags:
   - Reference
   - Secure context
   - payment
+browser-compat: api.PaymentRequest
 ---
 {{DefaultAPISidebar("Payment Request API")}}{{securecontext_header}}
 
@@ -55,16 +56,11 @@ You can find a complete guide in [Using the Payment Request API](/en-US/docs/Web
 
 ## Specifications
 
-| Specification                                                                  |
-| ------------------------------------------------------------------------------ |
-| [Payment Request API](https://w3c.github.io/payment-request/)                  |
-| [Payment Method Identifiers](https://w3c.github.io/payment-method-id/)         |
+{{Specifications}}
 
 ## Browser compatibility
 
-### PaymentRequest interface
-
-{{Compat("api.PaymentRequest", 0)}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/performance_api/index.md
+++ b/files/en-us/web/api/performance_api/index.md
@@ -7,6 +7,12 @@ tags:
   - Overview
   - Performance
   - Web Performance
+spec-urls:
+  - https://w3c.github.io/hr-time/
+  - https://w3c.github.io/navigation-timing/
+  - https://w3c.github.io/performance-timeline/
+  - https://w3c.github.io/resource-timing/
+  - https://w3c.github.io/user-timing/
 ---
 {{DefaultAPISidebar("High Resolution Time")}}
 
@@ -51,13 +57,7 @@ The {{domxref("Performance.navigation","navigation")}} property returns a {{domx
 
 ## Specifications
 
-| Specification                                                     |
-| ----------------------------------------------------------------- |
-| [High Resolution Time](https://w3c.github.io/hr-time/)            |
-| [Navigation Timing](https://w3c.github.io/navigation-timing/)     |
-| [Performance Timing](https://w3c.github.io/performance-timeline/) |
-| [Resource Timing](https://w3c.github.io/resource-timing/)         |
-| [User Timing](https://w3c.github.io/user-timing/)                 |
+{{Specifications}}
 
 ## Implementation status
 

--- a/files/en-us/web/api/performance_timeline/index.md
+++ b/files/en-us/web/api/performance_timeline/index.md
@@ -5,6 +5,7 @@ tags:
   - Guide
   - Overview
   - Web Performance
+spec-urls: https://w3c.github.io/performance-timeline/
 ---
 {{DefaultAPISidebar("Performance Timeline API")}}
 
@@ -54,9 +55,7 @@ Performance observers were added to the `Level 2` version of the standard and we
 
 ## Specifications
 
-| Specification                                                       |
-| ------------------------------------------------------------------- |
-| [Performance Timeline](https://w3c.github.io/performance-timeline/) |
+{{Specifications}}
 
 ## Implementation status
 

--- a/files/en-us/web/api/permissions_api/index.md
+++ b/files/en-us/web/api/permissions_api/index.md
@@ -9,6 +9,7 @@ tags:
   - Permissions API
   - Web
   - access
+browser-compat: api.Permissions
 ---
 {{DefaultAPISidebar("Permissions API")}}
 
@@ -50,15 +51,11 @@ Read more about how it works in our article [Using the Permissions API](/en-US/d
 
 ## Specifications
 
-| Specification                                     |
-| ------------------------------------------------- |
-| [Permissions](https://w3c.github.io/permissions/) |
+{{Specifications}}
 
 ## Browser compatibility
 
-### Permissions interface
-
-{{Compat("api.Permissions")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/picture-in-picture_api/index.md
+++ b/files/en-us/web/api/picture-in-picture_api/index.md
@@ -13,6 +13,7 @@ tags:
   - Video
   - View
   - pip
+browser-compat: api.PictureInPictureWindow
 ---
 {{DefaultAPISidebar("Picture-in-Picture API")}}
 
@@ -109,39 +110,11 @@ If the value is `null`, no video is in the floating window. So we can request a 
 
 ## Specifications
 
-| Specification                                                   |
-| --------------------------------------------------------------- |
-| [Picture-in-Picture](https://w3c.github.io/picture-in-picture/) |
+{{Specifications}}
 
 ## Browser compatibility
 
-### `HTMLVideoElement.requestPictureInPicture`
-
-{{Compat("api.HTMLVideoElement.requestPictureInPicture")}}
-
-### `HTMLVideoElement.autoPictureInPicture`
-
-{{Compat("api.HTMLVideoElement.autoPictureInPicture")}}
-
-### `HTMLVideoElement.disablePictureInPicture`
-
-{{Compat("api.HTMLVideoElement.disablePictureInPicture")}}
-
-### `Document.pictureInPictureEnabled`
-
-{{Compat("api.Document.pictureInPictureEnabled")}}
-
-### `Document.exitPictureInPicture`
-
-{{Compat("api.Document.exitPictureInPicture")}}
-
-### `Document.pictureInPictureElement`
-
-{{Compat("api.Document.pictureInPictureElement")}}
-
-### `PictureInPictureWindow`
-
-{{Compat("api.PictureInPictureWindow")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/pointer_events/index.md
+++ b/files/en-us/web/api/pointer_events/index.md
@@ -9,6 +9,7 @@ tags:
   - Pointer Events
   - Web
   - events
+browser-compat: api.PointerEvent
 ---
 {{DefaultAPISidebar("Pointer Events")}}
 
@@ -467,13 +468,11 @@ Here are some _best practices_ to consider when using pointer events:
 
 ## Specifications
 
-| Specification                                          |
-| ------------------------------------------------------ |
-| [Pointer Events](https://w3c.github.io/pointerevents/) |
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.PointerEvent")}}
+{{Compat}}
 
 Some new values have been defined for the {{cssxref("touch-action", "CSS touch-action")}} property as part of the {{SpecName('Pointer Events 3')}} specification but currently those new values have limited implementation support.
 

--- a/files/en-us/web/api/pointer_lock_api/index.md
+++ b/files/en-us/web/api/pointer_lock_api/index.md
@@ -8,6 +8,7 @@ tags:
   - Reference
   - mouse lock
   - pointer lock
+browser-compat: api.Element.requestPointerLock
 ---
 {{DefaultAPISidebar("Pointer Lock API")}}
 
@@ -233,15 +234,11 @@ While iframes work by default, "sandboxed" iframes block Pointer lock. To avoid 
 
 ## Specifications
 
-| Specification                                      |
-| -------------------------------------------------- |
-| [Pointer Lock](https://w3c.github.io/pointerlock/) |
+{{Specifications}}
 
 ## Browser compatibility
 
-### `Element.requestPointerLock`
-
-{{Compat("api.Element.requestPointerLock")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/presentation_api/index.md
+++ b/files/en-us/web/api/presentation_api/index.md
@@ -7,6 +7,7 @@ tags:
   - NeedsContent
   - Presentation API
   - Reference
+browser-compat: api.Presentation
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef("Presentation API")}}
 
@@ -258,15 +259,11 @@ Example codes below highlight the usage of main features of the Presentation API
 
 ## Specifications
 
-| Specification                                               |
-| ----------------------------------------------------------- |
-| [Presentation API](https://w3c.github.io/presentation-api/) |
+{{Specifications}}
 
 ## Browser compatibility
 
-### `Presentation`
-
-{{Compat("api.Presentation")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/reporting_api/index.md
+++ b/files/en-us/web/api/reporting_api/index.md
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Reporting
   - Secure context
+spec-urls: https://w3c.github.io/reporting/#intro
 ---
 {{SeeCompatTable}}{{APIRef("Reporting API")}}
 
@@ -120,9 +121,7 @@ This causes a deprecation report to be generated; because of the event handler w
 
 ## Specifications
 
-| Specification                                                | Status | Comment |
-| ------------------------------------------------------------ | ------ | ------- |
-| [Reporting API spec](https://w3c.github.io/reporting/#intro) |        |         |
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/resource_timing_api/index.md
+++ b/files/en-us/web/api/resource_timing_api/index.md
@@ -10,6 +10,7 @@ tags:
   - Resource Timing API
   - Timing
   - Web Performance
+spec-urls: https://w3c.github.io/resource-timing/
 ---
 {{DefaultAPISidebar("Resource Timing API")}}
 
@@ -63,9 +64,7 @@ The {{domxref("PerformanceResourceTiming")}} interface's {{domxref("PerformanceR
 
 ## Specifications
 
-| Specification                                             |
-| --------------------------------------------------------- |
-| [Resource Timing](https://w3c.github.io/resource-timing/) |
+{{Specifications}}
 
 ## Implementation status
 

--- a/files/en-us/web/api/screen_capture_api/index.md
+++ b/files/en-us/web/api/screen_capture_api/index.md
@@ -11,6 +11,7 @@ tags:
   - Screen Capture API
   - Screen Sharing
   - getDisplayMedia
+browser-compat: api.MediaDevices.getDisplayMedia
 ---
 {{DefaultAPISidebar("Screen Capture API")}}
 
@@ -93,13 +94,11 @@ See [Using Feature Policy](/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Pol
 
 ## Specifications
 
-| Specification                                                      |
-| ------------------------------------------------------------------ |
-| [Screen Capture](https://w3c.github.io/mediacapture-screen-share/) |
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.MediaDevices.getDisplayMedia")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/screen_wake_lock_api/index.md
+++ b/files/en-us/web/api/screen_wake_lock_api/index.md
@@ -9,6 +9,7 @@ tags:
   - Wake Lock
   - WakeLock
   - screen
+browser-compat: api.WakeLock
 ---
 {{DefaultAPISidebar("Screen Wake Lock API")}}
 
@@ -122,13 +123,11 @@ Access to Screen Wake Lock API is controlled by [Feature Policy](/en-US/docs/Web
 
 ## Specifications
 
-| Specification                                                   |
-| --------------------------------------------------------------- |
-| [Screen Wake Lock API](https://w3c.github.io/screen-wake-lock/) |
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.WakeLock")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/sensor_apis/index.md
+++ b/files/en-us/web/api/sensor_apis/index.md
@@ -9,6 +9,7 @@ tags:
   - Sensor
   - Sensor APIs
   - Sensors
+browser-compat: api.Sensor
 ---
 {{APIRef("Sensor API")}}
 
@@ -167,15 +168,8 @@ magSensor.start();
 
 ## Specifications
 
-| Specification                                                   |
-| --------------------------------------------------------------- |
-| [Generic Sensor API](https://w3c.github.io/sensors/)            |
-| [Accelerometer](https://w3c.github.io/accelerometer/)           |
-| [Ambient Light Sensor](https://w3c.github.io/ambient-light/)    |
-| [Gyroscope](https://w3c.github.io/gyroscope/)                   |
-| [Magnetometer](https://w3c.github.io/magnetometer/)             |
-| [Orientation Sensor](https://w3c.github.io/orientation-sensor/) |
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.Sensor")}}
+{{Compat}}

--- a/files/en-us/web/api/server-sent_events/index.md
+++ b/files/en-us/web/api/server-sent_events/index.md
@@ -6,6 +6,7 @@ tags:
   - Overview
   - SSE
   - Server-sent events
+spec-urls: https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events
 ---
 {{DefaultAPISidebar("Server Sent Events")}}
 
@@ -30,9 +31,7 @@ To learn how to use server-sent events, see our article [Using server-sent event
 
 ## Specifications
 
-| Specification                                                                                                                  |
-| ------------------------------------------------------------------------------------------------------------------------------ |
-| [HTML Living Standard # server-sent-events](https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events) |
+{{Specifications}}
 
 ## See also
 

--- a/files/en-us/web/api/service_worker_api/index.md
+++ b/files/en-us/web/api/service_worker_api/index.md
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Service Workers
   - Workers
+spec-urls: https://w3c.github.io/ServiceWorker/
 ---
 {{ServiceWorkerSidebar}}
 
@@ -125,9 +126,7 @@ In the future, service workers will be able to do a number of other useful thing
 
 ## Specifications
 
-| Specification                                           |
-| ------------------------------------------------------- |
-| [Service Workers](https://w3c.github.io/ServiceWorker/) |
+{{Specifications}}
 
 ## See also
 

--- a/files/en-us/web/api/storage_api/index.md
+++ b/files/en-us/web/api/storage_api/index.md
@@ -10,6 +10,7 @@ tags:
   - Storage
   - Storage API
   - Usage
+browser-compat: api.StorageManager
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Storage")}} {{AvailableInWorkers}}
 
@@ -79,15 +80,11 @@ navigator.storage.estimate().then(estimate => {
 
 ## Specifications
 
-| Specification                                               |
-| ----------------------------------------------------------- |
-| [Storage Living Standard](https://storage.spec.whatwg.org/) |
+{{Specifications}}
 
 ## Browser compatibility
 
-### `StorageManager`
-
-{{Compat("api.StorageManager")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/svg_api/index.md
+++ b/files/en-us/web/api/svg_api/index.md
@@ -8,6 +8,7 @@ tags:
   - Overview
   - Reference
   - Web
+spec-urls: https://svgwg.org/svg2-draft/
 ---
 {{DefaultAPISidebar("SVG")}}
 
@@ -153,9 +154,7 @@ Here are the DOM APIs for data types used in the definitions of SVG properties a
 
 ## Specifications
 
-| Specification                                       |
-| --------------------------------------------------- |
-| [Scalable Vector Graphics (SVG) Full 1.2 Specification](https://www.w3.org/TR/SVG12/) |
+{{Specifications}}
 
 ## See also
 

--- a/files/en-us/web/api/url_api/index.md
+++ b/files/en-us/web/api/url_api/index.md
@@ -13,6 +13,7 @@ tags:
   - URL API
   - Web
   - hostname
+browser-compat: api.URL
 ---
 {{DefaultAPISidebar("URL API")}}
 
@@ -103,13 +104,11 @@ A working version of this example can be [found on Glitch](https://url-api.glitc
 
 ## Specifications
 
-| Specification                                       |
-| --------------------------------------------------- |
-| [URL Living Standard](https://url.spec.whatwg.org/) |
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.URL")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/vibration_api/index.md
+++ b/files/en-us/web/api/vibration_api/index.md
@@ -6,6 +6,7 @@ tags:
   - Beginner
   - Mobile
   - Vibration
+browser-compat: api.Navigator.vibrate
 ---
 {{DefaultAPISidebar("Vibration API")}}
 
@@ -74,13 +75,11 @@ Of course, the snippet above doesn't take into account the array method of vibra
 
 ## Specifications
 
-| Specification                                     |
-| ------------------------------------------------- |
-| [Vibration API](https://w3c.github.io/vibration/) |
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.Navigator.vibrate")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/web_animations_api/index.md
+++ b/files/en-us/web/api/web_animations_api/index.md
@@ -7,6 +7,7 @@ tags:
   - Landing
   - Reference
   - Web Animations
+spec-urls: https://drafts.csswg.org/web-animations/
 ---
 {{DefaultAPISidebar("Web Animations")}}
 
@@ -49,9 +50,7 @@ The Web Animations API adds some new features to {{domxref("document")}} and {{d
 
 ## Specifications
 
-| Specification                                                |
-| ------------------------------------------------------------ |
-| [Web Animations](https://drafts.csswg.org/web-animations-1/) |
+{{Specifications}}
 
 ## See also
 

--- a/files/en-us/web/api/web_crypto_api/index.md
+++ b/files/en-us/web/api/web_crypto_api/index.md
@@ -6,6 +6,7 @@ tags:
   - Overview
   - Reference
   - Web Crypto API
+browser-compat: api.Crypto
 ---
 {{DefaultAPISidebar("Web Crypto API")}}
 
@@ -27,12 +28,8 @@ Some browsers implemented an interface called {{domxref("Crypto")}} without havi
 
 ## Specifications
 
-| Specification                                            |
-| -------------------------------------------------------- |
-| [Web Cryptography API](https://w3c.github.io/webcrypto/) |
+{{Specifications}}
 
 ## Browser compatibility
 
-### `Crypto`
-
-{{Compat("api.Crypto")}}
+{{Compat}}

--- a/files/en-us/web/api/web_midi_api/index.md
+++ b/files/en-us/web/api/web_midi_api/index.md
@@ -7,6 +7,7 @@ tags:
   - Overview
   - Reference
   - Web MIDI API
+spec-urls: https://webaudio.github.io/web-midi-api/
 ---
 {{DefaultAPISidebar("Web MIDI API")}}{{SecureContext_Header}}
 
@@ -96,9 +97,7 @@ function startLoggingMIDIInput( midiAccess, indexOfPort ) {
 
 ## Specifications
 
-| Specification                                            |
-| -------------------------------------------------------- |
-| [Web MIDI API](https://webaudio.github.io/web-midi-api/) |
+{{Specifications}}
 
 ## See also
 

--- a/files/en-us/web/api/web_nfc_api/index.md
+++ b/files/en-us/web/api/web_nfc_api/index.md
@@ -5,6 +5,7 @@ tags:
   - NDEF
   - Reference
   - Web NFC
+browser-compat: api.NDEFReader
 ---
 {{DefaultAPISidebar("Web NFC API")}}{{SeeCompatTable}}
 
@@ -23,10 +24,8 @@ The Web NFC API allows exchanging data over NFC via light-weight NFC Data Exchan
 
 ## Specifications
 
-| Specification                             | Status | Comment |
-| ----------------------------------------- | ------ | ------- |
-| [Web NFC](https://w3c.github.io/web-nfc/) | Draft  |         |
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.NDEFReader")}}
+{{Compat}}

--- a/files/en-us/web/api/web_periodic_background_synchronization_api/index.md
+++ b/files/en-us/web/api/web_periodic_background_synchronization_api/index.md
@@ -12,6 +12,7 @@ tags:
   - Sync
   - Web Periodic Background Synchronization API
   - periodic
+browser-compat: api.PeriodicSyncManager
 ---
 {{securecontext_header}}
 
@@ -105,13 +106,11 @@ self.addEventListener('periodicsync', event => {
 
 ## Specifications
 
-| Specification                                                                              |
-| ------------------------------------------------------------------------------------------ |
-| [Web Periodic Background Synchronization](https://wicg.github.io/periodic-background-sync/) |
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.PeriodicSyncManager")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/web_workers_api/index.md
+++ b/files/en-us/web/api/web_workers_api/index.md
@@ -6,6 +6,7 @@ tags:
   - Overview
   - Reference
   - Web Workers
+spec-urls: https://html.spec.whatwg.org/multipage/workers.html#workers
 ---
 {{DefaultAPISidebar("Web Workers API")}}
 
@@ -82,9 +83,7 @@ You can find out more information on how these demos work in [Using Web Workers]
 
 ## Specifications
 
-| Specification                                                                                 |
-| --------------------------------------------------------------------------------------------- |
-| [HTML Living Standard # workers](https://html.spec.whatwg.org/multipage/workers.html#workers) |
+{{Specifications}}
 
 ## See also
 

--- a/files/en-us/web/api/webotp_api/index.md
+++ b/files/en-us/web/api/webotp_api/index.md
@@ -6,6 +6,7 @@ tags:
   - WebOTP
   - Overview
   - Reference
+spec-urls: https://wicg.github.io/web-otp/
 ---
 {{securecontext_header}}{{DefaultAPISidebar("WebOTP API")}}
 
@@ -59,9 +60,7 @@ if ('OTPCredential' in window) {
 
 ## Specifications
 
-| Specification                                 |
-| --------------------------------------------- |
-| [WebOTP API](https://wicg.github.io/web-otp/) |
+{{Specifications}}
 
 ## See also
 

--- a/files/en-us/web/api/webrtc_api/index.md
+++ b/files/en-us/web/api/webrtc_api/index.md
@@ -12,6 +12,10 @@ tags:
   - WebRTC
   - WebRTC API
   - streaming
+spec-urls:
+  - https://w3c.github.io/webrtc-pc/)
+  - https://w3c.github.io/mediacapture-main/
+  - https://w3c.github.io/mediacapture-fromelement/
 ---
 {{DefaultAPISidebar("WebRTC")}}
 
@@ -192,11 +196,7 @@ These interfaces and events are related to interactivity with Public-Switched Te
 
 ## Specifications
 
-| Specification                                                                        |
-| ------------------------------------------------------------------------------------ |
-| [WebRTC: Real-Time Communication Between Browsers](https://w3c.github.io/webrtc-pc/) |
-| [Media Capture and Streams](https://w3c.github.io/mediacapture-main/)                |
-| [Media Capture from DOM Elements](https://w3c.github.io/mediacapture-fromelement/)   |
+{{Specifications}}
 
 ### WebRTC-proper protocols
 

--- a/files/en-us/web/api/websockets_api/index.md
+++ b/files/en-us/web/api/websockets_api/index.md
@@ -13,6 +13,7 @@ tags:
   - WebSockets
   - data
   - interactive
+browser-compat: api.WebSocket
 ---
 {{DefaultAPISidebar("Websockets API")}}
 
@@ -64,14 +65,11 @@ The **WebSocket API** is an advanced technology that makes it possible to open a
 
 ## Specifications
 
-| Specification                                                                                     |
-| ------------------------------------------------------------------------------------------------- |
-| [HTML Living Standard # network](https://websockets.spec.whatwg.org) |
-| [RFC 6455, The WebSocket Protocol](https://datatracker.ietf.org/doc/html/rfc6455)                 |
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.WebSocket")}}
+{{Compat}}
 
 ## See also
 


### PR DESCRIPTION
This change replaces most of the remaining manual spec tables in the API tree with calls to the `{{Specifications}` macro instead — in most cases, by moving the data into a `browser-compat` key, and in some cases by moving into a `spec-urls` key.