### PR TITLE
Add Web/API page types, part 30

### DIFF
--- a/files/en-us/web/api/xrsession/depthdataformat/index.md
+++ b/files/en-us/web/api/xrsession/depthdataformat/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRSession.depthDataFormat
 slug: Web/API/XRSession/depthDataFormat
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsession/depthusage/index.md
+++ b/files/en-us/web/api/xrsession/depthusage/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRSession.depthUsage
 slug: Web/API/XRSession/depthUsage
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsession/domoverlaystate/index.md
+++ b/files/en-us/web/api/xrsession/domoverlaystate/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRSession.domOverlayState
 slug: Web/API/XRSession/domOverlayState
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsession/end/index.md
+++ b/files/en-us/web/api/xrsession/end/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRSession.end()
 slug: Web/API/XRSession/end
+page-type: web-api-instance-method
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsession/end_event/index.md
+++ b/files/en-us/web/api/xrsession/end_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'XRSession: end event'
 slug: Web/API/XRSession/end_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/xrsession/environmentblendmode/index.md
+++ b/files/en-us/web/api/xrsession/environmentblendmode/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRSession.environmentBlendMode
 slug: Web/API/XRSession/environmentBlendMode
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsession/inputsources/index.md
+++ b/files/en-us/web/api/xrsession/inputsources/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRSession.inputSources
 slug: Web/API/XRSession/inputSources
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsession/inputsourceschange_event/index.md
+++ b/files/en-us/web/api/xrsession/inputsourceschange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'XRSession: inputsourceschange event'
 slug: Web/API/XRSession/inputsourceschange_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/xrsession/interactionmode/index.md
+++ b/files/en-us/web/api/xrsession/interactionmode/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRSession.interactionMode
 slug: Web/API/XRSession/interactionMode
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsession/preferredreflectionformat/index.md
+++ b/files/en-us/web/api/xrsession/preferredreflectionformat/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRSession.preferredReflectionFormat
 slug: Web/API/XRSession/preferredReflectionFormat
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsession/renderstate/index.md
+++ b/files/en-us/web/api/xrsession/renderstate/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRSession.renderState
 slug: Web/API/XRSession/renderState
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsession/requestanimationframe/index.md
+++ b/files/en-us/web/api/xrsession/requestanimationframe/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRSession.requestAnimationFrame()
 slug: Web/API/XRSession/requestAnimationFrame
+page-type: web-api-instance-method
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsession/requesthittestsource/index.md
+++ b/files/en-us/web/api/xrsession/requesthittestsource/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRSession.requestHitTestSource()
 slug: Web/API/XRSession/requestHitTestSource
+page-type: web-api-instance-method
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsession/requesthittestsourcefortransientinput/index.md
+++ b/files/en-us/web/api/xrsession/requesthittestsourcefortransientinput/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRSession.requestHitTestSourceForTransientInput()
 slug: Web/API/XRSession/requestHitTestSourceForTransientInput
+page-type: web-api-instance-method
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsession/requestlightprobe/index.md
+++ b/files/en-us/web/api/xrsession/requestlightprobe/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRSession.requestLightProbe()
 slug: Web/API/XRSession/requestLightProbe
+page-type: web-api-instance-method
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsession/requestreferencespace/index.md
+++ b/files/en-us/web/api/xrsession/requestreferencespace/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRSession.requestReferenceSpace()
 slug: Web/API/XRSession/requestReferenceSpace
+page-type: web-api-instance-method
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsession/select_event/index.md
+++ b/files/en-us/web/api/xrsession/select_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'XRSession: select event'
 slug: Web/API/XRSession/select_event
+page-type: web-api-event
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/xrsession/selectend_event/index.md
+++ b/files/en-us/web/api/xrsession/selectend_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'XRSession: selectend event'
 slug: Web/API/XRSession/selectend_event
+page-type: web-api-event
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsession/selectstart_event/index.md
+++ b/files/en-us/web/api/xrsession/selectstart_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'XRSession: selectstart event'
 slug: Web/API/XRSession/selectstart_event
+page-type: web-api-event
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsession/squeeze_event/index.md
+++ b/files/en-us/web/api/xrsession/squeeze_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'XRSession: squeeze event'
 slug: Web/API/XRSession/squeeze_event
+page-type: web-api-event
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsession/squeezeend_event/index.md
+++ b/files/en-us/web/api/xrsession/squeezeend_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'XRSession: squeezeend event'
 slug: Web/API/XRSession/squeezeend_event
+page-type: web-api-event
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsession/squeezestart_event/index.md
+++ b/files/en-us/web/api/xrsession/squeezestart_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'XRSession: squeezestart event'
 slug: Web/API/XRSession/squeezestart_event
+page-type: web-api-event
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsession/updaterenderstate/index.md
+++ b/files/en-us/web/api/xrsession/updaterenderstate/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRSession.updateRenderState()
 slug: Web/API/XRSession/updateRenderState
+page-type: web-api-instance-method
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsession/visibilitychange_event/index.md
+++ b/files/en-us/web/api/xrsession/visibilitychange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'XRSession: visibilitychange event'
 slug: Web/API/XRSession/visibilitychange_event
+page-type: web-api-event
 tags:
   - API
   - Event

--- a/files/en-us/web/api/xrsession/visibilitystate/index.md
+++ b/files/en-us/web/api/xrsession/visibilitystate/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRSession.visibilityState
 slug: Web/API/XRSession/visibilityState
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsessionevent/index.md
+++ b/files/en-us/web/api/xrsessionevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRSessionEvent
 slug: Web/API/XRSessionEvent
+page-type: web-api-interface
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsessionevent/session/index.md
+++ b/files/en-us/web/api/xrsessionevent/session/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRSessionEvent.session
 slug: Web/API/XRSessionEvent/session
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsessionevent/xrsessionevent/index.md
+++ b/files/en-us/web/api/xrsessionevent/xrsessionevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRSessionEvent()
 slug: Web/API/XRSessionEvent/XRSessionEvent
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/xrspace/index.md
+++ b/files/en-us/web/api/xrspace/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRSpace
 slug: Web/API/XRSpace
+page-type: web-api-interface
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsubimage/index.md
+++ b/files/en-us/web/api/xrsubimage/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRSubImage
 slug: Web/API/XRSubImage
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/xrsubimage/viewport/index.md
+++ b/files/en-us/web/api/xrsubimage/viewport/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRSubImage.viewport
 slug: Web/API/XRSubImage/viewport
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrsystem/devicechange_event/index.md
+++ b/files/en-us/web/api/xrsystem/devicechange_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'XRSystem: devicechange event'
 slug: Web/API/XRSystem/devicechange_event
+page-type: web-api-event
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsystem/index.md
+++ b/files/en-us/web/api/xrsystem/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRSystem
 slug: Web/API/XRSystem
+page-type: web-api-interface
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsystem/issessionsupported/index.md
+++ b/files/en-us/web/api/xrsystem/issessionsupported/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'XRSystem: isSessionSupported()'
 slug: Web/API/XRSystem/isSessionSupported
+page-type: web-api-instance-method
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrsystem/requestsession/index.md
+++ b/files/en-us/web/api/xrsystem/requestsession/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'XRSystem: requestSession()'
 slug: Web/API/XRSystem/requestSession
+page-type: web-api-instance-method
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrtransientinputhittestresult/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestresult/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRTransientInputHitTestResult
 slug: Web/API/XRTransientInputHitTestResult
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/xrtransientinputhittestresult/inputsource/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestresult/inputsource/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRTransientInputHitTestResult.inputSource
 slug: Web/API/XRTransientInputHitTestResult/inputSource
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrtransientinputhittestresult/results/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestresult/results/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRTransientInputHitTestResult.results
 slug: Web/API/XRTransientInputHitTestResult/results
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrtransientinputhittestsource/cancel/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestsource/cancel/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRTransientInputHitTestSource.cancel()
 slug: Web/API/XRTransientInputHitTestSource/cancel
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/xrtransientinputhittestsource/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestsource/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRTransientInputHitTestSource
 slug: Web/API/XRTransientInputHitTestSource
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/xrview/eye/index.md
+++ b/files/en-us/web/api/xrview/eye/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRView.eye
 slug: Web/API/XRView/eye
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrview/index.md
+++ b/files/en-us/web/api/xrview/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRView
 slug: Web/API/XRView
+page-type: web-api-interface
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrview/isfirstpersonobserver/index.md
+++ b/files/en-us/web/api/xrview/isfirstpersonobserver/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRView.isFirstPersonObserver
 slug: Web/API/XRView/isFirstPersonObserver
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrview/projectionmatrix/index.md
+++ b/files/en-us/web/api/xrview/projectionmatrix/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRView.projectionMatrix
 slug: Web/API/XRView/projectionMatrix
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrview/recommendedviewportscale/index.md
+++ b/files/en-us/web/api/xrview/recommendedviewportscale/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRView.recommendedViewportScale
 slug: Web/API/XRView/recommendedViewportScale
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrview/requestviewportscale/index.md
+++ b/files/en-us/web/api/xrview/requestviewportscale/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRView.requestViewportScale()
 slug: Web/API/XRView/requestViewportScale
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/xrview/transform/index.md
+++ b/files/en-us/web/api/xrview/transform/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRView.transform
 slug: Web/API/XRView/transform
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrviewerpose/index.md
+++ b/files/en-us/web/api/xrviewerpose/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRViewerPose
 slug: Web/API/XRViewerPose
+page-type: web-api-interface
 tags:
   - 3D
   - API

--- a/files/en-us/web/api/xrviewerpose/views/index.md
+++ b/files/en-us/web/api/xrviewerpose/views/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRViewerPose.views
 slug: Web/API/XRViewerPose/views
+page-type: web-api-instance-property
 tags:
   - 3D
   - API

--- a/files/en-us/web/api/xrviewport/height/index.md
+++ b/files/en-us/web/api/xrviewport/height/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRViewport.height
 slug: Web/API/XRViewport/height
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrviewport/index.md
+++ b/files/en-us/web/api/xrviewport/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRViewport
 slug: Web/API/XRViewport
+page-type: web-api-interface
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrviewport/width/index.md
+++ b/files/en-us/web/api/xrviewport/width/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRViewport.width
 slug: Web/API/XRViewport/width
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrviewport/x/index.md
+++ b/files/en-us/web/api/xrviewport/x/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRViewport.x
 slug: Web/API/XRViewport/x
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrviewport/y/index.md
+++ b/files/en-us/web/api/xrviewport/y/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRViewport.y
 slug: Web/API/XRViewport/y
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrwebglbinding/createcubelayer/index.md
+++ b/files/en-us/web/api/xrwebglbinding/createcubelayer/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLBinding.createCubeLayer()
 slug: Web/API/XRWebGLBinding/createCubeLayer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/xrwebglbinding/createcylinderlayer/index.md
+++ b/files/en-us/web/api/xrwebglbinding/createcylinderlayer/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLBinding.createCylinderLayer()
 slug: Web/API/XRWebGLBinding/createCylinderLayer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/xrwebglbinding/createequirectlayer/index.md
+++ b/files/en-us/web/api/xrwebglbinding/createequirectlayer/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLBinding.createEquirectLayer()
 slug: Web/API/XRWebGLBinding/createEquirectLayer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/xrwebglbinding/createprojectionlayer/index.md
+++ b/files/en-us/web/api/xrwebglbinding/createprojectionlayer/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLBinding.createProjectionLayer()
 slug: Web/API/XRWebGLBinding/createProjectionLayer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/xrwebglbinding/createquadlayer/index.md
+++ b/files/en-us/web/api/xrwebglbinding/createquadlayer/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLBinding.createQuadLayer()
 slug: Web/API/XRWebGLBinding/createQuadLayer
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/xrwebglbinding/getdepthinformation/index.md
+++ b/files/en-us/web/api/xrwebglbinding/getdepthinformation/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLBinding.getDepthInformation()
 slug: Web/API/XRWebGLBinding/getDepthInformation
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/xrwebglbinding/getreflectioncubemap/index.md
+++ b/files/en-us/web/api/xrwebglbinding/getreflectioncubemap/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLBinding.getReflectionCubeMap()
 slug: Web/API/XRWebGLBinding/getReflectionCubeMap
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/xrwebglbinding/getsubimage/index.md
+++ b/files/en-us/web/api/xrwebglbinding/getsubimage/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLBinding.getSubImage()
 slug: Web/API/XRWebGLBinding/getSubImage
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/xrwebglbinding/getviewsubimage/index.md
+++ b/files/en-us/web/api/xrwebglbinding/getviewsubimage/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLBinding.getViewSubImage()
 slug: Web/API/XRWebGLBinding/getViewSubImage
+page-type: web-api-instance-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/xrwebglbinding/index.md
+++ b/files/en-us/web/api/xrwebglbinding/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLBinding
 slug: Web/API/XRWebGLBinding
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/xrwebglbinding/nativeprojectionscalefactor/index.md
+++ b/files/en-us/web/api/xrwebglbinding/nativeprojectionscalefactor/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLBinding.nativeProjectionScaleFactor
 slug: Web/API/XRWebGLBinding/nativeProjectionScaleFactor
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrwebglbinding/xrwebglbinding/index.md
+++ b/files/en-us/web/api/xrwebglbinding/xrwebglbinding/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLBinding()
 slug: Web/API/XRWebGLBinding/XRWebGLBinding
+page-type: web-api-constructor
 tags:
   - API
   - Constructor

--- a/files/en-us/web/api/xrwebgldepthinformation/index.md
+++ b/files/en-us/web/api/xrwebgldepthinformation/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLDepthInformation
 slug: Web/API/XRWebGLDepthInformation
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/xrwebgldepthinformation/texture/index.md
+++ b/files/en-us/web/api/xrwebgldepthinformation/texture/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLDepthInformation.texture
 slug: Web/API/XRWebGLDepthInformation/texture
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrwebgllayer/antialias/index.md
+++ b/files/en-us/web/api/xrwebgllayer/antialias/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLLayer.antialias
 slug: Web/API/XRWebGLLayer/antialias
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrwebgllayer/fixedfoveation/index.md
+++ b/files/en-us/web/api/xrwebgllayer/fixedfoveation/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLLayer.fixedFoveation
 slug: Web/API/XRWebGLLayer/fixedFoveation
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrwebgllayer/framebuffer/index.md
+++ b/files/en-us/web/api/xrwebgllayer/framebuffer/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLLayer.framebuffer
 slug: Web/API/XRWebGLLayer/framebuffer
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrwebgllayer/framebufferheight/index.md
+++ b/files/en-us/web/api/xrwebgllayer/framebufferheight/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLLayer.framebufferHeight
 slug: Web/API/XRWebGLLayer/framebufferHeight
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrwebgllayer/framebufferwidth/index.md
+++ b/files/en-us/web/api/xrwebgllayer/framebufferwidth/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLLayer.framebufferWidth
 slug: Web/API/XRWebGLLayer/framebufferWidth
+page-type: web-api-instance-property
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrwebgllayer/getnativeframebufferscalefactor/index.md
+++ b/files/en-us/web/api/xrwebgllayer/getnativeframebufferscalefactor/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLLayer.getNativeFramebufferScaleFactor() static method
 slug: Web/API/XRWebGLLayer/getNativeFramebufferScaleFactor
+page-type: web-api-static-method
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrwebgllayer/getviewport/index.md
+++ b/files/en-us/web/api/xrwebgllayer/getviewport/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLLayer.getViewport()
 slug: Web/API/XRWebGLLayer/getViewport
+page-type: web-api-instance-method
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrwebgllayer/ignoredepthvalues/index.md
+++ b/files/en-us/web/api/xrwebgllayer/ignoredepthvalues/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLLayer.ignoreDepthValues
 slug: Web/API/XRWebGLLayer/ignoreDepthValues
+page-type: web-api-instance-property
 tags:
   - 3D
   - API

--- a/files/en-us/web/api/xrwebgllayer/index.md
+++ b/files/en-us/web/api/xrwebgllayer/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLLayer
 slug: Web/API/XRWebGLLayer
+page-type: web-api-interface
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrwebgllayer/xrwebgllayer/index.md
+++ b/files/en-us/web/api/xrwebgllayer/xrwebgllayer/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLLayer()
 slug: Web/API/XRWebGLLayer/XRWebGLLayer
+page-type: web-api-constructor
 tags:
   - API
   - AR

--- a/files/en-us/web/api/xrwebglsubimage/colortexture/index.md
+++ b/files/en-us/web/api/xrwebglsubimage/colortexture/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLSubImage.colorTexture
 slug: Web/API/XRWebGLSubImage/colorTexture
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrwebglsubimage/depthstenciltexture/index.md
+++ b/files/en-us/web/api/xrwebglsubimage/depthstenciltexture/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLSubImage.depthStencilTexture
 slug: Web/API/XRWebGLSubImage/depthStencilTexture
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrwebglsubimage/imageindex/index.md
+++ b/files/en-us/web/api/xrwebglsubimage/imageindex/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLSubImage.imageIndex
 slug: Web/API/XRWebGLSubImage/imageIndex
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrwebglsubimage/index.md
+++ b/files/en-us/web/api/xrwebglsubimage/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLSubImage
 slug: Web/API/XRWebGLSubImage
+page-type: web-api-interface
 tags:
   - API
   - Interface

--- a/files/en-us/web/api/xrwebglsubimage/textureheight/index.md
+++ b/files/en-us/web/api/xrwebglsubimage/textureheight/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLSubImage.textureHeight
 slug: Web/API/XRWebGLSubImage/textureHeight
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xrwebglsubimage/texturewidth/index.md
+++ b/files/en-us/web/api/xrwebglsubimage/texturewidth/index.md
@@ -1,6 +1,7 @@
 ---
 title: XRWebGLSubImage.textureWidth
 slug: Web/API/XRWebGLSubImage/textureWidth
+page-type: web-api-instance-property
 tags:
   - API
   - Property

--- a/files/en-us/web/api/xsltprocessor/basic_example/index.md
+++ b/files/en-us/web/api/xsltprocessor/basic_example/index.md
@@ -1,6 +1,7 @@
 ---
 title: XSLT Basic Example
 slug: Web/API/XSLTProcessor/Basic_Example
+page-type: guide
 tags:
   - XSLT
   - Example

--- a/files/en-us/web/api/xsltprocessor/browser_differences/index.md
+++ b/files/en-us/web/api/xsltprocessor/browser_differences/index.md
@@ -1,6 +1,7 @@
 ---
 title: Browser Differences
 slug: Web/API/XSLTProcessor/Browser_Differences
+page-type: guide
 ---
 ## Browser Differences
 

--- a/files/en-us/web/api/xsltprocessor/generating_html/index.md
+++ b/files/en-us/web/api/xsltprocessor/generating_html/index.md
@@ -1,6 +1,7 @@
 ---
 title: Generating HTML
 slug: Web/API/XSLTProcessor/Generating_HTML
+page-type: guide
 ---
 ## Generating HTML
 

--- a/files/en-us/web/api/xsltprocessor/index.md
+++ b/files/en-us/web/api/xsltprocessor/index.md
@@ -1,6 +1,7 @@
 ---
 title: XSLTProcessor
 slug: Web/API/XSLTProcessor
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/xsltprocessor/introduction/index.md
+++ b/files/en-us/web/api/xsltprocessor/introduction/index.md
@@ -1,6 +1,7 @@
 ---
 title: Introduction
 slug: Web/API/XSLTProcessor/Introduction
+page-type: guide
 ---
 ## Introduction
 

--- a/files/en-us/web/api/xsltprocessor/resources/index.md
+++ b/files/en-us/web/api/xsltprocessor/resources/index.md
@@ -1,6 +1,7 @@
 ---
 title: Resources
 slug: Web/API/XSLTProcessor/Resources
+page-type: guide
 ---
 ## Resources
 

--- a/files/en-us/web/api/xsltprocessor/xsl_transformations_in_mozilla_faq/index.md
+++ b/files/en-us/web/api/xsltprocessor/xsl_transformations_in_mozilla_faq/index.md
@@ -1,6 +1,7 @@
 ---
 title: XSL Transformations in Mozilla FAQ
 slug: Web/API/XSLTProcessor/XSL_Transformations_in_Mozilla_FAQ
+page-type: guide
 tags:
   - Guide
   - XSLT


### PR DESCRIPTION
See  https://github.com/mdn/content/issues/16255. This is part 30 of a series of PRs to add page types to the Web/API documentation.

This concludes adding "easy" page types to Web/API.