### PR TITLE
Remove redundant polyfill from btoa()

### DIFF
--- a/files/en-us/web/api/btoa/index.md
+++ b/files/en-us/web/api/btoa/index.md
@@ -9,9 +9,6 @@ tags:
   - Reference
   - Polyfill
   - Web
-  - btoa
-  - data
-  - strings
 browser-compat: api.btoa
 ---
 {{APIRef("HTML DOM")}}
@@ -143,4 +140,3 @@ See also the example `utf8_to_b64` and `b64_to_utf8` functions in the [Solution 
 - [`data` URLs](/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs)
 - {{domxref("atob","atob()")}}
 - {{Glossary("Base64")}}
-- [Polyfill](https://github.com/MaxArt2501/base64-js/blob/master/base64.js)


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Removes the second polyfill link.

#### Motivation
No need for another (older) polyfill.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
