### PR TITLE
Replace var with const on Javascript dataview/getbiguint64

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/dataview/getbiguint64/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/getbiguint64/index.md
@@ -54,7 +54,7 @@ There is no alignment constraint; multi-byte values may be fetched from any offs
 ### Using the `getBigUint64` method
 
 ```js
-var buffer = new ArrayBuffer(8);
+const buffer = new ArrayBuffer(8);
 var dataview = new DataView(buffer);
 dataview.getBigUint64(0); // 0n
 ```

--- a/files/en-us/web/javascript/reference/global_objects/dataview/getbiguint64/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/dataview/getbiguint64/index.md
@@ -55,7 +55,7 @@ There is no alignment constraint; multi-byte values may be fetched from any offs
 
 ```js
 const buffer = new ArrayBuffer(8);
-var dataview = new DataView(buffer);
+const dataview = new DataView(buffer);
 dataview.getBigUint64(0); // 0n
 ```
 


### PR DESCRIPTION
This PR replaces `var` with `const` on the `DataView.prototype.getbituint64`.