### PR TITLE
Add WebGL page types

### DIFF
--- a/files/en-us/web/api/ext_blend_minmax/index.md
+++ b/files/en-us/web/api/ext_blend_minmax/index.md
@@ -1,6 +1,7 @@
 ---
 title: EXT_blend_minmax
 slug: Web/API/EXT_blend_minmax
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/ext_color_buffer_float/index.md
+++ b/files/en-us/web/api/ext_color_buffer_float/index.md
@@ -1,6 +1,7 @@
 ---
 title: EXT_color_buffer_float
 slug: Web/API/EXT_color_buffer_float
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/ext_color_buffer_half_float/index.md
+++ b/files/en-us/web/api/ext_color_buffer_half_float/index.md
@@ -1,6 +1,7 @@
 ---
 title: EXT_color_buffer_half_float
 slug: Web/API/EXT_color_buffer_half_float
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/ext_disjoint_timer_query/beginqueryext/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/beginqueryext/index.md
@@ -1,6 +1,7 @@
 ---
 title: EXT_disjoint_timer_query.beginQueryEXT()
 slug: Web/API/EXT_disjoint_timer_query/beginQueryEXT
+page-type: webgl-extension-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/ext_disjoint_timer_query/createqueryext/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/createqueryext/index.md
@@ -1,6 +1,7 @@
 ---
 title: EXT_disjoint_timer_query.createQueryEXT()
 slug: Web/API/EXT_disjoint_timer_query/createQueryEXT
+page-type: webgl-extension-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/ext_disjoint_timer_query/deletequeryext/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/deletequeryext/index.md
@@ -1,6 +1,7 @@
 ---
 title: EXT_disjoint_timer_query.deleteQueryEXT()
 slug: Web/API/EXT_disjoint_timer_query/deleteQueryEXT
+page-type: webgl-extension-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/ext_disjoint_timer_query/endqueryext/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/endqueryext/index.md
@@ -1,6 +1,7 @@
 ---
 title: EXT_disjoint_timer_query.endQueryEXT()
 slug: Web/API/EXT_disjoint_timer_query/endQueryEXT
+page-type: webgl-extension-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/ext_disjoint_timer_query/getqueryext/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/getqueryext/index.md
@@ -1,6 +1,7 @@
 ---
 title: EXT_disjoint_timer_query.getQueryEXT()
 slug: Web/API/EXT_disjoint_timer_query/getQueryEXT
+page-type: webgl-extension-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/ext_disjoint_timer_query/getqueryobjectext/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/getqueryobjectext/index.md
@@ -1,6 +1,7 @@
 ---
 title: EXT_disjoint_timer_query.getQueryObjectEXT()
 slug: Web/API/EXT_disjoint_timer_query/getQueryObjectEXT
+page-type: webgl-extension-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/ext_disjoint_timer_query/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/index.md
@@ -1,6 +1,7 @@
 ---
 title: EXT_disjoint_timer_query
 slug: Web/API/EXT_disjoint_timer_query
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/ext_disjoint_timer_query/isqueryext/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/isqueryext/index.md
@@ -1,6 +1,7 @@
 ---
 title: EXT_disjoint_timer_query.isQueryEXT()
 slug: Web/API/EXT_disjoint_timer_query/isQueryEXT
+page-type: webgl-extension-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/ext_disjoint_timer_query/querycounterext/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/querycounterext/index.md
@@ -1,6 +1,7 @@
 ---
 title: EXT_disjoint_timer_query.queryCounterEXT()
 slug: Web/API/EXT_disjoint_timer_query/queryCounterEXT
+page-type: webgl-extension-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/ext_float_blend/index.md
+++ b/files/en-us/web/api/ext_float_blend/index.md
@@ -1,6 +1,7 @@
 ---
 title: EXT_float_blend
 slug: Web/API/EXT_float_blend
+page-type: webgl-extension
 tags:
   - 32-bit
   - API

--- a/files/en-us/web/api/ext_frag_depth/index.md
+++ b/files/en-us/web/api/ext_frag_depth/index.md
@@ -1,6 +1,7 @@
 ---
 title: EXT_frag_depth
 slug: Web/API/EXT_frag_depth
+page-type: webgl-extension
 tags:
   - API
   - Fragment Shader

--- a/files/en-us/web/api/ext_shader_texture_lod/index.md
+++ b/files/en-us/web/api/ext_shader_texture_lod/index.md
@@ -1,6 +1,7 @@
 ---
 title: EXT_shader_texture_lod
 slug: Web/API/EXT_shader_texture_lod
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/ext_srgb/index.md
+++ b/files/en-us/web/api/ext_srgb/index.md
@@ -1,6 +1,7 @@
 ---
 title: EXT_sRGB
 slug: Web/API/EXT_sRGB
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/ext_texture_compression_bptc/index.md
+++ b/files/en-us/web/api/ext_texture_compression_bptc/index.md
@@ -1,6 +1,7 @@
 ---
 title: EXT_texture_compression_bptc
 slug: Web/API/EXT_texture_compression_bptc
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/ext_texture_compression_rgtc/index.md
+++ b/files/en-us/web/api/ext_texture_compression_rgtc/index.md
@@ -1,6 +1,7 @@
 ---
 title: EXT_texture_compression_rgtc
 slug: Web/API/EXT_texture_compression_rgtc
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/ext_texture_filter_anisotropic/index.md
+++ b/files/en-us/web/api/ext_texture_filter_anisotropic/index.md
@@ -1,6 +1,7 @@
 ---
 title: EXT_texture_filter_anisotropic
 slug: Web/API/EXT_texture_filter_anisotropic
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/ext_texture_norm16/index.md
+++ b/files/en-us/web/api/ext_texture_norm16/index.md
@@ -1,6 +1,7 @@
 ---
 title: EXT_texture_norm16
 slug: Web/API/EXT_texture_norm16
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/khr_parallel_shader_compile/index.md
+++ b/files/en-us/web/api/khr_parallel_shader_compile/index.md
@@ -1,6 +1,7 @@
 ---
 title: KHR_parallel_shader_compile
 slug: Web/API/KHR_parallel_shader_compile
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/oes_element_index_uint/index.md
+++ b/files/en-us/web/api/oes_element_index_uint/index.md
@@ -1,6 +1,7 @@
 ---
 title: OES_element_index_uint
 slug: Web/API/OES_element_index_uint
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/oes_fbo_render_mipmap/index.md
+++ b/files/en-us/web/api/oes_fbo_render_mipmap/index.md
@@ -1,6 +1,7 @@
 ---
 title: OES_fbo_render_mipmap
 slug: Web/API/OES_fbo_render_mipmap
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/oes_standard_derivatives/index.md
+++ b/files/en-us/web/api/oes_standard_derivatives/index.md
@@ -1,6 +1,7 @@
 ---
 title: OES_standard_derivatives
 slug: Web/API/OES_standard_derivatives
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/oes_texture_float/index.md
+++ b/files/en-us/web/api/oes_texture_float/index.md
@@ -1,6 +1,7 @@
 ---
 title: OES_texture_float
 slug: Web/API/OES_texture_float
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/oes_texture_float_linear/index.md
+++ b/files/en-us/web/api/oes_texture_float_linear/index.md
@@ -1,6 +1,7 @@
 ---
 title: OES_texture_float_linear
 slug: Web/API/OES_texture_float_linear
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/oes_texture_half_float/index.md
+++ b/files/en-us/web/api/oes_texture_half_float/index.md
@@ -1,6 +1,7 @@
 ---
 title: OES_texture_half_float
 slug: Web/API/OES_texture_half_float
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/oes_texture_half_float_linear/index.md
+++ b/files/en-us/web/api/oes_texture_half_float_linear/index.md
@@ -1,6 +1,7 @@
 ---
 title: OES_texture_half_float_linear
 slug: Web/API/OES_texture_half_float_linear
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/oes_vertex_array_object/bindvertexarrayoes/index.md
+++ b/files/en-us/web/api/oes_vertex_array_object/bindvertexarrayoes/index.md
@@ -1,6 +1,7 @@
 ---
 title: OES_vertex_array_object.bindVertexArrayOES()
 slug: Web/API/OES_vertex_array_object/bindVertexArrayOES
+page-type: webgl-extension-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/oes_vertex_array_object/createvertexarrayoes/index.md
+++ b/files/en-us/web/api/oes_vertex_array_object/createvertexarrayoes/index.md
@@ -1,6 +1,7 @@
 ---
 title: OES_vertex_array_object.createVertexArrayOES()
 slug: Web/API/OES_vertex_array_object/createVertexArrayOES
+page-type: webgl-extension-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/oes_vertex_array_object/deletevertexarrayoes/index.md
+++ b/files/en-us/web/api/oes_vertex_array_object/deletevertexarrayoes/index.md
@@ -1,6 +1,7 @@
 ---
 title: OES_vertex_array_object.deleteVertexArrayOES()
 slug: Web/API/OES_vertex_array_object/deleteVertexArrayOES
+page-type: webgl-extension-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/oes_vertex_array_object/index.md
+++ b/files/en-us/web/api/oes_vertex_array_object/index.md
@@ -1,6 +1,7 @@
 ---
 title: OES_vertex_array_object
 slug: Web/API/OES_vertex_array_object
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/oes_vertex_array_object/isvertexarrayoes/index.md
+++ b/files/en-us/web/api/oes_vertex_array_object/isvertexarrayoes/index.md
@@ -1,6 +1,7 @@
 ---
 title: OES_vertex_array_object.isVertexArrayOES()
 slug: Web/API/OES_vertex_array_object/isVertexArrayOES
+page-type: webgl-extension-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/ovr_multiview2/framebuffertexturemultiviewovr/index.md
+++ b/files/en-us/web/api/ovr_multiview2/framebuffertexturemultiviewovr/index.md
@@ -1,6 +1,7 @@
 ---
 title: OVR_multiview2.framebufferTextureMultiviewOVR()
 slug: Web/API/OVR_multiview2/framebufferTextureMultiviewOVR
+page-type: webgl-extension-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/ovr_multiview2/index.md
+++ b/files/en-us/web/api/ovr_multiview2/index.md
@@ -1,6 +1,7 @@
 ---
 title: OVR_multiview2
 slug: Web/API/OVR_multiview2
+page-type: webgl-extension
 tags:
   - API
   - WebGL

--- a/files/en-us/web/api/webgl_color_buffer_float/index.md
+++ b/files/en-us/web/api/webgl_color_buffer_float/index.md
@@ -1,6 +1,7 @@
 ---
 title: WEBGL_color_buffer_float
 slug: Web/API/WEBGL_color_buffer_float
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/webgl_compressed_texture_astc/getsupportedprofiles/index.md
+++ b/files/en-us/web/api/webgl_compressed_texture_astc/getsupportedprofiles/index.md
@@ -1,6 +1,7 @@
 ---
 title: WEBGL_compressed_texture_astc.getSupportedProfiles()
 slug: Web/API/WEBGL_compressed_texture_astc/getSupportedProfiles
+page-type: webgl-extension-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl_compressed_texture_astc/index.md
+++ b/files/en-us/web/api/webgl_compressed_texture_astc/index.md
@@ -1,6 +1,7 @@
 ---
 title: WEBGL_compressed_texture_astc
 slug: Web/API/WEBGL_compressed_texture_astc
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/webgl_compressed_texture_etc/index.md
+++ b/files/en-us/web/api/webgl_compressed_texture_etc/index.md
@@ -1,6 +1,7 @@
 ---
 title: WEBGL_compressed_texture_etc
 slug: Web/API/WEBGL_compressed_texture_etc
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/webgl_compressed_texture_etc1/index.md
+++ b/files/en-us/web/api/webgl_compressed_texture_etc1/index.md
@@ -1,6 +1,7 @@
 ---
 title: WEBGL_compressed_texture_etc1
 slug: Web/API/WEBGL_compressed_texture_etc1
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/webgl_compressed_texture_pvrtc/index.md
+++ b/files/en-us/web/api/webgl_compressed_texture_pvrtc/index.md
@@ -1,6 +1,7 @@
 ---
 title: WEBGL_compressed_texture_pvrtc
 slug: Web/API/WEBGL_compressed_texture_pvrtc
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/webgl_compressed_texture_s3tc/index.md
+++ b/files/en-us/web/api/webgl_compressed_texture_s3tc/index.md
@@ -1,6 +1,7 @@
 ---
 title: WEBGL_compressed_texture_s3tc
 slug: Web/API/WEBGL_compressed_texture_s3tc
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/webgl_compressed_texture_s3tc_srgb/index.md
+++ b/files/en-us/web/api/webgl_compressed_texture_s3tc_srgb/index.md
@@ -1,6 +1,7 @@
 ---
 title: WEBGL_compressed_texture_s3tc_srgb
 slug: Web/API/WEBGL_compressed_texture_s3tc_srgb
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/webgl_debug_renderer_info/index.md
+++ b/files/en-us/web/api/webgl_debug_renderer_info/index.md
@@ -1,6 +1,7 @@
 ---
 title: WEBGL_debug_renderer_info
 slug: Web/API/WEBGL_debug_renderer_info
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/webgl_debug_shaders/gettranslatedshadersource/index.md
+++ b/files/en-us/web/api/webgl_debug_shaders/gettranslatedshadersource/index.md
@@ -1,6 +1,7 @@
 ---
 title: WEBGL_debug_shaders.getTranslatedShaderSource()
 slug: Web/API/WEBGL_debug_shaders/getTranslatedShaderSource
+page-type: webgl-extension-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl_debug_shaders/index.md
+++ b/files/en-us/web/api/webgl_debug_shaders/index.md
@@ -1,6 +1,7 @@
 ---
 title: WEBGL_debug_shaders
 slug: Web/API/WEBGL_debug_shaders
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/webgl_depth_texture/index.md
+++ b/files/en-us/web/api/webgl_depth_texture/index.md
@@ -1,6 +1,7 @@
 ---
 title: WEBGL_depth_texture
 slug: Web/API/WEBGL_depth_texture
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/webgl_draw_buffers/drawbufferswebgl/index.md
+++ b/files/en-us/web/api/webgl_draw_buffers/drawbufferswebgl/index.md
@@ -1,6 +1,7 @@
 ---
 title: WEBGL_draw_buffers.drawBuffersWEBGL()
 slug: Web/API/WEBGL_draw_buffers/drawBuffersWEBGL
+page-type: webgl-extension-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl_draw_buffers/index.md
+++ b/files/en-us/web/api/webgl_draw_buffers/index.md
@@ -1,6 +1,7 @@
 ---
 title: WEBGL_draw_buffers
 slug: Web/API/WEBGL_draw_buffers
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/webgl_lose_context/index.md
+++ b/files/en-us/web/api/webgl_lose_context/index.md
@@ -1,6 +1,7 @@
 ---
 title: WEBGL_lose_context
 slug: Web/API/WEBGL_lose_context
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/webgl_lose_context/losecontext/index.md
+++ b/files/en-us/web/api/webgl_lose_context/losecontext/index.md
@@ -1,6 +1,7 @@
 ---
 title: WEBGL_lose_context.loseContext()
 slug: Web/API/WEBGL_lose_context/loseContext
+page-type: webgl-extension-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl_lose_context/restorecontext/index.md
+++ b/files/en-us/web/api/webgl_lose_context/restorecontext/index.md
@@ -1,6 +1,7 @@
 ---
 title: WEBGL_lose_context.restoreContext()
 slug: Web/API/WEBGL_lose_context/restoreContext
+page-type: webgl-extension-method
 tags:
   - API
   - Method

--- a/files/en-us/web/api/webgl_multi_draw/index.md
+++ b/files/en-us/web/api/webgl_multi_draw/index.md
@@ -1,6 +1,7 @@
 ---
 title: WEBGL_multi_draw
 slug: Web/API/WEBGL_multi_draw
+page-type: webgl-extension
 tags:
   - API
   - Reference

--- a/files/en-us/web/api/webgl_multi_draw/multidrawarraysinstancedwebgl/index.md
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawarraysinstancedwebgl/index.md
@@ -1,6 +1,7 @@
 ---
 title: WEBGL_multi_draw.multiDrawArraysInstancedWEBGL()
 slug: Web/API/WEBGL_multi_draw/multiDrawArraysInstancedWEBGL
+page-type: webgl-extension-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/webgl_multi_draw/multidrawarrayswebgl/index.md
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawarrayswebgl/index.md
@@ -1,6 +1,7 @@
 ---
 title: WEBGL_multi_draw.multiDrawArraysWEBGL()
 slug: Web/API/WEBGL_multi_draw/multiDrawArraysWEBGL
+page-type: webgl-extension-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/webgl_multi_draw/multidrawelementsinstancedwebgl/index.md
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawelementsinstancedwebgl/index.md
@@ -1,6 +1,7 @@
 ---
 title: WEBGL_multi_draw.multiDrawElementsInstancedWEBGL()
 slug: Web/API/WEBGL_multi_draw/multiDrawElementsInstancedWEBGL
+page-type: webgl-extension-method
 tags:
   - Method
   - Reference

--- a/files/en-us/web/api/webgl_multi_draw/multidrawelementswebgl/index.md
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawelementswebgl/index.md
@@ -1,6 +1,7 @@
 ---
 title: WEBGL_multi_draw.multiDrawElementsWEBGL()
 slug: Web/API/WEBGL_multi_draw/multiDrawElementsWEBGL
+page-type: webgl-extension-method
 tags:
   - Method
   - Reference


### PR DESCRIPTION
This PR adds `webgl-extension` and `webgl-extension-method` page types, as discussed in https://github.com/mdn/content/issues/16255#issuecomment-1146300327.