### PR TITLE
RTCError event does not bubble

### DIFF
--- a/files/en-us/web/api/rtcdtlstransport/error_event/index.md
+++ b/files/en-us/web/api/rtcdtlstransport/error_event/index.md
@@ -25,7 +25,7 @@ An {{domxref("RTCDtlsTransport")}} receives an `error` event when a transport-le
   <tbody>
     <tr>
       <th scope="row">Bubbles</th>
-      <td>Yes</td>
+      <td>No</td>
     </tr>
     <tr>
       <th scope="row">Cancelable</th>


### PR DESCRIPTION
#### Summary
Set the "bubbles" property value of the event to false


#### Motivation
I don't see anything that suggests it does in the spec https://w3c.github.io/webrtc-pc/webrtc.html

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
