### PR TITLE
Remove prototype from a title (in Web/API)

### DIFF
--- a/files/en-us/web/api/paymentrequest/id/index.md
+++ b/files/en-us/web/api/paymentrequest/id/index.md
@@ -1,5 +1,5 @@
 ---
-title: PaymentRequest.prototype.id
+title: PaymentRequest.id
 slug: Web/API/PaymentRequest/id
 tags:
   - API


### PR DESCRIPTION
We dont use `.prototype`in Web/API