### PR TITLE
Fix anchor link to 'Targeting media types'

### DIFF
--- a/files/en-us/web/api/window/afterprint_event/index.md
+++ b/files/en-us/web/api/window/afterprint_event/index.md
@@ -10,7 +10,7 @@ browser-compat: api.Window.afterprint_event
 
 The **`afterprint`** event is fired after the associated document has started printing or the print preview has been closed.
 
-The {{domxref("Window.beforeprint_event", "beforeprint")}} and `afterprint` events allow pages to change their content before printing starts (perhaps to remove a banner, for example) and then revert those changes after printing has completed. In general, you should prefer the use of a [`@media print`](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#media_types) CSS at-rule, but it may be necessary to use these events in some cases.
+The {{domxref("Window.beforeprint_event", "beforeprint")}} and `afterprint` events allow pages to change their content before printing starts (perhaps to remove a banner, for example) and then revert those changes after printing has completed. In general, you should prefer the use of a [`@media print`](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#targeting_media_types) CSS at-rule, but it may be necessary to use these events in some cases.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
 I updated the  `@ media print`  link to the 'Targeting media types' anchor.

#### Motivation
The link for `@ media print` pointed to the non-existent anchor 'media_types`'on the 'Using media queries' page.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
