### PR TITLE
fix: replaces cell bgcolor by emojis

### DIFF
--- a/files/en-us/learn/forms/property_compatibility_table_for_form_controls/index.md
+++ b/files/en-us/learn/forms/property_compatibility_table_for_form_controls/index.md
@@ -21,11 +21,11 @@ The following compatibility tables try to summarize the state of CSS support for
 
 For each property, there are four possible values:
 
-- Yes
+- ✅ Yes
   - : There's reasonably consistent support for the property across browsers. You may still face strange side effects in certain edge cases.
-- Partial
+- ⚠️ Partial
   - : While the property works, you may frequently face strange side effects or inconsistencies. You should probably avoid these properties unless you master those side effects first.
-- No
+- ❌ No
   - : The property doesn't work or is so inconsistent that it's not reliable.
 - n.a.
   - : The property has no meaning for this type of widget.
@@ -89,22 +89,11 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
         {{cssxref("width")}}
       </th>
       <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+        style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -112,23 +101,11 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
       <th scope="row" style="vertical-align: top">
         {{cssxref("height")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1][2]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1][2]</sup>
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td>
         <ol>
@@ -149,23 +126,11 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
       <th scope="row" style="vertical-align: top">
         {{cssxref("border")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1][2]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1][2]</sup>
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td>
         <ol>
@@ -186,23 +151,11 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
       <th scope="row" style="vertical-align: top">
         {{cssxref("margin")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -210,23 +163,11 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
       <th scope="row" style="vertical-align: top">
         {{cssxref("padding")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1][2]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1][2]</sup>
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td>
         <ol>
@@ -252,23 +193,11 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("color")}}<sup>[1]</sup>
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td>
         <ol>
@@ -285,23 +214,11 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("font")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td>See the note about {{cssxref("line-height")}}</td>
     </tr>
@@ -309,23 +226,11 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("letter-spacing")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -333,23 +238,11 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-align")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -357,23 +250,11 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-decoration")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial
       </td>
       <td>See the note about Opera</td>
     </tr>
@@ -381,23 +262,11 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-indent")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -413,23 +282,11 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-overflow")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial
       </td>
       <td></td>
     </tr>
@@ -437,23 +294,11 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-shadow")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial
       </td>
       <td></td>
     </tr>
@@ -461,23 +306,11 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-transform")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -490,23 +323,11 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("background")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td>
         <ol>
@@ -524,23 +345,11 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("border-radius")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1][2]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1][2]</sup>
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td>
         <ol>
@@ -562,23 +371,11 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("box-shadow")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -610,23 +407,11 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
       <th scope="row" style="vertical-align: top">
         {{cssxref("width")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -634,23 +419,11 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
       <th scope="row" style="vertical-align: top">
         {{cssxref("height")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td>
         <ol>
@@ -665,23 +438,11 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
       <th scope="row" style="vertical-align: top">
         {{cssxref("border")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -689,23 +450,11 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
       <th scope="row" style="vertical-align: top">
         {{cssxref("margin")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -713,23 +462,11 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
       <th scope="row" style="vertical-align: top">
         {{cssxref("padding")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td>
         <ol>
@@ -749,23 +486,11 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("color")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -773,23 +498,11 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("font")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td>See the note about {{cssxref("line-height")}}.</td>
     </tr>
@@ -797,23 +510,11 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("letter-spacing")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -821,23 +522,11 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-align")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -845,23 +534,11 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-decoration")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -869,23 +546,11 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-indent")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -893,23 +558,11 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-overflow")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -917,23 +570,11 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-shadow")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial
       </td>
       <td></td>
     </tr>
@@ -941,23 +582,11 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-transform")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -970,23 +599,11 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("background")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -994,23 +611,11 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("border-radius")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes<sup>[1]</sup>
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -1025,23 +630,11 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("box-shadow")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -1073,23 +666,11 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
       <th scope="row" style="vertical-align: top">
         {{cssxref("width")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -1097,23 +678,11 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
       <th scope="row" style="vertical-align: top">
         {{cssxref("height")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -1128,23 +697,11 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
       <th scope="row" style="vertical-align: top">
         {{cssxref("border")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -1152,23 +709,11 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
       <th scope="row" style="vertical-align: top">
         {{cssxref("margin")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -1176,23 +721,11 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
       <th scope="row" style="vertical-align: top">
         {{cssxref("padding")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -1212,23 +745,11 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("color")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -1236,23 +757,11 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("font")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td>See the note about {{cssxref("line-height")}}.</td>
     </tr>
@@ -1260,23 +769,11 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("letter-spacing")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -1284,23 +781,11 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-align")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -1308,23 +793,11 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-decoration")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial
       </td>
       <td></td>
     </tr>
@@ -1332,23 +805,11 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-indent")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -1356,23 +817,11 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-overflow")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -1380,23 +829,11 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-shadow")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial
       </td>
       <td></td>
     </tr>
@@ -1417,23 +854,11 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("background")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td rowspan="3">
         <p>
@@ -1446,46 +871,22 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("border-radius")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
     </tr>
     <tr>
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("box-shadow")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
     </tr>
   </tbody>
@@ -1512,23 +913,11 @@ See the `{{htmlelement("input/checkbox", "checkbox")}}` and `{{htmlelement("inpu
       <th scope="row" style="vertical-align: top">
         {{cssxref("width")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -1542,23 +931,11 @@ See the `{{htmlelement("input/checkbox", "checkbox")}}` and `{{htmlelement("inpu
       <th scope="row" style="vertical-align: top">
         {{cssxref("height")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -1572,23 +949,11 @@ See the `{{htmlelement("input/checkbox", "checkbox")}}` and `{{htmlelement("inpu
       <th scope="row" style="vertical-align: top">
         {{cssxref("border")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -1596,23 +961,11 @@ See the `{{htmlelement("input/checkbox", "checkbox")}}` and `{{htmlelement("inpu
       <th scope="row" style="vertical-align: top">
         {{cssxref("margin")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -1621,22 +974,11 @@ See the `{{htmlelement("input/checkbox", "checkbox")}}` and `{{htmlelement("inpu
         {{cssxref("padding")}}
       </th>
       <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+       style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -1726,23 +1068,11 @@ See the `{{htmlelement("input/checkbox", "checkbox")}}` and `{{htmlelement("inpu
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("background")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -1750,23 +1080,11 @@ See the `{{htmlelement("input/checkbox", "checkbox")}}` and `{{htmlelement("inpu
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("border-radius")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -1774,23 +1092,11 @@ See the `{{htmlelement("input/checkbox", "checkbox")}}` and `{{htmlelement("inpu
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("box-shadow")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -1818,23 +1124,11 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
       <th scope="row" style="vertical-align: top">
         {{cssxref("width")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -1851,23 +1145,11 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
       <th scope="row" style="vertical-align: top">
         {{cssxref("height")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -1875,23 +1157,11 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
       <th scope="row" style="vertical-align: top">
         {{cssxref("border")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -1899,23 +1169,11 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
       <th scope="row" style="vertical-align: top">
         {{cssxref("margin")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -1923,23 +1181,11 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
       <th scope="row" style="vertical-align: top">
         {{cssxref("padding")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[2]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[2]</sup>
       </td>
       <td>
         <ol>
@@ -1966,23 +1212,11 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("color")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -1999,23 +1233,11 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("font")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -2032,23 +1254,11 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("letter-spacing")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -2068,23 +1278,11 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-align")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -2099,23 +1297,11 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-decoration")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -2131,23 +1317,11 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-indent")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1][2]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1][2]</sup>
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1][2]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1][2]</sup>
       </td>
       <td>
         <ol>
@@ -2163,23 +1337,11 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-overflow")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -2187,23 +1349,11 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-shadow")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1][2]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1][2]</sup>
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1][2]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1][2]</sup>
       </td>
       <td>
         <ol>
@@ -2219,23 +1369,11 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-transform")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -2255,23 +1393,11 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("background")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td rowspan="3">
         <ol>
@@ -2286,46 +1412,22 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("border-radius")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
     </tr>
     <tr>
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("box-shadow")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
     </tr>
   </tbody>
@@ -2354,23 +1456,11 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
       <th scope="row" style="vertical-align: top">
         {{cssxref("width")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -2378,23 +1468,11 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
       <th scope="row" style="vertical-align: top">
         {{cssxref("height")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -2402,23 +1480,11 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
       <th scope="row" style="vertical-align: top">
         {{cssxref("border")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -2426,23 +1492,11 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
       <th scope="row" style="vertical-align: top">
         {{cssxref("margin")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -2450,23 +1504,11 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
       <th scope="row" style="vertical-align: top">
         {{cssxref("padding")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -2487,23 +1529,11 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("color")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -2511,23 +1541,11 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("font")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td>See the note about {{cssxref("line-height")}}.</td>
     </tr>
@@ -2535,23 +1553,11 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("letter-spacing")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -2571,23 +1577,11 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-align")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -2602,23 +1596,11 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-decoration")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -2630,23 +1612,11 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-indent")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -2654,23 +1624,11 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-overflow")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -2678,23 +1636,11 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-shadow")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -2702,23 +1648,11 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-transform")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -2738,23 +1672,11 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("background")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -2762,23 +1684,11 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("border-radius")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes<sup>[1]</sup>
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -2793,23 +1703,11 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("box-shadow")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -2841,23 +1739,11 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
       <th scope="row" style="vertical-align: top">
         {{cssxref("width")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -2865,23 +1751,11 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
       <th scope="row" style="vertical-align: top">
         {{cssxref("height")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -2889,23 +1763,11 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
       <th scope="row" style="vertical-align: top">
         {{cssxref("border")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -2913,23 +1775,11 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
       <th scope="row" style="vertical-align: top">
         {{cssxref("margin")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -2937,23 +1787,11 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
       <th scope="row" style="vertical-align: top">
         {{cssxref("padding")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -2966,23 +1804,11 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("color")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -2990,23 +1816,11 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("font")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3014,23 +1828,11 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("letter-spacing")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3038,23 +1840,11 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-align")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3062,23 +1852,11 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-decoration")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3086,23 +1864,11 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-indent")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3110,23 +1876,11 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-overflow")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3134,23 +1888,11 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-shadow")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3158,23 +1900,11 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-transform")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3187,23 +1917,11 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("background")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3211,23 +1929,11 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("border-radius")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3235,23 +1941,11 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("box-shadow")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3279,23 +1973,11 @@ See the `{{htmlelement("input/file", "file")}}` input type.
       <th scope="row" style="vertical-align: top">
         {{cssxref("width")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3303,23 +1985,11 @@ See the `{{htmlelement("input/file", "file")}}` input type.
       <th scope="row" style="vertical-align: top">
         {{cssxref("height")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3327,23 +1997,11 @@ See the `{{htmlelement("input/file", "file")}}` input type.
       <th scope="row" style="vertical-align: top">
         {{cssxref("border")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3351,23 +2009,11 @@ See the `{{htmlelement("input/file", "file")}}` input type.
       <th scope="row" style="vertical-align: top">
         {{cssxref("margin")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -3375,23 +2021,11 @@ See the `{{htmlelement("input/file", "file")}}` input type.
       <th scope="row" style="vertical-align: top">
         {{cssxref("padding")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3404,23 +2038,11 @@ See the `{{htmlelement("input/file", "file")}}` input type.
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("color")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -3428,23 +2050,11 @@ See the `{{htmlelement("input/file", "file")}}` input type.
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("font")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -3459,23 +2069,11 @@ See the `{{htmlelement("input/file", "file")}}` input type.
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("letter-spacing")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -3487,23 +2085,11 @@ See the `{{htmlelement("input/file", "file")}}` input type.
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-align")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3511,23 +2097,11 @@ See the `{{htmlelement("input/file", "file")}}` input type.
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-decoration")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3535,23 +2109,11 @@ See the `{{htmlelement("input/file", "file")}}` input type.
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-indent")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -3565,23 +2127,11 @@ See the `{{htmlelement("input/file", "file")}}` input type.
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-overflow")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3589,23 +2139,11 @@ See the `{{htmlelement("input/file", "file")}}` input type.
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-shadow")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3613,23 +2151,11 @@ See the `{{htmlelement("input/file", "file")}}` input type.
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-transform")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3642,23 +2168,11 @@ See the `{{htmlelement("input/file", "file")}}` input type.
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("background")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -3673,23 +2187,11 @@ See the `{{htmlelement("input/file", "file")}}` input type.
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("border-radius")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3697,23 +2199,11 @@ See the `{{htmlelement("input/file", "file")}}` input type.
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("box-shadow")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -3745,23 +2235,11 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
       <th scope="row" style="vertical-align: top">
         {{cssxref("width")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3769,23 +2247,11 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
       <th scope="row" style="vertical-align: top">
         {{cssxref("height")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3793,23 +2259,11 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
       <th scope="row" style="vertical-align: top">
         {{cssxref("border")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3817,23 +2271,11 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
       <th scope="row" style="vertical-align: top">
         {{cssxref("margin")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -3841,23 +2283,11 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
       <th scope="row" style="vertical-align: top">
         {{cssxref("padding")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3870,23 +2300,11 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("color")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3894,23 +2312,11 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("font")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3918,23 +2324,11 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("letter-spacing")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3942,23 +2336,11 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-align")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3966,23 +2348,11 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-decoration")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -3990,23 +2360,11 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-indent")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -4014,23 +2372,11 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-overflow")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -4038,23 +2384,11 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-shadow")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -4062,23 +2396,11 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("text-transform")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -4091,23 +2413,11 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("background")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -4115,23 +2425,11 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("border-radius")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -4139,23 +2437,11 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("box-shadow")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
       <td></td>
     </tr>
@@ -4183,23 +2469,11 @@ See the `{{htmlelement("input/color", "color")}}` input type:
       <th scope="row" style="vertical-align: top">
         {{cssxref("width")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -4207,23 +2481,11 @@ See the `{{htmlelement("input/color", "color")}}` input type:
       <th scope="row" style="vertical-align: top">
         {{cssxref("height")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td>
         <ol>
@@ -4237,23 +2499,11 @@ See the `{{htmlelement("input/color", "color")}}` input type:
       <th scope="row" style="vertical-align: top">
         {{cssxref("border")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -4261,23 +2511,11 @@ See the `{{htmlelement("input/color", "color")}}` input type:
       <th scope="row" style="vertical-align: top">
         {{cssxref("margin")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -4285,23 +2523,11 @@ See the `{{htmlelement("input/color", "color")}}` input type:
       <th scope="row" style="vertical-align: top">
         {{cssxref("padding")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td>
         <ol>
@@ -4397,23 +2623,11 @@ See the `{{htmlelement("input/color", "color")}}` input type:
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("background")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
       <td rowspan="3">
         <ol>
@@ -4428,46 +2642,22 @@ See the `{{htmlelement("input/color", "color")}}` input type:
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("border-radius")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
     </tr>
     <tr>
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("box-shadow")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
     </tr>
   </tbody>
@@ -4494,23 +2684,11 @@ See the `{{htmlelement("meter")}}` and `{{htmlelement("progress")}}` elements:
       <th scope="row" style="vertical-align: top">
         {{cssxref("width")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -4518,23 +2696,11 @@ See the `{{htmlelement("meter")}}` and `{{htmlelement("progress")}}` elements:
       <th scope="row" style="vertical-align: top">
         {{cssxref("height")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -4542,23 +2708,11 @@ See the `{{htmlelement("meter")}}` and `{{htmlelement("progress")}}` elements:
       <th scope="row" style="vertical-align: top">
         {{cssxref("border")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -4566,23 +2720,11 @@ See the `{{htmlelement("meter")}}` and `{{htmlelement("progress")}}` elements:
       <th scope="row" style="vertical-align: top">
         {{cssxref("margin")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -4590,23 +2732,11 @@ See the `{{htmlelement("meter")}}` and `{{htmlelement("progress")}}` elements:
       <th scope="row" style="vertical-align: top">
         {{cssxref("padding")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -4706,23 +2836,11 @@ See the `{{htmlelement("meter")}}` and `{{htmlelement("progress")}}` elements:
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("background")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
       <td rowspan="3">
         <ol>
@@ -4737,46 +2855,22 @@ See the `{{htmlelement("meter")}}` and `{{htmlelement("progress")}}` elements:
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("border-radius")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
     </tr>
     <tr>
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("box-shadow")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
     </tr>
   </tbody>
@@ -4803,23 +2897,11 @@ See the `{{htmlelement("input/range", "range")}}` input type. There is no standa
       <th scope="row" style="vertical-align: top">
         {{cssxref("width")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -4827,23 +2909,11 @@ See the `{{htmlelement("input/range", "range")}}` input type. There is no standa
       <th scope="row" style="vertical-align: top">
         {{cssxref("height")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -4858,23 +2928,11 @@ See the `{{htmlelement("input/range", "range")}}` input type. There is no standa
       <th scope="row" style="vertical-align: top">
         {{cssxref("border")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No
+      <td style="text-align: center; vertical-align: top">
+        ❌ No
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -4882,23 +2940,11 @@ See the `{{htmlelement("input/range", "range")}}` input type. There is no standa
       <th scope="row" style="vertical-align: top">
         {{cssxref("margin")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -4906,23 +2952,11 @@ See the `{{htmlelement("input/range", "range")}}` input type. There is no standa
       <th scope="row" style="vertical-align: top">
         {{cssxref("padding")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td>
         <ol>
@@ -5019,23 +3053,11 @@ See the `{{htmlelement("input/range", "range")}}` input type. There is no standa
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("background")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
       <td rowspan="3">
         <ol>
@@ -5050,46 +3072,22 @@ See the `{{htmlelement("input/range", "range")}}` input type. There is no standa
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("border-radius")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
     </tr>
     <tr>
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("box-shadow")}}
       </th>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
-      <td
-        class="bg-red"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        No<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ❌ No<sup>[1]</sup>
       </td>
     </tr>
   </tbody>
@@ -5116,23 +3114,11 @@ See the `{{htmlelement("input/image", "image")}}` input type:
       <th scope="row" style="vertical-align: top">
         {{cssxref("width")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -5140,23 +3126,11 @@ See the `{{htmlelement("input/image", "image")}}` input type:
       <th scope="row" style="vertical-align: top">
         {{cssxref("height")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -5164,23 +3138,11 @@ See the `{{htmlelement("input/image", "image")}}` input type:
       <th scope="row" style="vertical-align: top">
         {{cssxref("border")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -5188,23 +3150,11 @@ See the `{{htmlelement("input/image", "image")}}` input type:
       <th scope="row" style="vertical-align: top">
         {{cssxref("margin")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -5212,23 +3162,11 @@ See the `{{htmlelement("input/image", "image")}}` input type:
       <th scope="row" style="vertical-align: top">
         {{cssxref("padding")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -5318,23 +3256,11 @@ See the `{{htmlelement("input/image", "image")}}` input type:
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("background")}}
       </th>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
-      <td
-        class="bg-green"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Yes
+      <td style="text-align: center; vertical-align: top">
+        ✅ Yes
       </td>
       <td></td>
     </tr>
@@ -5342,23 +3268,11 @@ See the `{{htmlelement("input/image", "image")}}` input type:
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("border-radius")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td>
         <ol>
@@ -5370,23 +3284,11 @@ See the `{{htmlelement("input/image", "image")}}` input type:
       <th scope="row" style="white-space: nowrap; vertical-align: top">
         {{cssxref("box-shadow")}}
       </th>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
-      <td
-        class="bg-yellow"
-        style="
-          text-align: center;
-          vertical-align: top;
-        "
-      >
-        Partial<sup>[1]</sup>
+      <td style="text-align: center; vertical-align: top">
+        ⚠️ Partial<sup>[1]</sup>
       </td>
       <td>
         <ol>

--- a/files/en-us/learn/forms/property_compatibility_table_for_form_controls/index.md
+++ b/files/en-us/learn/forms/property_compatibility_table_for_form_controls/index.md
@@ -89,18 +89,18 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
         {{cssxref("width")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -113,18 +113,18 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
         {{cssxref("height")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1][2]</sup>
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -150,18 +150,18 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
         {{cssxref("border")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1][2]</sup>
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -187,18 +187,18 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
         {{cssxref("margin")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -211,18 +211,18 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
         {{cssxref("padding")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1][2]</sup>
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -253,18 +253,18 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
         {{cssxref("color")}}<sup>[1]</sup>
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -286,18 +286,18 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
         {{cssxref("font")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -310,18 +310,18 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
         {{cssxref("letter-spacing")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -334,18 +334,18 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
         {{cssxref("text-align")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -358,18 +358,18 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
         {{cssxref("text-decoration")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -382,18 +382,18 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
         {{cssxref("text-indent")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1]</sup>
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -414,18 +414,18 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
         {{cssxref("text-overflow")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -438,18 +438,18 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
         {{cssxref("text-shadow")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -462,18 +462,18 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
         {{cssxref("text-transform")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -491,18 +491,18 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
         {{cssxref("background")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1]</sup>
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -525,18 +525,18 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
         {{cssxref("border-radius")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1][2]</sup>
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -563,18 +563,18 @@ See the `{{htmlelement("input/text", "text")}}`, `{{htmlelement("input/search", 
         {{cssxref("box-shadow")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -611,18 +611,18 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
         {{cssxref("width")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -635,18 +635,18 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
         {{cssxref("height")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1]</sup>
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -666,18 +666,18 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
         {{cssxref("border")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -690,18 +690,18 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
         {{cssxref("margin")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -714,18 +714,18 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
         {{cssxref("padding")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1]</sup>
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -750,18 +750,18 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
         {{cssxref("color")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -774,18 +774,18 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
         {{cssxref("font")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -798,18 +798,18 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
         {{cssxref("letter-spacing")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -822,18 +822,18 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
         {{cssxref("text-align")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -846,18 +846,18 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
         {{cssxref("text-decoration")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -870,18 +870,18 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
         {{cssxref("text-indent")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -894,18 +894,18 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
         {{cssxref("text-overflow")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -918,18 +918,18 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
         {{cssxref("text-shadow")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -942,18 +942,18 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
         {{cssxref("text-transform")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -971,18 +971,18 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
         {{cssxref("background")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -995,18 +995,18 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
         {{cssxref("border-radius")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes<sup>[1]</sup>
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -1026,18 +1026,18 @@ See the `{{htmlelement("input/button", "button")}}`,  `{{htmlelement("input/subm
         {{cssxref("box-shadow")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -1074,18 +1074,18 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
         {{cssxref("width")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -1098,18 +1098,18 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
         {{cssxref("height")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1]</sup>
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -1129,18 +1129,18 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
         {{cssxref("border")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -1153,18 +1153,18 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
         {{cssxref("margin")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -1177,18 +1177,18 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
         {{cssxref("padding")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1]</sup>
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -1213,18 +1213,18 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
         {{cssxref("color")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -1237,18 +1237,18 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
         {{cssxref("font")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -1261,18 +1261,18 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
         {{cssxref("letter-spacing")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -1285,18 +1285,18 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
         {{cssxref("text-align")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -1309,18 +1309,18 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
         {{cssxref("text-decoration")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -1333,18 +1333,18 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
         {{cssxref("text-indent")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -1357,18 +1357,18 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
         {{cssxref("text-overflow")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -1381,18 +1381,18 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
         {{cssxref("text-shadow")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -1418,18 +1418,18 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
         {{cssxref("background")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -1447,18 +1447,18 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
         {{cssxref("border-radius")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -1470,18 +1470,18 @@ See the  `{{htmlelement("input/number", "number")}}` input type. There is no sta
         {{cssxref("box-shadow")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -1513,18 +1513,18 @@ See the `{{htmlelement("input/checkbox", "checkbox")}}` and `{{htmlelement("inpu
         {{cssxref("width")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No<sup>[1]</sup>
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -1543,18 +1543,18 @@ See the `{{htmlelement("input/checkbox", "checkbox")}}` and `{{htmlelement("inpu
         {{cssxref("height")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No<sup>[1]</sup>
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -1573,18 +1573,18 @@ See the `{{htmlelement("input/checkbox", "checkbox")}}` and `{{htmlelement("inpu
         {{cssxref("border")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -1597,18 +1597,18 @@ See the `{{htmlelement("input/checkbox", "checkbox")}}` and `{{htmlelement("inpu
         {{cssxref("margin")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -1621,18 +1621,18 @@ See the `{{htmlelement("input/checkbox", "checkbox")}}` and `{{htmlelement("inpu
         {{cssxref("padding")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -1727,18 +1727,18 @@ See the `{{htmlelement("input/checkbox", "checkbox")}}` and `{{htmlelement("inpu
         {{cssxref("background")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -1751,18 +1751,18 @@ See the `{{htmlelement("input/checkbox", "checkbox")}}` and `{{htmlelement("inpu
         {{cssxref("border-radius")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -1775,18 +1775,18 @@ See the `{{htmlelement("input/checkbox", "checkbox")}}` and `{{htmlelement("inpu
         {{cssxref("box-shadow")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -1819,18 +1819,18 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
         {{cssxref("width")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1]</sup>
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -1852,18 +1852,18 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
         {{cssxref("height")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -1876,18 +1876,18 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
         {{cssxref("border")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -1900,18 +1900,18 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
         {{cssxref("margin")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -1924,18 +1924,18 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
         {{cssxref("padding")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No<sup>[1]</sup>
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -1967,18 +1967,18 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
         {{cssxref("color")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1]</sup>
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -2000,18 +2000,18 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
         {{cssxref("font")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1]</sup>
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -2033,18 +2033,18 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
         {{cssxref("letter-spacing")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1]</sup>
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -2069,18 +2069,18 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
         {{cssxref("text-align")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No<sup>[1]</sup>
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -2100,18 +2100,18 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
         {{cssxref("text-decoration")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1]</sup>
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -2132,18 +2132,18 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
         {{cssxref("text-indent")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1][2]</sup>
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -2164,18 +2164,18 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
         {{cssxref("text-overflow")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -2188,18 +2188,18 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
         {{cssxref("text-shadow")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1][2]</sup>
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -2220,18 +2220,18 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
         {{cssxref("text-transform")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1]</sup>
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -2256,18 +2256,18 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
         {{cssxref("background")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1]</sup>
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -2287,18 +2287,18 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
         {{cssxref("border-radius")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1]</sup>
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -2310,18 +2310,18 @@ See the `{{htmlelement("select")}}`,  `{{htmlelement("optgroup")}}` and  `{{html
         {{cssxref("box-shadow")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -2355,18 +2355,18 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
         {{cssxref("width")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -2379,18 +2379,18 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
         {{cssxref("height")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -2403,18 +2403,18 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
         {{cssxref("border")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -2427,18 +2427,18 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
         {{cssxref("margin")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -2451,18 +2451,18 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
         {{cssxref("padding")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1]</sup>
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -2488,18 +2488,18 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
         {{cssxref("color")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -2512,18 +2512,18 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
         {{cssxref("font")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -2536,18 +2536,18 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
         {{cssxref("letter-spacing")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1]</sup>
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -2572,18 +2572,18 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
         {{cssxref("text-align")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No<sup>[1]</sup>
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -2603,18 +2603,18 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
         {{cssxref("text-decoration")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No<sup>[1]</sup>
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -2631,18 +2631,18 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
         {{cssxref("text-indent")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -2655,18 +2655,18 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
         {{cssxref("text-overflow")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -2679,18 +2679,18 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
         {{cssxref("text-shadow")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -2703,18 +2703,18 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
         {{cssxref("text-transform")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1]</sup>
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -2739,18 +2739,18 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
         {{cssxref("background")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -2763,18 +2763,18 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
         {{cssxref("border-radius")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes<sup>[1]</sup>
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -2794,18 +2794,18 @@ See the `{{htmlelement("select")}}`, `{{htmlelement("optgroup")}}` and  `{{htmle
         {{cssxref("box-shadow")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -2842,18 +2842,18 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
         {{cssxref("width")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -2866,18 +2866,18 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
         {{cssxref("height")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -2890,18 +2890,18 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
         {{cssxref("border")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -2914,18 +2914,18 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
         {{cssxref("margin")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -2938,18 +2938,18 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
         {{cssxref("padding")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -2967,18 +2967,18 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
         {{cssxref("color")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -2991,18 +2991,18 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
         {{cssxref("font")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3015,18 +3015,18 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
         {{cssxref("letter-spacing")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3039,18 +3039,18 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
         {{cssxref("text-align")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3063,18 +3063,18 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
         {{cssxref("text-decoration")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3087,18 +3087,18 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
         {{cssxref("text-indent")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3111,18 +3111,18 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
         {{cssxref("text-overflow")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3135,18 +3135,18 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
         {{cssxref("text-shadow")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3159,18 +3159,18 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
         {{cssxref("text-transform")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3188,18 +3188,18 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
         {{cssxref("background")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3212,18 +3212,18 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
         {{cssxref("border-radius")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3236,18 +3236,18 @@ See the `{{htmlelement("datalist")}}` and `{{htmlelement("input")}}` elements an
         {{cssxref("box-shadow")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3280,18 +3280,18 @@ See the `{{htmlelement("input/file", "file")}}` input type.
         {{cssxref("width")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3304,18 +3304,18 @@ See the `{{htmlelement("input/file", "file")}}` input type.
         {{cssxref("height")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3328,18 +3328,18 @@ See the `{{htmlelement("input/file", "file")}}` input type.
         {{cssxref("border")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3352,18 +3352,18 @@ See the `{{htmlelement("input/file", "file")}}` input type.
         {{cssxref("margin")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -3376,18 +3376,18 @@ See the `{{htmlelement("input/file", "file")}}` input type.
         {{cssxref("padding")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3405,18 +3405,18 @@ See the `{{htmlelement("input/file", "file")}}` input type.
         {{cssxref("color")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -3429,18 +3429,18 @@ See the `{{htmlelement("input/file", "file")}}` input type.
         {{cssxref("font")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No<sup>[1]</sup>
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3460,18 +3460,18 @@ See the `{{htmlelement("input/file", "file")}}` input type.
         {{cssxref("letter-spacing")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1]</sup>
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -3488,18 +3488,18 @@ See the `{{htmlelement("input/file", "file")}}` input type.
         {{cssxref("text-align")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3512,18 +3512,18 @@ See the `{{htmlelement("input/file", "file")}}` input type.
         {{cssxref("text-decoration")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3536,18 +3536,18 @@ See the `{{htmlelement("input/file", "file")}}` input type.
         {{cssxref("text-indent")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1]</sup>
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -3566,18 +3566,18 @@ See the `{{htmlelement("input/file", "file")}}` input type.
         {{cssxref("text-overflow")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3590,18 +3590,18 @@ See the `{{htmlelement("input/file", "file")}}` input type.
         {{cssxref("text-shadow")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3614,18 +3614,18 @@ See the `{{htmlelement("input/file", "file")}}` input type.
         {{cssxref("text-transform")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3643,18 +3643,18 @@ See the `{{htmlelement("input/file", "file")}}` input type.
         {{cssxref("background")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No<sup>[1]</sup>
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3674,18 +3674,18 @@ See the `{{htmlelement("input/file", "file")}}` input type.
         {{cssxref("border-radius")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3698,18 +3698,18 @@ See the `{{htmlelement("input/file", "file")}}` input type.
         {{cssxref("box-shadow")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -3746,18 +3746,18 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
         {{cssxref("width")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3770,18 +3770,18 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
         {{cssxref("height")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3794,18 +3794,18 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
         {{cssxref("border")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3818,18 +3818,18 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
         {{cssxref("margin")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -3842,18 +3842,18 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
         {{cssxref("padding")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3871,18 +3871,18 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
         {{cssxref("color")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3895,18 +3895,18 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
         {{cssxref("font")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3919,18 +3919,18 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
         {{cssxref("letter-spacing")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3943,18 +3943,18 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
         {{cssxref("text-align")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3967,18 +3967,18 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
         {{cssxref("text-decoration")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -3991,18 +3991,18 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
         {{cssxref("text-indent")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -4015,18 +4015,18 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
         {{cssxref("text-overflow")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -4039,18 +4039,18 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
         {{cssxref("text-shadow")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -4063,18 +4063,18 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
         {{cssxref("text-transform")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -4092,18 +4092,18 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
         {{cssxref("background")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -4116,18 +4116,18 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
         {{cssxref("border-radius")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -4140,18 +4140,18 @@ See the `{{htmlelement("input/date", "date")}}` and `{{htmlelement("input/time",
         {{cssxref("box-shadow")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -4184,18 +4184,18 @@ See the `{{htmlelement("input/color", "color")}}` input type:
         {{cssxref("width")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -4208,18 +4208,18 @@ See the `{{htmlelement("input/color", "color")}}` input type:
         {{cssxref("height")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No<sup>[1]</sup>
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -4238,18 +4238,18 @@ See the `{{htmlelement("input/color", "color")}}` input type:
         {{cssxref("border")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -4262,18 +4262,18 @@ See the `{{htmlelement("input/color", "color")}}` input type:
         {{cssxref("margin")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -4286,18 +4286,18 @@ See the `{{htmlelement("input/color", "color")}}` input type:
         {{cssxref("padding")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No<sup>[1]</sup>
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -4398,18 +4398,18 @@ See the `{{htmlelement("input/color", "color")}}` input type:
         {{cssxref("background")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No<sup>[1]</sup>
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -4429,18 +4429,18 @@ See the `{{htmlelement("input/color", "color")}}` input type:
         {{cssxref("border-radius")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No<sup>[1]</sup>
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -4452,18 +4452,18 @@ See the `{{htmlelement("input/color", "color")}}` input type:
         {{cssxref("box-shadow")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No<sup>[1]</sup>
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -4495,18 +4495,18 @@ See the `{{htmlelement("meter")}}` and `{{htmlelement("progress")}}` elements:
         {{cssxref("width")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -4519,18 +4519,18 @@ See the `{{htmlelement("meter")}}` and `{{htmlelement("progress")}}` elements:
         {{cssxref("height")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -4543,18 +4543,18 @@ See the `{{htmlelement("meter")}}` and `{{htmlelement("progress")}}` elements:
         {{cssxref("border")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -4567,18 +4567,18 @@ See the `{{htmlelement("meter")}}` and `{{htmlelement("progress")}}` elements:
         {{cssxref("margin")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -4591,18 +4591,18 @@ See the `{{htmlelement("meter")}}` and `{{htmlelement("progress")}}` elements:
         {{cssxref("padding")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -4707,18 +4707,18 @@ See the `{{htmlelement("meter")}}` and `{{htmlelement("progress")}}` elements:
         {{cssxref("background")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No<sup>[1]</sup>
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -4738,18 +4738,18 @@ See the `{{htmlelement("meter")}}` and `{{htmlelement("progress")}}` elements:
         {{cssxref("border-radius")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No<sup>[1]</sup>
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -4761,18 +4761,18 @@ See the `{{htmlelement("meter")}}` and `{{htmlelement("progress")}}` elements:
         {{cssxref("box-shadow")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No<sup>[1]</sup>
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -4804,18 +4804,18 @@ See the `{{htmlelement("input/range", "range")}}` input type. There is no standa
         {{cssxref("width")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -4828,18 +4828,18 @@ See the `{{htmlelement("input/range", "range")}}` input type. There is no standa
         {{cssxref("height")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1]</sup>
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -4859,18 +4859,18 @@ See the `{{htmlelement("input/range", "range")}}` input type. There is no standa
         {{cssxref("border")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -4883,18 +4883,18 @@ See the `{{htmlelement("input/range", "range")}}` input type. There is no standa
         {{cssxref("margin")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -4907,18 +4907,18 @@ See the `{{htmlelement("input/range", "range")}}` input type. There is no standa
         {{cssxref("padding")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1]</sup>
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -5020,18 +5020,18 @@ See the `{{htmlelement("input/range", "range")}}` input type. There is no standa
         {{cssxref("background")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No<sup>[1]</sup>
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -5051,18 +5051,18 @@ See the `{{htmlelement("input/range", "range")}}` input type. There is no standa
         {{cssxref("border-radius")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No<sup>[1]</sup>
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -5074,18 +5074,18 @@ See the `{{htmlelement("input/range", "range")}}` input type. There is no standa
         {{cssxref("box-shadow")}}
       </th>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
         No<sup>[1]</sup>
       </td>
       <td
+        class="bg-red"
         style="
           text-align: center;
-          background-color: rgb(255, 153, 153);
           vertical-align: top;
         "
       >
@@ -5117,18 +5117,18 @@ See the `{{htmlelement("input/image", "image")}}` input type:
         {{cssxref("width")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -5141,18 +5141,18 @@ See the `{{htmlelement("input/image", "image")}}` input type:
         {{cssxref("height")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -5165,18 +5165,18 @@ See the `{{htmlelement("input/image", "image")}}` input type:
         {{cssxref("border")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -5189,18 +5189,18 @@ See the `{{htmlelement("input/image", "image")}}` input type:
         {{cssxref("margin")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -5213,18 +5213,18 @@ See the `{{htmlelement("input/image", "image")}}` input type:
         {{cssxref("padding")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -5319,18 +5319,18 @@ See the `{{htmlelement("input/image", "image")}}` input type:
         {{cssxref("background")}}
       </th>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
         Yes
       </td>
       <td
+        class="bg-green"
         style="
           text-align: center;
-          background-color: rgb(204, 255, 102);
           vertical-align: top;
         "
       >
@@ -5343,18 +5343,18 @@ See the `{{htmlelement("input/image", "image")}}` input type:
         {{cssxref("border-radius")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1]</sup>
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
@@ -5371,18 +5371,18 @@ See the `{{htmlelement("input/image", "image")}}` input type:
         {{cssxref("box-shadow")}}
       </th>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >
         Partial<sup>[1]</sup>
       </td>
       <td
+        class="bg-yellow"
         style="
           text-align: center;
-          background-color: rgb(255, 255, 102);
           vertical-align: top;
         "
       >


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Updates the [_CSS property compatibility table for form controls_](https://developer.mozilla.org/en-US/docs/Learn/Forms/Property_compatibility_table_for_form_controls) page to use emojis instead of table cell background-color.

#### Motivation
The background colors in [this article](https://developer.mozilla.org/en-US/docs/Learn/Forms/Property_compatibility_table_for_form_controls#compatibility_tables) are not readable with the dark theme.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
Fixes https://github.com/mdn/content/issues/16785.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
