### PR TITLE
Add Web/API page types, part 14

### DIFF
--- a/files/en-us/web/api/interventionreportbody/id/index.md
+++ b/files/en-us/web/api/interventionreportbody/id/index.md
@@ -1,6 +1,7 @@
 ---
 title: InterventionReportBody.id
 slug: Web/API/InterventionReportBody/id
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/interventionreportbody/linenumber/index.md
+++ b/files/en-us/web/api/interventionreportbody/linenumber/index.md
@@ -1,6 +1,7 @@
 ---
 title: InterventionReportBody.lineNumber
 slug: Web/API/InterventionReportBody/lineNumber
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/interventionreportbody/message/index.md
+++ b/files/en-us/web/api/interventionreportbody/message/index.md
@@ -1,6 +1,7 @@
 ---
 title: InterventionReportBody.message
 slug: Web/API/InterventionReportBody/message
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/interventionreportbody/sourcefile/index.md
+++ b/files/en-us/web/api/interventionreportbody/sourcefile/index.md
@@ -1,6 +1,7 @@
 ---
 title: InterventionReportBody.sourceFile
 slug: Web/API/InterventionReportBody/sourceFile
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/interventionreportbody/tojson/index.md
+++ b/files/en-us/web/api/interventionreportbody/tojson/index.md
@@ -1,6 +1,7 @@
 ---
 title: InterventionReportBody.toJSON()
 slug: Web/API/InterventionReportBody/toJSON
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/issecurecontext/index.md
+++ b/files/en-us/web/api/issecurecontext/index.md
@@ -1,6 +1,7 @@
 ---
 title: isSecureContext
 slug: Web/API/isSecureContext
+page-type: web-api-global-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/keyboard/getlayoutmap/index.md
+++ b/files/en-us/web/api/keyboard/getlayoutmap/index.md
@@ -1,6 +1,7 @@
 ---
 title: Keyboard.getLayoutMap()
 slug: Web/API/Keyboard/getLayoutMap
+page-type: web-api-instance-method
 tags:
   - API
   - Keyboard API

--- a/files/en-us/web/api/keyboard/index.md
+++ b/files/en-us/web/api/keyboard/index.md
@@ -1,6 +1,7 @@
 ---
 title: Keyboard
 slug: Web/API/Keyboard
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/keyboard/lock/index.md
+++ b/files/en-us/web/api/keyboard/lock/index.md
@@ -1,6 +1,7 @@
 ---
 title: Keyboard.lock()
 slug: Web/API/Keyboard/lock
+page-type: web-api-instance-method
 tags:
   - API
   - Keyboard API

--- a/files/en-us/web/api/keyboard/unlock/index.md
+++ b/files/en-us/web/api/keyboard/unlock/index.md
@@ -1,6 +1,7 @@
 ---
 title: Keyboard.unlock()
 slug: Web/API/Keyboard/unlock
+page-type: web-api-instance-method
 tags:
   - API
   - Keyboard API

--- a/files/en-us/web/api/keyboard_api/index.md
+++ b/files/en-us/web/api/keyboard_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Keyboard API
 slug: Web/API/Keyboard_API
+page-type: web-api-overview
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/keyboardevent/altkey/index.md
+++ b/files/en-us/web/api/keyboardevent/altkey/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyboardEvent.altKey
 slug: Web/API/KeyboardEvent/altKey
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/keyboardevent/charcode/index.md
+++ b/files/en-us/web/api/keyboardevent/charcode/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyboardEvent.charCode
 slug: Web/API/KeyboardEvent/charCode
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/keyboardevent/code/index.md
+++ b/files/en-us/web/api/keyboardevent/code/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyboardEvent.code
 slug: Web/API/KeyboardEvent/code
+page-type: web-api-instance-property
 tags:
   - API
   - Code

--- a/files/en-us/web/api/keyboardevent/ctrlkey/index.md
+++ b/files/en-us/web/api/keyboardevent/ctrlkey/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyboardEvent.ctrlKey
 slug: Web/API/KeyboardEvent/ctrlKey
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/keyboardevent/getmodifierstate/index.md
+++ b/files/en-us/web/api/keyboardevent/getmodifierstate/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyboardEvent.getModifierState()
 slug: Web/API/KeyboardEvent/getModifierState
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/keyboardevent/index.md
+++ b/files/en-us/web/api/keyboardevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyboardEvent
 slug: Web/API/KeyboardEvent
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/keyboardevent/initkeyboardevent/index.md
+++ b/files/en-us/web/api/keyboardevent/initkeyboardevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyboardEvent.initKeyboardEvent()
 slug: Web/API/KeyboardEvent/initKeyboardEvent
+page-type: web-api-instance-method
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/keyboardevent/initkeyevent/index.md
+++ b/files/en-us/web/api/keyboardevent/initkeyevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyboardEvent.initKeyEvent()
 slug: Web/API/KeyboardEvent/initKeyEvent
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/keyboardevent/iscomposing/index.md
+++ b/files/en-us/web/api/keyboardevent/iscomposing/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyboardEvent.isComposing
 slug: Web/API/KeyboardEvent/isComposing
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/keyboardevent/key/index.md
+++ b/files/en-us/web/api/keyboardevent/key/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyboardEvent.key
 slug: Web/API/KeyboardEvent/key
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/keyboardevent/keyboardevent/index.md
+++ b/files/en-us/web/api/keyboardevent/keyboardevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyboardEvent()
 slug: Web/API/KeyboardEvent/KeyboardEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/keyboardevent/keycode/index.md
+++ b/files/en-us/web/api/keyboardevent/keycode/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyboardEvent.keyCode
 slug: Web/API/KeyboardEvent/keyCode
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/keyboardevent/keyidentifier/index.md
+++ b/files/en-us/web/api/keyboardevent/keyidentifier/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyboardEvent.keyIdentifier
 slug: Web/API/KeyboardEvent/keyIdentifier
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/keyboardevent/location/index.md
+++ b/files/en-us/web/api/keyboardevent/location/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyboardEvent.location
 slug: Web/API/KeyboardEvent/location
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/keyboardevent/metakey/index.md
+++ b/files/en-us/web/api/keyboardevent/metakey/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyboardEvent.metaKey
 slug: Web/API/KeyboardEvent/metaKey
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/keyboardevent/repeat/index.md
+++ b/files/en-us/web/api/keyboardevent/repeat/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyboardEvent.repeat
 slug: Web/API/KeyboardEvent/repeat
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/keyboardevent/shiftkey/index.md
+++ b/files/en-us/web/api/keyboardevent/shiftkey/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyboardEvent.shiftKey
 slug: Web/API/KeyboardEvent/shiftKey
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/keyboardlayoutmap/entries/index.md
+++ b/files/en-us/web/api/keyboardlayoutmap/entries/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyboardLayoutMap.entries
 slug: Web/API/KeyboardLayoutMap/entries
+page-type: web-api-instance-property
 tags:
   - API
   - Entries

--- a/files/en-us/web/api/keyboardlayoutmap/foreach/index.md
+++ b/files/en-us/web/api/keyboardlayoutmap/foreach/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyboardLayoutMap.forEach()
 slug: Web/API/KeyboardLayoutMap/forEach
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/keyboardlayoutmap/get/index.md
+++ b/files/en-us/web/api/keyboardlayoutmap/get/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyboardLayoutMap.get()
 slug: Web/API/KeyboardLayoutMap/get
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/keyboardlayoutmap/has/index.md
+++ b/files/en-us/web/api/keyboardlayoutmap/has/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyboardLayoutMap.has()
 slug: Web/API/KeyboardLayoutMap/has
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/keyboardlayoutmap/index.md
+++ b/files/en-us/web/api/keyboardlayoutmap/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyboardLayoutMap
 slug: Web/API/KeyboardLayoutMap
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/keyboardlayoutmap/keys/index.md
+++ b/files/en-us/web/api/keyboardlayoutmap/keys/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyboardLayoutMap.keys
 slug: Web/API/KeyboardLayoutMap/keys
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/keyboardlayoutmap/size/index.md
+++ b/files/en-us/web/api/keyboardlayoutmap/size/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyboardLayoutMap.size
 slug: Web/API/KeyboardLayoutMap/size
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/keyboardlayoutmap/values/index.md
+++ b/files/en-us/web/api/keyboardlayoutmap/values/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyboardLayoutMap.values
 slug: Web/API/KeyboardLayoutMap/values
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/keyframeeffect/composite/index.md
+++ b/files/en-us/web/api/keyframeeffect/composite/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyframeEffect.composite
 slug: Web/API/KeyframeEffect/composite
+page-type: web-api-instance-property
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/keyframeeffect/getkeyframes/index.md
+++ b/files/en-us/web/api/keyframeeffect/getkeyframes/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyframeEffect.getKeyframes()
 slug: Web/API/KeyframeEffect/getKeyframes
+page-type: web-api-instance-method
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/keyframeeffect/index.md
+++ b/files/en-us/web/api/keyframeeffect/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyframeEffect
 slug: Web/API/KeyframeEffect
+page-type: web-api-interface
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/keyframeeffect/iterationcomposite/index.md
+++ b/files/en-us/web/api/keyframeeffect/iterationcomposite/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyframeEffect.iterationComposite
 slug: Web/API/KeyframeEffect/iterationComposite
+page-type: web-api-instance-property
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/keyframeeffect/keyframeeffect/index.md
+++ b/files/en-us/web/api/keyframeeffect/keyframeeffect/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyframeEffect()
 slug: Web/API/KeyframeEffect/KeyframeEffect
+page-type: web-api-constructor
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/keyframeeffect/setkeyframes/index.md
+++ b/files/en-us/web/api/keyframeeffect/setkeyframes/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyframeEffect.setKeyframes()
 slug: Web/API/KeyframeEffect/setKeyframes
+page-type: web-api-instance-method
 tags:
   - API
   - Animations

--- a/files/en-us/web/api/keyframeeffect/target/index.md
+++ b/files/en-us/web/api/keyframeeffect/target/index.md
@@ -1,6 +1,7 @@
 ---
 title: KeyframeEffect.target
 slug: Web/API/KeyframeEffect/target
+page-type: web-api-instance-property
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/largest_contentful_paint_api/index.md
+++ b/files/en-us/web/api/largest_contentful_paint_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Largest Contentful Paint API
 slug: Web/API/Largest_Contentful_Paint_API
+page-type: web-api-overview
 tags:
   - API
   - LargestContentfulPaint

--- a/files/en-us/web/api/largestcontentfulpaint/element/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/element/index.md
@@ -1,6 +1,7 @@
 ---
 title: LargestContentfulPaint.element
 slug: Web/API/LargestContentfulPaint/element
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/largestcontentfulpaint/id/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/id/index.md
@@ -1,6 +1,7 @@
 ---
 title: LargestContentfulPaint.id
 slug: Web/API/LargestContentfulPaint/id
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/largestcontentfulpaint/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/index.md
@@ -1,6 +1,7 @@
 ---
 title: LargestContentfulPaint
 slug: Web/API/LargestContentfulPaint
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/largestcontentfulpaint/loadtime/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/loadtime/index.md
@@ -1,6 +1,7 @@
 ---
 title: LargestContentfulPaint.loadTime
 slug: Web/API/LargestContentfulPaint/loadTime
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/largestcontentfulpaint/rendertime/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/rendertime/index.md
@@ -1,6 +1,7 @@
 ---
 title: LargestContentfulPaint.renderTime
 slug: Web/API/LargestContentfulPaint/renderTime
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/largestcontentfulpaint/size/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/size/index.md
@@ -1,6 +1,7 @@
 ---
 title: LargestContentfulPaint.size
 slug: Web/API/LargestContentfulPaint/size
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/largestcontentfulpaint/tojson/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/tojson/index.md
@@ -1,6 +1,7 @@
 ---
 title: LargestContentfulPaint.toJSON()
 slug: Web/API/LargestContentfulPaint/toJSON
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/largestcontentfulpaint/url/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/url/index.md
@@ -1,6 +1,7 @@
 ---
 title: LargestContentfulPaint.url
 slug: Web/API/LargestContentfulPaint/url
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/layout_instability_api/index.md
+++ b/files/en-us/web/api/layout_instability_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Layout Instability API
 slug: Web/API/Layout_Instability_API
+page-type: web-api-overview
 tags:
   - API
   - Layout Instability API

--- a/files/en-us/web/api/layoutshift/index.md
+++ b/files/en-us/web/api/layoutshift/index.md
@@ -1,6 +1,7 @@
 ---
 title: LayoutShift
 slug: Web/API/LayoutShift
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/layoutshiftattribution/currentrect/index.md
+++ b/files/en-us/web/api/layoutshiftattribution/currentrect/index.md
@@ -1,6 +1,7 @@
 ---
 title: LayoutShiftAttribution.currentRect
 slug: Web/API/LayoutShiftAttribution/currentRect
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/layoutshiftattribution/index.md
+++ b/files/en-us/web/api/layoutshiftattribution/index.md
@@ -1,6 +1,7 @@
 ---
 title: LayoutShiftAttribution
 slug: Web/API/LayoutShiftAttribution
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/layoutshiftattribution/node/index.md
+++ b/files/en-us/web/api/layoutshiftattribution/node/index.md
@@ -1,7 +1,7 @@
 ---
 title: LayoutShiftAttribution.node
 slug: Web/API/LayoutShiftAttribution/node
-page-type: web-api-instance-method
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/layoutshiftattribution/node/index.md
+++ b/files/en-us/web/api/layoutshiftattribution/node/index.md
@@ -1,6 +1,7 @@
 ---
 title: LayoutShiftAttribution.node
 slug: Web/API/LayoutShiftAttribution/node
+page-type: web-api-instance-method
 tags:
   - API
   - Property

--- a/files/en-us/web/api/layoutshiftattribution/previousrect/index.md
+++ b/files/en-us/web/api/layoutshiftattribution/previousrect/index.md
@@ -1,6 +1,7 @@
 ---
 title: LayoutShiftAttribution.previousRect
 slug: Web/API/LayoutShiftAttribution/previousRect
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/layoutshiftattribution/tojson/index.md
+++ b/files/en-us/web/api/layoutshiftattribution/tojson/index.md
@@ -1,6 +1,7 @@
 ---
 title: LayoutShiftAttribution.toJSON()
 slug: Web/API/LayoutShiftAttribution/toJSON
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/linearaccelerationsensor/index.md
+++ b/files/en-us/web/api/linearaccelerationsensor/index.md
@@ -1,6 +1,7 @@
 ---
 title: LinearAccelerationSensor
 slug: Web/API/LinearAccelerationSensor
+page-type: web-api-interface
 tags:
   - API
   - Accelerometer

--- a/files/en-us/web/api/linearaccelerationsensor/linearaccelerationsensor/index.md
+++ b/files/en-us/web/api/linearaccelerationsensor/linearaccelerationsensor/index.md
@@ -1,6 +1,7 @@
 ---
 title: LinearAccelerationSensor()
 slug: Web/API/LinearAccelerationSensor/LinearAccelerationSensor
+page-type: web-api-constructor
 tags:
   - API
   - Accelerometer

--- a/files/en-us/web/api/location/ancestororigins/index.md
+++ b/files/en-us/web/api/location/ancestororigins/index.md
@@ -1,6 +1,7 @@
 ---
 title: location.ancestorOrigins
 slug: Web/API/Location/ancestorOrigins
+page-type: web-api-instance-property
 tags:
   - API
   - Location

--- a/files/en-us/web/api/location/assign/index.md
+++ b/files/en-us/web/api/location/assign/index.md
@@ -1,6 +1,7 @@
 ---
 title: location.assign()
 slug: Web/API/Location/assign
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/location/hash/index.md
+++ b/files/en-us/web/api/location/hash/index.md
@@ -1,6 +1,7 @@
 ---
 title: location.hash
 slug: Web/API/Location/hash
+page-type: web-api-instance-property
 tags:
   - API
   - Location

--- a/files/en-us/web/api/location/host/index.md
+++ b/files/en-us/web/api/location/host/index.md
@@ -1,6 +1,7 @@
 ---
 title: location.host
 slug: Web/API/Location/host
+page-type: web-api-instance-property
 tags:
   - API
   - Location

--- a/files/en-us/web/api/location/hostname/index.md
+++ b/files/en-us/web/api/location/hostname/index.md
@@ -1,6 +1,7 @@
 ---
 title: location.hostname
 slug: Web/API/Location/hostname
+page-type: web-api-instance-property
 tags:
   - API
   - Location

--- a/files/en-us/web/api/location/href/index.md
+++ b/files/en-us/web/api/location/href/index.md
@@ -1,6 +1,7 @@
 ---
 title: location.href
 slug: Web/API/Location/href
+page-type: web-api-instance-property
 tags:
   - API
   - Location

--- a/files/en-us/web/api/location/index.md
+++ b/files/en-us/web/api/location/index.md
@@ -1,6 +1,7 @@
 ---
 title: Location
 slug: Web/API/Location
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/location/origin/index.md
+++ b/files/en-us/web/api/location/origin/index.md
@@ -1,6 +1,7 @@
 ---
 title: location.origin
 slug: Web/API/Location/origin
+page-type: web-api-instance-property
 tags:
   - API
   - Location

--- a/files/en-us/web/api/location/password/index.md
+++ b/files/en-us/web/api/location/password/index.md
@@ -1,6 +1,7 @@
 ---
 title: location.password
 slug: Web/API/Location/password
+page-type: web-api-instance-property
 tags:
   - API
   - Location

--- a/files/en-us/web/api/location/pathname/index.md
+++ b/files/en-us/web/api/location/pathname/index.md
@@ -1,6 +1,7 @@
 ---
 title: location.pathname
 slug: Web/API/Location/pathname
+page-type: web-api-instance-property
 tags:
   - API
   - Location

--- a/files/en-us/web/api/location/port/index.md
+++ b/files/en-us/web/api/location/port/index.md
@@ -1,6 +1,7 @@
 ---
 title: location.port
 slug: Web/API/Location/port
+page-type: web-api-instance-property
 tags:
   - API
   - Location

--- a/files/en-us/web/api/location/protocol/index.md
+++ b/files/en-us/web/api/location/protocol/index.md
@@ -1,6 +1,7 @@
 ---
 title: location.protocol
 slug: Web/API/Location/protocol
+page-type: web-api-instance-property
 tags:
   - API
   - Location

--- a/files/en-us/web/api/location/reload/index.md
+++ b/files/en-us/web/api/location/reload/index.md
@@ -1,6 +1,7 @@
 ---
 title: location.reload()
 slug: Web/API/Location/reload
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/location/replace/index.md
+++ b/files/en-us/web/api/location/replace/index.md
@@ -1,6 +1,7 @@
 ---
 title: location.replace()
 slug: Web/API/Location/replace
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/location/search/index.md
+++ b/files/en-us/web/api/location/search/index.md
@@ -1,6 +1,7 @@
 ---
 title: location.search
 slug: Web/API/Location/search
+page-type: web-api-instance-property
 tags:
   - API
   - Location

--- a/files/en-us/web/api/location/tostring/index.md
+++ b/files/en-us/web/api/location/tostring/index.md
@@ -1,6 +1,7 @@
 ---
 title: location.toString()
 slug: Web/API/Location/toString
+page-type: web-api-instance-method
 tags:
   - API
   - Location

--- a/files/en-us/web/api/location/username/index.md
+++ b/files/en-us/web/api/location/username/index.md
@@ -1,6 +1,7 @@
 ---
 title: location.username
 slug: Web/API/Location/username
+page-type: web-api-instance-property
 tags:
   - API
   - Location

--- a/files/en-us/web/api/lock/index.md
+++ b/files/en-us/web/api/lock/index.md
@@ -1,6 +1,7 @@
 ---
 title: Lock
 slug: Web/API/Lock
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/lock/mode/index.md
+++ b/files/en-us/web/api/lock/mode/index.md
@@ -1,6 +1,7 @@
 ---
 title: Locks.mode
 slug: Web/API/Lock/mode
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/lock/name/index.md
+++ b/files/en-us/web/api/lock/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: Locks.name
 slug: Web/API/Lock/name
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/lockmanager/index.md
+++ b/files/en-us/web/api/lockmanager/index.md
@@ -1,6 +1,7 @@
 ---
 title: LockManager
 slug: Web/API/LockManager
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/lockmanager/query/index.md
+++ b/files/en-us/web/api/lockmanager/query/index.md
@@ -1,6 +1,7 @@
 ---
 title: LockManager.query()
 slug: Web/API/LockManager/query
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/lockmanager/request/index.md
+++ b/files/en-us/web/api/lockmanager/request/index.md
@@ -1,6 +1,7 @@
 ---
 title: LockManager.request()
 slug: Web/API/LockManager/request
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/long_tasks_api/index.md
+++ b/files/en-us/web/api/long_tasks_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Long Tasks API
 slug: Web/API/Long_Tasks_API
+page-type: web-api-overview
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/magnetometer/index.md
+++ b/files/en-us/web/api/magnetometer/index.md
@@ -1,6 +1,7 @@
 ---
 title: Magnetometer
 slug: Web/API/Magnetometer
+page-type: web-api-interface
 tags:
   - API
   - Generic Sensor API

--- a/files/en-us/web/api/magnetometer/magnetometer/index.md
+++ b/files/en-us/web/api/magnetometer/magnetometer/index.md
@@ -1,6 +1,7 @@
 ---
 title: Magnetometer()
 slug: Web/API/Magnetometer/Magnetometer
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/magnetometer/x/index.md
+++ b/files/en-us/web/api/magnetometer/x/index.md
@@ -1,6 +1,7 @@
 ---
 title: Magnetometer.x
 slug: Web/API/Magnetometer/x
+page-type: web-api-instance-property
 tags:
   - API
   - Generic Sensor API

--- a/files/en-us/web/api/magnetometer/y/index.md
+++ b/files/en-us/web/api/magnetometer/y/index.md
@@ -1,6 +1,7 @@
 ---
 title: Magnetometer.y
 slug: Web/API/Magnetometer/y
+page-type: web-api-instance-property
 tags:
   - API
   - Generic Sensor API

--- a/files/en-us/web/api/magnetometer/z/index.md
+++ b/files/en-us/web/api/magnetometer/z/index.md
@@ -1,6 +1,7 @@
 ---
 title: Magnetometer.z
 slug: Web/API/Magnetometer/z
+page-type: web-api-instance-property
 tags:
   - API
   - Generic Sensor API

--- a/files/en-us/web/api/mathmlelement/index.md
+++ b/files/en-us/web/api/mathmlelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: MathMLElement
 slug: Web/API/MathMLElement
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/media_capabilities_api/index.md
+++ b/files/en-us/web/api/media_capabilities_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Media Capabilities API
 slug: Web/API/Media_Capabilities_API
+page-type: web-api-overview
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/media_capabilities_api/using_the_media_capabilities_api/index.md
+++ b/files/en-us/web/api/media_capabilities_api/using_the_media_capabilities_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using the Media Capabilities API
 slug: Web/API/Media_Capabilities_API/Using_the_Media_Capabilities_API
+page-type: guide
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/media_session_api/index.md
+++ b/files/en-us/web/api/media_session_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Media Session API
 slug: Web/API/Media_Session_API
+page-type: web-api-overview
 tags:
   - Audio
   - Media

--- a/files/en-us/web/api/media_source_extensions_api/index.md
+++ b/files/en-us/web/api/media_source_extensions_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Media Source API
 slug: Web/API/Media_Source_Extensions_API
+page-type: web-api-overview
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/media_source_extensions_api/transcoding_assets_for_mse/index.md
+++ b/files/en-us/web/api/media_source_extensions_api/transcoding_assets_for_mse/index.md
@@ -1,6 +1,7 @@
 ---
 title: Transcoding assets for Media Source Extensions
 slug: Web/API/Media_Source_Extensions_API/Transcoding_assets_for_MSE
+page-type: guide
 tags:
   - DASH
   - Dynamic Adaptive Streaming over HTTP

--- a/files/en-us/web/api/media_streams_api/constraints/index.md
+++ b/files/en-us/web/api/media_streams_api/constraints/index.md
@@ -1,6 +1,7 @@
 ---
 title: Capabilities, constraints, and settings
 slug: Web/API/Media_Streams_API/Constraints
+page-type: guide
 tags:
   - Advanced
   - Audio

--- a/files/en-us/web/api/media_streams_api/index.md
+++ b/files/en-us/web/api/media_streams_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Media Capture and Streams API (Media Stream)
 slug: Web/API/Media_Streams_API
+page-type: web-api-overview
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediacapabilities/decodinginfo/index.md
+++ b/files/en-us/web/api/mediacapabilities/decodinginfo/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaCapabilities.decodingInfo()
 slug: Web/API/MediaCapabilities/decodingInfo
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediacapabilities/encodinginfo/index.md
+++ b/files/en-us/web/api/mediacapabilities/encodinginfo/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaCapabilities.encodingInfo()
 slug: Web/API/MediaCapabilities/encodingInfo
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediacapabilities/index.md
+++ b/files/en-us/web/api/mediacapabilities/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaCapabilities
 slug: Web/API/MediaCapabilities
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediadeviceinfo/deviceid/index.md
+++ b/files/en-us/web/api/mediadeviceinfo/deviceid/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaDeviceInfo.deviceId
 slug: Web/API/MediaDeviceInfo/deviceId
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/mediadeviceinfo/groupid/index.md
+++ b/files/en-us/web/api/mediadeviceinfo/groupid/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaDeviceInfo.groupId
 slug: Web/API/MediaDeviceInfo/groupId
+page-type: web-api-instance-property
 tags:
   - API
   - Device

--- a/files/en-us/web/api/mediadeviceinfo/index.md
+++ b/files/en-us/web/api/mediadeviceinfo/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaDeviceInfo
 slug: Web/API/MediaDeviceInfo
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediadeviceinfo/kind/index.md
+++ b/files/en-us/web/api/mediadeviceinfo/kind/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaDeviceInfo.kind
 slug: Web/API/MediaDeviceInfo/kind
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/mediadeviceinfo/label/index.md
+++ b/files/en-us/web/api/mediadeviceinfo/label/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaDeviceInfo.label
 slug: Web/API/MediaDeviceInfo/label
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/mediadevices/devicechange_event/index.md
+++ b/files/en-us/web/api/mediadevices/devicechange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'MediaDevices: devicechange event'
 slug: Web/API/MediaDevices/devicechange_event
+page-type: web-api-event
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediadevices/enumeratedevices/index.md
+++ b/files/en-us/web/api/mediadevices/enumeratedevices/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaDevices.enumerateDevices()
 slug: Web/API/MediaDevices/enumerateDevices
+page-type: web-api-instance-method
 tags:
   - API
   - MediaDevices

--- a/files/en-us/web/api/mediadevices/getdisplaymedia/index.md
+++ b/files/en-us/web/api/mediadevices/getdisplaymedia/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaDevices.getDisplayMedia()
 slug: Web/API/MediaDevices/getDisplayMedia
+page-type: web-api-instance-method
 tags:
   - API
   - Capture

--- a/files/en-us/web/api/mediadevices/getsupportedconstraints/index.md
+++ b/files/en-us/web/api/mediadevices/getsupportedconstraints/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaDevices.getSupportedConstraints()
 slug: Web/API/MediaDevices/getSupportedConstraints
+page-type: web-api-instance-method
 tags:
   - API
   - Media

--- a/files/en-us/web/api/mediadevices/getusermedia/index.md
+++ b/files/en-us/web/api/mediadevices/getusermedia/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaDevices.getUserMedia()
 slug: Web/API/MediaDevices/getUserMedia
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediadevices/index.md
+++ b/files/en-us/web/api/mediadevices/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaDevices
 slug: Web/API/MediaDevices
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediadevices/selectaudiooutput/index.md
+++ b/files/en-us/web/api/mediadevices/selectaudiooutput/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaDevices.selectAudioOutput()
 slug: Web/API/MediaDevices/selectAudioOutput
+page-type: web-api-instance-method
 tags:
   - API
   - MediaDevices

--- a/files/en-us/web/api/mediaelementaudiosourcenode/index.md
+++ b/files/en-us/web/api/mediaelementaudiosourcenode/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaElementAudioSourceNode
 slug: Web/API/MediaElementAudioSourceNode
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediaelementaudiosourcenode/mediaelement/index.md
+++ b/files/en-us/web/api/mediaelementaudiosourcenode/mediaelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaElementAudioSourceNode.mediaElement
 slug: Web/API/MediaElementAudioSourceNode/mediaElement
+page-type: web-api-instance-property
 tags:
   - API
   - MediaElementAudioSourceNode

--- a/files/en-us/web/api/mediaelementaudiosourcenode/mediaelementaudiosourcenode/index.md
+++ b/files/en-us/web/api/mediaelementaudiosourcenode/mediaelementaudiosourcenode/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaElementAudioSourceNode()
 slug: Web/API/MediaElementAudioSourceNode/MediaElementAudioSourceNode
+page-type: web-api-constructor
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediaerror/code/index.md
+++ b/files/en-us/web/api/mediaerror/code/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaError.code
 slug: Web/API/MediaError/code
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediaerror/index.md
+++ b/files/en-us/web/api/mediaerror/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaError
 slug: Web/API/MediaError
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediaerror/message/index.md
+++ b/files/en-us/web/api/mediaerror/message/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaError.message
 slug: Web/API/MediaError/message
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediaerror/msextendedcode/index.md
+++ b/files/en-us/web/api/mediaerror/msextendedcode/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaError.msExtendedCode
 slug: Web/API/MediaError/msExtendedCode
+page-type: web-api-instance-property
 ---
 {{APIRef("DOM")}}
 

--- a/files/en-us/web/api/mediaimage/index.md
+++ b/files/en-us/web/api/mediaimage/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaImage
 slug: Web/API/MediaImage
+page-type: web-api-interface
 browser-compat: api.MediaImage
 ---
 {{APIRef("Media Session API")}}

--- a/files/en-us/web/api/mediakeymessageevent/index.md
+++ b/files/en-us/web/api/mediakeymessageevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeyMessageEvent
 slug: Web/API/MediaKeyMessageEvent
+page-type: web-api-interface
 tags:
   - API
   - EncryptedMediaExtensions

--- a/files/en-us/web/api/mediakeymessageevent/mediakeymessageevent/index.md
+++ b/files/en-us/web/api/mediakeymessageevent/mediakeymessageevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeyMessageEvent()
 slug: Web/API/MediaKeyMessageEvent/MediaKeyMessageEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/mediakeymessageevent/message/index.md
+++ b/files/en-us/web/api/mediakeymessageevent/message/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeyMessageEvent.message
 slug: Web/API/MediaKeyMessageEvent/message
+page-type: web-api-instance-property
 tags:
   - API
   - EncryptedMediaExtensions

--- a/files/en-us/web/api/mediakeymessageevent/messagetype/index.md
+++ b/files/en-us/web/api/mediakeymessageevent/messagetype/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeyMessageEvent.messageType
 slug: Web/API/MediaKeyMessageEvent/messageType
+page-type: web-api-instance-property
 tags:
   - API
   - EncryptedMediaExtensions

--- a/files/en-us/web/api/mediakeys/createsession/index.md
+++ b/files/en-us/web/api/mediakeys/createsession/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeys.createSession()
 slug: Web/API/MediaKeys/createSession
+page-type: web-api-instance-method
 tags:
   - API
   - EncryptedMediaExtensions

--- a/files/en-us/web/api/mediakeys/index.md
+++ b/files/en-us/web/api/mediakeys/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeys
 slug: Web/API/MediaKeys
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediakeys/setservercertificate/index.md
+++ b/files/en-us/web/api/mediakeys/setservercertificate/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeys.setServerCertificate()
 slug: Web/API/MediaKeys/setServerCertificate
+page-type: web-api-instance-method
 tags:
   - API
   - EncryptedMediaExtensions

--- a/files/en-us/web/api/mediakeysession/close/index.md
+++ b/files/en-us/web/api/mediakeysession/close/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeySession.close()
 slug: Web/API/MediaKeySession/close
+page-type: web-api-instance-method
 tags:
   - API
   - EncryptedMediaExtensions

--- a/files/en-us/web/api/mediakeysession/closed/index.md
+++ b/files/en-us/web/api/mediakeysession/closed/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeySession.closed
 slug: Web/API/MediaKeySession/closed
+page-type: web-api-instance-property
 tags:
   - API
   - EncryptedMediaExtensions

--- a/files/en-us/web/api/mediakeysession/expiration/index.md
+++ b/files/en-us/web/api/mediakeysession/expiration/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeySession.expiration
 slug: Web/API/MediaKeySession/expiration
+page-type: web-api-instance-property
 tags:
   - API
   - EncryptedMediaExtensions

--- a/files/en-us/web/api/mediakeysession/generaterequest/index.md
+++ b/files/en-us/web/api/mediakeysession/generaterequest/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeySession.generateRequest()
 slug: Web/API/MediaKeySession/generateRequest
+page-type: web-api-instance-method
 tags:
   - API
   - EncryptedMediaExtensions

--- a/files/en-us/web/api/mediakeysession/index.md
+++ b/files/en-us/web/api/mediakeysession/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeySession
 slug: Web/API/MediaKeySession
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediakeysession/keystatuses/index.md
+++ b/files/en-us/web/api/mediakeysession/keystatuses/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeySession.keyStatuses
 slug: Web/API/MediaKeySession/keyStatuses
+page-type: web-api-instance-property
 tags:
   - API
   - EncryptedMediaExtensions

--- a/files/en-us/web/api/mediakeysession/keystatuseschange_event/index.md
+++ b/files/en-us/web/api/mediakeysession/keystatuseschange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'MediaKeySession: keystatuseschange event'
 slug: Web/API/MediaKeySession/keystatuseschange_event
+page-type: web-api-event
 tags:
   - keystatuseschange
   - API

--- a/files/en-us/web/api/mediakeysession/load/index.md
+++ b/files/en-us/web/api/mediakeysession/load/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeySession.load()
 slug: Web/API/MediaKeySession/load
+page-type: web-api-instance-method
 tags:
   - API
   - EncryptedMediaExtensions

--- a/files/en-us/web/api/mediakeysession/message_event/index.md
+++ b/files/en-us/web/api/mediakeysession/message_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'MediaKeySession: message event'
 slug: Web/API/MediaKeySession/message_event
+page-type: web-api-event
 tags:
   - message
   - API

--- a/files/en-us/web/api/mediakeysession/remove/index.md
+++ b/files/en-us/web/api/mediakeysession/remove/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeySession.remove()
 slug: Web/API/MediaKeySession/remove
+page-type: web-api-instance-method
 tags:
   - API
   - EncryptedMediaExtensions

--- a/files/en-us/web/api/mediakeysession/sessionid/index.md
+++ b/files/en-us/web/api/mediakeysession/sessionid/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeySession.sessionId
 slug: Web/API/MediaKeySession/sessionId
+page-type: web-api-instance-property
 tags:
   - API
   - EncryptedMediaExtensions

--- a/files/en-us/web/api/mediakeysession/update/index.md
+++ b/files/en-us/web/api/mediakeysession/update/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeySession.update()
 slug: Web/API/MediaKeySession/update
+page-type: web-api-instance-method
 tags:
   - API
   - EncryptedMediaExtensions

--- a/files/en-us/web/api/mediakeystatusmap/entries/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/entries/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeyStatusMap.entries()
 slug: Web/API/MediaKeyStatusMap/entries
+page-type: web-api-instance-method
 tags:
   - API
   - EncryptedMediaExtensions

--- a/files/en-us/web/api/mediakeystatusmap/foreach/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/foreach/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeyStatusMap.forEach()
 slug: Web/API/MediaKeyStatusMap/forEach
+page-type: web-api-instance-method
 tags:
   - API
   - EncryptedMediaExtensions

--- a/files/en-us/web/api/mediakeystatusmap/get/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/get/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeyStatusMap.get()
 slug: Web/API/MediaKeyStatusMap/get
+page-type: web-api-instance-method
 tags:
   - API
   - EncryptedMediaExtensions

--- a/files/en-us/web/api/mediakeystatusmap/has/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/has/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeyStatusMap.has()
 slug: Web/API/MediaKeyStatusMap/has
+page-type: web-api-instance-method
 tags:
   - API
   - EncryptedMediaExtensions

--- a/files/en-us/web/api/mediakeystatusmap/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeyStatusMap
 slug: Web/API/MediaKeyStatusMap
+page-type: web-api-interface
 tags:
   - API
   - EncryptedMediaExtensions

--- a/files/en-us/web/api/mediakeystatusmap/keys/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/keys/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeyStatusMap.keys()
 slug: Web/API/MediaKeyStatusMap/keys
+page-type: web-api-instance-method
 tags:
   - API
   - EncryptedMediaExtensions

--- a/files/en-us/web/api/mediakeystatusmap/size/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/size/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeyStatusMap.size
 slug: Web/API/MediaKeyStatusMap/size
+page-type: web-api-instance-property
 tags:
   - API
   - EncryptedMediaExtensions

--- a/files/en-us/web/api/mediakeystatusmap/values/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/values/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeyStatusMap.values()
 slug: Web/API/MediaKeyStatusMap/values
+page-type: web-api-instance-method
 tags:
   - API
   - EncryptedMediaExtensions

--- a/files/en-us/web/api/mediakeysystemaccess/createmediakeys/index.md
+++ b/files/en-us/web/api/mediakeysystemaccess/createmediakeys/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeySystemAccess.createMediaKeys()
 slug: Web/API/MediaKeySystemAccess/createMediaKeys
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediakeysystemaccess/getconfiguration/index.md
+++ b/files/en-us/web/api/mediakeysystemaccess/getconfiguration/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeySystemAccess.getConfiguration()
 slug: Web/API/MediaKeySystemAccess/getConfiguration
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediakeysystemaccess/index.md
+++ b/files/en-us/web/api/mediakeysystemaccess/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeySystemAccess
 slug: Web/API/MediaKeySystemAccess
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediakeysystemaccess/keysystem/index.md
+++ b/files/en-us/web/api/mediakeysystemaccess/keysystem/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaKeySystemAccess.keySystem
 slug: Web/API/MediaKeySystemAccess/keySystem
+page-type: web-api-instance-property
 tags:
   - API
   - EncryptedMediaExtensions

--- a/files/en-us/web/api/medialist/index.md
+++ b/files/en-us/web/api/medialist/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaList
 slug: Web/API/MediaList
+page-type: web-api-interface
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/medialist/mediatext/index.md
+++ b/files/en-us/web/api/medialist/mediatext/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaList.mediaText
 slug: Web/API/MediaList/mediaText
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/mediametadata/album/index.md
+++ b/files/en-us/web/api/mediametadata/album/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaMetadata.album
 slug: Web/API/MediaMetadata/album
+page-type: web-api-instance-property
 tags:
   - API
   - MediaMetadata

--- a/files/en-us/web/api/mediametadata/artist/index.md
+++ b/files/en-us/web/api/mediametadata/artist/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaMetadata.artist
 slug: Web/API/MediaMetadata/artist
+page-type: web-api-instance-property
 tags:
   - Audio
   - Media

--- a/files/en-us/web/api/mediametadata/artwork/index.md
+++ b/files/en-us/web/api/mediametadata/artwork/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaMetadata.artwork
 slug: Web/API/MediaMetadata/artwork
+page-type: web-api-instance-property
 tags:
   - Audio
   - Media

--- a/files/en-us/web/api/mediametadata/index.md
+++ b/files/en-us/web/api/mediametadata/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaMetadata
 slug: Web/API/MediaMetadata
+page-type: web-api-interface
 tags:
   - Audio
   - Interface

--- a/files/en-us/web/api/mediametadata/mediametadata/index.md
+++ b/files/en-us/web/api/mediametadata/mediametadata/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaMetadata()
 slug: Web/API/MediaMetadata/MediaMetadata
+page-type: web-api-constructor
 tags:
   - Audio
   - Experimental

--- a/files/en-us/web/api/mediametadata/title/index.md
+++ b/files/en-us/web/api/mediametadata/title/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaMetadata.title
 slug: Web/API/MediaMetadata/title
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediaquerylist/addlistener/index.md
+++ b/files/en-us/web/api/mediaquerylist/addlistener/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaQueryList.addListener()
 slug: Web/API/MediaQueryList/addListener
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/mediaquerylist/change_event/index.md
+++ b/files/en-us/web/api/mediaquerylist/change_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'MediaQueryList: change event'
 slug: Web/API/MediaQueryList/change_event
+page-type: web-api-event
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/mediaquerylist/index.md
+++ b/files/en-us/web/api/mediaquerylist/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaQueryList
 slug: Web/API/MediaQueryList
+page-type: web-api-interface
 tags:
   - API
   - Adaptive Design

--- a/files/en-us/web/api/mediaquerylist/matches/index.md
+++ b/files/en-us/web/api/mediaquerylist/matches/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaQueryList.matches
 slug: Web/API/MediaQueryList/matches
+page-type: web-api-instance-property
 tags:
   - API
   - Adaptive Design

--- a/files/en-us/web/api/mediaquerylist/media/index.md
+++ b/files/en-us/web/api/mediaquerylist/media/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaQueryList.media
 slug: Web/API/MediaQueryList/media
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/mediaquerylist/removelistener/index.md
+++ b/files/en-us/web/api/mediaquerylist/removelistener/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaQueryList.removeListener()
 slug: Web/API/MediaQueryList/removeListener
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/mediaquerylistevent/index.md
+++ b/files/en-us/web/api/mediaquerylistevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaQueryListEvent
 slug: Web/API/MediaQueryListEvent
+page-type: web-api-interface
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/mediaquerylistevent/matches/index.md
+++ b/files/en-us/web/api/mediaquerylistevent/matches/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaQueryListEvent.matches
 slug: Web/API/MediaQueryListEvent/matches
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/mediaquerylistevent/media/index.md
+++ b/files/en-us/web/api/mediaquerylistevent/media/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaQueryListEvent.media
 slug: Web/API/MediaQueryListEvent/media
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/mediaquerylistevent/mediaquerylistevent/index.md
+++ b/files/en-us/web/api/mediaquerylistevent/mediaquerylistevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaQueryListEvent()
 slug: Web/API/MediaQueryListEvent/MediaQueryListEvent
+page-type: web-api-constructor
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/mediarecorder/audiobitspersecond/index.md
+++ b/files/en-us/web/api/mediarecorder/audiobitspersecond/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaRecorder.audioBitsPerSecond
 slug: Web/API/MediaRecorder/audioBitsPerSecond
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediarecorder/dataavailable_event/index.md
+++ b/files/en-us/web/api/mediarecorder/dataavailable_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'MediaRecorder: dataavailable event'
 slug: Web/API/MediaRecorder/dataavailable_event
+page-type: web-api-event
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediarecorder/error_event/index.md
+++ b/files/en-us/web/api/mediarecorder/error_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'MediaRecorder: error event'
 slug: Web/API/MediaRecorder/error_event
+page-type: web-api-event
 tags:
   - Event
 browser-compat: api.MediaRecorder.error_event

--- a/files/en-us/web/api/mediarecorder/index.md
+++ b/files/en-us/web/api/mediarecorder/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaRecorder
 slug: Web/API/MediaRecorder
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediarecorder/istypesupported/index.md
+++ b/files/en-us/web/api/mediarecorder/istypesupported/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaRecorder.isTypeSupported()
 slug: Web/API/MediaRecorder/isTypeSupported
+page-type: web-api-static-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediarecorder/mediarecorder/index.md
+++ b/files/en-us/web/api/mediarecorder/mediarecorder/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaRecorder()
 slug: Web/API/MediaRecorder/MediaRecorder
+page-type: web-api-constructor
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediarecorder/mimetype/index.md
+++ b/files/en-us/web/api/mediarecorder/mimetype/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaRecorder.mimeType
 slug: Web/API/MediaRecorder/mimeType
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediarecorder/pause/index.md
+++ b/files/en-us/web/api/mediarecorder/pause/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaRecorder.pause()
 slug: Web/API/MediaRecorder/pause
+page-type: web-api-instance-method
 tags:
   - API
   - Media Capture

--- a/files/en-us/web/api/mediarecorder/pause_event/index.md
+++ b/files/en-us/web/api/mediarecorder/pause_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'MediaRecorder: pause event'
 slug: Web/API/MediaRecorder/pause_event
+page-type: web-api-event
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediarecorder/requestdata/index.md
+++ b/files/en-us/web/api/mediarecorder/requestdata/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaRecorder.requestData()
 slug: Web/API/MediaRecorder/requestData
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediarecorder/resume/index.md
+++ b/files/en-us/web/api/mediarecorder/resume/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaRecorder.resume()
 slug: Web/API/MediaRecorder/resume
+page-type: web-api-instance-method
 tags:
   - API
   - Media Capture

--- a/files/en-us/web/api/mediarecorder/resume_event/index.md
+++ b/files/en-us/web/api/mediarecorder/resume_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'MediaRecorder: resume event'
 slug: Web/API/MediaRecorder/resume_event
+page-type: web-api-event
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediarecorder/start/index.md
+++ b/files/en-us/web/api/mediarecorder/start/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaRecorder.start()
 slug: Web/API/MediaRecorder/start
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediarecorder/start_event/index.md
+++ b/files/en-us/web/api/mediarecorder/start_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'MediaRecorder: start event'
 slug: Web/API/MediaRecorder/start_event
+page-type: web-api-event
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediarecorder/state/index.md
+++ b/files/en-us/web/api/mediarecorder/state/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaRecorder.state
 slug: Web/API/MediaRecorder/state
+page-type: web-api-instance-property
 tags:
   - API
   - Media Recorder API

--- a/files/en-us/web/api/mediarecorder/stop/index.md
+++ b/files/en-us/web/api/mediarecorder/stop/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaRecorder.stop()
 slug: Web/API/MediaRecorder/stop
+page-type: web-api-instance-method
 tags:
   - API
   - Media Capture

--- a/files/en-us/web/api/mediarecorder/stop_event/index.md
+++ b/files/en-us/web/api/mediarecorder/stop_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'MediaRecorder: stop event'
 slug: Web/API/MediaRecorder/stop_event
+page-type: web-api-event
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediarecorder/stream/index.md
+++ b/files/en-us/web/api/mediarecorder/stream/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaRecorder.stream
 slug: Web/API/MediaRecorder/stream
+page-type: web-api-instance-property
 tags:
   - API
   - Media Recorder API

--- a/files/en-us/web/api/mediarecorder/videobitspersecond/index.md
+++ b/files/en-us/web/api/mediarecorder/videobitspersecond/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaRecorder.videoBitsPerSecond
 slug: Web/API/MediaRecorder/videoBitsPerSecond
+page-type: web-api-instance-property
 browser-compat: api.MediaRecorder.videoBitsPerSecond
 ---
 {{SeeCompatTable}}{{APIRef("MediaStream Recording")}}

--- a/files/en-us/web/api/mediarecorder/warning_event/index.md
+++ b/files/en-us/web/api/mediarecorder/warning_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaRecorder.onwarning
 slug: Web/API/MediaRecorder/warning_event
+page-type: web-api-event
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediarecordererrorevent/error/index.md
+++ b/files/en-us/web/api/mediarecordererrorevent/error/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaRecorderErrorEvent.error
 slug: Web/API/MediaRecorderErrorEvent/error
+page-type: web-api-instance-property
 tags:
   - API
   - Error

--- a/files/en-us/web/api/mediarecordererrorevent/index.md
+++ b/files/en-us/web/api/mediarecordererrorevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaRecorderErrorEvent
 slug: Web/API/MediaRecorderErrorEvent
+page-type: web-api-interface
 tags:
   - AV
   - Audio

--- a/files/en-us/web/api/mediarecordererrorevent/mediarecordererrorevent/index.md
+++ b/files/en-us/web/api/mediarecordererrorevent/mediarecordererrorevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaRecorderErrorEvent()
 slug: Web/API/MediaRecorderErrorEvent/MediaRecorderErrorEvent
+page-type: web-api-constructor
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediasession/index.md
+++ b/files/en-us/web/api/mediasession/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaSession
 slug: Web/API/MediaSession
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediasession/metadata/index.md
+++ b/files/en-us/web/api/mediasession/metadata/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaSession.metadata
 slug: Web/API/MediaSession/metadata
+page-type: web-api-instance-property
 tags:
   - Audio
   - Media

--- a/files/en-us/web/api/mediasession/playbackstate/index.md
+++ b/files/en-us/web/api/mediasession/playbackstate/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaSession.playbackState
 slug: Web/API/MediaSession/playbackState
+page-type: web-api-instance-property
 tags:
   - Audio
   - Media

--- a/files/en-us/web/api/mediasession/setactionhandler/index.md
+++ b/files/en-us/web/api/mediasession/setactionhandler/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaSession.setActionHandler()
 slug: Web/API/MediaSession/setActionHandler
+page-type: web-api-static-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediasession/setactionhandler/index.md
+++ b/files/en-us/web/api/mediasession/setactionhandler/index.md
@@ -1,7 +1,7 @@
 ---
 title: MediaSession.setActionHandler()
 slug: Web/API/MediaSession/setActionHandler
-page-type: web-api-static-method
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediasession/setpositionstate/index.md
+++ b/files/en-us/web/api/mediasession/setpositionstate/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaSession.setPositionState()
 slug: Web/API/MediaSession/setPositionState
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediasource/activesourcebuffers/index.md
+++ b/files/en-us/web/api/mediasource/activesourcebuffers/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaSource.activeSourceBuffers
 slug: Web/API/MediaSource/activeSourceBuffers
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediasource/index.md
+++ b/files/en-us/web/api/mediasource/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaSource
 slug: Web/API/MediaSource
+page-type: web-api-interface
 tags:
   - API
   - Audio


### PR DESCRIPTION
See  https://github.com/mdn/content/issues/16255. This is part 14 of a series of PRs to add page types to the Web/API documentation.