### PR TITLE
Remove unnecessary argument to addEventListener

### DIFF
--- a/files/en-us/web/api/window/postmessage/index.md
+++ b/files/en-us/web/api/window/postmessage/index.md
@@ -200,7 +200,7 @@ window.addEventListener("message", (event) => {
   event.source.postMessage("hi there yourself!  the secret response " +
                            "is: rheeeeet!",
                            event.origin);
-}, false);
+});
 ```
 
 ### Notes


### PR DESCRIPTION
#### Summary
Remove unnecessary argument to addEventListener.

#### Motivation
The argment defaults to `false`. Therefore it's best to omit it, because inclusion of this argument is confusing for readers.

#### Supporting details

I was reading through this documentation page and was stumped when I noticed the third argument `false` being passed into `addEventListener`. I wanted to know _why_ that was being passed, so I researched what it is, and it's apparently `useCapture`, from the signature `addEventListener(type, listener, useCapture);` documented in the [addEventListener page](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener).

As a reader of the article on `Window.postMessage()` page, I ended up spending an inordinate amount of time reading the description of `useCapture`, trying to make sense of why it was included in the example code. Is this required for messages for some reason? Do we need to think about nested elements in the context of `postMessage`? I don't think so but maybe? ... and on and on.

Since `useCapture` is documented as optional, and "If not specified, `useCapture` defaults to false.", I recommend to remove its use from this page.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
