### PR TITLE
Add Web/API page types, part 20

### DIFF
--- a/files/en-us/web/api/rtcicecandidatepair/remote/index.md
+++ b/files/en-us/web/api/rtcicecandidatepair/remote/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePair.remote
 slug: Web/API/RTCIceCandidatePair/remote
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidatepairstats/availableincomingbitrate/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/availableincomingbitrate/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.availableIncomingBitrate
 slug: Web/API/RTCIceCandidatePairStats/availableIncomingBitrate
+page-type: web-api-instance-property
 tags:
   - API
   - Bandwidth

--- a/files/en-us/web/api/rtcicecandidatepairstats/availableoutgoingbitrate/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/availableoutgoingbitrate/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.availableOutgoingBitrate
 slug: Web/API/RTCIceCandidatePairStats/availableOutgoingBitrate
+page-type: web-api-instance-property
 tags:
   - API
   - Bandwidth

--- a/files/en-us/web/api/rtcicecandidatepairstats/bytesreceived/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/bytesreceived/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.bytesReceived
 slug: Web/API/RTCIceCandidatePairStats/bytesReceived
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidatepairstats/bytessent/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/bytessent/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.bytesSent
 slug: Web/API/RTCIceCandidatePairStats/bytesSent
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidatepairstats/circuitbreakertriggercount/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/circuitbreakertriggercount/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.circuitBreakerTriggerCount
 slug: Web/API/RTCIceCandidatePairStats/circuitBreakerTriggerCount
+page-type: web-api-instance-property
 tags:
   - API
   - Circuit-Breaker

--- a/files/en-us/web/api/rtcicecandidatepairstats/consentexpiredtimestamp/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/consentexpiredtimestamp/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.consentExpiredTimestamp
 slug: Web/API/RTCIceCandidatePairStats/consentExpiredTimestamp
+page-type: web-api-instance-property
 tags:
   - API
   - Binding

--- a/files/en-us/web/api/rtcicecandidatepairstats/consentrequestssent/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/consentrequestssent/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.consentRequestsSent
 slug: Web/API/RTCIceCandidatePairStats/consentRequestsSent
+page-type: web-api-instance-property
 tags:
   - API
   - Candidates

--- a/files/en-us/web/api/rtcicecandidatepairstats/currentroundtriptime/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/currentroundtriptime/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.currentRoundTripTime
 slug: Web/API/RTCIceCandidatePairStats/currentRoundTripTime
+page-type: web-api-instance-property
 tags:
   - API
   - Connectivity

--- a/files/en-us/web/api/rtcicecandidatepairstats/firstrequesttimestamp/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/firstrequesttimestamp/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.firstRequestTimestamp
 slug: Web/API/RTCIceCandidatePairStats/firstRequestTimestamp
+page-type: web-api-instance-property
 tags:
   - API
   - Connectivity

--- a/files/en-us/web/api/rtcicecandidatepairstats/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats
 slug: Web/API/RTCIceCandidatePairStats
+page-type: web-api-interface
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidatepairstats/lastpacketreceivedtimestamp/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/lastpacketreceivedtimestamp/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.lastPacketReceivedTimestamp
 slug: Web/API/RTCIceCandidatePairStats/lastPacketReceivedTimestamp
+page-type: web-api-instance-property
 tags:
   - API
   - ICE

--- a/files/en-us/web/api/rtcicecandidatepairstats/lastpacketsenttimestamp/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/lastpacketsenttimestamp/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidateStats.lastPacketSentTimestamp
 slug: Web/API/RTCIceCandidatePairStats/lastPacketSentTimestamp
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidatepairstats/lastrequesttimestamp/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/lastrequesttimestamp/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.lastRequestTimestamp
 slug: Web/API/RTCIceCandidatePairStats/lastRequestTimestamp
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidatepairstats/lastresponsetimestamp/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/lastresponsetimestamp/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidateStats.lastResponseTimestamp
 slug: Web/API/RTCIceCandidatePairStats/lastResponseTimestamp
+page-type: web-api-instance-property
 tags:
   - API
   - Connection

--- a/files/en-us/web/api/rtcicecandidatepairstats/localcandidateid/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/localcandidateid/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidateStats.localCandidateId
 slug: Web/API/RTCIceCandidatePairStats/localCandidateId
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidatepairstats/nominated/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/nominated/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.nominated
 slug: Web/API/RTCIceCandidatePairStats/nominated
+page-type: web-api-instance-property
 tags:
   - API
   - Flag

--- a/files/en-us/web/api/rtcicecandidatepairstats/packetsreceived/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/packetsreceived/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.packetsReceived
 slug: Web/API/RTCIceCandidatePairStats/packetsReceived
+page-type: web-api-instance-property
 tags:
   - API
   - Communication

--- a/files/en-us/web/api/rtcicecandidatepairstats/packetssent/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/packetssent/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.packetsSent
 slug: Web/API/RTCIceCandidatePairStats/packetsSent
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidatepairstats/priority/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/priority/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.priority
 slug: Web/API/RTCIceCandidatePairStats/priority
+page-type: web-api-instance-property
 tags:
   - API
   - ICE

--- a/files/en-us/web/api/rtcicecandidatepairstats/readable/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/readable/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.readable
 slug: Web/API/RTCIceCandidatePairStats/readable
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidatepairstats/remotecandidateid/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/remotecandidateid/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.remoteCandidateId
 slug: Web/API/RTCIceCandidatePairStats/remoteCandidateId
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidatepairstats/requestsreceived/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/requestsreceived/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.requestsReceived
 slug: Web/API/RTCIceCandidatePairStats/requestsReceived
+page-type: web-api-instance-property
 tags:
   - API
   - ICE

--- a/files/en-us/web/api/rtcicecandidatepairstats/requestssent/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/requestssent/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.requestsSent
 slug: Web/API/RTCIceCandidatePairStats/requestsSent
+page-type: web-api-instance-property
 tags:
   - API
   - Connectivity

--- a/files/en-us/web/api/rtcicecandidatepairstats/responsesreceived/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/responsesreceived/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.responsesReceived
 slug: Web/API/RTCIceCandidatePairStats/responsesReceived
+page-type: web-api-instance-property
 tags:
   - API
   - Connectivity

--- a/files/en-us/web/api/rtcicecandidatepairstats/responsessent/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/responsessent/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.responsesSent
 slug: Web/API/RTCIceCandidatePairStats/responsesSent
+page-type: web-api-instance-property
 tags:
   - API
   - Connectivity

--- a/files/en-us/web/api/rtcicecandidatepairstats/retransmissionsreceived/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/retransmissionsreceived/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.retransmissionsReceived
 slug: Web/API/RTCIceCandidatePairStats/retransmissionsReceived
+page-type: web-api-instance-property
 tags:
   - API
   - Connectivity

--- a/files/en-us/web/api/rtcicecandidatepairstats/retransmissionssent/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/retransmissionssent/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.retransmissionsSent
 slug: Web/API/RTCIceCandidatePairStats/retransmissionsSent
+page-type: web-api-instance-property
 browser-compat: api.RTCIceCandidatePairStats.retransmissionsSent
 ---
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcicecandidatepairstats/selected/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/selected/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.selected
 slug: Web/API/RTCIceCandidatePairStats/selected
+page-type: web-api-instance-property
 browser-compat: api.RTCIceCandidatePairStats.selected
 ---
 {{APIRef("WebRTC")}}{{non-standard_header}}

--- a/files/en-us/web/api/rtcicecandidatepairstats/state/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/state/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.state
 slug: Web/API/RTCIceCandidatePairStats/state
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidatepairstats/totalroundtriptime/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/totalroundtriptime/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.totalRoundTripTime
 slug: Web/API/RTCIceCandidatePairStats/totalRoundTripTime
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidatepairstats/transportid/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/transportid/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.transportId
 slug: Web/API/RTCIceCandidatePairStats/transportId
+page-type: web-api-instance-property
 tags:
   - API
   - ICE

--- a/files/en-us/web/api/rtcicecandidatepairstats/writable/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/writable/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidatePairStats.writable
 slug: Web/API/RTCIceCandidatePairStats/writable
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidatestats/address/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/address/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidateStats.address
 slug: Web/API/RTCIceCandidateStats/address
+page-type: web-api-instance-property
 tags:
   - API
   - Address

--- a/files/en-us/web/api/rtcicecandidatestats/candidatetype/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/candidatetype/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidateStats.candidateType
 slug: Web/API/RTCIceCandidateStats/candidateType
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidatestats/deleted/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/deleted/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidateStats.deleted
 slug: Web/API/RTCIceCandidateStats/deleted
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidatestats/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidateStats
 slug: Web/API/RTCIceCandidateStats
+page-type: web-api-interface
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidatestats/port/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/port/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidateStats.port
 slug: Web/API/RTCIceCandidateStats/port
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidatestats/priority/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/priority/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidateStats.priority
 slug: Web/API/RTCIceCandidateStats/priority
+page-type: web-api-instance-property
 browser-compat: api.RTCIceCandidateStats.priority
 ---
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcicecandidatestats/protocol/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/protocol/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidateStats.protocol
 slug: Web/API/RTCIceCandidateStats/protocol
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidatestats/relayprotocol/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/relayprotocol/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidateStats.relayProtocol
 slug: Web/API/RTCIceCandidateStats/relayProtocol
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidatestats/transportid/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/transportid/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidateStats.transportId
 slug: Web/API/RTCIceCandidateStats/transportId
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcicecandidatestats/url/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/url/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceCandidateStats.url
 slug: Web/API/RTCIceCandidateStats/url
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtciceparameters/index.md
+++ b/files/en-us/web/api/rtciceparameters/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceParameters
 slug: Web/API/RTCIceParameters
+page-type: web-api-interface
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtciceparameters/password/index.md
+++ b/files/en-us/web/api/rtciceparameters/password/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceParameters.password
 slug: Web/API/RTCIceParameters/password
+page-type: web-api-instance-property
 tags:
   - API
   - Candidates

--- a/files/en-us/web/api/rtciceparameters/usernamefragment/index.md
+++ b/files/en-us/web/api/rtciceparameters/usernamefragment/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceParameters.usernameFragment
 slug: Web/API/RTCIceParameters/usernameFragment
+page-type: web-api-instance-property
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtciceserver/credential/index.md
+++ b/files/en-us/web/api/rtciceserver/credential/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceServer.credential
 slug: Web/API/RTCIceServer/credential
+page-type: web-api-instance-property
 tags:
   - Credential
   - Experimental

--- a/files/en-us/web/api/rtciceserver/credentialtype/index.md
+++ b/files/en-us/web/api/rtciceserver/credentialtype/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceServer.credentialType
 slug: Web/API/RTCIceServer/credentialType
+page-type: web-api-instance-property
 tags:
   - Authentication
   - ICE

--- a/files/en-us/web/api/rtciceserver/index.md
+++ b/files/en-us/web/api/rtciceserver/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceServer
 slug: Web/API/RTCIceServer
+page-type: web-api-interface
 tags:
   - Authentication
   - Configuration

--- a/files/en-us/web/api/rtciceserver/url/index.md
+++ b/files/en-us/web/api/rtciceserver/url/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceServer.url
 slug: Web/API/RTCIceServer/url
+page-type: web-api-instance-property
 tags:
   - Experimental
   - Deprecated

--- a/files/en-us/web/api/rtciceserver/urls/index.md
+++ b/files/en-us/web/api/rtciceserver/urls/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceServers.urls
 slug: Web/API/RTCIceServer/urls
+page-type: web-api-instance-property
 tags:
   - Experimental
   - Property

--- a/files/en-us/web/api/rtciceserver/username/index.md
+++ b/files/en-us/web/api/rtciceserver/username/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceServer.username
 slug: Web/API/RTCIceServer/username
+page-type: web-api-instance-property
 tags:
   - Experimental
   - Property

--- a/files/en-us/web/api/rtcicetransport/component/index.md
+++ b/files/en-us/web/api/rtcicetransport/component/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceTransport.component
 slug: Web/API/RTCIceTransport/component
+page-type: web-api-instance-property
 tags:
   - API
   - ICE

--- a/files/en-us/web/api/rtcicetransport/gatheringstate/index.md
+++ b/files/en-us/web/api/rtcicetransport/gatheringstate/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceTransport.gatheringState
 slug: Web/API/RTCIceTransport/gatheringState
+page-type: web-api-instance-property
 tags:
   - API
   - Gatherer

--- a/files/en-us/web/api/rtcicetransport/gatheringstatechange_event/index.md
+++ b/files/en-us/web/api/rtcicetransport/gatheringstatechange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'RTCIceTransport: gatheringstatechange event'
 slug: Web/API/RTCIceTransport/gatheringstatechange_event
+page-type: web-api-event
 tags:
   - Connection
   - Connectivity

--- a/files/en-us/web/api/rtcicetransport/getlocalcandidates/index.md
+++ b/files/en-us/web/api/rtcicetransport/getlocalcandidates/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceTransport.getLocalCandidates()
 slug: Web/API/RTCIceTransport/getLocalCandidates
+page-type: web-api-instance-method
 tags:
   - API
   - Candidates

--- a/files/en-us/web/api/rtcicetransport/getlocalparameters/index.md
+++ b/files/en-us/web/api/rtcicetransport/getlocalparameters/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceTransport.getLocalParameters()
 slug: Web/API/RTCIceTransport/getLocalParameters
+page-type: web-api-instance-method
 tags:
   - API
   - Connectivity

--- a/files/en-us/web/api/rtcicetransport/getremotecandidates/index.md
+++ b/files/en-us/web/api/rtcicetransport/getremotecandidates/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceTransport.getRemoteCandidates()
 slug: Web/API/RTCIceTransport/getRemoteCandidates
+page-type: web-api-instance-method
 tags:
   - API
   - Candidates

--- a/files/en-us/web/api/rtcicetransport/getremoteparameters/index.md
+++ b/files/en-us/web/api/rtcicetransport/getremoteparameters/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceTransport.getRemoteParameters()
 slug: Web/API/RTCIceTransport/getRemoteParameters
+page-type: web-api-instance-method
 browser-compat: api.RTCIceTransport.getRemoteParameters
 ---
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcicetransport/getselectedcandidatepair/index.md
+++ b/files/en-us/web/api/rtcicetransport/getselectedcandidatepair/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceTransport.getSelectedCandidatePair()
 slug: Web/API/RTCIceTransport/getSelectedCandidatePair
+page-type: web-api-instance-method
 tags:
   - API
   - Candidates

--- a/files/en-us/web/api/rtcicetransport/index.md
+++ b/files/en-us/web/api/rtcicetransport/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceTransport
 slug: Web/API/RTCIceTransport
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcicetransport/role/index.md
+++ b/files/en-us/web/api/rtcicetransport/role/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceTransport.role
 slug: Web/API/RTCIceTransport/role
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcicetransport/selectedcandidatepairchange_event/index.md
+++ b/files/en-us/web/api/rtcicetransport/selectedcandidatepairchange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'RTCIceTransport: selectedcandidatepairchange event'
 slug: Web/API/RTCIceTransport/selectedcandidatepairchange_event
+page-type: web-api-event
 tags:
   - Connectivity
   - ICE

--- a/files/en-us/web/api/rtcicetransport/state/index.md
+++ b/files/en-us/web/api/rtcicetransport/state/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIceTransport.state
 slug: Web/API/RTCIceTransport/state
+page-type: web-api-instance-property
 tags:
   - API
   - Enumerated Type

--- a/files/en-us/web/api/rtcicetransport/statechange_event/index.md
+++ b/files/en-us/web/api/rtcicetransport/statechange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'RTCIceTransport: statechange event'
 slug: Web/API/RTCIceTransport/statechange_event
+page-type: web-api-event
 tags:
   - ICE
   - Negotiation

--- a/files/en-us/web/api/rtcidentityassertion/index.md
+++ b/files/en-us/web/api/rtcidentityassertion/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCIdentityAssertion
 slug: Web/API/RTCIdentityAssertion
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/averagertcpinterval/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/averagertcpinterval/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCInboundRtpStreamStats.averageRtcpInterval
 slug: Web/API/RTCInboundRtpStreamStats/averageRtcpInterval
+page-type: web-api-instance-property
 tags:
   - API
   - Packet

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/bytesreceived/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/bytesreceived/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCInboundRtpStreamStats.bytesReceived
 slug: Web/API/RTCInboundRtpStreamStats/bytesReceived
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/fecpacketsdiscarded/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/fecpacketsdiscarded/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCInboundRtpStreamStats.fecPacketsDiscarded
 slug: Web/API/RTCInboundRtpStreamStats/fecPacketsDiscarded
+page-type: web-api-instance-property
 tags:
   - API
   - Errors

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/fecpacketsreceived/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/fecpacketsreceived/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCInboundRtpStreamStats.fecPacketsReceived
 slug: Web/API/RTCInboundRtpStreamStats/fecPacketsReceived
+page-type: web-api-instance-property
 browser-compat: api.RTCInboundRtpStreamStats.fecPacketsReceived
 ---
 {{APIRef("WebRTC")}}

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/fircount/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/fircount/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCInboundRtpStreamStats.firCount
 slug: Web/API/RTCInboundRtpStreamStats/firCount
+page-type: web-api-instance-property
 tags:
   - API
   - FIR

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/framesdecoded/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/framesdecoded/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCInboundRtpStreamStats.framesDecoded
 slug: Web/API/RTCInboundRtpStreamStats/framesDecoded
+page-type: web-api-instance-property
 tags:
   - API
   - Decode

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCInboundRtpStreamStats
 slug: Web/API/RTCInboundRtpStreamStats
+page-type: web-api-interface
 tags:
   - API
   - Dictionary

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/lastpacketreceivedtimestamp/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/lastpacketreceivedtimestamp/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCInboundRtpStreamStats.lastPacketReceivedTimestamp
 slug: Web/API/RTCInboundRtpStreamStats/lastPacketReceivedTimestamp
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/nackcount/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/nackcount/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCInboundRtpStreamStats.nackCount
 slug: Web/API/RTCInboundRtpStreamStats/nackCount
+page-type: web-api-instance-property
 tags:
   - API
   - NACK

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/packetsduplicated/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/packetsduplicated/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCInboundRtpStreamStats.packetsDuplicated
 slug: Web/API/RTCInboundRtpStreamStats/packetsDuplicated
+page-type: web-api-instance-property
 tags:
   - API
   - Duplicate

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/packetsfaileddecryption/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/packetsfaileddecryption/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCInboundRtpStreamStats.packetsFailedDecryption
 slug: Web/API/RTCInboundRtpStreamStats/packetsFailedDecryption
+page-type: web-api-instance-property
 tags:
   - API
   - Decryption

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/perdscppacketsreceived/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/perdscppacketsreceived/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCInboundRtpStreamStats.perDscpPacketsReceived
 slug: Web/API/RTCInboundRtpStreamStats/perDscpPacketsReceived
+page-type: web-api-instance-property
 tags:
   - API
   - DCSP

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/plicount/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/plicount/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCInboundRtpStreamStats.pliCount
 slug: Web/API/RTCInboundRtpStreamStats/pliCount
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/qpsum/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/qpsum/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCInboundRtpStreamStats.qpSum
 slug: Web/API/RTCInboundRtpStreamStats/qpSum
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/receiverid/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/receiverid/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCInboundRtpStreamStats.receiverId
 slug: Web/API/RTCInboundRtpStreamStats/receiverId
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/remoteid/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/remoteid/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCInboundRtpStreamStats.remoteId
 slug: Web/API/RTCInboundRtpStreamStats/remoteId
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/slicount/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/slicount/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCInboundRtpStreamStats.sliCount
 slug: Web/API/RTCInboundRtpStreamStats/sliCount
+page-type: web-api-instance-property
 tags:
   - API
   - Corruption

--- a/files/en-us/web/api/rtcinboundrtpstreamstats/trackid/index.md
+++ b/files/en-us/web/api/rtcinboundrtpstreamstats/trackid/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCInboundRtpStreamStats.trackId
 slug: Web/API/RTCInboundRtpStreamStats/trackId
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/averagertcpinterval/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/averagertcpinterval/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCOutboundRtpStreamStats.averageRtcpInterval
 slug: Web/API/RTCOutboundRtpStreamStats/averageRtcpInterval
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/fircount/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/fircount/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCOutboundRtpStreamStats.firCount
 slug: Web/API/RTCOutboundRtpStreamStats/firCount
+page-type: web-api-instance-property
 tags:
   - API
   - FIR

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/framesencoded/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/framesencoded/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCOutboundRtpStreamStats.framesEncoded
 slug: Web/API/RTCOutboundRtpStreamStats/framesEncoded
+page-type: web-api-instance-property
 tags:
   - API
   - Encoding

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCOutboundRtpStreamStats
 slug: Web/API/RTCOutboundRtpStreamStats
+page-type: web-api-interface
 tags:
   - API
   - Dictionary

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/lastpacketsenttimestamp/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/lastpacketsenttimestamp/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCOutboundRtpStreamStats.lastPacketSentTimestamp
 slug: Web/API/RTCOutboundRtpStreamStats/lastPacketSentTimestamp
+page-type: web-api-instance-property
 tags:
   - API
   - Packet

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/nackcount/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/nackcount/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCOutboundRtpStreamStats.nackCount
 slug: Web/API/RTCOutboundRtpStreamStats/nackCount
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/perdscppacketssent/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/perdscppacketssent/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCOutboundRtpStreamStats.perDscpPacketsSent
 slug: Web/API/RTCOutboundRtpStreamStats/perDscpPacketsSent
+page-type: web-api-instance-property
 tags:
   - API
   - DSCP

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/plicount/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/plicount/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCOutboundRtpStreamStats.pliCount
 slug: Web/API/RTCOutboundRtpStreamStats/pliCount
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/qpsum/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/qpsum/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCOutboundRtpStreamStats.qpSum
 slug: Web/API/RTCOutboundRtpStreamStats/qpSum
+page-type: web-api-instance-property
 tags:
   - API
   - Encoding

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/qualitylimitationreason/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/qualitylimitationreason/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCOutboundRtpStreamStats.qualityLimitationReason
 slug: Web/API/RTCOutboundRtpStreamStats/qualityLimitationReason
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/remoteid/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/remoteid/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCOutboundRtpStreamStats.remoteId
 slug: Web/API/RTCOutboundRtpStreamStats/remoteId
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/slicount/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/slicount/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCOutboundRtpStreamStats.sliCount
 slug: Web/API/RTCOutboundRtpStreamStats/sliCount
+page-type: web-api-instance-property
 tags:
   - API
   - Corruption

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/trackid/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/trackid/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCOutboundRtpStreamStats.trackId
 slug: Web/API/RTCOutboundRtpStreamStats/trackId
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcpeerconnection/addicecandidate/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addicecandidate/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.addIceCandidate()
 slug: Web/API/RTCPeerConnection/addIceCandidate
+page-type: web-api-instance-method
 tags:
   - API
   - ICE

--- a/files/en-us/web/api/rtcpeerconnection/addstream/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addstream/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.addStream()
 slug: Web/API/RTCPeerConnection/addStream
+page-type: web-api-instance-method
 tags:
   - Deprecated
   - Method

--- a/files/en-us/web/api/rtcpeerconnection/addstream_event/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addstream_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'RTCPeerConnection: addstream event'
 slug: Web/API/RTCPeerConnection/addstream_event
+page-type: web-api-event
 tags:
   - Event
   - Media

--- a/files/en-us/web/api/rtcpeerconnection/addtrack/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addtrack/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.addTrack()
 slug: Web/API/RTCPeerConnection/addTrack
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcpeerconnection/addtransceiver/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addtransceiver/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.addTransceiver()
 slug: Web/API/RTCPeerConnection/addTransceiver
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcpeerconnection/cantrickleicecandidates/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/cantrickleicecandidates/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.canTrickleIceCandidates
 slug: Web/API/RTCPeerConnection/canTrickleIceCandidates
+page-type: web-api-instance-property
 tags:
   - API
   - ICE

--- a/files/en-us/web/api/rtcpeerconnection/close/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/close/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.close()
 slug: Web/API/RTCPeerConnection/close
+page-type: web-api-instance-method
 tags:
   - Method
   - RTCPeerConnection

--- a/files/en-us/web/api/rtcpeerconnection/connectionstate/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/connectionstate/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.connectionState
 slug: Web/API/RTCPeerConnection/connectionState
+page-type: web-api-instance-property
 tags:
   - Property
   - RTCPeerConnection

--- a/files/en-us/web/api/rtcpeerconnection/connectionstatechange_event/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/connectionstatechange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'RTCPeerConnection: connectionstatechange event'
 slug: Web/API/RTCPeerConnection/connectionstatechange_event
+page-type: web-api-event
 tags:
   - Event
   - RTCPeerConnection

--- a/files/en-us/web/api/rtcpeerconnection/createanswer/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/createanswer/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.createAnswer()
 slug: Web/API/RTCPeerConnection/createAnswer
+page-type: web-api-instance-method
 tags:
   - API
   - Media

--- a/files/en-us/web/api/rtcpeerconnection/createdatachannel/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/createdatachannel/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.createDataChannel()
 slug: Web/API/RTCPeerConnection/createDataChannel
+page-type: web-api-instance-method
 tags:
   - API
   - Media

--- a/files/en-us/web/api/rtcpeerconnection/createoffer/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/createoffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.createOffer()
 slug: Web/API/RTCPeerConnection/createOffer
+page-type: web-api-instance-method
 tags:
   - API
   - Media

--- a/files/en-us/web/api/rtcpeerconnection/currentlocaldescription/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/currentlocaldescription/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.currentLocalDescription
 slug: Web/API/RTCPeerConnection/currentLocalDescription
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/rtcpeerconnection/currentremotedescription/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/currentremotedescription/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.currentRemoteDescription
 slug: Web/API/RTCPeerConnection/currentRemoteDescription
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/rtcpeerconnection/datachannel_event/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/datachannel_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'RTCPeerConnection: datachannel event'
 slug: Web/API/RTCPeerConnection/datachannel_event
+page-type: web-api-event
 tags:
   - Channels
   - Connection

--- a/files/en-us/web/api/rtcpeerconnection/generatecertificate/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/generatecertificate/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.generateCertificate() static function
 slug: Web/API/RTCPeerConnection/generateCertificate
+page-type: web-api-static-method
 tags:
   - API
   - Media

--- a/files/en-us/web/api/rtcpeerconnection/getconfiguration/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/getconfiguration/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.getConfiguration()
 slug: Web/API/RTCPeerConnection/getConfiguration
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/rtcpeerconnection/getidentityassertion/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/getidentityassertion/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.getIdentityAssertion()
 slug: Web/API/RTCPeerConnection/getIdentityAssertion
+page-type: web-api-instance-method
 tags:
   - Method
   - RTCPeerConnection

--- a/files/en-us/web/api/rtcpeerconnection/getreceivers/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/getreceivers/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.getReceivers()
 slug: Web/API/RTCPeerConnection/getReceivers
+page-type: web-api-instance-method
 tags:
   - Media
   - Method

--- a/files/en-us/web/api/rtcpeerconnection/getsenders/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/getsenders/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.getSenders()
 slug: Web/API/RTCPeerConnection/getSenders
+page-type: web-api-instance-method
 tags:
   - Media
   - Method

--- a/files/en-us/web/api/rtcpeerconnection/getstats/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/getstats/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.getStats()
 slug: Web/API/RTCPeerConnection/getStats
+page-type: web-api-instance-method
 tags:
   - API
   - Connection

--- a/files/en-us/web/api/rtcpeerconnection/getstreambyid/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/getstreambyid/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.getStreamById()
 slug: Web/API/RTCPeerConnection/getStreamById
+page-type: web-api-instance-method
 tags:
   - Method
   - RTCPeerConnection

--- a/files/en-us/web/api/rtcpeerconnection/gettransceivers/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/gettransceivers/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.getTransceivers()
 slug: Web/API/RTCPeerConnection/getTransceivers
+page-type: web-api-instance-method
 tags:
   - API
   - Media

--- a/files/en-us/web/api/rtcpeerconnection/icecandidate_event/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/icecandidate_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'RTCPeerConnection: icecandidate event'
 slug: Web/API/RTCPeerConnection/icecandidate_event
+page-type: web-api-event
 tags:
   - API
   - Candidate

--- a/files/en-us/web/api/rtcpeerconnection/icecandidateerror_event/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/icecandidateerror_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'RTCPeerConnection: icecandidateerror event'
 slug: Web/API/RTCPeerConnection/icecandidateerror_event
+page-type: web-api-event
 tags:
   - API
   - Connection

--- a/files/en-us/web/api/rtcpeerconnection/iceconnectionstate/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/iceconnectionstate/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.iceConnectionState
 slug: Web/API/RTCPeerConnection/iceConnectionState
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcpeerconnection/iceconnectionstatechange_event/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/iceconnectionstatechange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'RTCPeerConnection: iceconnectionstatechange event'
 slug: Web/API/RTCPeerConnection/iceconnectionstatechange_event
+page-type: web-api-event
 tags:
   - API
   - Connection

--- a/files/en-us/web/api/rtcpeerconnection/icegatheringstate/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/icegatheringstate/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.iceGatheringState
 slug: Web/API/RTCPeerConnection/iceGatheringState
+page-type: web-api-instance-property
 tags:
   - Property
   - RTCPeerConnection

--- a/files/en-us/web/api/rtcpeerconnection/icegatheringstatechange_event/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/icegatheringstatechange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'RTCPeerConnection: icegatheringstatechange event'
 slug: Web/API/RTCPeerConnection/icegatheringstatechange_event
+page-type: web-api-event
 tags:
   - API
   - Connection

--- a/files/en-us/web/api/rtcpeerconnection/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection
 slug: Web/API/RTCPeerConnection
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcpeerconnection/localdescription/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/localdescription/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.localDescription
 slug: Web/API/RTCPeerConnection/localDescription
+page-type: web-api-instance-property
 tags:
   - Property
   - RTCPeerConnection

--- a/files/en-us/web/api/rtcpeerconnection/negotiationneeded_event/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/negotiationneeded_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'RTCPeerConnection: negotiationneeded event'
 slug: Web/API/RTCPeerConnection/negotiationneeded_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/rtcpeerconnection/peeridentity/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/peeridentity/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.peerIdentity
 slug: Web/API/RTCPeerConnection/peerIdentity
+page-type: web-api-instance-property
 tags:
   - API
   - Authentication

--- a/files/en-us/web/api/rtcpeerconnection/pendinglocaldescription/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/pendinglocaldescription/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.pendingLocalDescription
 slug: Web/API/RTCPeerConnection/pendingLocalDescription
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/rtcpeerconnection/pendingremotedescription/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/pendingremotedescription/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.pendingRemoteDescription
 slug: Web/API/RTCPeerConnection/pendingRemoteDescription
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/rtcpeerconnection/remotedescription/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/remotedescription/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.remoteDescription
 slug: Web/API/RTCPeerConnection/remoteDescription
+page-type: web-api-instance-property
 tags:
   - Property
   - RTCPeerConnection

--- a/files/en-us/web/api/rtcpeerconnection/removestream/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/removestream/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.removeStream()
 slug: Web/API/RTCPeerConnection/removeStream
+page-type: web-api-instance-method
 tags:
   - Deprecated
   - Media

--- a/files/en-us/web/api/rtcpeerconnection/removestream_event/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/removestream_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'RTCPeerConnection: removestream event'
 slug: Web/API/RTCPeerConnection/removestream_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/rtcpeerconnection/removetrack/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/removetrack/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.removeTrack()
 slug: Web/API/RTCPeerConnection/removeTrack
+page-type: web-api-instance-method
 tags:
   - Audio
   - Media

--- a/files/en-us/web/api/rtcpeerconnection/restartice/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/restartice/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.restartIce()
 slug: Web/API/RTCPeerConnection/restartIce
+page-type: web-api-instance-method
 tags:
   - API
   - ICE

--- a/files/en-us/web/api/rtcpeerconnection/rtcpeerconnection/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/rtcpeerconnection/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection()
 slug: Web/API/RTCPeerConnection/RTCPeerConnection
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/rtcpeerconnection/sctp/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/sctp/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.sctp
 slug: Web/API/RTCPeerConnection/sctp
+page-type: web-api-instance-property
 tags:
   - Property
   - RTCPeerConnection

--- a/files/en-us/web/api/rtcpeerconnection/setconfiguration/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/setconfiguration/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.setConfiguration()
 slug: Web/API/RTCPeerConnection/setConfiguration
+page-type: web-api-instance-method
 tags:
   - Configuration
   - Method

--- a/files/en-us/web/api/rtcpeerconnection/setidentityprovider/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/setidentityprovider/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.setIdentityProvider()
 slug: Web/API/RTCPeerConnection/setIdentityProvider
+page-type: web-api-instance-method
 tags:
   - Method
   - RTCPeerConnection

--- a/files/en-us/web/api/rtcpeerconnection/setlocaldescription/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/setlocaldescription/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.setLocalDescription()
 slug: Web/API/RTCPeerConnection/setLocalDescription
+page-type: web-api-instance-method
 tags:
   - API
   - Descriptions

--- a/files/en-us/web/api/rtcpeerconnection/setremotedescription/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/setremotedescription/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.setRemoteDescription()
 slug: Web/API/RTCPeerConnection/setRemoteDescription
+page-type: web-api-instance-method
 tags:
   - API
   - ICE

--- a/files/en-us/web/api/rtcpeerconnection/signalingstate/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/signalingstate/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnection.signalingState
 slug: Web/API/RTCPeerConnection/signalingState
+page-type: web-api-instance-property
 tags:
   - API
   - ICE

--- a/files/en-us/web/api/rtcpeerconnection/signalingstatechange_event/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/signalingstatechange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'RTCPeerConnection: signalingstatechange event'
 slug: Web/API/RTCPeerConnection/signalingstatechange_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/rtcpeerconnection/track_event/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/track_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'RTCPeerConnection: track event'
 slug: Web/API/RTCPeerConnection/track_event
+page-type: web-api-event
 tags:
   - DOM
   - DOM Event Reference

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/address/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/address/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnectionIceErrorEvent.address
 slug: Web/API/RTCPeerConnectionIceErrorEvent/address
+page-type: web-api-instance-property
 tags:
   - API
   - Address

--- a/files/en-us/web/api/rtcpeerconnectioniceerrorevent/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceerrorevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnectionIceErrorEvent
 slug: Web/API/RTCPeerConnectionIceErrorEvent
+page-type: web-api-interface
 tags:
   - API
   - Communication

--- a/files/en-us/web/api/rtcpeerconnectioniceevent/candidate/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceevent/candidate/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnectionIceEvent.candidate
 slug: Web/API/RTCPeerConnectionIceEvent/candidate
+page-type: web-api-instance-property
 tags:
   - Candidate
   - Negotiation

--- a/files/en-us/web/api/rtcpeerconnectioniceevent/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnectionIceEvent
 slug: Web/API/RTCPeerConnectionIceEvent
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/rtcpeerconnectioniceevent/rtcpeerconnectioniceevent/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceevent/rtcpeerconnectioniceevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCPeerConnectionIceEvent()
 slug: Web/API/RTCPeerConnectionIceEvent/RTCPeerConnectionIceEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/index.md
+++ b/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRemoteOutboundRtpStreamStats
 slug: Web/API/RTCRemoteOutboundRtpStreamStats
+page-type: web-api-interface
 tags:
   - API
   - Dictionary

--- a/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/localid/index.md
+++ b/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/localid/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRemoteOutboundRtpStreamStats.localId
 slug: Web/API/RTCRemoteOutboundRtpStreamStats/localId
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/remotetimestamp/index.md
+++ b/files/en-us/web/api/rtcremoteoutboundrtpstreamstats/remotetimestamp/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRemoteOutboundRtpStreamStats.remoteTimestamp
 slug: Web/API/RTCRemoteOutboundRtpStreamStats/remoteTimestamp
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/rtcrtcpparameters/index.md
+++ b/files/en-us/web/api/rtcrtcpparameters/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtcpParameters
 slug: Web/API/RTCRtcpParameters
+page-type: web-api-interface
 tags:
   - API
   - Configuration

--- a/files/en-us/web/api/rtcrtpcapabilities/index.md
+++ b/files/en-us/web/api/rtcrtpcapabilities/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpCapabilities
 slug: Web/API/RTCRtpCapabilities
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcrtpcodeccapability/index.md
+++ b/files/en-us/web/api/rtcrtpcodeccapability/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpCodecCapability
 slug: Web/API/RTCRtpCodecCapability
+page-type: web-api-interface
 tags:
   - API
   - Capability

--- a/files/en-us/web/api/rtcrtpcodecparameters/index.md
+++ b/files/en-us/web/api/rtcrtpcodecparameters/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpCodecParameters
 slug: Web/API/RTCRtpCodecParameters
+page-type: web-api-interface
 tags:
   - API
   - Codec Configuration

--- a/files/en-us/web/api/rtcrtpcontributingsource/audiolevel/index.md
+++ b/files/en-us/web/api/rtcrtpcontributingsource/audiolevel/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpContributingSource.audioLevel
 slug: Web/API/RTCRtpContributingSource/audioLevel
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/rtcrtpcontributingsource/index.md
+++ b/files/en-us/web/api/rtcrtpcontributingsource/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpContributingSource
 slug: Web/API/RTCRtpContributingSource
+page-type: web-api-interface
 tags:
   - API
   - Contributing Source

--- a/files/en-us/web/api/rtcrtpcontributingsource/rtptimestamp/index.md
+++ b/files/en-us/web/api/rtcrtpcontributingsource/rtptimestamp/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpContributingSource.rtpTimestamp
 slug: Web/API/RTCRtpContributingSource/rtpTimestamp
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcrtpcontributingsource/source/index.md
+++ b/files/en-us/web/api/rtcrtpcontributingsource/source/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpContributingSource.source
 slug: Web/API/RTCRtpContributingSource/source
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/rtcrtpcontributingsource/timestamp/index.md
+++ b/files/en-us/web/api/rtcrtpcontributingsource/timestamp/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpContributingSource.timestamp
 slug: Web/API/RTCRtpContributingSource/timestamp
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/rtcrtpencodingparameters/index.md
+++ b/files/en-us/web/api/rtcrtpencodingparameters/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpEncodingParameters
 slug: Web/API/RTCRtpEncodingParameters
+page-type: web-api-interface
 tags:
   - API
   - Codec

--- a/files/en-us/web/api/rtcrtpencodingparameters/maxbitrate/index.md
+++ b/files/en-us/web/api/rtcrtpencodingparameters/maxbitrate/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpEncodingParameters.maxBitrate
 slug: Web/API/RTCRtpEncodingParameters/maxBitrate
+page-type: web-api-instance-property
 tags:
   - API
   - BPS

--- a/files/en-us/web/api/rtcrtpencodingparameters/maxframerate/index.md
+++ b/files/en-us/web/api/rtcrtpencodingparameters/maxframerate/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpEncodingParameters.maxFramerate
 slug: Web/API/RTCRtpEncodingParameters/maxFramerate
+page-type: web-api-instance-property
 tags:
   - API
   - BPS

--- a/files/en-us/web/api/rtcrtpencodingparameters/scaleresolutiondownby/index.md
+++ b/files/en-us/web/api/rtcrtpencodingparameters/scaleresolutiondownby/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpEncodingParameters.scaleResolutionDownBy
 slug: Web/API/RTCRtpEncodingParameters/scaleResolutionDownBy
+page-type: web-api-instance-property
 tags:
   - API
   - Codec

--- a/files/en-us/web/api/rtcrtpparameters/index.md
+++ b/files/en-us/web/api/rtcrtpparameters/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpParameters
 slug: Web/API/RTCRtpParameters
+page-type: web-api-interface
 tags:
   - API
   - Configuration

--- a/files/en-us/web/api/rtcrtpreceiveparameters/index.md
+++ b/files/en-us/web/api/rtcrtpreceiveparameters/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpReceiveParameters
 slug: Web/API/RTCRtpReceiveParameters
+page-type: web-api-interface
 tags:
   - API
   - Configuration

--- a/files/en-us/web/api/rtcrtpreceiver/getcapabilities/index.md
+++ b/files/en-us/web/api/rtcrtpreceiver/getcapabilities/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpReceiver.getCapabilities() static function
 slug: Web/API/RTCRtpReceiver/getCapabilities
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcrtpreceiver/getcapabilities/index.md
+++ b/files/en-us/web/api/rtcrtpreceiver/getcapabilities/index.md
@@ -1,7 +1,7 @@
 ---
 title: RTCRtpReceiver.getCapabilities() static function
 slug: Web/API/RTCRtpReceiver/getCapabilities
-page-type: web-api-instance-method
+page-type: web-api-static-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcrtpreceiver/getcontributingsources/index.md
+++ b/files/en-us/web/api/rtcrtpreceiver/getcontributingsources/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpReceiver.getContributingSources()
 slug: Web/API/RTCRtpReceiver/getContributingSources
+page-type: web-api-instance-method
 tags:
   - API
   - CSRC

--- a/files/en-us/web/api/rtcrtpreceiver/getparameters/index.md
+++ b/files/en-us/web/api/rtcrtpreceiver/getparameters/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpReceiver.getParameters()
 slug: Web/API/RTCRtpReceiver/getParameters
+page-type: web-api-instance-method
 tags:
   - API
   - Configuration

--- a/files/en-us/web/api/rtcrtpreceiver/getstats/index.md
+++ b/files/en-us/web/api/rtcrtpreceiver/getstats/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpReceiver.getStats()
 slug: Web/API/RTCRtpReceiver/getStats
+page-type: web-api-instance-method
 tags:
   - API
   - Media

--- a/files/en-us/web/api/rtcrtpreceiver/getsynchronizationsources/index.md
+++ b/files/en-us/web/api/rtcrtpreceiver/getsynchronizationsources/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpReceiver.getSynchronizationSources()
 slug: Web/API/RTCRtpReceiver/getSynchronizationSources
+page-type: web-api-instance-method
 tags:
   - API
   - Media

--- a/files/en-us/web/api/rtcrtpreceiver/index.md
+++ b/files/en-us/web/api/rtcrtpreceiver/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpReceiver
 slug: Web/API/RTCRtpReceiver
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/rtcrtpreceiver/track/index.md
+++ b/files/en-us/web/api/rtcrtpreceiver/track/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpReceiver.track
 slug: Web/API/RTCRtpReceiver/track
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcrtpreceiver/transport/index.md
+++ b/files/en-us/web/api/rtcrtpreceiver/transport/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpReceiver.transport
 slug: Web/API/RTCRtpReceiver/transport
+page-type: web-api-instance-property
 tags:
   - API
   - Communications

--- a/files/en-us/web/api/rtcrtpsender/dtmf/index.md
+++ b/files/en-us/web/api/rtcrtpsender/dtmf/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpSender.dtmf
 slug: Web/API/RTCRtpSender/dtmf
+page-type: web-api-instance-property
 tags:
   - DTMF
   - Media

--- a/files/en-us/web/api/rtcrtpsender/getcapabilities/index.md
+++ b/files/en-us/web/api/rtcrtpsender/getcapabilities/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpSender.getCapabilities() static function
 slug: Web/API/RTCRtpSender/getCapabilities
+page-type: web-api-static-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcrtpsender/getparameters/index.md
+++ b/files/en-us/web/api/rtcrtpsender/getparameters/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpSender.getParameters()
 slug: Web/API/RTCRtpSender/getParameters
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcrtpsender/getstats/index.md
+++ b/files/en-us/web/api/rtcrtpsender/getstats/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpSender.getStats()
 slug: Web/API/RTCRtpSender/getStats
+page-type: web-api-instance-method
 tags:
   - API
   - Media

--- a/files/en-us/web/api/rtcrtpsender/index.md
+++ b/files/en-us/web/api/rtcrtpsender/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpSender
 slug: Web/API/RTCRtpSender
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcrtpsender/replacetrack/index.md
+++ b/files/en-us/web/api/rtcrtpsender/replacetrack/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpSender.replaceTrack()
 slug: Web/API/RTCRtpSender/replaceTrack
+page-type: web-api-instance-method
 tags:
   - Audio
   - Media

--- a/files/en-us/web/api/rtcrtpsender/setparameters/index.md
+++ b/files/en-us/web/api/rtcrtpsender/setparameters/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpSender.setParameters()
 slug: Web/API/RTCRtpSender/setParameters
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcrtpsender/setstreams/index.md
+++ b/files/en-us/web/api/rtcrtpsender/setstreams/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpSender.setStreams()
 slug: Web/API/RTCRtpSender/setStreams
+page-type: web-api-instance-method
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcrtpsender/track/index.md
+++ b/files/en-us/web/api/rtcrtpsender/track/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpSender.track
 slug: Web/API/RTCRtpSender/track
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcrtpsender/transport/index.md
+++ b/files/en-us/web/api/rtcrtpsender/transport/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpSender.transport
 slug: Web/API/RTCRtpSender/transport
+page-type: web-api-instance-property
 tags:
   - API
   - Connectivity

--- a/files/en-us/web/api/rtcrtpsendparameters/encodings/index.md
+++ b/files/en-us/web/api/rtcrtpsendparameters/encodings/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpSendParameters.encodings
 slug: Web/API/RTCRtpSendParameters/encodings
+page-type: web-api-instance-property
 tags:
   - API
   - Codec

--- a/files/en-us/web/api/rtcrtpsendparameters/index.md
+++ b/files/en-us/web/api/rtcrtpsendparameters/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpSendParameters
 slug: Web/API/RTCRtpSendParameters
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcrtpstreamstats/codecid/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/codecid/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpStreamStats.codecId
 slug: Web/API/RTCRtpStreamStats/codecId
+page-type: web-api-instance-property
 tags:
   - API
   - Codec

--- a/files/en-us/web/api/rtcrtpstreamstats/fircount/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/fircount/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpStreamStats.firCount
 slug: Web/API/RTCRtpStreamStats/firCount
+page-type: web-api-instance-property
 tags:
   - API
   - Dropped Frames

--- a/files/en-us/web/api/rtcrtpstreamstats/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpStreamStats
 slug: Web/API/RTCRtpStreamStats
+page-type: web-api-interface
 tags:
   - API
   - Dictionary

--- a/files/en-us/web/api/rtcrtpstreamstats/kind/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/kind/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpStreamStats.kind
 slug: Web/API/RTCRtpStreamStats/kind
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/rtcrtpstreamstats/nackcount/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/nackcount/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpStreamStats.nackCount
 slug: Web/API/RTCRtpStreamStats/nackCount
+page-type: web-api-instance-property
 tags:
   - API
   - Acknowledgement

--- a/files/en-us/web/api/rtcrtpstreamstats/plicount/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/plicount/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpStreamStats.pliCount
 slug: Web/API/RTCRtpStreamStats/pliCount
+page-type: web-api-instance-property
 tags:
   - API
   - Data Loss

--- a/files/en-us/web/api/rtcrtpstreamstats/qpsum/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/qpsum/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpStreamStats.qpSum
 slug: Web/API/RTCRtpStreamStats/qpSum
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/rtcrtpstreamstats/slicount/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/slicount/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpStreamStats.sliCount
 slug: Web/API/RTCRtpStreamStats/sliCount
+page-type: web-api-instance-property
 tags:
   - API
   - Media

--- a/files/en-us/web/api/rtcrtpstreamstats/ssrc/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/ssrc/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpStreamStats.ssrc
 slug: Web/API/RTCRtpStreamStats/ssrc
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/rtcrtpstreamstats/trackid/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/trackid/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpStreamStats.trackId
 slug: Web/API/RTCRtpStreamStats/trackId
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/rtcrtpstreamstats/transportid/index.md
+++ b/files/en-us/web/api/rtcrtpstreamstats/transportid/index.md
@@ -1,6 +1,7 @@
 ---
 title: RTCRtpStreamStats.transportId
 slug: Web/API/RTCRtpStreamStats/transportId
+page-type: web-api-instance-property
 tags:
   - API
   - Property


### PR DESCRIPTION
See  https://github.com/mdn/content/issues/16255. This is part 20 of a series of PRs to add page types to the Web/API documentation.