### PR TITLE
Minor change: Change var to const or let

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/datetimeformat/index.md
@@ -321,12 +321,12 @@ console.log(new Intl.DateTimeFormat('fr', { hour: 'numeric', hourCycle: 'h12',
 Use the `timeZoneName` option to output a string for the timezone ("GMT", "Pacific Time", etc.).
 
 ```js
-var date = Date.UTC(2021, 11, 17, 3, 0, 42);
+const date = Date.UTC(2021, 11, 17, 3, 0, 42);
 const timezoneNames = ['short', 'long', 'shortOffset', 'longOffset', 'shortGeneric', 'longGeneric']
 
 for (const zoneName of timezoneNames) {
   // Do something with currentValue
-  var formatter = new Intl.DateTimeFormat('en-US', {
+  const formatter = new Intl.DateTimeFormat('en-US', {
     timeZone: 'America/Los_Angeles',
     timeZoneName: zoneName,
   });

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/format/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/format/index.md
@@ -46,8 +46,8 @@ Use the `format` getter function for formatting a single date, here for
 Serbia:
 
 ```js
-var options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
-var dateTimeFormat = new Intl.DateTimeFormat('sr-RS', options);
+const options = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' };
+const dateTimeFormat = new Intl.DateTimeFormat('sr-RS', options);
 console.log(dateTimeFormat.format(new Date()));
 // → "недеља, 7. април 2013."
 ```
@@ -60,10 +60,10 @@ from which it was obtained, so it can be passed directly to
 {{jsxref("Array.prototype.map()")}}.
 
 ```js
-var a = [new Date(2012, 08), new Date(2012, 11), new Date(2012, 03)];
-var options = { year: 'numeric', month: 'long' };
-var dateTimeFormat = new Intl.DateTimeFormat('pt-BR', options);
-var formatted = a.map(dateTimeFormat.format);
+const a = [new Date(2012, 08), new Date(2012, 11), new Date(2012, 03)];
+const options = { year: 'numeric', month: 'long' };
+const dateTimeFormat = new Intl.DateTimeFormat('pt-BR', options);
+const formatted = a.map(dateTimeFormat.format);
 console.log(formatted.join('; '));
 // → "setembro de 2012; dezembro de 2012; abril de 2012"
 ```

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formattoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formattoparts/index.md
@@ -92,9 +92,9 @@ Possible types are the following:
 manipulated directly:
 
 ```js
-var date = Date.UTC(2012, 11, 17, 3, 0, 42);
+const date = Date.UTC(2012, 11, 17, 3, 0, 42);
 
-var formatter = new Intl.DateTimeFormat('en-us', {
+const formatter = new Intl.DateTimeFormat('en-us', {
   weekday: 'long',
   year: 'numeric',
   month: 'numeric',
@@ -147,7 +147,7 @@ a [switch statement](/en-US/docs/Web/JavaScript/Reference/Statements/switch),
 and {{jsxref("Array.prototype.join()")}}.
 
 ```js
-var dateString = formatter.formatToParts(date).map(({type, value}) => {
+const dateString = formatter.formatToParts(date).map(({type, value}) => {
   switch (type) {
     case 'dayPeriod': return `<b>${value}</b>`;
     default : return value;

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/resolvedoptions/index.md
@@ -69,8 +69,8 @@ The resulting object has the following properties:
 ### Using the resolvedOptions method
 
 ```js
-var germanFakeRegion = new Intl.DateTimeFormat('de-XX', { timeZone: 'UTC' });
-var usedOptions = germanFakeRegion.resolvedOptions();
+const germanFakeRegion = new Intl.DateTimeFormat('de-XX', { timeZone: 'UTC' });
+const usedOptions = germanFakeRegion.resolvedOptions();
 
 usedOptions.locale;          // "de"
 usedOptions.calendar;        // "gregory"

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/format/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/format/index.md
@@ -46,8 +46,8 @@ Use the `format` getter function for formatting a single currency value,
 here for Russia:
 
 ```js
-var options = { style: 'currency', currency: 'RUB' };
-var numberFormat = new Intl.NumberFormat('ru-RU', options);
+const options = { style: 'currency', currency: 'RUB' };
+const numberFormat = new Intl.NumberFormat('ru-RU', options);
 console.log(numberFormat.format(654321.987));
 // → "654 321,99 руб."
 ```
@@ -61,9 +61,9 @@ considered a historical artefact, as part of a convention which is no longer fol
 for new features, but is preserved to maintain compatibility with existing programs.
 
 ```js
-var a = [123456.789, 987654.321, 456789.123];
-var numberFormat = new Intl.NumberFormat('es-ES');
-var formatted = a.map(n => numberFormat.format(n));
+const a = [123456.789, 987654.321, 456789.123];
+const numberFormat = new Intl.NumberFormat('es-ES');
+const formatted = a.map(n => numberFormat.format(n));
 console.log(formatted.join('; '));
 // → "123.456,789; 987.654,321; 456.789,123"
 ```

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/formattoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/formattoparts/index.md
@@ -87,9 +87,9 @@ Possible types are the following:
 directly:
 
 ```js
-var number = 3500;
+const number = 3500;
 
-var formatter = new Intl.NumberFormat('de-DE', {
+const formatter = new Intl.NumberFormat('de-DE', {
   style: 'currency',
   currency: 'EUR'
 });
@@ -125,7 +125,7 @@ a [switch statement](/en-US/docs/Web/JavaScript/Reference/Statements/switch),
 [template literals](/en-US/docs/Web/JavaScript/Reference/Template_literals), and {{jsxref("Array.prototype.reduce()")}}.
 
 ```js
-var numberString = formatter.formatToParts(number).map(({type, value}) => {
+const numberString = formatter.formatToParts(number).map(({type, value}) => {
   switch (type) {
     case 'currency': return `<strong>${value}</strong>`;
     default : return value;

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/index.md
@@ -49,7 +49,7 @@ The **`Intl.NumberFormat`** object enables language-sensitive number formatting.
 In basic use without specifying a locale, a formatted string in the default locale and with default options is returned.
 
 ```js
-var number = 3500;
+const number = 3500;
 
 console.log(new Intl.NumberFormat().format(number));
 // → '3,500' if in US English locale
@@ -60,7 +60,7 @@ console.log(new Intl.NumberFormat().format(number));
 This example shows some of the variations in localized number formats. In order to get the format of the language used in the user interface of your application, make sure to specify that language (and possibly some fallback languages) using the `locales` argument:
 
 ```js
-var number = 123456.789;
+const number = 123456.789;
 
 // German uses comma as decimal separator and period for thousands
 console.log(new Intl.NumberFormat('de-DE').format(number));
@@ -89,7 +89,7 @@ console.log(new Intl.NumberFormat(['ban', 'id']).format(number));
 The results can be customized using the `options` argument:
 
 ```js
-var number = 123456.789;
+const number = 123456.789;
 
 // request a currency format
 console.log(new Intl.NumberFormat('de-DE', { style: 'currency', currency: 'EUR' }).format(number));

--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/resolvedoptions/index.md
@@ -81,8 +81,8 @@ Only one of the following two groups of properties is included:
 ### Using the `resolvedOptions` method
 
 ```js
-var de = new Intl.NumberFormat('de-DE');
-var usedOptions = de.resolvedOptions();
+const de = new Intl.NumberFormat('de-DE');
+const usedOptions = de.resolvedOptions();
 
 usedOptions.locale;                // "de-DE"
 usedOptions.numberingSystem;       // "latn"

--- a/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/pluralrules/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/pluralrules/index.md
@@ -89,7 +89,7 @@ with default options is returned. This is useful to distinguish between singular
 plural forms, e.g. "dog" and "dogs".
 
 ```js
-var pr = new Intl.PluralRules();
+const pr = new Intl.PluralRules();
 
 pr.select(0);
 // → 'other' if in US English locale
@@ -109,7 +109,7 @@ useful to figure out the ordinal indicator, e.g. "1st", "2nd", "3rd", "4th", "42
 and so forth.
 
 ```js
-var pr = new Intl.PluralRules('en-US', { type: 'ordinal' });
+const pr = new Intl.PluralRules('en-US', { type: 'ordinal' });
 
 const suffixes = new Map([
   ['one',   'st'],

--- a/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/pluralrules/resolvedoptions/index.md
@@ -62,8 +62,8 @@ Only one of the following two groups of properties is included:
 ### Using the resolvedOptions() method
 
 ```js
-var de = new Intl.PluralRules('de-DE');
-var usedOptions = de.resolvedOptions();
+const de = new Intl.PluralRules('de-DE');
+const usedOptions = de.resolvedOptions();
 
 usedOptions.locale;                // "de-DE"
 usedOptions.maximumFractionDigits; // 3

--- a/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/resolvedoptions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/relativetimeformat/resolvedoptions/index.md
@@ -60,8 +60,8 @@ The resulting object has the following properties:
 ### Using the resolvedOptions() method
 
 ```js
-var de = new Intl.RelativeTimeFormat('de-DE');
-var usedOptions = de.resolvedOptions();
+const de = new Intl.RelativeTimeFormat('de-DE');
+const usedOptions = de.resolvedOptions();
 
 usedOptions.locale;          // "de-DE"
 usedOptions.style;           // "long"

--- a/files/en-us/web/javascript/reference/global_objects/json/stringify/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/json/stringify/index.md
@@ -197,7 +197,7 @@ function replacer(key, value) {
   return value;
 }
 
-var foo = {foundation: 'Mozilla', model: 'box', week: 45, transport: 'car', month: 7};
+const foo = {foundation: 'Mozilla', model: 'box', week: 45, transport: 'car', month: 7};
 JSON.stringify(foo, replacer);
 // '{"week":45,"month":7}'
 ```
@@ -254,7 +254,7 @@ behavior: instead of the object being serialized, the value returned by the
 For example:
 
 ```js
-var obj = {
+const obj = {
     data: 'data',
 
     toJSON (key) {
@@ -316,7 +316,7 @@ function jsFriendlyJSONStringify (s) {
         replace(/\u2029/g, '\\u2029');
 }
 
-var s = {
+const s = {
     a: String.fromCharCode(0x2028),
     b: String.fromCharCode(0x2029)
 };
@@ -339,9 +339,9 @@ alert(jsFriendlyJSONStringify(s)); // {"a":"\u2028","b":"\u2029"}
 > same object within the stringification.
 
 ```js
-var a = JSON.stringify({ foo: "bar", baz: "quux" })
+const a = JSON.stringify({ foo: "bar", baz: "quux" })
 //'{"foo":"bar","baz":"quux"}'
-var b = JSON.stringify({ baz: "quux", foo: "bar" })
+const b = JSON.stringify({ baz: "quux", foo: "bar" })
 //'{"baz":"quux","foo":"bar"}'
 console.log(a !== b) // true
 
@@ -357,7 +357,7 @@ the applicability of `JSON.stringify()`:
 
 ```js
 // Creating an example of JSON
-var session = {
+const session = {
   'screens': [],
   'state': true
 };
@@ -374,7 +374,7 @@ localStorage.setItem('session', JSON.stringify(session));
 
 // Example of how to transform the String generated through
 // JSON.stringify() and saved in localStorage in JSON object again
-var restoredSession = JSON.parse(localStorage.getItem('session'));
+const restoredSession = JSON.parse(localStorage.getItem('session'));
 
 // Now restoredSession variable contains the object that was saved
 // in localStorage


### PR DESCRIPTION
#### Summary
Change var to const or let for datetimeformat, numberformat, pluralrules, relativetimeformat, and stringify objects.

#### Motivation
Write the docs effort.

#### Supporting details
none

#### Related issues
none

#### Metadata
This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x ] Fixes a typo, bug, or other error
