### PR TITLE
Make Kitchensink table test case forward-compatible

### DIFF
--- a/files/en-us/mdn/kitchensink/index.md
+++ b/files/en-us/mdn/kitchensink/index.md
@@ -120,10 +120,10 @@ _The formal syntax must be taken from the spec and added to the [MDN data reposi
 | `QUERY_COUNTER_BITS_EXT`     | 0x8864 | The number of bits used to hold the query result for the given target. |
 | `CURRENT_QUERY_EXT`          | 0x8865 | The currently active query. |
 | `QUERY_RESULT_EXT`           | 0x8866 | The query result. |
-| `QUERY_RESULT_AVAILABLE_EXT` | 0x8867 | A Boolean indicating whether or not a query result is available. |
+| `QUERY_RESULT_AVAILABLE_EXT` | 0x8867 | A Boolean indicating whether a query result is available. |
 | `TIME_ELAPSED_EXT`           | 0x88BF | Elapsed time (in nanoseconds). |
 | `TIMESTAMP_EXT`              | 0x8E28 | The current time. |
-| `GPU_DISJOINT_EXT`           | 0x8FBB | A Boolean indicating whether or not the GPU performed any disjoint operation. |
+| `GPU_DISJOINT_EXT`           | 0x8FBB | A Boolean indicating whether the GPU performed any disjoint operation. |
 
 ### HTML table
 

--- a/files/en-us/mdn/kitchensink/index.md
+++ b/files/en-us/mdn/kitchensink/index.md
@@ -113,9 +113,19 @@ _The formal syntax must be taken from the spec and added to the [MDN data reposi
 
 ## Tables
 
-| Specification                                                                                | Status                           | Comment |
-| -------------------------------------------------------------------------------------------- | -------------------------------- | ------- |
-| {{SpecName("HTML WHATWG", "#link-type-dns-prefetch", "dns-prefetch")}} | {{Spec2("HTML WHATWG")}} |         |
+### Markdown table
+
+| Constant name                | Value  | Description |
+| ---------------------------- | ------ | ----------- |
+| `QUERY_COUNTER_BITS_EXT`     | 0x8864 | The number of bits used to hold the query result for the given target. |
+| `CURRENT_QUERY_EXT`          | 0x8865 | The currently active query. |
+| `QUERY_RESULT_EXT`           | 0x8866 | The query result. |
+| `QUERY_RESULT_AVAILABLE_EXT` | 0x8867 | A Boolean indicating whether or not a query result is available. |
+| `TIME_ELAPSED_EXT`           | 0x88BF | Elapsed time (in nanoseconds). |
+| `TIMESTAMP_EXT`              | 0x8E28 | The current time. |
+| `GPU_DISJOINT_EXT`           | 0x8FBB | A Boolean indicating whether or not the GPU performed any disjoint operation. |
+
+### HTML table
 
 <table class="properties">
   <tbody>


### PR DESCRIPTION
This change makes the Markdown table test case in the Kitchensink page forward-compatible. Otherwise, without this change, it’s using the legacy/deprecated `SpecName` and `Spec2` macros — and is a legacy “manual” Specifications table (and we don’t have such tables in content any longer; rather, the tables are generated based on the `browser-compat` or `spec-urls` frontmatter metadata keys).