### PR TITLE
glossary: add missing semicolon to CSS example

### DIFF
--- a/files/en-us/glossary/css/index.md
+++ b/files/en-us/glossary/css/index.md
@@ -23,7 +23,7 @@ p {
   color: yellow;
 
   /* The "background-color" property defines the background color, in this case black. */
-  background-color: black
+  background-color: black;
 }
 ```
 


### PR DESCRIPTION
#### Summary
Add missing semicolon to CSS example.

#### Motivation
Inconsistent syntax can be confusing for beginners

- [x] Fixes a typo, bug, or other error
