### PR TITLE
Add Web/API page types, part 28

### DIFF
--- a/files/en-us/web/api/window/external/index.md
+++ b/files/en-us/web/api/window/external/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.external
 slug: Web/API/Window/external
+page-type: web-api-instance-property
 tags:
   - API
   - property

--- a/files/en-us/web/api/window/find/index.md
+++ b/files/en-us/web/api/window/find/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.find()
 slug: Web/API/Window/find
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/focus/index.md
+++ b/files/en-us/web/api/window/focus/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.focus()
 slug: Web/API/Window/focus
+page-type: web-api-instance-method
 tags:
   - API
   - Gecko

--- a/files/en-us/web/api/window/focus_event/index.md
+++ b/files/en-us/web/api/window/focus_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: focus event'
 slug: Web/API/Window/focus_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/window/forward/index.md
+++ b/files/en-us/web/api/window/forward/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.forward()
 slug: Web/API/Window/forward
+page-type: web-api-instance-method
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/window/frameelement/index.md
+++ b/files/en-us/web/api/window/frameelement/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.frameElement
 slug: Web/API/Window/frameElement
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/window/frames/index.md
+++ b/files/en-us/web/api/window/frames/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.frames
 slug: Web/API/Window/frames
+page-type: web-api-instance-property
 tags:
   - API
   - Gecko

--- a/files/en-us/web/api/window/fullscreen/index.md
+++ b/files/en-us/web/api/window/fullscreen/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.fullScreen
 slug: Web/API/Window/fullScreen
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/gamepadconnected_event/index.md
+++ b/files/en-us/web/api/window/gamepadconnected_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: gamepadconnected event'
 slug: Web/API/Window/gamepadconnected_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/window/gamepaddisconnected_event/index.md
+++ b/files/en-us/web/api/window/gamepaddisconnected_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: gamepaddisconnected event'
 slug: Web/API/Window/gamepaddisconnected_event
+page-type: web-api-event
 browser-compat: api.Window.gamepaddisconnected_event
 ---
 {{APIRef}}

--- a/files/en-us/web/api/window/getcomputedstyle/index.md
+++ b/files/en-us/web/api/window/getcomputedstyle/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.getComputedStyle()
 slug: Web/API/Window/getComputedStyle
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/window/getdefaultcomputedstyle/index.md
+++ b/files/en-us/web/api/window/getdefaultcomputedstyle/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.getDefaultComputedStyle()
 slug: Web/API/window/getDefaultComputedStyle
+page-type: web-api-instance-method
 tags:
   - API
   - CSS

--- a/files/en-us/web/api/window/getselection/index.md
+++ b/files/en-us/web/api/window/getselection/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.getSelection()
 slug: Web/API/Window/getSelection
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/hashchange_event/index.md
+++ b/files/en-us/web/api/window/hashchange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: hashchange event'
 slug: Web/API/Window/hashchange_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/window/history/index.md
+++ b/files/en-us/web/api/window/history/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.history
 slug: Web/API/Window/history
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/innerheight/index.md
+++ b/files/en-us/web/api/window/innerheight/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.innerHeight
 slug: Web/API/Window/innerHeight
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM

--- a/files/en-us/web/api/window/innerwidth/index.md
+++ b/files/en-us/web/api/window/innerwidth/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.innerWidth
 slug: Web/API/Window/innerWidth
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/window/languagechange_event/index.md
+++ b/files/en-us/web/api/window/languagechange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: languagechange event'
 slug: Web/API/Window/languagechange_event
+page-type: web-api-event
 tags:
   - Event
   - HTML DOM

--- a/files/en-us/web/api/window/length/index.md
+++ b/files/en-us/web/api/window/length/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.length
 slug: Web/API/Window/length
+page-type: web-api-instance-property
 tags:
   - API
   - Gecko

--- a/files/en-us/web/api/window/load_event/index.md
+++ b/files/en-us/web/api/window/load_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: load event'
 slug: Web/API/Window/load_event
+page-type: web-api-event
 tags:
   - Event
   - HTML DOM

--- a/files/en-us/web/api/window/localstorage/index.md
+++ b/files/en-us/web/api/window/localstorage/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.localStorage
 slug: Web/API/Window/localStorage
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/window/location/index.md
+++ b/files/en-us/web/api/window/location/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.location
 slug: Web/API/Window/location
+page-type: web-api-instance-property
 tags:
   - API
   - HTML

--- a/files/en-us/web/api/window/locationbar/index.md
+++ b/files/en-us/web/api/window/locationbar/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.locationbar
 slug: Web/API/Window/locationbar
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/matchmedia/index.md
+++ b/files/en-us/web/api/window/matchmedia/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.matchMedia()
 slug: Web/API/Window/matchMedia
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/window/menubar/index.md
+++ b/files/en-us/web/api/window/menubar/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.menubar
 slug: Web/API/Window/menubar
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/message_event/index.md
+++ b/files/en-us/web/api/window/message_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: message event'
 slug: Web/API/Window/message_event
+page-type: web-api-event
 tags:
   - Event
 browser-compat: api.Window.message_event

--- a/files/en-us/web/api/window/messageerror_event/index.md
+++ b/files/en-us/web/api/window/messageerror_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: messageerror event'
 slug: Web/API/Window/messageerror_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/window/moveby/index.md
+++ b/files/en-us/web/api/window/moveby/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.moveBy()
 slug: Web/API/Window/moveBy
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/window/moveto/index.md
+++ b/files/en-us/web/api/window/moveto/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.moveTo()
 slug: Web/API/Window/moveTo
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/window/mozinnerscreenx/index.md
+++ b/files/en-us/web/api/window/mozinnerscreenx/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.mozInnerScreenX
 slug: Web/API/Window/mozInnerScreenX
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/mozinnerscreeny/index.md
+++ b/files/en-us/web/api/window/mozinnerscreeny/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.mozInnerScreenY
 slug: Web/API/Window/mozInnerScreenY
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/name/index.md
+++ b/files/en-us/web/api/window/name/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.name
 slug: Web/API/Window/name
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/navigator/index.md
+++ b/files/en-us/web/api/window/navigator/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.navigator
 slug: Web/API/Window/navigator
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/offline_event/index.md
+++ b/files/en-us/web/api/window/offline_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: offline event'
 slug: Web/API/Window/offline_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/window/ondragdrop/index.md
+++ b/files/en-us/web/api/window/ondragdrop/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.ondragdrop
 slug: Web/API/Window/ondragdrop
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/online_event/index.md
+++ b/files/en-us/web/api/window/online_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: online event'
 slug: Web/API/Window/online_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/window/open/index.md
+++ b/files/en-us/web/api/window/open/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.open()
 slug: Web/API/Window/open
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/window/opendialog/index.md
+++ b/files/en-us/web/api/window/opendialog/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.openDialog()
 slug: Web/API/Window/openDialog
+page-type: web-api-instance-method
 tags:
   - API
   - Gecko

--- a/files/en-us/web/api/window/opener/index.md
+++ b/files/en-us/web/api/window/opener/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.opener
 slug: Web/API/Window/opener
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/orientation/index.md
+++ b/files/en-us/web/api/window/orientation/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.orientation
 slug: Web/API/Window/orientation
+page-type: web-api-instance-property
 tags:
   - NeedsContent
 browser-compat: api.Window.orientation

--- a/files/en-us/web/api/window/orientationchange_event/index.md
+++ b/files/en-us/web/api/window/orientationchange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: orientationchange event'
 slug: Web/API/Window/orientationchange_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/window/outerheight/index.md
+++ b/files/en-us/web/api/window/outerheight/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.outerHeight
 slug: Web/API/Window/outerHeight
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/window/outerwidth/index.md
+++ b/files/en-us/web/api/window/outerwidth/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.outerWidth
 slug: Web/API/Window/outerWidth
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/window/pagehide_event/index.md
+++ b/files/en-us/web/api/window/pagehide_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: pagehide event'
 slug: Web/API/Window/pagehide_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/window/pageshow_event/index.md
+++ b/files/en-us/web/api/window/pageshow_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: pageshow event'
 slug: Web/API/Window/pageshow_event
+page-type: web-api-event
 tags:
   - API
   - Document

--- a/files/en-us/web/api/window/pagexoffset/index.md
+++ b/files/en-us/web/api/window/pagexoffset/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.pageXOffset
 slug: Web/API/Window/pageXOffset
+page-type: web-api-instance-property
 tags:
   - API
   - Alias

--- a/files/en-us/web/api/window/pageyoffset/index.md
+++ b/files/en-us/web/api/window/pageyoffset/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.pageYOffset
 slug: Web/API/Window/pageYOffset
+page-type: web-api-instance-property
 tags:
   - API
   - Alias

--- a/files/en-us/web/api/window/parent/index.md
+++ b/files/en-us/web/api/window/parent/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.parent
 slug: Web/API/Window/parent
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/paste_event/index.md
+++ b/files/en-us/web/api/window/paste_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: paste event'
 slug: Web/API/Window/paste_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/window/personalbar/index.md
+++ b/files/en-us/web/api/window/personalbar/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.personalbar
 slug: Web/API/Window/personalbar
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/popstate_event/index.md
+++ b/files/en-us/web/api/window/popstate_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: popstate event'
 slug: Web/API/Window/popstate_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/window/postmessage/index.md
+++ b/files/en-us/web/api/window/postmessage/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.postMessage()
 slug: Web/API/Window/postMessage
+page-type: web-api-instance-method
 tags:
   - API
   - Cross-origin Communication

--- a/files/en-us/web/api/window/print/index.md
+++ b/files/en-us/web/api/window/print/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.print()
 slug: Web/API/Window/print
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/prompt/index.md
+++ b/files/en-us/web/api/window/prompt/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.prompt()
 slug: Web/API/Window/prompt
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/rejectionhandled_event/index.md
+++ b/files/en-us/web/api/window/rejectionhandled_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: rejectionhandled event'
 slug: Web/API/Window/rejectionhandled_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/window/releaseevents/index.md
+++ b/files/en-us/web/api/window/releaseevents/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.releaseEvents()
 slug: Web/API/Window/releaseEvents
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/window/requestanimationframe/index.md
+++ b/files/en-us/web/api/window/requestanimationframe/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.requestAnimationFrame()
 slug: Web/API/window/requestAnimationFrame
+page-type: web-api-instance-method
 tags:
   - API
   - Animations

--- a/files/en-us/web/api/window/requestfilesystem/index.md
+++ b/files/en-us/web/api/window/requestfilesystem/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.requestFileSystem()
 slug: Web/API/Window/requestFileSystem
+page-type: web-api-instance-method
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/window/requestidlecallback/index.md
+++ b/files/en-us/web/api/window/requestidlecallback/index.md
@@ -1,6 +1,7 @@
 ---
 title: window.requestIdleCallback()
 slug: Web/API/Window/requestIdleCallback
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/resize_event/index.md
+++ b/files/en-us/web/api/window/resize_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: resize event'
 slug: Web/API/Window/resize_event
+page-type: web-api-event
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/window/resizeby/index.md
+++ b/files/en-us/web/api/window/resizeby/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.resizeBy()
 slug: Web/API/Window/resizeBy
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/window/resizeto/index.md
+++ b/files/en-us/web/api/window/resizeto/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.resizeTo()
 slug: Web/API/Window/resizeTo
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/window/screen/index.md
+++ b/files/en-us/web/api/window/screen/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.screen
 slug: Web/API/Window/screen
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/window/screenleft/index.md
+++ b/files/en-us/web/api/window/screenleft/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.screenLeft
 slug: Web/API/Window/screenLeft
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/window/screentop/index.md
+++ b/files/en-us/web/api/window/screentop/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.screenTop
 slug: Web/API/Window/screenTop
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/window/screenx/index.md
+++ b/files/en-us/web/api/window/screenx/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.screenX
 slug: Web/API/Window/screenX
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/window/screeny/index.md
+++ b/files/en-us/web/api/window/screeny/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.screenY
 slug: Web/API/Window/screenY
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/window/scroll/index.md
+++ b/files/en-us/web/api/window/scroll/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.scroll()
 slug: Web/API/Window/scroll
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/window/scrollbars/index.md
+++ b/files/en-us/web/api/window/scrollbars/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.scrollbars
 slug: Web/API/Window/scrollbars
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/scrollby/index.md
+++ b/files/en-us/web/api/window/scrollby/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.scrollBy()
 slug: Web/API/Window/scrollBy
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/window/scrollbylines/index.md
+++ b/files/en-us/web/api/window/scrollbylines/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.scrollByLines()
 slug: Web/API/Window/scrollByLines
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/scrollbypages/index.md
+++ b/files/en-us/web/api/window/scrollbypages/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.scrollByPages()
 slug: Web/API/Window/scrollByPages
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/scrollmaxx/index.md
+++ b/files/en-us/web/api/window/scrollmaxx/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.scrollMaxX
 slug: Web/API/Window/scrollMaxX
+page-type: web-api-instance-property
 tags:
   - API
   - Gecko

--- a/files/en-us/web/api/window/scrollmaxy/index.md
+++ b/files/en-us/web/api/window/scrollmaxy/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.scrollMaxY
 slug: Web/API/Window/scrollMaxY
+page-type: web-api-instance-property
 tags:
   - API
   - DOM_0

--- a/files/en-us/web/api/window/scrollto/index.md
+++ b/files/en-us/web/api/window/scrollto/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.scrollTo()
 slug: Web/API/Window/scrollTo
+page-type: web-api-instance-method
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/window/scrollx/index.md
+++ b/files/en-us/web/api/window/scrollx/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.scrollX
 slug: Web/API/Window/scrollX
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/window/scrolly/index.md
+++ b/files/en-us/web/api/window/scrolly/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.scrollY
 slug: Web/API/Window/scrollY
+page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View

--- a/files/en-us/web/api/window/self/index.md
+++ b/files/en-us/web/api/window/self/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.self
 slug: Web/API/Window/self
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/sessionstorage/index.md
+++ b/files/en-us/web/api/window/sessionstorage/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.sessionStorage
 slug: Web/API/Window/sessionStorage
+page-type: web-api-instance-property
 tags:
   - APIs
   - Property

--- a/files/en-us/web/api/window/setimmediate/index.md
+++ b/files/en-us/web/api/window/setimmediate/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.setImmediate()
 slug: Web/API/Window/setImmediate
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/showdirectorypicker/index.md
+++ b/files/en-us/web/api/window/showdirectorypicker/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.showDirectoryPicker()
 slug: Web/API/Window/showDirectoryPicker
+page-type: web-api-instance-method
 tags:
   - Directory
   - File

--- a/files/en-us/web/api/window/showmodaldialog/index.md
+++ b/files/en-us/web/api/window/showmodaldialog/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.showModalDialog()
 slug: Web/API/Window/showModalDialog
+page-type: web-api-instance-method
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/window/showopenfilepicker/index.md
+++ b/files/en-us/web/api/window/showopenfilepicker/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.showOpenFilePicker()
 slug: Web/API/Window/showOpenFilePicker
+page-type: web-api-instance-method
 tags:
   - File
   - File System Access API

--- a/files/en-us/web/api/window/showsavefilepicker/index.md
+++ b/files/en-us/web/api/window/showsavefilepicker/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.showSaveFilePicker()
 slug: Web/API/Window/showSaveFilePicker
+page-type: web-api-instance-method
 tags:
   - Directory
   - File

--- a/files/en-us/web/api/window/sidebar/index.md
+++ b/files/en-us/web/api/window/sidebar/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.sidebar
 slug: Web/API/Window/sidebar
+page-type: web-api-instance-property
 tags:
   - HTML DOM
   - Property

--- a/files/en-us/web/api/window/sizetocontent/index.md
+++ b/files/en-us/web/api/window/sizetocontent/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.sizeToContent()
 slug: Web/API/Window/sizeToContent
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/speechsynthesis/index.md
+++ b/files/en-us/web/api/window/speechsynthesis/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.speechSynthesis
 slug: Web/API/Window/speechSynthesis
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/window/status/index.md
+++ b/files/en-us/web/api/window/status/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.status
 slug: Web/API/Window/status
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/statusbar/index.md
+++ b/files/en-us/web/api/window/statusbar/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.statusbar
 slug: Web/API/Window/statusbar
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/stop/index.md
+++ b/files/en-us/web/api/window/stop/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.stop()
 slug: Web/API/Window/stop
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/window/storage_event/index.md
+++ b/files/en-us/web/api/window/storage_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: storage event'
 slug: Web/API/Window/storage_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/window/toolbar/index.md
+++ b/files/en-us/web/api/window/toolbar/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.toolbar
 slug: Web/API/Window/toolbar
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/top/index.md
+++ b/files/en-us/web/api/window/top/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.top
 slug: Web/API/Window/top
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/transitioncancel_event/index.md
+++ b/files/en-us/web/api/window/transitioncancel_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: transitioncancel event'
 slug: Web/API/Window/transitioncancel_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/window/transitionend_event/index.md
+++ b/files/en-us/web/api/window/transitionend_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: transitionend event'
 slug: Web/API/Window/transitionend_event
+page-type: web-api-event
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/window/transitionrun_event/index.md
+++ b/files/en-us/web/api/window/transitionrun_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: transitionrun event'
 slug: Web/API/Window/transitionrun_event
+page-type: web-api-event
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/window/transitionstart_event/index.md
+++ b/files/en-us/web/api/window/transitionstart_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: transitionstart event'
 slug: Web/API/Window/transitionstart_event
+page-type: web-api-event
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/window/unhandledrejection_event/index.md
+++ b/files/en-us/web/api/window/unhandledrejection_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: unhandledrejection event'
 slug: Web/API/Window/unhandledrejection_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/window/unload_event/index.md
+++ b/files/en-us/web/api/window/unload_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: unload event'
 slug: Web/API/Window/unload_event
+page-type: web-api-event
 tags:
   - Event
   - Reference

--- a/files/en-us/web/api/window/updatecommands/index.md
+++ b/files/en-us/web/api/window/updatecommands/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.updateCommands()
 slug: Web/API/Window/updateCommands
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/visualviewport/index.md
+++ b/files/en-us/web/api/window/visualviewport/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.visualViewport
 slug: Web/API/Window/visualViewport
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/window/vrdisplayactivate_event/index.md
+++ b/files/en-us/web/api/window/vrdisplayactivate_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: vrdisplayactivate event'
 slug: Web/API/Window/vrdisplayactivate_event
+page-type: web-api-event
 tags:
   - Reference
   - WebVR

--- a/files/en-us/web/api/window/vrdisplayblur_event/index.md
+++ b/files/en-us/web/api/window/vrdisplayblur_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: vrdisplayblur event'
 slug: Web/API/Window/vrdisplayblur_event
+page-type: web-api-event
 tags:
   - Reference
   - WebVR

--- a/files/en-us/web/api/window/vrdisplayconnect_event/index.md
+++ b/files/en-us/web/api/window/vrdisplayconnect_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: vrdisplayconnect event'
 slug: Web/API/Window/vrdisplayconnect_event
+page-type: web-api-event
 tags:
   - Event
   - Reference

--- a/files/en-us/web/api/window/vrdisplaydeactivate_event/index.md
+++ b/files/en-us/web/api/window/vrdisplaydeactivate_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: vrdisplaydeactivate event'
 slug: Web/API/Window/vrdisplaydeactivate_event
+page-type: web-api-event
 tags:
   - Reference
   - WebVR

--- a/files/en-us/web/api/window/vrdisplaydisconnect_event/index.md
+++ b/files/en-us/web/api/window/vrdisplaydisconnect_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: vrdisplaydisconnect event'
 slug: Web/API/Window/vrdisplaydisconnect_event
+page-type: web-api-event
 tags:
   - Event
   - Reference

--- a/files/en-us/web/api/window/vrdisplayfocus_event/index.md
+++ b/files/en-us/web/api/window/vrdisplayfocus_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: vrdisplayfocus event'
 slug: Web/API/Window/vrdisplayfocus_event
+page-type: web-api-event
 tags:
   - Reference
   - WebVR

--- a/files/en-us/web/api/window/vrdisplaypointerrestricted_event/index.md
+++ b/files/en-us/web/api/window/vrdisplaypointerrestricted_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: vrdisplaypointerrestricted event'
 slug: Web/API/Window/vrdisplaypointerrestricted_event
+page-type: web-api-event
 tags:
   - Reference
   - Web VR

--- a/files/en-us/web/api/window/vrdisplaypointerunrestricted_event/index.md
+++ b/files/en-us/web/api/window/vrdisplaypointerunrestricted_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: vrdisplaypointerunrestricted event'
 slug: Web/API/Window/vrdisplaypointerunrestricted_event
+page-type: web-api-event
 tags:
   - Reference
   - WebVR

--- a/files/en-us/web/api/window/vrdisplaypresentchange_event/index.md
+++ b/files/en-us/web/api/window/vrdisplaypresentchange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Window: vrdisplaypresentchange event'
 slug: Web/API/Window/vrdisplaypresentchange_event
+page-type: web-api-event
 tags:
   - Event
   - Reference

--- a/files/en-us/web/api/window/webkitconvertpointfromnodetopage/index.md
+++ b/files/en-us/web/api/window/webkitconvertpointfromnodetopage/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.convertPointFromNodeToPage()
 slug: Web/API/Window/webkitConvertPointFromNodeToPage
+page-type: web-api-instance-method
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/window/webkitconvertpointfrompagetonode/index.md
+++ b/files/en-us/web/api/window/webkitconvertpointfrompagetonode/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.convertPointFromPageToNode()
 slug: Web/API/Window/webkitConvertPointFromPageToNode
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/window/window/index.md
+++ b/files/en-us/web/api/window/window/index.md
@@ -1,6 +1,7 @@
 ---
 title: Window.window
 slug: Web/API/Window/window
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/windowclient/focus/index.md
+++ b/files/en-us/web/api/windowclient/focus/index.md
@@ -1,6 +1,7 @@
 ---
 title: WindowClient.focus()
 slug: Web/API/WindowClient/focus
+page-type: web-api-instance-method
 tags:
   - API
   - Client

--- a/files/en-us/web/api/windowclient/focused/index.md
+++ b/files/en-us/web/api/windowclient/focused/index.md
@@ -1,6 +1,7 @@
 ---
 title: WindowClient.focused
 slug: Web/API/WindowClient/focused
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/windowclient/index.md
+++ b/files/en-us/web/api/windowclient/index.md
@@ -1,6 +1,7 @@
 ---
 title: WindowClient
 slug: Web/API/WindowClient
+page-type: web-api-interface
 tags:
   - API
   - Client

--- a/files/en-us/web/api/windowclient/navigate/index.md
+++ b/files/en-us/web/api/windowclient/navigate/index.md
@@ -1,6 +1,7 @@
 ---
 title: WindowClient.navigate()
 slug: Web/API/WindowClient/navigate
+page-type: web-api-instance-method
 tags:
   - API
   - Client

--- a/files/en-us/web/api/windowclient/visibilitystate/index.md
+++ b/files/en-us/web/api/windowclient/visibilitystate/index.md
@@ -1,6 +1,7 @@
 ---
 title: WindowClient.visibilityState
 slug: Web/API/WindowClient/visibilityState
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/windowcontrolsoverlay/geometrychange_event/index.md
+++ b/files/en-us/web/api/windowcontrolsoverlay/geometrychange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'WindowControlsOverlay: geometrychange event'
 slug: Web/API/WindowControlsOverlay/geometrychange_event
+page-type: web-api-event
 tags:
   - Event
   - Reference

--- a/files/en-us/web/api/windowcontrolsoverlay/gettitlebararearect/index.md
+++ b/files/en-us/web/api/windowcontrolsoverlay/gettitlebararearect/index.md
@@ -1,6 +1,7 @@
 ---
 title: WindowControlsOverlay.getTitlebarAreaRect()
 slug: Web/API/WindowControlsOverlay/getTitlebarAreaRect
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/windowcontrolsoverlay/index.md
+++ b/files/en-us/web/api/windowcontrolsoverlay/index.md
@@ -1,6 +1,7 @@
 ---
 title: WindowControlsOverlay
 slug: Web/API/WindowControlsOverlay
+page-type: web-api-interface
 tags:
   - API
   - Window Controls Overlay

--- a/files/en-us/web/api/windowcontrolsoverlay/visible/index.md
+++ b/files/en-us/web/api/windowcontrolsoverlay/visible/index.md
@@ -1,6 +1,7 @@
 ---
 title: WindowControlsOverlay.visible
 slug: Web/API/WindowControlsOverlay/visible
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/windowcontrolsoverlaygeometrychangeevent/index.md
+++ b/files/en-us/web/api/windowcontrolsoverlaygeometrychangeevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: WindowControlsOverlayGeometryChangeEvent
 slug: Web/API/WindowControlsOverlayGeometryChangeEvent
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/windowcontrolsoverlaygeometrychangeevent/titlebararearect/index.md
+++ b/files/en-us/web/api/windowcontrolsoverlaygeometrychangeevent/titlebararearect/index.md
@@ -1,6 +1,7 @@
 ---
 title: WindowControlsOverlayGeometryChangeEvent.titlebarAreaRect
 slug: Web/API/WindowControlsOverlayGeometryChangeEvent/titlebarAreaRect
+page-type: web-api-instance-property
 tags:
   - API
   - WindowControlsOverlayGeometryChangeEvent

--- a/files/en-us/web/api/windowcontrolsoverlaygeometrychangeevent/visible/index.md
+++ b/files/en-us/web/api/windowcontrolsoverlaygeometrychangeevent/visible/index.md
@@ -1,6 +1,7 @@
 ---
 title: WindowControlsOverlayGeometryChangeEvent.visible
 slug: Web/API/WindowControlsOverlayGeometryChangeEvent/visible
+page-type: web-api-instance-property
 tags:
   - API
   - WindowControlsOverlayGeometryChangeEvent

--- a/files/en-us/web/api/windowcontrolsoverlaygeometrychangeevent/windowcontrolsoverlaygeometrychangeevent/index.md
+++ b/files/en-us/web/api/windowcontrolsoverlaygeometrychangeevent/windowcontrolsoverlaygeometrychangeevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: WindowControlsOverlayGeometryChangeEvent()
 slug: Web/API/WindowControlsOverlayGeometryChangeEvent/WindowControlsOverlayGeometryChangeEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/worker/error_event/index.md
+++ b/files/en-us/web/api/worker/error_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Worker: error event'
 slug: Web/API/Worker/error_event
+page-type: web-api-event
 tags:
   - API
   - Worker

--- a/files/en-us/web/api/worker/index.md
+++ b/files/en-us/web/api/worker/index.md
@@ -1,6 +1,7 @@
 ---
 title: Worker
 slug: Web/API/Worker
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/worker/message_event/index.md
+++ b/files/en-us/web/api/worker/message_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Worker: message event'
 slug: Web/API/Worker/message_event
+page-type: web-api-event
 tags:
   - API
   - Worker

--- a/files/en-us/web/api/worker/messageerror_event/index.md
+++ b/files/en-us/web/api/worker/messageerror_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'Worker: messageerror event'
 slug: Web/API/Worker/messageerror_event
+page-type: web-api-event
 tags:
   - API
   - Worker

--- a/files/en-us/web/api/worker/postmessage/index.md
+++ b/files/en-us/web/api/worker/postmessage/index.md
@@ -1,6 +1,7 @@
 ---
 title: Worker.postMessage()
 slug: Web/API/Worker/postMessage
+page-type: web-api-instance-method
 tags:
   - API
   - JavaScript

--- a/files/en-us/web/api/worker/terminate/index.md
+++ b/files/en-us/web/api/worker/terminate/index.md
@@ -1,6 +1,7 @@
 ---
 title: Worker.terminate()
 slug: Web/API/Worker/terminate
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/worker/worker/index.md
+++ b/files/en-us/web/api/worker/worker/index.md
@@ -1,6 +1,7 @@
 ---
 title: Worker()
 slug: Web/API/Worker/Worker
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/workerglobalscope/console/index.md
+++ b/files/en-us/web/api/workerglobalscope/console/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerGlobalScope.console
 slug: Web/API/WorkerGlobalScope/console
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/workerglobalscope/dump/index.md
+++ b/files/en-us/web/api/workerglobalscope/dump/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerGlobalScope.dump()
 slug: Web/API/WorkerGlobalScope/dump
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/workerglobalscope/error_event/index.md
+++ b/files/en-us/web/api/workerglobalscope/error_event/index.md
@@ -1,7 +1,7 @@
 ---
 title: 'WorkerGlobalScope: error event'
 slug: Web/API/WorkerGlobalScope/error_event
-page-type: web-api-instance-method
+page-type: web-api-event
 tags:
   - API
   - EventHandler

--- a/files/en-us/web/api/workerglobalscope/error_event/index.md
+++ b/files/en-us/web/api/workerglobalscope/error_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'WorkerGlobalScope: error event'
 slug: Web/API/WorkerGlobalScope/error_event
+page-type: web-api-instance-method
 tags:
   - API
   - EventHandler

--- a/files/en-us/web/api/workerglobalscope/importscripts/index.md
+++ b/files/en-us/web/api/workerglobalscope/importscripts/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerGlobalScope.importScripts()
 slug: Web/API/WorkerGlobalScope/importScripts
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/workerglobalscope/index.md
+++ b/files/en-us/web/api/workerglobalscope/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerGlobalScope
 slug: Web/API/WorkerGlobalScope
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/workerglobalscope/languagechange_event/index.md
+++ b/files/en-us/web/api/workerglobalscope/languagechange_event/index.md
@@ -1,7 +1,7 @@
 ---
 title: 'WorkerGlobalScope: languagechange event'
 slug: Web/API/WorkerGlobalScope/languagechange_event
-page-type: web-api-instance-method
+page-type: web-api-instance-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/workerglobalscope/languagechange_event/index.md
+++ b/files/en-us/web/api/workerglobalscope/languagechange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'WorkerGlobalScope: languagechange event'
 slug: Web/API/WorkerGlobalScope/languagechange_event
+page-type: web-api-instance-method
 tags:
   - API
   - Event

--- a/files/en-us/web/api/workerglobalscope/location/index.md
+++ b/files/en-us/web/api/workerglobalscope/location/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerGlobalScope.location
 slug: Web/API/WorkerGlobalScope/location
+page-type: web-api-instance-property
 tags:
   - API
   - Location

--- a/files/en-us/web/api/workerglobalscope/navigator/index.md
+++ b/files/en-us/web/api/workerglobalscope/navigator/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerGlobalScope.navigator
 slug: Web/API/WorkerGlobalScope/navigator
+page-type: web-api-instance-property
 tags:
   - API
   - Navigator

--- a/files/en-us/web/api/workerglobalscope/offline_event/index.md
+++ b/files/en-us/web/api/workerglobalscope/offline_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'WorkerGlobalScope: offline event'
 slug: Web/API/WorkerGlobalScope/offline_event
+page-type: web-api-instance-method
 tags:
   - API
   - Event

--- a/files/en-us/web/api/workerglobalscope/offline_event/index.md
+++ b/files/en-us/web/api/workerglobalscope/offline_event/index.md
@@ -1,7 +1,7 @@
 ---
 title: 'WorkerGlobalScope: offline event'
 slug: Web/API/WorkerGlobalScope/offline_event
-page-type: web-api-instance-method
+page-type: web-api-instance-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/workerglobalscope/online_event/index.md
+++ b/files/en-us/web/api/workerglobalscope/online_event/index.md
@@ -1,7 +1,7 @@
 ---
 title: 'WorkerGlobalScope: online event'
 slug: Web/API/WorkerGlobalScope/online_event
-page-type: web-api-instance-method
+page-type: web-api-instance-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/workerglobalscope/online_event/index.md
+++ b/files/en-us/web/api/workerglobalscope/online_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'WorkerGlobalScope: online event'
 slug: Web/API/WorkerGlobalScope/online_event
+page-type: web-api-instance-method
 tags:
   - API
   - Event

--- a/files/en-us/web/api/workerglobalscope/self/index.md
+++ b/files/en-us/web/api/workerglobalscope/self/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerGlobalScope.self
 slug: Web/API/WorkerGlobalScope/self
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/workerlocation/hash/index.md
+++ b/files/en-us/web/api/workerlocation/hash/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerLocation.hash
 slug: Web/API/WorkerLocation/hash
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/workerlocation/host/index.md
+++ b/files/en-us/web/api/workerlocation/host/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerLocation.host
 slug: Web/API/WorkerLocation/host
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/workerlocation/hostname/index.md
+++ b/files/en-us/web/api/workerlocation/hostname/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerLocation.hostname
 slug: Web/API/WorkerLocation/hostname
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/workerlocation/href/index.md
+++ b/files/en-us/web/api/workerlocation/href/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerLocation.href
 slug: Web/API/WorkerLocation/href
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/workerlocation/index.md
+++ b/files/en-us/web/api/workerlocation/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerLocation
 slug: Web/API/WorkerLocation
+page-type: web-api-interface
 tags:
   - API
   - Web Workers

--- a/files/en-us/web/api/workerlocation/origin/index.md
+++ b/files/en-us/web/api/workerlocation/origin/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerLocation.origin
 slug: Web/API/WorkerLocation/origin
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/workerlocation/pathname/index.md
+++ b/files/en-us/web/api/workerlocation/pathname/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerLocation.pathname
 slug: Web/API/WorkerLocation/pathname
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/workerlocation/port/index.md
+++ b/files/en-us/web/api/workerlocation/port/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerLocation.port
 slug: Web/API/WorkerLocation/port
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/workerlocation/protocol/index.md
+++ b/files/en-us/web/api/workerlocation/protocol/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerLocation.protocol
 slug: Web/API/WorkerLocation/protocol
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/workerlocation/search/index.md
+++ b/files/en-us/web/api/workerlocation/search/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerLocation.search
 slug: Web/API/WorkerLocation/search
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/workerlocation/tostring/index.md
+++ b/files/en-us/web/api/workerlocation/tostring/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerLocation.toString()
 slug: Web/API/WorkerLocation/toString
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/workernavigator/appcodename/index.md
+++ b/files/en-us/web/api/workernavigator/appcodename/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerNavigator.appCodeName
 slug: Web/API/WorkerNavigator/appCodeName
+page-type: web-api-instance-property
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/workernavigator/appname/index.md
+++ b/files/en-us/web/api/workernavigator/appname/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerNavigator.appName
 slug: Web/API/WorkerNavigator/appName
+page-type: web-api-instance-property
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/workernavigator/appversion/index.md
+++ b/files/en-us/web/api/workernavigator/appversion/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerNavigator.appVersion
 slug: Web/API/WorkerNavigator/appVersion
+page-type: web-api-instance-property
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/workernavigator/connection/index.md
+++ b/files/en-us/web/api/workernavigator/connection/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerNavigator.connection
 slug: Web/API/WorkerNavigator/connection
+page-type: web-api-instance-property
 tags:
   - API
   - Connection

--- a/files/en-us/web/api/workernavigator/hardwareconcurrency/index.md
+++ b/files/en-us/web/api/workernavigator/hardwareconcurrency/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerNavigator.hardwareConcurrency
 slug: Web/API/WorkerNavigator/hardwareConcurrency
+page-type: web-api-instance-property
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/workernavigator/index.md
+++ b/files/en-us/web/api/workernavigator/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerNavigator
 slug: Web/API/WorkerNavigator
+page-type: web-api-interface
 tags:
   - API
   - HTML DOM

--- a/files/en-us/web/api/workernavigator/language/index.md
+++ b/files/en-us/web/api/workernavigator/language/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerNavigator.language
 slug: Web/API/WorkerNavigator/language
+page-type: web-api-instance-property
 tags:
   - API
   - Language

--- a/files/en-us/web/api/workernavigator/languages/index.md
+++ b/files/en-us/web/api/workernavigator/languages/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerNavigator.languages
 slug: Web/API/WorkerNavigator/languages
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/workernavigator/locks/index.md
+++ b/files/en-us/web/api/workernavigator/locks/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerNavigator.locks
 slug: Web/API/WorkerNavigator/locks
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/workernavigator/online/index.md
+++ b/files/en-us/web/api/workernavigator/online/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerNavigator.onLine
 slug: Web/API/WorkerNavigator/onLine
+page-type: web-api-instance-property
 tags:
   - API
   - DOM Reference

--- a/files/en-us/web/api/workernavigator/permissions/index.md
+++ b/files/en-us/web/api/workernavigator/permissions/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerNavigator.permissions
 slug: Web/API/WorkerNavigator/permissions
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/workernavigator/platform/index.md
+++ b/files/en-us/web/api/workernavigator/platform/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerNavigator.platform
 slug: Web/API/WorkerNavigator/platform
+page-type: web-api-instance-property
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/workernavigator/product/index.md
+++ b/files/en-us/web/api/workernavigator/product/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerNavigator.product
 slug: Web/API/WorkerNavigator/product
+page-type: web-api-instance-property
 tags:
   - API
   - Deprecated

--- a/files/en-us/web/api/workernavigator/serial/index.md
+++ b/files/en-us/web/api/workernavigator/serial/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerNavigator.serial
 slug: Web/API/WorkerNavigator/serial
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/workernavigator/storage/index.md
+++ b/files/en-us/web/api/workernavigator/storage/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerNavigator.storage
 slug: Web/API/WorkerNavigator/storage
+page-type: web-api-instance-property
 tags:
   - API
   - Navigator

--- a/files/en-us/web/api/workernavigator/useragent/index.md
+++ b/files/en-us/web/api/workernavigator/useragent/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerNavigator.userAgent
 slug: Web/API/WorkerNavigator/userAgent
+page-type: web-api-instance-property
 tags:
   - API
   - WorkerNavigator

--- a/files/en-us/web/api/workernavigator/useragentdata/index.md
+++ b/files/en-us/web/api/workernavigator/useragentdata/index.md
@@ -1,6 +1,7 @@
 ---
 title: WorkerNavigator.userAgentData
 slug: Web/API/WorkerNavigator/userAgentData
+page-type: web-api-instance-property
 tags:
   - API
   - Navigator

--- a/files/en-us/web/api/worklet/addmodule/index.md
+++ b/files/en-us/web/api/worklet/addmodule/index.md
@@ -1,6 +1,7 @@
 ---
 title: Worklet.addModule()
 slug: Web/API/Worklet/addModule
+page-type: web-api-instance-method
 tags:
   - API
   - Background

--- a/files/en-us/web/api/worklet/index.md
+++ b/files/en-us/web/api/worklet/index.md
@@ -1,6 +1,7 @@
 ---
 title: Worklet
 slug: Web/API/Worklet
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/writablestream/abort/index.md
+++ b/files/en-us/web/api/writablestream/abort/index.md
@@ -1,6 +1,7 @@
 ---
 title: WritableStream.abort()
 slug: Web/API/WritableStream/abort
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/writablestream/getwriter/index.md
+++ b/files/en-us/web/api/writablestream/getwriter/index.md
@@ -1,6 +1,7 @@
 ---
 title: WritableStream.getWriter()
 slug: Web/API/WritableStream/getWriter
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/writablestream/index.md
+++ b/files/en-us/web/api/writablestream/index.md
@@ -1,6 +1,7 @@
 ---
 title: WritableStream
 slug: Web/API/WritableStream
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/writablestream/locked/index.md
+++ b/files/en-us/web/api/writablestream/locked/index.md
@@ -1,6 +1,7 @@
 ---
 title: WritableStream.locked
 slug: Web/API/WritableStream/locked
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/writablestream/writablestream/index.md
+++ b/files/en-us/web/api/writablestream/writablestream/index.md
@@ -1,6 +1,7 @@
 ---
 title: WritableStream()
 slug: Web/API/WritableStream/WritableStream
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/writablestreamdefaultcontroller/error/index.md
+++ b/files/en-us/web/api/writablestreamdefaultcontroller/error/index.md
@@ -1,6 +1,7 @@
 ---
 title: WritableStreamDefaultController.error()
 slug: Web/API/WritableStreamDefaultController/error
+page-type: web-api-instance-method
 tags:
   - API
   - Error

--- a/files/en-us/web/api/writablestreamdefaultcontroller/index.md
+++ b/files/en-us/web/api/writablestreamdefaultcontroller/index.md
@@ -1,6 +1,7 @@
 ---
 title: WritableStreamDefaultController
 slug: Web/API/WritableStreamDefaultController
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/writablestreamdefaultwriter/abort/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/abort/index.md
@@ -1,6 +1,7 @@
 ---
 title: WritableStreamDefaultWriter.abort()
 slug: Web/API/WritableStreamDefaultWriter/abort
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/writablestreamdefaultwriter/close/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/close/index.md
@@ -1,6 +1,7 @@
 ---
 title: WritableStreamDefaultWriter.close()
 slug: Web/API/WritableStreamDefaultWriter/close
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/writablestreamdefaultwriter/closed/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/closed/index.md
@@ -1,6 +1,7 @@
 ---
 title: WritableStreamDefaultWriter.closed
 slug: Web/API/WritableStreamDefaultWriter/closed
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/writablestreamdefaultwriter/desiredsize/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/desiredsize/index.md
@@ -1,6 +1,7 @@
 ---
 title: WritableStreamDefaultWriter.desiredSize
 slug: Web/API/WritableStreamDefaultWriter/desiredSize
+page-type: web-api-instance-property
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/writablestreamdefaultwriter/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/index.md
@@ -1,6 +1,7 @@
 ---
 title: WritableStreamDefaultWriter
 slug: Web/API/WritableStreamDefaultWriter
+page-type: web-api-interface
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/writablestreamdefaultwriter/ready/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/ready/index.md
@@ -1,6 +1,7 @@
 ---
 title: WritableStreamDefaultWriter.ready
 slug: Web/API/WritableStreamDefaultWriter/ready
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/writablestreamdefaultwriter/releaselock/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/releaselock/index.md
@@ -1,6 +1,7 @@
 ---
 title: WritableStreamDefaultWriter.releaseLock()
 slug: Web/API/WritableStreamDefaultWriter/releaseLock
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/writablestreamdefaultwriter/writablestreamdefaultwriter/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/writablestreamdefaultwriter/index.md
@@ -1,6 +1,7 @@
 ---
 title: WritableStreamDefaultWriter()
 slug: Web/API/WritableStreamDefaultWriter/WritableStreamDefaultWriter
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/writablestreamdefaultwriter/write/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/write/index.md
@@ -1,6 +1,7 @@
 ---
 title: WritableStreamDefaultWriter.write()
 slug: Web/API/WritableStreamDefaultWriter/write
+page-type: web-api-instance-method
 tags:
   - API
   - Experimental

--- a/files/en-us/web/api/xmldocument/async/index.md
+++ b/files/en-us/web/api/xmldocument/async/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLDocument.async
 slug: Web/API/XMLDocument/async
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/xmldocument/index.md
+++ b/files/en-us/web/api/xmldocument/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLDocument
 slug: Web/API/XMLDocument
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/xmldocument/load/index.md
+++ b/files/en-us/web/api/xmldocument/load/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLDocument.load()
 slug: Web/API/XMLDocument/load
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/xmlhttprequest/abort/index.md
+++ b/files/en-us/web/api/xmlhttprequest/abort/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLHttpRequest.abort()
 slug: Web/API/XMLHttpRequest/abort
+page-type: web-api-instance-method
 tags:
   - AJAX
   - API

--- a/files/en-us/web/api/xmlhttprequest/abort_event/index.md
+++ b/files/en-us/web/api/xmlhttprequest/abort_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'XMLHttpRequest: abort event'
 slug: Web/API/XMLHttpRequest/abort_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/xmlhttprequest/channel/index.md
+++ b/files/en-us/web/api/xmlhttprequest/channel/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLHttpRequest.channel
 slug: Web/API/XMLHttpRequest/channel
+page-type: web-api-instance-property
 tags:
   - API
   - Non-standard

--- a/files/en-us/web/api/xmlhttprequest/error_event/index.md
+++ b/files/en-us/web/api/xmlhttprequest/error_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'XMLHttpRequest: error event'
 slug: Web/API/XMLHttpRequest/error_event
+page-type: web-api-event
 tags:
   - API
   - Error

--- a/files/en-us/web/api/xmlhttprequest/getallresponseheaders/index.md
+++ b/files/en-us/web/api/xmlhttprequest/getallresponseheaders/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLHttpRequest.getAllResponseHeaders()
 slug: Web/API/XMLHttpRequest/getAllResponseHeaders
+page-type: web-api-instance-method
 tags:
   - API
   - Fetch Headers

--- a/files/en-us/web/api/xmlhttprequest/getresponseheader/index.md
+++ b/files/en-us/web/api/xmlhttprequest/getresponseheader/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLHttpRequest.getResponseHeader()
 slug: Web/API/XMLHttpRequest/getResponseHeader
+page-type: web-api-instance-method
 tags:
   - API
   - Examine Header

--- a/files/en-us/web/api/xmlhttprequest/index.md
+++ b/files/en-us/web/api/xmlhttprequest/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLHttpRequest
 slug: Web/API/XMLHttpRequest
+page-type: web-api-interface
 tags:
   - AJAX
   - API


### PR DESCRIPTION
See  https://github.com/mdn/content/issues/16255. This is part 28 of a series of PRs to add page types to the Web/API documentation.