### PR TITLE
Move more compat data into browser-compat key

### DIFF
--- a/files/en-us/web/api/badging_api/index.md
+++ b/files/en-us/web/api/badging_api/index.md
@@ -7,6 +7,7 @@ tags:
   - Overview
   - Reference
   - Badging API
+browser-compat: api.Navigator.setAppBadge
 ---
 {{DefaultAPISidebar("Badging API")}}
 
@@ -92,7 +93,11 @@ navigator.setAppBadge(12)
 
 ## Specifications
 
-{{Specifications("api.Navigator.setAppBadge")}}
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/constraint_validation/index.md
+++ b/files/en-us/web/api/constraint_validation/index.md
@@ -7,6 +7,7 @@ tags:
   - Constraint validation
   - Landing
   - Reference
+browser-compat: api.ValidityState
 ---
 {{apiref()}}
 
@@ -107,7 +108,11 @@ In brief:
 
 ## Specifications
 
-{{Specifications("api.ValidityState")}}
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/css_painting_api/index.md
+++ b/files/en-us/web/api/css_painting_api/index.md
@@ -9,6 +9,7 @@ tags:
   - Houdini
   - Painting
   - Reference
+browser-compat: api.PaintWorkletGlobalScope
 ---
 {{DefaultAPISidebar("CSS Painting API")}}
 
@@ -145,11 +146,11 @@ While you can't play with the worklet's script, you can alter the custom propert
 
 ## Specifications
 
-{{Specifications("api.PaintWorkletGlobalScope")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-See the browser compatibility data for each CSS Painting API Interface.
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/api/css_properties_and_values_api/index.md
+++ b/files/en-us/web/api/css_properties_and_values_api/index.md
@@ -4,6 +4,7 @@ slug: Web/API/CSS_Properties_and_Values_API
 page-type: web-api-overview
 tags:
   - Houdini
+browser-compat: api.CSS.registerProperty
 ---
 {{SeeCompatTable}} The **CSS Properties and Values API** — part of the [CSS Houdini](/en-US/docs/Web/Guide/Houdini) umbrella of APIs — allows developers to explicitly define their {{cssxref('--*', 'CSS custom properties')}}, allowing for property type checking, default values, and properties that do or do not inherit their value.
 
@@ -39,11 +40,11 @@ The same registration can take place in [CSS](/en-US/docs/Web/CSS) using the {{c
 
 ## Specifications
 
-{{Specifications("api.CSS.registerProperty")}}
+{{Specifications}}
 
 ## Browser compatibility
 
-See individual interfaces
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/css/css_display/index.md
+++ b/files/en-us/web/css/css_display/index.md
@@ -69,8 +69,6 @@ browser-compat: css.properties.display
 
 {{Specifications}}
 
-In addition to the CSS Display Specification Level 3, further specifications define the behavior of various values of display.
-
 ## Browser compatibility
 
-{{Compat("css.properties.display", 10)}}
+{{Compat}}

--- a/files/en-us/web/css/overflow-anchor/guide_to_scroll_anchoring/index.md
+++ b/files/en-us/web/css/overflow-anchor/guide_to_scroll_anchoring/index.md
@@ -6,6 +6,7 @@ tags:
   - Guide
   - overflow-anchor
   - scroll anchoring
+browser-compat: css.properties.overflow-anchor
 ---
 {{CSSRef}}
 
@@ -81,6 +82,9 @@ Additionally, {{cssxref("position")}} changes anywhere inside the scrolling box 
 
 ## Browser compatibility
 
+{{Compat}}
+
+### Compatibility notes
+
 If you need to test whether scroll anchoring is available in a browser, use [Feature Queries](/en-US/docs/Web/CSS/@supports) to test support for the `overflow-anchor` property.
 
-{{Compat("css.properties.overflow-anchor")}}


### PR DESCRIPTION
This is another round of moving BCD feature names into the browser-compat key.