### PR TITLE
Add Web/API page types, part 26

### DIFF
--- a/files/en-us/web/api/wakelocksentinel/release/index.md
+++ b/files/en-us/web/api/wakelocksentinel/release/index.md
@@ -1,6 +1,7 @@
 ---
 title: WakeLockSentinel.release()
 slug: Web/API/WakeLockSentinel/release
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/wakelocksentinel/release_event/index.md
+++ b/files/en-us/web/api/wakelocksentinel/release_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'WakeLockSentinel: release event'
 slug: Web/API/WakeLockSentinel/release_event
+page-type: web-api-event
 tags:
   - Event Handler
   - Property

--- a/files/en-us/web/api/wakelocksentinel/released/index.md
+++ b/files/en-us/web/api/wakelocksentinel/released/index.md
@@ -1,6 +1,7 @@
 ---
 title: WakeLockSentinel.released
 slug: Web/API/WakeLockSentinel/released
+page-type: web-api-instance-property
 tags:
   - Property
   - Read-only

--- a/files/en-us/web/api/wakelocksentinel/type/index.md
+++ b/files/en-us/web/api/wakelocksentinel/type/index.md
@@ -1,6 +1,7 @@
 ---
 title: WakeLockSentinel.type
 slug: Web/API/WakeLockSentinel/type
+page-type: web-api-instance-property
 tags:
   - Property
   - Read-only

--- a/files/en-us/web/api/waveshapernode/curve/index.md
+++ b/files/en-us/web/api/waveshapernode/curve/index.md
@@ -1,6 +1,7 @@
 ---
 title: WaveShaperNode.curve
 slug: Web/API/WaveShaperNode/curve
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/waveshapernode/index.md
+++ b/files/en-us/web/api/waveshapernode/index.md
@@ -1,6 +1,7 @@
 ---
 title: WaveShaperNode
 slug: Web/API/WaveShaperNode
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/waveshapernode/oversample/index.md
+++ b/files/en-us/web/api/waveshapernode/oversample/index.md
@@ -1,6 +1,7 @@
 ---
 title: WaveShaperNode.oversample
 slug: Web/API/WaveShaperNode/oversample
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/waveshapernode/waveshapernode/index.md
+++ b/files/en-us/web/api/waveshapernode/waveshapernode/index.md
@@ -1,6 +1,7 @@
 ---
 title: WaveShaperNode()
 slug: Web/API/WaveShaperNode/WaveShaperNode
+page-type: web-api-constructor
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/web_animations_api/index.md
+++ b/files/en-us/web/api/web_animations_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Web Animations API
 slug: Web/API/Web_Animations_API
+page-type: web-api-overview
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/web_animations_api/keyframe_formats/index.md
+++ b/files/en-us/web/api/web_animations_api/keyframe_formats/index.md
@@ -1,6 +1,7 @@
 ---
 title: Keyframe Formats
 slug: Web/API/Web_Animations_API/Keyframe_Formats
+page-type: guide
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/web_animations_api/using_the_web_animations_api/index.md
+++ b/files/en-us/web/api/web_animations_api/using_the_web_animations_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using the Web Animations API
 slug: Web/API/Web_Animations_API/Using_the_Web_Animations_API
+page-type: guide
 tags:
   - Alice
   - Animations

--- a/files/en-us/web/api/web_animations_api/web_animations_api_concepts/index.md
+++ b/files/en-us/web/api/web_animations_api/web_animations_api_concepts/index.md
@@ -1,6 +1,7 @@
 ---
 title: Web Animations API Concepts
 slug: Web/API/Web_Animations_API/Web_Animations_API_Concepts
+page-type: guide
 tags:
   - Animations
   - Beginner

--- a/files/en-us/web/api/web_audio_api/advanced_techniques/index.md
+++ b/files/en-us/web/api/web_audio_api/advanced_techniques/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Advanced techniques: Creating and sequencing audio'
 slug: Web/API/Web_Audio_API/Advanced_techniques
+page-type: guide
 tags:
   - API
   - Advanced

--- a/files/en-us/web/api/web_audio_api/basic_concepts_behind_web_audio_api/index.md
+++ b/files/en-us/web/api/web_audio_api/basic_concepts_behind_web_audio_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Basic concepts behind Web Audio API
 slug: Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API
+page-type: guide
 tags:
   - Audio
   - Beginner

--- a/files/en-us/web/api/web_audio_api/best_practices/index.md
+++ b/files/en-us/web/api/web_audio_api/best_practices/index.md
@@ -1,6 +1,7 @@
 ---
 title: Web Audio API best practices
 slug: Web/API/Web_Audio_API/Best_practices
+page-type: guide
 tags:
   - Audio
   - Best practices

--- a/files/en-us/web/api/web_audio_api/controlling_multiple_parameters_with_constantsourcenode/index.md
+++ b/files/en-us/web/api/web_audio_api/controlling_multiple_parameters_with_constantsourcenode/index.md
@@ -1,6 +1,7 @@
 ---
 title: Controlling multiple parameters with ConstantSourceNode
 slug: Web/API/Web_Audio_API/Controlling_multiple_parameters_with_ConstantSourceNode
+page-type: guide
 tags:
   - Audio
   - Example

--- a/files/en-us/web/api/web_audio_api/index.md
+++ b/files/en-us/web/api/web_audio_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Web Audio API
 slug: Web/API/Web_Audio_API
+page-type: web-api-overview
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/web_audio_api/migrating_from_webkitaudiocontext/index.md
+++ b/files/en-us/web/api/web_audio_api/migrating_from_webkitaudiocontext/index.md
@@ -1,6 +1,7 @@
 ---
 title: Migrating from webkitAudioContext
 slug: Web/API/Web_Audio_API/Migrating_from_webkitAudioContext
+page-type: guide
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/web_audio_api/simple_synth/index.md
+++ b/files/en-us/web/api/web_audio_api/simple_synth/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Example and tutorial: Simple synth keyboard'
 slug: Web/API/Web_Audio_API/Simple_synth
+page-type: guide
 tags:
   - Audio
   - Example

--- a/files/en-us/web/api/web_audio_api/tools/index.md
+++ b/files/en-us/web/api/web_audio_api/tools/index.md
@@ -1,6 +1,7 @@
 ---
 title: Tools for analyzing Web Audio usage
 slug: Web/API/Web_Audio_API/Tools
+page-type: guide
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/web_audio_api/using_audioworklet/index.md
+++ b/files/en-us/web/api/web_audio_api/using_audioworklet/index.md
@@ -1,6 +1,7 @@
 ---
 title: Background audio processing using AudioWorklet
 slug: Web/API/Web_Audio_API/Using_AudioWorklet
+page-type: guide
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/web_audio_api/using_iir_filters/index.md
+++ b/files/en-us/web/api/web_audio_api/using_iir_filters/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using IIR filters
 slug: Web/API/Web_Audio_API/Using_IIR_filters
+page-type: guide
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/web_audio_api/using_web_audio_api/index.md
+++ b/files/en-us/web/api/web_audio_api/using_web_audio_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using the Web Audio API
 slug: Web/API/Web_Audio_API/Using_Web_Audio_API
+page-type: guide
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/web_audio_api/visualizations_with_web_audio_api/index.md
+++ b/files/en-us/web/api/web_audio_api/visualizations_with_web_audio_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Visualizations with Web Audio API
 slug: Web/API/Web_Audio_API/Visualizations_with_Web_Audio_API
+page-type: guide
 tags:
   - API
   - Web Audio API

--- a/files/en-us/web/api/web_audio_api/web_audio_spatialization_basics/index.md
+++ b/files/en-us/web/api/web_audio_api/web_audio_spatialization_basics/index.md
@@ -1,6 +1,7 @@
 ---
 title: Web audio spatialization basics
 slug: Web/API/Web_Audio_API/Web_audio_spatialization_basics
+page-type: guide
 tags:
   - PannerNode
   - Web Audio API

--- a/files/en-us/web/api/web_authentication_api/attestation_and_assertion/index.md
+++ b/files/en-us/web/api/web_authentication_api/attestation_and_assertion/index.md
@@ -1,6 +1,7 @@
 ---
 title: Attestation and Assertion
 slug: Web/API/Web_Authentication_API/Attestation_and_Assertion
+page-type: guide
 tags:
   - API
   - Guide

--- a/files/en-us/web/api/web_authentication_api/index.md
+++ b/files/en-us/web/api/web_authentication_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Web Authentication API
 slug: Web/API/Web_Authentication_API
+page-type: web-api-overview
 tags:
   - 2FA
   - API

--- a/files/en-us/web/api/web_bluetooth_api/index.md
+++ b/files/en-us/web/api/web_bluetooth_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Web Bluetooth API
 slug: Web/API/Web_Bluetooth_API
+page-type: web-api-overview
 tags:
   - API
   - Bluetooth

--- a/files/en-us/web/api/web_crypto_api/index.md
+++ b/files/en-us/web/api/web_crypto_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Web Crypto API
 slug: Web/API/Web_Crypto_API
+page-type: web-api-overview
 tags:
   - API
   - Overview

--- a/files/en-us/web/api/web_crypto_api/non-cryptographic_uses_of_subtle_crypto/index.md
+++ b/files/en-us/web/api/web_crypto_api/non-cryptographic_uses_of_subtle_crypto/index.md
@@ -1,6 +1,7 @@
 ---
 title: Non-cryptographic uses of SubtleCrypto
 slug: Web/API/Web_Crypto_API/Non-cryptographic_uses_of_subtle_crypto
+page-type: guide
 tags:
   - Web Crypto API
 ---

--- a/files/en-us/web/api/web_locks_api/index.md
+++ b/files/en-us/web/api/web_locks_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Web Locks API
 slug: Web/API/Web_Locks_API
+page-type: web-api-overview
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/web_midi_api/index.md
+++ b/files/en-us/web/api/web_midi_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Web MIDI API
 slug: Web/API/Web_MIDI_API
+page-type: web-api-overview
 tags:
   - API
   - MIDI

--- a/files/en-us/web/api/web_nfc_api/index.md
+++ b/files/en-us/web/api/web_nfc_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Web NFC API
 slug: Web/API/Web_NFC_API
+page-type: web-api-overview
 tags:
   - NDEF
   - Reference

--- a/files/en-us/web/api/web_periodic_background_synchronization_api/index.md
+++ b/files/en-us/web/api/web_periodic_background_synchronization_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Web Periodic Background Synchronization API
 slug: Web/API/Web_Periodic_Background_Synchronization_API
+page-type: web-api-overview
 tags:
   - API
   - Background

--- a/files/en-us/web/api/web_serial_api/index.md
+++ b/files/en-us/web/api/web_serial_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Web Serial API
 slug: Web/API/Web_Serial_API
+page-type: web-api-overview
 tags:
   - API
   - Web Serial

--- a/files/en-us/web/api/web_share_api/index.md
+++ b/files/en-us/web/api/web_share_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Web Share API
 slug: Web/API/Web_Share_API
+page-type: web-api-overview
 tags:
   - API
   - Apps

--- a/files/en-us/web/api/web_speech_api/index.md
+++ b/files/en-us/web/api/web_speech_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Web Speech API
 slug: Web/API/Web_Speech_API
+page-type: web-api-overview
 tags:
   - API
   - Landing

--- a/files/en-us/web/api/web_speech_api/using_the_web_speech_api/index.md
+++ b/files/en-us/web/api/web_speech_api/using_the_web_speech_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using the Web Speech API
 slug: Web/API/Web_Speech_API/Using_the_Web_Speech_API
+page-type: guide
 tags:
   - API
   - Guide

--- a/files/en-us/web/api/web_storage_api/index.md
+++ b/files/en-us/web/api/web_storage_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Web Storage API
 slug: Web/API/Web_Storage_API
+page-type: web-api-overview
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/web_storage_api/using_the_web_storage_api/index.md
+++ b/files/en-us/web/api/web_storage_api/using_the_web_storage_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using the Web Storage API
 slug: Web/API/Web_Storage_API/Using_the_Web_Storage_API
+page-type: guide
 tags:
   - API
   - Guide

--- a/files/en-us/web/api/web_workers_api/functions_and_classes_available_to_workers/index.md
+++ b/files/en-us/web/api/web_workers_api/functions_and_classes_available_to_workers/index.md
@@ -1,6 +1,7 @@
 ---
 title: Functions and classes available to Web Workers
 slug: Web/API/Web_Workers_API/Functions_and_classes_available_to_workers
+page-type: guide
 tags:
   - Reference
   - Web

--- a/files/en-us/web/api/web_workers_api/index.md
+++ b/files/en-us/web/api/web_workers_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Web Workers API
 slug: Web/API/Web_Workers_API
+page-type: web-api-overview
 tags:
   - API
   - Overview

--- a/files/en-us/web/api/web_workers_api/structured_clone_algorithm/index.md
+++ b/files/en-us/web/api/web_workers_api/structured_clone_algorithm/index.md
@@ -1,6 +1,7 @@
 ---
 title: The structured clone algorithm
 slug: Web/API/Web_Workers_API/Structured_clone_algorithm
+page-type: guide
 tags:
   - Advanced
   - DOM

--- a/files/en-us/web/api/web_workers_api/using_web_workers/index.md
+++ b/files/en-us/web/api/web_workers_api/using_web_workers/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using Web Workers
 slug: Web/API/Web_Workers_API/Using_web_workers
+page-type: guide
 tags:
   - Advanced
   - Firefox

--- a/files/en-us/web/api/webcodecs_api/index.md
+++ b/files/en-us/web/api/webcodecs_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebCodecs API
 slug: Web/API/WebCodecs_API
+page-type: web-api-overview
 tags:
   - API
   - WebCodecs

--- a/files/en-us/web/api/webgl2renderingcontext/beginquery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/beginquery/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.beginQuery()
 slug: Web/API/WebGL2RenderingContext/beginQuery
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/begintransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/begintransformfeedback/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.beginTransformFeedback()
 slug: Web/API/WebGL2RenderingContext/beginTransformFeedback
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/bindbufferbase/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/bindbufferbase/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.bindBufferBase()
 slug: Web/API/WebGL2RenderingContext/bindBufferBase
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/bindbufferrange/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/bindbufferrange/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.bindBufferRange()
 slug: Web/API/WebGL2RenderingContext/bindBufferRange
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/bindsampler/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/bindsampler/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.bindSampler()
 slug: Web/API/WebGL2RenderingContext/bindSampler
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/bindtransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/bindtransformfeedback/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.bindTransformFeedback()
 slug: Web/API/WebGL2RenderingContext/bindTransformFeedback
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/bindvertexarray/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/bindvertexarray/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.bindVertexArray()
 slug: Web/API/WebGL2RenderingContext/bindVertexArray
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/blitframebuffer/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/blitframebuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.blitFramebuffer()
 slug: Web/API/WebGL2RenderingContext/blitFramebuffer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/clearbuffer/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/clearbuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.clearBuffer[fiuv]()
 slug: Web/API/WebGL2RenderingContext/clearBuffer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/clientwaitsync/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/clientwaitsync/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.clientWaitSync()
 slug: Web/API/WebGL2RenderingContext/clientWaitSync
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/compressedtexsubimage3d/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/compressedtexsubimage3d/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.compressedTexSubImage3D()
 slug: Web/API/WebGL2RenderingContext/compressedTexSubImage3D
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/copybuffersubdata/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/copybuffersubdata/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.copyBufferSubData()
 slug: Web/API/WebGL2RenderingContext/copyBufferSubData
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/copytexsubimage3d/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/copytexsubimage3d/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.copyTexSubImage3D()
 slug: Web/API/WebGL2RenderingContext/copyTexSubImage3D
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/createquery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/createquery/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.createQuery()
 slug: Web/API/WebGL2RenderingContext/createQuery
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/createsampler/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/createsampler/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.createSampler()
 slug: Web/API/WebGL2RenderingContext/createSampler
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/createtransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/createtransformfeedback/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.createTransformFeedback()
 slug: Web/API/WebGL2RenderingContext/createTransformFeedback
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/createvertexarray/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/createvertexarray/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.createVertexArray()
 slug: Web/API/WebGL2RenderingContext/createVertexArray
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/deletequery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/deletequery/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.deleteQuery()
 slug: Web/API/WebGL2RenderingContext/deleteQuery
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/deletesampler/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/deletesampler/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.deleteSampler()
 slug: Web/API/WebGL2RenderingContext/deleteSampler
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/deletesync/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/deletesync/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.deleteSync()
 slug: Web/API/WebGL2RenderingContext/deleteSync
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/deletetransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/deletetransformfeedback/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.deleteTransformFeedback()
 slug: Web/API/WebGL2RenderingContext/deleteTransformFeedback
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/deletevertexarray/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/deletevertexarray/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.deleteVertexArray()
 slug: Web/API/WebGL2RenderingContext/deleteVertexArray
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/drawarraysinstanced/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/drawarraysinstanced/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.drawArraysInstanced()
 slug: Web/API/WebGL2RenderingContext/drawArraysInstanced
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/drawbuffers/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/drawbuffers/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.drawBuffers()
 slug: Web/API/WebGL2RenderingContext/drawBuffers
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/drawelementsinstanced/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/drawelementsinstanced/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.drawElementsInstanced()
 slug: Web/API/WebGL2RenderingContext/drawElementsInstanced
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/drawrangeelements/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/drawrangeelements/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.drawRangeElements()
 slug: Web/API/WebGL2RenderingContext/drawRangeElements
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/endquery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/endquery/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.endQuery()
 slug: Web/API/WebGL2RenderingContext/endQuery
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/endtransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/endtransformfeedback/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.endTransformFeedback()
 slug: Web/API/WebGL2RenderingContext/endTransformFeedback
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/fencesync/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/fencesync/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.fenceSync()
 slug: Web/API/WebGL2RenderingContext/fenceSync
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/framebuffertexturelayer/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/framebuffertexturelayer/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.framebufferTextureLayer()
 slug: Web/API/WebGL2RenderingContext/framebufferTextureLayer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockname/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockname/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.getActiveUniformBlockName()
 slug: Web/API/WebGL2RenderingContext/getActiveUniformBlockName
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockparameter/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.getActiveUniformBlockParameter()
 slug: Web/API/WebGL2RenderingContext/getActiveUniformBlockParameter
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/getactiveuniforms/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getactiveuniforms/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.getActiveUniforms()
 slug: Web/API/WebGL2RenderingContext/getActiveUniforms
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/getbuffersubdata/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getbuffersubdata/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.getBufferSubData()
 slug: Web/API/WebGL2RenderingContext/getBufferSubData
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/getfragdatalocation/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getfragdatalocation/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.getFragDataLocation()
 slug: Web/API/WebGL2RenderingContext/getFragDataLocation
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/getindexedparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getindexedparameter/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.getIndexedParameter()
 slug: Web/API/WebGL2RenderingContext/getIndexedParameter
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/getinternalformatparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getinternalformatparameter/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.getInternalformatParameter()
 slug: Web/API/WebGL2RenderingContext/getInternalformatParameter
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/getquery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getquery/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.getQuery()
 slug: Web/API/WebGL2RenderingContext/getQuery
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/getqueryparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getqueryparameter/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.getQueryParameter()
 slug: Web/API/WebGL2RenderingContext/getQueryParameter
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/getsamplerparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getsamplerparameter/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.getSamplerParameter()
 slug: Web/API/WebGL2RenderingContext/getSamplerParameter
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/getsyncparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getsyncparameter/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.getSyncParameter()
 slug: Web/API/WebGL2RenderingContext/getSyncParameter
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/gettransformfeedbackvarying/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/gettransformfeedbackvarying/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.getTransformFeedbackVarying()
 slug: Web/API/WebGL2RenderingContext/getTransformFeedbackVarying
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/getuniformblockindex/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getuniformblockindex/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.getUniformBlockIndex()
 slug: Web/API/WebGL2RenderingContext/getUniformBlockIndex
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/getuniformindices/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getuniformindices/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.getUniformIndices()
 slug: Web/API/WebGL2RenderingContext/getUniformIndices
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext
 slug: Web/API/WebGL2RenderingContext
+page-type: web-api-interface
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/webgl2renderingcontext/invalidateframebuffer/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/invalidateframebuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.invalidateFramebuffer()
 slug: Web/API/WebGL2RenderingContext/invalidateFramebuffer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/invalidatesubframebuffer/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/invalidatesubframebuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.invalidateSubFramebuffer()
 slug: Web/API/WebGL2RenderingContext/invalidateSubFramebuffer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/isquery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/isquery/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.isQuery()
 slug: Web/API/WebGL2RenderingContext/isQuery
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/issampler/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/issampler/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.isSampler()
 slug: Web/API/WebGL2RenderingContext/isSampler
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/issync/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/issync/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.isSync()
 slug: Web/API/WebGL2RenderingContext/isSync
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/istransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/istransformfeedback/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.isTransformFeedback()
 slug: Web/API/WebGL2RenderingContext/isTransformFeedback
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/isvertexarray/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/isvertexarray/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.isVertexArray()
 slug: Web/API/WebGL2RenderingContext/isVertexArray
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/pausetransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/pausetransformfeedback/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.pauseTransformFeedback()
 slug: Web/API/WebGL2RenderingContext/pauseTransformFeedback
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/readbuffer/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/readbuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.readBuffer()
 slug: Web/API/WebGL2RenderingContext/readBuffer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/renderbufferstoragemultisample/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/renderbufferstoragemultisample/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.renderbufferStorageMultisample()
 slug: Web/API/WebGL2RenderingContext/renderbufferStorageMultisample
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/resumetransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/resumetransformfeedback/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.resumeTransformFeedback()
 slug: Web/API/WebGL2RenderingContext/resumeTransformFeedback
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/samplerparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/samplerparameter/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.samplerParameter[if]()
 slug: Web/API/WebGL2RenderingContext/samplerParameter
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/teximage3d/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/teximage3d/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.texImage3D()
 slug: Web/API/WebGL2RenderingContext/texImage3D
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/texstorage2d/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/texstorage2d/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.texStorage2D()
 slug: Web/API/WebGL2RenderingContext/texStorage2D
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/texstorage3d/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/texstorage3d/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.texStorage3D()
 slug: Web/API/WebGL2RenderingContext/texStorage3D
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/texsubimage3d/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/texsubimage3d/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.texSubImage3D()
 slug: Web/API/WebGL2RenderingContext/texSubImage3D
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/transformfeedbackvaryings/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/transformfeedbackvaryings/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.transformFeedbackVaryings()
 slug: Web/API/WebGL2RenderingContext/transformFeedbackVaryings
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/uniform/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/uniform/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.uniform[1234][uif][v]()
 slug: Web/API/WebGL2RenderingContext/uniform
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/uniformblockbinding/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/uniformblockbinding/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.uniformBlockBinding()
 slug: Web/API/WebGL2RenderingContext/uniformBlockBinding
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/uniformmatrix/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/uniformmatrix/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.uniformMatrix[234]x[234]fv()
 slug: Web/API/WebGL2RenderingContext/uniformMatrix
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/vertexattribdivisor/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/vertexattribdivisor/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.vertexAttribDivisor()
 slug: Web/API/WebGL2RenderingContext/vertexAttribDivisor
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/vertexattribi/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/vertexattribi/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.vertexAttribI4[u]i[v]()
 slug: Web/API/WebGL2RenderingContext/vertexAttribI
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/vertexattribipointer/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/vertexattribipointer/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.vertexAttribIPointer()
 slug: Web/API/WebGL2RenderingContext/vertexAttribIPointer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl2renderingcontext/waitsync/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/waitsync/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL2RenderingContext.waitSync()
 slug: Web/API/WebGL2RenderingContext/waitSync
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl_api/basic_2d_animation_example/index.md
+++ b/files/en-us/web/api/webgl_api/basic_2d_animation_example/index.md
@@ -1,6 +1,7 @@
 ---
 title: A basic 2D WebGL animation example
 slug: Web/API/WebGL_API/Basic_2D_animation_example
+page-type: guide
 tags:
   - 2D Animation
   - 2D Graphics

--- a/files/en-us/web/api/webgl_api/by_example/basic_scissoring/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/basic_scissoring/index.md
@@ -1,6 +1,7 @@
 ---
 title: Basic scissoring
 slug: Web/API/WebGL_API/By_example/Basic_scissoring
+page-type: guide
 tags:
   - Beginner
   - Example

--- a/files/en-us/web/api/webgl_api/by_example/boilerplate_1/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/boilerplate_1/index.md
@@ -1,6 +1,7 @@
 ---
 title: Boilerplate 1
 slug: Web/API/WebGL_API/By_example/Boilerplate_1
+page-type: guide
 tags:
   - Beginner
   - Example

--- a/files/en-us/web/api/webgl_api/by_example/canvas_size_and_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/canvas_size_and_webgl/index.md
@@ -1,6 +1,7 @@
 ---
 title: Canvas size and WebGL
 slug: Web/API/WebGL_API/By_example/Canvas_size_and_WebGL
+page-type: guide
 tags:
   - Beginner
   - Example

--- a/files/en-us/web/api/webgl_api/by_example/clearing_by_clicking/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/clearing_by_clicking/index.md
@@ -1,6 +1,7 @@
 ---
 title: Clearing by clicking
 slug: Web/API/WebGL_API/By_example/Clearing_by_clicking
+page-type: guide
 tags:
   - Beginner
   - Example

--- a/files/en-us/web/api/webgl_api/by_example/clearing_with_colors/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/clearing_with_colors/index.md
@@ -1,6 +1,7 @@
 ---
 title: Clearing with colors
 slug: Web/API/WebGL_API/By_example/Clearing_with_colors
+page-type: guide
 tags:
   - Beginner
   - Example

--- a/files/en-us/web/api/webgl_api/by_example/color_masking/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/color_masking/index.md
@@ -1,6 +1,7 @@
 ---
 title: Color masking
 slug: Web/API/WebGL_API/By_example/Color_masking
+page-type: guide
 tags:
   - Beginner
   - Example

--- a/files/en-us/web/api/webgl_api/by_example/detect_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/detect_webgl/index.md
@@ -1,6 +1,7 @@
 ---
 title: Detect WebGL
 slug: Web/API/WebGL_API/By_example/Detect_WebGL
+page-type: guide
 tags:
   - Beginner
   - Example

--- a/files/en-us/web/api/webgl_api/by_example/hello_glsl/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/hello_glsl/index.md
@@ -1,6 +1,7 @@
 ---
 title: Hello GLSL
 slug: Web/API/WebGL_API/By_example/Hello_GLSL
+page-type: guide
 tags:
   - Beginner
   - Example

--- a/files/en-us/web/api/webgl_api/by_example/hello_vertex_attributes/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/hello_vertex_attributes/index.md
@@ -1,6 +1,7 @@
 ---
 title: Hello vertex attributes
 slug: Web/API/WebGL_API/By_example/Hello_vertex_attributes
+page-type: guide
 tags:
   - Beginner
   - Example

--- a/files/en-us/web/api/webgl_api/by_example/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL by example
 slug: Web/API/WebGL_API/By_example
+page-type: guide
 tags:
   - Beginner
   - Example

--- a/files/en-us/web/api/webgl_api/by_example/raining_rectangles/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/raining_rectangles/index.md
@@ -1,6 +1,7 @@
 ---
 title: Raining rectangles
 slug: Web/API/WebGL_API/By_example/Raining_rectangles
+page-type: guide
 tags:
   - Beginner
   - Example

--- a/files/en-us/web/api/webgl_api/by_example/scissor_animation/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/scissor_animation/index.md
@@ -1,6 +1,7 @@
 ---
 title: Scissor animation
 slug: Web/API/WebGL_API/By_example/Scissor_animation
+page-type: guide
 tags:
   - Animation
   - Beginner

--- a/files/en-us/web/api/webgl_api/by_example/simple_color_animation/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/simple_color_animation/index.md
@@ -1,6 +1,7 @@
 ---
 title: Simple color animation
 slug: Web/API/WebGL_API/By_example/Simple_color_animation
+page-type: guide
 tags:
   - Beginner
   - Example

--- a/files/en-us/web/api/webgl_api/by_example/textures_from_code/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/textures_from_code/index.md
@@ -1,6 +1,7 @@
 ---
 title: Textures from code
 slug: Web/API/WebGL_API/By_example/Textures_from_code
+page-type: guide
 tags:
   - Beginner
   - Example

--- a/files/en-us/web/api/webgl_api/by_example/video_textures/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/video_textures/index.md
@@ -1,6 +1,7 @@
 ---
 title: Video textures
 slug: Web/API/WebGL_API/By_example/Video_textures
+page-type: guide
 tags:
   - Advanced
   - Example

--- a/files/en-us/web/api/webgl_api/compressed_texture_formats/index.md
+++ b/files/en-us/web/api/webgl_api/compressed_texture_formats/index.md
@@ -1,6 +1,7 @@
 ---
 title: Compressed texture formats
 slug: Web/API/WebGL_API/Compressed_texture_formats
+page-type: guide
 ---
 The WebGL API provides methods to use compressed texture formats. These are useful to increase texture detail while limiting the additional video memory necessary. By default, no compressed formats are available: a corresponding compressed texture format extension must first be enabled.
 

--- a/files/en-us/web/api/webgl_api/constants/index.md
+++ b/files/en-us/web/api/webgl_api/constants/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL constants
 slug: Web/API/WebGL_API/Constants
+page-type: guide
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/webgl_api/data/index.md
+++ b/files/en-us/web/api/webgl_api/data/index.md
@@ -1,6 +1,7 @@
 ---
 title: Data in WebGL
 slug: Web/API/WebGL_API/Data
+page-type: guide
 tags:
   - 3D
   - 3D Graphics

--- a/files/en-us/web/api/webgl_api/index.md
+++ b/files/en-us/web/api/webgl_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'WebGL: 2D and 3D graphics for the web'
 slug: Web/API/WebGL_API
+page-type: web-api-overview
 tags:
   - 3D
   - 3D Graphics

--- a/files/en-us/web/api/webgl_api/matrix_math_for_the_web/index.md
+++ b/files/en-us/web/api/webgl_api/matrix_math_for_the_web/index.md
@@ -1,6 +1,7 @@
 ---
 title: Matrix math for the web
 slug: Web/API/WebGL_API/Matrix_math_for_the_web
+page-type: guide
 tags:
   - 3D
   - 3D2D

--- a/files/en-us/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/adding_2d_content_to_a_webgl_context/index.md
@@ -1,6 +1,7 @@
 ---
 title: Adding 2D content to a WebGL context
 slug: Web/API/WebGL_API/Tutorial/Adding_2D_content_to_a_WebGL_context
+page-type: guide
 tags:
   - 2D Graphics
   - 3D

--- a/files/en-us/web/api/webgl_api/tutorial/animating_objects_with_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/animating_objects_with_webgl/index.md
@@ -1,6 +1,7 @@
 ---
 title: Animating objects with WebGL
 slug: Web/API/WebGL_API/Tutorial/Animating_objects_with_WebGL
+page-type: guide
 tags:
   - Tutorial
   - WebGL

--- a/files/en-us/web/api/webgl_api/tutorial/animating_textures_in_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/animating_textures_in_webgl/index.md
@@ -1,6 +1,7 @@
 ---
 title: Animating textures in WebGL
 slug: Web/API/WebGL_API/Tutorial/Animating_textures_in_WebGL
+page-type: guide
 tags:
   - Media
   - Tutorial

--- a/files/en-us/web/api/webgl_api/tutorial/creating_3d_objects_using_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/creating_3d_objects_using_webgl/index.md
@@ -1,6 +1,7 @@
 ---
 title: Creating 3D objects using WebGL
 slug: Web/API/WebGL_API/Tutorial/Creating_3D_objects_using_WebGL
+page-type: guide
 tags:
   - 3D
   - Drawing

--- a/files/en-us/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/getting_started_with_webgl/index.md
@@ -1,6 +1,7 @@
 ---
 title: Getting started with WebGL
 slug: Web/API/WebGL_API/Tutorial/Getting_started_with_WebGL
+page-type: guide
 tags:
   - Tutorial
   - WebGL

--- a/files/en-us/web/api/webgl_api/tutorial/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL tutorial
 slug: Web/API/WebGL_API/Tutorial
+page-type: guide
 tags:
   - Overview
   - Tutorial

--- a/files/en-us/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
@@ -1,6 +1,7 @@
 ---
 title: Lighting in WebGL
 slug: Web/API/WebGL_API/Tutorial/Lighting_in_WebGL
+page-type: guide
 tags:
   - 3D
   - Fragments

--- a/files/en-us/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using shaders to apply color in WebGL
 slug: Web/API/WebGL_API/Tutorial/Using_shaders_to_apply_color_in_WebGL
+page-type: guide
 tags:
   - Graphics
   - Tutorial

--- a/files/en-us/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using textures in WebGL
 slug: Web/API/WebGL_API/Tutorial/Using_textures_in_WebGL
+page-type: guide
 tags:
   - Tutorial
   - WebGL

--- a/files/en-us/web/api/webgl_api/types/index.md
+++ b/files/en-us/web/api/webgl_api/types/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL types
 slug: Web/API/WebGL_API/Types
+page-type: guide
 tags:
   - Reference
   - Types

--- a/files/en-us/web/api/webgl_api/using_extensions/index.md
+++ b/files/en-us/web/api/webgl_api/using_extensions/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using WebGL extensions
 slug: Web/API/WebGL_API/Using_Extensions
+page-type: guide
 tags:
   - Advanced
   - WebGL

--- a/files/en-us/web/api/webgl_api/webgl_best_practices/index.md
+++ b/files/en-us/web/api/webgl_api/webgl_best_practices/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL best practices
 slug: Web/API/WebGL_API/WebGL_best_practices
+page-type: guide
 tags:
   - 2D
   - 3D

--- a/files/en-us/web/api/webgl_api/webgl_model_view_projection/index.md
+++ b/files/en-us/web/api/webgl_api/webgl_model_view_projection/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGL model view projection
 slug: Web/API/WebGL_API/WebGL_model_view_projection
+page-type: guide
 tags:
   - 3D
   - Graphics

--- a/files/en-us/web/api/webglactiveinfo/index.md
+++ b/files/en-us/web/api/webglactiveinfo/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLActiveInfo
 slug: Web/API/WebGLActiveInfo
+page-type: web-api-interface
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/webglactiveinfo/name/index.md
+++ b/files/en-us/web/api/webglactiveinfo/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLActiveInfo.name
 slug: Web/API/WebGLActiveInfo/name
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/webglactiveinfo/size/index.md
+++ b/files/en-us/web/api/webglactiveinfo/size/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLActiveInfo.size
 slug: Web/API/WebGLActiveInfo/size
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/webglactiveinfo/type/index.md
+++ b/files/en-us/web/api/webglactiveinfo/type/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLActiveInfo.type
 slug: Web/API/WebGLActiveInfo/type
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/webglbuffer/index.md
+++ b/files/en-us/web/api/webglbuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLBuffer
 slug: Web/API/WebGLBuffer
+page-type: web-api-interface
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/webglcontextevent/index.md
+++ b/files/en-us/web/api/webglcontextevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLContextEvent
 slug: Web/API/WebGLContextEvent
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/webglcontextevent/statusmessage/index.md
+++ b/files/en-us/web/api/webglcontextevent/statusmessage/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLContextEvent.statusMessage
 slug: Web/API/WebGLContextEvent/statusMessage
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/webglframebuffer/index.md
+++ b/files/en-us/web/api/webglframebuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLFramebuffer
 slug: Web/API/WebGLFramebuffer
+page-type: web-api-interface
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/webglprogram/index.md
+++ b/files/en-us/web/api/webglprogram/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLProgram
 slug: Web/API/WebGLProgram
+page-type: web-api-interface
 tags:
   - API
   - GL

--- a/files/en-us/web/api/webglquery/index.md
+++ b/files/en-us/web/api/webglquery/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLQuery
 slug: Web/API/WebGLQuery
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/webglrenderbuffer/index.md
+++ b/files/en-us/web/api/webglrenderbuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderbuffer
 slug: Web/API/WebGLRenderbuffer
+page-type: web-api-interface
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/webglrenderingcontext/activetexture/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/activetexture/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.activeTexture()
 slug: Web/API/WebGLRenderingContext/activeTexture
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/attachshader/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/attachshader/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.attachShader()
 slug: Web/API/WebGLRenderingContext/attachShader
+page-type: web-api-instance-method
 tags:
   - Method
   - WebGL

--- a/files/en-us/web/api/webglrenderingcontext/bindattriblocation/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/bindattriblocation/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.bindAttribLocation()
 slug: Web/API/WebGLRenderingContext/bindAttribLocation
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/bindbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/bindbuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.bindBuffer()
 slug: Web/API/WebGLRenderingContext/bindBuffer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/bindframebuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/bindframebuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.bindFramebuffer()
 slug: Web/API/WebGLRenderingContext/bindFramebuffer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/bindrenderbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/bindrenderbuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.bindRenderbuffer()
 slug: Web/API/WebGLRenderingContext/bindRenderbuffer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/bindtexture/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/bindtexture/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.bindTexture()
 slug: Web/API/WebGLRenderingContext/bindTexture
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/blendcolor/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/blendcolor/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.blendColor()
 slug: Web/API/WebGLRenderingContext/blendColor
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/blendequation/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/blendequation/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.blendEquation()
 slug: Web/API/WebGLRenderingContext/blendEquation
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/blendequationseparate/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/blendequationseparate/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.blendEquationSeparate()
 slug: Web/API/WebGLRenderingContext/blendEquationSeparate
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/blendfunc/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/blendfunc/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.blendFunc()
 slug: Web/API/WebGLRenderingContext/blendFunc
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/blendfuncseparate/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/blendfuncseparate/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.blendFuncSeparate()
 slug: Web/API/WebGLRenderingContext/blendFuncSeparate
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/bufferdata/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/bufferdata/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.bufferData()
 slug: Web/API/WebGLRenderingContext/bufferData
+page-type: web-api-instance-method
 tags:
   - API
   - Buffer

--- a/files/en-us/web/api/webglrenderingcontext/buffersubdata/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/buffersubdata/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.bufferSubData()
 slug: Web/API/WebGLRenderingContext/bufferSubData
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/canvas/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/canvas/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.canvas
 slug: Web/API/WebGLRenderingContext/canvas
+page-type: web-api-instance-property
 tags:
   - Property
   - Read-only

--- a/files/en-us/web/api/webglrenderingcontext/checkframebufferstatus/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/checkframebufferstatus/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.checkFramebufferStatus()
 slug: Web/API/WebGLRenderingContext/checkFramebufferStatus
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/clear/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/clear/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.clear()
 slug: Web/API/WebGLRenderingContext/clear
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/clearcolor/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/clearcolor/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.clearColor()
 slug: Web/API/WebGLRenderingContext/clearColor
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/cleardepth/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/cleardepth/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.clearDepth()
 slug: Web/API/WebGLRenderingContext/clearDepth
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/clearstencil/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/clearstencil/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.clearStencil()
 slug: Web/API/WebGLRenderingContext/clearStencil
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/colormask/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/colormask/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.colorMask()
 slug: Web/API/WebGLRenderingContext/colorMask
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/commit/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/commit/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.commit()
 slug: Web/API/WebGLRenderingContext/commit
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/webglrenderingcontext/compileshader/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/compileshader/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.compileShader()
 slug: Web/API/WebGLRenderingContext/compileShader
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/compressedteximage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/compressedteximage2d/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.compressedTexImage[23]D()
 slug: Web/API/WebGLRenderingContext/compressedTexImage2D
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/compressedtexsubimage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/compressedtexsubimage2d/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.compressedTexSubImage2D()
 slug: Web/API/WebGLRenderingContext/compressedTexSubImage2D
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/copyteximage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/copyteximage2d/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.copyTexImage2D()
 slug: Web/API/WebGLRenderingContext/copyTexImage2D
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/copytexsubimage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/copytexsubimage2d/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.copyTexSubImage2D()
 slug: Web/API/WebGLRenderingContext/copyTexSubImage2D
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/createbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/createbuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.createBuffer()
 slug: Web/API/WebGLRenderingContext/createBuffer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/createframebuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/createframebuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.createFramebuffer()
 slug: Web/API/WebGLRenderingContext/createFramebuffer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/createprogram/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/createprogram/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.createProgram()
 slug: Web/API/WebGLRenderingContext/createProgram
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/createrenderbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/createrenderbuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.createRenderbuffer()
 slug: Web/API/WebGLRenderingContext/createRenderbuffer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/createshader/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/createshader/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.createShader()
 slug: Web/API/WebGLRenderingContext/createShader
+page-type: web-api-instance-method
 tags:
   - API
   - Graphics

--- a/files/en-us/web/api/webglrenderingcontext/createtexture/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/createtexture/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.createTexture()
 slug: Web/API/WebGLRenderingContext/createTexture
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/cullface/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/cullface/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.cullFace()
 slug: Web/API/WebGLRenderingContext/cullFace
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/deletebuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/deletebuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.deleteBuffer()
 slug: Web/API/WebGLRenderingContext/deleteBuffer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/deleteframebuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/deleteframebuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.deleteFramebuffer()
 slug: Web/API/WebGLRenderingContext/deleteFramebuffer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/deleteprogram/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/deleteprogram/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.deleteProgram()
 slug: Web/API/WebGLRenderingContext/deleteProgram
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/deleterenderbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/deleterenderbuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.deleteRenderbuffer()
 slug: Web/API/WebGLRenderingContext/deleteRenderbuffer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/deleteshader/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/deleteshader/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.deleteShader()
 slug: Web/API/WebGLRenderingContext/deleteShader
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/deletetexture/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/deletetexture/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.deleteTexture()
 slug: Web/API/WebGLRenderingContext/deleteTexture
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext
 slug: Web/API/WebGLRenderingContext
+page-type: web-api-interface
 tags:
   - 2D
   - 3D


### PR DESCRIPTION
See  https://github.com/mdn/content/issues/16255. This is part 26 of a series of PRs to add page types to the Web/API documentation.