### PR TITLE
Updated the domxref links for Gameapd API

### DIFF
--- a/files/en-us/web/api/gamepadevent/index.md
+++ b/files/en-us/web/api/gamepadevent/index.md
@@ -11,7 +11,7 @@ browser-compat: api.GamepadEvent
 ---
 {{APIRef("Gamepad API")}}{{securecontext_header}}
 
-The GamepadEvent interface of the Gamepad API contains references to gamepads connected to the system, which is what the gamepad events {{domxref("Window.gamepadconnected")}} and {{domxref("Window.gamepaddisconnected")}} are fired in response to.
+The GamepadEvent interface of the Gamepad API contains references to gamepads connected to the system, which is what the gamepad events {{domxref("Window.gamepadconnected_event","gamepadconnected")}} and {{domxref("Window.gamepaddisconnected_event","gamepaddisconnected")}} are fired in response to.
 
 {{InheritanceDiagram}}
 
@@ -27,7 +27,7 @@ The GamepadEvent interface of the Gamepad API contains references to gamepads co
 
 ## Examples
 
-The gamepad property being called on a fired {{domxref("Window.gamepadconnected")}} event.
+The gamepad property being called on a fired {{domxref("Window.gamepadconnected_event", "gamepadconnected")}} event.
 
 ```js
 window.addEventListener("gamepadconnected", function(e) {
@@ -37,7 +37,7 @@ window.addEventListener("gamepadconnected", function(e) {
 });
 ```
 
-And on a {{domxref("Window.gamepaddisconnected")}} event.
+And on a {{domxref("Window.gamepaddisconnected_event","gamepaddisconnected")}} event.
 
 ```js
 window.addEventListener("gamepaddisconnected", function(e) {

--- a/files/en-us/web/api/gamepadevent/index.md
+++ b/files/en-us/web/api/gamepadevent/index.md
@@ -11,7 +11,7 @@ browser-compat: api.GamepadEvent
 ---
 {{APIRef("Gamepad API")}}{{securecontext_header}}
 
-The GamepadEvent interface of the Gamepad API contains references to gamepads connected to the system, which is what the gamepad events {{domxref("Window.gamepadconnected_event","gamepadconnected")}} and {{domxref("Window.gamepaddisconnected_event","gamepaddisconnected")}} are fired in response to.
+The GamepadEvent interface of the Gamepad API contains references to gamepads connected to the system, which is what the gamepad events {{domxref("Window.gamepadconnected_event", "gamepadconnected")}} and {{domxref("Window.gamepaddisconnected_event", "gamepaddisconnected")}} are fired in response to.
 
 {{InheritanceDiagram}}
 
@@ -37,7 +37,7 @@ window.addEventListener("gamepadconnected", function(e) {
 });
 ```
 
-And on a {{domxref("Window.gamepaddisconnected_event","gamepaddisconnected")}} event.
+And on a {{domxref("Window.gamepaddisconnected_event", "gamepaddisconnected")}} event.
 
 ```js
 window.addEventListener("gamepaddisconnected", function(e) {


### PR DESCRIPTION
links for connected and disconnected were changed to the ones as seen in https://developer.mozilla.org/en-US/docs/Web/API/Gamepad_API - the current ones don't work

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

I noticed when browsing this page that the links for `window.gamepadconnected` and it's `disconnected` counterpart were broken.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

Noticed this was a problem right after I noticed working links for the two events on the [Gamepad API](https://developer.mozilla.org/en-US/docs/Web/API/Gamepad_API). Over here the links actually worked.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

[The Gamepad API markdown page](https://github.com/mdn/content/blob/73cc9b528b45a869992d268f119853021b33d454/files/en-us/web/api/gamepad_api/index.md) is what I'm basing the changes off of, since the links over here work on the site itself

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
N/A

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
