### PR TITLE
Status role editorial updates

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/status_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/status_role/index.md
@@ -32,9 +32,9 @@ Elements with the role status have an implicit [`aria-live`](/en-US/docs/Web/Acc
 
   - : Defines when assistive technology should inform the user of updates to content. Elements with the role `status` have an implicit [aria-live](https://www.w3.org/TR/wai-aria-1.1/#aria-live) value of `polite`, meaning screen readers will announce changes inside the log when the user is idle.
 
-- [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label)
+- [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label) or [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby)
 
-  - : Some screen readers announce the name of a status element before announcing the content of the status element. Including an `aria-label` provides a method for prefacing the visible content of a status element with text that is not displayed when a screen reader reads the content.
+  - : Some screen readers announce the name of a status element before announcing its contents. If a name is visible, reference it using `aria-labelledby`. Including an `aria-label` provides a method for prefacing the visible content of a status element with text that is not displayed when a screen reader reads the content. Naming a status is not required so if nothing is appropriate both these attributes can be omitted.
 
 ## Specifications
 


### PR DESCRIPTION
This is a follow-on to the recently merged updated to the [timer role](https://github.com/mdn/content/pull/16014).  Specifically [this comment](https://github.com/mdn/content/pull/16014#discussion_r872888712).

This update aligns the `aria-label` (now `aria-label` or `aria-labelledby`) section to match the newer content of `timer`.
