### PR TITLE
Remove three-value <position> syntax from object-position

### DIFF
--- a/files/en-us/web/css/object-position/index.md
+++ b/files/en-us/web/css/object-position/index.md
@@ -43,8 +43,7 @@ object-position: 10ch 8em;
 /* Edge offsets values */
 object-position: bottom 10px right 20px;
 object-position: right 3em bottom 10px;
-object-position: bottom 10px right;
-object-position: top right 10px;
+object-position: top 0 right 10px;
 
 /* Global values */
 object-position: inherit;


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Changes `top right 10px` to `top 0 right 10px`.

#### Motivation
The property does not accept the syntax.

#### Supporting details
> Note: The [background-position](https://www.w3.org/TR/css-backgrounds-3/#propdef-background-position) property also accepts a three-value syntax. This has been disallowed generically because it creates parsing ambiguities when combined with other length or percentage components in a property value.

https://drafts.csswg.org/css-values/#position

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
