### PR TITLE
Add Web/API page types, part 15

### DIFF
--- a/files/en-us/web/api/mediasource/addsourcebuffer/index.md
+++ b/files/en-us/web/api/mediasource/addsourcebuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaSource.addSourceBuffer()
 slug: Web/API/MediaSource/addSourceBuffer
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediasource/clearliveseekablerange/index.md
+++ b/files/en-us/web/api/mediasource/clearliveseekablerange/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaSource.clearLiveSeekableRange()
 slug: Web/API/MediaSource/clearLiveSeekableRange
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediasource/duration/index.md
+++ b/files/en-us/web/api/mediasource/duration/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaSource.duration
 slug: Web/API/MediaSource/duration
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediasource/endofstream/index.md
+++ b/files/en-us/web/api/mediasource/endofstream/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaSource.endOfStream()
 slug: Web/API/MediaSource/endOfStream
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediasource/istypesupported/index.md
+++ b/files/en-us/web/api/mediasource/istypesupported/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaSource.isTypeSupported()
 slug: Web/API/MediaSource/isTypeSupported
+page-type: web-api-static-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediasource/mediasource/index.md
+++ b/files/en-us/web/api/mediasource/mediasource/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaSource()
 slug: Web/API/MediaSource/MediaSource
+page-type: web-api-constructor
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediasource/readystate/index.md
+++ b/files/en-us/web/api/mediasource/readystate/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaSource.readyState
 slug: Web/API/MediaSource/readyState
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediasource/removesourcebuffer/index.md
+++ b/files/en-us/web/api/mediasource/removesourcebuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaSource.removeSourceBuffer()
 slug: Web/API/MediaSource/removeSourceBuffer
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediasource/setliveseekablerange/index.md
+++ b/files/en-us/web/api/mediasource/setliveseekablerange/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaSource.setLiveSeekableRange()
 slug: Web/API/MediaSource/setLiveSeekableRange
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediasource/sourcebuffers/index.md
+++ b/files/en-us/web/api/mediasource/sourcebuffers/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaSource.sourceBuffers
 slug: Web/API/MediaSource/sourceBuffers
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediastream/active/index.md
+++ b/files/en-us/web/api/mediastream/active/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStream.active
 slug: Web/API/MediaStream/active
+page-type: web-api-instance-property
 tags:
   - API
   - Media Capture and Streams

--- a/files/en-us/web/api/mediastream/addtrack/index.md
+++ b/files/en-us/web/api/mediastream/addtrack/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStream.addTrack()
 slug: Web/API/MediaStream/addTrack
+page-type: web-api-instance-method
 tags:
   - API
   - Media Streams API

--- a/files/en-us/web/api/mediastream/addtrack_event/index.md
+++ b/files/en-us/web/api/mediastream/addtrack_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'MediaStream: addtrack event'
 slug: Web/API/MediaStream/addtrack_event
+page-type: web-api-event
 tags:
   - Event
 browser-compat: api.MediaStream.addtrack_event

--- a/files/en-us/web/api/mediastream/clone/index.md
+++ b/files/en-us/web/api/mediastream/clone/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStream.clone()
 slug: Web/API/MediaStream/clone
+page-type: web-api-instance-method
 tags:
   - API
   - Media Capture and Streams

--- a/files/en-us/web/api/mediastream/getaudiotracks/index.md
+++ b/files/en-us/web/api/mediastream/getaudiotracks/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStream.getAudioTracks()
 slug: Web/API/MediaStream/getAudioTracks
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediastream/gettrackbyid/index.md
+++ b/files/en-us/web/api/mediastream/gettrackbyid/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStream.getTrackById()
 slug: Web/API/MediaStream/getTrackById
+page-type: web-api-instance-method
 tags:
   - Media
   - MediaStream

--- a/files/en-us/web/api/mediastream/gettracks/index.md
+++ b/files/en-us/web/api/mediastream/gettracks/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStream.getTracks()
 slug: Web/API/MediaStream/getTracks
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/mediastream/getvideotracks/index.md
+++ b/files/en-us/web/api/mediastream/getvideotracks/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStream.getVideoTracks()
 slug: Web/API/MediaStream/getVideoTracks
+page-type: web-api-instance-method
 tags:
   - API
   - Media

--- a/files/en-us/web/api/mediastream/id/index.md
+++ b/files/en-us/web/api/mediastream/id/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStream.id
 slug: Web/API/MediaStream/id
+page-type: web-api-instance-property
 tags:
   - MediaStream
   - Property

--- a/files/en-us/web/api/mediastream/index.md
+++ b/files/en-us/web/api/mediastream/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStream
 slug: Web/API/MediaStream
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/mediastream/mediastream/index.md
+++ b/files/en-us/web/api/mediastream/mediastream/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStream()
 slug: Web/API/MediaStream/MediaStream
+page-type: web-api-constructor
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediastream/removetrack_event/index.md
+++ b/files/en-us/web/api/mediastream/removetrack_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'MediaStream: removetrack event'
 slug: Web/API/MediaStream/removetrack_event
+page-type: web-api-event
 tags:
   - Event
 browser-compat: api.MediaStream.removetrack_event

--- a/files/en-us/web/api/mediastream_image_capture_api/index.md
+++ b/files/en-us/web/api/mediastream_image_capture_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStream Image Capture API
 slug: Web/API/MediaStream_Image_Capture_API
+page-type: web-api-overview
 tags:
   - API
   - Image

--- a/files/en-us/web/api/mediastream_recording_api/index.md
+++ b/files/en-us/web/api/mediastream_recording_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStream Recording API
 slug: Web/API/MediaStream_Recording_API
+page-type: web-api-overview
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediastream_recording_api/recording_a_media_element/index.md
+++ b/files/en-us/web/api/mediastream_recording_api/recording_a_media_element/index.md
@@ -1,6 +1,7 @@
 ---
 title: Recording a media element
 slug: Web/API/MediaStream_Recording_API/Recording_a_media_element
+page-type: guide
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediastream_recording_api/using_the_mediastream_recording_api/index.md
+++ b/files/en-us/web/api/mediastream_recording_api/using_the_mediastream_recording_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using the MediaStream Recording API
 slug: Web/API/MediaStream_Recording_API/Using_the_MediaStream_Recording_API
+page-type: guide
 tags:
   - API
   - Example

--- a/files/en-us/web/api/mediastreamaudiodestinationnode/index.md
+++ b/files/en-us/web/api/mediastreamaudiodestinationnode/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamAudioDestinationNode
 slug: Web/API/MediaStreamAudioDestinationNode
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/mediastreamaudiodestinationnode/mediastreamaudiodestinationnode/index.md
+++ b/files/en-us/web/api/mediastreamaudiodestinationnode/mediastreamaudiodestinationnode/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamAudioDestinationNode()
 slug: Web/API/MediaStreamAudioDestinationNode/MediaStreamAudioDestinationNode
+page-type: web-api-constructor
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediastreamaudiodestinationnode/stream/index.md
+++ b/files/en-us/web/api/mediastreamaudiodestinationnode/stream/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamAudioDestinationNode.stream
 slug: Web/API/MediaStreamAudioDestinationNode/stream
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediastreamaudiosourcenode/index.md
+++ b/files/en-us/web/api/mediastreamaudiosourcenode/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamAudioSourceNode
 slug: Web/API/MediaStreamAudioSourceNode
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediastreamaudiosourcenode/mediastream/index.md
+++ b/files/en-us/web/api/mediastreamaudiosourcenode/mediastream/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamAudioSourceNode.mediaStream
 slug: Web/API/MediaStreamAudioSourceNode/mediaStream
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediastreamaudiosourcenode/mediastreamaudiosourcenode/index.md
+++ b/files/en-us/web/api/mediastreamaudiosourcenode/mediastreamaudiosourcenode/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamAudioSourceNode()
 slug: Web/API/MediaStreamAudioSourceNode/MediaStreamAudioSourceNode
+page-type: web-api-constructor
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediastreamevent/index.md
+++ b/files/en-us/web/api/mediastreamevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamEvent
 slug: Web/API/MediaStreamEvent
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/mediastreamevent/mediastreamevent/index.md
+++ b/files/en-us/web/api/mediastreamevent/mediastreamevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamEvent()
 slug: Web/API/MediaStreamEvent/MediaStreamEvent
+page-type: web-api-constructor
 tags:
   - Constructor
   - Deprecated

--- a/files/en-us/web/api/mediastreamevent/stream/index.md
+++ b/files/en-us/web/api/mediastreamevent/stream/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamEvent.stream
 slug: Web/API/MediaStreamEvent/stream
+page-type: web-api-instance-property
 tags:
   - Experimental
   - MediaStreamEvent

--- a/files/en-us/web/api/mediastreamtrack/applyconstraints/index.md
+++ b/files/en-us/web/api/mediastreamtrack/applyconstraints/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamTrack.applyConstraints()
 slug: Web/API/MediaStreamTrack/applyConstraints
+page-type: web-api-instance-method
 tags:
   - API
   - Constraints

--- a/files/en-us/web/api/mediastreamtrack/clone/index.md
+++ b/files/en-us/web/api/mediastreamtrack/clone/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamTrack.clone()
 slug: Web/API/MediaStreamTrack/clone
+page-type: web-api-instance-method
 tags:
   - API
   - Media Capture and Streams

--- a/files/en-us/web/api/mediastreamtrack/enabled/index.md
+++ b/files/en-us/web/api/mediastreamtrack/enabled/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamTrack.enabled
 slug: Web/API/MediaStreamTrack/enabled
+page-type: web-api-instance-property
 tags:
   - Media
   - Media Capture and Streams

--- a/files/en-us/web/api/mediastreamtrack/ended_event/index.md
+++ b/files/en-us/web/api/mediastreamtrack/ended_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'MediaStreamTrack: ended event'
 slug: Web/API/MediaStreamTrack/ended_event
+page-type: web-api-event
 tags:
   - Audio
   - Event

--- a/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
+++ b/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamTrack.getCapabilities()
 slug: Web/API/MediaStreamTrack/getCapabilities
+page-type: web-api-instance-method
 tags:
   - API
   - Media Capture and Streams API

--- a/files/en-us/web/api/mediastreamtrack/getconstraints/index.md
+++ b/files/en-us/web/api/mediastreamtrack/getconstraints/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamTrack.getConstraints()
 slug: Web/API/MediaStreamTrack/getConstraints
+page-type: web-api-instance-method
 tags:
   - API
   - Media Capture and Streams

--- a/files/en-us/web/api/mediastreamtrack/getsettings/index.md
+++ b/files/en-us/web/api/mediastreamtrack/getsettings/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamTrack.getSettings()
 slug: Web/API/MediaStreamTrack/getSettings
+page-type: web-api-instance-method
 tags:
   - API
   - Constraints

--- a/files/en-us/web/api/mediastreamtrack/id/index.md
+++ b/files/en-us/web/api/mediastreamtrack/id/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamTrack.id
 slug: Web/API/MediaStreamTrack/id
+page-type: web-api-instance-property
 tags:
   - Media Capture and Streams
   - MediaStreamTrack

--- a/files/en-us/web/api/mediastreamtrack/index.md
+++ b/files/en-us/web/api/mediastreamtrack/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamTrack
 slug: Web/API/MediaStreamTrack
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediastreamtrack/kind/index.md
+++ b/files/en-us/web/api/mediastreamtrack/kind/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamTrack.kind
 slug: Web/API/MediaStreamTrack/kind
+page-type: web-api-instance-property
 tags:
   - Media Capture and Streams
   - MediaStreamTrack

--- a/files/en-us/web/api/mediastreamtrack/label/index.md
+++ b/files/en-us/web/api/mediastreamtrack/label/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamTrack.label
 slug: Web/API/MediaStreamTrack/label
+page-type: web-api-instance-property
 tags:
   - Media Capture and Streams
   - MediaStreamTrack

--- a/files/en-us/web/api/mediastreamtrack/mute_event/index.md
+++ b/files/en-us/web/api/mediastreamtrack/mute_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'MediaStreamTrack: mute event'
 slug: Web/API/MediaStreamTrack/mute_event
+page-type: web-api-event
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediastreamtrack/muted/index.md
+++ b/files/en-us/web/api/mediastreamtrack/muted/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamTrack.muted
 slug: Web/API/MediaStreamTrack/muted
+page-type: web-api-instance-property
 tags:
   - API
   - Media Capture and Streams

--- a/files/en-us/web/api/mediastreamtrack/overconstrained_event/index.md
+++ b/files/en-us/web/api/mediastreamtrack/overconstrained_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'MediaStreamTrack: overconstrained event'
 slug: Web/API/MediaStreamTrack/overconstrained_event
+page-type: web-api-event
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/mediastreamtrack/readystate/index.md
+++ b/files/en-us/web/api/mediastreamtrack/readystate/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamTrack.readyState
 slug: Web/API/MediaStreamTrack/readyState
+page-type: web-api-instance-property
 tags:
   - API
   - Media Capture and Streams

--- a/files/en-us/web/api/mediastreamtrack/remote/index.md
+++ b/files/en-us/web/api/mediastreamtrack/remote/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamTrack.remote
 slug: Web/API/MediaStreamTrack/remote
+page-type: web-api-instance-property
 tags:
   - Deprecated
   - MediaStreamTrack

--- a/files/en-us/web/api/mediastreamtrack/stop/index.md
+++ b/files/en-us/web/api/mediastreamtrack/stop/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamTrack.stop()
 slug: Web/API/MediaStreamTrack/stop
+page-type: web-api-instance-method
 tags:
   - API
   - Media

--- a/files/en-us/web/api/mediastreamtrack/unmute_event/index.md
+++ b/files/en-us/web/api/mediastreamtrack/unmute_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'MediaStreamTrack: unmute event'
 slug: Web/API/MediaStreamTrack/unmute_event
+page-type: web-api-event
 tags:
   - Audio
   - Event

--- a/files/en-us/web/api/mediastreamtrackaudiosourcenode/index.md
+++ b/files/en-us/web/api/mediastreamtrackaudiosourcenode/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamTrackAudioSourceNode
 slug: Web/API/MediaStreamTrackAudioSourceNode
+page-type: web-api-interface
 browser-compat: api.MediaStreamTrackAudioSourceNode
 ---
 {{APIRef("Web Audio API")}}

--- a/files/en-us/web/api/mediastreamtrackaudiosourcenode/mediastreamtrackaudiosourcenode/index.md
+++ b/files/en-us/web/api/mediastreamtrackaudiosourcenode/mediastreamtrackaudiosourcenode/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamTrackAudioSourceNode()
 slug: Web/API/MediaStreamTrackAudioSourceNode/MediaStreamTrackAudioSourceNode
+page-type: web-api-constructor
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediastreamtrackevent/index.md
+++ b/files/en-us/web/api/mediastreamtrackevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamTrackEvent
 slug: Web/API/MediaStreamTrackEvent
+page-type: web-api-interface
 tags:
   - API
   - Event

--- a/files/en-us/web/api/mediastreamtrackevent/mediastreamtrackevent/index.md
+++ b/files/en-us/web/api/mediastreamtrackevent/mediastreamtrackevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamTrackEvent()
 slug: Web/API/MediaStreamTrackEvent/MediaStreamTrackEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/mediastreamtrackgenerator/index.md
+++ b/files/en-us/web/api/mediastreamtrackgenerator/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamTrackGenerator
 slug: Web/API/MediaStreamTrackGenerator
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/mediastreamtrackgenerator/mediastreamtrackgenerator/index.md
+++ b/files/en-us/web/api/mediastreamtrackgenerator/mediastreamtrackgenerator/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamTrackGenerator.MediaStreamTrackGenerator()
 slug: Web/API/MediaStreamTrackGenerator/MediaStreamTrackGenerator
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/mediastreamtrackgenerator/writable/index.md
+++ b/files/en-us/web/api/mediastreamtrackgenerator/writable/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamTrackGenerator.writable
 slug: Web/API/MediaStreamTrackGenerator/writable
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/mediastreamtrackprocessor/index.md
+++ b/files/en-us/web/api/mediastreamtrackprocessor/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamTrackProcessor
 slug: Web/API/MediaStreamTrackProcessor
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/mediastreamtrackprocessor/mediastreamtrackprocessor/index.md
+++ b/files/en-us/web/api/mediastreamtrackprocessor/mediastreamtrackprocessor/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamTrackProcessor.MediaStreamTrackProcessor()
 slug: Web/API/MediaStreamTrackProcessor/MediaStreamTrackProcessor
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/mediastreamtrackprocessor/readable/index.md
+++ b/files/en-us/web/api/mediastreamtrackprocessor/readable/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaStreamTrackProcessor.readable
 slug: Web/API/MediaStreamTrackProcessor/readable
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/mediatrackconstraints/aspectratio/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/aspectratio/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackConstraints.aspectRatio
 slug: Web/API/MediaTrackConstraints/aspectRatio
+page-type: web-api-instance-property
 tags:
   - API
   - Constraints

--- a/files/en-us/web/api/mediatrackconstraints/autogaincontrol/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/autogaincontrol/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackConstraints.autoGainControl
 slug: Web/API/MediaTrackConstraints/autoGainControl
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediatrackconstraints/channelcount/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/channelcount/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackConstraints.channelCount
 slug: Web/API/MediaTrackConstraints/channelCount
+page-type: web-api-instance-property
 tags:
   - API
   - Constraints

--- a/files/en-us/web/api/mediatrackconstraints/deviceid/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/deviceid/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackConstraints.deviceId
 slug: Web/API/MediaTrackConstraints/deviceId
+page-type: web-api-instance-property
 tags:
   - API
   - Constraints

--- a/files/en-us/web/api/mediatrackconstraints/displaysurface/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/displaysurface/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackConstraints.displaySurface
 slug: Web/API/MediaTrackConstraints/displaySurface
+page-type: web-api-instance-property
 tags:
   - API
   - Capture

--- a/files/en-us/web/api/mediatrackconstraints/echocancellation/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/echocancellation/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackConstraints.echoCancellation
 slug: Web/API/MediaTrackConstraints/echoCancellation
+page-type: web-api-instance-property
 tags:
   - API
   - Constraints

--- a/files/en-us/web/api/mediatrackconstraints/facingmode/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/facingmode/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackConstraints.facingMode
 slug: Web/API/MediaTrackConstraints/facingMode
+page-type: web-api-instance-property
 tags:
   - API
   - Constraints

--- a/files/en-us/web/api/mediatrackconstraints/framerate/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/framerate/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackConstraints.frameRate
 slug: Web/API/MediaTrackConstraints/frameRate
+page-type: web-api-instance-property
 tags:
   - API
   - Constraints

--- a/files/en-us/web/api/mediatrackconstraints/groupid/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/groupid/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackConstraints.groupId
 slug: Web/API/MediaTrackConstraints/groupId
+page-type: web-api-instance-property
 tags:
   - API
   - Constraints

--- a/files/en-us/web/api/mediatrackconstraints/height/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/height/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackConstraints.height
 slug: Web/API/MediaTrackConstraints/height
+page-type: web-api-instance-property
 tags:
   - API
   - Constraints

--- a/files/en-us/web/api/mediatrackconstraints/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackConstraints
 slug: Web/API/MediaTrackConstraints
+page-type: web-api-interface
 tags:
   - API
   - Constraints

--- a/files/en-us/web/api/mediatrackconstraints/latency/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/latency/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackConstraints.latency
 slug: Web/API/MediaTrackConstraints/latency
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediatrackconstraints/logicalsurface/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/logicalsurface/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackConstraints.logicalSurface
 slug: Web/API/MediaTrackConstraints/logicalSurface
+page-type: web-api-instance-property
 tags:
   - API
   - Capture

--- a/files/en-us/web/api/mediatrackconstraints/noisesuppression/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/noisesuppression/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackConstraints.noiseSuppression
 slug: Web/API/MediaTrackConstraints/noiseSuppression
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediatrackconstraints/samplerate/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/samplerate/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackConstraints.sampleRate
 slug: Web/API/MediaTrackConstraints/sampleRate
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediatrackconstraints/samplesize/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/samplesize/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackConstraints.sampleSize
 slug: Web/API/MediaTrackConstraints/sampleSize
+page-type: web-api-instance-property
 tags:
   - API
   - Constraints

--- a/files/en-us/web/api/mediatrackconstraints/volume/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/volume/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackConstraints.volume
 slug: Web/API/MediaTrackConstraints/volume
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediatrackconstraints/width/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/width/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackConstraints.width
 slug: Web/API/MediaTrackConstraints/width
+page-type: web-api-instance-property
 tags:
   - API
   - Constraints

--- a/files/en-us/web/api/mediatracksettings/aspectratio/index.md
+++ b/files/en-us/web/api/mediatracksettings/aspectratio/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSettings.aspectRatio
 slug: Web/API/MediaTrackSettings/aspectRatio
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/mediatracksettings/autogaincontrol/index.md
+++ b/files/en-us/web/api/mediatracksettings/autogaincontrol/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSettings.autoGainControl
 slug: Web/API/MediaTrackSettings/autoGainControl
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediatracksettings/channelcount/index.md
+++ b/files/en-us/web/api/mediatracksettings/channelcount/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSettings.channelCount
 slug: Web/API/MediaTrackSettings/channelCount
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediatracksettings/cursor/index.md
+++ b/files/en-us/web/api/mediatracksettings/cursor/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSettings.cursor
 slug: Web/API/MediaTrackSettings/cursor
+page-type: web-api-instance-property
 tags:
   - API
   - Capture

--- a/files/en-us/web/api/mediatracksettings/deviceid/index.md
+++ b/files/en-us/web/api/mediatracksettings/deviceid/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSettings.deviceId
 slug: Web/API/MediaTrackSettings/deviceId
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/mediatracksettings/displaysurface/index.md
+++ b/files/en-us/web/api/mediatracksettings/displaysurface/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSettings.displaySurface
 slug: Web/API/MediaTrackSettings/displaySurface
+page-type: web-api-instance-property
 tags:
   - API
   - Capture

--- a/files/en-us/web/api/mediatracksettings/echocancellation/index.md
+++ b/files/en-us/web/api/mediatracksettings/echocancellation/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSettings.echoCancellation
 slug: Web/API/MediaTrackSettings/echoCancellation
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediatracksettings/facingmode/index.md
+++ b/files/en-us/web/api/mediatracksettings/facingmode/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSettings.facingMode
 slug: Web/API/MediaTrackSettings/facingMode
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/mediatracksettings/framerate/index.md
+++ b/files/en-us/web/api/mediatracksettings/framerate/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSettings.frameRate
 slug: Web/API/MediaTrackSettings/frameRate
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/mediatracksettings/groupid/index.md
+++ b/files/en-us/web/api/mediatracksettings/groupid/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSettings.groupId
 slug: Web/API/MediaTrackSettings/groupId
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/mediatracksettings/height/index.md
+++ b/files/en-us/web/api/mediatracksettings/height/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSettings.height
 slug: Web/API/MediaTrackSettings/height
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/mediatracksettings/index.md
+++ b/files/en-us/web/api/mediatracksettings/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSettings
 slug: Web/API/MediaTrackSettings
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediatracksettings/latency/index.md
+++ b/files/en-us/web/api/mediatracksettings/latency/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSettings.latency
 slug: Web/API/MediaTrackSettings/latency
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediatracksettings/logicalsurface/index.md
+++ b/files/en-us/web/api/mediatracksettings/logicalsurface/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSettings.logicalSurface
 slug: Web/API/MediaTrackSettings/logicalSurface
+page-type: web-api-instance-property
 tags:
   - API
   - Capture

--- a/files/en-us/web/api/mediatracksettings/noisesuppression/index.md
+++ b/files/en-us/web/api/mediatracksettings/noisesuppression/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSettings.noiseSuppression
 slug: Web/API/MediaTrackSettings/noiseSuppression
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediatracksettings/samplerate/index.md
+++ b/files/en-us/web/api/mediatracksettings/samplerate/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSettings.sampleRate
 slug: Web/API/MediaTrackSettings/sampleRate
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediatracksettings/samplesize/index.md
+++ b/files/en-us/web/api/mediatracksettings/samplesize/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSettings.sampleSize
 slug: Web/API/MediaTrackSettings/sampleSize
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediatracksettings/volume/index.md
+++ b/files/en-us/web/api/mediatracksettings/volume/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSettings.volume
 slug: Web/API/MediaTrackSettings/volume
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediatracksettings/width/index.md
+++ b/files/en-us/web/api/mediatracksettings/width/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSettings.width
 slug: Web/API/MediaTrackSettings/width
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/mediatracksupportedconstraints/aspectratio/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/aspectratio/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSupportedConstraints.aspectRatio
 slug: Web/API/MediaTrackSupportedConstraints/aspectRatio
+page-type: web-api-instance-property
 tags:
   - API
   - Constraints

--- a/files/en-us/web/api/mediatracksupportedconstraints/autogaincontrol/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/autogaincontrol/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSupportedConstraints.autoGainControl
 slug: Web/API/MediaTrackSupportedConstraints/autoGainControl
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediatracksupportedconstraints/channelcount/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/channelcount/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSupportedConstraints.channelCount
 slug: Web/API/MediaTrackSupportedConstraints/channelCount
+page-type: web-api-instance-property
 tags:
   - API
   - Constraints

--- a/files/en-us/web/api/mediatracksupportedconstraints/deviceid/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/deviceid/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSupportedConstraints.deviceId
 slug: Web/API/MediaTrackSupportedConstraints/deviceId
+page-type: web-api-instance-property
 tags:
   - API
   - Constraints

--- a/files/en-us/web/api/mediatracksupportedconstraints/displaysurface/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/displaysurface/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSupportedConstraints.displaySurface
 slug: Web/API/MediaTrackSupportedConstraints/displaySurface
+page-type: web-api-instance-property
 tags:
   - API
   - Capture

--- a/files/en-us/web/api/mediatracksupportedconstraints/echocancellation/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/echocancellation/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSupportedConstraints.echoCancellation
 slug: Web/API/MediaTrackSupportedConstraints/echoCancellation
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/mediatracksupportedconstraints/facingmode/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/facingmode/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSupportedConstraints.facingMode
 slug: Web/API/MediaTrackSupportedConstraints/facingMode
+page-type: web-api-instance-property
 tags:
   - API
   - Constraints

--- a/files/en-us/web/api/mediatracksupportedconstraints/framerate/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/framerate/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSupportedConstraints.frameRate
 slug: Web/API/MediaTrackSupportedConstraints/frameRate
+page-type: web-api-instance-property
 tags:
   - API
   - Constraints

--- a/files/en-us/web/api/mediatracksupportedconstraints/groupid/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/groupid/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSupportedConstraints.groupId
 slug: Web/API/MediaTrackSupportedConstraints/groupId
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/mediatracksupportedconstraints/height/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/height/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSupportedConstraints.height
 slug: Web/API/MediaTrackSupportedConstraints/height
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/mediatracksupportedconstraints/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSupportedConstraints
 slug: Web/API/MediaTrackSupportedConstraints
+page-type: web-api-interface
 tags:
   - API
   - Capture

--- a/files/en-us/web/api/mediatracksupportedconstraints/latency/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/latency/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSupportedConstraints.latency
 slug: Web/API/MediaTrackSupportedConstraints/latency
+page-type: web-api-instance-property
 tags:
   - API
   - Constraints

--- a/files/en-us/web/api/mediatracksupportedconstraints/logicalsurface/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/logicalsurface/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSupportedConstraints.logicalSurface
 slug: Web/API/MediaTrackSupportedConstraints/logicalSurface
+page-type: web-api-instance-property
 tags:
   - API
   - Capture

--- a/files/en-us/web/api/mediatracksupportedconstraints/noisesuppression/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/noisesuppression/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSupportedConstraints.noiseSuppression
 slug: Web/API/MediaTrackSupportedConstraints/noiseSuppression
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/mediatracksupportedconstraints/samplerate/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/samplerate/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSupportedConstraints.sampleRate
 slug: Web/API/MediaTrackSupportedConstraints/sampleRate
+page-type: web-api-instance-property
 tags:
   - API
   - Constraints

--- a/files/en-us/web/api/mediatracksupportedconstraints/samplesize/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/samplesize/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSupportedConstraints.sampleSize
 slug: Web/API/MediaTrackSupportedConstraints/sampleSize
+page-type: web-api-instance-property
 tags:
   - API
   - Constraints

--- a/files/en-us/web/api/mediatracksupportedconstraints/volume/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/volume/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSupportedConstraints.volume
 slug: Web/API/MediaTrackSupportedConstraints/volume
+page-type: web-api-instance-property
 tags:
   - API
   - Constraints

--- a/files/en-us/web/api/mediatracksupportedconstraints/width/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/width/index.md
@@ -1,6 +1,7 @@
 ---
 title: MediaTrackSupportedConstraints.width
 slug: Web/API/MediaTrackSupportedConstraints/width
+page-type: web-api-instance-property
 browser-compat: api.MediaTrackSupportedConstraints.width
 ---
 {{APIRef("Media Capture and Streams")}}

--- a/files/en-us/web/api/merchantvalidationevent/complete/index.md
+++ b/files/en-us/web/api/merchantvalidationevent/complete/index.md
@@ -1,6 +1,7 @@
 ---
 title: MerchantValidationEvent.complete()
 slug: Web/API/MerchantValidationEvent/complete
+page-type: web-api-instance-method
 tags:
   - API
   - Commerce

--- a/files/en-us/web/api/merchantvalidationevent/index.md
+++ b/files/en-us/web/api/merchantvalidationevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: MerchantValidationEvent
 slug: Web/API/MerchantValidationEvent
+page-type: web-api-interface
 tags:
   - API
   - Commerce

--- a/files/en-us/web/api/merchantvalidationevent/merchantvalidationevent/index.md
+++ b/files/en-us/web/api/merchantvalidationevent/merchantvalidationevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: MerchantValidationEvent()
 slug: Web/API/MerchantValidationEvent/MerchantValidationEvent
+page-type: web-api-constructor
 tags:
   - API
   - Commerce

--- a/files/en-us/web/api/merchantvalidationevent/methodname/index.md
+++ b/files/en-us/web/api/merchantvalidationevent/methodname/index.md
@@ -1,6 +1,7 @@
 ---
 title: MerchantValidationEvent.methodName
 slug: Web/API/MerchantValidationEvent/methodName
+page-type: web-api-instance-property
 tags:
   - API
   - Commerce

--- a/files/en-us/web/api/merchantvalidationevent/validationurl/index.md
+++ b/files/en-us/web/api/merchantvalidationevent/validationurl/index.md
@@ -1,6 +1,7 @@
 ---
 title: MerchantValidationEvent.validationURL
 slug: Web/API/MerchantValidationEvent/validationURL
+page-type: web-api-instance-property
 tags:
   - API
   - Commerce

--- a/files/en-us/web/api/messagechannel/index.md
+++ b/files/en-us/web/api/messagechannel/index.md
@@ -1,6 +1,7 @@
 ---
 title: MessageChannel
 slug: Web/API/MessageChannel
+page-type: web-api-interface
 tags:
   - API
   - Channel Messaging API

--- a/files/en-us/web/api/messagechannel/messagechannel/index.md
+++ b/files/en-us/web/api/messagechannel/messagechannel/index.md
@@ -1,7 +1,7 @@
 ---
 title: MessageChannel()
 slug: Web/API/MessageChannel/MessageChannel
-page-type: web-api-event
+page-type: web-api-constructor
 tags:
   - API
   - Channel messaging

--- a/files/en-us/web/api/messagechannel/messagechannel/index.md
+++ b/files/en-us/web/api/messagechannel/messagechannel/index.md
@@ -1,6 +1,7 @@
 ---
 title: MessageChannel()
 slug: Web/API/MessageChannel/MessageChannel
+page-type: web-api-event
 tags:
   - API
   - Channel messaging

--- a/files/en-us/web/api/messagechannel/port1/index.md
+++ b/files/en-us/web/api/messagechannel/port1/index.md
@@ -1,6 +1,7 @@
 ---
 title: MessageChannel.port1
 slug: Web/API/MessageChannel/port1
+page-type: web-api-instance-property
 tags:
   - API
   - Channel messaging

--- a/files/en-us/web/api/messagechannel/port2/index.md
+++ b/files/en-us/web/api/messagechannel/port2/index.md
@@ -1,6 +1,7 @@
 ---
 title: MessageChannel.port2
 slug: Web/API/MessageChannel/port2
+page-type: web-api-instance-property
 tags:
   - API
   - Channel messaging

--- a/files/en-us/web/api/messageevent/data/index.md
+++ b/files/en-us/web/api/messageevent/data/index.md
@@ -1,6 +1,7 @@
 ---
 title: MessageEvent.data
 slug: Web/API/MessageEvent/data
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/messageevent/index.md
+++ b/files/en-us/web/api/messageevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: MessageEvent
 slug: Web/API/MessageEvent
+page-type: web-api-interface
 tags:
   - API
   - Channels

--- a/files/en-us/web/api/messageevent/lasteventid/index.md
+++ b/files/en-us/web/api/messageevent/lasteventid/index.md
@@ -1,6 +1,7 @@
 ---
 title: MessageEvent.lastEventId
 slug: Web/API/MessageEvent/lastEventId
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/messageevent/messageevent/index.md
+++ b/files/en-us/web/api/messageevent/messageevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: MessageEvent()
 slug: Web/API/MessageEvent/MessageEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/messageevent/origin/index.md
+++ b/files/en-us/web/api/messageevent/origin/index.md
@@ -1,6 +1,7 @@
 ---
 title: MessageEvent.origin
 slug: Web/API/MessageEvent/origin
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/messageevent/ports/index.md
+++ b/files/en-us/web/api/messageevent/ports/index.md
@@ -1,6 +1,7 @@
 ---
 title: MessageEvent.ports
 slug: Web/API/MessageEvent/ports
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/messageevent/source/index.md
+++ b/files/en-us/web/api/messageevent/source/index.md
@@ -1,6 +1,7 @@
 ---
 title: MessageEvent.source
 slug: Web/API/MessageEvent/source
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/messageport/close/index.md
+++ b/files/en-us/web/api/messageport/close/index.md
@@ -1,6 +1,7 @@
 ---
 title: MessagePort.close()
 slug: Web/API/MessagePort/close
+page-type: web-api-instance-method
 tags:
   - API
   - Channel messaging

--- a/files/en-us/web/api/messageport/index.md
+++ b/files/en-us/web/api/messageport/index.md
@@ -1,6 +1,7 @@
 ---
 title: MessagePort
 slug: Web/API/MessagePort
+page-type: web-api-interface
 tags:
   - API
   - Channel messaging

--- a/files/en-us/web/api/messageport/message_event/index.md
+++ b/files/en-us/web/api/messageport/message_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'MessagePort: message event'
 slug: Web/API/MessagePort/message_event
+page-type: web-api-event
 tags:
   - Event
 browser-compat: api.MessagePort.message_event

--- a/files/en-us/web/api/messageport/messageerror_event/index.md
+++ b/files/en-us/web/api/messageport/messageerror_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'MessagePort: messageerror event'
 slug: Web/API/MessagePort/messageerror_event
+page-type: web-api-event
 tags:
   - Event
 browser-compat: api.MessagePort.messageerror_event

--- a/files/en-us/web/api/messageport/postmessage/index.md
+++ b/files/en-us/web/api/messageport/postmessage/index.md
@@ -1,6 +1,7 @@
 ---
 title: MessagePort.postMessage()
 slug: Web/API/MessagePort/postMessage
+page-type: web-api-instance-method
 tags:
   - API
   - Channel messaging

--- a/files/en-us/web/api/messageport/start/index.md
+++ b/files/en-us/web/api/messageport/start/index.md
@@ -1,6 +1,7 @@
 ---
 title: MessagePort.start()
 slug: Web/API/MessagePort/start
+page-type: web-api-instance-method
 tags:
   - API
   - Channel messaging

--- a/files/en-us/web/api/metadata/index.md
+++ b/files/en-us/web/api/metadata/index.md
@@ -1,6 +1,7 @@
 ---
 title: Metadata
 slug: Web/API/Metadata
+page-type: web-api-interface
 tags:
   - API
   - File and Directory Entries API

--- a/files/en-us/web/api/metadata/modificationtime/index.md
+++ b/files/en-us/web/api/metadata/modificationtime/index.md
@@ -1,6 +1,7 @@
 ---
 title: Metadata.modificationTime
 slug: Web/API/Metadata/modificationTime
+page-type: web-api-instance-property
 tags:
   - API
   - File and Directory Entries API

--- a/files/en-us/web/api/metadata/size/index.md
+++ b/files/en-us/web/api/metadata/size/index.md
@@ -1,6 +1,7 @@
 ---
 title: Metadata.size
 slug: Web/API/Metadata/size
+page-type: web-api-instance-property
 tags:
   - API
   - File and Directory Entries API

--- a/files/en-us/web/api/microsoft_extensions/index.md
+++ b/files/en-us/web/api/microsoft_extensions/index.md
@@ -1,6 +1,7 @@
 ---
 title: Microsoft API extensions
 slug: Web/API/Microsoft_Extensions
+page-type: landing-page
 tags:
   - API
   - API:Microsoft Extensions

--- a/files/en-us/web/api/midiaccess/index.md
+++ b/files/en-us/web/api/midiaccess/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIDIAccess
 slug: Web/API/MIDIAccess
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/midiaccess/inputs/index.md
+++ b/files/en-us/web/api/midiaccess/inputs/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIDIAccess.inputs
 slug: Web/API/MIDIAccess/inputs
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/midiaccess/outputs/index.md
+++ b/files/en-us/web/api/midiaccess/outputs/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIDIAccess.outputs
 slug: Web/API/MIDIAccess/outputs
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/midiaccess/statechange_event/index.md
+++ b/files/en-us/web/api/midiaccess/statechange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'MIDIAccess: statechange event'
 slug: Web/API/MIDIAccess/statechange_event
+page-type: web-api-event
 tags:
   - statechange
   - API

--- a/files/en-us/web/api/midiaccess/sysexenabled/index.md
+++ b/files/en-us/web/api/midiaccess/sysexenabled/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIDIAccess.sysexEnabled
 slug: Web/API/MIDIAccess/sysexEnabled
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/midiconnectionevent/index.md
+++ b/files/en-us/web/api/midiconnectionevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIDIConnectionEvent
 slug: Web/API/MIDIConnectionEvent
+page-type: web-api-interface
 tags:
   - API
   - Draft

--- a/files/en-us/web/api/midiconnectionevent/midiconnectionevent/index.md
+++ b/files/en-us/web/api/midiconnectionevent/midiconnectionevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIDIConnectionEvent.MIDIConnectionEvent()
 slug: Web/API/MIDIConnectionEvent/MIDIConnectionEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/midiconnectionevent/port/index.md
+++ b/files/en-us/web/api/midiconnectionevent/port/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIDIConnectionEvent.port
 slug: Web/API/MIDIConnectionEvent/port
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/midiinput/index.md
+++ b/files/en-us/web/api/midiinput/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIDIInput
 slug: Web/API/MIDIInput
+page-type: web-api-interface
 tags:
   - API
   - Draft

--- a/files/en-us/web/api/midiinput/midimessage_event/index.md
+++ b/files/en-us/web/api/midiinput/midimessage_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'MIDIInput: midimessage event'
 slug: Web/API/MIDIInput/midimessage_event
+page-type: web-api-event
 tags:
   - midimessage
   - API

--- a/files/en-us/web/api/midiinputmap/index.md
+++ b/files/en-us/web/api/midiinputmap/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIDIInputMap
 slug: Web/API/MIDIInputMap
+page-type: web-api-interface
 tags:
   - NeedsContent
 browser-compat: api.MIDIInputMap

--- a/files/en-us/web/api/midimessageevent/data/index.md
+++ b/files/en-us/web/api/midimessageevent/data/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIDIMessageEvent.data
 slug: Web/API/MIDIMessageEvent/data
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/midimessageevent/index.md
+++ b/files/en-us/web/api/midimessageevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIDIMessageEvent
 slug: Web/API/MIDIMessageEvent
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/midimessageevent/midimessageevent/index.md
+++ b/files/en-us/web/api/midimessageevent/midimessageevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIDIMessageEvent()
 slug: Web/API/MIDIMessageEvent/MIDIMessageEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/midioutput/clear/index.md
+++ b/files/en-us/web/api/midioutput/clear/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIDIOutput.clear()
 slug: Web/API/MIDIOutput/clear
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/midioutput/index.md
+++ b/files/en-us/web/api/midioutput/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIDIOutput
 slug: Web/API/MIDIOutput
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/midioutput/send/index.md
+++ b/files/en-us/web/api/midioutput/send/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIDIOutput.send()
 slug: Web/API/MIDIOutput/send
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/midioutputmap/index.md
+++ b/files/en-us/web/api/midioutputmap/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIDIOutputMap
 slug: Web/API/MIDIOutputMap
+page-type: web-api-interface
 tags:
   - API
 browser-compat: api.MIDIOutputMap

--- a/files/en-us/web/api/midiport/close/index.md
+++ b/files/en-us/web/api/midiport/close/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIDIPort.close()
 slug: Web/API/MIDIPort/close
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/midiport/connection/index.md
+++ b/files/en-us/web/api/midiport/connection/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIDIPort.connection
 slug: Web/API/MIDIPort/connection
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/midiport/id/index.md
+++ b/files/en-us/web/api/midiport/id/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIDIPort.id
 slug: Web/API/MIDIPort/id
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/midiport/index.md
+++ b/files/en-us/web/api/midiport/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIDIPort
 slug: Web/API/MIDIPort
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/midiport/manufacturer/index.md
+++ b/files/en-us/web/api/midiport/manufacturer/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIDIPort.manufacturer
 slug: Web/API/MIDIPort/manufacturer
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/midiport/name/index.md
+++ b/files/en-us/web/api/midiport/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIDIPort.name
 slug: Web/API/MIDIPort/name
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/midiport/open/index.md
+++ b/files/en-us/web/api/midiport/open/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIDIPort.open()
 slug: Web/API/MIDIPort/open
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/midiport/state/index.md
+++ b/files/en-us/web/api/midiport/state/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIDIPort.state
 slug: Web/API/MIDIPort/state
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/midiport/statechange_event/index.md
+++ b/files/en-us/web/api/midiport/statechange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'MIDIPort: statechange event'
 slug: Web/API/MIDIPort/statechange_event
+page-type: web-api-event
 tags:
   - statechange
   - API

--- a/files/en-us/web/api/midiport/type/index.md
+++ b/files/en-us/web/api/midiport/type/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIDIPort.type
 slug: Web/API/MIDIPort/type
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/midiport/version/index.md
+++ b/files/en-us/web/api/midiport/version/index.md
@@ -1,6 +1,7 @@
 ---
 title: MIDIPort.version
 slug: Web/API/MIDIPort/version
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/mimetype/index.md
+++ b/files/en-us/web/api/mimetype/index.md
@@ -1,6 +1,7 @@
 ---
 title: MimeType
 slug: Web/API/MimeType
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/mimetypearray/index.md
+++ b/files/en-us/web/api/mimetypearray/index.md
@@ -1,6 +1,7 @@
 ---
 title: MimeTypeArray
 slug: Web/API/MimeTypeArray
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/mouseevent/altkey/index.md
+++ b/files/en-us/web/api/mouseevent/altkey/index.md
@@ -1,6 +1,7 @@
 ---
 title: MouseEvent.altKey
 slug: Web/API/MouseEvent/altKey
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/mouseevent/button/index.md
+++ b/files/en-us/web/api/mouseevent/button/index.md
@@ -1,6 +1,7 @@
 ---
 title: MouseEvent.button
 slug: Web/API/MouseEvent/button
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/mouseevent/buttons/index.md
+++ b/files/en-us/web/api/mouseevent/buttons/index.md
@@ -1,6 +1,7 @@
 ---
 title: MouseEvent.buttons
 slug: Web/API/MouseEvent/buttons
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/mouseevent/clientx/index.md
+++ b/files/en-us/web/api/mouseevent/clientx/index.md
@@ -1,6 +1,7 @@
 ---
 title: MouseEvent.clientX
 slug: Web/API/MouseEvent/clientX
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/mouseevent/clienty/index.md
+++ b/files/en-us/web/api/mouseevent/clienty/index.md
@@ -1,6 +1,7 @@
 ---
 title: MouseEvent.clientY
 slug: Web/API/MouseEvent/clientY
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/mouseevent/ctrlkey/index.md
+++ b/files/en-us/web/api/mouseevent/ctrlkey/index.md
@@ -1,6 +1,7 @@
 ---
 title: MouseEvent.ctrlKey
 slug: Web/API/MouseEvent/ctrlKey
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/mouseevent/getmodifierstate/index.md
+++ b/files/en-us/web/api/mouseevent/getmodifierstate/index.md
@@ -1,6 +1,7 @@
 ---
 title: MouseEvent.getModifierState()
 slug: Web/API/MouseEvent/getModifierState
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/mouseevent/index.md
+++ b/files/en-us/web/api/mouseevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: MouseEvent
 slug: Web/API/MouseEvent
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/mouseevent/initmouseevent/index.md
+++ b/files/en-us/web/api/mouseevent/initmouseevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: MouseEvent.initMouseEvent()
 slug: Web/API/MouseEvent/initMouseEvent
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/mouseevent/layerx/index.md
+++ b/files/en-us/web/api/mouseevent/layerx/index.md
@@ -1,6 +1,7 @@
 ---
 title: MouseEvent.layerX
 slug: Web/API/MouseEvent/layerX
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/mouseevent/layery/index.md
+++ b/files/en-us/web/api/mouseevent/layery/index.md
@@ -1,6 +1,7 @@
 ---
 title: MouseEvent.layerY
 slug: Web/API/MouseEvent/layerY
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/mouseevent/metakey/index.md
+++ b/files/en-us/web/api/mouseevent/metakey/index.md
@@ -1,6 +1,7 @@
 ---
 title: MouseEvent.metaKey
 slug: Web/API/MouseEvent/metaKey
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/mouseevent/mouseevent/index.md
+++ b/files/en-us/web/api/mouseevent/mouseevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: MouseEvent()
 slug: Web/API/MouseEvent/MouseEvent
+page-type: web-api-instance-property
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/mouseevent/movementx/index.md
+++ b/files/en-us/web/api/mouseevent/movementx/index.md
@@ -1,6 +1,7 @@
 ---
 title: MouseEvent.movementX
 slug: Web/API/MouseEvent/movementX
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/mouseevent/movementy/index.md
+++ b/files/en-us/web/api/mouseevent/movementy/index.md
@@ -1,6 +1,7 @@
 ---
 title: MouseEvent.movementY
 slug: Web/API/MouseEvent/movementY
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/mouseevent/mozinputsource/index.md
+++ b/files/en-us/web/api/mouseevent/mozinputsource/index.md
@@ -1,6 +1,7 @@
 ---
 title: MouseEvent.mozInputSource
 slug: Web/API/MouseEvent/mozInputSource
+page-type: web-api-instance-property
 tags:
   - API
   - NeedsCompatTable

--- a/files/en-us/web/api/mouseevent/offsetx/index.md
+++ b/files/en-us/web/api/mouseevent/offsetx/index.md
@@ -1,6 +1,7 @@
 ---
 title: MouseEvent.offsetX
 slug: Web/API/MouseEvent/offsetX
+page-type: web-api-instance-property
 tags:
   - API
   - MouseEvent

--- a/files/en-us/web/api/mouseevent/offsety/index.md
+++ b/files/en-us/web/api/mouseevent/offsety/index.md
@@ -1,6 +1,7 @@
 ---
 title: MouseEvent.offsetY
 slug: Web/API/MouseEvent/offsetY
+page-type: web-api-instance-property
 tags:
   - API
   - MouseEvent

--- a/files/en-us/web/api/mouseevent/pagex/index.md
+++ b/files/en-us/web/api/mouseevent/pagex/index.md
@@ -1,6 +1,7 @@
 ---
 title: MouseEvent.pageX
 slug: Web/API/MouseEvent/pageX
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/mouseevent/pagey/index.md
+++ b/files/en-us/web/api/mouseevent/pagey/index.md
@@ -1,6 +1,7 @@
 ---
 title: MouseEvent.pageY
 slug: Web/API/MouseEvent/pageY
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/mouseevent/region/index.md
+++ b/files/en-us/web/api/mouseevent/region/index.md
@@ -1,6 +1,7 @@
 ---
 title: MouseEvent.region
 slug: Web/API/MouseEvent/region
+page-type: web-api-instance-property
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/mouseevent/relatedtarget/index.md
+++ b/files/en-us/web/api/mouseevent/relatedtarget/index.md
@@ -1,6 +1,7 @@
 ---
 title: MouseEvent.relatedTarget
 slug: Web/API/MouseEvent/relatedTarget
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/mouseevent/screenx/index.md
+++ b/files/en-us/web/api/mouseevent/screenx/index.md
@@ -1,6 +1,7 @@
 ---
 title: MouseEvent.screenX
 slug: Web/API/MouseEvent/screenX
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/mouseevent/screeny/index.md
+++ b/files/en-us/web/api/mouseevent/screeny/index.md
@@ -1,6 +1,7 @@
 ---
 title: MouseEvent.screenY
 slug: Web/API/MouseEvent/screenY
+page-type: web-api-instance-property
 tags:
   - API
   - DOM Events

--- a/files/en-us/web/api/mouseevent/shiftkey/index.md
+++ b/files/en-us/web/api/mouseevent/shiftkey/index.md
@@ -1,6 +1,7 @@
 ---
 title: MouseEvent.shiftKey
 slug: Web/API/MouseEvent/shiftKey
+page-type: web-api-instance-property
 tags:
   - API
   - DOM


### PR DESCRIPTION
See  https://github.com/mdn/content/issues/16255. This is part 15 of a series of PRs to add page types to the Web/API documentation.