### PR TITLE
Add Web/API page types, part 17

### DIFF
--- a/files/en-us/web/api/notification/timestamp/index.md
+++ b/files/en-us/web/api/notification/timestamp/index.md
@@ -1,6 +1,7 @@
 ---
 title: Notification.timestamp
 slug: Web/API/Notification/timestamp
+page-type: web-api-instance-property
 tags:
   - API
   - Notification

--- a/files/en-us/web/api/notification/title/index.md
+++ b/files/en-us/web/api/notification/title/index.md
@@ -1,6 +1,7 @@
 ---
 title: Notification.title
 slug: Web/API/Notification/title
+page-type: web-api-instance-property
 tags:
   - API
   - Notification

--- a/files/en-us/web/api/notification/vibrate/index.md
+++ b/files/en-us/web/api/notification/vibrate/index.md
@@ -1,6 +1,7 @@
 ---
 title: Notification.vibrate
 slug: Web/API/Notification/vibrate
+page-type: web-api-instance-property
 tags:
   - API
   - Device

--- a/files/en-us/web/api/notificationevent/action/index.md
+++ b/files/en-us/web/api/notificationevent/action/index.md
@@ -1,6 +1,7 @@
 ---
 title: NotificationEvent.action
 slug: Web/API/NotificationEvent/action
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/notificationevent/index.md
+++ b/files/en-us/web/api/notificationevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: NotificationEvent
 slug: Web/API/NotificationEvent
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/notificationevent/notification/index.md
+++ b/files/en-us/web/api/notificationevent/notification/index.md
@@ -1,6 +1,7 @@
 ---
 title: NotificationEvent.notification
 slug: Web/API/NotificationEvent/notification
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/notificationevent/notificationevent/index.md
+++ b/files/en-us/web/api/notificationevent/notificationevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: NotificationEvent()
 slug: Web/API/NotificationEvent/NotificationEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/notifications_api/index.md
+++ b/files/en-us/web/api/notifications_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Notifications API
 slug: Web/API/Notifications_API
+page-type: web-api-overview
 tags:
   - Landing
   - Notifications

--- a/files/en-us/web/api/notifications_api/using_the_notifications_api/index.md
+++ b/files/en-us/web/api/notifications_api/using_the_notifications_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using the Notifications API
 slug: Web/API/Notifications_API/Using_the_Notifications_API
+page-type: guide
 tags:
   - API
   - Advanced

--- a/files/en-us/web/api/notifyaudioavailableevent/index.md
+++ b/files/en-us/web/api/notifyaudioavailableevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: NotifyAudioAvailableEvent
 slug: Web/API/NotifyAudioAvailableEvent
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/offlineaudiocompletionevent/index.md
+++ b/files/en-us/web/api/offlineaudiocompletionevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: OfflineAudioCompletionEvent
 slug: Web/API/OfflineAudioCompletionEvent
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/offlineaudiocompletionevent/offlineaudiocompletionevent/index.md
+++ b/files/en-us/web/api/offlineaudiocompletionevent/offlineaudiocompletionevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: OfflineAudioCompletionEvent()
 slug: Web/API/OfflineAudioCompletionEvent/OfflineAudioCompletionEvent
+page-type: web-api-constructor
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/offlineaudiocompletionevent/renderedbuffer/index.md
+++ b/files/en-us/web/api/offlineaudiocompletionevent/renderedbuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: OfflineAudioCompletionEvent.renderedBuffer
 slug: Web/API/OfflineAudioCompletionEvent/renderedBuffer
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/offlineaudiocontext/complete_event/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/complete_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'OfflineAudioContext: complete event'
 slug: Web/API/OfflineAudioContext/complete_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/offlineaudiocontext/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/index.md
@@ -1,6 +1,7 @@
 ---
 title: OfflineAudioContext
 slug: Web/API/OfflineAudioContext
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/offlineaudiocontext/length/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/length/index.md
@@ -1,6 +1,7 @@
 ---
 title: OfflineAudioContext.length
 slug: Web/API/OfflineAudioContext/length
+page-type: web-api-instance-property
 tags:
   - API
   - NeedsExample

--- a/files/en-us/web/api/offlineaudiocontext/offlineaudiocontext/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/offlineaudiocontext/index.md
@@ -1,6 +1,7 @@
 ---
 title: OfflineAudioContext()
 slug: Web/API/OfflineAudioContext/OfflineAudioContext
+page-type: web-api-constructor
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/offlineaudiocontext/resume/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/resume/index.md
@@ -1,6 +1,7 @@
 ---
 title: OfflineAudioContext.resume()
 slug: Web/API/OfflineAudioContext/resume
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/offlineaudiocontext/startrendering/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/startrendering/index.md
@@ -1,6 +1,7 @@
 ---
 title: OfflineAudioContext.startRendering()
 slug: Web/API/OfflineAudioContext/startRendering
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/offlineaudiocontext/suspend/index.md
+++ b/files/en-us/web/api/offlineaudiocontext/suspend/index.md
@@ -1,6 +1,7 @@
 ---
 title: OfflineAudioContext.suspend()
 slug: Web/API/OfflineAudioContext/suspend
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/offscreencanvas/converttoblob/index.md
+++ b/files/en-us/web/api/offscreencanvas/converttoblob/index.md
@@ -1,6 +1,7 @@
 ---
 title: OffscreenCanvas.convertToBlob()
 slug: Web/API/OffscreenCanvas/convertToBlob
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/offscreencanvas/getcontext/index.md
+++ b/files/en-us/web/api/offscreencanvas/getcontext/index.md
@@ -1,6 +1,7 @@
 ---
 title: OffscreenCanvas.getContext()
 slug: Web/API/OffscreenCanvas/getContext
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/offscreencanvas/height/index.md
+++ b/files/en-us/web/api/offscreencanvas/height/index.md
@@ -1,6 +1,7 @@
 ---
 title: OffscreenCanvas.height
 slug: Web/API/OffscreenCanvas/height
+page-type: web-api-instance-property
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/offscreencanvas/index.md
+++ b/files/en-us/web/api/offscreencanvas/index.md
@@ -1,6 +1,7 @@
 ---
 title: OffscreenCanvas
 slug: Web/API/OffscreenCanvas
+page-type: web-api-interface
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/offscreencanvas/offscreencanvas/index.md
+++ b/files/en-us/web/api/offscreencanvas/offscreencanvas/index.md
@@ -1,6 +1,7 @@
 ---
 title: OffscreenCanvas()
 slug: Web/API/OffscreenCanvas/OffscreenCanvas
+page-type: web-api-constructor
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/offscreencanvas/transfertoimagebitmap/index.md
+++ b/files/en-us/web/api/offscreencanvas/transfertoimagebitmap/index.md
@@ -1,6 +1,7 @@
 ---
 title: OffscreenCanvas.transferToImageBitmap()
 slug: Web/API/OffscreenCanvas/transferToImageBitmap
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/offscreencanvas/width/index.md
+++ b/files/en-us/web/api/offscreencanvas/width/index.md
@@ -1,6 +1,7 @@
 ---
 title: OffscreenCanvas.width
 slug: Web/API/OffscreenCanvas/width
+page-type: web-api-instance-property
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/orientationsensor/index.md
+++ b/files/en-us/web/api/orientationsensor/index.md
@@ -1,6 +1,7 @@
 ---
 title: OrientationSensor
 slug: Web/API/OrientationSensor
+page-type: web-api-interface
 tags:
   - API
   - Generic Sensor API

--- a/files/en-us/web/api/orientationsensor/populatematrix/index.md
+++ b/files/en-us/web/api/orientationsensor/populatematrix/index.md
@@ -1,6 +1,7 @@
 ---
 title: OrientationSensor.populateMatrix()
 slug: Web/API/OrientationSensor/populateMatrix
+page-type: web-api-instance-method
 tags:
   - API
   - Generic Sensor API

--- a/files/en-us/web/api/orientationsensor/quaternion/index.md
+++ b/files/en-us/web/api/orientationsensor/quaternion/index.md
@@ -1,6 +1,7 @@
 ---
 title: OrientationSensor.quaternion
 slug: Web/API/OrientationSensor/quaternion
+page-type: web-api-instance-property
 tags:
   - API
   - Generic Sensor API

--- a/files/en-us/web/api/origin/index.md
+++ b/files/en-us/web/api/origin/index.md
@@ -1,6 +1,7 @@
 ---
 title: origin
 slug: Web/API/origin
+page-type: web-api-global-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/oscillatornode/detune/index.md
+++ b/files/en-us/web/api/oscillatornode/detune/index.md
@@ -1,6 +1,7 @@
 ---
 title: OscillatorNode.detune
 slug: Web/API/OscillatorNode/detune
+page-type: web-api-instance-property
 tags:
   - API
   - OscillatorNode

--- a/files/en-us/web/api/oscillatornode/frequency/index.md
+++ b/files/en-us/web/api/oscillatornode/frequency/index.md
@@ -1,6 +1,7 @@
 ---
 title: OscillatorNode.frequency
 slug: Web/API/OscillatorNode/frequency
+page-type: web-api-instance-property
 tags:
   - API
   - OscillatorNode

--- a/files/en-us/web/api/oscillatornode/index.md
+++ b/files/en-us/web/api/oscillatornode/index.md
@@ -1,6 +1,7 @@
 ---
 title: OscillatorNode
 slug: Web/API/OscillatorNode
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/oscillatornode/oscillatornode/index.md
+++ b/files/en-us/web/api/oscillatornode/oscillatornode/index.md
@@ -1,6 +1,7 @@
 ---
 title: OscillatorNode()
 slug: Web/API/OscillatorNode/OscillatorNode
+page-type: web-api-constructor
 tags:
   - Audio
   - Constructor

--- a/files/en-us/web/api/oscillatornode/setperiodicwave/index.md
+++ b/files/en-us/web/api/oscillatornode/setperiodicwave/index.md
@@ -1,6 +1,7 @@
 ---
 title: OscillatorNode.setPeriodicWave()
 slug: Web/API/OscillatorNode/setPeriodicWave
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/oscillatornode/type/index.md
+++ b/files/en-us/web/api/oscillatornode/type/index.md
@@ -1,6 +1,7 @@
 ---
 title: OscillatorNode.type
 slug: Web/API/OscillatorNode/type
+page-type: web-api-instance-property
 tags:
   - API
   - OscillatorNode

--- a/files/en-us/web/api/otpcredential/code/index.md
+++ b/files/en-us/web/api/otpcredential/code/index.md
@@ -1,6 +1,7 @@
 ---
 title: OTPCredential.code
 slug: Web/API/OTPCredential/code
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/otpcredential/index.md
+++ b/files/en-us/web/api/otpcredential/index.md
@@ -1,6 +1,7 @@
 ---
 title: OTPCredential
 slug: Web/API/OTPCredential
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/overconstrainederror/constraint/index.md
+++ b/files/en-us/web/api/overconstrainederror/constraint/index.md
@@ -1,6 +1,7 @@
 ---
 title: OverconstrainedError.constraint
 slug: Web/API/OverconstrainedError/constraint
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/overconstrainederror/index.md
+++ b/files/en-us/web/api/overconstrainederror/index.md
@@ -1,6 +1,7 @@
 ---
 title: OverconstrainedError
 slug: Web/API/OverconstrainedError
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/overconstrainederror/overconstrainederror/index.md
+++ b/files/en-us/web/api/overconstrainederror/overconstrainederror/index.md
@@ -1,6 +1,7 @@
 ---
 title: OverconstrainedError()
 slug: Web/API/OverconstrainedError/OverconstrainedError
+page-type: web-api-constructor
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/page_visibility_api/index.md
+++ b/files/en-us/web/api/page_visibility_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Page Visibility API
 slug: Web/API/Page_Visibility_API
+page-type: web-api-overview
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/pagetransitionevent/index.md
+++ b/files/en-us/web/api/pagetransitionevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: PageTransitionEvent
 slug: Web/API/PageTransitionEvent
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/pagetransitionevent/persisted/index.md
+++ b/files/en-us/web/api/pagetransitionevent/persisted/index.md
@@ -1,6 +1,7 @@
 ---
 title: PageTransitionEvent.persisted
 slug: Web/API/PageTransitionEvent/persisted
+page-type: web-api-instance-property
 tags:
   - API
   - PageTransitionEvent

--- a/files/en-us/web/api/paintworklet/devicepixelratio/index.md
+++ b/files/en-us/web/api/paintworklet/devicepixelratio/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaintWorkletGlobalScope.devicePixelRatio
 slug: Web/API/PaintWorklet/devicePixelRatio
+page-type: web-api-instance-property
 tags:
   - CSS Paint API
   - DPI

--- a/files/en-us/web/api/paintworklet/index.md
+++ b/files/en-us/web/api/paintworklet/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaintWorklet
 slug: Web/API/PaintWorklet
+page-type: web-api-interface
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/paintworklet/registerpaint/index.md
+++ b/files/en-us/web/api/paintworklet/registerpaint/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaintWorkletGlobalScope.registerPaint
 slug: Web/API/PaintWorklet/registerPaint
+page-type: web-api-instance-method
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/pannernode/coneinnerangle/index.md
+++ b/files/en-us/web/api/pannernode/coneinnerangle/index.md
@@ -1,6 +1,7 @@
 ---
 title: PannerNode.coneInnerAngle
 slug: Web/API/PannerNode/coneInnerAngle
+page-type: web-api-instance-property
 tags:
   - API
   - PannerNode

--- a/files/en-us/web/api/pannernode/coneouterangle/index.md
+++ b/files/en-us/web/api/pannernode/coneouterangle/index.md
@@ -1,6 +1,7 @@
 ---
 title: PannerNode.coneOuterAngle
 slug: Web/API/PannerNode/coneOuterAngle
+page-type: web-api-instance-property
 tags:
   - API
   - PannerNode

--- a/files/en-us/web/api/pannernode/coneoutergain/index.md
+++ b/files/en-us/web/api/pannernode/coneoutergain/index.md
@@ -1,6 +1,7 @@
 ---
 title: PannerNode.coneOuterGain
 slug: Web/API/PannerNode/coneOuterGain
+page-type: web-api-instance-property
 tags:
   - API
   - PannerNode

--- a/files/en-us/web/api/pannernode/distancemodel/index.md
+++ b/files/en-us/web/api/pannernode/distancemodel/index.md
@@ -1,6 +1,7 @@
 ---
 title: PannerNode.distanceModel
 slug: Web/API/PannerNode/distanceModel
+page-type: web-api-instance-property
 tags:
   - API
   - PannerNode

--- a/files/en-us/web/api/pannernode/index.md
+++ b/files/en-us/web/api/pannernode/index.md
@@ -1,6 +1,7 @@
 ---
 title: PannerNode
 slug: Web/API/PannerNode
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/pannernode/maxdistance/index.md
+++ b/files/en-us/web/api/pannernode/maxdistance/index.md
@@ -1,6 +1,7 @@
 ---
 title: PannerNode.maxDistance
 slug: Web/API/PannerNode/maxDistance
+page-type: web-api-instance-property
 tags:
   - API
   - PannerNode

--- a/files/en-us/web/api/pannernode/orientationx/index.md
+++ b/files/en-us/web/api/pannernode/orientationx/index.md
@@ -1,6 +1,7 @@
 ---
 title: PannerNode.orientationX
 slug: Web/API/PannerNode/orientationX
+page-type: web-api-instance-property
 tags:
   - PannerNode
   - Property

--- a/files/en-us/web/api/pannernode/orientationy/index.md
+++ b/files/en-us/web/api/pannernode/orientationy/index.md
@@ -1,6 +1,7 @@
 ---
 title: PannerNode.orientationY
 slug: Web/API/PannerNode/orientationY
+page-type: web-api-instance-property
 tags:
   - API
   - PannerNode

--- a/files/en-us/web/api/pannernode/orientationz/index.md
+++ b/files/en-us/web/api/pannernode/orientationz/index.md
@@ -1,6 +1,7 @@
 ---
 title: PannerNode.orientationZ
 slug: Web/API/PannerNode/orientationZ
+page-type: web-api-instance-property
 tags:
   - Audio
   - PannerNode

--- a/files/en-us/web/api/pannernode/pannernode/index.md
+++ b/files/en-us/web/api/pannernode/pannernode/index.md
@@ -1,6 +1,7 @@
 ---
 title: PannerNode()
 slug: Web/API/PannerNode/PannerNode
+page-type: web-api-constructor
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/pannernode/panningmodel/index.md
+++ b/files/en-us/web/api/pannernode/panningmodel/index.md
@@ -1,6 +1,7 @@
 ---
 title: PannerNode.panningModel
 slug: Web/API/PannerNode/panningModel
+page-type: web-api-instance-property
 tags:
   - API
   - PannerNode

--- a/files/en-us/web/api/pannernode/positionx/index.md
+++ b/files/en-us/web/api/pannernode/positionx/index.md
@@ -1,6 +1,7 @@
 ---
 title: PannerNode.positionX
 slug: Web/API/PannerNode/positionX
+page-type: web-api-instance-property
 tags:
   - API
   - PannerNode

--- a/files/en-us/web/api/pannernode/positiony/index.md
+++ b/files/en-us/web/api/pannernode/positiony/index.md
@@ -1,6 +1,7 @@
 ---
 title: PannerNode.positionY
 slug: Web/API/PannerNode/positionY
+page-type: web-api-instance-property
 tags:
   - API
   - PannerNode

--- a/files/en-us/web/api/pannernode/positionz/index.md
+++ b/files/en-us/web/api/pannernode/positionz/index.md
@@ -1,6 +1,7 @@
 ---
 title: PannerNode.positionZ
 slug: Web/API/PannerNode/positionZ
+page-type: web-api-instance-property
 tags:
   - API
   - PannerNode

--- a/files/en-us/web/api/pannernode/refdistance/index.md
+++ b/files/en-us/web/api/pannernode/refdistance/index.md
@@ -1,6 +1,7 @@
 ---
 title: PannerNode.refDistance
 slug: Web/API/PannerNode/refDistance
+page-type: web-api-instance-property
 tags:
   - API
   - PannerNode

--- a/files/en-us/web/api/pannernode/rollofffactor/index.md
+++ b/files/en-us/web/api/pannernode/rollofffactor/index.md
@@ -1,6 +1,7 @@
 ---
 title: PannerNode.rolloffFactor
 slug: Web/API/PannerNode/rolloffFactor
+page-type: web-api-instance-property
 tags:
   - API
   - PannerNode

--- a/files/en-us/web/api/pannernode/setorientation/index.md
+++ b/files/en-us/web/api/pannernode/setorientation/index.md
@@ -1,6 +1,7 @@
 ---
 title: PannerNode.setOrientation()
 slug: Web/API/PannerNode/setOrientation
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/pannernode/setposition/index.md
+++ b/files/en-us/web/api/pannernode/setposition/index.md
@@ -1,6 +1,7 @@
 ---
 title: PannerNode.setPosition()
 slug: Web/API/PannerNode/setPosition
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/pannernode/setvelocity/index.md
+++ b/files/en-us/web/api/pannernode/setvelocity/index.md
@@ -1,6 +1,7 @@
 ---
 title: PannerNode.setVelocity()
 slug: Web/API/PannerNode/setVelocity
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/passwordcredential/iconurl/index.md
+++ b/files/en-us/web/api/passwordcredential/iconurl/index.md
@@ -1,6 +1,7 @@
 ---
 title: PasswordCredential.iconURL
 slug: Web/API/PasswordCredential/iconURL
+page-type: web-api-instance-property
 tags:
   - API
   - Credential Management API

--- a/files/en-us/web/api/passwordcredential/index.md
+++ b/files/en-us/web/api/passwordcredential/index.md
@@ -1,6 +1,7 @@
 ---
 title: PasswordCredential
 slug: Web/API/PasswordCredential
+page-type: web-api-interface
 tags:
   - API
   - Credential Management API

--- a/files/en-us/web/api/passwordcredential/name/index.md
+++ b/files/en-us/web/api/passwordcredential/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: PasswordCredential.name
 slug: Web/API/PasswordCredential/name
+page-type: web-api-instance-property
 tags:
   - API
   - Credential Management API

--- a/files/en-us/web/api/passwordcredential/password/index.md
+++ b/files/en-us/web/api/passwordcredential/password/index.md
@@ -1,6 +1,7 @@
 ---
 title: PasswordCredential.password
 slug: Web/API/PasswordCredential/password
+page-type: web-api-instance-property
 tags:
   - API
   - Credential Management API

--- a/files/en-us/web/api/passwordcredential/passwordcredential/index.md
+++ b/files/en-us/web/api/passwordcredential/passwordcredential/index.md
@@ -1,6 +1,7 @@
 ---
 title: PasswordCredential()
 slug: Web/API/PasswordCredential/PasswordCredential
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/path2d/addpath/index.md
+++ b/files/en-us/web/api/path2d/addpath/index.md
@@ -1,6 +1,7 @@
 ---
 title: Path2D.addPath()
 slug: Web/API/Path2D/addPath
+page-type: web-api-instance-method
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/path2d/index.md
+++ b/files/en-us/web/api/path2d/index.md
@@ -1,6 +1,7 @@
 ---
 title: Path2D
 slug: Web/API/Path2D
+page-type: web-api-interface
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/path2d/path2d/index.md
+++ b/files/en-us/web/api/path2d/path2d/index.md
@@ -1,6 +1,7 @@
 ---
 title: Path2D()
 slug: Web/API/Path2D/Path2D
+page-type: web-api-constructor
 tags:
   - API
   - Canvas

--- a/files/en-us/web/api/payment_request_api/concepts/index.md
+++ b/files/en-us/web/api/payment_request_api/concepts/index.md
@@ -1,6 +1,7 @@
 ---
 title: Payment processing concepts
 slug: Web/API/Payment_Request_API/Concepts
+page-type: guide
 tags:
   - API
   - Apple Pay

--- a/files/en-us/web/api/payment_request_api/index.md
+++ b/files/en-us/web/api/payment_request_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Payment Request API
 slug: Web/API/Payment_Request_API
+page-type: web-api-overview
 tags:
   - API
   - Commerce

--- a/files/en-us/web/api/payment_request_api/using_the_payment_request_api/index.md
+++ b/files/en-us/web/api/payment_request_api/using_the_payment_request_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using the Payment Request API
 slug: Web/API/Payment_Request_API/Using_the_Payment_Request_API
+page-type: guide
 tags:
   - Demos
   - Examples

--- a/files/en-us/web/api/paymentaddress/addressline/index.md
+++ b/files/en-us/web/api/paymentaddress/addressline/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentAddress.addressLine
 slug: Web/API/PaymentAddress/addressLine
+page-type: web-api-instance-property
 tags:
   - API
   - Address

--- a/files/en-us/web/api/paymentaddress/city/index.md
+++ b/files/en-us/web/api/paymentaddress/city/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentAddress.city
 slug: Web/API/PaymentAddress/city
+page-type: web-api-instance-property
 tags:
   - API
   - Address

--- a/files/en-us/web/api/paymentaddress/country/index.md
+++ b/files/en-us/web/api/paymentaddress/country/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentAddress.country
 slug: Web/API/PaymentAddress/country
+page-type: web-api-instance-property
 tags:
   - API
   - Address

--- a/files/en-us/web/api/paymentaddress/dependentlocality/index.md
+++ b/files/en-us/web/api/paymentaddress/dependentlocality/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentAddress.dependentLocality
 slug: Web/API/PaymentAddress/dependentLocality
+page-type: web-api-instance-property
 tags:
   - API
   - Payment Request

--- a/files/en-us/web/api/paymentaddress/index.md
+++ b/files/en-us/web/api/paymentaddress/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentAddress
 slug: Web/API/PaymentAddress
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/paymentaddress/languagecode/index.md
+++ b/files/en-us/web/api/paymentaddress/languagecode/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentAddress.languageCode
 slug: Web/API/PaymentAddress/languageCode
+page-type: web-api-instance-property
 tags:
   - API
   - Address

--- a/files/en-us/web/api/paymentaddress/organization/index.md
+++ b/files/en-us/web/api/paymentaddress/organization/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentAddress.organization
 slug: Web/API/PaymentAddress/organization
+page-type: web-api-instance-property
 tags:
   - API
   - Address

--- a/files/en-us/web/api/paymentaddress/phone/index.md
+++ b/files/en-us/web/api/paymentaddress/phone/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentAddress.phone
 slug: Web/API/PaymentAddress/phone
+page-type: web-api-instance-property
 tags:
   - API
   - Address

--- a/files/en-us/web/api/paymentaddress/postalcode/index.md
+++ b/files/en-us/web/api/paymentaddress/postalcode/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentAddress.postalCode
 slug: Web/API/PaymentAddress/postalCode
+page-type: web-api-instance-property
 tags:
   - API
   - Address

--- a/files/en-us/web/api/paymentaddress/recipient/index.md
+++ b/files/en-us/web/api/paymentaddress/recipient/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentAddress.recipient
 slug: Web/API/PaymentAddress/recipient
+page-type: web-api-instance-property
 tags:
   - API
   - Payment Request

--- a/files/en-us/web/api/paymentaddress/region/index.md
+++ b/files/en-us/web/api/paymentaddress/region/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentAddress.region
 slug: Web/API/PaymentAddress/region
+page-type: web-api-instance-property
 tags:
   - API
   - Address

--- a/files/en-us/web/api/paymentaddress/sortingcode/index.md
+++ b/files/en-us/web/api/paymentaddress/sortingcode/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentAddress.sortingCode
 slug: Web/API/PaymentAddress/sortingCode
+page-type: web-api-instance-property
 tags:
   - API
   - Address

--- a/files/en-us/web/api/paymentaddress/tojson/index.md
+++ b/files/en-us/web/api/paymentaddress/tojson/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentAddress.toJSON()
 slug: Web/API/PaymentAddress/toJSON
+page-type: web-api-instance-method
 tags:
   - API
   - Payment Request

--- a/files/en-us/web/api/paymentmethodchangeevent/index.md
+++ b/files/en-us/web/api/paymentmethodchangeevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentMethodChangeEvent
 slug: Web/API/PaymentMethodChangeEvent
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/paymentmethodchangeevent/methoddetails/index.md
+++ b/files/en-us/web/api/paymentmethodchangeevent/methoddetails/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentMethodChangeEvent.methodDetails
 slug: Web/API/PaymentMethodChangeEvent/methodDetails
+page-type: web-api-instance-property
 tags:
   - API
   - Commerce

--- a/files/en-us/web/api/paymentmethodchangeevent/methodname/index.md
+++ b/files/en-us/web/api/paymentmethodchangeevent/methodname/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentMethodChangeEvent.methodName
 slug: Web/API/PaymentMethodChangeEvent/methodName
+page-type: web-api-instance-property
 tags:
   - API
   - Commerce

--- a/files/en-us/web/api/paymentmethodchangeevent/paymentmethodchangeevent/index.md
+++ b/files/en-us/web/api/paymentmethodchangeevent/paymentmethodchangeevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentMethodChangeEvent
 slug: Web/API/PaymentMethodChangeEvent/PaymentMethodChangeEvent
+page-type: web-api-constructor
 tags:
   - API
   - Commerce

--- a/files/en-us/web/api/paymentrequest/abort/index.md
+++ b/files/en-us/web/api/paymentrequest/abort/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequest.abort()
 slug: Web/API/PaymentRequest/abort
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/paymentrequest/canmakepayment/index.md
+++ b/files/en-us/web/api/paymentrequest/canmakepayment/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequest.canMakePayment()
 slug: Web/API/PaymentRequest/canMakePayment
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/paymentrequest/id/index.md
+++ b/files/en-us/web/api/paymentrequest/id/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequest.prototype.id
 slug: Web/API/PaymentRequest/id
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/paymentrequest/index.md
+++ b/files/en-us/web/api/paymentrequest/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequest
 slug: Web/API/PaymentRequest
+page-type: web-api-interface
 tags:
   - API
   - Commerce

--- a/files/en-us/web/api/paymentrequest/merchantvalidation_event/index.md
+++ b/files/en-us/web/api/paymentrequest/merchantvalidation_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'PaymentRequest: merchantvalidation event'
 slug: Web/API/PaymentRequest/merchantvalidation_event
+page-type: web-api-event
 tags:
   - API
   - Commerce

--- a/files/en-us/web/api/paymentrequest/paymentmethodchange_event/index.md
+++ b/files/en-us/web/api/paymentrequest/paymentmethodchange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'PaymentRequest: paymentmethodchange event'
 slug: Web/API/PaymentRequest/paymentmethodchange_event
+page-type: web-api-event
 tags:
   - Event
   - Payment Request

--- a/files/en-us/web/api/paymentrequest/paymentrequest/index.md
+++ b/files/en-us/web/api/paymentrequest/paymentrequest/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequest()
 slug: Web/API/PaymentRequest/PaymentRequest
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/paymentrequest/shippingaddress/index.md
+++ b/files/en-us/web/api/paymentrequest/shippingaddress/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequest.shippingAddress
 slug: Web/API/PaymentRequest/shippingAddress
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/paymentrequest/shippingaddresschange_event/index.md
+++ b/files/en-us/web/api/paymentrequest/shippingaddresschange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'PaymentRequest: shippingaddresschange event'
 slug: Web/API/PaymentRequest/shippingaddresschange_event
+page-type: web-api-event
 tags:
   - API
   - Address

--- a/files/en-us/web/api/paymentrequest/shippingoption/index.md
+++ b/files/en-us/web/api/paymentrequest/shippingoption/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequest.shippingOption
 slug: Web/API/PaymentRequest/shippingOption
+page-type: web-api-instance-property
 tags:
   - API
   - Payment Request

--- a/files/en-us/web/api/paymentrequest/shippingoptionchange_event/index.md
+++ b/files/en-us/web/api/paymentrequest/shippingoptionchange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'PaymentRequest: shippingoptionchange event'
 slug: Web/API/PaymentRequest/shippingoptionchange_event
+page-type: web-api-event
 tags:
   - API
   - Commerce

--- a/files/en-us/web/api/paymentrequest/shippingtype/index.md
+++ b/files/en-us/web/api/paymentrequest/shippingtype/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequest.shippingType
 slug: Web/API/PaymentRequest/shippingType
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/paymentrequest/show/index.md
+++ b/files/en-us/web/api/paymentrequest/show/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequest.show()
 slug: Web/API/PaymentRequest/show
+page-type: web-api-instance-method
 tags:
   - API
   - Commerce

--- a/files/en-us/web/api/paymentrequestevent/index.md
+++ b/files/en-us/web/api/paymentrequestevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequestEvent
 slug: Web/API/PaymentRequestEvent
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/paymentrequestevent/instrumentkey/index.md
+++ b/files/en-us/web/api/paymentrequestevent/instrumentkey/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequestEvent.instrumentKey
 slug: Web/API/PaymentRequestEvent/instrumentKey
+page-type: web-api-instance-property
 browser-compat: api.PaymentRequestEvent.instrumentKey
 ---
 {{APIRef("Payment Request API")}}{{deprecated_header}}{{non-standard_header}}

--- a/files/en-us/web/api/paymentrequestevent/methoddata/index.md
+++ b/files/en-us/web/api/paymentrequestevent/methoddata/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequestEvent.methodData
 slug: Web/API/PaymentRequestEvent/methodData
+page-type: web-api-instance-property
 browser-compat: api.PaymentRequestEvent.methodData
 ---
 {{SeeCompatTable}}{{APIRef("Payment Request API")}}

--- a/files/en-us/web/api/paymentrequestevent/modifiers/index.md
+++ b/files/en-us/web/api/paymentrequestevent/modifiers/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequestEvent.modifiers
 slug: Web/API/PaymentRequestEvent/modifiers
+page-type: web-api-instance-property
 browser-compat: api.PaymentRequestEvent.modifiers
 ---
 {{SeeCompatTable}}{{APIRef("Payment Request API")}}

--- a/files/en-us/web/api/paymentrequestevent/openwindow/index.md
+++ b/files/en-us/web/api/paymentrequestevent/openwindow/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequestEvent.openWindow()
 slug: Web/API/PaymentRequestEvent/openWindow
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/paymentrequestevent/paymentrequestevent/index.md
+++ b/files/en-us/web/api/paymentrequestevent/paymentrequestevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequestEvent()
 slug: Web/API/PaymentRequestEvent/PaymentRequestEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/paymentrequestevent/paymentrequestid/index.md
+++ b/files/en-us/web/api/paymentrequestevent/paymentrequestid/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequestEvent.paymentRequestId
 slug: Web/API/PaymentRequestEvent/paymentRequestId
+page-type: web-api-instance-property
 tags:
   - API
   - Payment Request API

--- a/files/en-us/web/api/paymentrequestevent/paymentrequestorigin/index.md
+++ b/files/en-us/web/api/paymentrequestevent/paymentrequestorigin/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequestEvent.paymentRequestOrigin
 slug: Web/API/PaymentRequestEvent/paymentRequestOrigin
+page-type: web-api-instance-property
 tags:
   - API
   - Payment Request API

--- a/files/en-us/web/api/paymentrequestevent/respondwith/index.md
+++ b/files/en-us/web/api/paymentrequestevent/respondwith/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequestEvent.respondWith()
 slug: Web/API/PaymentRequestEvent/respondWith
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/paymentrequestevent/toporigin/index.md
+++ b/files/en-us/web/api/paymentrequestevent/toporigin/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequestEvent.topOrigin
 slug: Web/API/PaymentRequestEvent/topOrigin
+page-type: web-api-instance-property
 tags:
   - API
   - Payment Request API

--- a/files/en-us/web/api/paymentrequestevent/total/index.md
+++ b/files/en-us/web/api/paymentrequestevent/total/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequestEvent.total
 slug: Web/API/PaymentRequestEvent/total
+page-type: web-api-instance-property
 tags:
   - API
   - Payment Request API

--- a/files/en-us/web/api/paymentrequestupdateevent/index.md
+++ b/files/en-us/web/api/paymentrequestupdateevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequestUpdateEvent
 slug: Web/API/PaymentRequestUpdateEvent
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/paymentrequestupdateevent/paymentrequestupdateevent/index.md
+++ b/files/en-us/web/api/paymentrequestupdateevent/paymentrequestupdateevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequestUpdateEvent()
 slug: Web/API/PaymentRequestUpdateEvent/PaymentRequestUpdateEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/paymentrequestupdateevent/updatewith/index.md
+++ b/files/en-us/web/api/paymentrequestupdateevent/updatewith/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequestUpdateEvent.updateWith()
 slug: Web/API/PaymentRequestUpdateEvent/updateWith
+page-type: web-api-instance-method
 tags:
   - API
   - Change

--- a/files/en-us/web/api/paymentresponse/complete/index.md
+++ b/files/en-us/web/api/paymentresponse/complete/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentResponse.complete()
 slug: Web/API/PaymentResponse/complete
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/paymentresponse/details/index.md
+++ b/files/en-us/web/api/paymentresponse/details/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentResponse.details
 slug: Web/API/PaymentResponse/details
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/paymentresponse/index.md
+++ b/files/en-us/web/api/paymentresponse/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentResponse
 slug: Web/API/PaymentResponse
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/paymentresponse/methodname/index.md
+++ b/files/en-us/web/api/paymentresponse/methodname/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentResponse.methodName
 slug: Web/API/PaymentResponse/methodName
+page-type: web-api-instance-property
 tags:
   - API
   - Commerce

--- a/files/en-us/web/api/paymentresponse/payerdetailchange_event/index.md
+++ b/files/en-us/web/api/paymentresponse/payerdetailchange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'PaymentResponse: payerdetailchange event'
 slug: Web/API/PaymentResponse/payerdetailchange_event
+page-type: web-api-event
 tags:
   - Commerce
   - Payment Request API

--- a/files/en-us/web/api/paymentresponse/payeremail/index.md
+++ b/files/en-us/web/api/paymentresponse/payeremail/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentResponse.payerEmail
 slug: Web/API/PaymentResponse/payerEmail
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/paymentresponse/payername/index.md
+++ b/files/en-us/web/api/paymentresponse/payername/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentRequest.payerName
 slug: Web/API/PaymentResponse/payerName
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/paymentresponse/payerphone/index.md
+++ b/files/en-us/web/api/paymentresponse/payerphone/index.md
@@ -1,6 +1,7 @@
 ---
 title: PayerResponse.payerPhone
 slug: Web/API/PaymentResponse/payerPhone
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/paymentresponse/requestid/index.md
+++ b/files/en-us/web/api/paymentresponse/requestid/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentResponse.requestId
 slug: Web/API/PaymentResponse/requestId
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/paymentresponse/retry/index.md
+++ b/files/en-us/web/api/paymentresponse/retry/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentResponse.retry()
 slug: Web/API/PaymentResponse/retry
+page-type: web-api-instance-method
 tags:
   - API
   - Commerce

--- a/files/en-us/web/api/paymentresponse/shippingaddress/index.md
+++ b/files/en-us/web/api/paymentresponse/shippingaddress/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentResponse.shippingAddress
 slug: Web/API/PaymentResponse/shippingAddress
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/paymentresponse/shippingoption/index.md
+++ b/files/en-us/web/api/paymentresponse/shippingoption/index.md
@@ -1,6 +1,7 @@
 ---
 title: PaymentResponse.shippingOption
 slug: Web/API/PaymentResponse/shippingOption
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/pbkdf2params/index.md
+++ b/files/en-us/web/api/pbkdf2params/index.md
@@ -1,6 +1,7 @@
 ---
 title: Pbkdf2Params
 slug: Web/API/Pbkdf2Params
+page-type: web-api-interface
 tags:
   - API
   - Dictionary

--- a/files/en-us/web/api/performance/clearmarks/index.md
+++ b/files/en-us/web/api/performance/clearmarks/index.md
@@ -1,6 +1,7 @@
 ---
 title: performance.clearMarks()
 slug: Web/API/Performance/clearMarks
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/performance/clearmeasures/index.md
+++ b/files/en-us/web/api/performance/clearmeasures/index.md
@@ -1,6 +1,7 @@
 ---
 title: performance.clearMeasures()
 slug: Web/API/Performance/clearMeasures
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/performance/clearresourcetimings/index.md
+++ b/files/en-us/web/api/performance/clearresourcetimings/index.md
@@ -1,6 +1,7 @@
 ---
 title: performance.clearResourceTimings()
 slug: Web/API/Performance/clearResourceTimings
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/performance/getentries/index.md
+++ b/files/en-us/web/api/performance/getentries/index.md
@@ -1,6 +1,7 @@
 ---
 title: performance.getEntries()
 slug: Web/API/Performance/getEntries
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/performance/getentriesbyname/index.md
+++ b/files/en-us/web/api/performance/getentriesbyname/index.md
@@ -1,6 +1,7 @@
 ---
 title: performance.getEntriesByName()
 slug: Web/API/Performance/getEntriesByName
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/performance/getentriesbytype/index.md
+++ b/files/en-us/web/api/performance/getentriesbytype/index.md
@@ -1,6 +1,7 @@
 ---
 title: performance.getEntriesByType()
 slug: Web/API/Performance/getEntriesByType
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/performance/index.md
+++ b/files/en-us/web/api/performance/index.md
@@ -1,6 +1,7 @@
 ---
 title: Performance
 slug: Web/API/Performance
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/performance/mark/index.md
+++ b/files/en-us/web/api/performance/mark/index.md
@@ -1,6 +1,7 @@
 ---
 title: performance.mark()
 slug: Web/API/Performance/mark
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/performance/measure/index.md
+++ b/files/en-us/web/api/performance/measure/index.md
@@ -1,6 +1,7 @@
 ---
 title: performance.measure()
 slug: Web/API/Performance/measure
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/performance/memory/index.md
+++ b/files/en-us/web/api/performance/memory/index.md
@@ -1,6 +1,7 @@
 ---
 title: Performance.memory
 slug: Web/API/Performance/memory
+page-type: web-api-instance-property
 browser-compat: api.Performance.memory
 ---
 {{APIRef}}

--- a/files/en-us/web/api/performance/navigation/index.md
+++ b/files/en-us/web/api/performance/navigation/index.md
@@ -1,6 +1,7 @@
 ---
 title: Performance.navigation
 slug: Web/API/Performance/navigation
+page-type: web-api-instance-property
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/performance/now/index.md
+++ b/files/en-us/web/api/performance/now/index.md
@@ -1,6 +1,7 @@
 ---
 title: performance.now()
 slug: Web/API/Performance/now
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/performance/resourcetimingbufferfull_event/index.md
+++ b/files/en-us/web/api/performance/resourcetimingbufferfull_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Performance: resourcetimingbufferfull event'
 slug: Web/API/Performance/resourcetimingbufferfull_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/performance/setresourcetimingbuffersize/index.md
+++ b/files/en-us/web/api/performance/setresourcetimingbuffersize/index.md
@@ -1,6 +1,7 @@
 ---
 title: performance.setResourceTimingBufferSize()
 slug: Web/API/Performance/setResourceTimingBufferSize
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/performance/timeorigin/index.md
+++ b/files/en-us/web/api/performance/timeorigin/index.md
@@ -1,6 +1,7 @@
 ---
 title: Performance.timeOrigin
 slug: Web/API/Performance/timeOrigin
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/performance/timing/index.md
+++ b/files/en-us/web/api/performance/timing/index.md
@@ -1,6 +1,7 @@
 ---
 title: Performance.timing
 slug: Web/API/Performance/timing
+page-type: web-api-instance-property
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/performance/tojson/index.md
+++ b/files/en-us/web/api/performance/tojson/index.md
@@ -1,6 +1,7 @@
 ---
 title: performance.toJSON()
 slug: Web/API/Performance/toJSON
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/performance_api/index.md
+++ b/files/en-us/web/api/performance_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Performance API
 slug: Web/API/Performance_API
+page-type: web-api-overview
 tags:
   - Guide
   - NeedsContent

--- a/files/en-us/web/api/performance_api/using_the_performance_api/index.md
+++ b/files/en-us/web/api/performance_api/using_the_performance_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using the Performance API
 slug: Web/API/Performance_API/Using_the_Performance_API
+page-type: guide
 tags:
   - Guide
   - Performance

--- a/files/en-us/web/api/performance_property/index.md
+++ b/files/en-us/web/api/performance_property/index.md
@@ -1,6 +1,7 @@
 ---
 title: self.performance
 slug: Web/API/performance_property
+page-type: web-api-global-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/performance_timeline/index.md
+++ b/files/en-us/web/api/performance_timeline/index.md
@@ -1,6 +1,7 @@
 ---
 title: Performance Timeline
 slug: Web/API/Performance_Timeline
+page-type: web-api-overview
 tags:
   - Guide
   - Overview

--- a/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
+++ b/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using Performance Timeline
 slug: Web/API/Performance_Timeline/Using_Performance_Timeline
+page-type: guide
 tags:
   - Guide
   - Web Performance

--- a/files/en-us/web/api/performanceelementtiming/element/index.md
+++ b/files/en-us/web/api/performanceelementtiming/element/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceElementTiming.element
 slug: Web/API/PerformanceElementTiming/element
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceelementtiming/id/index.md
+++ b/files/en-us/web/api/performanceelementtiming/id/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceElementTiming.id
 slug: Web/API/PerformanceElementTiming/id
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceelementtiming/identifier/index.md
+++ b/files/en-us/web/api/performanceelementtiming/identifier/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceElementTiming.identifier
 slug: Web/API/PerformanceElementTiming/identifier
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceelementtiming/index.md
+++ b/files/en-us/web/api/performanceelementtiming/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceElementTiming
 slug: Web/API/PerformanceElementTiming
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/performanceelementtiming/intersectionrect/index.md
+++ b/files/en-us/web/api/performanceelementtiming/intersectionrect/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceElementTiming.intersectionRect
 slug: Web/API/PerformanceElementTiming/intersectionRect
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceelementtiming/loadtime/index.md
+++ b/files/en-us/web/api/performanceelementtiming/loadtime/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceElementTiming.loadTime
 slug: Web/API/PerformanceElementTiming/loadTime
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceelementtiming/naturalheight/index.md
+++ b/files/en-us/web/api/performanceelementtiming/naturalheight/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceElementTiming.naturalHeight
 slug: Web/API/PerformanceElementTiming/naturalHeight
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceelementtiming/naturalwidth/index.md
+++ b/files/en-us/web/api/performanceelementtiming/naturalwidth/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceElementTiming.naturalWidth
 slug: Web/API/PerformanceElementTiming/naturalWidth
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceelementtiming/rendertime/index.md
+++ b/files/en-us/web/api/performanceelementtiming/rendertime/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceElementTiming.renderTime
 slug: Web/API/PerformanceElementTiming/renderTime
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceelementtiming/tojson/index.md
+++ b/files/en-us/web/api/performanceelementtiming/tojson/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceElementTiming.toJSON()
 slug: Web/API/PerformanceElementTiming/toJSON
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/performanceelementtiming/url/index.md
+++ b/files/en-us/web/api/performanceelementtiming/url/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceElementTiming.url
 slug: Web/API/PerformanceElementTiming/url
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceentry/duration/index.md
+++ b/files/en-us/web/api/performanceentry/duration/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceEntry.duration
 slug: Web/API/PerformanceEntry/duration
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceentry/entrytype/index.md
+++ b/files/en-us/web/api/performanceentry/entrytype/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceEntry.entryType
 slug: Web/API/PerformanceEntry/entryType
+page-type: web-api-instance-property
 tags:
   - API
   - Performance Timeline API

--- a/files/en-us/web/api/performanceentry/index.md
+++ b/files/en-us/web/api/performanceentry/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceEntry
 slug: Web/API/PerformanceEntry
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/performanceentry/name/index.md
+++ b/files/en-us/web/api/performanceentry/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceEntry.name
 slug: Web/API/PerformanceEntry/name
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceentry/starttime/index.md
+++ b/files/en-us/web/api/performanceentry/starttime/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceEntry.startTime
 slug: Web/API/PerformanceEntry/startTime
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceentry/tojson/index.md
+++ b/files/en-us/web/api/performanceentry/tojson/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceEntry.toJSON()
 slug: Web/API/PerformanceEntry/toJSON
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/performanceeventtiming/index.md
+++ b/files/en-us/web/api/performanceeventtiming/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceEventTiming
 slug: Web/API/PerformanceEventTiming
+page-type: web-api-interface
 tags:
   - API
   - Event Timing API

--- a/files/en-us/web/api/performancelongtasktiming/attribution/index.md
+++ b/files/en-us/web/api/performancelongtasktiming/attribution/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceLongTaskTiming.attribution
 slug: Web/API/PerformanceLongTaskTiming/attribution
+page-type: web-api-instance-property
 browser-compat: api.PerformanceLongTaskTiming.attribution
 ---
 {{SeeCompatTable}}{{APIRef("Long Tasks")}}

--- a/files/en-us/web/api/performancelongtasktiming/index.md
+++ b/files/en-us/web/api/performancelongtasktiming/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceLongTaskTiming
 slug: Web/API/PerformanceLongTaskTiming
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/performancemark/index.md
+++ b/files/en-us/web/api/performancemark/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceMark
 slug: Web/API/PerformanceMark
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/performancemeasure/index.md
+++ b/files/en-us/web/api/performancemeasure/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceMeasure
 slug: Web/API/PerformanceMeasure
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/performancenavigation/index.md
+++ b/files/en-us/web/api/performancenavigation/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceNavigation
 slug: Web/API/PerformanceNavigation
+page-type: web-api-interface
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/performancenavigation/redirectcount/index.md
+++ b/files/en-us/web/api/performancenavigation/redirectcount/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceNavigation.redirectCount
 slug: Web/API/PerformanceNavigation/redirectCount
+page-type: web-api-instance-property
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/performancenavigation/type/index.md
+++ b/files/en-us/web/api/performancenavigation/type/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceNavigation.type
 slug: Web/API/PerformanceNavigation/type
+page-type: web-api-instance-property
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/performancenavigationtiming/domcomplete/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/domcomplete/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceNavigationTiming.domComplete
 slug: Web/API/PerformanceNavigationTiming/domComplete
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventend/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventend/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceNavigationTiming.domContentLoadedEventEnd
 slug: Web/API/PerformanceNavigationTiming/domContentLoadedEventEnd
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventstart/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventstart/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceNavigationTiming.domContentLoadedEventStart
 slug: Web/API/PerformanceNavigationTiming/domContentLoadedEventStart
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performancenavigationtiming/dominteractive/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/dominteractive/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceNavigationTiming.domInteractive
 slug: Web/API/PerformanceNavigationTiming/domInteractive
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performancenavigationtiming/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceNavigationTiming
 slug: Web/API/PerformanceNavigationTiming
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/performancenavigationtiming/loadeventend/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/loadeventend/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceNavigationTiming.loadEventEnd
 slug: Web/API/PerformanceNavigationTiming/loadEventEnd
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performancenavigationtiming/loadeventstart/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/loadeventstart/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceNavigationTiming.loadEventStart
 slug: Web/API/PerformanceNavigationTiming/loadEventStart
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performancenavigationtiming/redirectcount/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/redirectcount/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceNavigationTiming.redirectCount
 slug: Web/API/PerformanceNavigationTiming/redirectCount
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performancenavigationtiming/tojson/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/tojson/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceNavigationTiming.toJSON()
 slug: Web/API/PerformanceNavigationTiming/toJSON
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/performancenavigationtiming/type/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/type/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceNavigationTiming.type
 slug: Web/API/PerformanceNavigationTiming/type
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performancenavigationtiming/unloadeventend/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/unloadeventend/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceNavigationTiming.unloadEventEnd
 slug: Web/API/PerformanceNavigationTiming/unloadEventEnd
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performancenavigationtiming/unloadeventstart/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/unloadeventstart/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceNavigationTiming.unloadEventStart
 slug: Web/API/PerformanceNavigationTiming/unloadEventStart
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceobserver/disconnect/index.md
+++ b/files/en-us/web/api/performanceobserver/disconnect/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceObserver.disconnect()
 slug: Web/API/PerformanceObserver/disconnect
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/performanceobserver/index.md
+++ b/files/en-us/web/api/performanceobserver/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceObserver
 slug: Web/API/PerformanceObserver
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/performanceobserver/observe/index.md
+++ b/files/en-us/web/api/performanceobserver/observe/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceObserver.observe()
 slug: Web/API/PerformanceObserver/observe
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/performanceobserver/performanceobserver/index.md
+++ b/files/en-us/web/api/performanceobserver/performanceobserver/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceObserver()
 slug: Web/API/PerformanceObserver/PerformanceObserver
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/performanceobserver/supportedentrytypes/index.md
+++ b/files/en-us/web/api/performanceobserver/supportedentrytypes/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceObserver.supportedEntryTypes
 slug: Web/API/PerformanceObserver/supportedEntryTypes
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceobserver/takerecords/index.md
+++ b/files/en-us/web/api/performanceobserver/takerecords/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceObserver.takeRecords()
 slug: Web/API/PerformanceObserver/takeRecords
+page-type: web-api-instance-method
 tags:
   - API
   - Method


### PR DESCRIPTION
See  https://github.com/mdn/content/issues/16255. This is part 17 of a series of PRs to add page types to the Web/API documentation.