### PR TITLE
Add Web/API page types, part 18

### DIFF
--- a/files/en-us/web/api/performanceobserverentrylist/getentries/index.md
+++ b/files/en-us/web/api/performanceobserverentrylist/getentries/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceObserverEntryList.getEntries()
 slug: Web/API/PerformanceObserverEntryList/getEntries
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/performanceobserverentrylist/getentriesbyname/index.md
+++ b/files/en-us/web/api/performanceobserverentrylist/getentriesbyname/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceObserverEntryList.getEntriesByName()
 slug: Web/API/PerformanceObserverEntryList/getEntriesByName
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/performanceobserverentrylist/getentriesbytype/index.md
+++ b/files/en-us/web/api/performanceobserverentrylist/getentriesbytype/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceObserverEntryList.getEntriesByType()
 slug: Web/API/PerformanceObserverEntryList/getEntriesByType
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/performanceobserverentrylist/index.md
+++ b/files/en-us/web/api/performanceobserverentrylist/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceObserverEntryList
 slug: Web/API/PerformanceObserverEntryList
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/performancepainttiming/index.md
+++ b/files/en-us/web/api/performancepainttiming/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformancePaintTiming
 slug: Web/API/PerformancePaintTiming
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/performanceresourcetiming/connectend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/connectend/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceResourceTiming.connectEnd
 slug: Web/API/PerformanceResourceTiming/connectEnd
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceresourcetiming/connectstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/connectstart/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceResourceTiming.connectStart
 slug: Web/API/PerformanceResourceTiming/connectStart
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceresourcetiming/decodedbodysize/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/decodedbodysize/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceResourceTiming.decodedBodySize
 slug: Web/API/PerformanceResourceTiming/decodedBodySize
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceresourcetiming/domainlookupend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/domainlookupend/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceResourceTiming.domainLookupEnd
 slug: Web/API/PerformanceResourceTiming/domainLookupEnd
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceresourcetiming/domainlookupstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/domainlookupstart/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceResourceTiming.domainLookupStart
 slug: Web/API/PerformanceResourceTiming/domainLookupStart
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceresourcetiming/encodedbodysize/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/encodedbodysize/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceResourceTiming.encodedBodySize
 slug: Web/API/PerformanceResourceTiming/encodedBodySize
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceresourcetiming/fetchstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/fetchstart/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceResourceTiming.fetchStart
 slug: Web/API/PerformanceResourceTiming/fetchStart
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceresourcetiming/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceResourceTiming
 slug: Web/API/PerformanceResourceTiming
+page-type: web-api-interface
 tags:
   - DOM
   - Interface

--- a/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceResourceTiming.initiatorType
 slug: Web/API/PerformanceResourceTiming/initiatorType
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceresourcetiming/nexthopprotocol/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/nexthopprotocol/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceResourceTiming.nextHopProtocol
 slug: Web/API/PerformanceResourceTiming/nextHopProtocol
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceresourcetiming/redirectend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/redirectend/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceResourceTiming.redirectEnd
 slug: Web/API/PerformanceResourceTiming/redirectEnd
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceresourcetiming/redirectstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/redirectstart/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceResourceTiming.redirectStart
 slug: Web/API/PerformanceResourceTiming/redirectStart
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceresourcetiming/requeststart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/requeststart/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceResourceTiming.requestStart
 slug: Web/API/PerformanceResourceTiming/requestStart
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceresourcetiming/responseend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/responseend/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceResourceTiming.responseEnd
 slug: Web/API/PerformanceResourceTiming/responseEnd
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceresourcetiming/responsestart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/responsestart/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceResourceTiming.responseStart
 slug: Web/API/PerformanceResourceTiming/responseStart
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceresourcetiming/secureconnectionstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/secureconnectionstart/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceResourceTiming.secureConnectionStart
 slug: Web/API/PerformanceResourceTiming/secureConnectionStart
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceresourcetiming/servertiming/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/servertiming/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceResourceTiming.serverTiming
 slug: Web/API/PerformanceResourceTiming/serverTiming
+page-type: web-api-instance-property
 tags:
   - API
   - PerformanceResourceTiming

--- a/files/en-us/web/api/performanceresourcetiming/tojson/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/tojson/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceResourceTiming.toJSON()
 slug: Web/API/PerformanceResourceTiming/toJSON
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/performanceresourcetiming/transfersize/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/transfersize/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceResourceTiming.transferSize
 slug: Web/API/PerformanceResourceTiming/transferSize
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceresourcetiming/workerstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/workerstart/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceResourceTiming.workerStart
 slug: Web/API/PerformanceResourceTiming/workerStart
+page-type: web-api-instance-property
 tags:
   - API
   - PerformanceResourceTiming

--- a/files/en-us/web/api/performanceservertiming/description/index.md
+++ b/files/en-us/web/api/performanceservertiming/description/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceServerTiming.description
 slug: Web/API/PerformanceServerTiming/description
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceservertiming/duration/index.md
+++ b/files/en-us/web/api/performanceservertiming/duration/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceServerTiming.duration
 slug: Web/API/PerformanceServerTiming/duration
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceservertiming/index.md
+++ b/files/en-us/web/api/performanceservertiming/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceServerTiming
 slug: Web/API/PerformanceServerTiming
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/performanceservertiming/name/index.md
+++ b/files/en-us/web/api/performanceservertiming/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceServerTiming.name
 slug: Web/API/PerformanceServerTiming/name
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/performanceservertiming/tojson/index.md
+++ b/files/en-us/web/api/performanceservertiming/tojson/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceServerTiming.toJSON()
 slug: Web/API/PerformanceServerTiming/toJSON
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/performancetiming/connectend/index.md
+++ b/files/en-us/web/api/performancetiming/connectend/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceTiming.connectEnd
 slug: Web/API/PerformanceTiming/connectEnd
+page-type: web-api-instance-property
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/performancetiming/connectstart/index.md
+++ b/files/en-us/web/api/performancetiming/connectstart/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceTiming.connectStart
 slug: Web/API/PerformanceTiming/connectStart
+page-type: web-api-instance-property
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/performancetiming/domainlookupend/index.md
+++ b/files/en-us/web/api/performancetiming/domainlookupend/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceTiming.domainLookupEnd
 slug: Web/API/PerformanceTiming/domainLookupEnd
+page-type: web-api-instance-property
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/performancetiming/domainlookupstart/index.md
+++ b/files/en-us/web/api/performancetiming/domainlookupstart/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceTiming.domainLookupStart
 slug: Web/API/PerformanceTiming/domainLookupStart
+page-type: web-api-instance-property
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/performancetiming/domcomplete/index.md
+++ b/files/en-us/web/api/performancetiming/domcomplete/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceTiming.domComplete
 slug: Web/API/PerformanceTiming/domComplete
+page-type: web-api-instance-property
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/performancetiming/domcontentloadedeventend/index.md
+++ b/files/en-us/web/api/performancetiming/domcontentloadedeventend/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceTiming.domContentLoadedEventEnd
 slug: Web/API/PerformanceTiming/domContentLoadedEventEnd
+page-type: web-api-instance-property
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/performancetiming/domcontentloadedeventstart/index.md
+++ b/files/en-us/web/api/performancetiming/domcontentloadedeventstart/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceTiming.domContentLoadedEventStart
 slug: Web/API/PerformanceTiming/domContentLoadedEventStart
+page-type: web-api-instance-property
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/performancetiming/dominteractive/index.md
+++ b/files/en-us/web/api/performancetiming/dominteractive/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceTiming.domInteractive
 slug: Web/API/PerformanceTiming/domInteractive
+page-type: web-api-instance-property
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/performancetiming/domloading/index.md
+++ b/files/en-us/web/api/performancetiming/domloading/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceTiming.domLoading
 slug: Web/API/PerformanceTiming/domLoading
+page-type: web-api-instance-property
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/performancetiming/fetchstart/index.md
+++ b/files/en-us/web/api/performancetiming/fetchstart/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceTiming.fetchStart
 slug: Web/API/PerformanceTiming/fetchStart
+page-type: web-api-instance-property
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/performancetiming/index.md
+++ b/files/en-us/web/api/performancetiming/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceTiming
 slug: Web/API/PerformanceTiming
+page-type: web-api-interface
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/performancetiming/loadeventend/index.md
+++ b/files/en-us/web/api/performancetiming/loadeventend/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceTiming.loadEventEnd
 slug: Web/API/PerformanceTiming/loadEventEnd
+page-type: web-api-instance-property
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/performancetiming/loadeventstart/index.md
+++ b/files/en-us/web/api/performancetiming/loadeventstart/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceTiming.loadEventStart
 slug: Web/API/PerformanceTiming/loadEventStart
+page-type: web-api-instance-property
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/performancetiming/navigationstart/index.md
+++ b/files/en-us/web/api/performancetiming/navigationstart/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceTiming.navigationStart
 slug: Web/API/PerformanceTiming/navigationStart
+page-type: web-api-instance-property
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/performancetiming/redirectend/index.md
+++ b/files/en-us/web/api/performancetiming/redirectend/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceTiming.redirectEnd
 slug: Web/API/PerformanceTiming/redirectEnd
+page-type: web-api-instance-property
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/performancetiming/redirectstart/index.md
+++ b/files/en-us/web/api/performancetiming/redirectstart/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceTiming.redirectStart
 slug: Web/API/PerformanceTiming/redirectStart
+page-type: web-api-instance-property
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/performancetiming/requeststart/index.md
+++ b/files/en-us/web/api/performancetiming/requeststart/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceTiming.requestStart
 slug: Web/API/PerformanceTiming/requestStart
+page-type: web-api-instance-property
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/performancetiming/responseend/index.md
+++ b/files/en-us/web/api/performancetiming/responseend/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceTiming.responseEnd
 slug: Web/API/PerformanceTiming/responseEnd
+page-type: web-api-instance-property
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/performancetiming/responsestart/index.md
+++ b/files/en-us/web/api/performancetiming/responsestart/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceTiming.responseStart
 slug: Web/API/PerformanceTiming/responseStart
+page-type: web-api-instance-property
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/performancetiming/secureconnectionstart/index.md
+++ b/files/en-us/web/api/performancetiming/secureconnectionstart/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceTiming.secureConnectionStart
 slug: Web/API/PerformanceTiming/secureConnectionStart
+page-type: web-api-instance-property
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/performancetiming/unloadeventend/index.md
+++ b/files/en-us/web/api/performancetiming/unloadeventend/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceTiming.unloadEventEnd
 slug: Web/API/PerformanceTiming/unloadEventEnd
+page-type: web-api-instance-property
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/performancetiming/unloadeventstart/index.md
+++ b/files/en-us/web/api/performancetiming/unloadeventstart/index.md
@@ -1,6 +1,7 @@
 ---
 title: PerformanceTiming.unloadEventStart
 slug: Web/API/PerformanceTiming/unloadEventStart
+page-type: web-api-instance-property
 tags:
   - API
   - Backwards compatibility

--- a/files/en-us/web/api/periodicsyncevent/index.md
+++ b/files/en-us/web/api/periodicsyncevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: PeriodicSyncEvent
 slug: Web/API/PeriodicSyncEvent
+page-type: web-api-interface
 tags:
   - API
   - Background Sync

--- a/files/en-us/web/api/periodicsyncevent/periodicsyncevent/index.md
+++ b/files/en-us/web/api/periodicsyncevent/periodicsyncevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: PeriodicSyncEvent()
 slug: Web/API/PeriodicSyncEvent/PeriodicSyncEvent
+page-type: web-api-constructor
 tags:
   - Constructor
   - Offline

--- a/files/en-us/web/api/periodicsyncevent/tag/index.md
+++ b/files/en-us/web/api/periodicsyncevent/tag/index.md
@@ -1,6 +1,7 @@
 ---
 title: PeriodicSyncEvent.tag
 slug: Web/API/PeriodicSyncEvent/tag
+page-type: web-api-instance-property
 tags:
   - Offline
   - PWA

--- a/files/en-us/web/api/periodicsyncmanager/gettags/index.md
+++ b/files/en-us/web/api/periodicsyncmanager/gettags/index.md
@@ -1,6 +1,7 @@
 ---
 title: PeriodicSyncManager.getTags()
 slug: Web/API/PeriodicSyncManager/getTags
+page-type: web-api-instance-method
 tags:
   - Background Sync
   - Method

--- a/files/en-us/web/api/periodicsyncmanager/index.md
+++ b/files/en-us/web/api/periodicsyncmanager/index.md
@@ -1,6 +1,7 @@
 ---
 title: PeriodicSyncManager
 slug: Web/API/PeriodicSyncManager
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/periodicsyncmanager/register/index.md
+++ b/files/en-us/web/api/periodicsyncmanager/register/index.md
@@ -1,6 +1,7 @@
 ---
 title: PeriodicSyncManager.register()
 slug: Web/API/PeriodicSyncManager/register
+page-type: web-api-instance-method
 tags:
   - Background Sync
   - Method

--- a/files/en-us/web/api/periodicsyncmanager/unregister/index.md
+++ b/files/en-us/web/api/periodicsyncmanager/unregister/index.md
@@ -1,6 +1,7 @@
 ---
 title: PeriodicSyncManager.unregister()
 slug: Web/API/PeriodicSyncManager/unregister
+page-type: web-api-instance-method
 tags:
   - Background Sync
   - Method

--- a/files/en-us/web/api/periodicwave/index.md
+++ b/files/en-us/web/api/periodicwave/index.md
@@ -1,6 +1,7 @@
 ---
 title: PeriodicWave
 slug: Web/API/PeriodicWave
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/periodicwave/periodicwave/index.md
+++ b/files/en-us/web/api/periodicwave/periodicwave/index.md
@@ -1,6 +1,7 @@
 ---
 title: PeriodicWave()
 slug: Web/API/PeriodicWave/PeriodicWave
+page-type: web-api-constructor
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/permissions/index.md
+++ b/files/en-us/web/api/permissions/index.md
@@ -1,6 +1,7 @@
 ---
 title: Permissions
 slug: Web/API/Permissions
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/permissions/query/index.md
+++ b/files/en-us/web/api/permissions/query/index.md
@@ -1,6 +1,7 @@
 ---
 title: Permissions.query()
 slug: Web/API/Permissions/query
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/permissions/revoke/index.md
+++ b/files/en-us/web/api/permissions/revoke/index.md
@@ -1,6 +1,7 @@
 ---
 title: Permissions.revoke()
 slug: Web/API/Permissions/revoke
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/permissions_api/index.md
+++ b/files/en-us/web/api/permissions_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Permissions API
 slug: Web/API/Permissions_API
+page-type: web-api-overview
 tags:
   - API
   - Introduction

--- a/files/en-us/web/api/permissions_api/using_the_permissions_api/index.md
+++ b/files/en-us/web/api/permissions_api/using_the_permissions_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using the Permissions API
 slug: Web/API/Permissions_API/Using_the_Permissions_API
+page-type: guide
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/permissionstatus/change_event/index.md
+++ b/files/en-us/web/api/permissionstatus/change_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'PermissionStatus: change event'
 slug: Web/API/PermissionStatus/change_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/permissionstatus/index.md
+++ b/files/en-us/web/api/permissionstatus/index.md
@@ -1,6 +1,7 @@
 ---
 title: PermissionStatus
 slug: Web/API/PermissionStatus
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/permissionstatus/name/index.md
+++ b/files/en-us/web/api/permissionstatus/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: PermissionStatus.name
 slug: Web/API/PermissionStatus/name
+page-type: web-api-instance-property
 tags:
   - API
   - Event Handler

--- a/files/en-us/web/api/permissionstatus/state/index.md
+++ b/files/en-us/web/api/permissionstatus/state/index.md
@@ -1,6 +1,7 @@
 ---
 title: PermissionStatus.state
 slug: Web/API/PermissionStatus/state
+page-type: web-api-instance-property
 tags:
   - API
   - Event Handler

--- a/files/en-us/web/api/picture-in-picture_api/index.md
+++ b/files/en-us/web/api/picture-in-picture_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Picture-in-Picture API
 slug: Web/API/Picture-in-Picture_API
+page-type: web-api-overview
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/pictureinpictureevent/index.md
+++ b/files/en-us/web/api/pictureinpictureevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: PictureInPictureEvent
 slug: Web/API/PictureInPictureEvent
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/pictureinpictureevent/pictureinpictureevent/index.md
+++ b/files/en-us/web/api/pictureinpictureevent/pictureinpictureevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: PictureInPictureEvent()
 slug: Web/API/PictureInPictureEvent/PictureInPictureEvent
+page-type: web-api-constructor
 tags:
   - Reference
   - API

--- a/files/en-us/web/api/pictureinpicturewindow/height/index.md
+++ b/files/en-us/web/api/pictureinpicturewindow/height/index.md
@@ -1,6 +1,7 @@
 ---
 title: PictureInPictureWindow.height
 slug: Web/API/PictureInPictureWindow/height
+page-type: web-api-instance-property
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/pictureinpicturewindow/index.md
+++ b/files/en-us/web/api/pictureinpicturewindow/index.md
@@ -1,6 +1,7 @@
 ---
 title: PictureInPictureWindow
 slug: Web/API/PictureInPictureWindow
+page-type: web-api-interface
 tags:
   - API
   - Advanced

--- a/files/en-us/web/api/pictureinpicturewindow/resize_event/index.md
+++ b/files/en-us/web/api/pictureinpicturewindow/resize_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'PictureInPictureWindow: resize event'
 slug: Web/API/PictureInPictureWindow/resize_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/pictureinpicturewindow/width/index.md
+++ b/files/en-us/web/api/pictureinpicturewindow/width/index.md
@@ -1,6 +1,7 @@
 ---
 title: PictureInPictureWindow.width
 slug: Web/API/PictureInPictureWindow/width
+page-type: web-api-instance-property
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/plugin/index.md
+++ b/files/en-us/web/api/plugin/index.md
@@ -1,6 +1,7 @@
 ---
 title: Plugin
 slug: Web/API/Plugin
+page-type: web-api-interface
 tags:
   - API
   - Add-ons

--- a/files/en-us/web/api/pluginarray/index.md
+++ b/files/en-us/web/api/pluginarray/index.md
@@ -1,6 +1,7 @@
 ---
 title: PluginArray
 slug: Web/API/PluginArray
+page-type: web-api-interface
 tags:
   - API
   - Add-ons

--- a/files/en-us/web/api/pointer_events/index.md
+++ b/files/en-us/web/api/pointer_events/index.md
@@ -1,6 +1,7 @@
 ---
 title: Pointer events
 slug: Web/API/Pointer_events
+page-type: web-api-overview
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/pointer_events/multi-touch_interaction/index.md
+++ b/files/en-us/web/api/pointer_events/multi-touch_interaction/index.md
@@ -1,6 +1,7 @@
 ---
 title: Multi-touch interaction
 slug: Web/API/Pointer_events/Multi-touch_interaction
+page-type: guide
 tags:
   - Guide
   - Pointer Events

--- a/files/en-us/web/api/pointer_events/pinch_zoom_gestures/index.md
+++ b/files/en-us/web/api/pointer_events/pinch_zoom_gestures/index.md
@@ -1,6 +1,7 @@
 ---
 title: Pinch zoom gestures
 slug: Web/API/Pointer_events/Pinch_zoom_gestures
+page-type: guide
 tags:
   - Guide
   - PointerEvent

--- a/files/en-us/web/api/pointer_events/using_pointer_events/index.md
+++ b/files/en-us/web/api/pointer_events/using_pointer_events/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using Pointer Events
 slug: Web/API/Pointer_events/Using_Pointer_Events
+page-type: guide
 tags:
   - Guide
   - Input

--- a/files/en-us/web/api/pointer_lock_api/index.md
+++ b/files/en-us/web/api/pointer_lock_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Pointer Lock API
 slug: Web/API/Pointer_Lock_API
+page-type: web-api-overview
 tags:
   - API
   - Advanced

--- a/files/en-us/web/api/pointerevent/getcoalescedevents/index.md
+++ b/files/en-us/web/api/pointerevent/getcoalescedevents/index.md
@@ -1,6 +1,7 @@
 ---
 title: PointerEvent.getCoalescedEvents()
 slug: Web/API/PointerEvent/getCoalescedEvents
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/pointerevent/height/index.md
+++ b/files/en-us/web/api/pointerevent/height/index.md
@@ -1,6 +1,7 @@
 ---
 title: PointerEvent.height
 slug: Web/API/PointerEvent/height
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/pointerevent/index.md
+++ b/files/en-us/web/api/pointerevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: PointerEvent
 slug: Web/API/PointerEvent
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/pointerevent/isprimary/index.md
+++ b/files/en-us/web/api/pointerevent/isprimary/index.md
@@ -1,6 +1,7 @@
 ---
 title: PointerEvent.isPrimary
 slug: Web/API/PointerEvent/isPrimary
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/pointerevent/pointerevent/index.md
+++ b/files/en-us/web/api/pointerevent/pointerevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: PointerEvent()
 slug: Web/API/PointerEvent/PointerEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/pointerevent/pointerid/index.md
+++ b/files/en-us/web/api/pointerevent/pointerid/index.md
@@ -1,6 +1,7 @@
 ---
 title: PointerEvent.pointerId
 slug: Web/API/PointerEvent/pointerId
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/pointerevent/pointertype/index.md
+++ b/files/en-us/web/api/pointerevent/pointertype/index.md
@@ -1,6 +1,7 @@
 ---
 title: PointerEvent.pointerType
 slug: Web/API/PointerEvent/pointerType
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/pointerevent/pressure/index.md
+++ b/files/en-us/web/api/pointerevent/pressure/index.md
@@ -1,6 +1,7 @@
 ---
 title: PointerEvent.pressure
 slug: Web/API/PointerEvent/pressure
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/pointerevent/tangentialpressure/index.md
+++ b/files/en-us/web/api/pointerevent/tangentialpressure/index.md
@@ -1,6 +1,7 @@
 ---
 title: PointerEvent.tangentialPressure
 slug: Web/API/PointerEvent/tangentialPressure
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/pointerevent/tiltx/index.md
+++ b/files/en-us/web/api/pointerevent/tiltx/index.md
@@ -1,6 +1,7 @@
 ---
 title: PointerEvent.tiltX
 slug: Web/API/PointerEvent/tiltX
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/pointerevent/tilty/index.md
+++ b/files/en-us/web/api/pointerevent/tilty/index.md
@@ -1,6 +1,7 @@
 ---
 title: PointerEvent.tiltY
 slug: Web/API/PointerEvent/tiltY
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/pointerevent/twist/index.md
+++ b/files/en-us/web/api/pointerevent/twist/index.md
@@ -1,6 +1,7 @@
 ---
 title: PointerEvent.twist
 slug: Web/API/PointerEvent/twist
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/pointerevent/width/index.md
+++ b/files/en-us/web/api/pointerevent/width/index.md
@@ -1,6 +1,7 @@
 ---
 title: PointerEvent.width
 slug: Web/API/PointerEvent/width
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/popstateevent/index.md
+++ b/files/en-us/web/api/popstateevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: PopStateEvent
 slug: Web/API/PopStateEvent
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/positionsensorvrdevice/getimmediatestate/index.md
+++ b/files/en-us/web/api/positionsensorvrdevice/getimmediatestate/index.md
@@ -1,6 +1,7 @@
 ---
 title: PositionSensorVRDevice.getImmediateState()
 slug: Web/API/PositionSensorVRDevice/getImmediateState
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/positionsensorvrdevice/getstate/index.md
+++ b/files/en-us/web/api/positionsensorvrdevice/getstate/index.md
@@ -1,6 +1,7 @@
 ---
 title: PositionSensorVRDevice.getState()
 slug: Web/API/PositionSensorVRDevice/getState
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/positionsensorvrdevice/index.md
+++ b/files/en-us/web/api/positionsensorvrdevice/index.md
@@ -1,6 +1,7 @@
 ---
 title: PositionSensorVRDevice
 slug: Web/API/PositionSensorVRDevice
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/positionsensorvrdevice/resetsensor/index.md
+++ b/files/en-us/web/api/positionsensorvrdevice/resetsensor/index.md
@@ -1,6 +1,7 @@
 ---
 title: PositionSensorVRDevice.resetSensor()
 slug: Web/API/PositionSensorVRDevice/resetSensor
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/presentation/defaultrequest/index.md
+++ b/files/en-us/web/api/presentation/defaultrequest/index.md
@@ -1,6 +1,7 @@
 ---
 title: Presentation.defaultRequest
 slug: Web/API/Presentation/defaultRequest
+page-type: web-api-instance-property
 tags:
   - API
   - Presentation

--- a/files/en-us/web/api/presentation/index.md
+++ b/files/en-us/web/api/presentation/index.md
@@ -1,6 +1,7 @@
 ---
 title: Presentation
 slug: Web/API/Presentation
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/presentation/receiver/index.md
+++ b/files/en-us/web/api/presentation/receiver/index.md
@@ -1,6 +1,7 @@
 ---
 title: Presentation.receiver
 slug: Web/API/Presentation/receiver
+page-type: web-api-instance-property
 tags:
   - API
   - Presentation

--- a/files/en-us/web/api/presentation_api/index.md
+++ b/files/en-us/web/api/presentation_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Presentation API
 slug: Web/API/Presentation_API
+page-type: web-api-overview
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/presentationavailability/index.md
+++ b/files/en-us/web/api/presentationavailability/index.md
@@ -1,6 +1,7 @@
 ---
 title: PresentationAvailability
 slug: Web/API/PresentationAvailability
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/presentationavailability/value/index.md
+++ b/files/en-us/web/api/presentationavailability/value/index.md
@@ -1,6 +1,7 @@
 ---
 title: PresentationAvailability.value
 slug: Web/API/PresentationAvailability/value
+page-type: web-api-instance-property
 browser-compat: api.PresentationAvailability.value
 ---
 

--- a/files/en-us/web/api/presentationconnection/binarytype/index.md
+++ b/files/en-us/web/api/presentationconnection/binarytype/index.md
@@ -1,6 +1,7 @@
 ---
 title: PresentationConnection.binaryType
 slug: Web/API/PresentationConnection/binaryType
+page-type: web-api-instance-property
 tags:
   - API
   - NeedsBrowserCompatibility

--- a/files/en-us/web/api/presentationconnection/close/index.md
+++ b/files/en-us/web/api/presentationconnection/close/index.md
@@ -1,6 +1,7 @@
 ---
 title: PresentationConnection.close()
 slug: Web/API/PresentationConnection/close
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/presentationconnection/id/index.md
+++ b/files/en-us/web/api/presentationconnection/id/index.md
@@ -1,6 +1,7 @@
 ---
 title: PresentationConnection.id
 slug: Web/API/PresentationConnection/id
+page-type: web-api-instance-property
 tags:
   - API
   - NeedsBrowserCompatibility

--- a/files/en-us/web/api/presentationconnection/index.md
+++ b/files/en-us/web/api/presentationconnection/index.md
@@ -1,6 +1,7 @@
 ---
 title: PresentationConnection
 slug: Web/API/PresentationConnection
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/presentationconnection/send/index.md
+++ b/files/en-us/web/api/presentationconnection/send/index.md
@@ -1,6 +1,7 @@
 ---
 title: PresentationConnection.send()
 slug: Web/API/PresentationConnection/send
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/presentationconnection/state/index.md
+++ b/files/en-us/web/api/presentationconnection/state/index.md
@@ -1,6 +1,7 @@
 ---
 title: PresentationConnection.state
 slug: Web/API/PresentationConnection/state
+page-type: web-api-instance-property
 tags:
   - API
   - NeedsBrowserCompatibility

--- a/files/en-us/web/api/presentationconnection/terminate/index.md
+++ b/files/en-us/web/api/presentationconnection/terminate/index.md
@@ -1,6 +1,7 @@
 ---
 title: PresentationConnection.terminate()
 slug: Web/API/PresentationConnection/terminate
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/presentationconnection/url/index.md
+++ b/files/en-us/web/api/presentationconnection/url/index.md
@@ -1,6 +1,7 @@
 ---
 title: PresentationConnection.url
 slug: Web/API/PresentationConnection/url
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/presentationconnectionavailableevent/connection/index.md
+++ b/files/en-us/web/api/presentationconnectionavailableevent/connection/index.md
@@ -1,6 +1,7 @@
 ---
 title: PresentationConnectionAvailableEvent.connection
 slug: Web/API/PresentationConnectionAvailableEvent/connection
+page-type: web-api-instance-property
 browser-compat: api.PresentationConnectionAvailableEvent.connection
 ---
 {{APIRef("Presentation API")}}

--- a/files/en-us/web/api/presentationconnectionavailableevent/index.md
+++ b/files/en-us/web/api/presentationconnectionavailableevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: PresentationConnectionAvailableEvent
 slug: Web/API/PresentationConnectionAvailableEvent
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/presentationconnectionavailableevent/presentationconnectionavailableevent/index.md
+++ b/files/en-us/web/api/presentationconnectionavailableevent/presentationconnectionavailableevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: PresentationConnectionAvailableEvent
 slug: Web/API/PresentationConnectionAvailableEvent/PresentationConnectionAvailableEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/presentationconnectioncloseevent/index.md
+++ b/files/en-us/web/api/presentationconnectioncloseevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: PresentationConnectionCloseEvent
 slug: Web/API/PresentationConnectionCloseEvent
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/presentationconnectionlist/index.md
+++ b/files/en-us/web/api/presentationconnectionlist/index.md
@@ -1,6 +1,7 @@
 ---
 title: PresentationConnectionList
 slug: Web/API/PresentationConnectionList
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/presentationreceiver/index.md
+++ b/files/en-us/web/api/presentationreceiver/index.md
@@ -1,6 +1,7 @@
 ---
 title: PresentationReceiver
 slug: Web/API/PresentationReceiver
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/presentationrequest/getavailability/index.md
+++ b/files/en-us/web/api/presentationrequest/getavailability/index.md
@@ -1,6 +1,7 @@
 ---
 title: PresentationRequest.getAvailability()
 slug: Web/API/PresentationRequest/getAvailability
+page-type: web-api-instance-method
 browser-compat: api.PresentationRequest.getAvailability
 ---
 

--- a/files/en-us/web/api/presentationrequest/index.md
+++ b/files/en-us/web/api/presentationrequest/index.md
@@ -1,6 +1,7 @@
 ---
 title: PresentationRequest
 slug: Web/API/PresentationRequest
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/presentationrequest/presentationrequest/index.md
+++ b/files/en-us/web/api/presentationrequest/presentationrequest/index.md
@@ -1,6 +1,7 @@
 ---
 title: PresentationRequest()
 slug: Web/API/PresentationRequest/PresentationRequest
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/presentationrequest/reconnect/index.md
+++ b/files/en-us/web/api/presentationrequest/reconnect/index.md
@@ -1,6 +1,7 @@
 ---
 title: PresentationRequest.reconnect()
 slug: Web/API/PresentationRequest/reconnect
+page-type: web-api-instance-method
 tags:
   - Promise
   - controlled presentations

--- a/files/en-us/web/api/presentationrequest/start/index.md
+++ b/files/en-us/web/api/presentationrequest/start/index.md
@@ -1,6 +1,7 @@
 ---
 title: PresentationRequest.start()
 slug: Web/API/PresentationRequest/start
+page-type: web-api-instance-method
 tags:
   - Experimental
   - Method

--- a/files/en-us/web/api/processinginstruction/index.md
+++ b/files/en-us/web/api/processinginstruction/index.md
@@ -1,6 +1,7 @@
 ---
 title: ProcessingInstruction
 slug: Web/API/ProcessingInstruction
+page-type: web-api-interface
 tags:
   - Interface
   - Reference

--- a/files/en-us/web/api/processinginstruction/sheet/index.md
+++ b/files/en-us/web/api/processinginstruction/sheet/index.md
@@ -1,6 +1,7 @@
 ---
 title: ProcessingInstruction.sheet
 slug: Web/API/ProcessingInstruction/sheet
+page-type: web-api-instance-property
 tags:
   - Property
   - Reference

--- a/files/en-us/web/api/processinginstruction/target/index.md
+++ b/files/en-us/web/api/processinginstruction/target/index.md
@@ -1,6 +1,7 @@
 ---
 title: ProcessingInstruction.target
 slug: Web/API/ProcessingInstruction/target
+page-type: web-api-instance-property
 tags:
   - Property
   - Reference

--- a/files/en-us/web/api/progressevent/index.md
+++ b/files/en-us/web/api/progressevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: ProgressEvent
 slug: Web/API/ProgressEvent
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/progressevent/initprogressevent/index.md
+++ b/files/en-us/web/api/progressevent/initprogressevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: ProgressEvent.initProgressEvent()
 slug: Web/API/ProgressEvent/initProgressEvent
+page-type: web-api-instance-method
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/progressevent/lengthcomputable/index.md
+++ b/files/en-us/web/api/progressevent/lengthcomputable/index.md
@@ -1,6 +1,7 @@
 ---
 title: ProgressEvent.lengthComputable
 slug: Web/API/ProgressEvent/lengthComputable
+page-type: web-api-instance-property
 tags:
   - API
   - Progress Events

--- a/files/en-us/web/api/progressevent/loaded/index.md
+++ b/files/en-us/web/api/progressevent/loaded/index.md
@@ -1,6 +1,7 @@
 ---
 title: ProgressEvent.loaded
 slug: Web/API/ProgressEvent/loaded
+page-type: web-api-instance-property
 tags:
   - API
   - Progress Event

--- a/files/en-us/web/api/progressevent/progressevent/index.md
+++ b/files/en-us/web/api/progressevent/progressevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: ProgressEvent()
 slug: Web/API/ProgressEvent/ProgressEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/progressevent/total/index.md
+++ b/files/en-us/web/api/progressevent/total/index.md
@@ -1,6 +1,7 @@
 ---
 title: ProgressEvent.total
 slug: Web/API/ProgressEvent/total
+page-type: web-api-instance-property
 tags:
   - API
   - Progress Event

--- a/files/en-us/web/api/promiserejectionevent/index.md
+++ b/files/en-us/web/api/promiserejectionevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: PromiseRejectionEvent
 slug: Web/API/PromiseRejectionEvent
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/promiserejectionevent/promise/index.md
+++ b/files/en-us/web/api/promiserejectionevent/promise/index.md
@@ -1,6 +1,7 @@
 ---
 title: PromiseRejectionEvent.promise
 slug: Web/API/PromiseRejectionEvent/promise
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/promiserejectionevent/promiserejectionevent/index.md
+++ b/files/en-us/web/api/promiserejectionevent/promiserejectionevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: PromiseRejectionEvent()
 slug: Web/API/PromiseRejectionEvent/PromiseRejectionEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/promiserejectionevent/reason/index.md
+++ b/files/en-us/web/api/promiserejectionevent/reason/index.md
@@ -1,6 +1,7 @@
 ---
 title: PromiseRejectionEvent.reason
 slug: Web/API/PromiseRejectionEvent/reason
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/proximity_events/index.md
+++ b/files/en-us/web/api/proximity_events/index.md
@@ -1,6 +1,7 @@
 ---
 title: Proximity Events
 slug: Web/API/Proximity_Events
+page-type: web-api-overview
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/publickeycredential/getclientextensionresults/index.md
+++ b/files/en-us/web/api/publickeycredential/getclientextensionresults/index.md
@@ -1,6 +1,7 @@
 ---
 title: PublicKeyCredential.getClientExtensionResults()
 slug: Web/API/PublicKeyCredential/getClientExtensionResults
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/publickeycredential/id/index.md
+++ b/files/en-us/web/api/publickeycredential/id/index.md
@@ -1,6 +1,7 @@
 ---
 title: PublicKeyCredential.id
 slug: Web/API/PublicKeyCredential/id
+page-type: web-api-instance-property
 tags:
   - API
   - Credential Management API

--- a/files/en-us/web/api/publickeycredential/index.md
+++ b/files/en-us/web/api/publickeycredential/index.md
@@ -1,6 +1,7 @@
 ---
 title: PublicKeyCredential
 slug: Web/API/PublicKeyCredential
+page-type: web-api-interface
 tags:
   - API
   - Authentication

--- a/files/en-us/web/api/publickeycredential/isuserverifyingplatformauthenticatoravailable/index.md
+++ b/files/en-us/web/api/publickeycredential/isuserverifyingplatformauthenticatoravailable/index.md
@@ -1,6 +1,7 @@
 ---
 title: PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable()
 slug: Web/API/PublicKeyCredential/isUserVerifyingPlatformAuthenticatorAvailable
+page-type: web-api-static-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/publickeycredential/rawid/index.md
+++ b/files/en-us/web/api/publickeycredential/rawid/index.md
@@ -1,6 +1,7 @@
 ---
 title: PublicKeyCredential.rawId
 slug: Web/API/PublicKeyCredential/rawId
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/publickeycredential/response/index.md
+++ b/files/en-us/web/api/publickeycredential/response/index.md
@@ -1,6 +1,7 @@
 ---
 title: PublicKeyCredential.response
 slug: Web/API/PublicKeyCredential/response
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/publickeycredentialrequestoptions/index.md
+++ b/files/en-us/web/api/publickeycredentialrequestoptions/index.md
@@ -1,6 +1,7 @@
 ---
 title: PublicKeyCredentialRequestOptions
 slug: Web/API/PublicKeyCredentialRequestOptions
+page-type: web-api-interface
 tags:
   - API
   - Dictionary

--- a/files/en-us/web/api/push_api/best_practices/index.md
+++ b/files/en-us/web/api/push_api/best_practices/index.md
@@ -1,6 +1,7 @@
 ---
 title: Web Push API Notifications best practices
 slug: Web/API/Push_API/Best_Practices
+page-type: guide
 tags:
   - Apps
   - Beginner

--- a/files/en-us/web/api/push_api/index.md
+++ b/files/en-us/web/api/push_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Push API
 slug: Web/API/Push_API
+page-type: web-api-overview
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/pushevent/data/index.md
+++ b/files/en-us/web/api/pushevent/data/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushEvent.data
 slug: Web/API/PushEvent/data
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/pushevent/index.md
+++ b/files/en-us/web/api/pushevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushEvent
 slug: Web/API/PushEvent
+page-type: web-api-interface
 tags:
   - API
   - ExtendableEvent

--- a/files/en-us/web/api/pushevent/pushevent/index.md
+++ b/files/en-us/web/api/pushevent/pushevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushEvent()
 slug: Web/API/PushEvent/PushEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/pushmanager/getsubscription/index.md
+++ b/files/en-us/web/api/pushmanager/getsubscription/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushManager.getSubscription()
 slug: Web/API/PushManager/getSubscription
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/pushmanager/haspermission/index.md
+++ b/files/en-us/web/api/pushmanager/haspermission/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushManager.hasPermission()
 slug: Web/API/PushManager/hasPermission
+page-type: web-api-instance-method
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/pushmanager/index.md
+++ b/files/en-us/web/api/pushmanager/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushManager
 slug: Web/API/PushManager
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/pushmanager/permissionstate/index.md
+++ b/files/en-us/web/api/pushmanager/permissionstate/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushManager.permissionState()
 slug: Web/API/PushManager/permissionState
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/pushmanager/register/index.md
+++ b/files/en-us/web/api/pushmanager/register/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushManager.register()
 slug: Web/API/PushManager/register
+page-type: web-api-instance-method
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/pushmanager/registrations/index.md
+++ b/files/en-us/web/api/pushmanager/registrations/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushManager.registrations()
 slug: Web/API/PushManager/registrations
+page-type: web-api-instance-method
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/pushmanager/subscribe/index.md
+++ b/files/en-us/web/api/pushmanager/subscribe/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushManager.subscribe()
 slug: Web/API/PushManager/subscribe
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/pushmanager/supportedcontentencodings/index.md
+++ b/files/en-us/web/api/pushmanager/supportedcontentencodings/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushManager.supportedContentEncodings
 slug: Web/API/PushManager/supportedContentEncodings
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/pushmanager/unregister/index.md
+++ b/files/en-us/web/api/pushmanager/unregister/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushManager.unregister()
 slug: Web/API/PushManager/unregister
+page-type: web-api-instance-method
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/pushmessagedata/arraybuffer/index.md
+++ b/files/en-us/web/api/pushmessagedata/arraybuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushMessageData.arrayBuffer()
 slug: Web/API/PushMessageData/arrayBuffer
+page-type: web-api-instance-method
 tags:
   - API
   - ArrayBuffer

--- a/files/en-us/web/api/pushmessagedata/blob/index.md
+++ b/files/en-us/web/api/pushmessagedata/blob/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushMessageData.blob()
 slug: Web/API/PushMessageData/blob
+page-type: web-api-instance-method
 tags:
   - API
   - Blob

--- a/files/en-us/web/api/pushmessagedata/index.md
+++ b/files/en-us/web/api/pushmessagedata/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushMessageData
 slug: Web/API/PushMessageData
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/pushmessagedata/json/index.md
+++ b/files/en-us/web/api/pushmessagedata/json/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushMessageData.json()
 slug: Web/API/PushMessageData/json
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/pushmessagedata/text/index.md
+++ b/files/en-us/web/api/pushmessagedata/text/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushMessageData.text()
 slug: Web/API/PushMessageData/text
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/pushsubscription/endpoint/index.md
+++ b/files/en-us/web/api/pushsubscription/endpoint/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushSubscription.endpoint
 slug: Web/API/PushSubscription/endpoint
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/pushsubscription/expirationtime/index.md
+++ b/files/en-us/web/api/pushsubscription/expirationtime/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushSubscription.expirationTime
 slug: Web/API/PushSubscription/expirationTime
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/pushsubscription/getkey/index.md
+++ b/files/en-us/web/api/pushsubscription/getkey/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushSubscription.getKey()
 slug: Web/API/PushSubscription/getKey
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/pushsubscription/index.md
+++ b/files/en-us/web/api/pushsubscription/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushSubscription
 slug: Web/API/PushSubscription
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/pushsubscription/options/index.md
+++ b/files/en-us/web/api/pushsubscription/options/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushSubscription.options
 slug: Web/API/PushSubscription/options
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/pushsubscription/subscriptionid/index.md
+++ b/files/en-us/web/api/pushsubscription/subscriptionid/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushSubscription.subscriptionId
 slug: Web/API/PushSubscription/subscriptionId
+page-type: web-api-instance-property
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/pushsubscription/tojson/index.md
+++ b/files/en-us/web/api/pushsubscription/tojson/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushSubscription.toJSON()
 slug: Web/API/PushSubscription/toJSON
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/pushsubscription/unsubscribe/index.md
+++ b/files/en-us/web/api/pushsubscription/unsubscribe/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushSubscription.unsubscribe()
 slug: Web/API/PushSubscription/unsubscribe
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/pushsubscriptionoptions/applicationserverkey/index.md
+++ b/files/en-us/web/api/pushsubscriptionoptions/applicationserverkey/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushSubscriptionOptions.applicationServerKey
 slug: Web/API/PushSubscriptionOptions/applicationServerKey
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/pushsubscriptionoptions/index.md
+++ b/files/en-us/web/api/pushsubscriptionoptions/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushSubscriptionOptions
 slug: Web/API/PushSubscriptionOptions
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/pushsubscriptionoptions/uservisibleonly/index.md
+++ b/files/en-us/web/api/pushsubscriptionoptions/uservisibleonly/index.md
@@ -1,6 +1,7 @@
 ---
 title: PushSubscriptionOptions.userVisibleOnly
 slug: Web/API/PushSubscriptionOptions/userVisibleOnly
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/queuemicrotask/index.md
+++ b/files/en-us/web/api/queuemicrotask/index.md
@@ -1,6 +1,7 @@
 ---
 title: queueMicrotask()
 slug: Web/API/queueMicrotask
+page-type: web-api-global-function
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/radionodelist/index.md
+++ b/files/en-us/web/api/radionodelist/index.md
@@ -1,6 +1,7 @@
 ---
 title: RadioNodeList
 slug: Web/API/RadioNodeList
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/radionodelist/value/index.md
+++ b/files/en-us/web/api/radionodelist/value/index.md
@@ -1,6 +1,7 @@
 ---
 title: RadioNodeList.value
 slug: Web/API/RadioNodeList/value
+page-type: web-api-instance-property
 tags:
   - HTML DOM
   - Property

--- a/files/en-us/web/api/range/clonecontents/index.md
+++ b/files/en-us/web/api/range/clonecontents/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.cloneContents()
 slug: Web/API/Range/cloneContents
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/clonerange/index.md
+++ b/files/en-us/web/api/range/clonerange/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.cloneRange()
 slug: Web/API/Range/cloneRange
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/collapse/index.md
+++ b/files/en-us/web/api/range/collapse/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.collapse()
 slug: Web/API/Range/collapse
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/collapsed/index.md
+++ b/files/en-us/web/api/range/collapsed/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.collapsed
 slug: Web/API/Range/collapsed
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/commonancestorcontainer/index.md
+++ b/files/en-us/web/api/range/commonancestorcontainer/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.commonAncestorContainer
 slug: Web/API/Range/commonAncestorContainer
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/compareboundarypoints/index.md
+++ b/files/en-us/web/api/range/compareboundarypoints/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.compareBoundaryPoints()
 slug: Web/API/Range/compareBoundaryPoints
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/comparenode/index.md
+++ b/files/en-us/web/api/range/comparenode/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.compareNode()
 slug: Web/API/Range/compareNode
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/comparepoint/index.md
+++ b/files/en-us/web/api/range/comparepoint/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.comparePoint()
 slug: Web/API/Range/comparePoint
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/createcontextualfragment/index.md
+++ b/files/en-us/web/api/range/createcontextualfragment/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.createContextualFragment()
 slug: Web/API/Range/createContextualFragment
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/deletecontents/index.md
+++ b/files/en-us/web/api/range/deletecontents/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.deleteContents()
 slug: Web/API/Range/deleteContents
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/detach/index.md
+++ b/files/en-us/web/api/range/detach/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.detach()
 slug: Web/API/Range/detach
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/endcontainer/index.md
+++ b/files/en-us/web/api/range/endcontainer/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.endContainer
 slug: Web/API/Range/endContainer
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/endoffset/index.md
+++ b/files/en-us/web/api/range/endoffset/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.endOffset
 slug: Web/API/Range/endOffset
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/extractcontents/index.md
+++ b/files/en-us/web/api/range/extractcontents/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.extractContents()
 slug: Web/API/Range/extractContents
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/getboundingclientrect/index.md
+++ b/files/en-us/web/api/range/getboundingclientrect/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.getBoundingClientRect()
 slug: Web/API/Range/getBoundingClientRect
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/range/getclientrects/index.md
+++ b/files/en-us/web/api/range/getclientrects/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.getClientRects()
 slug: Web/API/Range/getClientRects
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/range/index.md
+++ b/files/en-us/web/api/range/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range
 slug: Web/API/Range
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/insertnode/index.md
+++ b/files/en-us/web/api/range/insertnode/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.insertNode()
 slug: Web/API/Range/insertNode
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/intersectsnode/index.md
+++ b/files/en-us/web/api/range/intersectsnode/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.intersectsNode()
 slug: Web/API/Range/intersectsNode
+page-type: web-api-instance-method
 tags:
   - API
   - DOM


### PR DESCRIPTION
See  https://github.com/mdn/content/issues/16255. This is part 18 of a series of PRs to add page types to the Web/API documentation.