### PR TITLE
Move compat data in browser-compat key for input element attributes

### DIFF
--- a/files/en-us/web/html/attributes/accept/index.md
+++ b/files/en-us/web/html/attributes/accept/index.md
@@ -8,7 +8,7 @@ tags:
   - HTML
   - Input
   - Reference
-spec-urls: https://html.spec.whatwg.org/multipage/input.html#attr-input-accept
+browser-compat: html.elements.input.attributes.accept
 ---
 
 {{HTMLSidebar}}
@@ -149,7 +149,7 @@ div {
 
 ## Browser compatibility
 
-{{Compat("html.elements.attribute.accept")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/html/attributes/capture/index.md
+++ b/files/en-us/web/html/attributes/capture/index.md
@@ -8,7 +8,7 @@ tags:
   - Capture
   - Constraint validation
   - HTML
-spec-urls: https://w3c.github.io/html-media-capture/#the-capture-attribute
+browser-compat: html.elements.input.attributes.capture
 ---
 
 {{HTMLSidebar}}
@@ -17,7 +17,7 @@ The **`capture`** attribute specifies that, optionally, a new file should be cap
 
 Values include `user` and `environment`. The capture attribute is supported on the {{HTMLElement("input/file", "file")}} input type.
 
-The `capture` attribute takes as it's value a string that specifies which camera to use for capture of image or video data, if the [accept](accept) attribute indicates that the input should be of one of those types.
+The `capture` attribute takes as its value a string that specifies which camera to use for capture of image or video data, if the [accept](accept) attribute indicates that the input should be of one of those types.
 
 | Value         | Description                                                |
 | ------------- | ---------------------------------------------------------- |
@@ -55,7 +55,7 @@ Note these work better on mobile devices; if your device is a desktop computer, 
 
 ## Browser compatibility
 
-{{Compat("html.elements.attribute.capture")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/html/attributes/pattern/index.md
+++ b/files/en-us/web/html/attributes/pattern/index.md
@@ -7,7 +7,7 @@ tags:
   - Constraint Validation API
   - HTML
   - Reference
-spec-urls: https://html.spec.whatwg.org/multipage/forms.html#attr-input-pattern
+browser-compat: html.elements.input.attributes.pattern
 ---
 
 {{HTMLSidebar}}
@@ -128,7 +128,7 @@ While `title`s are used by some browsers to populate error messaging, because br
 
 ## Browser compatibility
 
-{{Compat("html.elements.attributes.pattern")}}
+{{Compat}}
 
 ## See also
 

--- a/files/en-us/web/html/attributes/step/index.md
+++ b/files/en-us/web/html/attributes/step/index.md
@@ -8,7 +8,7 @@ tags:
   - HTML
   - Reference
   - step
-spec-urls: https://html.spec.whatwg.org/multipage/input.html#the-step-attribute
+browser-compat: html.elements.input.attributes.step
 ---
 
 {{HTMLSidebar}}
@@ -115,6 +115,10 @@ Provide instructions to help users understand how to complete the form and use i
 ## Specifications
 
 {{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
 
 ## See also
 


### PR DESCRIPTION
For attributes that are specific to just the `input` element, this change moves the BCD feature IDs out of the `Compat` macro call and into the `browser-compat` key. The articles for these features have broken BCD tables, so this change also updates/corrects the BCD features IDs to match https://github.com/mdn/browser-compat-data/pull/16493. And that BCD change makes it unnecessary for the MDN articles to have `spec-urls` keys — we now can get those with the `browser-compat` key — so this change also drops the (now-redundant) `spec-urls` keys.