### PR TITLE
Elaborate on Array.@@species behavior, new Promise.@@species page

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/@@species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/@@species/index.md
@@ -10,8 +10,7 @@ browser-compat: javascript.builtins.Array.@@species
 ---
 {{JSRef}}
 
-The **`Array[@@species]`** accessor property returns the
-`Array` constructor.
+The **`Array[@@species]`** accessor property returns the constructor used to construct return values from array methods.
 
 ## Syntax
 
@@ -21,23 +20,53 @@ Array[Symbol.species]
 
 ### Return value
 
-The {{jsxref("Array")}} constructor.
+The value of the constructor (`this`) on which `get @@species` was called. The return value is used to construct return values from array methods that create new arrays.
 
 ## Description
 
-The `species` accessor property returns the default constructor for
-`Array` objects. Subclass constructors may override it to change the
-constructor assignment.
+The `@@species` accessor property returns the default constructor for `Array` objects. Subclass constructors may override it to change the constructor assignment. The default implementation is basically:
+
+```js
+// Hypothetical underlying implementation for illustration
+class Array {
+  static get [Symbol.species]() {
+    return this;
+  }
+}
+```
+
+Because of this polymorphic implementation, `@@species` of derived subclasses would also return the constructor itself by default.
+
+```js
+class SubArray extends Array {}
+SubArray[Symbol.species] === SubArray; // true
+```
+
+When calling array methods that do not mutate the existing array but return a new array instance (for example, `filter` and `map`), the array's `constructor[@@species]` will be accessed. The returned constructor will be used to construct the return value of the array method. This makes it technically possible to make array methods return objects unrelated to arrays.
+
+```js
+class NotAnArray {
+  constructor(length) {
+    this.length = length;
+  }
+}
+
+const arr = [0, 1, 2];
+arr.constructor = { [Symbol.species]: NotAnArray };
+arr.map(i => i); // NotAnArray { '0': 0, '1': 1, '2': 2, length: 3 }
+arr.filter(i => i); // NotAnArray { '0': 1, '1': 2, length: 0 }
+arr.concat([1, 2]); // NotAnArray { '0': 0, '1': 1, '2': 2, '3': 1, '4': 2, length: 5 }
+```
 
 ## Examples
 
 ### Species in ordinary objects
 
-The `species` property returns the default constructor function, which is
-the `Array` constructor for `Array` objects:
+The `@@species` property returns the default constructor function, which is
+the `Array` constructor for `Array`.
 
 ```js
-Array[Symbol.species]; // function Array()
+Array[Symbol.species]; // [Function: Array]
 ```
 
 ### Species in derived objects

--- a/files/en-us/web/javascript/reference/global_objects/promise/@@species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/@@species/index.md
@@ -31,7 +31,7 @@ Promise[Symbol.species]; // [Function: Promise]
 
 ### Species in derived objects
 
-In an instance of a derived class from `Promise` (e.g. your custom `MyPromise`), the `MyPromise` species is the `MyPromise` constructor. However, you might want to overwrite this, in order to return parent `Promise` objects in your derived class methods.
+In an instance of a derived class from `Promise` (e.g. your custom `MyPromise`), the `MyPromise` species is the `MyPromise` constructor. However, you might want to override this, in order to return parent `Promise` objects in your derived class methods.
 
 ```js
 class MyPromise extends Promise {

--- a/files/en-us/web/javascript/reference/global_objects/promise/@@species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/@@species/index.md
@@ -31,7 +31,7 @@ Promise[Symbol.species]; // [Function: Promise]
 
 ### Species in derived objects
 
-In an instance of a derived class from `Promise` (e.g. your custom `MyPromise`), the `MyPromise` species is the `MyPromise` constructor. However, you might want to override this, in order to return parent `Promise` objects in your derived class methods.
+In an instance of a derived class from `Promise` (e.g. your custom `MyPromise`), the `MyPromise` species is the `MyPromise` constructor. However, you might want to overwrite this, in order to return parent `Promise` objects in your derived class methods.
 
 ```js
 class MyPromise extends Promise {

--- a/files/en-us/web/javascript/reference/global_objects/promise/@@species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/@@species/index.md
@@ -35,7 +35,7 @@ In an instance of a derived class from `Promise` (e.g. your custom `MyPromise`),
 
 ```js
 class MyPromise extends Promise {
-  // Overwrite MyPromise species to the parent Promise constructor
+  // Override MyPromise species to the parent Promise constructor
   static get [Symbol.species]() { return Promise; }
 }
 ```

--- a/files/en-us/web/javascript/reference/global_objects/promise/@@species/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/@@species/index.md
@@ -1,0 +1,75 @@
+---
+title: get Promise[@@species]
+slug: Web/JavaScript/Reference/Global_Objects/Promise/@@species
+tags:
+  - ECMAScript 2015
+  - JavaScript
+  - Method
+  - Promise
+  - Reference
+browser-compat: javascript.builtins.Promise.@@species
+---
+{{JSRef}}
+
+The **`Promise[@@species]`** accessor property returns the constructor used to construct return values from promise methods.
+
+## Description
+
+The `@@species` accessor property returns the default constructor for `Promise` objects. Subclass constructors may override it to change the constructor assignment.
+
+When chaining promise methods like `then`, `finally`, etc., the instance's `constructor[@@species]` will be accessed. The returned constructor will be used to construct the return value of the promise method.
+
+## Examples
+
+### Species in ordinary objects
+
+The `Symbol.species` property returns the default constructor function, which is the `Promise` constructor for `Promise` objects.
+
+```js
+Promise[Symbol.species]; // [Function: Promise]
+```
+
+### Species in derived objects
+
+In an instance of a derived class from `Promise` (e.g. your custom `MyPromise`), the `MyPromise` species is the `MyPromise` constructor. However, you might want to overwrite this, in order to return parent `Promise` objects in your derived class methods.
+
+```js
+class MyPromise extends Promise {
+  // Overwrite MyPromise species to the parent Promise constructor
+  static get [Symbol.species]() { return Promise; }
+}
+```
+
+By default, promise methods would return promises with the type of the subclass.
+
+```js
+class MyPromise extends Promise {
+  someValue = 1;
+}
+
+console.log(MyPromise.resolve(1).then(() => {}).someValue); // 1
+```
+
+By overriding `@@species`, the promise methods will return the base `Promise` type.
+
+```js
+class MyPromise extends Promise {
+  someValue = 1;
+  static get [Symbol.species]() { return Promise; }
+}
+
+console.log(MyPromise.resolve(1).then(() => {}).someValue); // undefined
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{jsxref("Array")}}
+- {{jsxref("Symbol.species")}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

I found the docs a bit lacking in this regard, so decided to elaborate on `Array.@@species` behavior because it's... quite interesting.

Also completed the missing `Promise.@@species` page.

I didn't sync the same content across all `@@species` pages because frankly some species are less interesting than others. (e.g. `Map.@@species` AFAIK is not used anywhere internally, and `RegExp.@@species` is not used in any "interesting" places.) Let me know if it's important to keep them in sync.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details

https://tc39.es/ecma262/#sec-get-promise-@@species

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
