### PR TITLE
Add inline onclick description

### DIFF
--- a/files/en-us/web/api/globaleventhandlers/onclick/index.md
+++ b/files/en-us/web/api/globaleventhandlers/onclick/index.md
@@ -37,7 +37,7 @@ It is also possible to add the event directly on to the HTML element. Like this:
 ```
 
 > **Note:** When this approach is used, one  must include
-> the parens `()` so that the function triggers when clicked.
+> the parenthesis `()` so that the function triggers when clicked.
 
 ### Value
 

--- a/files/en-us/web/api/globaleventhandlers/onclick/index.md
+++ b/files/en-us/web/api/globaleventhandlers/onclick/index.md
@@ -31,6 +31,14 @@ after the {{domxref("Element/mousedown_event", "mousedown")}} and
 target.onclick = functionRef;
 ```
 
+It is also possible to add the event directly on to the HTML element. Like this:
+```html
+<div onclick="functionRef()">Click here</div>
+```
+
+> **Note:** When this approach is used, one  must include
+> the parens `()` so that the function triggers when clicked.
+
 ### Value
 
 `functionRef` is a function name or a [function

--- a/files/en-us/web/api/globaleventhandlers/onclick/index.md
+++ b/files/en-us/web/api/globaleventhandlers/onclick/index.md
@@ -33,7 +33,7 @@ target.onclick = functionRef;
 
 It is also possible to add the event directly on to the HTML element. Like this:
 ```html
-<div onclick="functionRef()">Click here</div>
+<div onclick="functionRef(event)">Click here</div>
 ```
 
 > **Note:** When this approach is used, one  must include


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
I couldn't find any description on how to add the `onclick` handler directly on a target HTML element. I thought it might be useful to include it here.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I was looking over a stackoverflow question regarding click handlers, when I came to MDN for more information I could not find any reference on how to add the `onclick` handler directly on to a target HTML element.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
[`addEventListener` vs `onclick` - Stack Overflow](https://stackoverflow.com/questions/6348494/addeventlistener-vs-onclick)
[`EventTarget.addEventListener()` - Web APIs | MDN](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
