### PR TITLE
examples 2 & 3 wrong

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
@@ -58,14 +58,15 @@ The `finally()` method is very similar to calling
   is for precisely when you _do not care_ about the rejection reason, or the
   fulfillment value, and so there's no need to provide it. So for example:
 
-  - Unlike `Promise.resolve(2).then(() => {}, () => {})` (which
-    will be resolved with `undefined`),
-    `Promise.resolve(2).finally(() => {})` will be resolved with
-    `2`.
-  - Similarly, unlike `Promise.reject(3).then(() => {}, () => {})`
-    (which will be fulfilled with `undefined`),
-    `Promise.reject(3).finally(() => {})` will be rejected with
-    `3`.
+  - Unlike `Promise.resolve(2).then(res => {}, err => {})` (which
+    will be resolved with res = 2),
+    `Promise.resolve(2).finally(what => {})` will be resolved with
+    `what = undefined`.
+  - Similarly, unlike `Promise.reject(3).then(res => {}, err => {})`
+    (which will be rejected with err = 3),
+    `Promise.reject(3).finally(what => {})` will be rejected with
+    `what = undefined`.  No argument is ever passed to finally(), 
+    even if you try hard.
 
 > **Note:** A `throw` (or returning a rejected promise) in the
 > `finally` callback will reject the new promise with the rejection reason


### PR DESCRIPTION

#### Summary
These two examples were reversed (assuming the rest of the text is correct).  I also added callback arguments because it wasn't clear what 'finally()' is 'resolved' with if the callback has no arguments.

#### Motivation
The examples actually illustrate the OPPOSITE of what the text says.

#### Supporting details
see paragraph just above

#### Related issues
none

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
