### PR TITLE
Explicitly stating required parentheses

### DIFF
--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
@@ -161,20 +161,20 @@ parentheses around expression:
 params => ({foo: "a"}) // returning the object {foo: "a"}
 ```
 
-[Rest parameters](/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) are supported:
+[Rest parameters](/en-US/docs/Web/JavaScript/Reference/Functions/rest_parameters) are supported, and always require parentheses:
 
 ```js
 (a, b, ...r) => expression
 ```
 
-[Default parameters](/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters) are supported:
+[Default parameters](/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters) are supported, and always require parentheses:
 
 ```js
 (a=400, b=20, c) => expression
 ```
 
 [Destructuring](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment)
-within params supported:
+within params is supported, and always requires parentheses:
 
 ```js
 ([a, b] = [10, 20]) => a + b;  // result is 30


### PR DESCRIPTION
#### Summary
Stating that the "Advanced options" require parentheses around the parameters. This seems to be consistent with other parts of the page, which are explicit about when parentheses are required. Also added the word "is" to the Destructuring description for readability with the new text.

#### Motivation
Specificity of the documentation around arrow function expression parameters

#### Supporting details
N/A

#### Related issues


#### Metadata


This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
