### PR TITLE
Move compat data into browser-compat key (in docs in API tree)

### DIFF
--- a/files/en-us/web/api/background_synchronization_api/index.md
+++ b/files/en-us/web/api/background_synchronization_api/index.md
@@ -11,6 +11,7 @@ tags:
   - Service Workers
   - Sync
   - Web Background Synchronization API
+browser-compat: api.SyncManager
 ---
 {{securecontext_header}}
 
@@ -92,11 +93,11 @@ self.addEventListener('sync', event => {
 
 ## Specifications
 
-{{Specifications("api.SyncManager")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.SyncManager")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/background_tasks_api/index.md
+++ b/files/en-us/web/api/background_tasks_api/index.md
@@ -9,6 +9,7 @@ tags:
   - Overview
   - cancelIdleCallback
   - requestIdleCallback
+browser-compat: api.Window.requestIdleCallback
 ---
 {{DefaultAPISidebar("Background Tasks")}}
 
@@ -472,11 +473,11 @@ Below is the actual functioning result of the code above. Try it out, play with 
 
 ## Specifications
 
-{{Specifications("api.Window.requestIdleCallback")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.IdleDeadline")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/beacon_api/index.md
+++ b/files/en-us/web/api/beacon_api/index.md
@@ -5,6 +5,7 @@ tags:
   - Guide
   - Overview
   - Web Performance
+browser-compat: api.Navigator.sendBeacon
 ---
 {{DefaultAPISidebar("Beacon")}}
 
@@ -24,11 +25,11 @@ The method takes two arguments, the URL and the data to send in the request. The
 
 ## Specifications
 
-{{Specifications("api.Navigator.sendBeacon")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.Navigator.sendBeacon")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/broadcast_channel_api/index.md
+++ b/files/en-us/web/api/broadcast_channel_api/index.md
@@ -7,6 +7,7 @@ tags:
   - HTML API
   - Overview
   - Reference
+browser-compat: api.BroadcastChannel
 ---
 {{DefaultAPISidebar("Broadcast Channel API")}}
 
@@ -68,11 +69,11 @@ The messaging protocol is not defined and the different browsing contexts need t
 
 ## Specifications
 
-{{Specifications("api.BroadcastChannel")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.BroadcastChannel")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/compression_streams_api/index.md
+++ b/files/en-us/web/api/compression_streams_api/index.md
@@ -8,6 +8,7 @@ tags:
   - Decompression
   - Reference
   - Overview
+browser-compat: api.CompressionStream
 ---
 {{DefaultAPISidebar("Compression Streams API")}}
 
@@ -42,8 +43,8 @@ async function DecompressBlob(blob) {
 
 ## Specifications
 
-{{Specifications("api.CompressionStream")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.CompressionStream")}}
+{{Compat}}

--- a/files/en-us/web/api/console_api/index.md
+++ b/files/en-us/web/api/console_api/index.md
@@ -10,6 +10,7 @@ tags:
   - log
   - output
   - test
+browser-compat: api.console
 ---
 {{DefaultAPISidebar("Console API")}}
 
@@ -46,11 +47,11 @@ See the [console](/en-US/docs/Web/API/console#usage) reference page for more exa
 
 ## Specifications
 
-{{Specifications("api.console")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.console")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/contact_picker_api/index.md
+++ b/files/en-us/web/api/contact_picker_api/index.md
@@ -9,6 +9,7 @@ tags:
   - Overview
   - PWA
   - contact picker
+browser-compat: api.ContactsManager
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Contact Picker API")}}
 
@@ -96,11 +97,11 @@ async function getContacts() {
 
 ## Specifications
 
-{{Specifications("api.ContactsManager")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.ContactsManager")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/content_index_api/index.md
+++ b/files/en-us/web/api/content_index_api/index.md
@@ -9,6 +9,7 @@ tags:
   - Landing
   - PWA
   - content indexing
+browser-compat: api.ContentIndex
 ---
 {{DefaultAPISidebar("Content Index API")}}
 
@@ -192,11 +193,11 @@ The {{Event('contentdelete')}} event is only fired when the deletion happens due
 
 ## Specifications
 
-{{Specifications("api.ContentIndex")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.ContentIndex")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/cookie_store_api/index.md
+++ b/files/en-us/web/api/cookie_store_api/index.md
@@ -6,6 +6,7 @@ tags:
   - Cookie Store
   - Overview
   - Reference
+browser-compat: api.CookieStore
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Cookie Store")}}
 
@@ -35,8 +36,8 @@ The Cookie Store API provides an updated method of managing cookies. It is {{Glo
 
 ## Specifications
 
-{{Specifications("api.CookieStore")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.CookieStore")}}
+{{Compat}}

--- a/files/en-us/web/api/credential_management_api/index.md
+++ b/files/en-us/web/api/credential_management_api/index.md
@@ -9,6 +9,7 @@ tags:
   - Overview
   - Reference
   - credential management
+browser-compat: api.Credential
 ---
 {{DefaultAPISidebar("Credential Management API")}}{{ SeeCompatTable() }}
 
@@ -41,8 +42,8 @@ Later version of the spec allow credentials to be retrieved from a different sub
 
 ## Specifications
 
-{{Specifications("api.Credential")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.Credential")}}
+{{Compat}}

--- a/files/en-us/web/api/css/factory_functions/index.md
+++ b/files/en-us/web/api/css/factory_functions/index.md
@@ -8,6 +8,7 @@ tags:
   - Houdini
   - Reference
   - factory function
+browser-compat: api.CSS
 ---
 {{SeeCompatTable}}
 
@@ -93,11 +94,11 @@ console.log(currentMargin.value, currentMargin.unit); // 40, 'px'
 
 ## Specifications
 
-{{Specifications("api.CSS")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.CSS")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/css_counter_styles/index.md
+++ b/files/en-us/web/api/css_counter_styles/index.md
@@ -5,6 +5,7 @@ tags:
   - CSS
   - CSS Counter Styles
   - Overview
+browser-compat: api.CSSCounterStyleRule
 ---
 {{DefaultAPISidebar("CSS Counter Styles")}}{{SeeCompatTable}}
 
@@ -17,13 +18,11 @@ The CSS Counter Styles module allows to define custom counter styles, which can 
 
 ## Specifications
 
-{{Specifications("api.CSSCounterStyleRule")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-### `CSSCounterStyleRule` interface
-
-{{Compat("api.CSSCounterStyleRule")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/geolocation_api/index.md
+++ b/files/en-us/web/api/geolocation_api/index.md
@@ -6,6 +6,7 @@ tags:
   - Guide
   - Intermediate
   - Overview
+browser-compat: api.Geolocation
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Geolocation API")}}
 
@@ -51,11 +52,11 @@ See [Using the Geolocation API](/en-US/docs/Web/API/Geolocation_API/Using_the_Ge
 
 ## Specifications
 
-{{Specifications("api.Geolocation")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.Geolocation")}}
+{{Compat}}
 
 ### Availability
 

--- a/files/en-us/web/api/htmlelement/change_event/index.md
+++ b/files/en-us/web/api/htmlelement/change_event/index.md
@@ -9,6 +9,7 @@ tags:
   - HTMLElement
   - Reference
   - Web
+browser-compat: api.GlobalEventHandlers.onchange
 ---
 {{APIRef}}
 
@@ -125,10 +126,10 @@ function updateValue(e) {
 
 ## Specifications
 
-{{Specifications("api.GlobalEventHandlers.onchange")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.GlobalEventHandlers.onchange")}}
+{{Compat}}
 
 Different browsers do not always agree whether a `change` event should be fired for certain types of interaction. For example, keyboard navigation in {{HTMLElement("select")}} elements used to never fire a `change` event in Gecko until the user hit Enter or switched the focus away from the `<select>` (see {{bug("126379")}}). Since Firefox 63 (Quantum), this behavior is consistent between all major browsers, however.

--- a/files/en-us/web/api/media_capabilities_api/index.md
+++ b/files/en-us/web/api/media_capabilities_api/index.md
@@ -7,7 +7,7 @@ tags:
   - Media Capabilities
   - Overview
   - Reference
-spec-urls: https://w3c.github.io/media-capabilities/
+browser-compat: api.MediaCapabilities
 ---
 {{DefaultAPISidebar("Media Capabilities API")}}
 
@@ -66,11 +66,11 @@ Media capabilities information enables websites to enable adaptive streaming to 
 
 ## Specifications
 
-{{Specifications("api.MediaCapabilities")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.MediaCapabilities")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/notifications_api/using_the_notifications_api/index.md
+++ b/files/en-us/web/api/notifications_api/using_the_notifications_api/index.md
@@ -9,6 +9,7 @@ tags:
   - Notifications API
   - Push
   - Tutorial
+browser-compat: api.Notification
 ---
 {{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
 
@@ -256,11 +257,11 @@ window.addEventListener('load', function () {
 
 ## Specifications
 
-{{Specifications("api.Notification")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.Notification")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/remote_playback_api/index.md
+++ b/files/en-us/web/api/remote_playback_api/index.md
@@ -6,6 +6,7 @@ tags:
   - Overview
   - Reference
   - Remote Playback API
+browser-compat: api.RemotePlayback
 ---
 {{DefaultAPISidebar("Remote Playback API")}}
 
@@ -55,8 +56,8 @@ videoElem.remote.watchAvailability(availabilityCallback).catch(() => {
 
 ## Specifications
 
-{{Specifications("api.RemotePlayback")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.RemotePlayback")}}
+{{Compat}}

--- a/files/en-us/web/api/resize_observer_api/index.md
+++ b/files/en-us/web/api/resize_observer_api/index.md
@@ -12,6 +12,7 @@ tags:
   - Resize Observer API
   - observe
   - size
+browser-compat: api.ResizeObserver
 ---
 {{DefaultAPISidebar("Resize Observer API")}}
 
@@ -65,11 +66,11 @@ resizeObserver.observe(document.querySelector('div'));
 
 ## Specifications
 
-{{Specifications("api.ResizeObserver")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.ResizeObserver")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/visual_viewport_api/index.md
+++ b/files/en-us/web/api/visual_viewport_api/index.md
@@ -11,6 +11,7 @@ tags:
   - viewport
   - visual
   - visual viewport
+browser-compat: api.VisualViewport
 ---
 {{DefaultAPISidebar("Visual Viewport")}}
 
@@ -74,8 +75,8 @@ window.visualViewport.addEventListener('resize', viewportHandler);
 
 ## Specifications
 
-{{Specifications("api.VisualViewport")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.VisualViewport")}}
+{{Compat}}

--- a/files/en-us/web/api/web_audio_api/index.md
+++ b/files/en-us/web/api/web_audio_api/index.md
@@ -9,6 +9,7 @@ tags:
   - Overview
   - Web Audio API
   - sound
+browser-compat: api.AudioContext
 ---
 {{DefaultAPISidebar("Web Audio API")}}
 
@@ -198,13 +199,13 @@ You can find a number of examples at our [webaudio-example repo](https://github.
 
 ## Specifications
 
-{{Specifications("api.AudioContext")}}
+{{Specifications}}
 
 ## Browser compatibility
 
 ### AudioContext
 
-{{Compat("api.AudioContext", 0)}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/xmlhttprequest/html_in_xmlhttprequest/index.md
+++ b/files/en-us/web/api/xmlhttprequest/html_in_xmlhttprequest/index.md
@@ -10,6 +10,7 @@ tags:
   - Parsing HTML
   - Web
   - XMLHttpRequest
+browser-compat: api.XMLHttpRequest
 ---
 {{APIRef("XMLHttpRequest")}}
 
@@ -137,11 +138,11 @@ oReq.send(null);
 
 ## Specifications
 
-{{Specifications("api.XMLHttpRequest")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.XMLHttpRequest")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/xmlhttprequest/using_xmlhttprequest/index.md
+++ b/files/en-us/web/api/xmlhttprequest/using_xmlhttprequest/index.md
@@ -14,6 +14,7 @@ tags:
   - XHR
   - XML
   - XMLHttpRequest
+browser-compat: api.XMLHttpRequest
 ---
 {{APIRef("XMLHttpRequest")}}
 
@@ -920,11 +921,11 @@ Setting `overrideMimeType` does not work from a {{domxref("Worker")}}. See
 
 ## Specifications
 
-{{Specifications("api.XMLHttpRequest")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.XMLHttpRequest")}}
+{{Compat}}
 
 ## See also
 


### PR DESCRIPTION
For the following reasons:

  - consistency with handling of BCD features in other existing docs
  - streamlining out unnecessary repetition of BCD feature names
  - in keeping with the principle of making use of frontmatter metadata to store data — BCD feature names - rather than having the BCD feature names in the prose body of documents

...this change takes BCD feature names out of the arguments to the `Compat` and `Specifications` macros, and moves those BCD feature names into the value of the `browser-compat` frontmatter metadata key.

Every update in this change follows the same simple pattern: It takes the following:

```markdown
## Specifications

{{Specifications("api.SyncManager")}}

## Browser compatibility

{{Compat("api.SyncManager")}}
```

...and changes that into this:

```markdown
browser-compat: api.SyncManager
...
## Specifications

{{Specifications}}

## Browser compatibility

{{Compat}}
```

...that is, it takes the `"api.SyncManager"` BCD feature name that’s repeated in two different places in the prose body of the doc — as arguments to the `Compat` and `Specifications` macros — and moves it being given just once: in the `browser-compat` frontmatter metadata key.