### PR TITLE
fix: update head to fix livesample

### DIFF
--- a/files/en-us/web/api/element/getboundingclientrect/index.md
+++ b/files/en-us/web/api/element/getboundingclientrect/index.md
@@ -126,7 +126,7 @@ Also note how the values of `x`/`left`,
 to the absolute distance from the relevant edge of the viewport to that side of the
 element, in each case.
 
-#### Scrolling
+### Scrolling
 
 This example demonstrates how bounding client rect is changing when document is scrolled.
 


### PR DESCRIPTION
#### Summary

The `basic` example is not related to `scrolling` example, so update the head `#### Scrolling` to `### Scrolling` for separating it.

#### Supporting details

before

![image](https://user-images.githubusercontent.com/15844309/171776747-1032833a-b098-4f8a-b59e-004a0a1626f3.png)

after

![image](https://user-images.githubusercontent.com/15844309/171776721-fe54caf6-63ef-4832-bb6d-8b96dc158a9d.png)

#### Metadata

- [x] Fixes a typo, bug, or other error
