### PR TITLE
Fix constructor titles

### DIFF
--- a/files/en-us/web/api/encodedaudiochunk/encodedaudiochunk/index.md
+++ b/files/en-us/web/api/encodedaudiochunk/encodedaudiochunk/index.md
@@ -1,5 +1,5 @@
 ---
-title: EncodedAudioChunk.EncodedAudioChunk()
+title: EncodedAudioChunk()
 slug: Web/API/EncodedAudioChunk/EncodedAudioChunk
 page-type: web-api-constructor
 tags:

--- a/files/en-us/web/api/encodedvideochunk/encodedvideochunk/index.md
+++ b/files/en-us/web/api/encodedvideochunk/encodedvideochunk/index.md
@@ -1,5 +1,5 @@
 ---
-title: EncodedVideoChunk.EncodedVideoChunk()
+title: EncodedVideoChunk()
 slug: Web/API/EncodedVideoChunk/EncodedVideoChunk
 page-type: web-api-constructor
 tags:

--- a/files/en-us/web/api/idledetector/idledetector/index.md
+++ b/files/en-us/web/api/idledetector/idledetector/index.md
@@ -1,5 +1,5 @@
 ---
-title: IdleDetector.IdleDetector()
+title: IdleDetector()
 slug: Web/API/IdleDetector/IdleDetector
 page-type: web-api-constructor
 tags:

--- a/files/en-us/web/api/imagedecoder/imagedecoder/index.md
+++ b/files/en-us/web/api/imagedecoder/imagedecoder/index.md
@@ -1,5 +1,5 @@
 ---
-title: ImageDecoder.ImageDecoder()
+title: ImageDecoder()
 slug: Web/API/ImageDecoder/ImageDecoder
 page-type: web-api-constructor
 tags:

--- a/files/en-us/web/api/inputdevicecapabilities/inputdevicecapabilities/index.md
+++ b/files/en-us/web/api/inputdevicecapabilities/inputdevicecapabilities/index.md
@@ -1,5 +1,5 @@
 ---
-title: InputDeviceCapabilities
+title: InputDeviceCapabilities()
 slug: Web/API/InputDeviceCapabilities/InputDeviceCapabilities
 page-type: web-api-constructor
 browser-compat: api.InputDeviceCapabilities.InputDeviceCapabilities

--- a/files/en-us/web/api/mediastreamtrackgenerator/mediastreamtrackgenerator/index.md
+++ b/files/en-us/web/api/mediastreamtrackgenerator/mediastreamtrackgenerator/index.md
@@ -1,5 +1,5 @@
 ---
-title: MediaStreamTrackGenerator.MediaStreamTrackGenerator()
+title: MediaStreamTrackGenerator()
 slug: Web/API/MediaStreamTrackGenerator/MediaStreamTrackGenerator
 page-type: web-api-constructor
 tags:

--- a/files/en-us/web/api/mediastreamtrackprocessor/mediastreamtrackprocessor/index.md
+++ b/files/en-us/web/api/mediastreamtrackprocessor/mediastreamtrackprocessor/index.md
@@ -1,5 +1,5 @@
 ---
-title: MediaStreamTrackProcessor.MediaStreamTrackProcessor()
+title: MediaStreamTrackProcessor()
 slug: Web/API/MediaStreamTrackProcessor/MediaStreamTrackProcessor
 page-type: web-api-constructor
 tags:

--- a/files/en-us/web/api/midiconnectionevent/midiconnectionevent/index.md
+++ b/files/en-us/web/api/midiconnectionevent/midiconnectionevent/index.md
@@ -1,5 +1,5 @@
 ---
-title: MIDIConnectionEvent.MIDIConnectionEvent()
+title: MIDIConnectionEvent()
 slug: Web/API/MIDIConnectionEvent/MIDIConnectionEvent
 page-type: web-api-constructor
 tags:


### PR DESCRIPTION
A few constructor pages had wrong titles. This fixes it.