### PR TITLE
fix: minor, http redirects

### DIFF
--- a/files/en-us/web/security/transport_layer_security/index.md
+++ b/files/en-us/web/security/transport_layer_security/index.md
@@ -11,13 +11,13 @@ tags:
   - Security
   - TLS
 ---
-The security of any connection using Transport Layer Security (TLS) is heavily dependent upon the cipher suites and security parameters selected. This article's goal is to help you make these decisions to ensure the confidentiality and integrity communication between client and server. The Mozilla Operations Security (OpSec) team [maintains a wiki entry](https://wiki.mozilla.org/Security/Server_Side_TLS) with reference configurations for servers.
+The security of any connection using Transport Layer Security (TLS) is heavily dependent upon the cipher suites and security parameters selected. This article's goal is to help you make these decisions to ensure the confidentiality and integrity of communication between client and server. The Mozilla Operations Security (OpSec) team [maintains a wiki entry](https://wiki.mozilla.org/Security/Server_Side_TLS) with reference configurations for servers.
 
 The Transport Layer Security (TLS) protocol is the standard for enabling two networked applications or devices to exchange information privately and robustly. Applications that use TLS can choose their security parameters, which can have a substantial impact on the security and reliability of data. This article provides an overview of TLS and the kinds of decisions you need to make when securing your content.
 
 ## History
 
-When HTTPS was introduced, it was based on Secure Sockets Layer (SSL) 2.0, a technology introduced by Netscape. It was updated to SSL 3.0 not long after, and as its usage expanded, it became clear that a common, standard encryption technology needed to be specified to ensure interoperability among all web browsers and servers. The [Internet Engineering Task Force](https://www.ietf.org/) (IETF) specified TLS 1.0 in {{RFC(2246)}} in January, 1999. The current version of TLS is 1.3 ({{RFC(8446)}}).
+When HTTPS was introduced, it was based on Secure Sockets Layer (SSL) 2.0, a technology introduced by Netscape. It was updated to SSL 3.0 not long after, and as its usage expanded, it became clear that a common, standard encryption technology needed to be specified to ensure interoperability among all web browsers and servers. The [Internet Engineering Task Force](https://www.ietf.org/) (IETF) specified TLS 1.0 in {{RFC(2246)}} in January 1999. The current version of TLS is 1.3 ({{RFC(8446)}}).
 
 Despite the fact that the web now uses TLS for encryption, many people still refer to it as "SSL" out of habit.
 
@@ -50,7 +50,7 @@ Different software might use different names for the same cipher suites. For ins
 
 Correctly configuring your server is crucial. In general, you should try to limit cipher support to the newest ciphers possible which are compatible with the browsers you want to be able to connect to your site. The [Mozilla OpSec guide to TLS configurations](https://wiki.mozilla.org/Security/Server_Side_TLS) provides more information on recommended configurations.
 
-To assist you in configuring your site, Mozilla provides a helpful [TLS configuration generator](https://mozilla.github.io/server-side-tls/ssl-config-generator/) that will generate configuration files for the following Web servers:
+To assist you in configuring your site, Mozilla provides a helpful [TLS configuration generator](https://ssl-config.mozilla.org/) that will generate configuration files for the following Web servers:
 
 - Apache
 - Nginx
@@ -58,7 +58,7 @@ To assist you in configuring your site, Mozilla provides a helpful [TLS configur
 - HAProxy
 - Amazon Web Services CloudFormation Elastic Load Balancer
 
-Using the [configurator](https://mozilla.github.io/server-side-tls/ssl-config-generator/) is a recommended way to create the configuration to meet your needs; then copy and paste it into the appropriate file on your server and restart the server to pick up the changes. The configuration file may need some adjustments to include custom settings, so be sure to review the generated configuration before using it; installing the configuration file without ensuring any references to domain names and the like are correct will result in a server that just doesn't work.
+Using the [configurator](https://ssl-config.mozilla.org/) is a recommended way to create the configuration to meet your needs; then copy and paste it into the appropriate file on your server and restart the server to pick up the changes. The configuration file may need some adjustments to include custom settings, so be sure to review the generated configuration before using it; installing the configuration file without ensuring any references to domain names and the like are correct will result in a server that just doesn't work.
 
 ## TLS 1.3
 
@@ -69,7 +69,7 @@ Using the [configurator](https://mozilla.github.io/server-side-tls/ssl-config-ge
 - Improve privacy by encrypting more of the protocol.
 - Reduce the time needed to complete a handshake.
 
-TLS 1.3 changes much of the protocol fundamentals, but preserves almost all of the basic capabilities as previous versions of TLS. For the web, TLS 1.3 can be enabled without affecting compatibility with some rare exceptions (see below).
+TLS 1.3 changes much of the protocol fundamentals, but preserves almost all of the basic capabilities of previous TLS versions. For the web, TLS 1.3 can be enabled without affecting compatibility with some rare exceptions (see below).
 
 The major changes in TLS 1.3 are:
 


### PR DESCRIPTION
+preposition: integrity communication_integrity of communication
+rephrase: capabilities as previous versions of TLS_capabilities of previous TLS versions
-comma: January, 1999_January 1999
+http redirect: TLS configuration generator
*lost how to rephrase (please look into it): Once parameters and a data exchange mode where application data, such HTTP, is exchanged.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
