### PR TITLE
Document new svh/svw, lvh/lvw, dvh/dvw etc. viewport-percentage relative length units

### DIFF
--- a/files/en-us/web/css/length/index.md
+++ b/files/en-us/web/css/length/index.md
@@ -59,26 +59,26 @@ Font lengths define the `<length>` value in terms of the size of a particular ch
 
 The viewport-percentage length units are based on four different viewport sizes: small, large, dynamic, and default. The allowance for the different viewport sizes is in response to browser interfaces expanding and retracting dynamically and hiding and showing the content underneath.
 
-- Small
+- **Small**
   - : When you want the smallest possible viewport in response to browser interfaces expanding dynamically, you should use the small viewport size. The small viewport size allows the content you design to fill the entire viewport when browser interfaces are expanded. Choosing this size might also possibly leave empty spaces when browser interfaces retract.
 
     For example, an element that is sized using viewport-percentage units based on the small viewport size, the element will fill the screen perfectly without any of its content being obscured when all the dynamic browser interfaces are shown. When those browser interfaces are hidden, however, there might be extra space visible around the element. Therefore, the small viewport-percentage units are “safer” to use in general, but might not produce the most attractive layout after a user starts interacting with the page.
 
     The small viewport size is represented by the `sv` prefix and results in the `sv*` viewport-percentage length units. The sizes of the small viewport-percentage units are fixed, and therefore stable, unless the viewport itself is resized.
-- Large
+- **Large**
   - : When you want the largest possible viewport in response to browser interfaces retracting dynamically, you should use the large viewport size. The large viewport size allows the content you design to fill the entire viewport when browser interfaces are retracting. You need to be aware though that the content might get hidden when browser interfaces expand.
   
     For example, on mobile phones where the screen real-estate is at a premium, browsers often hide part or all of the title and address bar after a user starts scrolling the page. When an element is sized using a viewport-percentage unit based on the large viewport size, the content of the element will fill the entire visible page when these browser interfaces are hidden. However, when these retractable browser interfaces are shown, they can hide the content that is sized or positioned using the _large_ viewport-percentage units.
 
     The large viewport unit is represented by the `lv` prefix and results in the `lv*` viewport-percentage units. The sizes of the large viewport-percentage units are fixed, and therefore stable, unless the viewport itself is resized.
-- Dynamic
+- **Dynamic**
   - : When you want the viewport to be automatically sized in response to browser interfaces dynamically expanding or retracting, you can use the dynamic viewport size. The dynamic viewport size allows the content you design to fit exactly within the viewport, irrespective of the presence of dynamic browser interfaces.
   
     The dynamic viewport unit is represented by the `dv` prefix and results in the `dv*` viewport-percentage units. The sizes of the dynamic viewport-percentage units are not stable, even when the viewport itself is unchanged.
 
     > **Note:** While the dynamic viewport size can give you more control and flexibility, using viewport-percentage units based on the dynamic viewport size can cause the content to resize while a user is scrolling a page. This can lead to degradation of the user interface and cause a performance hit.
 
-- Default
+- **Default**
   - : The default viewport size is defined by the browser. The behavior of the resulting viewport-percentage unit could be equivalent to the viewport-percentage unit based on the small viewport size, the large viewport size, an intermediate size between the two, or the dynamic viewport size.
 
     For example, a browser might implement the default viewport-percentage unit for height (`vh`) that is equivalent to the large viewport-percentage height unit (`lvh`).

--- a/files/en-us/web/css/length/index.md
+++ b/files/en-us/web/css/length/index.md
@@ -25,9 +25,11 @@ The `<length>` data type consists of a {{cssxref("&lt;number&gt;")}} followed by
 
 The [specified value](/en-US/docs/Web/CSS/specified_value) of a length (_specified length_) is represented by its quantity and unit. The [computed value](/en-US/docs/Web/CSS/computed_value) of a length (_computed length_) is the specified length resolved to an absolute length, and its unit is not distinguished.
 
-The length units can be relative or absolute. Relative lengths represent a measurement in terms of some other distance. Depending on the unit, this can be the size of a specific character, the [line height](/en-US/docs/Web/CSS/line-height), or the size of the {{Glossary("viewport")}}. Style sheets that use relative units can more easily scale from one output environment to another. All the relative length units can be categorized into those associated with font and viewport.
+The `<length>` units can be relative or absolute. Relative lengths represent a measurement in terms of some other distance. Depending on the unit, this distance can be the size of a specific character, the [line height](/en-US/docs/Web/CSS/line-height), or the size of the {{Glossary("viewport")}}. Style sheets that use relative length units can more easily scale from one output environment to another.
 
 > **Note:** Child elements do not inherit the relative values as specified for their parent; they inherit the computed values.
+
+The relative length units listed here are based on font and viewport.
 
 ### Relative length units based on font
 
@@ -53,55 +55,67 @@ Font lengths define the `<length>` value in terms of the size of a particular ch
 - `rlh` {{experimental_inline}}
   - : Equal to the computed value of the {{Cssxref("line-height")}} property on the root element (typically {{HTMLElement("html")}}), converted to an absolute length. When used on the {{Cssxref("font-size")}} or {{Cssxref("line-height")}} properties of the root element, it refers to the properties' initial value.
 
-### Relative length units based on viewport-percentage lengths
+### Relative length units based on viewport
 
-The viewport-percentage length units are based on four different viewport sizes: default, small, large, and dynamic. The allowance for the different viewport sizes is in response to browser interfaces that dynamically expand and retract.
+The viewport-percentage length units are based on four different viewport sizes: small, large, dynamic, and default. The allowance for the different viewport sizes is in response to browser interfaces expanding and retracting dynamically and hiding and showing the content underneath.
 
-- Default
-  - : The default viewport size is defined by the browser. The behavior of the resulting viewport-percentage unit could be equivalent to the viewport-percentage unit based on either the small viewport size, the large viewport size, an intermediate size between the two, or the dynamic viewport size.
-  For example, a browser might implement the default viewport-percentage unit for height that is equivalent to the large viewport-percentage height unit.
 - Small
-  - : When you want the smallest possible viewport in response to browser UI dynamically expanding, you should use the small viewport size. In response to browser interfaces expanding, the small viewport size allows the content you design to fill the entire viewport. This might also possibly leave empty spaces when browser interfaces retract. 
-    For example, an element that is sized using viewport-percentage units based on the small viewport size, the element will fill the screen perfectly without any of its content being obscured when all the dynamic browser interfaces are shown. When those browser interfaces are hidden, however, there will be extra space around the element. The small viewport-percentage units are, therefore, “safer” to use in general, but might not produce the most attractive layout after a user starts interacting with the page.
-    The small viewport unit is represented by the `sv` prefix and results in the viewport-percentage variants `sv*`.
-    The sizes of the small viewport-percentage units are fixed, and therefore stable, unless the viewport itself is resized.
+  - : When you want the smallest possible viewport in response to browser interfaces expanding dynamically, you should use the small viewport size. The small viewport size allows the content you design to fill the entire viewport when browser interfaces are expanded. Choosing this size might also possibly leave empty spaces when browser interfaces retract.
+
+    For example, an element that is sized using viewport-percentage units based on the small viewport size, the element will fill the screen perfectly without any of its content being obscured when all the dynamic browser interfaces are shown. When those browser interfaces are hidden, however, there might be extra space visible around the element. Therefore, the small viewport-percentage units are “safer” to use in general, but might not produce the most attractive layout after a user starts interacting with the page.
+
+    The small viewport size is represented by the `sv` prefix and results in the `sv*` viewport-percentage length units. The sizes of the small viewport-percentage units are fixed, and therefore stable, unless the viewport itself is resized.
 - Large
-  - : When you want the largest possible viewport in response to browser interfaces dynamically retracting, you should use the large viewport size. In response to browser interfaces retracting, the large viewport size allows the content you design to fill the entire viewport. You need to be aware that the content might get hidden when browser interfaces expand.
-    For example, on mobile phones where the screen real-estate is at a premium, browsers often hide part or all of the title and address bar after a user starts scrolling the page. When viewport-percentage units based on the large viewport size are used, the content using these units will fill the entire visible page when these browser UI elements are hidden. However, when the retractable elements are shown, they can hide the content that is sized or positioned using these units.
-    The large viewport unit is represented by the `lv` prefix and results in the viewport-percentage variants `lv*`.
-    The sizes of the large viewport-percentage units are fixed, and therefore stable, unless the viewport itself is resized.
+  - : When you want the largest possible viewport in response to browser interfaces retracting dynamically, you should use the large viewport size. The large viewport size allows the content you design to fill the entire viewport when browser interfaces are retracting. You need to be aware though that the content might get hidden when browser interfaces expand.
+  
+    For example, on mobile phones where the screen real-estate is at a premium, browsers often hide part or all of the title and address bar after a user starts scrolling the page. When an element is sized using a viewport-percentage unit based on the large viewport size, the content of the element will fill the entire visible page when these browser interfaces are hidden. However, when these retractable browser interfaces are shown, they can hide the content that is sized or positioned using the _large_ viewport-percentage units.
+
+    The large viewport unit is represented by the `lv` prefix and results in the `lv*` viewport-percentage units. The sizes of the large viewport-percentage units are fixed, and therefore stable, unless the viewport itself is resized.
 - Dynamic
   - : When you want the viewport to be automatically sized in response to browser interfaces dynamically expanding or retracting, you can use the dynamic viewport size. The dynamic viewport size allows the content you design to fit exactly within the viewport, irrespective of the presence of dynamic browser interfaces.
-  The dynamic viewport unit is represented by the `dv` prefix and results in the viewport-percentage variants `dv*`.
-  The sizes of the dynamic viewport-percentage units are not stable, even when the viewport itself is unchanged.
-  > **Note:** While the dynamic viewport size can give you more control and flexibility, using viewport-percentage units based on the dynamic viewport size can cause the content to resize, like while a user is scrolling a page. This can lead to degradation of the user interface and performance.
+  
+    The dynamic viewport unit is represented by the `dv` prefix and results in the `dv*` viewport-percentage units. The sizes of the dynamic viewport-percentage units are not stable, even when the viewport itself is unchanged.
 
-Viewport-percentage lengths define `<length>` values in percentage relative to the size of the initial [containing block](/en-US/docs/Web/CSS/Containing_block), which in turn is based on either the size of the {{Glossary("viewport") or the page area, i.e., the visible portion of the document. When the height or width of the initial containing block is changed, the elements that are sized based on them are scaled accordingly. There is a viewport-percentage length unit variant corresponding to each of the viewport sizes. Viewport lengths are invalid in {{cssxref("@page")}} declaration blocks.
+    > **Note:** While the dynamic viewport size can give you more control and flexibility, using viewport-percentage units based on the dynamic viewport size can cause the content to resize while a user is scrolling a page. This can lead to degradation of the user interface and cause a performance hit.
+
+- Default
+  - : The default viewport size is defined by the browser. The behavior of the resulting viewport-percentage unit could be equivalent to the viewport-percentage unit based on the small viewport size, the large viewport size, an intermediate size between the two, or the dynamic viewport size.
+
+    For example, a browser might implement the default viewport-percentage unit for height (`vh`) that is equivalent to the large viewport-percentage height unit (`lvh`).
+
+Viewport-percentage lengths define `<length>` values in percentage relative to the size of the initial [containing block](/en-US/docs/Web/CSS/Containing_block), which in turn is based on either the size of the {{Glossary("viewport")}} or the page area, i.e., the visible portion of the document. When the height or width of the initial containing block is changed, the elements that are sized based on them are scaled accordingly. There is a viewport-percentage length unit variant corresponding to each of the viewport sizes, as described below.
+
+> **Note:** Viewport lengths are invalid in {{cssxref("@page")}} declaration blocks.
 
 - `vh`
   - : Represents a percentage of the height of the viewport's initial [containing block](/en-US/docs/Web/CSS/Containing_block). `1vh` is 1% of the viewport height. For example, if the viewport height is `300px`, then a value of `70vh` on a property will be `210px`.
-  For small, large, and dynamic viewport sizes, the respective viewport-percentage units are `svh`, `lvh`, and `dvh`.
-  `vh` represents the viewport-percentage length unit based on the browser default viewport size.
+
+    For small, large, and dynamic viewport sizes, the respective viewport-percentage units are `svh`, `lvh`, and `dvh`. `vh` represents the viewport-percentage length unit based on the browser default viewport size.
 - `vw`
-  - : Represents a percentage of the width of the viewport's initial [containing block](/en-US/docs/Web/CSS/Containing_block). `1vw` is 1% of the viewport width. For example, if the viewport width is `800px`, then `50vw` will be `400px`.
-  For small, large, and dynamic viewport sizes, the respective viewport-percentage units are `svw`, `lvw`, and `dvw`.
-  `vw` represents the viewport-percentage length unit based on the browser default viewport size.
+  - : Represents a percentage of the width of the viewport's initial [containing block](/en-US/docs/Web/CSS/Containing_block). `1vw` is 1% of the viewport width. For example, if the viewport width is `800px`, then a value of `50vw` on a property will be `400px`.
+
+    For small, large, and dynamic viewport sizes, the respective viewport-percentage units are `svw`, `lvw`, and `dvw`.
+    `vw` represents the viewport-percentage length unit based on the browser default viewport size.
 - `vmax`
   - : Represents in percentage the larger of `vw` and `vh`.
-  For small, large, and dynamic viewport sizes, the respective viewport-percentage units are `svmax`, `lvmax`, and `dvmax`.
-  `vmax` represents the viewport-percentage length unit based on the browser default viewport size.
+
+    For small, large, and dynamic viewport sizes, the respective viewport-percentage units are `svmax`, `lvmax`, and `dvmax`.
+    `vmax` represents the viewport-percentage length unit based on the browser default viewport size.
 - `vmin`
   - : Represents in percentage the smaller of `vw` and `vh`.
-  For small, large, and dynamic viewport sizes, the respective viewport-percentage units are `svmin`, `lvmin`, and `dvmin`.
-  `vmin` represents the viewport-percentage length unit based on the browser default viewport size.
+
+    For small, large, and dynamic viewport sizes, the respective viewport-percentage units are `svmin`, `lvmin`, and `dvmin`.
+    `vmin` represents the viewport-percentage length unit based on the browser default viewport size.
 - `vb` {{experimental_inline}}
   - : Represents percentage of the size of the initial [containing block](/en-US/docs/Web/CSS/Containing_block), in the direction of the root element's [block axis](/en-US/docs/Web/CSS/CSS_Logical_Properties#block_vs._inline).
-  For small, large, and dynamic viewport sizes, the respective viewport-percentage units are `svb`, `lvb`, and `dvb`, respectively.
-  `vb` represents the viewport-percentage length unit based on the browser default viewport size.
+
+    For small, large, and dynamic viewport sizes, the respective viewport-percentage units are `svb`, `lvb`, and `dvb`, respectively.
+    `vb` represents the viewport-percentage length unit based on the browser default viewport size.
 - `vi` {{experimental_inline}}
   - : Represents a percentage of the size of the initial [containing block](/en-US/docs/Web/CSS/Containing_block), in the direction of the root element's [inline axis](/en-US/docs/Web/CSS/CSS_Logical_Properties#block_vs._inline).
-  For small, large, and dynamic viewport sizes, the respective viewport-percentage units are `svi`, `lvi`, and `dvi`.
-  `vi` represents the viewport-percentage length unit based on the browser default viewport size.
+
+    For small, large, and dynamic viewport sizes, the respective viewport-percentage units are `svi`, `lvi`, and `dvi`.
+    `vi` represents the viewport-percentage length unit based on the browser default viewport size.
 
 #### Absolute length units
 

--- a/files/en-us/web/css/length/index.md
+++ b/files/en-us/web/css/length/index.md
@@ -19,34 +19,31 @@ The **`<length>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/CS
 
 ## Syntax
 
-The `<length>` data type consists of a {{cssxref("&lt;number&gt;")}} followed by one of the units listed below. As with all CSS dimensions, there is no space between the unit literal and the number. The length unit is optional after the number `0`.
+The `<length>` data type consists of a {{cssxref("&lt;number&gt;")}} followed by one of the units listed below. As with all CSS dimensions, there is no space between the number and the unit literal. Specifying the length unit is optional if the number is `0`.
 
-> **Note:** Some properties allow negative `<length>`s, while others do not.
+> **Note:** Some properties allow negative `<length>` values, while others do not.
 
-### Units
+The [specified value](/en-US/docs/Web/CSS/specified_value) of a length (_specified length_) is represented by its quantity and unit. The [computed value](/en-US/docs/Web/CSS/computed_value) of a length (_computed length_) is the specified length resolved to an absolute length, and its unit is not distinguished.
 
-#### Relative length units
+The length units can be relative or absolute. Relative lengths represent a measurement in terms of some other distance. Depending on the unit, this can be the size of a specific character, the [line height](/en-US/docs/Web/CSS/line-height), or the size of the {{Glossary("viewport")}}. Style sheets that use relative units can more easily scale from one output environment to another. All the relative length units can be categorized into those associated with font and viewport.
 
-Relative lengths represent a measurement in terms of some other distance. Depending on the unit, this can be the size of a specific character, the [line height](/en-US/docs/Web/CSS/line-height), or the size of the {{glossary("viewport")}}.
+> **Note:** Child elements do not inherit the relative values as specified for their parent; they inherit the computed values.
 
-##### Font-relative lengths
+### Relative length units based on font
 
-Font-relative lengths define the `<length>` value in terms of the size of a particular character or font attribute in the font currently in effect in an element or its parent.
+Font lengths define the `<length>` value in terms of the size of a particular character or font attribute in the font currently in effect in an element or its parent.
 
 > **Note:** These units, especially `em` and `rem`, are often used to create scalable layouts, which maintain the [vertical rhythm of the page](https://24ways.org/2006/compose-to-a-vertical-rhythm) even when the user changes the font size.
 
 - `cap` {{experimental_inline}}
   - : Represents the "cap height" (nominal height of capital letters) of the element's {{Cssxref("font")}}.
 - `ch`
-
-  - : Represents the width, or more precisely the {{Glossary("advance measure")}}, of the glyph "0" (zero, the Unicode character U+0030) in the element's {{Cssxref("font")}}.
-
-    In the cases where it is impossible or impractical to determine the measure of the "0" glyph, it must be assumed to be 0.5em wide by 1em tall.
-
+  - : Represents the width or more precisely the {{Glossary("advance measure")}} of the glyph `0` (zero, the Unicode character U+0030) in the element's {{Cssxref("font")}}.
+    In cases where it is impossible or impractical to determine the measure of the `0` glyph, it must be assumed to be `0.5em` wide by `1em` tall.
 - `em`
   - : Represents the calculated {{Cssxref("font-size")}} of the element. If used on the {{Cssxref("font-size")}} property itself, it represents the _inherited_ font-size of the element.
 - `ex`
-  - : Represents the [x-height](https://en.wikipedia.org/wiki/X-height) of the element's {{Cssxref("font")}}. On fonts with the "x" letter, this is generally the height of lowercase letters in the font; `1ex ≈ 0.5em` in many fonts.
+  - : Represents the [x-height](https://en.wikipedia.org/wiki/X-height) of the element's {{Cssxref("font")}}. In fonts with the `x` letter, this is generally the height of lowercase letters in the font; `1ex ≈ 0.5em` in many fonts.
 - `ic` {{experimental_inline}}
   - : Equal to the used {{Glossary("advance measure")}} of the "水" glyph (CJK water ideograph, U+6C34), found in the font used to render it.
 - `lh` {{experimental_inline}}
@@ -56,32 +53,65 @@ Font-relative lengths define the `<length>` value in terms of the size of a part
 - `rlh` {{experimental_inline}}
   - : Equal to the computed value of the {{Cssxref("line-height")}} property on the root element (typically {{HTMLElement("html")}}), converted to an absolute length. When used on the {{Cssxref("font-size")}} or {{Cssxref("line-height")}} properties of the root element, it refers to the properties' initial value.
 
-##### Viewport-percentage lengths
+### Relative length units based on viewport-percentage lengths
 
-Viewport-percentage lengths define the `<length>` value relative to the size of the {{glossary("viewport")}}, i.e., the visible portion of the document. Viewport lengths are invalid in {{cssxref("@page")}} declaration blocks.
+The viewport-percentage length units are based on four different viewport sizes: default, small, large, and dynamic. The allowance for the different viewport sizes is in response to browser interfaces that dynamically expand and retract.
+
+- Default
+  - : The default viewport size is defined by the browser. The behavior of the resulting viewport-percentage unit could be equivalent to the viewport-percentage unit based on either the small viewport size, the large viewport size, an intermediate size between the two, or the dynamic viewport size.
+  For example, a browser might implement the default viewport-percentage unit for height that is equivalent to the large viewport-percentage height unit.
+- Small
+  - : When you want the smallest possible viewport in response to browser UI dynamically expanding, you should use the small viewport size. In response to browser interfaces expanding, the small viewport size allows the content you design to fill the entire viewport. This might also possibly leave empty spaces when browser interfaces retract. 
+    For example, an element that is sized using viewport-percentage units based on the small viewport size, the element will fill the screen perfectly without any of its content being obscured when all the dynamic browser interfaces are shown. When those browser interfaces are hidden, however, there will be extra space around the element. The small viewport-percentage units are, therefore, “safer” to use in general, but might not produce the most attractive layout after a user starts interacting with the page.
+    The small viewport unit is represented by the `sv` prefix and results in the viewport-percentage variants `sv*`.
+    The sizes of the small viewport-percentage units are fixed, and therefore stable, unless the viewport itself is resized.
+- Large
+  - : When you want the largest possible viewport in response to browser interfaces dynamically retracting, you should use the large viewport size. In response to browser interfaces retracting, the large viewport size allows the content you design to fill the entire viewport. You need to be aware that the content might get hidden when browser interfaces expand.
+    For example, on mobile phones where the screen real-estate is at a premium, browsers often hide part or all of the title and address bar after a user starts scrolling the page. When viewport-percentage units based on the large viewport size are used, the content using these units will fill the entire visible page when these browser UI elements are hidden. However, when the retractable elements are shown, they can hide the content that is sized or positioned using these units.
+    The large viewport unit is represented by the `lv` prefix and results in the viewport-percentage variants `lv*`.
+    The sizes of the large viewport-percentage units are fixed, and therefore stable, unless the viewport itself is resized.
+- Dynamic
+  - : When you want the viewport to be automatically sized in response to browser interfaces dynamically expanding or retracting, you can use the dynamic viewport size. The dynamic viewport size allows the content you design to fit exactly within the viewport, irrespective of the presence of dynamic browser interfaces.
+  The dynamic viewport unit is represented by the `dv` prefix and results in the viewport-percentage variants `dv*`.
+  The sizes of the dynamic viewport-percentage units are not stable, even when the viewport itself is unchanged.
+  > **Note:** While the dynamic viewport size can give you more control and flexibility, using viewport-percentage units based on the dynamic viewport size can cause the content to resize, like while a user is scrolling a page. This can lead to degradation of the user interface and performance.
+
+Viewport-percentage lengths define `<length>` values in percentage relative to the size of the initial [containing block](/en-US/docs/Web/CSS/Containing_block), which in turn is based on either the size of the {{Glossary("viewport") or the page area, i.e., the visible portion of the document. When the height or width of the initial containing block is changed, the elements that are sized based on them are scaled accordingly. There is a viewport-percentage length unit variant corresponding to each of the viewport sizes. Viewport lengths are invalid in {{cssxref("@page")}} declaration blocks.
 
 - `vh`
-  - : Equal to 1% of the height of the viewport's initial [containing block](/en-US/docs/Web/CSS/Containing_block).
+  - : Represents a percentage of the height of the viewport's initial [containing block](/en-US/docs/Web/CSS/Containing_block). `1vh` is 1% of the viewport height. For example, if the viewport height is `300px`, then a value of `70vh` on a property will be `210px`.
+  For small, large, and dynamic viewport sizes, the respective viewport-percentage units are `svh`, `lvh`, and `dvh`.
+  `vh` represents the viewport-percentage length unit based on the browser default viewport size.
 - `vw`
-  - : Equal to 1% of the width of the viewport's initial [containing block](/en-US/docs/Web/CSS/Containing_block).
-- `vi` {{experimental_inline}}
-  - : Equal to 1% of the size of the initial [containing block](/en-US/docs/Web/CSS/Containing_block), in the direction of the root element's [inline axis](/en-US/docs/Web/CSS/CSS_Logical_Properties#block_vs._inline).
-- `vb` {{experimental_inline}}
-  - : Equal to 1% of the size of the initial [containing block](/en-US/docs/Web/CSS/Containing_block), in the direction of the root element's [block axis](/en-US/docs/Web/CSS/CSS_Logical_Properties#block_vs._inline).
-- `vmin`
-  - : Equal to the smaller of `vw` and `vh`.
+  - : Represents a percentage of the width of the viewport's initial [containing block](/en-US/docs/Web/CSS/Containing_block). `1vw` is 1% of the viewport width. For example, if the viewport width is `800px`, then `50vw` will be `400px`.
+  For small, large, and dynamic viewport sizes, the respective viewport-percentage units are `svw`, `lvw`, and `dvw`.
+  `vw` represents the viewport-percentage length unit based on the browser default viewport size.
 - `vmax`
-  - : Equal to the larger of `vw` and `vh`.
+  - : Represents in percentage the larger of `vw` and `vh`.
+  For small, large, and dynamic viewport sizes, the respective viewport-percentage units are `svmax`, `lvmax`, and `dvmax`.
+  `vmax` represents the viewport-percentage length unit based on the browser default viewport size.
+- `vmin`
+  - : Represents in percentage the smaller of `vw` and `vh`.
+  For small, large, and dynamic viewport sizes, the respective viewport-percentage units are `svmin`, `lvmin`, and `dvmin`.
+  `vmin` represents the viewport-percentage length unit based on the browser default viewport size.
+- `vb` {{experimental_inline}}
+  - : Represents percentage of the size of the initial [containing block](/en-US/docs/Web/CSS/Containing_block), in the direction of the root element's [block axis](/en-US/docs/Web/CSS/CSS_Logical_Properties#block_vs._inline).
+  For small, large, and dynamic viewport sizes, the respective viewport-percentage units are `svb`, `lvb`, and `dvb`, respectively.
+  `vb` represents the viewport-percentage length unit based on the browser default viewport size.
+- `vi` {{experimental_inline}}
+  - : Represents a percentage of the size of the initial [containing block](/en-US/docs/Web/CSS/Containing_block), in the direction of the root element's [inline axis](/en-US/docs/Web/CSS/CSS_Logical_Properties#block_vs._inline).
+  For small, large, and dynamic viewport sizes, the respective viewport-percentage units are `svi`, `lvi`, and `dvi`.
+  `vi` represents the viewport-percentage length unit based on the browser default viewport size.
 
 #### Absolute length units
 
-Absolute length units represent a physical measurement when the physical properties of the output medium are known, such as for print layout. This is done by anchoring one of the units to a physical unit, and then defining the others relative to it. The anchor is done differently for low-resolution devices, such as screens, versus high-resolution devices, such as printers.
+Absolute length units represent a physical measurement when the physical properties of the output medium are known, such as for print layout. This is done by anchoring one of the units to a physical unit and then defining the others relative to it. The anchoring is done differently for low-resolution devices, such as screens, versus high-resolution devices, such as printers.
 
-For low-dpi devices, the unit `px` represents the physical _reference pixel_; other units are defined relative to it. Thus, `1in` is defined as `96px`, which equals `72pt`. The consequence of this definition is that on such devices, dimensions described in inches (`in`), centimeters (`cm`), or millimeters (`mm`) don't necessary match the size of the physical unit with the same name.
+For low-dpi devices, the unit `px` represents the physical _reference pixel_; other units are defined relative to it. Thus, `1in` is defined as `96px`, which equals `72pt`. The consequence of this definition is that on such devices, dimensions described in inches (`in`), centimeters (`cm`), or millimeters (`mm`) don't necessarily match the size of the physical unit with the same name.
 
-For high-dpi devices, inches (`in`), centimeters (`cm`), and millimeters (`mm`) are the same as their physical counterparts. Therefore, the `px` unit is defined relative to them (1/96 of 1 inch).
+For high-dpi devices, inches (`in`), centimeters (`cm`), and millimeters (`mm`) are the same as their physical counterparts. Therefore, the `px` unit is defined relative to them (1/96 of `1in`).
 
-> **Note:** Many users increase their {{glossary("user agent")}}'s default font size to make text more legible. Absolute lengths can cause accessibility problems, since they are fixed and do not scale according to user settings. For this reason, prefer relative lengths (such as `em` or `rem`) when setting `font-size`.
+> **Note:** Many users increase their {{Glossary("user agent")}}'s default font size to make text more legible. Absolute lengths can cause accessibility problems because they are fixed and do not scale according to user settings. For this reason, prefer relative lengths (such as `em` or `rem`) when setting `font-size`.
 
 - `px`
   - : One pixel. For screen displays, it traditionally represents one device pixel (dot). However, for _printers_ and _high-resolution screens_, one CSS pixel implies multiple device pixels. `1px` = 1/96th of `1in`.
@@ -104,9 +134,9 @@ When animated, values of the `<length>` data type are interpolated as real, floa
 
 ## Examples
 
-### Length unit comparison
+### Comparing different length units
 
-The following demo provides you with an input field in which you can enter a `<length>` value (e.g. `300px`, `50%`, `30vw`) to set the width of a result bar that will appear below it once you've pressed the <kbd>Enter</kbd> or the <kbd>Return</kbd> key.
+The following example provides you with an input field in which you can enter a `<length>` value (e.g. `300px`, `50%`, `30vw`) to set the width of a result bar that will appear below it once you've pressed the <kbd>Enter</kbd> or the <kbd>Return</kbd> key.
 
 This allows you to compare and contrast the effect of different length units.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
- In Firefox release 101, new viewport sizes have been introduced: small (`s`), large (`l`), and dynamic (`d`).
   As a result, the existing viewport-percentage length units (`vw`, `vh`, `vmin`, `vmax`) can have more variants.
   Each can be of the type s, l, d resulting in:
   `svw`, `lvw`, `dvw`,
   `svh`, `lvh`, `dvh`,
   `svmin`, `lvmin`, `dvmin`,
    `svmax`, `lvmax`, `dvmax`
- `vw`, `vh`, `vmin`, `vmax` were already documented on this page (these are now considered the browser defaults).
   This PR adds a section to explain small (s), large (l), and dynamic (d) viewport sizes and also adds info about the new variants in the respective `vw`, `vh`, `vmin`, `vmax` sections.
- Additionally, in this PR:
  - Minor edits have been made to the rest of the page to improve clarity and some more info from the spec has been added  like specified and computed lengths
  - The existing page had heading levels going up to `<h5>` in the `Syntax` section. This has been fixed to avoid going below the heading level `<h3>`.
     Current structure:
     `## Syntax `
     `### Units`
     `#### Relative length units `
     `##### Font-relative lengths`
     `##### Viewport-percentage lengths`
     `#### Absolute length units `

     New structure in this PR:
     `## Syntax `
     The length units can be relative or absolute.
     The relative length units listed here are based on font and viewport.
     `### Relative length units based on font`
     `### Relative length units based on viewport`
     `### Absolute length units`

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
https://drafts.csswg.org/css-values/#viewport-relative-lengths

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://bugzilla.mozilla.org/show_bug.cgi?id=1610815

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Doc issue tracking this work: https://github.com/mdn/content/issues/15465

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [X] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
