### PR TITLE
Use flexbox for "styling links" example

### DIFF
--- a/files/en-us/learn/css/styling_text/styling_links/index.md
+++ b/files/en-us/learn/css/styling_text/styling_links/index.md
@@ -381,7 +381,7 @@ So that's it. Try revisiting the active learning section above and trying this n
 
 The tools you've explored so far in this article can also be used in other ways. For example, states like hover can be used to style many different elements, not just links — you might want to style the hover state of paragraphs, list items, or other things.
 
-In addition, links are quite commonly styled to look and behave like buttons in certain circumstances. A website navigation menu can be marked up as a set of links, and this can be easily styled to look like a set of control buttons or tabs that provide the user with access to other parts of the site. Let's explore how.
+In addition, links are quite commonly styled to look and behave like buttons in certain circumstances. A website navigation menu can be marked up as a set of links, and this can be styled to look like a set of control buttons or tabs that provide the user with access to other parts of the site. Let's explore how.
 
 First, some HTML:
 

--- a/files/en-us/learn/css/styling_text/styling_links/index.md
+++ b/files/en-us/learn/css/styling_text/styling_links/index.md
@@ -441,7 +441,7 @@ The CSS includes the styling for the container and the links it contains.
   - The container is a [flexbox](/en-US/docs/Learn/CSS/CSS_layout/Flexbox). The items it contains — the links, in this case — will be *flex items*.
   - The gap between the flex items will be `0.625%` of the container's width.
 - The third rule styles the links.
-  - The first declaration, `flex: 1`, meaning that the items will expand so they use all the available space in the container.
+  - The first declaration, `flex: 1`, meaning that the widths of the items will be adjusted so they use all the available space in the container.
   - Next, we turn off the default {{cssxref("text-decoration")}} and {{cssxref("outline")}} — we don't want those spoiling our look.
   - The last three declarations are to center the text inside each link, set the {{cssxref("line-height")}} to 3 to give the buttons some height (which also has the advantage of centering the text vertically), and set the text color to black.
 

--- a/files/en-us/learn/css/styling_text/styling_links/index.md
+++ b/files/en-us/learn/css/styling_text/styling_links/index.md
@@ -381,14 +381,18 @@ So that's it. Try revisiting the active learning section above and trying this n
 
 The tools you've explored so far in this article can also be used in other ways. For example, states like hover can be used to style many different elements, not just links — you might want to style the hover state of paragraphs, list items, or other things.
 
-In addition, links are quite commonly styled to look and behave like buttons in certain circumstances. A website navigation menu is usually marked up as a list containing links, and this can be easily styled to look like a set of control buttons or tabs that provide the user with access to other parts of the site. Let's explore how.
+In addition, links are quite commonly styled to look and behave like buttons in certain circumstances. A website navigation menu can be marked up as a set of links, and this can be easily styled to look like a set of control buttons or tabs that provide the user with access to other parts of the site. Let's explore how.
 
 First, some HTML:
 
 ```html
-<ul>
-  <li><a href="#">Home</a></li><li><a href="#">Pizza</a></li><li><a href="#">Music</a></li><li><a href="#">Wombats</a></li><li><a href="#">Finland</a></li>
-</ul>
+<nav class="container">
+  <a href="#">Home</a>
+  <a href="#">Pizza</a>
+  <a href="#">Music</a>
+  <a href="#">Wombats</a>
+  <a href="#">Finland</a>
+</nav>
 ```
 
 And now our CSS:
@@ -399,28 +403,17 @@ body,html {
   font-family: sans-serif;
 }
 
-ul {
-  padding: 0;
-  width: 100%;
-}
-
-li {
-  display: inline;
+.container {
+  display: flex;
+  gap: 0.625%;
 }
 
 a {
-  outline: none;
+  flex: 1;
   text-decoration: none;
-  display: inline-block;
-  width: 19.5%;
-  margin-right: 0.625%;
   text-align: center;
   line-height: 3;
   color: black;
-}
-
-li:last-child a {
-  margin-right: 0;
 }
 
 a:link, a:visited, a:focus {
@@ -441,18 +434,16 @@ This gives us the following result:
 
 {{ EmbedLiveSample('Styling_links_as_buttons', '100%', 120) }}
 
-Let's explain what's going on here, focusing on the most interesting parts:
+The HTML defines a {{HTMLElement("nav")}} element with a `"container"` class. The `<nav>` contains our links.
 
-- Our second rule removes the default {{cssxref("padding")}} from the {{htmlelement("ul")}} element, and sets its width to span 100% of the outer container (the {{htmlelement("body")}}, in this case).
-- {{htmlelement("li")}} elements are normally block by default (see [types of CSS boxes](/en-US/docs/Learn/CSS/Building_blocks/The_box_model#types_of_css_boxes) for a refresher), meaning that they will sit on their own lines. In this case, we are creating a horizontal list of links, so in the third rule we set the {{cssxref("display")}} property to inline, which causes the list items to sit on the same line as one another. They now behave like inline elements.
-- The fourth rule — which styles the {{htmlelement("a")}} element — is the most complicated here. Let's go through it step by step:
-
-  - As in previous examples, we start by turning off the default {{cssxref("text-decoration")}} and {{cssxref("outline")}} — we don't want those spoiling our look.
-  - Next, we set the {{cssxref("display")}} to `inline-block`. {{htmlelement("a")}} elements are inline by default and, while we don't want them to spill onto their own lines like a value of `block` would achieve, we do want to be able to size them. `inline-block` allows us to do this.
-  - Now onto the sizing! We want to fill up the whole width of the {{htmlelement("ul")}} and leave a little margin between each button (but not a gap at the right-hand edge). We also have 5 buttons whose sizes should all be the same. To do this, we set the {{cssxref("width")}} to 19.5% and the {{cssxref("margin-right")}} to 0.625%. You'll notice that all this width adds up to 100.625%, which would make the last button overflow the `<ul>` and fall down to the next line. However, we take it back down to 100% using the next rule, which selects only the last `<a>` in the list and removes the margin from it. Done!
-  - The last three declarations are pretty simple and are mainly just for cosmetic purposes. We center the text inside each link, set the {{cssxref("line-height")}} to 3 to give the buttons some height (which also has the advantage of centering the text vertically), and set the text color to black.
-
-> **Note:** You may have noticed that the list items in the HTML are all put on the same line as each other. This is done because spaces/line breaks in between inline block elements create spaces on the page, just like the spaces in between words; however, such spaces would break our horizontal navigation menu layout. So we've removed them. You can find more information about this problem (and solutions) at [Fighting the space between inline block elements](https://css-tricks.com/fighting-the-space-between-inline-block-elements/).
+The CSS includes the styling for the container and the links it contains.
+- The second rule says:
+  - The container is a [flexbox](/en-US/docs/Learn/CSS/CSS_layout/Flexbox). The items it contains — the links, in this case — will be *flex items*.
+  - The gap between the flex items will be `0.625%` of the container's width.
+- The third rule styles the links.
+  - The first declaration, `flex: 1`, meaning that the items will expand so they use all the available space in the container.
+  - Next, we turn off the default {{cssxref("text-decoration")}} and {{cssxref("outline")}} — we don't want those spoiling our look.
+  - The last three declarations are to center the text inside each link, set the {{cssxref("line-height")}} to 3 to give the buttons some height (which also has the advantage of centering the text vertically), and set the text color to black.
 
 ## Summary
 

--- a/files/en-us/learn/css/styling_text/styling_links/index.md
+++ b/files/en-us/learn/css/styling_text/styling_links/index.md
@@ -440,8 +440,8 @@ The CSS includes the styling for the container and the links it contains.
 - The second rule says:
   - The container is a [flexbox](/en-US/docs/Learn/CSS/CSS_layout/Flexbox). The items it contains — the links, in this case — will be *flex items*.
   - The gap between the flex items will be `0.625%` of the container's width.
-- The third rule styles the links.
-  - The first declaration, `flex: 1`, meaning that the widths of the items will be adjusted so they use all the available space in the container.
+- The third rule styles the links:
+  - The first declaration, `flex: 1`, means that the widths of the items will be adjusted so they use all the available space in the container.
   - Next, we turn off the default {{cssxref("text-decoration")}} and {{cssxref("outline")}} — we don't want those spoiling our look.
   - The last three declarations are to center the text inside each link, set the {{cssxref("line-height")}} to 3 to give the buttons some height (which also has the advantage of centering the text vertically), and set the text color to black.
 


### PR DESCRIPTION
I was looking at https://github.com/mdn/content/issues/16743 and thought flexbox would be a better solution than the current one.

Then I saw https://github.com/mdn/content/pull/16273 fixes the issue (by removing the formatting). But I still think flexbox is a better solution. So here's a PR that replaces the original with flexbox.

