### PR TITLE
Add Web/API page types, part 27

### DIFF
--- a/files/en-us/web/api/webglrenderingcontext/depthfunc/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/depthfunc/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.depthFunc()
 slug: Web/API/WebGLRenderingContext/depthFunc
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/depthmask/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/depthmask/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.depthMask()
 slug: Web/API/WebGLRenderingContext/depthMask
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/depthrange/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/depthrange/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.depthRange()
 slug: Web/API/WebGLRenderingContext/depthRange
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/detachshader/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/detachshader/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.detachShader()
 slug: Web/API/WebGLRenderingContext/detachShader
+page-type: web-api-instance-method
 tags:
   - Method
   - WebGL

--- a/files/en-us/web/api/webglrenderingcontext/disable/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/disable/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.disable()
 slug: Web/API/WebGLRenderingContext/disable
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/disablevertexattribarray/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/disablevertexattribarray/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.disableVertexAttribArray()
 slug: Web/API/WebGLRenderingContext/disableVertexAttribArray
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/drawarrays/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/drawarrays/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.drawArrays()
 slug: Web/API/WebGLRenderingContext/drawArrays
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/drawelements/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/drawelements/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.drawElements()
 slug: Web/API/WebGLRenderingContext/drawElements
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/drawingbufferheight/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/drawingbufferheight/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.drawingBufferHeight
 slug: Web/API/WebGLRenderingContext/drawingBufferHeight
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/webglrenderingcontext/drawingbufferwidth/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/drawingbufferwidth/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.drawingBufferWidth
 slug: Web/API/WebGLRenderingContext/drawingBufferWidth
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/webglrenderingcontext/enable/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/enable/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.enable()
 slug: Web/API/WebGLRenderingContext/enable
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/enablevertexattribarray/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/enablevertexattribarray/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.enableVertexAttribArray()
 slug: Web/API/WebGLRenderingContext/enableVertexAttribArray
+page-type: web-api-instance-method
 tags:
   - 3D
   - API

--- a/files/en-us/web/api/webglrenderingcontext/finish/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/finish/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.finish()
 slug: Web/API/WebGLRenderingContext/finish
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/flush/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/flush/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.flush()
 slug: Web/API/WebGLRenderingContext/flush
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/framebufferrenderbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/framebufferrenderbuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.framebufferRenderbuffer()
 slug: Web/API/WebGLRenderingContext/framebufferRenderbuffer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/framebuffertexture2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/framebuffertexture2d/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.framebufferTexture2D()
 slug: Web/API/WebGLRenderingContext/framebufferTexture2D
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/frontface/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/frontface/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.frontFace()
 slug: Web/API/WebGLRenderingContext/frontFace
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/generatemipmap/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/generatemipmap/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.generateMipmap()
 slug: Web/API/WebGLRenderingContext/generateMipmap
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/getactiveattrib/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getactiveattrib/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.getActiveAttrib()
 slug: Web/API/WebGLRenderingContext/getActiveAttrib
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/getactiveuniform/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getactiveuniform/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.getActiveUniform()
 slug: Web/API/WebGLRenderingContext/getActiveUniform
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/getattachedshaders/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getattachedshaders/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.getAttachedShaders()
 slug: Web/API/WebGLRenderingContext/getAttachedShaders
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/getattriblocation/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getattriblocation/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.getAttribLocation()
 slug: Web/API/WebGLRenderingContext/getAttribLocation
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/getbufferparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getbufferparameter/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.getBufferParameter()
 slug: Web/API/WebGLRenderingContext/getBufferParameter
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/getcontextattributes/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getcontextattributes/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.getContextAttributes()
 slug: Web/API/WebGLRenderingContext/getContextAttributes
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/geterror/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/geterror/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.getError()
 slug: Web/API/WebGLRenderingContext/getError
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/getextension/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getextension/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.getExtension()
 slug: Web/API/WebGLRenderingContext/getExtension
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/getframebufferattachmentparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getframebufferattachmentparameter/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.getFramebufferAttachmentParameter()
 slug: Web/API/WebGLRenderingContext/getFramebufferAttachmentParameter
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/getparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getparameter/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.getParameter()
 slug: Web/API/WebGLRenderingContext/getParameter
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/getprograminfolog/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getprograminfolog/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.getProgramInfoLog()
 slug: Web/API/WebGLRenderingContext/getProgramInfoLog
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/getprogramparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getprogramparameter/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.getProgramParameter()
 slug: Web/API/WebGLRenderingContext/getProgramParameter
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/getrenderbufferparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getrenderbufferparameter/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.getRenderbufferParameter()
 slug: Web/API/WebGLRenderingContext/getRenderbufferParameter
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/getshaderinfolog/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getshaderinfolog/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.getShaderInfoLog()
 slug: Web/API/WebGLRenderingContext/getShaderInfoLog
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/getshaderparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getshaderparameter/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.getShaderParameter()
 slug: Web/API/WebGLRenderingContext/getShaderParameter
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/getshaderprecisionformat/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getshaderprecisionformat/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.getShaderPrecisionFormat()
 slug: Web/API/WebGLRenderingContext/getShaderPrecisionFormat
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/getshadersource/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getshadersource/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.getShaderSource()
 slug: Web/API/WebGLRenderingContext/getShaderSource
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/getsupportedextensions/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getsupportedextensions/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.getSupportedExtensions()
 slug: Web/API/WebGLRenderingContext/getSupportedExtensions
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/gettexparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/gettexparameter/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.getTexParameter()
 slug: Web/API/WebGLRenderingContext/getTexParameter
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/getuniform/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getuniform/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.getUniform()
 slug: Web/API/WebGLRenderingContext/getUniform
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.getUniformLocation()
 slug: Web/API/WebGLRenderingContext/getUniformLocation
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/getvertexattrib/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getvertexattrib/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.getVertexAttrib()
 slug: Web/API/WebGLRenderingContext/getVertexAttrib
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/getvertexattriboffset/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getvertexattriboffset/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.getVertexAttribOffset()
 slug: Web/API/WebGLRenderingContext/getVertexAttribOffset
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/hint/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/hint/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.hint()
 slug: Web/API/WebGLRenderingContext/hint
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/isbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/isbuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.isBuffer()
 slug: Web/API/WebGLRenderingContext/isBuffer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/iscontextlost/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/iscontextlost/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.isContextLost()
 slug: Web/API/WebGLRenderingContext/isContextLost
+page-type: web-api-instance-method
 tags:
   - API
   - Context

--- a/files/en-us/web/api/webglrenderingcontext/isenabled/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/isenabled/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.isEnabled()
 slug: Web/API/WebGLRenderingContext/isEnabled
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/isframebuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/isframebuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.isFramebuffer()
 slug: Web/API/WebGLRenderingContext/isFramebuffer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/isprogram/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/isprogram/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.isProgram()
 slug: Web/API/WebGLRenderingContext/isProgram
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/isrenderbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/isrenderbuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.isRenderbuffer()
 slug: Web/API/WebGLRenderingContext/isRenderbuffer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/isshader/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/isshader/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.isShader()
 slug: Web/API/WebGLRenderingContext/isShader
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/istexture/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/istexture/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.isTexture()
 slug: Web/API/WebGLRenderingContext/isTexture
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/linewidth/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/linewidth/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.lineWidth()
 slug: Web/API/WebGLRenderingContext/lineWidth
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/linkprogram/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/linkprogram/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.linkProgram()
 slug: Web/API/WebGLRenderingContext/linkProgram
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/makexrcompatible/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/makexrcompatible/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.makeXRCompatible()
 slug: Web/API/WebGLRenderingContext/makeXRCompatible
+page-type: web-api-instance-method
 tags:
   - 3D
   - API

--- a/files/en-us/web/api/webglrenderingcontext/pixelstorei/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/pixelstorei/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.pixelStorei()
 slug: Web/API/WebGLRenderingContext/pixelStorei
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/polygonoffset/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/polygonoffset/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.polygonOffset()
 slug: Web/API/WebGLRenderingContext/polygonOffset
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/readpixels/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/readpixels/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.readPixels()
 slug: Web/API/WebGLRenderingContext/readPixels
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/renderbufferstorage/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/renderbufferstorage/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.renderbufferStorage()
 slug: Web/API/WebGLRenderingContext/renderbufferStorage
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/samplecoverage/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/samplecoverage/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.sampleCoverage()
 slug: Web/API/WebGLRenderingContext/sampleCoverage
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/scissor/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/scissor/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.scissor()
 slug: Web/API/WebGLRenderingContext/scissor
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/shadersource/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/shadersource/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.shaderSource()
 slug: Web/API/WebGLRenderingContext/shaderSource
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/stencilfunc/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilfunc/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.stencilFunc()
 slug: Web/API/WebGLRenderingContext/stencilFunc
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/stencilfuncseparate/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilfuncseparate/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.stencilFuncSeparate()
 slug: Web/API/WebGLRenderingContext/stencilFuncSeparate
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/stencilmask/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilmask/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.stencilMask()
 slug: Web/API/WebGLRenderingContext/stencilMask
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/stencilmaskseparate/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilmaskseparate/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.stencilMaskSeparate()
 slug: Web/API/WebGLRenderingContext/stencilMaskSeparate
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/stencilop/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilop/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.stencilOp()
 slug: Web/API/WebGLRenderingContext/stencilOp
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/stencilopseparate/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/stencilopseparate/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.stencilOpSeparate()
 slug: Web/API/WebGLRenderingContext/stencilOpSeparate
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/teximage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/teximage2d/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.texImage2D()
 slug: Web/API/WebGLRenderingContext/texImage2D
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/texparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/texparameter/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.texParameter[fi]()
 slug: Web/API/WebGLRenderingContext/texParameter
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/texsubimage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/texsubimage2d/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.texSubImage2D()
 slug: Web/API/WebGLRenderingContext/texSubImage2D
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/uniform/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/uniform/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.uniform[1234][fi][v]()
 slug: Web/API/WebGLRenderingContext/uniform
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/uniformmatrix/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/uniformmatrix/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.uniformMatrix[234]fv()
 slug: Web/API/WebGLRenderingContext/uniformMatrix
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/useprogram/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/useprogram/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.useProgram()
 slug: Web/API/WebGLRenderingContext/useProgram
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/validateprogram/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/validateprogram/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.validateProgram()
 slug: Web/API/WebGLRenderingContext/validateProgram
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/vertexattrib/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattrib/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.vertexAttrib[1234]f[v]()
 slug: Web/API/WebGLRenderingContext/vertexAttrib
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.vertexAttribPointer()
 slug: Web/API/WebGLRenderingContext/vertexAttribPointer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglrenderingcontext/viewport/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/viewport/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLRenderingContext.viewport()
 slug: Web/API/WebGLRenderingContext/viewport
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webglsampler/index.md
+++ b/files/en-us/web/api/webglsampler/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLSampler
 slug: Web/API/WebGLSampler
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/webglshader/index.md
+++ b/files/en-us/web/api/webglshader/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLShader
 slug: Web/API/WebGLShader
+page-type: web-api-interface
 tags:
   - Reference
   - WebGL

--- a/files/en-us/web/api/webglshaderprecisionformat/index.md
+++ b/files/en-us/web/api/webglshaderprecisionformat/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLShaderPrecisionFormat
 slug: Web/API/WebGLShaderPrecisionFormat
+page-type: web-api-interface
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/webglshaderprecisionformat/precision/index.md
+++ b/files/en-us/web/api/webglshaderprecisionformat/precision/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLShaderPrecisionFormat.precision
 slug: Web/API/WebGLShaderPrecisionFormat/precision
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/webglshaderprecisionformat/rangemax/index.md
+++ b/files/en-us/web/api/webglshaderprecisionformat/rangemax/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLShaderPrecisionFormat.rangeMax
 slug: Web/API/WebGLShaderPrecisionFormat/rangeMax
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/webglshaderprecisionformat/rangemin/index.md
+++ b/files/en-us/web/api/webglshaderprecisionformat/rangemin/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLShaderPrecisionFormat.rangeMin
 slug: Web/API/WebGLShaderPrecisionFormat/rangeMin
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/webglsync/index.md
+++ b/files/en-us/web/api/webglsync/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLSync
 slug: Web/API/WebGLSync
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/webgltexture/index.md
+++ b/files/en-us/web/api/webgltexture/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLTexture
 slug: Web/API/WebGLTexture
+page-type: web-api-interface
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/webgltransformfeedback/index.md
+++ b/files/en-us/web/api/webgltransformfeedback/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLTransformFeedback
 slug: Web/API/WebGLTransformFeedback
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/webgluniformlocation/index.md
+++ b/files/en-us/web/api/webgluniformlocation/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLUniformLocation
 slug: Web/API/WebGLUniformLocation
+page-type: web-api-interface
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/webglvertexarrayobject/index.md
+++ b/files/en-us/web/api/webglvertexarrayobject/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebGLVertexArrayObject
 slug: Web/API/WebGLVertexArrayObject
+page-type: web-api-interface
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/webhid_api/index.md
+++ b/files/en-us/web/api/webhid_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebHID API
 slug: Web/API/WebHID_API
+page-type: web-api-overview
 tags:
   - API
   - Advanced

--- a/files/en-us/web/api/webkitpoint/index.md
+++ b/files/en-us/web/api/webkitpoint/index.md
@@ -1,6 +1,7 @@
 ---
 title: Point
 slug: Web/API/WebKitPoint
+page-type: web-api-interface
 tags:
   - API
   - CSS Transforms

--- a/files/en-us/web/api/webotp_api/index.md
+++ b/files/en-us/web/api/webotp_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebOTP API
 slug: Web/API/WebOTP_API
+page-type: web-api-overview
 tags:
   - API
   - WebOTP

--- a/files/en-us/web/api/webrtc_api/adapter.js/index.md
+++ b/files/en-us/web/api/webrtc_api/adapter.js/index.md
@@ -1,6 +1,7 @@
 ---
 title: Improving compatibility using WebRTC adapter.js
 slug: Web/API/WebRTC_API/adapter.js
+page-type: guide
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/build_the_server/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/build_the_server/index.md
@@ -1,6 +1,7 @@
 ---
 title: Building the server
 slug: Web/API/WebRTC_API/Build_a_phone_with_peerjs/Build_the_server
+page-type: guide
 ---
 {{WebRTCSidebar}}
 

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/answer_a_call/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/answer_a_call/index.md
@@ -1,6 +1,7 @@
 ---
 title: Answering a Call
 slug: Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Answer_a_call
+page-type: guide
 ---
 {{WebRTCSidebar}}
 

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/create_a_peer_connection/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/create_a_peer_connection/index.md
@@ -1,6 +1,7 @@
 ---
 title: Creating a peer connection
 slug: >-
+page-type: guide
   Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Create_a_peer_connection
 ---
 {{WebRTCSidebar}}

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/create_a_peer_connection/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/create_a_peer_connection/index.md
@@ -1,8 +1,8 @@
 ---
 title: Creating a peer connection
 slug: >-
-page-type: guide
   Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Create_a_peer_connection
+page-type: guide
 ---
 {{WebRTCSidebar}}
 

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/creating_a_call/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/creating_a_call/index.md
@@ -1,6 +1,7 @@
 ---
 title: Creating a Call
 slug: Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Creating_a_call
+page-type: guide
 ---
 {{WebRTCSidebar}}
 

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/end_a_call/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/end_a_call/index.md
@@ -1,6 +1,7 @@
 ---
 title: Ending a call
 slug: Web/API/WebRTC_API/build_a_phone_with_peerjs/connect_peers/End_a_call
+page-type: guide
 ---
 {{WebRTCSidebar}}
 

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/get_microphone_permission/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/get_microphone_permission/index.md
@@ -1,6 +1,7 @@
 ---
 title: Getting browser microphone permission
 slug: >-
+page-type: guide
   Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Get_microphone_permission
 ---
 {{WebRTCSidebar}}{{PreviousMenuNext("Web/API/WebRTC_API/build_a_phone_with_peerjs/connect_peers", "Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Show_hide_html")}}

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/get_microphone_permission/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/get_microphone_permission/index.md
@@ -1,8 +1,8 @@
 ---
 title: Getting browser microphone permission
 slug: >-
-page-type: guide
   Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Get_microphone_permission
+page-type: guide
 ---
 {{WebRTCSidebar}}{{PreviousMenuNext("Web/API/WebRTC_API/build_a_phone_with_peerjs/connect_peers", "Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Show_hide_html")}}
 

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/index.md
@@ -1,6 +1,7 @@
 ---
 title: Connecting the peers
 slug: Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers
+page-type: guide
 ---
 {{WebRTCSidebar}}
 

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/show_hide_html/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/show_hide_html/index.md
@@ -1,6 +1,7 @@
 ---
 title: Showing and hiding HTML
 slug: Web/API/WebRTC_API/Build_a_phone_with_peerjs/Connect_peers/Show_hide_html
+page-type: guide
 ---
 {{WebRTCSidebar}}
 

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/deployment_and_further_reading/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/deployment_and_further_reading/index.md
@@ -1,6 +1,7 @@
 ---
 title: Deployment and further reading
 slug: Web/API/WebRTC_API/Build_a_phone_with_peerjs/Deployment_and_further_reading
+page-type: guide
 ---
 {{WebRTCSidebar}}
 

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/index.md
@@ -1,6 +1,7 @@
 ---
 title: Building an Internet-Connected Phone with PeerJS
 slug: Web/API/WebRTC_API/Build_a_phone_with_peerjs
+page-type: guide
 ---
 {{WebRTCSidebar}}
 

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/setup/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/setup/index.md
@@ -1,6 +1,7 @@
 ---
 title: Setup
 slug: Web/API/WebRTC_API/Build_a_phone_with_peerjs/Setup
+page-type: guide
 ---
 {{WebRTCSidebar}} {{PreviousMenuNext("Web/API/WebRTC_API/Build_a_phone_with_peerjs", "Web/API/WebRTC_API/Build_a_phone_with_peerjs/Build_the_server")}}
 

--- a/files/en-us/web/api/webrtc_api/connectivity/index.md
+++ b/files/en-us/web/api/webrtc_api/connectivity/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebRTC connectivity
 slug: Web/API/WebRTC_API/Connectivity
+page-type: guide
 tags:
   - API
   - Advanced

--- a/files/en-us/web/api/webrtc_api/high-level_guide/index.md
+++ b/files/en-us/web/api/webrtc_api/high-level_guide/index.md
@@ -1,6 +1,7 @@
 ---
 title: High-level guides
 slug: Web/API/WebRTC_API/High-level_guide
+page-type: guide
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/webrtc_api/index.md
+++ b/files/en-us/web/api/webrtc_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebRTC API
 slug: Web/API/WebRTC_API
+page-type: web-api-overview
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/webrtc_api/intro_to_rtp/index.md
+++ b/files/en-us/web/api/webrtc_api/intro_to_rtp/index.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction to the Real-time Transport Protocol (RTP)
 slug: Web/API/WebRTC_API/Intro_to_RTP
+page-type: guide
 tags:
   - API
   - Connectivity

--- a/files/en-us/web/api/webrtc_api/perfect_negotiation/index.md
+++ b/files/en-us/web/api/webrtc_api/perfect_negotiation/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Establishing a connection: The WebRTC perfect negotiation pattern'
 slug: Web/API/WebRTC_API/Perfect_negotiation
+page-type: guide
 tags:
   - API
   - Configure

--- a/files/en-us/web/api/webrtc_api/protocols/index.md
+++ b/files/en-us/web/api/webrtc_api/protocols/index.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction to WebRTC protocols
 slug: Web/API/WebRTC_API/Protocols
+page-type: guide
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/webrtc_api/session_lifetime/index.md
+++ b/files/en-us/web/api/webrtc_api/session_lifetime/index.md
@@ -1,6 +1,7 @@
 ---
 title: Lifetime of a WebRTC session
 slug: Web/API/WebRTC_API/Session_lifetime
+page-type: guide
 tags:
   - Advanced
   - Guide

--- a/files/en-us/web/api/webrtc_api/signaling_and_video_calling/index.md
+++ b/files/en-us/web/api/webrtc_api/signaling_and_video_calling/index.md
@@ -1,6 +1,7 @@
 ---
 title: Signaling and video calling
 slug: Web/API/WebRTC_API/Signaling_and_video_calling
+page-type: guide
 tags:
   - API
   - Audio

--- a/files/en-us/web/api/webrtc_api/simple_rtcdatachannel_sample/index.md
+++ b/files/en-us/web/api/webrtc_api/simple_rtcdatachannel_sample/index.md
@@ -1,6 +1,7 @@
 ---
 title: A simple RTCDataChannel sample
 slug: Web/API/WebRTC_API/Simple_RTCDataChannel_sample
+page-type: guide
 tags:
   - API
   - Communication

--- a/files/en-us/web/api/webrtc_api/taking_still_photos/index.md
+++ b/files/en-us/web/api/webrtc_api/taking_still_photos/index.md
@@ -1,6 +1,7 @@
 ---
 title: Taking still photos with WebRTC
 slug: Web/API/WebRTC_API/Taking_still_photos
+page-type: guide
 tags:
   - API
   - Advanced

--- a/files/en-us/web/api/webrtc_api/using_data_channels/index.md
+++ b/files/en-us/web/api/webrtc_api/using_data_channels/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using WebRTC data channels
 slug: Web/API/WebRTC_API/Using_data_channels
+page-type: guide
 tags:
   - Communications
   - Data Transfer

--- a/files/en-us/web/api/webrtc_api/using_dtmf/index.md
+++ b/files/en-us/web/api/webrtc_api/using_dtmf/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using DTMF with WebRTC
 slug: Web/API/WebRTC_API/Using_DTMF
+page-type: guide
 tags:
   - API
   - DTMF

--- a/files/en-us/web/api/webrtc_statistics_api/index.md
+++ b/files/en-us/web/api/webrtc_statistics_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebRTC Statistics API
 slug: Web/API/WebRTC_Statistics_API
+page-type: web-api-overview
 tags:
   - API
   - Draft

--- a/files/en-us/web/api/websocket/binarytype/index.md
+++ b/files/en-us/web/api/websocket/binarytype/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebSocket.binaryType
 slug: Web/API/WebSocket/binaryType
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/websocket/bufferedamount/index.md
+++ b/files/en-us/web/api/websocket/bufferedamount/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebSocket.bufferedAmount
 slug: Web/API/WebSocket/bufferedAmount
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/websocket/close/index.md
+++ b/files/en-us/web/api/websocket/close/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebSocket.close()
 slug: Web/API/WebSocket/close
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/websocket/close_event/index.md
+++ b/files/en-us/web/api/websocket/close_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'WebSocket: close event'
 slug: Web/API/WebSocket/close_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/websocket/error_event/index.md
+++ b/files/en-us/web/api/websocket/error_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'WebSocket: error event'
 slug: Web/API/WebSocket/error_event
+page-type: web-api-event
 tags:
   - API
   - Error

--- a/files/en-us/web/api/websocket/extensions/index.md
+++ b/files/en-us/web/api/websocket/extensions/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebSocket.extensions
 slug: Web/API/WebSocket/extensions
+page-type: web-api-instance-method
 tags:
   - API
   - Property

--- a/files/en-us/web/api/websocket/extensions/index.md
+++ b/files/en-us/web/api/websocket/extensions/index.md
@@ -1,7 +1,7 @@
 ---
 title: WebSocket.extensions
 slug: Web/API/WebSocket/extensions
-page-type: web-api-instance-method
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/websocket/index.md
+++ b/files/en-us/web/api/websocket/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebSocket
 slug: Web/API/WebSocket
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/websocket/message_event/index.md
+++ b/files/en-us/web/api/websocket/message_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'WebSocket: message event'
 slug: Web/API/WebSocket/message_event
+page-type: web-api-event
 tags:
   - Event
   - Reference

--- a/files/en-us/web/api/websocket/open_event/index.md
+++ b/files/en-us/web/api/websocket/open_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'WebSocket: open event'
 slug: Web/API/WebSocket/open_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/websocket/protocol/index.md
+++ b/files/en-us/web/api/websocket/protocol/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebSocket.protocol
 slug: Web/API/WebSocket/protocol
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/websocket/readystate/index.md
+++ b/files/en-us/web/api/websocket/readystate/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebSocket.readyState
 slug: Web/API/WebSocket/readyState
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/websocket/send/index.md
+++ b/files/en-us/web/api/websocket/send/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebSocket.send()
 slug: Web/API/WebSocket/send
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/websocket/url/index.md
+++ b/files/en-us/web/api/websocket/url/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebSocket.url
 slug: Web/API/WebSocket/url
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/websocket/websocket/index.md
+++ b/files/en-us/web/api/websocket/websocket/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebSocket()
 slug: Web/API/WebSocket/WebSocket
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/websockets_api/index.md
+++ b/files/en-us/web/api/websockets_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: The WebSocket API (WebSockets)
 slug: Web/API/WebSockets_API
+page-type: web-api-overview
 tags:
   - API
   - Client

--- a/files/en-us/web/api/websockets_api/writing_a_websocket_server_in_java/index.md
+++ b/files/en-us/web/api/websockets_api/writing_a_websocket_server_in_java/index.md
@@ -1,6 +1,7 @@
 ---
 title: Writing a WebSocket server in Java
 slug: Web/API/WebSockets_API/Writing_a_WebSocket_server_in_Java
+page-type: guide
 tags:
   - HTML5
   - Handshaking

--- a/files/en-us/web/api/websockets_api/writing_websocket_client_applications/index.md
+++ b/files/en-us/web/api/websockets_api/writing_websocket_client_applications/index.md
@@ -1,6 +1,7 @@
 ---
 title: Writing WebSocket client applications
 slug: Web/API/WebSockets_API/Writing_WebSocket_client_applications
+page-type: guide
 tags:
   - Client
   - Example

--- a/files/en-us/web/api/websockets_api/writing_websocket_server/index.md
+++ b/files/en-us/web/api/websockets_api/writing_websocket_server/index.md
@@ -1,6 +1,7 @@
 ---
 title: Writing a WebSocket server in C#
 slug: Web/API/WebSockets_API/Writing_WebSocket_server
+page-type: guide
 tags:
   - HTML5
   - NeedsMarkupWork

--- a/files/en-us/web/api/websockets_api/writing_websocket_servers/index.md
+++ b/files/en-us/web/api/websockets_api/writing_websocket_servers/index.md
@@ -1,6 +1,7 @@
 ---
 title: Writing WebSocket servers
 slug: Web/API/WebSockets_API/Writing_WebSocket_servers
+page-type: guide
 tags:
   - Guide
   - HTML5

--- a/files/en-us/web/api/webusb_api/index.md
+++ b/files/en-us/web/api/webusb_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebUSB API
 slug: Web/API/WebUSB_API
+page-type: web-api-overview
 tags:
   - API
   - Web USB

--- a/files/en-us/web/api/webvr_api/concepts/index.md
+++ b/files/en-us/web/api/webvr_api/concepts/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebVR concepts
 slug: Web/API/WebVR_API/Concepts
+page-type: guide
 tags:
   - Acceleration
   - Apps

--- a/files/en-us/web/api/webvr_api/index.md
+++ b/files/en-us/web/api/webvr_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebVR API
 slug: Web/API/WebVR_API
+page-type: web-api-overview
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/webvr_api/using_the_webvr_api/index.md
+++ b/files/en-us/web/api/webvr_api/using_the_webvr_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using the WebVR API
 slug: Web/API/WebVR_API/Using_the_WebVR_API
+page-type: guide
 tags:
   - '1.1'
   - API

--- a/files/en-us/web/api/webvr_api/using_vr_controllers_with_webvr/index.md
+++ b/files/en-us/web/api/webvr_api/using_vr_controllers_with_webvr/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using VR controllers with WebVR
 slug: Web/API/WebVR_API/Using_VR_controllers_with_WebVR
+page-type: guide
 tags:
   - Experimental
   - Gamepad API

--- a/files/en-us/web/api/webvtt_api/index.md
+++ b/files/en-us/web/api/webvtt_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Web Video Text Tracks Format (WebVTT)
 slug: Web/API/WebVTT_API
+page-type: web-api-overview
 tags:
   - API
   - Intermediate

--- a/files/en-us/web/api/webxr_device_api/bounded_reference_spaces/index.md
+++ b/files/en-us/web/api/webxr_device_api/bounded_reference_spaces/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using bounded reference spaces
 slug: Web/API/WebXR_Device_API/Bounded_reference_spaces
+page-type: guide
 tags:
   - 3D
   - Graphics

--- a/files/en-us/web/api/webxr_device_api/cameras/index.md
+++ b/files/en-us/web/api/webxr_device_api/cameras/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Viewpoints and viewers: Simulating cameras in WebXR'
 slug: Web/API/WebXR_Device_API/Cameras
+page-type: guide
 tags:
   - 3D
   - API

--- a/files/en-us/web/api/webxr_device_api/fundamentals/index.md
+++ b/files/en-us/web/api/webxr_device_api/fundamentals/index.md
@@ -1,6 +1,7 @@
 ---
 title: Fundamentals of WebXR
 slug: Web/API/WebXR_Device_API/Fundamentals
+page-type: guide
 tags:
   - API
   - AR

--- a/files/en-us/web/api/webxr_device_api/geometry/index.md
+++ b/files/en-us/web/api/webxr_device_api/geometry/index.md
@@ -1,6 +1,7 @@
 ---
 title: Geometry and reference spaces in WebXR
 slug: Web/API/WebXR_Device_API/Geometry
+page-type: guide
 tags:
   - API
   - Geometry

--- a/files/en-us/web/api/webxr_device_api/index.md
+++ b/files/en-us/web/api/webxr_device_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebXR Device API
 slug: Web/API/WebXR_Device_API
+page-type: web-api-overview
 tags:
   - API
   - AR

--- a/files/en-us/web/api/webxr_device_api/inputs/index.md
+++ b/files/en-us/web/api/webxr_device_api/inputs/index.md
@@ -1,6 +1,7 @@
 ---
 title: Inputs and input sources
 slug: Web/API/WebXR_Device_API/Inputs
+page-type: guide
 tags:
   - API
   - AR

--- a/files/en-us/web/api/webxr_device_api/lifecycle/index.md
+++ b/files/en-us/web/api/webxr_device_api/lifecycle/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebXR application life cycle
 slug: Web/API/WebXR_Device_API/Lifecycle
+page-type: guide
 tags:
   - API
   - Application

--- a/files/en-us/web/api/webxr_device_api/lighting/index.md
+++ b/files/en-us/web/api/webxr_device_api/lighting/index.md
@@ -1,6 +1,7 @@
 ---
 title: Lighting a WebXR setting
 slug: Web/API/WebXR_Device_API/Lighting
+page-type: guide
 tags:
   - 3D
   - API

--- a/files/en-us/web/api/webxr_device_api/movement_and_motion/index.md
+++ b/files/en-us/web/api/webxr_device_api/movement_and_motion/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Movement, orientation, and motion: A WebXR example'
 slug: Web/API/WebXR_Device_API/Movement_and_motion
+page-type: guide
 tags:
   - 3D
   - API

--- a/files/en-us/web/api/webxr_device_api/performance/index.md
+++ b/files/en-us/web/api/webxr_device_api/performance/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebXR performance guide
 slug: Web/API/WebXR_Device_API/Performance
+page-type: guide
 tags:
   - API
   - Guide

--- a/files/en-us/web/api/webxr_device_api/permissions_and_security/index.md
+++ b/files/en-us/web/api/webxr_device_api/permissions_and_security/index.md
@@ -1,6 +1,7 @@
 ---
 title: WebXR permissions and security
 slug: Web/API/WebXR_Device_API/Permissions_and_security
+page-type: guide
 ---
 {{DefaultAPISidebar("WebXR Device API")}}
 

--- a/files/en-us/web/api/webxr_device_api/perspective/index.md
+++ b/files/en-us/web/api/webxr_device_api/perspective/index.md
@@ -1,6 +1,7 @@
 ---
 title: A perspective retrospective for WebXR developers
 slug: Web/API/WebXR_Device_API/Perspective
+page-type: guide
 tags:
   - 3D
   - API

--- a/files/en-us/web/api/webxr_device_api/rendering/index.md
+++ b/files/en-us/web/api/webxr_device_api/rendering/index.md
@@ -1,6 +1,7 @@
 ---
 title: Rendering and the WebXR frame animation callback
 slug: Web/API/WebXR_Device_API/Rendering
+page-type: guide
 tags:
   - API
   - AR

--- a/files/en-us/web/api/webxr_device_api/spatial_tracking/index.md
+++ b/files/en-us/web/api/webxr_device_api/spatial_tracking/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Spaces and reference spaces: Spatial tracking in WebXR'
 slug: Web/API/WebXR_Device_API/Spatial_tracking
+page-type: guide
 tags:
   - 3D
   - API

--- a/files/en-us/web/api/webxr_device_api/startup_and_shutdown/index.md
+++ b/files/en-us/web/api/webxr_device_api/startup_and_shutdown/index.md
@@ -1,6 +1,7 @@
 ---
 title: Starting up and shutting down a WebXR session
 slug: Web/API/WebXR_Device_API/Startup_and_shutdown
+page-type: guide
 tags:
   - 3D
   - API

--- a/files/en-us/web/api/webxr_device_api/targeting/index.md
+++ b/files/en-us/web/api/webxr_device_api/targeting/index.md
@@ -1,6 +1,7 @@
 ---
 title: Targeting and hit detection
 slug: Web/API/WebXR_Device_API/Targeting
+page-type: guide
 tags:
   - Draft
 ---

--- a/files/en-us/web/api/wheelevent/deltamode/index.md
+++ b/files/en-us/web/api/wheelevent/deltamode/index.md
@@ -1,6 +1,7 @@
 ---
 title: WheelEvent.deltaMode
 slug: Web/API/WheelEvent/deltaMode
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/wheelevent/deltax/index.md
+++ b/files/en-us/web/api/wheelevent/deltax/index.md
@@ -1,6 +1,7 @@
 ---
 title: WheelEvent.deltaX
 slug: Web/API/WheelEvent/deltaX
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/wheelevent/deltay/index.md
+++ b/files/en-us/web/api/wheelevent/deltay/index.md
@@ -1,6 +1,7 @@
 ---
 title: WheelEvent.deltaY
 slug: Web/API/WheelEvent/deltaY
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/wheelevent/deltaz/index.md
+++ b/files/en-us/web/api/wheelevent/deltaz/index.md
@@ -1,6 +1,7 @@
 ---
 title: WheelEvent.deltaZ
 slug: Web/API/WheelEvent/deltaZ
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/wheelevent/index.md
+++ b/files/en-us/web/api/wheelevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: WheelEvent
 slug: Web/API/WheelEvent
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/wheelevent/wheelevent/index.md
+++ b/files/en-us/web/api/wheelevent/wheelevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: WheelEvent()
 slug: Web/API/WheelEvent/WheelEvent
+page-type: web-api-constructor
 tags:
   - Constructor
   - DOM

--- a/files/en-us/web/api/window/afterprint_event/index.md
+++ b/files/en-us/web/api/window/afterprint_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: afterprint event'
 slug: Web/API/Window/afterprint_event
+page-type: web-api-event
 tags:
   - Event
   - Reference

--- a/files/en-us/web/api/window/alert/index.md
+++ b/files/en-us/web/api/window/alert/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.alert()
 slug: Web/API/Window/alert
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/animationcancel_event/index.md
+++ b/files/en-us/web/api/window/animationcancel_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: animationcancel event'
 slug: Web/API/Window/animationcancel_event
+page-type: web-api-event
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/window/animationend_event/index.md
+++ b/files/en-us/web/api/window/animationend_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: animationend event'
 slug: Web/API/Window/animationend_event
+page-type: web-api-event
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/window/animationiteration_event/index.md
+++ b/files/en-us/web/api/window/animationiteration_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: animationiteration event'
 slug: Web/API/Window/animationiteration_event
+page-type: web-api-event
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/window/animationstart_event/index.md
+++ b/files/en-us/web/api/window/animationstart_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: animationstart event'
 slug: Web/API/Window/animationstart_event
+page-type: web-api-event
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/window/appinstalled_event/index.md
+++ b/files/en-us/web/api/window/appinstalled_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: appinstalled event'
 slug: Web/API/Window/appinstalled_event
+page-type: web-api-event
 tags:
   - API
   - Manifest

--- a/files/en-us/web/api/window/applicationcache/index.md
+++ b/files/en-us/web/api/window/applicationcache/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.applicationCache
 slug: Web/API/Window/applicationCache
+page-type: web-api-instance-property
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/window/back/index.md
+++ b/files/en-us/web/api/window/back/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.back()
 slug: Web/API/Window/back
+page-type: web-api-instance-method
 tags:
   - API
   - Firefox

--- a/files/en-us/web/api/window/beforeinstallprompt_event/index.md
+++ b/files/en-us/web/api/window/beforeinstallprompt_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: beforeinstallprompt event'
 slug: Web/API/Window/beforeinstallprompt_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/window/beforeprint_event/index.md
+++ b/files/en-us/web/api/window/beforeprint_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: beforeprint event'
 slug: Web/API/Window/beforeprint_event
+page-type: web-api-event
 tags:
   - Event
   - Reference

--- a/files/en-us/web/api/window/beforeunload_event/index.md
+++ b/files/en-us/web/api/window/beforeunload_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: beforeunload event'
 slug: Web/API/Window/beforeunload_event
+page-type: web-api-event
 tags:
   - Event
   - Reference

--- a/files/en-us/web/api/window/blur/index.md
+++ b/files/en-us/web/api/window/blur/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.blur()
 slug: Web/API/Window/blur
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/window/blur_event/index.md
+++ b/files/en-us/web/api/window/blur_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: blur event'
 slug: Web/API/Window/blur_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/window/cancelanimationframe/index.md
+++ b/files/en-us/web/api/window/cancelanimationframe/index.md
@@ -1,6 +1,7 @@
 ---
 title: window.cancelAnimationFrame()
 slug: Web/API/Window/cancelAnimationFrame
+page-type: web-api-instance-method
 tags:
   - API
   - Animation

--- a/files/en-us/web/api/window/cancelidlecallback/index.md
+++ b/files/en-us/web/api/window/cancelidlecallback/index.md
@@ -1,6 +1,7 @@
 ---
 title: window.cancelIdleCallback()
 slug: Web/API/Window/cancelIdleCallback
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/captureevents/index.md
+++ b/files/en-us/web/api/window/captureevents/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.captureEvents()
 slug: Web/API/Window/captureEvents
+page-type: web-api-instance-method
 tags:
   - API
   - Gecko

--- a/files/en-us/web/api/window/clearimmediate/index.md
+++ b/files/en-us/web/api/window/clearimmediate/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.clearImmediate()
 slug: Web/API/Window/clearImmediate
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/close/index.md
+++ b/files/en-us/web/api/window/close/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.close()
 slug: Web/API/Window/close
+page-type: web-api-instance-method
 tags:
   - API
   - Gecko

--- a/files/en-us/web/api/window/closed/index.md
+++ b/files/en-us/web/api/window/closed/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.closed
 slug: Web/API/Window/closed
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/confirm/index.md
+++ b/files/en-us/web/api/window/confirm/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.confirm()
 slug: Web/API/Window/confirm
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/console/index.md
+++ b/files/en-us/web/api/window/console/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.console
 slug: Web/API/Window/console
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/window/content/index.md
+++ b/files/en-us/web/api/window/content/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.content
 slug: Web/API/Window/content
+page-type: web-api-instance-property
 ---
 {{APIRef}}{{non-standard_header}}
 

--- a/files/en-us/web/api/window/copy_event/index.md
+++ b/files/en-us/web/api/window/copy_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: copy event'
 slug: Web/API/Window/copy_event
+page-type: web-api-event
 tags:
   - API
   - Clipboard API

--- a/files/en-us/web/api/window/customelements/index.md
+++ b/files/en-us/web/api/window/customelements/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.customElements
 slug: Web/API/Window/customElements
+page-type: web-api-instance-property
 tags:
   - API
   - CustomElementRegistry

--- a/files/en-us/web/api/window/cut_event/index.md
+++ b/files/en-us/web/api/window/cut_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: cut event'
 slug: Web/API/Window/cut_event
+page-type: web-api-event
 tags:
   - API
   - Clipboard API

--- a/files/en-us/web/api/window/defaultstatus/index.md
+++ b/files/en-us/web/api/window/defaultstatus/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.defaultStatus
 slug: Web/API/Window/defaultStatus
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/devicemotion_event/index.md
+++ b/files/en-us/web/api/window/devicemotion_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: devicemotion event'
 slug: Web/API/Window/devicemotion_event
+page-type: web-api-event
 tags:
   - API
   - Device Orientation API

--- a/files/en-us/web/api/window/deviceorientation_event/index.md
+++ b/files/en-us/web/api/window/deviceorientation_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: deviceorientation event'
 slug: Web/API/Window/deviceorientation_event
+page-type: web-api-event
 tags:
   - Device Orientation API
   - Sensors

--- a/files/en-us/web/api/window/deviceorientationabsolute_event/index.md
+++ b/files/en-us/web/api/window/deviceorientationabsolute_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: deviceorientationabsolute event'
 slug: Web/API/Window/deviceorientationabsolute_event
+page-type: web-api-event
 tags:
   - API
   - Device Orientation

--- a/files/en-us/web/api/window/devicepixelratio/index.md
+++ b/files/en-us/web/api/window/devicepixelratio/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.devicePixelRatio
 slug: Web/API/Window/devicePixelRatio
+page-type: web-api-instance-property
 tags:
   - API
   - Adaptive Design

--- a/files/en-us/web/api/window/document/index.md
+++ b/files/en-us/web/api/window/document/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.document
 slug: Web/API/Window/document
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/domcontentloaded_event/index.md
+++ b/files/en-us/web/api/window/domcontentloaded_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: DOMContentLoaded event'
 slug: Web/API/Window/DOMContentLoaded_event
+page-type: web-api-event
 tags:
   - Event
   - Reference

--- a/files/en-us/web/api/window/dump/index.md
+++ b/files/en-us/web/api/window/dump/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.dump()
 slug: Web/API/Window/dump
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/error_event/index.md
+++ b/files/en-us/web/api/window/error_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: error event'
 slug: Web/API/Window/error_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/window/event/index.md
+++ b/files/en-us/web/api/window/event/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.event
 slug: Web/API/Window/event
+page-type: web-api-instance-property
 tags:
   - API
   - Event

--- a/files/en-us/web/api/window/index.md
+++ b/files/en-us/web/api/window/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window
 slug: Web/API/Window
+page-type: web-api-interface
 tags:
   - API
   - Browser

--- a/files/en-us/web/api/window_controls_overlay_api/index.md
+++ b/files/en-us/web/api/window_controls_overlay_api/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window Controls Overlay API
 slug: Web/API/Window_Controls_Overlay_API
+page-type: web-api-overview
 tags:
   - API
   - Window Controls Overlay


### PR DESCRIPTION
See  https://github.com/mdn/content/issues/16255. This is part 27 of a series of PRs to add page types to the Web/API documentation.