### PR TITLE
Remove csssyntax macro calls from pseudo-class pages

### DIFF
--- a/files/en-us/web/css/_colon_-moz-only-whitespace/index.md
+++ b/files/en-us/web/css/_colon_-moz-only-whitespace/index.md
@@ -20,7 +20,9 @@ The **`:-moz-only-whitespace`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US
 
 ## Syntax
 
-{{CSSSyntax}}
+```
+:-moz-only-whitespace
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_-moz-submit-invalid/index.md
+++ b/files/en-us/web/css/_colon_-moz-submit-invalid/index.md
@@ -19,7 +19,9 @@ By default, no style is applied. You can use this pseudo-class to customize the 
 
 ## Syntax
 
-{{csssyntax}}
+```
+:-moz-submit-invalid
+```
 
 ## Specifications
 

--- a/files/en-us/web/css/_colon_active/index.md
+++ b/files/en-us/web/css/_colon_active/index.md
@@ -29,7 +29,9 @@ Styles defined by the `:active` pseudo-class will be overridden by any subsequen
 
 ## Syntax
 
-{{csssyntax}}
+```
+:active
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_any-link/index.md
+++ b/files/en-us/web/css/_colon_any-link/index.md
@@ -26,7 +26,9 @@ The **`:any-link`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CS
 
 ## Syntax
 
-{{csssyntax}}
+```
+:any-link
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_autofill/index.md
+++ b/files/en-us/web/css/_colon_autofill/index.md
@@ -24,7 +24,7 @@ The **`:autofill`** CSS [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) match
 
 ## Syntax
 
-```css
+```
 :autofill
 ```
 

--- a/files/en-us/web/css/_colon_blank/index.md
+++ b/files/en-us/web/css/_colon_blank/index.md
@@ -23,7 +23,9 @@ The **`:blank`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/P
 
 ## Syntax
 
-{{CSSSyntax}}
+```
+:blank
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_checked/index.md
+++ b/files/en-us/web/css/_colon_checked/index.md
@@ -34,7 +34,9 @@ The user can engage this state by checking/selecting an element, or disengage it
 
 ## Syntax
 
-{{csssyntax}}
+```
+:checked
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_default/index.md
+++ b/files/en-us/web/css/_colon_default/index.md
@@ -25,7 +25,9 @@ What this selector matches is defined in [HTML Standard §4.16.3 Pseudo-classes]
 
 ## Syntax
 
-{{csssyntax}}
+```
+:default
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_defined/index.md
+++ b/files/en-us/web/css/_colon_defined/index.md
@@ -28,7 +28,9 @@ simple-custom:defined {
 
 ## Syntax
 
-{{csssyntax}}
+```
+:defined
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_dir/index.md
+++ b/files/en-us/web/css/_colon_dir/index.md
@@ -37,10 +37,6 @@ The `:dir()` pseudo-class requires one parameter, representing the text directio
 - `rtl`
   - : Target right-to-left elements.
 
-### Formal syntax
-
-{{csssyntax}}
-
 ## Examples
 
 ### HTML

--- a/files/en-us/web/css/_colon_dir/index.md
+++ b/files/en-us/web/css/_colon_dir/index.md
@@ -30,6 +30,10 @@ The `:dir()` pseudo-class uses only the _semantic_ value of the directionality, 
 
 The `:dir()` pseudo-class requires one parameter, representing the text directionality you want to target.
 
+```
+:dir( [ ltr | rtl ] )
+```
+
 ### Parameters
 
 - `ltr`

--- a/files/en-us/web/css/_colon_disabled/index.md
+++ b/files/en-us/web/css/_colon_disabled/index.md
@@ -23,7 +23,9 @@ input:disabled {
 
 ## Syntax
 
-{{csssyntax}}
+```
+:disabled
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_empty/index.md
+++ b/files/en-us/web/css/_colon_empty/index.md
@@ -26,7 +26,9 @@ div:empty {
 
 ## Syntax
 
-{{CSSSyntax}}
+```
+:empty
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_enabled/index.md
+++ b/files/en-us/web/css/_colon_enabled/index.md
@@ -23,7 +23,9 @@ input:enabled {
 
 ## Syntax
 
-{{csssyntax}}
+```
+:enabled
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_first-child/index.md
+++ b/files/en-us/web/css/_colon_first-child/index.md
@@ -26,7 +26,9 @@ p:first-child {
 
 ## Syntax
 
-{{csssyntax}}
+```
+:first-child
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_first-of-type/index.md
+++ b/files/en-us/web/css/_colon_first-of-type/index.md
@@ -26,7 +26,9 @@ p:first-of-type {
 
 ## Syntax
 
-{{csssyntax}}
+```
+:first-of-type
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_first/index.md
+++ b/files/en-us/web/css/_colon_first/index.md
@@ -27,7 +27,9 @@ The **`:first`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/P
 
 ## Syntax
 
-{{csssyntax}}
+```
+:first
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_focus-visible/index.md
+++ b/files/en-us/web/css/_colon_focus-visible/index.md
@@ -20,7 +20,9 @@ This selector is useful to provide a different focus indicator based on the user
 
 ## Syntax
 
-{{CSSSyntax}}
+```
+:focus-visible
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_focus-within/index.md
+++ b/files/en-us/web/css/_colon_focus-within/index.md
@@ -27,7 +27,9 @@ This selector is useful, to take a common example, for highlighting an entire {{
 
 ## Syntax
 
-{{CSSSyntax}}
+```
+:focus-within
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_focus/index.md
+++ b/files/en-us/web/css/_colon_focus/index.md
@@ -26,7 +26,9 @@ input:focus {
 
 ## Syntax
 
-{{CSSSyntax}}
+```
+:focus
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_fullscreen/index.md
+++ b/files/en-us/web/css/_colon_fullscreen/index.md
@@ -18,7 +18,9 @@ The **`:fullscreen`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/
 
 ## Syntax
 
-{{csssyntax}}
+```
+:fullscreen
+```
 
 ## Usage notes
 

--- a/files/en-us/web/css/_colon_future/index.md
+++ b/files/en-us/web/css/_colon_future/index.md
@@ -15,7 +15,9 @@ The **`:future`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/
 
 ## Syntax
 
-{{csssyntax}}
+```
+:future
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_has/index.md
+++ b/files/en-us/web/css/_colon_has/index.md
@@ -21,7 +21,9 @@ let test = document.querySelector('a:has(> img)');
 
 ## Syntax
 
-{{CSSSyntax}}
+```
+:has( <forgiving-relative-selector-list> )
+```
 
 ## Description
 

--- a/files/en-us/web/css/_colon_host-context/index.md
+++ b/files/en-us/web/css/_colon_host-context/index.md
@@ -45,7 +45,9 @@ p {
 
 ## Syntax
 
-{{CSSSyntax}}
+```
+:host-context( <compound-selector> )
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_host/index.md
+++ b/files/en-us/web/css/_colon_host/index.md
@@ -30,7 +30,7 @@ The **`:host`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Ps
 
 ## Syntax
 
-```css
+```
 :host
 ```
 

--- a/files/en-us/web/css/_colon_host_function/index.md
+++ b/files/en-us/web/css/_colon_host_function/index.md
@@ -29,7 +29,9 @@ The most obvious use of this is to put a class name only on certain custom eleme
 
 ## Syntax
 
-{{CSSSyntax}}
+```
+:host( <compound-selector> )
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_hover/index.md
+++ b/files/en-us/web/css/_colon_hover/index.md
@@ -27,7 +27,9 @@ Styles defined by the `:hover` pseudo-class will be overridden by any subsequent
 
 ## Syntax
 
-{{csssyntax}}
+```
+:hover
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_in-range/index.md
+++ b/files/en-us/web/css/_colon_in-range/index.md
@@ -27,7 +27,9 @@ This pseudo-class is useful for giving the user a visual indication that a field
 
 ## Syntax
 
-{{csssyntax}}
+```
+:in-range
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_indeterminate/index.md
+++ b/files/en-us/web/css/_colon_indeterminate/index.md
@@ -33,7 +33,9 @@ Elements targeted by this selector are:
 
 ## Syntax
 
-{{csssyntax}}
+```
+:indeterminate
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_invalid/index.md
+++ b/files/en-us/web/css/_colon_invalid/index.md
@@ -25,7 +25,9 @@ This pseudo-class is useful for highlighting field errors for the user.
 
 ## Syntax
 
-{{csssyntax}}
+```
+:invalid
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_is/index.md
+++ b/files/en-us/web/css/_colon_is/index.md
@@ -261,7 +261,9 @@ some-element::after {
 
 ## Syntax
 
-{{CSSSyntax}}
+```
+:is( <forgiving-selector-list> )
+```
 
 ## Specifications
 

--- a/files/en-us/web/css/_colon_lang/index.md
+++ b/files/en-us/web/css/_colon_lang/index.md
@@ -27,7 +27,9 @@ p:lang(en) {
 
 ### Formal syntax
 
-{{csssyntax}}
+```
+:lang( <language-code> )
+```
 
 ### Parameter
 

--- a/files/en-us/web/css/_colon_last-child/index.md
+++ b/files/en-us/web/css/_colon_last-child/index.md
@@ -26,7 +26,9 @@ p:last-child {
 
 ## Syntax
 
-{{csssyntax}}
+```
+:last-child
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_last-of-type/index.md
+++ b/files/en-us/web/css/_colon_last-of-type/index.md
@@ -26,7 +26,9 @@ p:last-of-type {
 
 ## Syntax
 
-{{csssyntax}}
+```
+:last-of-type
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_left/index.md
+++ b/files/en-us/web/css/_colon_left/index.md
@@ -28,7 +28,9 @@ Whether a given page is "left" or "right" is determined by the major writing dir
 
 ## Syntax
 
-{{csssyntax}}
+```
+:left
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_link/index.md
+++ b/files/en-us/web/css/_colon_link/index.md
@@ -27,7 +27,9 @@ Styles defined by the `:link` pseudo-class will be overridden by any subsequent 
 
 ## Syntax
 
-{{csssyntax}}
+```
+:link
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_local-link/index.md
+++ b/files/en-us/web/css/_colon_local-link/index.md
@@ -16,7 +16,9 @@ a:local-link {
 
 ## Syntax
 
-{{csssyntax}}
+```
+:local-link
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_not/index.md
+++ b/files/en-us/web/css/_colon_not/index.md
@@ -29,7 +29,10 @@ The `:not()` pseudo-class has a number of [quirks, tricks, and unexpected result
 
 The `:not()` pseudo-class requires a comma-separated list of one or more selectors as its argument. The list must not contain another negation selector or a [pseudo-element](/en-US/docs/Web/CSS/Pseudo-elements).
 
-{{csssyntax}}
+```
+:not( <complex-selector-list> )
+```
+
 
 ## Description
 

--- a/files/en-us/web/css/_colon_nth-child/index.md
+++ b/files/en-us/web/css/_colon_nth-child/index.md
@@ -33,6 +33,10 @@ Note that, in the `element:nth-child()` syntax, the child count includes childre
 
 `:nth-child()` takes a single argument that describes a pattern for matching element indices in a list of siblings. Element indices are 1-based.
 
+```
+:nth-child( <nth> [ of <complex-selector-list> ]? )
+```
+
 ### Keyword values
 
 - `odd`
@@ -51,10 +55,6 @@ Note that, in the `element:nth-child()` syntax, the child count includes childre
     - `n` is all nonnegative integers, starting from 0.
 
     It can be read as the *An+B*th element of a list.
-
-### Formal syntax
-
-{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_nth-col/index.md
+++ b/files/en-us/web/css/_colon_nth-col/index.md
@@ -20,9 +20,9 @@ The `nth-col` pseudo-class is specified with a single argument, which represents
 
 See {{Cssxref(":nth-child")}} for a more detailed explanation of its syntax.
 
-### Formal syntax
-
-{{csssyntax}}
+```
+:nth-col
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_nth-last-child/index.md
+++ b/files/en-us/web/css/_colon_nth-last-child/index.md
@@ -29,6 +29,10 @@ The **`:nth-last-child()`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/doc
 
 The `nth-last-child` pseudo-class is specified with a single argument, which represents the pattern for matching elements, counting from the end.
 
+```
+:nth-last-child( <nth> [ of <complex-selector-list> ]? )
+```
+
 ### Keyword values
 
 - `odd`
@@ -40,10 +44,6 @@ The `nth-last-child` pseudo-class is specified with a single argument, which rep
 
 - `<An+B>`
   - : Represents elements whose numeric position in a series of siblings matches the pattern `An+B`, for every positive integer or zero value of `n`. The index of the first element, counting from the end, is `1`. The values `A` and `B` must both be {{cssxref("&lt;integer&gt;")}}s.
-
-### Formal syntax
-
-{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_nth-last-col/index.md
+++ b/files/en-us/web/css/_colon_nth-last-col/index.md
@@ -20,9 +20,9 @@ The `nth-last-col` pseudo-class is specified with a single argument, which repre
 
 See {{Cssxref(":nth-child")}} for a more detailed explanation of its syntax.
 
-### Formal syntax
-
-{{csssyntax}}
+```
+:nth-last-col
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_nth-last-of-type/index.md
+++ b/files/en-us/web/css/_colon_nth-last-of-type/index.md
@@ -31,9 +31,9 @@ The `nth-last-of-type` pseudo-class is specified with a single argument, which r
 
 See {{Cssxref(":nth-last-child")}} for a more detailed explanation of its syntax.
 
-### Formal syntax
-
-{{csssyntax}}
+```
+:nth-last-of-type( <an-plus-b> | even | odd )
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_nth-of-type/index.md
+++ b/files/en-us/web/css/_colon_nth-of-type/index.md
@@ -28,9 +28,9 @@ The `nth-of-type` pseudo-class is specified with a single argument, which repres
 
 See {{Cssxref(":nth-child")}} for a more detailed explanation of its syntax.
 
-### Formal syntax
-
-{{csssyntax}}
+```
+:nth-of-type( <an-plus-b> | even | odd )
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_only-child/index.md
+++ b/files/en-us/web/css/_colon_only-child/index.md
@@ -26,7 +26,9 @@ p:only-child {
 
 ## Syntax
 
-{{csssyntax}}
+```
+:only-child
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_only-of-type/index.md
+++ b/files/en-us/web/css/_colon_only-of-type/index.md
@@ -26,7 +26,9 @@ p:only-of-type {
 
 ## Syntax
 
-{{csssyntax}}
+```
+:only-of-type
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_optional/index.md
+++ b/files/en-us/web/css/_colon_optional/index.md
@@ -27,7 +27,9 @@ This pseudo-class is useful for styling fields that are not required to submit a
 
 ## Syntax
 
-{{csssyntax}}
+```
+:optional
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_out-of-range/index.md
+++ b/files/en-us/web/css/_colon_out-of-range/index.md
@@ -29,7 +29,9 @@ This pseudo-class is useful for giving the user a visual indication that a field
 
 ## Syntax
 
-{{csssyntax}}
+```
+:out-of-range
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_past/index.md
+++ b/files/en-us/web/css/_colon_past/index.md
@@ -15,7 +15,9 @@ The **`:past`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Ps
 
 ## Syntax
 
-{{csssyntax}}
+```
+:past
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_paused/index.md
+++ b/files/en-us/web/css/_colon_paused/index.md
@@ -22,7 +22,9 @@ A resource is paused either due to being in an non-activated state, or due to th
 
 ## Syntax
 
-{{csssyntax}}
+```
+:paused
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_picture-in-picture/index.md
+++ b/files/en-us/web/css/_colon_picture-in-picture/index.md
@@ -18,7 +18,9 @@ The **`:picture-in-picture`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/d
 
 ## Syntax
 
-{{csssyntax}}
+```
+:picture-in-picture
+```
 
 ## Usage notes
 

--- a/files/en-us/web/css/_colon_placeholder-shown/index.md
+++ b/files/en-us/web/css/_colon_placeholder-shown/index.md
@@ -22,7 +22,9 @@ The **`:placeholder-shown`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/do
 
 ## Syntax
 
-{{CSSSyntax}}
+```
+:placeholder-shown
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_playing/index.md
+++ b/files/en-us/web/css/_colon_playing/index.md
@@ -22,7 +22,9 @@ A resource is playing even if in buffering state or paused for any reason other 
 
 ## Syntax
 
-{{csssyntax}}
+```
+:playing
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_read-only/index.md
+++ b/files/en-us/web/css/_colon_read-only/index.md
@@ -27,7 +27,9 @@ p:read-only {
 
 ## Syntax
 
-{{csssyntax}}
+```
+:read-only
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_read-write/index.md
+++ b/files/en-us/web/css/_colon_read-write/index.md
@@ -27,7 +27,9 @@ p:read-write {
 
 ## Syntax
 
-{{csssyntax}}
+```
+:read-write
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_required/index.md
+++ b/files/en-us/web/css/_colon_required/index.md
@@ -27,7 +27,9 @@ This pseudo-class is useful for highlighting fields that must have valid data be
 
 ## Syntax
 
-{{csssyntax}}
+```
+:required
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_right/index.md
+++ b/files/en-us/web/css/_colon_right/index.md
@@ -28,7 +28,9 @@ Whether a given page is "left" or "right" is determined by the major writing dir
 
 ## Syntax
 
-{{csssyntax}}
+```
+:right
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_root/index.md
+++ b/files/en-us/web/css/_colon_root/index.md
@@ -27,7 +27,9 @@ The **`:root`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Ps
 
 ## Syntax
 
-{{csssyntax}}
+```
+:root
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_scope/index.md
+++ b/files/en-us/web/css/_colon_scope/index.md
@@ -27,7 +27,9 @@ Currently, when used in a stylesheet, `:scope` is the same as {{cssxref(":root")
 
 ## Syntax
 
-{{csssyntax}}
+```
+:scope
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_target-within/index.md
+++ b/files/en-us/web/css/_colon_target-within/index.md
@@ -16,7 +16,9 @@ div:target-within {
 
 ## Syntax
 
-{{CSSSyntax}}
+```
+:target-within
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_target/index.md
+++ b/files/en-us/web/css/_colon_target/index.md
@@ -35,7 +35,9 @@ The following element would be selected by a `:target` selector when the current
 
 ## Syntax
 
-{{csssyntax}}
+```
+:target
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_user-invalid/index.md
+++ b/files/en-us/web/css/_colon_user-invalid/index.md
@@ -19,7 +19,9 @@ The `:user-invalid` pseudo-class must match an {{CSSxRef(":invalid")}}, {{CSSxRe
 
 ## Syntax
 
-{{CSSSyntax}}
+```
+:user-invalid
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_user-valid/index.md
+++ b/files/en-us/web/css/_colon_user-valid/index.md
@@ -26,7 +26,9 @@ The result is that if the control was valid when the user started interacting wi
 
 ## Syntax
 
-{{CSSSyntax}}
+```
+:user-valid
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_valid/index.md
+++ b/files/en-us/web/css/_colon_valid/index.md
@@ -25,7 +25,9 @@ This pseudo-class is useful for highlighting correct fields for the user.
 
 ## Syntax
 
-{{csssyntax}}
+```
+:valid
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_visited/index.md
+++ b/files/en-us/web/css/_colon_visited/index.md
@@ -37,7 +37,9 @@ For privacy reasons, browsers strictly limit which styles you can apply using th
 
 ## Syntax
 
-{{csssyntax}}
+```
+visited
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_colon_where/index.md
+++ b/files/en-us/web/css/_colon_where/index.md
@@ -136,7 +136,9 @@ However, selectors inside `:where()` have specificity 0, so the orange footer li
 
 ## Syntax
 
-{{CSSSyntax}}
+```
+:where( <complex-selector-list> )
+```
 
 ## Specifications
 


### PR DESCRIPTION
Part of the prep for landing the CSSSyntax macro rewrite: https://github.com/mdn/yari/pull/4656#issuecomment-1116678114 : since webref doesn't include syntax for pseudo-classes, I'm replacing it with hardcoded values. In almost all cases the syntax is simple.

I've also tried to make page consistently use just "Syntax" rather than "Formal syntax", since the former seems to be the convention.