### PR TITLE
Error.prototype.cause - basic docs

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/error/cause/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/cause/index.md
@@ -15,7 +15,9 @@ It is used when catching and re-throwing an error with a more-specific or useful
 
 ## Value
 
-Any value can be passed as the cause, but an Error is expected.
+This is the value that was passed to the [`Error()` constructor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Error) in the `options.cause` argument.
+
+Any value may used.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/error/cause/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/cause/index.md
@@ -17,7 +17,7 @@ It is used when catching and re-throwing an error with a more-specific or useful
 
 This is the value that was passed to the [`Error()` constructor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Error) in the `options.cause` argument.
 
-Any value may used.
+The value can be of any type.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/error/cause/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/cause/index.md
@@ -1,0 +1,48 @@
+---
+title: Error.prototype.cause
+slug: Web/JavaScript/Reference/Global_Objects/Error/cause
+tags:
+  - JavaScript
+  - Property
+  - Prototype
+browser-compat: javascript.builtins.Error.cause
+---
+{{JSRef}}
+
+The **`cause`** property indicates the specific original cause of an error.
+
+It is used when catching and re-throwing an error with a more-specific or useful error message in order to still have access to the the original error.
+
+## Value
+
+Any value can be passed as the cause, but an Error is expected.
+
+## Examples
+
+### Rethrowing an error with a `cause`
+
+It is sometimes useful to catch an error and re-throw it with a new message.
+In this case you should pass the original error into the constructor for the new `Error`, as shown.
+
+```js
+  try {
+    frameworkThatCanThrow();
+  } catch (err) {
+    throw new Error('New error message', { cause: err });
+  }
+```
+
+For a more detailed example see [Error > Differentiate between similar errors](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#differentiate_between_similar_errors).
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{jsxref("Error.prototype.message")}}
+- {{jsxref("Error.prototype.toString()")}}

--- a/files/en-us/web/javascript/reference/global_objects/error/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/index.md
@@ -145,7 +145,7 @@ try {
 }
 ```
 
-[Custom error types](#custom_error_types) can also use make use of the [`cause`](#error.prototype.cause) property, provided the subclasses' constructor passes the `options` parameter when calling `super()`:
+[Custom error types](#custom_error_types) can also use the [`cause`](#error.prototype.cause) property, provided the subclasses' constructor passes the `options` parameter when calling `super()`:
 
 ```js
 class MyError extends Error {

--- a/files/en-us/web/javascript/reference/global_objects/error/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/index.md
@@ -54,6 +54,9 @@ Besides the generic `Error` constructor, there are other core error constructors
   - : Error message.
 - {{jsxref("Error.prototype.name")}}
   - : Error name.
+- {{jsxref("Error.prototype.cause")}}
+  - : Error cause.
+     If an error is caught and re-thrown, this property should contain the original error. 
 - {{jsxref("Error.prototype.fileName")}} {{non-standard_inline}}
   - : A non-standard Mozilla property for the path to the file that raised this error.
 - {{jsxref("Error.prototype.lineNumber")}} {{non-standard_inline}}
@@ -142,7 +145,7 @@ try {
 }
 ```
 
-You can also use the `cause` property in [custom error types](#custom_error_types), provided the subclasses' constructor passes the `options` parameter when calling `super()`:
+[Custom error types](#custom_error_types) can also use make use of the [`cause`](#error.prototype.cause) property, provided the subclasses' constructor passes the `options` parameter when calling `super()`:
 
 ```js
 class MyError extends Error {
@@ -153,13 +156,13 @@ class MyError extends Error {
 }
 ```
 
-### Custom Error Types
+### Custom error types
 
 You might want to define your own error types deriving from `Error` to be able to `throw new MyError()` and use `instanceof MyError` to check the kind of error in the exception handler. This results in cleaner and more consistent error handling code.
 
 See ["What's a good way to extend Error in JavaScript?"](https://stackoverflow.com/questions/1382107/whats-a-good-way-to-extend-error-in-javascript) on StackOverflow for an in-depth discussion.
 
-#### ES6 Custom Error Class
+#### ES6 CustomError class
 
 > **Warning:** Versions of Babel prior to 7 can handle `CustomError` class methods, but only when they are declared with [Object.defineProperty()](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/defineProperty). Otherwise, old versions of Babel and other transpilers will not correctly handle the following code without [additional configuration](https://github.com/loganfsmyth/babel-plugin-transform-builtin-extend).
 
@@ -193,7 +196,7 @@ try {
 }
 ```
 
-#### ES5 Custom Error Object
+#### ES5 CustomError object
 
 > **Warning:** All browsers include the `CustomError` constructor in the stack trace when using a prototypal declaration.
 


### PR DESCRIPTION
This adds a doc for `Error.prototype.cause`. The constructor was added but the property itself was somehow missed (by me) in https://github.com/mdn/content/pull/7316

This is very basic document, using existing example from the constructor page. 

Fixes #16682