### PR TITLE
Update the description of `onabort`

### DIFF
--- a/files/en-us/web/api/globaleventhandlers/onabort/index.md
+++ b/files/en-us/web/api/globaleventhandlers/onabort/index.md
@@ -17,7 +17,7 @@ browser-compat: api.GlobalEventHandlers.onabort
 
 The **`onabort`** property of the {{domxref("GlobalEventHandlers")}} mixin is the [event handler](/en-US/docs/Web/Events/Event_handlers) for processing `abort` events.
 
-Currently, only {{domxref("HTMLAudioElement")}} and {{domxref("HTMLVideoElement")}} interfaces (which inherit the {{domxref("HTMLMediaElement")}} interface) fire the {{domxref("HTMLMediaElement/abort_event", "abort")}} event.
+Currently, only the {{domxref("HTMLAudioElement")}} and {{domxref("HTMLVideoElement")}} interfaces (which inherit the {{domxref("HTMLMediaElement")}} interface) fire the {{domxref("HTMLMediaElement/abort_event", "abort")}} event.
 
 > **Note:** Previously the `abort` event is fired on `Window`, but it has been removed from the standard (see [HTML issue #3525](https://github.com/whatwg/html/issues/3525)).
 

--- a/files/en-us/web/api/globaleventhandlers/onabort/index.md
+++ b/files/en-us/web/api/globaleventhandlers/onabort/index.md
@@ -19,7 +19,7 @@ The **`onabort`** property of the {{domxref("GlobalEventHandlers")}} mixin is th
 
 Currently, only the {{domxref("HTMLAudioElement")}} and {{domxref("HTMLVideoElement")}} interfaces (which inherit the {{domxref("HTMLMediaElement")}} interface) fire the {{domxref("HTMLMediaElement/abort_event", "abort")}} event.
 
-> **Note:** Previously the `abort` event is fired on `Window`, but it has been removed from the standard (see [HTML issue #3525](https://github.com/whatwg/html/issues/3525)).
+> **Note:** Previously the `abort` event was fired on `Window`, but has since been removed from the standard (see [HTML issue #3525](https://github.com/whatwg/html/issues/3525)).
 
 ## Syntax
 

--- a/files/en-us/web/api/globaleventhandlers/onabort/index.md
+++ b/files/en-us/web/api/globaleventhandlers/onabort/index.md
@@ -4,7 +4,6 @@ slug: Web/API/GlobalEventHandlers/onabort
 tags:
   - API
   - Event Handler
-  - Experimental
   - GlobalEventHandlers
   - NeedsContent
   - NeedsHelp
@@ -14,37 +13,28 @@ tags:
   - Window
 browser-compat: api.GlobalEventHandlers.onabort
 ---
-{{ApiRef("HTML DOM")}} {{SeeCompatTable}}
+{{ApiRef("HTML DOM")}}
 
-The **`onabort`** property of the
-{{domxref("GlobalEventHandlers")}} mixin is the [event handler](/en-US/docs/Web/Events/Event_handlers) for
-processing {{event("abort")}} events sent to the window.
+The **`onabort`** property of the {{domxref("GlobalEventHandlers")}} mixin is the [event handler](/en-US/docs/Web/Events/Event_handlers) for processing `abort` events.
 
-While the [standard
-for aborting a document load](https://html.spec.whatwg.org/multipage/browsing-the-web.html#abort-a-document) is defined, [HTML issue #3525](https://github.com/whatwg/html/issues/3525) suggests that
-browsers should not currently fire the `abort` event on a `Window`
-that would trigger `onabort` to be called.
+Currently, only {{domxref("HTMLAudioElement")}} and {{domxref("HTMLVideoElement")}} interfaces (which inherit the {{domxref("HTMLMediaElement")}} interface) fire the {{domxref("HTMLMediaElement/abort_event", "abort")}} event.
 
-TODO: define what "abort" is. Closing the window via window manager? Stopping the load
-of the page? By which means and reasons (user, network/server)? At which stages would it
-fire / be caught? For IE, `onabort` is only available with
-`<img>` tags.
+> **Note:** Previously the `abort` event is fired on `Window`, but it has been removed from the standard (see [HTML issue #3525](https://github.com/whatwg/html/issues/3525)).
 
 ## Syntax
 
 ```js
-window.onabort = functionRef;
+element.onabort = functionRef;
 ```
 
 ### Value
 
-`functionRef` is a function name or a [function
-expression](/en-US/docs/Web/JavaScript/Reference/Operators/function).
+`functionRef` is a function name or a [function expression](/en-US/docs/Web/JavaScript/Reference/Operators/function).
 
 ## Example
 
 ```js
-window.onabort = function() {
+element.onabort = function() {
   alert('Load aborted.');
 }
 ```
@@ -56,5 +46,3 @@ window.onabort = function() {
 ## Browser compatibility
 
 {{Compat}}
-
-This property is not available with Firefox 2 or Safari.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Update the description of `onabort`.
- Remove a description of `abort` event on `Windows` because it has been removed from the spec.
- Add a description of `abort` event on `HTMLMediaElement` which fires `abort` events.
- Unmark `Experimental` because the all-major browsers support it.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
