### PR TITLE
Correct "Numbers and the '+' operator" section

### DIFF
--- a/files/en-us/web/javascript/guide/grammar_and_types/index.md
+++ b/files/en-us/web/javascript/guide/grammar_and_types/index.md
@@ -351,13 +351,14 @@ In expressions involving numeric and string values with the `+` operator, JavaSc
 ```js
 x = 'The answer is ' + 42 // "The answer is 42"
 y = 42 + ' is the answer' // "42 is the answer"
+'37' + 7 // "377"
 ```
 
 With all other operators, JavaScript does _not_ convert numeric values to strings. For example:
 
 ```js
 '37' - 7 // 30
-'37' + 7 // "377"
+'37' * 7 // 259
 ```
 
 ### Converting strings to numbers


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
In the `'37' + 7 // "377"` example, the numeric value is still converted to a string.
So, it was moved up to the right code group, and in its place, the operator and resulting value were changed according to the expected.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Readers might not understand why a code group expecting numbers not converted to a string, had an example with such.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
