### PR TITLE
Add Web/API page types, part 1

### DIFF
--- a/files/en-us/web/api/abortcontroller/abort/index.md
+++ b/files/en-us/web/api/abortcontroller/abort/index.md
@@ -1,6 +1,7 @@
 ---
 title: AbortController.abort()
 slug: Web/API/AbortController/abort
+page-type: web-api-instance-method
 tags:
   - API
   - AbortController

--- a/files/en-us/web/api/abortcontroller/abortcontroller/index.md
+++ b/files/en-us/web/api/abortcontroller/abortcontroller/index.md
@@ -1,6 +1,7 @@
 ---
 title: AbortController()
 slug: Web/API/AbortController/AbortController
+page-type: web-api-constructor
 tags:
   - API
   - AbortController

--- a/files/en-us/web/api/abortcontroller/index.md
+++ b/files/en-us/web/api/abortcontroller/index.md
@@ -1,6 +1,7 @@
 ---
 title: AbortController
 slug: Web/API/AbortController
+page-type: web-api-interface
 tags:
   - API
   - AbortController

--- a/files/en-us/web/api/abortcontroller/signal/index.md
+++ b/files/en-us/web/api/abortcontroller/signal/index.md
@@ -1,6 +1,7 @@
 ---
 title: AbortController.signal
 slug: Web/API/AbortController/signal
+page-type: web-api-instance-property
 tags:
   - API
   - AbortController

--- a/files/en-us/web/api/abortsignal/abort/index.md
+++ b/files/en-us/web/api/abortsignal/abort/index.md
@@ -1,6 +1,7 @@
 ---
 title: AbortSignal.abort()
 slug: Web/API/AbortSignal/abort
+page-type: web-api-static-method
 tags:
   - API
   - AbortSignal

--- a/files/en-us/web/api/abortsignal/abort_event/index.md
+++ b/files/en-us/web/api/abortsignal/abort_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'AbortSignal: abort event'
 slug: Web/API/AbortSignal/abort_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/abortsignal/aborted/index.md
+++ b/files/en-us/web/api/abortsignal/aborted/index.md
@@ -1,6 +1,7 @@
 ---
 title: AbortSignal.aborted
 slug: Web/API/AbortSignal/aborted
+page-type: web-api-instance-property
 tags:
   - API
   - AbortSignal

--- a/files/en-us/web/api/abortsignal/index.md
+++ b/files/en-us/web/api/abortsignal/index.md
@@ -1,6 +1,7 @@
 ---
 title: AbortSignal
 slug: Web/API/AbortSignal
+page-type: web-api-interface
 tags:
   - API
   - AbortSignal

--- a/files/en-us/web/api/abortsignal/reason/index.md
+++ b/files/en-us/web/api/abortsignal/reason/index.md
@@ -1,6 +1,7 @@
 ---
 title: AbortSignal.reason
 slug: Web/API/AbortSignal/reason
+page-type: web-api-instance-property
 tags:
   - API
   - AbortSignal

--- a/files/en-us/web/api/abortsignal/throwifaborted/index.md
+++ b/files/en-us/web/api/abortsignal/throwifaborted/index.md
@@ -1,6 +1,7 @@
 ---
 title: AbortSignal.throwIfAborted()
 slug: Web/API/AbortSignal/throwIfAborted
+page-type: web-api-instance-method
 tags:
   - API
   - AbortSignal

--- a/files/en-us/web/api/abortsignal/timeout/index.md
+++ b/files/en-us/web/api/abortsignal/timeout/index.md
@@ -1,6 +1,7 @@
 ---
 title: AbortSignal.timeout()
 slug: Web/API/AbortSignal/timeout
+page-type: web-api-static-method
 tags:
   - API
   - AbortSignal

--- a/files/en-us/web/api/absoluteorientationsensor/absoluteorientationsensor/index.md
+++ b/files/en-us/web/api/absoluteorientationsensor/absoluteorientationsensor/index.md
@@ -1,6 +1,7 @@
 ---
 title: AbsoluteOrientationSensor()
 slug: Web/API/AbsoluteOrientationSensor/AbsoluteOrientationSensor
+page-type: web-api-constructor
 tags:
   - API
   - AbsoluteOrientationSensor

--- a/files/en-us/web/api/absoluteorientationsensor/index.md
+++ b/files/en-us/web/api/absoluteorientationsensor/index.md
@@ -1,6 +1,7 @@
 ---
 title: AbsoluteOrientationSensor
 slug: Web/API/AbsoluteOrientationSensor
+page-type: web-api-interface
 tags:
   - API
   - AbsoluteOrientationSensor

--- a/files/en-us/web/api/abstractrange/collapsed/index.md
+++ b/files/en-us/web/api/abstractrange/collapsed/index.md
@@ -1,6 +1,7 @@
 ---
 title: AbstractRange.collapsed
 slug: Web/API/AbstractRange/collapsed
+page-type: web-api-instance-property
 tags:
   - Property
   - Reference

--- a/files/en-us/web/api/abstractrange/endcontainer/index.md
+++ b/files/en-us/web/api/abstractrange/endcontainer/index.md
@@ -1,6 +1,7 @@
 ---
 title: AbstractRange.endContainer
 slug: Web/API/AbstractRange/endContainer
+page-type: web-api-instance-property
 tags:
   - Property
   - Read-only

--- a/files/en-us/web/api/abstractrange/endoffset/index.md
+++ b/files/en-us/web/api/abstractrange/endoffset/index.md
@@ -1,6 +1,7 @@
 ---
 title: AbstractRange.endOffset
 slug: Web/API/AbstractRange/endOffset
+page-type: web-api-instance-property
 tags:
   - Property
   - Read-only

--- a/files/en-us/web/api/abstractrange/index.md
+++ b/files/en-us/web/api/abstractrange/index.md
@@ -1,6 +1,7 @@
 ---
 title: AbstractRange
 slug: Web/API/AbstractRange
+page-type: web-api-interface
 tags:
   - Interface
   - Reference

--- a/files/en-us/web/api/abstractrange/startcontainer/index.md
+++ b/files/en-us/web/api/abstractrange/startcontainer/index.md
@@ -1,6 +1,7 @@
 ---
 title: AbstractRange.startContainer
 slug: Web/API/AbstractRange/startContainer
+page-type: web-api-instance-property
 tags:
   - Property
   - Read-only

--- a/files/en-us/web/api/abstractrange/startoffset/index.md
+++ b/files/en-us/web/api/abstractrange/startoffset/index.md
@@ -1,6 +1,7 @@
 ---
 title: AbstractRange.startOffset
 slug: Web/API/AbstractRange/startOffset
+page-type: web-api-instance-property
 tags:
   - Property
   - Read-only

--- a/files/en-us/web/api/accelerometer/accelerometer/index.md
+++ b/files/en-us/web/api/accelerometer/accelerometer/index.md
@@ -1,6 +1,7 @@
 ---
 title: Accelerometer()
 slug: Web/API/Accelerometer/Accelerometer
+page-type: web-api-constructor
 tags:
   - API
   - Accelerometer

--- a/files/en-us/web/api/accelerometer/index.md
+++ b/files/en-us/web/api/accelerometer/index.md
@@ -1,6 +1,7 @@
 ---
 title: Accelerometer
 slug: Web/API/Accelerometer
+page-type: web-api-interface
 tags:
   - API
   - Accelerometer

--- a/files/en-us/web/api/accelerometer/x/index.md
+++ b/files/en-us/web/api/accelerometer/x/index.md
@@ -1,6 +1,7 @@
 ---
 title: Accelerometer.x
 slug: Web/API/Accelerometer/x
+page-type: web-api-instance-property
 tags:
   - API
   - Accelerometer

--- a/files/en-us/web/api/accelerometer/y/index.md
+++ b/files/en-us/web/api/accelerometer/y/index.md
@@ -1,6 +1,7 @@
 ---
 title: Accelerometer.y
 slug: Web/API/Accelerometer/y
+page-type: web-api-instance-property
 tags:
   - API
   - Accelerometer

--- a/files/en-us/web/api/accelerometer/z/index.md
+++ b/files/en-us/web/api/accelerometer/z/index.md
@@ -1,6 +1,7 @@
 ---
 title: Accelerometer.z
 slug: Web/API/Accelerometer/z
+page-type: web-api-instance-property
 tags:
   - API
   - Accelerometer

--- a/files/en-us/web/api/addresserrors/addressline/index.md
+++ b/files/en-us/web/api/addresserrors/addressline/index.md
@@ -1,6 +1,7 @@
 ---
 title: AddressErrors.addressLine
 slug: Web/API/AddressErrors/addressLine
+page-type: web-api-instance-property
 tags:
   - API
   - AddressErrors

--- a/files/en-us/web/api/addresserrors/city/index.md
+++ b/files/en-us/web/api/addresserrors/city/index.md
@@ -1,6 +1,7 @@
 ---
 title: AddressErrors.city
 slug: Web/API/AddressErrors/city
+page-type: web-api-instance-property
 tags:
   - API
   - Address

--- a/files/en-us/web/api/addresserrors/country/index.md
+++ b/files/en-us/web/api/addresserrors/country/index.md
@@ -1,6 +1,7 @@
 ---
 title: AddressErrors.country
 slug: Web/API/AddressErrors/country
+page-type: web-api-instance-property
 tags:
   - API
   - AddressErrors

--- a/files/en-us/web/api/addresserrors/dependentlocality/index.md
+++ b/files/en-us/web/api/addresserrors/dependentlocality/index.md
@@ -1,6 +1,7 @@
 ---
 title: AddressErrors.dependentLocality
 slug: Web/API/AddressErrors/dependentLocality
+page-type: web-api-instance-property
 tags:
   - API
   - AddressErrors

--- a/files/en-us/web/api/addresserrors/index.md
+++ b/files/en-us/web/api/addresserrors/index.md
@@ -1,6 +1,7 @@
 ---
 title: AddressErrors
 slug: Web/API/AddressErrors
+page-type: web-api-interface
 tags:
   - API
   - Address

--- a/files/en-us/web/api/addresserrors/languagecode/index.md
+++ b/files/en-us/web/api/addresserrors/languagecode/index.md
@@ -1,6 +1,7 @@
 ---
 title: AddressErrors.languageCode
 slug: Web/API/AddressErrors/languageCode
+page-type: web-api-instance-property
 tags:
   - API
   - Address

--- a/files/en-us/web/api/addresserrors/organization/index.md
+++ b/files/en-us/web/api/addresserrors/organization/index.md
@@ -1,6 +1,7 @@
 ---
 title: AddressErrors.organization
 slug: Web/API/AddressErrors/organization
+page-type: web-api-instance-property
 tags:
   - API
   - Address

--- a/files/en-us/web/api/addresserrors/phone/index.md
+++ b/files/en-us/web/api/addresserrors/phone/index.md
@@ -1,6 +1,7 @@
 ---
 title: AddressErrors.phone
 slug: Web/API/AddressErrors/phone
+page-type: web-api-instance-property
 tags:
   - API
   - Address

--- a/files/en-us/web/api/addresserrors/postalcode/index.md
+++ b/files/en-us/web/api/addresserrors/postalcode/index.md
@@ -1,6 +1,7 @@
 ---
 title: AddressErrors.postalCode
 slug: Web/API/AddressErrors/postalCode
+page-type: web-api-instance-property
 tags:
   - API
   - Address

--- a/files/en-us/web/api/addresserrors/recipient/index.md
+++ b/files/en-us/web/api/addresserrors/recipient/index.md
@@ -1,6 +1,7 @@
 ---
 title: AddressErrors.recipient
 slug: Web/API/AddressErrors/recipient
+page-type: web-api-instance-property
 tags:
   - API
   - Address

--- a/files/en-us/web/api/addresserrors/region/index.md
+++ b/files/en-us/web/api/addresserrors/region/index.md
@@ -1,6 +1,7 @@
 ---
 title: AddressErrors.region
 slug: Web/API/AddressErrors/region
+page-type: web-api-instance-property
 tags:
   - API
   - Address

--- a/files/en-us/web/api/addresserrors/sortingcode/index.md
+++ b/files/en-us/web/api/addresserrors/sortingcode/index.md
@@ -1,6 +1,7 @@
 ---
 title: AddressErrors.sortingCode
 slug: Web/API/AddressErrors/sortingCode
+page-type: web-api-instance-property
 tags:
   - API
   - Address

--- a/files/en-us/web/api/aescbcparams/index.md
+++ b/files/en-us/web/api/aescbcparams/index.md
@@ -1,6 +1,7 @@
 ---
 title: AesCbcParams
 slug: Web/API/AesCbcParams
+page-type: web-api-interface
 tags:
   - API
   - AesCbcParams

--- a/files/en-us/web/api/aesctrparams/index.md
+++ b/files/en-us/web/api/aesctrparams/index.md
@@ -1,6 +1,7 @@
 ---
 title: AesCtrParams
 slug: Web/API/AesCtrParams
+page-type: web-api-interface
 tags:
   - API
   - AesCtrParams

--- a/files/en-us/web/api/aesgcmparams/index.md
+++ b/files/en-us/web/api/aesgcmparams/index.md
@@ -1,6 +1,7 @@
 ---
 title: AesGcmParams
 slug: Web/API/AesGcmParams
+page-type: web-api-interface
 tags:
   - API
   - AesGcmParams

--- a/files/en-us/web/api/aeskeygenparams/index.md
+++ b/files/en-us/web/api/aeskeygenparams/index.md
@@ -1,6 +1,7 @@
 ---
 title: AesKeyGenParams
 slug: Web/API/AesKeyGenParams
+page-type: web-api-interface
 tags:
   - API
   - AesKeyGenParams

--- a/files/en-us/web/api/ambientlightsensor/ambientlightsensor/index.md
+++ b/files/en-us/web/api/ambientlightsensor/ambientlightsensor/index.md
@@ -1,6 +1,7 @@
 ---
 title: AmbientLightSensor()
 slug: Web/API/AmbientLightSensor/AmbientLightSensor
+page-type: web-api-constructor
 tags:
   - API
   - Ambient Light Sensor API

--- a/files/en-us/web/api/ambientlightsensor/illuminance/index.md
+++ b/files/en-us/web/api/ambientlightsensor/illuminance/index.md
@@ -1,6 +1,7 @@
 ---
 title: AmbientLightSensor.illuminance
 slug: Web/API/AmbientLightSensor/illuminance
+page-type: web-api-instance-property
 tags:
   - API
   - Ambient Light Level API

--- a/files/en-us/web/api/ambientlightsensor/index.md
+++ b/files/en-us/web/api/ambientlightsensor/index.md
@@ -1,6 +1,7 @@
 ---
 title: AmbientLightSensor
 slug: Web/API/AmbientLightSensor
+page-type: web-api-interface
 tags:
   - API
   - Ambient Light Sensor API

--- a/files/en-us/web/api/analysernode/analysernode/index.md
+++ b/files/en-us/web/api/analysernode/analysernode/index.md
@@ -1,6 +1,7 @@
 ---
 title: AnalyserNode()
 slug: Web/API/AnalyserNode/AnalyserNode
+page-type: web-api-constructor
 tags:
   - API
   - AnalyserNode

--- a/files/en-us/web/api/analysernode/fftsize/index.md
+++ b/files/en-us/web/api/analysernode/fftsize/index.md
@@ -1,6 +1,7 @@
 ---
 title: AnalyserNode.fftSize
 slug: Web/API/AnalyserNode/fftSize
+page-type: web-api-instance-property
 tags:
   - API
   - AnalyserNode

--- a/files/en-us/web/api/analysernode/frequencybincount/index.md
+++ b/files/en-us/web/api/analysernode/frequencybincount/index.md
@@ -1,6 +1,7 @@
 ---
 title: AnalyserNode.frequencyBinCount
 slug: Web/API/AnalyserNode/frequencyBinCount
+page-type: web-api-instance-property
 tags:
   - API
   - AnalyserNode

--- a/files/en-us/web/api/analysernode/getbytefrequencydata/index.md
+++ b/files/en-us/web/api/analysernode/getbytefrequencydata/index.md
@@ -1,6 +1,7 @@
 ---
 title: AnalyserNode.getByteFrequencyData()
 slug: Web/API/AnalyserNode/getByteFrequencyData
+page-type: web-api-instance-method
 tags:
   - API
   - AnalyserNode

--- a/files/en-us/web/api/analysernode/getbytetimedomaindata/index.md
+++ b/files/en-us/web/api/analysernode/getbytetimedomaindata/index.md
@@ -1,6 +1,7 @@
 ---
 title: AnalyserNode.getByteTimeDomainData()
 slug: Web/API/AnalyserNode/getByteTimeDomainData
+page-type: web-api-instance-method
 tags:
   - API
   - AnalyserNode

--- a/files/en-us/web/api/analysernode/getfloatfrequencydata/index.md
+++ b/files/en-us/web/api/analysernode/getfloatfrequencydata/index.md
@@ -1,6 +1,7 @@
 ---
 title: AnalyserNode.getFloatFrequencyData()
 slug: Web/API/AnalyserNode/getFloatFrequencyData
+page-type: web-api-instance-method
 tags:
   - API
   - AnalyserNode

--- a/files/en-us/web/api/analysernode/getfloattimedomaindata/index.md
+++ b/files/en-us/web/api/analysernode/getfloattimedomaindata/index.md
@@ -1,6 +1,7 @@
 ---
 title: AnalyserNode.getFloatTimeDomainData()
 slug: Web/API/AnalyserNode/getFloatTimeDomainData
+page-type: web-api-instance-method
 tags:
   - API
   - AnalyserNode

--- a/files/en-us/web/api/analysernode/index.md
+++ b/files/en-us/web/api/analysernode/index.md
@@ -1,6 +1,7 @@
 ---
 title: AnalyserNode
 slug: Web/API/AnalyserNode
+page-type: web-api-interface
 tags:
   - API
   - AnalyserNode

--- a/files/en-us/web/api/analysernode/maxdecibels/index.md
+++ b/files/en-us/web/api/analysernode/maxdecibels/index.md
@@ -1,6 +1,7 @@
 ---
 title: AnalyserNode.maxDecibels
 slug: Web/API/AnalyserNode/maxDecibels
+page-type: web-api-instance-property
 tags:
   - API
   - AnalyserNode

--- a/files/en-us/web/api/analysernode/mindecibels/index.md
+++ b/files/en-us/web/api/analysernode/mindecibels/index.md
@@ -1,6 +1,7 @@
 ---
 title: AnalyserNode.minDecibels
 slug: Web/API/AnalyserNode/minDecibels
+page-type: web-api-instance-property
 tags:
   - API
   - AnalyserNode

--- a/files/en-us/web/api/analysernode/smoothingtimeconstant/index.md
+++ b/files/en-us/web/api/analysernode/smoothingtimeconstant/index.md
@@ -1,6 +1,7 @@
 ---
 title: AnalyserNode.smoothingTimeConstant
 slug: Web/API/AnalyserNode/smoothingTimeConstant
+page-type: web-api-instance-property
 tags:
   - API
   - AnalyserNode

--- a/files/en-us/web/api/angle_instanced_arrays/drawarraysinstancedangle/index.md
+++ b/files/en-us/web/api/angle_instanced_arrays/drawarraysinstancedangle/index.md
@@ -1,6 +1,7 @@
 ---
 title: ANGLE_instanced_arrays.drawArraysInstancedANGLE()
 slug: Web/API/ANGLE_instanced_arrays/drawArraysInstancedANGLE
+page-type: web-api-instance-method
 tags:
   - ANGLE_instanced_arrays
   - API

--- a/files/en-us/web/api/angle_instanced_arrays/drawelementsinstancedangle/index.md
+++ b/files/en-us/web/api/angle_instanced_arrays/drawelementsinstancedangle/index.md
@@ -1,6 +1,7 @@
 ---
 title: ANGLE_instanced_arrays.drawElementsInstancedANGLE()
 slug: Web/API/ANGLE_instanced_arrays/drawElementsInstancedANGLE
+page-type: web-api-instance-method
 tags:
   - ANGLE_instanced_arrays
   - API

--- a/files/en-us/web/api/angle_instanced_arrays/index.md
+++ b/files/en-us/web/api/angle_instanced_arrays/index.md
@@ -1,6 +1,7 @@
 ---
 title: ANGLE_instanced_arrays
 slug: Web/API/ANGLE_instanced_arrays
+page-type: web-api-interface
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/angle_instanced_arrays/vertexattribdivisorangle/index.md
+++ b/files/en-us/web/api/angle_instanced_arrays/vertexattribdivisorangle/index.md
@@ -1,6 +1,7 @@
 ---
 title: ANGLE_instanced_arrays.vertexAttribDivisorANGLE()
 slug: Web/API/ANGLE_instanced_arrays/vertexAttribDivisorANGLE
+page-type: web-api-instance-method
 tags:
   - ANGLE_instanced_arrays
   - API

--- a/files/en-us/web/api/animation/animation/index.md
+++ b/files/en-us/web/api/animation/animation/index.md
@@ -1,6 +1,7 @@
 ---
 title: Animation()
 slug: Web/API/Animation/Animation
+page-type: web-api-constructor
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animation/cancel/index.md
+++ b/files/en-us/web/api/animation/cancel/index.md
@@ -1,6 +1,7 @@
 ---
 title: Animation.cancel()
 slug: Web/API/Animation/cancel
+page-type: web-api-instance-method
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animation/cancel_event/index.md
+++ b/files/en-us/web/api/animation/cancel_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Animation: cancel event'
 slug: Web/API/Animation/cancel_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/animation/commitstyles/index.md
+++ b/files/en-us/web/api/animation/commitstyles/index.md
@@ -1,6 +1,7 @@
 ---
 title: Animation.commitStyles()
 slug: Web/API/Animation/commitStyles
+page-type: web-api-instance-method
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animation/currenttime/index.md
+++ b/files/en-us/web/api/animation/currenttime/index.md
@@ -1,6 +1,7 @@
 ---
 title: Animation.currentTime
 slug: Web/API/Animation/currentTime
+page-type: web-api-instance-property
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animation/effect/index.md
+++ b/files/en-us/web/api/animation/effect/index.md
@@ -1,6 +1,7 @@
 ---
 title: Animation.effect
 slug: Web/API/Animation/effect
+page-type: web-api-instance-property
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animation/finish/index.md
+++ b/files/en-us/web/api/animation/finish/index.md
@@ -1,6 +1,7 @@
 ---
 title: Animation.finish()
 slug: Web/API/Animation/finish
+page-type: web-api-instance-method
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animation/finish_event/index.md
+++ b/files/en-us/web/api/animation/finish_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Animation: finish event'
 slug: Web/API/Animation/finish_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/animation/finished/index.md
+++ b/files/en-us/web/api/animation/finished/index.md
@@ -1,6 +1,7 @@
 ---
 title: Animation.finished
 slug: Web/API/Animation/finished
+page-type: web-api-instance-property
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animation/id/index.md
+++ b/files/en-us/web/api/animation/id/index.md
@@ -1,6 +1,7 @@
 ---
 title: Animation.id
 slug: Web/API/Animation/id
+page-type: web-api-instance-property
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animation/index.md
+++ b/files/en-us/web/api/animation/index.md
@@ -1,6 +1,7 @@
 ---
 title: Animation
 slug: Web/API/Animation
+page-type: web-api-interface
 tags:
   - API
   - Animations

--- a/files/en-us/web/api/animation/pause/index.md
+++ b/files/en-us/web/api/animation/pause/index.md
@@ -1,6 +1,7 @@
 ---
 title: Animation.pause()
 slug: Web/API/Animation/pause
+page-type: web-api-instance-method
 tags:
   - Animation
   - Method

--- a/files/en-us/web/api/animation/pending/index.md
+++ b/files/en-us/web/api/animation/pending/index.md
@@ -1,6 +1,7 @@
 ---
 title: Animation.pending
 slug: Web/API/Animation/pending
+page-type: web-api-instance-property
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animation/persist/index.md
+++ b/files/en-us/web/api/animation/persist/index.md
@@ -1,6 +1,7 @@
 ---
 title: Animation.persist()
 slug: Web/API/Animation/persist
+page-type: web-api-instance-method
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animation/play/index.md
+++ b/files/en-us/web/api/animation/play/index.md
@@ -1,6 +1,7 @@
 ---
 title: Animation.play()
 slug: Web/API/Animation/play
+page-type: web-api-instance-method
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animation/playbackrate/index.md
+++ b/files/en-us/web/api/animation/playbackrate/index.md
@@ -1,6 +1,7 @@
 ---
 title: Animation.playbackRate
 slug: Web/API/Animation/playbackRate
+page-type: web-api-instance-property
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animation/playstate/index.md
+++ b/files/en-us/web/api/animation/playstate/index.md
@@ -1,6 +1,7 @@
 ---
 title: Animation.playState
 slug: Web/API/Animation/playState
+page-type: web-api-instance-property
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animation/ready/index.md
+++ b/files/en-us/web/api/animation/ready/index.md
@@ -1,6 +1,7 @@
 ---
 title: Animation.ready
 slug: Web/API/Animation/ready
+page-type: web-api-instance-property
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animation/remove_event/index.md
+++ b/files/en-us/web/api/animation/remove_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Animation: remove event'
 slug: Web/API/Animation/remove_event
+page-type: web-api-event
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/animation/replacestate/index.md
+++ b/files/en-us/web/api/animation/replacestate/index.md
@@ -1,6 +1,7 @@
 ---
 title: Animation.replaceState
 slug: Web/API/Animation/replaceState
+page-type: web-api-instance-property
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animation/reverse/index.md
+++ b/files/en-us/web/api/animation/reverse/index.md
@@ -1,6 +1,7 @@
 ---
 title: Animation.reverse()
 slug: Web/API/Animation/reverse
+page-type: web-api-instance-method
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animation/starttime/index.md
+++ b/files/en-us/web/api/animation/starttime/index.md
@@ -1,6 +1,7 @@
 ---
 title: Animation.startTime
 slug: Web/API/Animation/startTime
+page-type: web-api-instance-property
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animation/timeline/index.md
+++ b/files/en-us/web/api/animation/timeline/index.md
@@ -1,6 +1,7 @@
 ---
 title: Animation.timeline
 slug: Web/API/Animation/timeline
+page-type: web-api-instance-property
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animation/updateplaybackrate/index.md
+++ b/files/en-us/web/api/animation/updateplaybackrate/index.md
@@ -1,6 +1,7 @@
 ---
 title: Animation.updatePlaybackRate()
 slug: Web/API/Animation/updatePlaybackRate
+page-type: web-api-instance-method
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
+++ b/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
@@ -1,6 +1,7 @@
 ---
 title: AnimationEffect.getComputedTiming()
 slug: Web/API/AnimationEffect/getComputedTiming
+page-type: web-api-instance-method
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animationeffect/gettiming/index.md
+++ b/files/en-us/web/api/animationeffect/gettiming/index.md
@@ -1,6 +1,7 @@
 ---
 title: AnimationEffect.getTiming()
 slug: Web/API/AnimationEffect/getTiming
+page-type: web-api-instance-method
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animationeffect/index.md
+++ b/files/en-us/web/api/animationeffect/index.md
@@ -1,6 +1,7 @@
 ---
 title: AnimationEffect
 slug: Web/API/AnimationEffect
+page-type: web-api-interface
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animationeffect/updatetiming/index.md
+++ b/files/en-us/web/api/animationeffect/updatetiming/index.md
@@ -1,6 +1,7 @@
 ---
 title: AnimationEffect.updateTiming()
 slug: Web/API/AnimationEffect/updateTiming
+page-type: web-api-instance-method
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animationevent/animationevent/index.md
+++ b/files/en-us/web/api/animationevent/animationevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: AnimationEvent()
 slug: Web/API/AnimationEvent/AnimationEvent
+page-type: web-api-constructor
 tags:
   - API
   - AnimationEvent

--- a/files/en-us/web/api/animationevent/animationname/index.md
+++ b/files/en-us/web/api/animationevent/animationname/index.md
@@ -1,6 +1,7 @@
 ---
 title: AnimationEvent.animationName
 slug: Web/API/AnimationEvent/animationName
+page-type: web-api-instance-property
 tags:
   - API
   - AnimationEvent

--- a/files/en-us/web/api/animationevent/elapsedtime/index.md
+++ b/files/en-us/web/api/animationevent/elapsedtime/index.md
@@ -1,6 +1,7 @@
 ---
 title: AnimationEvent.elapsedTime
 slug: Web/API/AnimationEvent/elapsedTime
+page-type: web-api-instance-property
 tags:
   - API
   - AnimationEvent

--- a/files/en-us/web/api/animationevent/index.md
+++ b/files/en-us/web/api/animationevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: AnimationEvent
 slug: Web/API/AnimationEvent
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/animationevent/pseudoelement/index.md
+++ b/files/en-us/web/api/animationevent/pseudoelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: AnimationEvent.pseudoElement
 slug: Web/API/AnimationEvent/pseudoElement
+page-type: web-api-instance-property
 tags:
   - API
   - AnimationEvent

--- a/files/en-us/web/api/animationplaybackevent/animationplaybackevent/index.md
+++ b/files/en-us/web/api/animationplaybackevent/animationplaybackevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: AnimationPlaybackEvent()
 slug: Web/API/AnimationPlaybackEvent/AnimationPlaybackEvent
+page-type: web-api-constructor
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animationplaybackevent/currenttime/index.md
+++ b/files/en-us/web/api/animationplaybackevent/currenttime/index.md
@@ -1,6 +1,7 @@
 ---
 title: AnimationPlaybackEvent.currentTime
 slug: Web/API/AnimationPlaybackEvent/currentTime
+page-type: web-api-instance-property
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animationplaybackevent/index.md
+++ b/files/en-us/web/api/animationplaybackevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: AnimationPlaybackEvent
 slug: Web/API/AnimationPlaybackEvent
+page-type: web-api-interface
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animationplaybackevent/timelinetime/index.md
+++ b/files/en-us/web/api/animationplaybackevent/timelinetime/index.md
@@ -1,6 +1,7 @@
 ---
 title: AnimationPlaybackEvent.timelineTime
 slug: Web/API/AnimationPlaybackEvent/timelineTime
+page-type: web-api-instance-property
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animationtimeline/currenttime/index.md
+++ b/files/en-us/web/api/animationtimeline/currenttime/index.md
@@ -1,6 +1,7 @@
 ---
 title: AnimationTimeline.currentTime
 slug: Web/API/AnimationTimeline/currentTime
+page-type: web-api-instance-property
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/animationtimeline/index.md
+++ b/files/en-us/web/api/animationtimeline/index.md
@@ -1,6 +1,7 @@
 ---
 title: AnimationTimeline
 slug: Web/API/AnimationTimeline
+page-type: web-api-interface
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/atob/index.md
+++ b/files/en-us/web/api/atob/index.md
@@ -1,6 +1,7 @@
 ---
 title: atob()
 slug: Web/API/atob
+page-type: web-api-global-function
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/attr/index.md
+++ b/files/en-us/web/api/attr/index.md
@@ -1,6 +1,7 @@
 ---
 title: Attr
 slug: Web/API/Attr
+page-type: web-api-interface
 tags:
   - Interface
   - Reference

--- a/files/en-us/web/api/attr/localname/index.md
+++ b/files/en-us/web/api/attr/localname/index.md
@@ -1,6 +1,7 @@
 ---
 title: Attr.localName
 slug: Web/API/Attr/localName
+page-type: web-api-instance-property
 tags:
   - Property
   - Reference

--- a/files/en-us/web/api/attr/name/index.md
+++ b/files/en-us/web/api/attr/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: Attr.name
 slug: Web/API/Attr/name
+page-type: web-api-instance-property
 tags:
   - Property
   - Reference

--- a/files/en-us/web/api/attr/namespaceuri/index.md
+++ b/files/en-us/web/api/attr/namespaceuri/index.md
@@ -1,6 +1,7 @@
 ---
 title: Attr.namespaceURI
 slug: Web/API/Attr/namespaceURI
+page-type: web-api-instance-property
 tags:
   - Property
   - Reference

--- a/files/en-us/web/api/attr/ownerelement/index.md
+++ b/files/en-us/web/api/attr/ownerelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: Attr.ownerElement
 slug: Web/API/Attr/ownerElement
+page-type: web-api-instance-property
 tags:
   - Property
   - Reference

--- a/files/en-us/web/api/attr/prefix/index.md
+++ b/files/en-us/web/api/attr/prefix/index.md
@@ -1,6 +1,7 @@
 ---
 title: Attr.prefix
 slug: Web/API/Attr/prefix
+page-type: web-api-instance-property
 tags:
   - Property
   - Reference

--- a/files/en-us/web/api/attr/specified/index.md
+++ b/files/en-us/web/api/attr/specified/index.md
@@ -1,6 +1,7 @@
 ---
 title: Attr.specified
 slug: Web/API/Attr/specified
+page-type: web-api-instance-property
 tags:
   - Property
   - Reference

--- a/files/en-us/web/api/attr/value/index.md
+++ b/files/en-us/web/api/attr/value/index.md
@@ -1,6 +1,7 @@
 ---
 title: Attr.value
 slug: Web/API/Attr/value
+page-type: web-api-instance-property
 tags:
   - Property
   - Reference

--- a/files/en-us/web/api/audiobuffer/audiobuffer/index.md
+++ b/files/en-us/web/api/audiobuffer/audiobuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioBuffer()
 slug: Web/API/AudioBuffer/AudioBuffer
+page-type: web-api-constructor
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiobuffer/copyfromchannel/index.md
+++ b/files/en-us/web/api/audiobuffer/copyfromchannel/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioBuffer.copyFromChannel()
 slug: Web/API/AudioBuffer/copyFromChannel
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiobuffer/copytochannel/index.md
+++ b/files/en-us/web/api/audiobuffer/copytochannel/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioBuffer.copyToChannel()
 slug: Web/API/AudioBuffer/copyToChannel
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiobuffer/duration/index.md
+++ b/files/en-us/web/api/audiobuffer/duration/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioBuffer.duration
 slug: Web/API/AudioBuffer/duration
+page-type: web-api-instance-property
 tags:
   - API
   - AudioBuffer

--- a/files/en-us/web/api/audiobuffer/getchanneldata/index.md
+++ b/files/en-us/web/api/audiobuffer/getchanneldata/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioBuffer.getChannelData()
 slug: Web/API/AudioBuffer/getChannelData
+page-type: web-api-instance-method
 tags:
   - API
   - AudioBuffer

--- a/files/en-us/web/api/audiobuffer/index.md
+++ b/files/en-us/web/api/audiobuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioBuffer
 slug: Web/API/AudioBuffer
+page-type: web-api-interface
 tags:
   - API
   - AudioBuffer

--- a/files/en-us/web/api/audiobuffer/length/index.md
+++ b/files/en-us/web/api/audiobuffer/length/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioBuffer.length
 slug: Web/API/AudioBuffer/length
+page-type: web-api-instance-property
 tags:
   - API
   - AudioBuffer

--- a/files/en-us/web/api/audiobuffer/numberofchannels/index.md
+++ b/files/en-us/web/api/audiobuffer/numberofchannels/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioBuffer.numberOfChannels
 slug: Web/API/AudioBuffer/numberOfChannels
+page-type: web-api-instance-property
 tags:
   - API
   - AudioBuffer

--- a/files/en-us/web/api/audiobuffer/samplerate/index.md
+++ b/files/en-us/web/api/audiobuffer/samplerate/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioBuffer.sampleRate
 slug: Web/API/AudioBuffer/sampleRate
+page-type: web-api-instance-property
 tags:
   - API
   - AudioBuffer

--- a/files/en-us/web/api/audiobuffersourcenode/audiobuffersourcenode/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/audiobuffersourcenode/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioBufferSourceNode()
 slug: Web/API/AudioBufferSourceNode/AudioBufferSourceNode
+page-type: web-api-constructor
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiobuffersourcenode/buffer/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/buffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioBufferSourceNode.buffer
 slug: Web/API/AudioBufferSourceNode/buffer
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiobuffersourcenode/detune/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/detune/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioBufferSourceNode.detune
 slug: Web/API/AudioBufferSourceNode/detune
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiobuffersourcenode/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioBufferSourceNode
 slug: Web/API/AudioBufferSourceNode
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiobuffersourcenode/loop/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/loop/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioBufferSourceNode.loop
 slug: Web/API/AudioBufferSourceNode/loop
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiobuffersourcenode/loopend/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/loopend/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioBufferSourceNode.loopEnd
 slug: Web/API/AudioBufferSourceNode/loopEnd
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiobuffersourcenode/loopstart/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/loopstart/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioBufferSourceNode.loopStart
 slug: Web/API/AudioBufferSourceNode/loopStart
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiobuffersourcenode/playbackrate/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/playbackrate/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioBufferSourceNode.playbackRate
 slug: Web/API/AudioBufferSourceNode/playbackRate
+page-type: web-api-instance-property
 tags:
   - API
   - AudioBufferSourceNode

--- a/files/en-us/web/api/audiobuffersourcenode/start/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/start/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioBufferSourceNode.start()
 slug: Web/API/AudioBufferSourceNode/start
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiocontext/audiocontext/index.md
+++ b/files/en-us/web/api/audiocontext/audiocontext/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioContext()
 slug: Web/API/AudioContext/AudioContext
+page-type: web-api-constructor
 tags:
   - Audio
   - Audio Context

--- a/files/en-us/web/api/audiocontext/baselatency/index.md
+++ b/files/en-us/web/api/audiocontext/baselatency/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioContext.baseLatency
 slug: Web/API/AudioContext/baseLatency
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiocontext/close/index.md
+++ b/files/en-us/web/api/audiocontext/close/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioContext.close()
 slug: Web/API/AudioContext/close
+page-type: web-api-instance-method
 tags:
   - API
   - AudioContext

--- a/files/en-us/web/api/audiocontext/createmediaelementsource/index.md
+++ b/files/en-us/web/api/audiocontext/createmediaelementsource/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioContext.createMediaElementSource()
 slug: Web/API/AudioContext/createMediaElementSource
+page-type: web-api-instance-method
 tags:
   - API
   - AudioContext

--- a/files/en-us/web/api/audiocontext/createmediastreamdestination/index.md
+++ b/files/en-us/web/api/audiocontext/createmediastreamdestination/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioContext.createMediaStreamDestination()
 slug: Web/API/AudioContext/createMediaStreamDestination
+page-type: web-api-instance-method
 tags:
   - API
   - AudioContext

--- a/files/en-us/web/api/audiocontext/createmediastreamsource/index.md
+++ b/files/en-us/web/api/audiocontext/createmediastreamsource/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioContext.createMediaStreamSource()
 slug: Web/API/AudioContext/createMediaStreamSource
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiocontext/createmediastreamtracksource/index.md
+++ b/files/en-us/web/api/audiocontext/createmediastreamtracksource/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioContext.createMediaStreamTrackSource()
 slug: Web/API/AudioContext/createMediaStreamTrackSource
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiocontext/getoutputtimestamp/index.md
+++ b/files/en-us/web/api/audiocontext/getoutputtimestamp/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioContext.getOutputTimestamp()
 slug: Web/API/AudioContext/getOutputTimestamp
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiocontext/index.md
+++ b/files/en-us/web/api/audiocontext/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioContext
 slug: Web/API/AudioContext
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiocontext/outputlatency/index.md
+++ b/files/en-us/web/api/audiocontext/outputlatency/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioContext.outputLatency
 slug: Web/API/AudioContext/outputLatency
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiocontext/resume/index.md
+++ b/files/en-us/web/api/audiocontext/resume/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioContext.resume()
 slug: Web/API/AudioContext/resume
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiocontext/suspend/index.md
+++ b/files/en-us/web/api/audiocontext/suspend/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioContext.suspend()
 slug: Web/API/AudioContext/suspend
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiodata/allocationsize/index.md
+++ b/files/en-us/web/api/audiodata/allocationsize/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioData.allocationSize()
 slug: Web/API/AudioData/allocationSize
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/audiodata/audiodata/index.md
+++ b/files/en-us/web/api/audiodata/audiodata/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioData()
 slug: Web/API/AudioData/AudioData
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/audiodata/clone/index.md
+++ b/files/en-us/web/api/audiodata/clone/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioData.clone()
 slug: Web/API/AudioData/clone
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/audiodata/close/index.md
+++ b/files/en-us/web/api/audiodata/close/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioData.close()
 slug: Web/API/AudioData/close
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/audiodata/copyto/index.md
+++ b/files/en-us/web/api/audiodata/copyto/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioData.copyTo()
 slug: Web/API/AudioData/copyTo
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/audiodata/duration/index.md
+++ b/files/en-us/web/api/audiodata/duration/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioData.duration
 slug: Web/API/AudioData/duration
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/audiodata/format/index.md
+++ b/files/en-us/web/api/audiodata/format/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioData.format
 slug: Web/API/AudioData/format
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/audiodata/index.md
+++ b/files/en-us/web/api/audiodata/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioData
 slug: Web/API/AudioData
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/audiodata/numberofchannels/index.md
+++ b/files/en-us/web/api/audiodata/numberofchannels/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioData.numberOfChannels
 slug: Web/API/AudioData/numberOfChannels
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/audiodata/numberofframes/index.md
+++ b/files/en-us/web/api/audiodata/numberofframes/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioData.numberOfFrames
 slug: Web/API/AudioData/numberOfFrames
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/audiodata/samplerate/index.md
+++ b/files/en-us/web/api/audiodata/samplerate/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioData.sampleRate
 slug: Web/API/AudioData/sampleRate
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/audiodata/timestamp/index.md
+++ b/files/en-us/web/api/audiodata/timestamp/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioData.timestamp
 slug: Web/API/AudioData/timestamp
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/audiodecoder/audiodecoder/index.md
+++ b/files/en-us/web/api/audiodecoder/audiodecoder/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioDecoder.AudioDecoder()
 slug: Web/API/AudioDecoder/AudioDecoder
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/audiodecoder/close/index.md
+++ b/files/en-us/web/api/audiodecoder/close/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioDecoder.close()
 slug: Web/API/AudioDecoder/close
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/audiodecoder/configure/index.md
+++ b/files/en-us/web/api/audiodecoder/configure/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioDecoder.configure()
 slug: Web/API/AudioDecoder/configure
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/audiodecoder/decode/index.md
+++ b/files/en-us/web/api/audiodecoder/decode/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioDecoder.decode()
 slug: Web/API/AudioDecoder/decode
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/audiodecoder/decodequeuesize/index.md
+++ b/files/en-us/web/api/audiodecoder/decodequeuesize/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioDecoder.decodeQueueSize
 slug: Web/API/AudioDecoder/decodeQueueSize
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/audiodecoder/flush/index.md
+++ b/files/en-us/web/api/audiodecoder/flush/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioDecoder.flush()
 slug: Web/API/AudioDecoder/flush
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/audiodecoder/index.md
+++ b/files/en-us/web/api/audiodecoder/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioDecoder
 slug: Web/API/AudioDecoder
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/audiodecoder/reset/index.md
+++ b/files/en-us/web/api/audiodecoder/reset/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioDecoder.reset()
 slug: Web/API/AudioDecoder/reset
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/audiodecoder/state/index.md
+++ b/files/en-us/web/api/audiodecoder/state/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioDecoder.state
 slug: Web/API/AudioDecoder/state
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/audiodestinationnode/index.md
+++ b/files/en-us/web/api/audiodestinationnode/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioDestinationNode
 slug: Web/API/AudioDestinationNode
+page-type: web-api-interface
 tags:
   - API
   - AudioDestinationNode

--- a/files/en-us/web/api/audiodestinationnode/maxchannelcount/index.md
+++ b/files/en-us/web/api/audiodestinationnode/maxchannelcount/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioDestinationNode.maxChannelCount
 slug: Web/API/AudioDestinationNode/maxChannelCount
+page-type: web-api-instance-property
 tags:
   - API
   - AudioDestinationNode

--- a/files/en-us/web/api/audioencoder/audioencoder/index.md
+++ b/files/en-us/web/api/audioencoder/audioencoder/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioEncoder.AudioEncoder()
 slug: Web/API/AudioEncoder/AudioEncoder
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/audioencoder/close/index.md
+++ b/files/en-us/web/api/audioencoder/close/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioEncoder.close()
 slug: Web/API/AudioEncoder/close
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/audioencoder/configure/index.md
+++ b/files/en-us/web/api/audioencoder/configure/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioEncoder.configure()
 slug: Web/API/AudioEncoder/configure
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/audioencoder/encode/index.md
+++ b/files/en-us/web/api/audioencoder/encode/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioEncoder.encode()
 slug: Web/API/AudioEncoder/encode
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/audioencoder/encodequeuesize/index.md
+++ b/files/en-us/web/api/audioencoder/encodequeuesize/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioEncoder.encodeQueueSize
 slug: Web/API/AudioEncoder/encodeQueueSize
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/audioencoder/flush/index.md
+++ b/files/en-us/web/api/audioencoder/flush/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioEncoder.flush()
 slug: Web/API/AudioEncoder/flush
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/audioencoder/index.md
+++ b/files/en-us/web/api/audioencoder/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioEncoder
 slug: Web/API/AudioEncoder
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/audioencoder/reset/index.md
+++ b/files/en-us/web/api/audioencoder/reset/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioEncoder.reset()
 slug: Web/API/AudioEncoder/reset
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/audioencoder/state/index.md
+++ b/files/en-us/web/api/audioencoder/state/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioEncoder.state
 slug: Web/API/AudioEncoder/state
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/audiolistener/dopplerfactor/index.md
+++ b/files/en-us/web/api/audiolistener/dopplerfactor/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioListener.dopplerFactor
 slug: Web/API/AudioListener/dopplerFactor
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiolistener/forwardx/index.md
+++ b/files/en-us/web/api/audiolistener/forwardx/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioListener.forwardX
 slug: Web/API/AudioListener/forwardX
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiolistener/forwardy/index.md
+++ b/files/en-us/web/api/audiolistener/forwardy/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioListener.forwardY
 slug: Web/API/AudioListener/forwardY
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiolistener/forwardz/index.md
+++ b/files/en-us/web/api/audiolistener/forwardz/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioListener.forwardZ
 slug: Web/API/AudioListener/forwardZ
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiolistener/index.md
+++ b/files/en-us/web/api/audiolistener/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioListener
 slug: Web/API/AudioListener
+page-type: web-api-interface
 tags:
   - API
   - AudioListener

--- a/files/en-us/web/api/audiolistener/positionx/index.md
+++ b/files/en-us/web/api/audiolistener/positionx/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioListener.positionX
 slug: Web/API/AudioListener/positionX
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiolistener/positiony/index.md
+++ b/files/en-us/web/api/audiolistener/positiony/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioListener.positionY
 slug: Web/API/AudioListener/positionY
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiolistener/positionz/index.md
+++ b/files/en-us/web/api/audiolistener/positionz/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioListener.positionZ
 slug: Web/API/AudioListener/positionZ
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiolistener/setorientation/index.md
+++ b/files/en-us/web/api/audiolistener/setorientation/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioListener.setOrientation()
 slug: Web/API/AudioListener/setOrientation
+page-type: web-api-instance-method
 tags:
   - API
   - AudioListener

--- a/files/en-us/web/api/audiolistener/setposition/index.md
+++ b/files/en-us/web/api/audiolistener/setposition/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioListener.setPosition()
 slug: Web/API/AudioListener/setPosition
+page-type: web-api-instance-method
 tags:
   - API
   - AudioListener

--- a/files/en-us/web/api/audiolistener/speedofsound/index.md
+++ b/files/en-us/web/api/audiolistener/speedofsound/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioListener.speedOfSound
 slug: Web/API/AudioListener/speedOfSound
+page-type: web-api-instance-property
 tags:
   - API
   - AudioListener

--- a/files/en-us/web/api/audiolistener/upx/index.md
+++ b/files/en-us/web/api/audiolistener/upx/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioListener.upX
 slug: Web/API/AudioListener/upX
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audiolistener/upy/index.md
+++ b/files/en-us/web/api/audiolistener/upy/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioListener.upY
 slug: Web/API/AudioListener/upY
+page-type: web-api-instance-property
 tags:
   - API
   - AudioListener

--- a/files/en-us/web/api/audiolistener/upz/index.md
+++ b/files/en-us/web/api/audiolistener/upz/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioListener.upZ
 slug: Web/API/AudioListener/upZ
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audionode/channelcount/index.md
+++ b/files/en-us/web/api/audionode/channelcount/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioNode.channelCount
 slug: Web/API/AudioNode/channelCount
+page-type: web-api-instance-property
 tags:
   - API
   - AudioNode

--- a/files/en-us/web/api/audionode/channelcountmode/index.md
+++ b/files/en-us/web/api/audionode/channelcountmode/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioNode.channelCountMode
 slug: Web/API/AudioNode/channelCountMode
+page-type: web-api-instance-property
 tags:
   - API
   - AudioNode

--- a/files/en-us/web/api/audionode/channelinterpretation/index.md
+++ b/files/en-us/web/api/audionode/channelinterpretation/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioNode.channelInterpretation
 slug: Web/API/AudioNode/channelInterpretation
+page-type: web-api-instance-property
 tags:
   - API
   - AudioNode

--- a/files/en-us/web/api/audionode/connect/index.md
+++ b/files/en-us/web/api/audionode/connect/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioNode.connect()
 slug: Web/API/AudioNode/connect
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audionode/context/index.md
+++ b/files/en-us/web/api/audionode/context/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioNode.context
 slug: Web/API/AudioNode/context
+page-type: web-api-instance-property
 tags:
   - API
   - AudioNode

--- a/files/en-us/web/api/audionode/disconnect/index.md
+++ b/files/en-us/web/api/audionode/disconnect/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioNode.disconnect()
 slug: Web/API/AudioNode/disconnect
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audionode/index.md
+++ b/files/en-us/web/api/audionode/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioNode
 slug: Web/API/AudioNode
+page-type: web-api-interface
 tags:
   - API
   - AudioNode

--- a/files/en-us/web/api/audionode/numberofinputs/index.md
+++ b/files/en-us/web/api/audionode/numberofinputs/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioNode.numberOfInputs
 slug: Web/API/AudioNode/numberOfInputs
+page-type: web-api-instance-property
 tags:
   - API
   - AudioNode

--- a/files/en-us/web/api/audionode/numberofoutputs/index.md
+++ b/files/en-us/web/api/audionode/numberofoutputs/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioNode.numberOfOutputs
 slug: Web/API/AudioNode/numberOfOutputs
+page-type: web-api-instance-property
 tags:
   - API
   - AudioNode

--- a/files/en-us/web/api/audioparam/cancelandholdattime/index.md
+++ b/files/en-us/web/api/audioparam/cancelandholdattime/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioParam.cancelAndHoldAtTime()
 slug: Web/API/AudioParam/cancelAndHoldAtTime
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audioparam/cancelscheduledvalues/index.md
+++ b/files/en-us/web/api/audioparam/cancelscheduledvalues/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioParam.cancelScheduledValues()
 slug: Web/API/AudioParam/cancelScheduledValues
+page-type: web-api-instance-method
 tags:
   - API
   - AudioParam

--- a/files/en-us/web/api/audioparam/defaultvalue/index.md
+++ b/files/en-us/web/api/audioparam/defaultvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioParam.defaultValue
 slug: Web/API/AudioParam/defaultValue
+page-type: web-api-instance-property
 tags:
   - API
   - AudioParam

--- a/files/en-us/web/api/audioparam/exponentialramptovalueattime/index.md
+++ b/files/en-us/web/api/audioparam/exponentialramptovalueattime/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioParam.exponentialRampToValueAtTime()
 slug: Web/API/AudioParam/exponentialRampToValueAtTime
+page-type: web-api-instance-method
 tags:
   - API
   - AudioParam

--- a/files/en-us/web/api/audioparam/index.md
+++ b/files/en-us/web/api/audioparam/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioParam
 slug: Web/API/AudioParam
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audioparam/linearramptovalueattime/index.md
+++ b/files/en-us/web/api/audioparam/linearramptovalueattime/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioParam.linearRampToValueAtTime()
 slug: Web/API/AudioParam/linearRampToValueAtTime
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audioparam/maxvalue/index.md
+++ b/files/en-us/web/api/audioparam/maxvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioParam.maxValue
 slug: Web/API/AudioParam/maxValue
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/audioparam/minvalue/index.md
+++ b/files/en-us/web/api/audioparam/minvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: AudioParam.minValue
 slug: Web/API/AudioParam/minValue
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/index.md
+++ b/files/en-us/web/api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Web APIs
 slug: Web/API
+page-type: landing-page
 tags:
   - API
   - DOM


### PR DESCRIPTION
This is part 1 of a series of PRs to add page types to the Web/API documentation.

This one is experimental, to see what it would look like. But if we like this I will file more like this, with 200 pages in each PR (about 30 PRs total to get through the set).

I've used the same page type names as in https://github.com/mdn/content/issues/16255, except lowercased and with dashes for spaces.

I'm going to ignore any pages that were identified as problematic in https://github.com/mdn/content/issues/16255.

It would be easy to do title updates and add short-title at the same time, maybe we should? But we would need a clear definition of all the titles and also updates to the sidebars (if we have short-title then these would be pretty simple though I think).

@Rumyra , @teoli2003 , @fiji-flo wdyt?