### PR TITLE
Add Web/API page types, part 8

### DIFF
--- a/files/en-us/web/api/element/mszoomto/index.md
+++ b/files/en-us/web/api/element/mszoomto/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.msZoomTo()
 slug: Web/API/Element/msZoomTo
+page-type: web-api-instance-method
 tags:
   - API
   - API:Microsoft Extensions

--- a/files/en-us/web/api/element/namespaceuri/index.md
+++ b/files/en-us/web/api/element/namespaceuri/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.namespaceURI
 slug: Web/API/Element/namespaceURI
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/nextelementsibling/index.md
+++ b/files/en-us/web/api/element/nextelementsibling/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.nextElementSibling
 slug: Web/API/Element/nextElementSibling
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/openorclosedshadowroot/index.md
+++ b/files/en-us/web/api/element/openorclosedshadowroot/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.openOrClosedShadowRoot
 slug: Web/API/Element/openOrClosedShadowRoot
+page-type: web-api-instance-property
 tags:
   - API
   - Add-ons

--- a/files/en-us/web/api/element/outerhtml/index.md
+++ b/files/en-us/web/api/element/outerhtml/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.outerHTML
 slug: Web/API/Element/outerHTML
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/part/index.md
+++ b/files/en-us/web/api/element/part/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.part
 slug: Web/API/Element/part
+page-type: web-api-instance-property
 tags:
   - API
   - Element

--- a/files/en-us/web/api/element/paste_event/index.md
+++ b/files/en-us/web/api/element/paste_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: paste event'
 slug: Web/API/Element/paste_event
+page-type: web-api-event
 tags:
   - Clipboard API
   - Event

--- a/files/en-us/web/api/element/prefix/index.md
+++ b/files/en-us/web/api/element/prefix/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.prefix
 slug: Web/API/Element/prefix
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/prepend/index.md
+++ b/files/en-us/web/api/element/prepend/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.prepend()
 slug: Web/API/Element/prepend
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/previouselementsibling/index.md
+++ b/files/en-us/web/api/element/previouselementsibling/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.previousElementSibling
 slug: Web/API/Element/previousElementSibling
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/queryselector/index.md
+++ b/files/en-us/web/api/element/queryselector/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.querySelector()
 slug: Web/API/Element/querySelector
+page-type: web-api-instance-method
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/element/queryselectorall/index.md
+++ b/files/en-us/web/api/element/queryselectorall/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.querySelectorAll()
 slug: Web/API/Element/querySelectorAll
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Selectors

--- a/files/en-us/web/api/element/releasepointercapture/index.md
+++ b/files/en-us/web/api/element/releasepointercapture/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.releasePointerCapture()
 slug: Web/API/Element/releasePointerCapture
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/remove/index.md
+++ b/files/en-us/web/api/element/remove/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.remove()
 slug: Web/API/Element/remove
+page-type: web-api-instance-method
 tags:
   - API
   - Element

--- a/files/en-us/web/api/element/removeattribute/index.md
+++ b/files/en-us/web/api/element/removeattribute/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.removeAttribute()
 slug: Web/API/Element/removeAttribute
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/removeattributenode/index.md
+++ b/files/en-us/web/api/element/removeattributenode/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.removeAttributeNode()
 slug: Web/API/Element/removeAttributeNode
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/removeattributens/index.md
+++ b/files/en-us/web/api/element/removeattributens/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.removeAttributeNS()
 slug: Web/API/Element/removeAttributeNS
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/replacechildren/index.md
+++ b/files/en-us/web/api/element/replacechildren/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.replaceChildren()
 slug: Web/API/Element/replaceChildren
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/replacewith/index.md
+++ b/files/en-us/web/api/element/replacewith/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.replaceWith()
 slug: Web/API/Element/replaceWith
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/requestfullscreen/index.md
+++ b/files/en-us/web/api/element/requestfullscreen/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.requestFullscreen()
 slug: Web/API/Element/requestFullscreen
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/requestpointerlock/index.md
+++ b/files/en-us/web/api/element/requestpointerlock/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.requestPointerLock()
 slug: Web/API/Element/requestPointerLock
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/scroll/index.md
+++ b/files/en-us/web/api/element/scroll/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.scroll()
 slug: Web/API/Element/scroll
+page-type: web-api-instance-method
 tags:
   - API
   - Element

--- a/files/en-us/web/api/element/scroll_event/index.md
+++ b/files/en-us/web/api/element/scroll_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: scroll event'
 slug: Web/API/Element/scroll_event
+page-type: web-api-event
 tags:
   - API
   - Element

--- a/files/en-us/web/api/element/scrollby/index.md
+++ b/files/en-us/web/api/element/scrollby/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.scrollBy()
 slug: Web/API/Element/scrollBy
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/element/scrollheight/index.md
+++ b/files/en-us/web/api/element/scrollheight/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.scrollHeight
 slug: Web/API/Element/scrollHeight
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/element/scrollintoview/index.md
+++ b/files/en-us/web/api/element/scrollintoview/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.scrollIntoView()
 slug: Web/API/Element/scrollIntoView
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM Views

--- a/files/en-us/web/api/element/scrollintoviewifneeded/index.md
+++ b/files/en-us/web/api/element/scrollintoviewifneeded/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.scrollIntoViewIfNeeded()
 slug: Web/API/Element/scrollIntoViewIfNeeded
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/scrollleft/index.md
+++ b/files/en-us/web/api/element/scrollleft/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.scrollLeft
 slug: Web/API/Element/scrollLeft
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/element/scrollleftmax/index.md
+++ b/files/en-us/web/api/element/scrollleftmax/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.scrollLeftMax
 slug: Web/API/Element/scrollLeftMax
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/element/scrollto/index.md
+++ b/files/en-us/web/api/element/scrollto/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.scrollTo()
 slug: Web/API/Element/scrollTo
+page-type: web-api-instance-method
 tags:
   - API
   - Element

--- a/files/en-us/web/api/element/scrolltop/index.md
+++ b/files/en-us/web/api/element/scrolltop/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.scrollTop
 slug: Web/API/Element/scrollTop
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/element/scrolltopmax/index.md
+++ b/files/en-us/web/api/element/scrolltopmax/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.scrollTopMax
 slug: Web/API/Element/scrollTopMax
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/element/scrollwidth/index.md
+++ b/files/en-us/web/api/element/scrollwidth/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.scrollWidth
 slug: Web/API/Element/scrollWidth
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/element/securitypolicyviolation_event/index.md
+++ b/files/en-us/web/api/element/securitypolicyviolation_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: securitypolicyviolation event'
 slug: Web/API/Element/securitypolicyviolation_event
+page-type: web-api-event
 tags:
   - CSP
   - API

--- a/files/en-us/web/api/element/select_event/index.md
+++ b/files/en-us/web/api/element/select_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: select event'
 slug: Web/API/Element/select_event
+page-type: web-api-event
 tags:
   - Element
   - Event

--- a/files/en-us/web/api/element/setattribute/index.md
+++ b/files/en-us/web/api/element/setattribute/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.setAttribute()
 slug: Web/API/Element/setAttribute
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/setattributenode/index.md
+++ b/files/en-us/web/api/element/setattributenode/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.setAttributeNode()
 slug: Web/API/Element/setAttributeNode
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/setattributenodens/index.md
+++ b/files/en-us/web/api/element/setattributenodens/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.setAttributeNodeNS()
 slug: Web/API/Element/setAttributeNodeNS
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/setattributens/index.md
+++ b/files/en-us/web/api/element/setattributens/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.setAttributeNS()
 slug: Web/API/Element/setAttributeNS
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/setcapture/index.md
+++ b/files/en-us/web/api/element/setcapture/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.setCapture()
 slug: Web/API/Element/setCapture
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/sethtml/index.md
+++ b/files/en-us/web/api/element/sethtml/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.setHTML()
 slug: Web/API/Element/setHTML
+page-type: web-api-instance-method
 tags:
   - HTML Sanitizer API
   - Method

--- a/files/en-us/web/api/element/setpointercapture/index.md
+++ b/files/en-us/web/api/element/setpointercapture/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.setPointerCapture()
 slug: Web/API/Element/setPointerCapture
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/shadowroot/index.md
+++ b/files/en-us/web/api/element/shadowroot/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.shadowRoot
 slug: Web/API/Element/shadowRoot
+page-type: web-api-instance-property
 tags:
   - API
   - Element

--- a/files/en-us/web/api/element/show_event/index.md
+++ b/files/en-us/web/api/element/show_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: show event'
 slug: Web/API/Element/show_event
+page-type: web-api-event
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/element/slot/index.md
+++ b/files/en-us/web/api/element/slot/index.md
@@ -1,7 +1,7 @@
 ---
 title: Element.slot
 slug: Web/API/Element/slot
-page-type: web-api-instance-method
+page-type: web-api-instance-property
 tags:
   - API
   - Element

--- a/files/en-us/web/api/element/slot/index.md
+++ b/files/en-us/web/api/element/slot/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.slot
 slug: Web/API/Element/slot
+page-type: web-api-instance-method
 tags:
   - API
   - Element

--- a/files/en-us/web/api/element/tagname/index.md
+++ b/files/en-us/web/api/element/tagname/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.tagName
 slug: Web/API/Element/tagName
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/element/toggleattribute/index.md
+++ b/files/en-us/web/api/element/toggleattribute/index.md
@@ -1,6 +1,7 @@
 ---
 title: Element.toggleAttribute()
 slug: Web/API/Element/toggleAttribute
+page-type: web-api-instance-method
 tags:
   - API
   - Element

--- a/files/en-us/web/api/element/touchcancel_event/index.md
+++ b/files/en-us/web/api/element/touchcancel_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: touchcancel event'
 slug: Web/API/Element/touchcancel_event
+page-type: web-api-event
 tags:
   - Event
   - Touch Events

--- a/files/en-us/web/api/element/touchend_event/index.md
+++ b/files/en-us/web/api/element/touchend_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: touchend event'
 slug: Web/API/Element/touchend_event
+page-type: web-api-event
 tags:
   - API
   - Element

--- a/files/en-us/web/api/element/touchmove_event/index.md
+++ b/files/en-us/web/api/element/touchmove_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: touchmove event'
 slug: Web/API/Element/touchmove_event
+page-type: web-api-event
 tags:
   - Event
   - Touch Events

--- a/files/en-us/web/api/element/touchstart_event/index.md
+++ b/files/en-us/web/api/element/touchstart_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: touchstart event'
 slug: Web/API/Element/touchstart_event
+page-type: web-api-event
 tags:
   - Event
   - Touch Events

--- a/files/en-us/web/api/element/webkitmouseforcechanged_event/index.md
+++ b/files/en-us/web/api/element/webkitmouseforcechanged_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: webkitmouseforcechanged event'
 slug: Web/API/Element/webkitmouseforcechanged_event
+page-type: web-api-event
 tags:
   - Event
   - Force Touch

--- a/files/en-us/web/api/element/webkitmouseforcedown_event/index.md
+++ b/files/en-us/web/api/element/webkitmouseforcedown_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: webkitmouseforcedown event'
 slug: Web/API/Element/webkitmouseforcedown_event
+page-type: web-api-event
 tags:
   - Element
   - Event

--- a/files/en-us/web/api/element/webkitmouseforceup_event/index.md
+++ b/files/en-us/web/api/element/webkitmouseforceup_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: webkitmouseforceup event'
 slug: Web/API/Element/webkitmouseforceup_event
+page-type: web-api-event
 tags:
   - Element
   - Event

--- a/files/en-us/web/api/element/webkitmouseforcewillbegin_event/index.md
+++ b/files/en-us/web/api/element/webkitmouseforcewillbegin_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: webkitmouseforcewillbegin event'
 slug: Web/API/Element/webkitmouseforcewillbegin_event
+page-type: web-api-event
 tags:
   - API
   - Element

--- a/files/en-us/web/api/element/wheel_event/index.md
+++ b/files/en-us/web/api/element/wheel_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Element: wheel event'
 slug: Web/API/Element/wheel_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/elementinternals/ariaatomic/index.md
+++ b/files/en-us/web/api/elementinternals/ariaatomic/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaAtomic
 slug: Web/API/ElementInternals/ariaAtomic
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariaautocomplete/index.md
+++ b/files/en-us/web/api/elementinternals/ariaautocomplete/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaAutoComplete
 slug: Web/API/ElementInternals/ariaAutoComplete
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariabusy/index.md
+++ b/files/en-us/web/api/elementinternals/ariabusy/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaBusy
 slug: Web/API/ElementInternals/ariaBusy
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariachecked/index.md
+++ b/files/en-us/web/api/elementinternals/ariachecked/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaChecked
 slug: Web/API/ElementInternals/ariaChecked
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariacolcount/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolcount/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaColCount
 slug: Web/API/ElementInternals/ariaColCount
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariacolindex/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolindex/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaColIndex
 slug: Web/API/ElementInternals/ariaColIndex
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariacolindextext/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolindextext/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaColIndexText
 slug: Web/API/ElementInternals/ariaColIndexText
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariacolspan/index.md
+++ b/files/en-us/web/api/elementinternals/ariacolspan/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaColSpan
 slug: Web/API/ElementInternals/ariaColSpan
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariacurrent/index.md
+++ b/files/en-us/web/api/elementinternals/ariacurrent/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaCurrent
 slug: Web/API/ElementInternals/ariaCurrent
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariadescription/index.md
+++ b/files/en-us/web/api/elementinternals/ariadescription/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaDescription
 slug: Web/API/ElementInternals/ariaDescription
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariadisabled/index.md
+++ b/files/en-us/web/api/elementinternals/ariadisabled/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaDisabled
 slug: Web/API/ElementInternals/ariaDisabled
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariaexpanded/index.md
+++ b/files/en-us/web/api/elementinternals/ariaexpanded/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaExpanded
 slug: Web/API/ElementInternals/ariaExpanded
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariahaspopup/index.md
+++ b/files/en-us/web/api/elementinternals/ariahaspopup/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaHasPopup
 slug: Web/API/ElementInternals/ariaHasPopup
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariahidden/index.md
+++ b/files/en-us/web/api/elementinternals/ariahidden/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaHidden
 slug: Web/API/ElementInternals/ariaHidden
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariakeyshortcuts/index.md
+++ b/files/en-us/web/api/elementinternals/ariakeyshortcuts/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaKeyShortcuts
 slug: Web/API/ElementInternals/ariaKeyShortcuts
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/arialabel/index.md
+++ b/files/en-us/web/api/elementinternals/arialabel/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaLabel
 slug: Web/API/ElementInternals/ariaLabel
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/arialevel/index.md
+++ b/files/en-us/web/api/elementinternals/arialevel/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaLevel
 slug: Web/API/ElementInternals/ariaLevel
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/arialive/index.md
+++ b/files/en-us/web/api/elementinternals/arialive/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaLive
 slug: Web/API/ElementInternals/ariaLive
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariamodal/index.md
+++ b/files/en-us/web/api/elementinternals/ariamodal/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaModal
 slug: Web/API/ElementInternals/ariaModal
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariamultiline/index.md
+++ b/files/en-us/web/api/elementinternals/ariamultiline/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaMultiLine
 slug: Web/API/ElementInternals/ariaMultiLine
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariamultiselectable/index.md
+++ b/files/en-us/web/api/elementinternals/ariamultiselectable/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaMultiSelectable
 slug: Web/API/ElementInternals/ariaMultiSelectable
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariaorientation/index.md
+++ b/files/en-us/web/api/elementinternals/ariaorientation/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaOrientation
 slug: Web/API/ElementInternals/ariaOrientation
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariaplaceholder/index.md
+++ b/files/en-us/web/api/elementinternals/ariaplaceholder/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaPlaceholder
 slug: Web/API/ElementInternals/ariaPlaceholder
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariaposinset/index.md
+++ b/files/en-us/web/api/elementinternals/ariaposinset/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaPosInSet
 slug: Web/API/ElementInternals/ariaPosInSet
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariapressed/index.md
+++ b/files/en-us/web/api/elementinternals/ariapressed/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaPressed
 slug: Web/API/ElementInternals/ariaPressed
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariareadonly/index.md
+++ b/files/en-us/web/api/elementinternals/ariareadonly/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaReadOnly
 slug: Web/API/ElementInternals/ariaReadOnly
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariarelevant/index.md
+++ b/files/en-us/web/api/elementinternals/ariarelevant/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaRelevant
 slug: Web/API/ElementInternals/ariaRelevant
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariarequired/index.md
+++ b/files/en-us/web/api/elementinternals/ariarequired/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaRequired
 slug: Web/API/ElementInternals/ariaRequired
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariaroledescription/index.md
+++ b/files/en-us/web/api/elementinternals/ariaroledescription/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaRoleDescription
 slug: Web/API/ElementInternals/ariaRoleDescription
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariarowcount/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowcount/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaRowCount
 slug: Web/API/ElementInternals/ariaRowCount
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariarowindex/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowindex/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaRowIndex
 slug: Web/API/ElementInternals/ariaRowIndex
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariarowindextext/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowindextext/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaRowIndexText
 slug: Web/API/ElementInternals/ariaRowIndexText
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariarowspan/index.md
+++ b/files/en-us/web/api/elementinternals/ariarowspan/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaRowSpan
 slug: Web/API/ElementInternals/ariaRowSpan
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariaselected/index.md
+++ b/files/en-us/web/api/elementinternals/ariaselected/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaSelected
 slug: Web/API/ElementInternals/ariaSelected
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariasetsize/index.md
+++ b/files/en-us/web/api/elementinternals/ariasetsize/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaSetSize
 slug: Web/API/ElementInternals/ariaSetSize
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariasort/index.md
+++ b/files/en-us/web/api/elementinternals/ariasort/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaSort
 slug: Web/API/ElementInternals/ariaSort
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariavaluemax/index.md
+++ b/files/en-us/web/api/elementinternals/ariavaluemax/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaValueMax
 slug: Web/API/ElementInternals/ariaValueMax
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariavaluemin/index.md
+++ b/files/en-us/web/api/elementinternals/ariavaluemin/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaValueMin
 slug: Web/API/ElementInternals/ariaValueMin
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariavaluenow/index.md
+++ b/files/en-us/web/api/elementinternals/ariavaluenow/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaValueNow
 slug: Web/API/ElementInternals/ariaValueNow
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/ariavaluetext/index.md
+++ b/files/en-us/web/api/elementinternals/ariavaluetext/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.ariaValueText
 slug: Web/API/ElementInternals/ariaValueText
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/checkvalidity/index.md
+++ b/files/en-us/web/api/elementinternals/checkvalidity/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.checkValidity()
 slug: Web/API/ElementInternals/checkValidity
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/elementinternals/form/index.md
+++ b/files/en-us/web/api/elementinternals/form/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.form
 slug: Web/API/ElementInternals/form
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/index.md
+++ b/files/en-us/web/api/elementinternals/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals
 slug: Web/API/ElementInternals
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/elementinternals/labels/index.md
+++ b/files/en-us/web/api/elementinternals/labels/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.labels
 slug: Web/API/ElementInternals/labels
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/reportvalidity/index.md
+++ b/files/en-us/web/api/elementinternals/reportvalidity/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.reportValidity()
 slug: Web/API/ElementInternals/reportValidity
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/elementinternals/role/index.md
+++ b/files/en-us/web/api/elementinternals/role/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.role
 slug: Web/API/ElementInternals/role
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/setformvalue/index.md
+++ b/files/en-us/web/api/elementinternals/setformvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.setFormValue()
 slug: Web/API/ElementInternals/setFormValue
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/elementinternals/setvalidity/index.md
+++ b/files/en-us/web/api/elementinternals/setvalidity/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.setValidity()
 slug: Web/API/ElementInternals/setValidity
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/elementinternals/shadowroot/index.md
+++ b/files/en-us/web/api/elementinternals/shadowroot/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.shadowRoot
 slug: Web/API/ElementInternals/shadowRoot
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/states/index.md
+++ b/files/en-us/web/api/elementinternals/states/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.states
 slug: Web/API/ElementInternals/states
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/validationmessage/index.md
+++ b/files/en-us/web/api/elementinternals/validationmessage/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.validationMessage
 slug: Web/API/ElementInternals/validationMessage
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/validity/index.md
+++ b/files/en-us/web/api/elementinternals/validity/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.validity
 slug: Web/API/ElementInternals/validity
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/elementinternals/willvalidate/index.md
+++ b/files/en-us/web/api/elementinternals/willvalidate/index.md
@@ -1,6 +1,7 @@
 ---
 title: ElementInternals.willValidate
 slug: Web/API/ElementInternals/willValidate
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/encodedaudiochunk/bytelength/index.md
+++ b/files/en-us/web/api/encodedaudiochunk/bytelength/index.md
@@ -1,6 +1,7 @@
 ---
 title: EncodedAudioChunk.byteLength
 slug: Web/API/EncodedAudioChunk/byteLength
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/encodedaudiochunk/copyto/index.md
+++ b/files/en-us/web/api/encodedaudiochunk/copyto/index.md
@@ -1,6 +1,7 @@
 ---
 title: EncodedAudioChunk.copyTo()
 slug: Web/API/EncodedAudioChunk/copyTo
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/encodedaudiochunk/duration/index.md
+++ b/files/en-us/web/api/encodedaudiochunk/duration/index.md
@@ -1,6 +1,7 @@
 ---
 title: EncodedAudioChunk.duration
 slug: Web/API/EncodedAudioChunk/duration
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/encodedaudiochunk/encodedaudiochunk/index.md
+++ b/files/en-us/web/api/encodedaudiochunk/encodedaudiochunk/index.md
@@ -1,6 +1,7 @@
 ---
 title: EncodedAudioChunk.EncodedAudioChunk()
 slug: Web/API/EncodedAudioChunk/EncodedAudioChunk
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/encodedaudiochunk/index.md
+++ b/files/en-us/web/api/encodedaudiochunk/index.md
@@ -1,6 +1,7 @@
 ---
 title: EncodedAudioChunk
 slug: Web/API/EncodedAudioChunk
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/encodedaudiochunk/timestamp/index.md
+++ b/files/en-us/web/api/encodedaudiochunk/timestamp/index.md
@@ -1,6 +1,7 @@
 ---
 title: EncodedAudioChunk.timestamp
 slug: Web/API/EncodedAudioChunk/timestamp
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/encodedaudiochunk/type/index.md
+++ b/files/en-us/web/api/encodedaudiochunk/type/index.md
@@ -1,6 +1,7 @@
 ---
 title: EncodedAudioChunk.type
 slug: Web/API/EncodedAudioChunk/type
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/encodedvideochunk/bytelength/index.md
+++ b/files/en-us/web/api/encodedvideochunk/bytelength/index.md
@@ -1,6 +1,7 @@
 ---
 title: EncodedVideoChunk.byteLength
 slug: Web/API/EncodedVideoChunk/byteLength
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/encodedvideochunk/copyto/index.md
+++ b/files/en-us/web/api/encodedvideochunk/copyto/index.md
@@ -1,6 +1,7 @@
 ---
 title: EncodedVideoChunk.copyTo()
 slug: Web/API/EncodedVideoChunk/copyTo
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/encodedvideochunk/duration/index.md
+++ b/files/en-us/web/api/encodedvideochunk/duration/index.md
@@ -1,6 +1,7 @@
 ---
 title: EncodedVideoChunk.duration
 slug: Web/API/EncodedVideoChunk/duration
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/encodedvideochunk/encodedvideochunk/index.md
+++ b/files/en-us/web/api/encodedvideochunk/encodedvideochunk/index.md
@@ -1,6 +1,7 @@
 ---
 title: EncodedVideoChunk.EncodedVideoChunk()
 slug: Web/API/EncodedVideoChunk/EncodedVideoChunk
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/encodedvideochunk/index.md
+++ b/files/en-us/web/api/encodedvideochunk/index.md
@@ -1,6 +1,7 @@
 ---
 title: EncodedVideoChunk
 slug: Web/API/EncodedVideoChunk
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/encodedvideochunk/timestamp/index.md
+++ b/files/en-us/web/api/encodedvideochunk/timestamp/index.md
@@ -1,6 +1,7 @@
 ---
 title: EncodedVideoChunk.timestamp
 slug: Web/API/EncodedVideoChunk/timestamp
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/encodedvideochunk/type/index.md
+++ b/files/en-us/web/api/encodedvideochunk/type/index.md
@@ -1,6 +1,7 @@
 ---
 title: EncodedVideoChunk.type
 slug: Web/API/EncodedVideoChunk/type
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/encoding_api/encodings/index.md
+++ b/files/en-us/web/api/encoding_api/encodings/index.md
@@ -1,6 +1,7 @@
 ---
 title: Encoding API Encodings
 slug: Web/API/Encoding_API/Encodings
+page-type: guide
 tags:
   - API
   - Encoding

--- a/files/en-us/web/api/encoding_api/index.md
+++ b/files/en-us/web/api/encoding_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Encoding API
 slug: Web/API/Encoding_API
+page-type: web-api-overview
 tags:
   - API
   - Encoding

--- a/files/en-us/web/api/encrypted_media_extensions_api/index.md
+++ b/files/en-us/web/api/encrypted_media_extensions_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Encrypted Media Extensions API
 slug: Web/API/Encrypted_Media_Extensions_API
+page-type: web-api-overview
 tags:
   - API
   - EME

--- a/files/en-us/web/api/errorevent/index.md
+++ b/files/en-us/web/api/errorevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: ErrorEvent
 slug: Web/API/ErrorEvent
+page-type: web-api-interface
 tags:
   - API
   - Event

--- a/files/en-us/web/api/event/bubbles/index.md
+++ b/files/en-us/web/api/event/bubbles/index.md
@@ -1,6 +1,7 @@
 ---
 title: Event.bubbles
 slug: Web/API/Event/bubbles
+page-type: web-api-instance-property
 tags:
   - Property
   - Read-only

--- a/files/en-us/web/api/event/cancelable/index.md
+++ b/files/en-us/web/api/event/cancelable/index.md
@@ -1,6 +1,7 @@
 ---
 title: Event.cancelable
 slug: Web/API/Event/cancelable
+page-type: web-api-instance-property
 tags:
   - Property
   - Read-only

--- a/files/en-us/web/api/event/cancelbubble/index.md
+++ b/files/en-us/web/api/event/cancelbubble/index.md
@@ -1,6 +1,7 @@
 ---
 title: Event.cancelBubble
 slug: Web/API/Event/cancelBubble
+page-type: web-api-instance-property
 tags:
   - Property
   - Reference

--- a/files/en-us/web/api/event/comparison_of_event_targets/index.md
+++ b/files/en-us/web/api/event/comparison_of_event_targets/index.md
@@ -1,6 +1,7 @@
 ---
 title: Comparison of Event Targets
 slug: Web/API/Event/Comparison_of_Event_Targets
+page-type: guide
 tags:
   - DOM
   - Gecko

--- a/files/en-us/web/api/event/composed/index.md
+++ b/files/en-us/web/api/event/composed/index.md
@@ -1,6 +1,7 @@
 ---
 title: Event.composed
 slug: Web/API/Event/composed
+page-type: web-api-instance-property
 tags:
   - Property
   - Read-only

--- a/files/en-us/web/api/event/composedpath/index.md
+++ b/files/en-us/web/api/event/composedpath/index.md
@@ -1,6 +1,7 @@
 ---
 title: Event.composedPath()
 slug: Web/API/Event/composedPath
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/event/currenttarget/index.md
+++ b/files/en-us/web/api/event/currenttarget/index.md
@@ -1,6 +1,7 @@
 ---
 title: Event.currentTarget
 slug: Web/API/Event/currentTarget
+page-type: web-api-instance-property
 tags:
   - Property
   - Read-only

--- a/files/en-us/web/api/event/defaultprevented/index.md
+++ b/files/en-us/web/api/event/defaultprevented/index.md
@@ -1,6 +1,7 @@
 ---
 title: Event.defaultPrevented
 slug: Web/API/Event/defaultPrevented
+page-type: web-api-instance-property
 tags:
   - Property
   - Read-only

--- a/files/en-us/web/api/event/event/index.md
+++ b/files/en-us/web/api/event/event/index.md
@@ -1,6 +1,7 @@
 ---
 title: Event()
 slug: Web/API/Event/Event
+page-type: web-api-constructor
 tags:
   - Constructor
   - Reference

--- a/files/en-us/web/api/event/eventphase/index.md
+++ b/files/en-us/web/api/event/eventphase/index.md
@@ -1,6 +1,7 @@
 ---
 title: Event.eventPhase
 slug: Web/API/Event/eventPhase
+page-type: web-api-instance-property
 tags:
   - Property
   - Read-only

--- a/files/en-us/web/api/event/explicitoriginaltarget/index.md
+++ b/files/en-us/web/api/event/explicitoriginaltarget/index.md
@@ -1,6 +1,7 @@
 ---
 title: Event.explicitOriginalTarget
 slug: Web/API/Event/explicitOriginalTarget
+page-type: web-api-instance-property
 tags:
   - Non-standard
   - Property

--- a/files/en-us/web/api/event/index.md
+++ b/files/en-us/web/api/event/index.md
@@ -1,6 +1,7 @@
 ---
 title: Event
 slug: Web/API/Event
+page-type: web-api-interface
 tags:
   - Interface
   - Reference

--- a/files/en-us/web/api/event/initevent/index.md
+++ b/files/en-us/web/api/event/initevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: Event.initEvent()
 slug: Web/API/Event/initEvent
+page-type: web-api-instance-method
 tags:
   - Deprecated
   - Method

--- a/files/en-us/web/api/event/istrusted/index.md
+++ b/files/en-us/web/api/event/istrusted/index.md
@@ -1,6 +1,7 @@
 ---
 title: Event.isTrusted
 slug: Web/API/Event/isTrusted
+page-type: web-api-instance-property
 tags:
   - Property
   - Read-only

--- a/files/en-us/web/api/event/originaltarget/index.md
+++ b/files/en-us/web/api/event/originaltarget/index.md
@@ -1,6 +1,7 @@
 ---
 title: Event.originalTarget
 slug: Web/API/Event/originalTarget
+page-type: web-api-instance-property
 tags:
   - Non-standard
   - Property

--- a/files/en-us/web/api/event/preventdefault/index.md
+++ b/files/en-us/web/api/event/preventdefault/index.md
@@ -1,6 +1,7 @@
 ---
 title: Event.preventDefault()
 slug: Web/API/Event/preventDefault
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/event/returnvalue/index.md
+++ b/files/en-us/web/api/event/returnvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: Event.returnValue
 slug: Web/API/Event/returnValue
+page-type: web-api-instance-property
 tags:
   - Property
   - Reference

--- a/files/en-us/web/api/event/srcelement/index.md
+++ b/files/en-us/web/api/event/srcelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: Event.srcElement
 slug: Web/API/Event/srcElement
+page-type: web-api-instance-property
 tags:
   - Deprecated
   - Property

--- a/files/en-us/web/api/event/stopimmediatepropagation/index.md
+++ b/files/en-us/web/api/event/stopimmediatepropagation/index.md
@@ -1,6 +1,7 @@
 ---
 title: Event.stopImmediatePropagation()
 slug: Web/API/Event/stopImmediatePropagation
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/event/stoppropagation/index.md
+++ b/files/en-us/web/api/event/stoppropagation/index.md
@@ -1,6 +1,7 @@
 ---
 title: Event.stopPropagation()
 slug: Web/API/Event/stopPropagation
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/event/target/index.md
+++ b/files/en-us/web/api/event/target/index.md
@@ -1,6 +1,7 @@
 ---
 title: Event.target
 slug: Web/API/Event/target
+page-type: web-api-instance-property
 tags:
   - Property
   - Reference

--- a/files/en-us/web/api/event/timestamp/index.md
+++ b/files/en-us/web/api/event/timestamp/index.md
@@ -1,6 +1,7 @@
 ---
 title: Event.timeStamp
 slug: Web/API/Event/timeStamp
+page-type: web-api-instance-property
 tags:
   - Property
   - Reference

--- a/files/en-us/web/api/event/type/index.md
+++ b/files/en-us/web/api/event/type/index.md
@@ -1,6 +1,7 @@
 ---
 title: Event.type
 slug: Web/API/Event/type
+page-type: web-api-instance-property
 tags:
   - Property
   - Read-only

--- a/files/en-us/web/api/eventsource/close/index.md
+++ b/files/en-us/web/api/eventsource/close/index.md
@@ -1,6 +1,7 @@
 ---
 title: EventSource.close()
 slug: Web/API/EventSource/close
+page-type: web-api-instance-method
 tags:
   - API
   - EventSource

--- a/files/en-us/web/api/eventsource/error_event/index.md
+++ b/files/en-us/web/api/eventsource/error_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'EventSource: error event'
 slug: Web/API/EventSource/error_event
+page-type: web-api-event
 tags:
   - API
   - Error

--- a/files/en-us/web/api/eventsource/eventsource/index.md
+++ b/files/en-us/web/api/eventsource/eventsource/index.md
@@ -1,6 +1,7 @@
 ---
 title: EventSource()
 slug: Web/API/EventSource/EventSource
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/eventsource/index.md
+++ b/files/en-us/web/api/eventsource/index.md
@@ -1,6 +1,7 @@
 ---
 title: EventSource
 slug: Web/API/EventSource
+page-type: web-api-interface
 tags:
   - API
   - Communications

--- a/files/en-us/web/api/eventsource/message_event/index.md
+++ b/files/en-us/web/api/eventsource/message_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'EventSource: message event'
 slug: Web/API/EventSource/message_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/eventsource/open_event/index.md
+++ b/files/en-us/web/api/eventsource/open_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'EventSource: open event'
 slug: Web/API/EventSource/open_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/eventsource/readystate/index.md
+++ b/files/en-us/web/api/eventsource/readystate/index.md
@@ -1,6 +1,7 @@
 ---
 title: EventSource.readyState
 slug: Web/API/EventSource/readyState
+page-type: web-api-instance-property
 tags:
   - API
   - EventSource

--- a/files/en-us/web/api/eventsource/url/index.md
+++ b/files/en-us/web/api/eventsource/url/index.md
@@ -1,6 +1,7 @@
 ---
 title: EventSource.url
 slug: Web/API/EventSource/url
+page-type: web-api-instance-property
 tags:
   - API
   - EventSource

--- a/files/en-us/web/api/eventsource/withcredentials/index.md
+++ b/files/en-us/web/api/eventsource/withcredentials/index.md
@@ -1,6 +1,7 @@
 ---
 title: EventSource.withCredentials
 slug: Web/API/EventSource/withCredentials
+page-type: web-api-instance-property
 tags:
   - API
   - EventSource

--- a/files/en-us/web/api/eventtarget/addeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.md
@@ -1,6 +1,7 @@
 ---
 title: EventTarget.addEventListener()
 slug: Web/API/EventTarget/addEventListener
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/eventtarget/dispatchevent/index.md
+++ b/files/en-us/web/api/eventtarget/dispatchevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: EventTarget.dispatchEvent()
 slug: Web/API/EventTarget/dispatchEvent
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/eventtarget/eventtarget/index.md
+++ b/files/en-us/web/api/eventtarget/eventtarget/index.md
@@ -1,6 +1,7 @@
 ---
 title: EventTarget()
 slug: Web/API/EventTarget/EventTarget
+page-type: web-api-constructor
 tags:
   - Constructor
   - Reference

--- a/files/en-us/web/api/eventtarget/index.md
+++ b/files/en-us/web/api/eventtarget/index.md
@@ -1,6 +1,7 @@
 ---
 title: EventTarget
 slug: Web/API/EventTarget
+page-type: web-api-interface
 tags:
   - Interface
   - Reference

--- a/files/en-us/web/api/eventtarget/removeeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/removeeventlistener/index.md
@@ -1,6 +1,7 @@
 ---
 title: EventTarget.removeEventListener()
 slug: Web/API/EventTarget/removeEventListener
+page-type: web-api-instance-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/extendablecookiechangeevent/changed/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/changed/index.md
@@ -1,6 +1,7 @@
 ---
 title: ExtendableCookieChangeEvent.changed
 slug: Web/API/ExtendableCookieChangeEvent/changed
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/extendablecookiechangeevent/deleted/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/deleted/index.md
@@ -1,6 +1,7 @@
 ---
 title: ExtendableCookieChangeEvent.deleted
 slug: Web/API/ExtendableCookieChangeEvent/deleted
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: ExtendableCookieChangeEvent()
 slug: Web/API/ExtendableCookieChangeEvent/ExtendableCookieChangeEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/extendablecookiechangeevent/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: ExtendableCookieChangeEvent
 slug: Web/API/ExtendableCookieChangeEvent
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/extendableevent/extendableevent/index.md
+++ b/files/en-us/web/api/extendableevent/extendableevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: ExtendableEvent()
 slug: Web/API/ExtendableEvent/ExtendableEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/extendableevent/index.md
+++ b/files/en-us/web/api/extendableevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: ExtendableEvent
 slug: Web/API/ExtendableEvent
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/extendableevent/waituntil/index.md
+++ b/files/en-us/web/api/extendableevent/waituntil/index.md
@@ -1,6 +1,7 @@
 ---
 title: ExtendableEvent.waitUntil()
 slug: Web/API/ExtendableEvent/waitUntil
+page-type: web-api-instance-method
 tags:
   - API
   - ExtendableEvent

--- a/files/en-us/web/api/extendablemessageevent/data/index.md
+++ b/files/en-us/web/api/extendablemessageevent/data/index.md
@@ -1,6 +1,7 @@
 ---
 title: ExtendableMessageEvent.data
 slug: Web/API/ExtendableMessageEvent/data
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/extendablemessageevent/extendablemessageevent/index.md
+++ b/files/en-us/web/api/extendablemessageevent/extendablemessageevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: ExtendableMessageEvent()
 slug: Web/API/ExtendableMessageEvent/ExtendableMessageEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/extendablemessageevent/index.md
+++ b/files/en-us/web/api/extendablemessageevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: ExtendableMessageEvent
 slug: Web/API/ExtendableMessageEvent
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/extendablemessageevent/lasteventid/index.md
+++ b/files/en-us/web/api/extendablemessageevent/lasteventid/index.md
@@ -1,6 +1,7 @@
 ---
 title: ExtendableMessageEvent.lastEventId
 slug: Web/API/ExtendableMessageEvent/lastEventId
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/extendablemessageevent/origin/index.md
+++ b/files/en-us/web/api/extendablemessageevent/origin/index.md
@@ -1,6 +1,7 @@
 ---
 title: ExtendableMessageEvent.origin
 slug: Web/API/ExtendableMessageEvent/origin
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/extendablemessageevent/ports/index.md
+++ b/files/en-us/web/api/extendablemessageevent/ports/index.md
@@ -1,6 +1,7 @@
 ---
 title: ExtendableMessageEvent.ports
 slug: Web/API/ExtendableMessageEvent/ports
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/extendablemessageevent/source/index.md
+++ b/files/en-us/web/api/extendablemessageevent/source/index.md
@@ -1,6 +1,7 @@
 ---
 title: ExtendableMessageEvent.source
 slug: Web/API/ExtendableMessageEvent/source
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/eyedropper/eyedropper/index.md
+++ b/files/en-us/web/api/eyedropper/eyedropper/index.md
@@ -1,6 +1,7 @@
 ---
 title: EyeDropper()
 slug: Web/API/EyeDropper/EyeDropper
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/eyedropper/index.md
+++ b/files/en-us/web/api/eyedropper/index.md
@@ -1,6 +1,7 @@
 ---
 title: EyeDropper
 slug: Web/API/EyeDropper
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/eyedropper/open/index.md
+++ b/files/en-us/web/api/eyedropper/open/index.md
@@ -1,6 +1,7 @@
 ---
 title: EyeDropper.open()
 slug: Web/API/EyeDropper/open
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/eyedropper_api/index.md
+++ b/files/en-us/web/api/eyedropper_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: EyeDropper API
 slug: Web/API/EyeDropper_API
+page-type: web-api-overview
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/featurepolicy/allowedfeatures/index.md
+++ b/files/en-us/web/api/featurepolicy/allowedfeatures/index.md
@@ -1,6 +1,7 @@
 ---
 title: FeaturePolicy.allowedFeatures()
 slug: Web/API/FeaturePolicy/allowedFeatures
+page-type: web-api-instance-method
 tags:
   - API
   - Directive

--- a/files/en-us/web/api/featurepolicy/allowsfeature/index.md
+++ b/files/en-us/web/api/featurepolicy/allowsfeature/index.md
@@ -1,6 +1,7 @@
 ---
 title: FeaturePolicy.allowsFeature()
 slug: Web/API/FeaturePolicy/allowsFeature
+page-type: web-api-instance-method
 browser-compat: api.FeaturePolicy.allowsFeature
 ---
 {{APIRef("Feature Policy API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/featurepolicy/features/index.md
+++ b/files/en-us/web/api/featurepolicy/features/index.md
@@ -1,6 +1,7 @@
 ---
 title: FeaturePolicy.features()
 slug: Web/API/FeaturePolicy/features
+page-type: web-api-instance-method
 browser-compat: api.FeaturePolicy.features
 ---
 {{APIRef("Feature Policy API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/featurepolicy/getallowlistforfeature/index.md
+++ b/files/en-us/web/api/featurepolicy/getallowlistforfeature/index.md
@@ -1,6 +1,7 @@
 ---
 title: FeaturePolicy.getAllowlistForFeature()
 slug: Web/API/FeaturePolicy/getAllowlistForFeature
+page-type: web-api-instance-method
 tags:
   - API
   - Feature Policy

--- a/files/en-us/web/api/featurepolicy/index.md
+++ b/files/en-us/web/api/featurepolicy/index.md
@@ -1,6 +1,7 @@
 ---
 title: FeaturePolicy
 slug: Web/API/FeaturePolicy
+page-type: web-api-interface
 tags:
   - API
   - Feature Policy

--- a/files/en-us/web/api/federatedcredential/federatedcredential/index.md
+++ b/files/en-us/web/api/federatedcredential/federatedcredential/index.md
@@ -1,6 +1,7 @@
 ---
 title: FederatedCredential()
 slug: Web/API/FederatedCredential/FederatedCredential
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/federatedcredential/index.md
+++ b/files/en-us/web/api/federatedcredential/index.md
@@ -1,6 +1,7 @@
 ---
 title: FederatedCredential
 slug: Web/API/FederatedCredential
+page-type: web-api-interface
 tags:
   - API
   - Credential Management API

--- a/files/en-us/web/api/federatedcredential/protocol/index.md
+++ b/files/en-us/web/api/federatedcredential/protocol/index.md
@@ -1,6 +1,7 @@
 ---
 title: FederatedCredential.protocol
 slug: Web/API/FederatedCredential/protocol
+page-type: web-api-instance-property
 tags:
   - API
   - Credential Management API

--- a/files/en-us/web/api/federatedcredential/provider/index.md
+++ b/files/en-us/web/api/federatedcredential/provider/index.md
@@ -1,6 +1,7 @@
 ---
 title: FederatedCredential.provider
 slug: Web/API/FederatedCredential/provider
+page-type: web-api-instance-property
 tags:
   - API
   - Credential Management API

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -1,6 +1,7 @@
 ---
 title: fetch()
 slug: Web/API/fetch
+page-type: web-api-global-function
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/fetch_api/basic_concepts/index.md
+++ b/files/en-us/web/api/fetch_api/basic_concepts/index.md
@@ -1,6 +1,7 @@
 ---
 title: Fetch basic concepts
 slug: Web/API/Fetch_API/Basic_concepts
+page-type: guide
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/fetch_api/cross-global_fetch_usage/index.md
+++ b/files/en-us/web/api/fetch_api/cross-global_fetch_usage/index.md
@@ -1,6 +1,7 @@
 ---
 title: Cross-global fetch usage
 slug: Web/API/Fetch_API/Cross-global_fetch_usage
+page-type: guide
 tags:
   - Cross global
   - Fetch

--- a/files/en-us/web/api/fetch_api/index.md
+++ b/files/en-us/web/api/fetch_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Fetch API
 slug: Web/API/Fetch_API
+page-type: web-api-overview
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/fetch_api/using_fetch/index.md
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using the Fetch API
 slug: Web/API/Fetch_API/Using_Fetch
+page-type: guide
 tags:
   - API
   - BODY

--- a/files/en-us/web/api/fetchevent/clientid/index.md
+++ b/files/en-us/web/api/fetchevent/clientid/index.md
@@ -1,6 +1,7 @@
 ---
 title: FetchEvent.clientId
 slug: Web/API/FetchEvent/clientId
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/fetchevent/fetchevent/index.md
+++ b/files/en-us/web/api/fetchevent/fetchevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: FetchEvent()
 slug: Web/API/FetchEvent/FetchEvent
+page-type: web-api-instance-property
 tags:
   - API
   - Communication

--- a/files/en-us/web/api/fetchevent/fetchevent/index.md
+++ b/files/en-us/web/api/fetchevent/fetchevent/index.md
@@ -1,7 +1,7 @@
 ---
 title: FetchEvent()
 slug: Web/API/FetchEvent/FetchEvent
-page-type: web-api-instance-property
+page-type: web-api-constructor
 tags:
   - API
   - Communication

--- a/files/en-us/web/api/fetchevent/index.md
+++ b/files/en-us/web/api/fetchevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: FetchEvent
 slug: Web/API/FetchEvent
+page-type: web-api-interface
 tags:
   - API
   - FetchEvent

--- a/files/en-us/web/api/fetchevent/isreload/index.md
+++ b/files/en-us/web/api/fetchevent/isreload/index.md
@@ -1,6 +1,7 @@
 ---
 title: FetchEvent.isReload
 slug: Web/API/FetchEvent/isReload
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental


### PR DESCRIPTION
See  https://github.com/mdn/content/issues/16255. This is part 8 of a series of PRs to add page types to the Web/API documentation.