### PR TITLE
Do not refer to hash algorithms as encryption

### DIFF
--- a/files/en-us/web/http/authentication/index.md
+++ b/files/en-us/web/http/authentication/index.md
@@ -90,7 +90,7 @@ Some common authentication schemes include:
 - **Bearer**
   - : See {{rfc(6750)}}, bearer tokens to access OAuth 2.0-protected resources
 - **Digest**
-  - : See {{rfc(7616)}}. Firefox 93 and later support SHA-256 encryption. Previous versions only support MD5 hashing (not recommended).
+  - : See {{rfc(7616)}}. Firefox 93 and later support the SHA-256 algorithm. Previous versions only support MD5 hashing (not recommended).
 - **HOBA**
   - : See {{rfc(7486)}}, Section 3, **H**TTP **O**rigin-**B**ound **A**uthentication, digital-signature-based
 - **Mutual**

--- a/files/en-us/web/http/headers/content-security-policy/sources/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/sources/index.md
@@ -68,7 +68,7 @@ Relevant directives include the {{Glossary("fetch directive", "fetch directives"
 
 - `'<hash-algorithm>-<base64-value>'`
   - : A sha256, sha384 or sha512 hash of scripts or styles.
-    The use of this source consists of two portions separated by a dash: the encryption algorithm used to create the hash and the base64-encoded hash of the script or style.
+    The use of this source consists of two portions separated by a dash: the algorithm used to create the hash and the base64-encoded hash of the script or style.
     When generating the hash, don't include the \<script> or \<style> tags and note that capitalization and whitespace matter, including leading or trailing whitespace.
     See [unsafe inline script](/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_inline_script) for an example.
     In CSP 2.0, this is applied only to inline scripts. CSP 3.0 allows it in the case of `script-src` for external scripts.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
No longer refers to a hash function as encryption

#### Motivation
Hashing isn't encryption, so this may confuse readers

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
