### PR TITLE
Fix link to polyfill in JSON.stringify docs

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/json/stringify/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/json/stringify/index.md
@@ -417,5 +417,5 @@ result of `JSON.stringify` do you need to carefully handle
 
 ## See also
 
-- [Polyfill of modern `JSON.stringify` behavior (symbol and well-formed unicode) in `core-js`](https://github.com/zloirock/core-js#ecmascript-function)
+- [Polyfill of modern `JSON.stringify` behavior (symbol and well-formed unicode) in `core-js`](https://github.com/zloirock/core-js#ecmascript-json)
 - {{JSxRef("JSON.parse()")}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fix link to polyfill in JSON.stringify docs
#### Motivation
The current link scrolls to the `Function` section of the readme. It should scroll to `JSON` instead.

#### Supporting details
Old link: https://github.com/zloirock/core-js#ecmascript-function
New link: https://github.com/zloirock/core-js#ecmascript-json

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
