### PR TITLE
Fix height of embedded live sample

### DIFF
--- a/files/en-us/web/api/validitystate/patternmismatch/index.md
+++ b/files/en-us/web/api/validitystate/patternmismatch/index.md
@@ -43,7 +43,7 @@ input:invalid {
 }
 ```
 
-{{EmbedLiveSample("Examples", 300, 40)}}
+{{EmbedLiveSample("Examples", 300, 87)}}
 
 Note, in this case, we get a `patternMismatch` not a {{domxref('validityState.tooLong')}} or {{domxref('validityState.tooShort')}} if the values are too long or too short because it is the pattern that is dictating the length of the value. Had we used [`minlength`](/en-US/docs/Web/HTML/Attributes/minlength) and [`maxlength`](/en-US/docs/Web/HTML/Attributes/maxlength) attributes instead, we may have seen {{domxref('validityState.tooLong')}} or {{domxref('validityState.tooShort')}} being true.
 


### PR DESCRIPTION
Label line-height: 21
Paragraph margin: 16 * 2 = 32
Iframe padding: 16 * 2 = 32
Iframe border: 1 * 2 = 2
Sum: 87

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Some embeds are cutoff, this is probably an issue higher up as there are other pages with the same issue.
![Screenshot 2022-05-23 at 15 24 57](https://user-images.githubusercontent.com/1109982/169830979-23c7ffaf-7221-40dd-9175-21788b9ca6b6.png)


#### Motivation
It allows the viewers to see the embedded live sample.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error


