### PR TITLE
Mention that super is determined by object literal, not by `this` scope

### DIFF
--- a/files/en-us/web/javascript/reference/operators/super/index.md
+++ b/files/en-us/web/javascript/reference/operators/super/index.md
@@ -169,7 +169,7 @@ Object.setPrototypeOf(obj2, obj1);
 obj2.method2(); // logs "method 1"
 ```
 
-Note that the reference of `super` is determined by the object literal `super` was declared in, not the object the method is called on. Therefore, unbinding or re-binding a method doesn't change the reference of `super` in it (although they do change the reference of [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this)). You can see `super` as a variable in the object literal scope, which the methods create a closure over. (But also beware that it's not actually not a variable—see below)
+Note that the reference of `super` is determined by the object literal `super` was declared in, not the object the method is called on. Therefore, unbinding or re-binding a method doesn't change the reference of `super` in it (although they do change the reference of [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this)). You can see `super` as a variable in the object literal scope, which the methods create a closure over. (But also beware that it's not actually not a variable — see below)
 
 ```js
 const parent1 = { prop: 1 };

--- a/files/en-us/web/javascript/reference/operators/super/index.md
+++ b/files/en-us/web/javascript/reference/operators/super/index.md
@@ -169,7 +169,7 @@ Object.setPrototypeOf(obj2, obj1);
 obj2.method2(); // logs "method 1"
 ```
 
-Note that the reference of `super` is determined by the object literal `super` was declared in, not the object the method is called on. Therefore, unbinding or re-binding a method doesn't change the reference of `super` in it (although they do change the reference of [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this)). You can see `super` as a variable in the object literal scope, which the methods create a closure over.
+Note that the reference of `super` is determined by the object literal `super` was declared in, not the object the method is called on. Therefore, unbinding or re-binding a method doesn't change the reference of `super` in it (although they do change the reference of [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this)). You can see `super` as a variable in the object literal scope, which the methods create a closure over. (But also beware that it's not actually not a variable—see below)
 
 ```js
 const parent1 = { prop: 1 };
@@ -191,7 +191,7 @@ const anotherChild = { __proto__: parent2, myParent };
 anotherChild.myParent(); // still logs "1"
 ```
 
-Note also that `super.prop` is a special syntax for property lookup on the prototype, but `super` itself is not a reference to the prototype, unlike `this`, which can be used like a normal value.
+Note also that `super.prop` is a special syntax for property lookup on the prototype, but `super` itself is not a variable that points to the prototype.
 
 ```js
 const child = {

--- a/files/en-us/web/javascript/reference/operators/super/index.md
+++ b/files/en-us/web/javascript/reference/operators/super/index.md
@@ -169,6 +169,38 @@ Object.setPrototypeOf(obj2, obj1);
 obj2.method2(); // logs "method 1"
 ```
 
+Note that the reference of `super` is determined by the object literal `super` was declared in, not the object the method is called on. Therefore, unbinding or re-binding a method doesn't change the reference of `super` in it (although they do change the reference of [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this)). You can see `super` as a variable in the object literal scope, which the methods create a closure over.
+
+```js
+const parent1 = { prop: 1 };
+const parent2 = { prop: 2 };
+
+const child = {
+  myParent() {
+    console.log(super.prop);
+  },
+};
+
+Object.setPrototypeOf(child, parent1);
+child.myParent(); // logs "1"
+
+const myParent = child.myParent;
+myParent(); // still logs "1"
+
+const anotherChild = { __proto__: parent2, myParent };
+anotherChild.myParent(); // still logs "1"
+```
+
+Note also that `super.prop` is a special syntax for property lookup on the prototype, but `super` itself is not a reference to the prototype, unlike `this`, which can be used like a normal value.
+
+```js
+const child = {
+  myParent() {
+    console.log(super); // SyntaxError: 'super' keyword unexpected here
+  },
+};
+```
+
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation

I've personally struggled about this when I was exploring the behavior of `super`, because MDN has very little information about it. I decided that a little more explanation can make lives easier for others trying to understand `super` in object literals.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
