### PR TITLE
Add reference to takeRecords() in the Note

### DIFF
--- a/files/en-us/web/api/mutationobserver/disconnect/index.md
+++ b/files/en-us/web/api/mutationobserver/disconnect/index.md
@@ -46,6 +46,8 @@ None.
 
 > **Note:** All notifications of mutations that have already been
 > _detected_, but _not yet reported_ to the observer, are discarded.
+> To hold on to and handle the detected but unreported mutations, use 
+> {{domxref("MutationObserver.takeRecords()", "takeRecords()")}}.
 
 ## Usage notes
 

--- a/files/en-us/web/api/mutationobserver/disconnect/index.md
+++ b/files/en-us/web/api/mutationobserver/disconnect/index.md
@@ -47,7 +47,7 @@ None.
 > **Note:** All notifications of mutations that have already been
 > _detected_, but _not yet reported_ to the observer, are discarded.
 > To hold on to and handle the detected but unreported mutations, use 
-> {{domxref("MutationObserver.takeRecords()", "takeRecords()")}}.
+> the {{domxref("MutationObserver.takeRecords()", "takeRecords()")}} method.
 
 ## Usage notes
 


### PR DESCRIPTION
takeRecords() is used primarily when disconnecting a MutationObserver instance to allow handling of detected but as-yet unreported mutations.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Added a reference to takeRecords() at a relevant spot in the Note section.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
There is no reference yet to takeRecords() in this article on disconnect(). takeRecords() is used closely with disconnect().
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
