### PR TITLE
Fix `check-redirects` workflow error

### DIFF
--- a/.github/workflows/pr-check_redirects.yml
+++ b/.github/workflows/pr-check_redirects.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
     paths:
+      - package.json
+      - yarn.lock
       - files/**
       - .github/workflows/pr-check_redirects.yml
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "up-to-date-check": "node scripts/up-to-date-check.js",
     "start": "yarn up-to-date-check && env-cmd --silent cross-env CONTENT_ROOT=files REACT_APP_DISABLE_AUTH=true BUILD_OUT_ROOT=build node node_modules/@mdn/yari/server",
     "filecheck": "env-cmd --silent cross-env CONTENT_ROOT=files node node_modules/@mdn/yari/filecheck/cli.js --cwd=.",
-    "content": "env-cmd --silent cross-env CONTENT_ROOT=files node node_modules/@mdn/yari/tool/cli.ts",
+    "content": "env-cmd --silent cross-env CONTENT_ROOT=files ts-node node_modules/@mdn/yari/tool/cli.ts",
     "build": "env-cmd --silent cross-env CONTENT_ROOT=files BUILD_OUT_ROOT=build node node_modules/@mdn/yari/build/cli.js"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "up-to-date-check": "node scripts/up-to-date-check.js",
     "start": "yarn up-to-date-check && env-cmd --silent cross-env CONTENT_ROOT=files REACT_APP_DISABLE_AUTH=true BUILD_OUT_ROOT=build node node_modules/@mdn/yari/server",
     "filecheck": "env-cmd --silent cross-env CONTENT_ROOT=files node node_modules/@mdn/yari/filecheck/cli.js --cwd=.",
-    "content": "env-cmd --silent cross-env CONTENT_ROOT=files node node_modules/@mdn/yari/tool/cli.js",
+    "content": "env-cmd --silent cross-env CONTENT_ROOT=files node node_modules/@mdn/yari/tool/cli.ts",
     "build": "env-cmd --silent cross-env CONTENT_ROOT=files BUILD_OUT_ROOT=build node node_modules/@mdn/yari/build/cli.js"
   },
   "dependencies": {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary/Motivation
<!-- ✍️ In a sentence or two, describe your changes -->

Politely poking @mdn/core-yari-dev (and @caugner if I may) for a review :)

Following mdn/yari#6386, `yari/tool/cli.js` was converted to TypeScript and is now found at `yari/tool/cli.ts`, which I believe is causing the Check Redirects workflow to run with errors.

This PR updates `package.json` so that `yarn content` uses the path `yari/tool/cli.ts` (with the correct `.ts` file ending), to hopefully fix the [workflow errors](https://github.com/mdn/content/actions/workflows/pr-check_redirects.yml). No other workflow seems to be affected.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

The workflow error:

```
$ env-cmd --silent cross-env CONTENT_ROOT=files node node_modules/@mdn/yari/tool/cli.js validate-redirects en-us --strict
node:internal/modules/cjs/loader:93[6](https://github.com/mdn/content/runs/6712996419?check_suite_focus=true#step:5:7)
  throw err;
  ^

Error: Cannot find module '/home/runner/work/content/content/node_modules/@mdn/yari/tool/cli.js'
```

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->

