### PR TITLE
Fix statement in reference error that let isn't hoisted

### DIFF
--- a/files/en-us/web/javascript/reference/errors/cant_access_lexical_declaration_before_init/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_access_lexical_declaration_before_init/index.md
@@ -38,7 +38,7 @@ Note also that this issue does not occur for variables declared using `var`, bec
 
 ### Invalid cases
 
-In this case, the variable "foo" is accessed before it is declared.
+In this case, the variable `foo` is accessed before it is declared.
 At this point is has not been initialized with a value, so accessing the variable throws a reference error.
 
 ```js example-bad

--- a/files/en-us/web/javascript/reference/errors/cant_access_lexical_declaration_before_init/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_access_lexical_declaration_before_init/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'ReferenceError: can''t access lexical declaration`X'' before initialization'
+title: "ReferenceError: can't access lexical declaration 'X' before initialization"
 slug: Web/JavaScript/Reference/Errors/Cant_access_lexical_declaration_before_init
 tags:
   - Error
@@ -9,18 +9,14 @@ tags:
 ---
 {{jsSidebar("Errors")}}
 
-The JavaScript exception "can't access lexical declaration \`_variable_' before
-initialization" occurs when a lexical variable was accessed before it was initialized.
-This happens within any block statement, when
-[`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let) or
-[`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const)
-declarations are accessed before they are defined.
+The JavaScript exception "can't access lexical declaration \`_variable_' before initialization" occurs when a lexical variable was accessed before it was initialized.
+This happens within any block statement, when [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let) or [`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const) variables are accessed before the line in which they are declared is executed.
 
 ## Message
 
 ```js
 ReferenceError: Cannot access 'X' before initialization (Edge)
-ReferenceError: can't access lexical declaration `X' before initialization (Firefox)
+ReferenceError: can't access lexical declaration 'X' before initialization (Firefox)
 ReferenceError: 'x' is not defined (Chrome)
 ```
 
@@ -30,45 +26,40 @@ ReferenceError: 'x' is not defined (Chrome)
 
 ## What went wrong?
 
-A lexical variable was accessed before it was initialized. This happens within any
-block statement, when
-[`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let) or
-[`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const)
-declarations are accessed before they are defined.
+A lexical variable was accessed before it was initialized.
+This happens within any block statement, when variables declared with [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let) or [`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const) are accessed before the line in which they are declared has been executed.
+
+Note that it is the execution order of access and variable declaration that matters, not the order in which the lines appear in the code.
+For more information see: [Temporal Dead Zone and errors with let](/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_and_errors_with_let).
+
+Note also that this issue does not occur for variables declared using `var`, because they are initialized with a default value of `undefined` when they are [hoisted](/en-US/docs/Glossary/Hoisting).
 
 ## Examples
 
 ### Invalid cases
 
-In this case, the variable "foo" is accessed, even before it is declared which throws an reference error ( because variables declared using `let/const` are not [hoisted](/en-US/docs/Glossary/Hoisting) ).
+In this case, the variable "foo" is accessed before it is declared.
+At this point is has not been initialized with a value, so accessing the variable throws a reference error.
 
 ```js example-bad
 function test() {
-
-  // Accessing the variable foo before it's declared
-
-  console.log(foo);     // ReferenceError: can't access lexical
-  let foo = 33;         // 'foo' is declared here using the 'let' keyword
-
+  // Accessing the 'let' variable foo before it's declared
+  console.log(foo);     // ReferenceError: foo is not initialized
+  let foo = 33;         // 'foo' is declared and initialized here using the 'let' keyword
 }
+
 test();
 ```
 
 ### Valid cases
 
-In the following example, we correctly declare a variable using the `let` keyword before accessing it, so we encounter no error. And in contrast, notice how we are accessing the `bar` variable even before it is declared — without encountering any error. That's because of the [hoisted](/en-US/docs/Glossary/Hoisting) nature of `var` variables.
+In the following example, we correctly declare a variable using the `let` keyword before accessing it.
 
 ```js example-good
 function test(){
-
    // Declaring variable foo
    let foo = 33;
-   console.log(foo, bar);    // 33 undefined
-   var bar = 12;
+   console.log(foo);    // 33
 }
 test();
 ```
-
-## See also
-
-- [Temporal Dead Zone and errors with let](/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_and_errors_with_let)


### PR DESCRIPTION
Doc incorrectly stated that let isn't hoisted.

I removed that statement and tidied a few other errors. 

Fixes #16882