### PR TITLE
Drop misleading statement from “JavaScript object basics” doc

### DIFF
--- a/files/en-us/learn/javascript/objects/basics/index.md
+++ b/files/en-us/learn/javascript/objects/basics/index.md
@@ -296,7 +296,11 @@ This function creates and returns a new object each time we call it. The object 
 - a property `name`
 - a method `introduceSelf()`.
 
-Note that `createPerson()` takes a parameter `name` to set the value of the `name` property, but the value of the `introduceSelf()` method will be the same for all objects created using this function. This is a very common pattern for creating objects. You can see here how being able to use `this` in the definition of `introduceSelf()` enables us to use the same code for every object we create.
+Note that `createPerson()` takes a parameter `name` to set the value of the `name` property, but the value of the `introduceSelf()` method will be the same for all objects created using this function. This is a very common pattern for creating objects. 
+
+still we can replace this keyword with the name of empty initialized object, but for now you can imagine that maybe, with use of `this` we can put
+methods definitions somewhere else (to avoiding fulling memory with repetitive things) and use these functions on objects with different shape.
+
 
 Now we can create as many objects as we like, reusing the definition:
 

--- a/files/en-us/learn/javascript/objects/basics/index.md
+++ b/files/en-us/learn/javascript/objects/basics/index.md
@@ -298,9 +298,6 @@ This function creates and returns a new object each time we call it. The object 
 
 Note that `createPerson()` takes a parameter `name` to set the value of the `name` property, but the value of the `introduceSelf()` method will be the same for all objects created using this function. This is a very common pattern for creating objects. 
 
-still we can replace this keyword with the name of empty initialized object, but for now you can imagine that maybe, with use of `this` we can put
-methods definitions somewhere else (to avoiding fulling memory with repetitive things) and use these functions on objects with different shape.
-
 
 Now we can create as many objects as we like, reusing the definition:
 


### PR DESCRIPTION
the line that I removed has misleading information about `this`.
the line:
(You can see here how being able to use `this` in the definition of `introduceSelf()` enables us to use the same code for every object we create.)

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
