### PR TITLE
Drop unnecessary subheadings from Browser Compatibility sections

### DIFF
--- a/files/en-us/web/api/css_font_loading_api/index.md
+++ b/files/en-us/web/api/css_font_loading_api/index.md
@@ -32,6 +32,4 @@ The CSS Font Loading API provides events and interfaces for dynamically loading 
 
 ## Browser compatibility
 
-### FontFace
-
 {{Compat}}

--- a/files/en-us/web/api/mediastream_recording_api/index.md
+++ b/files/en-us/web/api/mediastream_recording_api/index.md
@@ -132,8 +132,6 @@ To learn more about using the MediaStream Recording API, see [Using the MediaStr
 
 ## Browser compatibility
 
-### `MediaRecorder`
-
 {{Compat}}
 
 ## See also

--- a/files/en-us/web/css/fit-content/index.md
+++ b/files/en-us/web/css/fit-content/index.md
@@ -66,8 +66,6 @@ block-size: fit-content
 
 ## Browser compatibility
 
-### Supported for width (and other sizing properties)
-
 {{Compat}}
 
 ## See also

--- a/files/en-us/web/css/max-content/index.md
+++ b/files/en-us/web/css/max-content/index.md
@@ -109,8 +109,6 @@ max-content: unset;
 
 ## Browser compatibility
 
-### Supported for width (and other sizing properties)
-
 {{Compat}}
 
 ## See also

--- a/files/en-us/web/css/min-content/index.md
+++ b/files/en-us/web/css/min-content/index.md
@@ -101,6 +101,4 @@ min-content: unset;
 
 ## Browser compatibility
 
-### Supported for width (and other sizing properties)
-
 {{Compat}}

--- a/files/en-us/web/svg/attribute/crossorigin/index.md
+++ b/files/en-us/web/svg/attribute/crossorigin/index.md
@@ -58,8 +58,6 @@ It follows the same processing rules as the HTML attribute {{htmlattrxref("cross
 
 ## Browser compatibility
 
-### \<link crossorigin>
-
 {{Compat}}
 
 <!-- TODO: This should link to an attribute of the element instead


### PR DESCRIPTION
The BCD table header rows already provide the information about what features they’re for. Putting subheadings in the Browser Compatibility section is inconsistent with the vast majority of other documents, which have no subheadings in their Browser Compatibility sections.