### PR TITLE
Increase embed height so footer shows in example

### DIFF
--- a/files/en-us/web/css/grid-template-areas/index.md
+++ b/files/en-us/web/css/grid-template-areas/index.md
@@ -103,7 +103,7 @@ grid-template-areas: unset;
 
 #### Result
 
-{{EmbedLiveSample("Specifying_named_grid_areas", "100%", "250px")}}
+{{EmbedLiveSample("Specifying_named_grid_areas", "100%", "285px")}}
 
 ## Specifications
 


### PR DESCRIPTION
The height of the iframe didn't take into account the vertical padding, so the footer was hidden by default. On macOS, the scrollbar is also hidden by default, so the result was confusing. Increasing the iframe's height eliminates this issue.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Increased height of embed iframe to reveal full layout from example.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
So others won't be confused about what happened to the hidden footer like I was.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
