### PR TITLE
Move compat data into browser-compat key (webextensions subtree)

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/clipboard/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/clipboard/index.md
@@ -8,6 +8,7 @@ tags:
   - Extensions
   - Reference
   - WebExtensions
+browser-compat: webextensions.api.clipboard
 ---
 {{AddonSidebar}}
 
@@ -28,7 +29,9 @@ To use this API you need the `"clipboardWrite"` extension [permission](/en-US/do
 
 ## Browser compatibility
 
-{{Compat("webextensions.api.clipboard")}} {{WebExtExamples("h2")}}
+{{Compat}}
+
+{{WebExtExamples("h2")}}
 
 > **Note:**
 >

--- a/files/en-us/mozilla/add-ons/webextensions/api/clipboard/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/clipboard/index.md
@@ -29,9 +29,9 @@ To use this API you need the `"clipboardWrite"` extension [permission](/en-US/do
 
 ## Browser compatibility
 
-{{Compat}}
-
 {{WebExtExamples("h2")}}
+
+{{Compat}}
 
 > **Note:**
 >

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/index.md
@@ -36,9 +36,9 @@ Listen for the user executing commands that you have registered using the [`comm
 
 ## Browser compatibility
 
-{{Compat}}
-
 {{WebExtExamples("h2")}}
+
+{{Compat}}
 
 > **Note:**
 >

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/index.md
@@ -9,6 +9,7 @@ tags:
   - Reference
   - WebExtensions
   - commands
+browser-compat: webextensions.api.commands
 ---
 {{AddonSidebar}}
 
@@ -35,7 +36,9 @@ Listen for the user executing commands that you have registered using the [`comm
 
 ## Browser compatibility
 
-{{Compat("webextensions.api.commands")}} {{WebExtExamples("h2")}}
+{{Compat}}
+
+{{WebExtExamples("h2")}}
 
 > **Note:**
 >

--- a/files/en-us/mozilla/add-ons/webextensions/api/find/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/find/index.md
@@ -8,6 +8,7 @@ tags:
   - Reference
   - WebExtensions
   - find
+browser-compat: webextensions.api.find
 ---
 {{AddonSidebar}}
 
@@ -26,4 +27,6 @@ To use this API you need to have the "find" [permission](/en-US/docs/Mozilla/Add
 
 ## Browser compatibility
 
-{{Compat("webextensions.api.find", 1, 1)}} {{WebExtExamples("h2")}}
+{{Compat}}
+
+{{WebExtExamples("h2")}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/find/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/find/index.md
@@ -27,6 +27,6 @@ To use this API you need to have the "find" [permission](/en-US/docs/Mozilla/Add
 
 ## Browser compatibility
 
-{{Compat}}
-
 {{WebExtExamples("h2")}}
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/index.md
@@ -154,9 +154,9 @@ browser.menus.create({
 
 ## Browser compatibility
 
-{{Compat}}
-
 {{WebExtExamples("h2")}}
+
+{{Compat}}
 
 > **Note:**
 >

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/index.md
@@ -11,6 +11,7 @@ tags:
   - WebExtensions
   - contextMenus
   - menus
+browser-compat: webextensions.api.menus
 ---
 {{AddonSidebar}}
 
@@ -153,7 +154,7 @@ browser.menus.create({
 
 ## Browser compatibility
 
-{{ Compat("webextensions.api.menus", 1, "true") }}
+{{Compat}}
 
 {{WebExtExamples("h2")}}
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/index.md
@@ -11,6 +11,7 @@ tags:
   - Web Development
   - WebExtensions
   - pkcs11
+browser-compat: webextensions.api.pkcs11
 ---
 {{AddonSidebar}}
 
@@ -63,4 +64,6 @@ For details about the manifest file's contents and location, see [Native manifes
 
 ## Browser compatibility
 
-{{Compat("webextensions.api.pkcs11", 1, 1)}} {{WebExtExamples("h2")}}
+{{Compat}}
+
+{{WebExtExamples("h2")}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/index.md
@@ -64,6 +64,6 @@ For details about the manifest file's contents and location, see [Native manifes
 
 ## Browser compatibility
 
-{{Compat}}
-
 {{WebExtExamples("h2")}}
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/search/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/search/index.md
@@ -9,6 +9,7 @@ tags:
   - Search
   - Search Engines
   - WebExtensions
+browser-compat: webextensions.api.search
 ---
 {{AddonSidebar}}
 
@@ -25,4 +26,6 @@ To use this API you need to have the `"search"` [permission](/en-US/docs/Mozilla
 
 ## Browser compatibility
 
-{{Compat("webextensions.api.search", 1, 1)}} {{WebExtExamples("h2")}}
+{{Compat}}
+
+{{WebExtExamples("h2")}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/search/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/search/index.md
@@ -26,6 +26,6 @@ To use this API you need to have the `"search"` [permission](/en-US/docs/Mozilla
 
 ## Browser compatibility
 
-{{Compat}}
-
 {{WebExtExamples("h2")}}
+
+{{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/browser_compatibility_for_manifest.json/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/browser_compatibility_for_manifest.json/index.md
@@ -5,10 +5,11 @@ tags:
   - Add-ons
   - WebExtensions
   - manifest.json
+browser-compat: webextensions.manifest
 ---
 {{AddonSidebar}}
 
-{{Compat("webextensions.manifest",2)}}
+{{Compat}}
 
 > **Note:**
 >

--- a/files/en-us/mozilla/add-ons/webextensions/match_patterns/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/match_patterns/index.md
@@ -369,6 +369,4 @@ The special value `<all_urls>` matches all URLs under any of the supported schem
 
 ## Browser compatibility
 
-### scheme
-
 {{Compat}}

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_styles/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_styles/index.md
@@ -8,6 +8,7 @@ tags:
   - Extensions
   - Guide
   - WebExtensions
+browser-compat: webextensions.browser_style
 ---
 {{AddonSidebar}}
 
@@ -109,7 +110,7 @@ Most styles are automatically applied, but some elements require you to add the 
 
 ## Browser compatibility
 
-{{Compat("webextensions.browser_style")}}
+{{Compat}}
 
 ## Firefox Panel Components
 

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_styles/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_styles/index.md
@@ -8,7 +8,6 @@ tags:
   - Extensions
   - Guide
   - WebExtensions
-browser-compat: webextensions.browser_style
 ---
 {{AddonSidebar}}
 
@@ -110,7 +109,7 @@ Most styles are automatically applied, but some elements require you to add the 
 
 ## Browser compatibility
 
-{{Compat}}
+For browser compatibility information refer to the browser compatibility sections of the [action](en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action#browser_compatibility), ([browser_action](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action#browser_compatibility), [page_action](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action#browser_compatibility), [sidebar_action](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action#browser_compatibility), and [options_ui](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui#browser_compatibility) manifest keys.
 
 ## Firefox Panel Components
 

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_styles/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_styles/index.md
@@ -109,7 +109,7 @@ Most styles are automatically applied, but some elements require you to add the 
 
 ## Browser compatibility
 
-For browser compatibility information refer to the browser compatibility sections of the [action](en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action#browser_compatibility), ([browser_action](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action#browser_compatibility), [page_action](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action#browser_compatibility), [sidebar_action](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action#browser_compatibility), and [options_ui](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui#browser_compatibility) manifest keys.
+For browser compatibility information refer to the browser compatibility sections of the [action](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/action#browser_compatibility), [browser_action](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action#browser_compatibility), [page_action](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/page_action#browser_compatibility), [sidebar_action](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/sidebar_action#browser_compatibility), and [options_ui](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui#browser_compatibility) manifest keys.
 
 ## Firefox Panel Components
 


### PR DESCRIPTION
Similar to https://github.com/mdn/content/pull/16737, but just for the `mozilla/add-ons/webextensions` subtree, this change, for these reasons:

- consistency with handling of BCD features in other existing docs
- streamlining out unnecessary repetition of BCD feature names
- in keeping with the principle of making use of frontmatter metadata to store data — BCD feature names - rather than having the BCD feature names in the prose body of documents

...this takes BCD feature names out of the arguments to the `Compat` macro, and moves those BCD feature names into the value of the `browser-compat` frontmatter metadata key.

I separated out these changes to the `webextensions` subtree into a different PR than https://github.com/mdn/content/pull/16737 because I’m not as familiar with the contents of these docs, so it seem prudent to ensure the changes get specific review from Web Extensions reviewers.