### PR TITLE
Drop the Browser Compatibility section from EXSLT pages

### DIFF
--- a/files/en-us/web/exslt/exsl/index.md
+++ b/files/en-us/web/exslt/exsl/index.md
@@ -11,7 +11,3 @@ tags:
 The EXSLT Common package provides basic functions that expand upon the capabilities of XSLT. The namespace for the Common package is `http://exslt.org/common`.
 
 {{SubpagesWithSummaries}}
-
-## Browser compatibility
-
-{{Compat("xslt.exslt.exsl")}}

--- a/files/en-us/web/exslt/math/index.md
+++ b/files/en-us/web/exslt/math/index.md
@@ -11,7 +11,3 @@ tags:
 The EXSLT Math package provides functions for working with numeric values and comparing nodes. The namespace for the Math package is `http://exslt.org/math`.
 
 {{SubpagesWithSummaries}}
-
-## Browser compatibility
-
-{{Compat("xslt.exslt.math")}}

--- a/files/en-us/web/exslt/regexp/index.md
+++ b/files/en-us/web/exslt/regexp/index.md
@@ -11,7 +11,3 @@ tags:
 The EXSLT Regular Expressions package provides functions that allow testing, matching, and replacing text using JavaScript style regular expressions. The namespace for the Regular Expressions package is `http://exslt.org/regular-expressions`.
 
 {{SubpagesWithSummaries}}
-
-## Browser compatibility
-
-{{Compat("xslt.exslt.regexp")}}

--- a/files/en-us/web/exslt/set/index.md
+++ b/files/en-us/web/exslt/set/index.md
@@ -11,7 +11,3 @@ tags:
 The EXSLT Sets package offers functions that let you perform set manipulation. The namespace for these functions is `http://exslt.org/sets`.
 
 {{SubpagesWithSummaries}}
-
-## Browser compatibility
-
-{{Compat("xslt.exslt.set")}}

--- a/files/en-us/web/exslt/str/index.md
+++ b/files/en-us/web/exslt/str/index.md
@@ -11,7 +11,3 @@ tags:
 The EXSLT Strings package provides functions that allow the manipulation of strings. The namespace for the Strings package is `http://exslt.org/strings`.
 
 {{SubpagesWithSummaries}}
-
-## Browser compatibility
-
-{{Compat("xslt.exslt.str")}}


### PR DESCRIPTION
The entire `xslt` subdirectory is now gone from BCD, so the Browser·Compatibility·sections/tables on these pages just show “No compatibility data found”.
