### PR TITLE
Added link to proposed `shared` field in `WebAssembly.Memory()` constructor

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/webassembly/memory/memory/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/memory/memory/index.md
@@ -105,7 +105,7 @@ This memory's `buffer` property will return a
 
 ## Specifications
 
-The `shared` attribute is only documented in [this proposal](https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md#javascript-api-changes) and not part of the specs.
+The `shared` attribute is only documented in [this proposal](https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md#javascript-api-changes) and not part of the official specs.
 
 {{Specifications}}
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/memory/memory/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/memory/memory/index.md
@@ -105,7 +105,7 @@ This memory's `buffer` property will return a
 
 ## Specifications
 
-The `shared` attribute is only documented in [this proposal](https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md#javascript-api-changes) and not part of the official specs.
+The `shared` attribute is only documented in [the Threading proposal for WebAssembly](https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md#javascript-api-changes) and not part of the official specs.
 
 {{Specifications}}
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/memory/memory/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/memory/memory/index.md
@@ -105,6 +105,8 @@ This memory's `buffer` property will return a
 
 ## Specifications
 
+The `shared` attribute is only documented in [this proposal](https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md#javascript-api-changes) and not part of the specs.
+
 {{Specifications}}
 
 ## Browser compatibility


### PR DESCRIPTION
This PR closes #860.
#860 complains about the `shared` attribute in the `memoryDescriptor`, which is used in the `WebAssembly.Memory()` constructor. The attribute is apparently supported by SpiderMonkey but not part of the [official specs](https://webassembly.github.io/spec/js-api/index.html), which are referenced in the MDN article. Though, it is documented in [a proposal](https://github.com/WebAssembly/threads/blob/master/proposals/threads/Overview.md#javascript-api-changes).
This PR adds a note to this proposal, which, to my knowledge, is the way of [adding specs for non-standard features](https://developer.mozilla.org/en-US/docs/MDN/Structures/Specification_tables#non-standard_features).

- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
