### PR TITLE
Remove note from HTML spellcheck attribute that it can't accept an empty string

### DIFF
--- a/files/en-us/web/html/global_attributes/index.md
+++ b/files/en-us/web/html/global_attributes/index.md
@@ -101,7 +101,7 @@ In addition to the basic HTML global attributes, the following global attributes
 
   - : An enumerated attribute defines whether the element may be checked for spelling errors. It may have the following values:
 
-    - `true`, which indicates that the element should be, if possible, checked for spelling errors;
+    - empty string or `true`, which indicates that the element should be, if possible, checked for spelling errors;
     - `false`, which indicates that the element should not be checked for spelling errors.
 
 - [`style`](/en-US/docs/Web/HTML/Global_attributes/style)
@@ -120,7 +120,7 @@ In addition to the basic HTML global attributes, the following global attributes
 
   - : An enumerated attribute that is used to specify whether an element's attribute values and the values of its {{DOMxRef("Text")}} node children are to be translated when the page is localized, or whether to leave them unchanged. It can have the following values:
 
-    - empty string and `yes`, which indicates that the element will be translated.
+    - empty string or `yes`, which indicates that the element will be translated.
     - `no`, which indicates that the element will not be translated.
 
 ## Specifications

--- a/files/en-us/web/html/global_attributes/spellcheck/index.md
+++ b/files/en-us/web/html/global_attributes/spellcheck/index.md
@@ -16,10 +16,8 @@ The **`spellcheck`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) 
 
 It may have the following values:
 
-- `true`, which indicates that the element should be, if possible, checked for spelling errors;
+- empty string or `true`, which indicates that the element should be, if possible, checked for spelling errors;
 - `false`, which indicates that the element should not be checked for spelling errors.
-
-> **Note:** The `spellcheck` attribute is an _enumerated_ one and not a _Boolean_ one. This means that the explicit usage of one of the values `true` or `false` is mandatory, and that a shorthand like `<textarea spellcheck></textarea>` is not allowed. The correct usage is `<textarea spellcheck="true"></textarea>`.
 
 If this attribute is not set, its default value is element-type and browser-defined. This default value may also be _inherited_, which means that the element content will be checked for spelling errors only if its nearest ancestor has a _spellcheck_ state of `true`.
 

--- a/files/en-us/web/html/global_attributes/translate/index.md
+++ b/files/en-us/web/html/global_attributes/translate/index.md
@@ -15,8 +15,8 @@ The **`translate`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) i
 
 It can have the following values:
 
-- empty string or "`yes`", which indicates that the element should be translated when the page is localized.
-- "`no`", which indicates that the element must not be translated.
+- empty string or `yes`, which indicates that the element should be translated when the page is localized.
+- `no`, which indicates that the element must not be translated.
 
 Although not all browsers recognize this attribute, it is respected by automatic translation systems such as Google Translate, and may also be respected by tools used by human translators. As such it's important that web authors use this attribute to mark content that should not be translated.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Adds _empty string_ to allowed values of `spellcheck`.

#### Motivation
The attribute can now accept an empty string.

#### Supporting details
https://html.spec.whatwg.org/multipage/interaction.html#attr-spellcheck

> The spellcheck attribute ... whose keywords are the empty string, true and false. The empty string and the true keyword map to the true state.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
