### PR TITLE
Fixing anchor link to HTTP headers page

### DIFF
--- a/files/en-us/web/http/headers/transfer-encoding/index.md
+++ b/files/en-us/web/http/headers/transfer-encoding/index.md
@@ -20,7 +20,7 @@ user.
 > HTTP 1.1's chunked transfer encoding mechanism, as it provides its own, more efficient,
 > mechanisms for data streaming.
 
-`Transfer-Encoding` is a [hop-by-hop header](/en-US/docs/Web/HTTP/Headers), that is applied to a
+`Transfer-Encoding` is a [hop-by-hop header](/en-US/docs/Web/HTTP/Headers#hop-by-hop_headers), that is applied to a
 message between two nodes, not to a resource itself. Each segment of a multi-node
 connection can use different `Transfer-Encoding` values. If you want to
 compress data over the whole connection, use the end-to-end

--- a/files/en-us/web/http/headers/transfer-encoding/index.md
+++ b/files/en-us/web/http/headers/transfer-encoding/index.md
@@ -20,7 +20,7 @@ user.
 > HTTP 1.1's chunked transfer encoding mechanism, as it provides its own, more efficient,
 > mechanisms for data streaming.
 
-`Transfer-Encoding` is a [hop-by-hop header](/en-US/docs/Web/HTTP/Headers#hbh), that is applied to a
+`Transfer-Encoding` is a [hop-by-hop header](/en-US/docs/Web/HTTP/Headers), that is applied to a
 message between two nodes, not to a resource itself. Each segment of a multi-node
 connection can use different `Transfer-Encoding` values. If you want to
 compress data over the whole connection, use the end-to-end


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
I removed the anchor on the 'hop-by-hop' link to the HTTP headers page.

#### Motivation
The anchor currently linked to by the 'hop-by-hop' link does not exist on the HTTP headers page.  There were no closer anchors that I could find.


#### Related issues
It seems that this anchor disappeared when the page was converted to markdown. See https://github.com/mdn/content/pull/15833#discussion_r869722758

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
