### PR TITLE
Fix anchor links to attributes on the same page

### DIFF
--- a/files/en-us/web/html/element/input/file/index.md
+++ b/files/en-us/web/html/element/input/file/index.md
@@ -44,9 +44,9 @@ browser-compat: html.elements.input.type_file
     <tr>
       <td><strong>Additional Attributes</strong></td>
       <td>
-        {{htmlattrxref("accept", "input/file")}},
-        {{htmlattrxref("capture", "input/file")}},
-        {{htmlattrxref("multiple", "input/file")}}
+        <a href="#accept" aria-current="page"><code>accept</code></a>,
+        <a href="#capture" aria-current="page"><code>capture</code></a>,
+        <a href="#multiple" aria-current="page"><code>multiple</code></a>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

The internal links to `accept`, `capture` and `multiple` linked to `#attr-accept`, `#attr-capture` and `#attr-multiple` respectively. These anchors do not exist on this page.

<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
This will help others to find more information about these attributes without the need to search for it, they only have to click the link in the summary table.


This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
