### PR TITLE
Fix typo in File() syntax section

### DIFF
--- a/files/en-us/web/api/file/file/index.md
+++ b/files/en-us/web/api/file/file/index.md
@@ -17,7 +17,7 @@ object instance.
 ## Syntax
 
 ```js
-new File(bits, name
+new File(bits, name)
 new File(bits, name, options)
 ```
 


### PR DESCRIPTION
Fixes a typo.