### PR TITLE
Fix title in wasm reference variable instructions

### DIFF
--- a/files/en-us/webassembly/reference/variables/index.md
+++ b/files/en-us/webassembly/reference/variables/index.md
@@ -1,5 +1,5 @@
 ---
-title: WebAssembly numeric comparison
+title: WebAssembly variable instructions
 slug: WebAssembly/Reference/Variables
 tags:
   - WebAssembly


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Changes title on https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Variables from `Webassembly numeric comparison` to `Webassembly variable instructions`.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The title did not reflect the content on the page.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
n/a

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
n/a

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
