### PR TITLE
Add VideoFrame.copyTo()

### DIFF
--- a/files/en-us/web/api/videoframe/copyto/index.md
+++ b/files/en-us/web/api/videoframe/copyto/index.md
@@ -27,17 +27,18 @@ copyTo(destination, options)
 - `options`{{Optional_Inline}}
   - : An object containing the following:
     - `rect`{{Optional_Inline}}
-      - : The rectangle of pixels to copy from the `VideoFrame`. If unspecified the {{domxref("VideoFrame.visibleRect","visibleRect")}} will be used. This is in the format of a dictionary object containing:
+      - : The rectangle of pixels to copy from the `VideoFrame`. If unspecified, the {{domxref("VideoFrame.visibleRect","visibleRect")}} will be used. This is in the format of a dictionary object containing:
         - `x`: The x-coordinate.
         - `y`: The y-coordinate.
         - `width`: The width of the frame.
         - `height`: The height of the frame.
     - `layout`{{Optional_Inline}}
-      - : A list containing the following values for each plane in the `VideoFrame`. Planes may not overlap. If unspecified the planes will be tightly packed:
+      - : A list containing the following values for each plane in the `VideoFrame`:
         - `offset`
           - : An integer representing the offset in bytes where the given plane begins.
         - `stride`
           - : An integer representing the number of bytes, including padding, used by each row of the plane.
+        Planes may not overlap. If no `layout` is specified, the planes will be tightly packed.
 
 ### Return value
 

--- a/files/en-us/web/api/videoframe/copyto/index.md
+++ b/files/en-us/web/api/videoframe/copyto/index.md
@@ -1,0 +1,61 @@
+---
+title: VideoFrame.copyTo()
+slug: Web/API/VideoFrame/copyTo
+tags:
+  - API
+  - Method
+  - Reference
+  - copyTo
+  - VideoFrame
+browser-compat: api.VideoFrame.copyTo
+---
+{{DefaultAPISidebar("Web Codecs API")}}
+
+The **`copyTo()`** method of the {{domxref("VideoFrame")}} interface copies the contents of the `VideoFrame` to an `ArrayBuffer`.
+
+## Syntax
+
+```js
+copyTo(destination)
+copyTo(destination, options)
+```
+
+### Parameters
+
+- `destination`
+  - : An `ArrayBuffer` or `ArrayBufferView` to copy to.
+- `options`{{Optional_Inline}}
+  - : An object containing the following:
+    - `rect`{{Optional_Inline}}
+      - : The rectangle of pixels to copy from the `VideoFrame`. If unspecified the {{domxref("VideoFrame.visibleRect","visibleRect")}} will be used. This is in the format of a dictionary object containing:
+        - `x`: The x-coordinate.
+        - `y`: The y-coordinate.
+        - `width`: The width of the frame.
+        - `height`: The height of the frame.
+    - `layout`{{Optional_Inline}}
+      - : A list containing the following values for each plane in the `VideoFrame`. Planes may not overlap. If unspecified the planes will be tightly packed:
+        - `offset`
+          - : An integer representing the offset in bytes where the given plane begins.
+        - `stride`
+          - : An integer representing the number of bytes, including padding, used by each row of the plane.
+
+### Return value
+
+A `Promise` that resolves to the layout of the copy when the copy has completed.
+
+## Examples
+
+The following example copies the entire contents of `videoFrame`.
+
+```js
+let buffer = new Uint8Array(videoFrame.allocationSize());
+let layout = await videoFrame.copyTo(buffer);
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/videoframe/index.md
+++ b/files/en-us/web/api/videoframe/index.md
@@ -56,6 +56,8 @@ Created frames may then turned into a media track, for example with the {{domxre
 
 - {{domxref("VideoFrame.allocationSize()")}}
   - : Returns the number of bytes required to hold the `VideoFrame` as filtered by options passed into the method.
+- {{domxref("VideoFrame.copyTo()")}}
+  - : Copies the contents of the `VideoFrame` to an `ArrayBuffer`.
 - {{domxref("VideoFrame.clone()")}}
   - : Creates a new `VideoFrame` object with reference to the same media resource as the original.
 - {{domxref("VideoFrame.close()")}}

--- a/files/en-us/web/api/videoframe/videoframe/index.md
+++ b/files/en-us/web/api/videoframe/videoframe/index.md
@@ -37,7 +37,7 @@ The first type of constructor (see above) creates a new {{domxref("VideoFrame")}
         - `"keep"`: Indicates that the user agent should preserve alpha channel data.
         - `"discard"`: Indicates that the user agent should ignore or remove alpha channel data.
     - `visibleRect`{{Optional_Inline}}
-      - : A dictionary representing the visible rectangle of the `VideoFrame`, contatining the following:
+      - : A dictionary representing the visible rectangle of the `VideoFrame`, containing the following:
         - `x`
           - : The x-coordinate.
         - `y`
@@ -47,9 +47,9 @@ The first type of constructor (see above) creates a new {{domxref("VideoFrame")}
         - `height`
           - : The height of the frame.
     - `displayWidth`{{Optional_Inline}}
-      - : The width of the `VideoFrame` when displayed after applying aspect ratio adjustments.
+      - : The width of the `VideoFrame` when displayed after applying aspect-ratio adjustments.
     - `displayHeight`{{Optional_Inline}}
-      - : The height of the `VideoFrame` when displayed after applying aspect ratio adjustments.
+      - : The height of the `VideoFrame` when displayed after applying aspect-ratio adjustments.
 
 The second type of constructor (see above) creates a new {{domxref("VideoFrame")}} from an {{domxref("ArrayBuffer")}}. Its parameters are:
 
@@ -77,13 +77,14 @@ The second type of constructor (see above) creates a new {{domxref("VideoFrame")
     - `duration`{{Optional_Inline}}
       - : An integer representing the duration of the frame in microseconds.
     - `layout`{{Optional_Inline}}
-      - : A list containing the following values for each plane in the `VideoFrame`. Planes may not overlap. If unspecified the planes will be tightly packed:
+      - : A list containing the following values for each plane in the `VideoFrame`:
         - `offset`
           - : An integer representing the offset in bytes where the given plane begins.
         - `stride`
           - : An integer representing the number of bytes, including padding, used by each row of the plane.
+        Planes may not overlap. If no `layout` is specified, the planes will be tightly packed.
     - `visibleRect`{{Optional_Inline}}
-      - : A dictionary representing the visible rectangle of the `VideoFrame`, contatining the following:
+      - : A dictionary representing the visible rectangle of the `VideoFrame`, containing the following:
         - `x`
           - : The x-coordinate.
         - `y`
@@ -97,7 +98,7 @@ The second type of constructor (see above) creates a new {{domxref("VideoFrame")
     - `displayHeight`{{Optional_Inline}}
       - : The height of the `VideoFrame` when displayed after applying aspect ratio adjustments.
     - `colorSpace`
-      - : A dicationary representing the color space of the `VideoFrame`, containting the following:
+      - : A dictionary representing the color space of the `VideoFrame`, containing the following:
         - `primaries`
           - : A string representing the video color primaries, described on the page for the {{domxref("VideoColorSpace.primaries")}} property.
         - `transfer`
@@ -105,7 +106,7 @@ The second type of constructor (see above) creates a new {{domxref("VideoFrame")
         - `matrix`
           - : A string representing the video color matrix, described on the page for the {{domxref("VideoColorSpace.matrix")}} property.
         - `fullRange`
-          - : A Boolean. If `true` indicates that full-range color values are used.
+          - : A Boolean. If `true`, indicates that full-range color values are used.
 
 ## Examples
 

--- a/files/en-us/web/api/videoframe/videoframe/index.md
+++ b/files/en-us/web/api/videoframe/videoframe/index.md
@@ -28,14 +28,28 @@ The first type of constructor (see above) creates a new {{domxref("VideoFrame")}
   - : A {{domxref("CanvasImageSource")}} containing the image data for the new `VideoFrame`.
 - `init`{{Optional_Inline}}
   - : A dictionary object containing the following:
-    - `duration`
+    - `duration`{{Optional_Inline}}
       - : An integer representing the duration of the frame in microseconds.
     - `timestamp`
       - : An integer representing the timestamp of the frame in microseconds.
-    - `alpha`
+    - `alpha`{{Optional_Inline}}
       - : A string, describing how the user agent should behave when dealing with alpha channels. The default value is "keep".
         - `"keep"`: Indicates that the user agent should preserve alpha channel data.
         - `"discard"`: Indicates that the user agent should ignore or remove alpha channel data.
+    - `visibleRect`{{Optional_Inline}}
+      - : A dictionary representing the visible rectangle of the `VideoFrame`, contatining the following:
+        - `x`
+          - : The x-coordinate.
+        - `y`
+          - : The y-coordinate.
+        - `width`
+          - : The width of the frame.
+        - `height`
+          - : The height of the frame.
+    - `displayWidth`{{Optional_Inline}}
+      - : The width of the `VideoFrame` when displayed after applying aspect ratio adjustments.
+    - `displayHeight`{{Optional_Inline}}
+      - : The height of the `VideoFrame` when displayed after applying aspect ratio adjustments.
 
 The second type of constructor (see above) creates a new {{domxref("VideoFrame")}} from an {{domxref("ArrayBuffer")}}. Its parameters are:
 
@@ -55,13 +69,43 @@ The second type of constructor (see above) creates a new {{domxref("VideoFrame")
         - `"BGRA"`
         - `"BGRX"`
     - `codedWidth`
-      - : An integer representing the timestamp of the frame in microseconds.
+      - : Width of the `VideoFrame` in pixels, potentially including non-visible padding, and prior to considering potential ratio adjustments.
     - `codedHeight`
-      - : An integer representing the timestamp of the frame in microseconds.
+      - : Height of the `VideoFrame` in pixels, potentially including non-visible padding, and prior to considering potential ratio adjustments.
     - `timestamp`
       - : An integer representing the timestamp of the frame in microseconds.
     - `duration`{{Optional_Inline}}
       - : An integer representing the duration of the frame in microseconds.
+    - `layout`{{Optional_Inline}}
+      - : A list containing the following values for each plane in the `VideoFrame`. Planes may not overlap. If unspecified the planes will be tightly packed:
+        - `offset`
+          - : An integer representing the offset in bytes where the given plane begins.
+        - `stride`
+          - : An integer representing the number of bytes, including padding, used by each row of the plane.
+    - `visibleRect`{{Optional_Inline}}
+      - : A dictionary representing the visible rectangle of the `VideoFrame`, contatining the following:
+        - `x`
+          - : The x-coordinate.
+        - `y`
+          - : The y-coordinate.
+        - `width`
+          - : The width of the frame.
+        - `height`
+          - : The height of the frame.
+    - `displayWidth`{{Optional_Inline}}
+      - : The width of the `VideoFrame` when displayed after applying aspect ratio adjustments.
+    - `displayHeight`{{Optional_Inline}}
+      - : The height of the `VideoFrame` when displayed after applying aspect ratio adjustments.
+    - `colorSpace`
+      - : A dicationary representing the color space of the `VideoFrame`, containting the following:
+        - `primaries`
+          - : A string representing the video color primaries, described on the page for the {{domxref("VideoColorSpace.primaries")}} property.
+        - `transfer`
+          - : A string representing the video color transfer function, described on the page for the {{domxref("VideoColorSpace.transfer")}} property.
+        - `matrix`
+          - : A string representing the video color matrix, described on the page for the {{domxref("VideoColorSpace.matrix")}} property.
+        - `fullRange`
+          - : A Boolean. If `true` indicates that full-range color values are used.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

Adds documentation for `VideoFrame.copyTo()`, plus some other small fixes to the `VideoFrame` documentation.

#### Motivation

Help users find this method.

#### Supporting details

It's in the [WebCodecs specification](https://www.w3.org/TR/webcodecs/#dom-videoframe-copyto).

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
