### PR TITLE
Add webapi page types 7

### DIFF
--- a/files/en-us/web/api/domimplementation/hasfeature/index.md
+++ b/files/en-us/web/api/domimplementation/hasfeature/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMImplementation.hasFeature()
 slug: Web/API/DOMImplementation/hasFeature
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/dommatrix/dommatrix/index.md
+++ b/files/en-us/web/api/dommatrix/dommatrix/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMMatrix()
 slug: Web/API/DOMMatrix/DOMMatrix
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/dommatrix/index.md
+++ b/files/en-us/web/api/dommatrix/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMMatrix (WebKitCSSMatrix)
 slug: Web/API/DOMMatrix
+page-type: web-api-interface
 tags:
   - API
   - DOMMatrix

--- a/files/en-us/web/api/dommatrixreadonly/dommatrixreadonly/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/dommatrixreadonly/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMMatrixReadOnly()
 slug: Web/API/DOMMatrixReadOnly/DOMMatrixReadOnly
+page-type: web-api-constructor
 tags:
   - Constructor
   - Reference

--- a/files/en-us/web/api/dommatrixreadonly/flipx/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/flipx/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMMatrixReadOnly.flipX()
 slug: Web/API/DOMMatrixReadOnly/flipX
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/dommatrixreadonly/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMMatrixReadOnly
 slug: Web/API/DOMMatrixReadOnly
+page-type: web-api-interface
 tags:
   - Interface
   - Reference

--- a/files/en-us/web/api/dommatrixreadonly/scale/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/scale/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMMatrixReadOnly.scale()
 slug: Web/API/DOMMatrixReadOnly/scale
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/dommatrixreadonly/translate/index.md
+++ b/files/en-us/web/api/dommatrixreadonly/translate/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMMatrixReadOnly.translate()
 slug: Web/API/DOMMatrixReadOnly/translate
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/domparser/domparser/index.md
+++ b/files/en-us/web/api/domparser/domparser/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMParser()
 slug: Web/API/DOMParser/DOMParser
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/domparser/index.md
+++ b/files/en-us/web/api/domparser/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMParser
 slug: Web/API/DOMParser
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/domparser/index.md
+++ b/files/en-us/web/api/domparser/index.md
@@ -1,7 +1,7 @@
 ---
 title: DOMParser
 slug: Web/API/DOMParser
-page-type: web-api-instance-method
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/domparser/parsefromstring/index.md
+++ b/files/en-us/web/api/domparser/parsefromstring/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMParser.parseFromString()
 slug: Web/API/DOMParser/parseFromString
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/dompoint/dompoint/index.md
+++ b/files/en-us/web/api/dompoint/dompoint/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMPoint()
 slug: Web/API/DOMPoint/DOMPoint
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/dompoint/frompoint/index.md
+++ b/files/en-us/web/api/dompoint/frompoint/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMPoint.fromPoint()
 slug: Web/API/DOMPoint/fromPoint
+page-type: web-api-static-method
 tags:
   - API
   - Coordinates

--- a/files/en-us/web/api/dompoint/index.md
+++ b/files/en-us/web/api/dompoint/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMPoint
 slug: Web/API/DOMPoint
+page-type: web-api-interface
 tags:
   - API
   - Coordinate

--- a/files/en-us/web/api/dompoint/w/index.md
+++ b/files/en-us/web/api/dompoint/w/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMPoint.w
 slug: Web/API/DOMPoint/w
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/dompoint/x/index.md
+++ b/files/en-us/web/api/dompoint/x/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMPoint.x
 slug: Web/API/DOMPoint/x
+page-type: web-api-instance-property
 tags:
   - API
   - Coordinates

--- a/files/en-us/web/api/dompoint/y/index.md
+++ b/files/en-us/web/api/dompoint/y/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMPoint.y
 slug: Web/API/DOMPoint/y
+page-type: web-api-instance-property
 tags:
   - API
   - Coordinate

--- a/files/en-us/web/api/dompoint/z/index.md
+++ b/files/en-us/web/api/dompoint/z/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMPoint.z
 slug: Web/API/DOMPoint/z
+page-type: web-api-instance-property
 tags:
   - API
   - Coordinate

--- a/files/en-us/web/api/dompointreadonly/dompointreadonly/index.md
+++ b/files/en-us/web/api/dompointreadonly/dompointreadonly/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMPointReadOnly()
 slug: Web/API/DOMPointReadOnly/DOMPointReadOnly
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/dompointreadonly/frompoint/index.md
+++ b/files/en-us/web/api/dompointreadonly/frompoint/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMPointReadOnly.fromPoint()
 slug: Web/API/DOMPointReadOnly/fromPoint
+page-type: web-api-static-method
 tags:
   - API
   - Coordinates

--- a/files/en-us/web/api/dompointreadonly/index.md
+++ b/files/en-us/web/api/dompointreadonly/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMPointReadOnly
 slug: Web/API/DOMPointReadOnly
+page-type: web-api-interface
 tags:
   - API
   - Coordinate

--- a/files/en-us/web/api/dompointreadonly/tojson/index.md
+++ b/files/en-us/web/api/dompointreadonly/tojson/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMPointReadOnly.toJSON()
 slug: Web/API/DOMPointReadOnly/toJSON
+page-type: web-api-instance-method
 tags:
   - API
   - Coordinates

--- a/files/en-us/web/api/dompointreadonly/w/index.md
+++ b/files/en-us/web/api/dompointreadonly/w/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMPointReadOnly.w
 slug: Web/API/DOMPointReadOnly/w
+page-type: web-api-instance-property
 tags:
   - API
   - Coordinates

--- a/files/en-us/web/api/dompointreadonly/x/index.md
+++ b/files/en-us/web/api/dompointreadonly/x/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMPointReadOnly.x
 slug: Web/API/DOMPointReadOnly/x
+page-type: web-api-instance-property
 tags:
   - API
   - Coordinates

--- a/files/en-us/web/api/dompointreadonly/y/index.md
+++ b/files/en-us/web/api/dompointreadonly/y/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMPointReadOnly.y
 slug: Web/API/DOMPointReadOnly/y
+page-type: web-api-instance-property
 tags:
   - API
   - Coordinates

--- a/files/en-us/web/api/dompointreadonly/z/index.md
+++ b/files/en-us/web/api/dompointreadonly/z/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMPointReadOnly.z
 slug: Web/API/DOMPointReadOnly/z
+page-type: web-api-instance-property
 tags:
   - API
   - Coordinates

--- a/files/en-us/web/api/domquad/index.md
+++ b/files/en-us/web/api/domquad/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMQuad
 slug: Web/API/DOMQuad
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/domrect/domrect/index.md
+++ b/files/en-us/web/api/domrect/domrect/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMRect()
 slug: Web/API/DOMRect/DOMRect
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/domrect/fromrect/index.md
+++ b/files/en-us/web/api/domrect/fromrect/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMRect.fromRect()
 slug: Web/API/DOMRect/fromRect
+page-type: web-api-static-method
 tags:
   - API
   - DOMRect

--- a/files/en-us/web/api/domrect/index.md
+++ b/files/en-us/web/api/domrect/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMRect
 slug: Web/API/DOMRect
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/domrectreadonly/bottom/index.md
+++ b/files/en-us/web/api/domrectreadonly/bottom/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMRectReadOnly.bottom
 slug: Web/API/DOMRectReadOnly/bottom
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/domrectreadonly/domrectreadonly/index.md
+++ b/files/en-us/web/api/domrectreadonly/domrectreadonly/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMRectReadOnly()
 slug: Web/API/DOMRectReadOnly/DOMRectReadOnly
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/domrectreadonly/fromrect/index.md
+++ b/files/en-us/web/api/domrectreadonly/fromrect/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMRectReadOnly.fromRect()
 slug: Web/API/DOMRectReadOnly/fromRect
+page-type: web-api-static-method
 tags:
   - API
   - DOMRectReadOnly

--- a/files/en-us/web/api/domrectreadonly/height/index.md
+++ b/files/en-us/web/api/domrectreadonly/height/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMRectReadOnly.height
 slug: Web/API/DOMRectReadOnly/height
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/domrectreadonly/index.md
+++ b/files/en-us/web/api/domrectreadonly/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMRectReadOnly
 slug: Web/API/DOMRectReadOnly
+page-type: web-api-interface
 tags:
   - API
   - DOMRectReadOnly

--- a/files/en-us/web/api/domrectreadonly/left/index.md
+++ b/files/en-us/web/api/domrectreadonly/left/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMRectReadOnly.left
 slug: Web/API/DOMRectReadOnly/left
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/domrectreadonly/right/index.md
+++ b/files/en-us/web/api/domrectreadonly/right/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMRectReadOnly.right
 slug: Web/API/DOMRectReadOnly/right
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/domrectreadonly/top/index.md
+++ b/files/en-us/web/api/domrectreadonly/top/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMRectReadOnly.top
 slug: Web/API/DOMRectReadOnly/top
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/domrectreadonly/width/index.md
+++ b/files/en-us/web/api/domrectreadonly/width/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMRectReadOnly.width
 slug: Web/API/DOMRectReadOnly/width
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/domrectreadonly/x/index.md
+++ b/files/en-us/web/api/domrectreadonly/x/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMRectReadOnly.x
 slug: Web/API/DOMRectReadOnly/x
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/domrectreadonly/y/index.md
+++ b/files/en-us/web/api/domrectreadonly/y/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMRectReadOnly.y
 slug: Web/API/DOMRectReadOnly/y
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/domstring/binary/index.md
+++ b/files/en-us/web/api/domstring/binary/index.md
@@ -1,6 +1,7 @@
 ---
 title: Binary strings
 slug: Web/API/DOMString/Binary
+page-type: guide
 tags:
   - DOM
   - JavaScript

--- a/files/en-us/web/api/domstringlist/index.md
+++ b/files/en-us/web/api/domstringlist/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMStringList
 slug: Web/API/DOMStringList
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/domstringmap/index.md
+++ b/files/en-us/web/api/domstringmap/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMStringMap
 slug: Web/API/DOMStringMap
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/domtokenlist/add/index.md
+++ b/files/en-us/web/api/domtokenlist/add/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMTokenList.add()
 slug: Web/API/DOMTokenList/add
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/domtokenlist/contains/index.md
+++ b/files/en-us/web/api/domtokenlist/contains/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMTokenList.contains()
 slug: Web/API/DOMTokenList/contains
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/domtokenlist/entries/index.md
+++ b/files/en-us/web/api/domtokenlist/entries/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMTokenList.entries()
 slug: Web/API/DOMTokenList/entries
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/domtokenlist/foreach/index.md
+++ b/files/en-us/web/api/domtokenlist/foreach/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMTokenList.forEach()
 slug: Web/API/DOMTokenList/forEach
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/domtokenlist/index.md
+++ b/files/en-us/web/api/domtokenlist/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMTokenList
 slug: Web/API/DOMTokenList
+page-type: web-api-interface
 tags:
   - Interface
   - Reference

--- a/files/en-us/web/api/domtokenlist/item/index.md
+++ b/files/en-us/web/api/domtokenlist/item/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMTokenList.item()
 slug: Web/API/DOMTokenList/item
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/domtokenlist/keys/index.md
+++ b/files/en-us/web/api/domtokenlist/keys/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMTokenList.keys()
 slug: Web/API/DOMTokenList/keys
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/domtokenlist/length/index.md
+++ b/files/en-us/web/api/domtokenlist/length/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMTokenList.length
 slug: Web/API/DOMTokenList/length
+page-type: web-api-instance-property
 tags:
   - Property
   - Reference

--- a/files/en-us/web/api/domtokenlist/remove/index.md
+++ b/files/en-us/web/api/domtokenlist/remove/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMTokenList.remove()
 slug: Web/API/DOMTokenList/remove
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/domtokenlist/replace/index.md
+++ b/files/en-us/web/api/domtokenlist/replace/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMTokenList.replace()
 slug: Web/API/DOMTokenList/replace
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/domtokenlist/supports/index.md
+++ b/files/en-us/web/api/domtokenlist/supports/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMTokenList.supports()
 slug: Web/API/DOMTokenList/supports
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/domtokenlist/toggle/index.md
+++ b/files/en-us/web/api/domtokenlist/toggle/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMTokenList.toggle()
 slug: Web/API/DOMTokenList/toggle
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/domtokenlist/value/index.md
+++ b/files/en-us/web/api/domtokenlist/value/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMTokenList.value
 slug: Web/API/DOMTokenList/value
+page-type: web-api-instance-property
 tags:
   - Property
   - Reference

--- a/files/en-us/web/api/domtokenlist/values/index.md
+++ b/files/en-us/web/api/domtokenlist/values/index.md
@@ -1,6 +1,7 @@
 ---
 title: DOMTokenList.values()
 slug: Web/API/DOMTokenList/values
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/dragevent/datatransfer/index.md
+++ b/files/en-us/web/api/dragevent/datatransfer/index.md
@@ -1,6 +1,7 @@
 ---
 title: DragEvent.dataTransfer
 slug: Web/API/DragEvent/dataTransfer
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/dragevent/dragevent/index.md
+++ b/files/en-us/web/api/dragevent/dragevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: DragEvent()
 slug: Web/API/DragEvent/DragEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/dragevent/index.md
+++ b/files/en-us/web/api/dragevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: DragEvent
 slug: Web/API/DragEvent
+page-type: web-api-interface
 tags:
   - API
   - DragEvent

--- a/files/en-us/web/api/dynamicscompressornode/attack/index.md
+++ b/files/en-us/web/api/dynamicscompressornode/attack/index.md
@@ -1,6 +1,7 @@
 ---
 title: DynamicsCompressorNode.attack
 slug: Web/API/DynamicsCompressorNode/attack
+page-type: web-api-instance-property
 tags:
   - API
   - Attack

--- a/files/en-us/web/api/dynamicscompressornode/dynamicscompressornode/index.md
+++ b/files/en-us/web/api/dynamicscompressornode/dynamicscompressornode/index.md
@@ -1,6 +1,7 @@
 ---
 title: DynamicsCompressorNode()
 slug: Web/API/DynamicsCompressorNode/DynamicsCompressorNode
+page-type: web-api-constructor
 tags:
   - Audio
   - Constructor

--- a/files/en-us/web/api/dynamicscompressornode/index.md
+++ b/files/en-us/web/api/dynamicscompressornode/index.md
@@ -1,6 +1,7 @@
 ---
 title: DynamicsCompressorNode
 slug: Web/API/DynamicsCompressorNode
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/dynamicscompressornode/knee/index.md
+++ b/files/en-us/web/api/dynamicscompressornode/knee/index.md
@@ -1,6 +1,7 @@
 ---
 title: DynamicsCompressorNode.knee
 slug: Web/API/DynamicsCompressorNode/knee
+page-type: web-api-instance-property
 tags:
   - API
   - DynamicsCompressorNode

--- a/files/en-us/web/api/dynamicscompressornode/ratio/index.md
+++ b/files/en-us/web/api/dynamicscompressornode/ratio/index.md
@@ -1,6 +1,7 @@
 ---
 title: DynamicsCompressorNode.ratio
 slug: Web/API/DynamicsCompressorNode/ratio
+page-type: web-api-instance-property
 tags:
   - API
   - DynamicsCompressorNode

--- a/files/en-us/web/api/dynamicscompressornode/reduction/index.md
+++ b/files/en-us/web/api/dynamicscompressornode/reduction/index.md
@@ -1,6 +1,7 @@
 ---
 title: DynamicsCompressorNode.reduction
 slug: Web/API/DynamicsCompressorNode/reduction
+page-type: web-api-instance-property
 tags:
   - API
   - DynamicsCompressorNode

--- a/files/en-us/web/api/dynamicscompressornode/release/index.md
+++ b/files/en-us/web/api/dynamicscompressornode/release/index.md
@@ -1,6 +1,7 @@
 ---
 title: DynamicsCompressorNode.release
 slug: Web/API/DynamicsCompressorNode/release
+page-type: web-api-instance-property
 tags:
   - API
   - DynamicsCompressorNode

--- a/files/en-us/web/api/dynamicscompressornode/threshold/index.md
+++ b/files/en-us/web/api/dynamicscompressornode/threshold/index.md
@@ -1,6 +1,7 @@
 ---
 title: DynamicsCompressorNode.threshold
 slug: Web/API/DynamicsCompressorNode/threshold
+page-type: web-api-instance-property
 tags:
   - API
   - DynamicsCompressorNode

--- a/files/en-us/web/api/ecdhkeyderiveparams/index.md
+++ b/files/en-us/web/api/ecdhkeyderiveparams/index.md
@@ -1,6 +1,7 @@
 ---
 title: EcdhKeyDeriveParams
 slug: Web/API/EcdhKeyDeriveParams
+page-type: web-api-interface
 tags:
   - API
   - Dictionary

--- a/files/en-us/web/api/ecdsaparams/index.md
+++ b/files/en-us/web/api/ecdsaparams/index.md
@@ -1,6 +1,7 @@
 ---
 title: EcdsaParams
 slug: Web/API/EcdsaParams
+page-type: web-api-interface
 tags:
   - API
   - Dictionary

--- a/files/en-us/web/api/eckeygenparams/index.md
+++ b/files/en-us/web/api/eckeygenparams/index.md
@@ -1,6 +1,7 @@
 ---
 title: EcKeyGenParams
 slug: Web/API/EcKeyGenParams
+page-type: web-api-interface
 tags:
   - API
   - Dictionary

--- a/files/en-us/web/api/eckeyimportparams/index.md
+++ b/files/en-us/web/api/eckeyimportparams/index.md
@@ -1,6 +1,7 @@
 ---
 title: EcKeyImportParams
 slug: Web/API/EcKeyImportParams
+page-type: web-api-interface
 tags:
   - API
   - Dictionary

--- a/files/en-us/web/api/element/after/index.md
+++ b/files/en-us/web/api/element/after/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.after()
 slug: Web/API/Element/after
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/afterscriptexecute_event/index.md
+++ b/files/en-us/web/api/element/afterscriptexecute_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: afterscriptexecute event'
 slug: Web/API/Element/afterscriptexecute_event
+page-type: web-api-event
 tags:
   - Event
   - Non-standard

--- a/files/en-us/web/api/element/animate/index.md
+++ b/files/en-us/web/api/element/animate/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.animate()
 slug: Web/API/Element/animate
+page-type: web-api-instance-method
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/element/append/index.md
+++ b/files/en-us/web/api/element/append/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.append()
 slug: Web/API/Element/append
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/ariaatomic/index.md
+++ b/files/en-us/web/api/element/ariaatomic/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaAtomic
 slug: Web/API/Element/ariaAtomic
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariaautocomplete/index.md
+++ b/files/en-us/web/api/element/ariaautocomplete/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaAutoComplete
 slug: Web/API/Element/ariaAutoComplete
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariabusy/index.md
+++ b/files/en-us/web/api/element/ariabusy/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaBusy
 slug: Web/API/Element/ariaBusy
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariachecked/index.md
+++ b/files/en-us/web/api/element/ariachecked/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaChecked
 slug: Web/API/Element/ariaChecked
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariacolcount/index.md
+++ b/files/en-us/web/api/element/ariacolcount/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaColCount
 slug: Web/API/Element/ariaColCount
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariacolindex/index.md
+++ b/files/en-us/web/api/element/ariacolindex/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaColIndex
 slug: Web/API/Element/ariaColIndex
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariacolindextext/index.md
+++ b/files/en-us/web/api/element/ariacolindextext/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaColIndexText
 slug: Web/API/Element/ariaColIndexText
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariacolspan/index.md
+++ b/files/en-us/web/api/element/ariacolspan/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaColSpan
 slug: Web/API/Element/ariaColSpan
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariacurrent/index.md
+++ b/files/en-us/web/api/element/ariacurrent/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaCurrent
 slug: Web/API/Element/ariaCurrent
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariadescription/index.md
+++ b/files/en-us/web/api/element/ariadescription/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaDescription
 slug: Web/API/Element/ariaDescription
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariadisabled/index.md
+++ b/files/en-us/web/api/element/ariadisabled/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaDisabled
 slug: Web/API/Element/ariaDisabled
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariaexpanded/index.md
+++ b/files/en-us/web/api/element/ariaexpanded/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaExpanded
 slug: Web/API/Element/ariaExpanded
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariahaspopup/index.md
+++ b/files/en-us/web/api/element/ariahaspopup/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaHasPopup
 slug: Web/API/Element/ariaHasPopup
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariahidden/index.md
+++ b/files/en-us/web/api/element/ariahidden/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaHidden
 slug: Web/API/Element/ariaHidden
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariakeyshortcuts/index.md
+++ b/files/en-us/web/api/element/ariakeyshortcuts/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaKeyShortcuts
 slug: Web/API/Element/ariaKeyShortcuts
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/arialabel/index.md
+++ b/files/en-us/web/api/element/arialabel/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaLabel
 slug: Web/API/Element/ariaLabel
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/arialevel/index.md
+++ b/files/en-us/web/api/element/arialevel/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaLevel
 slug: Web/API/Element/ariaLevel
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/arialive/index.md
+++ b/files/en-us/web/api/element/arialive/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaLive
 slug: Web/API/Element/ariaLive
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariamodal/index.md
+++ b/files/en-us/web/api/element/ariamodal/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaModal
 slug: Web/API/Element/ariaModal
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariamultiline/index.md
+++ b/files/en-us/web/api/element/ariamultiline/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaMultiLine
 slug: Web/API/Element/ariaMultiLine
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariamultiselectable/index.md
+++ b/files/en-us/web/api/element/ariamultiselectable/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaMultiSelectable
 slug: Web/API/Element/ariaMultiSelectable
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariaorientation/index.md
+++ b/files/en-us/web/api/element/ariaorientation/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaOrientation
 slug: Web/API/Element/ariaOrientation
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariaplaceholder/index.md
+++ b/files/en-us/web/api/element/ariaplaceholder/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaPlaceholder
 slug: Web/API/Element/ariaPlaceholder
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariaposinset/index.md
+++ b/files/en-us/web/api/element/ariaposinset/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaPosInSet
 slug: Web/API/Element/ariaPosInSet
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariapressed/index.md
+++ b/files/en-us/web/api/element/ariapressed/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaPressed
 slug: Web/API/Element/ariaPressed
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariareadonly/index.md
+++ b/files/en-us/web/api/element/ariareadonly/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaReadOnly
 slug: Web/API/Element/ariaReadOnly
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariarelevant/index.md
+++ b/files/en-us/web/api/element/ariarelevant/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaRelevant
 slug: Web/API/Element/ariaRelevant
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariarequired/index.md
+++ b/files/en-us/web/api/element/ariarequired/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaRequired
 slug: Web/API/Element/ariaRequired
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariaroledescription/index.md
+++ b/files/en-us/web/api/element/ariaroledescription/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaRoleDescription
 slug: Web/API/Element/ariaRoleDescription
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariarowcount/index.md
+++ b/files/en-us/web/api/element/ariarowcount/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaRowCount
 slug: Web/API/Element/ariaRowCount
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariarowindex/index.md
+++ b/files/en-us/web/api/element/ariarowindex/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaRowIndex
 slug: Web/API/Element/ariaRowIndex
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariarowindextext/index.md
+++ b/files/en-us/web/api/element/ariarowindextext/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaRowIndexText
 slug: Web/API/Element/ariaRowIndexText
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariarowspan/index.md
+++ b/files/en-us/web/api/element/ariarowspan/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaRowSpan
 slug: Web/API/Element/ariaRowSpan
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariaselected/index.md
+++ b/files/en-us/web/api/element/ariaselected/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaSelected
 slug: Web/API/Element/ariaSelected
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariasetsize/index.md
+++ b/files/en-us/web/api/element/ariasetsize/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaSetSize
 slug: Web/API/Element/ariaSetSize
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariasort/index.md
+++ b/files/en-us/web/api/element/ariasort/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaSort
 slug: Web/API/Element/ariaSort
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariavaluemax/index.md
+++ b/files/en-us/web/api/element/ariavaluemax/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaValueMax
 slug: Web/API/Element/ariaValueMax
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariavaluemin/index.md
+++ b/files/en-us/web/api/element/ariavaluemin/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaValueMin
 slug: Web/API/Element/ariaValueMin
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariavaluenow/index.md
+++ b/files/en-us/web/api/element/ariavaluenow/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaValueNow
 slug: Web/API/Element/ariaValueNow
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/ariavaluetext/index.md
+++ b/files/en-us/web/api/element/ariavaluetext/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.ariaValueText
 slug: Web/API/Element/ariaValueText
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/assignedslot/index.md
+++ b/files/en-us/web/api/element/assignedslot/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.assignedSlot
 slug: Web/API/Element/assignedSlot
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/element/attachshadow/index.md
+++ b/files/en-us/web/api/element/attachshadow/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.attachShadow()
 slug: Web/API/Element/attachShadow
+page-type: web-api-instance-method
 tags:
   - API
   - Element

--- a/files/en-us/web/api/element/attributes/index.md
+++ b/files/en-us/web/api/element/attributes/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.attributes
 slug: Web/API/Element/attributes
+page-type: web-api-instance-property
 tags:
   - API
   - Attributes

--- a/files/en-us/web/api/element/auxclick_event/index.md
+++ b/files/en-us/web/api/element/auxclick_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: auxclick event'
 slug: Web/API/Element/auxclick_event
+page-type: web-api-event
 tags:
   - Element
   - Event

--- a/files/en-us/web/api/element/before/index.md
+++ b/files/en-us/web/api/element/before/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.before()
 slug: Web/API/Element/before
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/beforescriptexecute_event/index.md
+++ b/files/en-us/web/api/element/beforescriptexecute_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: beforescriptexecute event'
 slug: Web/API/Element/beforescriptexecute_event
+page-type: web-api-event
 tags:
   - DOM
   - Non-standard

--- a/files/en-us/web/api/element/blur_event/index.md
+++ b/files/en-us/web/api/element/blur_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: blur event'
 slug: Web/API/Element/blur_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/childelementcount/index.md
+++ b/files/en-us/web/api/element/childelementcount/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.childElementCount
 slug: Web/API/Element/childElementCount
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/children/index.md
+++ b/files/en-us/web/api/element/children/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.children
 slug: Web/API/Element/children
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/classlist/index.md
+++ b/files/en-us/web/api/element/classlist/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.classList
 slug: Web/API/Element/classList
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/classname/index.md
+++ b/files/en-us/web/api/element/classname/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.className
 slug: Web/API/Element/className
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/click_event/index.md
+++ b/files/en-us/web/api/element/click_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: click event'
 slug: Web/API/Element/click_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/clientheight/index.md
+++ b/files/en-us/web/api/element/clientheight/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.clientHeight
 slug: Web/API/Element/clientHeight
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/element/clientleft/index.md
+++ b/files/en-us/web/api/element/clientleft/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.clientLeft
 slug: Web/API/Element/clientLeft
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/element/clienttop/index.md
+++ b/files/en-us/web/api/element/clienttop/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.clientTop
 slug: Web/API/Element/clientTop
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/element/clientwidth/index.md
+++ b/files/en-us/web/api/element/clientwidth/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.clientWidth
 slug: Web/API/Element/clientWidth
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/element/closest/index.md
+++ b/files/en-us/web/api/element/closest/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.closest()
 slug: Web/API/Element/closest
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Selector

--- a/files/en-us/web/api/element/compositionend_event/index.md
+++ b/files/en-us/web/api/element/compositionend_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: compositionend event'
 slug: Web/API/Element/compositionend_event
+page-type: web-api-event
 tags:
   - Event
   - Reference

--- a/files/en-us/web/api/element/compositionstart_event/index.md
+++ b/files/en-us/web/api/element/compositionstart_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: compositionstart event'
 slug: Web/API/Element/compositionstart_event
+page-type: web-api-event
 tags:
   - Element
   - Event

--- a/files/en-us/web/api/element/compositionupdate_event/index.md
+++ b/files/en-us/web/api/element/compositionupdate_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: compositionupdate event'
 slug: Web/API/Element/compositionupdate_event
+page-type: web-api-event
 tags:
   - Event
   - Reference

--- a/files/en-us/web/api/element/computedstylemap/index.md
+++ b/files/en-us/web/api/element/computedstylemap/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.computedStyleMap()
 slug: Web/API/Element/computedStyleMap
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Typed Object Model API

--- a/files/en-us/web/api/element/contextmenu_event/index.md
+++ b/files/en-us/web/api/element/contextmenu_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: contextmenu event'
 slug: Web/API/Element/contextmenu_event
+page-type: web-api-event
 tags:
   - API
   - Context

--- a/files/en-us/web/api/element/copy_event/index.md
+++ b/files/en-us/web/api/element/copy_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: copy event'
 slug: Web/API/Element/copy_event
+page-type: web-api-event
 tags:
   - API
   - Clipboard API

--- a/files/en-us/web/api/element/createshadowroot/index.md
+++ b/files/en-us/web/api/element/createshadowroot/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.createShadowRoot()
 slug: Web/API/Element/createShadowRoot
+page-type: web-api-instance-method
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/element/cut_event/index.md
+++ b/files/en-us/web/api/element/cut_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: cut event'
 slug: Web/API/Element/cut_event
+page-type: web-api-event
 tags:
   - API
   - Clipboard API

--- a/files/en-us/web/api/element/dblclick_event/index.md
+++ b/files/en-us/web/api/element/dblclick_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: dblclick event'
 slug: Web/API/Element/dblclick_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/domactivate_event/index.md
+++ b/files/en-us/web/api/element/domactivate_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: DOMActivate event'
 slug: Web/API/Element/DOMActivate_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/dommousescroll_event/index.md
+++ b/files/en-us/web/api/element/dommousescroll_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: DOMMouseScroll event'
 slug: Web/API/Element/DOMMouseScroll_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/error_event/index.md
+++ b/files/en-us/web/api/element/error_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: error event'
 slug: Web/API/Element/error_event
+page-type: web-api-event
 tags:
   - Audio
   - DOM

--- a/files/en-us/web/api/element/firstelementchild/index.md
+++ b/files/en-us/web/api/element/firstelementchild/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.firstElementChild
 slug: Web/API/Element/firstElementChild
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/focus_event/index.md
+++ b/files/en-us/web/api/element/focus_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: focus event'
 slug: Web/API/Element/focus_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/focusin_event/index.md
+++ b/files/en-us/web/api/element/focusin_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: focusin event'
 slug: Web/API/Element/focusin_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/focusout_event/index.md
+++ b/files/en-us/web/api/element/focusout_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: focusout event'
 slug: Web/API/Element/focusout_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/fullscreenchange_event/index.md
+++ b/files/en-us/web/api/element/fullscreenchange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: fullscreenchange event'
 slug: Web/API/Element/fullscreenchange_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/element/fullscreenerror_event/index.md
+++ b/files/en-us/web/api/element/fullscreenerror_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: fullscreenerror event'
 slug: Web/API/Element/fullscreenerror_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/element/gesturechange_event/index.md
+++ b/files/en-us/web/api/element/gesturechange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: gesturechange event'
 slug: Web/API/Element/gesturechange_event
+page-type: web-api-event
 tags:
   - Event
   - Non-standard

--- a/files/en-us/web/api/element/gestureend_event/index.md
+++ b/files/en-us/web/api/element/gestureend_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: gestureend event'
 slug: Web/API/Element/gestureend_event
+page-type: web-api-event
 tags:
   - Event
   - Non-standard

--- a/files/en-us/web/api/element/gesturestart_event/index.md
+++ b/files/en-us/web/api/element/gesturestart_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: gesturestart event'
 slug: Web/API/Element/gesturestart_event
+page-type: web-api-event
 tags:
   - Event
   - Non-standard

--- a/files/en-us/web/api/element/getanimations/index.md
+++ b/files/en-us/web/api/element/getanimations/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.getAnimations()
 slug: Web/API/Element/getAnimations
+page-type: web-api-instance-method
 tags:
   - API
   - Animatable

--- a/files/en-us/web/api/element/getattribute/index.md
+++ b/files/en-us/web/api/element/getattribute/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.getAttribute()
 slug: Web/API/Element/getAttribute
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/getattributenames/index.md
+++ b/files/en-us/web/api/element/getattributenames/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.getAttributeNames()
 slug: Web/API/Element/getAttributeNames
+page-type: web-api-instance-method
 tags:
   - API
   - Attribute

--- a/files/en-us/web/api/element/getattributenode/index.md
+++ b/files/en-us/web/api/element/getattributenode/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.getAttributeNode()
 slug: Web/API/Element/getAttributeNode
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/getattributenodens/index.md
+++ b/files/en-us/web/api/element/getattributenodens/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.getAttributeNodeNS()
 slug: Web/API/Element/getAttributeNodeNS
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/getattributens/index.md
+++ b/files/en-us/web/api/element/getattributens/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.getAttributeNS()
 slug: Web/API/Element/getAttributeNS
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/getboundingclientrect/index.md
+++ b/files/en-us/web/api/element/getboundingclientrect/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.getBoundingClientRect()
 slug: Web/API/Element/getBoundingClientRect
+page-type: web-api-instance-method
 tags:
   - API
   - Boundary

--- a/files/en-us/web/api/element/getclientrects/index.md
+++ b/files/en-us/web/api/element/getclientrects/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.getClientRects()
 slug: Web/API/Element/getClientRects
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/element/getelementsbyclassname/index.md
+++ b/files/en-us/web/api/element/getelementsbyclassname/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.getElementsByClassName()
 slug: Web/API/Element/getElementsByClassName
+page-type: web-api-instance-method
 tags:
   - API
   - Classes

--- a/files/en-us/web/api/element/getelementsbytagname/index.md
+++ b/files/en-us/web/api/element/getelementsbytagname/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.getElementsByTagName()
 slug: Web/API/Element/getElementsByTagName
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/getelementsbytagnamens/index.md
+++ b/files/en-us/web/api/element/getelementsbytagnamens/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.getElementsByTagNameNS()
 slug: Web/API/Element/getElementsByTagNameNS
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/hasattribute/index.md
+++ b/files/en-us/web/api/element/hasattribute/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.hasAttribute()
 slug: Web/API/Element/hasAttribute
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/hasattributens/index.md
+++ b/files/en-us/web/api/element/hasattributens/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.hasAttributeNS()
 slug: Web/API/Element/hasAttributeNS
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/hasattributes/index.md
+++ b/files/en-us/web/api/element/hasattributes/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.hasAttributes()
 slug: Web/API/Element/hasAttributes
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/haspointercapture/index.md
+++ b/files/en-us/web/api/element/haspointercapture/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.hasPointerCapture()
 slug: Web/API/Element/hasPointerCapture
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/id/index.md
+++ b/files/en-us/web/api/element/id/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.id
 slug: Web/API/Element/id
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/index.md
+++ b/files/en-us/web/api/element/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element
 slug: Web/API/Element
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/innerhtml/index.md
+++ b/files/en-us/web/api/element/innerhtml/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.innerHTML
 slug: Web/API/Element/innerHTML
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/insertadjacentelement/index.md
+++ b/files/en-us/web/api/element/insertadjacentelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.insertAdjacentElement()
 slug: Web/API/Element/insertAdjacentElement
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/insertadjacenthtml/index.md
+++ b/files/en-us/web/api/element/insertadjacenthtml/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.insertAdjacentHTML()
 slug: Web/API/Element/insertAdjacentHTML
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/insertadjacenttext/index.md
+++ b/files/en-us/web/api/element/insertadjacenttext/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.insertAdjacentText()
 slug: Web/API/Element/insertAdjacentText
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/keydown_event/index.md
+++ b/files/en-us/web/api/element/keydown_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: keydown event'
 slug: Web/API/Element/keydown_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/keypress_event/index.md
+++ b/files/en-us/web/api/element/keypress_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: keypress event'
 slug: Web/API/Element/keypress_event
+page-type: web-api-event
 tags:
   - API
   - Element

--- a/files/en-us/web/api/element/keyup_event/index.md
+++ b/files/en-us/web/api/element/keyup_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: keyup event'
 slug: Web/API/Element/keyup_event
+page-type: web-api-event
 tags:
   - DOM
   - Element

--- a/files/en-us/web/api/element/lastelementchild/index.md
+++ b/files/en-us/web/api/element/lastelementchild/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.lastElementChild
 slug: Web/API/Element/lastElementChild
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/localname/index.md
+++ b/files/en-us/web/api/element/localname/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.localName
 slug: Web/API/Element/localName
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/matches/index.md
+++ b/files/en-us/web/api/element/matches/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.matches()
 slug: Web/API/Element/matches
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Selector

--- a/files/en-us/web/api/element/mousedown_event/index.md
+++ b/files/en-us/web/api/element/mousedown_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: mousedown event'
 slug: Web/API/Element/mousedown_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/mouseenter_event/index.md
+++ b/files/en-us/web/api/element/mouseenter_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: mouseenter event'
 slug: Web/API/Element/mouseenter_event
+page-type: web-api-event
 tags:
   - API
   - Cursor

--- a/files/en-us/web/api/element/mouseleave_event/index.md
+++ b/files/en-us/web/api/element/mouseleave_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: mouseleave event'
 slug: Web/API/Element/mouseleave_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/mousemove_event/index.md
+++ b/files/en-us/web/api/element/mousemove_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: mousemove event'
 slug: Web/API/Element/mousemove_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/mouseout_event/index.md
+++ b/files/en-us/web/api/element/mouseout_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: mouseout event'
 slug: Web/API/Element/mouseout_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/mouseover_event/index.md
+++ b/files/en-us/web/api/element/mouseover_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: mouseover event'
 slug: Web/API/Element/mouseover_event
+page-type: web-api-event
 tags:
   - API
   - Cursor

--- a/files/en-us/web/api/element/mouseup_event/index.md
+++ b/files/en-us/web/api/element/mouseup_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: mouseup event'
 slug: Web/API/Element/mouseup_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/mousewheel_event/index.md
+++ b/files/en-us/web/api/element/mousewheel_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: mousewheel event'
 slug: Web/API/Element/mousewheel_event
+page-type: web-api-event
 tags:
   - DOM
   - Deprecated

--- a/files/en-us/web/api/element/mozmousepixelscroll_event/index.md
+++ b/files/en-us/web/api/element/mozmousepixelscroll_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: MozMousePixelScroll event'
 slug: Web/API/Element/MozMousePixelScroll_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/mscontentzoom_event/index.md
+++ b/files/en-us/web/api/element/mscontentzoom_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: msContentZoom event'
 slug: Web/API/Element/msContentZoom_event
+page-type: web-api-event
 tags:
   - Event
   - Event:Microsoft Extensions

--- a/files/en-us/web/api/element/msgesturechange_event/index.md
+++ b/files/en-us/web/api/element/msgesturechange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: MSGestureChange event'
 slug: Web/API/Element/MSGestureChange_event
+page-type: web-api-event
 tags:
   - Event
   - Non-standard

--- a/files/en-us/web/api/element/msgestureend_event/index.md
+++ b/files/en-us/web/api/element/msgestureend_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: MSGestureEnd event'
 slug: Web/API/Element/MSGestureEnd_event
+page-type: web-api-event
 tags:
   - Event
   - Non-standard

--- a/files/en-us/web/api/element/msgesturehold_event/index.md
+++ b/files/en-us/web/api/element/msgesturehold_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: MSGestureHold event'
 slug: Web/API/Element/MSGestureHold_event
+page-type: web-api-event
 tags:
   - Event
   - Non-standard

--- a/files/en-us/web/api/element/msgesturestart_event/index.md
+++ b/files/en-us/web/api/element/msgesturestart_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: MSGestureStart event'
 slug: Web/API/Element/MSGestureStart_event
+page-type: web-api-event
 tags:
   - Event
   - Non-standard

--- a/files/en-us/web/api/element/msgesturetap_event/index.md
+++ b/files/en-us/web/api/element/msgesturetap_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: MSGestureTap event'
 slug: Web/API/Element/MSGestureTap_event
+page-type: web-api-event
 tags:
   - Event
   - Non-standard

--- a/files/en-us/web/api/element/msinertiastart_event/index.md
+++ b/files/en-us/web/api/element/msinertiastart_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: MSInertiaStart event'
 slug: Web/API/Element/MSInertiaStart_event
+page-type: web-api-event
 tags:
   - Event
   - Non-standard

--- a/files/en-us/web/api/element/msmanipulationstatechanged_event/index.md
+++ b/files/en-us/web/api/element/msmanipulationstatechanged_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: MSManipulationStateChanged event'
 slug: Web/API/Element/MSManipulationStateChanged_event
+page-type: web-api-event
 tags:
   - Event
   - Event:Microsoft Extensions

--- a/files/en-us/web/api/element_timing_api/index.md
+++ b/files/en-us/web/api/element_timing_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element Timing API
 slug: Web/API/Element_timing_API
+page-type: web-api-overview
 tags:
   - API
   - ElementTiming


### PR DESCRIPTION
See  https://github.com/mdn/content/issues/16255. This is part 7 of a series of PRs to add page types to the Web/API documentation.