### PR TITLE
Remove extraneous space in a title

### DIFF
--- a/files/en-us/web/api/rtcicecandidate/tojson/index.md
+++ b/files/en-us/web/api/rtcicecandidate/tojson/index.md
@@ -1,5 +1,5 @@
 ---
-title: RTCIceCandidate. toJSON()
+title: RTCIceCandidate.toJSON()
 slug: Web/API/RTCIceCandidate/toJSON
 page-type: web-api-instance-method
 tags:


### PR DESCRIPTION
There was an extra space in the title.