### PR TITLE
FormData is not "write only"

### DIFF
--- a/files/en-us/learn/forms/sending_forms_through_javascript/index.md
+++ b/files/en-us/learn/forms/sending_forms_through_javascript/index.md
@@ -121,7 +121,7 @@ Here's the live result:
 
 Building an HTTP request by hand can be overwhelming. Fortunately, the [XMLHttpRequest specification](https://www.w3.org/TR/XMLHttpRequest/) provides a newer, simpler way to handle form data requests with the {{domxref("FormData","FormData")}} object.
 
-The {{domxref("FormData","FormData")}} object can be used to build form data for transmission, or to get the data within a form element to manage how it's sent. Note that {{domxref("FormData","FormData")}} objects are "write only", which means you can change them, but not retrieve their contents.
+The {{domxref("FormData","FormData")}} object can be used to build form data for transmission, or to get the data within a form element to manage how it's sent.
 
 Using this object is detailed in [Using FormData Objects](/en-US/docs/Web/API/FormData/Using_FormData_Objects), but here are two examples:
 


### PR DESCRIPTION
#### Summary
The doco states FormData objects are "write only" however this is no longer the case. The contents inside a FormData can read out. 

#### Motivation
I didn't think to get data straight out of FormData because I was mislead by this document and want to avoid others being misled in the same way.

#### Supporting details
Example of how data can read out - [How to convert FormData (HTML5 object) to JSON](https://stackoverflow.com/questions/41431322/how-to-convert-formdata-html5-object-to-json)

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error