### PR TITLE
Use currentcolor (lowercase)

### DIFF
--- a/files/en-us/learn/css/styling_text/fundamentals/index.md
+++ b/files/en-us/learn/css/styling_text/fundamentals/index.md
@@ -466,7 +466,7 @@ The four properties are as follows:
 1. The horizontal offset of the shadow from the original text — this can take most available CSS [length and size units](/en-US/docs/Learn/CSS/Building_blocks/Values_and_units#length_and_size), but you'll most commonly use `px`; positive values move the shadow right, and negative values left. This value has to be included.
 2. The vertical offset of the shadow from the original text. This behaves similarly to the horizontal offset, except that it moves the shadow up/down, not left/right. This value has to be included.
 3. The blur radius: a higher value means the shadow is dispersed more widely. If this value is not included, it defaults to 0, which means no blur. This can take most available CSS [length and size units](/en-US/docs/Learn/CSS/Building_blocks/Values_and_units#length_and_size).
-4. The base color of the shadow, which can take any [CSS color unit](/en-US/docs/Learn/CSS/Building_blocks/Values_and_units#colors). If not included, it defaults to [`currentColor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword), i.e. the shadow's color is taken from the element's [`color`](/en-US/docs/Web/CSS/color) property.
+4. The base color of the shadow, which can take any [CSS color unit](/en-US/docs/Learn/CSS/Building_blocks/Values_and_units#colors). If not included, it defaults to [`currentcolor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword), i.e. the shadow's color is taken from the element's [`color`](/en-US/docs/Web/CSS/color) property.
 
 #### Multiple shadows
 

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_todo_list_beginning/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_todo_list_beginning/index.md
@@ -531,7 +531,7 @@ body {
 .c-cb > label::before {
   content: "";
   position: absolute;
-  border: 2px solid currentColor;
+  border: 2px solid currentcolor;
   background: transparent;
 }
 .c-cb > input[type="checkbox"]:focus + label::before {

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_stores/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_stores/index.md
@@ -167,7 +167,7 @@ Let's now create our `Alert` component and see how we can read values from the s
     }
     div svg {
       height: 1.6rem;
-      fill: currentColor;
+      fill: currentcolor;
       width: 1.4rem;
       margin-right: 0.5rem;
     }

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_todo_list_beginning/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_todo_list_beginning/index.md
@@ -665,7 +665,7 @@ body {
 .c-cb > label::before {
   content: "";
   position: absolute;
-  border: 2px solid currentColor;
+  border: 2px solid currentcolor;
   background: transparent;
 }
 .c-cb > input[type="checkbox"]:focus + label::before {

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_styling/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_styling/index.md
@@ -426,7 +426,7 @@ Next, copy the following CSS into the newly created `<style>` element:
   left: 0;
   width: 40px;
   height: 40px;
-  border: 2px solid currentColor;
+  border: 2px solid currentcolor;
   background: transparent;
 }
 .custom-checkbox > input[type="checkbox"]:focus + label::before {

--- a/files/en-us/mozilla/firefox/releases/68/index.md
+++ b/files/en-us/mozilla/firefox/releases/68/index.md
@@ -70,7 +70,7 @@ This article provides information about the changes in Firefox 68 that will affe
 
 - The {{CSSxRef("-webkit-line-clamp")}} property has been implemented for compatibility with other browsers ({{bug(866102)}}).
 - Support has been added for the {{CSSxRef("::marker")}} pseudo-element ({{bug(205202)}}) and animation for `::marker` pseudos ({{bug(1538618)}})
-- We changed {{CSSxRef("color_value#currentcolor_keyword", "currentColor")}} to be a computed value (except for the {{cssxref("color")}} property)  ({{bug(760345)}}).
+- We changed {{CSSxRef("color_value#currentcolor_keyword", "currentcolor")}} to be a computed value (except for the {{cssxref("color")}} property)  ({{bug(760345)}}).
 - Support has been fixed for the `ch` length unit so it now matches the spec (fallback for no '0' glyph, vertical metrics) ({{bug(282126)}})
 - The {{CSSxRef("counter-set")}} property has been implemented. ({{bug(1518201)}}).
 - We now implement list numbering using a built-in "list-item" counter; this fixes list numbering bugs ({{bug(288704)}}).

--- a/files/en-us/web/accessibility/aria/roles/meter_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/meter_role/index.md
@@ -72,7 +72,7 @@ An example of a meter using `role="meter"`:
        y="0"
        width="100%"
        height="100%"
-       fill="currentColor"></rect>
+       fill="currentcolor"></rect>
   </svg>
 </div>
 ```

--- a/files/en-us/web/accessibility/aria/roles/slider_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/slider_role/index.md
@@ -145,7 +145,7 @@ The position of the thumb is the maximum value minus the current value times the
   position: absolute;
   height: 1rem;
   width: 2rem;
-  background-color: currentColor;
+  background-color: currentcolor;
   left: -0.5rem;
 }
 ```

--- a/files/en-us/web/css/box-shadow/index.md
+++ b/files/en-us/web/css/box-shadow/index.md
@@ -85,7 +85,7 @@ To specify multiple shadows, provide a comma-separated list of shadows.
   - : This is a fourth {{cssxref("&lt;length&gt;")}} value. Positive values will cause the shadow to expand and grow bigger, negative values will cause the shadow to shrink. If not specified, it will be `0` (the shadow will be the same size as the element).
 - `<color>`
   - : See {{cssxref("&lt;color&gt;")}} values for possible keywords and notations.
-    If not specified, it defaults to {{cssxref("&lt;color&gt;","currentColor","#currentcolor_keyword")}}.
+    If not specified, it defaults to {{cssxref("&lt;color&gt;","currentcolor","#currentcolor_keyword")}}.
 
 ### Interpolation
 

--- a/files/en-us/web/css/color_value/color_keywords/index.md
+++ b/files/en-us/web/css/color_value/color_keywords/index.md
@@ -31,7 +31,7 @@ There are a few caveats to consider when using color keywords:
 
 - Though many keywords have been adapted from [X11](https://en.wikipedia.org/wiki/X_Window_System), their RGB values may differ from the corresponding color on X11 systems since manufacturers sometimes tailor X11 colors to their specific hardware.
 
-- In addition to the color keywords, the [`<color>`](/en-US/docs/Web/CSS/color_value) data type supports other keywords: [`transparent`](/en-US/docs/Web/CSS/color_value#transparent_keyword) to create a wholly transparent color, [`currentColor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword) that represents the value of an element's {{Cssxref("color")}} property lets you use the `color` value on properties that do not receive it by default, as well as _[system color keywords](/en-US/docs/Web/CSS/color_value#system_colors)_ that represents colors that matches those of the OS.
+- In addition to the color keywords, the [`<color>`](/en-US/docs/Web/CSS/color_value) data type supports other keywords: [`transparent`](/en-US/docs/Web/CSS/color_value#transparent_keyword) to create a wholly transparent color, [`currentcolor`](/en-US/docs/Web/CSS/color_value#currentcolor_keyword) that represents the value of an element's {{Cssxref("color")}} property lets you use the `color` value on properties that do not receive it by default, as well as _[system color keywords](/en-US/docs/Web/CSS/color_value#system_colors)_ that represents colors that matches those of the OS.
 
 ## List of all color keywords
 

--- a/files/en-us/web/css/color_value/index.md
+++ b/files/en-us/web/css/color_value/index.md
@@ -61,21 +61,21 @@ The `transparent` keyword represents a fully transparent color. This makes the b
 
 > **Note:** `transparent` wasn't a true color in CSS Level 2 (Revision 1). It was a special keyword that could be used instead of a regular `<color>` value on two CSS properties: {{Cssxref("background")}} and {{Cssxref("border")}}. It was essentially added to allow developers to override an inherited solid color. With the advent of alpha channels in CSS Colors Level 3, `transparent` was redefined as a true color. It can now be used wherever a `<color>` value can be used.
 
-### currentColor keyword
+### currentcolor keyword
 
-The `currentColor` keyword represents the value of an element's {{Cssxref("color")}} property. This lets you use the `color` value on properties that do not receive it by default.
+The `currentcolor` keyword represents the value of an element's {{Cssxref("color")}} property. This lets you use the `color` value on properties that do not receive it by default.
 
-If `currentColor` is used as the value of the `color` property, it instead takes its value from the inherited value of the `color` property.
+If `currentcolor` is used as the value of the `color` property, it instead takes its value from the inherited value of the `color` property.
 
 ```html
-<div style="color: blue; border: 1px dashed currentColor;">
+<div style="color: blue; border: 1px dashed currentcolor;">
   The color of this text is blue.
-  <div style="background: currentColor; height:9px;"></div>
+  <div style="background: currentcolor; height:9px;"></div>
   This block is surrounded by a blue border.
 </div>
 ```
 
-{{EmbedLiveSample('currentColor_keyword', 600, 80)}}
+{{EmbedLiveSample('currentcolor_keyword', 600, 80)}}
 
 ### RGB color model
 

--- a/files/en-us/web/css/mozilla_extensions/index.md
+++ b/files/en-us/web/css/mozilla_extensions/index.md
@@ -277,7 +277,7 @@ Property: {{CSSxRef("background-image")}}
 
 Property: {{CSSxRef("border-color")}}
 
-- `-moz-use-text-color`{{deprecated_inline}} (removed in {{bug(1306214)}}); use {{CSSxRef("color_value#currentColor_keyword","currentcolor")}} instead.
+- `-moz-use-text-color`{{deprecated_inline}} (removed in {{bug(1306214)}}); use {{CSSxRef("color_value#currentcolor_keyword","currentcolor")}} instead.
 
 ### order-style and outline-style
 

--- a/files/en-us/web/css/text-decoration-color/index.md
+++ b/files/en-us/web/css/text-decoration-color/index.md
@@ -30,7 +30,7 @@ CSS does not provide a direct mechanism for specifying a unique color for each l
 
 ```css
 /* <color> values */
-text-decoration-color: currentColor;
+text-decoration-color: currentcolor;
 text-decoration-color: red;
 text-decoration-color: #00ff00;
 text-decoration-color: rgba(255, 128, 128, 0.5);


### PR DESCRIPTION
Like 

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

Fix `currentcolor` case to use the same as the one used by  CSSWG does in [CSS Color Module Level 4](https://www.w3.org/TR/css-color-4/#currentcolor-color)
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
For homogenization, some (most) pages already use the lowercase version.

#### Supporting details
N/A

#### Related issues
N/A

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
