### PR TITLE
[webextensions] fix content_security_policy header (2 = 3)

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.md
@@ -62,7 +62,7 @@ In Manifest V2 there is one content security policy specified against the key, l
 "content_security_policy": "default-src 'self'"
 ```
 
-## Manifest V2 syntax
+## Manifest V3 syntax
 
 In Manifest V3, the `content_security_policy` key is an object that may have any of the following properties, all optional:
 


### PR DESCRIPTION
[The article](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_security_policy) currently has two "Manifest v2" sections, while one of them should clearly be "MV3".

This PR fixes that typo that originated from PR #15704.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
