### PR TITLE
Replace curly apostrophes by regular apostrophes

### DIFF
--- a/files/en-us/web/api/cache/index.md
+++ b/files/en-us/web/api/cache/index.md
@@ -151,7 +151,7 @@ self.addEventListener('fetch', function(event) {
 
 ### Cookies and Cache objects
 
-The [Fetch API](/en-US/docs/Web/API/Fetch_API) requires {{httpheader("Set-Cookie")}} headers to be stripped before returning a {{domxref("Response")}} object from {{domxref("fetch()")}}. So a `Response` stored in a `Cache` won't contain `Set-Cookie` headers, and therefore won’t cause any cookies to be stored.
+The [Fetch API](/en-US/docs/Web/API/Fetch_API) requires {{httpheader("Set-Cookie")}} headers to be stripped before returning a {{domxref("Response")}} object from {{domxref("fetch()")}}. So a `Response` stored in a `Cache` won't contain `Set-Cookie` headers, and therefore won't cause any cookies to be stored.
 
 ## Specifications
 

--- a/files/en-us/web/api/fetch_api/using_fetch/index.md
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.md
@@ -25,7 +25,7 @@ The `fetch` specification differs from `jQuery.ajax()` in the following signific
 - The Promise returned from `fetch()` **won't reject on HTTP error status** even if the response is an HTTP 404 or 500. Instead, as soon as the server responds with headers, the Promise will resolve normally (with the {{domxref("Response/ok", "ok")}} property of the response set to false if the response isn't in the range 200–299), and it will only reject on network failure or if anything prevented the request from completing.
 - Unless `fetch()` is called with the [`credentials`](/en-US/docs/Web/API/fetch#credentials) option set to `include`, `fetch()`:
   - won't send cookies in cross-origin requests
-  - won’t set any cookies sent back in cross-origin responses
+  - won't set any cookies sent back in cross-origin responses
 
 A basic fetch request is really simple to set up. Have a look at the following code:
 

--- a/files/en-us/web/api/mediastream_recording_api/recording_a_media_element/index.md
+++ b/files/en-us/web/api/mediastream_recording_api/recording_a_media_element/index.md
@@ -238,7 +238,7 @@ startButton.addEventListener("click", function() {
   })
   .catch((error) => {
     if (error.name === "NotFoundError") {
-      log("Camera or microphone not found. Can’t record.");
+      log("Camera or microphone not found. Can't record.");
     } else {
       log(error);
     }

--- a/files/en-us/web/api/navigator/platform/index.md
+++ b/files/en-us/web/api/navigator/platform/index.md
@@ -13,13 +13,13 @@ browser-compat: api.Navigator.platform
 ---
 {{ APIRef("HTML DOM") }}
 
-The **`platform`** property read-only property of the {{domxref("Navigator")}} interface returns a string identifying the platform on which the user’s browser is running.
+The **`platform`** property read-only property of the {{domxref("Navigator")}} interface returns a string identifying the platform on which the user's browser is running.
 
-> **Note:** In general, you should whenever possible avoid writing code that uses methods or properties like this one to try to find out information about the user’s environment, and instead write code that does [feature detection](/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Feature_detection).
+> **Note:** In general, you should whenever possible avoid writing code that uses methods or properties like this one to try to find out information about the user's environment, and instead write code that does [feature detection](/en-US/docs/Learn/Tools_and_testing/Cross_browser_testing/Feature_detection).
 
 ## Value
 
-A string identifying the platform on which the user’s browser is running; for example: `"MacIntel"`, `"Win32"`, `"Linux x86_64"`, `"Linux x86_64"`.
+A string identifying the platform on which the user's browser is running; for example: `"MacIntel"`, `"Win32"`, `"Linux x86_64"`, `"Linux x86_64"`.
 
 ## Examples
 
@@ -32,7 +32,7 @@ if (navigator.platform.indexOf("Mac") === 0 || navigator.platform === "iPhone") 
 }
 ```
 
-That is, check if `navigator.platform` starts with `"Mac"` or else is an exact match for `"iPhone"`, and then based on whether either of those is true, choose the modifier key your web application’s UI will advise users to press in keyboard shortcuts.
+That is, check if `navigator.platform` starts with `"Mac"` or else is an exact match for `"iPhone"`, and then based on whether either of those is true, choose the modifier key your web application's UI will advise users to press in keyboard shortcuts.
 
 ## Usage notes
 

--- a/files/en-us/web/api/settimeout/index.md
+++ b/files/en-us/web/api/settimeout/index.md
@@ -75,7 +75,7 @@ To call a function repeatedly (e.g., every _N_ milliseconds), consider using
 
 ### Non-number delay values are silently coerced into numbers
 
-If `setTimeout()` is called with [_delay_](#delay) value that’s not a number, implicit [type coercion](/en-US/docs/Glossary/Type_coercion) is silently done on the value to convert it to a number. For example, the following code incorrectly uses the string `"1000"` for the _delay_ value, rather than the number `1000` – but it nevertheless works, because when the code runs, the string is coerced into the number `1000`, and so the code executes 1 second later.
+If `setTimeout()` is called with [_delay_](#delay) value that's not a number, implicit [type coercion](/en-US/docs/Glossary/Type_coercion) is silently done on the value to convert it to a number. For example, the following code incorrectly uses the string `"1000"` for the _delay_ value, rather than the number `1000` – but it nevertheless works, because when the code runs, the string is coerced into the number `1000`, and so the code executes 1 second later.
 
 ```js example-bad
 setTimeout(() => {
@@ -91,7 +91,7 @@ setTimeout(() => {
 }, "1 second")
 ```
 
-Therefore, don’t use strings for the _delay_ value but instead always use numbers:
+Therefore, don't use strings for the _delay_ value but instead always use numbers:
 
 ```js example-good
 setTimeout(() => {

--- a/files/en-us/web/api/transformstreamdefaultcontroller/enqueue/index.md
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/enqueue/index.md
@@ -34,7 +34,7 @@ None ({{jsxref("undefined")}}).
 
 - {{jsxref("TypeError")}}
   - : The stream is not readable.
-    This might occur if the stream is errored via `controller.error()`, or when it is closed without its controller’s `controller.close()` method ever being called.
+    This might occur if the stream is errored via `controller.error()`, or when it is closed without its controller's `controller.close()` method ever being called.
 
 ## Examples
 

--- a/files/en-us/web/api/url/port/index.md
+++ b/files/en-us/web/api/url/port/index.md
@@ -15,7 +15,7 @@ browser-compat: api.URL.port
 The **`port`** property of the {{domxref("URL")}} interface is
 a string containing the port number of the URL.
 
-> **Note:** If an input string passed to the [`URL()`](/en-US/docs/Web/API/URL/URL) constructor doesn’t contain an explicit port number (e.g., `https://localhost`) or contains a port number that’s the default port number corresponding to the protocol part of the input string (e.g., `https://localhost:443`), then in the [`URL`](/en-US/docs/Web/API/URL) object the constructor returns, the value of the port property will be the empty string: `''`.
+> **Note:** If an input string passed to the [`URL()`](/en-US/docs/Web/API/URL/URL) constructor doesn't contain an explicit port number (e.g., `https://localhost`) or contains a port number that's the default port number corresponding to the protocol part of the input string (e.g., `https://localhost:443`), then in the [`URL`](/en-US/docs/Web/API/URL) object the constructor returns, the value of the port property will be the empty string: `''`.
 
 {{AvailableInWorkers}}
 


### PR DESCRIPTION
We don't use curly quotes on MDN. This is a periodic check to replace the ones that get it.