### PR TITLE
Add Web/API page types, part 19

### DIFF
--- a/files/en-us/web/api/range/ispointinrange/index.md
+++ b/files/en-us/web/api/range/ispointinrange/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.isPointInRange()
 slug: Web/API/Range/isPointInRange
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/range/index.md
+++ b/files/en-us/web/api/range/range/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range()
 slug: Web/API/Range/Range
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/range/selectnode/index.md
+++ b/files/en-us/web/api/range/selectnode/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.selectNode()
 slug: Web/API/Range/selectNode
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/selectnodecontents/index.md
+++ b/files/en-us/web/api/range/selectnodecontents/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.selectNodeContents()
 slug: Web/API/Range/selectNodeContents
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/setend/index.md
+++ b/files/en-us/web/api/range/setend/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.setEnd()
 slug: Web/API/Range/setEnd
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/setendafter/index.md
+++ b/files/en-us/web/api/range/setendafter/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.setEndAfter()
 slug: Web/API/Range/setEndAfter
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/setendbefore/index.md
+++ b/files/en-us/web/api/range/setendbefore/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.setEndBefore()
 slug: Web/API/Range/setEndBefore
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/setstart/index.md
+++ b/files/en-us/web/api/range/setstart/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.setStart()
 slug: Web/API/Range/setStart
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/setstartafter/index.md
+++ b/files/en-us/web/api/range/setstartafter/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.setStartAfter()
 slug: Web/API/Range/setStartAfter
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/setstartbefore/index.md
+++ b/files/en-us/web/api/range/setstartbefore/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.setStartBefore()
 slug: Web/API/Range/setStartBefore
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/startcontainer/index.md
+++ b/files/en-us/web/api/range/startcontainer/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.startContainer
 slug: Web/API/Range/startContainer
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/startoffset/index.md
+++ b/files/en-us/web/api/range/startoffset/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.startOffset
 slug: Web/API/Range/startOffset
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/surroundcontents/index.md
+++ b/files/en-us/web/api/range/surroundcontents/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.surroundContents()
 slug: Web/API/Range/surroundContents
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/range/tostring/index.md
+++ b/files/en-us/web/api/range/tostring/index.md
@@ -1,6 +1,7 @@
 ---
 title: Range.toString()
 slug: Web/API/Range/toString
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/readablebytestreamcontroller/byobrequest/index.md
+++ b/files/en-us/web/api/readablebytestreamcontroller/byobrequest/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableByteStreamController.byobRequest
 slug: Web/API/ReadableByteStreamController/byobRequest
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/readablebytestreamcontroller/close/index.md
+++ b/files/en-us/web/api/readablebytestreamcontroller/close/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableByteStreamController.close()
 slug: Web/API/ReadableByteStreamController/close
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/readablebytestreamcontroller/desiredsize/index.md
+++ b/files/en-us/web/api/readablebytestreamcontroller/desiredsize/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableByteStreamController.desiredSize
 slug: Web/API/ReadableByteStreamController/desiredSize
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/readablebytestreamcontroller/enqueue/index.md
+++ b/files/en-us/web/api/readablebytestreamcontroller/enqueue/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableByteStreamController.enqueue()
 slug: Web/API/ReadableByteStreamController/enqueue
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/readablebytestreamcontroller/error/index.md
+++ b/files/en-us/web/api/readablebytestreamcontroller/error/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableByteStreamController.error()
 slug: Web/API/ReadableByteStreamController/error
+page-type: web-api-instance-method
 tags:
   - API
   - Error

--- a/files/en-us/web/api/readablebytestreamcontroller/index.md
+++ b/files/en-us/web/api/readablebytestreamcontroller/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableByteStreamController
 slug: Web/API/ReadableByteStreamController
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/readablestream/cancel/index.md
+++ b/files/en-us/web/api/readablestream/cancel/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStream.cancel()
 slug: Web/API/ReadableStream/cancel
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/readablestream/getreader/index.md
+++ b/files/en-us/web/api/readablestream/getreader/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStream.getReader()
 slug: Web/API/ReadableStream/getReader
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStream
 slug: Web/API/ReadableStream
+page-type: web-api-interface
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/readablestream/locked/index.md
+++ b/files/en-us/web/api/readablestream/locked/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStream.locked
 slug: Web/API/ReadableStream/locked
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/readablestream/pipethrough/index.md
+++ b/files/en-us/web/api/readablestream/pipethrough/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStream.pipeThrough()
 slug: Web/API/ReadableStream/pipeThrough
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/readablestream/pipeto/index.md
+++ b/files/en-us/web/api/readablestream/pipeto/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStream.pipeTo()
 slug: Web/API/ReadableStream/pipeTo
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/readablestream/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/readablestream/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStream()
 slug: Web/API/ReadableStream/ReadableStream
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/readablestream/tee/index.md
+++ b/files/en-us/web/api/readablestream/tee/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStream.tee()
 slug: Web/API/ReadableStream/tee
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/readablestreambyobreader/cancel/index.md
+++ b/files/en-us/web/api/readablestreambyobreader/cancel/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStreamBYOBReader.cancel()
 slug: Web/API/ReadableStreamBYOBReader/cancel
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/readablestreambyobreader/closed/index.md
+++ b/files/en-us/web/api/readablestreambyobreader/closed/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStreamBYOBReader.closed
 slug: Web/API/ReadableStreamBYOBReader/closed
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/readablestreambyobreader/index.md
+++ b/files/en-us/web/api/readablestreambyobreader/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStreamBYOBReader
 slug: Web/API/ReadableStreamBYOBReader
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/readablestreambyobreader/read/index.md
+++ b/files/en-us/web/api/readablestreambyobreader/read/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStreamBYOBReader.read()
 slug: Web/API/ReadableStreamBYOBReader/read
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/readablestreambyobreader/readablestreambyobreader/index.md
+++ b/files/en-us/web/api/readablestreambyobreader/readablestreambyobreader/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStreamBYOBReader()
 slug: Web/API/ReadableStreamBYOBReader/ReadableStreamBYOBReader
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/readablestreambyobreader/releaselock/index.md
+++ b/files/en-us/web/api/readablestreambyobreader/releaselock/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStreamBYOBReader.releaseLock()
 slug: Web/API/ReadableStreamBYOBReader/releaseLock
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/readablestreambyobrequest/index.md
+++ b/files/en-us/web/api/readablestreambyobrequest/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStreamBYOBRequest
 slug: Web/API/ReadableStreamBYOBRequest
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/readablestreambyobrequest/respond/index.md
+++ b/files/en-us/web/api/readablestreambyobrequest/respond/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStreamBYOBRequest.respond()
 slug: Web/API/ReadableStreamBYOBRequest/respond
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/readablestreambyobrequest/respondwithnewview/index.md
+++ b/files/en-us/web/api/readablestreambyobrequest/respondwithnewview/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStreamBYOBRequest.respondWithNewView()
 slug: Web/API/ReadableStreamBYOBRequest/respondWithNewView
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/readablestreambyobrequest/view/index.md
+++ b/files/en-us/web/api/readablestreambyobrequest/view/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStreamBYOBRequest.view
 slug: Web/API/ReadableStreamBYOBRequest/view
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/readablestreamdefaultcontroller/close/index.md
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/close/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStreamDefaultController.close()
 slug: Web/API/ReadableStreamDefaultController/close
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/readablestreamdefaultcontroller/desiredsize/index.md
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/desiredsize/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStreamDefaultController.desiredSize
 slug: Web/API/ReadableStreamDefaultController/desiredSize
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/readablestreamdefaultcontroller/enqueue/index.md
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/enqueue/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStreamDefaultController.enqueue()
 slug: Web/API/ReadableStreamDefaultController/enqueue
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/readablestreamdefaultcontroller/error/index.md
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/error/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStreamDefaultController.error()
 slug: Web/API/ReadableStreamDefaultController/error
+page-type: web-api-instance-method
 tags:
   - API
   - Error

--- a/files/en-us/web/api/readablestreamdefaultcontroller/index.md
+++ b/files/en-us/web/api/readablestreamdefaultcontroller/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStreamDefaultController
 slug: Web/API/ReadableStreamDefaultController
+page-type: web-api-interface
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/readablestreamdefaultreader/cancel/index.md
+++ b/files/en-us/web/api/readablestreamdefaultreader/cancel/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStreamDefaultReader.cancel()
 slug: Web/API/ReadableStreamDefaultReader/cancel
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/readablestreamdefaultreader/closed/index.md
+++ b/files/en-us/web/api/readablestreamdefaultreader/closed/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStreamDefaultReader.closed
 slug: Web/API/ReadableStreamDefaultReader/closed
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/readablestreamdefaultreader/index.md
+++ b/files/en-us/web/api/readablestreamdefaultreader/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStreamDefaultReader
 slug: Web/API/ReadableStreamDefaultReader
+page-type: web-api-interface
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/readablestreamdefaultreader/read/index.md
+++ b/files/en-us/web/api/readablestreamdefaultreader/read/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStreamDefaultReader.read()
 slug: Web/API/ReadableStreamDefaultReader/read
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/readablestreamdefaultreader/readablestreamdefaultreader/index.md
+++ b/files/en-us/web/api/readablestreamdefaultreader/readablestreamdefaultreader/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStreamDefaultReader()
 slug: Web/API/ReadableStreamDefaultReader/ReadableStreamDefaultReader
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/readablestreamdefaultreader/releaselock/index.md
+++ b/files/en-us/web/api/readablestreamdefaultreader/releaselock/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReadableStreamDefaultReader.releaseLock()
 slug: Web/API/ReadableStreamDefaultReader/releaseLock
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/relativeorientationsensor/index.md
+++ b/files/en-us/web/api/relativeorientationsensor/index.md
@@ -1,6 +1,7 @@
 ---
 title: RelativeOrientationSensor
 slug: Web/API/RelativeOrientationSensor
+page-type: web-api-interface
 tags:
   - API
   - Generic Sensor API

--- a/files/en-us/web/api/relativeorientationsensor/relativeorientationsensor/index.md
+++ b/files/en-us/web/api/relativeorientationsensor/relativeorientationsensor/index.md
@@ -1,6 +1,7 @@
 ---
 title: RelativeOrientationSensor()
 slug: Web/API/RelativeOrientationSensor/RelativeOrientationSensor
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/remote_playback_api/index.md
+++ b/files/en-us/web/api/remote_playback_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Remote Playback API
 slug: Web/API/Remote_Playback_API
+page-type: web-api-overview
 tags:
   - API
   - Overview

--- a/files/en-us/web/api/remoteplayback/cancelwatchavailability/index.md
+++ b/files/en-us/web/api/remoteplayback/cancelwatchavailability/index.md
@@ -1,6 +1,7 @@
 ---
 title: RemotePlayback.cancelWatchAvailability()
 slug: Web/API/RemotePlayback/cancelWatchAvailability
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/remoteplayback/connect_event/index.md
+++ b/files/en-us/web/api/remoteplayback/connect_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'RemotePlayback: connect event'
 slug: Web/API/RemotePlayback/connect_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/remoteplayback/connecting_event/index.md
+++ b/files/en-us/web/api/remoteplayback/connecting_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'RemotePlayback: connecting event'
 slug: Web/API/RemotePlayback/connecting_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/remoteplayback/disconnect_event/index.md
+++ b/files/en-us/web/api/remoteplayback/disconnect_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'RemotePlayback: disconnect event'
 slug: Web/API/RemotePlayback/disconnect_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/remoteplayback/index.md
+++ b/files/en-us/web/api/remoteplayback/index.md
@@ -1,6 +1,7 @@
 ---
 title: RemotePlayback
 slug: Web/API/RemotePlayback
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/remoteplayback/prompt/index.md
+++ b/files/en-us/web/api/remoteplayback/prompt/index.md
@@ -1,6 +1,7 @@
 ---
 title: RemotePlayback.prompt()
 slug: Web/API/RemotePlayback/prompt
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/remoteplayback/state/index.md
+++ b/files/en-us/web/api/remoteplayback/state/index.md
@@ -1,6 +1,7 @@
 ---
 title: RemotePlayback.state
 slug: Web/API/RemotePlayback/state
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/remoteplayback/watchavailability/index.md
+++ b/files/en-us/web/api/remoteplayback/watchavailability/index.md
@@ -1,6 +1,7 @@
 ---
 title: RemotePlayback.watchAvailability()
 slug: Web/API/RemotePlayback/watchAvailability
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/report/body/index.md
+++ b/files/en-us/web/api/report/body/index.md
@@ -1,6 +1,7 @@
 ---
 title: Report.body
 slug: Web/API/Report/body
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/report/index.md
+++ b/files/en-us/web/api/report/index.md
@@ -1,6 +1,7 @@
 ---
 title: Report
 slug: Web/API/Report
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/report/type/index.md
+++ b/files/en-us/web/api/report/type/index.md
@@ -1,6 +1,7 @@
 ---
 title: Report.type
 slug: Web/API/Report/type
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/report/url/index.md
+++ b/files/en-us/web/api/report/url/index.md
@@ -1,6 +1,7 @@
 ---
 title: Report.url
 slug: Web/API/Report/url
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/reportbody/index.md
+++ b/files/en-us/web/api/reportbody/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReportBody
 slug: Web/API/ReportBody
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/reportbody/tojson/index.md
+++ b/files/en-us/web/api/reportbody/tojson/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReportBody.toJSON()
 slug: Web/API/ReportBody/toJSON
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/reporterror/index.md
+++ b/files/en-us/web/api/reporterror/index.md
@@ -1,6 +1,7 @@
 ---
 title: reportError()
 slug: Web/API/reportError
+page-type: web-api-global-function
 tags:
   - API
   - Method

--- a/files/en-us/web/api/reporting_api/index.md
+++ b/files/en-us/web/api/reporting_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Reporting API
 slug: Web/API/Reporting_API
+page-type: web-api-overview
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/reportingobserver/disconnect/index.md
+++ b/files/en-us/web/api/reportingobserver/disconnect/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReportingObserver.disconnect()
 slug: Web/API/ReportingObserver/disconnect
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/reportingobserver/index.md
+++ b/files/en-us/web/api/reportingobserver/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReportingObserver
 slug: Web/API/ReportingObserver
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/reportingobserver/observe/index.md
+++ b/files/en-us/web/api/reportingobserver/observe/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReportingObserver.observe()
 slug: Web/API/ReportingObserver/observe
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/reportingobserver/reportingobserver/index.md
+++ b/files/en-us/web/api/reportingobserver/reportingobserver/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReportingObserver()
 slug: Web/API/ReportingObserver/ReportingObserver
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/reportingobserver/takerecords/index.md
+++ b/files/en-us/web/api/reportingobserver/takerecords/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReportingObserver.takeRecords()
 slug: Web/API/ReportingObserver/takeRecords
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/reportingobserveroptions/index.md
+++ b/files/en-us/web/api/reportingobserveroptions/index.md
@@ -1,6 +1,7 @@
 ---
 title: ReportingObserverOptions
 slug: Web/API/ReportingObserverOptions
+page-type: web-api-interface
 tags:
   - API
   - Dictionary

--- a/files/en-us/web/api/request/arraybuffer/index.md
+++ b/files/en-us/web/api/request/arraybuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: Request.arrayBuffer()
 slug: Web/API/Request/arrayBuffer
+page-type: web-api-instance-method
 tags:
   - API
   - ArrayBuffer

--- a/files/en-us/web/api/request/blob/index.md
+++ b/files/en-us/web/api/request/blob/index.md
@@ -1,6 +1,7 @@
 ---
 title: Request.blob()
 slug: Web/API/Request/blob
+page-type: web-api-instance-method
 tags:
   - API
   - Blob

--- a/files/en-us/web/api/request/body/index.md
+++ b/files/en-us/web/api/request/body/index.md
@@ -1,6 +1,7 @@
 ---
 title: Request.body
 slug: Web/API/Request/body
+page-type: web-api-instance-property
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/request/bodyused/index.md
+++ b/files/en-us/web/api/request/bodyused/index.md
@@ -1,6 +1,7 @@
 ---
 title: Request.bodyUsed
 slug: Web/API/Request/bodyUsed
+page-type: web-api-instance-property
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/request/cache/index.md
+++ b/files/en-us/web/api/request/cache/index.md
@@ -1,6 +1,7 @@
 ---
 title: Request.cache
 slug: Web/API/Request/cache
+page-type: web-api-instance-property
 tags:
   - API
   - Cache

--- a/files/en-us/web/api/request/clone/index.md
+++ b/files/en-us/web/api/request/clone/index.md
@@ -1,6 +1,7 @@
 ---
 title: Request.clone()
 slug: Web/API/Request/clone
+page-type: web-api-instance-method
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/request/credentials/index.md
+++ b/files/en-us/web/api/request/credentials/index.md
@@ -1,6 +1,7 @@
 ---
 title: Request.credentials
 slug: Web/API/Request/credentials
+page-type: web-api-instance-property
 tags:
   - API
   - Cookies

--- a/files/en-us/web/api/request/destination/index.md
+++ b/files/en-us/web/api/request/destination/index.md
@@ -1,6 +1,7 @@
 ---
 title: Request.destination
 slug: Web/API/Request/destination
+page-type: web-api-instance-property
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/request/formdata/index.md
+++ b/files/en-us/web/api/request/formdata/index.md
@@ -1,6 +1,7 @@
 ---
 title: Request.formData()
 slug: Web/API/Request/formData
+page-type: web-api-instance-method
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/request/headers/index.md
+++ b/files/en-us/web/api/request/headers/index.md
@@ -1,6 +1,7 @@
 ---
 title: Request.headers
 slug: Web/API/Request/headers
+page-type: web-api-instance-property
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/request/index.md
+++ b/files/en-us/web/api/request/index.md
@@ -1,6 +1,7 @@
 ---
 title: Request
 slug: Web/API/Request
+page-type: web-api-interface
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/request/integrity/index.md
+++ b/files/en-us/web/api/request/integrity/index.md
@@ -1,6 +1,7 @@
 ---
 title: Request.integrity
 slug: Web/API/Request/integrity
+page-type: web-api-instance-property
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/request/json/index.md
+++ b/files/en-us/web/api/request/json/index.md
@@ -1,6 +1,7 @@
 ---
 title: Request.json()
 slug: Web/API/Request/json
+page-type: web-api-instance-method
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/request/method/index.md
+++ b/files/en-us/web/api/request/method/index.md
@@ -1,6 +1,7 @@
 ---
 title: Request.method
 slug: Web/API/Request/method
+page-type: web-api-instance-property
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/request/mode/index.md
+++ b/files/en-us/web/api/request/mode/index.md
@@ -1,6 +1,7 @@
 ---
 title: Request.mode
 slug: Web/API/Request/mode
+page-type: web-api-instance-property
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/request/priority/index.md
+++ b/files/en-us/web/api/request/priority/index.md
@@ -1,6 +1,7 @@
 ---
 title: Request.priority
 slug: Web/API/Request/priority
+page-type: web-api-instance-property
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/request/redirect/index.md
+++ b/files/en-us/web/api/request/redirect/index.md
@@ -1,6 +1,7 @@
 ---
 title: Request.redirect
 slug: Web/API/Request/redirect
+page-type: web-api-instance-property
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/request/referrer/index.md
+++ b/files/en-us/web/api/request/referrer/index.md
@@ -1,6 +1,7 @@
 ---
 title: Request.referrer
 slug: Web/API/Request/referrer
+page-type: web-api-instance-property
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/request/referrerpolicy/index.md
+++ b/files/en-us/web/api/request/referrerpolicy/index.md
@@ -1,6 +1,7 @@
 ---
 title: Request.referrerPolicy
 slug: Web/API/Request/referrerPolicy
+page-type: web-api-instance-property
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/request/request/index.md
+++ b/files/en-us/web/api/request/request/index.md
@@ -1,6 +1,7 @@
 ---
 title: Request()
 slug: Web/API/Request/Request
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/request/text/index.md
+++ b/files/en-us/web/api/request/text/index.md
@@ -1,6 +1,7 @@
 ---
 title: Request.text()
 slug: Web/API/Request/text
+page-type: web-api-instance-method
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/request/url/index.md
+++ b/files/en-us/web/api/request/url/index.md
@@ -1,6 +1,7 @@
 ---
 title: Request.url
 slug: Web/API/Request/url
+page-type: web-api-instance-property
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/resize_observer_api/index.md
+++ b/files/en-us/web/api/resize_observer_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Resize Observer API
 slug: Web/API/Resize_Observer_API
+page-type: web-api-overview
 tags:
   - API
   - Draft

--- a/files/en-us/web/api/resizeobserver/disconnect/index.md
+++ b/files/en-us/web/api/resizeobserver/disconnect/index.md
@@ -1,6 +1,7 @@
 ---
 title: ResizeObserver.disconnect()
 slug: Web/API/ResizeObserver/disconnect
+page-type: web-api-instance-property
 tags:
   - API
   - Method

--- a/files/en-us/web/api/resizeobserver/disconnect/index.md
+++ b/files/en-us/web/api/resizeobserver/disconnect/index.md
@@ -1,7 +1,7 @@
 ---
 title: ResizeObserver.disconnect()
 slug: Web/API/ResizeObserver/disconnect
-page-type: web-api-instance-property
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/resizeobserver/index.md
+++ b/files/en-us/web/api/resizeobserver/index.md
@@ -1,6 +1,7 @@
 ---
 title: ResizeObserver
 slug: Web/API/ResizeObserver
+page-type: web-api-interface
 tags:
   - API
   - Bounding Box

--- a/files/en-us/web/api/resizeobserver/observe/index.md
+++ b/files/en-us/web/api/resizeobserver/observe/index.md
@@ -1,6 +1,7 @@
 ---
 title: ResizeObserver.observe()
 slug: Web/API/ResizeObserver/observe
+page-type: web-api-instance-property
 tags:
   - API
   - Method

--- a/files/en-us/web/api/resizeobserver/observe/index.md
+++ b/files/en-us/web/api/resizeobserver/observe/index.md
@@ -1,7 +1,7 @@
 ---
 title: ResizeObserver.observe()
 slug: Web/API/ResizeObserver/observe
-page-type: web-api-instance-property
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/resizeobserver/resizeobserver/index.md
+++ b/files/en-us/web/api/resizeobserver/resizeobserver/index.md
@@ -1,6 +1,7 @@
 ---
 title: ResizeObserver()
 slug: Web/API/ResizeObserver/ResizeObserver
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/resizeobserver/unobserve/index.md
+++ b/files/en-us/web/api/resizeobserver/unobserve/index.md
@@ -1,6 +1,7 @@
 ---
 title: ResizeObserver.unobserve()
 slug: Web/API/ResizeObserver/unobserve
+page-type: web-api-instance-property
 tags:
   - API
   - Method

--- a/files/en-us/web/api/resizeobserver/unobserve/index.md
+++ b/files/en-us/web/api/resizeobserver/unobserve/index.md
@@ -1,7 +1,7 @@
 ---
 title: ResizeObserver.unobserve()
 slug: Web/API/ResizeObserver/unobserve
-page-type: web-api-instance-property
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/resizeobserverentry/borderboxsize/index.md
+++ b/files/en-us/web/api/resizeobserverentry/borderboxsize/index.md
@@ -1,6 +1,7 @@
 ---
 title: ResizeObserverEntry.borderBoxSize
 slug: Web/API/ResizeObserverEntry/borderBoxSize
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/resizeobserverentry/contentboxsize/index.md
+++ b/files/en-us/web/api/resizeobserverentry/contentboxsize/index.md
@@ -1,6 +1,7 @@
 ---
 title: ResizeObserverEntry.contentBoxSize
 slug: Web/API/ResizeObserverEntry/contentBoxSize
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/resizeobserverentry/contentrect/index.md
+++ b/files/en-us/web/api/resizeobserverentry/contentrect/index.md
@@ -1,6 +1,7 @@
 ---
 title: ResizeObserverEntry.contentRect
 slug: Web/API/ResizeObserverEntry/contentRect
+page-type: web-api-instance-property
 tags:
   - API
   - Bounding Box

--- a/files/en-us/web/api/resizeobserverentry/devicepixelcontentboxsize/index.md
+++ b/files/en-us/web/api/resizeobserverentry/devicepixelcontentboxsize/index.md
@@ -1,6 +1,7 @@
 ---
 title: ResizeObserverEntry.devicePixelContentBoxSize
 slug: Web/API/ResizeObserverEntry/devicePixelContentBoxSize
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/resizeobserverentry/index.md
+++ b/files/en-us/web/api/resizeobserverentry/index.md
@@ -1,6 +1,7 @@
 ---
 title: ResizeObserverEntry
 slug: Web/API/ResizeObserverEntry
+page-type: web-api-interface
 tags:
   - API
   - Bounding Box

--- a/files/en-us/web/api/resizeobserverentry/target/index.md
+++ b/files/en-us/web/api/resizeobserverentry/target/index.md
@@ -1,6 +1,7 @@
 ---
 title: ResizeObserverEntry.target
 slug: Web/API/ResizeObserverEntry/target
+page-type: web-api-instance-property
 tags:
   - API
   - Bounding Box

--- a/files/en-us/web/api/resizeobserversize/blocksize/index.md
+++ b/files/en-us/web/api/resizeobserversize/blocksize/index.md
@@ -1,6 +1,7 @@
 ---
 title: ResizeObserverSize.blockSize
 slug: Web/API/ResizeObserverSize/blockSize
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/resizeobserversize/index.md
+++ b/files/en-us/web/api/resizeobserversize/index.md
@@ -1,6 +1,7 @@
 ---
 title: ResizeObserverSize
 slug: Web/API/ResizeObserverSize
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/resizeobserversize/inlinesize/index.md
+++ b/files/en-us/web/api/resizeobserversize/inlinesize/index.md
@@ -1,6 +1,7 @@
 ---
 title: ResizeObserverSize.inlineSize
 slug: Web/API/ResizeObserverSize/inlineSize
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/resource_timing_api/index.md
+++ b/files/en-us/web/api/resource_timing_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Resource Timing API
 slug: Web/API/Resource_Timing_API
+page-type: web-api-overview
 tags:
   - API
   - Guide

--- a/files/en-us/web/api/resource_timing_api/using_the_resource_timing_api/index.md
+++ b/files/en-us/web/api/resource_timing_api/using_the_resource_timing_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using the Resource Timing API
 slug: Web/API/Resource_Timing_API/Using_the_Resource_Timing_API
+page-type: guide
 tags:
   - API
   - Guide

--- a/files/en-us/web/api/response/arraybuffer/index.md
+++ b/files/en-us/web/api/response/arraybuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: Response.arrayBuffer()
 slug: Web/API/Response/arrayBuffer
+page-type: web-api-instance-method
 tags:
   - API
   - ArrayBuffer

--- a/files/en-us/web/api/response/blob/index.md
+++ b/files/en-us/web/api/response/blob/index.md
@@ -1,6 +1,7 @@
 ---
 title: Response.blob()
 slug: Web/API/Response/blob
+page-type: web-api-instance-method
 tags:
   - API
   - Blob

--- a/files/en-us/web/api/response/body/index.md
+++ b/files/en-us/web/api/response/body/index.md
@@ -1,6 +1,7 @@
 ---
 title: Response.body
 slug: Web/API/Response/body
+page-type: web-api-instance-property
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/response/bodyused/index.md
+++ b/files/en-us/web/api/response/bodyused/index.md
@@ -1,6 +1,7 @@
 ---
 title: Response.bodyUsed
 slug: Web/API/Response/bodyUsed
+page-type: web-api-instance-property
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/response/clone/index.md
+++ b/files/en-us/web/api/response/clone/index.md
@@ -1,6 +1,7 @@
 ---
 title: Response.clone()
 slug: Web/API/Response/clone
+page-type: web-api-instance-method
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/response/error/index.md
+++ b/files/en-us/web/api/response/error/index.md
@@ -1,6 +1,7 @@
 ---
 title: Response.error()
 slug: Web/API/Response/error
+page-type: web-api-static-method
 tags:
   - API
   - Error

--- a/files/en-us/web/api/response/formdata/index.md
+++ b/files/en-us/web/api/response/formdata/index.md
@@ -1,6 +1,7 @@
 ---
 title: Response.formData()
 slug: Web/API/Response/formData
+page-type: web-api-instance-method
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/response/headers/index.md
+++ b/files/en-us/web/api/response/headers/index.md
@@ -1,6 +1,7 @@
 ---
 title: Response.headers
 slug: Web/API/Response/headers
+page-type: web-api-instance-property
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/response/index.md
+++ b/files/en-us/web/api/response/index.md
@@ -1,6 +1,7 @@
 ---
 title: Response
 slug: Web/API/Response
+page-type: web-api-interface
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/response/json/index.md
+++ b/files/en-us/web/api/response/json/index.md
@@ -1,6 +1,7 @@
 ---
 title: Response.json()
 slug: Web/API/Response/json
+page-type: web-api-instance-method
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/response/ok/index.md
+++ b/files/en-us/web/api/response/ok/index.md
@@ -1,6 +1,7 @@
 ---
 title: Response.ok
 slug: Web/API/Response/ok
+page-type: web-api-instance-property
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/response/redirect/index.md
+++ b/files/en-us/web/api/response/redirect/index.md
@@ -1,7 +1,7 @@
 ---
 title: Response.redirect()
 slug: Web/API/Response/redirect
-page-type: web-api-instance-method
+page-type: web-api-static-method
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/response/redirect/index.md
+++ b/files/en-us/web/api/response/redirect/index.md
@@ -1,6 +1,7 @@
 ---
 title: Response.redirect()
 slug: Web/API/Response/redirect
+page-type: web-api-instance-method
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/response/redirected/index.md
+++ b/files/en-us/web/api/response/redirected/index.md
@@ -1,6 +1,7 @@
 ---
 title: Response.redirected
 slug: Web/API/Response/redirected
+page-type: web-api-instance-property
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/response/response/index.md
+++ b/files/en-us/web/api/response/response/index.md
@@ -1,6 +1,7 @@
 ---
 title: Response()
 slug: Web/API/Response/Response
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/response/status/index.md
+++ b/files/en-us/web/api/response/status/index.md
@@ -1,6 +1,7 @@
 ---
 title: Response.status
 slug: Web/API/Response/status
+page-type: web-api-instance-property
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/response/statustext/index.md
+++ b/files/en-us/web/api/response/statustext/index.md
@@ -1,6 +1,7 @@
 ---
 title: Response.statusText
 slug: Web/API/Response/statusText
+page-type: web-api-instance-property
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/response/text/index.md
+++ b/files/en-us/web/api/response/text/index.md
@@ -1,6 +1,7 @@
 ---
 title: Response.text()
 slug: Web/API/Response/text
+page-type: web-api-instance-method
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/response/type/index.md
+++ b/files/en-us/web/api/response/type/index.md
@@ -1,6 +1,7 @@
 ---
 title: Response.type
 slug: Web/API/Response/type
+page-type: web-api-instance-property
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/response/url/index.md
+++ b/files/en-us/web/api/response/url/index.md
@@ -1,6 +1,7 @@
 ---
 title: Response.url
 slug: Web/API/Response/url
+page-type: web-api-instance-property
 tags:
   - API
   - Fetch

--- a/files/en-us/web/api/rsahashedimportparams/index.md
+++ b/files/en-us/web/api/rsahashedimportparams/index.md
@@ -1,6 +1,7 @@
 ---
 title: RsaHashedImportParams
 slug: Web/API/RsaHashedImportParams
+page-type: web-api-interface
 tags:
   - API
   - Dictionary

--- a/files/en-us/web/api/rsahashedkeygenparams/index.md
+++ b/files/en-us/web/api/rsahashedkeygenparams/index.md
@@ -1,6 +1,7 @@
 ---
 title: RsaHashedKeyGenParams
 slug: Web/API/RsaHashedKeyGenParams
+page-type: web-api-interface
 tags:
   - API
   - Dictionary

--- a/files/en-us/web/api/rsaoaepparams/index.md
+++ b/files/en-us/web/api/rsaoaepparams/index.md
@@ -1,6 +1,7 @@
 ---
 title: RsaOaepParams
 slug: Web/API/RsaOaepParams
+page-type: web-api-interface
 tags:
   - API
   - Dictionary

--- a/files/en-us/web/api/rsapssparams/index.md
+++ b/files/en-us/web/api/rsapssparams/index.md
@@ -1,6 +1,7 @@
 ---
 title: RsaPssParams
 slug: Web/API/RsaPssParams
+page-type: web-api-interface
 tags:
   - API
   - Dictionary

--- a/files/en-us/web/api/rtccertificate/index.md
+++ b/files/en-us/web/api/rtccertificate/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCCertificate
 slug: Web/API/RTCCertificate
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/rtcdatachannel/binarytype/index.md
+++ b/files/en-us/web/api/rtcdatachannel/binarytype/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDataChannel.binaryType
 slug: Web/API/RTCDataChannel/binaryType
+page-type: web-api-instance-property
 tags:
   - Property
   - RTCDataChannel

--- a/files/en-us/web/api/rtcdatachannel/bufferedamount/index.md
+++ b/files/en-us/web/api/rtcdatachannel/bufferedamount/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDataChannel.bufferedAmount
 slug: Web/API/RTCDataChannel/bufferedAmount
+page-type: web-api-instance-property
 tags:
   - Property
   - RTCDataChannel

--- a/files/en-us/web/api/rtcdatachannel/bufferedamountlow_event/index.md
+++ b/files/en-us/web/api/rtcdatachannel/bufferedamountlow_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'RTCDataChannel: bufferedamountlow event'
 slug: Web/API/RTCDataChannel/bufferedamountlow_event
+page-type: web-api-event
 tags:
   - API
   - Buffer

--- a/files/en-us/web/api/rtcdatachannel/bufferedamountlowthreshold/index.md
+++ b/files/en-us/web/api/rtcdatachannel/bufferedamountlowthreshold/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDataChannel.bufferedAmountLowThreshold
 slug: Web/API/RTCDataChannel/bufferedAmountLowThreshold
+page-type: web-api-instance-property
 tags:
   - Property
   - RTCDataChannel

--- a/files/en-us/web/api/rtcdatachannel/close/index.md
+++ b/files/en-us/web/api/rtcdatachannel/close/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDataChannel.close()
 slug: Web/API/RTCDataChannel/close
+page-type: web-api-instance-method
 tags:
   - API
   - Communication

--- a/files/en-us/web/api/rtcdatachannel/close_event/index.md
+++ b/files/en-us/web/api/rtcdatachannel/close_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'RTCDataChannel: close event'
 slug: Web/API/RTCDataChannel/close_event
+page-type: web-api-event
 tags:
   - API
   - Connection

--- a/files/en-us/web/api/rtcdatachannel/closing_event/index.md
+++ b/files/en-us/web/api/rtcdatachannel/closing_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'RTCDataChannel: closing event'
 slug: Web/API/RTCDataChannel/closing_event
+page-type: web-api-event
 tags:
   - API
   - Communications

--- a/files/en-us/web/api/rtcdatachannel/error_event/index.md
+++ b/files/en-us/web/api/rtcdatachannel/error_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'RTCDataChannel: error event'
 slug: Web/API/RTCDataChannel/error_event
+page-type: web-api-event
 tags:
   - API
   - Connectivity

--- a/files/en-us/web/api/rtcdatachannel/id/index.md
+++ b/files/en-us/web/api/rtcdatachannel/id/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDataChannel.id
 slug: Web/API/RTCDataChannel/id
+page-type: web-api-instance-property
 tags:
   - Property
   - RTCDataChannel

--- a/files/en-us/web/api/rtcdatachannel/index.md
+++ b/files/en-us/web/api/rtcdatachannel/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDataChannel
 slug: Web/API/RTCDataChannel
+page-type: web-api-interface
 tags:
   - API
   - Communication

--- a/files/en-us/web/api/rtcdatachannel/label/index.md
+++ b/files/en-us/web/api/rtcdatachannel/label/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDataChannel.label
 slug: Web/API/RTCDataChannel/label
+page-type: web-api-instance-property
 tags:
   - Property
   - RTCDataChannel

--- a/files/en-us/web/api/rtcdatachannel/maxpacketlifetime/index.md
+++ b/files/en-us/web/api/rtcdatachannel/maxpacketlifetime/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDataChannel.maxPacketLifeTime
 slug: Web/API/RTCDataChannel/maxPacketLifeTime
+page-type: web-api-instance-property
 tags:
   - Property
   - RTCDataChannel

--- a/files/en-us/web/api/rtcdatachannel/maxretransmits/index.md
+++ b/files/en-us/web/api/rtcdatachannel/maxretransmits/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDataChannel.maxRetransmits
 slug: Web/API/RTCDataChannel/maxRetransmits
+page-type: web-api-instance-property
 tags:
   - Property
   - RTCDataChannel

--- a/files/en-us/web/api/rtcdatachannel/message_event/index.md
+++ b/files/en-us/web/api/rtcdatachannel/message_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'RTCDataChannel: message event'
 slug: Web/API/RTCDataChannel/message_event
+page-type: web-api-event
 tags:
   - API
   - Data Channel

--- a/files/en-us/web/api/rtcdatachannel/negotiated/index.md
+++ b/files/en-us/web/api/rtcdatachannel/negotiated/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDataChannel.negotiated
 slug: Web/API/RTCDataChannel/negotiated
+page-type: web-api-instance-property
 tags:
   - Networking
   - Property

--- a/files/en-us/web/api/rtcdatachannel/open_event/index.md
+++ b/files/en-us/web/api/rtcdatachannel/open_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'RTCDataChannel: open event'
 slug: Web/API/RTCDataChannel/open_event
+page-type: web-api-event
 tags:
   - API
   - Connectivity

--- a/files/en-us/web/api/rtcdatachannel/ordered/index.md
+++ b/files/en-us/web/api/rtcdatachannel/ordered/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDataChannel.ordered
 slug: Web/API/RTCDataChannel/ordered
+page-type: web-api-instance-property
 tags:
   - Property
   - RTCDataChannel

--- a/files/en-us/web/api/rtcdatachannel/protocol/index.md
+++ b/files/en-us/web/api/rtcdatachannel/protocol/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDataChannel.protocol
 slug: Web/API/RTCDataChannel/protocol
+page-type: web-api-instance-property
 tags:
   - Property
   - Protocol

--- a/files/en-us/web/api/rtcdatachannel/readystate/index.md
+++ b/files/en-us/web/api/rtcdatachannel/readystate/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDataChannel.readyState
 slug: Web/API/RTCDataChannel/readyState
+page-type: web-api-instance-property
 tags:
   - Property
   - RTCDataChannel

--- a/files/en-us/web/api/rtcdatachannel/reliable/index.md
+++ b/files/en-us/web/api/rtcdatachannel/reliable/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDataChannel.reliable
 slug: Web/API/RTCDataChannel/reliable
+page-type: web-api-instance-property
 tags:
   - Deprecated
   - Non-standard

--- a/files/en-us/web/api/rtcdatachannel/send/index.md
+++ b/files/en-us/web/api/rtcdatachannel/send/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDataChannel.send()
 slug: Web/API/RTCDataChannel/send
+page-type: web-api-instance-method
 tags:
   - API
   - Communication

--- a/files/en-us/web/api/rtcdatachannel/stream/index.md
+++ b/files/en-us/web/api/rtcdatachannel/stream/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDataChannel.stream
 slug: Web/API/RTCDataChannel/stream
+page-type: web-api-instance-property
 tags:
   - Non-standard
   - Deprecated

--- a/files/en-us/web/api/rtcdatachannelevent/channel/index.md
+++ b/files/en-us/web/api/rtcdatachannelevent/channel/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDataChannelEvent.channel
 slug: Web/API/RTCDataChannelEvent/channel
+page-type: web-api-instance-property
 tags:
   - Property
   - RTCDataChannelEvent

--- a/files/en-us/web/api/rtcdatachannelevent/index.md
+++ b/files/en-us/web/api/rtcdatachannelevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDataChannelEvent
 slug: Web/API/RTCDataChannelEvent
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/rtcdatachannelevent/rtcdatachannelevent/index.md
+++ b/files/en-us/web/api/rtcdatachannelevent/rtcdatachannelevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDataChannelEvent()
 slug: Web/API/RTCDataChannelEvent/RTCDataChannelEvent
+page-type: web-api-constructor
 tags:
   - Constructor
   - RTCDataChannelEvent

--- a/files/en-us/web/api/rtcdtlstransport/error_event/index.md
+++ b/files/en-us/web/api/rtcdtlstransport/error_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'RTCDtlsTransport: error event'
 slug: Web/API/RTCDtlsTransport/error_event
+page-type: web-api-event
 tags:
   - API
   - Connection

--- a/files/en-us/web/api/rtcdtlstransport/icetransport/index.md
+++ b/files/en-us/web/api/rtcdtlstransport/icetransport/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDtlsTransport.iceTransport
 slug: Web/API/RTCDtlsTransport/iceTransport
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/rtcdtlstransport/index.md
+++ b/files/en-us/web/api/rtcdtlstransport/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDtlsTransport
 slug: Web/API/RTCDtlsTransport
+page-type: web-api-interface
 tags:
   - API
   - Draft

--- a/files/en-us/web/api/rtcdtlstransport/state/index.md
+++ b/files/en-us/web/api/rtcdtlstransport/state/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDtlsTransport.state
 slug: Web/API/RTCDtlsTransport/state
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/rtcdtmfsender/index.md
+++ b/files/en-us/web/api/rtcdtmfsender/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDTMFSender
 slug: Web/API/RTCDTMFSender
+page-type: web-api-interface
 tags:
   - Audio
   - DTMF

--- a/files/en-us/web/api/rtcdtmfsender/insertdtmf/index.md
+++ b/files/en-us/web/api/rtcdtmfsender/insertdtmf/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDTMFSender.insertDTMF()
 slug: Web/API/RTCDTMFSender/insertDTMF
+page-type: web-api-instance-method
 tags:
   - API
   - DTMF

--- a/files/en-us/web/api/rtcdtmfsender/tonebuffer/index.md
+++ b/files/en-us/web/api/rtcdtmfsender/tonebuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDTMFSender.toneBuffer
 slug: Web/API/RTCDTMFSender/toneBuffer
+page-type: web-api-instance-property
 tags:
   - Audio
   - DTMF

--- a/files/en-us/web/api/rtcdtmfsender/tonechange_event/index.md
+++ b/files/en-us/web/api/rtcdtmfsender/tonechange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'RTCDTMFSender: tonechange event'
 slug: Web/API/RTCDTMFSender/tonechange_event
+page-type: web-api-event
 tags:
   - DTMF
   - RTCDTMFSender

--- a/files/en-us/web/api/rtcdtmftonechangeevent/index.md
+++ b/files/en-us/web/api/rtcdtmftonechangeevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDTMFToneChangeEvent
 slug: Web/API/RTCDTMFToneChangeEvent
+page-type: web-api-interface
 tags:
   - DTMF
   - Reference

--- a/files/en-us/web/api/rtcdtmftonechangeevent/rtcdtmftonechangeevent/index.md
+++ b/files/en-us/web/api/rtcdtmftonechangeevent/rtcdtmftonechangeevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDTMFToneChangeEvent()
 slug: Web/API/RTCDTMFToneChangeEvent/RTCDTMFToneChangeEvent
+page-type: web-api-constructor
 tags:
   - Constructor
   - DTMF

--- a/files/en-us/web/api/rtcdtmftonechangeevent/tone/index.md
+++ b/files/en-us/web/api/rtcdtmftonechangeevent/tone/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCDTMFToneChangeEvent.tone
 slug: Web/API/RTCDTMFToneChangeEvent/tone
+page-type: web-api-instance-property
 tags:
   - Media
   - Property

--- a/files/en-us/web/api/rtcerror/errordetail/index.md
+++ b/files/en-us/web/api/rtcerror/errordetail/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCError.errorDetail
 slug: Web/API/RTCError/errorDetail
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcerror/index.md
+++ b/files/en-us/web/api/rtcerror/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCError
 slug: Web/API/RTCError
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcerror/receivedalert/index.md
+++ b/files/en-us/web/api/rtcerror/receivedalert/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCError.receivedAlert
 slug: Web/API/RTCError/receivedAlert
+page-type: web-api-instance-property
 tags:
   - API
   - DTLS

--- a/files/en-us/web/api/rtcerror/sctpcausecode/index.md
+++ b/files/en-us/web/api/rtcerror/sctpcausecode/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCError.sctpCauseCode
 slug: Web/API/RTCError/sctpCauseCode
+page-type: web-api-instance-property
 tags:
   - API
   - Error

--- a/files/en-us/web/api/rtcerror/sdplinenumber/index.md
+++ b/files/en-us/web/api/rtcerror/sdplinenumber/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCError.sdpLineNumber
 slug: Web/API/RTCError/sdpLineNumber
+page-type: web-api-instance-property
 tags:
   - API
   - Error

--- a/files/en-us/web/api/rtcerror/sentalert/index.md
+++ b/files/en-us/web/api/rtcerror/sentalert/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCError.sentAlert
 slug: Web/API/RTCError/sentAlert
+page-type: web-api-instance-property
 tags:
   - API
   - DTLS

--- a/files/en-us/web/api/rtcerrorevent/error/index.md
+++ b/files/en-us/web/api/rtcerrorevent/error/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCErrorEvent.error
 slug: Web/API/RTCErrorEvent/error
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcerrorevent/index.md
+++ b/files/en-us/web/api/rtcerrorevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCErrorEvent
 slug: Web/API/RTCErrorEvent
+page-type: web-api-interface
 tags:
   - API
   - Error

--- a/files/en-us/web/api/rtcicecandidate/address/index.md
+++ b/files/en-us/web/api/rtcicecandidate/address/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidate.address
 slug: Web/API/RTCIceCandidate/address
+page-type: web-api-instance-property
 tags:
   - API
   - Address

--- a/files/en-us/web/api/rtcicecandidate/candidate/index.md
+++ b/files/en-us/web/api/rtcicecandidate/candidate/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidate.candidate
 slug: Web/API/RTCIceCandidate/candidate
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidate/component/index.md
+++ b/files/en-us/web/api/rtcicecandidate/component/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidate.component
 slug: Web/API/RTCIceCandidate/component
+page-type: web-api-instance-property
 tags:
   - API
   - ICE

--- a/files/en-us/web/api/rtcicecandidate/foundation/index.md
+++ b/files/en-us/web/api/rtcicecandidate/foundation/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidate.foundation
 slug: Web/API/RTCIceCandidate/foundation
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidate/index.md
+++ b/files/en-us/web/api/rtcicecandidate/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidate
 slug: Web/API/RTCIceCandidate
+page-type: web-api-interface
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidate/port/index.md
+++ b/files/en-us/web/api/rtcicecandidate/port/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidate.port
 slug: Web/API/RTCIceCandidate/port
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidate/priority/index.md
+++ b/files/en-us/web/api/rtcicecandidate/priority/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidate.priority
 slug: Web/API/RTCIceCandidate/priority
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidate/protocol/index.md
+++ b/files/en-us/web/api/rtcicecandidate/protocol/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidate.protocol
 slug: Web/API/RTCIceCandidate/protocol
+page-type: web-api-instance-property
 tags:
   - API
   - ICE

--- a/files/en-us/web/api/rtcicecandidate/relatedaddress/index.md
+++ b/files/en-us/web/api/rtcicecandidate/relatedaddress/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidate.relatedAddress
 slug: Web/API/RTCIceCandidate/relatedAddress
+page-type: web-api-instance-property
 tags:
   - API
   - Address

--- a/files/en-us/web/api/rtcicecandidate/relatedport/index.md
+++ b/files/en-us/web/api/rtcicecandidate/relatedport/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidate.relatedPort
 slug: Web/API/RTCIceCandidate/relatedPort
+page-type: web-api-instance-property
 tags:
   - API
   - Address

--- a/files/en-us/web/api/rtcicecandidate/rtcicecandidate/index.md
+++ b/files/en-us/web/api/rtcicecandidate/rtcicecandidate/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidate()
 slug: Web/API/RTCIceCandidate/RTCIceCandidate
+page-type: web-api-constructor
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcicecandidate/sdpmid/index.md
+++ b/files/en-us/web/api/rtcicecandidate/sdpmid/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidate.sdpMid
 slug: Web/API/RTCIceCandidate/sdpMid
+page-type: web-api-instance-property
 tags:
   - API
   - ICE

--- a/files/en-us/web/api/rtcicecandidate/sdpmlineindex/index.md
+++ b/files/en-us/web/api/rtcicecandidate/sdpmlineindex/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidate.sdpMLineIndex
 slug: Web/API/RTCIceCandidate/sdpMLineIndex
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidate/tcptype/index.md
+++ b/files/en-us/web/api/rtcicecandidate/tcptype/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidate.tcpType
 slug: Web/API/RTCIceCandidate/tcpType
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidate/tojson/index.md
+++ b/files/en-us/web/api/rtcicecandidate/tojson/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidate. toJSON()
 slug: Web/API/RTCIceCandidate/toJSON
+page-type: web-api-instance-method
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidate/type/index.md
+++ b/files/en-us/web/api/rtcicecandidate/type/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidate.type
 slug: Web/API/RTCIceCandidate/type
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidate/usernamefragment/index.md
+++ b/files/en-us/web/api/rtcicecandidate/usernamefragment/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidate.usernameFragment
 slug: Web/API/RTCIceCandidate/usernameFragment
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidatepair/index.md
+++ b/files/en-us/web/api/rtcicecandidatepair/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePair
 slug: Web/API/RTCIceCandidatePair
+page-type: web-api-interface
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidatepair/local/index.md
+++ b/files/en-us/web/api/rtcicecandidatepair/local/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePair.local
 slug: Web/API/RTCIceCandidatePair/local
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate


### PR DESCRIPTION
See  https://github.com/mdn/content/issues/16255. This is part 19 of a series of PRs to add page types to the Web/API documentation.