### PR TITLE
Remove references to bitwise ops in wasm memory page

### DIFF
--- a/files/en-us/webassembly/reference/memory/index.md
+++ b/files/en-us/webassembly/reference/memory/index.md
@@ -1,5 +1,5 @@
 ---
-title: WebAssembly memory
+title: WebAssembly memory instructions
 slug: WebAssembly/Reference/Memory
 tags:
   - WebAssembly

--- a/files/en-us/webassembly/reference/memory/index.md
+++ b/files/en-us/webassembly/reference/memory/index.md
@@ -10,9 +10,7 @@ tags:
 ---
 {{WebAssemblySidebar}}
 
-WebAssembly bitwise instructions.
-
-> **Note:** These bitwise instructions are only available for the integer types and not for the floating point types.
+WebAssembly memory instructions.
 
 - [`Grow`](/en-US/docs/WebAssembly/Reference/Memory/Grow)
   - : Increase the size of the memory instance.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
On https://developer.mozilla.org/en-US/docs/WebAssembly/Reference/Memory:
- Changes main content from `webassembly bitwise instructions` to `webassembly memory instructions`
- Removes note about use of bitwise instructions on floats
- Changes title from `Webassembly memory` to `Webassembly memory instructions` to avoid confusion with https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
- the subheading is not what the content is about
- the note is not related to the page's content
- avoids confusion with https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/Memory (thanks to @OnkarRuikar for pointing this out)

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
n/a

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
n/a

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
