### PR TITLE
Fixing link to id HTML global attribute

### DIFF
--- a/files/en-us/web/css/id_selectors/index.md
+++ b/files/en-us/web/css/id_selectors/index.md
@@ -10,7 +10,7 @@ browser-compat: css.selectors.id
 ---
 {{CSSRef}}
 
-The CSS **ID selector** matches an element based on the value of the element's {{htmlattrxref("id")}} attribute. In order for the element to be selected, its `id` attribute must match exactly the value given in the selector.
+The CSS **ID selector** matches an element based on the value of the element's [`id`](/en-US/docs/Web/HTML/Global_attributes/id) attribute. In order for the element to be selected, its `id` attribute must match exactly the value given in the selector.
 
 ```css
 /* The element with id="demo" */


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
I replaced the link to the id HTML global attribute.

#### Motivation
The link to the id HTML global attribute went to a non-existent anchor. 

#### Related issues
 #15725 was a similar issue.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
