### PR TITLE
Remove unnecessary comment about colour coding

### DIFF
--- a/files/en-us/learn/server-side/django/generic_views/index.md
+++ b/files/en-us/learn/server-side/django/generic_views/index.md
@@ -360,7 +360,7 @@ Let's consider a few real examples of patterns:
         <p>
           This is the RE used in our URL mapper. It matches a string that has
           <code>book/</code> at the start of the line (<strong>^book/</strong>),
-          then has one or more digits (<code>\d+</code>), and then ends (with no 
+          then has one or more digits (<code>\d+</code>), and then ends (with no
           non-digit characters before the end of line marker).
         </p>
         <p>

--- a/files/en-us/learn/server-side/django/generic_views/index.md
+++ b/files/en-us/learn/server-side/django/generic_views/index.md
@@ -360,7 +360,7 @@ Let's consider a few real examples of patterns:
         <p>
           This is the RE used in our URL mapper. It matches a string that has
           <code>book/</code> at the start of the line (<strong>^book/</strong>),
-          then has one or more digits (<code>\d+</code>), and then ends (with no
+          then has one or more digits (<code>\d+</code>), and then ends (with no 
           non-digit characters before the end of line marker).
         </p>
         <p>
@@ -569,7 +569,8 @@ This method is needed because you declare a `ForeignKey` (one-to many) field onl
 >
 > Last but not least, you should sort by an attribute/column that actually has an index (unique or not) on your database to avoid performance issues. Of course, this will not be necessary here (we are probably getting ahead of ourselves with so few books and users), but it is something worth keeping in mind for future projects.
 
-The second interesting (and non-obvious) thing in the template is where we set a class (`text-success`, `text-danger`, `text-warning`) to color-code the human readable status text for each book instance ("available", "maintenance", etc.). Astute readers will note that the method `BookInstance.get_status_display()` that we use to get the status text does not appear elsewhere in the code.
+The second interesting (and non-obvious) thing in the template is where we display the status text for each book instance ("available", "maintenance", etc.).
+Astute readers will note that the method `BookInstance.get_status_display()` that we use to get the status text does not appear elsewhere in the code.
 
 ```python
  <p class="{% if copy.status == 'a' %}text-success{% elif copy.status == 'm' %}text-danger{% else %}text-warning{% endif %}">


### PR DESCRIPTION
The text was supposed to provide context about what the code in the section was doing. But a reader found it confusing to conflate the django call and the colour coding (which comes from bootstrap).

Removing that text certainly does no harm.

Fixes #16409