### PR TITLE
showPicker - remove live examples that cannot work

### DIFF
--- a/files/en-us/web/api/htmlinputelement/showpicker/index.md
+++ b/files/en-us/web/api/htmlinputelement/showpicker/index.md
@@ -55,9 +55,12 @@ if ('showPicker' in HTMLInputElement.prototype) {
 }
 ```
 
-### Showing the normal pickers
+### Normal input pickers
 
-This example shows how the picker can be launched for each of the inputs that normally support this feature.
+This example shows how this feature can be used for `color` and `file` input pickers.
+
+> **Note:** Pickers for `date`, `datetime-local`, `month`, `time`, `week` are launched in the same way.
+> They cannot be shown here because live examples run in a cross-origin frame, and would cause a [`SecurityError`](#securityerror)
 
 #### HTML
 
@@ -68,33 +71,8 @@ This example shows how the picker can be launched for each of the inputs that no
 </p>
 
 <p>
-<input type="date">
-<button id ="date">Show the date picker</button>
-</p>
-
-<p>
-<input type="datetime-local">
-<button id ="datetime-local">Show the datetime-local picker</button>
-</p>
-
-<p>
 <input type="file">
 <button id ="file">Show the file picker</button>
-</p>
-
-<p>
-<input type="month">
-<button id ="month">Show the month picker</button>
-</p>
-
-<p>
-<input type="time">
-<button id ="time">Show the time picker</button>
-</p>
-
-<p>
-<input type="week">
-<button id ="week">Show the week picker</button>
 </p>
 ```
 
@@ -119,15 +97,14 @@ document.querySelectorAll("button").forEach((button) => {
 
 Click the button next to each input type to show its picker.
 
-{{EmbedLiveSample("Showing the normal pickers","600px", "350px")}}
+{{EmbedLiveSample("Showing the normal pickers","100%", "140px")}}
+
 
 ### showPicker() for a datalist input
 
-This example shows how to show the picker for a input that specifies a text-based [`<datalist>`](/en-US/docs/Web/HTML/Element/datalist) (the same approach would work for other lists).
+`showPicker()` can launch the picker for a list of options defined in a [`<datalist>`](/en-US/docs/Web/HTML/Element/datalist).
 
-#### HTML
-
-Here we define a `<datalist>` in HTML consisting of a number of internet browsers.
+First we define a `<datalist>` in HTML consisting of a number of internet browsers, an input of type `text` that uses it, and a button.
 
 ```html
 <datalist id="browsers">
@@ -142,9 +119,7 @@ Here we define a `<datalist>` in HTML consisting of a number of internet browser
 <button>Select browser</button>
 ```
 
-#### JavaScript
-
-The code below shows the picker for the input when the button is clicked.
+The code below adds an event listener that calls `showPicker()` when the button is clicked.
 
 ```js
   const button = document.querySelector("button");
@@ -159,17 +134,10 @@ The code below shows the picker for the input when the button is clicked.
   });
 ```
 
-#### Result
-
-Click the button to show the picker for the "browser options" input:
-
-{{EmbedLiveSample("showPicker() for a datalist input","600px", "50px")}}
 
 ### showPicker() for autocomplete
 
-This example shows how to show the picker for an [`autocomplete`](/en-US/docs/Web/HTML/Attributes/autocomplete) input.
-
-#### HTML
+`showPicker()` can launch a picker for an [`autocomplete`](/en-US/docs/Web/HTML/Attributes/autocomplete) input.
 
 Here we define an input that takes an autocomplete option of "name".
 
@@ -178,8 +146,6 @@ Here we define an input that takes an autocomplete option of "name".
 <button>Show autocomplete options</button>
 ```
 
-#### JavaScript
-
 The code below shows the picker for the input when the button is clicked.
 
 ```js
@@ -194,12 +160,6 @@ The code below shows the picker for the input when the button is clicked.
     }
   });
 ```
-
-#### Result
-
-Click the button to show the picker for the "name" autocomplete input:
-
-{{EmbedLiveSample("showPicker() for autocomplete","600px", "50px")}}
 
 ## Specifications
 


### PR DESCRIPTION
This removes the normal input examples from [`HTMLInputElement.showPicker`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/showPicker) that have (unfixable) cross origin requirements. 
It also adds a note that they are used in the same way but can't be done here because would cause a securityerror.

The datalist and autocomplete examples have just been made into normal text examples rather than live examples.

Fixes #16582

