### PR TITLE
OpenSearch is replaced by WebExtension API for published add-ons

### DIFF
--- a/files/en-us/web/opensearch/index.md
+++ b/files/en-us/web/opensearch/index.md
@@ -18,6 +18,8 @@ Firefox also supports additional features not in the OpenSearch standard, such a
 
 OpenSearch description files can be advertised as described in [Autodiscovery of search plugins](#autodiscovery_of_search_plugins), and can be installed programmatically as described in [Adding search engines from web pages](/en-US/docs/Web/OpenSearch).
 
+OpenSearch plugins can't be uploaded anymore on AMO. Search engine feature must use WebExtension API with [chrome settings](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides) in `manifest.json` file.
+
 ## OpenSearch description file
 
 The XML file that describes a search engine follows the basic template below. Sections in _\[square brackets]_ should be customized for the specific plugin you're writing.

--- a/files/en-us/web/opensearch/index.md
+++ b/files/en-us/web/opensearch/index.md
@@ -18,7 +18,7 @@ Firefox also supports additional features not in the OpenSearch standard, such a
 
 OpenSearch description files can be advertised as described in [Autodiscovery of search plugins](#autodiscovery_of_search_plugins), and can be installed programmatically as described in [Adding search engines from web pages](/en-US/docs/Web/OpenSearch).
 
-OpenSearch plugins can't be uploaded anymore on AMO. Search engine feature must use WebExtension API with [chrome settings](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides) in `manifest.json` file.
+OpenSearch plugins can't be uploaded anymore on [addons.mozilla.org](https://addons.mozilla.org) (AMO). Search engine feature must use WebExtension API with [chrome settings](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides) in `manifest.json` file.
 
 ## OpenSearch description file
 

--- a/files/en-us/web/opensearch/index.md
+++ b/files/en-us/web/opensearch/index.md
@@ -16,7 +16,7 @@ The **[OpenSearch description format](https://github.com/dewitt/opensearch)** le
 
 Firefox also supports additional features not in the OpenSearch standard, such as search suggestions and the `<SearchForm>` element. This article focuses on creating OpenSearch-compatible search plugins that support these additional Firefox features.
 
-OpenSearch description files can be advertised as described in [Autodiscovery of search plugins](#autodiscovery_of_search_plugins), and can be installed programmatically as described in [Adding search engines from web pages](/en-US/docs/Web/OpenSearch).
+OpenSearch description files can be advertised as described in [Autodiscovery of search plugins](#autodiscovery_of_search_plugins), and can be installed programmatically.
 
 > **Warning:** OpenSearch plugins can't be uploaded anymore on [addons.mozilla.org](https://addons.mozilla.org) (AMO). Search engine feature must use WebExtension API with [chrome settings](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides) in `manifest.json` file.
 

--- a/files/en-us/web/opensearch/index.md
+++ b/files/en-us/web/opensearch/index.md
@@ -18,7 +18,7 @@ Firefox also supports additional features not in the OpenSearch standard, such a
 
 OpenSearch description files can be advertised as described in [Autodiscovery of search plugins](#autodiscovery_of_search_plugins), and can be installed programmatically as described in [Adding search engines from web pages](/en-US/docs/Web/OpenSearch).
 
-OpenSearch plugins can't be uploaded anymore on [addons.mozilla.org](https://addons.mozilla.org) (AMO). Search engine feature must use WebExtension API with [chrome settings](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides) in `manifest.json` file.
+> **Warning:** OpenSearch plugins can't be uploaded anymore on [addons.mozilla.org](https://addons.mozilla.org) (AMO). Search engine feature must use WebExtension API with [chrome settings](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/chrome_settings_overrides) in `manifest.json` file.
 
 ## OpenSearch description file
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
The PR updates documentation to help developers of search engine add-ons to use the supported tool (WebExtension instead of OpenSearch).

#### Motivation
This need has been discussed in #3148. However, no patch was provided. So I made this one.

#### Related issues
Fixes #3148
