### PR TITLE
Rectify awkwardness in “Window.frames” doc

### DIFF
--- a/files/en-us/web/api/window/frames/index.md
+++ b/files/en-us/web/api/window/frames/index.md
@@ -26,7 +26,7 @@ A list of frame objects. It is similar to an
 - `frameList === window` evaluates to true.
 - Each item in the window\.frames pseudo-array represents the {{domxref("Window")}}
   object corresponding to the given {{HTMLElement("frame")}}'s or
-  {{HTMLElement("iframe")}}'s content, not the iframe DOM element (i.e.,
+  {{HTMLElement("iframe")}}'s content, not the `frame` or `iframe` DOM element (i.e.,
   `window.frames[0]` is the same thing as
   `document.getElementsByTagName("iframe")[0].contentWindow`).
 - For more details about the returned value, refer to this [thread on mozilla.dev.platform](https://groups.google.com/d/topic/mozilla.dev.platform/VijG80aFnU8?hl=en&pli=1).

--- a/files/en-us/web/api/window/frames/index.md
+++ b/files/en-us/web/api/window/frames/index.md
@@ -26,7 +26,7 @@ A list of frame objects. It is similar to an
 - `frameList === window` evaluates to true.
 - Each item in the window\.frames pseudo-array represents the {{domxref("Window")}}
   object corresponding to the given {{HTMLElement("frame")}}'s or
-  {{HTMLElement("iframe")}}'s content, not the (i)frame DOM element (i.e.,
+  {{HTMLElement("iframe")}}'s content, not the iframe DOM element (i.e.,
   `window.frames[0]` is the same thing as
   `document.getElementsByTagName("iframe")[0].contentWindow`).
 - For more details about the returned value, refer to this [thread on mozilla.dev.platform](https://groups.google.com/d/topic/mozilla.dev.platform/VijG80aFnU8?hl=en&pli=1).


### PR DESCRIPTION
iframe was written as (i)frame, this has been corrected in this PR

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
iframe was written as (i)frame, this has been corrected in this PR
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
