### PR TITLE
Add Web/API page types, part 3

### DIFF
--- a/files/en-us/web/api/bluetoothuuid/getdescriptor/index.md
+++ b/files/en-us/web/api/bluetoothuuid/getdescriptor/index.md
@@ -1,6 +1,7 @@
 ---
 title: BluetoothUUID.getDescriptor()
 slug: Web/API/BluetoothUUID/getDescriptor
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/bluetoothuuid/getservice/index.md
+++ b/files/en-us/web/api/bluetoothuuid/getservice/index.md
@@ -1,6 +1,7 @@
 ---
 title: BluetoothUUID.getService()
 slug: Web/API/BluetoothUUID/getService
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/broadcast_channel_api/index.md
+++ b/files/en-us/web/api/broadcast_channel_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Broadcast Channel API
 slug: Web/API/Broadcast_Channel_API
+page-type: web-api-overview
 tags:
   - API
   - Broadcast Channel API

--- a/files/en-us/web/api/broadcastchannel/broadcastchannel/index.md
+++ b/files/en-us/web/api/broadcastchannel/broadcastchannel/index.md
@@ -1,6 +1,7 @@
 ---
 title: BroadcastChannel()
 slug: Web/API/BroadcastChannel/BroadcastChannel
+page-type: web-api-constructor
 tags:
   - API
   - Broadcast Channel API

--- a/files/en-us/web/api/broadcastchannel/close/index.md
+++ b/files/en-us/web/api/broadcastchannel/close/index.md
@@ -1,6 +1,7 @@
 ---
 title: BroadcastChannel.close()
 slug: Web/API/BroadcastChannel/close
+page-type: web-api-instance-method
 tags:
   - Broadcast Channel API
   - Method

--- a/files/en-us/web/api/broadcastchannel/index.md
+++ b/files/en-us/web/api/broadcastchannel/index.md
@@ -1,6 +1,7 @@
 ---
 title: BroadcastChannel
 slug: Web/API/BroadcastChannel
+page-type: web-api-interface
 tags:
   - API
   - Broadcast Channel API

--- a/files/en-us/web/api/broadcastchannel/message_event/index.md
+++ b/files/en-us/web/api/broadcastchannel/message_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'BroadcastChannel: message event'
 slug: Web/API/BroadcastChannel/message_event
+page-type: web-api-event
 tags:
   - Event
   - Reference

--- a/files/en-us/web/api/broadcastchannel/messageerror_event/index.md
+++ b/files/en-us/web/api/broadcastchannel/messageerror_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'BroadcastChannel: messageerror event'
 slug: Web/API/BroadcastChannel/messageerror_event
+page-type: web-api-event
 tags:
   - Event
 browser-compat: api.BroadcastChannel.messageerror_event

--- a/files/en-us/web/api/broadcastchannel/name/index.md
+++ b/files/en-us/web/api/broadcastchannel/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: BroadcastChannel.name
 slug: Web/API/BroadcastChannel/name
+page-type: web-api-instance-property
 tags:
   - Broadcast Channel API
   - Property

--- a/files/en-us/web/api/broadcastchannel/postmessage/index.md
+++ b/files/en-us/web/api/broadcastchannel/postmessage/index.md
@@ -1,6 +1,7 @@
 ---
 title: BroadcastChannel.postMessage()
 slug: Web/API/BroadcastChannel/postMessage
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/btoa/index.md
+++ b/files/en-us/web/api/btoa/index.md
@@ -1,6 +1,7 @@
 ---
 title: btoa()
 slug: Web/API/btoa
+page-type: web-api-global-function
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.md
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/bytelengthqueuingstrategy/index.md
@@ -1,6 +1,7 @@
 ---
 title: ByteLengthQueuingStrategy()
 slug: Web/API/ByteLengthQueuingStrategy/ByteLengthQueuingStrategy
+page-type: web-api-constructor
 tags:
   - API
   - ByteLengthQueuingStrategy

--- a/files/en-us/web/api/bytelengthqueuingstrategy/index.md
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/index.md
@@ -1,6 +1,7 @@
 ---
 title: ByteLengthQueuingStrategy
 slug: Web/API/ByteLengthQueuingStrategy
+page-type: web-api-interface
 tags:
   - API
   - ByteLengthQueuingStrategy

--- a/files/en-us/web/api/bytelengthqueuingstrategy/size/index.md
+++ b/files/en-us/web/api/bytelengthqueuingstrategy/size/index.md
@@ -1,6 +1,7 @@
 ---
 title: ByteLengthQueuingStrategy.size()
 slug: Web/API/ByteLengthQueuingStrategy/size
+page-type: web-api-instance-method
 tags:
   - API
   - ByteLengthQueuingStrategy

--- a/files/en-us/web/api/cache/add/index.md
+++ b/files/en-us/web/api/cache/add/index.md
@@ -1,6 +1,7 @@
 ---
 title: Cache.add()
 slug: Web/API/Cache/add
+page-type: web-api-instance-method
 tags:
   - API
   - Cache

--- a/files/en-us/web/api/cache/addall/index.md
+++ b/files/en-us/web/api/cache/addall/index.md
@@ -1,6 +1,7 @@
 ---
 title: Cache.addAll()
 slug: Web/API/Cache/addAll
+page-type: web-api-instance-method
 tags:
   - API
   - Cache

--- a/files/en-us/web/api/cache/delete/index.md
+++ b/files/en-us/web/api/cache/delete/index.md
@@ -1,6 +1,7 @@
 ---
 title: Cache.delete()
 slug: Web/API/Cache/delete
+page-type: web-api-instance-method
 tags:
   - API
   - Cache

--- a/files/en-us/web/api/cache/index.md
+++ b/files/en-us/web/api/cache/index.md
@@ -1,6 +1,7 @@
 ---
 title: Cache
 slug: Web/API/Cache
+page-type: web-api-interface
 tags:
   - API
   - Cache

--- a/files/en-us/web/api/cache/keys/index.md
+++ b/files/en-us/web/api/cache/keys/index.md
@@ -1,6 +1,7 @@
 ---
 title: Cache.keys()
 slug: Web/API/Cache/keys
+page-type: web-api-instance-method
 tags:
   - API
   - Cache

--- a/files/en-us/web/api/cache/match/index.md
+++ b/files/en-us/web/api/cache/match/index.md
@@ -1,6 +1,7 @@
 ---
 title: Cache.match()
 slug: Web/API/Cache/match
+page-type: web-api-instance-method
 tags:
   - API
   - Cache

--- a/files/en-us/web/api/cache/matchall/index.md
+++ b/files/en-us/web/api/cache/matchall/index.md
@@ -1,6 +1,7 @@
 ---
 title: Cache.matchAll()
 slug: Web/API/Cache/matchAll
+page-type: web-api-instance-method
 tags:
   - API
   - Cache

--- a/files/en-us/web/api/cache/put/index.md
+++ b/files/en-us/web/api/cache/put/index.md
@@ -1,6 +1,7 @@
 ---
 title: Cache.put()
 slug: Web/API/Cache/put
+page-type: web-api-instance-method
 tags:
   - API
   - Cache

--- a/files/en-us/web/api/caches/index.md
+++ b/files/en-us/web/api/caches/index.md
@@ -1,6 +1,7 @@
 ---
 title: caches
 slug: Web/API/caches
+page-type: web-api-global-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/cachestorage/delete/index.md
+++ b/files/en-us/web/api/cachestorage/delete/index.md
@@ -1,6 +1,7 @@
 ---
 title: CacheStorage.delete()
 slug: Web/API/CacheStorage/delete
+page-type: web-api-instance-method
 tags:
   - API
   - CacheStorage

--- a/files/en-us/web/api/cachestorage/has/index.md
+++ b/files/en-us/web/api/cachestorage/has/index.md
@@ -1,6 +1,7 @@
 ---
 title: CacheStorage.has()
 slug: Web/API/CacheStorage/has
+page-type: web-api-instance-method
 tags:
   - API
   - CacheStorage

--- a/files/en-us/web/api/cachestorage/index.md
+++ b/files/en-us/web/api/cachestorage/index.md
@@ -1,6 +1,7 @@
 ---
 title: CacheStorage
 slug: Web/API/CacheStorage
+page-type: web-api-interface
 tags:
   - API
   - CacheStorage

--- a/files/en-us/web/api/cachestorage/keys/index.md
+++ b/files/en-us/web/api/cachestorage/keys/index.md
@@ -1,6 +1,7 @@
 ---
 title: CacheStorage.keys()
 slug: Web/API/CacheStorage/keys
+page-type: web-api-instance-method
 tags:
   - API
   - CacheStorage

--- a/files/en-us/web/api/cachestorage/match/index.md
+++ b/files/en-us/web/api/cachestorage/match/index.md
@@ -1,6 +1,7 @@
 ---
 title: CacheStorage.match()
 slug: Web/API/CacheStorage/match
+page-type: web-api-instance-method
 tags:
   - API
   - CacheStorage

--- a/files/en-us/web/api/cachestorage/open/index.md
+++ b/files/en-us/web/api/cachestorage/open/index.md
@@ -1,6 +1,7 @@
 ---
 title: CacheStorage.open()
 slug: Web/API/CacheStorage/open
+page-type: web-api-instance-method
 tags:
   - API
   - CacheStorage

--- a/files/en-us/web/api/canvas_api/a_basic_ray-caster/index.md
+++ b/files/en-us/web/api/canvas_api/a_basic_ray-caster/index.md
@@ -1,6 +1,7 @@
 ---
 title: A basic ray-caster
 slug: Web/API/Canvas_API/A_basic_ray-caster
+page-type: guide
 tags:
   - Advanced
   - Canvas

--- a/files/en-us/web/api/canvas_api/index.md
+++ b/files/en-us/web/api/canvas_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Canvas API
 slug: Web/API/Canvas_API
+page-type: web-api-overview
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvas_api/manipulating_video_using_canvas/index.md
+++ b/files/en-us/web/api/canvas_api/manipulating_video_using_canvas/index.md
@@ -1,6 +1,7 @@
 ---
 title: Manipulating video using canvas
 slug: Web/API/Canvas_API/Manipulating_video_using_canvas
+page-type: guide
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvas_api/tutorial/advanced_animations/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/advanced_animations/index.md
@@ -1,6 +1,7 @@
 ---
 title: Advanced animations
 slug: Web/API/Canvas_API/Tutorial/Advanced_animations
+page-type: guide
 tags:
   - Canvas
   - Graphics

--- a/files/en-us/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
@@ -1,6 +1,7 @@
 ---
 title: Applying styles and colors
 slug: Web/API/Canvas_API/Tutorial/Applying_styles_and_colors
+page-type: guide
 tags:
   - Canvas
   - Graphics

--- a/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_animations/index.md
@@ -1,6 +1,7 @@
 ---
 title: Basic animations
 slug: Web/API/Canvas_API/Tutorial/Basic_animations
+page-type: guide
 tags:
   - Canvas
   - Graphics

--- a/files/en-us/web/api/canvas_api/tutorial/basic_usage/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_usage/index.md
@@ -1,6 +1,7 @@
 ---
 title: Basic usage of canvas
 slug: Web/API/Canvas_API/Tutorial/Basic_usage
+page-type: guide
 tags:
   - Canvas
   - Graphics

--- a/files/en-us/web/api/canvas_api/tutorial/compositing/example/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/compositing/example/index.md
@@ -1,6 +1,7 @@
 ---
 title: Compositing example
 slug: Web/API/Canvas_API/Tutorial/Compositing/Example
+page-type: guide
 tags:
   - Canvas
   - Example

--- a/files/en-us/web/api/canvas_api/tutorial/compositing/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/compositing/index.md
@@ -1,6 +1,7 @@
 ---
 title: Compositing and clipping
 slug: Web/API/Canvas_API/Tutorial/Compositing
+page-type: guide
 tags:
   - Canvas
   - Graphics

--- a/files/en-us/web/api/canvas_api/tutorial/drawing_shapes/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/drawing_shapes/index.md
@@ -1,6 +1,7 @@
 ---
 title: Drawing shapes with canvas
 slug: Web/API/Canvas_API/Tutorial/Drawing_shapes
+page-type: guide
 tags:
   - Canvas
   - Graphics

--- a/files/en-us/web/api/canvas_api/tutorial/drawing_text/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/drawing_text/index.md
@@ -1,6 +1,7 @@
 ---
 title: Drawing text
 slug: Web/API/Canvas_API/Tutorial/Drawing_text
+page-type: guide
 tags:
   - Canvas
   - Graphics

--- a/files/en-us/web/api/canvas_api/tutorial/finale/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/finale/index.md
@@ -1,6 +1,7 @@
 ---
 title: Finale
 slug: Web/API/Canvas_API/Tutorial/Finale
+page-type: guide
 tags:
   - Canvas
   - Graphics

--- a/files/en-us/web/api/canvas_api/tutorial/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/index.md
@@ -1,6 +1,7 @@
 ---
 title: Canvas tutorial
 slug: Web/API/Canvas_API/Tutorial
+page-type: guide
 tags:
   - Canvas
   - Graphics

--- a/files/en-us/web/api/canvas_api/tutorial/optimizing_canvas/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/optimizing_canvas/index.md
@@ -1,6 +1,7 @@
 ---
 title: Optimizing canvas
 slug: Web/API/Canvas_API/Tutorial/Optimizing_canvas
+page-type: guide
 tags:
   - Advanced
   - Canvas

--- a/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/pixel_manipulation_with_canvas/index.md
@@ -1,6 +1,7 @@
 ---
 title: Pixel manipulation with canvas
 slug: Web/API/Canvas_API/Tutorial/Pixel_manipulation_with_canvas
+page-type: guide
 tags:
   - Canvas
   - Graphics

--- a/files/en-us/web/api/canvas_api/tutorial/transformations/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/transformations/index.md
@@ -1,6 +1,7 @@
 ---
 title: Transformations
 slug: Web/API/Canvas_API/Tutorial/Transformations
+page-type: guide
 tags:
   - Canvas
   - Graphics

--- a/files/en-us/web/api/canvas_api/tutorial/using_images/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/using_images/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using images
 slug: Web/API/Canvas_API/Tutorial/Using_images
+page-type: guide
 tags:
   - Advanced
   - Canvas

--- a/files/en-us/web/api/canvascapturemediastreamtrack/canvas/index.md
+++ b/files/en-us/web/api/canvascapturemediastreamtrack/canvas/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasCaptureMediaStreamTrack.canvas
 slug: Web/API/CanvasCaptureMediaStreamTrack/canvas
+page-type: web-api-instance-property
 tags:
   - Canvas
   - CanvasCaptureMediaStreamTrack

--- a/files/en-us/web/api/canvascapturemediastreamtrack/index.md
+++ b/files/en-us/web/api/canvascapturemediastreamtrack/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasCaptureMediaStreamTrack
 slug: Web/API/CanvasCaptureMediaStreamTrack
+page-type: web-api-interface
 tags:
   - CanvasCaptureMediaStreamTrack
   - Experimental

--- a/files/en-us/web/api/canvascapturemediastreamtrack/requestframe/index.md
+++ b/files/en-us/web/api/canvascapturemediastreamtrack/requestframe/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasCaptureMediaStreamTrack.requestFrame()
 slug: Web/API/CanvasCaptureMediaStreamTrack/requestFrame
+page-type: web-api-instance-method
 tags:
   - Canvas
   - CanvasCaptureMediaStream

--- a/files/en-us/web/api/canvasgradient/addcolorstop/index.md
+++ b/files/en-us/web/api/canvasgradient/addcolorstop/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasGradient.addColorStop()
 slug: Web/API/CanvasGradient/addColorStop
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasgradient/index.md
+++ b/files/en-us/web/api/canvasgradient/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasGradient
 slug: Web/API/CanvasGradient
+page-type: web-api-interface
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvaspattern/index.md
+++ b/files/en-us/web/api/canvaspattern/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasPattern
 slug: Web/API/CanvasPattern
+page-type: web-api-interface
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvaspattern/settransform/index.md
+++ b/files/en-us/web/api/canvaspattern/settransform/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasPattern.setTransform()
 slug: Web/API/CanvasPattern/setTransform
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/arc/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/arc/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.arc()
 slug: Web/API/CanvasRenderingContext2D/arc
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/arcto/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/arcto/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.arcTo()
 slug: Web/API/CanvasRenderingContext2D/arcTo
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/beginpath/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/beginpath/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.beginPath()
 slug: Web/API/CanvasRenderingContext2D/beginPath
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/beziercurveto/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/beziercurveto/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.bezierCurveTo()
 slug: Web/API/CanvasRenderingContext2D/bezierCurveTo
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/canvas/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/canvas/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.canvas
 slug: Web/API/CanvasRenderingContext2D/canvas
+page-type: web-api-instance-property
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/clearrect/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/clearrect/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.clearRect()
 slug: Web/API/CanvasRenderingContext2D/clearRect
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/clip/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/clip/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.clip()
 slug: Web/API/CanvasRenderingContext2D/clip
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/closepath/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/closepath/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.closePath()
 slug: Web/API/CanvasRenderingContext2D/closePath
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/createconicgradient/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createconicgradient/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.createConicGradient()
 slug: Web/API/CanvasRenderingContext2D/createConicGradient
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/createimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createimagedata/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.createImageData()
 slug: Web/API/CanvasRenderingContext2D/createImageData
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/createlineargradient/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createlineargradient/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.createLinearGradient()
 slug: Web/API/CanvasRenderingContext2D/createLinearGradient
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.createPattern()
 slug: Web/API/CanvasRenderingContext2D/createPattern
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/createradialgradient/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createradialgradient/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.createRadialGradient()
 slug: Web/API/CanvasRenderingContext2D/createRadialGradient
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/direction/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/direction/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.direction
 slug: Web/API/CanvasRenderingContext2D/direction
+page-type: web-api-instance-property
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/drawfocusifneeded/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawfocusifneeded/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.drawFocusIfNeeded()
 slug: Web/API/CanvasRenderingContext2D/drawFocusIfNeeded
+page-type: web-api-instance-method
 tags:
   - API
   - Accessibility

--- a/files/en-us/web/api/canvasrenderingcontext2d/drawimage/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawimage/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.drawImage()
 slug: Web/API/CanvasRenderingContext2D/drawImage
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/drawwidgetasonscreen/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawwidgetasonscreen/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.drawWidgetAsOnScreen()
 slug: Web/API/CanvasRenderingContext2D/drawWidgetAsOnScreen
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/drawwindow/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawwindow/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.drawWindow()
 slug: Web/API/CanvasRenderingContext2D/drawWindow
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/ellipse/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/ellipse/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.ellipse()
 slug: Web/API/CanvasRenderingContext2D/ellipse
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/fill/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fill/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.fill()
 slug: Web/API/CanvasRenderingContext2D/fill
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/fillrect/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fillrect/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.fillRect()
 slug: Web/API/CanvasRenderingContext2D/fillRect
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/fillstyle/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fillstyle/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.fillStyle
 slug: Web/API/CanvasRenderingContext2D/fillStyle
+page-type: web-api-instance-property
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/filltext/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/filltext/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.fillText()
 slug: Web/API/CanvasRenderingContext2D/fillText
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/filter/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/filter/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.filter
 slug: Web/API/CanvasRenderingContext2D/filter
+page-type: web-api-instance-property
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/font/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/font/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.font
 slug: Web/API/CanvasRenderingContext2D/font
+page-type: web-api-instance-property
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/getcontextattributes/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getcontextattributes/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.getContextAttributes()
 slug: Web/API/CanvasRenderingContext2D/getContextAttributes
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getimagedata/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.getImageData()
 slug: Web/API/CanvasRenderingContext2D/getImageData
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/getlinedash/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/getlinedash/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.getLineDash()
 slug: Web/API/CanvasRenderingContext2D/getLineDash
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/gettransform/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/gettransform/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.getTransform()
 slug: Web/API/CanvasRenderingContext2D/getTransform
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/globalalpha/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/globalalpha/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.globalAlpha
 slug: Web/API/CanvasRenderingContext2D/globalAlpha
+page-type: web-api-instance-property
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/globalcompositeoperation/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.globalCompositeOperation
 slug: Web/API/CanvasRenderingContext2D/globalCompositeOperation
+page-type: web-api-instance-property
 tags:
   - API
   - Blending

--- a/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingenabled/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingenabled/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.imageSmoothingEnabled
 slug: Web/API/CanvasRenderingContext2D/imageSmoothingEnabled
+page-type: web-api-instance-property
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingquality/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/imagesmoothingquality/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.imageSmoothingQuality
 slug: Web/API/CanvasRenderingContext2D/imageSmoothingQuality
+page-type: web-api-instance-property
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D
 slug: Web/API/CanvasRenderingContext2D
+page-type: web-api-interface
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/ispointinpath/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/ispointinpath/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.isPointInPath()
 slug: Web/API/CanvasRenderingContext2D/isPointInPath
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/ispointinstroke/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/ispointinstroke/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.isPointInStroke()
 slug: Web/API/CanvasRenderingContext2D/isPointInStroke
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/linecap/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linecap/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.lineCap
 slug: Web/API/CanvasRenderingContext2D/lineCap
+page-type: web-api-instance-property
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/linedashoffset/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linedashoffset/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.lineDashOffset
 slug: Web/API/CanvasRenderingContext2D/lineDashOffset
+page-type: web-api-instance-property
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/linejoin/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linejoin/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.lineJoin
 slug: Web/API/CanvasRenderingContext2D/lineJoin
+page-type: web-api-instance-property
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/lineto/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/lineto/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.lineTo()
 slug: Web/API/CanvasRenderingContext2D/lineTo
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/linewidth/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/linewidth/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.lineWidth
 slug: Web/API/CanvasRenderingContext2D/lineWidth
+page-type: web-api-instance-property
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/measuretext/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/measuretext/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.measureText()
 slug: Web/API/CanvasRenderingContext2D/measureText
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/miterlimit/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/miterlimit/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.miterLimit
 slug: Web/API/CanvasRenderingContext2D/miterLimit
+page-type: web-api-instance-property
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/moveto/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/moveto/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.moveTo()
 slug: Web/API/CanvasRenderingContext2D/moveTo
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/putimagedata/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/putimagedata/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.putImageData()
 slug: Web/API/CanvasRenderingContext2D/putImageData
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/quadraticcurveto/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/quadraticcurveto/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.quadraticCurveTo()
 slug: Web/API/CanvasRenderingContext2D/quadraticCurveTo
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/rect/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/rect/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.rect()
 slug: Web/API/CanvasRenderingContext2D/rect
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/resettransform/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/resettransform/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.resetTransform()
 slug: Web/API/CanvasRenderingContext2D/resetTransform
+page-type: web-api-instance-method
 tags:
   - Canvas
   - CanvasRenderingContext2D

--- a/files/en-us/web/api/canvasrenderingcontext2d/restore/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/restore/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.restore()
 slug: Web/API/CanvasRenderingContext2D/restore
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/rotate/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/rotate/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.rotate()
 slug: Web/API/CanvasRenderingContext2D/rotate
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/save/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/save/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.save()
 slug: Web/API/CanvasRenderingContext2D/save
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/scale/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/scale/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.scale()
 slug: Web/API/CanvasRenderingContext2D/scale
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/scrollpathintoview/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/scrollpathintoview/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.scrollPathIntoView()
 slug: Web/API/CanvasRenderingContext2D/scrollPathIntoView
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/setlinedash/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/setlinedash/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.setLineDash()
 slug: Web/API/CanvasRenderingContext2D/setLineDash
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/settransform/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/settransform/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.setTransform()
 slug: Web/API/CanvasRenderingContext2D/setTransform
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/shadowblur/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/shadowblur/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.shadowBlur
 slug: Web/API/CanvasRenderingContext2D/shadowBlur
+page-type: web-api-instance-property
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/shadowcolor/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/shadowcolor/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.shadowColor
 slug: Web/API/CanvasRenderingContext2D/shadowColor
+page-type: web-api-instance-property
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/shadowoffsetx/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/shadowoffsetx/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.shadowOffsetX
 slug: Web/API/CanvasRenderingContext2D/shadowOffsetX
+page-type: web-api-instance-property
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/shadowoffsety/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/shadowoffsety/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.shadowOffsetY
 slug: Web/API/CanvasRenderingContext2D/shadowOffsetY
+page-type: web-api-instance-property
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/stroke/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/stroke/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.stroke()
 slug: Web/API/CanvasRenderingContext2D/stroke
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/strokerect/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/strokerect/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.strokeRect()
 slug: Web/API/CanvasRenderingContext2D/strokeRect
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/strokestyle/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/strokestyle/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.strokeStyle
 slug: Web/API/CanvasRenderingContext2D/strokeStyle
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/strokestyle/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/strokestyle/index.md
@@ -1,7 +1,7 @@
 ---
 title: CanvasRenderingContext2D.strokeStyle
 slug: Web/API/CanvasRenderingContext2D/strokeStyle
-page-type: web-api-instance-method
+page-type: web-api-instance-property
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/stroketext/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/stroketext/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.strokeText()
 slug: Web/API/CanvasRenderingContext2D/strokeText
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/textalign/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/textalign/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.textAlign
 slug: Web/API/CanvasRenderingContext2D/textAlign
+page-type: web-api-instance-property
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/textbaseline/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/textbaseline/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.textBaseline
 slug: Web/API/CanvasRenderingContext2D/textBaseline
+page-type: web-api-instance-property
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/transform/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/transform/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.transform()
 slug: Web/API/CanvasRenderingContext2D/transform
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/canvasrenderingcontext2d/translate/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/translate/index.md
@@ -1,6 +1,7 @@
 ---
 title: CanvasRenderingContext2D.translate()
 slug: Web/API/CanvasRenderingContext2D/translate
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/caretposition/index.md
+++ b/files/en-us/web/api/caretposition/index.md
@@ -1,6 +1,7 @@
 ---
 title: CaretPosition
 slug: Web/API/CaretPosition
+page-type: web-api-interface
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/cdatasection/index.md
+++ b/files/en-us/web/api/cdatasection/index.md
@@ -1,6 +1,7 @@
 ---
 title: CDATASection
 slug: Web/API/CDATASection
+page-type: web-api-interface
 tags:
   - Interface
   - Reference

--- a/files/en-us/web/api/channel_messaging_api/index.md
+++ b/files/en-us/web/api/channel_messaging_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Channel Messaging API
 slug: Web/API/Channel_Messaging_API
+page-type: web-api-overview
 tags:
   - API
   - Channel messaging

--- a/files/en-us/web/api/channel_messaging_api/using_channel_messaging/index.md
+++ b/files/en-us/web/api/channel_messaging_api/using_channel_messaging/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using channel messaging
 slug: Web/API/Channel_Messaging_API/Using_channel_messaging
+page-type: guide
 tags:
   - API
   - Channel messaging

--- a/files/en-us/web/api/channelmergernode/channelmergernode/index.md
+++ b/files/en-us/web/api/channelmergernode/channelmergernode/index.md
@@ -1,6 +1,7 @@
 ---
 title: ChannelMergerNode()
 slug: Web/API/ChannelMergerNode/ChannelMergerNode
+page-type: web-api-constructor
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/channelmergernode/index.md
+++ b/files/en-us/web/api/channelmergernode/index.md
@@ -1,6 +1,7 @@
 ---
 title: ChannelMergerNode
 slug: Web/API/ChannelMergerNode
+page-type: web-api-interface
 tags:
   - API
   - ChannelMergerNode

--- a/files/en-us/web/api/channelsplitternode/channelsplitternode/index.md
+++ b/files/en-us/web/api/channelsplitternode/channelsplitternode/index.md
@@ -1,6 +1,7 @@
 ---
 title: ChannelSplitterNode()
 slug: Web/API/ChannelSplitterNode/ChannelSplitterNode
+page-type: web-api-constructor
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/channelsplitternode/index.md
+++ b/files/en-us/web/api/channelsplitternode/index.md
@@ -1,6 +1,7 @@
 ---
 title: ChannelSplitterNode
 slug: Web/API/ChannelSplitterNode
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/characterdata/after/index.md
+++ b/files/en-us/web/api/characterdata/after/index.md
@@ -1,6 +1,7 @@
 ---
 title: CharacterData.after()
 slug: Web/API/CharacterData/after
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/characterdata/appenddata/index.md
+++ b/files/en-us/web/api/characterdata/appenddata/index.md
@@ -1,6 +1,7 @@
 ---
 title: CharacterData.appendData()
 slug: Web/API/CharacterData/appendData
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/characterdata/before/index.md
+++ b/files/en-us/web/api/characterdata/before/index.md
@@ -1,6 +1,7 @@
 ---
 title: CharacterData.before()
 slug: Web/API/CharacterData/before
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/characterdata/data/index.md
+++ b/files/en-us/web/api/characterdata/data/index.md
@@ -1,6 +1,7 @@
 ---
 title: CharacterData.data
 slug: Web/API/CharacterData/data
+page-type: web-api-instance-property
 tags:
   - Property
   - Reference

--- a/files/en-us/web/api/characterdata/deletedata/index.md
+++ b/files/en-us/web/api/characterdata/deletedata/index.md
@@ -1,6 +1,7 @@
 ---
 title: CharacterData.deleteData()
 slug: Web/API/CharacterData/deleteData
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/characterdata/index.md
+++ b/files/en-us/web/api/characterdata/index.md
@@ -1,6 +1,7 @@
 ---
 title: CharacterData
 slug: Web/API/CharacterData
+page-type: web-api-interface
 tags:
   - Interface
   - Reference

--- a/files/en-us/web/api/characterdata/insertdata/index.md
+++ b/files/en-us/web/api/characterdata/insertdata/index.md
@@ -1,6 +1,7 @@
 ---
 title: CharacterData.insertData()
 slug: Web/API/CharacterData/insertData
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/characterdata/length/index.md
+++ b/files/en-us/web/api/characterdata/length/index.md
@@ -1,6 +1,7 @@
 ---
 title: CharacterData.length
 slug: Web/API/CharacterData/length
+page-type: web-api-instance-property
 tags:
   - Property
   - Reference

--- a/files/en-us/web/api/characterdata/nextelementsibling/index.md
+++ b/files/en-us/web/api/characterdata/nextelementsibling/index.md
@@ -1,6 +1,7 @@
 ---
 title: CharacterData.nextElementSibling
 slug: Web/API/CharacterData/nextElementSibling
+page-type: web-api-instance-property
 tags:
   - Property
   - Reference

--- a/files/en-us/web/api/characterdata/previouselementsibling/index.md
+++ b/files/en-us/web/api/characterdata/previouselementsibling/index.md
@@ -1,6 +1,7 @@
 ---
 title: CharacterData.previousElementSibling
 slug: Web/API/CharacterData/previousElementSibling
+page-type: web-api-instance-property
 tags:
   - Property
   - Read-only

--- a/files/en-us/web/api/characterdata/remove/index.md
+++ b/files/en-us/web/api/characterdata/remove/index.md
@@ -1,6 +1,7 @@
 ---
 title: CharacterData.remove()
 slug: Web/API/CharacterData/remove
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/characterdata/replacedata/index.md
+++ b/files/en-us/web/api/characterdata/replacedata/index.md
@@ -1,6 +1,7 @@
 ---
 title: CharacterData.replaceData()
 slug: Web/API/CharacterData/replaceData
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/characterdata/replacewith/index.md
+++ b/files/en-us/web/api/characterdata/replacewith/index.md
@@ -1,6 +1,7 @@
 ---
 title: CharacterData.replaceWith()
 slug: Web/API/CharacterData/replaceWith
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/characterdata/substringdata/index.md
+++ b/files/en-us/web/api/characterdata/substringdata/index.md
@@ -1,6 +1,7 @@
 ---
 title: CharacterData.substringData()
 slug: Web/API/CharacterData/substringData
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/clearinterval/index.md
+++ b/files/en-us/web/api/clearinterval/index.md
@@ -1,6 +1,7 @@
 ---
 title: clearInterval()
 slug: Web/API/clearInterval
+page-type: web-api-global-function
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/cleartimeout/index.md
+++ b/files/en-us/web/api/cleartimeout/index.md
@@ -1,6 +1,7 @@
 ---
 title: clearTimeout()
 slug: Web/API/clearTimeout
+page-type: web-api-global-function
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/client/frametype/index.md
+++ b/files/en-us/web/api/client/frametype/index.md
@@ -1,6 +1,7 @@
 ---
 title: Client.frameType
 slug: Web/API/Client/frameType
+page-type: web-api-instance-property
 tags:
   - API
   - Client

--- a/files/en-us/web/api/client/id/index.md
+++ b/files/en-us/web/api/client/id/index.md
@@ -1,6 +1,7 @@
 ---
 title: Client.id
 slug: Web/API/Client/id
+page-type: web-api-instance-property
 tags:
   - API
   - Client

--- a/files/en-us/web/api/client/index.md
+++ b/files/en-us/web/api/client/index.md
@@ -1,6 +1,7 @@
 ---
 title: Client
 slug: Web/API/Client
+page-type: web-api-interface
 tags:
   - API
   - Client

--- a/files/en-us/web/api/client/postmessage/index.md
+++ b/files/en-us/web/api/client/postmessage/index.md
@@ -1,6 +1,7 @@
 ---
 title: Client.postMessage()
 slug: Web/API/Client/postMessage
+page-type: web-api-instance-method
 tags:
   - API
   - Client

--- a/files/en-us/web/api/client/type/index.md
+++ b/files/en-us/web/api/client/type/index.md
@@ -1,6 +1,7 @@
 ---
 title: Client.type
 slug: Web/API/Client/type
+page-type: web-api-instance-property
 tags:
   - API
   - Client

--- a/files/en-us/web/api/client/url/index.md
+++ b/files/en-us/web/api/client/url/index.md
@@ -1,6 +1,7 @@
 ---
 title: Client.url
 slug: Web/API/Client/url
+page-type: web-api-instance-property
 tags:
   - API
   - Client

--- a/files/en-us/web/api/clients/claim/index.md
+++ b/files/en-us/web/api/clients/claim/index.md
@@ -1,6 +1,7 @@
 ---
 title: Clients.claim()
 slug: Web/API/Clients/claim
+page-type: web-api-instance-method
 tags:
   - API
   - Clients

--- a/files/en-us/web/api/clients/get/index.md
+++ b/files/en-us/web/api/clients/get/index.md
@@ -1,6 +1,7 @@
 ---
 title: Clients.get()
 slug: Web/API/Clients/get
+page-type: web-api-instance-method
 tags:
   - API
   - Clients

--- a/files/en-us/web/api/clients/index.md
+++ b/files/en-us/web/api/clients/index.md
@@ -1,6 +1,7 @@
 ---
 title: Clients
 slug: Web/API/Clients
+page-type: web-api-interface
 tags:
   - API
   - Clients

--- a/files/en-us/web/api/clients/matchall/index.md
+++ b/files/en-us/web/api/clients/matchall/index.md
@@ -1,6 +1,7 @@
 ---
 title: Clients.matchAll()
 slug: Web/API/Clients/matchAll
+page-type: web-api-instance-method
 tags:
   - API
   - Clients

--- a/files/en-us/web/api/clients/openwindow/index.md
+++ b/files/en-us/web/api/clients/openwindow/index.md
@@ -1,6 +1,7 @@
 ---
 title: Clients.openWindow()
 slug: Web/API/Clients/openWindow
+page-type: web-api-instance-method
 tags:
   - API
   - Clients

--- a/files/en-us/web/api/clipboard/index.md
+++ b/files/en-us/web/api/clipboard/index.md
@@ -1,6 +1,7 @@
 ---
 title: Clipboard
 slug: Web/API/Clipboard
+page-type: web-api-interface
 tags:
   - API
   - Clip

--- a/files/en-us/web/api/clipboard/read/index.md
+++ b/files/en-us/web/api/clipboard/read/index.md
@@ -1,6 +1,7 @@
 ---
 title: Clipboard.read()
 slug: Web/API/Clipboard/read
+page-type: web-api-instance-method
 tags:
   - API
   - Clip

--- a/files/en-us/web/api/clipboard/readtext/index.md
+++ b/files/en-us/web/api/clipboard/readtext/index.md
@@ -1,6 +1,7 @@
 ---
 title: Clipboard.readText()
 slug: Web/API/Clipboard/readText
+page-type: web-api-instance-method
 tags:
   - API
   - Async Clipboard API

--- a/files/en-us/web/api/clipboard/write/index.md
+++ b/files/en-us/web/api/clipboard/write/index.md
@@ -1,6 +1,7 @@
 ---
 title: Clipboard.write()
 slug: Web/API/Clipboard/write
+page-type: web-api-instance-method
 tags:
   - API
   - Clip

--- a/files/en-us/web/api/clipboard/writetext/index.md
+++ b/files/en-us/web/api/clipboard/writetext/index.md
@@ -1,6 +1,7 @@
 ---
 title: Clipboard.writeText()
 slug: Web/API/Clipboard/writeText
+page-type: web-api-instance-method
 tags:
   - API
   - Clip

--- a/files/en-us/web/api/clipboard_api/index.md
+++ b/files/en-us/web/api/clipboard_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Clipboard API
 slug: Web/API/Clipboard_API
+page-type: web-api-overview
 tags:
   - API
   - Async Clipboard API

--- a/files/en-us/web/api/clipboardevent/clipboarddata/index.md
+++ b/files/en-us/web/api/clipboardevent/clipboarddata/index.md
@@ -1,6 +1,7 @@
 ---
 title: ClipboardEvent.clipboardData
 slug: Web/API/ClipboardEvent/clipboardData
+page-type: web-api-instance-property
 tags:
   - API
   - Clipboard

--- a/files/en-us/web/api/clipboardevent/clipboardevent/index.md
+++ b/files/en-us/web/api/clipboardevent/clipboardevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: ClipboardEvent()
 slug: Web/API/ClipboardEvent/ClipboardEvent
+page-type: web-api-constructor
 tags:
   - API
   - Clipboard

--- a/files/en-us/web/api/clipboardevent/index.md
+++ b/files/en-us/web/api/clipboardevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: ClipboardEvent
 slug: Web/API/ClipboardEvent
+page-type: web-api-interface
 tags:
   - API
   - Clipboard

--- a/files/en-us/web/api/clipboarditem/clipboarditem/index.md
+++ b/files/en-us/web/api/clipboarditem/clipboarditem/index.md
@@ -1,6 +1,7 @@
 ---
 title: ClipboardItem()
 slug: Web/API/ClipboardItem/ClipboardItem
+page-type: web-api-instance-property
 tags:
   - API
   - Clipboard

--- a/files/en-us/web/api/clipboarditem/gettype/index.md
+++ b/files/en-us/web/api/clipboarditem/gettype/index.md
@@ -1,6 +1,7 @@
 ---
 title: ClipboardItem.getType()
 slug: Web/API/ClipboardItem/getType
+page-type: web-api-instance-method
 tags:
   - Clipboard
   - Clipboard API

--- a/files/en-us/web/api/clipboarditem/index.md
+++ b/files/en-us/web/api/clipboarditem/index.md
@@ -1,6 +1,7 @@
 ---
 title: ClipboardItem
 slug: Web/API/ClipboardItem
+page-type: web-api-interface
 tags:
   - API
   - Clipboard

--- a/files/en-us/web/api/clipboarditem/presentationstyle/index.md
+++ b/files/en-us/web/api/clipboarditem/presentationstyle/index.md
@@ -1,6 +1,7 @@
 ---
 title: ClipboardItem.presentationStyle
 slug: Web/API/ClipboardItem/presentationStyle
+page-type: web-api-instance-property
 tags:
   - API
   - Clipboard

--- a/files/en-us/web/api/clipboarditem/types/index.md
+++ b/files/en-us/web/api/clipboarditem/types/index.md
@@ -1,6 +1,7 @@
 ---
 title: ClipboardItem.types
 slug: Web/API/ClipboardItem/types
+page-type: web-api-instance-property
 tags:
   - API
   - Clipboard

--- a/files/en-us/web/api/closeevent/closeevent/index.md
+++ b/files/en-us/web/api/closeevent/closeevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: CloseEvent()
 slug: Web/API/CloseEvent/CloseEvent
+page-type: web-api-constructor
 tags:
   - API
   - CloseEvent

--- a/files/en-us/web/api/closeevent/code/index.md
+++ b/files/en-us/web/api/closeevent/code/index.md
@@ -1,6 +1,7 @@
 ---
 title: CloseEvent.code
 slug: Web/API/CloseEvent/code
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/closeevent/index.md
+++ b/files/en-us/web/api/closeevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: CloseEvent
 slug: Web/API/CloseEvent
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/closeevent/initcloseevent/index.md
+++ b/files/en-us/web/api/closeevent/initcloseevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: CloseEvent.initCloseEvent()
 slug: Web/API/CloseEvent/initCloseEvent
+page-type: web-api-instance-method
 tags:
   - API
   - CloseEvent

--- a/files/en-us/web/api/closeevent/reason/index.md
+++ b/files/en-us/web/api/closeevent/reason/index.md
@@ -1,6 +1,7 @@
 ---
 title: CloseEvent.reason
 slug: Web/API/CloseEvent/reason
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/closeevent/wasclean/index.md
+++ b/files/en-us/web/api/closeevent/wasclean/index.md
@@ -1,6 +1,7 @@
 ---
 title: CloseEvent.wasClean
 slug: Web/API/CloseEvent/wasClean
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/comment/comment/index.md
+++ b/files/en-us/web/api/comment/comment/index.md
@@ -1,6 +1,7 @@
 ---
 title: Comment()
 slug: Web/API/Comment/Comment
+page-type: web-api-constructor
 tags:
   - Constructor
   - Reference

--- a/files/en-us/web/api/comment/index.md
+++ b/files/en-us/web/api/comment/index.md
@@ -1,6 +1,7 @@
 ---
 title: Comment
 slug: Web/API/Comment
+page-type: web-api-interface
 tags:
   - Interface
   - Reference

--- a/files/en-us/web/api/compositionevent/compositionevent/index.md
+++ b/files/en-us/web/api/compositionevent/compositionevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: CompositionEvent()
 slug: Web/API/CompositionEvent/CompositionEvent
+page-type: web-api-constructor
 tags:
   - API
   - CompositionEvent

--- a/files/en-us/web/api/compositionevent/data/index.md
+++ b/files/en-us/web/api/compositionevent/data/index.md
@@ -1,6 +1,7 @@
 ---
 title: CompositionEvent.data
 slug: Web/API/CompositionEvent/data
+page-type: web-api-instance-property
 tags:
   - API
   - CompositionEvent

--- a/files/en-us/web/api/compositionevent/index.md
+++ b/files/en-us/web/api/compositionevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: CompositionEvent
 slug: Web/API/CompositionEvent
+page-type: web-api-interface
 tags:
   - API
   - CompositionEvent

--- a/files/en-us/web/api/compositionevent/initcompositionevent/index.md
+++ b/files/en-us/web/api/compositionevent/initcompositionevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: CompositionEvent.initCompositionEvent()
 slug: Web/API/CompositionEvent/initCompositionEvent
+page-type: web-api-instance-method
 tags:
   - API
   - CompositionEvent

--- a/files/en-us/web/api/compositionevent/locale/index.md
+++ b/files/en-us/web/api/compositionevent/locale/index.md
@@ -1,6 +1,7 @@
 ---
 title: CompositionEvent.locale
 slug: Web/API/CompositionEvent/locale
+page-type: web-api-instance-property
 tags:
   - API
   - CompositionEvent

--- a/files/en-us/web/api/compression_streams_api/index.md
+++ b/files/en-us/web/api/compression_streams_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Compression Streams API
 slug: Web/API/Compression_Streams_API
+page-type: web-api-overview
 tags:
   - API
   - Compression_Streams_API

--- a/files/en-us/web/api/compressionstream/compressionstream/index.md
+++ b/files/en-us/web/api/compressionstream/compressionstream/index.md
@@ -1,6 +1,7 @@
 ---
 title: CompressionStream()
 slug: Web/API/CompressionStream/CompressionStream
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/compressionstream/index.md
+++ b/files/en-us/web/api/compressionstream/index.md
@@ -1,6 +1,7 @@
 ---
 title: CompressionStream
 slug: Web/API/CompressionStream
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/compressionstream/readable/index.md
+++ b/files/en-us/web/api/compressionstream/readable/index.md
@@ -1,6 +1,7 @@
 ---
 title: CompressionStream.readable
 slug: Web/API/CompressionStream/readable
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/compressionstream/writable/index.md
+++ b/files/en-us/web/api/compressionstream/writable/index.md
@@ -1,6 +1,7 @@
 ---
 title: CompressionStream.writable
 slug: Web/API/CompressionStream/writable
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/console/assert/index.md
+++ b/files/en-us/web/api/console/assert/index.md
@@ -1,6 +1,7 @@
 ---
 title: console.assert()
 slug: Web/API/console/assert
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/console/clear/index.md
+++ b/files/en-us/web/api/console/clear/index.md
@@ -1,6 +1,7 @@
 ---
 title: console.clear()
 slug: Web/API/console/clear
+page-type: web-api-instance-method
 tags:
   - API
   - Debugging

--- a/files/en-us/web/api/console/count/index.md
+++ b/files/en-us/web/api/console/count/index.md
@@ -1,6 +1,7 @@
 ---
 title: console.count()
 slug: Web/API/console/count
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/console/countreset/index.md
+++ b/files/en-us/web/api/console/countreset/index.md
@@ -1,6 +1,7 @@
 ---
 title: console.countReset()
 slug: Web/API/console/countReset
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/console/debug/index.md
+++ b/files/en-us/web/api/console/debug/index.md
@@ -1,6 +1,7 @@
 ---
 title: console.debug()
 slug: Web/API/console/debug
+page-type: web-api-instance-method
 tags:
   - API
   - Debug

--- a/files/en-us/web/api/console/dir/index.md
+++ b/files/en-us/web/api/console/dir/index.md
@@ -1,6 +1,7 @@
 ---
 title: console.dir()
 slug: Web/API/console/dir
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/console/dirxml/index.md
+++ b/files/en-us/web/api/console/dirxml/index.md
@@ -1,6 +1,7 @@
 ---
 title: console.dirxml()
 slug: Web/API/console/dirxml
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/console/error/index.md
+++ b/files/en-us/web/api/console/error/index.md
@@ -1,6 +1,7 @@
 ---
 title: console.error()
 slug: Web/API/console/error
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/console/group/index.md
+++ b/files/en-us/web/api/console/group/index.md
@@ -1,6 +1,7 @@
 ---
 title: console.group()
 slug: Web/API/console/group
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/console/groupcollapsed/index.md
+++ b/files/en-us/web/api/console/groupcollapsed/index.md
@@ -1,6 +1,7 @@
 ---
 title: console.groupCollapsed()
 slug: Web/API/console/groupCollapsed
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/console/groupend/index.md
+++ b/files/en-us/web/api/console/groupend/index.md
@@ -1,6 +1,7 @@
 ---
 title: console.groupEnd()
 slug: Web/API/console/groupEnd
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/console/index.md
+++ b/files/en-us/web/api/console/index.md
@@ -1,6 +1,7 @@
 ---
 title: console
 slug: Web/API/console
+page-type: web-api-interface
 tags:
   - API
   - Debugging

--- a/files/en-us/web/api/console_api/index.md
+++ b/files/en-us/web/api/console_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Console API
 slug: Web/API/Console_API
+page-type: guide
 tags:
   - API
   - Debugging


### PR DESCRIPTION
See  https://github.com/mdn/content/issues/16255. This is part 3 of a series of PRs to add page types to the Web/API documentation.