### PR TITLE
Add webapi page types 11

### DIFF
--- a/files/en-us/web/api/htmlcanvaselement/mozopaque/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/mozopaque/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLCanvasElement.mozOpaque
 slug: Web/API/HTMLCanvasElement/mozOpaque
+page-type: web-api-instance-property
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/htmlcanvaselement/toblob/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/toblob/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLCanvasElement.toBlob()
 slug: Web/API/HTMLCanvasElement/toBlob
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/htmlcanvaselement/todataurl/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/todataurl/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLCanvasElement.toDataURL()
 slug: Web/API/HTMLCanvasElement/toDataURL
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/htmlcanvaselement/transfercontroltooffscreen/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/transfercontroltooffscreen/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLCanvasElement.transferControlToOffscreen()
 slug: Web/API/HTMLCanvasElement/transferControlToOffscreen
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/htmlcanvaselement/webglcontextcreationerror_event/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/webglcontextcreationerror_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLCanvasElement: webglcontextcreationerror event'
 slug: Web/API/HTMLCanvasElement/webglcontextcreationerror_event
+page-type: web-api-event
 tags:
   - WebGL
 browser-compat: api.HTMLCanvasElement.webglcontextcreationerror_event

--- a/files/en-us/web/api/htmlcanvaselement/webglcontextlost_event/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/webglcontextlost_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLCanvasElement: webglcontextlost event'
 slug: Web/API/HTMLCanvasElement/webglcontextlost_event
+page-type: web-api-event
 tags:
   - Event
   - Reference

--- a/files/en-us/web/api/htmlcanvaselement/webglcontextrestored_event/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/webglcontextrestored_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLCanvasElement: webglcontextrestored event'
 slug: Web/API/HTMLCanvasElement/webglcontextrestored_event
+page-type: web-api-event
 tags:
   - WebGL
 browser-compat: api.HTMLCanvasElement.webglcontextrestored_event

--- a/files/en-us/web/api/htmlcanvaselement/width/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/width/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLCanvasElement.width
 slug: Web/API/HTMLCanvasElement/width
+page-type: web-api-instance-property
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/htmlcollection/index.md
+++ b/files/en-us/web/api/htmlcollection/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLCollection
 slug: Web/API/HTMLCollection
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/htmlcollection/item/index.md
+++ b/files/en-us/web/api/htmlcollection/item/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLCollection.item()
 slug: Web/API/HTMLCollection/item
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlcollection/length/index.md
+++ b/files/en-us/web/api/htmlcollection/length/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLCollection.length
 slug: Web/API/HTMLCollection/length
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlcollection/nameditem/index.md
+++ b/files/en-us/web/api/htmlcollection/nameditem/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLCollection.namedItem()
 slug: Web/API/HTMLCollection/namedItem
+page-type: web-api-instance-property
 tags:
   - API
   - Element Lists

--- a/files/en-us/web/api/htmlcollection/nameditem/index.md
+++ b/files/en-us/web/api/htmlcollection/nameditem/index.md
@@ -1,7 +1,7 @@
 ---
 title: HTMLCollection.namedItem()
 slug: Web/API/HTMLCollection/namedItem
-page-type: web-api-instance-property
+page-type: web-api-instance-method
 tags:
   - API
   - Element Lists

--- a/files/en-us/web/api/htmlcontentelement/getdistributednodes/index.md
+++ b/files/en-us/web/api/htmlcontentelement/getdistributednodes/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLContentElement.getDistributedNodes()
 slug: Web/API/HTMLContentElement/getDistributedNodes
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlcontentelement/index.md
+++ b/files/en-us/web/api/htmlcontentelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLContentElement
 slug: Web/API/HTMLContentElement
+page-type: web-api-interface
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/htmlcontentelement/select/index.md
+++ b/files/en-us/web/api/htmlcontentelement/select/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLContentElement.select
 slug: Web/API/HTMLContentElement/select
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmldataelement/index.md
+++ b/files/en-us/web/api/htmldataelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLDataElement
 slug: Web/API/HTMLDataElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmldataelement/value/index.md
+++ b/files/en-us/web/api/htmldataelement/value/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLDataElement.value
 slug: Web/API/HTMLDataElement/value
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmldatalistelement/index.md
+++ b/files/en-us/web/api/htmldatalistelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLDataListElement
 slug: Web/API/HTMLDataListElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmldetailselement/index.md
+++ b/files/en-us/web/api/htmldetailselement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLDetailsElement
 slug: Web/API/HTMLDetailsElement
+page-type: web-api-interface
 tags:
   - API
   - HTML

--- a/files/en-us/web/api/htmldetailselement/toggle_event/index.md
+++ b/files/en-us/web/api/htmldetailselement/toggle_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLDetailsElement: toggle event'
 slug: Web/API/HTMLDetailsElement/toggle_event
+page-type: web-api-event
 tags:
   - Event
   - HTMLDetailsElement

--- a/files/en-us/web/api/htmldialogelement/cancel_event/index.md
+++ b/files/en-us/web/api/htmldialogelement/cancel_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLDialogElement: cancel event'
 slug: Web/API/HTMLDialogElement/cancel_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/htmldialogelement/close/index.md
+++ b/files/en-us/web/api/htmldialogelement/close/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLDialogElement.close()
 slug: Web/API/HTMLDialogElement/close
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/htmldialogelement/close_event/index.md
+++ b/files/en-us/web/api/htmldialogelement/close_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLDialogElement: close event'
 slug: Web/API/HTMLDialogElement/close_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/htmldialogelement/index.md
+++ b/files/en-us/web/api/htmldialogelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLDialogElement
 slug: Web/API/HTMLDialogElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmldialogelement/open/index.md
+++ b/files/en-us/web/api/htmldialogelement/open/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLDialogElement.open
 slug: Web/API/HTMLDialogElement/open
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/htmldialogelement/returnvalue/index.md
+++ b/files/en-us/web/api/htmldialogelement/returnvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLDialogElement.returnValue
 slug: Web/API/HTMLDialogElement/returnValue
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/htmldialogelement/show/index.md
+++ b/files/en-us/web/api/htmldialogelement/show/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLDialogElement.show()
 slug: Web/API/HTMLDialogElement/show
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/htmldialogelement/showmodal/index.md
+++ b/files/en-us/web/api/htmldialogelement/showmodal/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLDialogElement.showModal()
 slug: Web/API/HTMLDialogElement/showModal
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/htmldivelement/index.md
+++ b/files/en-us/web/api/htmldivelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLDivElement
 slug: Web/API/HTMLDivElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmldlistelement/index.md
+++ b/files/en-us/web/api/htmldlistelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLDListElement
 slug: Web/API/HTMLDListElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmldocument/index.md
+++ b/files/en-us/web/api/htmldocument/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLDocument
 slug: Web/API/HTMLDocument
+page-type: web-api-interface
 tags:
   - API
   - Document

--- a/files/en-us/web/api/htmlelement/accesskey/index.md
+++ b/files/en-us/web/api/htmlelement/accesskey/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement.accessKey
 slug: Web/API/HTMLElement/accessKey
+page-type: web-api-instance-property
 browser-compat: api.HTMLElement.accessKey
 ---
 {{APIRef("DOM")}}

--- a/files/en-us/web/api/htmlelement/accesskeylabel/index.md
+++ b/files/en-us/web/api/htmlelement/accesskeylabel/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement.accessKeyLabel
 slug: Web/API/HTMLElement/accessKeyLabel
+page-type: web-api-instance-property
 browser-compat: api.HTMLElement.accessKeyLabel
 ---
 {{ APIRef("HTML DOM") }}

--- a/files/en-us/web/api/htmlelement/animationcancel_event/index.md
+++ b/files/en-us/web/api/htmlelement/animationcancel_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: animationcancel event'
 slug: Web/API/HTMLElement/animationcancel_event
+page-type: web-api-event
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/htmlelement/animationend_event/index.md
+++ b/files/en-us/web/api/htmlelement/animationend_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: animationend event'
 slug: Web/API/HTMLElement/animationend_event
+page-type: web-api-event
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/htmlelement/animationiteration_event/index.md
+++ b/files/en-us/web/api/htmlelement/animationiteration_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: animationiteration event'
 slug: Web/API/HTMLElement/animationiteration_event
+page-type: web-api-event
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/htmlelement/animationstart_event/index.md
+++ b/files/en-us/web/api/htmlelement/animationstart_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: animationstart event'
 slug: Web/API/HTMLElement/animationstart_event
+page-type: web-api-event
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/htmlelement/attachinternals/index.md
+++ b/files/en-us/web/api/htmlelement/attachinternals/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement.attachInternals()
 slug: Web/API/HTMLElement/attachInternals
+page-type: web-api-instance-method
 tags:
   - API
   - Element

--- a/files/en-us/web/api/htmlelement/beforeinput_event/index.md
+++ b/files/en-us/web/api/htmlelement/beforeinput_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: beforeinput event'
 slug: Web/API/HTMLElement/beforeinput_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/htmlelement/blur/index.md
+++ b/files/en-us/web/api/htmlelement/blur/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement.blur()
 slug: Web/API/HTMLElement/blur
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlelement/change_event/index.md
+++ b/files/en-us/web/api/htmlelement/change_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: change event'
 slug: Web/API/HTMLElement/change_event
+page-type: web-api-event
 tags:
   - Change
   - Event

--- a/files/en-us/web/api/htmlelement/click/index.md
+++ b/files/en-us/web/api/htmlelement/click/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement.click()
 slug: Web/API/HTMLElement/click
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlelement/contenteditable/index.md
+++ b/files/en-us/web/api/htmlelement/contenteditable/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement.contentEditable
 slug: Web/API/HTMLElement/contentEditable
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlelement/contextmenu/index.md
+++ b/files/en-us/web/api/htmlelement/contextmenu/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement.contextMenu
 slug: Web/API/HTMLElement/contextMenu
+page-type: web-api-instance-property
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/htmlelement/copy_event/index.md
+++ b/files/en-us/web/api/htmlelement/copy_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: copy event'
 slug: Web/API/HTMLElement/copy_event
+page-type: web-api-event
 tags:
   - API
   - Clipboard API

--- a/files/en-us/web/api/htmlelement/cut_event/index.md
+++ b/files/en-us/web/api/htmlelement/cut_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: cut event'
 slug: Web/API/HTMLElement/cut_event
+page-type: web-api-event
 tags:
   - API
   - Clipboard API

--- a/files/en-us/web/api/htmlelement/dataset/index.md
+++ b/files/en-us/web/api/htmlelement/dataset/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement.dataset
 slug: Web/API/HTMLElement/dataset
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlelement/dir/index.md
+++ b/files/en-us/web/api/htmlelement/dir/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement.dir
 slug: Web/API/HTMLElement/dir
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlelement/enterkeyhint/index.md
+++ b/files/en-us/web/api/htmlelement/enterkeyhint/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement.enterKeyHint
 slug: Web/API/HTMLElement/enterKeyHint
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlelement/focus/index.md
+++ b/files/en-us/web/api/htmlelement/focus/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement.focus()
 slug: Web/API/HTMLElement/focus
+page-type: web-api-instance-method
 tags:
   - API
   - Focus

--- a/files/en-us/web/api/htmlelement/gotpointercapture_event/index.md
+++ b/files/en-us/web/api/htmlelement/gotpointercapture_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: gotpointercapture event'
 slug: Web/API/HTMLElement/gotpointercapture_event
+page-type: web-api-event
 tags:
   - Event
   - HTML DOM

--- a/files/en-us/web/api/htmlelement/hidden/index.md
+++ b/files/en-us/web/api/htmlelement/hidden/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement.hidden
 slug: Web/API/HTMLElement/hidden
+page-type: web-api-instance-property
 tags:
   - API
   - Attribute

--- a/files/en-us/web/api/htmlelement/index.md
+++ b/files/en-us/web/api/htmlelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement
 slug: Web/API/HTMLElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlelement/inert/index.md
+++ b/files/en-us/web/api/htmlelement/inert/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement.inert
 slug: Web/API/HTMLElement/inert
+page-type: web-api-instance-property
 browser-compat: api.HTMLElement.inert
 ---
 {{ APIRef("HTML DOM") }}

--- a/files/en-us/web/api/htmlelement/innertext/index.md
+++ b/files/en-us/web/api/htmlelement/innertext/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement.innerText
 slug: Web/API/HTMLElement/innerText
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlelement/input_event/index.md
+++ b/files/en-us/web/api/htmlelement/input_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: input event'
 slug: Web/API/HTMLElement/input_event
+page-type: web-api-event
 tags:
   - Content
   - Edit

--- a/files/en-us/web/api/htmlelement/iscontenteditable/index.md
+++ b/files/en-us/web/api/htmlelement/iscontenteditable/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement.isContentEditable
 slug: Web/API/HTMLElement/isContentEditable
+page-type: web-api-instance-property
 tags:
   - API
   - Editing

--- a/files/en-us/web/api/htmlelement/lang/index.md
+++ b/files/en-us/web/api/htmlelement/lang/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement.lang
 slug: Web/API/HTMLElement/lang
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlelement/lostpointercapture_event/index.md
+++ b/files/en-us/web/api/htmlelement/lostpointercapture_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: lostpointercapture event'
 slug: Web/API/HTMLElement/lostpointercapture_event
+page-type: web-api-event
 tags:
   - Event
   - HTML DOM

--- a/files/en-us/web/api/htmlelement/nonce/index.md
+++ b/files/en-us/web/api/htmlelement/nonce/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement.nonce
 slug: Web/API/HTMLElement/nonce
+page-type: web-api-instance-property
 tags:
   - API
   - Content Security Policy

--- a/files/en-us/web/api/htmlelement/offsetheight/index.md
+++ b/files/en-us/web/api/htmlelement/offsetheight/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement.offsetHeight
 slug: Web/API/HTMLElement/offsetHeight
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/htmlelement/offsetleft/index.md
+++ b/files/en-us/web/api/htmlelement/offsetleft/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement.offsetLeft
 slug: Web/API/HTMLElement/offsetLeft
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/htmlelement/offsetparent/index.md
+++ b/files/en-us/web/api/htmlelement/offsetparent/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement.offsetParent
 slug: Web/API/HTMLElement/offsetParent
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/htmlelement/offsettop/index.md
+++ b/files/en-us/web/api/htmlelement/offsettop/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement.offsetTop
 slug: Web/API/HTMLElement/offsetTop
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/htmlelement/offsetwidth/index.md
+++ b/files/en-us/web/api/htmlelement/offsetwidth/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement.offsetWidth
 slug: Web/API/HTMLElement/offsetWidth
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/htmlelement/outertext/index.md
+++ b/files/en-us/web/api/htmlelement/outertext/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement.outerText
 slug: Web/API/HTMLElement/outerText
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlelement/paste_event/index.md
+++ b/files/en-us/web/api/htmlelement/paste_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: paste event'
 slug: Web/API/HTMLElement/paste_event
+page-type: web-api-event
 tags:
   - API
   - Clipboard API

--- a/files/en-us/web/api/htmlelement/pointercancel_event/index.md
+++ b/files/en-us/web/api/htmlelement/pointercancel_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: pointercancel event'
 slug: Web/API/HTMLElement/pointercancel_event
+page-type: web-api-event
 tags:
   - Event
   - HTML DOM

--- a/files/en-us/web/api/htmlelement/pointerdown_event/index.md
+++ b/files/en-us/web/api/htmlelement/pointerdown_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: pointerdown event'
 slug: Web/API/HTMLElement/pointerdown_event
+page-type: web-api-event
 tags:
   - Event
   - HTML DOM

--- a/files/en-us/web/api/htmlelement/pointerenter_event/index.md
+++ b/files/en-us/web/api/htmlelement/pointerenter_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: pointerenter event'
 slug: Web/API/HTMLElement/pointerenter_event
+page-type: web-api-event
 tags:
   - Event
   - HTML DOM

--- a/files/en-us/web/api/htmlelement/pointerleave_event/index.md
+++ b/files/en-us/web/api/htmlelement/pointerleave_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: pointerleave event'
 slug: Web/API/HTMLElement/pointerleave_event
+page-type: web-api-event
 tags:
   - Event
   - HTML DOM

--- a/files/en-us/web/api/htmlelement/pointermove_event/index.md
+++ b/files/en-us/web/api/htmlelement/pointermove_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: pointermove event'
 slug: Web/API/HTMLElement/pointermove_event
+page-type: web-api-event
 tags:
   - Event
   - HTML DOM

--- a/files/en-us/web/api/htmlelement/pointerout_event/index.md
+++ b/files/en-us/web/api/htmlelement/pointerout_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: pointerout event'
 slug: Web/API/HTMLElement/pointerout_event
+page-type: web-api-event
 tags:
   - Event
   - HTML DOM

--- a/files/en-us/web/api/htmlelement/pointerover_event/index.md
+++ b/files/en-us/web/api/htmlelement/pointerover_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: pointerover event'
 slug: Web/API/HTMLElement/pointerover_event
+page-type: web-api-event
 tags:
   - Event
   - PointerEvent

--- a/files/en-us/web/api/htmlelement/pointerup_event/index.md
+++ b/files/en-us/web/api/htmlelement/pointerup_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: pointerup event'
 slug: Web/API/HTMLElement/pointerup_event
+page-type: web-api-event
 tags:
   - Event
   - HTML DOM

--- a/files/en-us/web/api/htmlelement/style/index.md
+++ b/files/en-us/web/api/htmlelement/style/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement.style
 slug: Web/API/HTMLElement/style
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/htmlelement/tabindex/index.md
+++ b/files/en-us/web/api/htmlelement/tabindex/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement.tabIndex
 slug: Web/API/HTMLElement/tabIndex
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlelement/title/index.md
+++ b/files/en-us/web/api/htmlelement/title/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLElement.title
 slug: Web/API/HTMLElement/title
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlelement/transitioncancel_event/index.md
+++ b/files/en-us/web/api/htmlelement/transitioncancel_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: transitioncancel event'
 slug: Web/API/HTMLElement/transitioncancel_event
+page-type: web-api-event
 tags:
   - CSS Transitions
   - Event

--- a/files/en-us/web/api/htmlelement/transitionend_event/index.md
+++ b/files/en-us/web/api/htmlelement/transitionend_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: transitionend event'
 slug: Web/API/HTMLElement/transitionend_event
+page-type: web-api-event
 tags:
   - CSS Transitions
   - Event

--- a/files/en-us/web/api/htmlelement/transitionrun_event/index.md
+++ b/files/en-us/web/api/htmlelement/transitionrun_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: transitionrun event'
 slug: Web/API/HTMLElement/transitionrun_event
+page-type: web-api-event
 tags:
   - CSS Transitions
   - Event

--- a/files/en-us/web/api/htmlelement/transitionstart_event/index.md
+++ b/files/en-us/web/api/htmlelement/transitionstart_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: transitionstart event'
 slug: Web/API/HTMLElement/transitionstart_event
+page-type: web-api-event
 tags:
   - CSS Transitions
   - Event

--- a/files/en-us/web/api/htmlembedelement/index.md
+++ b/files/en-us/web/api/htmlembedelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLEmbedElement
 slug: Web/API/HTMLEmbedElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlfieldsetelement/index.md
+++ b/files/en-us/web/api/htmlfieldsetelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLFieldSetElement
 slug: Web/API/HTMLFieldSetElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlfontelement/color/index.md
+++ b/files/en-us/web/api/htmlfontelement/color/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLFontElement.color
 slug: Web/API/HTMLFontElement/color
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlfontelement/face/index.md
+++ b/files/en-us/web/api/htmlfontelement/face/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLFontElement.face
 slug: Web/API/HTMLFontElement/face
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlfontelement/index.md
+++ b/files/en-us/web/api/htmlfontelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLFontElement
 slug: Web/API/HTMLFontElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlfontelement/size/index.md
+++ b/files/en-us/web/api/htmlfontelement/size/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLFontElement.size
 slug: Web/API/HTMLFontElement/size
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlformcontrolscollection/index.md
+++ b/files/en-us/web/api/htmlformcontrolscollection/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLFormControlsCollection
 slug: Web/API/HTMLFormControlsCollection
+page-type: web-api-interface
 tags:
   - API
   - Collection

--- a/files/en-us/web/api/htmlformcontrolscollection/nameditem/index.md
+++ b/files/en-us/web/api/htmlformcontrolscollection/nameditem/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLFormControlsCollection.namedItem()
 slug: Web/API/HTMLFormControlsCollection/namedItem
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlformelement/acceptcharset/index.md
+++ b/files/en-us/web/api/htmlformelement/acceptcharset/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLFormElement.acceptCharset
 slug: Web/API/HTMLFormElement/acceptCharset
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlformelement/action/index.md
+++ b/files/en-us/web/api/htmlformelement/action/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLFormElement.action
 slug: Web/API/HTMLFormElement/action
+page-type: web-api-instance-property
 tags:
   - API
   - Forms

--- a/files/en-us/web/api/htmlformelement/elements/index.md
+++ b/files/en-us/web/api/htmlformelement/elements/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLFormElement.elements
 slug: Web/API/HTMLFormElement/elements
+page-type: web-api-instance-property
 tags:
   - API
   - Elements

--- a/files/en-us/web/api/htmlformelement/encoding/index.md
+++ b/files/en-us/web/api/htmlformelement/encoding/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLFormElement.encoding
 slug: Web/API/HTMLFormElement/encoding
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlformelement/enctype/index.md
+++ b/files/en-us/web/api/htmlformelement/enctype/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLFormElement.enctype
 slug: Web/API/HTMLFormElement/enctype
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlformelement/formdata_event/index.md
+++ b/files/en-us/web/api/htmlformelement/formdata_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLFormElement: formdata event'
 slug: Web/API/HTMLFormElement/formdata_event
+page-type: web-api-event
 tags:
   - Event
   - Forms

--- a/files/en-us/web/api/htmlformelement/index.md
+++ b/files/en-us/web/api/htmlformelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLFormElement
 slug: Web/API/HTMLFormElement
+page-type: web-api-interface
 tags:
   - API
   - Form Element

--- a/files/en-us/web/api/htmlformelement/length/index.md
+++ b/files/en-us/web/api/htmlformelement/length/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLFormElement.length
 slug: Web/API/HTMLFormElement/length
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlformelement/method/index.md
+++ b/files/en-us/web/api/htmlformelement/method/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLFormElement.method
 slug: Web/API/HTMLFormElement/method
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlformelement/name/index.md
+++ b/files/en-us/web/api/htmlformelement/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLFormElement.name
 slug: Web/API/HTMLFormElement/name
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlformelement/reportvalidity/index.md
+++ b/files/en-us/web/api/htmlformelement/reportvalidity/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLFormElement.reportValidity()
 slug: Web/API/HTMLFormElement/reportValidity
+page-type: web-api-instance-method
 tags:
   - HTML
   - HTMLFormElement

--- a/files/en-us/web/api/htmlformelement/requestsubmit/index.md
+++ b/files/en-us/web/api/htmlformelement/requestsubmit/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLFormElement.requestSubmit()
 slug: Web/API/HTMLFormElement/requestSubmit
+page-type: web-api-instance-method
 tags:
   - API
   - HTML

--- a/files/en-us/web/api/htmlformelement/reset/index.md
+++ b/files/en-us/web/api/htmlformelement/reset/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLFormElement.reset()
 slug: Web/API/HTMLFormElement/reset
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlformelement/reset_event/index.md
+++ b/files/en-us/web/api/htmlformelement/reset_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLFormElement: reset event'
 slug: Web/API/HTMLFormElement/reset_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/htmlformelement/submit/index.md
+++ b/files/en-us/web/api/htmlformelement/submit/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLFormElement.submit()
 slug: Web/API/HTMLFormElement/submit
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlformelement/submit_event/index.md
+++ b/files/en-us/web/api/htmlformelement/submit_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLFormElement: submit event'
 slug: Web/API/HTMLFormElement/submit_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/htmlformelement/target/index.md
+++ b/files/en-us/web/api/htmlformelement/target/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLFormElement.target
 slug: Web/API/HTMLFormElement/target
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlframesetelement/index.md
+++ b/files/en-us/web/api/htmlframesetelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLFrameSetElement
 slug: Web/API/HTMLFrameSetElement
+page-type: web-api-interface
 tags:
   - API
   - HTML-DOM

--- a/files/en-us/web/api/htmlheadelement/index.md
+++ b/files/en-us/web/api/htmlheadelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLHeadElement
 slug: Web/API/HTMLHeadElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlheadingelement/index.md
+++ b/files/en-us/web/api/htmlheadingelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLHeadingElement
 slug: Web/API/HTMLHeadingElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlhrelement/index.md
+++ b/files/en-us/web/api/htmlhrelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLHRElement
 slug: Web/API/HTMLHRElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlhtmlelement/index.md
+++ b/files/en-us/web/api/htmlhtmlelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLHtmlElement
 slug: Web/API/HTMLHtmlElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlhtmlelement/version/index.md
+++ b/files/en-us/web/api/htmlhtmlelement/version/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLHtmlElement.version
 slug: Web/API/HTMLHtmlElement/version
+page-type: web-api-interface
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/htmlhtmlelement/version/index.md
+++ b/files/en-us/web/api/htmlhtmlelement/version/index.md
@@ -1,7 +1,7 @@
 ---
 title: HTMLHtmlElement.version
 slug: Web/API/HTMLHtmlElement/version
-page-type: web-api-interface
+page-type: web-api-instance-property
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/htmliframeelement/allowpaymentrequest/index.md
+++ b/files/en-us/web/api/htmliframeelement/allowpaymentrequest/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLIFrameElement.allowPaymentRequest
 slug: Web/API/HTMLIFrameElement/allowPaymentRequest
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmliframeelement/contentdocument/index.md
+++ b/files/en-us/web/api/htmliframeelement/contentdocument/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLIFrameElement.contentDocument
 slug: Web/API/HTMLIFrameElement/contentDocument
+page-type: web-api-instance-property
 browser-compat: api.HTMLIFrameElement.contentDocument
 ---
 

--- a/files/en-us/web/api/htmliframeelement/contentwindow/index.md
+++ b/files/en-us/web/api/htmliframeelement/contentwindow/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLIFrameElement.contentWindow
 slug: Web/API/HTMLIFrameElement/contentWindow
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmliframeelement/csp/index.md
+++ b/files/en-us/web/api/htmliframeelement/csp/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLIFrameElement.csp
 slug: Web/API/HTMLIFrameElement/csp
+page-type: web-api-instance-property
 tags:
   - API
   - CSP

--- a/files/en-us/web/api/htmliframeelement/featurepolicy/index.md
+++ b/files/en-us/web/api/htmliframeelement/featurepolicy/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLIFrameElement.featurePolicy
 slug: Web/API/HTMLIFrameElement/featurePolicy
+page-type: web-api-instance-property
 tags:
   - API
   - Feature Policy

--- a/files/en-us/web/api/htmliframeelement/fetchpriority/index.md
+++ b/files/en-us/web/api/htmliframeelement/fetchpriority/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLIFrameElement.fetchPriority
 slug: Web/API/HTMLIFrameElement/fetchPriority
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmliframeelement/index.md
+++ b/files/en-us/web/api/htmliframeelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLIFrameElement
 slug: Web/API/HTMLIFrameElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmliframeelement/referrerpolicy/index.md
+++ b/files/en-us/web/api/htmliframeelement/referrerpolicy/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLIFrameElement.referrerPolicy
 slug: Web/API/HTMLIFrameElement/referrerPolicy
+page-type: web-api-instance-property
 tags:
   - API
   - HTMLIFrameElement

--- a/files/en-us/web/api/htmliframeelement/src/index.md
+++ b/files/en-us/web/api/htmliframeelement/src/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLIFrameElement.src
 slug: Web/API/HTMLIFrameElement/src
+page-type: web-api-instance-property
 browser-compat: api.HTMLIFrameElement.src
 ---
 {{APIRef}}

--- a/files/en-us/web/api/htmliframeelement/srcdoc/index.md
+++ b/files/en-us/web/api/htmliframeelement/srcdoc/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLIFrameElement.srcdoc
 slug: Web/API/HTMLIFrameElement/srcdoc
+page-type: web-api-instance-property
 browser-compat: api.HTMLIFrameElement.srcdoc
 ---
 {{APIRef('HTMLIFrameElement')}}

--- a/files/en-us/web/api/htmlimageelement/align/index.md
+++ b/files/en-us/web/api/htmlimageelement/align/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement.align
 slug: Web/API/HTMLImageElement/align
+page-type: web-api-instance-property
 tags:
   - API
   - Align

--- a/files/en-us/web/api/htmlimageelement/alt/index.md
+++ b/files/en-us/web/api/htmlimageelement/alt/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement.alt
 slug: Web/API/HTMLImageElement/alt
+page-type: web-api-instance-property
 tags:
   - API
   - Element

--- a/files/en-us/web/api/htmlimageelement/border/index.md
+++ b/files/en-us/web/api/htmlimageelement/border/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement.border
 slug: Web/API/HTMLImageElement/border
+page-type: web-api-instance-property
 tags:
   - API
   - HTML

--- a/files/en-us/web/api/htmlimageelement/complete/index.md
+++ b/files/en-us/web/api/htmlimageelement/complete/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement.complete
 slug: Web/API/HTMLImageElement/complete
+page-type: web-api-instance-property
 tags:
   - API
   - Fetching

--- a/files/en-us/web/api/htmlimageelement/crossorigin/index.md
+++ b/files/en-us/web/api/htmlimageelement/crossorigin/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement.crossOrigin
 slug: Web/API/HTMLImageElement/crossOrigin
+page-type: web-api-instance-property
 tags:
   - API
   - CORS

--- a/files/en-us/web/api/htmlimageelement/currentsrc/index.md
+++ b/files/en-us/web/api/htmlimageelement/currentsrc/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement.currentSrc
 slug: Web/API/HTMLImageElement/currentSrc
+page-type: web-api-instance-property
 tags:
   - API
   - HTMLImageElement

--- a/files/en-us/web/api/htmlimageelement/decode/index.md
+++ b/files/en-us/web/api/htmlimageelement/decode/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement.decode()
 slug: Web/API/HTMLImageElement/decode
+page-type: web-api-instance-method
 tags:
   - API
   - Decode

--- a/files/en-us/web/api/htmlimageelement/decoding/index.md
+++ b/files/en-us/web/api/htmlimageelement/decoding/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement.decoding
 slug: Web/API/HTMLImageElement/decoding
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlimageelement/fetchpriority/index.md
+++ b/files/en-us/web/api/htmlimageelement/fetchpriority/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement.fetchPriority
 slug: Web/API/HTMLImageElement/fetchPriority
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlimageelement/height/index.md
+++ b/files/en-us/web/api/htmlimageelement/height/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement.height
 slug: Web/API/HTMLImageElement/height
+page-type: web-api-instance-property
 tags:
   - API
   - HTML

--- a/files/en-us/web/api/htmlimageelement/hspace/index.md
+++ b/files/en-us/web/api/htmlimageelement/hspace/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement.hspace
 slug: Web/API/HTMLImageElement/hspace
+page-type: web-api-instance-property
 tags:
   - API
   - HTML

--- a/files/en-us/web/api/htmlimageelement/image/index.md
+++ b/files/en-us/web/api/htmlimageelement/image/index.md
@@ -1,6 +1,7 @@
 ---
 title: Image()
 slug: Web/API/HTMLImageElement/Image
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/htmlimageelement/index.md
+++ b/files/en-us/web/api/htmlimageelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement
 slug: Web/API/HTMLImageElement
+page-type: web-api-interface
 tags:
   - API
   - Element

--- a/files/en-us/web/api/htmlimageelement/ismap/index.md
+++ b/files/en-us/web/api/htmlimageelement/ismap/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement.isMap
 slug: Web/API/HTMLImageElement/isMap
+page-type: web-api-instance-property
 tags:
   - API
   - HTML

--- a/files/en-us/web/api/htmlimageelement/loading/index.md
+++ b/files/en-us/web/api/htmlimageelement/loading/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement.loading
 slug: Web/API/HTMLImageElement/loading
+page-type: web-api-instance-property
 tags:
   - API
   - Content

--- a/files/en-us/web/api/htmlimageelement/longdesc/index.md
+++ b/files/en-us/web/api/htmlimageelement/longdesc/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement.longDesc
 slug: Web/API/HTMLImageElement/longDesc
+page-type: web-api-instance-property
 tags:
   - API
   - HTML

--- a/files/en-us/web/api/htmlimageelement/name/index.md
+++ b/files/en-us/web/api/htmlimageelement/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement.name
 slug: Web/API/HTMLImageElement/name
+page-type: web-api-instance-property
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/htmlimageelement/naturalheight/index.md
+++ b/files/en-us/web/api/htmlimageelement/naturalheight/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement.naturalHeight
 slug: Web/API/HTMLImageElement/naturalHeight
+page-type: web-api-instance-property
 tags:
   - API
   - HTMLImageElement

--- a/files/en-us/web/api/htmlimageelement/naturalwidth/index.md
+++ b/files/en-us/web/api/htmlimageelement/naturalwidth/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement.naturalWidth
 slug: Web/API/HTMLImageElement/naturalWidth
+page-type: web-api-instance-property
 tags:
   - API
   - HTML

--- a/files/en-us/web/api/htmlimageelement/referrerpolicy/index.md
+++ b/files/en-us/web/api/htmlimageelement/referrerpolicy/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement.referrerPolicy
 slug: Web/API/HTMLImageElement/referrerPolicy
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/htmlimageelement/sizes/index.md
+++ b/files/en-us/web/api/htmlimageelement/sizes/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement.sizes
 slug: Web/API/HTMLImageElement/sizes
+page-type: web-api-instance-property
 tags:
   - API
   - HTML

--- a/files/en-us/web/api/htmlimageelement/src/index.md
+++ b/files/en-us/web/api/htmlimageelement/src/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement.src
 slug: Web/API/HTMLImageElement/src
+page-type: web-api-instance-property
 tags:
   - 1x
   - API

--- a/files/en-us/web/api/htmlimageelement/srcset/index.md
+++ b/files/en-us/web/api/htmlimageelement/srcset/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement.srcset
 slug: Web/API/HTMLImageElement/srcset
+page-type: web-api-instance-property
 tags:
   - API
   - HTML

--- a/files/en-us/web/api/htmlimageelement/usemap/index.md
+++ b/files/en-us/web/api/htmlimageelement/usemap/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement.useMap
 slug: Web/API/HTMLImageElement/useMap
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/htmlimageelement/vspace/index.md
+++ b/files/en-us/web/api/htmlimageelement/vspace/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement.vspace
 slug: Web/API/HTMLImageElement/vspace
+page-type: web-api-instance-property
 tags:
   - API
   - HTML

--- a/files/en-us/web/api/htmlimageelement/width/index.md
+++ b/files/en-us/web/api/htmlimageelement/width/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement.width
 slug: Web/API/HTMLImageElement/width
+page-type: web-api-instance-property
 tags:
   - API
   - HTML

--- a/files/en-us/web/api/htmlimageelement/x/index.md
+++ b/files/en-us/web/api/htmlimageelement/x/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement.x
 slug: Web/API/HTMLImageElement/x
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/htmlimageelement/y/index.md
+++ b/files/en-us/web/api/htmlimageelement/y/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLImageElement.y
 slug: Web/API/HTMLImageElement/y
+page-type: web-api-instance-property
 browser-compat: api.HTMLImageElement.y
 ---
 {{APIRef("HTML DOM")}}

--- a/files/en-us/web/api/htmlinputelement/checkvalidity/index.md
+++ b/files/en-us/web/api/htmlinputelement/checkvalidity/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLInputElement.checkValidity()
 slug: Web/API/HTMLInputElement/checkValidity
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlinputelement/index.md
+++ b/files/en-us/web/api/htmlinputelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLInputElement
 slug: Web/API/HTMLInputElement
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/htmlinputelement/invalid_event/index.md
+++ b/files/en-us/web/api/htmlinputelement/invalid_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLInputElement: invalid event'
 slug: Web/API/HTMLInputElement/invalid_event
+page-type: web-api-event
 tags:
   - API
   - Constraint Validation API

--- a/files/en-us/web/api/htmlinputelement/labels/index.md
+++ b/files/en-us/web/api/htmlinputelement/labels/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLInputElement.labels
 slug: Web/API/HTMLInputElement/labels
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlinputelement/multiple/index.md
+++ b/files/en-us/web/api/htmlinputelement/multiple/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLInputElement.multiple
 slug: Web/API/HTMLInputElement/multiple
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlinputelement/reportvalidity/index.md
+++ b/files/en-us/web/api/htmlinputelement/reportvalidity/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLInputElement.reportValidity()
 slug: Web/API/HTMLInputElement/reportValidity
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlinputelement/search_event/index.md
+++ b/files/en-us/web/api/htmlinputelement/search_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLInputElement: search event'
 slug: Web/API/HTMLInputElement/search_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/htmlinputelement/select/index.md
+++ b/files/en-us/web/api/htmlinputelement/select/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLInputElement.select()
 slug: Web/API/HTMLInputElement/select
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlinputelement/selectionchange_event/index.md
+++ b/files/en-us/web/api/htmlinputelement/selectionchange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLInputElement: selectionchange event'
 slug: Web/API/HTMLInputElement/selectionchange_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/htmlinputelement/setcustomvalidity/index.md
+++ b/files/en-us/web/api/htmlinputelement/setcustomvalidity/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLInputElement.setCustomValidity()
 slug: Web/API/HTMLInputElement/setCustomValidity
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlinputelement/setrangetext/index.md
+++ b/files/en-us/web/api/htmlinputelement/setrangetext/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLInputElement.setRangeText()
 slug: Web/API/HTMLInputElement/setRangeText
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlinputelement/setselectionrange/index.md
+++ b/files/en-us/web/api/htmlinputelement/setselectionrange/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLInputElement.setSelectionRange()
 slug: Web/API/HTMLInputElement/setSelectionRange
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlinputelement/showpicker/index.md
+++ b/files/en-us/web/api/htmlinputelement/showpicker/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLInputElement.showPicker()
 slug: Web/API/HTMLInputElement/showPicker
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlinputelement/stepdown/index.md
+++ b/files/en-us/web/api/htmlinputelement/stepdown/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLInputElement.stepDown()
 slug: Web/API/HTMLInputElement/stepDown
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlinputelement/stepup/index.md
+++ b/files/en-us/web/api/htmlinputelement/stepup/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLInputElement.stepUp()
 slug: Web/API/HTMLInputElement/stepUp
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlinputelement/webkitdirectory/index.md
+++ b/files/en-us/web/api/htmlinputelement/webkitdirectory/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLInputElement.webkitdirectory
 slug: Web/API/HTMLInputElement/webkitdirectory
+page-type: web-api-instance-property
 tags:
   - API
   - File and Directory Entries API

--- a/files/en-us/web/api/htmlinputelement/webkitentries/index.md
+++ b/files/en-us/web/api/htmlinputelement/webkitentries/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLInputElement.webkitEntries
 slug: Web/API/HTMLInputElement/webkitEntries
+page-type: web-api-instance-property
 tags:
   - API
   - File and Directory Entries API

--- a/files/en-us/web/api/htmlkeygenelement/index.md
+++ b/files/en-us/web/api/htmlkeygenelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLKeygenElement
 slug: Web/API/HTMLKeygenElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmllabelelement/control/index.md
+++ b/files/en-us/web/api/htmllabelelement/control/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLLabelElement.control
 slug: Web/API/HTMLLabelElement/control
+page-type: web-api-instance-property
 tags:
   - Forms
   - HTML DOM

--- a/files/en-us/web/api/htmllabelelement/form/index.md
+++ b/files/en-us/web/api/htmllabelelement/form/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLLabelElement.form
 slug: Web/API/HTMLLabelElement/form
+page-type: web-api-instance-property
 tags:
   - Forms
   - HTML DOM

--- a/files/en-us/web/api/htmllabelelement/htmlfor/index.md
+++ b/files/en-us/web/api/htmllabelelement/htmlfor/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLLabelElement.htmlFor
 slug: Web/API/HTMLLabelElement/htmlFor
+page-type: web-api-instance-property
 tags:
   - Forms
   - HTML DOM

--- a/files/en-us/web/api/htmllabelelement/index.md
+++ b/files/en-us/web/api/htmllabelelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLLabelElement
 slug: Web/API/HTMLLabelElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmllegendelement/index.md
+++ b/files/en-us/web/api/htmllegendelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLLegendElement
 slug: Web/API/HTMLLegendElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmllielement/index.md
+++ b/files/en-us/web/api/htmllielement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLLIElement
 slug: Web/API/HTMLLIElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmllinkelement/as/index.md
+++ b/files/en-us/web/api/htmllinkelement/as/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLLinkElement.as
 slug: Web/API/HTMLLinkElement/as
+page-type: web-api-instance-property
 tags:
   - API
   - Element

--- a/files/en-us/web/api/htmllinkelement/fetchpriority/index.md
+++ b/files/en-us/web/api/htmllinkelement/fetchpriority/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLLinkElement.fetchPriority
 slug: Web/API/HTMLLinkElement/fetchPriority
+page-type: web-api-instance-property
 tags:
   - API
   - Element

--- a/files/en-us/web/api/htmllinkelement/index.md
+++ b/files/en-us/web/api/htmllinkelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLLinkElement
 slug: Web/API/HTMLLinkElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmllinkelement/referrerpolicy/index.md
+++ b/files/en-us/web/api/htmllinkelement/referrerpolicy/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLLinkElement.referrerPolicy
 slug: Web/API/HTMLLinkElement/referrerPolicy
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/htmllinkelement/rel/index.md
+++ b/files/en-us/web/api/htmllinkelement/rel/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLLinkElement.rel
 slug: Web/API/HTMLLinkElement/rel
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmllinkelement/rellist/index.md
+++ b/files/en-us/web/api/htmllinkelement/rellist/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLLinkElement.relList
 slug: Web/API/HTMLLinkElement/relList
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlmapelement/index.md
+++ b/files/en-us/web/api/htmlmapelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMapElement
 slug: Web/API/HTMLMapElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlmarqueeelement/index.md
+++ b/files/en-us/web/api/htmlmarqueeelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMarqueeElement
 slug: Web/API/HTMLMarqueeElement
+page-type: web-api-interface
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/htmlmediaelement/abort_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/abort_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLMediaElement: abort event'
 slug: Web/API/HTMLMediaElement/abort_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/htmlmediaelement/audiotracks/index.md
+++ b/files/en-us/web/api/htmlmediaelement/audiotracks/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.audioTracks
 slug: Web/API/HTMLMediaElement/audioTracks
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/htmlmediaelement/autoplay/index.md
+++ b/files/en-us/web/api/htmlmediaelement/autoplay/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.autoplay
 slug: Web/API/HTMLMediaElement/autoplay
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/htmlmediaelement/buffered/index.md
+++ b/files/en-us/web/api/htmlmediaelement/buffered/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.buffered
 slug: Web/API/HTMLMediaElement/buffered
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlmediaelement/canplay_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/canplay_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLMediaElement: canplay event'
 slug: Web/API/HTMLMediaElement/canplay_event
+page-type: web-api-event
 tags:
   - Audio
   - Event

--- a/files/en-us/web/api/htmlmediaelement/canplaythrough_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/canplaythrough_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLMediaElement: canplaythrough event'
 slug: Web/API/HTMLMediaElement/canplaythrough_event
+page-type: web-api-event
 tags:
   - Audio
   - Event

--- a/files/en-us/web/api/htmlmediaelement/canplaytype/index.md
+++ b/files/en-us/web/api/htmlmediaelement/canplaytype/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.canPlayType()
 slug: Web/API/HTMLMediaElement/canPlayType
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/htmlmediaelement/capturestream/index.md
+++ b/files/en-us/web/api/htmlmediaelement/capturestream/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.captureStream()
 slug: Web/API/HTMLMediaElement/captureStream
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/htmlmediaelement/controller/index.md
+++ b/files/en-us/web/api/htmlmediaelement/controller/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.controller
 slug: Web/API/HTMLMediaElement/controller
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlmediaelement/controls/index.md
+++ b/files/en-us/web/api/htmlmediaelement/controls/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.controls
 slug: Web/API/HTMLMediaElement/controls
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlmediaelement/controlslist/index.md
+++ b/files/en-us/web/api/htmlmediaelement/controlslist/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.controlsList
 slug: Web/API/HTMLMediaElement/controlsList
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlmediaelement/crossorigin/index.md
+++ b/files/en-us/web/api/htmlmediaelement/crossorigin/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.crossOrigin
 slug: Web/API/HTMLMediaElement/crossOrigin
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlmediaelement/currentsrc/index.md
+++ b/files/en-us/web/api/htmlmediaelement/currentsrc/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.currentSrc
 slug: Web/API/HTMLMediaElement/currentSrc
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlmediaelement/currenttime/index.md
+++ b/files/en-us/web/api/htmlmediaelement/currenttime/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.currentTime
 slug: Web/API/HTMLMediaElement/currentTime
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/htmlmediaelement/defaultmuted/index.md
+++ b/files/en-us/web/api/htmlmediaelement/defaultmuted/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.defaultMuted
 slug: Web/API/HTMLMediaElement/defaultMuted
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlmediaelement/defaultplaybackrate/index.md
+++ b/files/en-us/web/api/htmlmediaelement/defaultplaybackrate/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.defaultPlaybackRate
 slug: Web/API/HTMLMediaElement/defaultPlaybackRate
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlmediaelement/index.md
+++ b/files/en-us/web/api/htmlmediaelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement
 slug: Web/API/HTMLMediaElement
+page-type: web-api-interface
 tags:
   - API
   - Audio


### PR DESCRIPTION
See  https://github.com/mdn/content/issues/16255. This is part 11 of a series of PRs to add page types to the Web/API documentation.