### PR TITLE
Add Web/API page types, part 5

### DIFF
--- a/files/en-us/web/api/cssrotate/x/index.md
+++ b/files/en-us/web/api/cssrotate/x/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSRotate.x
 slug: Web/API/CSSRotate/x
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssrotate/y/index.md
+++ b/files/en-us/web/api/cssrotate/y/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSRotate.y
 slug: Web/API/CSSRotate/y
+page-type: web-api-instance-property
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/cssrotate/z/index.md
+++ b/files/en-us/web/api/cssrotate/z/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSRotate.z
 slug: Web/API/CSSRotate/z
+page-type: web-api-instance-property
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/cssrule/csstext/index.md
+++ b/files/en-us/web/api/cssrule/csstext/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSRule.cssText
 slug: Web/API/CSSRule/cssText
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssrule/index.md
+++ b/files/en-us/web/api/cssrule/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSRule
 slug: Web/API/CSSRule
+page-type: web-api-interface
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssrule/parentrule/index.md
+++ b/files/en-us/web/api/cssrule/parentrule/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSRule.parentRule
 slug: Web/API/CSSRule/parentRule
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssrule/parentstylesheet/index.md
+++ b/files/en-us/web/api/cssrule/parentstylesheet/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSRule.parentStyleSheet
 slug: Web/API/CSSRule/parentStyleSheet
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssrule/type/index.md
+++ b/files/en-us/web/api/cssrule/type/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSRule.type
 slug: Web/API/CSSRule/type
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssrulelist/index.md
+++ b/files/en-us/web/api/cssrulelist/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSRuleList
 slug: Web/API/CSSRuleList
+page-type: web-api-interface
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssrulelist/item/index.md
+++ b/files/en-us/web/api/cssrulelist/item/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSRuleList.item()
 slug: Web/API/CSSRuleList/item
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/cssrulelist/length/index.md
+++ b/files/en-us/web/api/cssrulelist/length/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSRuleList.length
 slug: Web/API/CSSRuleList/length
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/cssscale/cssscale/index.md
+++ b/files/en-us/web/api/cssscale/cssscale/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSScale()
 slug: Web/API/CSSScale/CSSScale
+page-type: web-api-constructor
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssscale/index.md
+++ b/files/en-us/web/api/cssscale/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSScale
 slug: Web/API/CSSScale
+page-type: web-api-interface
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssscale/x/index.md
+++ b/files/en-us/web/api/cssscale/x/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSScale.x
 slug: Web/API/CSSScale/x
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssscale/y/index.md
+++ b/files/en-us/web/api/cssscale/y/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSScale.y
 slug: Web/API/CSSScale/y
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssscale/z/index.md
+++ b/files/en-us/web/api/cssscale/z/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSScale.z
 slug: Web/API/CSSScale/z
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssskew/ax/index.md
+++ b/files/en-us/web/api/cssskew/ax/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSSkew.ax
 slug: Web/API/CSSSkew/ax
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssskew/ay/index.md
+++ b/files/en-us/web/api/cssskew/ay/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSSkew.ay
 slug: Web/API/CSSSkew/ay
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssskew/cssskew/index.md
+++ b/files/en-us/web/api/cssskew/cssskew/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSSkew()
 slug: Web/API/CSSSkew/CSSSkew
+page-type: web-api-constructor
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/cssskew/index.md
+++ b/files/en-us/web/api/cssskew/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSSkew
 slug: Web/API/CSSSkew
+page-type: web-api-interface
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/cssskewx/ax/index.md
+++ b/files/en-us/web/api/cssskewx/ax/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSSkewX.ax
 slug: Web/API/CSSSkewX/ax
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssskewx/cssskewx/index.md
+++ b/files/en-us/web/api/cssskewx/cssskewx/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSSkewX()
 slug: Web/API/CSSSkewX/CSSSkewX
+page-type: web-api-constructor
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssskewx/index.md
+++ b/files/en-us/web/api/cssskewx/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSSkewX
 slug: Web/API/CSSSkewX
+page-type: web-api-interface
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssskewy/ay/index.md
+++ b/files/en-us/web/api/cssskewy/ay/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSSkewY.ay
 slug: Web/API/CSSSkewY/ay
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssskewy/cssskewy/index.md
+++ b/files/en-us/web/api/cssskewy/cssskewy/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSSkewY()
 slug: Web/API/CSSSkewY/CSSSkewY
+page-type: web-api-constructor
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssskewy/index.md
+++ b/files/en-us/web/api/cssskewy/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSSkewY
 slug: Web/API/CSSSkewY
+page-type: web-api-interface
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssstyledeclaration/cssfloat/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/cssfloat/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleDeclaration.cssFloat
 slug: Web/API/CSSStyleDeclaration/cssFloat
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssstyledeclaration/csstext/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/csstext/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleDeclaration.cssText
 slug: Web/API/CSSStyleDeclaration/cssText
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssstyledeclaration/getpropertycssvalue/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/getpropertycssvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleDeclaration.getPropertyCSSValue()
 slug: Web/API/CSSStyleDeclaration/getPropertyCSSValue
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssstyledeclaration/getpropertypriority/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/getpropertypriority/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleDeclaration.getPropertyPriority()
 slug: Web/API/CSSStyleDeclaration/getPropertyPriority
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssstyledeclaration/getpropertyvalue/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/getpropertyvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleDeclaration.getPropertyValue()
 slug: Web/API/CSSStyleDeclaration/getPropertyValue
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssstyledeclaration/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleDeclaration
 slug: Web/API/CSSStyleDeclaration
+page-type: web-api-interface
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssstyledeclaration/item/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/item/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleDeclaration.item()
 slug: Web/API/CSSStyleDeclaration/item
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssstyledeclaration/length/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/length/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleDeclaration.length
 slug: Web/API/CSSStyleDeclaration/length
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssstyledeclaration/parentrule/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/parentrule/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleDeclaration.parentRule
 slug: Web/API/CSSStyleDeclaration/parentRule
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssstyledeclaration/removeproperty/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/removeproperty/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleDeclaration.removeProperty()
 slug: Web/API/CSSStyleDeclaration/removeProperty
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssstyledeclaration/setproperty/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/setproperty/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleDeclaration.setProperty()
 slug: Web/API/CSSStyleDeclaration/setProperty
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssstylerule/index.md
+++ b/files/en-us/web/api/cssstylerule/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleRule
 slug: Web/API/CSSStyleRule
+page-type: web-api-interface
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssstylerule/selectortext/index.md
+++ b/files/en-us/web/api/cssstylerule/selectortext/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleRule.selectorText
 slug: Web/API/CSSStyleRule/selectorText
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssstylerule/style/index.md
+++ b/files/en-us/web/api/cssstylerule/style/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleRule.style
 slug: Web/API/CSSStyleRule/style
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssstylerule/stylemap/index.md
+++ b/files/en-us/web/api/cssstylerule/stylemap/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleRule.styleMap
 slug: Web/API/CSSStyleRule/styleMap
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssstylesheet/addrule/index.md
+++ b/files/en-us/web/api/cssstylesheet/addrule/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleSheet.addRule()
 slug: Web/API/CSSStyleSheet/addRule
+page-type: web-api-instance-method
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/cssstylesheet/cssrules/index.md
+++ b/files/en-us/web/api/cssstylesheet/cssrules/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleSheet.cssRules
 slug: Web/API/CSSStyleSheet/cssRules
+page-type: web-api-instance-property
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/cssstylesheet/cssstylesheet/index.md
+++ b/files/en-us/web/api/cssstylesheet/cssstylesheet/index.md
@@ -1,7 +1,7 @@
 ---
 title: CSSStyleSheet()
 slug: Web/API/CSSStyleSheet/CSSStyleSheet
-page-type: web-api-instance-method
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/cssstylesheet/cssstylesheet/index.md
+++ b/files/en-us/web/api/cssstylesheet/cssstylesheet/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleSheet()
 slug: Web/API/CSSStyleSheet/CSSStyleSheet
+page-type: web-api-instance-method
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/cssstylesheet/deleterule/index.md
+++ b/files/en-us/web/api/cssstylesheet/deleterule/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleSheet.deleteRule()
 slug: Web/API/CSSStyleSheet/deleteRule
+page-type: web-api-instance-method
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/cssstylesheet/index.md
+++ b/files/en-us/web/api/cssstylesheet/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleSheet
 slug: Web/API/CSSStyleSheet
+page-type: web-api-interface
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/cssstylesheet/insertrule/index.md
+++ b/files/en-us/web/api/cssstylesheet/insertrule/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleSheet.insertRule()
 slug: Web/API/CSSStyleSheet/insertRule
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssstylesheet/ownerrule/index.md
+++ b/files/en-us/web/api/cssstylesheet/ownerrule/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleSheet.ownerRule
 slug: Web/API/CSSStyleSheet/ownerRule
+page-type: web-api-instance-property
 tags:
   - '@import'
   - API

--- a/files/en-us/web/api/cssstylesheet/removerule/index.md
+++ b/files/en-us/web/api/cssstylesheet/removerule/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleSheet.removeRule()
 slug: Web/API/CSSStyleSheet/removeRule
+page-type: web-api-instance-method
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/cssstylesheet/replace/index.md
+++ b/files/en-us/web/api/cssstylesheet/replace/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleSheet.replace()
 slug: Web/API/CSSStyleSheet/replace
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/cssstylesheet/replacesync/index.md
+++ b/files/en-us/web/api/cssstylesheet/replacesync/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleSheet.replaceSync()
 slug: Web/API/CSSStyleSheet/replaceSync
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/cssstylesheet/rules/index.md
+++ b/files/en-us/web/api/cssstylesheet/rules/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleSheet.rules
 slug: Web/API/CSSStyleSheet/rules
+page-type: web-api-instance-property
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/cssstylevalue/index.md
+++ b/files/en-us/web/api/cssstylevalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleValue
 slug: Web/API/CSSStyleValue
+page-type: web-api-interface
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssstylevalue/parse/index.md
+++ b/files/en-us/web/api/cssstylevalue/parse/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleValue.parse()
 slug: Web/API/CSSStyleValue/parse
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssstylevalue/parseall/index.md
+++ b/files/en-us/web/api/cssstylevalue/parseall/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSStyleValue.parseAll()
 slug: Web/API/CSSStyleValue/parseAll
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/csssupportsrule/index.md
+++ b/files/en-us/web/api/csssupportsrule/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSSupportsRule
 slug: Web/API/CSSSupportsRule
+page-type: web-api-interface
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/csstransformcomponent/index.md
+++ b/files/en-us/web/api/csstransformcomponent/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSTransformComponent
 slug: Web/API/CSSTransformComponent
+page-type: web-api-interface
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/csstransformcomponent/is2d/index.md
+++ b/files/en-us/web/api/csstransformcomponent/is2d/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSTransformComponent.is2D
 slug: Web/API/CSSTransformComponent/is2D
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/csstransformcomponent/tomatrix/index.md
+++ b/files/en-us/web/api/csstransformcomponent/tomatrix/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSTransformComponent.toMatrix()
 slug: Web/API/CSSTransformComponent/toMatrix
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/csstransformcomponent/tostring/index.md
+++ b/files/en-us/web/api/csstransformcomponent/tostring/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSTransformComponent.toString()
 slug: Web/API/CSSTransformComponent/toString
+page-type: web-api-instance-method
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/csstransformvalue/csstransformvalue/index.md
+++ b/files/en-us/web/api/csstransformvalue/csstransformvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSTransformValue()
 slug: Web/API/CSSTransformValue/CSSTransformValue
+page-type: web-api-constructor
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/csstransformvalue/entries/index.md
+++ b/files/en-us/web/api/csstransformvalue/entries/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSTransformValue.entries()
 slug: Web/API/CSSTransformValue/entries
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/csstransformvalue/foreach/index.md
+++ b/files/en-us/web/api/csstransformvalue/foreach/index.md
@@ -1,6 +1,7 @@
 ---
 title: cssTransformValue.forEach()
 slug: Web/API/CSSTransformValue/forEach
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/csstransformvalue/index.md
+++ b/files/en-us/web/api/csstransformvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSTransformValue
 slug: Web/API/CSSTransformValue
+page-type: web-api-interface
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/csstransformvalue/is2d/index.md
+++ b/files/en-us/web/api/csstransformvalue/is2d/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSTransformValue.is2D
 slug: Web/API/CSSTransformValue/is2D
+page-type: web-api-instance-property
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/csstransformvalue/keys/index.md
+++ b/files/en-us/web/api/csstransformvalue/keys/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSTransformValue.keys()
 slug: Web/API/CSSTransformValue/keys
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/csstransformvalue/length/index.md
+++ b/files/en-us/web/api/csstransformvalue/length/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSTransformValue.length
 slug: Web/API/CSSTransformValue/length
+page-type: web-api-instance-property
 tags:
   - API
   - CSS T

--- a/files/en-us/web/api/csstransformvalue/tomatrix/index.md
+++ b/files/en-us/web/api/csstransformvalue/tomatrix/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSTransformValue.toMatrix()
 slug: Web/API/CSSTransformValue/toMatrix
+page-type: web-api-instance-method
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/csstransformvalue/values/index.md
+++ b/files/en-us/web/api/csstransformvalue/values/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSTransformValue.values()
 slug: Web/API/CSSTransformValue/values
+page-type: web-api-instance-method
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/csstransition/index.md
+++ b/files/en-us/web/api/csstransition/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSTransition
 slug: Web/API/CSSTransition
+page-type: web-api-interface
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/csstransition/transitionproperty/index.md
+++ b/files/en-us/web/api/csstransition/transitionproperty/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSTransition.transitionProperty
 slug: Web/API/CSSTransition/transitionProperty
+page-type: web-api-instance-property
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/csstranslate/csstranslate/index.md
+++ b/files/en-us/web/api/csstranslate/csstranslate/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSTranslate()
 slug: Web/API/CSSTranslate/CSSTranslate
+page-type: web-api-constructor
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/csstranslate/index.md
+++ b/files/en-us/web/api/csstranslate/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSTranslate
 slug: Web/API/CSSTranslate
+page-type: web-api-interface
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/csstranslate/x/index.md
+++ b/files/en-us/web/api/csstranslate/x/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSTranslate.x
 slug: Web/API/CSSTranslate/x
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/csstranslate/y/index.md
+++ b/files/en-us/web/api/csstranslate/y/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSTranslate.y
 slug: Web/API/CSSTranslate/y
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/csstranslate/z/index.md
+++ b/files/en-us/web/api/csstranslate/z/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSTranslate.z
 slug: Web/API/CSSTranslate/z
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssunitvalue/cssunitvalue/index.md
+++ b/files/en-us/web/api/cssunitvalue/cssunitvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSUnitValue()
 slug: Web/API/CSSUnitValue/CSSUnitValue
+page-type: web-api-constructor
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssunitvalue/index.md
+++ b/files/en-us/web/api/cssunitvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSUnitValue
 slug: Web/API/CSSUnitValue
+page-type: web-api-interface
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssunitvalue/unit/index.md
+++ b/files/en-us/web/api/cssunitvalue/unit/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSUnitValue.unit
 slug: Web/API/CSSUnitValue/unit
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssunitvalue/value/index.md
+++ b/files/en-us/web/api/cssunitvalue/value/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSUnitValue.value
 slug: Web/API/CSSUnitValue/value
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssunparsedvalue/cssunparsedvalue/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/cssunparsedvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSUnparsedValue()
 slug: Web/API/CSSUnparsedValue/CSSUnparsedValue
+page-type: web-api-constructor
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssunparsedvalue/entries/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/entries/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSUnparsedValue.entries()
 slug: Web/API/CSSUnparsedValue/entries
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssunparsedvalue/foreach/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/foreach/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSUnparsedValue.forEach()
 slug: Web/API/CSSUnparsedValue/forEach
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssunparsedvalue/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSUnparsedValue
 slug: Web/API/CSSUnparsedValue
+page-type: web-api-interface
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssunparsedvalue/keys/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/keys/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSUnparsedValue.keys()
 slug: Web/API/CSSUnparsedValue/keys
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssunparsedvalue/length/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/length/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSUnparsedValue.length
 slug: Web/API/CSSUnparsedValue/length
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssunparsedvalue/values/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/values/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSUnparsedValue.values()
 slug: Web/API/CSSUnparsedValue/values
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssvalue/csstext/index.md
+++ b/files/en-us/web/api/cssvalue/csstext/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSValue.cssText
 slug: Web/API/CSSValue/cssText
+page-type: web-api-instance-property
 tags:
   - API
   - CSSValue

--- a/files/en-us/web/api/cssvalue/cssvaluetype/index.md
+++ b/files/en-us/web/api/cssvalue/cssvaluetype/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSValue.cssValueType
 slug: Web/API/CSSValue/cssValueType
+page-type: web-api-instance-property
 tags:
   - API
   - CSSValue

--- a/files/en-us/web/api/cssvalue/index.md
+++ b/files/en-us/web/api/cssvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSValue
 slug: Web/API/CSSValue
+page-type: web-api-interface
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssvaluelist/index.md
+++ b/files/en-us/web/api/cssvaluelist/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSValueList
 slug: Web/API/CSSValueList
+page-type: web-api-interface
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/cssvaluelist/item/index.md
+++ b/files/en-us/web/api/cssvaluelist/item/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSValueList.item()
 slug: Web/API/CSSValueList/item
+page-type: web-api-instance-method
 tags:
   - API
   - CSSValueList

--- a/files/en-us/web/api/cssvaluelist/length/index.md
+++ b/files/en-us/web/api/cssvaluelist/length/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSValueList.length
 slug: Web/API/CSSValueList/length
+page-type: web-api-instance-property
 tags:
   - API
   - CSSValueList

--- a/files/en-us/web/api/cssvariablereferencevalue/cssvariablereferencevalue/index.md
+++ b/files/en-us/web/api/cssvariablereferencevalue/cssvariablereferencevalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSVariableReferenceValue()
 slug: Web/API/CSSVariableReferenceValue/CSSVariableReferenceValue
+page-type: web-api-constructor
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssvariablereferencevalue/fallback/index.md
+++ b/files/en-us/web/api/cssvariablereferencevalue/fallback/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSVariableReferenceValue.fallback
 slug: Web/API/CSSVariableReferenceValue/fallback
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssvariablereferencevalue/index.md
+++ b/files/en-us/web/api/cssvariablereferencevalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSVariableReferenceValue
 slug: Web/API/CSSVariableReferenceValue
+page-type: web-api-interface
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/cssvariablereferencevalue/variable/index.md
+++ b/files/en-us/web/api/cssvariablereferencevalue/variable/index.md
@@ -1,6 +1,7 @@
 ---
 title: CSSVariableReferenceValue.variable
 slug: Web/API/CSSVariableReferenceValue/variable
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/customelementregistry/define/index.md
+++ b/files/en-us/web/api/customelementregistry/define/index.md
@@ -1,6 +1,7 @@
 ---
 title: CustomElementRegistry.define()
 slug: Web/API/CustomElementRegistry/define
+page-type: web-api-instance-method
 tags:
   - API
   - CustomElementRegistry

--- a/files/en-us/web/api/customelementregistry/get/index.md
+++ b/files/en-us/web/api/customelementregistry/get/index.md
@@ -1,6 +1,7 @@
 ---
 title: CustomElementRegistry.get()
 slug: Web/API/CustomElementRegistry/get
+page-type: web-api-instance-method
 tags:
   - API
   - CustomElementRegistry

--- a/files/en-us/web/api/customelementregistry/index.md
+++ b/files/en-us/web/api/customelementregistry/index.md
@@ -1,6 +1,7 @@
 ---
 title: CustomElementRegistry
 slug: Web/API/CustomElementRegistry
+page-type: web-api-interface
 tags:
   - API
   - CustomElementRegistry

--- a/files/en-us/web/api/customelementregistry/upgrade/index.md
+++ b/files/en-us/web/api/customelementregistry/upgrade/index.md
@@ -1,6 +1,7 @@
 ---
 title: CustomElementRegistry.upgrade()
 slug: Web/API/CustomElementRegistry/upgrade
+page-type: web-api-instance-method
 tags:
   - API
   - CustomElementRegistry

--- a/files/en-us/web/api/customelementregistry/whendefined/index.md
+++ b/files/en-us/web/api/customelementregistry/whendefined/index.md
@@ -1,6 +1,7 @@
 ---
 title: CustomElementRegistry.whenDefined()
 slug: Web/API/CustomElementRegistry/whenDefined
+page-type: web-api-instance-method
 tags:
   - API
   - CustomElementRegistry

--- a/files/en-us/web/api/customevent/customevent/index.md
+++ b/files/en-us/web/api/customevent/customevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: CustomEvent()
 slug: Web/API/CustomEvent/CustomEvent
+page-type: web-api-constructor
 tags:
   - Constructor
   - Reference

--- a/files/en-us/web/api/customevent/detail/index.md
+++ b/files/en-us/web/api/customevent/detail/index.md
@@ -1,6 +1,7 @@
 ---
 title: CustomEvent.detail
 slug: Web/API/CustomEvent/detail
+page-type: web-api-instance-property
 tags:
   - Property
   - Reference

--- a/files/en-us/web/api/customevent/index.md
+++ b/files/en-us/web/api/customevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: CustomEvent
 slug: Web/API/CustomEvent
+page-type: web-api-interface
 tags:
   - Interface
   - Reference

--- a/files/en-us/web/api/customevent/initcustomevent/index.md
+++ b/files/en-us/web/api/customevent/initcustomevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: CustomEvent.initCustomEvent()
 slug: Web/API/CustomEvent/initCustomEvent
+page-type: web-api-instance-method
 tags:
   - Deprecated
   - Method

--- a/files/en-us/web/api/customstateset/add/index.md
+++ b/files/en-us/web/api/customstateset/add/index.md
@@ -1,6 +1,7 @@
 ---
 title: CustomStateSet.add()
 slug: Web/API/CustomStateSet/add
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/customstateset/clear/index.md
+++ b/files/en-us/web/api/customstateset/clear/index.md
@@ -1,6 +1,7 @@
 ---
 title: CustomStateSet.clear()
 slug: Web/API/CustomStateSet/clear
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/customstateset/delete/index.md
+++ b/files/en-us/web/api/customstateset/delete/index.md
@@ -1,6 +1,7 @@
 ---
 title: CustomStateSet.delete()
 slug: Web/API/CustomStateSet/delete
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/customstateset/entries/index.md
+++ b/files/en-us/web/api/customstateset/entries/index.md
@@ -1,6 +1,7 @@
 ---
 title: CustomStateSet.entries()
 slug: Web/API/CustomStateSet/entries
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/customstateset/foreach/index.md
+++ b/files/en-us/web/api/customstateset/foreach/index.md
@@ -1,6 +1,7 @@
 ---
 title: CustomStateSet.forEach()
 slug: Web/API/CustomStateSet/forEach
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/customstateset/has/index.md
+++ b/files/en-us/web/api/customstateset/has/index.md
@@ -1,6 +1,7 @@
 ---
 title: CustomStateSet.has()
 slug: Web/API/CustomStateSet/has
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -1,6 +1,7 @@
 ---
 title: CustomStateSet
 slug: Web/API/CustomStateSet
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/customstateset/keys/index.md
+++ b/files/en-us/web/api/customstateset/keys/index.md
@@ -1,6 +1,7 @@
 ---
 title: CustomStateSet.keys()
 slug: Web/API/CustomStateSet/keys
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/customstateset/size/index.md
+++ b/files/en-us/web/api/customstateset/size/index.md
@@ -1,6 +1,7 @@
 ---
 title: CustomStateSet.size
 slug: Web/API/CustomStateSet/size
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/customstateset/values/index.md
+++ b/files/en-us/web/api/customstateset/values/index.md
@@ -1,6 +1,7 @@
 ---
 title: CustomStateSet.values()
 slug: Web/API/CustomStateSet/values
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/datatransfer/addelement/index.md
+++ b/files/en-us/web/api/datatransfer/addelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransfer.addElement()
 slug: Web/API/DataTransfer/addElement
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/datatransfer/cleardata/index.md
+++ b/files/en-us/web/api/datatransfer/cleardata/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransfer.clearData()
 slug: Web/API/DataTransfer/clearData
+page-type: web-api-instance-method
 tags:
   - API
   - DataTransfer

--- a/files/en-us/web/api/datatransfer/datatransfer/index.md
+++ b/files/en-us/web/api/datatransfer/datatransfer/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransfer()
 slug: Web/API/DataTransfer/DataTransfer
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/datatransfer/dropeffect/index.md
+++ b/files/en-us/web/api/datatransfer/dropeffect/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransfer.dropEffect
 slug: Web/API/DataTransfer/dropEffect
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/datatransfer/effectallowed/index.md
+++ b/files/en-us/web/api/datatransfer/effectallowed/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransfer.effectAllowed
 slug: Web/API/DataTransfer/effectAllowed
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/datatransfer/files/index.md
+++ b/files/en-us/web/api/datatransfer/files/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransfer.files
 slug: Web/API/DataTransfer/files
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/datatransfer/getdata/index.md
+++ b/files/en-us/web/api/datatransfer/getdata/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransfer.getData()
 slug: Web/API/DataTransfer/getData
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/datatransfer/index.md
+++ b/files/en-us/web/api/datatransfer/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransfer
 slug: Web/API/DataTransfer
+page-type: web-api-interface
 tags:
   - API
   - DataTransfer

--- a/files/en-us/web/api/datatransfer/items/index.md
+++ b/files/en-us/web/api/datatransfer/items/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransfer.items
 slug: Web/API/DataTransfer/items
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/datatransfer/mozcleardataat/index.md
+++ b/files/en-us/web/api/datatransfer/mozcleardataat/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransfer.mozClearDataAt()
 slug: Web/API/DataTransfer/mozClearDataAt
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/datatransfer/mozcursor/index.md
+++ b/files/en-us/web/api/datatransfer/mozcursor/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransfer.mozCursor
 slug: Web/API/DataTransfer/mozCursor
+page-type: web-api-instance-property
 tags:
   - API
   - Non-standard

--- a/files/en-us/web/api/datatransfer/mozgetdataat/index.md
+++ b/files/en-us/web/api/datatransfer/mozgetdataat/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransfer.mozGetDataAt()
 slug: Web/API/DataTransfer/mozGetDataAt
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/datatransfer/mozitemcount/index.md
+++ b/files/en-us/web/api/datatransfer/mozitemcount/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransfer.mozItemCount
 slug: Web/API/DataTransfer/mozItemCount
+page-type: web-api-instance-property
 tags:
   - API
   - Non-standard

--- a/files/en-us/web/api/datatransfer/mozsetdataat/index.md
+++ b/files/en-us/web/api/datatransfer/mozsetdataat/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransfer.mozSetDataAt()
 slug: Web/API/DataTransfer/mozSetDataAt
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/datatransfer/mozsourcenode/index.md
+++ b/files/en-us/web/api/datatransfer/mozsourcenode/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransfer.mozSourceNode
 slug: Web/API/DataTransfer/mozSourceNode
+page-type: web-api-instance-property
 tags:
   - API
   - Non-standard

--- a/files/en-us/web/api/datatransfer/moztypesat/index.md
+++ b/files/en-us/web/api/datatransfer/moztypesat/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransfer.mozTypesAt()
 slug: Web/API/DataTransfer/mozTypesAt
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/datatransfer/mozusercancelled/index.md
+++ b/files/en-us/web/api/datatransfer/mozusercancelled/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransfer.mozUserCancelled
 slug: Web/API/DataTransfer/mozUserCancelled
+page-type: web-api-instance-property
 tags:
   - API
   - Non-standard

--- a/files/en-us/web/api/datatransfer/setdata/index.md
+++ b/files/en-us/web/api/datatransfer/setdata/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransfer.setData()
 slug: Web/API/DataTransfer/setData
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/datatransfer/setdragimage/index.md
+++ b/files/en-us/web/api/datatransfer/setdragimage/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransfer.setDragImage()
 slug: Web/API/DataTransfer/setDragImage
+page-type: web-api-instance-method
 tags:
   - API
   - H5 DnD

--- a/files/en-us/web/api/datatransfer/types/index.md
+++ b/files/en-us/web/api/datatransfer/types/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransfer.types
 slug: Web/API/DataTransfer/types
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/datatransferitem/getasfile/index.md
+++ b/files/en-us/web/api/datatransferitem/getasfile/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransferItem.getAsFile()
 slug: Web/API/DataTransferItem/getAsFile
+page-type: web-api-instance-method
 tags:
   - API
   - DataTransferItem

--- a/files/en-us/web/api/datatransferitem/getasfilesystemhandle/index.md
+++ b/files/en-us/web/api/datatransferitem/getasfilesystemhandle/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransferItem.getAsFileSystemHandle()
 slug: Web/API/DataTransferItem/getAsFileSystemHandle
+page-type: web-api-instance-method
 tags:
   - DataTransferItem
   - Directory

--- a/files/en-us/web/api/datatransferitem/getasstring/index.md
+++ b/files/en-us/web/api/datatransferitem/getasstring/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransferItem.getAsString()
 slug: Web/API/DataTransferItem/getAsString
+page-type: web-api-instance-method
 tags:
   - API
   - DataTransferItem

--- a/files/en-us/web/api/datatransferitem/index.md
+++ b/files/en-us/web/api/datatransferitem/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransferItem
 slug: Web/API/DataTransferItem
+page-type: web-api-interface
 tags:
   - API
   - DataTransferItem

--- a/files/en-us/web/api/datatransferitem/kind/index.md
+++ b/files/en-us/web/api/datatransferitem/kind/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransferItem.kind
 slug: Web/API/DataTransferItem/kind
+page-type: web-api-instance-property
 tags:
   - API
   - DataTransferItem

--- a/files/en-us/web/api/datatransferitem/type/index.md
+++ b/files/en-us/web/api/datatransferitem/type/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransferItem.type
 slug: Web/API/DataTransferItem/type
+page-type: web-api-instance-property
 tags:
   - API
   - DataTransferItem

--- a/files/en-us/web/api/datatransferitem/webkitgetasentry/index.md
+++ b/files/en-us/web/api/datatransferitem/webkitgetasentry/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransferItem.webkitGetAsEntry()
 slug: Web/API/DataTransferItem/webkitGetAsEntry
+page-type: web-api-instance-method
 tags:
   - API
   - DataTransferItem

--- a/files/en-us/web/api/datatransferitemlist/add/index.md
+++ b/files/en-us/web/api/datatransferitemlist/add/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransferItemList.add()
 slug: Web/API/DataTransferItemList/add
+page-type: web-api-instance-method
 tags:
   - API
   - Add

--- a/files/en-us/web/api/datatransferitemlist/clear/index.md
+++ b/files/en-us/web/api/datatransferitemlist/clear/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransferItemList.clear()
 slug: Web/API/DataTransferItemList/clear
+page-type: web-api-instance-method
 tags:
   - API
   - DataTransferItemList

--- a/files/en-us/web/api/datatransferitemlist/index.md
+++ b/files/en-us/web/api/datatransferitemlist/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransferItemList
 slug: Web/API/DataTransferItemList
+page-type: web-api-interface
 tags:
   - API
   - DataTransferItemList

--- a/files/en-us/web/api/datatransferitemlist/length/index.md
+++ b/files/en-us/web/api/datatransferitemlist/length/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransferItemList.length
 slug: Web/API/DataTransferItemList/length
+page-type: web-api-instance-property
 tags:
   - API
   - DataTransferItemList

--- a/files/en-us/web/api/datatransferitemlist/remove/index.md
+++ b/files/en-us/web/api/datatransferitemlist/remove/index.md
@@ -1,6 +1,7 @@
 ---
 title: DataTransferItemList.remove()
 slug: Web/API/DataTransferItemList/remove
+page-type: web-api-instance-method
 tags:
   - API
   - DataTransferItemList

--- a/files/en-us/web/api/decompressionstream/decompressionstream/index.md
+++ b/files/en-us/web/api/decompressionstream/decompressionstream/index.md
@@ -1,6 +1,7 @@
 ---
 title: DecompressionStream()
 slug: Web/API/DecompressionStream/DecompressionStream
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/decompressionstream/index.md
+++ b/files/en-us/web/api/decompressionstream/index.md
@@ -1,6 +1,7 @@
 ---
 title: DecompressionStream
 slug: Web/API/DecompressionStream
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/decompressionstream/readable/index.md
+++ b/files/en-us/web/api/decompressionstream/readable/index.md
@@ -1,6 +1,7 @@
 ---
 title: DecompressionStream.readable
 slug: Web/API/DecompressionStream/readable
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/decompressionstream/writable/index.md
+++ b/files/en-us/web/api/decompressionstream/writable/index.md
@@ -1,6 +1,7 @@
 ---
 title: DecompressionStream.writable
 slug: Web/API/DecompressionStream/writable
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/dedicatedworkerglobalscope/close/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/close/index.md
@@ -1,6 +1,7 @@
 ---
 title: DedicatedWorkerGlobalScope.close()
 slug: Web/API/DedicatedWorkerGlobalScope/close
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/dedicatedworkerglobalscope/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/index.md
@@ -1,6 +1,7 @@
 ---
 title: DedicatedWorkerGlobalScope
 slug: Web/API/DedicatedWorkerGlobalScope
+page-type: web-api-interface
 tags:
   - API
   - DedicatedWorkerGlobalScope

--- a/files/en-us/web/api/dedicatedworkerglobalscope/message_event/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/message_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'DedicatedWorkerGlobalScope: message event'
 slug: Web/API/DedicatedWorkerGlobalScope/message_event
+page-type: web-api-event
 tags:
   - Event
   - message

--- a/files/en-us/web/api/dedicatedworkerglobalscope/messageerror_event/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/messageerror_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'DedicatedWorkerGlobalScope: messageerror event'
 slug: Web/API/DedicatedWorkerGlobalScope/messageerror_event
+page-type: web-api-event
 tags:
   - API
   - DedicatedWorkerGlobalScope

--- a/files/en-us/web/api/dedicatedworkerglobalscope/name/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: DedicatedWorkerGlobalScope.name
 slug: Web/API/DedicatedWorkerGlobalScope/name
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/dedicatedworkerglobalscope/postmessage/index.md
+++ b/files/en-us/web/api/dedicatedworkerglobalscope/postmessage/index.md
@@ -1,6 +1,7 @@
 ---
 title: DedicatedWorkerGlobalScope.postMessage()
 slug: Web/API/DedicatedWorkerGlobalScope/postMessage
+page-type: web-api-instance-method
 tags:
   - API
   - DedicatedWorkerGlobalScope

--- a/files/en-us/web/api/delaynode/delaynode/index.md
+++ b/files/en-us/web/api/delaynode/delaynode/index.md
@@ -1,6 +1,7 @@
 ---
 title: DelayNode()
 slug: Web/API/DelayNode/DelayNode
+page-type: web-api-constructor
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/delaynode/delaytime/index.md
+++ b/files/en-us/web/api/delaynode/delaytime/index.md
@@ -1,6 +1,7 @@
 ---
 title: DelayNode.delayTime
 slug: Web/API/DelayNode/delayTime
+page-type: web-api-instance-property
 tags:
   - API
   - DelayNode

--- a/files/en-us/web/api/delaynode/index.md
+++ b/files/en-us/web/api/delaynode/index.md
@@ -1,6 +1,7 @@
 ---
 title: DelayNode
 slug: Web/API/DelayNode
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/deprecationreportbody/anticipatedremoval/index.md
+++ b/files/en-us/web/api/deprecationreportbody/anticipatedremoval/index.md
@@ -1,6 +1,7 @@
 ---
 title: DeprecationReportBody.anticipatedRemoval
 slug: Web/API/DeprecationReportBody/anticipatedRemoval
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/deprecationreportbody/columnnumber/index.md
+++ b/files/en-us/web/api/deprecationreportbody/columnnumber/index.md
@@ -1,6 +1,7 @@
 ---
 title: DeprecationReportBody.columnNumber
 slug: Web/API/DeprecationReportBody/columnNumber
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/deprecationreportbody/id/index.md
+++ b/files/en-us/web/api/deprecationreportbody/id/index.md
@@ -1,6 +1,7 @@
 ---
 title: DeprecationReportBody.id
 slug: Web/API/DeprecationReportBody/id
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/deprecationreportbody/index.md
+++ b/files/en-us/web/api/deprecationreportbody/index.md
@@ -1,6 +1,7 @@
 ---
 title: DeprecationReportBody
 slug: Web/API/DeprecationReportBody
+page-type: web-api-interface
 tags:
   - API
   - DeprecationReportBody

--- a/files/en-us/web/api/deprecationreportbody/linenumber/index.md
+++ b/files/en-us/web/api/deprecationreportbody/linenumber/index.md
@@ -1,6 +1,7 @@
 ---
 title: DeprecationReportBody.lineNumber
 slug: Web/API/DeprecationReportBody/lineNumber
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/deprecationreportbody/message/index.md
+++ b/files/en-us/web/api/deprecationreportbody/message/index.md
@@ -1,6 +1,7 @@
 ---
 title: DeprecationReportBody.message
 slug: Web/API/DeprecationReportBody/message
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/deprecationreportbody/sourcefile/index.md
+++ b/files/en-us/web/api/deprecationreportbody/sourcefile/index.md
@@ -1,6 +1,7 @@
 ---
 title: DeprecationReportBody.sourceFile
 slug: Web/API/DeprecationReportBody/sourceFile
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/deprecationreportbody/tojson/index.md
+++ b/files/en-us/web/api/deprecationreportbody/tojson/index.md
@@ -1,6 +1,7 @@
 ---
 title: DeprecationReportBody.toJSON()
 slug: Web/API/DeprecationReportBody/toJSON
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/device_memory_api/index.md
+++ b/files/en-us/web/api/device_memory_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Device Memory API
 slug: Web/API/Device_Memory_API
+page-type: web-api-overview
 tags:
   - Device Memory API
 spec-urls: https://w3c.github.io/device-memory/

--- a/files/en-us/web/api/devicemotionevent/acceleration/index.md
+++ b/files/en-us/web/api/devicemotionevent/acceleration/index.md
@@ -1,6 +1,7 @@
 ---
 title: DeviceMotionEvent.acceleration
 slug: Web/API/DeviceMotionEvent/acceleration
+page-type: web-api-instance-property
 tags:
   - API
   - Device Orientation

--- a/files/en-us/web/api/devicemotionevent/accelerationincludinggravity/index.md
+++ b/files/en-us/web/api/devicemotionevent/accelerationincludinggravity/index.md
@@ -1,6 +1,7 @@
 ---
 title: DeviceMotionEvent.accelerationIncludingGravity
 slug: Web/API/DeviceMotionEvent/accelerationIncludingGravity
+page-type: web-api-instance-property
 tags:
   - API
   - Device Orientation

--- a/files/en-us/web/api/devicemotionevent/devicemotionevent/index.md
+++ b/files/en-us/web/api/devicemotionevent/devicemotionevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: DeviceMotionEvent()
 slug: Web/API/DeviceMotionEvent/DeviceMotionEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/devicemotionevent/index.md
+++ b/files/en-us/web/api/devicemotionevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: DeviceMotionEvent
 slug: Web/API/DeviceMotionEvent
+page-type: web-api-interface
 tags:
   - API
   - Device Orientation

--- a/files/en-us/web/api/devicemotionevent/interval/index.md
+++ b/files/en-us/web/api/devicemotionevent/interval/index.md
@@ -1,6 +1,7 @@
 ---
 title: DeviceMotionEvent.interval
 slug: Web/API/DeviceMotionEvent/interval
+page-type: web-api-instance-property
 tags:
   - API
   - Device Orientation

--- a/files/en-us/web/api/devicemotionevent/rotationrate/index.md
+++ b/files/en-us/web/api/devicemotionevent/rotationrate/index.md
@@ -1,6 +1,7 @@
 ---
 title: DeviceMotionEvent.rotationRate
 slug: Web/API/DeviceMotionEvent/rotationRate
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/devicemotioneventacceleration/index.md
+++ b/files/en-us/web/api/devicemotioneventacceleration/index.md
@@ -1,6 +1,7 @@
 ---
 title: DeviceMotionEventAcceleration
 slug: Web/API/DeviceMotionEventAcceleration
+page-type: web-api-interface
 tags:
   - API
   - DeviceAcceleration

--- a/files/en-us/web/api/devicemotioneventacceleration/x/index.md
+++ b/files/en-us/web/api/devicemotioneventacceleration/x/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'DeviceMotionEventAcceleration: x'
 slug: Web/API/DeviceMotionEventAcceleration/x
+page-type: web-api-instance-property
 tags:
   - API
   - DeviceAcceleration

--- a/files/en-us/web/api/devicemotioneventacceleration/y/index.md
+++ b/files/en-us/web/api/devicemotioneventacceleration/y/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'DeviceMotionEventAcceleration: y'
 slug: Web/API/DeviceMotionEventAcceleration/y
+page-type: web-api-instance-property
 tags:
   - API
   - DeviceAcceleration

--- a/files/en-us/web/api/devicemotioneventacceleration/z/index.md
+++ b/files/en-us/web/api/devicemotioneventacceleration/z/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'DeviceMotionEventAcceleration: z'
 slug: Web/API/DeviceMotionEventAcceleration/z
+page-type: web-api-instance-property
 tags:
   - API
   - DeviceAcceleration

--- a/files/en-us/web/api/devicemotioneventrotationrate/alpha/index.md
+++ b/files/en-us/web/api/devicemotioneventrotationrate/alpha/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'DeviceMotionEventRotationRate: alpha'
 slug: Web/API/DeviceMotionEventRotationRate/alpha
+page-type: web-api-instance-property
 tags:
   - API
   - Device Orientation

--- a/files/en-us/web/api/devicemotioneventrotationrate/beta/index.md
+++ b/files/en-us/web/api/devicemotioneventrotationrate/beta/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'DeviceMotionEventRotationRate: beta'
 slug: Web/API/DeviceMotionEventRotationRate/beta
+page-type: web-api-instance-property
 tags:
   - API
   - Device Orientation

--- a/files/en-us/web/api/devicemotioneventrotationrate/gamma/index.md
+++ b/files/en-us/web/api/devicemotioneventrotationrate/gamma/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'DeviceMotionEventRotationRate: gamma'
 slug: Web/API/DeviceMotionEventRotationRate/gamma
+page-type: web-api-instance-property
 tags:
   - API
   - Device Orientation

--- a/files/en-us/web/api/devicemotioneventrotationrate/index.md
+++ b/files/en-us/web/api/devicemotioneventrotationrate/index.md
@@ -1,6 +1,7 @@
 ---
 title: DeviceMotionEventRotationRate
 slug: Web/API/DeviceMotionEventRotationRate
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/deviceorientationevent/absolute/index.md
+++ b/files/en-us/web/api/deviceorientationevent/absolute/index.md
@@ -1,6 +1,7 @@
 ---
 title: DeviceOrientationEvent.absolute
 slug: Web/API/DeviceOrientationEvent/absolute
+page-type: web-api-instance-property
 tags:
   - API
   - Device Orientation API

--- a/files/en-us/web/api/deviceorientationevent/alpha/index.md
+++ b/files/en-us/web/api/deviceorientationevent/alpha/index.md
@@ -1,6 +1,7 @@
 ---
 title: DeviceOrientationEvent.alpha
 slug: Web/API/DeviceOrientationEvent/alpha
+page-type: web-api-instance-property
 tags:
   - API
   - DeviceOrientation API

--- a/files/en-us/web/api/deviceorientationevent/beta/index.md
+++ b/files/en-us/web/api/deviceorientationevent/beta/index.md
@@ -1,6 +1,7 @@
 ---
 title: DeviceOrientationEvent.beta
 slug: Web/API/DeviceOrientationEvent/beta
+page-type: web-api-instance-property
 tags:
   - API
   - Device Orientation API

--- a/files/en-us/web/api/deviceorientationevent/deviceorientationevent/index.md
+++ b/files/en-us/web/api/deviceorientationevent/deviceorientationevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: DeviceOrientationEvent()
 slug: Web/API/DeviceOrientationEvent/DeviceOrientationEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/deviceorientationevent/gamma/index.md
+++ b/files/en-us/web/api/deviceorientationevent/gamma/index.md
@@ -1,6 +1,7 @@
 ---
 title: DeviceOrientationEvent.gamma
 slug: Web/API/DeviceOrientationEvent/gamma
+page-type: web-api-instance-property
 tags:
   - API
   - Device Orientation API

--- a/files/en-us/web/api/deviceorientationevent/index.md
+++ b/files/en-us/web/api/deviceorientationevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: DeviceOrientationEvent
 slug: Web/API/DeviceOrientationEvent
+page-type: web-api-interface
 tags:
   - API
   - Device Orientation API

--- a/files/en-us/web/api/deviceproximityevent/index.md
+++ b/files/en-us/web/api/deviceproximityevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: DeviceProximityEvent
 slug: Web/API/DeviceProximityEvent
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/directoryentrysync/index.md
+++ b/files/en-us/web/api/directoryentrysync/index.md
@@ -1,6 +1,7 @@
 ---
 title: DirectoryEntrySync
 slug: Web/API/DirectoryEntrySync
+page-type: web-api-interface
 tags:
   - API
   - File API

--- a/files/en-us/web/api/directoryreadersync/index.md
+++ b/files/en-us/web/api/directoryreadersync/index.md
@@ -1,6 +1,7 @@
 ---
 title: DirectoryReaderSync
 slug: Web/API/DirectoryReaderSync
+page-type: web-api-interface
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/document/index.md
+++ b/files/en-us/web/api/document/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document
 slug: Web/API/Document
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document_object_model/examples/index.md
+++ b/files/en-us/web/api/document_object_model/examples/index.md
@@ -1,6 +1,7 @@
 ---
 title: Examples of web and XML development using the DOM
 slug: Web/API/Document_Object_Model/Examples
+page-type: guide
 tags:
   - DOM
   - DOM Reference

--- a/files/en-us/web/api/document_object_model/how_to_create_a_dom_tree/index.md
+++ b/files/en-us/web/api/document_object_model/how_to_create_a_dom_tree/index.md
@@ -1,6 +1,7 @@
 ---
 title: How to create a DOM tree
 slug: Web/API/Document_object_model/How_to_create_a_DOM_tree
+page-type: guide
 tags:
   - AJAX
   - Add-ons

--- a/files/en-us/web/api/document_object_model/index.md
+++ b/files/en-us/web/api/document_object_model/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document Object Model (DOM)
 slug: Web/API/Document_Object_Model
+page-type: web-api-overview
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document_object_model/introduction/index.md
+++ b/files/en-us/web/api/document_object_model/introduction/index.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction to the DOM
 slug: Web/API/Document_Object_Model/Introduction
+page-type: guide
 tags:
   - Beginner
   - DOM

--- a/files/en-us/web/api/document_object_model/locating_dom_elements_using_selectors/index.md
+++ b/files/en-us/web/api/document_object_model/locating_dom_elements_using_selectors/index.md
@@ -1,6 +1,7 @@
 ---
 title: Locating DOM elements using selectors
 slug: Web/API/Document_object_model/Locating_DOM_elements_using_selectors
+page-type: guide
 tags:
   - Beginner
   - DOM

--- a/files/en-us/web/api/document_object_model/traversing_an_html_table_with_javascript_and_dom_interfaces/index.md
+++ b/files/en-us/web/api/document_object_model/traversing_an_html_table_with_javascript_and_dom_interfaces/index.md
@@ -1,6 +1,7 @@
 ---
 title: Traversing an HTML table with JavaScript and DOM Interfaces
 slug: >-
+page-type: guide
   Web/API/Document_Object_Model/Traversing_an_HTML_table_with_JavaScript_and_DOM_Interfaces
 tags:
   - API

--- a/files/en-us/web/api/document_object_model/traversing_an_html_table_with_javascript_and_dom_interfaces/index.md
+++ b/files/en-us/web/api/document_object_model/traversing_an_html_table_with_javascript_and_dom_interfaces/index.md
@@ -1,8 +1,8 @@
 ---
 title: Traversing an HTML table with JavaScript and DOM Interfaces
 slug: >-
-page-type: guide
   Web/API/Document_Object_Model/Traversing_an_HTML_table_with_JavaScript_and_DOM_Interfaces
+page-type: guide
 tags:
   - API
   - DOM


### PR DESCRIPTION
See  https://github.com/mdn/content/issues/16255. This is part 5 of a series of PRs to add page types to the Web/API documentation.