### PR TITLE
parseFloat() behavior with Infinity

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/parsefloat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/parsefloat/index.md
@@ -50,7 +50,7 @@ number.
 - Leading and trailing spaces in the argument are ignored.
 - If the argument's first character can't be converted to a number (it's not any of
   the above characters), `parseFloat` returns {{jsxref("NaN")}}.
-- `parseFloat` can also parse and return {{jsxref("Infinity")}}.
+- `parseFloat` can also parse and return {{jsxref("Infinity")}} if the string starts with {{jsxref("Infinity")}} preceded by none or more white spaces.
 - `parseFloat` converts {{jsxref("BigInt")}} syntax to {{jsxref("Number", "Numbers")}}, losing precision. This happens because the trailing `n`
   character is discarded.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
parseFloat() doesn't have the behavior with Infinity properly explained.

#### Motivation
I couldn't find this behavior anywhere else.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
