### PR TITLE
Js reference update

### DIFF
--- a/files/en-us/web/javascript/reference/index.md
+++ b/files/en-us/web/javascript/reference/index.md
@@ -321,6 +321,10 @@ This part of the JavaScript section on MDN serves as a repository of facts about
 - {{JSxRef("Functions/get", "getter", "", 1)}}
 - {{JSxRef("Functions/set", "setter", "", 1)}}
 
+## Classes
+
+[JavaScript classes.](/en-US/docs/Web/JavaScript/Reference/Classes)
+
 ## Additional reference pages
 
 - {{JSxRef("Lexical_grammar", "", "", 1)}}

--- a/files/en-us/web/javascript/reference/index.md
+++ b/files/en-us/web/javascript/reference/index.md
@@ -313,10 +313,10 @@ This part of the JavaScript section on MDN serves as a repository of facts about
 
 This chapter documents how to work with [JavaScript functions](/en-US/docs/Web/JavaScript/Reference/Functions) to develop your applications.
 
-- [`arguments`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments)
-- [Arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions)
-- [Default parameters](/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters)
-- [Rest parameters](/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters)
+- {{JSxRef("Functions/arguments", "arguments")}}
+- {{JSXRef("Functions/Arrow_functions", "Arrow Functions", "", 1)}}
+- {{JSxRef("Functions/Default_parameters", "Default parameters", "", 1)}}
+- {{JSxRef("Functions/rest_parameters", "Rest parameters", "", 1)}}
 
 ## Additional reference pages
 

--- a/files/en-us/web/javascript/reference/index.md
+++ b/files/en-us/web/javascript/reference/index.md
@@ -311,12 +311,15 @@ This part of the JavaScript section on MDN serves as a repository of facts about
 
 ## Functions
 
-This chapter documents how to work with [JavaScript functions](/en-US/docs/Web/JavaScript/Reference/Functions) to develop your applications.
+[JavaScript functions.](/en-US/docs/Web/JavaScript/Reference/Functions)
 
-- {{JSxRef("Functions/arguments", "arguments")}}
 - {{JSXRef("Functions/Arrow_functions", "Arrow Functions", "", 1)}}
 - {{JSxRef("Functions/Default_parameters", "Default parameters", "", 1)}}
 - {{JSxRef("Functions/rest_parameters", "Rest parameters", "", 1)}}
+- {{JSxRef("Functions/arguments", "arguments")}}
+- {{JSxRef("Functions/Method_definitions", "Method definitions", "", 1)}}
+- {{JSxRef("Functions/get", "getter", "", 1)}}
+- {{JSxRef("Functions/set", "setter", "", 1)}}
 
 ## Additional reference pages
 

--- a/files/en-us/web/javascript/reference/index.md
+++ b/files/en-us/web/javascript/reference/index.md
@@ -320,7 +320,7 @@ This chapter documents how to work with [JavaScript functions](/en-US/docs/Web/J
 
 ## Additional reference pages
 
-- [Lexical grammar](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar)
+- {{JSxRef("Lexical_grammar", "", "", 1)}}
 - [Data types and data structures](/en-US/docs/Web/JavaScript/Data_structures)
-- [Strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode)
-- [Deprecated features](/en-US/docs/Web/JavaScript/Reference/Deprecated_and_obsolete_features)
+- {{JSxRef("Strict_mode", "Strict mode", "", 1)}}
+- {{JSxRef("Deprecated_and_obsolete_features", "Deprecated features", "", 1)}}

--- a/files/en-us/web/javascript/reference/index.md
+++ b/files/en-us/web/javascript/reference/index.md
@@ -327,7 +327,7 @@ This part of the JavaScript section on MDN serves as a repository of facts about
 
 ## Additional reference pages
 
-- {{JSxRef("Lexical_grammar", "", "", 1)}}
+- {{JSxRef("Lexical_grammar", "Lexical grammar", "", 1)}}
 - [Data types and data structures](/en-US/docs/Web/JavaScript/Data_structures)
 - {{JSxRef("Strict_mode", "Strict mode", "", 1)}}
 - {{JSxRef("Deprecated_and_obsolete_features", "Deprecated features", "", 1)}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

- Updated Functions section of the references to use `JSxRef` macros.
- Added Classes section which was previously **only assessable from search**.

Note: The classes section of JavaScript Reference is very underdeveloped.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

While searching through the docs, I found that the [Classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes) was not visible in the Reference page and was only accessible through search, so I added it to make things consistent. 

While doing so I also updated the Functions section to use `JSxRef` macros.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [X] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
