### PR TITLE
removal of broken link

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/status_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/status_role/index.md
@@ -42,7 +42,6 @@ Elements with the role status have an implicit [`aria-live`](/en-US/docs/Web/Acc
 
 ## See Also
 
-- [ARIA: using the `status` role](/en-US/docs/Web/Accessibility/ARIA/aria_techniques/using_the_status_role)
 - [ARIA: `alert` role](/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role)
 - [ARIA: `log` role](/en-US/docs/Web/Accessibility/ARIA/Roles/log_role)
 - [ARIA: `marquee` role](/en-US/docs/Web/Accessibility/ARIA/Roles/marquee_role)


### PR DESCRIPTION
Noticed this after reviewing the preview of my PR #16602, but the 'using the status role' seems to have been removed.  So, removing it from this doc