### PR TITLE
FF102 Supports transferable streams in nightly

### DIFF
--- a/files/en-us/glossary/transferable_objects/index.md
+++ b/files/en-us/glossary/transferable_objects/index.md
@@ -76,7 +76,7 @@ console.log(original.byteLength);  // 0
 
 ## Supported objects
 
-The items that can be _transferred_ are:
+The items that various specifications indicate can be _transferred_ are:
 
 - {{jsxref("ArrayBuffer")}}
 - {{domxref("MessagePort")}}
@@ -88,6 +88,9 @@ The items that can be _transferred_ are:
 - {{domxref("VideoFrame")}}
 - {{domxref("OffscreenCanvas")}}
 - {{domxref("RTCDataChannel")}}
+
+Browser support should be indicated in the respective object's compatibility information by the `transferable` subfeature (see [`RTCDataChannel`](/en-US/docs/Web/API/RTCDataChannel#browser_compatibility) for an example).
+At time of writing, not all transferable objects have been updated with this information.
 
 > **Note:** Transferrable objects are marked up in [Web IDL files](https://github.com/w3c/webref/tree/main/ed/idl) with the attribute `[Transferrable]`.
 

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -1528,6 +1528,52 @@ Note that since locking the screen orientation isn't typically supported on desk
   </tbody>
 </table>
 
+
+
+### Streaming API
+
+#### Transferable streams
+
+[`ReadableStream`](/en-US/docs/Web/API/ReadableStream), [`WritableStream`](/en-US/docs/Web/API/WritableStream), [`TransformStream`](/en-US/docs/Web/API/TransformStream) are now [Transferable objects](/en-US/docs/Glossary/Transferable_objects), which means that ownership can be transfered when sharing the objects between a window and workers using `postMessage`, or when using [structuredClone()](/en-US/docs/Web/API/structuredClone) to copy an object.
+After transfering, the original object cannot be used.
+See {{bug(1659025)}} for more details.
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version changed</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>102</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>102</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>102</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>102</td>
+      <td>No.</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2"><code>dom.streams.transferable.enabled</code></td>
+    </tr>
+  </tbody>
+</table>
+
 ## Security and privacy
 
 ### Block plain text requests from Flash on encrypted pages


### PR DESCRIPTION
FF102 supports transferable streams objects in Nightly. 

There wasn't much work to do here. I've added the feature to experimental features.

I would have cross linked the affected APIs to [Transferable objects](https://developer.mozilla.org/en-US/docs/Glossary/Transferable_objects) but I did that a month or so ago. What I did do though is make it clear that browser support is not complete, and how you find out what is supported.

PS Would have liked to add BCD table linking to all the transferable object keys instead of above note, but this is not yet supported.

This is part of docs work for #16930