### PR TITLE
Add Web/API page types, part 9

### DIFF
--- a/files/en-us/web/api/fetchevent/preloadresponse/index.md
+++ b/files/en-us/web/api/fetchevent/preloadresponse/index.md
@@ -1,6 +1,7 @@
 ---
 title: FetchEvent.preloadResponse
 slug: Web/API/FetchEvent/preloadResponse
+page-type: web-api-instance-property
 tags:
   - API
   - FetchEvent

--- a/files/en-us/web/api/fetchevent/replacesclientid/index.md
+++ b/files/en-us/web/api/fetchevent/replacesclientid/index.md
@@ -1,6 +1,7 @@
 ---
 title: FetchEvent.replacesClientId
 slug: Web/API/FetchEvent/replacesClientId
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/fetchevent/request/index.md
+++ b/files/en-us/web/api/fetchevent/request/index.md
@@ -1,6 +1,7 @@
 ---
 title: FetchEvent.request
 slug: Web/API/FetchEvent/request
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/fetchevent/respondwith/index.md
+++ b/files/en-us/web/api/fetchevent/respondwith/index.md
@@ -1,6 +1,7 @@
 ---
 title: FetchEvent.respondWith()
 slug: Web/API/FetchEvent/respondWith
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/fetchevent/resultingclientid/index.md
+++ b/files/en-us/web/api/fetchevent/resultingclientid/index.md
@@ -1,6 +1,7 @@
 ---
 title: FetchEvent.resultingClientId
 slug: Web/API/FetchEvent/resultingClientId
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/file/file/index.md
+++ b/files/en-us/web/api/file/file/index.md
@@ -1,6 +1,7 @@
 ---
 title: File()
 slug: Web/API/File/File
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/file/index.md
+++ b/files/en-us/web/api/file/index.md
@@ -1,6 +1,7 @@
 ---
 title: File
 slug: Web/API/File
+page-type: web-api-interface
 tags:
   - API
   - File API

--- a/files/en-us/web/api/file/lastmodified/index.md
+++ b/files/en-us/web/api/file/lastmodified/index.md
@@ -1,6 +1,7 @@
 ---
 title: File.lastModified
 slug: Web/API/File/lastModified
+page-type: web-api-instance-property
 tags:
   - API
   - File API

--- a/files/en-us/web/api/file/lastmodifieddate/index.md
+++ b/files/en-us/web/api/file/lastmodifieddate/index.md
@@ -1,6 +1,7 @@
 ---
 title: File.lastModifiedDate
 slug: Web/API/File/lastModifiedDate
+page-type: web-api-instance-property
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/file/name/index.md
+++ b/files/en-us/web/api/file/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: File.name
 slug: Web/API/File/name
+page-type: web-api-instance-property
 tags:
   - API
   - File API

--- a/files/en-us/web/api/file/type/index.md
+++ b/files/en-us/web/api/file/type/index.md
@@ -1,6 +1,7 @@
 ---
 title: File.type
 slug: Web/API/File/type
+page-type: web-api-instance-property
 tags:
   - API
   - File API

--- a/files/en-us/web/api/file/using_files_from_web_applications/index.md
+++ b/files/en-us/web/api/file/using_files_from_web_applications/index.md
@@ -1,7 +1,6 @@
 ---
 title: Using files from web applications
 slug: Web/API/File/Using_files_from_web_applications
-page-type: guide
 tags:
   - Files
   - HTML5

--- a/files/en-us/web/api/file/using_files_from_web_applications/index.md
+++ b/files/en-us/web/api/file/using_files_from_web_applications/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using files from web applications
 slug: Web/API/File/Using_files_from_web_applications
+page-type: guide
 tags:
   - Files
   - HTML5

--- a/files/en-us/web/api/file/webkitrelativepath/index.md
+++ b/files/en-us/web/api/file/webkitrelativepath/index.md
@@ -1,6 +1,7 @@
 ---
 title: File.webkitRelativePath
 slug: Web/API/File/webkitRelativePath
+page-type: web-api-instance-property
 tags:
   - API
   - File API

--- a/files/en-us/web/api/file_and_directory_entries_api/firefox_support/index.md
+++ b/files/en-us/web/api/file_and_directory_entries_api/firefox_support/index.md
@@ -1,6 +1,7 @@
 ---
 title: File and Directory Entries API support in Firefox
 slug: Web/API/File_and_Directory_Entries_API/Firefox_support
+page-type: guide
 tags:
   - API
   - Chrome

--- a/files/en-us/web/api/file_and_directory_entries_api/index.md
+++ b/files/en-us/web/api/file_and_directory_entries_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: File and Directory Entries API
 slug: Web/API/File_and_Directory_Entries_API
+page-type: web-api-overview
 tags:
   - API
   - File and Directory Entries API

--- a/files/en-us/web/api/file_and_directory_entries_api/introduction/index.md
+++ b/files/en-us/web/api/file_and_directory_entries_api/introduction/index.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction to the File and Directory Entries API
 slug: Web/API/File_and_Directory_Entries_API/Introduction
+page-type: guide
 tags:
   - API
   - Beginner

--- a/files/en-us/web/api/file_system_access_api/index.md
+++ b/files/en-us/web/api/file_system_access_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: File System Access API
 slug: Web/API/File_System_Access_API
+page-type: web-api-overview
 tags:
   - API
   - Directory

--- a/files/en-us/web/api/fileentrysync/index.md
+++ b/files/en-us/web/api/fileentrysync/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileEntrySync
 slug: Web/API/FileEntrySync
+page-type: web-api-interface
 tags:
   - API
   - File

--- a/files/en-us/web/api/filelist/index.md
+++ b/files/en-us/web/api/filelist/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileList
 slug: Web/API/FileList
+page-type: web-api-interface
 tags:
   - API
   - File API

--- a/files/en-us/web/api/filereader/abort/index.md
+++ b/files/en-us/web/api/filereader/abort/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileReader.abort()
 slug: Web/API/FileReader/abort
+page-type: web-api-instance-method
 tags:
   - API
   - File API

--- a/files/en-us/web/api/filereader/abort_event/index.md
+++ b/files/en-us/web/api/filereader/abort_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'FileReader: abort event'
 slug: Web/API/FileReader/abort_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/filereader/error/index.md
+++ b/files/en-us/web/api/filereader/error/index.md
@@ -1,7 +1,7 @@
 ---
 title: FileReader.error
 slug: Web/API/FileReader/error
-page-type: web-api-instance-method
+page-type: web-api-instance-property
 tags:
   - API
   - File API

--- a/files/en-us/web/api/filereader/error/index.md
+++ b/files/en-us/web/api/filereader/error/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileReader.error
 slug: Web/API/FileReader/error
+page-type: web-api-instance-method
 tags:
   - API
   - File API

--- a/files/en-us/web/api/filereader/error_event/index.md
+++ b/files/en-us/web/api/filereader/error_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'FileReader: error event'
 slug: Web/API/FileReader/error_event
+page-type: web-api-event
 tags:
   - API
   - Error

--- a/files/en-us/web/api/filereader/filereader/index.md
+++ b/files/en-us/web/api/filereader/filereader/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileReader()
 slug: Web/API/FileReader/FileReader
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/filereader/index.md
+++ b/files/en-us/web/api/filereader/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileReader
 slug: Web/API/FileReader
+page-type: web-api-interface
 tags:
   - API
   - File API

--- a/files/en-us/web/api/filereader/load_event/index.md
+++ b/files/en-us/web/api/filereader/load_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'FileReader: load event'
 slug: Web/API/FileReader/load_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/filereader/loadend_event/index.md
+++ b/files/en-us/web/api/filereader/loadend_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'FileReader: loadend event'
 slug: Web/API/FileReader/loadend_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/filereader/loadstart_event/index.md
+++ b/files/en-us/web/api/filereader/loadstart_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'FileReader: loadstart event'
 slug: Web/API/FileReader/loadstart_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/filereader/progress_event/index.md
+++ b/files/en-us/web/api/filereader/progress_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'FileReader: progress event'
 slug: Web/API/FileReader/progress_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/filereader/readasarraybuffer/index.md
+++ b/files/en-us/web/api/filereader/readasarraybuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileReader.readAsArrayBuffer()
 slug: Web/API/FileReader/readAsArrayBuffer
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/filereader/readasbinarystring/index.md
+++ b/files/en-us/web/api/filereader/readasbinarystring/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileReader.readAsBinaryString()
 slug: Web/API/FileReader/readAsBinaryString
+page-type: web-api-instance-method
 tags:
   - API
   - File API

--- a/files/en-us/web/api/filereader/readasdataurl/index.md
+++ b/files/en-us/web/api/filereader/readasdataurl/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileReader.readAsDataURL()
 slug: Web/API/FileReader/readAsDataURL
+page-type: web-api-instance-method
 tags:
   - API
   - Base 64

--- a/files/en-us/web/api/filereader/readastext/index.md
+++ b/files/en-us/web/api/filereader/readastext/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileReader.readAsText()
 slug: Web/API/FileReader/readAsText
+page-type: web-api-instance-method
 tags:
   - API
   - File API

--- a/files/en-us/web/api/filereader/readystate/index.md
+++ b/files/en-us/web/api/filereader/readystate/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileReader.readyState
 slug: Web/API/FileReader/readyState
+page-type: web-api-instance-property
 tags:
   - API
   - File API

--- a/files/en-us/web/api/filereader/result/index.md
+++ b/files/en-us/web/api/filereader/result/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileReader.result
 slug: Web/API/FileReader/result
+page-type: web-api-instance-property
 tags:
   - API
   - File API

--- a/files/en-us/web/api/filereadersync/index.md
+++ b/files/en-us/web/api/filereadersync/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileReaderSync
 slug: Web/API/FileReaderSync
+page-type: web-api-interface
 tags:
   - API
   - NeedsMarkupWork

--- a/files/en-us/web/api/filereadersync/readasarraybuffer/index.md
+++ b/files/en-us/web/api/filereadersync/readasarraybuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileReaderSync.readAsArrayBuffer()
 slug: Web/API/FileReaderSync/readAsArrayBuffer
+page-type: web-api-instance-method
 browser-compat: api.FileReaderSync.readAsArrayBuffer
 ---
 {{APIRef("File API")}}The `readAsArrayBuffer()` method of the {{DOMxRef("FileReaderSync")}} interface allows to read {{DOMxRef("File")}} or {{DOMxRef("Blob")}} objects in a synchronous way into an {{jsxref("ArrayBuffer")}}. This interface is [only available](/en-US/docs/Web/API/Web_Workers_API/Functions_and_classes_available_to_workers) in [workers](/en-US/docs/Web/API/Worker) as it enables synchronous I/O that could potentially block.

--- a/files/en-us/web/api/filereadersync/readasbinarystring/index.md
+++ b/files/en-us/web/api/filereadersync/readasbinarystring/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileReaderSync.readAsBinaryString()
 slug: Web/API/FileReaderSync/readAsBinaryString
+page-type: web-api-instance-method
 tags:
   - Reference
   - Deprecated

--- a/files/en-us/web/api/filereadersync/readasdataurl/index.md
+++ b/files/en-us/web/api/filereadersync/readasdataurl/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileReaderSync.readAsDataURL()
 slug: Web/API/FileReaderSync/readAsDataURL
+page-type: web-api-instance-method
 browser-compat: api.FileReaderSync.readAsDataURL
 ---
 {{APIRef("File API")}}

--- a/files/en-us/web/api/filereadersync/readastext/index.md
+++ b/files/en-us/web/api/filereadersync/readastext/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileReaderSync.readAsText()
 slug: Web/API/FileReaderSync/readAsText
+page-type: web-api-instance-method
 browser-compat: api.FileReaderSync.readAsText
 ---
 {{APIRef("File API")}}

--- a/files/en-us/web/api/filesystem/index.md
+++ b/files/en-us/web/api/filesystem/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystem
 slug: Web/API/FileSystem
+page-type: web-api-interface
 tags:
   - API
   - File API

--- a/files/en-us/web/api/filesystem/name/index.md
+++ b/files/en-us/web/api/filesystem/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystem.name
 slug: Web/API/FileSystem/name
+page-type: web-api-instance-property
 tags:
   - API
   - File and Directory Entries API

--- a/files/en-us/web/api/filesystem/root/index.md
+++ b/files/en-us/web/api/filesystem/root/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystem.root
 slug: Web/API/FileSystem/root
+page-type: web-api-instance-property
 tags:
   - API
   - File and Directory Entries API

--- a/files/en-us/web/api/filesystemdirectoryentry/createreader/index.md
+++ b/files/en-us/web/api/filesystemdirectoryentry/createreader/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemDirectoryEntry.createReader()
 slug: Web/API/FileSystemDirectoryEntry/createReader
+page-type: web-api-instance-method
 tags:
   - API
   - File and Directory Entries API

--- a/files/en-us/web/api/filesystemdirectoryentry/getdirectory/index.md
+++ b/files/en-us/web/api/filesystemdirectoryentry/getdirectory/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemDirectoryEntry.getDirectory()
 slug: Web/API/FileSystemDirectoryEntry/getDirectory
+page-type: web-api-instance-method
 tags:
   - API
   - File and Directory Entries API

--- a/files/en-us/web/api/filesystemdirectoryentry/getfile/index.md
+++ b/files/en-us/web/api/filesystemdirectoryentry/getfile/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemDirectoryEntry.getFile()
 slug: Web/API/FileSystemDirectoryEntry/getFile
+page-type: web-api-instance-method
 tags:
   - API
   - File and Directory Entries API

--- a/files/en-us/web/api/filesystemdirectoryentry/index.md
+++ b/files/en-us/web/api/filesystemdirectoryentry/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemDirectoryEntry
 slug: Web/API/FileSystemDirectoryEntry
+page-type: web-api-interface
 tags:
   - API
   - File API

--- a/files/en-us/web/api/filesystemdirectoryentry/removerecursively/index.md
+++ b/files/en-us/web/api/filesystemdirectoryentry/removerecursively/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemDirectoryEntry.removeRecursively()
 slug: Web/API/FileSystemDirectoryEntry/removeRecursively
+page-type: web-api-instance-method
 tags:
   - API
   - File and Directory Entries API

--- a/files/en-us/web/api/filesystemdirectoryhandle/entries/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/entries/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemDirectoryHandle.entries()
 slug: Web/API/FileSystemDirectoryHandle/entries
+page-type: web-api-instance-method
 tags:
   - Directories
   - File System Access API

--- a/files/en-us/web/api/filesystemdirectoryhandle/getdirectoryhandle/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/getdirectoryhandle/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemDirectoryHandle.getDirectoryHandle()
 slug: Web/API/FileSystemDirectoryHandle/getDirectoryHandle
+page-type: web-api-instance-method
 tags:
   - Directories
   - Directory

--- a/files/en-us/web/api/filesystemdirectoryhandle/getfilehandle/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/getfilehandle/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemDirectoryHandle.getFileHandle()
 slug: Web/API/FileSystemDirectoryHandle/getFileHandle
+page-type: web-api-instance-method
 tags:
   - Directory
   - File

--- a/files/en-us/web/api/filesystemdirectoryhandle/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemDirectoryHandle
 slug: Web/API/FileSystemDirectoryHandle
+page-type: web-api-interface
 tags:
   - Directories
   - Directory

--- a/files/en-us/web/api/filesystemdirectoryhandle/keys/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/keys/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemDirectoryHandle.keys()
 slug: Web/API/FileSystemDirectoryHandle/keys
+page-type: web-api-instance-method
 tags:
   - Directories
   - File System Access API

--- a/files/en-us/web/api/filesystemdirectoryhandle/removeentry/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/removeentry/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemDirectoryHandle.removeEntry()
 slug: Web/API/FileSystemDirectoryHandle/removeEntry
+page-type: web-api-instance-method
 tags:
   - Directory
   - File

--- a/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/resolve/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemDirectoryHandle.resolve()
 slug: Web/API/FileSystemDirectoryHandle/resolve
+page-type: web-api-instance-method
 tags:
   - Directory
   - File

--- a/files/en-us/web/api/filesystemdirectoryhandle/values/index.md
+++ b/files/en-us/web/api/filesystemdirectoryhandle/values/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemDirectoryHandle.values()
 slug: Web/API/FileSystemDirectoryHandle/values
+page-type: web-api-instance-method
 tags:
   - Directory
   - File

--- a/files/en-us/web/api/filesystemdirectoryreader/index.md
+++ b/files/en-us/web/api/filesystemdirectoryreader/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemDirectoryReader
 slug: Web/API/FileSystemDirectoryReader
+page-type: web-api-interface
 tags:
   - API
   - File and Directory Entries API

--- a/files/en-us/web/api/filesystemdirectoryreader/readentries/index.md
+++ b/files/en-us/web/api/filesystemdirectoryreader/readentries/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemDirectoryReader.readEntries()
 slug: Web/API/FileSystemDirectoryReader/readEntries
+page-type: web-api-instance-method
 tags:
   - API
   - File and Directory Entries API

--- a/files/en-us/web/api/filesystementry/copyto/index.md
+++ b/files/en-us/web/api/filesystementry/copyto/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemEntry.copyTo()
 slug: Web/API/FileSystemEntry/copyTo
+page-type: web-api-instance-method
 tags:
   - API
   - File and Directory Entries APIs

--- a/files/en-us/web/api/filesystementry/filesystem/index.md
+++ b/files/en-us/web/api/filesystementry/filesystem/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemEntry.filesystem
 slug: Web/API/FileSystemEntry/filesystem
+page-type: web-api-instance-property
 tags:
   - API
   - File and Directory Entries API

--- a/files/en-us/web/api/filesystementry/fullpath/index.md
+++ b/files/en-us/web/api/filesystementry/fullpath/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemEntry.fullPath
 slug: Web/API/FileSystemEntry/fullPath
+page-type: web-api-instance-property
 tags:
   - API
   - File and Directory Entries API

--- a/files/en-us/web/api/filesystementry/getmetadata/index.md
+++ b/files/en-us/web/api/filesystementry/getmetadata/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemEntry.getMetadata()
 slug: Web/API/FileSystemEntry/getMetadata
+page-type: web-api-instance-method
 tags:
   - API
   - File and Directory Entries API

--- a/files/en-us/web/api/filesystementry/getparent/index.md
+++ b/files/en-us/web/api/filesystementry/getparent/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemEntry.getParent()
 slug: Web/API/FileSystemEntry/getParent
+page-type: web-api-instance-method
 tags:
   - API
   - File and Directory Entry API

--- a/files/en-us/web/api/filesystementry/index.md
+++ b/files/en-us/web/api/filesystementry/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemEntry
 slug: Web/API/FileSystemEntry
+page-type: web-api-interface
 tags:
   - API
   - Entry

--- a/files/en-us/web/api/filesystementry/isdirectory/index.md
+++ b/files/en-us/web/api/filesystementry/isdirectory/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemEntry.isDirectory
 slug: Web/API/FileSystemEntry/isDirectory
+page-type: web-api-instance-property
 tags:
   - API
   - File and Directory Entries API

--- a/files/en-us/web/api/filesystementry/isfile/index.md
+++ b/files/en-us/web/api/filesystementry/isfile/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemEntry.isFile
 slug: Web/API/FileSystemEntry/isFile
+page-type: web-api-instance-property
 tags:
   - API
   - File and Directory Entries API

--- a/files/en-us/web/api/filesystementry/moveto/index.md
+++ b/files/en-us/web/api/filesystementry/moveto/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemEntry.moveTo()
 slug: Web/API/FileSystemEntry/moveTo
+page-type: web-api-instance-method
 tags:
   - API
   - File and Directory Entries API

--- a/files/en-us/web/api/filesystementry/name/index.md
+++ b/files/en-us/web/api/filesystementry/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemEntry.name
 slug: Web/API/FileSystemEntry/name
+page-type: web-api-instance-property
 tags:
   - API
   - File and Directory Entries API

--- a/files/en-us/web/api/filesystementry/remove/index.md
+++ b/files/en-us/web/api/filesystementry/remove/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemEntry.remove()
 slug: Web/API/FileSystemEntry/remove
+page-type: web-api-instance-method
 tags:
   - API
   - File and Directory Entries API

--- a/files/en-us/web/api/filesystementry/tourl/index.md
+++ b/files/en-us/web/api/filesystementry/tourl/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemEntry.toURL()
 slug: Web/API/FileSystemEntry/toURL
+page-type: web-api-instance-method
 tags:
   - API
   - File and Directory Entries API

--- a/files/en-us/web/api/filesystemfileentry/createwriter/index.md
+++ b/files/en-us/web/api/filesystemfileentry/createwriter/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemFileEntry.createWriter()
 slug: Web/API/FileSystemFileEntry/createWriter
+page-type: web-api-instance-method
 tags:
   - API
   - File and Directory Entries API

--- a/files/en-us/web/api/filesystemfileentry/file/index.md
+++ b/files/en-us/web/api/filesystemfileentry/file/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemFileEntry.file()
 slug: Web/API/FileSystemFileEntry/file
+page-type: web-api-instance-method
 tags:
   - API
   - File

--- a/files/en-us/web/api/filesystemfileentry/index.md
+++ b/files/en-us/web/api/filesystemfileentry/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemFileEntry
 slug: Web/API/FileSystemFileEntry
+page-type: web-api-interface
 tags:
   - API
   - File and Directory Entries API

--- a/files/en-us/web/api/filesystemfilehandle/createwritable/index.md
+++ b/files/en-us/web/api/filesystemfilehandle/createwritable/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemFileHandle.createWritable()
 slug: Web/API/FileSystemFileHandle/createWritable
+page-type: web-api-instance-method
 tags:
   - Directory
   - File

--- a/files/en-us/web/api/filesystemfilehandle/getfile/index.md
+++ b/files/en-us/web/api/filesystemfilehandle/getfile/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemFileHandle.getFile()
 slug: Web/API/FileSystemFileHandle/getFile
+page-type: web-api-instance-method
 tags:
   - Directory
   - File

--- a/files/en-us/web/api/filesystemfilehandle/index.md
+++ b/files/en-us/web/api/filesystemfilehandle/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemFileHandle
 slug: Web/API/FileSystemFileHandle
+page-type: web-api-interface
 tags:
   - Directory
   - File

--- a/files/en-us/web/api/filesystemhandle/index.md
+++ b/files/en-us/web/api/filesystemhandle/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemHandle
 slug: Web/API/FileSystemHandle
+page-type: web-api-interface
 tags:
   - Directories
   - File System Access API

--- a/files/en-us/web/api/filesystemhandle/issameentry/index.md
+++ b/files/en-us/web/api/filesystemhandle/issameentry/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemHandle.isSameEntry()
 slug: Web/API/FileSystemHandle/isSameEntry
+page-type: web-api-instance-method
 tags:
   - Directory
   - File

--- a/files/en-us/web/api/filesystemhandle/kind/index.md
+++ b/files/en-us/web/api/filesystemhandle/kind/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemHandle.kind
 slug: Web/API/FileSystemHandle/kind
+page-type: web-api-instance-property
 tags:
   - Directory
   - File

--- a/files/en-us/web/api/filesystemhandle/name/index.md
+++ b/files/en-us/web/api/filesystemhandle/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemHandle.name
 slug: Web/API/FileSystemHandle/name
+page-type: web-api-instance-property
 tags:
   - Directory
   - File

--- a/files/en-us/web/api/filesystemhandle/querypermission/index.md
+++ b/files/en-us/web/api/filesystemhandle/querypermission/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemHandle.queryPermission()
 slug: Web/API/FileSystemHandle/queryPermission
+page-type: web-api-instance-method
 tags:
   - Directory
   - File

--- a/files/en-us/web/api/filesystemhandle/requestpermission/index.md
+++ b/files/en-us/web/api/filesystemhandle/requestpermission/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemHandle.requestPermission()
 slug: Web/API/FileSystemHandle/requestPermission
+page-type: web-api-instance-method
 tags:
   - Directory
   - File

--- a/files/en-us/web/api/filesystemsync/index.md
+++ b/files/en-us/web/api/filesystemsync/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemSync
 slug: Web/API/FileSystemSync
+page-type: web-api-interface
 tags:
   - API
   - File API

--- a/files/en-us/web/api/filesystemwritablefilestream/index.md
+++ b/files/en-us/web/api/filesystemwritablefilestream/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemWritableFileStream
 slug: Web/API/FileSystemWritableFileStream
+page-type: web-api-interface
 tags:
   - File
   - File System Access API

--- a/files/en-us/web/api/filesystemwritablefilestream/seek/index.md
+++ b/files/en-us/web/api/filesystemwritablefilestream/seek/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemWritableFileStream.seek()
 slug: Web/API/FileSystemWritableFileStream/seek
+page-type: web-api-instance-method
 tags:
   - File
   - File System Access API

--- a/files/en-us/web/api/filesystemwritablefilestream/truncate/index.md
+++ b/files/en-us/web/api/filesystemwritablefilestream/truncate/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemWritableFileStream.truncate()
 slug: Web/API/FileSystemWritableFileStream/truncate
+page-type: web-api-instance-method
 tags:
   - File
   - File System Access API

--- a/files/en-us/web/api/filesystemwritablefilestream/write/index.md
+++ b/files/en-us/web/api/filesystemwritablefilestream/write/index.md
@@ -1,6 +1,7 @@
 ---
 title: FileSystemWritableFileStream.write()
 slug: Web/API/FileSystemWritableFileStream/write
+page-type: web-api-instance-method
 tags:
   - File
   - File System Access API

--- a/files/en-us/web/api/focusevent/focusevent/index.md
+++ b/files/en-us/web/api/focusevent/focusevent/index.md
@@ -1,7 +1,7 @@
 ---
 title: FocusEvent()
 slug: Web/API/FocusEvent/FocusEvent
-page-type: web-api-event
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/focusevent/focusevent/index.md
+++ b/files/en-us/web/api/focusevent/focusevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: FocusEvent()
 slug: Web/API/FocusEvent/FocusEvent
+page-type: web-api-event
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/focusevent/index.md
+++ b/files/en-us/web/api/focusevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: FocusEvent
 slug: Web/API/FocusEvent
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/focusevent/relatedtarget/index.md
+++ b/files/en-us/web/api/focusevent/relatedtarget/index.md
@@ -1,6 +1,7 @@
 ---
 title: FocusEvent.relatedTarget
 slug: Web/API/FocusEvent/relatedTarget
+page-type: web-api-instance-property
 tags:
   - API
   - Event

--- a/files/en-us/web/api/fontface/ascentoverride/index.md
+++ b/files/en-us/web/api/fontface/ascentoverride/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFace.ascentOverride
 slug: Web/API/FontFace/ascentOverride
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/fontface/descentoverride/index.md
+++ b/files/en-us/web/api/fontface/descentoverride/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFace.descentOverride
 slug: Web/API/FontFace/descentOverride
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/fontface/display/index.md
+++ b/files/en-us/web/api/fontface/display/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFace.display
 slug: Web/API/FontFace/display
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Font Loading API

--- a/files/en-us/web/api/fontface/family/index.md
+++ b/files/en-us/web/api/fontface/family/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFace.family
 slug: Web/API/FontFace/family
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Font Loading API

--- a/files/en-us/web/api/fontface/featuresettings/index.md
+++ b/files/en-us/web/api/fontface/featuresettings/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFace.featureSettings
 slug: Web/API/FontFace/featureSettings
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Font Loading API

--- a/files/en-us/web/api/fontface/fontface/index.md
+++ b/files/en-us/web/api/fontface/fontface/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFace()
 slug: Web/API/FontFace/FontFace
+page-type: web-api-constructor
 tags:
   - API
   - CSS Font Loading API

--- a/files/en-us/web/api/fontface/index.md
+++ b/files/en-us/web/api/fontface/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFace
 slug: Web/API/FontFace
+page-type: web-api-interface
 tags:
   - API
   - CSS Font Loading API

--- a/files/en-us/web/api/fontface/linegapoverride/index.md
+++ b/files/en-us/web/api/fontface/linegapoverride/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFace.lineGapOverride
 slug: Web/API/FontFace/lineGapOverride
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/fontface/load/index.md
+++ b/files/en-us/web/api/fontface/load/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFace.load()
 slug: Web/API/FontFace/load
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Font Loading API

--- a/files/en-us/web/api/fontface/loaded/index.md
+++ b/files/en-us/web/api/fontface/loaded/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFace.loaded
 slug: Web/API/FontFace/loaded
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Font Loading API

--- a/files/en-us/web/api/fontface/status/index.md
+++ b/files/en-us/web/api/fontface/status/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFace.status
 slug: Web/API/FontFace/status
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Font Loading API

--- a/files/en-us/web/api/fontface/stretch/index.md
+++ b/files/en-us/web/api/fontface/stretch/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFace.stretch
 slug: Web/API/FontFace/stretch
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Font Loading API

--- a/files/en-us/web/api/fontface/style/index.md
+++ b/files/en-us/web/api/fontface/style/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFace.style
 slug: Web/API/FontFace/style
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Font Loading API

--- a/files/en-us/web/api/fontface/unicoderange/index.md
+++ b/files/en-us/web/api/fontface/unicoderange/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFace.unicodeRange
 slug: Web/API/FontFace/unicodeRange
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Font Loading API

--- a/files/en-us/web/api/fontface/variant/index.md
+++ b/files/en-us/web/api/fontface/variant/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFace.variant
 slug: Web/API/FontFace/variant
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Font Loading API

--- a/files/en-us/web/api/fontface/variationsettings/index.md
+++ b/files/en-us/web/api/fontface/variationsettings/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFace.variationSettings
 slug: Web/API/FontFace/variationSettings
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Font Loading API

--- a/files/en-us/web/api/fontface/weight/index.md
+++ b/files/en-us/web/api/fontface/weight/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFace.weight
 slug: Web/API/FontFace/weight
+page-type: web-api-instance-property
 tags:
   - API
   - CSS Font Loading API

--- a/files/en-us/web/api/fontfaceset/add/index.md
+++ b/files/en-us/web/api/fontfaceset/add/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFaceSet.add()
 slug: Web/API/FontFaceSet/add
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/fontfaceset/check/index.md
+++ b/files/en-us/web/api/fontfaceset/check/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFaceSet.check()
 slug: Web/API/FontFaceSet/check
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Font Loading API

--- a/files/en-us/web/api/fontfaceset/clear/index.md
+++ b/files/en-us/web/api/fontfaceset/clear/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFaceSet.clear()
 slug: Web/API/FontFaceSet/clear
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/fontfaceset/delete/index.md
+++ b/files/en-us/web/api/fontfaceset/delete/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFaceSet.delete()
 slug: Web/API/FontFaceSet/delete
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/fontfaceset/entries/index.md
+++ b/files/en-us/web/api/fontfaceset/entries/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFaceSet.entries()
 slug: Web/API/FontFaceSet/entries
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/fontfaceset/foreach/index.md
+++ b/files/en-us/web/api/fontfaceset/foreach/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFaceSet.forEach()
 slug: Web/API/FontFaceSet/forEach
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/fontfaceset/has/index.md
+++ b/files/en-us/web/api/fontfaceset/has/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFaceSet.has()
 slug: Web/API/FontFaceSet/has
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/fontfaceset/index.md
+++ b/files/en-us/web/api/fontfaceset/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFaceSet
 slug: Web/API/FontFaceSet
+page-type: web-api-interface
 tags:
   - API
   - CSS Font Loading API

--- a/files/en-us/web/api/fontfaceset/keys/index.md
+++ b/files/en-us/web/api/fontfaceset/keys/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFaceSet.keys()
 slug: Web/API/FontFaceSet/keys
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/fontfaceset/load/index.md
+++ b/files/en-us/web/api/fontfaceset/load/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFaceSet.load()
 slug: Web/API/FontFaceSet/load
+page-type: web-api-instance-method
 tags:
   - API
   - CSS Font Loading API

--- a/files/en-us/web/api/fontfaceset/loading_event/index.md
+++ b/files/en-us/web/api/fontfaceset/loading_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'FontFaceSet: loading event'
 slug: Web/API/FontFaceSet/loading_event
+page-type: web-api-event
 tags:
   - API
   - Property

--- a/files/en-us/web/api/fontfaceset/loadingdone_event/index.md
+++ b/files/en-us/web/api/fontfaceset/loadingdone_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'FontFaceSet: loadingdone event'
 slug: Web/API/FontFaceSet/loadingdone_event
+page-type: web-api-event
 tags:
   - API
   - Property

--- a/files/en-us/web/api/fontfaceset/loadingerror_event/index.md
+++ b/files/en-us/web/api/fontfaceset/loadingerror_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'FontFaceSet: loadingerror event'
 slug: Web/API/FontFaceSet/loadingerror_event
+page-type: web-api-event
 tags:
   - API
   - Property

--- a/files/en-us/web/api/fontfaceset/ready/index.md
+++ b/files/en-us/web/api/fontfaceset/ready/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFaceSet.ready
 slug: Web/API/FontFaceSet/ready
+page-type: web-api-instance-property
 tags:
   - API
   - CSSFontLoading API

--- a/files/en-us/web/api/fontfaceset/size/index.md
+++ b/files/en-us/web/api/fontfaceset/size/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFaceSet.size
 slug: Web/API/FontFaceSet/size
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/fontfaceset/status/index.md
+++ b/files/en-us/web/api/fontfaceset/status/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFaceSet.status
 slug: Web/API/FontFaceSet/status
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/fontfaceset/values/index.md
+++ b/files/en-us/web/api/fontfaceset/values/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFaceSet.values()
 slug: Web/API/FontFaceSet/values
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/fontfacesetloadevent/fontfaces/index.md
+++ b/files/en-us/web/api/fontfacesetloadevent/fontfaces/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFaceSetLoadEvent.fontfaces
 slug: Web/API/FontFaceSetLoadEvent/fontfaces
+page-type: web-api-instance-property
 tags:
   - API
   - CSSFontLoading

--- a/files/en-us/web/api/fontfacesetloadevent/fontfacesetloadevent/index.md
+++ b/files/en-us/web/api/fontfacesetloadevent/fontfacesetloadevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFaceSetLoadEvent()
 slug: Web/API/FontFaceSetLoadEvent/FontFaceSetLoadEvent
+page-type: web-api-constructor
 tags:
   - API
   - CSSFontLoading

--- a/files/en-us/web/api/fontfacesetloadevent/index.md
+++ b/files/en-us/web/api/fontfacesetloadevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: FontFaceSetLoadEvent
 slug: Web/API/FontFaceSetLoadEvent
+page-type: web-api-interface
 tags:
   - API
   - CSSFontLoading

--- a/files/en-us/web/api/force_touch_events/index.md
+++ b/files/en-us/web/api/force_touch_events/index.md
@@ -1,6 +1,7 @@
 ---
 title: Force Touch events
 slug: Web/API/Force_Touch_events
+page-type: web-api-interface
 tags:
   - Advanced
   - DOM

--- a/files/en-us/web/api/force_touch_events/index.md
+++ b/files/en-us/web/api/force_touch_events/index.md
@@ -1,7 +1,7 @@
 ---
 title: Force Touch events
 slug: Web/API/Force_Touch_events
-page-type: web-api-interface
+page-type: web-api-overview
 tags:
   - Advanced
   - DOM

--- a/files/en-us/web/api/formdata/append/index.md
+++ b/files/en-us/web/api/formdata/append/index.md
@@ -1,6 +1,7 @@
 ---
 title: FormData.append()
 slug: Web/API/FormData/append
+page-type: web-api-instance-method
 tags:
   - API
   - Append

--- a/files/en-us/web/api/formdata/delete/index.md
+++ b/files/en-us/web/api/formdata/delete/index.md
@@ -1,6 +1,7 @@
 ---
 title: FormData.delete()
 slug: Web/API/FormData/delete
+page-type: web-api-instance-method
 tags:
   - API
   - FormData

--- a/files/en-us/web/api/formdata/entries/index.md
+++ b/files/en-us/web/api/formdata/entries/index.md
@@ -1,6 +1,7 @@
 ---
 title: FormData.entries()
 slug: Web/API/FormData/entries
+page-type: web-api-instance-method
 tags:
   - API
   - FormData

--- a/files/en-us/web/api/formdata/formdata/index.md
+++ b/files/en-us/web/api/formdata/formdata/index.md
@@ -1,6 +1,7 @@
 ---
 title: FormData()
 slug: Web/API/FormData/FormData
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/formdata/get/index.md
+++ b/files/en-us/web/api/formdata/get/index.md
@@ -1,6 +1,7 @@
 ---
 title: FormData.get()
 slug: Web/API/FormData/get
+page-type: web-api-instance-method
 tags:
   - API
   - FormData

--- a/files/en-us/web/api/formdata/getall/index.md
+++ b/files/en-us/web/api/formdata/getall/index.md
@@ -1,6 +1,7 @@
 ---
 title: FormData.getAll()
 slug: Web/API/FormData/getAll
+page-type: web-api-instance-method
 tags:
   - API
   - FormData

--- a/files/en-us/web/api/formdata/has/index.md
+++ b/files/en-us/web/api/formdata/has/index.md
@@ -1,6 +1,7 @@
 ---
 title: FormData.has()
 slug: Web/API/FormData/has
+page-type: web-api-instance-method
 tags:
   - API
   - FormData

--- a/files/en-us/web/api/formdata/index.md
+++ b/files/en-us/web/api/formdata/index.md
@@ -1,6 +1,7 @@
 ---
 title: FormData
 slug: Web/API/FormData
+page-type: web-api-interface
 tags:
   - API
   - FormData

--- a/files/en-us/web/api/formdata/keys/index.md
+++ b/files/en-us/web/api/formdata/keys/index.md
@@ -1,6 +1,7 @@
 ---
 title: FormData.keys()
 slug: Web/API/FormData/keys
+page-type: web-api-instance-method
 tags:
   - API
   - FormData

--- a/files/en-us/web/api/formdata/set/index.md
+++ b/files/en-us/web/api/formdata/set/index.md
@@ -1,6 +1,7 @@
 ---
 title: FormData.set()
 slug: Web/API/FormData/set
+page-type: web-api-instance-method
 tags:
   - API
   - FormData

--- a/files/en-us/web/api/formdata/using_formdata_objects/index.md
+++ b/files/en-us/web/api/formdata/using_formdata_objects/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using FormData Objects
 slug: Web/API/FormData/Using_FormData_Objects
+page-type: guide
 tags:
   - AJAX
   - Blob

--- a/files/en-us/web/api/formdata/values/index.md
+++ b/files/en-us/web/api/formdata/values/index.md
@@ -1,6 +1,7 @@
 ---
 title: FormData.values()
 slug: Web/API/FormData/values
+page-type: web-api-instance-method
 tags:
   - API
   - FormData

--- a/files/en-us/web/api/formdataevent/formdata/index.md
+++ b/files/en-us/web/api/formdataevent/formdata/index.md
@@ -1,6 +1,7 @@
 ---
 title: FormDataEvent.formData
 slug: Web/API/FormDataEvent/formData
+page-type: web-api-instance-property
 tags:
   - API
   - FormDataEvent

--- a/files/en-us/web/api/formdataevent/formdataevent/index.md
+++ b/files/en-us/web/api/formdataevent/formdataevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: FormDataEvent()
 slug: Web/API/FormDataEvent/FormDataEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/formdataevent/index.md
+++ b/files/en-us/web/api/formdataevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: FormDataEvent
 slug: Web/API/FormDataEvent
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/fullscreen_api/guide/index.md
+++ b/files/en-us/web/api/fullscreen_api/guide/index.md
@@ -1,6 +1,7 @@
 ---
 title: Guide to the Fullscreen API
 slug: Web/API/Fullscreen_API/Guide
+page-type: guide
 tags:
   - API
   - Drawing

--- a/files/en-us/web/api/fullscreen_api/index.md
+++ b/files/en-us/web/api/fullscreen_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Fullscreen API
 slug: Web/API/Fullscreen_API
+page-type: web-api-overview
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/gainnode/gain/index.md
+++ b/files/en-us/web/api/gainnode/gain/index.md
@@ -1,6 +1,7 @@
 ---
 title: GainNode.gain
 slug: Web/API/GainNode/gain
+page-type: web-api-instance-property
 tags:
   - API
   - Gain

--- a/files/en-us/web/api/gainnode/gainnode/index.md
+++ b/files/en-us/web/api/gainnode/gainnode/index.md
@@ -1,6 +1,7 @@
 ---
 title: GainNode()
 slug: Web/API/GainNode/GainNode
+page-type: web-api-constructor
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/gainnode/index.md
+++ b/files/en-us/web/api/gainnode/index.md
@@ -1,6 +1,7 @@
 ---
 title: GainNode
 slug: Web/API/GainNode
+page-type: web-api-interface
 tags:
   - API
   - GainNode

--- a/files/en-us/web/api/gamepad/axes/index.md
+++ b/files/en-us/web/api/gamepad/axes/index.md
@@ -1,6 +1,7 @@
 ---
 title: Gamepad.axes
 slug: Web/API/Gamepad/axes
+page-type: web-api-instance-property
 tags:
   - API
   - Gamepad API

--- a/files/en-us/web/api/gamepad/buttons/index.md
+++ b/files/en-us/web/api/gamepad/buttons/index.md
@@ -1,6 +1,7 @@
 ---
 title: Gamepad.buttons
 slug: Web/API/Gamepad/buttons
+page-type: web-api-instance-property
 tags:
   - API
   - Gamepad API

--- a/files/en-us/web/api/gamepad/connected/index.md
+++ b/files/en-us/web/api/gamepad/connected/index.md
@@ -1,6 +1,7 @@
 ---
 title: Gamepad.connected
 slug: Web/API/Gamepad/connected
+page-type: web-api-instance-property
 tags:
   - API
   - Gamepad API

--- a/files/en-us/web/api/gamepad/displayid/index.md
+++ b/files/en-us/web/api/gamepad/displayid/index.md
@@ -1,6 +1,7 @@
 ---
 title: Gamepad.displayId
 slug: Web/API/Gamepad/displayId
+page-type: web-api-instance-property
 tags:
   - API
   - Gamepad

--- a/files/en-us/web/api/gamepad/hand/index.md
+++ b/files/en-us/web/api/gamepad/hand/index.md
@@ -1,6 +1,7 @@
 ---
 title: Gamepad.hand
 slug: Web/API/Gamepad/hand
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/gamepad/hapticactuators/index.md
+++ b/files/en-us/web/api/gamepad/hapticactuators/index.md
@@ -1,6 +1,7 @@
 ---
 title: Gamepad.hapticActuators
 slug: Web/API/Gamepad/hapticActuators
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/gamepad/id/index.md
+++ b/files/en-us/web/api/gamepad/id/index.md
@@ -1,6 +1,7 @@
 ---
 title: Gamepad.id
 slug: Web/API/Gamepad/id
+page-type: web-api-instance-property
 tags:
   - API
   - Gamepad API

--- a/files/en-us/web/api/gamepad/index.md
+++ b/files/en-us/web/api/gamepad/index.md
@@ -1,6 +1,7 @@
 ---
 title: Gamepad
 slug: Web/API/Gamepad
+page-type: web-api-interface
 tags:
   - API
   - Gamepad API

--- a/files/en-us/web/api/gamepad/index/index.md
+++ b/files/en-us/web/api/gamepad/index/index.md
@@ -1,6 +1,7 @@
 ---
 title: Gamepad.index
 slug: Web/API/Gamepad/index
+page-type: web-api-instance-property
 tags:
   - API
   - Gamepad API

--- a/files/en-us/web/api/gamepad/mapping/index.md
+++ b/files/en-us/web/api/gamepad/mapping/index.md
@@ -1,6 +1,7 @@
 ---
 title: Gamepad.mapping
 slug: Web/API/Gamepad/mapping
+page-type: web-api-instance-property
 tags:
   - API
   - Gamepad API

--- a/files/en-us/web/api/gamepad/pose/index.md
+++ b/files/en-us/web/api/gamepad/pose/index.md
@@ -1,6 +1,7 @@
 ---
 title: Gamepad.pose
 slug: Web/API/Gamepad/pose
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/gamepad/timestamp/index.md
+++ b/files/en-us/web/api/gamepad/timestamp/index.md
@@ -1,6 +1,7 @@
 ---
 title: Gamepad.timestamp
 slug: Web/API/Gamepad/timestamp
+page-type: web-api-instance-property
 tags:
   - API
   - Gamepad API

--- a/files/en-us/web/api/gamepad/vibrationactuator/index.md
+++ b/files/en-us/web/api/gamepad/vibrationactuator/index.md
@@ -1,6 +1,7 @@
 ---
 title: Gamepad.vibrationActuator
 slug: Web/API/Gamepad/vibrationActuator
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/gamepad_api/index.md
+++ b/files/en-us/web/api/gamepad_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Gamepad API
 slug: Web/API/Gamepad_API
+page-type: web-api-overview
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/gamepad_api/using_the_gamepad_api/index.md
+++ b/files/en-us/web/api/gamepad_api/using_the_gamepad_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using the Gamepad API
 slug: Web/API/Gamepad_API/Using_the_Gamepad_API
+page-type: guide
 tags:
   - API
   - Advanced

--- a/files/en-us/web/api/gamepadbutton/index.md
+++ b/files/en-us/web/api/gamepadbutton/index.md
@@ -1,6 +1,7 @@
 ---
 title: GamepadButton
 slug: Web/API/GamepadButton
+page-type: web-api-interface
 tags:
   - API
   - Gamepad API

--- a/files/en-us/web/api/gamepadbutton/pressed/index.md
+++ b/files/en-us/web/api/gamepadbutton/pressed/index.md
@@ -1,6 +1,7 @@
 ---
 title: GamepadButton.pressed
 slug: Web/API/GamepadButton/pressed
+page-type: web-api-instance-property
 tags:
   - API
   - Gamepad API

--- a/files/en-us/web/api/gamepadbutton/touched/index.md
+++ b/files/en-us/web/api/gamepadbutton/touched/index.md
@@ -1,6 +1,7 @@
 ---
 title: GamepadButton.touched
 slug: Web/API/GamepadButton/touched
+page-type: web-api-instance-property
 tags:
   - API
   - Gamepad API

--- a/files/en-us/web/api/gamepadbutton/value/index.md
+++ b/files/en-us/web/api/gamepadbutton/value/index.md
@@ -1,6 +1,7 @@
 ---
 title: GamepadButton.value
 slug: Web/API/GamepadButton/value
+page-type: web-api-instance-property
 tags:
   - API
   - Gamepad API

--- a/files/en-us/web/api/gamepadevent/gamepad/index.md
+++ b/files/en-us/web/api/gamepadevent/gamepad/index.md
@@ -1,6 +1,7 @@
 ---
 title: GamepadEvent.gamepad
 slug: Web/API/GamepadEvent/gamepad
+page-type: web-api-instance-property
 tags:
   - API
   - Gamepad API

--- a/files/en-us/web/api/gamepadevent/gamepadevent/index.md
+++ b/files/en-us/web/api/gamepadevent/gamepadevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: GamepadEvent()
 slug: Web/API/GamepadEvent/GamepadEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/gamepadevent/index.md
+++ b/files/en-us/web/api/gamepadevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: GamepadEvent
 slug: Web/API/GamepadEvent
+page-type: web-api-interface
 tags:
   - API
   - Gamepad API

--- a/files/en-us/web/api/gamepadhapticactuator/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/index.md
@@ -1,6 +1,7 @@
 ---
 title: GamepadHapticActuator
 slug: Web/API/GamepadHapticActuator
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/gamepadhapticactuator/playeffect/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/playeffect/index.md
@@ -1,6 +1,7 @@
 ---
 title: GamepadHapticActuator.playEffect()
 slug: Web/API/GamepadHapticActuator/playEffect
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/gamepadhapticactuator/pulse/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/pulse/index.md
@@ -1,6 +1,7 @@
 ---
 title: GamepadHapticActuator.pulse()
 slug: Web/API/GamepadHapticActuator/pulse
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/gamepadhapticactuator/type/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/type/index.md
@@ -1,6 +1,7 @@
 ---
 title: GamepadHapticActuator.type
 slug: Web/API/GamepadHapticActuator/type
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/gamepadpose/angularacceleration/index.md
+++ b/files/en-us/web/api/gamepadpose/angularacceleration/index.md
@@ -1,6 +1,7 @@
 ---
 title: GamepadPose.angularAcceleration
 slug: Web/API/GamepadPose/angularAcceleration
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/gamepadpose/angularvelocity/index.md
+++ b/files/en-us/web/api/gamepadpose/angularvelocity/index.md
@@ -1,6 +1,7 @@
 ---
 title: GamepadPose.angularVelocity
 slug: Web/API/GamepadPose/angularVelocity
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/gamepadpose/hasorientation/index.md
+++ b/files/en-us/web/api/gamepadpose/hasorientation/index.md
@@ -1,6 +1,7 @@
 ---
 title: GamepadPose.hasOrientation
 slug: Web/API/GamepadPose/hasOrientation
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/gamepadpose/hasposition/index.md
+++ b/files/en-us/web/api/gamepadpose/hasposition/index.md
@@ -1,6 +1,7 @@
 ---
 title: GamepadPose.hasPosition
 slug: Web/API/GamepadPose/hasPosition
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/gamepadpose/index.md
+++ b/files/en-us/web/api/gamepadpose/index.md
@@ -1,6 +1,7 @@
 ---
 title: GamepadPose
 slug: Web/API/GamepadPose
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/gamepadpose/linearacceleration/index.md
+++ b/files/en-us/web/api/gamepadpose/linearacceleration/index.md
@@ -1,6 +1,7 @@
 ---
 title: GamepadPose.linearAcceleration
 slug: Web/API/GamepadPose/linearAcceleration
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/gamepadpose/linearvelocity/index.md
+++ b/files/en-us/web/api/gamepadpose/linearvelocity/index.md
@@ -1,6 +1,7 @@
 ---
 title: GamepadPose.linearVelocity
 slug: Web/API/GamepadPose/linearVelocity
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/gamepadpose/orientation/index.md
+++ b/files/en-us/web/api/gamepadpose/orientation/index.md
@@ -1,6 +1,7 @@
 ---
 title: GamepadPose.orientation
 slug: Web/API/GamepadPose/orientation
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/gamepadpose/position/index.md
+++ b/files/en-us/web/api/gamepadpose/position/index.md
@@ -1,6 +1,7 @@
 ---
 title: GamepadPose.position
 slug: Web/API/GamepadPose/position
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/geolocation/clearwatch/index.md
+++ b/files/en-us/web/api/geolocation/clearwatch/index.md
@@ -1,6 +1,7 @@
 ---
 title: Geolocation.clearWatch()
 slug: Web/API/Geolocation/clearWatch
+page-type: web-api-instance-method
 tags:
   - API
   - Geolocation

--- a/files/en-us/web/api/geolocation/getcurrentposition/index.md
+++ b/files/en-us/web/api/geolocation/getcurrentposition/index.md
@@ -1,6 +1,7 @@
 ---
 title: Geolocation.getCurrentPosition()
 slug: Web/API/Geolocation/getCurrentPosition
+page-type: web-api-instance-method
 tags:
   - API
   - Geolocation

--- a/files/en-us/web/api/geolocation/index.md
+++ b/files/en-us/web/api/geolocation/index.md
@@ -1,6 +1,7 @@
 ---
 title: Geolocation
 slug: Web/API/Geolocation
+page-type: web-api-interface
 tags:
   - API
   - Advanced

--- a/files/en-us/web/api/geolocation/watchposition/index.md
+++ b/files/en-us/web/api/geolocation/watchposition/index.md
@@ -1,6 +1,7 @@
 ---
 title: Geolocation.watchPosition()
 slug: Web/API/Geolocation/watchPosition
+page-type: web-api-instance-method
 tags:
   - API
   - Geolocation

--- a/files/en-us/web/api/geolocation_api/index.md
+++ b/files/en-us/web/api/geolocation_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Geolocation API
 slug: Web/API/Geolocation_API
+page-type: web-api-overview
 tags:
   - Geolocation API
   - Guide

--- a/files/en-us/web/api/geolocation_api/using_the_geolocation_api/index.md
+++ b/files/en-us/web/api/geolocation_api/using_the_geolocation_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using the Geolocation API
 slug: Web/API/Geolocation_API/Using_the_Geolocation_API
+page-type: guide
 tags:
   - Geolocation API
   - Guide

--- a/files/en-us/web/api/geolocationcoordinates/accuracy/index.md
+++ b/files/en-us/web/api/geolocationcoordinates/accuracy/index.md
@@ -1,6 +1,7 @@
 ---
 title: GeolocationCoordinates.accuracy
 slug: Web/API/GeolocationCoordinates/accuracy
+page-type: web-api-instance-property
 tags:
   - API
   - Geolocation API

--- a/files/en-us/web/api/geolocationcoordinates/altitude/index.md
+++ b/files/en-us/web/api/geolocationcoordinates/altitude/index.md
@@ -1,6 +1,7 @@
 ---
 title: GeolocationCoordinates.altitude
 slug: Web/API/GeolocationCoordinates/altitude
+page-type: web-api-instance-property
 tags:
   - API
   - Geolocation API

--- a/files/en-us/web/api/geolocationcoordinates/altitudeaccuracy/index.md
+++ b/files/en-us/web/api/geolocationcoordinates/altitudeaccuracy/index.md
@@ -1,6 +1,7 @@
 ---
 title: GeolocationCoordinates.altitudeAccuracy
 slug: Web/API/GeolocationCoordinates/altitudeAccuracy
+page-type: web-api-instance-property
 tags:
   - API
   - Geolocation API

--- a/files/en-us/web/api/geolocationcoordinates/heading/index.md
+++ b/files/en-us/web/api/geolocationcoordinates/heading/index.md
@@ -1,6 +1,7 @@
 ---
 title: GeolocationCoordinates.heading
 slug: Web/API/GeolocationCoordinates/heading
+page-type: web-api-instance-property
 tags:
   - API
   - Geolocation API

--- a/files/en-us/web/api/geolocationcoordinates/index.md
+++ b/files/en-us/web/api/geolocationcoordinates/index.md
@@ -1,6 +1,7 @@
 ---
 title: GeolocationCoordinates
 slug: Web/API/GeolocationCoordinates
+page-type: web-api-interface
 tags:
   - API
   - Geolocation API

--- a/files/en-us/web/api/geolocationcoordinates/latitude/index.md
+++ b/files/en-us/web/api/geolocationcoordinates/latitude/index.md
@@ -1,6 +1,7 @@
 ---
 title: GeolocationCoordinates.latitude
 slug: Web/API/GeolocationCoordinates/latitude
+page-type: web-api-instance-property
 tags:
   - API
   - Geolocation API

--- a/files/en-us/web/api/geolocationcoordinates/longitude/index.md
+++ b/files/en-us/web/api/geolocationcoordinates/longitude/index.md
@@ -1,6 +1,7 @@
 ---
 title: GeolocationCoordinates.longitude
 slug: Web/API/GeolocationCoordinates/longitude
+page-type: web-api-instance-property
 tags:
   - API
   - GPS

--- a/files/en-us/web/api/geolocationcoordinates/speed/index.md
+++ b/files/en-us/web/api/geolocationcoordinates/speed/index.md
@@ -1,6 +1,7 @@
 ---
 title: GeolocationCoordinates.speed
 slug: Web/API/GeolocationCoordinates/speed
+page-type: web-api-instance-property
 tags:
   - API
   - Geolocation API

--- a/files/en-us/web/api/geolocationposition/coords/index.md
+++ b/files/en-us/web/api/geolocationposition/coords/index.md
@@ -1,6 +1,7 @@
 ---
 title: GeolocationPosition.coords
 slug: Web/API/GeolocationPosition/coords
+page-type: web-api-instance-property
 tags:
   - API
   - Geolocation API

--- a/files/en-us/web/api/geolocationposition/index.md
+++ b/files/en-us/web/api/geolocationposition/index.md
@@ -1,6 +1,7 @@
 ---
 title: GeolocationPosition
 slug: Web/API/GeolocationPosition
+page-type: web-api-interface
 tags:
   - API
   - Geolocation API

--- a/files/en-us/web/api/geolocationposition/timestamp/index.md
+++ b/files/en-us/web/api/geolocationposition/timestamp/index.md
@@ -1,6 +1,7 @@
 ---
 title: GeolocationPosition.timestamp
 slug: Web/API/GeolocationPosition/timestamp
+page-type: web-api-instance-property
 tags:
   - API
   - Geolocation API


### PR DESCRIPTION
See  https://github.com/mdn/content/issues/16255. This is part 9 of a series of PRs to add page types to the Web/API documentation.