### PR TITLE
Add space after comma

### DIFF
--- a/files/en-us/web/api/notification/renotify/index.md
+++ b/files/en-us/web/api/notification/renotify/index.md
@@ -29,12 +29,12 @@ it has been replaced; a simple `options` object is created, and then the
 notification is fired using the `Notification()` constructor.
 
 ```js
-var options = {
+const options = {
   body: 'Do you like my Notification?',
   renotify: true
 }
 
-var n = new Notification('Test notification', options);
+const n = new Notification('Test notification', options);
 
 console.log(n.renotify) // should log true
 ```
@@ -49,5 +49,4 @@ console.log(n.renotify) // should log true
 
 ## See also
 
-- [Using
-  the Notifications API](/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API)
+- [Using the Notifications API](/en-US/docs/Web/API/Notifications_API/Using_the_Notifications_API)

--- a/files/en-us/web/api/notification/renotify/index.md
+++ b/files/en-us/web/api/notification/renotify/index.md
@@ -34,7 +34,7 @@ var options = {
   renotify: true
 }
 
-var n = new Notification('Test notification',options);
+var n = new Notification('Test notification', options);
 
 console.log(n.renotify) // should log true
 ```


### PR DESCRIPTION
Add space after comma to fit better with common styling.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Adds a space after the comma, before the next argument in the list.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
For better readability and to follow best practices
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
The [style guide](https://developer.mozilla.org/en-US/docs/MDN/Guidelines/Writing_style_guide#code_sample_style_and_formatting) follows this practice.
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
n/a
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
