### PR TITLE
Add backpressure information to tee, clone

### DIFF
--- a/files/en-us/web/api/readablestream/tee/index.md
+++ b/files/en-us/web/api/readablestream/tee/index.md
@@ -19,7 +19,7 @@ new {{domxref("ReadableStream")}} instances.
 
 This is useful for allowing two readers to read a stream sequentially or simultaneously,
 perhaps at different speeds.
-You might do this for example in a ServiceWorker if you want to fetch
+For example, you might do this in a ServiceWorker if you want to fetch
 a response from the server and stream it to the browser, but also stream it to the
 ServiceWorker cache. Since a response body cannot be consumed more than once, you'd need
 two copies to do this.
@@ -28,7 +28,7 @@ A teed stream will backpressure to the speed of the *faster* consumed `ReadableS
 and unread data is buffered onto the internal buffer
 of the slower consumed `ReadableStream` without any limit or backpressure.
 If only one branch is consumed, then the entire body will be buffered in memory.
-Therefore, you should not use the build-in `tee()` to read very large streams
+Therefore, you should not use the built-in `tee()` to read very large streams
 in parallel at different speeds.
 Instead, search for an implementation that backpressures
 to the speed of the *slower* consumed branch.

--- a/files/en-us/web/api/readablestream/tee/index.md
+++ b/files/en-us/web/api/readablestream/tee/index.md
@@ -24,12 +24,12 @@ a response from the server and stream it to the browser, but also stream it to t
 ServiceWorker cache. Since a response body cannot be consumed more than once, you'd need
 two copies to do this.
 
-A teed stream will partially signal backpressure at the rate of the *faster* consumer
+A teed stream will partially signal backpressure at the rate of the _faster_ consumer
 of the two `ReadableStream` branches,
 and unread data is enqueued internally on the slower consumed `ReadableStream`
 without any limit or backpressure.
-That is, when *both* branches have an unread element in their internal queue,
-then the original `ReadableStream`’s controller’s queue will start to fill up,
+That is, when _both_ branches have an unread element in their internal queue,
+then the original `ReadableStream`’s controller’s internal queue will start to fill up,
 and once its {{domxref("ReadableStreamDefaultController.desiredSize", "desiredSize")}} ≤ 0
 or byte stream controller {{domxref("ReadableByteStreamController.desiredSize", "desiredSize")}} ≤ 0,
 then the controller will stop calling `pull(controller)` on the
@@ -38,7 +38,7 @@ If only one branch is consumed, then the entire body will be enqueued in memory.
 Therefore, you should not use the built-in `tee()` to read very large streams
 in parallel at different speeds.
 Instead, search for an implementation that fully backpressures
-to the speed of the *slower* consumed branch.
+to the speed of the _slower_ consumed branch.
 
 To cancel the stream you then need to cancel both resulting branches. Teeing a stream
 will generally lock it for the duration, preventing other readers from locking it.

--- a/files/en-us/web/api/readablestream/tee/index.md
+++ b/files/en-us/web/api/readablestream/tee/index.md
@@ -17,11 +17,21 @@ The **`tee()`** method of the
 two-element array containing the two resulting branches as
 new {{domxref("ReadableStream")}} instances.
 
-This is useful for allowing two readers to read a stream simultaneously, perhaps at
-different speeds. You might do this for example in a ServiceWorker if you want to fetch
+This is useful for allowing two readers to read a stream sequentially or simultaneously,
+perhaps at different speeds.
+You might do this for example in a ServiceWorker if you want to fetch
 a response from the server and stream it to the browser, but also stream it to the
 ServiceWorker cache. Since a response body cannot be consumed more than once, you'd need
 two copies to do this.
+
+A teed stream will backpressure to the speed of the *faster* consumed `ReadableStream`,
+and unread data is buffered onto the internal buffer
+of the slower consumed `ReadableStream` without any limit or backpressure.
+If only one branch is consumed, then the entire body will be buffered in memory.
+Therefore, you should not use the build-in `tee()` to read very large streams
+in parallel at different speeds.
+Instead, search for an implementation that backpressures
+to the speed of the *slower* consumed branch.
 
 To cancel the stream you then need to cancel both resulting branches. Teeing a stream
 will generally lock it for the duration, preventing other readers from locking it.

--- a/files/en-us/web/api/request/clone/index.md
+++ b/files/en-us/web/api/request/clone/index.md
@@ -15,10 +15,10 @@ browser-compat: api.Request.clone
 The **`clone()`** method of the {{domxref("Request")}} interface creates a copy of the current `Request` object.
 
 Like the underlying {{domxref("ReadableStream.tee")}} api,
-the {{domxref("Request.body", "body")}} of a cloned `Request`
-will backpressure to the speed of the *faster* consumed `ReadableStream`,
-and unread data is buffered onto the internal buffer
-of the slower consumed `ReadableStream` without any limit or backpressure.
+the {{domxref("Request.body", "body")}} of a cloned `Response`
+will signal backpressure at the rate of the *faster* consumer of the two bodies,
+and unread data is enqueued internally on the slower consumed `body`
+without any limit or backpressure.
 Beware when you construct a `Request` from a stream and then `clone` it.
 
 `clone()` throws a {{jsxref("TypeError")}} if the request body has already been used. In fact, the main reason `clone()` exists is to allow multiple uses of body objects (when they are one-use only.)

--- a/files/en-us/web/api/request/clone/index.md
+++ b/files/en-us/web/api/request/clone/index.md
@@ -14,6 +14,13 @@ browser-compat: api.Request.clone
 
 The **`clone()`** method of the {{domxref("Request")}} interface creates a copy of the current `Request` object.
 
+Like the underlying {{domxref("ReadableStream.tee")}} api,
+the {{domxref("Request.body", "body")}} of a cloned `Request`
+will backpressure to the speed of the *faster* consumed `ReadableStream`,
+and unread data is buffered onto the internal buffer
+of the slower consumed `ReadableStream` without any limit or backpressure.
+Beware when you construct a `Request` from a stream and then `clone` it.
+
 `clone()` throws a {{jsxref("TypeError")}} if the request body has already been used. In fact, the main reason `clone()` exists is to allow multiple uses of body objects (when they are one-use only.)
 
 If you intend to modify the request, you may prefer the {{domxref("Request")}} constructor.

--- a/files/en-us/web/api/request/clone/index.md
+++ b/files/en-us/web/api/request/clone/index.md
@@ -16,7 +16,7 @@ The **`clone()`** method of the {{domxref("Request")}} interface creates a copy 
 
 Like the underlying {{domxref("ReadableStream.tee")}} api,
 the {{domxref("Request.body", "body")}} of a cloned `Response`
-will signal backpressure at the rate of the *faster* consumer of the two bodies,
+will signal backpressure at the rate of the _faster_ consumer of the two bodies,
 and unread data is enqueued internally on the slower consumed `body`
 without any limit or backpressure.
 Beware when you construct a `Request` from a stream and then `clone` it.

--- a/files/en-us/web/api/response/clone/index.md
+++ b/files/en-us/web/api/response/clone/index.md
@@ -16,7 +16,7 @@ The **`clone()`** method of the {{domxref("Response")}} interface creates a clon
 
 Like the underlying {{domxref("ReadableStream.tee")}} api,
 the {{domxref("Response.body", "body")}} of a cloned `Response`
-will signal backpressure at the rate of the *faster* consumer of the two bodies,
+will signal backpressure at the rate of the _faster_ consumer of the two bodies,
 and unread data is enqueued internally on the slower consumed `body`
 without any limit or backpressure.
 Backpressure refers to the mechanism by which the streaming consumer of data

--- a/files/en-us/web/api/response/clone/index.md
+++ b/files/en-us/web/api/response/clone/index.md
@@ -16,11 +16,17 @@ The **`clone()`** method of the {{domxref("Response")}} interface creates a clon
 
 Like the underlying {{domxref("ReadableStream.tee")}} api,
 the {{domxref("Response.body", "body")}} of a cloned `Response`
-will backpressure to the speed of the *faster* consumed `ReadableStream`,
-and unread data is buffered onto the internal buffer
-of the slower consumed `ReadableStream` without any limit or backpressure.
-If only one branch is consumed, then the entire body will be buffered in memory.
-Therefore, you should not use the built-in `clone()` to read very large bodies
+will signal backpressure at the rate of the *faster* consumer of the two bodies,
+and unread data is enqueued internally on the slower consumed `body`
+without any limit or backpressure.
+Backpressure refers to the mechanism by which the streaming consumer of data
+(in this case, the code that reads the body)
+slows down the producer of data (such as the TCP server)
+so as not to load large amounts of data in memory
+that is waiting to be used by the application.
+If only one cloned branch is consumed, then the entire body will be buffered in memory.
+Therefore, `clone()` is one way to read a response twice in sequence,
+but you should not use it to read very large bodies
 in parallel at different speeds.
 
 `clone()` throws a {{jsxref("TypeError")}} if the response body has already been used.

--- a/files/en-us/web/api/response/clone/index.md
+++ b/files/en-us/web/api/response/clone/index.md
@@ -14,6 +14,15 @@ browser-compat: api.Response.clone
 
 The **`clone()`** method of the {{domxref("Response")}} interface creates a clone of a response object, identical in every way, but stored in a different variable.
 
+Like the underlying {{domxref("ReadableStream.tee")}} api,
+the {{domxref("Response.body", "body")}} of a cloned `Response`
+will backpressure to the speed of the *faster* consumed `ReadableStream`,
+and unread data is buffered onto the internal buffer
+of the slower consumed `ReadableStream` without any limit or backpressure.
+If only one branch is consumed, then the entire body will be buffered in memory.
+Therefore, you should not use the build-in `clone()` to read very large bodies
+in parallel at different speeds.
+
 `clone()` throws a {{jsxref("TypeError")}} if the response body has already been used.
 In fact, the main reason `clone()` exists is to allow multiple uses of body objects (when they are one-use only.)
 

--- a/files/en-us/web/api/response/clone/index.md
+++ b/files/en-us/web/api/response/clone/index.md
@@ -20,7 +20,7 @@ will backpressure to the speed of the *faster* consumed `ReadableStream`,
 and unread data is buffered onto the internal buffer
 of the slower consumed `ReadableStream` without any limit or backpressure.
 If only one branch is consumed, then the entire body will be buffered in memory.
-Therefore, you should not use the build-in `clone()` to read very large bodies
+Therefore, you should not use the built-in `clone()` to read very large bodies
 in parallel at different speeds.
 
 `clone()` throws a {{jsxref("TypeError")}} if the response body has already been used.


### PR DESCRIPTION
Add information on what causes backpressure to ReadableStream.tee, Request.clone, Response.clone.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Add warning that `ReadableStream.tee`, `Request.clone`, `Response.clone` will backpressure to the speed of the faster consumer, and unread data will be buffered at the slower `ReadableStream` without limit and without backpressure.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

I researched this issue when I studied the discrepancy between nodejs implementations such as node-fetch and minipass-fetch based on `Readable.pipe` (which backpressures to the slower consumed stream to limit buffering) and browsers (which backpressure to the faster consumed stream and have unlimited buffering). I wrote my findings in https://github.com/node-fetch/node-fetch/issues/1568

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

The original sin was that the implementation of tee in the streams spec backpressured to the faster rather than the slower stream https://github.com/whatwg/streams/pull/311, which contradicted the bounded-buffering suggestion in [Stream requirements:. You must be able to pipe a stream to more than one writable stream.](https://github.com/whatwg/streams/blob/e9355ce79925947e8eb496563d599c329769d315/Requirements.md#you-must-be-able-to-pipe-a-stream-to-more-than-one-writable-stream) which said, “The tee stream can use a number of strategies to govern how the speed of its outputs affect the backpressure signals it gives off, but  the simplest strategy is to pass aggregate backpressure signals directly up the chain, thus letting the speed of the slowest output determine the speed of the tee.”

The informative text in the streams spec is ambiguous; it suggests that tee is useful for “independent” consumers ([Streams Specification: 2.1. Readable Streams](https://streams.spec.whatwg.org/#rs-model), [Streams Specification 4.2.4. ReadableStream example with tee](https://streams.spec.whatwg.org/#example-tee-and-pipe)). But `tee()` is dangerous to use for independent consumers, since the slower consumer buffers without backpressure or limit and will use up all your memory and crash. But if we can’t fix `tee()`, at least we should document its shortcomings.
.
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
