### PR TITLE
Remove superfluous word "it" in autoplay guide

### DIFF
--- a/files/en-us/web/media/autoplay_guide/index.md
+++ b/files/en-us/web/media/autoplay_guide/index.md
@@ -85,7 +85,7 @@ An {{HTMLElement("audio")}} element using the `autoplay` attribute might look li
 
 #### Example 2: Detecting autoplay failure
 
-If you rely on autoplay for anything important, or if autoplay failure will impact your app in any way, you will probably want to be able to tell when it autoplay didn't begin. Unfortunately, in the case of the {{htmlattrxref("autoplay", "audio")}} attribute, recognizing whether or not autoplay successfully began is tricky. There's not an event triggered when autoplay fails. Nor is there an exception thrown or a callback you can set up or even a flag on the media element that tells you if autoplay worked. All you can really do is examine a few values and make an educated guess as to whether or not autoplay worked.
+If you rely on autoplay for anything important, or if autoplay failure will impact your app in any way, you will probably want to be able to tell when autoplay didn't begin. Unfortunately, in the case of the {{htmlattrxref("autoplay", "audio")}} attribute, recognizing whether or not autoplay successfully began is tricky. There's not an event triggered when autoplay fails. Nor is there an exception thrown or a callback you can set up or even a flag on the media element that tells you if autoplay worked. All you can really do is examine a few values and make an educated guess as to whether or not autoplay worked.
 
 A better approach, if you're able to adjust the direction you look at things from, is to instead rely on knowing that playback of the media has successfully started, instead of when it fails to start. You can do this easily, by listening for the {{event("play")}} event to be fired on the media element.
 


### PR DESCRIPTION
#### Summary
Remove the word "it" from the sentence "you will probably want to be able to tell when it autoplay didn't begin". There might be a better alternative to removing "it", please do let me know what's preferred and I'll make the change.

#### Motivation
To make documentation easier to read.

#### Supporting details
Not applicable.

#### Related issues
Not applicable.

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error