### PR TITLE
TypeError also thrown in array destructuring

### DIFF
--- a/files/en-us/web/javascript/reference/errors/is_not_iterable/index.md
+++ b/files/en-us/web/javascript/reference/errors/is_not_iterable/index.md
@@ -10,8 +10,9 @@ tags:
 {{jsSidebar("Errors")}}
 
 The JavaScript exception "is not iterable" occurs when the value which is given as the
-right-hand side of [`for...of`](/en-US/docs/Web/JavaScript/Guide/Loops_and_iteration#for...of_statement)
-or as argument of a function such as {{jsxref("Promise.all")}} or {{jsxref("TypedArray.from")}},
+right-hand side of [`for...of`](/en-US/docs/Web/JavaScript/Guide/Loops_and_iteration#for...of_statement),
+as argument of a function such as {{jsxref("Promise.all")}} or {{jsxref("TypedArray.from")}},
+or as the right-hand side of an array [destructuring assignement](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment),
 is not an [iterable object](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
 
 ## Message
@@ -27,14 +28,27 @@ TypeError: 'x' is not a function or its return value is not iterable (Chrome)
 
 ## What went wrong?
 
-The value which is given as the right-hand side of [`for...of`](/en-US/docs/Web/JavaScript/Guide/Loops_and_iteration#for...of_statement)
+The value which is given as the right-hand side of [`for...of`](/en-US/docs/Web/JavaScript/Guide/Loops_and_iteration#for...of_statement),
 or as argument of a function such as {{jsxref("Promise.all")}} or {{jsxref("TypedArray.from")}},
+or as the right-hand side of an array [destructuring assignement](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment),
 is not an [iterable object](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols).
 An iterable can be a built-in iterable type such as
 {{jsxref("Array")}}, {{jsxref("String")}} or {{jsxref("Map")}}, a generator result, or
 an object implementing the [iterable protocol](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol).
 
 ## Examples
+
+### Array destructuring a non-iterable
+
+```js example-bad
+const myobj = { arrayOrObjProp1: {}, arrayOrObjProp2: [42] };
+
+const { arrayOrObjProp1: [value1], arrayOrObjProp2: [value2] } = myobj; // TypeError: object is not iterable
+
+console.log(value1, value2);
+```
+
+The non-iterable might turn to be `undefined` in some runtime environments.
 
 ### Iterating over Object properties
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

`TypeError: "x" is not iterable` is also thrown when array destructuring a non-iterable

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

I got this error when destructuring, and got misled because I found this doc.

I've tried in Node, Chrome, and Firefox, and something like `const [a] = {}` throws this TypeError, "x is not iterable". 

Note that in Node and Chrome, `const [a] = undefined` also throws it, but in Firefox it throws `TypeError: undefined has no properties`.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

In [the spec](https://262.ecma-international.org/12.0/#sec-destructuring-assignment), it says that array destructuring should try to [`GetIterator`](https://262.ecma-international.org/12.0/#sec-getiterator) of the right-hand side, and `GetIterator`, in turn, should find either `@@asyncIterator` or `@@iterator` or throw a `TypeError`. (Gosh I hope I read that right haha).

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
