### PR TITLE
Fix misleading wording regarding the type='module' attribute

### DIFF
--- a/files/en-us/web/html/element/script/index.md
+++ b/files/en-us/web/html/element/script/index.md
@@ -150,7 +150,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
   - : This attribute indicates the type of script represented. The value of this attribute will be in one of the following categories:
 
     - **Omitted or a JavaScript MIME type:** This indicates the script is JavaScript. The HTML5 specification urges authors to omit the attribute rather than provide a redundant MIME type. In earlier browsers, this identified the scripting language of the embedded or imported (via the `src` attribute) code. JavaScript MIME types are [listed in the specification](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#javascript_types).
-    - **`module`:** Causes the code to be treated as a JavaScript module. The processing of the script contents is not affected by the `charset` and `defer` attributes.
+    - **`module`:** Causes the code to be treated as a JavaScript module. The processing of the script contents is deferred. The `charset` and `defer` attributes have no effect.
       For information on using `module`, see our [JavaScript modules](/en-US/docs/Web/JavaScript/Guide/Modules) guide.
       Unlike classic scripts, module scripts require the use of the CORS protocol for cross-origin fetching.
     - **Any other value:** The embedded content is treated as a data block which won't be processed by the browser. Developers must use a valid MIME type that is not a JavaScript MIME type to denote data blocks. The `src` attribute will be ignored.
@@ -164,7 +164,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 ## Notes
 
-Scripts without {{HTMLAttrxRef("async", "script")}} , {{HTMLAttrxRef("defer", "script")}} or `type="module"` attributes, as well as inline scripts, are fetched and executed immediately, before the browser continues to parse the page.
+Scripts without {{HTMLAttrxRef("async", "script")}} , {{HTMLAttrxRef("defer", "script")}} or `type="module"` attributes, as well as inline scripts without the `type="module"` attribute, are fetched and executed immediately, before the browser continues to parse the page.
 
 The script should be served with the `text/javascript` MIME type, but browsers are lenient and only block them if the script is served with an image type (`image/*`); a video type (`video/*`); an audio (`audio/*`) type; or `text/csv`. If the script is blocked, an {{domxref("Element/error_event", "error")}} is sent to the element, if not a {{domxref("Element/load_event", "load")}} event is sent.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The wording is misleading because it implies Inline script is always executed immediately, while in reality the type="module" attribute will defer the execution of inline script, similar in effect as the `defer` attribute.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Reading the MDN page mislead me to think that the type="module" has no effect on inline script execution time
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ✅] Rewrites (or significantly expands) a document: Tiny rewrite
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->

## Change 1: Emphasis the role of type="module" to defer the parsing, which is an import characteristic (not obvious yet important)

**Before**: 
```
The processing of the script contents is not affected by the `charset` and `defer` attributes.
```
**After**: 
```
The processing of the script contents is deferred. The `charset` and `defer` attributes have no effect.
```

## Change 2: Fix a logic error: Inline scripts may be executed later as long as they have the type="module" attribute
**Before**: 
```
Scripts without async , defer or type="module" attributes, as well as inline scripts, are fetched and executed immediately, before the browser continues to parse the page.
```
**After**: 
```
Scripts without async , defer or type="module" attributes, as well as inline scripts without the `type="module"` attribute, are fetched and executed immediately, before the browser continues to parse the page.
```
