### PR TITLE
Correct index of the bottom-right corner of subset

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
@@ -61,7 +61,7 @@ getImageData(sx, sy, sw, sh)
 An {{domxref("ImageData")}} object containing the image data for the rectangle of the
 canvas specified. The coordinates of the rectangle's top-left corner are
 `(sx, sy)`, while the coordinates of the bottom corner are
-`(sx + sw, sy + sh)`.
+`(sx + sw - 1, sy + sh - 1)`.
 
 ### Exceptions
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
I hope I'm not mistaken but according to when I ran `CanvasRenderingContext2D.getImageData()`, the rectangle obtained starts from upper-left point whose index is (x, y) and ends lower-left point at (x + w - 1, y + h - 1)
