### PR TITLE
Downgrade @mdn/yari from 1.1.14 to 1.1.26 and check scripts when dependencies change

### DIFF
--- a/.github/workflows/pr-check_scripts.yml
+++ b/.github/workflows/pr-check_scripts.yml
@@ -1,0 +1,157 @@
+name: Check scripts
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - package.json
+      - yarn.lock
+
+jobs:
+  scripts:
+    strategy:
+      matrix:
+      
+  up-to-date-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: yarn
+
+      - name: Cache node_modules
+        uses: actions/cache@v3
+        id: cached-node_modules
+        with:
+          path: |
+            node_modules
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+
+      - name: yarn install
+        if: steps.cached-node_modules.outputs.cache-hit != 'true'
+        run: |
+          yarn --frozen-lockfile
+
+      - run: yarn up-to-date-check
+
+  start:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: yarn
+
+      - name: Cache node_modules
+        uses: actions/cache@v3
+        id: cached-node_modules
+        with:
+          path: |
+            node_modules
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+
+      - name: yarn install
+        if: steps.cached-node_modules.outputs.cache-hit != 'true'
+        run: |
+          yarn --frozen-lockfile
+
+      - name: yarn start
+        run: yarn start > /tmp/stdout.log 2> /tmp/stderr.log &
+
+      - name: Wait for server
+        run: |
+          # Just a slight delay to wait until the dev server is ready.
+          sleep 3
+
+          curl --retry-connrefused --retry 5 http://localhost:5042 > /dev/null
+
+      - name: Debug server's stdout and stderr if tests failed
+        if: failure()
+        run: |
+          echo "STDOUT..................................................."
+          cat /tmp/stdout.log
+          echo ""
+          echo "STDERR..................................................."
+          cat /tmp/stderr.log
+
+  filecheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: yarn
+
+      - name: Cache node_modules
+        uses: actions/cache@v3
+        id: cached-node_modules
+        with:
+          path: |
+            node_modules
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+
+      - name: yarn install
+        if: steps.cached-node_modules.outputs.cache-hit != 'true'
+        run: |
+          yarn --frozen-lockfile
+
+      - run: yarn filecheck --help
+
+  content:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: yarn
+
+      - name: Install all yarn packages
+        run: |
+          yarn --frozen-lockfile
+
+      - run: yarn content --help
+
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: yarn
+
+      - name: Cache node_modules
+        uses: actions/cache@v3
+        id: cached-node_modules
+        with:
+          path: |
+            node_modules
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+
+      - name: yarn install
+        if: steps.cached-node_modules.outputs.cache-hit != 'true'
+        run: |
+          yarn --frozen-lockfile
+
+      - run: yarn build --help

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "env-cmd --silent cross-env CONTENT_ROOT=files BUILD_OUT_ROOT=build node node_modules/@mdn/yari/build/cli.js"
   },
   "dependencies": {
-    "@mdn/yari": "1.1.26",
+    "@mdn/yari": "1.1.14",
     "cross-env": "7.0.3",
     "env-cmd": "10.1.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,22 +34,22 @@
     lodash.isundefined "^3.0.1"
     lodash.uniq "^4.5.0"
 
-"@mdn/browser-compat-data@^5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-5.0.1.tgz#e71fe19c5ba99413fae9305cc9ed060eeb07ea45"
-  integrity sha512-c+RIBgZSqSWgxZdNWLaaCAfBon2YM4pz0QD+VoT32rIOGChJl3l99E7B/xSWvVlSSiE7jQkEuJx3hbKoUdAi3w==
+"@mdn/browser-compat-data@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@mdn/browser-compat-data/-/browser-compat-data-4.2.1.tgz#1fead437f3957ceebe2e8c3f46beccdb9bc575b8"
+  integrity sha512-EWUguj2kd7ldmrF9F+vI5hUOralPd+sdsUnYbRy33vZTuZkduC1shE9TtEMEjAQwyfyMb4ole5KtjF8MsnQOlA==
 
-"@mdn/yari@1.1.26":
-  version "1.1.26"
-  resolved "https://registry.yarnpkg.com/@mdn/yari/-/yari-1.1.26.tgz#24469db4f1b9f3144ecc52eeb463731194636108"
-  integrity sha512-0TgySL34WiQn57kGhoWF63IUgTVf4J6J/TaSNnNLCe6ENuiCL8QZJE3/VhkTZxWYmuxs9u4i71+xL0w8wb7wjQ==
+"@mdn/yari@1.1.14":
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/@mdn/yari/-/yari-1.1.14.tgz#cb41a1fff7d953db1860a3969bef22946d11c565"
+  integrity sha512-3qvgTh/HoU2vSWb64ZYDzJ2tO6QJ5DaZD+/YnHD21KXHR70WwVzHhwWF2aXy5Q0510Js+onMWfgtF1+dwfs06Q==
   dependencies:
     "@caporal/core" "^2.0.2"
     "@fast-csv/parse" "^4.3.6"
-    "@mdn/browser-compat-data" "^5.0.1"
+    "@mdn/browser-compat-data" "^4.2.1"
     "@use-it/interval" "^1.0.0"
     accept-language-parser "^1.5.0"
-    browser-specs "^3.12.0"
+    browser-specs "^3.11.0"
     chalk "^4.1.2"
     cheerio "^1.0.0-rc.11"
     cli-progress "^3.11.1"
@@ -570,10 +570,10 @@ braces@^3.0.1:
   dependencies:
     fill-range "^7.0.1"
 
-browser-specs@^3.12.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/browser-specs/-/browser-specs-3.12.0.tgz#87252d060f191baa7d895f4e6ee7290691506903"
-  integrity sha512-wntVE7WNbCuTJ5KhzlHGtZIjmn+iZaBjSYu1IAms5WKTPvkAn6A9xf2+ed0qaXTuh+cLhS/FgV4SQ/CtYYkFhg==
+browser-specs@^3.11.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/browser-specs/-/browser-specs-3.11.0.tgz#baf60e637e5672ecb8239144cc6e26460c1c1ace"
+  integrity sha512-upxgBq5oc8TNet5stM+nv4/43gtGiMkce/WoAiEHHI4H7RcqBDa64T73CohBjjfPsKzxvTSgteOoQllDDpBEqg==
 
 buffer-alloc-unsafe@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
This reverts commit 691d6023f91180eb955b3c10ee24ee8b66ee3839, **and** introduces a "Check scripts" workflow that runs all `package.json` scripts when dependencies change.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
1. This downgrades yari to fix the failing scripts (due to a TypeScript migration in yari) as a workaround.
2. This prevents future yari bumps from being merged if it breaks any of the scripts.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
