### PR TITLE
Move more compat data into browser-compat key

### DIFF
--- a/files/en-us/web/api/canvas_api/index.md
+++ b/files/en-us/web/api/canvas_api/index.md
@@ -9,6 +9,7 @@ tags:
   - JavaScript
   - Overview
   - Reference
+browser-compat: html.elements.canvas
 ---
 {{CanvasSidebar}}
 
@@ -98,11 +99,11 @@ The Canvas API is extremely powerful, but not always simple to use. The librarie
 
 ## Specifications
 
-{{Specifications("html.elements.canvas")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-Mozilla applications gained support for `<canvas>` starting with Gecko 1.8 ([Firefox 1.5](/en-US/docs/Mozilla/Firefox/Releases/1.5)). The element was originally introduced by Apple for the macOS Dashboard and Safari. Internet Explorer supports `<canvas>` from version 9 onwards; for earlier versions of IE, a page can effectively add support for `<canvas>` by including a script from Google's [Explorer Canvas](https://github.com/arv/explorercanvas) project. Google Chrome and Opera 9 also support `<canvas>`.
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/element_timing_api/index.md
+++ b/files/en-us/web/api/element_timing_api/index.md
@@ -7,7 +7,7 @@ tags:
   - Performance
   - Overview
   - Reference
-spec-urls: https://wicg.github.io/element-timing/
+browser-compat: api.PerformanceElementTiming
 ---
 {{DefaultAPISidebar("Element Timing")}}
 
@@ -52,9 +52,7 @@ observer.observe({ entryTypes: ["element"] });
 
 ## Browser compatibility
 
-### PerformanceElementTiming
-
-{{Compat("api.PerformanceElementTiming")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/encrypted_media_extensions_api/index.md
+++ b/files/en-us/web/api/encrypted_media_extensions_api/index.md
@@ -10,7 +10,7 @@ tags:
   - NeedsContent
   - Overview
   - Reference
-spec-urls: https://w3c.github.io/encrypted-media/
+browser-compat: api.Navigator.requestMediaKeySystemAccess
 ---
 {{DefaultAPISidebar("Encrypted Media Extensions")}}
 
@@ -35,6 +35,4 @@ The Encrypted Media Extensions API provides interfaces for controlling the playb
 
 ## Browser compatibility
 
-### Navigator.requestMediaKeySystemAccess()
-
-{{Compat("api.Navigator.requestMediaKeySystemAccess")}}
+{{Compat}}

--- a/files/en-us/web/api/fetch_api/index.md
+++ b/files/en-us/web/api/fetch_api/index.md
@@ -9,7 +9,7 @@ tags:
   - Response
   - XMLHttpRequest
   - request
-spec-urls: https://fetch.spec.whatwg.org/
+browser-compat: api.fetch
 ---
 {{DefaultAPISidebar("Fetch API")}}
 
@@ -64,7 +64,7 @@ Browsers have started to add experimental support for the {{DOMxRef("AbortContro
 
 ## Browser compatibility
 
-{{Compat("api.fetch")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/gamepad_api/index.md
+++ b/files/en-us/web/api/gamepad_api/index.md
@@ -7,9 +7,7 @@ tags:
   - Gamepad API
   - Games
   - Overview
-spec-urls:
-  - https://w3c.github.io/gamepad/extensions.html
-  - https://w3c.github.io/gamepad/
+browser-compat: api.Gamepad
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Gamepad API")}}
 
@@ -58,7 +56,7 @@ See also the [extensions to the Gamepad interface](/en-US/docs/Web/API/Gamepad#e
 
 ## Browser compatibility
 
-{{Compat("api.Gamepad")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/history_api/index.md
+++ b/files/en-us/web/api/history_api/index.md
@@ -7,7 +7,7 @@ tags:
   - HTML DOM
   - History
   - History API
-spec-urls: https://html.spec.whatwg.org/multipage/browsers.html#history
+browser-compat: api.History
 ---
 {{DefaultAPISidebar("History API")}}
 
@@ -95,7 +95,7 @@ history.go(2)  // alerts "location: http://example.com/example.html?page=3, stat
 
 ## Browser compatibility
 
-{{Compat("api.History")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/html_dom_api/index.md
+++ b/files/en-us/web/api/html_dom_api/index.md
@@ -14,7 +14,7 @@ tags:
   - Web
   - Windows
   - hierarchy
-spec-urls: https://html.spec.whatwg.org/multipage/
+browser-compat: api.HTMLElement
 ---
 {{DefaultAPISidebar("HTML DOM")}}
 
@@ -370,7 +370,7 @@ The HTML for the form looks like this:
 
 ## Browser compatibility
 
-{{Compat("api.HTMLElement")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/intersection_observer_api/index.md
+++ b/files/en-us/web/api/intersection_observer_api/index.md
@@ -11,7 +11,7 @@ tags:
   - Performance
   - Reference
   - Web
-spec-urls: https://w3c.github.io/IntersectionObserver/
+browser-compat: api.IntersectionObserver
 ---
 {{DefaultAPISidebar("Intersection Observer API")}}
 
@@ -586,7 +586,7 @@ There's an even more extensive example at [Timing element visibility with the In
 
 ## Browser compatibility
 
-{{Compat("api.IntersectionObserver")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/media_capabilities_api/using_the_media_capabilities_api/index.md
+++ b/files/en-us/web/api/media_capabilities_api/using_the_media_capabilities_api/index.md
@@ -11,6 +11,7 @@ tags:
   - Media Capabilities API
   - Video
   - capabilities
+browser-compat: api.MediaCapabilities
 ---
 {{APIRef("Media Capabilities API")}}
 
@@ -242,7 +243,7 @@ document.getElementById('try-it').addEventListener('click', mc.tryIt);
 
 ## Browser compatibility
 
-{{Compat("api.MediaCapabilities")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/media_session_api/index.md
+++ b/files/en-us/web/api/media_session_api/index.md
@@ -10,7 +10,7 @@ tags:
   - Overview
   - Reference
   - Video
-spec-urls: https://w3c.github.io/mediasession/
+browser-compat: api.MediaSession
 ---
 {{DefaultAPISidebar("Media Session API")}}
 
@@ -97,4 +97,4 @@ playButton.addEventListener('pointerup', function(event) {
 
 ## Browser compatibility
 
-{{Compat("api.MediaSession")}}
+{{Compat}}

--- a/files/en-us/web/api/media_source_extensions_api/index.md
+++ b/files/en-us/web/api/media_source_extensions_api/index.md
@@ -69,9 +69,7 @@ There are numerous available free and open source tools for transcoding content 
 
 ## Browser compatibility
 
-### MediaSource interface
-
-{{Compat("api.MediaSource", 0)}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/media_streams_api/constraints/index.md
+++ b/files/en-us/web/api/media_streams_api/constraints/index.md
@@ -13,7 +13,7 @@ tags:
   - Settings
   - Video
   - WebRTC
-spec-urls: https://w3c.github.io/mediacapture-main/#constrainable-interface
+browser-compat: api.MediaDevices.getSupportedConstraints
 ---
 {{DefaultAPISidebar("Media Capture and Streams")}}
 
@@ -551,9 +551,7 @@ Here you can see the complete example in action.
 
 ## Browser compatibility
 
-### `MediaDevices.getSupportedConstraints`
-
-{{Compat("api.MediaDevices.getSupportedConstraints")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/media_streams_api/index.md
+++ b/files/en-us/web/api/media_streams_api/index.md
@@ -9,6 +9,7 @@ tags:
   - Media Streams API
   - Overview
   - Video
+browser-compat: api.MediaStream
 ---
 {{DefaultAPISidebar("Media Capture and Streams")}}
 
@@ -67,7 +68,7 @@ The [Capabilities, constraints, and settings](/en-US/docs/Web/API/Media_Streams_
 
 ## Browser compatibility
 
-{{Compat("api.MediaStream")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/mediastream_image_capture_api/index.md
+++ b/files/en-us/web/api/mediastream_image_capture_api/index.md
@@ -9,7 +9,7 @@ tags:
   - Overview
   - Reference
   - Video
-spec-urls: https://w3c.github.io/mediacapture-image/
+browser-compat: api.ImageCapture
 ---
 {{DefaultAPISidebar("Image Capture API")}}{{SeeCompatTable}}
 
@@ -63,7 +63,7 @@ let imageCapture = new ImageCapture(track);
 
 ## Browser compatibility
 
-{{Compat("api.ImageCapture")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/mediastream_recording_api/using_the_mediastream_recording_api/index.md
+++ b/files/en-us/web/api/mediastream_recording_api/using_the_mediastream_recording_api/index.md
@@ -264,9 +264,7 @@ Finally, we set an `onclick` handler on the delete button to be a function that 
 
 ## Browser compatibility
 
-### `MediaRecorder`
-
-{{Compat("api.MediaRecorder")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/pointer_events/using_pointer_events/index.md
+++ b/files/en-us/web/api/pointer_events/using_pointer_events/index.md
@@ -8,7 +8,7 @@ tags:
   - PointerEvent
   - events
   - touch
-spec-urls: https://w3c.github.io/pointerevents/
+browser-compat: api.PointerEvent
 ---
 {{DefaultAPISidebar("Pointer Events")}}
 
@@ -233,9 +233,7 @@ function log(msg) {
 
 ## Browser compatibility
 
-### `PointerEvent` interface
-
-{{Compat("api.PointerEvent", 0)}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/rtcicecandidatestats/mozlocaltransport/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/mozlocaltransport/index.md
@@ -19,6 +19,7 @@ tags:
   - WebRTC
   - WebRTC API
   - mozLocalTransport
+browser-compat: api.RTCIceCandidateStats.relayProtocol
 ---
 {{APIRef("WebRTC")}}{{deprecated_header}}{{non-standard_header}}
 
@@ -32,4 +33,4 @@ Not part of any specification.
 
 ## Browser compatibility
 
-{{Compat("api.RTCIceCandidateStats.relayProtocol")}}
+{{Compat}}

--- a/files/en-us/web/api/screen_capture_api/using_screen_capture/index.md
+++ b/files/en-us/web/api/screen_capture_api/using_screen_capture/index.md
@@ -15,6 +15,7 @@ tags:
   - display
   - getDisplayMedia
   - screen
+browser-compat: api.MediaDevices.getDisplayMedia
 ---
 {{DefaultAPISidebar("Screen Capture API")}}
 
@@ -335,7 +336,7 @@ If you're performing screen capture within an `<iframe>`, you can request permis
 
 ## Browser compatibility
 
-{{Compat("api.MediaDevices.getDisplayMedia")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/screen_orientation_api/index.md
+++ b/files/en-us/web/api/screen_orientation_api/index.md
@@ -7,7 +7,7 @@ tags:
   - NeedsContent
   - Overview
   - Screen Orientation
-spec-urls: https://w3c.github.io/screen-orientation/
+browser-compat: api.ScreenOrientation
 ---
 {{DefaultAPISidebar("Screen Orientation API")}}
 
@@ -23,4 +23,4 @@ The **Screen Orientation API** provides information about the orientation of the
 
 ## Browser compatibility
 
-{{Compat("api.ScreenOrientation")}}
+{{Compat}}

--- a/files/en-us/web/api/server-sent_events/using_server-sent_events/index.md
+++ b/files/en-us/web/api/server-sent_events/using_server-sent_events/index.md
@@ -10,6 +10,7 @@ tags:
   - Server Sent Events
   - Server-sent events
   - messaging
+browser-compat: api.EventSource
 ---
 {{DefaultAPISidebar("Server Sent Events")}}
 
@@ -200,6 +201,4 @@ data: {"username": "bobby", "time": "02:34:11", "text": "Hi everyone."}
 
 ## Browser compatibility
 
-### `EventSource`
-
-{{Compat("api.EventSource")}}
+{{Compat}}

--- a/files/en-us/web/api/serviceworkerglobalscope/sync_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/sync_event/index.md
@@ -62,11 +62,11 @@ self.onsync = event => {
 
 ## Specifications
 
-{{Specifications("api.SyncEvent")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-{{Compat("api.SyncEvent")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/web_animations_api/keyframe_formats/index.md
+++ b/files/en-us/web/api/web_animations_api/keyframe_formats/index.md
@@ -11,7 +11,7 @@ tags:
   - setKeyframes()
   - waapi
   - web animations api
-spec-urls: https://drafts.csswg.org/web-animations-1/#processing-a-keyframes-argument
+browser-compat: api.Element.animate
 ---
 {{ SeeCompatTable() }}{{ APIRef("Web Animations API") }}
 
@@ -128,9 +128,7 @@ The following special attributes may also be specified:
 
 ## Browser compatibility
 
-### `Element.animate`
-
-{{Compat("api.Element.animate")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/web_bluetooth_api/index.md
+++ b/files/en-us/web/api/web_bluetooth_api/index.md
@@ -7,7 +7,7 @@ tags:
   - Overview
   - Reference
   - Web Bluetooth API
-spec-urls: https://webbluetoothcg.github.io/web-bluetooth/
+browser-compat: api.Bluetooth
 ---
 {{DefaultAPISidebar("Bluetooth API")}}{{SeeCompatTable}}
 
@@ -38,4 +38,4 @@ The Web Bluetooth API provides the ability to connect and interact with Bluetoot
 
 ## Browser compatibility
 
-{{Compat("api.Bluetooth")}}
+{{Compat}}

--- a/files/en-us/web/api/web_serial_api/index.md
+++ b/files/en-us/web/api/web_serial_api/index.md
@@ -6,7 +6,7 @@ tags:
   - Web Serial
   - Overview
   - Reference
-spec-urls: https://wicg.github.io/serial/
+browser-compat: api.Serial
 ---
 {{securecontext_header}}{{DefaultAPISidebar("Web Serial API")}}
 
@@ -91,7 +91,7 @@ while (port.readable) {
 
 ## Browser compatibility
 
-{{Compat("api.Serial")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/webhid_api/index.md
+++ b/files/en-us/web/api/webhid_api/index.md
@@ -6,7 +6,7 @@ tags:
   - Advanced
   - WebHID
   - WebHID API
-spec-urls: https://wicg.github.io/webhid/
+browser-compat: api.HID
 ---
 {{DefaultAPISidebar("WebHID API")}}{{SeeCompatTable}}
 
@@ -87,4 +87,4 @@ navigator.hid.addEventListener('disconnect', (event) => {
 
 ## Browser compatibility
 
-{{Compat("api.HID")}}
+{{Compat}}

--- a/files/en-us/web/api/webvr_api/index.md
+++ b/files/en-us/web/api/webvr_api/index.md
@@ -11,6 +11,7 @@ tags:
   - VR
   - Virtual Reality
   - WebVR
+browser-compat: api.Navigator.getVRDisplays
 ---
 {{DefaultAPISidebar("WebVR API")}}{{Deprecated_Header}}
 
@@ -133,9 +134,7 @@ Until all browsers have implemented the new [WebXR APIs](/en-US/docs/Web/API/Web
 
 ## Browser compatibility
 
-### `Navigator.getVRDisplays`
-
-{{Compat("api.Navigator.getVRDisplays")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/webxr_device_api/index.md
+++ b/files/en-us/web/api/webxr_device_api/index.md
@@ -13,6 +13,7 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+browser-compat: api.Navigator.xr
 ---
 {{DefaultAPISidebar("WebXR Device API")}} {{SecureContext_Header}}
 
@@ -243,7 +244,7 @@ The following guides and tutorials are a great resource to learn how to comprehe
 
 ## Browser compatibility
 
-{{Compat("api.Navigator.xr")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/css/color_value/hsla/index.md
+++ b/files/en-us/web/css/color_value/hsla/index.md
@@ -9,6 +9,7 @@ tags:
   - Web
   - color
   - hsla
+browser-compat: css.types.color.hsla
 ---
 {{CSSRef}}
 
@@ -37,10 +38,10 @@ hsla(235 100% 50% / 1); /* CSS Colors 4 space-separated values */
 - Functional notation: `hsla(H S L[ / A])`
   - : CSS Colors Level 4 adds support for space-separated values in the functional notation.
 
+## Specifications
+
+{{Specifications}}
+
 ## Browser compatibility
 
-{{Compat("css.types.color.alpha")}}
-
-### Space-separated values
-
-{{Compat("css.types.color.space_separated_functional_notation")}}
+{{Compat}}

--- a/files/en-us/web/css/color_value/rgb/index.md
+++ b/files/en-us/web/css/color_value/rgb/index.md
@@ -9,6 +9,7 @@ tags:
   - Web
   - color
   - rgb
+browser-compat: css.types.color.rgb
 ---
 {{CSSRef}}
 
@@ -36,12 +37,4 @@ rgb(255 255 255 / .5); /* white with 50% opacity, using CSS Colors 4 space-separ
 
 ## Browser compatibility
 
-{{Compat("css.types.color.rgb_functional_notation")}}
-
-### Space-separated values
-
-{{Compat("css.types.color.space_separated_functional_notation")}}
-
-### Accepts alpha value
-
-{{Compat("css.types.color.rgb_function_accepts_alpha")}}
+{{Compat}}

--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -7,7 +7,7 @@ tags:
   - Guide
   - Overview
   - Reference
-spec-urls: https://drafts.csswg.org/css-animations/
+browser-compat: css.properties.animation
 ---
 {{CSSRef}}
 
@@ -48,9 +48,7 @@ spec-urls: https://drafts.csswg.org/css-animations/
 
 ## Browser compatibility
 
-### `animation` property
-
-{{Compat("css.properties.animation")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/css/css_charsets/index.md
+++ b/files/en-us/web/css/css_charsets/index.md
@@ -7,7 +7,7 @@ tags:
   - Guide
   - Overview
   - Reference
-spec-urls: https://www.w3.org/TR/CSS22/syndata.html#x57
+browser-compat: css.at-rules.charset
 ---
 {{CSSRef}}
 
@@ -25,6 +25,4 @@ spec-urls: https://www.w3.org/TR/CSS22/syndata.html#x57
 
 ## Browser compatibility
 
-### `@charset` rule
-
-{{Compat("css.at-rules.charset")}}
+{{Compat}}

--- a/files/en-us/web/css/css_device_adaptation/index.md
+++ b/files/en-us/web/css/css_device_adaptation/index.md
@@ -7,7 +7,7 @@ tags:
   - Guide
   - Overview
   - Reference
-spec-urls: https://drafts.csswg.org/css-device-adapt/
+browser-compat: css.at-rules.viewport
 ---
 {{CSSRef}}
 
@@ -25,6 +25,4 @@ spec-urls: https://drafts.csswg.org/css-device-adapt/
 
 ## Browser compatibility
 
-### `@viewport` rule
-
-{{Compat("css.at-rules.viewport")}}
+{{Compat}}

--- a/files/en-us/web/css/css_display/index.md
+++ b/files/en-us/web/css/css_display/index.md
@@ -7,7 +7,7 @@ tags:
   - Guide
   - Overview
   - Reference
-spec-urls: https://drafts.csswg.org/css-display/#the-display-properties
+browser-compat: css.properties.display
 ---
 {{CSSRef}}
 

--- a/files/en-us/web/css/css_grid_layout/subgrid/index.md
+++ b/files/en-us/web/css/css_grid_layout/subgrid/index.md
@@ -7,7 +7,7 @@ tags:
   - CSS Grid
   - Guide
   - subgrid
-spec-urls: https://drafts.csswg.org/css-grid/
+browser-compat: css.properties.grid-template-columns.subgrid
 ---
 {{CSSRef}}
 
@@ -97,7 +97,7 @@ As the subgrid value acts in much the same way as a regular nested grid, it is e
 
 ## Browser compatibility
 
-{{Compat("css.properties.grid-template-columns.subgrid")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/css/css_motion_path/index.md
+++ b/files/en-us/web/css/css_motion_path/index.md
@@ -9,7 +9,7 @@ tags:
   - Motion Path
   - Overview
   - Reference
-spec-urls: https://drafts.fxtf.org/motion/
+browser-compat: css.properties.offset-path
 ---
 {{CSSRef}}{{SeeCompatTable}}
 
@@ -61,6 +61,4 @@ The idea is that when you want to animate an element moving along a path, you pr
 
 ## Browser compatibility
 
-### offset property
-
-{{Compat("css.properties.offset-path")}}
+{{Compat}}

--- a/files/en-us/web/css/css_namespaces/index.md
+++ b/files/en-us/web/css/css_namespaces/index.md
@@ -8,7 +8,7 @@ tags:
   - Overview
   - Reference
   - Web
-spec-urls: https://drafts.csswg.org/css-namespaces/
+browser-compat: css.at-rules.namespace
 ---
 {{CSSRef}}
 
@@ -26,6 +26,4 @@ spec-urls: https://drafts.csswg.org/css-namespaces/
 
 ## Browser compatibility
 
-### `@namespace` rule
-
-{{Compat("css.at-rules.namespace")}}
+{{Compat}}

--- a/files/en-us/web/css/cssom_view/index.md
+++ b/files/en-us/web/css/cssom_view/index.md
@@ -9,7 +9,7 @@ tags:
   - Layout
   - Overview
   - Reference
-spec-urls: https://drafts.csswg.org/cssom-view/
+browser-compat: css.properties.scroll-behavior
 ---
 {{CSSRef}}
 
@@ -32,6 +32,4 @@ spec-urls: https://drafts.csswg.org/cssom-view/
 
 ## Browser compatibility
 
-### `scroll-behavior` property
-
-{{Compat("css.properties.scroll-behavior")}}
+{{Compat}}

--- a/files/en-us/web/css/display-box/index.md
+++ b/files/en-us/web/css/display-box/index.md
@@ -8,7 +8,7 @@ tags:
   - Data Type
   - Reference
   - display-box
-spec-urls: https://drafts.csswg.org/css-display/#typedef-display-box
+browser-compat: css.properties.display.contents
 ---
 {{CSSRef}}
 
@@ -96,9 +96,7 @@ In this example the outer {{htmlelement("div")}} has a 2-pixel red border and a 
 
 ## Browser compatibility
 
-### Support of contents
-
-{{Compat("css.properties.display.contents", 10)}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/css/display-outside/index.md
+++ b/files/en-us/web/css/display-outside/index.md
@@ -8,7 +8,7 @@ tags:
   - Data Type
   - Reference
   - display-outside
-spec-urls: https://drafts.csswg.org/css-display/#typedef-display-outside
+browser-compat: css.properties.display.display-outside
 ---
 {{CSSRef}}
 
@@ -55,7 +55,7 @@ span {
 
 ## Browser compatibility
 
-{{Compat("css.properties.display.display-outside", 10)}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/css/easing-function/index.md
+++ b/files/en-us/web/css/easing-function/index.md
@@ -11,7 +11,7 @@ tags:
   - Layout
   - Reference
   - easing-function
-spec-urls: https://drafts.csswg.org/css-easing/#typedef-easing-function
+browser-compat: css.types.easing-function
 ---
 {{CSSRef}}
 
@@ -321,7 +321,7 @@ steps(0, jump-none)
 
 ## Browser compatibility
 
-{{Compat("css.types.easing-function", 2)}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/css/layout_cookbook/breadcrumb_navigation/index.md
+++ b/files/en-us/web/css/layout_cookbook/breadcrumb_navigation/index.md
@@ -8,6 +8,7 @@ tags:
   - Navigation
   - cookbook
   - flexbox
+browser-compat: css.properties.flex
 ---
 {{CSSRef}}
 
@@ -47,11 +48,7 @@ I have used the [`aria-label`](/en-US/docs/Web/Accessibility/ARIA/Attributes/ari
 
 ## Browser compatibility
 
-The various layout methods have different browser support. See the charts below for details on basic support for the properties used.
-
-### Flexbox
-
-{{Compat("css.properties.flex")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/css/layout_cookbook/grid_wrapper/index.md
+++ b/files/en-us/web/css/layout_cookbook/grid_wrapper/index.md
@@ -7,6 +7,7 @@ tags:
   - Layout
   - cookbook
   - recipes
+browser-compat: css.properties.grid-template-columns
 ---
 {{CSSRef}}
 
@@ -69,11 +70,7 @@ Although Grid enables us to position items anywhere (within reason), it is impor
 
 ## Browser compatibility
 
-The various layout methods have different browser support. See the charts below for details on basic support for the properties used.
-
-### grid-template-columns
-
-{{Compat("css.properties.grid-template-columns")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/css/layout_cookbook/split_navigation/index.md
+++ b/files/en-us/web/css/layout_cookbook/split_navigation/index.md
@@ -8,6 +8,7 @@ tags:
   - Navigation
   - cookbook
   - flexbox
+browser-compat: css.properties.flex
 ---
 {{CSSRef}}
 
@@ -37,11 +38,7 @@ In this case the left auto margin takes up any available space and pushes the it
 
 ## Browser compatibility
 
-The various layout methods have different browser support. See the charts below for details on basic support for the properties used.
-
-### Flexbox
-
-{{Compat("css.properties.flex")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/css/media_queries/testing_media_queries/index.md
+++ b/files/en-us/web/css/media_queries/testing_media_queries/index.md
@@ -12,6 +12,7 @@ tags:
   - Responsive Design
   - Web
   - matchMedia
+browser-compat: api.MediaQueryList
 ---
 {{CSSRef}}
 
@@ -87,9 +88,7 @@ mediaQueryList.removeEventListener('change', handleOrientationChange);
 
 ## Browser compatibility
 
-### `MediaQueryList` interface
-
-{{Compat("api.MediaQueryList")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/html/attributes/max/index.md
+++ b/files/en-us/web/html/attributes/max/index.md
@@ -12,6 +12,7 @@ spec-urls:
   - https://html.spec.whatwg.org/multipage/input.html#the-min-and-max-attributes
   - https://html.spec.whatwg.org/multipage/forms.html#the-progress-element
   - https://html.spec.whatwg.org/multipage/forms.html#the-meter-element
+browser-compat: html.elements.attributes.max
 ---
 
 {{HTMLSidebar}}
@@ -138,7 +139,7 @@ Provide instructions to help users understand how to complete the form and use i
 
 ## Browser compatibility
 
-{{Compat("html.elements.attributes.max")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/html/attributes/required/index.md
+++ b/files/en-us/web/html/attributes/required/index.md
@@ -7,7 +7,7 @@ tags:
   - Constraint validation
   - Forms
   - required
-spec-urls: https://html.spec.whatwg.org/multipage/forms.html#attr-input-required
+browser-compat: html.elements.attributes.required
 ---
 
 {{HTMLSidebar}}
@@ -70,7 +70,7 @@ Provide an indication to users informing them the form control is required. Ensu
 
 ## Browser compatibility
 
-{{Compat("html.elements.attributes.required")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/html/attributes/size/index.md
+++ b/files/en-us/web/html/attributes/size/index.md
@@ -7,7 +7,7 @@ tags:
   - Input
   - Reference
   - Select
-spec-urls: https://html.spec.whatwg.org/multipage/input.html#attr-input-size
+browser-compat: html.elements.attribute.size
 ---
 
 {{HTMLSidebar}}
@@ -49,7 +49,7 @@ By adding `size` on some input types, the width of the input can be controlled. 
 
 ## Browser compatibility
 
-{{Compat("html.elements.attribute.size")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/html/global_attributes/index.md
+++ b/files/en-us/web/html/global_attributes/index.md
@@ -6,7 +6,7 @@ tags:
   - HTML
   - Reference
   - Web
-spec-urls: https://html.spec.whatwg.org/multipage/dom.html#global-attributes
+browser-compat: html.global_attributes
 ---
 
 {{HTMLSidebar("Global_attributes")}}
@@ -129,7 +129,7 @@ In addition to the basic HTML global attributes, the following global attributes
 
 ## Browser compatibility
 
-{{Compat("html.global_attributes")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/cors/index.md
+++ b/files/en-us/web/http/cors/index.md
@@ -13,7 +13,7 @@ tags:
   - Security
   - XMLHttpRequest
   - l10n:priority
-spec-urls: https://fetch.spec.whatwg.org/#cors-protocol
+browser-compat: http.headers.Access-Control-Allow-Origin
 ---
 {{HTTPSidebar}}
 
@@ -492,7 +492,7 @@ Examples of this usage can be [found above](#preflighted_requests).
 
 ## Browser compatibility
 
-{{Compat("http.headers.Access-Control-Allow-Origin")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/http/csp/index.md
+++ b/files/en-us/web/http/csp/index.md
@@ -8,6 +8,7 @@ tags:
   - Guide
   - Security
   - access
+browser-compat: http.headers.csp
 ---
 {{HTTPSidebar}}
 
@@ -231,7 +232,9 @@ In summary, this is done to prevent leaking sensitive information about cross-or
 
 ## Browser compatibility
 
-{{Compat("http.headers.csp")}}
+{{Compat}}
+
+### Compatibility notes
 
 A specific incompatibility exists in some versions of the Safari web browser, whereby if a Content Security Policy header is set, but not a Same Origin header,
 the browser will block self-hosted content and off-site content, and incorrectly report that this is due to the Content Security Policy not allowing the content.

--- a/files/en-us/web/http/status/index.md
+++ b/files/en-us/web/http/status/index.md
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Status code
   - Web
+browser-compat: http.status
 ---
 {{HTTPSidebar}}
 
@@ -208,7 +209,7 @@ The below status codes are defined by [section 10 of RFC 2616](https://datatrack
 
 ## Browser compatibility
 
-{{Compat("http.status")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/javascript/guide/working_with_private_class_features/index.md
+++ b/files/en-us/web/javascript/guide/working_with_private_class_features/index.md
@@ -5,6 +5,7 @@ tags:
   - Document
   - Guide
   - JavaScript
+browser-compat: javascript.classes
 ---
 {{jsSidebar("JavaScript Guide")}}
 
@@ -225,4 +226,4 @@ scalar1.add({}) // throws informative exception
 
 ## Browser compatibility
 
-{{Compat("javascript.classes")}}
+{{Compat}}

--- a/files/en-us/web/mathml/index.md
+++ b/files/en-us/web/mathml/index.md
@@ -7,6 +7,7 @@ tags:
   - Reference
   - Web
   - XML
+browser-compat: mathml.elements.math
 ---
 {{MathMLRef}}
 
@@ -48,4 +49,4 @@ Here you'll find links to documentation, examples, and tools to help you work wi
 
 ## Browser compatibility
 
-{{Compat("mathml.elements.math", 0)}}
+{{Compat}}

--- a/files/en-us/webassembly/index.md
+++ b/files/en-us/webassembly/index.md
@@ -5,7 +5,7 @@ tags:
   - Landing
   - WebAssembly
   - wasm
-spec-urls: https://webassembly.github.io/spec/js-api/
+browser-compat: javascript.builtins.WebAssembly
 ---
 {{WebAssemblySidebar}}
 
@@ -76,7 +76,7 @@ And what's even better is that it is being developed as a web standard via the [
 
 ## Browser compatibility
 
-{{Compat("javascript.builtins.WebAssembly")}}
+{{Compat}}
 
 ## See also
 


### PR DESCRIPTION
For the following reasons:

- consistency with handling of BCD features in other existing docs
- streamlining out unnecessary repetition of BCD feature names
- in keeping with the principle of making use of frontmatter metadata to store data — BCD feature names - rather than having the BCD feature names in the prose body of documents

...this change takes BCD feature names out of the arguments to the `Compat` macro (and sometimes, `Specifications` macro also), and moves those BCD feature names into the value of the `browser-compat` frontmatter metadata key — sometimes replacing an existing `spec-urls` key with a `browser-compat` key.

Most of the changes follow that same simple pattern – with some exceptions:

- In a number of cases, this also drops some unnecessary subheadings from the Browser Compatibility section (the BCD table header rows already provide the information about what features they’re for).

- In a few cases, this takes some prose from the beginning of the Browser Compatibility section, and moves it into a new Compatibility Notes subsection section at the end of the Browser Compatibility section — the reason being that when generating the table from the `browser-compat` value, Yari always puts the BCD table as the first child of the Browser Compatibility section, and takes any intervening paragraphs and moves them after the BCD table.

- And in a few cases, this change just drops some paragraphs from the Browser Compatibility section — due to them containing outdated or unnecessary information.