### PR TITLE
Replace CSSSyntax macro call in pseudo-element docs with hardcoded va…

### DIFF
--- a/files/en-us/web/css/_doublecolon_-moz-color-swatch/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-color-swatch/index.md
@@ -18,7 +18,9 @@ The **`::-moz-color-swatch`** [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US
 
 ## Syntax
 
-{{csssyntax}}
+```
+::-moz-color-swatch
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_doublecolon_-moz-focus-inner/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-focus-inner/index.md
@@ -20,7 +20,9 @@ The **`::-moz-focus-inner`** [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US/
 
 ## Syntax
 
-{{csssyntax}}
+```
+::-moz-focus-inner
+```
 
 ## Example
 

--- a/files/en-us/web/css/_doublecolon_-moz-page-sequence/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-page-sequence/index.md
@@ -17,7 +17,9 @@ The **`::-moz-page-sequence`** [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-U
 
 ## Syntax
 
-{{CSSSyntax}}
+```
+::-moz-page-sequence
+```
 
 ## Specifications
 

--- a/files/en-us/web/css/_doublecolon_-moz-page/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-page/index.md
@@ -18,7 +18,9 @@ The **`::-moz-page`** [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US/docs/We
 
 ## Syntax
 
-{{CSSSyntax}}
+```
+::-moz-page
+```
 
 ## Specifications
 

--- a/files/en-us/web/css/_doublecolon_-moz-progress-bar/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-progress-bar/index.md
@@ -18,7 +18,9 @@ If you want to select the unfinished part of {{HTMLElement("progress")}} in Mozi
 
 ## Syntax
 
-{{csssyntax}}
+```
+::-moz-progress-bar
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_doublecolon_-moz-range-progress/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-range-progress/index.md
@@ -18,7 +18,9 @@ The **`::-moz-range-progress`** [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-
 
 ## Syntax
 
-{{csssyntax}}
+```
+::-moz-range-progress
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_doublecolon_-moz-range-thumb/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-range-thumb/index.md
@@ -18,7 +18,9 @@ The **`::-moz-range-thumb`** [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US/
 
 ## Syntax
 
-{{csssyntax}}
+```
+::-moz-range-thumb
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_doublecolon_-moz-range-track/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-range-track/index.md
@@ -18,7 +18,9 @@ The **`::-moz-range-track`** [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US/
 
 ## Syntax
 
-{{csssyntax}}
+```
+::-moz-range-track
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_doublecolon_-moz-scrolled-page-sequence/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-scrolled-page-sequence/index.md
@@ -18,7 +18,9 @@ The **`::-moz-scrolled-page-sequence`** [CSS](/en-US/docs/Web/CSS) [pseudo-eleme
 
 ## Syntax
 
-{{CSSSyntax}}
+```
+::-moz-scrolled-page-sequence
+```
 
 ## Specifications
 

--- a/files/en-us/web/css/_doublecolon_after/index.md
+++ b/files/en-us/web/css/_doublecolon_after/index.md
@@ -25,7 +25,9 @@ a::after {
 
 ## Syntax
 
-{{CSSSyntax}}
+```
+::after
+```
 
 > **Note:** CSS3 introduced the `::after` notation (with two colons) to distinguish [pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes) from [pseudo-elements](/en-US/docs/Web/CSS/Pseudo-elements). Browsers also accept `:after`, introduced in CSS2.
 

--- a/files/en-us/web/css/_doublecolon_backdrop/index.md
+++ b/files/en-us/web/css/_doublecolon_backdrop/index.md
@@ -34,7 +34,9 @@ All fullscreen elements are placed in a last-in/first out (LIFO) stack in the to
 
 ## Syntax
 
-{{CSSSyntax}}
+```
+::backdrop
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_doublecolon_before/index.md
+++ b/files/en-us/web/css/_doublecolon_before/index.md
@@ -25,7 +25,9 @@ a::before {
 
 ## Syntax
 
-{{csssyntax}}
+```
+::before
+```
 
 > **Note:** CSS3 introduced the `::before` notation (with two colons) to distinguish [pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes) from [pseudo-elements](/en-US/docs/Web/CSS/Pseudo-elements). Browsers also accept `:before`, introduced in CSS2.
 

--- a/files/en-us/web/css/_doublecolon_cue-region/index.md
+++ b/files/en-us/web/css/_doublecolon_cue-region/index.md
@@ -27,7 +27,9 @@ The properties are applied to the entire set of cues as if they were a single un
 
 ## Syntax
 
-{{CSSSyntax}}
+```
+::cue-region | ::cue-region( <selector> )
+```
 
 ## Permitted properties
 

--- a/files/en-us/web/css/_doublecolon_cue/index.md
+++ b/files/en-us/web/css/_doublecolon_cue/index.md
@@ -28,7 +28,9 @@ The properties are applied to the entire set of cues as if they were a single un
 
 ## Syntax
 
-{{CSSSyntax}}
+```
+::cue | ::cue( <selector> )
+```
 
 ## Permitted properties
 

--- a/files/en-us/web/css/_doublecolon_first-letter/index.md
+++ b/files/en-us/web/css/_doublecolon_first-letter/index.md
@@ -44,7 +44,9 @@ Only a small subset of CSS properties can be used with the `::first-letter` pseu
 
 ## Syntax
 
-{{csssyntax}}
+```
+::first-letter
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_doublecolon_first-line/index.md
+++ b/files/en-us/web/css/_doublecolon_first-line/index.md
@@ -36,7 +36,9 @@ Only a small subset of CSS properties can be used with the `::first-line` pseudo
 
 ## Syntax
 
-{{csssyntax}}
+```
+::first-line
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_doublecolon_marker/index.md
+++ b/files/en-us/web/css/_doublecolon_marker/index.md
@@ -36,7 +36,9 @@ Only certain CSS properties can be used in a rule with `::marker` as a selector:
 
 ## Syntax
 
-{{CSSSyntax}}
+```
+::marker
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_doublecolon_part/index.md
+++ b/files/en-us/web/css/_doublecolon_part/index.md
@@ -23,7 +23,9 @@ custom-element::part(foo) {
 
 ## Syntax
 
-{{CSSSyntax}}
+```
+::part( <ident>+ )
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_doublecolon_placeholder/index.md
+++ b/files/en-us/web/css/_doublecolon_placeholder/index.md
@@ -26,7 +26,9 @@ Only the subset of CSS properties that apply to the {{cssxref("::first-line")}} 
 
 ## Syntax
 
-{{csssyntax}}
+```
+::placeholder
+```
 
 ## Accessibility concerns
 

--- a/files/en-us/web/css/_doublecolon_selection/index.md
+++ b/files/en-us/web/css/_doublecolon_selection/index.md
@@ -33,11 +33,8 @@ In particular, {{CSSxRef("background-image")}} is ignored.
 
 ## Syntax
 
-```css
-/* Legacy Firefox syntax (version 61 and below) */
-::-moz-selection
-
-{{CSSSyntax}}
+```
+::selection
 ```
 
 ## Examples

--- a/files/en-us/web/css/_doublecolon_slotted/index.md
+++ b/files/en-us/web/css/_doublecolon_slotted/index.md
@@ -31,7 +31,9 @@ This only works when used inside CSS placed within a [shadow DOM](/en-US/docs/We
 
 ## Syntax
 
-{{csssyntax}}
+```
+::slotted( <compound-selector> )
+```
 
 ## Examples
 

--- a/files/en-us/web/css/_doublecolon_target-text/index.md
+++ b/files/en-us/web/css/_doublecolon_target-text/index.md
@@ -22,7 +22,9 @@ The **`::target-text`** [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US/docs/
 
 ## Syntax
 
-{{csssyntax}}
+```
+::target-text
+```
 
 ## Examples
 


### PR DESCRIPTION
Part of the prep for landing the CSSSyntax macro rewrite: https://github.com/mdn/yari/pull/4656#issuecomment-1116678114 : since webref doesn't include syntax for pseudo-elements, I'm replacing it with hardcoded values. In almost all cases the syntax is simple.
