### PR TITLE
Add Web/API page types, part 4

### DIFF
--- a/files/en-us/web/api/console/info/index.md
+++ b/files/en-us/web/api/console/info/index.md
@@ -1,6 +1,7 @@
 ---
 title: console.info()
 slug: Web/API/console/info
+page-type: web-api-instance-method
 tags:
   - API
   - Debugging

--- a/files/en-us/web/api/console/log/index.md
+++ b/files/en-us/web/api/console/log/index.md
@@ -1,6 +1,7 @@
 ---
 title: console.log()
 slug: Web/API/console/log
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/console/profile/index.md
+++ b/files/en-us/web/api/console/profile/index.md
@@ -1,6 +1,7 @@
 ---
 title: console.profile()
 slug: Web/API/console/profile
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/console/profileend/index.md
+++ b/files/en-us/web/api/console/profileend/index.md
@@ -1,6 +1,7 @@
 ---
 title: console.profileEnd()
 slug: Web/API/console/profileEnd
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/console/table/index.md
+++ b/files/en-us/web/api/console/table/index.md
@@ -1,6 +1,7 @@
 ---
 title: console.table()
 slug: Web/API/console/table
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/console/time/index.md
+++ b/files/en-us/web/api/console/time/index.md
@@ -1,6 +1,7 @@
 ---
 title: console.time()
 slug: Web/API/console/time
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/console/timeend/index.md
+++ b/files/en-us/web/api/console/timeend/index.md
@@ -1,6 +1,7 @@
 ---
 title: console.timeEnd()
 slug: Web/API/console/timeEnd
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/console/timelog/index.md
+++ b/files/en-us/web/api/console/timelog/index.md
@@ -1,6 +1,7 @@
 ---
 title: console.timeLog()
 slug: Web/API/console/timeLog
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/console/timestamp/index.md
+++ b/files/en-us/web/api/console/timestamp/index.md
@@ -1,6 +1,7 @@
 ---
 title: console.timeStamp()
 slug: Web/API/console/timeStamp
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/console/trace/index.md
+++ b/files/en-us/web/api/console/trace/index.md
@@ -1,6 +1,7 @@
 ---
 title: console.trace()
 slug: Web/API/console/trace
+page-type: web-api-instance-method
 tags:
   - API
   - Chrome

--- a/files/en-us/web/api/console/warn/index.md
+++ b/files/en-us/web/api/console/warn/index.md
@@ -1,6 +1,7 @@
 ---
 title: console.warn()
 slug: Web/API/console/warn
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/constantsourcenode/constantsourcenode/index.md
+++ b/files/en-us/web/api/constantsourcenode/constantsourcenode/index.md
@@ -1,6 +1,7 @@
 ---
 title: ConstantSourceNode()
 slug: Web/API/ConstantSourceNode/ConstantSourceNode
+page-type: web-api-constructor
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/constantsourcenode/index.md
+++ b/files/en-us/web/api/constantsourcenode/index.md
@@ -1,6 +1,7 @@
 ---
 title: ConstantSourceNode
 slug: Web/API/ConstantSourceNode
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/constantsourcenode/offset/index.md
+++ b/files/en-us/web/api/constantsourcenode/offset/index.md
@@ -1,6 +1,7 @@
 ---
 title: ConstantSourceNode.offset
 slug: Web/API/ConstantSourceNode/offset
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/constraint_validation/index.md
+++ b/files/en-us/web/api/constraint_validation/index.md
@@ -1,6 +1,7 @@
 ---
 title: Constraint validation API
 slug: Web/API/Constraint_validation
+page-type: web-api-overview
 tags:
   - API
   - Constraint validation

--- a/files/en-us/web/api/contact_picker_api/index.md
+++ b/files/en-us/web/api/contact_picker_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Contact Picker API
 slug: Web/API/Contact_Picker_API
+page-type: web-api-overview
 tags:
   - API
   - Contact Picker API

--- a/files/en-us/web/api/contactaddress/index.md
+++ b/files/en-us/web/api/contactaddress/index.md
@@ -1,6 +1,7 @@
 ---
 title: ContactAddress
 slug: Web/API/ContactAddress
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/contactsmanager/getproperties/index.md
+++ b/files/en-us/web/api/contactsmanager/getproperties/index.md
@@ -1,6 +1,7 @@
 ---
 title: ContactsManager.getProperties()
 slug: Web/API/ContactsManager/getProperties
+page-type: web-api-instance-method
 tags:
   - Contact Picker API
   - Contacts

--- a/files/en-us/web/api/contactsmanager/index.md
+++ b/files/en-us/web/api/contactsmanager/index.md
@@ -1,6 +1,7 @@
 ---
 title: ContactsManager
 slug: Web/API/ContactsManager
+page-type: web-api-interface
 tags:
   - Contact Picker API
   - Contacts

--- a/files/en-us/web/api/contactsmanager/select/index.md
+++ b/files/en-us/web/api/contactsmanager/select/index.md
@@ -1,6 +1,7 @@
 ---
 title: ContactsManager.select()
 slug: Web/API/ContactsManager/select
+page-type: web-api-instance-method
 tags:
   - Contact Picker API
   - Contacts

--- a/files/en-us/web/api/content_index_api/index.md
+++ b/files/en-us/web/api/content_index_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Content Index API
 slug: Web/API/Content_Index_API
+page-type: web-api-overview
 tags:
   - API
   - Content

--- a/files/en-us/web/api/contentindex/add/index.md
+++ b/files/en-us/web/api/contentindex/add/index.md
@@ -1,6 +1,7 @@
 ---
 title: ContentIndex.add()
 slug: Web/API/ContentIndex/add
+page-type: web-api-instance-method
 tags:
   - Content
   - Content Index API

--- a/files/en-us/web/api/contentindex/delete/index.md
+++ b/files/en-us/web/api/contentindex/delete/index.md
@@ -1,6 +1,7 @@
 ---
 title: ContentIndex.delete()
 slug: Web/API/ContentIndex/delete
+page-type: web-api-instance-method
 tags:
   - Content
   - Content Index API

--- a/files/en-us/web/api/contentindex/getall/index.md
+++ b/files/en-us/web/api/contentindex/getall/index.md
@@ -1,6 +1,7 @@
 ---
 title: ContentIndex.getAll()
 slug: Web/API/ContentIndex/getAll
+page-type: web-api-instance-method
 tags:
   - Content
   - Content Index API

--- a/files/en-us/web/api/contentindex/index.md
+++ b/files/en-us/web/api/contentindex/index.md
@@ -1,6 +1,7 @@
 ---
 title: ContentIndex
 slug: Web/API/ContentIndex
+page-type: web-api-interface
 tags:
   - Content
   - Index

--- a/files/en-us/web/api/contentindexevent/contentindexevent/index.md
+++ b/files/en-us/web/api/contentindexevent/contentindexevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: ContentIndexEvent()
 slug: Web/API/ContentIndexEvent/ContentIndexEvent
+page-type: web-api-constructor
 tags:
   - Constructor
   - Content

--- a/files/en-us/web/api/contentindexevent/id/index.md
+++ b/files/en-us/web/api/contentindexevent/id/index.md
@@ -1,6 +1,7 @@
 ---
 title: ContentIndexEvent.id
 slug: Web/API/ContentIndexEvent/id
+page-type: web-api-instance-property
 tags:
   - Content
   - Content Index API

--- a/files/en-us/web/api/contentindexevent/index.md
+++ b/files/en-us/web/api/contentindexevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: ContentIndexEvent
 slug: Web/API/ContentIndexEvent
+page-type: web-api-interface
 tags:
   - Content
   - Content Index API

--- a/files/en-us/web/api/convolvernode/buffer/index.md
+++ b/files/en-us/web/api/convolvernode/buffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: ConvolverNode.buffer
 slug: Web/API/ConvolverNode/buffer
+page-type: web-api-instance-property
 tags:
   - API
   - Buffer

--- a/files/en-us/web/api/convolvernode/convolvernode/index.md
+++ b/files/en-us/web/api/convolvernode/convolvernode/index.md
@@ -1,6 +1,7 @@
 ---
 title: ConvolverNode()
 slug: Web/API/ConvolverNode/ConvolverNode
+page-type: web-api-constructor
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/convolvernode/index.md
+++ b/files/en-us/web/api/convolvernode/index.md
@@ -1,6 +1,7 @@
 ---
 title: ConvolverNode
 slug: Web/API/ConvolverNode
+page-type: web-api-interface
 tags:
   - API
   - ConvolverNode

--- a/files/en-us/web/api/convolvernode/normalize/index.md
+++ b/files/en-us/web/api/convolvernode/normalize/index.md
@@ -1,6 +1,7 @@
 ---
 title: ConvolverNode.normalize
 slug: Web/API/ConvolverNode/normalize
+page-type: web-api-instance-property
 tags:
   - API
   - ConvolverNode

--- a/files/en-us/web/api/cookie_store_api/index.md
+++ b/files/en-us/web/api/cookie_store_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Cookie Store API
 slug: Web/API/Cookie_Store_API
+page-type: web-api-overview
 tags:
   - API
   - Cookie Store

--- a/files/en-us/web/api/cookiechangeevent/changed/index.md
+++ b/files/en-us/web/api/cookiechangeevent/changed/index.md
@@ -1,6 +1,7 @@
 ---
 title: CookieChangeEvent.changed
 slug: Web/API/CookieChangeEvent/changed
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.md
+++ b/files/en-us/web/api/cookiechangeevent/cookiechangeevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: CookieChangeEvent()
 slug: Web/API/CookieChangeEvent/CookieChangeEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/cookiechangeevent/deleted/index.md
+++ b/files/en-us/web/api/cookiechangeevent/deleted/index.md
@@ -1,6 +1,7 @@
 ---
 title: CookieChangeEvent.deleted
 slug: Web/API/CookieChangeEvent/deleted
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/cookiechangeevent/index.md
+++ b/files/en-us/web/api/cookiechangeevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: CookieChangeEvent
 slug: Web/API/CookieChangeEvent
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/cookiestore/change_event/index.md
+++ b/files/en-us/web/api/cookiestore/change_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'CookieStore: change event'
 slug: Web/API/CookieStore/change_event
+page-type: web-api-event
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/cookiestore/delete/index.md
+++ b/files/en-us/web/api/cookiestore/delete/index.md
@@ -1,6 +1,7 @@
 ---
 title: CookieStore.delete()
 slug: Web/API/CookieStore/delete
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/cookiestore/get/index.md
+++ b/files/en-us/web/api/cookiestore/get/index.md
@@ -1,6 +1,7 @@
 ---
 title: CookieStore.get()
 slug: Web/API/CookieStore/get
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/cookiestore/getall/index.md
+++ b/files/en-us/web/api/cookiestore/getall/index.md
@@ -1,6 +1,7 @@
 ---
 title: CookieStore.getAll()
 slug: Web/API/CookieStore/getAll
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/cookiestore/index.md
+++ b/files/en-us/web/api/cookiestore/index.md
@@ -1,6 +1,7 @@
 ---
 title: CookieStore
 slug: Web/API/CookieStore
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/cookiestore/set/index.md
+++ b/files/en-us/web/api/cookiestore/set/index.md
@@ -1,6 +1,7 @@
 ---
 title: CookieStore.set()
 slug: Web/API/CookieStore/set
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/cookiestoremanager/getsubscriptions/index.md
+++ b/files/en-us/web/api/cookiestoremanager/getsubscriptions/index.md
@@ -1,6 +1,7 @@
 ---
 title: CookieStoreManager.getSubscriptions()
 slug: Web/API/CookieStoreManager/getSubscriptions
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/cookiestoremanager/index.md
+++ b/files/en-us/web/api/cookiestoremanager/index.md
@@ -1,6 +1,7 @@
 ---
 title: CookieStoreManager
 slug: Web/API/CookieStoreManager
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/cookiestoremanager/subscribe/index.md
+++ b/files/en-us/web/api/cookiestoremanager/subscribe/index.md
@@ -1,6 +1,7 @@
 ---
 title: CookieStoreManager.subscribe()
 slug: Web/API/CookieStoreManager/subscribe
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/cookiestoremanager/unsubscribe/index.md
+++ b/files/en-us/web/api/cookiestoremanager/unsubscribe/index.md
@@ -1,6 +1,7 @@
 ---
 title: CookieStoreManager.unsubscribe()
 slug: Web/API/CookieStoreManager/unsubscribe
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/countqueuingstrategy/countqueuingstrategy/index.md
+++ b/files/en-us/web/api/countqueuingstrategy/countqueuingstrategy/index.md
@@ -1,6 +1,7 @@
 ---
 title: CountQueuingStrategy()
 slug: Web/API/CountQueuingStrategy/CountQueuingStrategy
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/countqueuingstrategy/index.md
+++ b/files/en-us/web/api/countqueuingstrategy/index.md
@@ -1,6 +1,7 @@
 ---
 title: CountQueuingStrategy
 slug: Web/API/CountQueuingStrategy
+page-type: web-api-interface
 tags:
   - API
   - CountQueuingStrategy

--- a/files/en-us/web/api/countqueuingstrategy/size/index.md
+++ b/files/en-us/web/api/countqueuingstrategy/size/index.md
@@ -1,6 +1,7 @@
 ---
 title: CountQueuingStrategy.size()
 slug: Web/API/CountQueuingStrategy/size
+page-type: web-api-instance-method
 tags:
   - API
   - CountQueuingStrategy

--- a/files/en-us/web/api/crashreportbody/index.md
+++ b/files/en-us/web/api/crashreportbody/index.md
@@ -1,6 +1,7 @@
 ---
 title: CrashReportBody
 slug: Web/API/CrashReportBody
+page-type: web-api-interface
 tags:
   - API
   - CrashReportBody

--- a/files/en-us/web/api/createimagebitmap/index.md
+++ b/files/en-us/web/api/createimagebitmap/index.md
@@ -1,6 +1,7 @@
 ---
 title: createImageBitmap()
 slug: Web/API/createImageBitmap
+page-type: web-api-global-function
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/credential/id/index.md
+++ b/files/en-us/web/api/credential/id/index.md
@@ -1,6 +1,7 @@
 ---
 title: Credential.id
 slug: Web/API/Credential/id
+page-type: web-api-instance-property
 tags:
   - API
   - Credential

--- a/files/en-us/web/api/credential/index.md
+++ b/files/en-us/web/api/credential/index.md
@@ -1,6 +1,7 @@
 ---
 title: Credential
 slug: Web/API/Credential
+page-type: web-api-interface
 tags:
   - API
   - Credential Management API

--- a/files/en-us/web/api/credential/type/index.md
+++ b/files/en-us/web/api/credential/type/index.md
@@ -1,6 +1,7 @@
 ---
 title: Credential.type
 slug: Web/API/Credential/type
+page-type: web-api-instance-property
 tags:
   - API
   - Credential

--- a/files/en-us/web/api/credential_management_api/index.md
+++ b/files/en-us/web/api/credential_management_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Credential Management API
 slug: Web/API/Credential_Management_API
+page-type: web-api-overview
 tags:
   - API
   - Credential Management API

--- a/files/en-us/web/api/credentialscontainer/create/index.md
+++ b/files/en-us/web/api/credentialscontainer/create/index.md
@@ -1,6 +1,7 @@
 ---
 title: CredentialsContainer.create()
 slug: Web/API/CredentialsContainer/create
+page-type: web-api-instance-method
 tags:
   - API
   - Credential Management API

--- a/files/en-us/web/api/credentialscontainer/get/index.md
+++ b/files/en-us/web/api/credentialscontainer/get/index.md
@@ -1,6 +1,7 @@
 ---
 title: CredentialsContainer.get()
 slug: Web/API/CredentialsContainer/get
+page-type: web-api-instance-method
 tags:
   - API
   - Credential Management API

--- a/files/en-us/web/api/credentialscontainer/index.md
+++ b/files/en-us/web/api/credentialscontainer/index.md
@@ -1,6 +1,7 @@
 ---
 title: CredentialsContainer
 slug: Web/API/CredentialsContainer
+page-type: web-api-interface
 tags:
   - API
   - Credential Management API

--- a/files/en-us/web/api/credentialscontainer/preventsilentaccess/index.md
+++ b/files/en-us/web/api/credentialscontainer/preventsilentaccess/index.md
@@ -1,6 +1,7 @@
 ---
 title: CredentialsContainer.preventSilentAccess()
 slug: Web/API/CredentialsContainer/preventSilentAccess
+page-type: web-api-instance-method
 tags:
   - API
   - Credential Management API

--- a/files/en-us/web/api/credentialscontainer/store/index.md
+++ b/files/en-us/web/api/credentialscontainer/store/index.md
@@ -1,6 +1,7 @@
 ---
 title: CredentialsContainer.store()
 slug: Web/API/CredentialsContainer/store
+page-type: web-api-instance-method
 tags:
   - API
   - Credential Management API

--- a/files/en-us/web/api/crossoriginisolated/index.md
+++ b/files/en-us/web/api/crossoriginisolated/index.md
@@ -1,6 +1,7 @@
 ---
 title: crossOriginIsolated
 slug: Web/API/crossOriginIsolated
+page-type: web-api-global-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/crypto/getrandomvalues/index.md
+++ b/files/en-us/web/api/crypto/getrandomvalues/index.md
@@ -1,6 +1,7 @@
 ---
 title: Crypto.getRandomValues()
 slug: Web/API/Crypto/getRandomValues
+page-type: web-api-instance-method
 tags:
   - API
   - Crypto

--- a/files/en-us/web/api/crypto/index.md
+++ b/files/en-us/web/api/crypto/index.md
@@ -1,6 +1,7 @@
 ---
 title: Crypto
 slug: Web/API/Crypto
+page-type: web-api-interface
 tags:
   - API
   - Code

--- a/files/en-us/web/api/crypto/randomuuid/index.md
+++ b/files/en-us/web/api/crypto/randomuuid/index.md
@@ -1,6 +1,7 @@
 ---
 title: Crypto.randomUUID()
 slug: Web/API/Crypto/randomUUID
+page-type: web-api-instance-method
 tags:
   - API
   - Crypto

--- a/files/en-us/web/api/crypto/subtle/index.md
+++ b/files/en-us/web/api/crypto/subtle/index.md
@@ -1,6 +1,7 @@
 ---
 title: Crypto.subtle
 slug: Web/API/Crypto/subtle
+page-type: web-api-instance-property
 tags:
   - API
   - Cryptography

--- a/files/en-us/web/api/crypto_property/index.md
+++ b/files/en-us/web/api/crypto_property/index.md
@@ -1,6 +1,7 @@
 ---
 title: self.crypto
 slug: Web/API/crypto_property
+page-type: web-api-global-property
 tags:
   - API
   - Crypto

--- a/files/en-us/web/api/cryptokey/index.md
+++ b/files/en-us/web/api/cryptokey/index.md
@@ -1,6 +1,7 @@
 ---
 title: CryptoKey
 slug: Web/API/CryptoKey
+page-type: web-api-interface
 tags:
   - API
   - Code

--- a/files/en-us/web/api/cryptokeypair/index.md
+++ b/files/en-us/web/api/cryptokeypair/index.md
@@ -1,6 +1,7 @@
 ---
 title: CryptoKeyPair
 slug: Web/API/CryptoKeyPair
+page-type: web-api-interface
 tags:
   - API
   - CryptoKeyPair

--- a/files/en-us/web/api/css/escape/index.md
+++ b/files/en-us/web/api/css/escape/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS.escape()
 slug: Web/API/CSS/escape
+page-type: web-api-static-method
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/css/factory_functions/index.md
+++ b/files/en-us/web/api/css/factory_functions/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS numeric factory functions
 slug: Web/API/CSS/factory_functions
+page-type: web-api-static-method
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/css/index.md
+++ b/files/en-us/web/api/css/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS
 slug: Web/API/CSS
+page-type: web-api-interface
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/css/paintworklet/index.md
+++ b/files/en-us/web/api/css/paintworklet/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS.paintWorklet (Static property)
 slug: Web/API/CSS/paintWorklet
+page-type: web-api-static-property
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/css/registerproperty/index.md
+++ b/files/en-us/web/api/css/registerproperty/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS.registerProperty()
 slug: Web/API/CSS/RegisterProperty
+page-type: web-api-static-method
 tags:
   - CSS
   - Houdini

--- a/files/en-us/web/api/css/supports/index.md
+++ b/files/en-us/web/api/css/supports/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS.supports()
 slug: Web/API/CSS/supports
+page-type: web-api-static-method
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/css_counter_styles/index.md
+++ b/files/en-us/web/api/css_counter_styles/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Counter Styles
 slug: Web/API/CSS_Counter_Styles
+page-type: web-api-overview
 tags:
   - CSS
   - CSS Counter Styles

--- a/files/en-us/web/api/css_font_loading_api/index.md
+++ b/files/en-us/web/api/css_font_loading_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Font Loading API
 slug: Web/API/CSS_Font_Loading_API
+page-type: web-api-overview
 tags:
   - API
   - CSSFontLoading

--- a/files/en-us/web/api/css_object_model/css_declaration/index.md
+++ b/files/en-us/web/api/css_object_model/css_declaration/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Declaration
 slug: Web/API/CSS_Object_Model/CSS_Declaration
+page-type: guide
 tags:
   - CSS
   - CSS Object Model

--- a/files/en-us/web/api/css_object_model/css_declaration_block/index.md
+++ b/files/en-us/web/api/css_object_model/css_declaration_block/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Declaration Block
 slug: Web/API/CSS_Object_Model/CSS_Declaration_Block
+page-type: guide
 tags:
   - CSS
   - CSS Object Model

--- a/files/en-us/web/api/css_object_model/determining_the_dimensions_of_elements/index.md
+++ b/files/en-us/web/api/css_object_model/determining_the_dimensions_of_elements/index.md
@@ -1,6 +1,7 @@
 ---
 title: Determining the dimensions of elements
 slug: Web/API/CSS_Object_Model/Determining_the_dimensions_of_elements
+page-type: guide
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/css_object_model/index.md
+++ b/files/en-us/web/api/css_object_model/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Object Model (CSSOM)
 slug: Web/API/CSS_Object_Model
+page-type: web-api-overview
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/css_object_model/managing_screen_orientation/index.md
+++ b/files/en-us/web/api/css_object_model/managing_screen_orientation/index.md
@@ -1,6 +1,7 @@
 ---
 title: Managing screen orientation
 slug: Web/API/CSS_Object_Model/Managing_screen_orientation
+page-type: guide
 tags:
   - API
   - Advanced

--- a/files/en-us/web/api/css_object_model/using_dynamic_styling_information/index.md
+++ b/files/en-us/web/api/css_object_model/using_dynamic_styling_information/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using dynamic styling information
 slug: Web/API/CSS_Object_Model/Using_dynamic_styling_information
+page-type: guide
 tags:
   - API
   - Beginner

--- a/files/en-us/web/api/css_painting_api/guide/index.md
+++ b/files/en-us/web/api/css_painting_api/guide/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using the CSS Painting API
 slug: Web/API/CSS_Painting_API/Guide
+page-type: guide
 tags:
   - CSS
   - CSS Paint API

--- a/files/en-us/web/api/css_painting_api/index.md
+++ b/files/en-us/web/api/css_painting_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Painting API
 slug: Web/API/CSS_Painting_API
+page-type: web-api-overview
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/css_properties_and_values_api/guide/index.md
+++ b/files/en-us/web/api/css_properties_and_values_api/guide/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using the CSS properties and values API
 slug: Web/API/CSS_Properties_and_Values_API/guide
+page-type: guide
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/css_properties_and_values_api/index.md
+++ b/files/en-us/web/api/css_properties_and_values_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Properties and Values API
 slug: Web/API/CSS_Properties_and_Values_API
+page-type: web-api-overview
 tags:
   - Houdini
 ---

--- a/files/en-us/web/api/css_typed_om_api/guide/index.md
+++ b/files/en-us/web/api/css_typed_om_api/guide/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using the CSS Typed Object Model
 slug: Web/API/CSS_Typed_OM_API/Guide
+page-type: guide
 tags:
   - CSS
   - CSS Typed OM

--- a/files/en-us/web/api/css_typed_om_api/index.md
+++ b/files/en-us/web/api/css_typed_om_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSS Typed Object Model API
 slug: Web/API/CSS_Typed_OM_API
+page-type: web-api-overview
 tags:
   - CSS Typed OM
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssanimation/animationname/index.md
+++ b/files/en-us/web/api/cssanimation/animationname/index.md
@@ -1,5 +1,5 @@
 ---
-title: CSSAnimation
+title: CSSAnimation.animationName
 slug: Web/API/CSSAnimation/animationName
 page-type: web-api-instance-property
 tags:

--- a/files/en-us/web/api/cssanimation/animationname/index.md
+++ b/files/en-us/web/api/cssanimation/animationname/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSAnimation
 slug: Web/API/CSSAnimation/animationName
+page-type: web-api-instance-property
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/cssanimation/index.md
+++ b/files/en-us/web/api/cssanimation/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSAnimation
 slug: Web/API/CSSAnimation
+page-type: web-api-interface
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/cssconditionrule/conditiontext/index.md
+++ b/files/en-us/web/api/cssconditionrule/conditiontext/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSConditionRule.conditionText
 slug: Web/API/CSSConditionRule/conditionText
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssconditionrule/index.md
+++ b/files/en-us/web/api/cssconditionrule/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSConditionRule
 slug: Web/API/CSSConditionRule
+page-type: web-api-interface
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/csscounterstylerule/additivesymbols/index.md
+++ b/files/en-us/web/api/csscounterstylerule/additivesymbols/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSCounterStyleRule.additiveSymbols
 slug: Web/API/CSSCounterStyleRule/additiveSymbols
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/csscounterstylerule/fallback/index.md
+++ b/files/en-us/web/api/csscounterstylerule/fallback/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSCounterStyleRule.fallback
 slug: Web/API/CSSCounterStyleRule/fallback
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/csscounterstylerule/index.md
+++ b/files/en-us/web/api/csscounterstylerule/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSCounterStyleRule
 slug: Web/API/CSSCounterStyleRule
+page-type: web-api-interface
 tags:
   - API
   - CSS Counter Styles

--- a/files/en-us/web/api/csscounterstylerule/name/index.md
+++ b/files/en-us/web/api/csscounterstylerule/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSCounterStyleRule.name
 slug: Web/API/CSSCounterStyleRule/name
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/csscounterstylerule/negative/index.md
+++ b/files/en-us/web/api/csscounterstylerule/negative/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSCounterStyleRule.negative
 slug: Web/API/CSSCounterStyleRule/negative
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/csscounterstylerule/pad/index.md
+++ b/files/en-us/web/api/csscounterstylerule/pad/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSCounterStyleRule.pad
 slug: Web/API/CSSCounterStyleRule/pad
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/csscounterstylerule/prefix/index.md
+++ b/files/en-us/web/api/csscounterstylerule/prefix/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSCounterStyleRule.prefix
 slug: Web/API/CSSCounterStyleRule/prefix
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/csscounterstylerule/range/index.md
+++ b/files/en-us/web/api/csscounterstylerule/range/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSCounterStyleRule.range
 slug: Web/API/CSSCounterStyleRule/range
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/csscounterstylerule/speakas/index.md
+++ b/files/en-us/web/api/csscounterstylerule/speakas/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSCounterStyleRule.speakAs
 slug: Web/API/CSSCounterStyleRule/speakAs
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/csscounterstylerule/suffix/index.md
+++ b/files/en-us/web/api/csscounterstylerule/suffix/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSCounterStyleRule.suffix
 slug: Web/API/CSSCounterStyleRule/suffix
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/csscounterstylerule/symbols/index.md
+++ b/files/en-us/web/api/csscounterstylerule/symbols/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSCounterStyleRule.symbols
 slug: Web/API/CSSCounterStyleRule/symbols
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/csscounterstylerule/system/index.md
+++ b/files/en-us/web/api/csscounterstylerule/system/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSCounterStyleRule.system
 slug: Web/API/CSSCounterStyleRule/system
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/cssfontfacerule/index.md
+++ b/files/en-us/web/api/cssfontfacerule/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSFontFaceRule
 slug: Web/API/CSSFontFaceRule
+page-type: web-api-interface
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssfontfacerule/style/index.md
+++ b/files/en-us/web/api/cssfontfacerule/style/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSFontFaceRule.style
 slug: Web/API/CSSFontFaceRule/style
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssgroupingrule/cssrules/index.md
+++ b/files/en-us/web/api/cssgroupingrule/cssrules/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSGroupingRule.cssRules
 slug: Web/API/CSSGroupingRule/cssRules
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssgroupingrule/deleterule/index.md
+++ b/files/en-us/web/api/cssgroupingrule/deleterule/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSGroupingRule.deleteRule()
 slug: Web/API/CSSGroupingRule/deleteRule
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssgroupingrule/index.md
+++ b/files/en-us/web/api/cssgroupingrule/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSGroupingRule
 slug: Web/API/CSSGroupingRule
+page-type: web-api-interface
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssgroupingrule/insertrule/index.md
+++ b/files/en-us/web/api/cssgroupingrule/insertrule/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSGroupingRule.insertRule()
 slug: Web/API/CSSGroupingRule/insertRule
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssimagevalue/index.md
+++ b/files/en-us/web/api/cssimagevalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSImageValue
 slug: Web/API/CSSImageValue
+page-type: web-api-interface
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssimportrule/href/index.md
+++ b/files/en-us/web/api/cssimportrule/href/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSImportRule.href
 slug: Web/API/CSSImportRule/href
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssimportrule/index.md
+++ b/files/en-us/web/api/cssimportrule/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSImportRule
 slug: Web/API/CSSImportRule
+page-type: web-api-interface
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssimportrule/media/index.md
+++ b/files/en-us/web/api/cssimportrule/media/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSImportRule.media
 slug: Web/API/CSSImportRule/media
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssimportrule/stylesheet/index.md
+++ b/files/en-us/web/api/cssimportrule/stylesheet/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSImportRule.stylesheet
 slug: Web/API/CSSImportRule/stylesheet
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/csskeyframerule/index.md
+++ b/files/en-us/web/api/csskeyframerule/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSKeyframeRule
 slug: Web/API/CSSKeyframeRule
+page-type: web-api-interface
 tags:
   - API
   - CSS Animations

--- a/files/en-us/web/api/csskeyframerule/keytext/index.md
+++ b/files/en-us/web/api/csskeyframerule/keytext/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSKeyframeRule.keyText
 slug: Web/API/CSSKeyframeRule/keyText
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/csskeyframerule/style/index.md
+++ b/files/en-us/web/api/csskeyframerule/style/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSKeyframeRule.style
 slug: Web/API/CSSkeyframeRule/style
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/csskeyframesrule/appendrule/index.md
+++ b/files/en-us/web/api/csskeyframesrule/appendrule/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSKeyframesRule.appendRule()
 slug: Web/API/CSSKeyframesRule/appendRule
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/csskeyframesrule/cssrules/index.md
+++ b/files/en-us/web/api/csskeyframesrule/cssrules/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSKeyframesRule.cssRules
 slug: Web/API/CSSKeyframesRule/cssRules
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/csskeyframesrule/deleterule/index.md
+++ b/files/en-us/web/api/csskeyframesrule/deleterule/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSKeyframesRule.deleteRule()
 slug: Web/API/CSSKeyframesRule/deleteRule
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/csskeyframesrule/findrule/index.md
+++ b/files/en-us/web/api/csskeyframesrule/findrule/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSKeyframesRule.findRule()
 slug: Web/API/CSSKeyframesRule/findRule
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/csskeyframesrule/index.md
+++ b/files/en-us/web/api/csskeyframesrule/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSKeyframesRule
 slug: Web/API/CSSKeyframesRule
+page-type: web-api-interface
 tags:
   - API
   - CSS Animations

--- a/files/en-us/web/api/csskeyframesrule/name/index.md
+++ b/files/en-us/web/api/csskeyframesrule/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSKeyframesRule.name
 slug: Web/API/CSSKeyframesRule/name
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/csskeywordvalue/csskeywordvalue/index.md
+++ b/files/en-us/web/api/csskeywordvalue/csskeywordvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSKeywordValue()
 slug: Web/API/CSSKeywordValue/CSSKeywordValue
+page-type: web-api-constructor
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/csskeywordvalue/index.md
+++ b/files/en-us/web/api/csskeywordvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSKeywordValue
 slug: Web/API/CSSKeywordValue
+page-type: web-api-interface
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/csskeywordvalue/value/index.md
+++ b/files/en-us/web/api/csskeywordvalue/value/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSKeywordValue.value
 slug: Web/API/CSSKeywordValue/value
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssmathinvert/cssmathinvert/index.md
+++ b/files/en-us/web/api/cssmathinvert/cssmathinvert/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSMathInvert()
 slug: Web/API/CSSMathInvert/CSSMathInvert
+page-type: web-api-constructor
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssmathinvert/index.md
+++ b/files/en-us/web/api/cssmathinvert/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSMathInvert
 slug: Web/API/CSSMathInvert
+page-type: web-api-interface
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssmathinvert/value/index.md
+++ b/files/en-us/web/api/cssmathinvert/value/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSMathInvert.value
 slug: Web/API/CSSMathInvert/value
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssmathmax/cssmathmax/index.md
+++ b/files/en-us/web/api/cssmathmax/cssmathmax/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSMathMax()
 slug: Web/API/CSSMathMax/CSSMathMax
+page-type: web-api-constructor
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssmathmax/index.md
+++ b/files/en-us/web/api/cssmathmax/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSMathMax
 slug: Web/API/CSSMathMax
+page-type: web-api-interface
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssmathmax/values/index.md
+++ b/files/en-us/web/api/cssmathmax/values/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSMathMax.values
 slug: Web/API/CSSMathMax/values
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssmathmin/cssmathmin/index.md
+++ b/files/en-us/web/api/cssmathmin/cssmathmin/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSMathMin()
 slug: Web/API/CSSMathMin/CSSMathMin
+page-type: web-api-constructor
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssmathmin/index.md
+++ b/files/en-us/web/api/cssmathmin/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSMathMin
 slug: Web/API/CSSMathMin
+page-type: web-api-interface
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssmathmin/values/index.md
+++ b/files/en-us/web/api/cssmathmin/values/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSMathMin.values
 slug: Web/API/CSSMathMin/values
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssmathnegate/cssmathnegate/index.md
+++ b/files/en-us/web/api/cssmathnegate/cssmathnegate/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSMathNegate()
 slug: Web/API/CSSMathNegate/CSSMathNegate
+page-type: web-api-constructor
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssmathnegate/index.md
+++ b/files/en-us/web/api/cssmathnegate/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSMathNegate
 slug: Web/API/CSSMathNegate
+page-type: web-api-interface
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssmathnegate/value/index.md
+++ b/files/en-us/web/api/cssmathnegate/value/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSMathNegate.value
 slug: Web/API/CSSMathNegate/value
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssmathproduct/cssmathproduct/index.md
+++ b/files/en-us/web/api/cssmathproduct/cssmathproduct/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSMathProduct()
 slug: Web/API/CSSMathProduct/CSSMathProduct
+page-type: web-api-constructor
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssmathproduct/index.md
+++ b/files/en-us/web/api/cssmathproduct/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSMathProduct
 slug: Web/API/CSSMathProduct
+page-type: web-api-interface
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssmathproduct/values/index.md
+++ b/files/en-us/web/api/cssmathproduct/values/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSMathProduct.values
 slug: Web/API/CSSMathProduct/values
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssmathsum/cssmathsum/index.md
+++ b/files/en-us/web/api/cssmathsum/cssmathsum/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSMathSum()
 slug: Web/API/CSSMathSum/CSSMathSum
+page-type: web-api-constructor
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssmathsum/index.md
+++ b/files/en-us/web/api/cssmathsum/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSMathSum
 slug: Web/API/CSSMathSum
+page-type: web-api-interface
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssmathsum/values/index.md
+++ b/files/en-us/web/api/cssmathsum/values/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSMathSum.values
 slug: Web/API/CSSMathSum/values
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssmathvalue/index.md
+++ b/files/en-us/web/api/cssmathvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSMathValue
 slug: Web/API/CSSMathValue
+page-type: web-api-interface
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssmathvalue/operator/index.md
+++ b/files/en-us/web/api/cssmathvalue/operator/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSMathValue.operator
 slug: Web/API/CSSMathValue/operator
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssmatrixcomponent/cssmatrixcomponent/index.md
+++ b/files/en-us/web/api/cssmatrixcomponent/cssmatrixcomponent/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSMatrixComponent()
 slug: Web/API/CSSMatrixComponent/CSSMatrixComponent
+page-type: web-api-constructor
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssmatrixcomponent/index.md
+++ b/files/en-us/web/api/cssmatrixcomponent/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSMatrixComponent
 slug: Web/API/CSSMatrixComponent
+page-type: web-api-interface
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssmatrixcomponent/matrix/index.md
+++ b/files/en-us/web/api/cssmatrixcomponent/matrix/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSMatrixComponent.matrix
 slug: Web/API/CSSMatrixComponent/matrix
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssmediarule/index.md
+++ b/files/en-us/web/api/cssmediarule/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSMediaRule
 slug: Web/API/CSSMediaRule
+page-type: web-api-interface
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssmediarule/media/index.md
+++ b/files/en-us/web/api/cssmediarule/media/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSMediaRule.media
 slug: Web/API/CSSMediaRule/media
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssnamespacerule/index.md
+++ b/files/en-us/web/api/cssnamespacerule/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSNamespaceRule
 slug: Web/API/CSSNamespaceRule
+page-type: web-api-interface
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssnamespacerule/namespaceuri/index.md
+++ b/files/en-us/web/api/cssnamespacerule/namespaceuri/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSNamespaceRule.namespaceURI
 slug: Web/API/CSSNamespaceRule/namespaceURI
+page-type: web-api-instance-property
 tags:
   - API
   - CSSNamespaceRule

--- a/files/en-us/web/api/cssnamespacerule/prefix/index.md
+++ b/files/en-us/web/api/cssnamespacerule/prefix/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSNamespaceRule.prefix
 slug: Web/API/CSSNamespaceRule/prefix
+page-type: web-api-instance-property
 tags:
   - API
   - CSSNamespaceRule

--- a/files/en-us/web/api/cssnumericarray/index.md
+++ b/files/en-us/web/api/cssnumericarray/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSNumericArray
 slug: Web/API/CSSNumericArray
+page-type: web-api-interface
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssnumericarray/length/index.md
+++ b/files/en-us/web/api/cssnumericarray/length/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSNumericArray.length
 slug: Web/API/CSSNumericArray/length
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssnumericvalue/add/index.md
+++ b/files/en-us/web/api/cssnumericvalue/add/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSNumericValue.add()
 slug: Web/API/CSSNumericValue/add
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssnumericvalue/div/index.md
+++ b/files/en-us/web/api/cssnumericvalue/div/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSNumericValue.div()
 slug: Web/API/CSSNumericValue/div
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssnumericvalue/equals/index.md
+++ b/files/en-us/web/api/cssnumericvalue/equals/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSNumericValue.equals()
 slug: Web/API/CSSNumericValue/equals
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssnumericvalue/index.md
+++ b/files/en-us/web/api/cssnumericvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSNumericValue
 slug: Web/API/CSSNumericValue
+page-type: web-api-interface
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssnumericvalue/max/index.md
+++ b/files/en-us/web/api/cssnumericvalue/max/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSNumericValue.max()
 slug: Web/API/CSSNumericValue/max
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssnumericvalue/min/index.md
+++ b/files/en-us/web/api/cssnumericvalue/min/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSNumericValue.min()
 slug: Web/API/CSSNumericValue/min
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssnumericvalue/mul/index.md
+++ b/files/en-us/web/api/cssnumericvalue/mul/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSNumericValue.mul()
 slug: Web/API/CSSNumericValue/mul
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssnumericvalue/parse/index.md
+++ b/files/en-us/web/api/cssnumericvalue/parse/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSNumericValue.parse()
 slug: Web/API/CSSNumericValue/parse
+page-type: web-api-static-method
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssnumericvalue/sub/index.md
+++ b/files/en-us/web/api/cssnumericvalue/sub/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSNumericValue.sub()
 slug: Web/API/CSSNumericValue/sub
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssnumericvalue/to/index.md
+++ b/files/en-us/web/api/cssnumericvalue/to/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSNumericValue.to()
 slug: Web/API/CSSNumericValue/to
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssnumericvalue/tosum/index.md
+++ b/files/en-us/web/api/cssnumericvalue/tosum/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSNumericValue.toSum()
 slug: Web/API/CSSNumericValue/toSum
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssnumericvalue/type/index.md
+++ b/files/en-us/web/api/cssnumericvalue/type/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSNumericValue.type()
 slug: Web/API/CSSNumericValue/type
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/csspagerule/index.md
+++ b/files/en-us/web/api/csspagerule/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPageRule
 slug: Web/API/CSSPageRule
+page-type: web-api-interface
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/csspagerule/selectortext/index.md
+++ b/files/en-us/web/api/csspagerule/selectortext/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPageRule.selectorText
 slug: Web/API/CSSPageRule/selectorText
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/csspagerule/style/index.md
+++ b/files/en-us/web/api/csspagerule/style/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPageRule.style
 slug: Web/API/CSSPageRule/style
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssperspective/cssperspective/index.md
+++ b/files/en-us/web/api/cssperspective/cssperspective/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPerspective()
 slug: Web/API/CSSPerspective/CSSPerspective
+page-type: web-api-constructor
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssperspective/index.md
+++ b/files/en-us/web/api/cssperspective/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPerspective
 slug: Web/API/CSSPerspective
+page-type: web-api-interface
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssperspective/length/index.md
+++ b/files/en-us/web/api/cssperspective/length/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPerspective.length
 slug: Web/API/CSSPerspective/length
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/csspositionvalue/csspositionvalue/index.md
+++ b/files/en-us/web/api/csspositionvalue/csspositionvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPositionValue()
 slug: Web/API/CSSPositionValue/CSSPositionValue
+page-type: web-api-constructor
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/csspositionvalue/index.md
+++ b/files/en-us/web/api/csspositionvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPositionValue
 slug: Web/API/CSSPositionValue
+page-type: web-api-interface
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/csspositionvalue/x/index.md
+++ b/files/en-us/web/api/csspositionvalue/x/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPositionValue.x
 slug: Web/API/CSSPositionValue/x
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/csspositionvalue/y/index.md
+++ b/files/en-us/web/api/csspositionvalue/y/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPositionValue.y
 slug: Web/API/CSSPositionValue/y
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssprimitivevalue/getcountervalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/getcountervalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPrimitiveValue.getCounterValue()
 slug: Web/API/CSSPrimitiveValue/getCounterValue
+page-type: web-api-instance-method
 tags:
   - API
   - CSSPrimitiveValue

--- a/files/en-us/web/api/cssprimitivevalue/getfloatvalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/getfloatvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPrimitiveValue.getFloatValue()
 slug: Web/API/CSSPrimitiveValue/getFloatValue
+page-type: web-api-instance-method
 tags:
   - API
   - CSSPrimitiveValue

--- a/files/en-us/web/api/cssprimitivevalue/getrectvalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/getrectvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPrimitiveValue.getRectValue()
 slug: Web/API/CSSPrimitiveValue/getRectValue
+page-type: web-api-instance-method
 tags:
   - API
   - CSSPrimitiveValue

--- a/files/en-us/web/api/cssprimitivevalue/getrgbcolorvalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/getrgbcolorvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPrimitiveValue.getRGBColorValue()
 slug: Web/API/CSSPrimitiveValue/getRGBColorValue
+page-type: web-api-instance-method
 tags:
   - API
   - CSSPrimitiveValue

--- a/files/en-us/web/api/cssprimitivevalue/getstringvalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/getstringvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPrimitiveValue.getStringValue()
 slug: Web/API/CSSPrimitiveValue/getStringValue
+page-type: web-api-instance-method
 tags:
   - API
   - CSSPrimitiveValue

--- a/files/en-us/web/api/cssprimitivevalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPrimitiveValue
 slug: Web/API/CSSPrimitiveValue
+page-type: web-api-interface
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssprimitivevalue/primitivetype/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/primitivetype/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPrimitiveValue.primitiveType
 slug: Web/API/CSSPrimitiveValue/primitiveType
+page-type: web-api-instance-property
 tags:
   - API
   - CSSPrimitiveValue

--- a/files/en-us/web/api/cssprimitivevalue/setfloatvalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/setfloatvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPrimitiveValue.setFloatValue()
 slug: Web/API/CSSPrimitiveValue/setFloatValue
+page-type: web-api-instance-method
 tags:
   - API
   - CSSPrimitiveValue

--- a/files/en-us/web/api/cssprimitivevalue/setstringvalue/index.md
+++ b/files/en-us/web/api/cssprimitivevalue/setstringvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPrimitiveValue.setStringValue()
 slug: Web/API/CSSPrimitiveValue/setStringValue
+page-type: web-api-instance-method
 tags:
   - API
   - CSSPrimitiveValue

--- a/files/en-us/web/api/csspropertyrule/index.md
+++ b/files/en-us/web/api/csspropertyrule/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPropertyRule
 slug: Web/API/CSSPropertyRule
+page-type: web-api-interface
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/csspropertyrule/inherits/index.md
+++ b/files/en-us/web/api/csspropertyrule/inherits/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPropertyRule.inherits
 slug: Web/API/CSSPropertyRule/inherits
+page-type: web-api-instance-property
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/csspropertyrule/initialvalue/index.md
+++ b/files/en-us/web/api/csspropertyrule/initialvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPropertyRule.initialValue
 slug: Web/API/CSSPropertyRule/initialvalue
+page-type: web-api-instance-property
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/csspropertyrule/name/index.md
+++ b/files/en-us/web/api/csspropertyrule/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPropertyRule.name
 slug: Web/API/CSSPropertyRule/name
+page-type: web-api-instance-property
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/csspropertyrule/syntax/index.md
+++ b/files/en-us/web/api/csspropertyrule/syntax/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPropertyRule.syntax
 slug: Web/API/CSSPropertyRule/syntax
+page-type: web-api-instance-property
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/csspseudoelement/element/index.md
+++ b/files/en-us/web/api/csspseudoelement/element/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPseudoElement.element
 slug: Web/API/CSSPseudoElement/element
+page-type: web-api-instance-property
 tags:
   - API
   - CSSPseudoElement

--- a/files/en-us/web/api/csspseudoelement/index.md
+++ b/files/en-us/web/api/csspseudoelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPseudoElement
 slug: Web/API/CSSPseudoElement
+page-type: web-api-interface
 tags:
   - API
   - CSSPseudoElement

--- a/files/en-us/web/api/csspseudoelement/type/index.md
+++ b/files/en-us/web/api/csspseudoelement/type/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSPseudoElement.type
 slug: Web/API/CSSPseudoElement/type
+page-type: web-api-instance-property
 tags:
   - API
   - CSSPseudoElement

--- a/files/en-us/web/api/cssrotate/angle/index.md
+++ b/files/en-us/web/api/cssrotate/angle/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSRotate.angle
 slug: Web/API/CSSRotate/angle
+page-type: web-api-instance-property
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/cssrotate/cssrotate/index.md
+++ b/files/en-us/web/api/cssrotate/cssrotate/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSRotate()
 slug: Web/API/CSSRotate/CSSRotate
+page-type: web-api-constructor
 tags:
   - API
   - CSS Types Object Model API

--- a/files/en-us/web/api/cssrotate/index.md
+++ b/files/en-us/web/api/cssrotate/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSRotate
 slug: Web/API/CSSRotate
+page-type: web-api-interface
 tags:
   - API
   - CSS


### PR DESCRIPTION
See  https://github.com/mdn/content/issues/16255. This is part 4 of a series of PRs to add page types to the Web/API documentation.