### PR TITLE
correct the description

### DIFF
--- a/files/en-us/mdn/structures/macros/other/index.md
+++ b/files/en-us/mdn/structures/macros/other/index.md
@@ -32,8 +32,7 @@ We have an assortment of macros that can be used to automatically generate the c
 
 We have macros specifically designed to create [quicklinks](/en-US/docs/MDN/Structures/Quicklinks):
 
-- [`QuickLinksWithSubpages`](https://github.com/mdn/yari/blob/main/kumascript/macros/QuickLinksWithSubpages.ejs) creates a set of quicklinks comprised of the pages below the current page (or specified page, if one is given).
-Up to two total levels of depth are generated.
+- [`QuickLinksWithSubpages`](https://github.com/mdn/yari/blob/main/kumascript/macros/QuickLinksWithSubpages.ejs) creates a set of quicklinks comprised of the pages below the current page (or specified page, if one is given). Up to two total levels of depth are generated.
 
 ## Deprecated
 

--- a/files/en-us/mdn/structures/macros/other/index.md
+++ b/files/en-us/mdn/structures/macros/other/index.md
@@ -30,7 +30,7 @@ We have an assortment of macros that can be used to automatically generate the c
 
 ### Quicklinks
 
-We have macros specifically designed to create [quicklinks](/en-US/docs/MDN/Structures/Quicklinks):
+We have one macro specifically designed to create [quicklinks](/en-US/docs/MDN/Structures/Quicklinks):
 
 - [`QuickLinksWithSubpages`](https://github.com/mdn/yari/blob/main/kumascript/macros/QuickLinksWithSubpages.ejs) creates a set of quicklinks comprised of the pages below the current page (or specified page, if one is given). Up to two total levels of depth are generated.
 


### PR DESCRIPTION
#### Summary

The description about `QuickLinksWithSubpages` has been in a single line, remove the new-line to correct it.

#### Motivation

Fix the mistake made in 2d8250cce4283dd03b9d327b3c07c5c185d07db3.

#### Supporting details

before

![image](https://user-images.githubusercontent.com/15844309/170152202-87a16413-bb6a-4078-8925-17d84dc42406.png)

after

![image](https://user-images.githubusercontent.com/15844309/170152242-99b56d89-ada4-4aa8-9216-f571bb89df6c.png)

#### Metadata

- [x] Fixes a typo, bug, or other error
