### PR TITLE
Remove some arguments from a code example

### DIFF
--- a/files/en-us/learn/javascript/client-side_web_apis/drawing_graphics/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/drawing_graphics/index.md
@@ -369,7 +369,7 @@ It is possible to render external images onto your canvas. These can be simple i
 3. We could now try to embed the image using `drawImage()`, but we need to make sure the image file has been loaded first, otherwise the code will fail. We can achieve this using the `load` event, which will only be fired when the image has finished loading. Add the following block below the previous one:
 
     ```js
-    image.addEventListener('load', () => ctx.drawImage(image, 20, 20, 185, 175, 50, 50, 185, 175));
+    image.addEventListener('load', () => ctx.drawImage(image, 20, 20));
     ```
 
     If you load your example in the browser now, you should see the image embedded in the canvas.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Step 3 says:

> Add the following block below the previous one:
`image.addEventListener('load', () => ctx.drawImage(image, 20, 20, 185, 175, 50, 50, 185, 175));`

…while step 4 says:

> Update your ctx.drawImage() line like so:
`ctx.drawImage(image, 20, 20, 185, 175, 50, 50, 185, 175);`

These two `ctx.drawImage()` probably should have different arguments.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
