### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/getownpropertynames/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/getownpropertynames/index.md
@@ -34,7 +34,7 @@ An array of strings that corresponds to the properties found directly in the giv
 
 ## Description
 
-`Object.getOwnPropertyNames()` returns an array whose elements are strings corresponding to the enumerable and non-enumerable properties found directly in a given object `obj`. The ordering of the enumerable properties in the array is consistent with the ordering exposed by a {{jsxref("Statements/for...in", "for...in")}} loop (or by {{jsxref("Object.keys()")}}) over the properties of the object. According to ES6, the integer keys of the object (both enumerable and non-enumerable) are added in ascending order to the array first, followed by the string keys in the order of insertion.
+`Object.getOwnPropertyNames()` returns an array whose elements are strings corresponding to the enumerable and non-enumerable properties found directly in a given object `obj`. The ordering of the enumerable properties in the array is consistent with the ordering exposed by a {{jsxref("Statements/for...in", "for...in")}} loop (or by {{jsxref("Object.keys()")}}) over the properties of the object. According to ES6, the non-negative integer keys of the object (both enumerable and non-enumerable) are added in ascending order to the array first, followed by the string keys in the order of insertion.
 
 In ES5, if the argument to this method is not an object (a primitive), then it will cause a {{jsxref("TypeError")}}. In ES2015, a non-object argument will be coerced to an object.
 


### PR DESCRIPTION
Negative integer keys are not listed before other string keys.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Negative integer keys are not listed before other string keys.

#### Motivation
Fix an erroneous description (strictly speaking, integer keys included negative integers).

#### Supporting details
Simple test:

```javascript
const o={a:0}; o[-1]=0; o[0] = 0; o[1] = 0; o[-2]= 0; 
console.log(Object.getOwnPropertyNames(o));
```

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
