### PR TITLE
Fix example size

### DIFF
--- a/files/en-us/web/css/@font-face/index.md
+++ b/files/en-us/web/css/@font-face/index.md
@@ -139,7 +139,7 @@ This example specifies a downloadable font to use, applying it to the entire bod
 
 The output of this example code looks like so:
 
-{{EmbedGHLiveSample("css-examples/web-fonts/basic-web-font.html", '100%', 50)}}
+{{EmbedGHLiveSample("css-examples/web-fonts/basic-web-font.html", '100%', '100')}}
 
 ### Specifying local font alternatives
 


### PR DESCRIPTION
The example here was so small you couldn't see the output at all. It would be great to fix this in Yari (https://github.com/mdn/yari/issues/6445), but in the meantime we can fix it in content.