### PR TITLE
Remove CSSSyntax calls from at-rule descriptors; replace with hardcod…

### DIFF
--- a/files/en-us/web/css/@counter-style/additive-symbols/index.md
+++ b/files/en-us/web/css/@counter-style/additive-symbols/index.md
@@ -30,7 +30,11 @@ When the `system` descriptor is `cyclic`, `numeric`, `alphabetic`, `symbolic`, o
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+[ <integer [0,∞]> && <symbol> ]#
+
+<symbol> = <string> | <image> | <custom-ident>
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@counter-style/fallback/index.md
+++ b/files/en-us/web/css/@counter-style/fallback/index.md
@@ -37,7 +37,11 @@ A couple of scenarios where a fallback style will be used are:
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+<counter-style-name>
+
+<counter-style-name> = <custom-ident>
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@counter-style/negative/index.md
+++ b/files/en-us/web/css/@counter-style/negative/index.md
@@ -38,7 +38,14 @@ If the counter value is negative, the symbol provided as value for the descripto
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+<symbol> <symbol>?
+
+<symbol> =
+  <string>       |
+  <image>        |
+  <custom-ident>
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@counter-style/pad/index.md
+++ b/files/en-us/web/css/@counter-style/pad/index.md
@@ -35,7 +35,14 @@ If a marker representation is smaller than the specified pad length, then the ma
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+<integer> && <symbol>
+
+<symbol> =
+  <string>       |
+  <image>        |
+  <custom-ident>
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@counter-style/prefix/index.md
+++ b/files/en-us/web/css/@counter-style/prefix/index.md
@@ -34,7 +34,14 @@ prefix: url(bullet.png);
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+<symbol>
+
+<symbol> =
+  <string>       |
+  <image>        |
+  <custom-ident>
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@counter-style/range/index.md
+++ b/files/en-us/web/css/@counter-style/range/index.md
@@ -60,7 +60,10 @@ When range is specified as integers, the value `infinite` can be used to denote 
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+[ [ <integer> | infinite ]{2} ]# |
+auto
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@counter-style/speak-as/index.md
+++ b/files/en-us/web/css/@counter-style/speak-as/index.md
@@ -61,7 +61,16 @@ Assistive technology support is very limited for the `speak-as` property. Do not
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+auto                 |
+bullets              |
+numbers              |
+words                |
+spell-out            |
+<counter-style-name>
+
+<counter-style-name> = <custom-ident>
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@counter-style/suffix/index.md
+++ b/files/en-us/web/css/@counter-style/suffix/index.md
@@ -34,7 +34,14 @@ suffix: url(bullet.png);
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+<symbol>
+
+<symbol> =
+  <string>       |
+  <image>        |
+  <custom-ident>
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@counter-style/symbols/index.md
+++ b/files/en-us/web/css/@counter-style/symbols/index.md
@@ -48,7 +48,14 @@ The `symbols` descriptor must be specified when the value of the {{cssxref('@cou
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+<symbol>+
+
+<symbol> =
+  <string>       |
+  <image>        |
+  <custom-ident>
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@counter-style/system/index.md
+++ b/files/en-us/web/css/@counter-style/system/index.md
@@ -76,7 +76,17 @@ This may take one of three forms:
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+cyclic                             |
+numeric                            |
+alphabetic                         |
+symbolic                           |
+additive                           |
+[ fixed <integer>? ]               |
+[ extends <counter-style-name> ]
+
+<counter-style-name> = <custom-ident>
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/ascent-override/index.md
+++ b/files/en-us/web/css/@font-face/ascent-override/index.md
@@ -34,7 +34,9 @@ ascent-override: 90%;
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+normal | <percentage>
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/descent-override/index.md
+++ b/files/en-us/web/css/@font-face/descent-override/index.md
@@ -34,7 +34,9 @@ descent-override: 90%;
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+normal | <percentage>
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/font-display/index.md
+++ b/files/en-us/web/css/@font-face/font-display/index.md
@@ -66,7 +66,9 @@ The font display timeline is based on a timer that begins the moment the user ag
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+[ auto | block | swap | fallback | optional ]
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/font-family/index.md
+++ b/files/en-us/web/css/@font-face/font-family/index.md
@@ -36,7 +36,13 @@ font-family: examplefont;
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+<family-name>
+
+<family-name> =
+  <string>        |
+  <custom-ident>+
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/font-stretch/index.md
+++ b/files/en-us/web/css/@font-face/font-stretch/index.md
@@ -125,7 +125,21 @@ People with dyslexia and other cognitive conditions may have difficulty reading 
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+<font-stretch-absolute>{1,2}
+
+<font-stretch-absolute> =
+  normal          |
+  ultra-condensed |
+  extra-condensed |
+  condensed       |
+  semi-condensed  |
+  semi-expanded   |
+  expanded        |
+  extra-expanded  |
+  ultra-expanded  |
+  <percentage>
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/font-style/index.md
+++ b/files/en-us/web/css/@font-face/font-style/index.md
@@ -45,7 +45,11 @@ font-style: oblique 30deg 50deg;
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+normal               |
+italic               |
+oblique <angle>{0,2}
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/font-variant/index.md
+++ b/files/en-us/web/css/@font-face/font-variant/index.md
@@ -52,7 +52,37 @@ font-variant: unset;
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+normal |
+none   |
+[ <common-lig-values>                      ||
+  <discretionary-lig-values>               ||
+  <historical-lig-values>                  ||
+  <contextual-alt-values>                  ||
+  stylistic(<feature-value-name>)          ||
+  historical-forms                         ||
+  styleset(<feature-value-name>#)          ||
+  character-variant(<feature-value-name>#) ||
+  swash(<feature-value-name>)              ||
+  ornaments(<feature-value-name>)          ||
+  annotation(<feature-value-name>)         ||
+  [ small-caps      |
+    all-small-caps  |
+    petite-caps     |
+    all-petite-caps |
+    unicase         |
+    titling-caps
+  ]                                        ||
+  <numeric-figure-values>                  ||
+  <numeric-spacing-values>                 ||
+  <numeric-fraction-values>                ||
+  ordinal                                  ||
+  slashed-zero                             ||
+  <east-asian-variant-values>              ||
+  <east-asian-width-values>                ||
+  ruby
+]
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/font-variation-settings/index.md
+++ b/files/en-us/web/css/@font-face/font-variation-settings/index.md
@@ -37,7 +37,10 @@ font-variation-settings: "xhgt" 0.7;
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+normal                 |
+[ <string> <number> ]#
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/font-weight/index.md
+++ b/files/en-us/web/css/@font-face/font-weight/index.md
@@ -81,7 +81,11 @@ People experiencing low vision conditions may have difficulty reading text set w
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+<font-weight-absolute>{1,2}
+
+<font-weight-absolute> = normal | bold | <number [1,1000]>
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/line-gap-override/index.md
+++ b/files/en-us/web/css/@font-face/line-gap-override/index.md
@@ -34,7 +34,9 @@ line-gap-override: 90%;
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+normal | <percentage>
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/size-adjust/index.md
+++ b/files/en-us/web/css/@font-face/size-adjust/index.md
@@ -35,7 +35,9 @@ All metrics associated with this font are scaled by the given percentage. This i
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+<percentage [0,∞]>
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/src/index.md
+++ b/files/en-us/web/css/@font-face/src/index.md
@@ -55,7 +55,13 @@ As with other URLs in CSS, the URL may be relative, in which case it is resolved
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+[ <url> [ format( <string># ) ]? | local( <family-name> ) ]#
+
+<family-name> =
+  <string>        |
+  <custom-ident>+
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@font-face/unicode-range/index.md
+++ b/files/en-us/web/css/@font-face/unicode-range/index.md
@@ -46,7 +46,9 @@ The purpose of this descriptor is to allow the font resources to be segmented so
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+<unicode-range>#
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@page/size/index.md
+++ b/files/en-us/web/css/@page/size/index.md
@@ -84,7 +84,24 @@ size: A4 portrait;
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+<length>{1,2}                               |
+auto                                        |
+[ <page-size> || [ portrait | landscape ] ]
+
+where
+<page-size> =
+  A5     |
+  A4     |
+  A3     |
+  B5     |
+  B4     |
+  JIS-B5 |
+  JIS-B4 |
+  letter |
+  legal  |
+  ledger
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@property/inherits/index.md
+++ b/files/en-us/web/css/@property/inherits/index.md
@@ -42,7 +42,9 @@ The **`inherits`** [CSS](/en-US/docs/Web/CSS) descriptor is required when using 
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+true | false
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@property/initial-value/index.md
+++ b/files/en-us/web/css/@property/initial-value/index.md
@@ -41,7 +41,9 @@ A string with a value which is a correct value for the chosen `syntax`.
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+<string>
+```
 
 ## Examples
 

--- a/files/en-us/web/css/@property/syntax/index.md
+++ b/files/en-us/web/css/@property/syntax/index.md
@@ -66,7 +66,9 @@ A string with a supported syntax as defined by the specification. Supported synt
 
 ## Formal syntax
 
-{{csssyntax}}
+```
+<string>
+```
 
 ## Examples
 


### PR DESCRIPTION
Part of the prep for landing the CSSSyntax macro rewrite: https://github.com/mdn/yari/pull/4656#issuecomment-1116678114 .

Although webref does include syntax for at-rule descriptors, the new macro doesn't yet know how to extract it. So for the time being I'm replacing the macro calls with hardcoded syntax values.

Once the new macro is merged I'll file a new PR to support at-rule descriptors, and undo this change.
