### PR TITLE
Convert multi-BCD-table docs to browser-compat YAML array values

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/interact_with_the_clipboard/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/interact_with_the_clipboard/index.md
@@ -12,6 +12,9 @@ tags:
   - WebExtensions
   - copy
   - paste
+browser-compat:
+  - api.Clipboard
+  - webextensions.api.clipboard
 ---
 {{AddonSidebar}}
 
@@ -171,13 +174,7 @@ Firefox supports the `"clipboardRead"` [permission](/en-US/docs/Mozilla/Add-ons/
 
 ## Browser compatibility
 
-### navigator.clipboard
-
-{{Compat("api.Clipboard")}}
-
-### clipboard.setImageData
-
-{{Compat("webextensions.api.clipboard")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_styles/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_styles/index.md
@@ -8,6 +8,12 @@ tags:
   - Extensions
   - Guide
   - WebExtensions
+browser-compat:
+  - webextensions.manifest.action
+  - webextensions.manifest.browser_action
+  - webextensions.manifest.page_action
+  - webextensions.manifest.sidebar_action
+  - webextensions.manifest.options_ui
 ---
 {{AddonSidebar}}
 
@@ -109,7 +115,7 @@ Most styles are automatically applied, but some elements require you to add the 
 
 ## Browser compatibility
 
-For browser compatibility information refer to the browser compatibility sections of the [action](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action#browser_compatibility), [browser_action](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action#browser_compatibility), [page_action](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action#browser_compatibility), [sidebar_action](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action#browser_compatibility), and [options_ui](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui#browser_compatibility) manifest keys.
+{{Compat}}
 
 ## Firefox Panel Components
 

--- a/files/en-us/web/api/channel_messaging_api/index.md
+++ b/files/en-us/web/api/channel_messaging_api/index.md
@@ -8,6 +8,9 @@ tags:
   - HTML API
   - Overview
   - Reference
+browser-compat:
+  - api.MessageChannel
+  - api.MessagePort
 ---
 {{DefaultAPISidebar("Channel Messaging API")}}
 
@@ -41,17 +44,11 @@ Find out more about how to use this API in [Using channel messaging](/en-US/docs
 
 ## Specifications
 
-{{Specifications("api.MessageChannel")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-### `MessageChannel`
-
-{{Compat("api.MessageChannel", 0)}}
-
-### `MessagePort`
-
-{{Compat("api.MessagePort", 0)}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/channel_messaging_api/using_channel_messaging/index.md
+++ b/files/en-us/web/api/channel_messaging_api/using_channel_messaging/index.md
@@ -9,6 +9,9 @@ tags:
   - MessageChannel
   - MessagePort
   - Tutorial
+browser-compat:
+  - api.MessageChannel
+  - api.MessagePort
 ---
 {{DefaultAPISidebar("Channel Messaging API")}}
 
@@ -136,17 +139,11 @@ When a message is received back from the IFrame confirming that the original mes
 
 ## Specifications
 
-{{Specifications("api.MessageChannel")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-### `MessageChannel`
-
-{{Compat("api.MessageChannel", 0)}}
-
-### `MessagePort`
-
-{{Compat("api.MessagePort", 0)}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/clipboard_api/index.md
+++ b/files/en-us/web/api/clipboard_api/index.md
@@ -15,6 +15,10 @@ tags:
   - Reference
   - copy
   - paste
+browser-compat:
+  - api.Clipboard
+  - api.ClipboardEvent
+  - api.ClipboardItem
 ---
 {{DefaultAPISidebar("Clipboard API")}}
 
@@ -46,21 +50,11 @@ This snippet fetches the text from the clipboard and appends it to the first ele
 
 ## Specifications
 
-{{Specifications("api.Clipboard")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-### Clipboard
-
-{{Compat("api.Clipboard")}}
-
-### ClipboardEvent
-
-{{Compat("api.ClipboardEvent")}}
-
-### ClipboardItem
-
-{{Compat("api.ClipboardItem")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/css_typed_om_api/index.md
+++ b/files/en-us/web/api/css_typed_om_api/index.md
@@ -7,6 +7,11 @@ tags:
   - CSS Typed Object Model API
   - Houdini
   - Reference
+browser-compat:
+  - api.CSSStyleValue
+  - api.StylePropertyMap
+  - api.CSSUnparsedValue
+  - api.CSSKeywordValue
 ---
 {{DefaultAPISidebar("CSS Typed Object Model API")}}
 
@@ -108,16 +113,11 @@ CSSStyleValue is the base class through which all CSS values are expressed. Subc
 
 ## Specifications
 
-{{Specifications("api.CSSStyleValue")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-See individual interfaces
-
-- [CSSStyleValue](/en-US/docs/Web/API/CSSStyleValue#browser_compatibility)
-- [StylePropertyMap](/en-US/docs/Web/API/StylePropertyMap#browser_compatibility)
-- [CSSUnparsedValue](/en-US/docs/Web/API/CSSUnparsedValue#browser_compatibility)
-- [CSSKeywordValue](/en-US/docs/Web/API/CSSKeywordValue#browser_compatibility)
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/device_memory_api/index.md
+++ b/files/en-us/web/api/device_memory_api/index.md
@@ -4,7 +4,9 @@ slug: Web/API/Device_Memory_API
 page-type: web-api-overview
 tags:
   - Device Memory API
-spec-urls: https://w3c.github.io/device-memory/
+browser-compat:
+  - api.Navigator.deviceMemory
+  - http.headers.Device-Memory
 ---
 {{DefaultAPISidebar("Device Memory API")}}{{securecontext_header}}{{SeeCompatTable}}
 
@@ -32,13 +34,7 @@ You may also use the [Client Hints](/en-US/docs/Web/HTTP/Client_hints) HTTP Head
 
 ## Browser compatibility
 
-### JavaScript interface
-
-{{Compat("api.Navigator.deviceMemory")}}
-
-### Client Hints extension
-
-{{Compat("http.headers.Device-Memory")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/dommatrix/index.md
+++ b/files/en-us/web/api/dommatrix/index.md
@@ -11,7 +11,9 @@ tags:
   - Interface
   - Reference
   - matrix
-browser-compat: api.DOMMatrix
+browser-compat:
+  - api.DOMMatrix
+  - api.WebKitCSSMatrix
 ---
 {{APIRef("Geometry Interfaces")}}
 
@@ -110,8 +112,6 @@ The `DOMMatrix` interface is designed with the intent that it will be used for a
 ## Browser compatibility
 
 {{Compat}}
-
-{{Compat("api.WebKitCSSMatrix")}}
 
 ## See also
 

--- a/files/en-us/web/api/ecdsaparams/index.md
+++ b/files/en-us/web/api/ecdsaparams/index.md
@@ -8,7 +8,9 @@ tags:
   - EcdsaParams
   - Reference
   - Web Crypto API
-spec-urls: https://w3c.github.io/webcrypto/#dfn-EcdsaParams
+browser-compat:
+  - api.SubtleCrypto.sign
+  - api.SubtleCrypto.verify
 ---
 {{ APIRef("Web Crypto API") }}
 
@@ -40,7 +42,7 @@ See the examples for {{domxref("SubtleCrypto.sign()")}} or {{domxref("SubtleCryp
 
 Browsers that support the "ECDSA" algorithm for the {{domxref("SubtleCrypto.sign()")}} and {{domxref("SubtleCrypto.verify()")}} methods will support this type.
 
-{{Compat("api.SubtleCrypto.sign")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/encoding_api/index.md
+++ b/files/en-us/web/api/encoding_api/index.md
@@ -7,7 +7,9 @@ tags:
   - Encoding
   - Overview
   - Reference
-spec-urls: https://encoding.spec.whatwg.org/
+browser-compat:
+  - api.TextDecoder
+  - api.TextEncoder
 ---
 {{DefaultAPISidebar("Encoding API")}}
 
@@ -30,13 +32,7 @@ The API provides four interfaces: {{domxref("TextDecoder")}}, {{domxref("TextEnc
 
 ## Browser compatibility
 
-### `TextDecoder`
-
-{{Compat("api.TextDecoder")}}
-
-### `TextEncoder`
-
-{{Compat("api.TextEncoder")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/file_system_access_api/index.md
+++ b/files/en-us/web/api/file_system_access_api/index.md
@@ -12,7 +12,11 @@ tags:
   - Landing
   - Overview
   - working with files
-spec-urls: https://fs.spec.whatwg.org/
+browser-compat:
+  - api.FileSystemHandle
+  - api.FileSystemFileHandle
+  - api.FileSystemDirectoryHandle
+  - api.FileSystemWritableFileStream
 ---
 {{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
 
@@ -175,10 +179,7 @@ writableStream.write({ type: "truncate", size: size })
 
 ## Browser compatibility
 
-{{Compat("api.FileSystemHandle")}}
-{{Compat("api.FileSystemFileHandle")}}
-{{Compat("api.FileSystemDirectoryHandle")}}
-{{Compat("api.FileSystemWritableFileStream")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/fullscreen_api/guide/index.md
+++ b/files/en-us/web/api/fullscreen_api/guide/index.md
@@ -14,7 +14,9 @@ tags:
   - full screen
   - fullscreen
   - screen
-spec-urls: https://fullscreen.spec.whatwg.org/
+browser-compat:
+  - api.Document.fullscreen
+  - api.Document.fullscreenEnabled
 ---
 {{DefaultAPISidebar("Fullscreen API")}}
 
@@ -185,13 +187,7 @@ For the moment not all browsers are implementing the unprefixed version of the A
 
 ## Browser compatibility
 
-### `Document.fullscreen`
-
-{{Compat("api.Document.fullscreen")}}
-
-### `Document.fullscreenEnabled`
-
-{{Compat("api.Document.fullscreenEnabled")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/fullscreen_api/index.md
+++ b/files/en-us/web/api/fullscreen_api/index.md
@@ -17,7 +17,12 @@ tags:
   - View
   - fullscreen
   - screen
-spec-urls: https://fullscreen.spec.whatwg.org/
+browser-compat:
+  - api.Document.fullscreen
+  - api.Document.fullscreenElement
+  - api.Document.fullscreenEnabled
+  - api.Document.exitFullscreen
+  - api.Element.requestFullscreen
 ---
 {{DefaultAPISidebar("Fullscreen API")}}
 
@@ -129,25 +134,7 @@ If fullscreen mode is already active (`fullscreenElement` is not `null`), we cal
 
 ## Browser compatibility
 
-### `Document.fullscreen`
-
-{{Compat("api.Document.fullscreen")}}
-
-### `Document.fullscreenElement`
-
-{{Compat("api.Document.fullscreenElement")}}
-
-### `Document.fullscreenEnabled`
-
-{{Compat("api.Document.fullscreenEnabled")}}
-
-### `Document.exitFullscreen`
-
-{{Compat("api.Document.exitFullscreen")}}
-
-### `Element.requestFullscreen`
-
-{{Compat("api.Element.requestFullscreen")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/keyboard_api/index.md
+++ b/files/en-us/web/api/keyboard_api/index.md
@@ -10,9 +10,9 @@ tags:
   - Keyboard Map
   - Overview
   - Reference
-spec-urls:
-  - https://wicg.github.io/keyboard-map/
-  - https://wicg.github.io/keyboard-lock/
+browser-compat:
+  - api.Keyboard
+  - api.KeyboardLayoutMap
 ---
 {{SeeCompatTable}}{{APIRef("Keyboard API")}}
 
@@ -78,10 +78,4 @@ The codes passed {{domxref('Keyboard.lock')}} and the various methods of the {{d
 
 ## Browser compatibility
 
-### Keyboard API
-
-{{Compat("api.Keyboard")}}
-
-### Keyboard lock API
-
-{{Compat("api.KeyboardLayoutMap")}}
+{{Compat}}

--- a/files/en-us/web/api/long_tasks_api/index.md
+++ b/files/en-us/web/api/long_tasks_api/index.md
@@ -14,7 +14,9 @@ tags:
   - Reference
   - TaskAttributionTiming
   - Web Performance
-spec-urls: https://w3c.github.io/longtasks/
+browser-compat:
+  - api.PerformanceLongTaskTiming
+  - api.TaskAttributionTiming
 ---
 {{DefaultAPISidebar("Long Tasks")}}
 
@@ -80,13 +82,7 @@ observer.observe({entryTypes: ["longtask"]});
 
 ## Browser compatibility
 
-### `PerformanceLongTaskTiming`
-
-{{Compat("api.PerformanceLongTaskTiming")}}
-
-### `TaskAttributionTiming`
-
-{{Compat("api.TaskAttributionTiming")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/network_information_api/index.md
+++ b/files/en-us/web/api/network_information_api/index.md
@@ -8,7 +8,9 @@ tags:
   - Network Information API
   - Reference
   - WebAPI
-browser-compat: api.NetworkInformation
+browser-compat:
+  - api.NetworkInformation
+  - api.Navigator.connection
 ---
 {{DefaultAPISidebar("Network Information API")}}{{SeeCompatTable}}
 
@@ -60,17 +62,9 @@ if (connection) {
 
 {{Specifications}}
 
-{{Specifications("api.Navigator.connection")}}
-
 ## Browser compatibility
 
-### NetworkInformation
-
 {{Compat}}
-
-### Navigator.connection
-
-{{Compat("api.Navigator.connection")}}
 
 ## See also
 

--- a/files/en-us/web/api/push_api/index.md
+++ b/files/en-us/web/api/push_api/index.md
@@ -10,6 +10,9 @@ tags:
   - Push
   - Reference
   - Service Workers
+browser-compat:
+  - api.PushEvent
+  - api.PushMessageData
 ---
 {{ApiRef("Push API")}}
 
@@ -62,19 +65,11 @@ Mozilla's [ServiceWorker Cookbook](https://github.com/mdn/serviceworker-cookbook
 
 ## Specifications
 
-| Specification                               |
-| ------------------------------------------- |
-| [Push API](https://w3c.github.io/push-api/) |
+{{Specifications}}
 
 ## Browser compatibility
 
-### `PushEvent`
-
-{{Compat("api.PushEvent")}}
-
-### `PushMessageData`
-
-{{Compat("api.PushMessageData")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/storage_access_api/index.md
+++ b/files/en-us/web/api/storage_access_api/index.md
@@ -7,6 +7,9 @@ tags:
   - Reference
   - Storage
   - Storage Access API
+browser-compat:
+  - api.Document.hasStorageAccess
+  - api.Document.requestStorageAccess
 ---
 {{DefaultAPISidebar("Storage Access API")}}{{SeeCompatTable}}
 
@@ -78,9 +81,7 @@ The API is currently only at the proposal stage — the standardization process 
 
 ## Browser compatibility
 
-{{Compat("api.Document.hasStorageAccess")}}
-
-{{Compat("api.Document.requestStorageAccess")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/streams_api/index.md
+++ b/files/en-us/web/api/streams_api/index.md
@@ -9,6 +9,9 @@ tags:
   - Landing
   - Reference
   - Streams
+browser-compat:
+  - api.ReadableStream
+  - api.WritableStream
 ---
 {{DefaultAPISidebar("Streams")}}
 
@@ -103,19 +106,11 @@ Examples from other developers:
 
 ## Specifications
 
-| Specification                                               |
-| ----------------------------------------------------------- |
-| [Streams Living Standard](https://streams.spec.whatwg.org/) |
+{{Specifications}}
 
 ## Browser compatibility
 
-### ReadableStream
-
-{{Compat("api.ReadableStream")}}
-
-### WritableStream
-
-{{Compat("api.WritableStream")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/web_authentication_api/index.md
+++ b/files/en-us/web/api/web_authentication_api/index.md
@@ -10,6 +10,13 @@ tags:
   - Reference
   - Web Authentication API
   - WebAuthn
+browser-compat:
+  - api.Credential
+  - api.CredentialsContainer
+  - api.PublicKeyCredential
+  - api.AuthenticatorResponse
+  - api.AuthenticatorAttestationResponse
+  - api.AuthenticatorAssertionResponse
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Web Authentication API")}}
 
@@ -192,32 +199,8 @@ navigator.credentials.create(createCredentialDefaultArgs)
 
 ## Specifications
 
-| Specification                                                                                      |
-| -------------------------------------------------------------------------------------------------- |
-| [Web Authentication: An API for accessing Public Key Credentials](https://w3c.github.io/webauthn/) |
+{{Specifications}}
 
 ## Browser compatibility
 
-### Credential
-
-{{Compat("api.Credential")}}
-
-### CredentialsContainer
-
-{{Compat("api.CredentialsContainer")}}
-
-### PublicKeyCredential
-
-{{Compat("api.PublicKeyCredential")}}
-
-### AuthenticatorResponse
-
-{{Compat("api.AuthenticatorResponse")}}
-
-### AuthenticatorAttestationResponse
-
-{{Compat("api.AuthenticatorAttestationResponse")}}
-
-### AuthenticatorAssertionResponse
-
-{{Compat("api.AuthenticatorAssertionResponse")}}
+{{Compat}}

--- a/files/en-us/web/api/web_locks_api/index.md
+++ b/files/en-us/web/api/web_locks_api/index.md
@@ -10,7 +10,9 @@ tags:
   - Reference
   - Web Locks API
   - lock
-spec-urls: https://w3c.github.io/web-locks/
+browser-compat:
+  - api.LockManager
+  - api.Lock
 ---
 {{SeeCompatTable}}{{APIRef("Web Locks")}}{{DefaultAPISidebar}}{{securecontext_header}}
 
@@ -115,10 +117,4 @@ A deadlock occurs when a process can no longer make progress because each part i
 
 ## Browser compatibility
 
-### LockManager
-
-{{Compat("api.LockManager")}}
-
-### Lock
-
-{{Compat("api.Lock")}}
+{{Compat}}

--- a/files/en-us/web/api/web_share_api/index.md
+++ b/files/en-us/web/api/web_share_api/index.md
@@ -10,6 +10,9 @@ tags:
   - Landing
   - Overview
   - Reference
+browser-compat:
+  - api.Navigator.share
+  - api.Navigator.canShare
 ---
 {{DefaultAPISidebar("Web Share API")}}
 
@@ -73,12 +76,11 @@ The above example is taken from our [Web share test](https://mdn.github.io/dom-e
 
 ## Specifications
 
-{{Specifications("api.Navigator.share")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.Navigator.share")}}
-{{Compat("api.Navigator.canShare")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/web_speech_api/index.md
+++ b/files/en-us/web/api/web_speech_api/index.md
@@ -10,6 +10,9 @@ tags:
   - recognition
   - speech
   - synthesis
+browser-compat:
+  - api.SpeechRecognition
+  - api.SpeechSynthesis
 ---
 {{DefaultAPISidebar("Web Speech API")}}
 
@@ -73,19 +76,11 @@ The [Web Speech API examples](https://github.com/mdn/dom-examples/tree/master/we
 
 ## Specifications
 
-| Specification      |
-| ------------------ |
-| [Web Speech API](https://wicg.github.io/speech-api/) |
+{{Specifications}}
 
 ## Browser compatibility
 
-### `SpeechRecognition`
-
-{{Compat("api.SpeechRecognition", 0)}}
-
-### `SpeechSynthesis`
-
-{{Compat("api.SpeechSynthesis", 0)}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/web_storage_api/index.md
+++ b/files/en-us/web/api/web_storage_api/index.md
@@ -10,6 +10,9 @@ tags:
   - Web Storage API
   - localStorage
   - sessionStorage
+browser-compat:
+  - api.Window.localStorage
+  - api.Window.sessionStorage
 ---
 {{DefaultAPISidebar("Web Storage API")}}
 
@@ -55,19 +58,11 @@ In addition, we have provided an [event output page](https://mdn.github.io/dom-e
 
 ## Specifications
 
-| Specification                                                                                          |
-| ------------------------------------------------------------------------------------------------------ |
-| [HTML Living Standard # webstorage](https://html.spec.whatwg.org/multipage/webstorage.html#webstorage) |
+{{Specifications}}
 
 ## Browser compatibility
 
-### `Window.localStorage`
-
-{{Compat("api.Window.localStorage")}}
-
-### `Window.sessionStorage`
-
-{{Compat("api.Window.sessionStorage")}}
+{{Compat}}
 
 ## Private Browsing / Incognito modes
 

--- a/files/en-us/web/api/web_storage_api/using_the_web_storage_api/index.md
+++ b/files/en-us/web/api/web_storage_api/using_the_web_storage_api/index.md
@@ -9,7 +9,9 @@ tags:
   - Web Storage API
   - localStorage
   - sessionStorage
-spec-urls: https://html.spec.whatwg.org/multipage/webstorage.html#webstorage
+browser-compat:
+  - api.Window.localStorage
+  - api.Window.sessionStorage
 ---
 {{DefaultAPISidebar("Web Storage API")}}
 
@@ -204,13 +206,7 @@ Web Storage also provides a couple of simple methods to remove data. We don't us
 
 ## Browser compatibility
 
-### `Window.localStorage`
-
-{{Compat("api.Window.localStorage")}}
-
-### `Window.sessionStorage`
-
-{{Compat("api.Window.sessionStorage")}}
+{{Compat}}
 
 All browsers have varying capacity levels for both localStorage and sessionStorage. Here is a [detailed rundown of all the storage capacities for various browsers](http://dev-test.nemikor.com/web-storage/support-test/).
 

--- a/files/en-us/web/api/webgl_api/index.md
+++ b/files/en-us/web/api/webgl_api/index.md
@@ -14,6 +14,9 @@ tags:
   - Reference
   - WebGL
   - WebGL API
+browser-compat:
+  - api.WebGLRenderingContext
+  - api.WebGL2RenderingContext
 ---
 {{WebGLSidebar}}
 
@@ -167,22 +170,11 @@ Below, you'll find an assortment of guides to help you learn WebGL concepts and 
 
 ## Specifications
 
-| Specification                                                                       |
-| ----------------------------------------------------------------------------------- |
-| [WebGL Specification](https://www.khronos.org/registry/webgl/specs/latest/1.0/)     |
-| [WebGL 2.0 Specification](https://www.khronos.org/registry/webgl/specs/latest/2.0/) |
-| [OpenGL ES 2.0](https://www.khronos.org/registry/OpenGL-Refpages/es2.0/xhtml/)      |
-| [OpenGL ES 3.0](https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/)       |
+{{Specifications}}
 
 ## Browser compatibility
 
-### WebGL 1
-
-{{Compat("api.WebGLRenderingContext", 0)}}
-
-### WebGL 2
-
-{{Compat("api.WebGL2RenderingContext", 0)}}
+{{Compat}}
 
 ### Compatibility notes
 

--- a/files/en-us/web/api/webglrenderingcontext/compressedteximage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/compressedteximage2d/index.md
@@ -10,7 +10,9 @@ tags:
   - WebGL
   - WebGL extension
   - WebGLRenderingContext
-browser-compat: api.WebGLRenderingContext.compressedTexImage2D
+browser-compat:
+  - api.WebGLRenderingContext.compressedTexImage2D
+  - api.WebGL2RenderingContext.compressedTexImage3D
 ---
 {{APIRef("WebGL")}}
 
@@ -194,13 +196,7 @@ gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
 
 ## Browser compatibility
 
-### compressedTexImage2D
-
 {{Compat}}
-
-### compressedTexImage3D
-
-{{Compat("api.WebGL2RenderingContext.compressedTexImage3D")}}
 
 ## See also
 

--- a/files/en-us/web/api/webglrenderingcontext/texparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/texparameter/index.md
@@ -9,7 +9,9 @@ tags:
   - Textures
   - WebGL
   - WebGLRenderingContext
-browser-compat: api.WebGLRenderingContext.texParameterf
+browser-compat:
+  - api.WebGLRenderingContext.texParameterf
+  - api.WebGLRenderingContext.texParameteri
 ---
 {{APIRef("WebGL")}}
 
@@ -165,13 +167,7 @@ gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_NEAREST)
 
 ## Browser compatibility
 
-### `WebGLRenderingContext.texParameterf()`
-
 {{Compat}}
-
-### `WebGLRenderingContext.texParameteri()`
-
-{{Compat("api.WebGLRenderingContext.texParameteri")}}
 
 ## See also
 

--- a/files/en-us/web/api/webvtt_api/index.md
+++ b/files/en-us/web/api/webvtt_api/index.md
@@ -15,6 +15,9 @@ tags:
   - captions
   - subtitles
   - text tracks
+browser-compat:
+  - api.VTTCue
+  - api.TextTrack
 ---
 {{DefaultAPISidebar("WebVTT")}}
 
@@ -787,19 +790,11 @@ Where p and a are the tags which are used in HTML for paragraph and link, respec
 
 ## Specifications
 
-| Specification                                                             |
-| ------------------------------------------------------------------------- |
-| [WebVTT: The Web Video Text Tracks Format](https://w3c.github.io/webvtt/) |
+{{Specifications}}
 
 ## Browser compatibility
 
-### `VTTCue` interface
-
-{{Compat("api.VTTCue", 0)}}
-
-### `TextTrack` interface
-
-{{Compat("api.TextTrack", 0)}}
+{{Compat}}
 
 ### Notes
 

--- a/files/en-us/web/css/_doublecolon_-webkit-scrollbar/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-scrollbar/index.md
@@ -10,6 +10,14 @@ tags:
   - Pseudo-element
   - Reference
   - Selector
+browser-compat:
+  - css.selectors.-webkit-scrollbar
+  - css.selectors.-webkit-scrollbar-button
+  - css.selectors.-webkit-scrollbar-thumb
+  - css.selectors.-webkit-scrollbar-track
+  - css.selectors.-webkit-scrollbar-track-piece
+  - css.selectors.-webkit-scrollbar-corner
+  - css.selectors.-webkit-resizer
 ---
 {{CSSRef}}{{Non-standard_Header}}
 
@@ -100,33 +108,7 @@ Not part of any standard.
 
 ## Browser compatibility
 
-### `::-webkit-scrollbar`
-
-{{Compat("css.selectors.-webkit-scrollbar")}}
-
-### `::-webkit-scrollbar-button`
-
-{{Compat("css.selectors.-webkit-scrollbar-button")}}
-
-### `::-webkit-scrollbar-thumb`
-
-{{Compat("css.selectors.-webkit-scrollbar-thumb")}}
-
-### `::-webkit-scrollbar-track`
-
-{{Compat("css.selectors.-webkit-scrollbar-track")}}
-
-### `::-webkit-scrollbar-track-piece`
-
-{{Compat("css.selectors.-webkit-scrollbar-track-piece")}}
-
-### `::-webkit-scrollbar-corner`
-
-{{Compat("css.selectors.-webkit-scrollbar-corner")}}
-
-### `::-webkit-resizer`
-
-{{Compat("css.selectors.-webkit-resizer")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/css/color_value/rgba/index.md
+++ b/files/en-us/web/css/color_value/rgba/index.md
@@ -9,6 +9,8 @@ tags:
   - Web
   - color
   - rgba
+browser-compat:
+  - css.types.color.rgba
 ---
 {{CSSRef}}
 
@@ -31,10 +33,10 @@ rgba(255 255 255 / 0.5); /* CSS Colors 4 space-separated values */
 - Functional notation: `rgba(R G B[ / A])`
   - : CSS Colors Level 4 adds support for space-separated values in the functional notation.
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
-{{Compat("css.types.color.alpha")}}
-
-### Space-separated values
-
-{{Compat("css.types.color.space_separated_functional_notation")}}
+{{Compat}}

--- a/files/en-us/web/css/compositing_and_blending/index.md
+++ b/files/en-us/web/css/compositing_and_blending/index.md
@@ -7,7 +7,10 @@ tags:
   - Guide
   - Overview
   - Reference
-spec-urls: https://drafts.fxtf.org/compositing-1/
+browser-compat:
+  - css.properties.background-blend-mode
+  - css.properties.isolation
+  - css.properties.mix-blend-mode
 ---
 {{CSSRef}}
 
@@ -31,14 +34,4 @@ spec-urls: https://drafts.fxtf.org/compositing-1/
 
 ## Browser compatibility
 
-### `background-blend-mode` property
-
-{{Compat("css.properties.background-blend-mode")}}
-
-### `isolation` property
-
-{{Compat("css.properties.isolation")}}
-
-### `mix-blend-mode` property
-
-{{Compat("css.properties.mix-blend-mode")}}
+{{Compat}}

--- a/files/en-us/web/css/css_conditional_rules/index.md
+++ b/files/en-us/web/css/css_conditional_rules/index.md
@@ -7,7 +7,11 @@ tags:
   - Guide
   - Overview
   - Reference
-spec-urls: https://drafts.csswg.org/css-conditional/
+browser-compat:
+  - css.at-rules.document
+  - css.at-rules.import
+  - css.at-rules.media
+  - css.at-rules.supports
 ---
 {{CSSRef}}
 
@@ -28,18 +32,4 @@ spec-urls: https://drafts.csswg.org/css-conditional/
 
 ## Browser compatibility
 
-### `@document` rule
-
-{{Compat("css.at-rules.document")}}
-
-### `@import` rule
-
-{{Compat("css.at-rules.import")}}
-
-### `@media` rule
-
-{{Compat("css.at-rules.media")}}
-
-### `@supports` rule
-
-{{Compat("css.at-rules.supports")}}
+{{Compat}}

--- a/files/en-us/web/css/css_containment/index.md
+++ b/files/en-us/web/css/css_containment/index.md
@@ -7,7 +7,10 @@ tags:
   - Guide
   - Paint
   - Performance
-spec-urls: https://drafts.csswg.org/css-contain/#contain-property
+browser-compat:
+  - css.properties.contain
+  - css.properties.content-visibility
+
 ---
 {{CSSRef}}
 The aim of the CSS Containment specification is to improve performance of web pages by allowing developers to isolate a subtree of the page from the rest of the page. If the browser knows that a part of the page is independent, rendering can be optimized and performance improved. The specification defines a single CSS property {{cssxref("contain")}}. This document describes the basic aims of the specification.
@@ -134,9 +137,7 @@ contain: strict style;
 
 ## Browser compatibility
 
-{{Compat("css.properties.contain")}}
-
-{{Compat("css.properties.content-visibility")}}
+{{Compat}}
 
 ## External resources
 

--- a/files/en-us/web/css/css_containment/index.md
+++ b/files/en-us/web/css/css_containment/index.md
@@ -10,7 +10,6 @@ tags:
 browser-compat:
   - css.properties.contain
   - css.properties.content-visibility
-
 ---
 {{CSSRef}}
 The aim of the CSS Containment specification is to improve performance of web pages by allowing developers to isolate a subtree of the page from the rest of the page. If the browser knows that a part of the page is independent, rendering can be optimized and performance improved. The specification defines a single CSS property {{cssxref("contain")}}. This document describes the basic aims of the specification.

--- a/files/en-us/web/css/css_counter_styles/index.md
+++ b/files/en-us/web/css/css_counter_styles/index.md
@@ -8,7 +8,10 @@ tags:
   - NeedsContent
   - Overview
   - Reference
-spec-urls: https://drafts.csswg.org/css-counter-styles/
+browser-compat:
+  - css.at-rules.counter-style
+  - css.properties.counter-increment
+  - css.properties.counter-reset
 ---
 {{CSSRef}}
 
@@ -50,14 +53,4 @@ spec-urls: https://drafts.csswg.org/css-counter-styles/
 
 ## Browser compatibility
 
-### `@counter-style` rule
-
-{{Compat("css.at-rules.counter-style")}}
-
-### `counter-increment` property
-
-{{Compat("css.properties.counter-increment")}}
-
-### `counter-reset` property
-
-{{Compat("css.properties.counter-reset")}}
+{{Compat}}

--- a/files/en-us/web/css/css_scrollbars/index.md
+++ b/files/en-us/web/css/css_scrollbars/index.md
@@ -6,7 +6,9 @@ tags:
   - Guide
   - Overview
   - css scrollbars
-spec-urls: https://drafts.csswg.org/css-scrollbars/
+browser-compat:
+  - css.properties.scrollbar-width
+  - css.properties.scrollbar-color
 ---
 {{CSSRef}}{{SeeCompatTable}}
 
@@ -49,25 +51,19 @@ Dandelion cucumber earthnut pea peanut soko zucchini.
 - {{CSSxRef("scrollbar-width")}}
 - {{CSSxRef("scrollbar-color")}}
 
-## Specifications
-
-{{Specifications}}
-
 ## Accessibility concerns
 
 When you customize scrollbars, consider they have enough contrast and that their hit area is large enough for people who use touch input.
 
 - [Baseline Rules for Scrollbar Usability | Adrian Roselli](https://adrianroselli.com/2019/01/baseline-rules-for-scrollbar-usability.html)
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
-### scrollbar-width
-
-{{Compat("css.properties.scrollbar-width")}}
-
-### scrollbar-color
-
-{{Compat("css.properties.scrollbar-color")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/css/display-inside/index.md
+++ b/files/en-us/web/css/display-inside/index.md
@@ -9,6 +9,13 @@ tags:
   - Reference
   - display-inside
 spec-urls: https://drafts.csswg.org/css-display/#typedef-display-inside
+browser-compat:
+  - css.properties.display.multi-keyword_values
+  - css.properties.display.flow-root
+  - css.properties.display.table_values
+  - css.properties.display.grid
+  - css.properties.display.flex
+  - css.properties.display.ruby_values
 ---
 {{CSSRef}}
 
@@ -81,31 +88,7 @@ In this example the parent box has been given `display: flow-root` and so establ
 
 ## Browser compatibility
 
-### Support of multiple keyword values
-
-{{Compat("css.properties.display.multi-keyword_values", 10)}}
-
-- Chromium bug: <https://bugs.chromium.org/p/chromium/issues/detail?id=804600>
-
-### Support of flow-root
-
-{{Compat("css.properties.display.flow-root", 10)}}
-
-### Support of table
-
-{{Compat("css.properties.display.table_values", 10)}}
-
-### Support of grid
-
-{{Compat("css.properties.display.grid", 10)}}
-
-### Support of flex
-
-{{Compat("css.properties.display.flex", 10)}}
-
-### Support of ruby
-
-{{Compat("css.properties.display.ruby_values", 10)}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/css/display-internal/index.md
+++ b/files/en-us/web/css/display-internal/index.md
@@ -8,7 +8,9 @@ tags:
   - Data Type
   - Reference
   - display-internal
-spec-urls: https://drafts.csswg.org/css-display/#typedef-display-internal
+browser-compat:
+  - css.properties.display.table_values
+  - css.properties.display.ruby_values
 ---
 {{CSSRef}}
 
@@ -91,17 +93,7 @@ label, input {
 
 ## Browser compatibility
 
-### Support of table values
-
-`table`, `table-cell`, `table-column`, `table-column-group`, `table-footer-group`, `table-header-group`, `table-row`, and `table-row-group`
-
-{{Compat("css.properties.display.table_values", 10)}}
-
-### Support of ruby values
-
-`ruby`, `ruby-base`, `ruby-base-container`, `ruby-text`, and `ruby-text-container`
-
-{{Compat("css.properties.display.ruby_values", 10)}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/css/display-legacy/index.md
+++ b/files/en-us/web/css/display-legacy/index.md
@@ -9,6 +9,11 @@ tags:
   - Reference
   - display-legacy
 spec-urls: https://drafts.csswg.org/css-display/#typedef-display-legacy
+browser-compat:
+  - css.properties.display.inline-block
+  - css.properties.display.inline-table
+  - css.properties.display.inline-flex
+  - css.properties.display.inline-grid
 ---
 {{CSSRef}}
 
@@ -83,21 +88,7 @@ In the new syntax the inline flex container would be created using two values, i
 
 ## Browser compatibility
 
-### Support of inline-block
-
-{{Compat("css.properties.display.inline-block", 10)}}
-
-### Support of inline-table
-
-{{Compat("css.properties.display.inline-table", 10)}}
-
-### Support of inline-flex
-
-{{Compat("css.properties.display.inline-flex", 10)}}
-
-### Support of inline-grid
-
-{{Compat("css.properties.display.inline-grid", 10)}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/css/filter_effects/index.md
+++ b/files/en-us/web/css/filter_effects/index.md
@@ -7,7 +7,9 @@ tags:
   - Guide
   - Overview
   - Reference
-spec-urls: https://drafts.fxtf.org/filter-effects/#FilterProperty
+browser-compat:
+  - css.properties.backdrop-filter
+  - css.properties.filter
 ---
 {{CSSRef}}
 
@@ -30,10 +32,4 @@ spec-urls: https://drafts.fxtf.org/filter-effects/#FilterProperty
 
 ## Browser compatibility
 
-### `backdrop-filter` property
-
-{{Compat("css.properties.backdrop-filter")}}
-
-### `filter` property
-
-{{Compat("css.properties.filter")}}
+{{Compat}}

--- a/files/en-us/web/css/fit-content_function/index.md
+++ b/files/en-us/web/css/fit-content_function/index.md
@@ -9,7 +9,9 @@ tags:
   - Layout
   - Reference
   - Web
-spec-urls: https://drafts.csswg.org/css-grid/#valdef-grid-template-columns-fit-content
+browser-compat:
+  - css.properties.width.fit-content_function
+  - css.properties.grid-template-columns.fit-content
 ---
 {{CSSRef}}
 
@@ -95,13 +97,7 @@ fit-content(40%)
 
 ## Browser compatibility
 
-### Supported for width (and other sizing properties)
-
-{{Compat("css.properties.width.fit-content_function")}}
-
-### Supported in grid layout
-
-{{Compat("css.properties.grid-template-columns.fit-content")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/css/layout_cookbook/card/index.md
+++ b/files/en-us/web/css/layout_cookbook/card/index.md
@@ -8,6 +8,9 @@ tags:
   - Guide
   - card
   - css layout
+browser-compat:
+  - css.properties.grid-template-columns
+  - css.properties.grid-template-rows
 ---
 {{CSSRef}}
 
@@ -62,15 +65,7 @@ Depending on the content of your card there may be things you could, or should d
 
 ## Browser compatibility
 
-The various layout methods have different browser support. See the charts below for details on basic support for the properties used.
-
-### grid-template-columns
-
-{{Compat("css.properties.grid-template-columns")}}
-
-### grid-template-rows
-
-{{Compat("css.properties.grid-template-rows")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/css/layout_cookbook/center_an_element/index.md
+++ b/files/en-us/web/css/layout_cookbook/center_an_element/index.md
@@ -10,6 +10,9 @@ tags:
   - centering
   - cookbook
   - flexbox
+browser-compat:
+  - css.properties.align-items
+  - css.properties.justify-content
 ---
 {{CSSRef}}
 
@@ -37,15 +40,7 @@ In the future we may be able to center elements without needing to turn the pare
 
 ## Browser compatibility
 
-The various layout methods have different browser support. See the charts below for details on basic support for the properties used.
-
-### align-items
-
-{{Compat("css.properties.align-items")}}
-
-### justify-content
-
-{{Compat("css.properties.justify-content")}}
+{{Compat}}
 
 ## Resources on MDN
 

--- a/files/en-us/web/css/layout_cookbook/column_layouts/index.md
+++ b/files/en-us/web/css/layout_cookbook/column_layouts/index.md
@@ -10,6 +10,12 @@ tags:
   - cookbook
   - flexbox
   - grid
+browser-compat:
+  - css.properties.column-width
+  - css.properties.column-rule
+  - css.properties.flex
+  - css.properties.flex-wrap
+  - css.properties.grid-template-columns
 ---
 {{CSSRef}}
 
@@ -91,27 +97,7 @@ Use Grid:
 
 ## Browser compatibility
 
-The various layout methods have different browser support. See the charts below for details on basic support for the properties used.
-
-### column-width
-
-{{Compat("css.properties.column-width")}}
-
-### column-rule
-
-{{Compat("css.properties.column-rule")}}
-
-### flex
-
-{{Compat("css.properties.flex")}}
-
-### flex-wrap
-
-{{Compat("css.properties.flex-wrap")}}
-
-### grid-template-columns
-
-{{Compat("css.properties.grid-template-columns")}}
+{{Compat}}
 
 ## Resources on MDN
 

--- a/files/en-us/web/css/layout_cookbook/list_group_with_badges/index.md
+++ b/files/en-us/web/css/layout_cookbook/list_group_with_badges/index.md
@@ -9,6 +9,9 @@ tags:
   - cookbook
   - flexbox
   - lists
+browser-compat:
+  - css.properties.justify-content
+  - css.properties.align-items
 ---
 {{CSSRef}}
 
@@ -38,15 +41,7 @@ To align the content horizontally, I use the {{cssxref("align-items")}} property
 
 ## Browser compatibility
 
-The various layout methods have different browser support. See the charts below for details on basic support for the properties used.
-
-### justify-content
-
-{{Compat("css.properties.justify-content")}}
-
-### align-items
-
-{{Compat("css.properties.align-items")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/css/layout_cookbook/media_objects/index.md
+++ b/files/en-us/web/css/layout_cookbook/media_objects/index.md
@@ -10,6 +10,9 @@ tags:
   - fit-content
   - float
   - grid
+browser-compat:
+  - css.properties.grid-template-areas
+  - css.properties.float
 ---
 {{CSSRef}}
 
@@ -71,12 +74,4 @@ What you will need to do is remove any margins applied to the item, and any widt
 
 ## Browser compatibility
 
-The various layout methods have different browser support. See the charts below for details on basic support for the properties used.
-
-### grid-template-areas
-
-{{Compat("css.properties.grid-template-areas")}}
-
-### float
-
-{{Compat("css.properties.float")}}
+{{Compat}}

--- a/files/en-us/web/css/layout_cookbook/pagination/index.md
+++ b/files/en-us/web/css/layout_cookbook/pagination/index.md
@@ -8,6 +8,9 @@ tags:
   - css layout
   - flexbox
   - pagination
+browser-compat:
+  - css.properties.justify-content
+  - css.properties.column-gap.flex_context
 ---
 {{CSSRef}}
 
@@ -57,19 +60,13 @@ We have also added some additional content that would be read by a screenreader 
 
 The "See Also" section at the end of this document has links to related accessibility topics.
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
-The various layout methods have different browser support. See the charts below for details on basic support for the properties used.
-
-_Include the compat data for key properties you used, as in the example below which includes align-items._
-
-### justify-content
-
-{{Compat("css.properties.justify-content")}}
-
-### column-gap in Flex layout
-
-{{Compat("css.properties.column-gap.flex_context")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/css/layout_cookbook/sticky_footers/index.md
+++ b/files/en-us/web/css/layout_cookbook/sticky_footers/index.md
@@ -9,6 +9,11 @@ tags:
   - flexbox
   - grid
   - sticky footer
+browser-compat:
+  - css.properties.grid-template-rows
+  - css.properties.flex-direction
+  - css.properties.flex-grow
+  - css.properties.flex-shrink
 ---
 {{CSSRef}}
 
@@ -49,21 +54,7 @@ The flexbox example starts out in the same way, but we use `display:flex` rather
 
 ## Browser compatibility
 
-### grid-template-rows
-
-{{Compat("css.properties.grid-template-rows")}}
-
-### flex-direction
-
-{{Compat("css.properties.flex-direction")}}
-
-### flex-grow
-
-{{Compat("css.properties.flex-grow")}}
-
-### flex-shrink
-
-{{Compat("css.properties.flex-shrink")}}
+{{Compat}}
 
 ## Resources on MDN
 

--- a/files/en-us/web/events/detecting_device_orientation/index.md
+++ b/files/en-us/web/events/detecting_device_orientation/index.md
@@ -9,7 +9,10 @@ tags:
   - Motion
   - Orientation
   - Reference
-spec-urls: https://w3c.github.io/deviceorientation/
+browser-compat:
+  - api.DeviceMotionEvent
+  - api.DeviceOrientationEvent
+
 ---
 {{DefaultAPISidebar("Device Orientation Events")}}
 
@@ -176,13 +179,7 @@ Finally, {{domxref("DeviceMotionEvent.interval","interval")}} represents the int
 
 ## Browser compatibility
 
-### `DeviceMotionEvent`
-
-{{Compat("api.DeviceMotionEvent")}}
-
-### `DeviceOrientationEvent`
-
-{{Compat("api.DeviceOrientationEvent")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/guide/woff/index.md
+++ b/files/en-us/web/guide/woff/index.md
@@ -6,9 +6,9 @@ tags:
   - NeedsMobileBrowserCompatibility
   - WOFF
   - WOFF2
-spec-urls:
-  - https://www.w3.org/TR/WOFF/
-  - https://w3c.github.io/woff/woff2/
+browser-compat:
+  - css.at-rules.font-face.WOFF
+  - css.at-rules.font-face.WOFF_2
 ---
 **WOFF** (the **Web Open Font Format**) is a web font format developed by Mozilla in concert with Type Supply, LettError, and other organizations. It uses a compressed version of the same table-based `sfnt` structure used by TrueType, OpenType, and Open Font Format, but adds metadata and private-use data structures, including predefined fields allowing foundries and vendors to provide license information if desired.
 
@@ -34,7 +34,7 @@ You can use the {{cssxref("@font-face")}} CSS property to use WOFF fonts for tex
 
 ## Browser compatibility
 
-{{Compat("css.at-rules.font-face")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/html/attributes/crossorigin/index.md
+++ b/files/en-us/web/html/attributes/crossorigin/index.md
@@ -9,9 +9,12 @@ tags:
   - NeedsContent
   - Reference
   - Security
-spec-urls:
-  - https://html.spec.whatwg.org/multipage/infrastructure.html#cors-settings-attributes
-  - https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-crossorigin
+spec-urls: https://html.spec.whatwg.org/multipage/infrastructure.html#cors-settings-attributes
+browser-compat:
+  - html.elements.img.crossorigin
+  - html.elements.link.crossorigin
+  - html.elements.script.crossorigin
+  - html.elements.video.crossorigin
 ---
 {{HTMLSidebar}}
 
@@ -83,17 +86,7 @@ The `use-credentials` value must be used when fetching a [manifest](/en-US/docs/
 
 ## Browser compatibility
 
-### script crossorigin
-
-{{Compat("html.elements.script.crossorigin")}}
-
-### video crossorigin
-
-{{Compat("html.elements.video.crossorigin")}}
-
-### link crossorigin
-
-{{Compat("html.elements.link.crossorigin")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/html/attributes/disabled/index.md
+++ b/files/en-us/web/html/attributes/disabled/index.md
@@ -7,7 +7,14 @@ tags:
   - Constraint validation
   - Forms
   - required
-spec-urls: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-disabled
+browser-compat:
+  - html.elements.button.disabled
+  - html.elements.fieldset.disabled
+  - html.elements.input.attributes.disabled
+  - html.elements.optgroup.disabled
+  - html.elements.option.disabled
+  - html.elements.select.disabled
+  - html.elements.textarea.disabled
 ---
 
 {{HTMLSidebar}}
@@ -110,7 +117,7 @@ When form controls are disabled, many browsers will display them in a lighter, g
 
 ## Browser compatibility
 
-{{Compat("html.elements.attributes.disabled")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/html/attributes/for/index.md
+++ b/files/en-us/web/html/attributes/for/index.md
@@ -7,9 +7,9 @@ tags:
   - HTML
   - for
   - Reference
-spec-urls:
-  - https://html.spec.whatwg.org/multipage/forms.html#attr-label-for
-  - https://html.spec.whatwg.org/multipage/form-elements.html#attr-output-for
+browser-compat:
+  - html.elements.label.for
+  - html.elements.output.for
 ---
 
 {{HTMLSidebar}}
@@ -43,10 +43,4 @@ See examples of usage on the element pages for {{htmlelement("label")}} and {{ht
 
 ## Browser compatibility
 
-### Support with label
-
-{{Compat("html.elements.label.for")}}
-
-### Support with output
-
-{{Compat("html.elements.output.for")}}
+{{Compat}}

--- a/files/en-us/web/html/attributes/max/index.md
+++ b/files/en-us/web/html/attributes/max/index.md
@@ -8,11 +8,10 @@ tags:
   - HTML
   - max
   - Reference
-spec-urls:
-  - https://html.spec.whatwg.org/multipage/input.html#the-min-and-max-attributes
-  - https://html.spec.whatwg.org/multipage/forms.html#the-progress-element
-  - https://html.spec.whatwg.org/multipage/forms.html#the-meter-element
-browser-compat: html.elements.attributes.max
+browser-compat:
+  - html.elements.input.attributes.max
+  - html.elements.meter.max
+  - html.elements.progress.max
 ---
 
 {{HTMLSidebar}}

--- a/files/en-us/web/html/attributes/maxlength/index.md
+++ b/files/en-us/web/html/attributes/maxlength/index.md
@@ -10,7 +10,9 @@ tags:
   - Reference
   - maxlength
   - textarea
-spec-urls: https://html.spec.whatwg.org/multipage/input.html#attr-input-maxlength
+browser-compat:
+  - html.elements.input.attributes.maxlength
+  - html.elements.textarea.maxlength
 ---
 
 {{HTMLSidebar}}
@@ -39,7 +41,7 @@ While the browser will generally prevent user from entering more text than the m
 
 ## Browser compatibility
 
-{{Compat("html.elements.attribute.maxlength")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/html/attributes/min/index.md
+++ b/files/en-us/web/html/attributes/min/index.md
@@ -8,7 +8,9 @@ tags:
   - HTML
   - min
   - Reference
-spec-urls: https://html.spec.whatwg.org/multipage/input.html#the-min-and-max-attributes
+browser-compat:
+  - html.elements.input.attributes.min
+  - html.elements.meter.min
 ---
 
 {{HTMLSidebar}}
@@ -147,7 +149,7 @@ Provide instructions to help users understand how to complete the form and use i
 
 ## Browser compatibility
 
-{{Compat("html.elements.attributes.min")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/html/attributes/minlength/index.md
+++ b/files/en-us/web/html/attributes/minlength/index.md
@@ -10,7 +10,9 @@ tags:
   - Reference
   - minlength
   - textarea
-spec-urls: https://html.spec.whatwg.org/multipage/input.html#attr-input-minlength
+browser-compat:
+  - html.elements.input.attributes.minlength
+  - html.elements.textarea.minlength
 ---
 
 {{HTMLSidebar}}
@@ -49,7 +51,7 @@ input:invalid:focus {
 
 ## Browser compatibility
 
-{{Compat("html.elements.attribute.minlength")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/html/attributes/readonly/index.md
+++ b/files/en-us/web/html/attributes/readonly/index.md
@@ -7,7 +7,9 @@ tags:
   - Constraint validation
   - Forms
   - required
-spec-urls: https://html.spec.whatwg.org/multipage/forms.html#attr-input-readonly
+browser-compat:
+  - html.elements.input.attributes.readonly
+  - html.elements.textarea.readonly
 ---
 
 {{HTMLSidebar}}
@@ -79,7 +81,7 @@ If the element is read-only, then the element's value can not be updated by the 
 
 ## Browser compatibility
 
-{{Compat("html.elements.attributes.readonly")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/html/attributes/rel/index.md
+++ b/files/en-us/web/html/attributes/rel/index.md
@@ -8,10 +8,10 @@ tags:
   - Link
   - form
   - rel
-spec-urls:
-  - https://html.spec.whatwg.org/multipage/links.html#linkTypes
-  - https://w3c.github.io/preload/#x2.link-type-preload
-  - https://www.w3.org/TR/resource-hints/#dfn-preconnect
+browser-compat:
+  - html.elements.link.rel
+  - html.elements.a.rel
+  - html.elements.area.rel
 ---
 
 {{HTMLSidebar}}
@@ -193,17 +193,7 @@ The `rel` attribute has no default value. If the attribute is omitted or if none
 
 ## Browser compatibility
 
-### `rel` attribute for the `link` element
-
-{{Compat("html.elements.link.rel")}}
-
-### `rel` attribute for the `a` element
-
-{{Compat("html.elements.a.rel")}}
-
-### `rel` attribute for the `area` element
-
-{{Compat("html.elements.area.rel")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/javascript/guide/modules/index.md
+++ b/files/en-us/web/javascript/guide/modules/index.md
@@ -7,6 +7,9 @@ tags:
   - Modules
   - export
   - import
+browser-compat:
+  - javascript.statements.import
+  - javascript.statements.export
 ---
 {{JSSidebar("JavaScript Guide")}}{{Previous("Web/JavaScript/Guide/Meta_programming")}}
 
@@ -20,17 +23,11 @@ It has therefore made sense in recent years to start thinking about providing me
 
 The good news is that modern browsers have started to support module functionality natively, and this is what this article is all about. This can only be a good thing — browsers can optimize loading of modules, making it more efficient than having to use a library and do all of that extra client-side processing and extra round trips.
 
-## Browser support
+Use of native JavaScript modules is dependent on the {{JSxRef("Statements/import", "import")}} and {{JSxRef("Statements/export", "export")}} statements; these are supported in browsers as shown in the compatibility table below.
 
-Use of native JavaScript modules is dependent on the {{JSxRef("Statements/import", "import")}} and {{JSxRef("Statements/export", "export")}} statements; these are supported in browsers as follows:
+## Browser compatibility
 
-### import
-
-{{Compat("javascript.statements.import")}}
-
-### export
-
-{{Compat("javascript.statements.export")}}
+{{Compat}}
 
 ## Introducing an example
 

--- a/files/en-us/web/security/subresource_integrity/index.md
+++ b/files/en-us/web/security/subresource_integrity/index.md
@@ -7,7 +7,9 @@ tags:
   - Intro
   - Networking
   - Security
-spec-urls: https://w3c.github.io/webappsec-subresource-integrity/
+browser-compat:
+  - html.elements.link.integrity
+  - html.elements.script.integrity
 ---
 **Subresource Integrity** (SRI) is a security feature that enables browsers to verify that resources they fetch (for example, from a [CDN](/en-US/docs/Glossary/CDN)) are delivered without unexpected manipulation. It works by allowing you to provide a cryptographic hash that a fetched resource must match.
 
@@ -60,7 +62,7 @@ shasum -b -a 384 FILENAME.js | awk '{ print $1 }' | xxd -r -p | base64
 
 In a Windows environment, you can create a tool for generating SRI hashes with the following code:
 
-```bat
+```batch
 @echo off
 set bits=384
 openssl dgst -sha%bits% -binary %1% | openssl base64 -A > tmp
@@ -117,9 +119,7 @@ Browsers handle SRI by doing the following:
 
 ## Browser compatibility
 
-### \<script integrity>
-
-{{Compat("html.elements.script.integrity")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/web_components/index.md
+++ b/files/en-us/web/web_components/index.md
@@ -14,6 +14,9 @@ tags:
   - custom elements
   - shadow dom
   - slot
+browser-compat:
+  - html.elements.template
+  - api.ShadowRoot
 ---
 {{DefaultAPISidebar("Web Components")}}
 
@@ -143,22 +146,11 @@ We are building up a number of examples in our [web-components-examples](https:/
 
 ## Specifications
 
-### The `template` element and custom elements
-
-{{Specifications("html.elements.template")}}
-
-### The shadow DOM
-
-{{Specifications("api.ShadowRoot")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-In general:
-
-- Web components are supported by default in Firefox (version 63), Chrome, Opera, and Edge (version 79).
-- Safari supports a number of web component features, but less than the above browsers.
-
-For detailed browser support of specific features, you'll have to consult the reference pages listed above.
+{{Compat}}
 
 ## See also
 


### PR DESCRIPTION
For all docs currently having multiple BCD tables (multiple `{{Compat}}` macro calls) this change moves the compat data into the `browser-compat`  key — replacing the multiple BCD tables with one unified multi-feature BCD table — for these reasons:

  - consistency with handling of BCD features in other existing docs
  - streamlining out unnecessary repetition of BCD feature names
  - in keeping with the principle of making use of frontmatter metadata to store data — BCD feature names — rather than having the BCD feature names in the prose body of documents

This change also replaces a number of the last remaining manual spec tables with `{{Specifications}}` macros calls — again, for cases where the article cited multiple BCD features and multiple spec URLs.

Because this change requires Yari support for processing YAML arrays in the `browser-compat` key, this is blocked on <s>https://github.com/mdn/yari/pull/6004</s> https://github.com/mdn/yari/pull/6358.