### PR TITLE
<input type="date"> remove "major problem" note from Handling browser support section

### DIFF
--- a/files/en-us/web/html/element/input/date/index.md
+++ b/files/en-us/web/html/element/input/date/index.md
@@ -227,8 +227,6 @@ input:valid+span::after {
 
 ## Handling browser support
 
-As mentioned, the major problem with date inputs is [browser support](#browser_compatibility).
-
 Unsupporting browsers gracefully degrade to a text input, but this creates problems in consistency of user interface (the presented controls are different) and data handling.
 
 The second problem is the more serious one; with date input supported, the value is normalized to the format `yyyy-mm-dd`. But with a text input, the browser has no recognition of what format the date should be in, and there are many different formats in which people write dates. For example:

--- a/files/en-us/web/html/element/input/date/index.md
+++ b/files/en-us/web/html/element/input/date/index.md
@@ -127,11 +127,9 @@ For `date` inputs, the value of `step` is given in days; and is treated as a num
 
 ## Using date inputs
 
-Date inputs sound convenient — they provide an easy interface for choosing dates, and they normalize the data format sent to the server regardless of the user's locale. However, there are currently issues with `<input type="date">` because of its limited browser support.
+Date inputs sound convenient — they provide an easy interface for choosing dates, and they normalize the data format sent to the server regardless of the user's locale.
 
-In this section, we'll look at basic and then more complex uses of `<input type="date">`, and offer advice on mitigating the browser support issue later (see [Handling browser support](#handling_browser_support)).
-
-> **Note:** Hopefully, over time browser support will become ubiquitous, and this problem will fade away.
+In this section, we'll look at basic and then more complex uses of `<input type="date">`, and offer advice on mitigating browser support issues later (see [Handling browser support](#handling_browser_support)).
 
 ### Basic uses of date
 

--- a/files/en-us/web/html/element/input/date/index.md
+++ b/files/en-us/web/html/element/input/date/index.md
@@ -127,9 +127,9 @@ For `date` inputs, the value of `step` is given in days; and is treated as a num
 
 ## Using date inputs
 
-Date inputs sound convenient — they provide an easy interface for choosing dates, and they normalize the data format sent to the server regardless of the user's locale.
+Date inputs provide an easy interface for choosing dates, and they normalize the data format sent to the server regardless of the user's locale.
 
-In this section, we'll look at basic and then more complex uses of `<input type="date">`, and offer advice on mitigating browser support issues later (see [Handling browser support](#handling_browser_support)).
+In this section, we'll look at basic and then more complex uses of `<input type="date">`.
 
 ### Basic uses of date
 
@@ -225,7 +225,7 @@ input:valid+span::after {
 
 ## Handling browser support
 
-Unsupporting browsers gracefully degrade to a text input, but this creates problems in consistency of user interface (the presented controls are different) and data handling.
+Browsers that don't support this input type gracefully degrade to a text input, but this creates problems in consistency of user interface (the presented controls are different) and data handling.
 
 The second problem is the more serious one; with date input supported, the value is normalized to the format `yyyy-mm-dd`. But with a text input, the browser has no recognition of what format the date should be in, and there are many different formats in which people write dates. For example:
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

The browser support for `<input type="date">` shows it's supported in most browsers except Internet Explorer. So having a note that says "As mentioned, the major problem with date inputs is browser support" doesn't make sense.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date#handling_browser_support

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

What's described should be consistent with the browsers compatibility table

🔗 https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date#browser_compatibility

<img width="814" alt="image" src="https://user-images.githubusercontent.com/3720424/170209676-1c484713-a31b-46de-aceb-cec13fdbb730.png">

I don't see a "major problem" in the compatibility section hence I propose removing that sentence

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
