### PR TITLE
Add Web/API page types, part 29

### DIFF
--- a/files/en-us/web/api/xmlhttprequest/html_in_xmlhttprequest/index.md
+++ b/files/en-us/web/api/xmlhttprequest/html_in_xmlhttprequest/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTML in XMLHttpRequest
 slug: Web/API/XMLHttpRequest/HTML_in_XMLHttpRequest
+page-type: guide
 tags:
   - API
   - Guide

--- a/files/en-us/web/api/xmlhttprequest/load_event/index.md
+++ b/files/en-us/web/api/xmlhttprequest/load_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'XMLHttpRequest: load event'
 slug: Web/API/XMLHttpRequest/load_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/xmlhttprequest/loadend_event/index.md
+++ b/files/en-us/web/api/xmlhttprequest/loadend_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'XMLHttpRequest: loadend event'
 slug: Web/API/XMLHttpRequest/loadend_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/xmlhttprequest/loadstart_event/index.md
+++ b/files/en-us/web/api/xmlhttprequest/loadstart_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'XMLHttpRequest: loadstart event'
 slug: Web/API/XMLHttpRequest/loadstart_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/xmlhttprequest/mozanon/index.md
+++ b/files/en-us/web/api/xmlhttprequest/mozanon/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLHttpRequest.mozAnon
 slug: Web/API/XMLHttpRequest/mozAnon
+page-type: web-api-instance-property
 tags:
   - API
   - Authentication

--- a/files/en-us/web/api/xmlhttprequest/mozbackgroundrequest/index.md
+++ b/files/en-us/web/api/xmlhttprequest/mozbackgroundrequest/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLHttpRequest.mozBackgroundRequest
 slug: Web/API/XMLHttpRequest/mozBackgroundRequest
+page-type: web-api-instance-property
 tags:
   - API
   - Background Service

--- a/files/en-us/web/api/xmlhttprequest/mozsystem/index.md
+++ b/files/en-us/web/api/xmlhttprequest/mozsystem/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLHttpRequest.mozSystem
 slug: Web/API/XMLHttpRequest/mozSystem
+page-type: web-api-instance-property
 tags:
   - AP
   - Non-standard

--- a/files/en-us/web/api/xmlhttprequest/open/index.md
+++ b/files/en-us/web/api/xmlhttprequest/open/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLHttpRequest.open()
 slug: Web/API/XMLHttpRequest/open
+page-type: web-api-instance-method
 tags:
   - API
   - HTTP

--- a/files/en-us/web/api/xmlhttprequest/overridemimetype/index.md
+++ b/files/en-us/web/api/xmlhttprequest/overridemimetype/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLHttpRequest.overrideMimeType()
 slug: Web/API/XMLHttpRequest/overrideMimeType
+page-type: web-api-instance-method
 tags:
   - API
   - File Type

--- a/files/en-us/web/api/xmlhttprequest/progress_event/index.md
+++ b/files/en-us/web/api/xmlhttprequest/progress_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'XMLHttpRequest: progress event'
 slug: Web/API/XMLHttpRequest/progress_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/xmlhttprequest/readystate/index.md
+++ b/files/en-us/web/api/xmlhttprequest/readystate/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLHttpRequest.readyState
 slug: Web/API/XMLHttpRequest/readyState
+page-type: web-api-instance-property
 tags:
   - AJAX
   - Property

--- a/files/en-us/web/api/xmlhttprequest/readystatechange_event/index.md
+++ b/files/en-us/web/api/xmlhttprequest/readystatechange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'XMLHttpRequest: readystatechange event'
 slug: Web/API/XMLHttpRequest/readystatechange_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/xmlhttprequest/response/index.md
+++ b/files/en-us/web/api/xmlhttprequest/response/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLHttpRequest.response
 slug: Web/API/XMLHttpRequest/response
+page-type: web-api-instance-property
 tags:
   - AJAX
   - API

--- a/files/en-us/web/api/xmlhttprequest/responsetext/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responsetext/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLHttpRequest.responseText
 slug: Web/API/XMLHttpRequest/responseText
+page-type: web-api-instance-property
 tags:
   - API
   - Fetching Text

--- a/files/en-us/web/api/xmlhttprequest/responsetype/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responsetype/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLHttpRequest.responseType
 slug: Web/API/XMLHttpRequest/responseType
+page-type: web-api-instance-property
 tags:
   - AJAX
   - API

--- a/files/en-us/web/api/xmlhttprequest/responseurl/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responseurl/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLHttpRequest.responseURL
 slug: Web/API/XMLHttpRequest/responseURL
+page-type: web-api-instance-property
 tags:
   - AJAX
   - Property

--- a/files/en-us/web/api/xmlhttprequest/responsexml/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responsexml/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLHttpRequest.responseXML
 slug: Web/API/XMLHttpRequest/responseXML
+page-type: web-api-instance-property
 tags:
   - AJAX
   - API

--- a/files/en-us/web/api/xmlhttprequest/send/index.md
+++ b/files/en-us/web/api/xmlhttprequest/send/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLHttpRequest.send()
 slug: Web/API/XMLHttpRequest/send
+page-type: web-api-instance-method
 tags:
   - AJAX
   - API

--- a/files/en-us/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.md
+++ b/files/en-us/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.md
@@ -1,6 +1,7 @@
 ---
 title: Sending and Receiving Binary Data
 slug: Web/API/XMLHttpRequest/Sending_and_Receiving_Binary_Data
+page-type: guide
 tags:
   - AJAX
   - FileReader

--- a/files/en-us/web/api/xmlhttprequest/setrequestheader/index.md
+++ b/files/en-us/web/api/xmlhttprequest/setrequestheader/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLHttpRequest.setRequestHeader()
 slug: Web/API/XMLHttpRequest/setRequestHeader
+page-type: web-api-instance-method
 tags:
   - API
   - HTTP

--- a/files/en-us/web/api/xmlhttprequest/status/index.md
+++ b/files/en-us/web/api/xmlhttprequest/status/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLHttpRequest.status
 slug: Web/API/XMLHttpRequest/status
+page-type: web-api-instance-property
 tags:
   - API
   - Error

--- a/files/en-us/web/api/xmlhttprequest/statustext/index.md
+++ b/files/en-us/web/api/xmlhttprequest/statustext/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLHttpRequest.statusText
 slug: Web/API/XMLHttpRequest/statusText
+page-type: web-api-instance-property
 tags:
   - AJAX
   - API

--- a/files/en-us/web/api/xmlhttprequest/synchronous_and_asynchronous_requests/index.md
+++ b/files/en-us/web/api/xmlhttprequest/synchronous_and_asynchronous_requests/index.md
@@ -1,6 +1,7 @@
 ---
 title: Synchronous and asynchronous requests
 slug: Web/API/XMLHttpRequest/Synchronous_and_Asynchronous_Requests
+page-type: guide
 tags:
   - Communication
   - DOM

--- a/files/en-us/web/api/xmlhttprequest/timeout/index.md
+++ b/files/en-us/web/api/xmlhttprequest/timeout/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLHttpRequest.timeout
 slug: Web/API/XMLHttpRequest/timeout
+page-type: web-api-instance-property
 tags:
   - AJAX
   - Asynchronous XHR

--- a/files/en-us/web/api/xmlhttprequest/timeout_event/index.md
+++ b/files/en-us/web/api/xmlhttprequest/timeout_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'XMLHttpRequest: timeout event'
 slug: Web/API/XMLHttpRequest/timeout_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/xmlhttprequest/upload/index.md
+++ b/files/en-us/web/api/xmlhttprequest/upload/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLHttpRequest.upload
 slug: Web/API/XMLHttpRequest/upload
+page-type: web-api-instance-property
 tags:
   - AJAX
   - API

--- a/files/en-us/web/api/xmlhttprequest/using_xmlhttprequest/index.md
+++ b/files/en-us/web/api/xmlhttprequest/using_xmlhttprequest/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using XMLHttpRequest
 slug: Web/API/XMLHttpRequest/Using_XMLHttpRequest
+page-type: guide
 tags:
   - AJAX
   - AJAXfile

--- a/files/en-us/web/api/xmlhttprequest/using_xmlhttprequest_in_ie6/index.md
+++ b/files/en-us/web/api/xmlhttprequest/using_xmlhttprequest_in_ie6/index.md
@@ -1,6 +1,7 @@
 ---
 title: Using XMLHttpRequest in IE6
 slug: Web/API/XMLHttpRequest/Using_XMLHttpRequest_in_IE6
+page-type: guide
 tags:
   - Web Development
   - Web Standards

--- a/files/en-us/web/api/xmlhttprequest/withcredentials/index.md
+++ b/files/en-us/web/api/xmlhttprequest/withcredentials/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLHttpRequest.withCredentials
 slug: Web/API/XMLHttpRequest/withCredentials
+page-type: web-api-instance-property
 tags:
   - AJAX
   - API

--- a/files/en-us/web/api/xmlhttprequest/xmlhttprequest/index.md
+++ b/files/en-us/web/api/xmlhttprequest/xmlhttprequest/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLHttpRequest()
 slug: Web/API/XMLHttpRequest/XMLHttpRequest
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/xmlhttprequesteventtarget/index.md
+++ b/files/en-us/web/api/xmlhttprequesteventtarget/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLHttpRequestEventTarget
 slug: Web/API/XMLHttpRequestEventTarget
+page-type: web-api-interface
 tags:
   - AJAX
   - API

--- a/files/en-us/web/api/xmlserializer/index.md
+++ b/files/en-us/web/api/xmlserializer/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLSerializer
 slug: Web/API/XMLSerializer
+page-type: web-api-interface
 tags:
   - Converting
   - DOM Parsing

--- a/files/en-us/web/api/xmlserializer/serializetostring/index.md
+++ b/files/en-us/web/api/xmlserializer/serializetostring/index.md
@@ -1,6 +1,7 @@
 ---
 title: XMLSerializer.serializeToString()
 slug: Web/API/XMLSerializer/serializeToString
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/xpathevaluator/createexpression/index.md
+++ b/files/en-us/web/api/xpathevaluator/createexpression/index.md
@@ -1,6 +1,7 @@
 ---
 title: XPathEvaluator.createExpression()
 slug: Web/API/XPathEvaluator/createExpression
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/xpathevaluator/creatensresolver/index.md
+++ b/files/en-us/web/api/xpathevaluator/creatensresolver/index.md
@@ -1,6 +1,7 @@
 ---
 title: XPathEvaluator.createNSResolver()
 slug: Web/API/XPathEvaluator/createNSResolver
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/xpathevaluator/evaluate/index.md
+++ b/files/en-us/web/api/xpathevaluator/evaluate/index.md
@@ -1,6 +1,7 @@
 ---
 title: XPathEvaluator.evaluate()
 slug: Web/API/XPathEvaluator/evaluate
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/xpathevaluator/index.md
+++ b/files/en-us/web/api/xpathevaluator/index.md
@@ -1,6 +1,7 @@
 ---
 title: XPathEvaluator
 slug: Web/API/XPathEvaluator
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/xpathexception/code/index.md
+++ b/files/en-us/web/api/xpathexception/code/index.md
@@ -1,6 +1,7 @@
 ---
 title: XPathException.code
 slug: Web/API/XPathException/code
+page-type: web-api-instance-property
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/xpathexception/index.md
+++ b/files/en-us/web/api/xpathexception/index.md
@@ -1,6 +1,7 @@
 ---
 title: XPathException
 slug: Web/API/XPathException
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/xpathexpression/evaluate/index.md
+++ b/files/en-us/web/api/xpathexpression/evaluate/index.md
@@ -1,6 +1,7 @@
 ---
 title: XPathExpression.evaluate()
 slug: Web/API/XPathExpression/evaluate
+page-type: web-api-instance-method
 tags:
   - API
   - DOM XPath API

--- a/files/en-us/web/api/xpathexpression/index.md
+++ b/files/en-us/web/api/xpathexpression/index.md
@@ -1,6 +1,7 @@
 ---
 title: XPathExpression
 slug: Web/API/XPathExpression
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/xpathnsresolver/index.md
+++ b/files/en-us/web/api/xpathnsresolver/index.md
@@ -1,6 +1,7 @@
 ---
 title: XPathNSResolver
 slug: Web/API/XPathNSResolver
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/xpathnsresolver/lookupnamespaceuri/index.md
+++ b/files/en-us/web/api/xpathnsresolver/lookupnamespaceuri/index.md
@@ -1,6 +1,7 @@
 ---
 title: XPathNSResolver.lookupNamespaceURI()
 slug: Web/API/XPathNSResolver/lookupNamespaceURI
+page-type: web-api-instance-method
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/xpathresult/booleanvalue/index.md
+++ b/files/en-us/web/api/xpathresult/booleanvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: XPathResult.booleanValue
 slug: Web/API/XPathResult/booleanValue
+page-type: web-api-instance-property
 tags:
   - API
   - DOM XPath API

--- a/files/en-us/web/api/xpathresult/index.md
+++ b/files/en-us/web/api/xpathresult/index.md
@@ -1,6 +1,7 @@
 ---
 title: XPathResult
 slug: Web/API/XPathResult
+page-type: web-api-interface
 tags:
   - API
   - DOM XPath API

--- a/files/en-us/web/api/xpathresult/invaliditeratorstate/index.md
+++ b/files/en-us/web/api/xpathresult/invaliditeratorstate/index.md
@@ -1,6 +1,7 @@
 ---
 title: XPathResult.invalidIteratorState
 slug: Web/API/XPathResult/invalidIteratorState
+page-type: web-api-instance-property
 tags:
   - API
   - DOM XPath API

--- a/files/en-us/web/api/xpathresult/iteratenext/index.md
+++ b/files/en-us/web/api/xpathresult/iteratenext/index.md
@@ -1,6 +1,7 @@
 ---
 title: XPathResult.iterateNext()
 slug: Web/API/XPathResult/iterateNext
+page-type: web-api-instance-method
 tags:
   - API
   - DOM XPath API

--- a/files/en-us/web/api/xpathresult/numbervalue/index.md
+++ b/files/en-us/web/api/xpathresult/numbervalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: XPathResult.numberValue
 slug: Web/API/XPathResult/numberValue
+page-type: web-api-instance-property
 tags:
   - API
   - DOM XPath API

--- a/files/en-us/web/api/xpathresult/resulttype/index.md
+++ b/files/en-us/web/api/xpathresult/resulttype/index.md
@@ -1,6 +1,7 @@
 ---
 title: XPathResult.resultType
 slug: Web/API/XPathResult/resultType
+page-type: web-api-instance-property
 tags:
   - API
   - DOM XPath API

--- a/files/en-us/web/api/xpathresult/singlenodevalue/index.md
+++ b/files/en-us/web/api/xpathresult/singlenodevalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: XPathResult.singleNodeValue
 slug: Web/API/XPathResult/singleNodeValue
+page-type: web-api-instance-property
 tags:
   - API
   - DOM XPath API

--- a/files/en-us/web/api/xpathresult/snapshotitem/index.md
+++ b/files/en-us/web/api/xpathresult/snapshotitem/index.md
@@ -1,6 +1,7 @@
 ---
 title: XPathResult.snapshotItem()
 slug: Web/API/XPathResult/snapshotItem
+page-type: web-api-instance-method
 tags:
   - API
   - DOM XPath API

--- a/files/en-us/web/api/xpathresult/snapshotlength/index.md
+++ b/files/en-us/web/api/xpathresult/snapshotlength/index.md
@@ -1,6 +1,7 @@
 ---
 title: XPathResult.snapshotLength
 slug: Web/API/XPathResult/snapshotLength
+page-type: web-api-instance-property
 tags:
   - API
   - DOM XPath API

--- a/files/en-us/web/api/xpathresult/stringvalue/index.md
+++ b/files/en-us/web/api/xpathresult/stringvalue/index.md
@@ -1,6 +1,7 @@
 ---
 title: XPathResult.stringValue
 slug: Web/API/XPathResult/stringValue
+page-type: web-api-instance-property
 tags:
   - API
   - DOM XPath API

--- a/files/en-us/web/api/xranchor/anchorspace/index.md
+++ b/files/en-us/web/api/xranchor/anchorspace/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRAnchor.anchorSpace
 slug: Web/API/XRAnchor/anchorSpace
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xranchor/delete/index.md
+++ b/files/en-us/web/api/xranchor/delete/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRAnchor.delete()
 slug: Web/API/XRAnchor/delete
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/xranchor/index.md
+++ b/files/en-us/web/api/xranchor/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRAnchor
 slug: Web/API/XRAnchor
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/xranchorset/index.md
+++ b/files/en-us/web/api/xranchorset/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRAnchorSet
 slug: Web/API/XRAnchorSet
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/xrboundedreferencespace/boundsgeometry/index.md
+++ b/files/en-us/web/api/xrboundedreferencespace/boundsgeometry/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRBoundedReferenceSpace.boundsGeometry
 slug: Web/API/XRBoundedReferenceSpace/boundsGeometry
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrboundedreferencespace/index.md
+++ b/files/en-us/web/api/xrboundedreferencespace/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRBoundedReferenceSpace
 slug: Web/API/XRBoundedReferenceSpace
+page-type: web-api-interface
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrcompositionlayer/blendtexturesourcealpha/index.md
+++ b/files/en-us/web/api/xrcompositionlayer/blendtexturesourcealpha/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRCompositionLayer.blendTextureSourceAlpha
 slug: Web/API/XRCompositionLayer/blendTextureSourceAlpha
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrcompositionlayer/chromaticaberrationcorrection/index.md
+++ b/files/en-us/web/api/xrcompositionlayer/chromaticaberrationcorrection/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRCompositionLayer.chromaticAberrationCorrection
 slug: Web/API/XRCompositionLayer/chromaticAberrationCorrection
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrcompositionlayer/destroy/index.md
+++ b/files/en-us/web/api/xrcompositionlayer/destroy/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRCompositionLayer.destroy()
 slug: Web/API/XRCompositionLayer/destroy
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/xrcompositionlayer/index.md
+++ b/files/en-us/web/api/xrcompositionlayer/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRCompositionLayer
 slug: Web/API/XRCompositionLayer
+page-type: web-api-interface
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrcompositionlayer/layout/index.md
+++ b/files/en-us/web/api/xrcompositionlayer/layout/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRCompositionLayer.layout
 slug: Web/API/XRCompositionLayer/layout
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrcompositionlayer/miplevels/index.md
+++ b/files/en-us/web/api/xrcompositionlayer/miplevels/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRCompositionLayer.mipLevels
 slug: Web/API/XRCompositionLayer/mipLevels
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrcompositionlayer/needsredraw/index.md
+++ b/files/en-us/web/api/xrcompositionlayer/needsredraw/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRCompositionLayer.needsRedraw
 slug: Web/API/XRCompositionLayer/needsRedraw
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrcpudepthinformation/data/index.md
+++ b/files/en-us/web/api/xrcpudepthinformation/data/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRCPUDepthInformation.data
 slug: Web/API/XRCPUDepthInformation/data
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrcpudepthinformation/getdepthinmeters/index.md
+++ b/files/en-us/web/api/xrcpudepthinformation/getdepthinmeters/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRCPUDepthInformation.getDepthInMeters()
 slug: Web/API/XRCPUDepthInformation/getDepthInMeters
+page-type: web-api-instance-method
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrcpudepthinformation/index.md
+++ b/files/en-us/web/api/xrcpudepthinformation/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRCPUDepthInformation
 slug: Web/API/XRCPUDepthInformation
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/xrcubelayer/index.md
+++ b/files/en-us/web/api/xrcubelayer/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRCubeLayer
 slug: Web/API/XRCubeLayer
+page-type: web-api-interface
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrcubelayer/orientation/index.md
+++ b/files/en-us/web/api/xrcubelayer/orientation/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRCubeLayer.orientation
 slug: Web/API/XRCubeLayer/orientation
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrcubelayer/redraw_event/index.md
+++ b/files/en-us/web/api/xrcubelayer/redraw_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'XRCubeLayer: redraw event'
 slug: Web/API/XRCubeLayer/redraw_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/xrcubelayer/space/index.md
+++ b/files/en-us/web/api/xrcubelayer/space/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRCubeLayer.space
 slug: Web/API/XRCubeLayer/space
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrcylinderlayer/aspectratio/index.md
+++ b/files/en-us/web/api/xrcylinderlayer/aspectratio/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRCylinderLayer.aspectRatio
 slug: Web/API/XRCylinderLayer/aspectRatio
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrcylinderlayer/centralangle/index.md
+++ b/files/en-us/web/api/xrcylinderlayer/centralangle/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRCylinderLayer.centralAngle
 slug: Web/API/XRCylinderLayer/centralAngle
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrcylinderlayer/index.md
+++ b/files/en-us/web/api/xrcylinderlayer/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRCylinderLayer
 slug: Web/API/XRCylinderLayer
+page-type: web-api-interface
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrcylinderlayer/radius/index.md
+++ b/files/en-us/web/api/xrcylinderlayer/radius/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRCylinderLayer.radius
 slug: Web/API/XRCylinderLayer/radius
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrcylinderlayer/redraw_event/index.md
+++ b/files/en-us/web/api/xrcylinderlayer/redraw_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'XRCylinderLayer: redraw event'
 slug: Web/API/XRCylinderLayer/redraw_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/xrcylinderlayer/space/index.md
+++ b/files/en-us/web/api/xrcylinderlayer/space/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRCylinderLayer.space
 slug: Web/API/XRCylinderLayer/space
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrcylinderlayer/transform/index.md
+++ b/files/en-us/web/api/xrcylinderlayer/transform/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRCylinderLayer.transform
 slug: Web/API/XRCylinderLayer/transform
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrdepthinformation/height/index.md
+++ b/files/en-us/web/api/xrdepthinformation/height/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRDepthInformation.height
 slug: Web/API/XRDepthInformation/height
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrdepthinformation/index.md
+++ b/files/en-us/web/api/xrdepthinformation/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRDepthInformation
 slug: Web/API/XRDepthInformation
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/xrdepthinformation/normdepthbufferfromnormview/index.md
+++ b/files/en-us/web/api/xrdepthinformation/normdepthbufferfromnormview/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRDepthInformation.normDepthBufferFromNormView
 slug: Web/API/XRDepthInformation/normDepthBufferFromNormView
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrdepthinformation/rawvaluetometers/index.md
+++ b/files/en-us/web/api/xrdepthinformation/rawvaluetometers/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRDepthInformation.rawValueToMeters
 slug: Web/API/XRDepthInformation/rawValueToMeters
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrdepthinformation/width/index.md
+++ b/files/en-us/web/api/xrdepthinformation/width/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRDepthInformation.width
 slug: Web/API/XRDepthInformation/width
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrequirectlayer/centralhorizontalangle/index.md
+++ b/files/en-us/web/api/xrequirectlayer/centralhorizontalangle/index.md
@@ -1,6 +1,7 @@
 ---
 title: XREquirectLayer.centralHorizontalAngle
 slug: Web/API/XREquirectLayer/centralHorizontalAngle
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrequirectlayer/index.md
+++ b/files/en-us/web/api/xrequirectlayer/index.md
@@ -1,6 +1,7 @@
 ---
 title: XREquirectLayer
 slug: Web/API/XREquirectLayer
+page-type: web-api-interface
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrequirectlayer/lowerverticalangle/index.md
+++ b/files/en-us/web/api/xrequirectlayer/lowerverticalangle/index.md
@@ -1,6 +1,7 @@
 ---
 title: XREquirectLayer.lowerVerticalAngle
 slug: Web/API/XREquirectLayer/lowerVerticalAngle
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrequirectlayer/radius/index.md
+++ b/files/en-us/web/api/xrequirectlayer/radius/index.md
@@ -1,6 +1,7 @@
 ---
 title: XREquirectLayer.radius
 slug: Web/API/XREquirectLayer/radius
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrequirectlayer/redraw_event/index.md
+++ b/files/en-us/web/api/xrequirectlayer/redraw_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'XREquirectLayer: redraw event'
 slug: Web/API/XREquirectLayer/redraw_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/xrequirectlayer/space/index.md
+++ b/files/en-us/web/api/xrequirectlayer/space/index.md
@@ -1,6 +1,7 @@
 ---
 title: XREquirectLayer.space
 slug: Web/API/XREquirectLayer/space
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrequirectlayer/transform/index.md
+++ b/files/en-us/web/api/xrequirectlayer/transform/index.md
@@ -1,6 +1,7 @@
 ---
 title: XREquirectLayer.transform
 slug: Web/API/XREquirectLayer/transform
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrequirectlayer/upperverticalangle/index.md
+++ b/files/en-us/web/api/xrequirectlayer/upperverticalangle/index.md
@@ -1,6 +1,7 @@
 ---
 title: XREquirectLayer.upperVerticalAngle
 slug: Web/API/XREquirectLayer/upperVerticalAngle
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrframe/createanchor/index.md
+++ b/files/en-us/web/api/xrframe/createanchor/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRFrame.createAnchor()
 slug: Web/API/XRFrame/createAnchor
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/xrframe/filljointradii/index.md
+++ b/files/en-us/web/api/xrframe/filljointradii/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRFrame.fillJointRadii()
 slug: Web/API/XRFrame/fillJointRadii
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/xrframe/fillposes/index.md
+++ b/files/en-us/web/api/xrframe/fillposes/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRFrame.fillPoses()
 slug: Web/API/XRFrame/fillPoses
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/xrframe/getdepthinformation/index.md
+++ b/files/en-us/web/api/xrframe/getdepthinformation/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRFrame.getDepthInformation()
 slug: Web/API/XRFrame/getDepthInformation
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/xrframe/gethittestresults/index.md
+++ b/files/en-us/web/api/xrframe/gethittestresults/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRFrame.getHitTestResults()
 slug: Web/API/XRFrame/getHitTestResults
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/xrframe/gethittestresultsfortransientinput/index.md
+++ b/files/en-us/web/api/xrframe/gethittestresultsfortransientinput/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRFrame.getHitTestResultsForTransientInput()
 slug: Web/API/XRFrame/getHitTestResultsForTransientInput
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/xrframe/getjointpose/index.md
+++ b/files/en-us/web/api/xrframe/getjointpose/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRFrame.getJointPose()
 slug: Web/API/XRFrame/getJointPose
+page-type: web-api-instance-method
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrframe/getlightestimate/index.md
+++ b/files/en-us/web/api/xrframe/getlightestimate/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRFrame.getLightEstimate()
 slug: Web/API/XRFrame/getLightEstimate
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/xrframe/getpose/index.md
+++ b/files/en-us/web/api/xrframe/getpose/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRFrame.getPose()
 slug: Web/API/XRFrame/getPose
+page-type: web-api-instance-method
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrframe/getviewerpose/index.md
+++ b/files/en-us/web/api/xrframe/getviewerpose/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRFrame.getViewerPose()
 slug: Web/API/XRFrame/getViewerPose
+page-type: web-api-instance-method
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrframe/index.md
+++ b/files/en-us/web/api/xrframe/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRFrame
 slug: Web/API/XRFrame
+page-type: web-api-interface
 tags:
   - 3D
   - API

--- a/files/en-us/web/api/xrframe/session/index.md
+++ b/files/en-us/web/api/xrframe/session/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRFrame.session
 slug: Web/API/XRFrame/session
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrframe/trackedanchors/index.md
+++ b/files/en-us/web/api/xrframe/trackedanchors/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRFrame.trackedAnchors
 slug: Web/API/XRFrame/trackedAnchors
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrhand/index.md
+++ b/files/en-us/web/api/xrhand/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRHand
 slug: Web/API/XRHand
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/xrhittestresult/createanchor/index.md
+++ b/files/en-us/web/api/xrhittestresult/createanchor/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRHitTestResult.createAnchor()
 slug: Web/API/XRHitTestResult/createAnchor
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/xrhittestresult/getpose/index.md
+++ b/files/en-us/web/api/xrhittestresult/getpose/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRHitTestResult.getPose()
 slug: Web/API/XRHitTestResult/getPose
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/xrhittestresult/index.md
+++ b/files/en-us/web/api/xrhittestresult/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRHitTestResult
 slug: Web/API/XRHitTestResult
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/xrhittestsource/cancel/index.md
+++ b/files/en-us/web/api/xrhittestsource/cancel/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRHitTestSource.cancel()
 slug: Web/API/XRHitTestSource/cancel
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/xrhittestsource/index.md
+++ b/files/en-us/web/api/xrhittestsource/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRHitTestSource
 slug: Web/API/XRHitTestSource
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/xrinputsource/gamepad/index.md
+++ b/files/en-us/web/api/xrinputsource/gamepad/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRInputSource.gamepad
 slug: Web/API/XRInputSource/gamepad
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrinputsource/gripspace/index.md
+++ b/files/en-us/web/api/xrinputsource/gripspace/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRInputSource.gripSpace
 slug: Web/API/XRInputSource/gripSpace
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrinputsource/hand/index.md
+++ b/files/en-us/web/api/xrinputsource/hand/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRInputSource.hand
 slug: Web/API/XRInputSource/hand
+page-type: web-api-instance-property
 tags:
   - API
   - Controller

--- a/files/en-us/web/api/xrinputsource/handedness/index.md
+++ b/files/en-us/web/api/xrinputsource/handedness/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRInputSource.handedness
 slug: Web/API/XRInputSource/handedness
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrinputsource/index.md
+++ b/files/en-us/web/api/xrinputsource/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRInputSource
 slug: Web/API/XRInputSource
+page-type: web-api-interface
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrinputsource/profiles/index.md
+++ b/files/en-us/web/api/xrinputsource/profiles/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRInputSource.profiles
 slug: Web/API/XRInputSource/profiles
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrinputsource/targetraymode/index.md
+++ b/files/en-us/web/api/xrinputsource/targetraymode/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRInputSource.targetRayMode
 slug: Web/API/XRInputSource/targetRayMode
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrinputsource/targetrayspace/index.md
+++ b/files/en-us/web/api/xrinputsource/targetrayspace/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRInputSource.targetRaySpace
 slug: Web/API/XRInputSource/targetRaySpace
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrinputsourcearray/entries/index.md
+++ b/files/en-us/web/api/xrinputsourcearray/entries/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRInputSourceArray.entries()
 slug: Web/API/XRInputSourceArray/entries
+page-type: web-api-instance-method
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrinputsourcearray/foreach/index.md
+++ b/files/en-us/web/api/xrinputsourcearray/foreach/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRInputSourceArray.forEach()
 slug: Web/API/XRInputSourceArray/forEach
+page-type: web-api-instance-method
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrinputsourcearray/index.md
+++ b/files/en-us/web/api/xrinputsourcearray/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRInputSourceArray
 slug: Web/API/XRInputSourceArray
+page-type: web-api-interface
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrinputsourcearray/keys/index.md
+++ b/files/en-us/web/api/xrinputsourcearray/keys/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRInputSourceArray.keys()
 slug: Web/API/XRInputSourceArray/keys
+page-type: web-api-instance-method
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrinputsourcearray/length/index.md
+++ b/files/en-us/web/api/xrinputsourcearray/length/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRInputSourceArray.length
 slug: Web/API/XRInputSourceArray/length
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrinputsourcearray/values/index.md
+++ b/files/en-us/web/api/xrinputsourcearray/values/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRInputSourceArray.values()
 slug: Web/API/XRInputSourceArray/values
+page-type: web-api-instance-method
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrinputsourceevent/frame/index.md
+++ b/files/en-us/web/api/xrinputsourceevent/frame/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRInputSourceEvent.frame
 slug: Web/API/XRInputSourceEvent/frame
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrinputsourceevent/index.md
+++ b/files/en-us/web/api/xrinputsourceevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRInputSourceEvent
 slug: Web/API/XRInputSourceEvent
+page-type: web-api-interface
 tags:
   - 3D
   - API

--- a/files/en-us/web/api/xrinputsourceevent/inputsource/index.md
+++ b/files/en-us/web/api/xrinputsourceevent/inputsource/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRInputSourceEvent.inputSource
 slug: Web/API/XRInputSourceEvent/inputSource
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrinputsourceevent/xrinputsourceevent/index.md
+++ b/files/en-us/web/api/xrinputsourceevent/xrinputsourceevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRInputSourceEvent()
 slug: Web/API/XRInputSourceEvent/XRInputSourceEvent
+page-type: web-api-constructor
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrinputsourceschangeevent/added/index.md
+++ b/files/en-us/web/api/xrinputsourceschangeevent/added/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRInputSourcesChangeEvent.added
 slug: Web/API/XRInputSourcesChangeEvent/added
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrinputsourceschangeevent/index.md
+++ b/files/en-us/web/api/xrinputsourceschangeevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRInputSourcesChangeEvent
 slug: Web/API/XRInputSourcesChangeEvent
+page-type: web-api-interface
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrinputsourceschangeevent/removed/index.md
+++ b/files/en-us/web/api/xrinputsourceschangeevent/removed/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRInputSourcesChangeEvent.removed
 slug: Web/API/XRInputSourcesChangeEvent/removed
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrinputsourceschangeevent/session/index.md
+++ b/files/en-us/web/api/xrinputsourceschangeevent/session/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRInputSourcesChangeEvent.session
 slug: Web/API/XRInputSourcesChangeEvent/session
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrinputsourceschangeevent/xrinputsourceschangeevent/index.md
+++ b/files/en-us/web/api/xrinputsourceschangeevent/xrinputsourceschangeevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRInputSourcesChangeEvent()
 slug: Web/API/XRInputSourcesChangeEvent/XRInputSourcesChangeEvent
+page-type: web-api-constructor
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrjointpose/index.md
+++ b/files/en-us/web/api/xrjointpose/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRJointPose
 slug: Web/API/XRJointPose
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/xrjointpose/radius/index.md
+++ b/files/en-us/web/api/xrjointpose/radius/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRJointPose.radius
 slug: Web/API/XRJointPose/radius
+page-type: web-api-instance-property
 tags:
   - API
   - Controller

--- a/files/en-us/web/api/xrjointspace/index.md
+++ b/files/en-us/web/api/xrjointspace/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRJointSpace
 slug: Web/API/XRJointSpace
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/xrjointspace/jointname/index.md
+++ b/files/en-us/web/api/xrjointspace/jointname/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRJointSpace.jointName
 slug: Web/API/XRJointSpace/jointName
+page-type: web-api-instance-property
 tags:
   - API
   - Controller

--- a/files/en-us/web/api/xrlayer/index.md
+++ b/files/en-us/web/api/xrlayer/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRLayer
 slug: Web/API/XRLayer
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/xrlayerevent/index.md
+++ b/files/en-us/web/api/xrlayerevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRLayerEvent
 slug: Web/API/XRLayerEvent
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/xrlayerevent/layer/index.md
+++ b/files/en-us/web/api/xrlayerevent/layer/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRLayerEvent.layer
 slug: Web/API/XRLayerEvent/layer
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrlayerevent/xrlayerevent/index.md
+++ b/files/en-us/web/api/xrlayerevent/xrlayerevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRLayerEvent()
 slug: Web/API/XRLayerEvent/XRLayerEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/xrlightestimate/index.md
+++ b/files/en-us/web/api/xrlightestimate/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRLightEstimate
 slug: Web/API/XRLightEstimate
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/xrlightestimate/primarylightdirection/index.md
+++ b/files/en-us/web/api/xrlightestimate/primarylightdirection/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRLightEstimate.primaryLightDirection
 slug: Web/API/XRLightEstimate/primaryLightDirection
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrlightestimate/primarylightintensity/index.md
+++ b/files/en-us/web/api/xrlightestimate/primarylightintensity/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRLightEstimate.primaryLightIntensity
 slug: Web/API/XRLightEstimate/primaryLightIntensity
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrlightestimate/sphericalharmonicscoefficients/index.md
+++ b/files/en-us/web/api/xrlightestimate/sphericalharmonicscoefficients/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRLightEstimate.sphericalHarmonicsCoefficients
 slug: Web/API/XRLightEstimate/sphericalHarmonicsCoefficients
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrlightprobe/index.md
+++ b/files/en-us/web/api/xrlightprobe/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRLightProbe
 slug: Web/API/XRLightProbe
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/xrlightprobe/probespace/index.md
+++ b/files/en-us/web/api/xrlightprobe/probespace/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRLightProbe.probeSpace
 slug: Web/API/XRLightProbe/probeSpace
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrlightprobe/reflectionchange_event/index.md
+++ b/files/en-us/web/api/xrlightprobe/reflectionchange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'XRLightProbe: reflectionchange event'
 slug: Web/API/XRLightProbe/reflectionchange_event
+page-type: web-api-event
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrmediabinding/createcylinderlayer/index.md
+++ b/files/en-us/web/api/xrmediabinding/createcylinderlayer/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRMediaBinding.createCylinderLayer()
 slug: Web/API/XRMediaBinding/createCylinderLayer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/xrmediabinding/createequirectlayer/index.md
+++ b/files/en-us/web/api/xrmediabinding/createequirectlayer/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRMediaBinding.createEquirectLayer()
 slug: Web/API/XRMediaBinding/createEquirectLayer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/xrmediabinding/createquadlayer/index.md
+++ b/files/en-us/web/api/xrmediabinding/createquadlayer/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRMediaBinding.createQuadLayer()
 slug: Web/API/XRMediaBinding/createQuadLayer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/xrmediabinding/index.md
+++ b/files/en-us/web/api/xrmediabinding/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRMediaBinding
 slug: Web/API/XRMediaBinding
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/xrmediabinding/xrmediabinding/index.md
+++ b/files/en-us/web/api/xrmediabinding/xrmediabinding/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRMediaBinding()
 slug: Web/API/XRMediaBinding/XRMediaBinding
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/xrpermissionstatus/granted/index.md
+++ b/files/en-us/web/api/xrpermissionstatus/granted/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRPermissionStatus.granted
 slug: Web/API/XRPermissionStatus/granted
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrpermissionstatus/index.md
+++ b/files/en-us/web/api/xrpermissionstatus/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRPermissionStatus
 slug: Web/API/XRPermissionStatus
+page-type: web-api-interface
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrpose/angularvelocity/index.md
+++ b/files/en-us/web/api/xrpose/angularvelocity/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRPose.angularVelocity
 slug: Web/API/XRPose/angularVelocity
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrpose/emulatedposition/index.md
+++ b/files/en-us/web/api/xrpose/emulatedposition/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRPose.emulatedPosition
 slug: Web/API/XRPose/emulatedPosition
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrpose/index.md
+++ b/files/en-us/web/api/xrpose/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRPose
 slug: Web/API/XRPose
+page-type: web-api-interface
 tags:
   - 3DoF
   - 6DoF

--- a/files/en-us/web/api/xrpose/linearvelocity/index.md
+++ b/files/en-us/web/api/xrpose/linearvelocity/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRPose.linearVelocity
 slug: Web/API/XRPose/linearVelocity
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrpose/transform/index.md
+++ b/files/en-us/web/api/xrpose/transform/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRPose.transform
 slug: Web/API/XRPose/transform
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrprojectionlayer/fixedfoveation/index.md
+++ b/files/en-us/web/api/xrprojectionlayer/fixedfoveation/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRProjectionLayer.fixedFoveation
 slug: Web/API/XRProjectionLayer/fixedFoveation
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrprojectionlayer/ignoredepthvalues/index.md
+++ b/files/en-us/web/api/xrprojectionlayer/ignoredepthvalues/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRProjectionLayer.ignoreDepthValues
 slug: Web/API/XRProjectionLayer/ignoreDepthValues
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrprojectionlayer/index.md
+++ b/files/en-us/web/api/xrprojectionlayer/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRProjectionLayer
 slug: Web/API/XRProjectionLayer
+page-type: web-api-interface
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrprojectionlayer/texturearraylength/index.md
+++ b/files/en-us/web/api/xrprojectionlayer/texturearraylength/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRProjectionLayer.textureArrayLength
 slug: Web/API/XRProjectionLayer/textureArrayLength
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrprojectionlayer/textureheight/index.md
+++ b/files/en-us/web/api/xrprojectionlayer/textureheight/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRProjectionLayer.textureHeight
 slug: Web/API/XRProjectionLayer/textureHeight
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrprojectionlayer/texturewidth/index.md
+++ b/files/en-us/web/api/xrprojectionlayer/texturewidth/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRProjectionLayer.textureWidth
 slug: Web/API/XRProjectionLayer/textureWidth
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrquadlayer/height/index.md
+++ b/files/en-us/web/api/xrquadlayer/height/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRQuadLayer.height
 slug: Web/API/XRQuadLayer/height
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrquadlayer/index.md
+++ b/files/en-us/web/api/xrquadlayer/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRQuadLayer
 slug: Web/API/XRQuadLayer
+page-type: web-api-interface
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrquadlayer/redraw_event/index.md
+++ b/files/en-us/web/api/xrquadlayer/redraw_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'XRQuadLayer: redraw event'
 slug: Web/API/XRQuadLayer/redraw_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/xrquadlayer/space/index.md
+++ b/files/en-us/web/api/xrquadlayer/space/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRQuadLayer.space
 slug: Web/API/XRQuadLayer/space
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrquadlayer/transform/index.md
+++ b/files/en-us/web/api/xrquadlayer/transform/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRQuadLayer.transform
 slug: Web/API/XRQuadLayer/transform
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrquadlayer/width/index.md
+++ b/files/en-us/web/api/xrquadlayer/width/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRQuadLayer.width
 slug: Web/API/XRQuadLayer/width
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrray/direction/index.md
+++ b/files/en-us/web/api/xrray/direction/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRRay.direction
 slug: Web/API/XRRay/direction
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrray/index.md
+++ b/files/en-us/web/api/xrray/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRRay
 slug: Web/API/XRRay
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/xrray/matrix/index.md
+++ b/files/en-us/web/api/xrray/matrix/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRRay.matrix
 slug: Web/API/XRRay/matrix
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrray/origin/index.md
+++ b/files/en-us/web/api/xrray/origin/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRRay.origin
 slug: Web/API/XRRay/origin
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrray/xrray/index.md
+++ b/files/en-us/web/api/xrray/xrray/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRRay()
 slug: Web/API/XRRay/XRRay
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/xrreferencespace/getoffsetreferencespace/index.md
+++ b/files/en-us/web/api/xrreferencespace/getoffsetreferencespace/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRReferenceSpace.getOffsetReferenceSpace()
 slug: Web/API/XRReferenceSpace/getOffsetReferenceSpace
+page-type: web-api-instance-method
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrreferencespace/index.md
+++ b/files/en-us/web/api/xrreferencespace/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRReferenceSpace
 slug: Web/API/XRReferenceSpace
+page-type: web-api-interface
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrreferencespace/reset_event/index.md
+++ b/files/en-us/web/api/xrreferencespace/reset_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'XRReferenceSpace: reset event'
 slug: Web/API/XRReferenceSpace/reset_event
+page-type: web-api-event
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrreferencespaceevent/index.md
+++ b/files/en-us/web/api/xrreferencespaceevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRReferenceSpaceEvent
 slug: Web/API/XRReferenceSpaceEvent
+page-type: web-api-interface
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrreferencespaceevent/referencespace/index.md
+++ b/files/en-us/web/api/xrreferencespaceevent/referencespace/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRReferenceSpaceEvent.referenceSpace
 slug: Web/API/XRReferenceSpaceEvent/referenceSpace
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrreferencespaceevent/transform/index.md
+++ b/files/en-us/web/api/xrreferencespaceevent/transform/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRReferenceSpaceEvent.transform
 slug: Web/API/XRReferenceSpaceEvent/transform
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrreferencespaceevent/xrreferencespaceevent/index.md
+++ b/files/en-us/web/api/xrreferencespaceevent/xrreferencespaceevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRReferenceSpaceEvent()
 slug: Web/API/XRReferenceSpaceEvent/XRReferenceSpaceEvent
+page-type: web-api-constructor
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrrenderstate/baselayer/index.md
+++ b/files/en-us/web/api/xrrenderstate/baselayer/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRRenderState.baseLayer
 slug: Web/API/XRRenderState/baseLayer
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrrenderstate/depthfar/index.md
+++ b/files/en-us/web/api/xrrenderstate/depthfar/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRRenderState.depthFar
 slug: Web/API/XRRenderState/depthFar
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrrenderstate/depthnear/index.md
+++ b/files/en-us/web/api/xrrenderstate/depthnear/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRRenderState.depthNear
 slug: Web/API/XRRenderState/depthNear
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrrenderstate/index.md
+++ b/files/en-us/web/api/xrrenderstate/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRRenderState
 slug: Web/API/XRRenderState
+page-type: web-api-interface
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrrenderstate/inlineverticalfieldofview/index.md
+++ b/files/en-us/web/api/xrrenderstate/inlineverticalfieldofview/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRRenderState.inlineVerticalFieldOfView
 slug: Web/API/XRRenderState/inlineVerticalFieldOfView
+page-type: web-api-instance-property
 tags:
   - API
   - Field of View

--- a/files/en-us/web/api/xrrenderstate/layers/index.md
+++ b/files/en-us/web/api/xrrenderstate/layers/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRRenderState.layers
 slug: Web/API/XRRenderState/layers
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrrigidtransform/index.md
+++ b/files/en-us/web/api/xrrigidtransform/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRRigidTransform
 slug: Web/API/XRRigidTransform
+page-type: web-api-interface
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrrigidtransform/inverse/index.md
+++ b/files/en-us/web/api/xrrigidtransform/inverse/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRRigidTransform.inverse
 slug: Web/API/XRRigidTransform/inverse
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrrigidtransform/matrix/index.md
+++ b/files/en-us/web/api/xrrigidtransform/matrix/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRRigidTransform.matrix
 slug: Web/API/XRRigidTransform/matrix
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrrigidtransform/orientation/index.md
+++ b/files/en-us/web/api/xrrigidtransform/orientation/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRRigidTransform.orientation
 slug: Web/API/XRRigidTransform/orientation
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrrigidtransform/position/index.md
+++ b/files/en-us/web/api/xrrigidtransform/position/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRRigidTransform.position
 slug: Web/API/XRRigidTransform/position
+page-type: web-api-instance-property
 tags:
   - 3D
   - API

--- a/files/en-us/web/api/xrrigidtransform/xrrigidtransform/index.md
+++ b/files/en-us/web/api/xrrigidtransform/xrrigidtransform/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRRigidTransform()
 slug: Web/API/XRRigidTransform/XRRigidTransform
+page-type: web-api-constructor
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsession/cancelanimationframe/index.md
+++ b/files/en-us/web/api/xrsession/cancelanimationframe/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRSession.cancelAnimationFrame()
 slug: Web/API/XRSession/cancelAnimationFrame
+page-type: web-api-instance-method
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsession/index.md
+++ b/files/en-us/web/api/xrsession/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRSession
 slug: Web/API/XRSession
+page-type: web-api-interface
 tags:
   - API
   - AR


### PR DESCRIPTION
See  https://github.com/mdn/content/issues/16255. This is part 29 of a series of PRs to add page types to the Web/API documentation.