### PR TITLE
Fix Date.setMonth description

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/date/setmonth/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/setmonth/index.md
@@ -11,8 +11,7 @@ browser-compat: javascript.builtins.Date.setMonth
 ---
 {{JSRef}}
 
-The **`setMonth()`** method sets the month for a specified date
-according to the currently set year.
+The **`setMonth()`** method sets the month for a specified date according to the currently set year.
 
 {{EmbedInteractiveExample("pages/js/date-setmonth.html")}}
 
@@ -48,9 +47,9 @@ incremented by 1, and 3 will be used for month.
 
 The current day of month will have an impact on the behavior of this method.
 Conceptually it will add the number of days given by the current day of the month to the
-1st day of the new month specified as the parameter, to return the new date. For
-example, if the current value is 31st August 2016, calling setMonth with a value of 1
-will return 2nd March 2016. This is because in 2016 February had 29 days.
+1st day of the new month specified as the parameter, to return the new date.
+For example, if the current value is 31st January 2016, calling setMonth with a value of 1 will return 2nd March 2016.
+This is because in 2016 February had 29 days.
 
 ## Examples
 


### PR DESCRIPTION
Description was wrong - example used inferred that month after 31st August 2016 was February. Fix is to change date from 31st August 2016 to 31st January 2016

Fixes #16916