### PR TITLE
Change text to link for encodeURI reference

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/encodeuricomponent/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/encodeuricomponent/index.md
@@ -43,8 +43,7 @@ Not Escaped:
     A-Z a-z 0-9 - _ . ! ~ * ' ( )
 ```
 
-`encodeURIComponent()` differs from **`encodeURI`**
-as follows:
+`encodeURIComponent()` differs from {{jsxref("encodeURI", "encodeURI()")}} as follows:
 
 ```js
 const set1 = ";,/?:@&=+$";  // Reserved Characters

--- a/files/en-us/web/javascript/reference/global_objects/encodeuricomponent/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/encodeuricomponent/index.md
@@ -43,7 +43,7 @@ Not Escaped:
     A-Z a-z 0-9 - _ . ! ~ * ' ( )
 ```
 
-`encodeURIComponent()` differs from {{jsxref("encodeURI", "encodeURI()")}} as follows:
+`encodeURIComponent()` differs from {{jsxref("encodeURI()")}} as follows:
 
 ```js
 const set1 = ";,/?:@&=+$";  // Reserved Characters

--- a/files/en-us/web/javascript/reference/global_objects/encodeuricomponent/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/encodeuricomponent/index.md
@@ -43,7 +43,7 @@ Not Escaped:
     A-Z a-z 0-9 - _ . ! ~ * ' ( )
 ```
 
-`encodeURIComponent()` differs from {{jsxref("encodeURI()")}} as follows:
+`encodeURIComponent()` differs from {{jsxref("encodeURI", "encodeURI()")}} as follows:
 
 ```js
 const set1 = ";,/?:@&=+$";  // Reserved Characters


### PR DESCRIPTION
#### Summary
Making the docs more accessible and easy to navigate, by adding a link to encodeURI.

#### Motivation
To make it easier to nav to a related page.

#### Supporting details
See backlink for the other page here: https://github.com/mdn/content/blob/main/files/en-us/web/javascript/reference/global_objects/encodeuri/index.md?plain=1#L66-L67

#### Metadata
- [x] Fixes a typo, bug, or other error

