### PR TITLE
Fix cases of Specification macro with unnecessary args

### DIFF
--- a/files/en-us/web/css/align-content/index.md
+++ b/files/en-us/web/css/align-content/index.md
@@ -248,7 +248,7 @@ display.addEventListener('change', function (evt) {
 
 ## Specifications
 
-{{Specifications("css.properties.align-content.grid_context")}}
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/css/align-items/index.md
+++ b/files/en-us/web/css/align-items/index.md
@@ -231,7 +231,7 @@ display.addEventListener('change', function (evt) {
 
 ## Specifications
 
-{{Specifications("css.properties.align-items.grid_context")}}
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/css/align-self/index.md
+++ b/files/en-us/web/css/align-self/index.md
@@ -135,7 +135,7 @@ div:nth-child(3) {
 
 ## Specifications
 
-{{Specifications("css.properties.align-self.grid_context")}}
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/css/break-after/index.md
+++ b/files/en-us/web/css/break-after/index.md
@@ -190,7 +190,7 @@ article {
 
 ## Specifications
 
-{{Specifications("css.properties.break-after.multicol_context")}}
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/css/break-before/index.md
+++ b/files/en-us/web/css/break-before/index.md
@@ -190,7 +190,7 @@ article {
 
 ## Specifications
 
-{{Specifications("css.properties.break-before.multicol_context")}}
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/css/break-inside/index.md
+++ b/files/en-us/web/css/break-inside/index.md
@@ -156,7 +156,7 @@ article {
 
 ## Specifications
 
-{{Specifications("css.properties.break-inside.multicol_context")}}
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/css/column-gap/index.md
+++ b/files/en-us/web/css/column-gap/index.md
@@ -154,7 +154,7 @@ The `column-gap` property is specified as one of the values listed below.
 
 ## Specifications
 
-{{Specifications("css.properties.column-gap.grid_context")}}
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/css/gap/index.md
+++ b/files/en-us/web/css/gap/index.md
@@ -178,7 +178,7 @@ This property is specified as a value for `<'row-gap'>` followed optionally by a
 
 ## Specifications
 
-{{Specifications("css.properties.gap.grid_context")}}
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/css/justify-content/index.md
+++ b/files/en-us/web/css/justify-content/index.md
@@ -168,7 +168,7 @@ justifyContent.addEventListener("change", function (evt) {
 
 ## Specifications
 
-{{Specifications("css.properties.justify-content.grid_context")}}
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/css/justify-items/index.md
+++ b/files/en-us/web/css/justify-items/index.md
@@ -181,7 +181,7 @@ article {
 
 ## Specifications
 
-{{Specifications("css.properties.justify-items.grid_context")}}
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/css/justify-self/index.md
+++ b/files/en-us/web/css/justify-self/index.md
@@ -190,7 +190,7 @@ article {
 
 ## Specifications
 
-{{Specifications("css.properties.justify-self.grid_context")}}
+{{Specifications}}
 
 ## Browser compatibility
 

--- a/files/en-us/web/css/row-gap/index.md
+++ b/files/en-us/web/css/row-gap/index.md
@@ -125,7 +125,7 @@ row-gap: unset;
 
 ## Specifications
 
-{{Specifications("css.properties.row-gap.grid_context")}}
+{{Specifications}}
 
 ## Browser compatibility
 


### PR DESCRIPTION
A number of `Specifications` macro calls have arguments that are unnecessary because the spec URLs for the BCD feature in the argument are already provided by the BCD feature given in the `browser-compat` key.

For example, `files/en-us/web/css/align-content/index.md` has this combo:

```markdown
browser-compat: css.properties.align-content
...
{{Specifications("css.properties.align-content.grid_context")}}
```

Looking at https://github.com/mdn/browser-compat-data/blob/main/css/properties/align-content.json#L4 (that is, the BCD feature `css.properties.align-content)` in BCD, we find this:

```json
"spec_url": [
  "https://drafts.csswg.org/css-align/#align-justify-content",
  "https://drafts.csswg.org/css-flexbox/#align-content-property"
],
```

Looking at https://github.com/mdn/browser-compat-data/blob/main/css/properties/align-content.json#L472 (that is, the BCD feature `css.properties.align-content.grid_context)` in BCD, we find this:

```json
"spec_url": [
  "https://drafts.csswg.org/css-align/#align-justify-content",
  "https://drafts.csswg.org/css-flexbox/#align-content-property"
],
```

That is, the `css.properties.align-content` feature and its subfeature `css.properties.align-content.grid_context` have exactly the same spec URLs in BCD — so there’s therefore no need to give the `Specifications` macro the `css.properties.align-content.grid_context` argument.

Specifically, removing that argument doesn’t cause any change in the rendered output for the `Specifications` table in that document; with the argument removed, the table still shows the same set of spec URLs.

All the updates in this change are for files where the source follows the same pattern described above: the argument given to the `Specifications` macro is unnecessary because it doesn’t change the output.