### PR TITLE
Nomenclature: clarify that let&const are declarations, not statements

### DIFF
--- a/files/en-us/web/javascript/reference/classes/index.md
+++ b/files/en-us/web/javascript/reference/classes/index.md
@@ -259,7 +259,7 @@ class Rectangle {
 }
 ```
 
-We don't need statements like `let`,`const`, and `var` before fields.
+We don't need keywords like `let`, `const`, or `var` to declare fields.
 
 By declaring fields up-front, class definitions become more self-documenting, and the fields are always present.
 

--- a/files/en-us/web/javascript/reference/statements/const/index.md
+++ b/files/en-us/web/javascript/reference/statements/const/index.md
@@ -38,12 +38,6 @@ const { bar } = foo; // where foo = { bar:10, baz:12 };
 /* This creates a constant with the name 'bar', which has a value of 10 */
 ```
 
-Unlike `var`, `const` begins _Declarations_, not _Statements_. That means you cannot use a lone `const` declaration as the body of a block (which makes sense, since there's no way to access the variable).
-
-```js
-if (true) const a = 1; // SyntaxError: Unexpected token 'const'
-```
-
 ## Description
 
 This declaration creates a constant whose scope can be either global or local to the
@@ -63,6 +57,12 @@ All the considerations about the
 apply to both {{jsxref("Statements/let", "let")}} and `const`.
 
 A constant cannot share its name with a function or a variable in the same scope.
+
+> **Note:** Unlike `var`, `const` begins _Declarations_, not _Statements_. That means you cannot use a lone `const` declaration as the body of a block (which makes sense, since there's no way to access the variable).
+>
+> ```js
+> if (true) const a = 1; // SyntaxError: Unexpected token 'const'
+> ```
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/statements/const/index.md
+++ b/files/en-us/web/javascript/reference/statements/const/index.md
@@ -58,11 +58,11 @@ apply to both {{jsxref("Statements/let", "let")}} and `const`.
 
 A constant cannot share its name with a function or a variable in the same scope.
 
-> **Note:** Unlike `var`, `const` begins _Declarations_, not _Statements_. That means you cannot use a lone `const` declaration as the body of a block (which makes sense, since there's no way to access the variable).
->
-> ```js
-> if (true) const a = 1; // SyntaxError: Unexpected token 'const'
-> ```
+Unlike `var`, `const` begins _Declarations_, not _Statements_. That means you cannot use a lone `const` declaration as the body of a block (which makes sense, since there's no way to access the variable).
+
+```js
+if (true) const a = 1; // SyntaxError: Unexpected token 'const'
+```
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/statements/const/index.md
+++ b/files/en-us/web/javascript/reference/statements/const/index.md
@@ -38,6 +38,12 @@ const { bar } = foo; // where foo = { bar:10, baz:12 };
 /* This creates a constant with the name 'bar', which has a value of 10 */
 ```
 
+Unlike `var`, `const` begins _Declarations_, not _Statements_. That means you cannot use a lone `const` declaration as the body of a block (which makes sense, since there's no way to access the variable).
+
+```js
+if (true) const a = 1; // SyntaxError: Unexpected token 'const'
+```
+
 ## Description
 
 This declaration creates a constant whose scope can be either global or local to the
@@ -45,9 +51,7 @@ block in which it is declared. Global constants do **not** become
 properties of the {{domxref("window")}} object, unlike {{jsxref("Statements/var",
   "var")}} variables.
 
-An initializer for a constant is required. You must specify its value in the same
-statement in which it's declared. (This makes sense, given that it can't be changed
-later.)
+An initializer for a constant is required. You must specify its value in the same declaration. (This makes sense, given that it can't be changed later.)
 
 The **`const` declaration** creates a read-only reference to a
 value. It does **not** mean the value it holds is immutable—just that the

--- a/files/en-us/web/javascript/reference/statements/let/index.md
+++ b/files/en-us/web/javascript/reference/statements/let/index.md
@@ -41,12 +41,6 @@ let { bar } = foo; // where foo = { bar:10, baz:12 };
 /* This creates a variable with the name 'bar', which has a value of 10 */
 ```
 
-Unlike `var`, `let` begins _Declarations_, not _Statements_. That means you cannot use a lone `let` declaration as the body of a block (which makes sense, since there's no way to access the variable).
-
-```js
-if (true) let a = 1; // SyntaxError: Lexical declaration cannot appear in a single-statement context
-```
-
 ## Description
 
 **`let`** allows you to declare variables that are limited to
@@ -62,8 +56,13 @@ globally (in the top-most scope).
 
 An explanation of why the name "**let**" was chosen can be found [here](https://stackoverflow.com/questions/37916940/why-was-the-name-let-chosen-for-block-scoped-variable-declarations-in-javascri).
 
-> **Note:** Many issues with `let` variables can be avoided by declaring them at the
-> top of the scope in which they are used (doing so may impact readability).
+> **Note:** Many issues with `let` variables can be avoided by declaring them at the top of the scope in which they are used (doing so may impact readability).
+> 
+> Unlike `var`, `let` begins _Declarations_, not _Statements_. That means you cannot use a lone `let` declaration as the body of a block (which makes sense, since there's no way to access the variable).
+>
+> ```js
+> if (true) let a = 1; // SyntaxError: Lexical declaration cannot appear in a single-statement context
+> ```
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/statements/let/index.md
+++ b/files/en-us/web/javascript/reference/statements/let/index.md
@@ -56,13 +56,13 @@ globally (in the top-most scope).
 
 An explanation of why the name "**let**" was chosen can be found [here](https://stackoverflow.com/questions/37916940/why-was-the-name-let-chosen-for-block-scoped-variable-declarations-in-javascri).
 
-> **Note:** Many issues with `let` variables can be avoided by declaring them at the top of the scope in which they are used (doing so may impact readability).
-> 
-> Unlike `var`, `let` begins _Declarations_, not _Statements_. That means you cannot use a lone `let` declaration as the body of a block (which makes sense, since there's no way to access the variable).
->
-> ```js
-> if (true) let a = 1; // SyntaxError: Lexical declaration cannot appear in a single-statement context
-> ```
+Many issues with `let` variables can be avoided by declaring them at the top of the scope in which they are used (doing so may impact readability).
+ 
+Unlike `var`, `let` begins _Declarations_, not _Statements_. That means you cannot use a lone `let` declaration as the body of a block (which makes sense, since there's no way to access the variable).
+
+```js
+if (true) let a = 1; // SyntaxError: Lexical declaration cannot appear in a single-statement context
+```
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/statements/let/index.md
+++ b/files/en-us/web/javascript/reference/statements/let/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.statements.let
 ---
 {{jsSidebar("Statements")}}
 
-The **`let`** statement declares a block-scoped local variable,
+The **`let`** declaration declares a block-scoped local variable,
 optionally initializing it to a value.
 
 {{EmbedInteractiveExample("pages/js/statement-let.html")}}
@@ -39,6 +39,12 @@ syntax can also be used to declare variables.
 ```js
 let { bar } = foo; // where foo = { bar:10, baz:12 };
 /* This creates a variable with the name 'bar', which has a value of 10 */
+```
+
+Unlike `var`, `let` begins _Declarations_, not _Statements_. That means you cannot use a lone `let` declaration as the body of a block (which makes sense, since there's no way to access the variable).
+
+```js
+if (true) let a = 1; // SyntaxError: Lexical declaration cannot appear in a single-statement context
 ```
 
 ## Description


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

#### Motivation

I've noticed that there's a bit misnomer when we say "the `let` statement", because `let` is a declaration. I'm relieved that "statements & declarations" are part of the same category, so no bigger refactoring needed, but I still decided to make the wording clearer.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
