### PR TITLE
FF101 Relnote for constructable style sheets

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1441,48 +1441,6 @@ The [Payment Request API](/en-US/docs/Web/API/Payment_Request_API) provides supp
   </tbody>
 </table>
 
-### Constructable stylesheets
-
-The addition of a constructor to the {{domxref("CSSStyleSheet")}} interface as well as a variety of related changes makes it possible to directly create new stylesheets without having to add the sheet to the HTML. This makes it much easier to create reusable stylesheets for use with [Shadow DOM](/en-US/docs/Web/Web_Components/Using_shadow_DOM). Our implementation is not yet complete; see {{bug(1520690)}} for more details.
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>73</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>73</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>73</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>73</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2">
-        <code>layout.css.constructable-stylesheets.enabled</code>
-      </td>
-    </tr>
-  </tbody>
-</table>
-
 ### WebShare API
 
 The [Web Share API](/en-US/docs/Web/API/Web_Share_API) allows sharing of files, URLs and other data from a site.

--- a/files/en-us/mozilla/firefox/releases/101/index.md
+++ b/files/en-us/mozilla/firefox/releases/101/index.md
@@ -58,6 +58,11 @@ The [`prefers-contrast`](/en-US/docs/Web/CSS/@media/prefers-contrast) media feat
   Note that zero if a valid frame rate value, but is interpreted by Firefox as "no frame rate limit".
   For more information see {{bug(1611957)}}.
 
+- _Constructable stylesheets_ are now supported, making it much easier to create reusable stylesheets for use with [Shadow DOM](/en-US/docs/Web/Web_Components/Using_shadow_DOM).
+  The update includes the addition of a [`CSSStyleSheet()` constructor](/en-US/docs/Web/API/CSSStyleSheet/CSSStyleSheet) for creating new stylesheets, and the {{domxref("CSSStyleSheet.replace()")}} and {{domxref("CSSStyleSheet.replaceSync()")}} methods that can be used to add CSS rules to them.
+  See {{bug(1520690)}} for more information.
+
+
 #### Media, WebRTC, and Web Audio
 
 #### Removals

--- a/files/en-us/web/api/cssstylesheet/cssstylesheet/index.md
+++ b/files/en-us/web/api/cssstylesheet/cssstylesheet/index.md
@@ -53,4 +53,6 @@ console.log(stylesheet.media);
 
 ## See also
 
+- [Constructable Stylesheets](https://web.dev/constructable-stylesheets/) (web.dev)
+- [Using the Shadow DOM](/en-US/docs/Web/Web_Components/Using_shadow_DOM)
 - [construct-style-sheets-polyfill](https://www.npmjs.com/package/construct-style-sheets-polyfill)

--- a/files/en-us/web/api/cssstylesheet/replace/index.md
+++ b/files/en-us/web/api/cssstylesheet/replace/index.md
@@ -62,3 +62,8 @@ stylesheet.replace('body { font-size: 1.4em; } p { color: red; }')
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [Constructable Stylesheets](https://web.dev/constructable-stylesheets/) (web.dev)
+- [Using the Shadow DOM](/en-US/docs/Web/Web_Components/Using_shadow_DOM)

--- a/files/en-us/web/api/cssstylesheet/replacesync/index.md
+++ b/files/en-us/web/api/cssstylesheet/replacesync/index.md
@@ -54,3 +54,8 @@ stylesheet.replaceSync('body { font-size: 1.4em; } p { color: red; }');
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- [Constructable Stylesheets](https://web.dev/constructable-stylesheets/) (web.dev)
+- [Using the Shadow DOM](/en-US/docs/Web/Web_Components/Using_shadow_DOM)


### PR DESCRIPTION
FF101 adds support for constructable stylesheets in https://bugzilla.mozilla.org/show_bug.cgi?id=1644102#c11

This adds a release note for that update and removes the note from the experimental features. It also adds links to the web-dev docs on the topic. Note that we will need to add docs on this to Using Shadow Dom, but that is a task for a different PR.

Other docs work on this can be tracked in #16624