### PR TITLE
Add Web/API page types, part 24

### DIFF
--- a/files/en-us/web/api/texttrack/id/index.md
+++ b/files/en-us/web/api/texttrack/id/index.md
@@ -1,6 +1,7 @@
 ---
 title: TextTrack.id
 slug: Web/API/TextTrack/id
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/texttrack/inbandmetadatatrackdispatchtype/index.md
+++ b/files/en-us/web/api/texttrack/inbandmetadatatrackdispatchtype/index.md
@@ -1,6 +1,7 @@
 ---
 title: TextTrack.inBandMetadataTrackDispatchType
 slug: Web/API/TextTrack/inBandMetadataTrackDispatchType
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/texttrack/kind/index.md
+++ b/files/en-us/web/api/texttrack/kind/index.md
@@ -1,6 +1,7 @@
 ---
 title: TextTrack.kind
 slug: Web/API/TextTrack/kind
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/texttrack/label/index.md
+++ b/files/en-us/web/api/texttrack/label/index.md
@@ -1,6 +1,7 @@
 ---
 title: TextTrack.label
 slug: Web/API/TextTrack/label
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/texttrack/language/index.md
+++ b/files/en-us/web/api/texttrack/language/index.md
@@ -1,6 +1,7 @@
 ---
 title: TextTrack.language
 slug: Web/API/TextTrack/language
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/texttrack/mode/index.md
+++ b/files/en-us/web/api/texttrack/mode/index.md
@@ -1,6 +1,7 @@
 ---
 title: TextTrack.mode
 slug: Web/API/TextTrack/mode
+page-type: web-api-instance-property
 tags:
   - Accessibility
   - NeedsExample

--- a/files/en-us/web/api/texttrack/removecue/index.md
+++ b/files/en-us/web/api/texttrack/removecue/index.md
@@ -1,6 +1,7 @@
 ---
 title: TextTrack.removeCue()
 slug: Web/API/TextTrack/removeCue
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/texttrackcue/endtime/index.md
+++ b/files/en-us/web/api/texttrackcue/endtime/index.md
@@ -1,6 +1,7 @@
 ---
 title: TextTrackCue.endTime
 slug: Web/API/TextTrackCue/endTime
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/texttrackcue/enter_event/index.md
+++ b/files/en-us/web/api/texttrackcue/enter_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'TextTrackCue: enter event'
 slug: Web/API/TextTrackCue/enter_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/texttrackcue/exit_event/index.md
+++ b/files/en-us/web/api/texttrackcue/exit_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'TextTrackCue: exit event'
 slug: Web/API/TextTrackCue/exit_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/texttrackcue/id/index.md
+++ b/files/en-us/web/api/texttrackcue/id/index.md
@@ -1,6 +1,7 @@
 ---
 title: TextTrackCue.id
 slug: Web/API/TextTrackCue/id
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/texttrackcue/index.md
+++ b/files/en-us/web/api/texttrackcue/index.md
@@ -1,6 +1,7 @@
 ---
 title: TextTrackCue
 slug: Web/API/TextTrackCue
+page-type: web-api-interface
 tags:
   - API
   - Accessibility

--- a/files/en-us/web/api/texttrackcue/pauseonexit/index.md
+++ b/files/en-us/web/api/texttrackcue/pauseonexit/index.md
@@ -1,6 +1,7 @@
 ---
 title: TextTrackCue.pauseOnExit
 slug: Web/API/TextTrackCue/pauseOnExit
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/texttrackcue/starttime/index.md
+++ b/files/en-us/web/api/texttrackcue/starttime/index.md
@@ -1,6 +1,7 @@
 ---
 title: TextTrackCue.startTime
 slug: Web/API/TextTrackCue/startTime
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/texttrackcue/track/index.md
+++ b/files/en-us/web/api/texttrackcue/track/index.md
@@ -1,6 +1,7 @@
 ---
 title: TextTrackCue.track
 slug: Web/API/TextTrackCue/track
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/texttrackcuelist/getcuebyid/index.md
+++ b/files/en-us/web/api/texttrackcuelist/getcuebyid/index.md
@@ -1,6 +1,7 @@
 ---
 title: TextTrackCueList.getCueById()
 slug: Web/API/TextTrackCueList/getCueById
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/texttrackcuelist/index.md
+++ b/files/en-us/web/api/texttrackcuelist/index.md
@@ -1,6 +1,7 @@
 ---
 title: TextTrackCueList
 slug: Web/API/TextTrackCueList
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/texttrackcuelist/length/index.md
+++ b/files/en-us/web/api/texttrackcuelist/length/index.md
@@ -1,6 +1,7 @@
 ---
 title: TextTrackCueList.length
 slug: Web/API/TextTrackCueList/length
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/texttracklist/addtrack_event/index.md
+++ b/files/en-us/web/api/texttracklist/addtrack_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'TextTrackList: addtrack event'
 slug: Web/API/TextTrackList/addtrack_event
+page-type: web-api-event
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/texttracklist/change_event/index.md
+++ b/files/en-us/web/api/texttracklist/change_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'TextTrackList: change event'
 slug: Web/API/TextTrackList/change_event
+page-type: web-api-event
 tags:
   - Event
   - TextTrack

--- a/files/en-us/web/api/texttracklist/gettrackbyid/index.md
+++ b/files/en-us/web/api/texttracklist/gettrackbyid/index.md
@@ -1,6 +1,7 @@
 ---
 title: TextTrackList.getTrackById()
 slug: Web/API/TextTrackList/getTrackById
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/texttracklist/index.md
+++ b/files/en-us/web/api/texttracklist/index.md
@@ -1,6 +1,7 @@
 ---
 title: TextTrackList
 slug: Web/API/TextTrackList
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/texttracklist/length/index.md
+++ b/files/en-us/web/api/texttracklist/length/index.md
@@ -1,6 +1,7 @@
 ---
 title: TextTrackList.length
 slug: Web/API/TextTrackList/length
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/texttracklist/removetrack_event/index.md
+++ b/files/en-us/web/api/texttracklist/removetrack_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'TextTrackList: removeTrack event'
 slug: Web/API/TextTrackList/removeTrack_event
+page-type: web-api-event
 tags:
   - API
   - Media Streams API

--- a/files/en-us/web/api/timeevent/index.md
+++ b/files/en-us/web/api/timeevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: TimeEvent
 slug: Web/API/TimeEvent
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/timeranges/end/index.md
+++ b/files/en-us/web/api/timeranges/end/index.md
@@ -1,6 +1,7 @@
 ---
 title: TimeRanges.end()
 slug: Web/API/TimeRanges/end
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/timeranges/index.md
+++ b/files/en-us/web/api/timeranges/index.md
@@ -1,6 +1,7 @@
 ---
 title: TimeRanges
 slug: Web/API/TimeRanges
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/timeranges/length/index.md
+++ b/files/en-us/web/api/timeranges/length/index.md
@@ -1,6 +1,7 @@
 ---
 title: TimeRanges.length
 slug: Web/API/TimeRanges/length
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/timeranges/start/index.md
+++ b/files/en-us/web/api/timeranges/start/index.md
@@ -1,6 +1,7 @@
 ---
 title: TimeRanges.start()
 slug: Web/API/TimeRanges/start
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/touch/clientx/index.md
+++ b/files/en-us/web/api/touch/clientx/index.md
@@ -1,6 +1,7 @@
 ---
 title: Touch.clientX
 slug: Web/API/Touch/clientX
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/touch/clienty/index.md
+++ b/files/en-us/web/api/touch/clienty/index.md
@@ -1,6 +1,7 @@
 ---
 title: Touch.clientY
 slug: Web/API/Touch/clientY
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/touch/force/index.md
+++ b/files/en-us/web/api/touch/force/index.md
@@ -1,6 +1,7 @@
 ---
 title: Touch.force
 slug: Web/API/Touch/force
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/touch/identifier/index.md
+++ b/files/en-us/web/api/touch/identifier/index.md
@@ -1,6 +1,7 @@
 ---
 title: Touch.identifier
 slug: Web/API/Touch/identifier
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/touch/index.md
+++ b/files/en-us/web/api/touch/index.md
@@ -1,6 +1,7 @@
 ---
 title: Touch
 slug: Web/API/Touch
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/touch/msmanipulationviewsenabled/index.md
+++ b/files/en-us/web/api/touch/msmanipulationviewsenabled/index.md
@@ -1,6 +1,7 @@
 ---
 title: Touch.msManipulationViewsEnabled
 slug: Web/API/Touch/MsManipulationViewsEnabled
+page-type: web-api-instance-property
 tags:
   - msManipulationViesEnabled
 ---

--- a/files/en-us/web/api/touch/pagex/index.md
+++ b/files/en-us/web/api/touch/pagex/index.md
@@ -1,6 +1,7 @@
 ---
 title: Touch.pageX
 slug: Web/API/Touch/pageX
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/touch/pagey/index.md
+++ b/files/en-us/web/api/touch/pagey/index.md
@@ -1,6 +1,7 @@
 ---
 title: Touch.pageY
 slug: Web/API/Touch/pageY
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/touch/radiusx/index.md
+++ b/files/en-us/web/api/touch/radiusx/index.md
@@ -1,6 +1,7 @@
 ---
 title: Touch.radiusX
 slug: Web/API/Touch/radiusX
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/touch/radiusy/index.md
+++ b/files/en-us/web/api/touch/radiusy/index.md
@@ -1,6 +1,7 @@
 ---
 title: Touch.radiusY
 slug: Web/API/Touch/radiusY
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/touch/rotationangle/index.md
+++ b/files/en-us/web/api/touch/rotationangle/index.md
@@ -1,6 +1,7 @@
 ---
 title: Touch.rotationAngle
 slug: Web/API/Touch/rotationAngle
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/touch/screenx/index.md
+++ b/files/en-us/web/api/touch/screenx/index.md
@@ -1,6 +1,7 @@
 ---
 title: Touch.screenX
 slug: Web/API/Touch/screenX
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/touch/screeny/index.md
+++ b/files/en-us/web/api/touch/screeny/index.md
@@ -1,6 +1,7 @@
 ---
 title: Touch.screenY
 slug: Web/API/Touch/screenY
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/touch/target/index.md
+++ b/files/en-us/web/api/touch/target/index.md
@@ -1,6 +1,7 @@
 ---
 title: Touch.target
 slug: Web/API/Touch/target
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/touch/touch/index.md
+++ b/files/en-us/web/api/touch/touch/index.md
@@ -1,6 +1,7 @@
 ---
 title: Touch()
 slug: Web/API/Touch/Touch
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/touch_events/index.md
+++ b/files/en-us/web/api/touch_events/index.md
@@ -1,6 +1,7 @@
 ---
 title: Touch events
 slug: Web/API/Touch_events
+page-type: web-api-overview
 tags:
   - Advanced
   - DOM

--- a/files/en-us/web/api/touch_events/mozilla_experimental_events/index.md
+++ b/files/en-us/web/api/touch_events/mozilla_experimental_events/index.md
@@ -1,6 +1,7 @@
 ---
 title: Touch events (Mozilla experimental)
 slug: Web/API/Touch_events/Mozilla_experimental_events
+page-type: guide
 tags:
   - DOM
   - Gecko DOM Reference

--- a/files/en-us/web/api/touch_events/multi-touch_interaction/index.md
+++ b/files/en-us/web/api/touch_events/multi-touch_interaction/index.md
@@ -1,6 +1,7 @@
 ---
 title: Multi-touch interaction
 slug: Web/API/Touch_events/Multi-touch_interaction
+page-type: guide
 tags:
   - Guide
   - TouchEvent

--- a/files/en-us/web/api/touch_events/using_touch_events/index.md
+++ b/files/en-us/web/api/touch_events/using_touch_events/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using Touch Events
 slug: Web/API/Touch_events/Using_Touch_Events
+page-type: guide
 tags:
   - Guide
   - TouchEvent

--- a/files/en-us/web/api/touchevent/altkey/index.md
+++ b/files/en-us/web/api/touchevent/altkey/index.md
@@ -1,6 +1,7 @@
 ---
 title: TouchEvent.altKey
 slug: Web/API/TouchEvent/altKey
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/touchevent/changedtouches/index.md
+++ b/files/en-us/web/api/touchevent/changedtouches/index.md
@@ -1,6 +1,7 @@
 ---
 title: TouchEvent.changedTouches
 slug: Web/API/TouchEvent/changedTouches
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/touchevent/ctrlkey/index.md
+++ b/files/en-us/web/api/touchevent/ctrlkey/index.md
@@ -1,6 +1,7 @@
 ---
 title: TouchEvent.ctrlKey
 slug: Web/API/TouchEvent/ctrlKey
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/touchevent/index.md
+++ b/files/en-us/web/api/touchevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: TouchEvent
 slug: Web/API/TouchEvent
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/touchevent/metakey/index.md
+++ b/files/en-us/web/api/touchevent/metakey/index.md
@@ -1,6 +1,7 @@
 ---
 title: TouchEvent.metaKey
 slug: Web/API/TouchEvent/metaKey
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/touchevent/shiftkey/index.md
+++ b/files/en-us/web/api/touchevent/shiftkey/index.md
@@ -1,6 +1,7 @@
 ---
 title: TouchEvent.shiftKey
 slug: Web/API/TouchEvent/shiftKey
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/touchevent/targettouches/index.md
+++ b/files/en-us/web/api/touchevent/targettouches/index.md
@@ -1,6 +1,7 @@
 ---
 title: TouchEvent.targetTouches
 slug: Web/API/TouchEvent/targetTouches
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/touchevent/touches/index.md
+++ b/files/en-us/web/api/touchevent/touches/index.md
@@ -1,6 +1,7 @@
 ---
 title: TouchEvent.touches
 slug: Web/API/TouchEvent/touches
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/touchevent/touchevent/index.md
+++ b/files/en-us/web/api/touchevent/touchevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: TouchEvent()
 slug: Web/API/TouchEvent/TouchEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/touchlist/index.md
+++ b/files/en-us/web/api/touchlist/index.md
@@ -1,6 +1,7 @@
 ---
 title: TouchList
 slug: Web/API/TouchList
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/touchlist/item/index.md
+++ b/files/en-us/web/api/touchlist/item/index.md
@@ -1,6 +1,7 @@
 ---
 title: TouchList.item()
 slug: Web/API/TouchList/item
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/touchlist/length/index.md
+++ b/files/en-us/web/api/touchlist/length/index.md
@@ -1,6 +1,7 @@
 ---
 title: TouchList.length
 slug: Web/API/TouchList/length
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/trackevent/index.md
+++ b/files/en-us/web/api/trackevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrackEvent
 slug: Web/API/TrackEvent
+page-type: web-api-interface
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/trackevent/track/index.md
+++ b/files/en-us/web/api/trackevent/track/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrackEvent.track
 slug: Web/API/TrackEvent/track
+page-type: web-api-instance-property
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/trackevent/trackevent/index.md
+++ b/files/en-us/web/api/trackevent/trackevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrackEvent()
 slug: Web/API/TrackEvent/TrackEvent
+page-type: web-api-constructor
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/transformstream/index.md
+++ b/files/en-us/web/api/transformstream/index.md
@@ -1,6 +1,7 @@
 ---
 title: TransformStream
 slug: Web/API/TransformStream
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/transformstream/readable/index.md
+++ b/files/en-us/web/api/transformstream/readable/index.md
@@ -1,6 +1,7 @@
 ---
 title: TransformStream.readable
 slug: Web/API/TransformStream/readable
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/transformstream/transformstream/index.md
+++ b/files/en-us/web/api/transformstream/transformstream/index.md
@@ -1,6 +1,7 @@
 ---
 title: TransformStream()
 slug: Web/API/TransformStream/TransformStream
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/transformstream/writable/index.md
+++ b/files/en-us/web/api/transformstream/writable/index.md
@@ -1,6 +1,7 @@
 ---
 title: TransformStream.writable
 slug: Web/API/TransformStream/writable
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/transformstreamdefaultcontroller/desiredsize/index.md
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/desiredsize/index.md
@@ -1,6 +1,7 @@
 ---
 title: TransformStreamDefaultController.desiredSize
 slug: Web/API/TransformStreamDefaultController/desiredSize
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/transformstreamdefaultcontroller/enqueue/index.md
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/enqueue/index.md
@@ -1,6 +1,7 @@
 ---
 title: TransformStreamDefaultController.enqueue()
 slug: Web/API/TransformStreamDefaultController/enqueue
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/transformstreamdefaultcontroller/error/index.md
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/error/index.md
@@ -1,6 +1,7 @@
 ---
 title: TransformStreamDefaultController.error()
 slug: Web/API/TransformStreamDefaultController/error
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/transformstreamdefaultcontroller/index.md
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/index.md
@@ -1,6 +1,7 @@
 ---
 title: TransformStreamDefaultController
 slug: Web/API/TransformStreamDefaultController
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/transformstreamdefaultcontroller/terminate/index.md
+++ b/files/en-us/web/api/transformstreamdefaultcontroller/terminate/index.md
@@ -1,6 +1,7 @@
 ---
 title: TransformStreamDefaultController.terminate()
 slug: Web/API/TransformStreamDefaultController/terminate
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/transitionevent/elapsedtime/index.md
+++ b/files/en-us/web/api/transitionevent/elapsedtime/index.md
@@ -1,6 +1,7 @@
 ---
 title: TransitionEvent.elapsedTime
 slug: Web/API/TransitionEvent/elapsedTime
+page-type: web-api-instance-property
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/transitionevent/index.md
+++ b/files/en-us/web/api/transitionevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: TransitionEvent
 slug: Web/API/TransitionEvent
+page-type: web-api-interface
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/transitionevent/inittransitionevent/index.md
+++ b/files/en-us/web/api/transitionevent/inittransitionevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: TransitionEvent.initTransitionEvent()
 slug: Web/API/TransitionEvent/initTransitionEvent
+page-type: web-api-instance-method
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/transitionevent/propertyname/index.md
+++ b/files/en-us/web/api/transitionevent/propertyname/index.md
@@ -1,6 +1,7 @@
 ---
 title: TransitionEvent.propertyName
 slug: Web/API/TransitionEvent/propertyName
+page-type: web-api-instance-property
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/transitionevent/pseudoelement/index.md
+++ b/files/en-us/web/api/transitionevent/pseudoelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: TransitionEvent.pseudoElement
 slug: Web/API/TransitionEvent/pseudoElement
+page-type: web-api-instance-property
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/transitionevent/transitionevent/index.md
+++ b/files/en-us/web/api/transitionevent/transitionevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: TransitionEvent()
 slug: Web/API/TransitionEvent/TransitionEvent
+page-type: web-api-constructor
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/treewalker/currentnode/index.md
+++ b/files/en-us/web/api/treewalker/currentnode/index.md
@@ -1,6 +1,7 @@
 ---
 title: TreeWalker.currentNode
 slug: Web/API/TreeWalker/currentNode
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/treewalker/filter/index.md
+++ b/files/en-us/web/api/treewalker/filter/index.md
@@ -1,6 +1,7 @@
 ---
 title: TreeWalker.filter
 slug: Web/API/TreeWalker/filter
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/treewalker/firstchild/index.md
+++ b/files/en-us/web/api/treewalker/firstchild/index.md
@@ -1,6 +1,7 @@
 ---
 title: TreeWalker.firstChild()
 slug: Web/API/TreeWalker/firstChild
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/treewalker/index.md
+++ b/files/en-us/web/api/treewalker/index.md
@@ -1,6 +1,7 @@
 ---
 title: TreeWalker
 slug: Web/API/TreeWalker
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/treewalker/lastchild/index.md
+++ b/files/en-us/web/api/treewalker/lastchild/index.md
@@ -1,6 +1,7 @@
 ---
 title: TreeWalker.lastChild()
 slug: Web/API/TreeWalker/lastChild
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/treewalker/nextnode/index.md
+++ b/files/en-us/web/api/treewalker/nextnode/index.md
@@ -1,6 +1,7 @@
 ---
 title: TreeWalker.nextNode()
 slug: Web/API/TreeWalker/nextNode
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/treewalker/nextsibling/index.md
+++ b/files/en-us/web/api/treewalker/nextsibling/index.md
@@ -1,6 +1,7 @@
 ---
 title: TreeWalker.nextSibling()
 slug: Web/API/TreeWalker/nextSibling
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/treewalker/parentnode/index.md
+++ b/files/en-us/web/api/treewalker/parentnode/index.md
@@ -1,6 +1,7 @@
 ---
 title: TreeWalker.parentNode()
 slug: Web/API/TreeWalker/parentNode
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/treewalker/previousnode/index.md
+++ b/files/en-us/web/api/treewalker/previousnode/index.md
@@ -1,6 +1,7 @@
 ---
 title: TreeWalker.previousNode()
 slug: Web/API/TreeWalker/previousNode
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/treewalker/previoussibling/index.md
+++ b/files/en-us/web/api/treewalker/previoussibling/index.md
@@ -1,6 +1,7 @@
 ---
 title: TreeWalker.previousSibling()
 slug: Web/API/TreeWalker/previousSibling
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/treewalker/root/index.md
+++ b/files/en-us/web/api/treewalker/root/index.md
@@ -1,6 +1,7 @@
 ---
 title: TreeWalker.root
 slug: Web/API/TreeWalker/root
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/treewalker/whattoshow/index.md
+++ b/files/en-us/web/api/treewalker/whattoshow/index.md
@@ -1,6 +1,7 @@
 ---
 title: TreeWalker.whatToShow
 slug: Web/API/TreeWalker/whatToShow
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/trusted_types_api/index.md
+++ b/files/en-us/web/api/trusted_types_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Trusted Types API
 slug: Web/API/Trusted_Types_API
+page-type: web-api-overview
 tags:
   - API
   - Overview

--- a/files/en-us/web/api/trustedhtml/index.md
+++ b/files/en-us/web/api/trustedhtml/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrustedHTML
 slug: Web/API/TrustedHTML
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/trustedhtml/tojson/index.md
+++ b/files/en-us/web/api/trustedhtml/tojson/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrustedHTML.toJSON()
 slug: Web/API/TrustedHTML/toJSON
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/trustedhtml/tostring/index.md
+++ b/files/en-us/web/api/trustedhtml/tostring/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrustedHTML.toString()
 slug: Web/API/TrustedHTML/toString
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/trustedscript/index.md
+++ b/files/en-us/web/api/trustedscript/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrustedScript
 slug: Web/API/TrustedScript
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/trustedscript/tojson/index.md
+++ b/files/en-us/web/api/trustedscript/tojson/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrustedScript.toJSON()
 slug: Web/API/TrustedScript/toJSON
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/trustedscript/tostring/index.md
+++ b/files/en-us/web/api/trustedscript/tostring/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrustedScript.toString()
 slug: Web/API/TrustedScript/toString
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/trustedscripturl/index.md
+++ b/files/en-us/web/api/trustedscripturl/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrustedScriptURL
 slug: Web/API/TrustedScriptURL
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/trustedscripturl/tojson/index.md
+++ b/files/en-us/web/api/trustedscripturl/tojson/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrustedScriptURL.toJSON()
 slug: Web/API/TrustedScriptURL/toJSON
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/trustedscripturl/tostring/index.md
+++ b/files/en-us/web/api/trustedscripturl/tostring/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrustedScriptURL.toString()
 slug: Web/API/TrustedScriptURL/toString
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/trustedtypepolicy/createhtml/index.md
+++ b/files/en-us/web/api/trustedtypepolicy/createhtml/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrustedTypePolicy.createHTML()
 slug: Web/API/TrustedTypePolicy/createHTML
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/trustedtypepolicy/createscript/index.md
+++ b/files/en-us/web/api/trustedtypepolicy/createscript/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrustedTypePolicy.createScript()
 slug: Web/API/TrustedTypePolicy/createScript
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/trustedtypepolicy/createscripturl/index.md
+++ b/files/en-us/web/api/trustedtypepolicy/createscripturl/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrustedTypePolicy.createScriptURL()
 slug: Web/API/TrustedTypePolicy/createScriptURL
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/trustedtypepolicy/index.md
+++ b/files/en-us/web/api/trustedtypepolicy/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrustedTypePolicy
 slug: Web/API/TrustedTypePolicy
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/trustedtypepolicy/name/index.md
+++ b/files/en-us/web/api/trustedtypepolicy/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrustedTypePolicy.name
 slug: Web/API/TrustedTypePolicy/name
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrustedTypePolicyFactory.createPolicy()
 slug: Web/API/TrustedTypePolicyFactory/createPolicy
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/trustedtypepolicyfactory/defaultpolicy/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/defaultpolicy/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrustedTypePolicyFactory.defaultPolicy
 slug: Web/API/TrustedTypePolicyFactory/defaultPolicy
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/trustedtypepolicyfactory/emptyhtml/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/emptyhtml/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrustedTypePolicyFactory.emptyHTML
 slug: Web/API/TrustedTypePolicyFactory/emptyHTML
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/trustedtypepolicyfactory/emptyscript/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/emptyscript/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrustedTypePolicyFactory.emptyScript
 slug: Web/API/TrustedTypePolicyFactory/emptyScript
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrustedTypePolicyFactory.getAttributeType()
 slug: Web/API/TrustedTypePolicyFactory/getAttributeType
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrustedTypePolicyFactory.getPropertyType()
 slug: Web/API/TrustedTypePolicyFactory/getPropertyType
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/trustedtypepolicyfactory/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrustedTypePolicyFactory
 slug: Web/API/TrustedTypePolicyFactory
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/ishtml/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrustedTypePolicyFactory.isHTML()
 slug: Web/API/TrustedTypePolicyFactory/isHTML
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscript/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrustedTypePolicyFactory.isScript()
 slug: Web/API/TrustedTypePolicyFactory/isScript
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/isscripturl/index.md
@@ -1,6 +1,7 @@
 ---
 title: TrustedTypePolicyFactory.isScriptURL()
 slug: Web/API/TrustedTypePolicyFactory/isScriptURL
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/udp_socket_api/index.md
+++ b/files/en-us/web/api/udp_socket_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: UDP Socket API
 slug: Web/API/UDP_Socket_API
+page-type: web-api-overview
 tags:
   - UDPSocket
   - mozUDPSocket

--- a/files/en-us/web/api/ui_events/index.md
+++ b/files/en-us/web/api/ui_events/index.md
@@ -1,6 +1,7 @@
 ---
 title: UI Events
 slug: Web/API/UI_Events
+page-type: web-api-overview
 tags:
   - API
   - Overview

--- a/files/en-us/web/api/ui_events/keyboard_event_code_values/index.md
+++ b/files/en-us/web/api/ui_events/keyboard_event_code_values/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Code values for keyboard events'
 slug: Web/API/UI_Events/Keyboard_event_code_values
+page-type: guide
 ---
 {{DefaultAPISidebar("UI Events")}}
 

--- a/files/en-us/web/api/ui_events/keyboard_event_key_values/index.md
+++ b/files/en-us/web/api/ui_events/keyboard_event_key_values/index.md
@@ -1,6 +1,7 @@
 ---
 title: Key values for keyboard events
 slug: Web/API/UI_Events/Keyboard_event_key_values
+page-type: guide
 tags:
   - Characters
   - DOM

--- a/files/en-us/web/api/uievent/detail/index.md
+++ b/files/en-us/web/api/uievent/detail/index.md
@@ -1,6 +1,7 @@
 ---
 title: UIEvent.detail
 slug: Web/API/UIEvent/detail
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/uievent/index.md
+++ b/files/en-us/web/api/uievent/index.md
@@ -1,6 +1,7 @@
 ---
 title: UIEvent
 slug: Web/API/UIEvent
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/uievent/inituievent/index.md
+++ b/files/en-us/web/api/uievent/inituievent/index.md
@@ -1,6 +1,7 @@
 ---
 title: UIEvent.initUIEvent()
 slug: Web/API/UIEvent/initUIEvent
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/uievent/sourcecapabilities/index.md
+++ b/files/en-us/web/api/uievent/sourcecapabilities/index.md
@@ -1,6 +1,7 @@
 ---
 title: UIEvent.sourceCapabilities
 slug: Web/API/UIEvent/sourceCapabilities
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/uievent/uievent/index.md
+++ b/files/en-us/web/api/uievent/uievent/index.md
@@ -1,6 +1,7 @@
 ---
 title: UIEvent()
 slug: Web/API/UIEvent/UIEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/uievent/view/index.md
+++ b/files/en-us/web/api/uievent/view/index.md
@@ -1,6 +1,7 @@
 ---
 title: UIEvent.view
 slug: Web/API/UIEvent/view
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/uievent/which/index.md
+++ b/files/en-us/web/api/uievent/which/index.md
@@ -1,6 +1,7 @@
 ---
 title: UIEvent.which
 slug: Web/API/UIEvent/which
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/url/createobjecturl/index.md
+++ b/files/en-us/web/api/url/createobjecturl/index.md
@@ -1,6 +1,7 @@
 ---
 title: URL.createObjectURL()
 slug: Web/API/URL/createObjectURL
+page-type: web-api-static-method
 tags:
   - API
   - Blob

--- a/files/en-us/web/api/url/hash/index.md
+++ b/files/en-us/web/api/url/hash/index.md
@@ -1,6 +1,7 @@
 ---
 title: URL.hash
 slug: Web/API/URL/hash
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/url/host/index.md
+++ b/files/en-us/web/api/url/host/index.md
@@ -1,6 +1,7 @@
 ---
 title: URL.host
 slug: Web/API/URL/host
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/url/hostname/index.md
+++ b/files/en-us/web/api/url/hostname/index.md
@@ -1,6 +1,7 @@
 ---
 title: URL.hostname
 slug: Web/API/URL/hostname
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/url/href/index.md
+++ b/files/en-us/web/api/url/href/index.md
@@ -1,6 +1,7 @@
 ---
 title: URL.href
 slug: Web/API/URL/href
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/url/index.md
+++ b/files/en-us/web/api/url/index.md
@@ -1,6 +1,7 @@
 ---
 title: URL
 slug: Web/API/URL
+page-type: web-api-interface
 tags:
   - API
   - Address

--- a/files/en-us/web/api/url/origin/index.md
+++ b/files/en-us/web/api/url/origin/index.md
@@ -1,6 +1,7 @@
 ---
 title: URL.origin
 slug: Web/API/URL/origin
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/url/password/index.md
+++ b/files/en-us/web/api/url/password/index.md
@@ -1,6 +1,7 @@
 ---
 title: URL.password
 slug: Web/API/URL/password
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/url/pathname/index.md
+++ b/files/en-us/web/api/url/pathname/index.md
@@ -1,6 +1,7 @@
 ---
 title: URL.pathname
 slug: Web/API/URL/pathname
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/url/port/index.md
+++ b/files/en-us/web/api/url/port/index.md
@@ -1,6 +1,7 @@
 ---
 title: URL.port
 slug: Web/API/URL/port
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/url/protocol/index.md
+++ b/files/en-us/web/api/url/protocol/index.md
@@ -1,6 +1,7 @@
 ---
 title: URL.protocol
 slug: Web/API/URL/protocol
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/url/revokeobjecturl/index.md
+++ b/files/en-us/web/api/url/revokeobjecturl/index.md
@@ -1,6 +1,7 @@
 ---
 title: URL.revokeObjectURL()
 slug: Web/API/URL/revokeObjectURL
+page-type: web-api-static-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/url/search/index.md
+++ b/files/en-us/web/api/url/search/index.md
@@ -1,6 +1,7 @@
 ---
 title: URL.search
 slug: Web/API/URL/search
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/url/searchparams/index.md
+++ b/files/en-us/web/api/url/searchparams/index.md
@@ -1,6 +1,7 @@
 ---
 title: URL.searchParams
 slug: Web/API/URL/searchParams
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/url/tojson/index.md
+++ b/files/en-us/web/api/url/tojson/index.md
@@ -1,6 +1,7 @@
 ---
 title: URL.toJSON()
 slug: Web/API/URL/toJSON
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/url/tostring/index.md
+++ b/files/en-us/web/api/url/tostring/index.md
@@ -1,6 +1,7 @@
 ---
 title: URL.toString()
 slug: Web/API/URL/toString
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/url/url/index.md
+++ b/files/en-us/web/api/url/url/index.md
@@ -1,6 +1,7 @@
 ---
 title: URL()
 slug: Web/API/URL/URL
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/url/username/index.md
+++ b/files/en-us/web/api/url/username/index.md
@@ -1,6 +1,7 @@
 ---
 title: URL.username
 slug: Web/API/URL/username
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/url_api/index.md
+++ b/files/en-us/web/api/url_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: URL API
 slug: Web/API/URL_API
+page-type: web-api-overview
 tags:
   - API
   - Address

--- a/files/en-us/web/api/url_pattern_api/index.md
+++ b/files/en-us/web/api/url_pattern_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: URL Pattern API
 slug: Web/API/URL_Pattern_API
+page-type: web-api-overview
 tags:
   - API
   - Overview

--- a/files/en-us/web/api/urlpattern/exec/index.md
+++ b/files/en-us/web/api/urlpattern/exec/index.md
@@ -1,6 +1,7 @@
 ---
 title: URLPattern.exec()
 slug: Web/API/URLPattern/exec
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/urlpattern/hash/index.md
+++ b/files/en-us/web/api/urlpattern/hash/index.md
@@ -1,6 +1,7 @@
 ---
 title: URLPattern.hash
 slug: Web/API/URLPattern/hash
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/urlpattern/hostname/index.md
+++ b/files/en-us/web/api/urlpattern/hostname/index.md
@@ -1,6 +1,7 @@
 ---
 title: URLPattern.hostname
 slug: Web/API/URLPattern/hostname
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/urlpattern/index.md
+++ b/files/en-us/web/api/urlpattern/index.md
@@ -1,6 +1,7 @@
 ---
 title: URLPattern
 slug: Web/API/URLPattern
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/urlpattern/password/index.md
+++ b/files/en-us/web/api/urlpattern/password/index.md
@@ -1,6 +1,7 @@
 ---
 title: URLPattern.password
 slug: Web/API/URLPattern/password
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/urlpattern/pathname/index.md
+++ b/files/en-us/web/api/urlpattern/pathname/index.md
@@ -1,6 +1,7 @@
 ---
 title: URLPattern.pathname
 slug: Web/API/URLPattern/pathname
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/urlpattern/port/index.md
+++ b/files/en-us/web/api/urlpattern/port/index.md
@@ -1,6 +1,7 @@
 ---
 title: URLPattern.port
 slug: Web/API/URLPattern/port
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/urlpattern/protocol/index.md
+++ b/files/en-us/web/api/urlpattern/protocol/index.md
@@ -1,6 +1,7 @@
 ---
 title: URLPattern.protocol
 slug: Web/API/URLPattern/protocol
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/urlpattern/search/index.md
+++ b/files/en-us/web/api/urlpattern/search/index.md
@@ -1,6 +1,7 @@
 ---
 title: URLPattern.search
 slug: Web/API/URLPattern/search
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/urlpattern/test/index.md
+++ b/files/en-us/web/api/urlpattern/test/index.md
@@ -1,6 +1,7 @@
 ---
 title: URLPattern.test()
 slug: Web/API/URLPattern/test
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/urlpattern/urlpattern/index.md
+++ b/files/en-us/web/api/urlpattern/urlpattern/index.md
@@ -1,6 +1,7 @@
 ---
 title: URLPattern()
 slug: Web/API/URLPattern/URLPattern
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/urlpattern/username/index.md
+++ b/files/en-us/web/api/urlpattern/username/index.md
@@ -1,6 +1,7 @@
 ---
 title: URLPattern.username
 slug: Web/API/URLPattern/username
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/urlsearchparams/append/index.md
+++ b/files/en-us/web/api/urlsearchparams/append/index.md
@@ -1,6 +1,7 @@
 ---
 title: URLSearchParams.append()
 slug: Web/API/URLSearchParams/append
+page-type: web-api-instance-method
 tags:
   - API
   - Append

--- a/files/en-us/web/api/urlsearchparams/delete/index.md
+++ b/files/en-us/web/api/urlsearchparams/delete/index.md
@@ -1,6 +1,7 @@
 ---
 title: URLSearchParams.delete()
 slug: Web/API/URLSearchParams/delete
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/urlsearchparams/entries/index.md
+++ b/files/en-us/web/api/urlsearchparams/entries/index.md
@@ -1,6 +1,7 @@
 ---
 title: URLSearchParams.entries()
 slug: Web/API/URLSearchParams/entries
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/urlsearchparams/foreach/index.md
+++ b/files/en-us/web/api/urlsearchparams/foreach/index.md
@@ -1,6 +1,7 @@
 ---
 title: URLSearchParams.forEach()
 slug: Web/API/URLSearchParams/forEach
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/urlsearchparams/get/index.md
+++ b/files/en-us/web/api/urlsearchparams/get/index.md
@@ -1,6 +1,7 @@
 ---
 title: URLSearchParams.get()
 slug: Web/API/URLSearchParams/get
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/urlsearchparams/getall/index.md
+++ b/files/en-us/web/api/urlsearchparams/getall/index.md
@@ -1,6 +1,7 @@
 ---
 title: URLSearchParams.getAll()
 slug: Web/API/URLSearchParams/getAll
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/urlsearchparams/has/index.md
+++ b/files/en-us/web/api/urlsearchparams/has/index.md
@@ -1,6 +1,7 @@
 ---
 title: URLSearchParams.has()
 slug: Web/API/URLSearchParams/has
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/urlsearchparams/index.md
+++ b/files/en-us/web/api/urlsearchparams/index.md
@@ -1,6 +1,7 @@
 ---
 title: URLSearchParams
 slug: Web/API/URLSearchParams
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/urlsearchparams/keys/index.md
+++ b/files/en-us/web/api/urlsearchparams/keys/index.md
@@ -1,6 +1,7 @@
 ---
 title: URLSearchParams.keys()
 slug: Web/API/URLSearchParams/keys
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/urlsearchparams/set/index.md
+++ b/files/en-us/web/api/urlsearchparams/set/index.md
@@ -1,6 +1,7 @@
 ---
 title: URLSearchParams.set()
 slug: Web/API/URLSearchParams/set
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/urlsearchparams/sort/index.md
+++ b/files/en-us/web/api/urlsearchparams/sort/index.md
@@ -1,6 +1,7 @@
 ---
 title: URLSearchParams.sort()
 slug: Web/API/URLSearchParams/sort
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/urlsearchparams/tostring/index.md
+++ b/files/en-us/web/api/urlsearchparams/tostring/index.md
@@ -1,6 +1,7 @@
 ---
 title: URLSearchParams.toString()
 slug: Web/API/URLSearchParams/toString
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
+++ b/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
@@ -1,6 +1,7 @@
 ---
 title: URLSearchParams()
 slug: Web/API/URLSearchParams/URLSearchParams
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/urlsearchparams/values/index.md
+++ b/files/en-us/web/api/urlsearchparams/values/index.md
@@ -1,6 +1,7 @@
 ---
 title: URLSearchParams.values()
 slug: Web/API/URLSearchParams/values
+page-type: web-api-instance-method
 tags:
   - API
   - Iterator

--- a/files/en-us/web/api/usb/connect_event/index.md
+++ b/files/en-us/web/api/usb/connect_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'USB: connect event'
 slug: Web/API/USB/connect_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/usb/disconnect_event/index.md
+++ b/files/en-us/web/api/usb/disconnect_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'USB: disconnect event'
 slug: Web/API/USB/disconnect_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/usb/getdevices/index.md
+++ b/files/en-us/web/api/usb/getdevices/index.md
@@ -1,6 +1,7 @@
 ---
 title: USB.getDevices()
 slug: Web/API/USB/getDevices
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/usb/index.md
+++ b/files/en-us/web/api/usb/index.md
@@ -1,6 +1,7 @@
 ---
 title: USB
 slug: Web/API/USB
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/usb/requestdevice/index.md
+++ b/files/en-us/web/api/usb/requestdevice/index.md
@@ -1,6 +1,7 @@
 ---
 title: USB.requestDevice()
 slug: Web/API/USB/requestDevice
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/usbalternateinterface/index.md
+++ b/files/en-us/web/api/usbalternateinterface/index.md
@@ -1,6 +1,7 @@
 ---
 title: USBAlternateInterface
 slug: Web/API/USBAlternateInterface
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/usbconfiguration/configurationname/index.md
+++ b/files/en-us/web/api/usbconfiguration/configurationname/index.md
@@ -1,6 +1,7 @@
 ---
 title: USBConfiguration.configurationName
 slug: Web/API/USBConfiguration/configurationName
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/usbconfiguration/configurationvalue/index.md
+++ b/files/en-us/web/api/usbconfiguration/configurationvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: USBConfiguration.configurationValue
 slug: Web/API/USBConfiguration/configurationValue
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/usbconfiguration/index.md
+++ b/files/en-us/web/api/usbconfiguration/index.md
@@ -1,6 +1,7 @@
 ---
 title: USBConfiguration
 slug: Web/API/USBConfiguration
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/usbconfiguration/interfaces/index.md
+++ b/files/en-us/web/api/usbconfiguration/interfaces/index.md
@@ -1,6 +1,7 @@
 ---
 title: USBConfiguration.interfaces
 slug: Web/API/USBConfiguration/interfaces
+page-type: web-api-instance-property
 tags:
   - API
   - Interfaces

--- a/files/en-us/web/api/usbconfiguration/usbconfiguration/index.md
+++ b/files/en-us/web/api/usbconfiguration/usbconfiguration/index.md
@@ -1,6 +1,7 @@
 ---
 title: USBConfiguration()
 slug: Web/API/USBConfiguration/USBConfiguration
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/usbconnectionevent/device/index.md
+++ b/files/en-us/web/api/usbconnectionevent/device/index.md
@@ -1,6 +1,7 @@
 ---
 title: USBConnectionEvent.device
 slug: Web/API/USBConnectionEvent/device
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/usbconnectionevent/index.md
+++ b/files/en-us/web/api/usbconnectionevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: USBConnectionEvent
 slug: Web/API/USBConnectionEvent
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/usbconnectionevent/usbconnectionevent/index.md
+++ b/files/en-us/web/api/usbconnectionevent/usbconnectionevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: USBConnectionEvent()
 slug: Web/API/USBConnectionEvent/USBConnectionEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/usbdevice/claiminterface/index.md
+++ b/files/en-us/web/api/usbdevice/claiminterface/index.md
@@ -1,6 +1,7 @@
 ---
 title: USBDevice.claimInterface()
 slug: Web/API/USBDevice/claimInterface
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/usbdevice/clearhalt/index.md
+++ b/files/en-us/web/api/usbdevice/clearhalt/index.md
@@ -1,6 +1,7 @@
 ---
 title: USBDevice.clearHalt()
 slug: Web/API/USBDevice/clearHalt
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/usbdevice/close/index.md
+++ b/files/en-us/web/api/usbdevice/close/index.md
@@ -1,6 +1,7 @@
 ---
 title: USBDevice.close()
 slug: Web/API/USBDevice/close
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/usbdevice/configuration/index.md
+++ b/files/en-us/web/api/usbdevice/configuration/index.md
@@ -1,6 +1,7 @@
 ---
 title: USBDevice.configuration
 slug: Web/API/USBDevice/configuration
+page-type: web-api-instance-property
 tags:
   - API
   - Configuration

--- a/files/en-us/web/api/usbdevice/configurations/index.md
+++ b/files/en-us/web/api/usbdevice/configurations/index.md
@@ -1,6 +1,7 @@
 ---
 title: USBDevice.configurations
 slug: Web/API/USBDevice/configurations
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/usbdevice/controltransferin/index.md
+++ b/files/en-us/web/api/usbdevice/controltransferin/index.md
@@ -1,6 +1,7 @@
 ---
 title: USBDevice.controlTransferIn()
 slug: Web/API/USBDevice/controlTransferIn
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/usbdevice/controltransferout/index.md
+++ b/files/en-us/web/api/usbdevice/controltransferout/index.md
@@ -1,6 +1,7 @@
 ---
 title: USBDevice.controlTransferOut()
 slug: Web/API/USBDevice/controlTransferOut
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/usbdevice/deviceclass/index.md
+++ b/files/en-us/web/api/usbdevice/deviceclass/index.md
@@ -1,6 +1,7 @@
 ---
 title: USBDevice.deviceClass
 slug: Web/API/USBDevice/deviceClass
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/usbdevice/deviceprotocol/index.md
+++ b/files/en-us/web/api/usbdevice/deviceprotocol/index.md
@@ -1,6 +1,7 @@
 ---
 title: USBDevice.deviceProtocol
 slug: Web/API/USBDevice/deviceProtocol
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/usbdevice/devicesubclass/index.md
+++ b/files/en-us/web/api/usbdevice/devicesubclass/index.md
@@ -1,6 +1,7 @@
 ---
 title: USBDevice.deviceSubclass
 slug: Web/API/USBDevice/deviceSubclass
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/usbdevice/deviceversionmajor/index.md
+++ b/files/en-us/web/api/usbdevice/deviceversionmajor/index.md
@@ -1,6 +1,7 @@
 ---
 title: USBDevice.deviceVersionMajor
 slug: Web/API/USBDevice/deviceVersionMajor
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/usbdevice/deviceversionminor/index.md
+++ b/files/en-us/web/api/usbdevice/deviceversionminor/index.md
@@ -1,6 +1,7 @@
 ---
 title: USBDevice.deviceVersionMinor
 slug: Web/API/USBDevice/deviceVersionMinor
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/usbdevice/deviceversionsubminor/index.md
+++ b/files/en-us/web/api/usbdevice/deviceversionsubminor/index.md
@@ -1,6 +1,7 @@
 ---
 title: USBDevice.deviceVersionSubminor
 slug: Web/API/USBDevice/deviceVersionSubminor
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/usbdevice/index.md
+++ b/files/en-us/web/api/usbdevice/index.md
@@ -1,6 +1,7 @@
 ---
 title: USBDevice
 slug: Web/API/USBDevice
+page-type: web-api-interface
 tags:
   - API
   - Interface


### PR DESCRIPTION
See  https://github.com/mdn/content/issues/16255. This is part 24 of a series of PRs to add page types to the Web/API documentation.