### PR TITLE
FF102 Ship TransformStream and ReadableStream.pipeThrough

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -900,45 +900,6 @@ With this feature enabled, Firefox supports [JPEG XL](https://jpeg.org/jpegxl/) 
   </tbody>
 </table>
 
-#### Streams API: TransformStreams
-
-Support for [transform streams](/en-US/docs/Web/API/Streams_API#transform_streams), including the classes [`TransformStream`](/en-US/docs/Web/API/TransformStream) and [`TransformStreamDefaultController`](/en-US/docs/Web/API/TransformStreamDefaultController), and the method [`ReadableStream.pipeThrough()`](/en-US/docs/Web/API/ReadableStream/pipeThrough).
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version added</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>101</td>
-      <td>Yes</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>101</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>101</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>—</td>
-      <td>—</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>dom.streams.transform_streams.enabled</code></td>
-    </tr>
-  </tbody>
-</table>
 
 ### Service Workers
 

--- a/files/en-us/mozilla/firefox/releases/102/index.md
+++ b/files/en-us/mozilla/firefox/releases/102/index.md
@@ -39,13 +39,17 @@ This article provides information about the changes in Firefox 102 that will aff
 
 - The Non-standard interfaces [IDBMutableFile](/en-US/docs/Web/API/IDBMutableFile), [IDBFileHandle](/en-US/docs/Web/API/IDBFileHandle), [IDBFileRequest](/en-US/docs/Web/API/IDBFileRequest), and the method [IDBDatabase.createMutableFile()](/en-US/docs/Web/API/IDBDatabase#idbdatabase.createmutablefile), have been disabled by default, in preparation for removal in a future release ({{bug(1764771)}}).
 
+- [Transform streams](/en-US/docs/Web/API/TransformStream) are now supported, allowing you to pipe from a {{domxref("ReadableStream")}} to a {{domxref("WritableStream")}}, executing a transformation on the chunks.
+  The update includes the new interfaces [`TransformStream`](/en-US/docs/Web/API/TransformStream) and [`TransformStreamDefaultController`](/en-US/docs/Web/API/TransformStreamDefaultController), and the method [`ReadableStream.pipeThrough()`](/en-US/docs/Web/API/ReadableStream/pipeThrough) ({{bug(1767507)}}).
+
+
 #### DOM
 
 - The Firefox-only property {{domxref("Window.sidebar")}} has been moved behind a preference, and is planned for removal ({{bug(1768486)}}).
 
 #### Media, WebRTC, and Web Audio
 
-- [Transform streams](/en-US/docs/Web/API/Streams_API#transform_streams) are now supported, including the classes [`TransformStream`](/en-US/docs/Web/API/TransformStream) and [`TransformStreamDefaultController`](/en-US/docs/Web/API/TransformStreamDefaultController), and the method [`ReadableStream.pipeThrough()`](/en-US/docs/Web/API/ReadableStream/pipeThrough) ({{bug(1767507)}}).
+
 
 #### Removals
 

--- a/files/en-us/mozilla/firefox/releases/102/index.md
+++ b/files/en-us/mozilla/firefox/releases/102/index.md
@@ -45,6 +45,8 @@ This article provides information about the changes in Firefox 102 that will aff
 
 #### Media, WebRTC, and Web Audio
 
+- [Transform streams](/en-US/docs/Web/API/Streams_API#transform_streams) are now supported, including the classes [`TransformStream`](/en-US/docs/Web/API/TransformStream) and [`TransformStreamDefaultController`](/en-US/docs/Web/API/TransformStreamDefaultController), and the method [`ReadableStream.pipeThrough()`](/en-US/docs/Web/API/ReadableStream/pipeThrough) ({{bug(1767507)}}).
+
 #### Removals
 
 ### WebAssembly


### PR DESCRIPTION
FF102 ships  [TransformStream](https://developer.mozilla.org/en-US/docs/Web/API/TransformStream), [TransformStreamDefaultController](https://developer.mozilla.org/en-US/docs/Web/API/TransformStreamDefaultController),[ReadableStream.pipeThrough](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/pipeThrough) in https://bugzilla.mozilla.org/show_bug.cgi?id=1767507

Most of the docs work was done in FF101 when it moved into nightly (or earlier). All this does is remove the experimental features section and add a release note.

Related docs work can be tracked in #16813