### PR TITLE
Add note that userScripts and contentScripts are replaced in MV3

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/index.md
@@ -14,6 +14,8 @@ browser-compat: webextensions.api.contentScripts
 
 Use this API to register content scripts. Registering a content script instructs the browser to insert the given content scripts into pages that match the given URL patterns.
 
+> **Note:** When using Manifest V3 or higher, use {{WebExtAPIRef("scripting.registerContentScripts()")}} to register scripts.
+
 This API is very similar to the [`"content_scripts"`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) [`manifest.json`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json) key, except that with  `"content_scripts"` , the set of content scripts and associated patterns is fixed at install time. With the `contentScripts` API, an extension can register and unregister scripts at runtime.
 
 To use the API, call {{WebExtAPIRef("contentScripts.register()")}} passing in an object defining the scripts to register, the URL patterns, and other options. This returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that is resolved with a {{WebExtAPIRef("contentScripts.RegisteredContentScript")}} object.

--- a/files/en-us/mozilla/add-ons/webextensions/api/userscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/userscripts/index.md
@@ -16,6 +16,8 @@ browser-compat: webextensions.api.userScripts
 
 Use this API to register user scripts, third-party scripts designed to manipulate webpages or provide new features. Registering a user script instructs the browser to attach the script to pages that match the URL patterns specified during registration.
 
+> **Note:** When using Manifest V3 or higher, use {{WebExtAPIRef("scripting.registerContentScripts()")}} to register scripts.
+
 This API offers similar capabilities to {{WebExtAPIRef("contentScripts")}} but with features suited to handling third-party scripts:
 
 - execution is in an isolated sandbox: each user script is run in an isolated sandbox within the web content processes, preventing accidental or deliberate interference among scripts.


### PR DESCRIPTION
#### Summary
Add notes that userScripts and contentScripts are replaced in MV3 by scripting.registerContentScripts()

#### Metadata

This PR…
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error