### PR TITLE
Add the word "you"

### DIFF
--- a/files/en-us/learn/html/tables/advanced/index.md
+++ b/files/en-us/learn/html/tables/advanced/index.md
@@ -438,7 +438,7 @@ There are a few other things you could learn about tables in HTML, but this is a
 
 If you are already learning CSS and have done well on the assessment, you can move on and learn about styling HTML tables — see [Styling tables](/en-US/docs/Learn/CSS/Building_blocks/Styling_tables).
 
-If want to get started with learning CSS, check out the [CSS Learning Area](/en-US/docs/Learn/CSS)!
+If you want to get started with learning CSS, check out the [CSS Learning Area](/en-US/docs/Learn/CSS)!
 
 {{PreviousMenuNext("Learn/HTML/Tables/Basics", "Learn/HTML/Tables/Structuring_planet_data", "Learn/HTML/Tables")}}
 


### PR DESCRIPTION
At the end of the article, the pronoun "you" is missing from the sentence "If want to get started with learning CSS...".

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
At the end of the article, the pronoun "you" is missing from the sentence "If want to get started with learning CSS...". I simply added it to where it was missing.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The sentence wasn't grammatically correct, which could cause confusion for some readers. My change will hopefully prevent this confusion.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
