### PR TITLE
Update spec and compat table for @media shape feature

### DIFF
--- a/files/en-us/web/css/@media/shape/index.md
+++ b/files/en-us/web/css/@media/shape/index.md
@@ -5,10 +5,11 @@ tags:
   - '@media'
   - CSS
   - Reference
+  - Experimental
   - media feature
-browser-compat: css.at-rules.media.shape
+spec-urls: https://drafts.csswg.org/css-round-display/#shape-media-feature
 ---
-{{CSSRef}}
+{{CSSRef}}{{SeeCompatTable}}
 
 The `shape` [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#media_features) can be used to test the shape of the device to distinguish rectangular and round displays.
 
@@ -69,7 +70,7 @@ This HTML will apply a special stylesheet for devices that have round screens.
 
 ## Browser compatibility
 
-{{Compat}}
+There is no browser implementing this feature.
 
 ## See also
 


### PR DESCRIPTION
There is no browser implementing this feature. Add a `spec-urls` YAML header, and a text to signal this.