### PR TITLE
Add Web/API page types, part 12

### DIFF
--- a/files/en-us/web/api/htmlmediaelement/disableremoteplayback/index.md
+++ b/files/en-us/web/api/htmlmediaelement/disableremoteplayback/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.disableRemotePlayback
 slug: Web/API/HTMLMediaElement/disableRemotePlayback
+page-type: web-api-instance-property
 browser-compat: api.HTMLMediaElement.disableRemotePlayback
 ---
 {{APIRef("HTML DOM")}}

--- a/files/en-us/web/api/htmlmediaelement/duration/index.md
+++ b/files/en-us/web/api/htmlmediaelement/duration/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.duration
 slug: Web/API/HTMLMediaElement/duration
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlmediaelement/durationchange_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/durationchange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLMediaElement: durationchange event'
 slug: Web/API/HTMLMediaElement/durationchange_event
+page-type: web-api-event
 tags:
   - Audio
   - Event

--- a/files/en-us/web/api/htmlmediaelement/emptied_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/emptied_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLMediaElement: emptied event'
 slug: Web/API/HTMLMediaElement/emptied_event
+page-type: web-api-event
 tags:
   - Audio
   - Event

--- a/files/en-us/web/api/htmlmediaelement/ended/index.md
+++ b/files/en-us/web/api/htmlmediaelement/ended/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.ended
 slug: Web/API/HTMLMediaElement/ended
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlmediaelement/ended_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/ended_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLMediaElement: ended event'
 slug: Web/API/HTMLMediaElement/ended_event
+page-type: web-api-event
 tags:
   - Audio
   - Event

--- a/files/en-us/web/api/htmlmediaelement/error/index.md
+++ b/files/en-us/web/api/htmlmediaelement/error/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.error
 slug: Web/API/HTMLMediaElement/error
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/htmlmediaelement/error_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/error_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLMediaElement: error event'
 slug: Web/API/HTMLMediaElement/error_event
+page-type: web-api-event
 tags:
   - API
   - Error

--- a/files/en-us/web/api/htmlmediaelement/fastseek/index.md
+++ b/files/en-us/web/api/htmlmediaelement/fastseek/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.fastSeek()
 slug: Web/API/HTMLMediaElement/fastSeek
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/htmlmediaelement/load/index.md
+++ b/files/en-us/web/api/htmlmediaelement/load/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.load()
 slug: Web/API/HTMLMediaElement/load
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/htmlmediaelement/loadeddata_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/loadeddata_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLMediaElement: loadeddata event'
 slug: Web/API/HTMLMediaElement/loadeddata_event
+page-type: web-api-event
 tags:
   - Audio
   - Event

--- a/files/en-us/web/api/htmlmediaelement/loadedmetadata_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/loadedmetadata_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLMediaElement: loadedmetadata event'
 slug: Web/API/HTMLMediaElement/loadedmetadata_event
+page-type: web-api-event
 tags:
   - Audio
   - Event

--- a/files/en-us/web/api/htmlmediaelement/loadstart_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/loadstart_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLMediaElement: loadstart event'
 slug: Web/API/HTMLMediaElement/loadstart_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/htmlmediaelement/loop/index.md
+++ b/files/en-us/web/api/htmlmediaelement/loop/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.loop
 slug: Web/API/HTMLMediaElement/loop
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlmediaelement/mediagroup/index.md
+++ b/files/en-us/web/api/htmlmediaelement/mediagroup/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.mediaGroup
 slug: Web/API/HTMLMediaElement/mediaGroup
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlmediaelement/mscleareffects/index.md
+++ b/files/en-us/web/api/htmlmediaelement/mscleareffects/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.msClearEffects
 slug: Web/API/HTMLMediaElement/msClearEffects
+page-type: web-api-instance-property
 tags:
   - msClearEffects
 ---

--- a/files/en-us/web/api/htmlmediaelement/msinsertaudioeffect/index.md
+++ b/files/en-us/web/api/htmlmediaelement/msinsertaudioeffect/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.msInsertAudioEffect()
 slug: Web/API/HTMLMediaElement/msInsertAudioEffect
+page-type: web-api-instance-method
 tags:
   - API
   - API:Microsoft Extensions

--- a/files/en-us/web/api/htmlmediaelement/muted/index.md
+++ b/files/en-us/web/api/htmlmediaelement/muted/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.muted
 slug: Web/API/HTMLMediaElement/muted
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlmediaelement/networkstate/index.md
+++ b/files/en-us/web/api/htmlmediaelement/networkstate/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.networkState
 slug: Web/API/HTMLMediaElement/networkState
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlmediaelement/onerror/index.md
+++ b/files/en-us/web/api/htmlmediaelement/onerror/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.onerror
 slug: Web/API/HTMLMediaElement/onerror
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/htmlmediaelement/pause/index.md
+++ b/files/en-us/web/api/htmlmediaelement/pause/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.pause()
 slug: Web/API/HTMLMediaElement/pause
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/htmlmediaelement/pause_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/pause_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLMediaElement: pause event'
 slug: Web/API/HTMLMediaElement/pause_event
+page-type: web-api-event
 tags:
   - Audio
   - Event

--- a/files/en-us/web/api/htmlmediaelement/paused/index.md
+++ b/files/en-us/web/api/htmlmediaelement/paused/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.paused
 slug: Web/API/HTMLMediaElement/paused
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlmediaelement/play/index.md
+++ b/files/en-us/web/api/htmlmediaelement/play/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.play()
 slug: Web/API/HTMLMediaElement/play
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/htmlmediaelement/play_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/play_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLMediaElement: play event'
 slug: Web/API/HTMLMediaElement/play_event
+page-type: web-api-event
 tags:
   - Audio
   - Event

--- a/files/en-us/web/api/htmlmediaelement/playbackrate/index.md
+++ b/files/en-us/web/api/htmlmediaelement/playbackrate/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.playbackRate
 slug: Web/API/HTMLMediaElement/playbackRate
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlmediaelement/playing_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/playing_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLMediaElement: playing event'
 slug: Web/API/HTMLMediaElement/playing_event
+page-type: web-api-event
 tags:
   - API
   - HTMLMediaElement

--- a/files/en-us/web/api/htmlmediaelement/preservespitch/index.md
+++ b/files/en-us/web/api/htmlmediaelement/preservespitch/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.preservesPitch
 slug: Web/API/HTMLMediaElement/preservesPitch
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlmediaelement/progress_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/progress_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLMediaElement: progress event'
 slug: Web/API/HTMLMediaElement/progress_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/htmlmediaelement/ratechange_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/ratechange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLMediaElement: ratechange event'
 slug: Web/API/HTMLMediaElement/ratechange_event
+page-type: web-api-event
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/htmlmediaelement/readystate/index.md
+++ b/files/en-us/web/api/htmlmediaelement/readystate/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.readyState
 slug: Web/API/HTMLMediaElement/readyState
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlmediaelement/seekable/index.md
+++ b/files/en-us/web/api/htmlmediaelement/seekable/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.seekable
 slug: Web/API/HTMLMediaElement/seekable
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/htmlmediaelement/seeked_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/seeked_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLMediaElement: seeked event'
 slug: Web/API/HTMLMediaElement/seeked_event
+page-type: web-api-event
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/htmlmediaelement/seeking_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/seeking_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLMediaElement: seeking event'
 slug: Web/API/HTMLMediaElement/seeking_event
+page-type: web-api-event
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/htmlmediaelement/seektonextframe/index.md
+++ b/files/en-us/web/api/htmlmediaelement/seektonextframe/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.seekToNextFrame()
 slug: Web/API/HTMLMediaElement/seekToNextFrame
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/htmlmediaelement/setmediakeys/index.md
+++ b/files/en-us/web/api/htmlmediaelement/setmediakeys/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.setMediaKeys()
 slug: Web/API/HTMLMediaElement/setMediaKeys
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/htmlmediaelement/setsinkid/index.md
+++ b/files/en-us/web/api/htmlmediaelement/setsinkid/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.setSinkId()
 slug: Web/API/HTMLMediaElement/setSinkId
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/htmlmediaelement/sinkid/index.md
+++ b/files/en-us/web/api/htmlmediaelement/sinkid/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.sinkId
 slug: Web/API/HTMLMediaElement/sinkId
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/htmlmediaelement/src/index.md
+++ b/files/en-us/web/api/htmlmediaelement/src/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.src
 slug: Web/API/HTMLMediaElement/src
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlmediaelement/srcobject/index.md
+++ b/files/en-us/web/api/htmlmediaelement/srcobject/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.srcObject
 slug: Web/API/HTMLMediaElement/srcObject
+page-type: web-api-instance-property
 tags:
   - API
   - HTML

--- a/files/en-us/web/api/htmlmediaelement/stalled_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/stalled_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLMediaElement: stalled event'
 slug: Web/API/HTMLMediaElement/stalled_event
+page-type: web-api-event
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/htmlmediaelement/suspend_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/suspend_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLMediaElement: suspend event'
 slug: Web/API/HTMLMediaElement/suspend_event
+page-type: web-api-event
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/htmlmediaelement/texttracks/index.md
+++ b/files/en-us/web/api/htmlmediaelement/texttracks/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.textTracks
 slug: Web/API/HTMLMediaElement/textTracks
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/htmlmediaelement/timeupdate_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/timeupdate_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLMediaElement: timeupdate event'
 slug: Web/API/HTMLMediaElement/timeupdate_event
+page-type: web-api-event
 tags:
   - Audio
   - Event

--- a/files/en-us/web/api/htmlmediaelement/videotracks/index.md
+++ b/files/en-us/web/api/htmlmediaelement/videotracks/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.videoTracks
 slug: Web/API/HTMLMediaElement/videoTracks
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlmediaelement/volume/index.md
+++ b/files/en-us/web/api/htmlmediaelement/volume/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.volume
 slug: Web/API/HTMLMediaElement/volume
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlmediaelement/volumechange_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/volumechange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLMediaElement: volumechange event'
 slug: Web/API/HTMLMediaElement/volumechange_event
+page-type: web-api-event
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/htmlmediaelement/waiting_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/waiting_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLMediaElement: waiting event'
 slug: Web/API/HTMLMediaElement/waiting_event
+page-type: web-api-event
 tags:
   - Audio
   - Event

--- a/files/en-us/web/api/htmlmenuelement/index.md
+++ b/files/en-us/web/api/htmlmenuelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMenuElement
 slug: Web/API/HTMLMenuElement
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/htmlmenuitemelement/index.md
+++ b/files/en-us/web/api/htmlmenuitemelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMenuItemElement
 slug: Web/API/HTMLMenuItemElement
+page-type: web-api-interface
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/htmlmetaelement/index.md
+++ b/files/en-us/web/api/htmlmetaelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMetaElement
 slug: Web/API/HTMLMetaElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlmeterelement/index.md
+++ b/files/en-us/web/api/htmlmeterelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMeterElement
 slug: Web/API/HTMLMeterElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlmeterelement/labels/index.md
+++ b/files/en-us/web/api/htmlmeterelement/labels/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMeterElement.labels
 slug: Web/API/HTMLMeterElement/labels
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlmodelement/index.md
+++ b/files/en-us/web/api/htmlmodelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLModElement
 slug: Web/API/HTMLModElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlobjectelement/checkvalidity/index.md
+++ b/files/en-us/web/api/htmlobjectelement/checkvalidity/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLObjectElement.checkValidity()
 slug: Web/API/HTMLObjectElement/checkValidity
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlobjectelement/contentdocument/index.md
+++ b/files/en-us/web/api/htmlobjectelement/contentdocument/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLObjectElement.contentDocument
 slug: Web/API/HTMLObjectElement/contentDocument
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlobjectelement/contentwindow/index.md
+++ b/files/en-us/web/api/htmlobjectelement/contentwindow/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLObjectElement.contentWindow
 slug: Web/API/HTMLObjectElement/contentWindow
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlobjectelement/data/index.md
+++ b/files/en-us/web/api/htmlobjectelement/data/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLObjectElement.data
 slug: Web/API/HTMLObjectElement/data
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlobjectelement/form/index.md
+++ b/files/en-us/web/api/htmlobjectelement/form/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLObjectElement.form
 slug: Web/API/HTMLObjectElement/form
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlobjectelement/height/index.md
+++ b/files/en-us/web/api/htmlobjectelement/height/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLObjectElement.height
 slug: Web/API/HTMLObjectElement/height
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlobjectelement/index.md
+++ b/files/en-us/web/api/htmlobjectelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLObjectElement
 slug: Web/API/HTMLObjectElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlobjectelement/name/index.md
+++ b/files/en-us/web/api/htmlobjectelement/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLObjectElement.name
 slug: Web/API/HTMLObjectElement/name
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlobjectelement/setcustomvalidity/index.md
+++ b/files/en-us/web/api/htmlobjectelement/setcustomvalidity/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLObjectElement.setCustomValidity()
 slug: Web/API/HTMLObjectElement/setCustomValidity
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlobjectelement/type/index.md
+++ b/files/en-us/web/api/htmlobjectelement/type/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLObjectElement.type
 slug: Web/API/HTMLObjectElement/type
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlobjectelement/usemap/index.md
+++ b/files/en-us/web/api/htmlobjectelement/usemap/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLObjectElement.useMap
 slug: Web/API/HTMLObjectElement/useMap
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlobjectelement/validationmessage/index.md
+++ b/files/en-us/web/api/htmlobjectelement/validationmessage/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLObjectElement.validationMessage
 slug: Web/API/HTMLObjectElement/validationMessage
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlobjectelement/validity/index.md
+++ b/files/en-us/web/api/htmlobjectelement/validity/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLObjectElement.validity
 slug: Web/API/HTMLObjectElement/validity
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlobjectelement/width/index.md
+++ b/files/en-us/web/api/htmlobjectelement/width/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLObjectElement.width
 slug: Web/API/HTMLObjectElement/width
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlobjectelement/willvalidate/index.md
+++ b/files/en-us/web/api/htmlobjectelement/willvalidate/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLObjectElement.willValidate
 slug: Web/API/HTMLObjectElement/willValidate
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlolistelement/index.md
+++ b/files/en-us/web/api/htmlolistelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLOListElement
 slug: Web/API/HTMLOListElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmloptgroupelement/index.md
+++ b/files/en-us/web/api/htmloptgroupelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLOptGroupElement
 slug: Web/API/HTMLOptGroupElement
+page-type: web-api-interface
 tags:
   - API
   - Forms

--- a/files/en-us/web/api/htmloptionelement/index.md
+++ b/files/en-us/web/api/htmloptionelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLOptionElement
 slug: Web/API/HTMLOptionElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmloptionelement/option/index.md
+++ b/files/en-us/web/api/htmloptionelement/option/index.md
@@ -1,6 +1,7 @@
 ---
 title: Option()
 slug: Web/API/HTMLOptionElement/Option
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/htmloptionscollection/index.md
+++ b/files/en-us/web/api/htmloptionscollection/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLOptionsCollection
 slug: Web/API/HTMLOptionsCollection
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmloutputelement/index.md
+++ b/files/en-us/web/api/htmloutputelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLOutputElement
 slug: Web/API/HTMLOutputElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmloutputelement/labels/index.md
+++ b/files/en-us/web/api/htmloutputelement/labels/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLOutputElement.labels
 slug: Web/API/HTMLOutputElement/labels
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlparagraphelement/index.md
+++ b/files/en-us/web/api/htmlparagraphelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLParagraphElement
 slug: Web/API/HTMLParagraphElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlparamelement/index.md
+++ b/files/en-us/web/api/htmlparamelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLParamElement
 slug: Web/API/HTMLParamElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlpictureelement/index.md
+++ b/files/en-us/web/api/htmlpictureelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLPictureElement
 slug: Web/API/HTMLPictureElement
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/htmlpreelement/index.md
+++ b/files/en-us/web/api/htmlpreelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLPreElement
 slug: Web/API/HTMLPreElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlprogresselement/index.md
+++ b/files/en-us/web/api/htmlprogresselement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLProgressElement
 slug: Web/API/HTMLProgressElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlprogresselement/labels/index.md
+++ b/files/en-us/web/api/htmlprogresselement/labels/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLProgressElement.labels
 slug: Web/API/HTMLProgressElement/labels
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlquoteelement/index.md
+++ b/files/en-us/web/api/htmlquoteelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLQuoteElement
 slug: Web/API/HTMLQuoteElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlscriptelement/index.md
+++ b/files/en-us/web/api/htmlscriptelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLScriptElement
 slug: Web/API/HTMLScriptElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlscriptelement/referrerpolicy/index.md
+++ b/files/en-us/web/api/htmlscriptelement/referrerpolicy/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLScriptElement.referrerPolicy
 slug: Web/API/HTMLScriptElement/referrerPolicy
+page-type: web-api-instance-property
 tags:
   - API
   - HTMLScriptElement

--- a/files/en-us/web/api/htmlscriptelement/supports/index.md
+++ b/files/en-us/web/api/htmlscriptelement/supports/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLScriptElement.supports()
 slug: Web/API/HTMLScriptElement/supports
+page-type: web-api-static-method
 tags:
   - API
   - HTMLScriptElement

--- a/files/en-us/web/api/htmlselectelement/add/index.md
+++ b/files/en-us/web/api/htmlselectelement/add/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLSelectElement.add()
 slug: Web/API/HTMLSelectElement/add
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlselectelement/autofocus/index.md
+++ b/files/en-us/web/api/htmlselectelement/autofocus/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLSelectElement.autofocus
 slug: Web/API/HTMLSelectElement/autofocus
+page-type: web-api-instance-property
 tags:
   - API
   - HTML forms

--- a/files/en-us/web/api/htmlselectelement/checkvalidity/index.md
+++ b/files/en-us/web/api/htmlselectelement/checkvalidity/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLSelectElement.checkValidity()
 slug: Web/API/HTMLSelectElement/checkValidity
+page-type: web-api-instance-method
 tags:
   - API
   - Constraint Validation API

--- a/files/en-us/web/api/htmlselectelement/disabled/index.md
+++ b/files/en-us/web/api/htmlselectelement/disabled/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLSelectElement.disabled
 slug: Web/API/HTMLSelectElement/disabled
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlselectelement/form/index.md
+++ b/files/en-us/web/api/htmlselectelement/form/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLSelectElement.form
 slug: Web/API/HTMLSelectElement/form
+page-type: web-api-instance-property
 tags:
   - API
   - HTMLSelectElement

--- a/files/en-us/web/api/htmlselectelement/index.md
+++ b/files/en-us/web/api/htmlselectelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLSelectElement
 slug: Web/API/HTMLSelectElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlselectelement/item/index.md
+++ b/files/en-us/web/api/htmlselectelement/item/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLSelectElement.item()
 slug: Web/API/HTMLSelectElement/item
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlselectelement/labels/index.md
+++ b/files/en-us/web/api/htmlselectelement/labels/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLSelectElement.labels
 slug: Web/API/HTMLSelectElement/labels
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlselectelement/nameditem/index.md
+++ b/files/en-us/web/api/htmlselectelement/nameditem/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLSelectElement.namedItem()
 slug: Web/API/HTMLSelectElement/namedItem
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlselectelement/options/index.md
+++ b/files/en-us/web/api/htmlselectelement/options/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLSelectElement.options
 slug: Web/API/HTMLSelectElement/options
+page-type: web-api-instance-property
 tags:
   - API
   - HTMLSelectElement

--- a/files/en-us/web/api/htmlselectelement/remove/index.md
+++ b/files/en-us/web/api/htmlselectelement/remove/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLSelectElement.remove()
 slug: Web/API/HTMLSelectElement/remove
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlselectelement/selectedindex/index.md
+++ b/files/en-us/web/api/htmlselectelement/selectedindex/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLSelectElement.selectedIndex
 slug: Web/API/HTMLSelectElement/selectedIndex
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlselectelement/selectedoptions/index.md
+++ b/files/en-us/web/api/htmlselectelement/selectedoptions/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLSelectElement.selectedOptions
 slug: Web/API/HTMLSelectElement/selectedOptions
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlselectelement/setcustomvalidity/index.md
+++ b/files/en-us/web/api/htmlselectelement/setcustomvalidity/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLSelectElement.setCustomValidity()
 slug: Web/API/HTMLSelectElement/setCustomValidity
+page-type: web-api-instance-method
 tags:
   - API
   - Constrain Validation API

--- a/files/en-us/web/api/htmlselectelement/type/index.md
+++ b/files/en-us/web/api/htmlselectelement/type/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLSelectElement.type
 slug: Web/API/HTMLSelectElement/type
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlshadowelement/getdistributednodes/index.md
+++ b/files/en-us/web/api/htmlshadowelement/getdistributednodes/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLShadowElement.getDistributedNodes()
 slug: Web/API/HTMLShadowElement/getDistributedNodes
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlshadowelement/index.md
+++ b/files/en-us/web/api/htmlshadowelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLShadowElement
 slug: Web/API/HTMLShadowElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlslotelement/assign/index.md
+++ b/files/en-us/web/api/htmlslotelement/assign/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLSlotElement.assign()
 slug: Web/API/HTMLSlotElement/assign
+page-type: web-api-instance-method
 tags:
   - API
   - HTMLSlotElement

--- a/files/en-us/web/api/htmlslotelement/assignedelements/index.md
+++ b/files/en-us/web/api/htmlslotelement/assignedelements/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLSlotElement.assignedElements()
 slug: Web/API/HTMLSlotElement/assignedElements
+page-type: web-api-instance-method
 tags:
   - API
   - HTMLSlotElement

--- a/files/en-us/web/api/htmlslotelement/assignednodes/index.md
+++ b/files/en-us/web/api/htmlslotelement/assignednodes/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLSlotElement.assignedNodes()
 slug: Web/API/HTMLSlotElement/assignedNodes
+page-type: web-api-instance-method
 tags:
   - API
   - HTMLSlotElement

--- a/files/en-us/web/api/htmlslotelement/index.md
+++ b/files/en-us/web/api/htmlslotelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLSlotElement
 slug: Web/API/HTMLSlotElement
+page-type: web-api-interface
 tags:
   - API
   - HTMLSlotElement

--- a/files/en-us/web/api/htmlslotelement/name/index.md
+++ b/files/en-us/web/api/htmlslotelement/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLSlotElement.name
 slug: Web/API/HTMLSlotElement/name
+page-type: web-api-instance-property
 tags:
   - API
   - HTMLSlotElement

--- a/files/en-us/web/api/htmlslotelement/slotchange_event/index.md
+++ b/files/en-us/web/api/htmlslotelement/slotchange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLSlotElement: slotchange event'
 slug: Web/API/HTMLSlotElement/slotchange_event
+page-type: web-api-event
 tags:
   - Event
   - Reference

--- a/files/en-us/web/api/htmlsourceelement/index.md
+++ b/files/en-us/web/api/htmlsourceelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLSourceElement
 slug: Web/API/HTMLSourceElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlspanelement/index.md
+++ b/files/en-us/web/api/htmlspanelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLSpanElement
 slug: Web/API/HTMLSpanElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlstyleelement/index.md
+++ b/files/en-us/web/api/htmlstyleelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLStyleElement
 slug: Web/API/HTMLStyleElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlstyleelement/media/index.md
+++ b/files/en-us/web/api/htmlstyleelement/media/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLStyleElement.media
 slug: Web/API/HTMLStyleElement/media
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlstyleelement/scoped/index.md
+++ b/files/en-us/web/api/htmlstyleelement/scoped/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLStyleElement.scoped
 slug: Web/API/HTMLStyleElement/scoped
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlstyleelement/type/index.md
+++ b/files/en-us/web/api/htmlstyleelement/type/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLStyleElement.type
 slug: Web/API/HTMLStyleElement/type
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltablecaptionelement/index.md
+++ b/files/en-us/web/api/htmltablecaptionelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableCaptionElement
 slug: Web/API/HTMLTableCaptionElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltablecellelement/index.md
+++ b/files/en-us/web/api/htmltablecellelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableCellElement
 slug: Web/API/HTMLTableCellElement
+page-type: web-api-interface
 tags:
   - API
   - Cells

--- a/files/en-us/web/api/htmltablecolelement/index.md
+++ b/files/en-us/web/api/htmltablecolelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableColElement
 slug: Web/API/HTMLTableColElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltableelement/align/index.md
+++ b/files/en-us/web/api/htmltableelement/align/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableElement.align
 slug: Web/API/HTMLTableElement/align
+page-type: web-api-instance-property
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/htmltableelement/bgcolor/index.md
+++ b/files/en-us/web/api/htmltableelement/bgcolor/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableElement.bgColor
 slug: Web/API/HTMLTableElement/bgColor
+page-type: web-api-instance-property
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/htmltableelement/border/index.md
+++ b/files/en-us/web/api/htmltableelement/border/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableElement.border
 slug: Web/API/HTMLTableElement/border
+page-type: web-api-instance-property
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/htmltableelement/caption/index.md
+++ b/files/en-us/web/api/htmltableelement/caption/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableElement.caption
 slug: Web/API/HTMLTableElement/caption
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltableelement/cellpadding/index.md
+++ b/files/en-us/web/api/htmltableelement/cellpadding/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableElement.cellPadding
 slug: Web/API/HTMLTableElement/cellPadding
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltableelement/cellspacing/index.md
+++ b/files/en-us/web/api/htmltableelement/cellspacing/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableElement.cellSpacing
 slug: Web/API/HTMLTableElement/cellSpacing
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltableelement/createcaption/index.md
+++ b/files/en-us/web/api/htmltableelement/createcaption/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableElement.createCaption()
 slug: Web/API/HTMLTableElement/createCaption
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltableelement/createtbody/index.md
+++ b/files/en-us/web/api/htmltableelement/createtbody/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableElement.createTBody()
 slug: Web/API/HTMLTableElement/createTBody
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltableelement/createtfoot/index.md
+++ b/files/en-us/web/api/htmltableelement/createtfoot/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableElement.createTFoot()
 slug: Web/API/HTMLTableElement/createTFoot
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltableelement/createthead/index.md
+++ b/files/en-us/web/api/htmltableelement/createthead/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableElement.createTHead()
 slug: Web/API/HTMLTableElement/createTHead
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltableelement/deletecaption/index.md
+++ b/files/en-us/web/api/htmltableelement/deletecaption/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableElement.deleteCaption()
 slug: Web/API/HTMLTableElement/deleteCaption
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltableelement/deleterow/index.md
+++ b/files/en-us/web/api/htmltableelement/deleterow/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableElement.deleteRow()
 slug: Web/API/HTMLTableElement/deleteRow
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltableelement/deletetfoot/index.md
+++ b/files/en-us/web/api/htmltableelement/deletetfoot/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableElement.deleteTFoot()
 slug: Web/API/HTMLTableElement/deleteTFoot
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltableelement/deletethead/index.md
+++ b/files/en-us/web/api/htmltableelement/deletethead/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableElement.deleteTHead()
 slug: Web/API/HTMLTableElement/deleteTHead
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltableelement/frame/index.md
+++ b/files/en-us/web/api/htmltableelement/frame/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableElement.frame
 slug: Web/API/HTMLTableElement/frame
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltableelement/index.md
+++ b/files/en-us/web/api/htmltableelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableElement
 slug: Web/API/HTMLTableElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltableelement/insertrow/index.md
+++ b/files/en-us/web/api/htmltableelement/insertrow/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableElement.insertRow()
 slug: Web/API/HTMLTableElement/insertRow
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltableelement/rows/index.md
+++ b/files/en-us/web/api/htmltableelement/rows/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableElement.rows
 slug: Web/API/HTMLTableElement/rows
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltableelement/rules/index.md
+++ b/files/en-us/web/api/htmltableelement/rules/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableElement.rules
 slug: Web/API/HTMLTableElement/rules
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltableelement/summary/index.md
+++ b/files/en-us/web/api/htmltableelement/summary/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableElement.summary
 slug: Web/API/HTMLTableElement/summary
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltableelement/tbodies/index.md
+++ b/files/en-us/web/api/htmltableelement/tbodies/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableElement.tBodies
 slug: Web/API/HTMLTableElement/tBodies
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltableelement/tfoot/index.md
+++ b/files/en-us/web/api/htmltableelement/tfoot/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableElement.tFoot
 slug: Web/API/HTMLTableElement/tFoot
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltableelement/thead/index.md
+++ b/files/en-us/web/api/htmltableelement/thead/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableElement.tHead
 slug: Web/API/HTMLTableElement/tHead
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltableelement/width/index.md
+++ b/files/en-us/web/api/htmltableelement/width/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableElement.width
 slug: Web/API/HTMLTableElement/width
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltablerowelement/index.md
+++ b/files/en-us/web/api/htmltablerowelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableRowElement
 slug: Web/API/HTMLTableRowElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltablerowelement/insertcell/index.md
+++ b/files/en-us/web/api/htmltablerowelement/insertcell/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableRowElement.insertCell()
 slug: Web/API/HTMLTableRowElement/insertCell
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltablerowelement/rowindex/index.md
+++ b/files/en-us/web/api/htmltablerowelement/rowindex/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableRowElement.rowIndex
 slug: Web/API/HTMLTableRowElement/rowIndex
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltablesectionelement/index.md
+++ b/files/en-us/web/api/htmltablesectionelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTableSectionElement
 slug: Web/API/HTMLTableSectionElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltemplateelement/content/index.md
+++ b/files/en-us/web/api/htmltemplateelement/content/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTemplateElement.content
 slug: Web/API/HTMLTemplateElement/content
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltemplateelement/index.md
+++ b/files/en-us/web/api/htmltemplateelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTemplateElement
 slug: Web/API/HTMLTemplateElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltextareaelement/index.md
+++ b/files/en-us/web/api/htmltextareaelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTextAreaElement
 slug: Web/API/HTMLTextAreaElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltextareaelement/labels/index.md
+++ b/files/en-us/web/api/htmltextareaelement/labels/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTextAreaElement.labels
 slug: Web/API/HTMLTextAreaElement/labels
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltextareaelement/selectionchange_event/index.md
+++ b/files/en-us/web/api/htmltextareaelement/selectionchange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLTextAreaElement: selectionchange event'
 slug: Web/API/HTMLTextAreaElement/selectionchange_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/htmltimeelement/datetime/index.md
+++ b/files/en-us/web/api/htmltimeelement/datetime/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTimeElement.dateTime
 slug: Web/API/HTMLTimeElement/dateTime
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltimeelement/index.md
+++ b/files/en-us/web/api/htmltimeelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTimeElement
 slug: Web/API/HTMLTimeElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltitleelement/index.md
+++ b/files/en-us/web/api/htmltitleelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTitleElement
 slug: Web/API/HTMLTitleElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltrackelement/cuechange_event/index.md
+++ b/files/en-us/web/api/htmltrackelement/cuechange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLTrackElement: cuechange event'
 slug: Web/API/HTMLTrackElement/cuechange_event
+page-type: web-api-event
 tags:
   - API
   - Accessibility

--- a/files/en-us/web/api/htmltrackelement/index.md
+++ b/files/en-us/web/api/htmltrackelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTrackElement
 slug: Web/API/HTMLTrackElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmltrackelement/src/index.md
+++ b/files/en-us/web/api/htmltrackelement/src/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLTrackElement.src
 slug: Web/API/HTMLTrackElement/src
+page-type: web-api-instance-property
 tags:
   - HTML
   - HTML DOM

--- a/files/en-us/web/api/htmlulistelement/index.md
+++ b/files/en-us/web/api/htmlulistelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLUListElement
 slug: Web/API/HTMLUListElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlunknownelement/index.md
+++ b/files/en-us/web/api/htmlunknownelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLUnknownElement
 slug: Web/API/HTMLUnknownElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlvideoelement/autopictureinpicture/index.md
+++ b/files/en-us/web/api/htmlvideoelement/autopictureinpicture/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLVideoElement.autoPictureInPicture
 slug: Web/API/HTMLVideoElement/autoPictureInPicture
+page-type: web-api-instance-property
 tags:
   - API
   - HTML

--- a/files/en-us/web/api/htmlvideoelement/disablepictureinpicture/index.md
+++ b/files/en-us/web/api/htmlvideoelement/disablepictureinpicture/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLVideoElement.disablePictureInPicture
 slug: Web/API/HTMLVideoElement/disablePictureInPicture
+page-type: web-api-instance-property
 tags:
   - API
   - HTML

--- a/files/en-us/web/api/htmlvideoelement/enterpictureinpicture_event/index.md
+++ b/files/en-us/web/api/htmlvideoelement/enterpictureinpicture_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLVideoElement: enterpictureinpicture event'
 slug: Web/API/HTMLVideoElement/enterpictureinpicture_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/htmlvideoelement/getvideoplaybackquality/index.md
+++ b/files/en-us/web/api/htmlvideoelement/getvideoplaybackquality/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLVideoElement.getVideoPlaybackQuality()
 slug: Web/API/HTMLVideoElement/getVideoPlaybackQuality
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/htmlvideoelement/index.md
+++ b/files/en-us/web/api/htmlvideoelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLVideoElement
 slug: Web/API/HTMLVideoElement
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/htmlvideoelement/leavepictureinpicture_event/index.md
+++ b/files/en-us/web/api/htmlvideoelement/leavepictureinpicture_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLVideoElement: leavepictureinpicture event'
 slug: Web/API/HTMLVideoElement/leavepictureinpicture_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/htmlvideoelement/msframestep/index.md
+++ b/files/en-us/web/api/htmlvideoelement/msframestep/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLVideoElement.msFrameStep()
 slug: Web/API/HTMLVideoElement/msFrameStep
+page-type: web-api-instance-method
 tags:
   - API
   - API:Microsoft Extensions

--- a/files/en-us/web/api/htmlvideoelement/mshorizontalmirror/index.md
+++ b/files/en-us/web/api/htmlvideoelement/mshorizontalmirror/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLVideoElement.msHorizontalMirror
 slug: Web/API/HTMLVideoElement/msHorizontalMirror
+page-type: web-api-instance-property
 tags:
   - API
   - API:Microsoft Extensions

--- a/files/en-us/web/api/htmlvideoelement/msinsertvideoeffect/index.md
+++ b/files/en-us/web/api/htmlvideoelement/msinsertvideoeffect/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLVideoElement.msInsertVideoEffect()
 slug: Web/API/HTMLVideoElement/msInsertVideoEffect
+page-type: web-api-instance-method
 tags:
   - API
   - API:Microsoft Extensions

--- a/files/en-us/web/api/htmlvideoelement/msislayoutoptimalforplayback/index.md
+++ b/files/en-us/web/api/htmlvideoelement/msislayoutoptimalforplayback/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLVideoElement.msIsLayoutOptimalForPlayback
 slug: Web/API/HTMLVideoElement/msIsLayoutOptimalForPlayback
+page-type: web-api-instance-property
 tags:
   - API
   - API:Microsoft Extensions

--- a/files/en-us/web/api/htmlvideoelement/msisstereo3d/index.md
+++ b/files/en-us/web/api/htmlvideoelement/msisstereo3d/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLVideoElement.msIsStereo3D
 slug: Web/API/HTMLVideoElement/msIsStereo3D
+page-type: web-api-instance-property
 tags:
   - API
   - API:Microsoft Extensions

--- a/files/en-us/web/api/htmlvideoelement/mssetvideorectangle/index.md
+++ b/files/en-us/web/api/htmlvideoelement/mssetvideorectangle/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLVideoElement.msSetVideoRectangle
 slug: Web/API/HTMLVideoElement/msSetVideoRectangle
+page-type: web-api-instance-property
 tags:
   - msSetVideoRectangle
 ---

--- a/files/en-us/web/api/htmlvideoelement/msstereo3dpackingmode/index.md
+++ b/files/en-us/web/api/htmlvideoelement/msstereo3dpackingmode/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLVideoElement.msStereo3DPackingMode
 slug: Web/API/HTMLVideoElement/msStereo3DPackingMode
+page-type: web-api-instance-property
 tags:
   - msStereo3DPackingMode
 ---

--- a/files/en-us/web/api/htmlvideoelement/msstereo3drendermode/index.md
+++ b/files/en-us/web/api/htmlvideoelement/msstereo3drendermode/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLVideoElement.msStereo3DRenderMode
 slug: Web/API/HTMLVideoElement/msStereo3DRenderMode
+page-type: web-api-instance-property
 tags:
   - msStereo3DRenderMode
 ---

--- a/files/en-us/web/api/htmlvideoelement/mszoom/index.md
+++ b/files/en-us/web/api/htmlvideoelement/mszoom/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLVideoElement.msZoom
 slug: Web/API/HTMLVideoElement/msZoom
+page-type: web-api-instance-property
 tags:
   - API
   - API:Microsoft Extensions

--- a/files/en-us/web/api/htmlvideoelement/onmsvideoformatchanged/index.md
+++ b/files/en-us/web/api/htmlvideoelement/onmsvideoformatchanged/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLVideoElement.onMSVideoFormatChanged
 slug: Web/API/HTMLVideoElement/onMSVideoFormatChanged
+page-type: web-api-instance-property
 tags:
   - onMsVideoFormatChanged
 ---

--- a/files/en-us/web/api/htmlvideoelement/onmsvideoframestepcompleted/index.md
+++ b/files/en-us/web/api/htmlvideoelement/onmsvideoframestepcompleted/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLVideoElement.onMSVideoFrameStepCompleted
 slug: Web/API/HTMLVideoElement/onMSVideoFrameStepCompleted
+page-type: web-api-instance-property
 tags:
   - onMSVideoFrameStepCompleted
 ---

--- a/files/en-us/web/api/htmlvideoelement/onmsvideooptimallayoutchanged/index.md
+++ b/files/en-us/web/api/htmlvideoelement/onmsvideooptimallayoutchanged/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLVideoElement.onMSVideoOptimalLayoutChanged
 slug: Web/API/HTMLVideoElement/onMSVideoOptimalLayoutChanged
+page-type: web-api-instance-property
 tags:
   - onMSVideoOptimalLayoutChanged
 ---

--- a/files/en-us/web/api/htmlvideoelement/requestpictureinpicture/index.md
+++ b/files/en-us/web/api/htmlvideoelement/requestpictureinpicture/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLVideoElement.requestPictureInPicture()
 slug: Web/API/HTMLVideoElement/requestPictureInPicture
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/htmlvideoelement/videoheight/index.md
+++ b/files/en-us/web/api/htmlvideoelement/videoheight/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLVideoElement.videoHeight
 slug: Web/API/HTMLVideoElement/videoHeight
+page-type: web-api-instance-property
 tags:
   - API
   - HTML

--- a/files/en-us/web/api/htmlvideoelement/videowidth/index.md
+++ b/files/en-us/web/api/htmlvideoelement/videowidth/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLVideoElement.videoWidth
 slug: Web/API/HTMLVideoElement/videoWidth
+page-type: web-api-instance-property
 tags:
   - API
   - HTML

--- a/files/en-us/web/api/idbcursor/advance/index.md
+++ b/files/en-us/web/api/idbcursor/advance/index.md
@@ -1,6 +1,7 @@
 ---
 title: IDBCursor.advance()
 slug: Web/API/IDBCursor/advance
+page-type: web-api-instance-method
 tags:
   - API
   - Database

--- a/files/en-us/web/api/idbcursor/continue/index.md
+++ b/files/en-us/web/api/idbcursor/continue/index.md
@@ -1,6 +1,7 @@
 ---
 title: IDBCursor.continue()
 slug: Web/API/IDBCursor/continue
+page-type: web-api-instance-method
 tags:
   - API
   - Database

--- a/files/en-us/web/api/idbcursor/continueprimarykey/index.md
+++ b/files/en-us/web/api/idbcursor/continueprimarykey/index.md
@@ -1,6 +1,7 @@
 ---
 title: IDBCursor.continuePrimaryKey()
 slug: Web/API/IDBCursor/continuePrimaryKey
+page-type: web-api-instance-method
 tags:
   - API
   - IDBCursor

--- a/files/en-us/web/api/idbcursor/delete/index.md
+++ b/files/en-us/web/api/idbcursor/delete/index.md
@@ -1,6 +1,7 @@
 ---
 title: IDBCursor.delete()
 slug: Web/API/IDBCursor/delete
+page-type: web-api-instance-method
 tags:
   - API
   - Database

--- a/files/en-us/web/api/idbcursor/direction/index.md
+++ b/files/en-us/web/api/idbcursor/direction/index.md
@@ -1,6 +1,7 @@
 ---
 title: IDBCursor.direction
 slug: Web/API/IDBCursor/direction
+page-type: web-api-instance-property
 tags:
   - API
   - Database

--- a/files/en-us/web/api/idbcursor/index.md
+++ b/files/en-us/web/api/idbcursor/index.md
@@ -1,6 +1,7 @@
 ---
 title: IDBCursor
 slug: Web/API/IDBCursor
+page-type: web-api-interface
 tags:
   - API
   - IDBCursor

--- a/files/en-us/web/api/idbcursor/key/index.md
+++ b/files/en-us/web/api/idbcursor/key/index.md
@@ -1,6 +1,7 @@
 ---
 title: IDBCursor.key
 slug: Web/API/IDBCursor/key
+page-type: web-api-instance-property
 tags:
   - API
   - Database

--- a/files/en-us/web/api/idbcursor/primarykey/index.md
+++ b/files/en-us/web/api/idbcursor/primarykey/index.md
@@ -1,6 +1,7 @@
 ---
 title: IDBCursor.primaryKey
 slug: Web/API/IDBCursor/primaryKey
+page-type: web-api-instance-property
 tags:
   - API
   - Database

--- a/files/en-us/web/api/idbcursor/request/index.md
+++ b/files/en-us/web/api/idbcursor/request/index.md
@@ -1,6 +1,7 @@
 ---
 title: IDBCursor.request
 slug: Web/API/IDBCursor/request
+page-type: web-api-instance-property
 tags:
   - API
   - Database

--- a/files/en-us/web/api/idbcursor/source/index.md
+++ b/files/en-us/web/api/idbcursor/source/index.md
@@ -1,6 +1,7 @@
 ---
 title: IDBCursor.source
 slug: Web/API/IDBCursor/source
+page-type: web-api-instance-property
 tags:
   - API
   - Database

--- a/files/en-us/web/api/idbcursor/update/index.md
+++ b/files/en-us/web/api/idbcursor/update/index.md
@@ -1,6 +1,7 @@
 ---
 title: IDBCursor.update()
 slug: Web/API/IDBCursor/update
+page-type: web-api-instance-method
 tags:
   - API
   - Database

--- a/files/en-us/web/api/idbcursorwithvalue/index.md
+++ b/files/en-us/web/api/idbcursorwithvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: IDBCursorWithValue
 slug: Web/API/IDBCursorWithValue
+page-type: web-api-interface
 tags:
   - API
   - DOM Reference

--- a/files/en-us/web/api/idbcursorwithvalue/value/index.md
+++ b/files/en-us/web/api/idbcursorwithvalue/value/index.md
@@ -1,6 +1,7 @@
 ---
 title: IDBCursorWithValue.value
 slug: Web/API/IDBCursorWithValue/value
+page-type: web-api-instance-property
 tags:
   - API
   - Database

--- a/files/en-us/web/api/idbdatabase/close/index.md
+++ b/files/en-us/web/api/idbdatabase/close/index.md
@@ -1,6 +1,7 @@
 ---
 title: IDBDatabase.close()
 slug: Web/API/IDBDatabase/close
+page-type: web-api-instance-method
 tags:
   - API
   - Database

--- a/files/en-us/web/api/idbdatabase/close_event/index.md
+++ b/files/en-us/web/api/idbdatabase/close_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'IDBDatabase: close event'
 slug: Web/API/IDBDatabase/close_event
+page-type: web-api-event
 tags:
   - Event
   - Reference

--- a/files/en-us/web/api/idbdatabase/createobjectstore/index.md
+++ b/files/en-us/web/api/idbdatabase/createobjectstore/index.md
@@ -1,6 +1,7 @@
 ---
 title: IDBDatabase.createObjectStore()
 slug: Web/API/IDBDatabase/createObjectStore
+page-type: web-api-instance-method
 tags:
   - API
   - Database

--- a/files/en-us/web/api/idbdatabase/deleteobjectstore/index.md
+++ b/files/en-us/web/api/idbdatabase/deleteobjectstore/index.md
@@ -1,6 +1,7 @@
 ---
 title: IDBDatabase.deleteObjectStore()
 slug: Web/API/IDBDatabase/deleteObjectStore
+page-type: web-api-instance-method
 tags:
   - API
   - Database

--- a/files/en-us/web/api/idbdatabase/index.md
+++ b/files/en-us/web/api/idbdatabase/index.md
@@ -1,6 +1,7 @@
 ---
 title: IDBDatabase
 slug: Web/API/IDBDatabase
+page-type: web-api-interface
 tags:
   - API
   - Database

--- a/files/en-us/web/api/idbdatabase/name/index.md
+++ b/files/en-us/web/api/idbdatabase/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: IDBDatabase.name
 slug: Web/API/IDBDatabase/name
+page-type: web-api-instance-property
 tags:
   - API
   - Database

--- a/files/en-us/web/api/idbdatabase/objectstorenames/index.md
+++ b/files/en-us/web/api/idbdatabase/objectstorenames/index.md
@@ -1,6 +1,7 @@
 ---
 title: IDBDatabase.objectStoreNames
 slug: Web/API/IDBDatabase/objectStoreNames
+page-type: web-api-instance-property
 tags:
   - API
   - Database


### PR DESCRIPTION
See  https://github.com/mdn/content/issues/16255. This is part 12 of a series of PRs to add page types to the Web/API documentation.