### PR TITLE
Replace {{event}} to {{domxref}} for the drag and drop events

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-dropeffect/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-dropeffect/index.md
@@ -30,7 +30,7 @@ Including the attribute provides assistive technologies the ability to convey th
 
 The `aria-dropeffect` property is expected to be replaced by a new feature in a future version of WAI-ARIA and is considered deprecated.
 
-Typically, drop effect functions can only be provided once an object has been grabbed for a drag operation, as the drop effect functions available are dependent on the object being dragged. Therefore, you'll generally add `aria-dropeffect` to all the potential drop targets when the {{event("dragstart")}} event is fired.
+Typically, drop effect functions can only be provided once an object has been grabbed for a drag operation, as the drop effect functions available are dependent on the object being dragged. Therefore, you'll generally add `aria-dropeffect` to all the potential drop targets when the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event is fired.
 
 ## Values
 
@@ -64,7 +64,7 @@ Used in **ALL** roles.
 - HTML [Drag and Drop API](/en-US/docs/Web/API/HTML_Drag_and_Drop_API)
 - {{domxref('dataTransfer')}}
 - {{domxref('DataTransfer.dropEffect')}}
-- {{event("dragstart")}}
+- {{domxref("HTMLElement/dragstart_event", "dragstart")}}
 
 <section id="Quick_links">
 <strong><a href="/en-US/docs/Web/Accessibility/ARIA/Attributes">WAI-ARIA states and properties</a></strong>

--- a/files/en-us/web/accessibility/aria/attributes/aria-grabbed/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-grabbed/index.md
@@ -51,7 +51,7 @@ Used in **ALL** [roles](/en-US/docs/Web/Accessibility/ARIA/Roles)
 - HTML [Drag and Drop API](/en-US/docs/Web/API/HTML_Drag_and_Drop_API)
 - {{domxref('dataTransfer')}}
 - {{domxref('DataTransfer.dropEffect')}}
-- {{event("dragstart")}}
+- {{domxref("HTMLElement/dragstart_event", "dragstart")}}
 - [Accessible Drag and Drop](https://dev.opera.com/articles/accessible-drag-and-drop/) by Gez Lemon
 
 <section id="Quick_links">

--- a/files/en-us/web/api/datatransfer/addelement/index.md
+++ b/files/en-us/web/api/datatransfer/addelement/index.md
@@ -14,8 +14,8 @@ browser-compat: api.DataTransfer.addElement
 {{Non-standard_header()}}
 
 The **`DataTransfer.addElement()`** method sets the drag source
-to the given element. This element will be the element to which {{event("drag")}} and
-{{event("dragend")}} events are fired, and not the default target (the node that was
+to the given element. This element will be the element to which {{domxref("HTMLElement/drag_event", "drag")}} and
+{{domxref("HTMLElement/dragend_event", "dragend")}} events are fired, and not the default target (the node that was
 dragged).
 
 > **Note:** This method is Firefox-specific.

--- a/files/en-us/web/api/datatransfer/cleardata/index.md
+++ b/files/en-us/web/api/datatransfer/cleardata/index.md
@@ -24,7 +24,7 @@ This method does _not_ remove files from the drag operation, so it's possible
 for there still to be an entry with the type `"Files"` left in the object's
 {{domxref("DataTransfer.types")}} list if there are any files included in the drag.
 
-> **Note:** This method can only be used in the handler for the {{event("dragstart")}} event,
+> **Note:** This method can only be used in the handler for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event,
 > because that's the only time the drag operation's data store is writeable.
 
 ## Syntax

--- a/files/en-us/web/api/datatransfer/dropeffect/index.md
+++ b/files/en-us/web/api/datatransfer/dropeffect/index.md
@@ -22,18 +22,18 @@ to a string value. On getting, it returns its current value. On setting, if the 
 value is one of the values listed below, then the property's current value will be set
 to the new value and other values will be ignored.
 
-For the {{event("dragenter")}} and {{event("dragover")}} events,
+For the {{domxref("HTMLElement/dragenter_event", "dragenter")}} and {{domxref("HTMLElement/dragover_event", "dragover")}} events,
 `dropEffect` will be initialized based on what action the user is requesting.
 How this is determined is platform specific, but typically the user can press modifier
 keys such as the alt key to adjust the desired action. Within event handlers for
-{{event("dragenter")}} and {{event("dragover")}} events, `dropEffect` should
+{{domxref("HTMLElement/dragenter_event", "dragenter")}} and {{domxref("HTMLElement/dragover_event", "dragover")}} events, `dropEffect` should
 be modified if a different action is desired than the action that the user is
 requesting.
 
-For the {{event("drop")}} and {{event("dragend")}} events, `dropEffect` will
+For the {{domxref("HTMLElement/drop_event", "drop")}} and {{domxref("HTMLElement/dragend_event", "dragend")}} events, `dropEffect` will
 be set to the action that was desired, which will be the value `dropEffect`
-had after the last {{event("dragenter")}} or {{event("dragover")}} event. In a
-{{event("dragend")}} event, for instance, if the desired dropEffect is "move", then the
+had after the last {{domxref("HTMLElement/dragenter_event", "dragenter")}} or {{domxref("HTMLElement/dragover_event", "dragover")}} event. In a
+{{domxref("HTMLElement/dragend_event", "dragend")}} event, for instance, if the desired dropEffect is "move", then the
 data being dragged should be removed from the source.
 
 ## Value

--- a/files/en-us/web/api/datatransfer/effectallowed/index.md
+++ b/files/en-us/web/api/datatransfer/effectallowed/index.md
@@ -19,14 +19,14 @@ dragged will be moved, and the _link_ operation is used to indicate that some
 form of relationship or connection will be created between the source and drop
 locations.
 
-This property should be set in the {{event("dragstart")}} event to set the desired drag
-effect for the drag source. Within the {{event("dragenter")}} and {{event("dragover")}}
+This property should be set in the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event to set the desired drag
+effect for the drag source. Within the {{domxref("HTMLElement/dragenter_event", "dragenter")}} and {{domxref("HTMLElement/dragover_event", "dragover")}}
 event handlers, this property will be set to whatever value was assigned during the
-{{event("dragstart")}} event, thus `effectAllowed` may be used to determine
+{{domxref("HTMLElement/dragstart_event", "dragstart")}} event, thus `effectAllowed` may be used to determine
 which effect is permitted.
 
 Assigning a value to `effectAllowed` in events other than
-{{event("dragstart")}} has no effect.
+{{domxref("HTMLElement/dragstart_event", "dragstart")}} has no effect.
 
 ## Value
 

--- a/files/en-us/web/api/datatransfer/index.md
+++ b/files/en-us/web/api/datatransfer/index.md
@@ -36,7 +36,7 @@ This object is available from the {{domxref("DragEvent.dataTransfer","dataTransf
 - {{domxref("DataTransfer.items")}} {{readonlyInline}}
   - : Gives a {{domxref("DataTransferItemList")}} object which is a list of all of the drag data.
 - {{domxref("DataTransfer.types")}} {{readonlyInline}}
-  - : An array of {{domxref("DOMString","strings")}} giving the formats that were set in the {{event("dragstart")}} event.
+  - : An array of {{domxref("DOMString","strings")}} giving the formats that were set in the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event.
 
 ### Gecko properties
 

--- a/files/en-us/web/api/datatransfer/mozcleardataat/index.md
+++ b/files/en-us/web/api/datatransfer/mozcleardataat/index.md
@@ -50,7 +50,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 This example shows the use of the `mozClearDataAt()` method in a
-{{event("dragend")}} event handler.
+{{domxref("HTMLElement/dragend_event", "dragend")}} event handler.
 
 ```js
 function dragend_handler(event)

--- a/files/en-us/web/api/datatransfer/mozgetdataat/index.md
+++ b/files/en-us/web/api/datatransfer/mozgetdataat/index.md
@@ -46,7 +46,7 @@ mozGetDataAt(type, index)
 ## Examples
 
 This example shows the use of the `mozGetDataAt()` method in a
-{{event("drop")}} event handler.
+{{domxref("HTMLElement/drop_event", "drop")}} event handler.
 
 ```js
 function drop_handler(event)

--- a/files/en-us/web/api/datatransfer/mozsetdataat/index.md
+++ b/files/en-us/web/api/datatransfer/mozsetdataat/index.md
@@ -59,7 +59,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 This example shows the use of the `mozSetDataAt()` method in a
-{{event("dragstart")}} handler.
+{{domxref("HTMLElement/dragstart_event", "dragstart")}} handler.
 
 ```js
 function dragstart_handler(event)

--- a/files/en-us/web/api/datatransfer/mozsourcenode/index.md
+++ b/files/en-us/web/api/datatransfer/mozsourcenode/index.md
@@ -31,7 +31,7 @@ A {{domxref("Node")}} representing `node` where the drag originated. Returns
 ## Examples
 
 This example shows the use of the `mozSourceNode` property in the
-{{event("dragend")}} event handler.
+{{domxref("HTMLElement/dragend_event", "dragend")}} event handler.
 
 ```js
 function dragend_handler(event)

--- a/files/en-us/web/api/datatransfer/moztypesat/index.md
+++ b/files/en-us/web/api/datatransfer/moztypesat/index.md
@@ -41,7 +41,7 @@ A list of data formats (which are strings). If the index
 ## Examples
 
 This example shows the use of the `mozTypesAt()` method in a
-{{event("drop")}} event handler.
+{{domxref("HTMLElement/drop_event", "drop")}} event handler.
 
 ```js
 function drop_handler(event)

--- a/files/en-us/web/api/datatransfer/mozusercancelled/index.md
+++ b/files/en-us/web/api/datatransfer/mozusercancelled/index.md
@@ -14,9 +14,9 @@ browser-compat: api.DataTransfer.mozUserCancelled
 {{ Non-standard_header() }}
 
 The **`DataTransfer.mozUserCancelled`** property is used in the
-{{event("dragend")}} event handler to determine if the user canceled the drag or not. If
+{{domxref("HTMLElement/dragend_event", "dragend")}} event handler to determine if the user canceled the drag or not. If
 the user canceled the event, the property returns `true` and returns
-`false` otherwise. This property only applies to the {{event("dragend")}}
+`false` otherwise. This property only applies to the {{domxref("HTMLElement/dragend_event", "dragend")}}
 event.
 
 > **Note:** This property is Firefox-specific.
@@ -31,7 +31,7 @@ event and returns `false` otherwise.
 ## Examples
 
 This example shows the use of the `mozUserCancelled` property in the
-{{event("dragend")}} event handler.
+{{domxref("HTMLElement/dragend_event", "dragend")}} event handler.
 
 ```js
 function dragend_handler(event)

--- a/files/en-us/web/api/datatransfer/setdragimage/index.md
+++ b/files/en-us/web/api/datatransfer/setdragimage/index.md
@@ -13,7 +13,7 @@ browser-compat: api.DataTransfer.setDragImage
 {{APIRef("HTML Drag and Drop API")}}
 
 When a drag occurs, a translucent image is generated from the drag target (the element
-the {{event("dragstart")}} event is fired at), and follows the mouse pointer during the
+the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event is fired at), and follows the mouse pointer during the
 drag. This image is created automatically, so you do not need to create it yourself.
 However, if a custom image is desired, the
 **`DataTransfer.setDragImage()`** method can be used to set the
@@ -25,7 +25,7 @@ appear relative to the mouse pointer. These coordinates define the offset into t
 where the mouse cursor should be. For instance, to display the image so that the pointer
 is at its center, use values that are half the width and height of the image.
 
-This method must be called in the {{event("dragstart")}} event handler.
+This method must be called in the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event handler.
 
 ## Syntax
 

--- a/files/en-us/web/api/datatransfer/types/index.md
+++ b/files/en-us/web/api/datatransfer/types/index.md
@@ -13,7 +13,7 @@ browser-compat: api.DataTransfer.types
 
 The **`DataTransfer.types`** read-only property returns an
 array of the drag data formats (as strings) that were set in
-the {{event("dragstart")}} event. The order of the formats is the same order as the data
+the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event. The order of the formats is the same order as the data
 included in the drag operation.
 
 The formats are Unicode strings giving the type or format of the data, generally given

--- a/files/en-us/web/api/datatransferitem/getasfile/index.md
+++ b/files/en-us/web/api/datatransferitem/getasfile/index.md
@@ -36,7 +36,7 @@ None.
 ## Examples
 
 This example shows the use of the `getAsFile()` method in a
-{{event("drop")}} event handler.
+{{domxref("HTMLElement/drop_event", "drop")}} event handler.
 
 ```js
 function drop_handler(ev) {

--- a/files/en-us/web/api/datatransferitem/getasstring/index.md
+++ b/files/en-us/web/api/datatransferitem/getasstring/index.md
@@ -46,7 +46,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 This example shows the use of the `getAsString()` method as an _inline
-function_ in a {{event("drop")}} event handler.
+function_ in a {{domxref("HTMLElement/drop_event", "drop")}} event handler.
 
 ```js
 function drop_handler(ev) {

--- a/files/en-us/web/api/datatransferitem/webkitgetasentry/index.md
+++ b/files/en-us/web/api/datatransferitem/webkitgetasentry/index.md
@@ -39,7 +39,7 @@ The method aborts and returns `null` if the dropped item isn't a file, or if the
 
 ## Examples
 
-In this example, a drop zone is created, which responds to the {{event("drop")}} event
+In this example, a drop zone is created, which responds to the {{domxref("HTMLElement/drop_event", "drop")}} event
 by scanning through the dropped files and directories, outputting a hierarchical
 directory listing.
 
@@ -135,7 +135,7 @@ After that, {{domxref("FileSystemDirectoryReader.readEntries", "directoryReader.
 These are each, in turn, passed into a recursive call to `scanFiles()` to process them.
 Any of them which are files are inserted into the list; any which are directories are inserted into the list and a new level of the list's hierarchy is added below, and so forth.
 
-Then come the event handlers. First, we prevent the {{event("dragover")}} event from being handled by the default handler, so that our drop zone can receive the drop:
+Then come the event handlers. First, we prevent the {{domxref("HTMLElement/dragover_event", "dragover")}} event from being handled by the default handler, so that our drop zone can receive the drop:
 
 ```js
 dropzone.addEventListener("dragover", function(event) {
@@ -143,7 +143,7 @@ dropzone.addEventListener("dragover", function(event) {
 }, false);
 ```
 
-The event handler that kicks everything off, of course, is the handler for the {{event("drop")}} event:
+The event handler that kicks everything off, of course, is the handler for the {{domxref("HTMLElement/drop_event", "drop")}} event:
 
 ```js
 dropzone.addEventListener("drop", function(event) {
@@ -192,4 +192,4 @@ This API has no official W3C or WHATWG specification.
 - [Introduction to the File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API/Introduction)
 - {{domxref("DataTransferItem")}}
 - {{domxref("FileSystemEntry")}}, {{domxref("FileSystemFileEntry")}}, and {{domxref("FileSystemDirectoryEntry")}}
-- Events: {{event("dragover")}} and {{event("drop")}}
+- Events: {{domxref("HTMLElement/dragover_event", "dragover")}} and {{domxref("HTMLElement/drop_event", "drop")}}

--- a/files/en-us/web/api/datatransferitemlist/clear/index.md
+++ b/files/en-us/web/api/datatransferitemlist/clear/index.md
@@ -17,7 +17,7 @@ The {{domxref("DataTransferItemList")}} method
 objects from the drag data items list, leaving the list empty.
 
 The drag data store in which this list is kept is only writable while handling the
-{{event("dragstart")}} event. While handling {{event("drop")}}, the drag data store is
+{{domxref("HTMLElement/dragstart_event", "dragstart")}} event. While handling {{domxref("HTMLElement/drop_event", "drop")}}, the drag data store is
 in read-only mode, and this method silently does nothing. No exception is thrown.
 
 ## Syntax

--- a/files/en-us/web/api/dragevent/datatransfer/index.md
+++ b/files/en-us/web/api/dragevent/datatransfer/index.md
@@ -23,7 +23,7 @@ A {{domxref("DataTransfer")}} object which contains the {{domxref("DragEvent","d
 ## Examples
 
 This example illustrates accessing the drag and drop data within the
-{{event("dragend")}} event handler.
+{{domxref("HTMLElement/dragend_event", "dragend")}} event handler.
 
 ```js
 function processData(d) {

--- a/files/en-us/web/api/dragevent/index.md
+++ b/files/en-us/web/api/dragevent/index.md
@@ -30,37 +30,37 @@ Although this interface has a constructor, it is not possible to create a useful
 
 ## Event types
 
-- {{event('drag')}}
+- {{domxref("HTMLElement/drag_event", "drag")}}
   - : This event is fired when an element or text selection is being dragged.
-- {{event('dragend')}}
+- {{domxref("HTMLElement/dragend_event", "dragend")}}
   - : This event is fired when a drag operation is being ended (by releasing a mouse button or hitting the escape key).
-- {{event('dragenter')}}
+- {{domxref("HTMLElement/dragenter_event", "dragenter")}}
   - : This event is fired when a dragged element or text selection enters a valid drop target.
-- {{event('dragleave')}}
+- {{domxref("HTMLElement/dragleave_event", "dragleave")}}
   - : This event is fired when a dragged element or text selection leaves a valid drop target.
-- {{event('dragover')}}
+- {{domxref("HTMLElement/dragover_event", "dragover")}}
   - : This event is fired continuously when an element or text selection is being dragged and the mouse pointer is over a valid drop target (every 50 ms WHEN mouse is not moving ELSE much faster between 5 ms (slow movement) and 1ms (fast movement) approximately. This firing pattern is different than {{Event("mouseover")}} ).
-- {{event('dragstart')}}
+- {{domxref("HTMLElement/dragstart_event", "dragstart")}}
   - : This event is fired when the user starts dragging an element or text selection.
-- {{event('drop')}}
+- {{domxref("HTMLElement/drop_event", "drop")}}
   - : This event is fired when an element or text selection is dropped on a valid drop target.
 
 ## GlobalEventHandlers
 
 - {{domxref('GlobalEventHandlers.ondrag')}}
-  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{event('drag')}} event.
+  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{domxref("HTMLElement/drag_event", "drag")}} event.
 - {{domxref('GlobalEventHandlers.ondragend')}}
-  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{event('dragend')}} event.
+  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{domxref("HTMLElement/dragend_event", "dragend")}} event.
 - {{domxref('GlobalEventHandlers.ondragenter')}}
-  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{event('dragenter')}} event.
+  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{domxref("HTMLElement/dragenter_event", "dragenter")}} event.
 - {{domxref('GlobalEventHandlers.ondragleave')}}
-  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{event('dragleave')}} event.
+  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{domxref("HTMLElement/dragleave_event", "dragleave")}} event.
 - {{domxref('GlobalEventHandlers.ondragover')}}
-  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{event('dragover')}} event.
+  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{domxref("HTMLElement/dragover_event", "dragover")}} event.
 - {{domxref('GlobalEventHandlers.ondragstart')}}
-  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{event('dragstart')}} event.
+  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event.
 - {{domxref('GlobalEventHandlers.ondrop')}}
-  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{event('drop')}} event.
+  - : A {{domxref('GlobalEventHandlers','global event handler')}} for the {{domxref("HTMLElement/drop_event", "drop")}} event.
 
 ## Example
 

--- a/files/en-us/web/api/file/using_files_from_web_applications/index.md
+++ b/files/en-us/web/api/file/using_files_from_web_applications/index.md
@@ -197,7 +197,7 @@ dropbox.addEventListener("dragover", dragover, false);
 dropbox.addEventListener("drop", drop, false);
 ```
 
-In this example, we're turning the element with the ID `dropbox` into our drop zone. This is done by adding listeners for the {{event('dragenter')}}, {{event('dragover')}}, and {{event('drop')}} events.
+In this example, we're turning the element with the ID `dropbox` into our drop zone. This is done by adding listeners for the {{domxref("HTMLElement/dragenter_event", "dragenter")}}, {{domxref("HTMLElement/dragover_event", "dragover")}}, and {{domxref("HTMLElement/drop_event", "drop")}} events.
 
 We don't actually need to do anything with the `dragenter` and `dragover` events in our case, so these functions are both simple. They just stop propagation of the event and prevent the default action from occurring:
 

--- a/files/en-us/web/api/file_and_directory_entries_api/index.md
+++ b/files/en-us/web/api/file_and_directory_entries_api/index.md
@@ -17,7 +17,7 @@ The File and Directory Entries API simulates a local file system that web apps c
 
 There are two ways to get access to file systems defined in the current specification draft:
 
-- When handling a {{event("drop")}} event for drag and drop, you can call {{domxref("DataTransferItem.webkitGetAsEntry()")}} to get the {{domxref("FileSystemEntry")}} for a dropped item. If the result isn't `null`, then it's a dropped file or directory, and you can use file system calls to work with it.
+- When handling a {{domxref("HTMLElement/drop_event", "drop")}} event for drag and drop, you can call {{domxref("DataTransferItem.webkitGetAsEntry()")}} to get the {{domxref("FileSystemEntry")}} for a dropped item. If the result isn't `null`, then it's a dropped file or directory, and you can use file system calls to work with it.
 - The {{domxref("HTMLInputElement.webkitEntries")}} property lets you access the {{domxref("FileSystemFileEntry")}} objects for the currently selected files, but only if they are dragged-and-dropped onto the file chooser ({{bug(1326031)}}). If {{domxref("HTMLInputElement.webkitdirectory")}} is `true`, the {{HTMLElement("input")}} element is instead a directory picker, and you get {{domxref("FileSystemDirectoryEntry")}} objects for each selected directory.
 
 ## Interfaces

--- a/files/en-us/web/api/globaleventhandlers/index.md
+++ b/files/en-us/web/api/globaleventhandlers/index.md
@@ -59,19 +59,19 @@ These event handlers are defined on the {{domxref("GlobalEventHandlers")}} mixin
 - {{domxref("GlobalEventHandlers.ondblclick")}}
   - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("dblclick")}} event is raised.
 - {{domxref("GlobalEventHandlers.ondrag")}}
-  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("drag")}} event is raised.
+  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("HTMLElement/drag_event", "drag")}} event is raised.
 - {{domxref("GlobalEventHandlers.ondragend")}}
-  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("dragend")}} event is raised.
+  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("HTMLElement/dragend_event", "dragend")}} event is raised.
 - {{domxref("GlobalEventHandlers.ondragenter")}}
-  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("dragenter")}} event is raised.
+  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("HTMLElement/dragenter_event", "dragenter")}} event is raised.
 - {{domxref("GlobalEventHandlers.ondragleave")}}
-  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("dragleave")}} event is raised.
+  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("HTMLElement/dragleave_event", "dragleave")}} event is raised.
 - {{domxref("GlobalEventHandlers.ondragover")}}
-  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("dragover")}} event is raised.
+  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("HTMLElement/dragover_event", "dragover")}} event is raised.
 - {{domxref("GlobalEventHandlers.ondragstart")}}
-  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("dragstart")}} event is raised.
+  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event is raised.
 - {{domxref("GlobalEventHandlers.ondrop")}}
-  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("drop")}} event is raised.
+  - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{domxref("HTMLElement/drop_event", "drop")}} event is raised.
 - {{domxref("GlobalEventHandlers.ondurationchange")}}
   - : An [event handler](/en-US/docs/Web/Events/Event_handlers) representing the code to be called when the {{event("durationchange")}} event is raised.
 - {{domxref("GlobalEventHandlers.onemptied")}}

--- a/files/en-us/web/api/globaleventhandlers/ondrag/index.md
+++ b/files/en-us/web/api/globaleventhandlers/ondrag/index.md
@@ -10,7 +10,7 @@ browser-compat: api.GlobalEventHandlers.ondrag
 ---
 {{ApiRef("HTML DOM")}}
 
-A {{domxref("GlobalEventHandlers","global event handler")}} for the {{event("drag")}}
+A {{domxref("GlobalEventHandlers","global event handler")}} for the {{domxref("HTMLElement/drag_event", "drag")}}
 event.
 
 ## Syntax
@@ -93,4 +93,7 @@ function dragover_handler(ev) {
 
 ## See also
 
-- {{event("drag")}}
+- {{domxref("Window")}}: {{domxref("Window/drag_event", "drag")}} event
+- {{domxref("Document")}}: {{domxref("Document/drag_event", "drag")}} event
+- {{domxref("HTMLElement")}}: {{domxref("HTMLElement/drag_event", "drag")}} event
+- {{domxref("SVGElement")}}: {{domxref("SVGElement/drag_event", "drag")}} event

--- a/files/en-us/web/api/globaleventhandlers/ondragend/index.md
+++ b/files/en-us/web/api/globaleventhandlers/ondragend/index.md
@@ -11,7 +11,7 @@ browser-compat: api.GlobalEventHandlers.ondragend
 {{ApiRef("HTML DOM")}}
 
 A {{domxref("GlobalEventHandlers","global event handler")}} for the
-{{event("dragend")}} event.
+{{domxref("HTMLElement/dragend_event", "dragend")}} event.
 
 ## Syntax
 
@@ -28,7 +28,7 @@ targetElement.ondragend = dragendHandler;
 
 This example demonstrates using the
 {{domxref("GlobalEventHandlers.ondragend","ondragend")}} global event handler to set an
-element's {{event("dragend")}} event handler.
+element's {{domxref("HTMLElement/dragend_event", "dragend")}} event handler.
 
 ### HTML
 
@@ -144,4 +144,7 @@ button.addEventListener("click", () => {
 
 ## See also
 
-- {{event("dragend")}}
+- {{domxref("Window")}}: {{domxref("Window/dragend_event", "dragend")}} event
+- {{domxref("Document")}}: {{domxref("Document/dragend_event", "dragend")}} event
+- {{domxref("HTMLElement")}}: {{domxref("HTMLElement/dragend_event", "dragend")}} event
+- {{domxref("SVGElement")}}: {{domxref("SVGElement/dragend_event", "dragend")}} event

--- a/files/en-us/web/api/globaleventhandlers/ondragenter/index.md
+++ b/files/en-us/web/api/globaleventhandlers/ondragenter/index.md
@@ -11,7 +11,7 @@ browser-compat: api.GlobalEventHandlers.ondragenter
 {{ApiRef("HTML DOM")}}
 
 A {{domxref("GlobalEventHandlers","global event handler")}} for the
-{{event("dragenter")}} event.
+{{domxref("HTMLElement/dragenter_event", "dragenter")}} event.
 
 ## Syntax
 
@@ -28,7 +28,7 @@ var dragenterHandler = targetElement.ondragenter;
 
 This example demonstrates using the
 {{domxref("GlobalEventHandlers.ondragenter","ondragenter")}} global event handler to set an
-element's {{event("dragenter")}} event handler.
+element's {{domxref("HTMLElement/dragenter_event", "dragenter")}} event handler.
 
 ### HTML
 
@@ -143,4 +143,4 @@ button.addEventListener("click", () => {
 
 ## See also
 
-- {{event("dragenter")}}
+- {{domxref("HTMLElement/dragenter_event", "dragenter")}}

--- a/files/en-us/web/api/globaleventhandlers/ondragleave/index.md
+++ b/files/en-us/web/api/globaleventhandlers/ondragleave/index.md
@@ -11,7 +11,7 @@ browser-compat: api.GlobalEventHandlers.ondragleave
 {{ApiRef("HTML DOM")}}
 
 A {{domxref("GlobalEventHandlers","global event handler")}} for the
-{{event("dragleave")}} event.
+{{domxref("HTMLElement/dragleave_event", "dragleave")}} event.
 
 ## Syntax
 
@@ -28,7 +28,7 @@ targetElement.ondragleave = dragleaveHandler;
 
 This example demonstrates using the
 {{domxref("GlobalEventHandlers.ondragleave","ondragleave")}} global event handler to set an
-element's {{event("dragleave")}} event handler.
+element's {{domxref("HTMLElement/dragleave_event", "dragleave")}} event handler.
 
 ### HTML
 
@@ -147,4 +147,4 @@ button.addEventListener("click", () => {
 
 ## See also
 
-- {{event("dragleave")}}
+- {{domxref("HTMLElement/dragleave_event", "dragleave")}}

--- a/files/en-us/web/api/globaleventhandlers/ondragover/index.md
+++ b/files/en-us/web/api/globaleventhandlers/ondragover/index.md
@@ -11,7 +11,7 @@ browser-compat: api.GlobalEventHandlers.ondragover
 {{ApiRef("HTML DOM")}}
 
 A {{domxref("GlobalEventHandlers","global event handler")}} for the
-{{event("dragover")}} event.
+{{domxref("HTMLElement/dragover_event", "dragover")}} event.
 
 ## Syntax
 
@@ -147,4 +147,4 @@ button.addEventListener("click", () => {
 
 ## See also
 
-- {{event("dragover")}}
+- {{domxref("HTMLElement/dragover_event", "dragover")}}

--- a/files/en-us/web/api/globaleventhandlers/ondragstart/index.md
+++ b/files/en-us/web/api/globaleventhandlers/ondragstart/index.md
@@ -11,7 +11,7 @@ browser-compat: api.GlobalEventHandlers.ondragstart
 {{ApiRef("HTML DOM")}}
 
 A {{domxref("GlobalEventHandlers","global event handler")}} for the
-{{event("dragstart")}} event.
+{{domxref("HTMLElement/dragstart_event", "dragstart")}} event.
 
 ## Syntax
 
@@ -148,4 +148,4 @@ button.addEventListener("click", () => {
 
 ## See also
 
-- {{event("dragstart")}}
+- {{domxref("HTMLElement/dragstart_event", "dragstart")}}

--- a/files/en-us/web/api/globaleventhandlers/ondrop/index.md
+++ b/files/en-us/web/api/globaleventhandlers/ondrop/index.md
@@ -10,7 +10,7 @@ browser-compat: api.GlobalEventHandlers.ondrop
 ---
 {{ApiRef("HTML DOM")}}
 
-A {{domxref("GlobalEventHandlers","global event handler")}} for the {{event("drop")}}
+A {{domxref("GlobalEventHandlers","global event handler")}} for the {{domxref("HTMLElement/drop_event", "drop")}}
 event.
 
 ## Syntax
@@ -28,7 +28,7 @@ var dropHandler = targetElement.ondrop;
 
 This example demonstrates the use of the
 {{domxref("GlobalEventHandlers.ondrop","ondrop")}} attribute to define an element's
-{{event("drop")}} event handler.
+{{domxref("HTMLElement/drop_event", "drop")}} event handler.
 
 ```js
 <!DOCTYPE html>
@@ -94,4 +94,4 @@ function dragover_handler(ev) {
 
 ## See also
 
-- {{event("drop")}}
+- {{domxref("HTMLElement/drop_event", "drop")}}

--- a/files/en-us/web/api/html_drag_and_drop_api/drag_operations/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/drag_operations/index.md
@@ -23,7 +23,7 @@ In HTML, apart from the default behavior for images, links, and selections, no o
 To make other HTML elements draggable, three things must be done:
 
 1. Set the {{htmlattrxref("draggable")}} attribute to `"true"` on the element that you wish to make draggable.
-2. Add a listener for the `{{event("dragstart")}}` event.
+2. Add a listener for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event.
 3. [Set the drag data](/en-US/docs/Web/API/DataTransfer/setData) in the above listener.
 
 Here is an example which allows a section of content to be dragged.
@@ -42,7 +42,7 @@ The `{{htmlattrxref("draggable")}}` attribute may be used on any element, includ
 
 ## Starting a Drag Operation
 
-In this example, a listener is added for the {{event("dragstart")}} event by using the {{domxref("GlobalEventHandlers.ondragstart","ondragstart")}} attribute.
+In this example, a listener is added for the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event by using the {{domxref("GlobalEventHandlers.ondragstart","ondragstart")}} attribute.
 
 ```html
 <p draggable="true" ondragstart="event.dataTransfer.setData('text/plain', 'This text may be dragged')">
@@ -50,11 +50,11 @@ In this example, a listener is added for the {{event("dragstart")}} event by usi
 </p>
 ```
 
-When a user begins to drag, the {{event("dragstart")}} event is fired.
+When a user begins to drag, the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event is fired.
 
-In this example the {{event("dragstart")}} listener is added to the draggable element itself. However, you could listen to a higher ancestor as drag events bubble up as most other events do.
+In this example the {{domxref("HTMLElement/dragstart_event", "dragstart")}} listener is added to the draggable element itself. However, you could listen to a higher ancestor as drag events bubble up as most other events do.
 
-Within the {{event("dragstart")}} event, you can specify the **drag data**, the **feedback image**, and the **drag effects**, all of which are described below. However, only the **drag data** is required. (The default image and drag effects are suitable in most situations.)
+Within the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event, you can specify the **drag data**, the **feedback image**, and the **drag effects**, all of which are described below. However, only the **drag data** is required. (The default image and drag effects are suitable in most situations.)
 
 ## Drag Data
 
@@ -62,7 +62,7 @@ All {{domxref("DragEvent","drag events")}} have a property called {{domxref("Dra
 
 When a drag occurs, data must be associated with the drag which identifies _what_ is being dragged. For example, when dragging the selected text within a textbox, the data associated with the _drag data item_ is the text itself. Similarly, when dragging a link on a web page, the drag data item is the link's URL.
 
-The {{domxref("DataTransfer","drag data")}} contains two pieces of information, the **type** (or format) of the data, and the data's **value**. The format is a type string (such as [`text/plain`](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types#text) for text data), and the value is a string of text. When the drag begins, you add data by providing a type and the data. During the drag, in an event listener for the `{{event("dragenter")}}` and `{{event("dragover")}}` events, you use the data types of the data being dragged to check whether a drop is allowed. For instance, a drop target that accepts links would check for the type [`text/uri-list`](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types#link). During a drop event, a listener would retrieve the data being dragged and insert it at the drop location.
+The {{domxref("DataTransfer","drag data")}} contains two pieces of information, the **type** (or format) of the data, and the data's **value**. The format is a type string (such as [`text/plain`](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types#text) for text data), and the value is a string of text. When the drag begins, you add data by providing a type and the data. During the drag, in an event listener for the {{domxref("HTMLElement/dragenter_event", "dragenter")}} and {{domxref("HTMLElement/dragover_event", "dragover")}} events, you use the data types of the data being dragged to check whether a drop is allowed. For instance, a drop target that accepts links would check for the type [`text/uri-list`](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types#link). During a drop event, a listener would retrieve the data being dragged and insert it at the drop location.
 
 The {{domxref("DataTransfer","drag data's")}} {{domxref("DataTransfer.types","types")}} property returns a list of MIME-type like strings, such as [`text/plain`](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types#text) or [`image/jpeg`](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types#image). You can also create your own types. The most commonly used types are listed in the article [Recommended Drag Types](/en-US/docs/Web/API/HTML_Drag_and_Drop_API/Recommended_drag_types).
 
@@ -103,7 +103,7 @@ The `type` argument to the {{domxref("DataTransfer.clearData","clearData()")}} m
 
 ## Setting the drag feedback image
 
-When a drag occurs, a translucent image is generated from the drag target (the element the "{{event("dragstart")}}" event is fired at), and follows the user's pointer during the drag. This image is created automatically, so you do not need to create it yourself. However, you can use {{domxref("DataTransfer.setDragImage","setDragImage()")}} to specify a custom drag feedback image.
+When a drag occurs, a translucent image is generated from the drag target (the element the "{{domxref("HTMLElement/dragstart_event", "dragstart")}}" event is fired at), and follows the user's pointer during the drag. This image is created automatically, so you do not need to create it yourself. However, you can use {{domxref("DataTransfer.setDragImage","setDragImage()")}} to specify a custom drag feedback image.
 
 ```js
 event.dataTransfer.setDragImage(image, xOffset, yOffset);
@@ -138,7 +138,7 @@ In this example, we make one canvas the drag image. As the canvas is `50`×`50` 
 
 When dragging, there are several operations that may be performed. The `copy` operation is used to indicate that the data being dragged will be copied from its present location to the drop location. The `move` operation is used to indicate that the data being dragged will be moved, and the `link` operation is used to indicate that some form of relationship or connection will be created between the source and drop locations.
 
-You can specify which of the three operations are allowed for a drag source by setting the {{domxref("DataTransfer.effectAllowed","effectAllowed")}} property within a `{{event("dragstart")}}` event listener.
+You can specify which of the three operations are allowed for a drag source by setting the {{domxref("DataTransfer.effectAllowed","effectAllowed")}} property within a {{domxref("HTMLElement/dragstart_event", "dragstart")}} event listener.
 
 ```js
 event.dataTransfer.effectAllowed = "copy";
@@ -169,11 +169,11 @@ You can combine the values in various ways:
 
 Note that these values must be used exactly as listed above. For example, setting the {{domxref("DataTransfer.effectAllowed","effectAllowed")}} property to `copyMove` allows a copy or move operation but prevents the user from performing a link operation. If you don't change the {{domxref("DataTransfer.effectAllowed","effectAllowed")}} property, then any operation is allowed, just like with the '`all`' value. So you don't need to adjust this property unless you want to exclude specific types.
 
-During a drag operation, a listener for the `{{event("dragenter")}}` or `{{event("dragover")}}` events can check the {{domxref("DataTransfer.effectAllowed","effectAllowed")}} property to see which operations are permitted. A related property, {{domxref("DataTransfer.dropEffect","dropEffect")}}, should be set within one of these events to specify which single operation should be performed. Valid values for {{domxref("DataTransfer.dropEffect","dropEffect")}} are `none`, `copy`, `move`, or `link`. The combination values are not used for this property.
+During a drag operation, a listener for the {{domxref("HTMLElement/dragenter_event", "dragenter")}} or {{domxref("HTMLElement/dragover_event", "dragover")}} events can check the {{domxref("DataTransfer.effectAllowed","effectAllowed")}} property to see which operations are permitted. A related property, {{domxref("DataTransfer.dropEffect","dropEffect")}}, should be set within one of these events to specify which single operation should be performed. Valid values for {{domxref("DataTransfer.dropEffect","dropEffect")}} are `none`, `copy`, `move`, or `link`. The combination values are not used for this property.
 
-With the `{{event("dragenter")}}` and `{{event("dragover")}}` event, the {{domxref("DataTransfer.dropEffect","dropEffect")}} property is initialized to the effect that the user is requesting. The user can modify the desired effect by pressing modifier keys. Although the exact keys used vary by platform, typically the <kbd>Shift</kbd> and <kbd>Control</kbd> keys would be used to switch between copying, moving, and linking. The mouse pointer will change to indicate which operation is desired. For instance, for a `copy`, the cursor might appear with a plus sign next to it.
+With the {{domxref("HTMLElement/dragenter_event", "dragenter")}} and {{domxref("HTMLElement/dragover_event", "dragover")}} event, the {{domxref("DataTransfer.dropEffect","dropEffect")}} property is initialized to the effect that the user is requesting. The user can modify the desired effect by pressing modifier keys. Although the exact keys used vary by platform, typically the <kbd>Shift</kbd> and <kbd>Control</kbd> keys would be used to switch between copying, moving, and linking. The mouse pointer will change to indicate which operation is desired. For instance, for a `copy`, the cursor might appear with a plus sign next to it.
 
-You can modify the {{domxref("DataTransfer.dropEffect","dropEffect")}} property during the `{{event("dragenter")}}` or `{{event("dragover")}}` events, if for example, a particular drop target only supports certain operations. You can modify the {{domxref("DataTransfer.dropEffect","dropEffect")}} property to override the user effect, and enforce a specific drop operation to occur. Note that this effect must be one listed within the {{domxref("DataTransfer.effectAllowed","effectAllowed")}} property. Otherwise, it will be set to an alternate value that is allowed.
+You can modify the {{domxref("DataTransfer.dropEffect","dropEffect")}} property during the {{domxref("HTMLElement/dragenter_event", "dragenter")}} or {{domxref("HTMLElement/dragover_event", "dragover")}} events, if for example, a particular drop target only supports certain operations. You can modify the {{domxref("DataTransfer.dropEffect","dropEffect")}} property to override the user effect, and enforce a specific drop operation to occur. Note that this effect must be one listed within the {{domxref("DataTransfer.effectAllowed","effectAllowed")}} property. Otherwise, it will be set to an alternate value that is allowed.
 
 ```js
 event.dataTransfer.dropEffect = "copy";
@@ -183,11 +183,11 @@ In this example, copy is the effect that is performed.
 
 You can use the value `none` to indicate that no drop is allowed at this location, although it is preferred not to cancel the event in this case.
 
-Within the `{{event("drop")}}` and `{{event("dragend")}}` events, you can check the {{domxref("DataTransfer.dropEffect","dropEffect")}} property to determine which effect was ultimately chosen.  If the chosen effect were "`move`", then the original data should be removed from the source of the drag within the `{{event("dragend")}}` event.
+Within the {{domxref("HTMLElement/drop_event", "drop")}} and {{domxref("HTMLElement/dragend_event", "dragend")}} events, you can check the {{domxref("DataTransfer.dropEffect","dropEffect")}} property to determine which effect was ultimately chosen.  If the chosen effect were "`move`", then the original data should be removed from the source of the drag within the {{domxref("HTMLElement/dragend_event", "dragend")}} event.
 
 ## Specifying Drop Targets
 
-A listener for the `{{event("dragenter")}}` and `{{event("dragover")}}` events are used to indicate valid drop targets, that is, places where dragged items may be dropped. Most areas of a web page or application are not valid places to drop data. Thus, the default handling of these events is not to allow a drop.
+A listener for the {{domxref("HTMLElement/dragenter_event", "dragenter")}} and {{domxref("HTMLElement/dragover_event", "dragover")}} events are used to indicate valid drop targets, that is, places where dragged items may be dropped. Most areas of a web page or application are not valid places to drop data. Thus, the default handling of these events is not to allow a drop.
 
 If you want to allow a drop, you must prevent the default handling by cancelling both the `dragenter` and `dragover` events. You can do this either by returning `false` from attribute-defined event listeners, or by calling the event's {{domxref("Event.preventDefault","preventDefault()")}} method. The latter may be more feasible in a function defined in a separate script.
 
@@ -196,7 +196,7 @@ If you want to allow a drop, you must prevent the default handling by cancelling
 <div ondragover="event.preventDefault()">
 ```
 
-Calling the {{domxref("Event.preventDefault","preventDefault()")}} method during both a `{{event("dragenter")}}` and `{{event("dragover")}}` event will indicate that a drop is allowed at that location. However, you will commonly wish to call the {{domxref("Event.preventDefault","preventDefault()")}} method only in certain situations (for example, only if a link is being dragged).
+Calling the {{domxref("Event.preventDefault","preventDefault()")}} method during both a {{domxref("HTMLElement/dragenter_event", "dragenter")}} and {{domxref("HTMLElement/dragover_event", "dragover")}} event will indicate that a drop is allowed at that location. However, you will commonly wish to call the {{domxref("Event.preventDefault","preventDefault()")}} method only in certain situations (for example, only if a link is being dragged).
 
 To do this, call a function which checks a condition and only cancels the event when the condition is met. If the condition is not met, don't cancel the event, and a drop will not occur there if the user releases the mouse button.
 
@@ -229,23 +229,23 @@ However, you can also update the user interface with an insertion point or highl
 }
 ```
 
-In this example, the element with the class `droparea` will receive a 1 pixel black outline while it is a valid drop target, that is, if the {{domxref("Event.preventDefault","preventDefault()")}} method was called during the `{{event("dragenter")}}` event.
+In this example, the element with the class `droparea` will receive a 1 pixel black outline while it is a valid drop target, that is, if the {{domxref("Event.preventDefault","preventDefault()")}} method was called during the {{domxref("HTMLElement/dragenter_event", "dragenter")}} event.
 
-> **Note:** You must cancel the `{{event("dragenter")}}` event for this pseudoclass to apply, as this state is not checked for the `{{event("dragover")}}` event.
+> **Note:** You must cancel the {{domxref("HTMLElement/dragenter_event", "dragenter")}} event for this pseudoclass to apply, as this state is not checked for the {{domxref("HTMLElement/dragover_event", "dragover")}} event.
 
-For more complex visual effects, you can also perform other operations during the `{{event("dragenter")}}` event. For example, by inserting an element at the location where the drop will occur. This might be an insertion marker, or an element that represents the dragged element in its new location. To do this, you could create an [image](/en-US/docs/XUL/image) or [separator](/en-US/docs/XUL/separator) element and insert it into the document during the `{{event("dragenter")}}` event.
+For more complex visual effects, you can also perform other operations during the {{domxref("HTMLElement/dragenter_event", "dragenter")}} event. For example, by inserting an element at the location where the drop will occur. This might be an insertion marker, or an element that represents the dragged element in its new location. To do this, you could create an [image](/en-US/docs/XUL/image) or [separator](/en-US/docs/XUL/separator) element and insert it into the document during the {{domxref("HTMLElement/dragenter_event", "dragenter")}} event.
 
-The `{{event("dragover")}}` event will fire at the element the mouse is pointing at. Naturally, you may need to move the insertion marker around a `{{event("dragover")}}` event as well. You can use the event's {{domxref("MouseEvent.clientX","clientX")}} and {{domxref("MouseEvent.clientY","clientY")}} properties as with other mouse events to determine the location of the mouse pointer.
+The {{domxref("HTMLElement/dragover_event", "dragover")}} event will fire at the element the mouse is pointing at. Naturally, you may need to move the insertion marker around a {{domxref("HTMLElement/dragover_event", "dragover")}} event as well. You can use the event's {{domxref("MouseEvent.clientX","clientX")}} and {{domxref("MouseEvent.clientY","clientY")}} properties as with other mouse events to determine the location of the mouse pointer.
 
-Finally, the `{{event("dragleave")}}` event will fire at an element when the drag leaves the element. This is the time when you should remove any insertion markers or highlighting. You do not need to cancel this event. Any highlighting or other visual effects specified using the `:-moz-drag-over` pseudoclass will be removed automatically. The `{{event("dragleave")}}` event will always fire, even if the drag is cancelled, so you can always ensure that any insertion point cleanup can be done during this event.
+Finally, the {{domxref("HTMLElement/dragleave_event", "dragleave")}} event will fire at an element when the drag leaves the element. This is the time when you should remove any insertion markers or highlighting. You do not need to cancel this event. Any highlighting or other visual effects specified using the `:-moz-drag-over` pseudoclass will be removed automatically. The {{domxref("HTMLElement/dragleave_event", "dragleave")}} event will always fire, even if the drag is cancelled, so you can always ensure that any insertion point cleanup can be done during this event.
 
 ## Performing a Drop
 
 When the user releases the mouse, the drag and drop operation ends.
 
-If the mouse is released over an element that is a valid drop target, that is, one that cancelled the last `{{event("dragenter")}}` or `{{event("dragover")}}` event, then the drop will be successful, and a `{{event("drop")}}` event will fire at the target. Otherwise, the drag operation is cancelled, and no `{{event("drop")}}` event is fired.
+If the mouse is released over an element that is a valid drop target, that is, one that cancelled the last {{domxref("HTMLElement/dragenter_event", "dragenter")}} or {{domxref("HTMLElement/dragover_event", "dragover")}} event, then the drop will be successful, and a {{domxref("HTMLElement/drop_event", "drop")}} event will fire at the target. Otherwise, the drag operation is cancelled, and no {{domxref("HTMLElement/drop_event", "drop")}} event is fired.
 
-During the `{{event("drop")}}` event, you should retrieve that data that was dropped from the event and insert it at the drop location. You can use the {{domxref("DataTransfer.dropEffect","dropEffect")}} property to determine which drag operation was desired.
+During the {{domxref("HTMLElement/drop_event", "drop")}} event, you should retrieve that data that was dropped from the event and insert it at the drop location. You can use the {{domxref("DataTransfer.dropEffect","dropEffect")}} property to determine which drag operation was desired.
 
 As with all drag-related events, the event's {{domxref("DataTransfer","dataTransfer")}} property will hold the data that is being dragged. The {{domxref("DataTransfer.getData","getData()")}} method may be used to retrieve the data again.
 
@@ -257,7 +257,7 @@ function onDrop(event) {
 }
 ```
 
-The {{domxref("DataTransfer.getData","getData()")}} method takes one argument, the type of data to retrieve. It will return the string value that was set when {{domxref("DataTransfer.setData","setData()")}} was called at the beginning of the drag operation. An empty string will be returned if data of that type does not exist. (Naturally, though, you would likely know that the right type of data was available, as it was previously checked during a `{{event("dragover")}}` event.)
+The {{domxref("DataTransfer.getData","getData()")}} method takes one argument, the type of data to retrieve. It will return the string value that was set when {{domxref("DataTransfer.setData","setData()")}} was called at the beginning of the drag operation. An empty string will be returned if data of that type does not exist. (Naturally, though, you would likely know that the right type of data was available, as it was previously checked during a {{domxref("HTMLElement/dragover_event", "dragover")}} event.)
 
 In the example here, once the data has been retrieved, we insert the string as the textual content of the target. This has the effect of inserting the dragged text where it was dropped, assuming that the drop target is an area of text such as a `p` or `div` element.
 
@@ -308,13 +308,13 @@ function doDrop(event) {
 
 ## Finishing a Drag
 
-Once the drag is complete, a `{{event("dragend")}}` event is fired at the source of the drag (the same element that received the `{{event("dragstart")}}` event). This event will fire if the drag was successful or if it was cancelled. However, you can use the {{domxref("DataTransfer.dropEffect","dropEffect")}} property to determine which drop operation occurred.
+Once the drag is complete, a {{domxref("HTMLElement/dragend_event", "dragend")}} event is fired at the source of the drag (the same element that received the {{domxref("HTMLElement/dragstart_event", "dragstart")}} event). This event will fire if the drag was successful or if it was cancelled. However, you can use the {{domxref("DataTransfer.dropEffect","dropEffect")}} property to determine which drop operation occurred.
 
-If the {{domxref("DataTransfer.dropEffect","dropEffect")}} property has the value `none` during a `{{event("dragend")}}`, then the drag was cancelled. Otherwise, the effect specifies which operation was performed. The source can use this information after a `move` operation to remove the dragged item from the old location. The {{domxref("DataTransfer.mozUserCancelled","mozUserCancelled")}} property will be set to `true` if the user cancelled the drag (by pressing <kbd>Escape</kbd>), and `false` if the drag was cancelled for other reasons such as an invalid drop target, or if it was successful.
+If the {{domxref("DataTransfer.dropEffect","dropEffect")}} property has the value `none` during a {{domxref("HTMLElement/dragend_event", "dragend")}}, then the drag was cancelled. Otherwise, the effect specifies which operation was performed. The source can use this information after a `move` operation to remove the dragged item from the old location. The {{domxref("DataTransfer.mozUserCancelled","mozUserCancelled")}} property will be set to `true` if the user cancelled the drag (by pressing <kbd>Escape</kbd>), and `false` if the drag was cancelled for other reasons such as an invalid drop target, or if it was successful.
 
-A drop can occur inside the same window or over another application. The `{{event("dragend")}}` event will always fire regardless. The event's {{domxref("MouseEvent.screenX","screenX")}} and {{domxref("MouseEvent.screenY","screenY")}} properties will be set to the screen coordinates where the drop occurred.
+A drop can occur inside the same window or over another application. The {{domxref("HTMLElement/dragend_event", "dragend")}} event will always fire regardless. The event's {{domxref("MouseEvent.screenX","screenX")}} and {{domxref("MouseEvent.screenY","screenY")}} properties will be set to the screen coordinates where the drop occurred.
 
-After the `{{event("dragend")}}` event has finished propagating, the drag and drop operation is complete.
+After the {{domxref("HTMLElement/dragend_event", "dragend")}} event has finished propagating, the drag and drop operation is complete.
 
 ## See also
 

--- a/files/en-us/web/api/html_drag_and_drop_api/file_drag_and_drop/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/file_drag_and_drop/index.md
@@ -10,13 +10,13 @@ tags:
 
 HTML Drag and Drop interfaces enable web applications to drag and drop files on a web page. This document describes how an application can accept one or more files that are dragged from the underlying platform's _file manager_ and dropped on a web page.
 
-The main steps to drag and drop are to define a _drop zone_ (i.e. a target element for the file drop) and to define event handlers for the {{event("drop")}} and {{event("dragover")}} events. These steps are described below, including example code snippets. The full source code is available in [MDN's drag-and-drop repository](https://github.com/mdn/dom-examples/tree/master/drag-and-drop) (pull requests and/or issues are welcome).
+The main steps to drag and drop are to define a _drop zone_ (i.e. a target element for the file drop) and to define event handlers for the {{domxref("HTMLElement/drop_event", "drop")}} and {{domxref("HTMLElement/dragover_event", "dragover")}} events. These steps are described below, including example code snippets. The full source code is available in [MDN's drag-and-drop repository](https://github.com/mdn/dom-examples/tree/master/drag-and-drop) (pull requests and/or issues are welcome).
 
 Note that {{domxref("HTML_Drag_and_Drop_API","HTML drag and drop")}} defines two different APIs to support dragging and dropping files. One API is the {{domxref("DataTransfer")}} interface and the second API is the {{domxref("DataTransferItem")}} and {{domxref("DataTransferItemList")}} interfaces. This example illustrates the use of both APIs (and does not use any Gecko specific interfaces).
 
 ## Define the drop _zone_
 
-The _target element_ of the {{event("drop")}} event needs an {{domxref("GlobalEventHandlers.ondrop","ondrop")}} global event handler. The following code snippet shows how this is done with a {{HTMLelement("div")}} element:
+The _target element_ of the {{domxref("HTMLElement/drop_event", "drop")}} event needs an {{domxref("GlobalEventHandlers.ondrop","ondrop")}} global event handler. The following code snippet shows how this is done with a {{HTMLelement("div")}} element:
 
 ```html
 <div id="drop_zone" ondrop="dropHandler(event);">
@@ -24,7 +24,7 @@ The _target element_ of the {{event("drop")}} event needs an {{domxref("GlobalEv
 </div>
 ```
 
-Typically, an application will include a {{event("dragover")}} event handler on the drop target element and that handler will turn off the browser's default drag behavior. To add this handler, you need to include a {{domxref("GlobalEventHandlers.ondragover","ondragover")}} global event handler:
+Typically, an application will include a {{domxref("HTMLElement/dragover_event", "dragover")}} event handler on the drop target element and that handler will turn off the browser's default drag behavior. To add this handler, you need to include a {{domxref("GlobalEventHandlers.ondragover","ondragover")}} global event handler:
 
 ```html
 <div id="drop_zone" ondrop="dropHandler(event);" ondragover="dragOverHandler(event);">
@@ -46,7 +46,7 @@ Lastly, an application may want to style the drop target element to visually ind
 
 ## Process the drop
 
-The {{event("drop")}} event is fired when the user drops the file(s). In the following drop handler, if the browser supports {{domxref("DataTransferItemList")}} interface, the {{domxref("DataTransferItem.getAsFile","getAsFile()")}} method is used to access each file; otherwise the {{domxref("DataTransfer")}} interface's {{domxref("DataTransfer.files","files")}} property is used to access each file.
+The {{domxref("HTMLElement/drop_event", "drop")}} event is fired when the user drops the file(s). In the following drop handler, if the browser supports {{domxref("DataTransferItemList")}} interface, the {{domxref("DataTransferItem.getAsFile","getAsFile()")}} method is used to access each file; otherwise the {{domxref("DataTransfer")}} interface's {{domxref("DataTransfer.files","files")}} property is used to access each file.
 
 This example shows how to write the name of each dragged file to the console. In a _real_ application, an application may want to process a file using the {{domxref("File","File API")}}.
 
@@ -79,7 +79,7 @@ function dropHandler(ev) {
 
 ## Prevent the browser's default drag behavior
 
-The following {{event("dragover")}} event handler calls {{domxref("Event.preventDefault","preventDefault()")}} to turn off the browser's default drag and drop handler.
+The following {{domxref("HTMLElement/dragover_event", "dragover")}} event handler calls {{domxref("Event.preventDefault","preventDefault()")}} to turn off the browser's default drag and drop handler.
 
 ```js
 function dragOverHandler(ev) {

--- a/files/en-us/web/api/html_drag_and_drop_api/multiple_items/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/multiple_items/index.md
@@ -17,7 +17,7 @@ The drag processing described in this document use the {{domxref("DataTransfer")
 
 ## Setting and getting with indices
 
-The {{domxref("DataTransfer.mozSetDataAt","mozSetDataAt()")}} method allows you to add multiple items during a {{event("dragstart")}} event. This function similarly to {{domxref("DataTransfer.setData","setData()")}}
+The {{domxref("DataTransfer.mozSetDataAt","mozSetDataAt()")}} method allows you to add multiple items during a {{domxref("HTMLElement/dragstart_event", "dragstart")}} event. This function similarly to {{domxref("DataTransfer.setData","setData()")}}
 
 ```js
 var dt = event.dataTransfer;
@@ -66,7 +66,7 @@ Fortunately, you don't normally need to clear items often; it's more common to j
 
 Common cases where dragging multiple items is used is when dragging multiple files or bookmarks. In this case, add the appropriate formats for each item. Although not required, you should always add the same formats for each item. The ensures that receiving drop targets can expect consistent data.
 
-To check if multiple files are being dragged, check the {{domxref("DataTransfer.mozItemCount","mozItemCount")}} property. It will be set to the number of items being dragged. If a particular drop target only supports dropping a single item, it could either reject the dragged items or it could just use just the first item. To reject the items, either don't cancel the {{event("dragover")}} event, or set the {{domxref("DataTransfer.effectAllowed","effectAllowed")}} property to `none`. You may wish to do both in case another listener has already cancelled the event.
+To check if multiple files are being dragged, check the {{domxref("DataTransfer.mozItemCount","mozItemCount")}} property. It will be set to the number of items being dragged. If a particular drop target only supports dropping a single item, it could either reject the dragged items or it could just use just the first item. To reject the items, either don't cancel the {{domxref("HTMLElement/dragover_event", "dragover")}} event, or set the {{domxref("DataTransfer.effectAllowed","effectAllowed")}} property to `none`. You may wish to do both in case another listener has already cancelled the event.
 
 To just take the first item being dropped, use the {{domxref("DataTransfer.getData","getData()")}} method as with a single item. This is convenient as drop targets which only need to support a single item do not need to do anything extra.
 
@@ -155,7 +155,7 @@ function output(text)
 </html>
 ```
 
-This example cancels both the `{{event("dragenter")}}` and `{{event("dragover")}}` events by calling the {{domxref("Event.preventDefault","preventDefault()")}}. method. This allows a drop to occur on that element.
+This example cancels both the {{domxref("HTMLElement/dragenter_event", "dragenter")}} and `{{domxref("HTMLElement/dragover_event", "dragover")}}` events by calling the {{domxref("Event.preventDefault","preventDefault()")}}. method. This allows a drop to occur on that element.
 
 The `dodrop` event handler is called when dropping an item. It checks the {{domxref("DataTransfer.mozItemCount","mozItemCount")}} property to check how many items have been dropped and iterates over them. For each item, the {{domxref("DataTransfer.mozTypesAt","mozTypesAt()")}} method is called to get the list of types. This list is iterated over to get all of the data associated with the drag.
 

--- a/files/en-us/web/api/htmlelement/drag_event/index.md
+++ b/files/en-us/web/api/htmlelement/drag_event/index.md
@@ -1,0 +1,175 @@
+---
+title: 'HTMLElement: drag event'
+slug: Web/API/HTMLElement/drag_event
+tags:
+  - API
+  - DOM
+  - Element
+  - Drag
+  - DragEvent
+  - Event
+  - Reference
+  - Web
+  - drag and drop
+browser-compat: api.HTMLElement.drag_event
+---
+{{APIRef}}
+
+The `drag` event is fired every few hundred milliseconds as an element or text selection is being dragged by the user.
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Bubbles</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">Cancelable</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">Default action</th>
+      <td>Continue the drag &#x26; drop operation.</td>
+    </tr>
+    <tr>
+      <th scope="row">Interface</th>
+      <td>{{domxref("DragEvent")}}</td>
+    </tr>
+    <tr>
+      <th scope="row">Event handler property</th>
+      <td>
+        {{domxref("GlobalEventHandlers/ondrag", "ondrag")}}
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Examples
+
+### Drag and drop example
+
+#### HTML
+
+```html
+<div class="dropzone">
+  <div id="draggable" draggable="true">
+    This div is draggable
+  </div>
+</div>
+<div class="dropzone" id="droptarget"></div>
+```
+
+#### CSS
+
+```css
+body {
+  /* Prevent the user selecting text in the example */
+  user-select: none;
+}
+
+#draggable {
+  text-align: center;
+  background: white;
+}
+
+.dropzone {
+  width: 200px;
+  height: 20px;
+  background: blueviolet;
+  margin: 10px;
+  padding: 10px;
+}
+
+.dropzone.dragover {
+  background-color: purple;
+}
+
+.dragging {
+  opacity: .5;
+}
+```
+
+#### JavaScript
+
+```js
+let dragged;
+
+/* events fired on the draggable target */
+const source = document.getElementById("draggable");
+source.addEventListener("drag", event => {
+  console.log("dragging");
+});
+
+source.addEventListener("dragstart", event => {
+  // store a ref. on the dragged elem
+  dragged = event.target;
+  // make it half transparent
+  event.target.classList.add("dragging");
+});
+
+source.addEventListener("dragend", event => {
+  // reset the transparency
+  event.target.classList.remove("dragging");
+});
+
+/* events fired on the drop targets */
+const target = document.getElementById("droptarget");
+target.addEventListener("dragover", event => {
+  // prevent default to allow drop
+  event.preventDefault();
+}, false);
+
+target.addEventListener("dragenter", event => {
+  // highlight potential drop target when the draggable element enters it
+  if (event.target.classList.contains("dropzone")) {
+    event.target.classList.add("dragover");
+  }
+});
+
+target.addEventListener("dragleave", event => {
+  // reset background of potential drop target when the draggable element leaves it
+  if (event.target.classList.contains("dropzone")) {
+    event.target.classList.remove("dragover");
+  }
+});
+
+target.addEventListener("drop", event => {
+  // prevent default action (open as link for some elements)
+  event.preventDefault();
+  // move dragged element to the selected drop target
+  if (event.target.classList.contains("dropzone")) {
+    event.target.classList.remove("dragover");
+    dragged.parentNode.removeChild(dragged);
+    event.target.appendChild(dragged);
+  }
+});
+```
+
+#### Result
+
+{{EmbedLiveSample('Drag and drop example')}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- Other drag and drop events:
+
+  - {{domxref("HTMLElement/dragstart_event", "dragstart")}}
+  - {{domxref("HTMLElement/dragend_event", "dragend")}}
+  - {{domxref("HTMLElement/dragover_event", "dragover")}}
+  - {{domxref("HTMLElement/dragenter_event", "dragenter")}}
+  - {{domxref("HTMLElement/dragleave_event", "dragleave")}}
+  - {{domxref("HTMLElement/drop_event", "drop")}}
+
+- This event on other targets:
+
+  - {{domxref("Window")}}: {{domxref("Window/drag_event", "drag")}} event
+  - {{domxref("Document")}}: {{domxref("Document/drag_event", "drag")}} event
+  - {{domxref("SVGElement")}}: {{domxref("SVGElement/drag_event", "drag")}} event

--- a/files/en-us/web/api/htmlelement/dragend_event/index.md
+++ b/files/en-us/web/api/htmlelement/dragend_event/index.md
@@ -1,0 +1,135 @@
+---
+title: 'HTMLElement: dragend event'
+slug: Web/API/HTMLElement/dragend_event
+tags:
+  - API
+  - DOM
+  - HTMLElement
+  - DragEvent
+  - Event
+  - Reference
+  - Web
+  - drag and drop
+  - dragend
+browser-compat: api.HTMLElement.dragend_event
+---
+{{APIRef}}
+
+The `dragend` event is fired when a drag operation is being ended (by releasing a mouse button or hitting the escape key).
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Bubbles</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">Cancelable</th>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th scope="row">Default action</th>
+      <td>Varies</td>
+    </tr>
+    <tr>
+      <th scope="row">Interface</th>
+      <td>{{domxref("DragEvent")}}</td>
+    </tr>
+    <tr>
+      <th scope="row">Event handler property</th>
+      <td>
+        {{domxref("GlobalEventHandlers/ondragend", "ondragend")}}
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Examples
+
+### Resetting opacity on drag end
+
+In this example, we have a draggable element inside a container. Try grabbing the element, dragging it, and then releasing it.
+
+We make the element half-transparent while it is being dragged, and listen for the `dragend` event to reset the element's opacity when it is released.
+
+For a more complete example of drag and drop, see the page for the [`drag`](/en-US/docs/Web/API/HTMLElement/drag_event) event.
+
+#### HTML
+
+```html
+<div id="container">
+  <div id="draggable" draggable="true">
+    This div is draggable
+  </div>
+</div>
+<div class="dropzone"></div>
+```
+
+#### CSS
+
+```css
+body {
+  /* Prevent the user selecting text in the example */
+  user-select: none;
+}
+
+#draggable {
+  text-align: center;
+  background: white;
+}
+
+#container {
+  width: 200px;
+  height: 20px;
+  background: blueviolet;
+  padding: 10px;
+}
+
+.dragging {
+  opacity: .5;
+}
+```
+
+#### JavaScript
+
+```js
+const source = document.getElementById("draggable");
+source.addEventListener("dragstart", event => {
+  // make it half transparent
+  event.target.classList.add("dragging");
+});
+
+source.addEventListener("dragend", event => {
+  // reset the transparency
+  event.target.classList.remove("dragging");
+});
+```
+
+#### Result
+
+{{EmbedLiveSample('Resetting opacity on drag end')}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- Other drag and drop events:
+
+  - {{domxref("HTMLElement/drag_event", "drag")}}
+  - {{domxref("HTMLElement/dragstart_event", "dragstart")}}
+  - {{domxref("HTMLElement/dragover_event", "dragover")}}
+  - {{domxref("HTMLElement/dragenter_event", "dragenter")}}
+  - {{domxref("HTMLElement/dragleave_event", "dragleave")}}
+  - {{domxref("HTMLElement/drop_event", "drop")}}
+
+- This event on other targets:
+
+  - {{domxref("Window")}}: {{domxref("Window/dragend_event", "dragend")}} event
+  - {{domxref("Document")}}: {{domxref("Document/dragend_event", "dragend")}} event
+  - {{domxref("SVGElement")}}: {{domxref("SVGElement/dragend_event", "dragend")}} event

--- a/files/en-us/web/api/htmlelement/dragenter_event/index.md
+++ b/files/en-us/web/api/htmlelement/dragenter_event/index.md
@@ -1,0 +1,142 @@
+---
+title: 'HTMLElement: dragenter event'
+slug: Web/API/HTMLElement/dragenter_event
+tags:
+  - API
+  - DOM
+  - HTMLElement
+  - DragEvent
+  - Event
+  - Reference
+  - Web
+  - drag and drop
+  - dragenter
+browser-compat: api.HTMLElement.dragenter_event
+---
+{{APIRef}}
+
+The `dragenter` event is fired when a dragged element or text selection enters a valid drop target.
+
+The target object is the _immediate user selection_ (the element directly indicated by the user as the drop target), or the {{HTMLElement("body")}} element.
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Bubbles</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">Cancelable</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">Default action</th>
+      <td>Reject immediate user selection as potential target element.</td>
+    </tr>
+    <tr>
+      <th scope="row">Interface</th>
+      <td>{{domxref("DragEvent")}}</td>
+    </tr>
+    <tr>
+      <th scope="row">Event handler property</th>
+      <td>
+        {{domxref("GlobalEventHandlers/ondragenter", "ondragenter")}}
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Examples
+
+### Styling drop zones on dragenter
+
+In this example, we have a draggable element inside a container. Try grabbing the element, dragging it over the other container, and then releasing it.
+
+We listen for the `dragenter` event to give the other container a purple background while the draggable element is over it, to signal that the draggable element could be dropped on to the container.
+
+Note though that in this partial example we haven't implemented dropping: for a complete example of drag and drop, see the page for the [`drag`](/en-US/docs/Web/API/HTMLElement/drag_event) event.
+
+#### HTML
+
+```html
+<div class="dropzone">
+  <div id="draggable" draggable="true">
+    This div is draggable
+  </div>
+</div>
+<div class="dropzone" id="droptarget"></div>
+```
+
+#### CSS
+
+```css
+body {
+  /* Prevent the user selecting text in the example */
+  user-select: none;
+}
+
+#draggable {
+  text-align: center;
+  background: white;
+}
+
+.dropzone {
+  width: 200px;
+  height: 20px;
+  background: blueviolet;
+  margin: 10px;
+  padding: 10px;
+}
+
+.dropzone.dragover {
+  background-color: purple;
+}
+```
+
+#### JavaScript
+
+```js
+const target = document.getElementById("droptarget");
+target.addEventListener("dragenter", event => {
+  // highlight potential drop target when the draggable element enters it
+  if (event.target.classList.contains("dropzone")) {
+    event.target.classList.add("dragover");
+  }
+});
+
+target.addEventListener("dragleave", event => {
+  // reset background of potential drop target when the draggable element leaves it
+  if (event.target.classList.contains("dropzone")) {
+    event.target.classList.remove("dragover");
+  }
+});
+```
+
+#### Result
+
+{{EmbedLiveSample('Styling drop zones on dragenter')}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- Other drag and drop events:
+
+  - {{domxref("HTMLElement/drag_event", "drag")}}
+  - {{domxref("HTMLElement/dragstart_event", "dragstart")}}
+  - {{domxref("HTMLElement/dragend_event", "dragend")}}
+  - {{domxref("HTMLElement/dragover_event", "dragover")}}
+  - {{domxref("HTMLElement/dragleave_event", "dragleave")}}
+  - {{domxref("HTMLElement/drop_event", "drop")}}
+
+- This event on other targets:
+
+  - {{domxref("Window")}}: {{domxref("Window/dragenter_event", "dragenter")}} event
+  - {{domxref("Document")}}: {{domxref("Document/dragenter_event", "dragenter")}} event
+  - {{domxref("SVGElement")}}: {{domxref("SVGElement/dragenter_event", "dragenter")}} event

--- a/files/en-us/web/api/htmlelement/dragleave_event/index.md
+++ b/files/en-us/web/api/htmlelement/dragleave_event/index.md
@@ -1,0 +1,140 @@
+---
+title: 'HTMLElement: dragleave event'
+slug: Web/API/HTMLElement/dragleave_event
+tags:
+  - API
+  - DOM
+  - HTMLElement
+  - DragEvent
+  - Event
+  - Reference
+  - Web
+  - drag and drop
+  - dragleave
+browser-compat: api.HTMLElement.dragleave_event
+---
+{{APIRef}}
+
+The `dragleave` event is fired when a dragged element or text selection leaves a valid drop target.
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Bubbles</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">Cancelable</th>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th scope="row">Default action</th>
+      <td>None.</td>
+    </tr>
+    <tr>
+      <th scope="row">Interface</th>
+      <td>{{domxref("DragEvent")}}</td>
+    </tr>
+    <tr>
+      <th scope="row">Event handler property</th>
+      <td>
+        {{domxref("GlobalEventHandlers/ondragleave", "ondragleave")}}
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Examples
+
+### Resetting drop zone styles on dragleave
+
+In this example, we have a draggable element inside a container. Try grabbing the element, dragging it over the other container, and then releasing it.
+
+We give the other container a purple background while the draggable element is over it, to signal that the draggable element could be dropped on to the container. We listen for the `dragleave` event to reset the container background when the draggable element is dragged off the container.
+
+Note though that in this partial example we haven't implemented dropping: for a complete example of drag and drop, see the page for the [`drag`](/en-US/docs/Web/API/HTMLElement/drag_event) event.
+
+#### HTML
+
+```html
+<div class="dropzone">
+  <div id="draggable" draggable="true">
+    This div is draggable
+  </div>
+</div>
+<div class="dropzone" id="droptarget"></div>
+```
+
+#### CSS
+
+```css
+body {
+  /* Prevent the user selecting text in the example */
+  user-select: none;
+}
+
+#draggable {
+  text-align: center;
+  background: white;
+}
+
+.dropzone {
+  width: 200px;
+  height: 20px;
+  background: blueviolet;
+  margin: 10px;
+  padding: 10px;
+}
+
+.dropzone.dragover {
+  background-color: purple;
+}
+```
+
+#### JavaScript
+
+```js
+const target = document.getElementById("droptarget");
+target.addEventListener("dragenter", event => {
+  // highlight potential drop target when the draggable element enters it
+  if (event.target.classList.contains("dropzone")) {
+    event.target.classList.add("dragover");
+  }
+});
+
+target.addEventListener("dragleave", event => {
+  // reset background of potential drop target when the draggable element leaves it
+  if (event.target.classList.contains("dropzone")) {
+    event.target.classList.remove("dragover");
+  }
+});
+```
+
+#### Result
+
+{{EmbedLiveSample('Resetting drop zone styles on dragleave')}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- Other drag and drop events:
+
+  - {{domxref("HTMLElement/drag_event", "drag")}}
+  - {{domxref("HTMLElement/dragstart_event", "dragstart")}}
+  - {{domxref("HTMLElement/dragend_event", "dragend")}}
+  - {{domxref("HTMLElement/dragover_event", "dragover")}}
+  - {{domxref("HTMLElement/dragenter_event", "dragenter")}}
+  - {{domxref("HTMLElement/drop_event", "drop")}}
+
+- This event on other targets:
+
+  - {{domxref("Window")}}: {{domxref("Window/dragleave_event", "dragleave")}} event
+  - {{domxref("Document")}}: {{domxref("Document/dragleave_event", "dragleave")}} event
+  - {{domxref("SVGElement")}}: {{domxref("SVGElement/dragleave_event", "dragleave")}} event

--- a/files/en-us/web/api/htmlelement/dragover_event/index.md
+++ b/files/en-us/web/api/htmlelement/dragover_event/index.md
@@ -1,0 +1,150 @@
+---
+title: 'HTMLElement: dragover event'
+slug: Web/API/HTMLElement/dragover_event
+tags:
+  - API
+  - DOM
+  - HTMLElement
+  - DragEvent
+  - Event
+  - Reference
+  - Web
+  - drag and drop
+browser-compat: api.HTMLElement.dragover_event
+---
+{{APIRef}}
+
+The `dragover` event is fired when an element or text selection is being dragged over a valid drop target (every few hundred milliseconds).
+
+The event is fired on the drop target(s).
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Bubbles</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">Cancelable</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">Default action</th>
+      <td>Reset the current drag operation to "none".</td>
+    </tr>
+    <tr>
+      <th scope="row">Interface</th>
+      <td>{{domxref("DragEvent")}}</td>
+    </tr>
+    <tr>
+      <th scope="row">Event handler property</th>
+      <td>
+        {{domxref("GlobalEventHandlers/ondragover", "ondragover")}}
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Examples
+
+### A minimal drag and drop example
+
+In this example, we have a draggable element inside a container. Try grabbing the element, dragging it over the other container, and then releasing it.
+
+We use three event handlers here:
+
+- in the `dragstart` event handler, we get a reference to the element that the user dragged
+- in the `dragover` event handler for the target container, we call `event.preventDefault()`, which enables it to receive `drop` events.
+- in the `drop` event handler for the drop zone, we handle moving the draggable element from the original container to the drop zone.
+
+For a more complete example of drag and drop, see the page for the [`drag`](/en-US/docs/Web/API/HTMLElement/drag_event) event.
+
+#### HTML
+
+```html
+<div class="dropzone">
+  <div id="draggable" draggable="true">
+    This div is draggable
+  </div>
+</div>
+<div class="dropzone" id="droptarget"></div>
+```
+
+#### CSS
+
+```css
+body {
+  /* Prevent the user selecting text in the example */
+  user-select: none;
+}
+
+#draggable {
+  text-align: center;
+  background: white;
+}
+
+.dropzone {
+  width: 200px;
+  height: 20px;
+  background: blueviolet;
+  margin: 10px;
+  padding: 10px;
+}
+```
+
+#### JavaScript
+
+```js
+let dragged = null;
+
+const source = document.getElementById("draggable");
+source.addEventListener("dragstart", event => {
+  // store a ref. on the dragged elem
+  dragged = event.target;
+});
+
+const target = document.getElementById("droptarget");
+target.addEventListener("dragover", event => {
+  // prevent default to allow drop
+  event.preventDefault();
+});
+
+target.addEventListener("drop", event => {
+  // prevent default action (open as link for some elements)
+  event.preventDefault();
+  // move dragged element to the selected drop target
+  if (event.target.className == "dropzone") {
+    dragged.parentNode.removeChild(dragged);
+    event.target.appendChild(dragged);
+  }
+});
+```
+
+#### Result
+
+{{EmbedLiveSample('A minimal drag and drop example')}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- Other drag and drop events:
+
+  - {{domxref("HTMLElement/drag_event", "drag")}}
+  - {{domxref("HTMLElement/dragstart_event", "dragstart")}}
+  - {{domxref("HTMLElement/dragend_event", "dragend")}}
+  - {{domxref("HTMLElement/dragenter_event", "dragenter")}}
+  - {{domxref("HTMLElement/dragleave_event", "dragleave")}}
+  - {{domxref("HTMLElement/drop_event", "drop")}}
+
+- This event on other targets:
+
+  - {{domxref("Window")}}: {{domxref("Window/dragover_event", "dragover")}} event
+  - {{domxref("Document")}}: {{domxref("Document/dragover_event", "dragover")}} event
+  - {{domxref("SVGElement")}}: {{domxref("SVGElement/dragover_event", "dragover")}} event

--- a/files/en-us/web/api/htmlelement/dragstart_event/index.md
+++ b/files/en-us/web/api/htmlelement/dragstart_event/index.md
@@ -1,0 +1,130 @@
+---
+title: 'HTMLElement: dragstart event'
+slug: Web/API/HTMLElement/dragstart_event
+tags:
+  - DOM
+  - Event
+  - Reference
+  - drag and drop
+browser-compat: api.HTMLElement.dragstart_event
+---
+{{APIRef}}
+
+The `dragstart` event is fired when the user starts dragging an element or text selection.
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Bubbles</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">Cancelable</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">Default action</th>
+      <td>Initiate the drag-and-drop operation.</td>
+    </tr>
+    <tr>
+      <th scope="row">Interface</th>
+      <td>{{domxref("DragEvent")}}</td>
+    </tr>
+    <tr>
+      <th scope="row">Event handler property</th>
+      <td>
+        {{domxref("GlobalEventHandlers/ondragstart", "ondragstart")}}
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Examples
+
+### Setting opacity on drag start
+
+In this example, we have a draggable element inside a container. Try grabbing the element, dragging it, and then releasing it.
+
+We listen for the `dragstart` event to make the element half transparent while it is being dragged.
+
+For a more complete example of drag and drop, see the page for the [`drag`](/en-US/docs/Web/API/HTMLElement/drag_event) event.
+
+#### HTML
+
+```html
+<div id="container">
+  <div id="draggable" draggable="true">
+    This div is draggable
+  </div>
+</div>
+<div class="dropzone"></div>
+```
+
+#### CSS
+
+```css
+body {
+  /* Prevent the user selecting text in the example */
+  user-select: none;
+}
+
+#draggable {
+  text-align: center;
+  background: white;
+}
+
+#container {
+  width: 200px;
+  height: 20px;
+  background: blueviolet;
+  padding: 10px;
+}
+
+.dragging {
+  opacity: .5;
+}
+```
+
+#### JavaScript
+
+```js
+const source = document.getElementById("draggable");
+source.addEventListener("dragstart", event => {
+  // make it half transparent
+  event.target.classList.add("dragging");
+});
+
+source.addEventListener("dragend", event => {
+  // reset the transparency
+  event.target.classList.remove("dragging");
+});
+```
+
+#### Result
+
+{{EmbedLiveSample('Setting opacity on drag start')}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- Other drag and drop events:
+
+  - {{domxref("HTMLElement/drag_event", "drag")}}
+  - {{domxref("HTMLElement/dragend_event", "dragend")}}
+  - {{domxref("HTMLElement/dragover_event", "dragover")}}
+  - {{domxref("HTMLElement/dragenter_event", "dragenter")}}
+  - {{domxref("HTMLElement/dragleave_event", "dragleave")}}
+  - {{domxref("HTMLElement/drop_event", "drop")}}
+
+- This event on other targets:
+
+  - {{domxref("Window")}}: {{domxref("Window/dragstart_event", "dragstart")}} event
+  - {{domxref("Document")}}: {{domxref("Document/dragstart_event", "dragstart")}} event
+  - {{domxref("SVGElement")}}: {{domxref("SVGElement/dragstart_event", "dragstart")}} event

--- a/files/en-us/web/api/htmlelement/drop_event/index.md
+++ b/files/en-us/web/api/htmlelement/drop_event/index.md
@@ -1,0 +1,147 @@
+---
+title: 'HTMLElement: drop event'
+slug: Web/API/HTMLElement/drop_event
+tags:
+  - DOM
+  - Drag Event
+  - Drop
+  - Event
+  - HTML 5
+  - Reference
+  - drag and drop
+browser-compat: api.HTMLElement.drop_event
+---
+{{APIRef}}
+
+The **`drop`** event is fired when an element or text selection is dropped on a valid drop target.
+
+<table class="properties">
+  <tbody>
+    <tr>
+      <th scope="row">Bubbles</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">Cancelable</th>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th scope="row">Default action</th>
+      <td>Varies</td>
+    </tr>
+    <tr>
+      <th scope="row">Interface</th>
+      <td>{{domxref("DragEvent")}}</td>
+    </tr>
+    <tr>
+      <th scope="row">Event handler property</th>
+      <td>
+        {{domxref("GlobalEventHandlers/ondrop", "ondrop")}}
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+## Examples
+
+### A minimal drag and drop example
+
+In this example, we have a draggable element inside a container. Try grabbing the element, dragging it over the other container, and then releasing it.
+
+We use three event handlers here:
+
+- in the `dragstart` event handler, we get a reference to the element that the user dragged
+- in the `dragover` event handler for the target container, we call `event.preventDefault()`, which enables it to receive `drop` events.
+- in the `drop` event handler for the drop zone, we handle moving the draggable element from the original container to the drop zone.
+
+For a more complete example of drag and drop, see the page for the [`drag`](/en-US/docs/Web/API/HTMLElement/drag_event) event.
+
+#### HTML
+
+```html
+<div class="dropzone">
+  <div id="draggable" draggable="true">
+    This div is draggable
+  </div>
+</div>
+<div class="dropzone" id="droptarget"></div>
+```
+
+#### CSS
+
+```css
+body {
+  /* Prevent the user selecting text in the example */
+  user-select: none;
+}
+
+#draggable {
+  text-align: center;
+  background: white;
+}
+
+.dropzone {
+  width: 200px;
+  height: 20px;
+  background: blueviolet;
+  margin: 10px;
+  padding: 10px;
+}
+```
+
+#### JavaScript
+
+```js
+let dragged = null;
+
+const source = document.getElementById("draggable");
+source.addEventListener("dragstart", event => {
+  // store a ref. on the dragged elem
+  dragged = event.target;
+});
+
+const target = document.getElementById("droptarget");
+target.addEventListener("dragover", event => {
+  // prevent default to allow drop
+  event.preventDefault();
+});
+
+target.addEventListener("drop", event => {
+  // prevent default action (open as link for some elements)
+  event.preventDefault();
+  // move dragged element to the selected drop target
+  if (event.target.className == "dropzone") {
+    dragged.parentNode.removeChild(dragged);
+    event.target.appendChild(dragged);
+  }
+});
+```
+
+#### Result
+
+{{EmbedLiveSample('A minimal drag and drop example')}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- Other drag and drop events:
+
+  - {{domxref("HTMLElement/drag_event", "drag")}}
+  - {{domxref("HTMLElement/dragstart_event", "dragstart")}}
+  - {{domxref("HTMLElement/dragend_event", "dragend")}}
+  - {{domxref("HTMLElement/dragover_event", "dragover")}}
+  - {{domxref("HTMLElement/dragenter_event", "dragenter")}}
+  - {{domxref("HTMLElement/dragleave_event", "dragleave")}}
+
+- This event on other targets:
+
+  - {{domxref("Window")}}: {{domxref("Window/drop_event", "drop")}} event
+  - {{domxref("Document")}}: {{domxref("Document/drop_event", "drop")}} event
+  - {{domxref("SVGElement")}}: {{domxref("SVGElement/drop_event", "drop")}} event

--- a/files/en-us/web/api/mouseevent/relatedtarget/index.md
+++ b/files/en-us/web/api/mouseevent/relatedtarget/index.md
@@ -63,7 +63,7 @@ That is:
       </td>
     </tr>
     <tr>
-      <td>{{Event("dragenter")}}</td>
+      <td>{{domxref("HTMLElement/dragenter_event", "dragenter")}}</td>
       <td>
         The {{domxref("EventTarget")}} the pointing device entered to
       </td>
@@ -72,7 +72,7 @@ That is:
       </td>
     </tr>
     <tr>
-      <td>{{Event("dragleave")}}</td>
+      <td>{{domxref("HTMLElement/dragleave_event", "dragleave")}}</td>
       <td>
         The {{domxref("EventTarget")}} the pointing device exited from
       </td>

--- a/files/en-us/web/api/performanceeventtiming/index.md
+++ b/files/en-us/web/api/performanceeventtiming/index.md
@@ -21,12 +21,12 @@ The `PerformanceEventTiming` interface of the Event Timing API provides timing i
 - {{event("compositionupdate")}}
 - {{event("contextmenu")}}
 - {{event("dblclick")}}
-- {{event("dragend")}}
-- {{event("dragenter")}}
-- {{event("dragleave")}}
-- {{event("dragover")}}
-- {{event("dragstart")}}
-- {{event("drop")}}
+- {{domxref("HTMLElement/dragend_event", "dragend")}}
+- {{domxref("HTMLElement/dragenter_event", "dragenter")}}
+- {{domxref("HTMLElement/dragleave_event", "dragleave")}}
+- {{domxref("HTMLElement/dragover_event", "dragover")}}
+- {{domxref("HTMLElement/dragstart_event", "dragstart")}}
+- {{domxref("HTMLElement/drop_event", "drop")}}
 - {{event("input")}}
 - {{event("keydown")}}
 - {{event("keypress")}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Replace {{event}} to {{domxref}} for the drag and drop events.
- Create `HTMLElement/*_event` for `DragEvent`s because most of these events are sent to elements.
- Replace macros

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
