### PR TITLE
Minor: var to const; small word changes

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/webassembly/module/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/module/index.md
@@ -31,7 +31,9 @@ A **`WebAssembly.Module`** object contains stateless WebAssembly code that has a
 
 ### Sending a compiled module to a worker
 
-The following example (see our [index-compile.html](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/index-compile.html) demo on GitHub, and [view it live](https://mdn.github.io/webassembly-examples/js-api-examples/index-compile.html) also) compiles the loaded `simple.wasm` byte code using the {{jsxref("WebAssembly.compileStreaming()")}} method and then sends the resulting `Module` instance to a [worker](/en-US/docs/Web/API/Web_Workers_API) using {{domxref("Worker/postMessage", "postMessage()")}}.
+The following example compiles the loaded `simple.wasm` byte code using the {{jsxref("WebAssembly.compileStreaming()")}} method and sends the resulting `Module` instance to a [worker](/en-US/docs/Web/API/Web_Workers_API) using {{domxref("Worker/postMessage", "postMessage()")}}.
+
+See the `index-compile.html` [source code](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/index-compile.html) or [view it live](https://mdn.github.io/webassembly-examples/js-api-examples/index-compile.html).
 
 ```js
 var worker = new Worker("wasm_worker.js");
@@ -42,10 +44,10 @@ WebAssembly.compileStreaming(fetch('simple.wasm'))
 );
 ```
 
-In the worker (see [`wasm_worker.js`](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/wasm_worker.js)) we define an import object for the module to use, then set up an event handler to receive the module from the main thread. When the module is received, we create an instance from it using the {{jsxref("WebAssembly.instantiate()")}} method and invoke an exported function from inside it.
+The worker function [`wasm_worker.js`](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/wasm_worker.js) defines an import object for the module to use. The function then sets up an event handler to receive the module from the main thread. When the module is received, we create an instance from it using the {{jsxref("WebAssembly.instantiate()")}} method and invoke an exported function from inside it.
 
 ```js
-var importObject = {
+const importObject = {
   imports: {
     imported_func: function(arg) {
       console.log(arg);
@@ -55,7 +57,7 @@ var importObject = {
 
 onmessage = function(e) {
   console.log('module received from main thread');
-  var mod = e.data;
+  const mod = e.data;
 
   WebAssembly.instantiate(mod, importObject).then(function(instance) {
     instance.exports.exported_func();


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Changed all instances of "var" to "const". Small word changes.

#### Motivation
Update syntax to modern standards.

#### Supporting details
None

#### Related issues
None

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
