### PR TITLE
Add browser-compat key and compat table to SVG xlink:href doc

### DIFF
--- a/files/en-us/web/svg/attribute/xlink_colon_href/index.md
+++ b/files/en-us/web/svg/attribute/xlink_colon_href/index.md
@@ -5,24 +5,7 @@ tags:
   - NeedsCompatTable
   - SVG
   - SVG Attribute
-spec-urls:
-  - https://www.w3.org/TR/SVG11/linking.html#AElementXLinkHrefAttribute
-  - https://www.w3.org/TR/SVG11/text.html#AltGlyphElementHrefAttribute
-  - https://www.w3.org/TR/SVG11/animate.html#HrefAttribute
-  - https://www.w3.org/TR/SVG11/interact.html#CursorElementHrefAttribute
-  - https://www.w3.org/TR/SVG11/filters.html#feImageElementHrefAttribute
-  - https://www.w3.org/TR/SVG11/filters.html#FilterElementHrefAttribute
-  - https://www.w3.org/TR/SVG11/fonts.html#FontFaceUriElementHrefAttribute
-  - https://www.w3.org/TR/SVG11/text.html#GlyphRefElementHrefAttribute
-  - https://www.w3.org/TR/SVG11/struct.html#ImageElementHrefAttribute
-  - https://www.w3.org/TR/SVG11/pservers.html#LinearGradientElementHrefAttribute
-  - https://www.w3.org/TR/SVG11/animate.html#MPathElementHrefAttribute
-  - https://www.w3.org/TR/SVG11/pservers.html#PatternElementHrefAttribute
-  - https://www.w3.org/TR/SVG11/pservers.html#RadialGradientElementHrefAttribute
-  - https://www.w3.org/TR/SVG11/script.html#ScriptElementHrefAttribute
-  - https://www.w3.org/TR/SVG11/text.html#TextPathElementHrefAttribute
-  - https://www.w3.org/TR/SVG11/struct.html#UseElementHrefAttribute
-  - https://www.w3.org/TR/SVG11/text.html#TRefElementHrefAttribute
+browser-compat: svg.elements.a.xlink_href
 ---
 {{SVGRef}}{{Deprecated_Header}}
 
@@ -512,6 +495,10 @@ For {{SVGElement("tref")}}, `xlink:href` defines a reference to an element whose
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/16300 • Related BCD issue: https://github.com/mdn/browser-compat-data/pull/16386
