### PR TITLE
Remove csssyntax at rules

### DIFF
--- a/files/en-us/web/css/@charset/index.md
+++ b/files/en-us/web/css/@charset/index.md
@@ -29,19 +29,14 @@ As there are several ways to define the character encoding of a style sheet, the
 
 ## Syntax
 
-```css
-@charset "UTF-8";
-@charset "iso-8859-15";
+```
+@charset "<charset>";
 ```
 
 where:
 
 - _charset_
   - : Is a {{cssxref("&lt;string&gt;")}} denoting the character encoding to be used. It must be the name of a web-safe character encoding defined in the [IANA-registry](https://www.iana.org/assignments/character-sets/character-sets.xhtml), and must be double-quoted, following exactly one space character (U+0020), and immediately terminated with a semicolon. If several names are associated with an encoding, only the one marked with *preferred* must be used.
-
-## Formal syntax
-
-{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/@charset/index.md
+++ b/files/en-us/web/css/@charset/index.md
@@ -30,13 +30,18 @@ As there are several ways to define the character encoding of a style sheet, the
 ## Syntax
 
 ```
+@charset "UTF-8";
+@charset "iso-8859-15";
+```
+
+### Formal syntax
+
+```
 @charset "<charset>";
 ```
 
-where:
-
 - _charset_
-  - : Is a {{cssxref("&lt;string&gt;")}} denoting the character encoding to be used. It must be the name of a web-safe character encoding defined in the [IANA-registry](https://www.iana.org/assignments/character-sets/character-sets.xhtml), and must be double-quoted, following exactly one space character (U+0020), and immediately terminated with a semicolon. If several names are associated with an encoding, only the one marked with *preferred* must be used.
+  - : A {{cssxref("&lt;string&gt;")}} denoting the character encoding to be used. It must be the name of a web-safe character encoding defined in the [IANA-registry](https://www.iana.org/assignments/character-sets/character-sets.xhtml), and must be double-quoted, following exactly one space character (U+0020), and immediately terminated with a semicolon. If several names are associated with an encoding, only the one marked with *preferred* must be used.
 
 ## Examples
 

--- a/files/en-us/web/css/@color-profile/index.md
+++ b/files/en-us/web/css/@color-profile/index.md
@@ -59,8 +59,6 @@ The `src` descriptor specifies the URL to retrieve the color-profile information
 
 ## Formal syntax
 
-{{csssyntax}}
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/css/@counter-style/index.md
+++ b/files/en-us/web/css/@counter-style/index.md
@@ -94,7 +94,9 @@ Each `@counter-style` is identified by a name and has a set of descriptors.
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+@counter-style <counter-style-name> { <declaration-list> }
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@document/index.md
+++ b/files/en-us/web/css/@document/index.md
@@ -40,8 +40,16 @@ Escaped values provided to the `regexp()` function must additionally be escaped 
 
 ## Formal syntax
 
-{{csssyntax}}
-
+```
+@document [ <url>                    |
+            url-prefix(<string>)     |
+            domain(<string>)         |
+            media-document(<string>) |
+            regexp(<string>)
+          ]# {
+  <group-rule-body>
+}
+```
 ## Examples
 
 ### Specifying document for CSS rule

--- a/files/en-us/web/css/@font-face/index.md
+++ b/files/en-us/web/css/@font-face/index.md
@@ -106,7 +106,11 @@ The `@font-face` at-rule may be used not only at the top level of a CSS, but als
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+@font-face {
+  <declaration-list>
+}
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@font-feature-values/index.md
+++ b/files/en-us/web/css/@font-feature-values/index.md
@@ -33,7 +33,9 @@ The `@font-feature-values` at-rule may be used either at the top level of your C
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+@font-feature-values <family-name># { <declaration-list> }
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@import/index.md
+++ b/files/en-us/web/css/@import/index.md
@@ -47,7 +47,11 @@ The `@import` rule can also be used to create a [cascade layer](/en-US/docs/Web/
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+@import [ <url> | <string> ]
+        [ supports( [ <supports-condition> | <declaration> ] ) ]?
+        <media-query-list>? ;
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@keyframes/index.md
+++ b/files/en-us/web/css/@keyframes/index.md
@@ -110,7 +110,9 @@ Declarations in a keyframe qualified with `!important` are ignored.
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+@keyframes <keyframes-name> { <rule-list> }
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@layer/index.md
+++ b/files/en-us/web/css/@layer/index.md
@@ -110,7 +110,11 @@ To append rules to the `layout` layer inside `framework`, join the two names wit
 
 ## Formal syntax
 
-{{CSSSyntax}}
+```
+@layer [ <layer-name># | <layer-name>?  {
+  <stylesheet>
+} ]
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@media/index.md
+++ b/files/en-us/web/css/@media/index.md
@@ -177,7 +177,11 @@ Because of this potential, a browser may opt to fudge the returned values in som
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+@media <media-query-list> {
+  <stylesheet>
+}
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@namespace/index.md
+++ b/files/en-us/web/css/@namespace/index.md
@@ -42,7 +42,9 @@ In [HTML5](/en-US/docs/Glossary/HTML5), known [foreign elements](https://html.sp
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+@namespace <namespace-prefix>? [ <string> | <url> ] ;
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@page/index.md
+++ b/files/en-us/web/css/@page/index.md
@@ -44,7 +44,11 @@ The `@page` at-rule can be accessed via the CSS object model interface {{domxref
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+@page <page-selector-list> {
+  <page-body>
+}
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@property/index.md
+++ b/files/en-us/web/css/@property/index.md
@@ -69,7 +69,11 @@ window.CSS.registerProperty({
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+@property <custom-property-name> {
+  <declaration-list>
+}
+```
 
 ## Specifications
 

--- a/files/en-us/web/css/@scroll-timeline/index.md
+++ b/files/en-us/web/css/@scroll-timeline/index.md
@@ -106,7 +106,9 @@ The `scroll-offset` property determines where, within the scrolling, the animati
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+@scroll-timeline <timeline-name> { <declaration-list> }
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@supports/index.md
+++ b/files/en-us/web/css/@supports/index.md
@@ -110,7 +110,11 @@ Multiple disjunctions can be juxtaposed without the need of more parentheses. Th
 
 ## Formal syntax
 
-{{CSSSyntax}}
+```
+@supports <supports-condition> {
+  <stylesheet>
+}
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@viewport/index.md
+++ b/files/en-us/web/css/@viewport/index.md
@@ -68,7 +68,11 @@ Browser support for `@viewport` is weak at this time, with support being largely
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+@viewport {
+  <group-rule-body>
+}
+```
 
 ## Examples
 


### PR DESCRIPTION
Part of the prep for landing the CSSSyntax macro rewrite: https://github.com/mdn/yari/pull/4656#issuecomment-1116678114 : since webref doesn't include syntax for at-rules, I'm replacing it with hardcoded values.

I've used the syntax from the spec wherever I could find it (in preference to what's in mdn/data). I didn't show syntax for subcomponents, only for the top level.

I couldn't find any definition for `@color-profile`.