### PR TITLE
Fix garbled link

### DIFF
--- a/files/en-us/web/api/response/response/index.md
+++ b/files/en-us/web/api/response/response/index.md
@@ -49,7 +49,7 @@ new Response(body, options)
     - `headers`
       - : Any headers you want to add to your response, contained
         within a {{domxref("Headers")}} object or object literal of
-        {{jsxref("String")}} key/value pairs (see [HTTP headers](/en- `US`    /docs/Web/HTTP/Headers) for a reference).
+        {{jsxref("String")}} key/value pairs (see [HTTP headers](/en-US/docs/Web/HTTP/Headers) for a reference).
 
 ## Examples
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/commit/23901d9f5b2f1d45dc9b3d02e0d3197c0275ff4c#r74680840

Some Markdown was caught inside the link. This fixes it.