### PR TITLE
Add Web/API page types, part 6

### DIFF
--- a/files/en-us/web/api/document/activeelement/index.md
+++ b/files/en-us/web/api/document/activeelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.activeElement
 slug: Web/API/Document/activeElement
+page-type: web-api-instance-property
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/adoptnode/index.md
+++ b/files/en-us/web/api/document/adoptnode/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.adoptNode()
 slug: Web/API/Document/adoptNode
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/afterscriptexecute_event/index.md
+++ b/files/en-us/web/api/document/afterscriptexecute_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: afterscriptexecute event'
 slug: Web/API/Document/afterscriptexecute_event
+page-type: web-api-event
 tags:
  - Document
  - afterscriptexecute

--- a/files/en-us/web/api/document/alinkcolor/index.md
+++ b/files/en-us/web/api/document/alinkcolor/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.alinkColor
 slug: Web/API/Document/alinkColor
+page-type: web-api-instance-property
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/document/all/index.md
+++ b/files/en-us/web/api/document/all/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.all
 slug: Web/API/Document/all
+page-type: web-api-instance-property
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/document/anchors/index.md
+++ b/files/en-us/web/api/document/anchors/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.anchors
 slug: Web/API/Document/anchors
+page-type: web-api-instance-property
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/document/animationcancel_event/index.md
+++ b/files/en-us/web/api/document/animationcancel_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: animationcancel event'
 slug: Web/API/Document/animationcancel_event
+page-type: web-api-event
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/document/animationend_event/index.md
+++ b/files/en-us/web/api/document/animationend_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: animationend event'
 slug: Web/API/Document/animationend_event
+page-type: web-api-event
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/document/animationiteration_event/index.md
+++ b/files/en-us/web/api/document/animationiteration_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: animationiteration event'
 slug: Web/API/Document/animationiteration_event
+page-type: web-api-event
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/document/animationstart_event/index.md
+++ b/files/en-us/web/api/document/animationstart_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: animationstart event'
 slug: Web/API/Document/animationstart_event
+page-type: web-api-event
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/document/append/index.md
+++ b/files/en-us/web/api/document/append/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.append()
 slug: Web/API/Document/append
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/applets/index.md
+++ b/files/en-us/web/api/document/applets/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.applets
 slug: Web/API/Document/applets
+page-type: web-api-instance-property
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/document/beforescriptexecute_event/index.md
+++ b/files/en-us/web/api/document/beforescriptexecute_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: beforescriptexecute event'
 slug: Web/API/Document/beforescriptexecute_event
+page-type: web-api-event
 tags:
  - Document
  - beforescriptexecute

--- a/files/en-us/web/api/document/bgcolor/index.md
+++ b/files/en-us/web/api/document/bgcolor/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.bgColor
 slug: Web/API/Document/bgColor
+page-type: web-api-instance-property
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/document/body/index.md
+++ b/files/en-us/web/api/document/body/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.body
 slug: Web/API/Document/body
+page-type: web-api-instance-property
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/caretpositionfrompoint/index.md
+++ b/files/en-us/web/api/document/caretpositionfrompoint/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.caretPositionFromPoint()
 slug: Web/API/Document/caretPositionFromPoint
+page-type: web-api-instance-method
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/caretrangefrompoint/index.md
+++ b/files/en-us/web/api/document/caretrangefrompoint/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.caretRangeFromPoint()
 slug: Web/API/Document/caretRangeFromPoint
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/document/characterset/index.md
+++ b/files/en-us/web/api/document/characterset/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.characterSet
 slug: Web/API/Document/characterSet
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/childelementcount/index.md
+++ b/files/en-us/web/api/document/childelementcount/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.childElementCount
 slug: Web/API/Document/childElementCount
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/children/index.md
+++ b/files/en-us/web/api/document/children/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.children
 slug: Web/API/Document/children
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/clear/index.md
+++ b/files/en-us/web/api/document/clear/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.clear()
 slug: Web/API/Document/clear
+page-type: web-api-instance-method
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/document/close/index.md
+++ b/files/en-us/web/api/document/close/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.close()
 slug: Web/API/Document/close
+page-type: web-api-instance-method
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/compatmode/index.md
+++ b/files/en-us/web/api/document/compatmode/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.compatMode
 slug: Web/API/Document/compatMode
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/contenttype/index.md
+++ b/files/en-us/web/api/document/contenttype/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.contentType
 slug: Web/API/Document/contentType
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/cookie/index.md
+++ b/files/en-us/web/api/document/cookie/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.cookie
 slug: Web/API/Document/cookie
+page-type: web-api-instance-property
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/copy_event/index.md
+++ b/files/en-us/web/api/document/copy_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: copy event'
 slug: Web/API/Document/copy_event
+page-type: web-api-event
 tags:
   - API
   - Clipboard API

--- a/files/en-us/web/api/document/createattribute/index.md
+++ b/files/en-us/web/api/document/createattribute/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.createAttribute()
 slug: Web/API/Document/createAttribute
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/createattributens/index.md
+++ b/files/en-us/web/api/document/createattributens/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.createAttributeNS()
 slug: Web/API/Document/createAttributeNS
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/createcdatasection/index.md
+++ b/files/en-us/web/api/document/createcdatasection/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.createCDATASection()
 slug: Web/API/Document/createCDATASection
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/createcomment/index.md
+++ b/files/en-us/web/api/document/createcomment/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.createComment()
 slug: Web/API/Document/createComment
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/createdocumentfragment/index.md
+++ b/files/en-us/web/api/document/createdocumentfragment/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.createDocumentFragment()
 slug: Web/API/Document/createDocumentFragment
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/createelement/index.md
+++ b/files/en-us/web/api/document/createelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.createElement()
 slug: Web/API/Document/createElement
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/createelementns/index.md
+++ b/files/en-us/web/api/document/createelementns/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.createElementNS()
 slug: Web/API/Document/createElementNS
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/createentityreference/index.md
+++ b/files/en-us/web/api/document/createentityreference/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.createEntityReference()
 slug: Web/API/Document/createEntityReference
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/createevent/index.md
+++ b/files/en-us/web/api/document/createevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.createEvent()
 slug: Web/API/Document/createEvent
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/createexpression/index.md
+++ b/files/en-us/web/api/document/createexpression/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.createExpression()
 slug: Web/API/Document/createExpression
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/createnodeiterator/index.md
+++ b/files/en-us/web/api/document/createnodeiterator/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.createNodeIterator()
 slug: Web/API/Document/createNodeIterator
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/creatensresolver/index.md
+++ b/files/en-us/web/api/document/creatensresolver/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.createNSResolver()
 slug: Web/API/Document/createNSResolver
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/createprocessinginstruction/index.md
+++ b/files/en-us/web/api/document/createprocessinginstruction/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.createProcessingInstruction()
 slug: Web/API/Document/createProcessingInstruction
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/createrange/index.md
+++ b/files/en-us/web/api/document/createrange/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.createRange()
 slug: Web/API/Document/createRange
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/createtextnode/index.md
+++ b/files/en-us/web/api/document/createtextnode/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.createTextNode()
 slug: Web/API/Document/createTextNode
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/createtouch/index.md
+++ b/files/en-us/web/api/document/createtouch/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.createTouch()
 slug: Web/API/Document/createTouch
+page-type: web-api-instance-method
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/document/createtouchlist/index.md
+++ b/files/en-us/web/api/document/createtouchlist/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.createTouchList()
 slug: Web/API/Document/createTouchList
+page-type: web-api-instance-method
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/document/createtreewalker/index.md
+++ b/files/en-us/web/api/document/createtreewalker/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.createTreeWalker()
 slug: Web/API/Document/createTreeWalker
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/currentscript/index.md
+++ b/files/en-us/web/api/document/currentscript/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.currentScript
 slug: Web/API/Document/currentScript
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/cut_event/index.md
+++ b/files/en-us/web/api/document/cut_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: cut event'
 slug: Web/API/Document/cut_event
+page-type: web-api-event
 tags:
   - API
   - Clipboard API

--- a/files/en-us/web/api/document/defaultview/index.md
+++ b/files/en-us/web/api/document/defaultview/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.defaultView
 slug: Web/API/Document/defaultView
+page-type: web-api-instance-property
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/designmode/index.md
+++ b/files/en-us/web/api/document/designmode/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.designMode
 slug: Web/API/Document/designMode
+page-type: web-api-instance-property
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/dir/index.md
+++ b/files/en-us/web/api/document/dir/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.dir
 slug: Web/API/Document/dir
+page-type: web-api-instance-property
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/doctype/index.md
+++ b/files/en-us/web/api/document/doctype/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.doctype
 slug: Web/API/Document/doctype
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/document/index.md
+++ b/files/en-us/web/api/document/document/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document()
 slug: Web/API/Document/Document
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/document/documentelement/index.md
+++ b/files/en-us/web/api/document/documentelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.documentElement
 slug: Web/API/Document/documentElement
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/documenturi/index.md
+++ b/files/en-us/web/api/document/documenturi/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.documentURI
 slug: Web/API/Document/documentURI
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/domain/index.md
+++ b/files/en-us/web/api/document/domain/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.domain
 slug: Web/API/Document/domain
+page-type: web-api-instance-property
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/domcontentloaded_event/index.md
+++ b/files/en-us/web/api/document/domcontentloaded_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: DOMContentLoaded event'
 slug: Web/API/Document/DOMContentLoaded_event
+page-type: web-api-event
 tags:
   - API
   - DOMContentLoaded

--- a/files/en-us/web/api/document/drag_event/index.md
+++ b/files/en-us/web/api/document/drag_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: drag event'
 slug: Web/API/Document/drag_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/dragend_event/index.md
+++ b/files/en-us/web/api/document/dragend_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: dragend event'
 slug: Web/API/Document/dragend_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/dragenter_event/index.md
+++ b/files/en-us/web/api/document/dragenter_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: dragenter event'
 slug: Web/API/Document/dragenter_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/dragleave_event/index.md
+++ b/files/en-us/web/api/document/dragleave_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: dragleave event'
 slug: Web/API/Document/dragleave_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/dragover_event/index.md
+++ b/files/en-us/web/api/document/dragover_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: dragover event'
 slug: Web/API/Document/dragover_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/dragstart_event/index.md
+++ b/files/en-us/web/api/document/dragstart_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: dragstart event'
 slug: Web/API/Document/dragstart_event
+page-type: web-api-event
 tags:
   - DOM
   - Event

--- a/files/en-us/web/api/document/drop_event/index.md
+++ b/files/en-us/web/api/document/drop_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: drop event'
 slug: Web/API/Document/drop_event
+page-type: web-api-event
 tags:
   - DOM
   - Drag Event

--- a/files/en-us/web/api/document/elementfrompoint/index.md
+++ b/files/en-us/web/api/document/elementfrompoint/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.elementFromPoint()
 slug: Web/API/Document/elementFromPoint
+page-type: web-api-instance-method
 tags:
   - API
   - Coordinates

--- a/files/en-us/web/api/document/elementsfrompoint/index.md
+++ b/files/en-us/web/api/document/elementsfrompoint/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.elementsFromPoint()
 slug: Web/API/Document/elementsFromPoint
+page-type: web-api-instance-method
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/embeds/index.md
+++ b/files/en-us/web/api/document/embeds/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.embeds
 slug: Web/API/Document/embeds
+page-type: web-api-instance-property
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/enablestylesheetsforset/index.md
+++ b/files/en-us/web/api/document/enablestylesheetsforset/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.enableStyleSheetsForSet()
 slug: Web/API/Document/enableStyleSheetsForSet
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/document/evaluate/index.md
+++ b/files/en-us/web/api/document/evaluate/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.evaluate()
 slug: Web/API/Document/evaluate
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/execcommand/index.md
+++ b/files/en-us/web/api/document/execcommand/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.execCommand()
 slug: Web/API/Document/execCommand
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/exitfullscreen/index.md
+++ b/files/en-us/web/api/document/exitfullscreen/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.exitFullscreen()
 slug: Web/API/Document/exitFullscreen
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/exitpictureinpicture/index.md
+++ b/files/en-us/web/api/document/exitpictureinpicture/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.exitPictureInPicture()
 slug: Web/API/Document/exitPictureInPicture
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/exitpointerlock/index.md
+++ b/files/en-us/web/api/document/exitpointerlock/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.exitPointerLock()
 slug: Web/API/Document/exitPointerLock
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/document/featurepolicy/index.md
+++ b/files/en-us/web/api/document/featurepolicy/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.featurePolicy
 slug: Web/API/Document/featurePolicy
+page-type: web-api-instance-property
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/fgcolor/index.md
+++ b/files/en-us/web/api/document/fgcolor/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.fgColor
 slug: Web/API/Document/fgColor
+page-type: web-api-instance-property
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/document/firstelementchild/index.md
+++ b/files/en-us/web/api/document/firstelementchild/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.firstElementChild
 slug: Web/API/Document/firstElementChild
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/fonts/index.md
+++ b/files/en-us/web/api/document/fonts/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.fonts
 slug: Web/API/Document/fonts
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/forms/index.md
+++ b/files/en-us/web/api/document/forms/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.forms
 slug: Web/API/Document/forms
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/fullscreen/index.md
+++ b/files/en-us/web/api/document/fullscreen/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.fullscreen
 slug: Web/API/Document/fullscreen
+page-type: web-api-instance-property
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/document/fullscreenchange_event/index.md
+++ b/files/en-us/web/api/document/fullscreenchange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: fullscreenchange event'
 slug: Web/API/Document/fullscreenchange_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/document/fullscreenelement/index.md
+++ b/files/en-us/web/api/document/fullscreenelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.fullscreenElement
 slug: Web/API/Document/fullscreenElement
+page-type: web-api-instance-property
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/fullscreenenabled/index.md
+++ b/files/en-us/web/api/document/fullscreenenabled/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.fullscreenEnabled
 slug: Web/API/Document/fullscreenEnabled
+page-type: web-api-instance-property
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/fullscreenerror_event/index.md
+++ b/files/en-us/web/api/document/fullscreenerror_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: fullscreenerror event'
 slug: Web/API/Document/fullscreenerror_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/document/getanimations/index.md
+++ b/files/en-us/web/api/document/getanimations/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.getAnimations()
 slug: Web/API/Document/getAnimations
+page-type: web-api-instance-method
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/document/getelementbyid/index.md
+++ b/files/en-us/web/api/document/getelementbyid/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.getElementById()
 slug: Web/API/Document/getElementById
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/getelementsbyclassname/index.md
+++ b/files/en-us/web/api/document/getelementsbyclassname/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.getElementsByClassName()
 slug: Web/API/Document/getElementsByClassName
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/getelementsbyname/index.md
+++ b/files/en-us/web/api/document/getelementsbyname/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.getElementsByName()
 slug: Web/API/Document/getElementsByName
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/getelementsbytagname/index.md
+++ b/files/en-us/web/api/document/getelementsbytagname/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.getElementsByTagName()
 slug: Web/API/Document/getElementsByTagName
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/getelementsbytagnamens/index.md
+++ b/files/en-us/web/api/document/getelementsbytagnamens/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.getElementsByTagNameNS()
 slug: Web/API/Document/getElementsByTagNameNS
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/getselection/index.md
+++ b/files/en-us/web/api/document/getselection/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.getSelection()
 slug: Web/API/Document/getSelection
+page-type: web-api-instance-method
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/gotpointercapture_event/index.md
+++ b/files/en-us/web/api/document/gotpointercapture_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: gotpointercapture event'
 slug: Web/API/Document/gotpointercapture_event
+page-type: web-api-event
 tags:
   - Document
   - Event

--- a/files/en-us/web/api/document/hasfocus/index.md
+++ b/files/en-us/web/api/document/hasfocus/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.hasFocus()
 slug: Web/API/Document/hasFocus
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/hasstorageaccess/index.md
+++ b/files/en-us/web/api/document/hasstorageaccess/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.hasStorageAccess()
 slug: Web/API/Document/hasStorageAccess
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/head/index.md
+++ b/files/en-us/web/api/document/head/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.head
 slug: Web/API/Document/head
+page-type: web-api-instance-property
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/height/index.md
+++ b/files/en-us/web/api/document/height/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.height
 slug: Web/API/Document/height
+page-type: web-api-instance-property
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/hidden/index.md
+++ b/files/en-us/web/api/document/hidden/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.hidden
 slug: Web/API/Document/hidden
+page-type: web-api-instance-property
 tags:
   - DOM
   - Document

--- a/files/en-us/web/api/document/images/index.md
+++ b/files/en-us/web/api/document/images/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.images
 slug: Web/API/Document/images
+page-type: web-api-instance-property
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/implementation/index.md
+++ b/files/en-us/web/api/document/implementation/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.implementation
 slug: Web/API/Document/implementation
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/importnode/index.md
+++ b/files/en-us/web/api/document/importnode/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.importNode()
 slug: Web/API/Document/importNode
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/keydown_event/index.md
+++ b/files/en-us/web/api/document/keydown_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: keydown event'
 slug: Web/API/Document/keydown_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/keypress_event/index.md
+++ b/files/en-us/web/api/document/keypress_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: keypress event'
 slug: Web/API/Document/keypress_event
+page-type: web-api-event
 tags:
   - DOM
   - Deprecated

--- a/files/en-us/web/api/document/keyup_event/index.md
+++ b/files/en-us/web/api/document/keyup_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: keyup event'
 slug: Web/API/Document/keyup_event
+page-type: web-api-event
 tags:
   - DOM
   - Document

--- a/files/en-us/web/api/document/lastelementchild/index.md
+++ b/files/en-us/web/api/document/lastelementchild/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.lastElementChild
 slug: Web/API/Document/lastElementChild
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/lastmodified/index.md
+++ b/files/en-us/web/api/document/lastmodified/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.lastModified
 slug: Web/API/Document/lastModified
+page-type: web-api-instance-property
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/laststylesheetset/index.md
+++ b/files/en-us/web/api/document/laststylesheetset/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.lastStyleSheetSet
 slug: Web/API/Document/lastStyleSheetSet
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/document/linkcolor/index.md
+++ b/files/en-us/web/api/document/linkcolor/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.linkColor
 slug: Web/API/Document/linkColor
+page-type: web-api-instance-property
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/document/links/index.md
+++ b/files/en-us/web/api/document/links/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.links
 slug: Web/API/Document/links
+page-type: web-api-instance-property
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/location/index.md
+++ b/files/en-us/web/api/document/location/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.location
 slug: Web/API/Document/location
+page-type: web-api-instance-property
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/lostpointercapture_event/index.md
+++ b/files/en-us/web/api/document/lostpointercapture_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: lostpointercapture event'
 slug: Web/API/Document/lostpointercapture_event
+page-type: web-api-event
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/mozsetimageelement/index.md
+++ b/files/en-us/web/api/document/mozsetimageelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.mozSetImageElement()
 slug: Web/API/Document/mozSetImageElement
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/mozsyntheticdocument/index.md
+++ b/files/en-us/web/api/document/mozsyntheticdocument/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.mozSyntheticDocument
 slug: Web/API/Document/mozSyntheticDocument
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/mozsyntheticdocument/index.md
+++ b/files/en-us/web/api/document/mozsyntheticdocument/index.md
@@ -1,7 +1,7 @@
 ---
 title: Document.mozSyntheticDocument
 slug: Web/API/Document/mozSyntheticDocument
-page-type: web-api-instance-method
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/open/index.md
+++ b/files/en-us/web/api/document/open/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.open()
 slug: Web/API/Document/open
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/origin/index.md
+++ b/files/en-us/web/api/document/origin/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.origin
 slug: Web/API/Document/origin
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/paste_event/index.md
+++ b/files/en-us/web/api/document/paste_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: paste event'
 slug: Web/API/Document/paste_event
+page-type: web-api-event
 tags:
   - API
   - Clipboard API

--- a/files/en-us/web/api/document/pictureinpictureelement/index.md
+++ b/files/en-us/web/api/document/pictureinpictureelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.pictureInPictureElement
 slug: Web/API/Document/pictureInPictureElement
+page-type: web-api-instance-property
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/pictureinpictureenabled/index.md
+++ b/files/en-us/web/api/document/pictureinpictureenabled/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.pictureInPictureEnabled
 slug: Web/API/Document/pictureInPictureEnabled
+page-type: web-api-instance-property
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/plugins/index.md
+++ b/files/en-us/web/api/document/plugins/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.plugins
 slug: Web/API/Document/plugins
+page-type: web-api-instance-property
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/pointercancel_event/index.md
+++ b/files/en-us/web/api/document/pointercancel_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: pointercancel event'
 slug: Web/API/Document/pointercancel_event
+page-type: web-api-event
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/pointerdown_event/index.md
+++ b/files/en-us/web/api/document/pointerdown_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: pointerdown event'
 slug: Web/API/Document/pointerdown_event
+page-type: web-api-event
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/pointerenter_event/index.md
+++ b/files/en-us/web/api/document/pointerenter_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: pointerenter event'
 slug: Web/API/Document/pointerenter_event
+page-type: web-api-event
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/pointerleave_event/index.md
+++ b/files/en-us/web/api/document/pointerleave_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: pointerleave event'
 slug: Web/API/Document/pointerleave_event
+page-type: web-api-event
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/pointerlockchange_event/index.md
+++ b/files/en-us/web/api/document/pointerlockchange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: pointerlockchange event'
 slug: Web/API/Document/pointerlockchange_event
+page-type: web-api-event
 tags:
   - Document
   - Event

--- a/files/en-us/web/api/document/pointerlockelement/index.md
+++ b/files/en-us/web/api/document/pointerlockelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.pointerLockElement
 slug: Web/API/Document/pointerLockElement
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/pointerlockerror_event/index.md
+++ b/files/en-us/web/api/document/pointerlockerror_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: pointerlockerror event'
 slug: Web/API/Document/pointerlockerror_event
+page-type: web-api-event
 tags:
   - Document
   - Event

--- a/files/en-us/web/api/document/pointermove_event/index.md
+++ b/files/en-us/web/api/document/pointermove_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: pointermove event'
 slug: Web/API/Document/pointermove_event
+page-type: web-api-event
 tags:
   - Document
   - Event

--- a/files/en-us/web/api/document/pointerout_event/index.md
+++ b/files/en-us/web/api/document/pointerout_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: pointerout event'
 slug: Web/API/Document/pointerout_event
+page-type: web-api-event
 tags:
   - Document
   - Event

--- a/files/en-us/web/api/document/pointerover_event/index.md
+++ b/files/en-us/web/api/document/pointerover_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: pointerover event'
 slug: Web/API/Document/pointerover_event
+page-type: web-api-event
 tags:
   - Document
   - Event

--- a/files/en-us/web/api/document/pointerup_event/index.md
+++ b/files/en-us/web/api/document/pointerup_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: pointerup event'
 slug: Web/API/Document/pointerup_event
+page-type: web-api-event
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/preferredstylesheetset/index.md
+++ b/files/en-us/web/api/document/preferredstylesheetset/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.preferredStyleSheetSet
 slug: Web/API/Document/preferredStyleSheetSet
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/document/prepend/index.md
+++ b/files/en-us/web/api/document/prepend/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.prepend()
 slug: Web/API/Document/prepend
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/querycommandenabled/index.md
+++ b/files/en-us/web/api/document/querycommandenabled/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.queryCommandEnabled()
 slug: Web/API/Document/queryCommandEnabled
+page-type: web-api-instance-method
 tags:
   - CSS
   - Document

--- a/files/en-us/web/api/document/querycommandstate/index.md
+++ b/files/en-us/web/api/document/querycommandstate/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.queryCommandState()
 slug: Web/API/Document/queryCommandState
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/querycommandsupported/index.md
+++ b/files/en-us/web/api/document/querycommandsupported/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.queryCommandSupported()
 slug: Web/API/Document/queryCommandSupported
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/queryselector/index.md
+++ b/files/en-us/web/api/document/queryselector/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.querySelector()
 slug: Web/API/Document/querySelector
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Selectors

--- a/files/en-us/web/api/document/queryselectorall/index.md
+++ b/files/en-us/web/api/document/queryselectorall/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.querySelectorAll()
 slug: Web/API/Document/querySelectorAll
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Selectors

--- a/files/en-us/web/api/document/readystate/index.md
+++ b/files/en-us/web/api/document/readystate/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.readyState
 slug: Web/API/Document/readyState
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/document/readystatechange_event/index.md
+++ b/files/en-us/web/api/document/readystatechange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: readystatechange event'
 slug: Web/API/Document/readystatechange_event
+page-type: web-api-event
 tags:
   - Event
   - Reference

--- a/files/en-us/web/api/document/referrer/index.md
+++ b/files/en-us/web/api/document/referrer/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.referrer
 slug: Web/API/Document/referrer
+page-type: web-api-instance-property
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/registerelement/index.md
+++ b/files/en-us/web/api/document/registerelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.registerElement()
 slug: Web/API/Document/registerElement
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/releasecapture/index.md
+++ b/files/en-us/web/api/document/releasecapture/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.releaseCapture()
 slug: Web/API/Document/releaseCapture
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/replacechildren/index.md
+++ b/files/en-us/web/api/document/replacechildren/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.replaceChildren()
 slug: Web/API/Document/replaceChildren
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/requeststorageaccess/index.md
+++ b/files/en-us/web/api/document/requeststorageaccess/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.requestStorageAccess()
 slug: Web/API/Document/requestStorageAccess
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/rootelement/index.md
+++ b/files/en-us/web/api/document/rootelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.rootElement
 slug: Web/API/Document/rootElement
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/scripts/index.md
+++ b/files/en-us/web/api/document/scripts/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.scripts
 slug: Web/API/Document/scripts
+page-type: web-api-instance-property
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/scroll_event/index.md
+++ b/files/en-us/web/api/document/scroll_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: scroll event'
 slug: Web/API/Document/scroll_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/scrollingelement/index.md
+++ b/files/en-us/web/api/document/scrollingelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.scrollingElement
 slug: Web/API/Document/scrollingElement
+page-type: web-api-instance-property
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/selectedstylesheetset/index.md
+++ b/files/en-us/web/api/document/selectedstylesheetset/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.selectedStyleSheetSet
 slug: Web/API/Document/selectedStyleSheetSet
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/document/selectionchange_event/index.md
+++ b/files/en-us/web/api/document/selectionchange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: selectionchange event'
 slug: Web/API/Document/selectionchange_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/document/selectstart_event/index.md
+++ b/files/en-us/web/api/document/selectstart_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: selectstart event'
 slug: Web/API/Document/selectstart_event
+page-type: web-api-event
 tags:
   - Document
   - Event

--- a/files/en-us/web/api/document/stylesheets/index.md
+++ b/files/en-us/web/api/document/stylesheets/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.styleSheets
 slug: Web/API/Document/styleSheets
+page-type: web-api-instance-property
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/stylesheetsets/index.md
+++ b/files/en-us/web/api/document/stylesheetsets/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.styleSheetSets
 slug: Web/API/Document/styleSheetSets
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/document/timeline/index.md
+++ b/files/en-us/web/api/document/timeline/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.timeline
 slug: Web/API/Document/timeline
+page-type: web-api-instance-property
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/document/title/index.md
+++ b/files/en-us/web/api/document/title/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.title
 slug: Web/API/Document/title
+page-type: web-api-instance-property
 tags:
   - API
   - Command API

--- a/files/en-us/web/api/document/touchcancel_event/index.md
+++ b/files/en-us/web/api/document/touchcancel_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: touchcancel event'
 slug: Web/API/Document/touchcancel_event
+page-type: web-api-event
 tags:
   - Document
   - Event

--- a/files/en-us/web/api/document/touchend_event/index.md
+++ b/files/en-us/web/api/document/touchend_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: touchend event'
 slug: Web/API/Document/touchend_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/document/touchmove_event/index.md
+++ b/files/en-us/web/api/document/touchmove_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: touchmove event'
 slug: Web/API/Document/touchmove_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/touchstart_event/index.md
+++ b/files/en-us/web/api/document/touchstart_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: touchstart event'
 slug: Web/API/Document/touchstart_event
+page-type: web-api-event
 tags:
   - Document
   - Event

--- a/files/en-us/web/api/document/transitioncancel_event/index.md
+++ b/files/en-us/web/api/document/transitioncancel_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: transitioncancel event'
 slug: Web/API/Document/transitioncancel_event
+page-type: web-api-event
 tags:
   - API
   - CSS Transitions

--- a/files/en-us/web/api/document/transitionend_event/index.md
+++ b/files/en-us/web/api/document/transitionend_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: transitionend event'
 slug: Web/API/Document/transitionend_event
+page-type: web-api-event
 tags:
   - CSS transition
   - Document

--- a/files/en-us/web/api/document/transitionrun_event/index.md
+++ b/files/en-us/web/api/document/transitionrun_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: transitionrun event'
 slug: Web/API/Document/transitionrun_event
+page-type: web-api-event
 tags:
   - Document
   - Event

--- a/files/en-us/web/api/document/transitionstart_event/index.md
+++ b/files/en-us/web/api/document/transitionstart_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: transitionstart event'
 slug: Web/API/Document/transitionstart_event
+page-type: web-api-event
 tags:
   - DOM
   - Document

--- a/files/en-us/web/api/document/url/index.md
+++ b/files/en-us/web/api/document/url/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.URL
 slug: Web/API/Document/URL
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/visibilitychange_event/index.md
+++ b/files/en-us/web/api/document/visibilitychange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: visibilitychange event'
 slug: Web/API/Document/visibilitychange_event
+page-type: web-api-event
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/visibilitystate/index.md
+++ b/files/en-us/web/api/document/visibilitystate/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.visibilityState
 slug: Web/API/Document/visibilityState
+page-type: web-api-instance-property
 tags:
   - DOM
   - Document

--- a/files/en-us/web/api/document/vlinkcolor/index.md
+++ b/files/en-us/web/api/document/vlinkcolor/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.vlinkColor
 slug: Web/API/Document/vlinkColor
+page-type: web-api-instance-property
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/document/wheel_event/index.md
+++ b/files/en-us/web/api/document/wheel_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Document: wheel event'
 slug: Web/API/Document/wheel_event
+page-type: web-api-event
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/width/index.md
+++ b/files/en-us/web/api/document/width/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.width
 slug: Web/API/Document/width
+page-type: web-api-instance-property
 tags:
   - API
   - Document

--- a/files/en-us/web/api/document/write/index.md
+++ b/files/en-us/web/api/document/write/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.write()
 slug: Web/API/Document/write
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/writeln/index.md
+++ b/files/en-us/web/api/document/writeln/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.writeln()
 slug: Web/API/Document/writeln
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/xmlencoding/index.md
+++ b/files/en-us/web/api/document/xmlencoding/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.xmlEncoding
 slug: Web/API/Document/xmlEncoding
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document/xmlversion/index.md
+++ b/files/en-us/web/api/document/xmlversion/index.md
@@ -1,6 +1,7 @@
 ---
 title: Document.xmlVersion
 slug: Web/API/Document/xmlVersion
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/document_object_model/using_the_w3c_dom_level_1_core/example/index.md
+++ b/files/en-us/web/api/document_object_model/using_the_w3c_dom_level_1_core/example/index.md
@@ -1,6 +1,7 @@
 ---
 title: Example
 slug: Web/API/Document_object_model/Using_the_W3C_DOM_Level_1_Core/Example
+page-type: guide
 tags:
   - DOM
 ---

--- a/files/en-us/web/api/document_object_model/using_the_w3c_dom_level_1_core/index.md
+++ b/files/en-us/web/api/document_object_model/using_the_w3c_dom_level_1_core/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using the W3C DOM Level 1 Core
 slug: Web/API/Document_object_model/Using_the_W3C_DOM_Level_1_Core
+page-type: guide
 tags:
   - DOM
   - NeedsUpdate

--- a/files/en-us/web/api/document_object_model/whitespace/index.md
+++ b/files/en-us/web/api/document_object_model/whitespace/index.md
@@ -1,6 +1,7 @@
 ---
 title: How whitespace is handled by HTML, CSS, and in the DOM
 slug: Web/API/Document_Object_Model/Whitespace
+page-type: guide
 tags:
   - CSS
   - DOM

--- a/files/en-us/web/api/documentfragment/append/index.md
+++ b/files/en-us/web/api/documentfragment/append/index.md
@@ -1,6 +1,7 @@
 ---
 title: DocumentFragment.append()
 slug: Web/API/DocumentFragment/append
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/documentfragment/childelementcount/index.md
+++ b/files/en-us/web/api/documentfragment/childelementcount/index.md
@@ -1,6 +1,7 @@
 ---
 title: DocumentFragment.childElementCount
 slug: Web/API/DocumentFragment/childElementCount
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/documentfragment/children/index.md
+++ b/files/en-us/web/api/documentfragment/children/index.md
@@ -1,6 +1,7 @@
 ---
 title: DocumentFragment.children
 slug: Web/API/DocumentFragment/children
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/documentfragment/documentfragment/index.md
+++ b/files/en-us/web/api/documentfragment/documentfragment/index.md
@@ -1,6 +1,7 @@
 ---
 title: DocumentFragment()
 slug: Web/API/DocumentFragment/DocumentFragment
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/documentfragment/firstelementchild/index.md
+++ b/files/en-us/web/api/documentfragment/firstelementchild/index.md
@@ -1,6 +1,7 @@
 ---
 title: DocumentFragment.firstElementChild
 slug: Web/API/DocumentFragment/firstElementChild
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/documentfragment/index.md
+++ b/files/en-us/web/api/documentfragment/index.md
@@ -1,6 +1,7 @@
 ---
 title: DocumentFragment
 slug: Web/API/DocumentFragment
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/documentfragment/lastelementchild/index.md
+++ b/files/en-us/web/api/documentfragment/lastelementchild/index.md
@@ -1,6 +1,7 @@
 ---
 title: DocumentFragment.lastElementChild
 slug: Web/API/DocumentFragment/lastElementChild
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/documentfragment/prepend/index.md
+++ b/files/en-us/web/api/documentfragment/prepend/index.md
@@ -1,6 +1,7 @@
 ---
 title: DocumentFragment.prepend()
 slug: Web/API/DocumentFragment/prepend
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/documentfragment/queryselector/index.md
+++ b/files/en-us/web/api/documentfragment/queryselector/index.md
@@ -1,6 +1,7 @@
 ---
 title: DocumentFragment.querySelector()
 slug: Web/API/DocumentFragment/querySelector
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/documentfragment/queryselectorall/index.md
+++ b/files/en-us/web/api/documentfragment/queryselectorall/index.md
@@ -1,6 +1,7 @@
 ---
 title: DocumentFragment.querySelectorAll()
 slug: Web/API/DocumentFragment/querySelectorAll
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/documentfragment/replacechildren/index.md
+++ b/files/en-us/web/api/documentfragment/replacechildren/index.md
@@ -1,6 +1,7 @@
 ---
 title: DocumentFragment.replaceChildren()
 slug: Web/API/DocumentFragment/replaceChildren
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/documenttimeline/documenttimeline/index.md
+++ b/files/en-us/web/api/documenttimeline/documenttimeline/index.md
@@ -1,6 +1,7 @@
 ---
 title: DocumentTimeline()
 slug: Web/API/DocumentTimeline/DocumentTimeline
+page-type: web-api-constructor
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/documenttimeline/index.md
+++ b/files/en-us/web/api/documenttimeline/index.md
@@ -1,6 +1,7 @@
 ---
 title: DocumentTimeline
 slug: Web/API/DocumentTimeline
+page-type: web-api-interface
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/documenttype/after/index.md
+++ b/files/en-us/web/api/documenttype/after/index.md
@@ -1,6 +1,7 @@
 ---
 title: DocumentType.after()
 slug: Web/API/DocumentType/after
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/documenttype/before/index.md
+++ b/files/en-us/web/api/documenttype/before/index.md
@@ -1,6 +1,7 @@
 ---
 title: DocumentType.before()
 slug: Web/API/DocumentType/before
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/documenttype/index.md
+++ b/files/en-us/web/api/documenttype/index.md
@@ -1,6 +1,7 @@
 ---
 title: DocumentType
 slug: Web/API/DocumentType
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/documenttype/remove/index.md
+++ b/files/en-us/web/api/documenttype/remove/index.md
@@ -1,6 +1,7 @@
 ---
 title: DocumentType.remove()
 slug: Web/API/DocumentType/remove
+page-type: web-api-instance-method
 tags:
   - API
   - DocumentType

--- a/files/en-us/web/api/documenttype/replacewith/index.md
+++ b/files/en-us/web/api/documenttype/replacewith/index.md
@@ -1,6 +1,7 @@
 ---
 title: DocumentType.replaceWith()
 slug: Web/API/DocumentType/replaceWith
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/domerror/index.md
+++ b/files/en-us/web/api/domerror/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMError
 slug: Web/API/DOMError
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/domexception/code/index.md
+++ b/files/en-us/web/api/domexception/code/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMException.code
 slug: Web/API/DOMException/code
+page-type: web-api-instance-property
 tags:
   - API
   - Code

--- a/files/en-us/web/api/domexception/domexception/index.md
+++ b/files/en-us/web/api/domexception/domexception/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMException()
 slug: Web/API/DOMException/DOMException
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/domexception/index.md
+++ b/files/en-us/web/api/domexception/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMException
 slug: Web/API/DOMException
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/domexception/message/index.md
+++ b/files/en-us/web/api/domexception/message/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMException.message
 slug: Web/API/DOMException/message
+page-type: web-api-instance-property
 tags:
   - API
   - DOMException

--- a/files/en-us/web/api/domexception/name/index.md
+++ b/files/en-us/web/api/domexception/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMException.name
 slug: Web/API/DOMException/name
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/domimplementation/createdocument/index.md
+++ b/files/en-us/web/api/domimplementation/createdocument/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMImplementation.createDocument()
 slug: Web/API/DOMImplementation/createDocument
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/domimplementation/createdocumenttype/index.md
+++ b/files/en-us/web/api/domimplementation/createdocumenttype/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMImplementation.createDocumentType()
 slug: Web/API/DOMImplementation/createDocumentType
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/domimplementation/createhtmldocument/index.md
+++ b/files/en-us/web/api/domimplementation/createhtmldocument/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMImplementation.createHTMLDocument()
 slug: Web/API/DOMImplementation/createHTMLDocument
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/domimplementation/index.md
+++ b/files/en-us/web/api/domimplementation/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMImplementation
 slug: Web/API/DOMImplementation
+page-type: web-api-interface
 tags:
   - API
   - DOM


### PR DESCRIPTION
See  https://github.com/mdn/content/issues/16255. This is part 6 of a series of PRs to add page types to the Web/API documentation.