### PR TITLE
Better nav for audioworklet

### DIFF
--- a/files/en-us/web/api/audioworklet/index.md
+++ b/files/en-us/web/api/audioworklet/index.md
@@ -57,3 +57,4 @@ See {{domxref("AudioWorkletNode")}} for complete examples of custom audio node c
 - {{domxref("AudioWorkletGlobalScope")}} — the global execution context of an `AudioWorklet`
 - [Web Audio API](/en-US/docs/Web/API/Web_Audio_API)
 - [Using the Web Audio API](/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API)
+- [Using AudioWorklet](/en-US/docs/Web/API/Web_Audio_API/Using_AudioWorklet)

--- a/files/en-us/web/api/audioworkletglobalscope/index.md
+++ b/files/en-us/web/api/audioworkletglobalscope/index.md
@@ -98,3 +98,4 @@ testNode.connect(audioContext.destination)
 
 - [Web Audio API](/en-US/docs/Web/API/Web_Audio_API)
 - [Using the Web Audio API](/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API)
+- [Using AudioWorklet](/en-US/docs/Web/API/Web_Audio_API/Using_AudioWorklet)

--- a/files/en-us/web/api/audioworkletnode/index.md
+++ b/files/en-us/web/api/audioworkletnode/index.md
@@ -89,3 +89,4 @@ randomNoiseNode.connect(audioContext.destination)
 
 - [Web Audio API](/en-US/docs/Web/API/Web_Audio_API)
 - [Using the Web Audio API](/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API)
+- [Using AudioWorklet](/en-US/docs/Web/API/Web_Audio_API/Using_AudioWorklet)

--- a/files/en-us/web/api/audioworkletprocessor/index.md
+++ b/files/en-us/web/api/audioworkletprocessor/index.md
@@ -105,3 +105,4 @@ whiteNoiseNode.connect(audioContext.destination)
 
 - [Web Audio API](/en-US/docs/Web/API/Web_Audio_API)
 - [Using the Web Audio API](/en-US/docs/Web/API/Web_Audio_API/Using_Web_Audio_API)
+- [Using AudioWorklet](/en-US/docs/Web/API/Web_Audio_API/Using_AudioWorklet)

--- a/files/en-us/web/api/web_audio_api/best_practices/index.md
+++ b/files/en-us/web/api/web_audio_api/best_practices/index.md
@@ -7,7 +7,7 @@ tags:
   - Guide
   - Web Audio API
 ---
-{{apiref("Web Audio API")}}
+{{DefaultAPISidebar("Web Audio API")}}
 
 There's no strict right or wrong way when writing creative code. As long as you consider security, performance, and accessibility, you can adapt to your own style. In this article, we'll share a number of _best practices_ — guidelines, tips, and tricks for working with the Web Audio API.
 

--- a/files/en-us/web/api/web_audio_api/controlling_multiple_parameters_with_constantsourcenode/index.md
+++ b/files/en-us/web/api/web_audio_api/controlling_multiple_parameters_with_constantsourcenode/index.md
@@ -11,7 +11,7 @@ tags:
   - Web Audio
   - Web Audio API
 ---
-{{APIRef("Web Audio API")}}
+{{DefaultAPISidebar("Web Audio API")}}
 
 This article demonstrates how to use a {{domxref("ConstantSourceNode")}} to link multiple parameters together so they share the same value, which can be changed by setting the value of the {{domxref("ConstantSourceNode.offset")}} parameter.
 

--- a/files/en-us/web/api/web_audio_api/migrating_from_webkitaudiocontext/index.md
+++ b/files/en-us/web/api/web_audio_api/migrating_from_webkitaudiocontext/index.md
@@ -12,7 +12,6 @@ tags:
   - porting
   - webkitAudioContext
 ---
-
 {{DefaultAPISidebar("Web Audio API")}}
 
 In this article, we cover the differences in Web Audio API since it was first implemented in WebKit and how to update your code to use the modern Web Audio API.

--- a/files/en-us/web/api/web_audio_api/tools/index.md
+++ b/files/en-us/web/api/web_audio_api/tools/index.md
@@ -12,7 +12,7 @@ tags:
   - Web Audio API
   - sound
 ---
-{{APIRef("Web Audio API")}}
+{{DefaultAPISidebar("Web Audio API")}}
 
 While working on your Web Audio API code, you may find that you need tools to analyze the graph of nodes you create or to otherwise debug your work. This article discusses tools available to help you do that.
 

--- a/files/en-us/web/api/web_audio_api/using_audioworklet/index.md
+++ b/files/en-us/web/api/web_audio_api/using_audioworklet/index.md
@@ -14,7 +14,7 @@ tags:
   - WebAudio API
   - sound
 ---
-{{APIRef("Web Audio API")}}
+{{DefaultAPISidebar("Web Audio API")}}
 
 This article explains how to create an audio worklet processor and use it in a Web Audio application.
 

--- a/files/en-us/web/api/web_audio_api/visualizations_with_web_audio_api/index.md
+++ b/files/en-us/web/api/web_audio_api/visualizations_with_web_audio_api/index.md
@@ -10,7 +10,6 @@ tags:
   - visualization
   - waveform
 ---
-
 {{DefaultAPISidebar("Web Audio API")}}
 
 One of the most interesting features of the Web Audio API is the ability to extract frequency, waveform, and other data from your audio source, which can then be used to create visualizations. This article explains how, and provides a couple of basic use cases.

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -1529,6 +1529,7 @@
         "/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API",
         "/docs/Web/API/Web_Audio_API/Best_practices",
         "/docs/Web/API/Web_Audio_API/Advanced_techniques",
+        "/docs/Web/API/Web_Audio_API/Using_AudioWorklet",
         "/docs/Web/API/Web_Audio_API/Controlling_multiple_parameters_with_ConstantSourceNode",
         "/docs/Web/API/Web_Audio_API/Porting_webkitAudioContext_code_to_standards_based_AudioContext",
         "/docs/Web/API/Web_Audio_API/Simple_synth",


### PR DESCRIPTION
We have a guide to using AudioWorklet, but it's not in GroupData, so it doesn't appear in the sidebar, nor is is listed in "See also" for worklet interfaces. So it was basically unfindable.

This should fix that, and also fixes a few sidebars in Web Audio guide pages.