### PR TITLE
Fixed typo in link to link_role on aria-haspopup page

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-haspopup/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-haspopup/index.md
@@ -62,7 +62,7 @@ Used in roles:
 - [`button`](/en-US/docs/Web/Accessibility/ARIA/Roles/button_role)
 - [`combobox`](/en-US/docs/Web/Accessibility/ARIA/Roles/combobox_role)
 - [`gridcell`](/en-US/docs/Web/Accessibility/ARIA/Roles/gridcell_role)
-- [`link`](/en-US/docs/Web/Accessibility/ARIA/Roles/:ink_role)
+- [`link`](/en-US/docs/Web/Accessibility/ARIA/Roles/link_role)
 - [`menuitem`](/en-US/docs/Web/Accessibility/ARIA/Roles/menuitem_role)
 - [`slider`](/en-US/docs/Web/Accessibility/ARIA/Roles/slider_role)
 - [`tab`](/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role)


### PR DESCRIPTION
#### Summary
Fixed typo in link to link_role on `aria-haspopup` page.

#### Motivation
Broken link prevents useful navigation to a related page.

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error