### PR TITLE
chore: add target-repo input to action

### DIFF
--- a/.github/workflows/idle-issues.yml
+++ b/.github/workflows/idle-issues.yml
@@ -6,3 +6,5 @@ on:
 jobs:
   idle:
     uses: mdn/workflows/.github/workflows/idle-issues.yml@main
+    with:
+      target-repo: "mdn/content"


### PR DESCRIPTION
Adds the `target-repo` required input to the idle-issues workflow.
Update required in preparation for https://github.com/mdn/workflows/pull/55
