### PR TITLE
Move IE API pages, part 1

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -7819,6 +7819,7 @@
 /en-US/docs/Web/API/Document/mozCancelFullScreen	/en-US/docs/Web/API/Document/exitFullscreen
 /en-US/docs/Web/API/Document/mozFullScreenElement	/en-US/docs/Web/API/Document/fullscreenElement
 /en-US/docs/Web/API/Document/mozFullScreenEnabled	/en-US/docs/Web/API/Document/fullscreenEnabled
+/en-US/docs/Web/API/Document/msthumbnailclick	/en-US/docs/Web/API/Document/msthumbnailclick_event
 /en-US/docs/Web/API/Document/namespaceURI	/en-US/docs/Web/API/Element/namespaceURI
 /en-US/docs/Web/API/Document/onabort	/en-US/docs/Web/API/HTMLMediaElement/abort_event
 /en-US/docs/Web/API/Document/onafterscriptexecute	/en-US/docs/Web/API/Document/afterscriptexecute_event
@@ -8694,6 +8695,7 @@
 /en-US/docs/Web/API/MsAudioDeviceType	/en-US/docs/Web/API/HTMLAudioElement/msAudioDeviceType
 /en-US/docs/Web/API/MsClearEffects	/en-US/docs/Web/API/HTMLMediaElement/msClearEffects
 /en-US/docs/Web/API/MsExtendedCode	/en-US/docs/Web/API/MediaError/msExtendedCode
+/en-US/docs/Web/API/MsFirstPaint	/en-US/docs/Web/API/PerformanceTiming/MsFirstPaint
 /en-US/docs/Web/API/MsHorizontalMirror	/en-US/docs/Web/API/HTMLVideoElement/msHorizontalMirror
 /en-US/docs/Web/API/MsInsertAudioEffect	/en-US/docs/Web/API/HTMLMediaElement/msInsertAudioEffect
 /en-US/docs/Web/API/MsInsertVideoEffect	/en-US/docs/Web/API/HTMLVideoElement/msInsertVideoEffect
@@ -10204,9 +10206,13 @@
 /en-US/docs/Web/API/mozRTCSessionDescription/toJSON	/en-US/docs/Web/API/RTCSessionDescription/toJSON
 /en-US/docs/Web/API/msCaching	/en-US/docs/Web/API/XMLHttpRequest/msCaching
 /en-US/docs/Web/API/msCachingEnabled	/en-US/docs/Web/API/XMLHttpRequest/msCachingEnabled
+/en-US/docs/Web/API/msCapsLockWarningOff	/en-US/docs/Web/API/Document/msCapsLockWarningOff
 /en-US/docs/Web/API/msConvertURL	/en-US/docs/Web/API/Event
 /en-US/docs/Web/API/msFrameStep	/en-US/docs/Web/API/HTMLVideoElement/msFrameStep
+/en-US/docs/Web/API/msGetPropertyEnabled	/en-US/docs/Web/API/CSSStyleDeclaration/msGetPropertyEnabled
 /en-US/docs/Web/API/msMatchesSelector	/en-US/docs/Web/API/Element/matches
+/en-US/docs/Web/API/msPutPropertyEnabled	/en-US/docs/Web/API/CSSStyleDeclaration/msPutPropertyEnabled
+/en-US/docs/Web/API/msthumbnailclick	/en-US/docs/Web/API/Document/msthumbnailclick_event
 /en-US/docs/Web/API/mute	/en-US/docs/Web/API/MediaStreamTrack/mute_event
 /en-US/docs/Web/API/navigator.doNotTrack	/en-US/docs/Web/API/Navigator/doNotTrack
 /en-US/docs/Web/API/navigator.geolocation.clearWatch	/en-US/docs/Web/API/Geolocation/clearWatch

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -28479,6 +28479,18 @@
       "Qantas94Heavy"
     ]
   },
+  "Web/API/CSSStyleDeclaration/msGetPropertyEnabled": {
+    "modified": "2019-03-18T21:28:41.337Z",
+    "contributors": [
+      "mattwojo"
+    ]
+  },
+  "Web/API/CSSStyleDeclaration/msPutPropertyEnabled": {
+    "modified": "2019-03-18T21:31:05.818Z",
+    "contributors": [
+      "mattwojo"
+    ]
+  },
   "Web/API/CSSStyleDeclaration/parentRule": {
     "modified": "2020-12-10T15:02:27.217Z",
     "contributors": [
@@ -35787,6 +35799,18 @@
       "kscarfone",
       "gurdev_singh",
       "Sheppy"
+    ]
+  },
+  "Web/API/Document/msCapsLockWarningOff": {
+    "modified": "2019-03-18T21:29:49.753Z",
+    "contributors": [
+      "mattwojo"
+    ]
+  },
+  "Web/API/Document/msthumbnailclick_event": {
+    "modified": "2019-03-18T21:29:51.663Z",
+    "contributors": [
+      "mattwojo"
     ]
   },
   "Web/API/Document/open": {
@@ -58019,13 +58043,6 @@
       "Masayuki"
     ]
   },
-  "Web/API/MsFirstPaint": {
-    "modified": "2019-03-18T21:32:14.582Z",
-    "contributors": [
-      "mattwojo",
-      "erikadoyle"
-    ]
-  },
   "Web/API/MsGraphicsTrustStatus": {
     "modified": "2019-03-18T21:32:30.054Z",
     "contributors": [
@@ -63671,6 +63688,13 @@
       "ocke",
       "trevorh",
       "teoli"
+    ]
+  },
+  "Web/API/PerformanceTiming/MsFirstPaint": {
+    "modified": "2019-03-18T21:32:14.582Z",
+    "contributors": [
+      "mattwojo",
+      "erikadoyle"
     ]
   },
   "Web/API/PerformanceTiming/connectEnd": {
@@ -87904,26 +87928,8 @@
       "jpmedley"
     ]
   },
-  "Web/API/msCapsLockWarningOff": {
-    "modified": "2019-03-18T21:29:49.753Z",
-    "contributors": [
-      "mattwojo"
-    ]
-  },
-  "Web/API/msGetPropertyEnabled": {
-    "modified": "2019-03-18T21:28:41.337Z",
-    "contributors": [
-      "mattwojo"
-    ]
-  },
   "Web/API/msGetRegionContent": {
     "modified": "2019-03-18T21:28:47.734Z",
-    "contributors": [
-      "mattwojo"
-    ]
-  },
-  "Web/API/msPutPropertyEnabled": {
-    "modified": "2019-03-18T21:31:05.818Z",
     "contributors": [
       "mattwojo"
     ]
@@ -87943,12 +87949,6 @@
   },
   "Web/API/mssitemodejumplistitemremoved": {
     "modified": "2019-03-18T21:30:05.132Z",
-    "contributors": [
-      "mattwojo"
-    ]
-  },
-  "Web/API/msthumbnailclick": {
-    "modified": "2019-03-18T21:29:51.663Z",
     "contributors": [
       "mattwojo"
     ]

--- a/files/en-us/web/api/cssstyledeclaration/msgetpropertyenabled/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/msgetpropertyenabled/index.md
@@ -1,5 +1,5 @@
 ---
-title: msGetPropertyEnabled
+title: CSSStyleDeclaration.msGetPropertyEnabled()
 slug: Web/API/CSSStyleDeclaration/msGetPropertyEnabled
 page-type: web-api-instance-method
 tags:

--- a/files/en-us/web/api/cssstyledeclaration/msgetpropertyenabled/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/msgetpropertyenabled/index.md
@@ -4,6 +4,8 @@ slug: Web/API/CSSStyleDeclaration/msGetPropertyEnabled
 page-type: web-api-instance-method
 tags:
   - msGetPropertyEnabled
+  - Method
+  - Non-standard
 ---
 {{APIRef("CSSOM")}}
 

--- a/files/en-us/web/api/cssstyledeclaration/msgetpropertyenabled/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/msgetpropertyenabled/index.md
@@ -1,14 +1,15 @@
 ---
 title: msGetPropertyEnabled
-slug: Web/API/msGetPropertyEnabled
+slug: Web/API/CSSStyleDeclaration/msGetPropertyEnabled
+page-type: web-api-instance-method
 tags:
   - msGetPropertyEnabled
 ---
-{{APIRef("HTMLMediaElement")}}
+{{APIRef("CSSOM")}}
 
 {{Non-standard_header()}}
 
-The **`msGetPropertyEnabled`** returns whether a given property in the style object is enabled.
+The **`msGetPropertyEnabled()`** method returns whether a given property in the style object is enabled.
 
 This proprietary method is specific to Internet Explorer browser.
 

--- a/files/en-us/web/api/cssstyledeclaration/msputpropertyenabled/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/msputpropertyenabled/index.md
@@ -1,6 +1,6 @@
 ---
 title: msPutPropertyEnabled
-slug: Web/API/msPutPropertyEnabled
+slug: Web/API/CSSStyleDeclaration/msPutPropertyEnabled
 page-type: web-api-instance-method
 tags:
   - msPutPropertyEnabled

--- a/files/en-us/web/api/cssstyledeclaration/msputpropertyenabled/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/msputpropertyenabled/index.md
@@ -4,6 +4,8 @@ slug: Web/API/CSSStyleDeclaration/msPutPropertyEnabled
 page-type: web-api-instance-method
 tags:
   - msPutPropertyEnabled
+  - Method
+  - Non-standard
 ---
 {{APIRef("HTMLMediaElement")}}
 

--- a/files/en-us/web/api/cssstyledeclaration/msputpropertyenabled/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/msputpropertyenabled/index.md
@@ -1,6 +1,7 @@
 ---
 title: msPutPropertyEnabled
 slug: Web/API/msPutPropertyEnabled
+page-type: web-api-instance-method
 tags:
   - msPutPropertyEnabled
 ---
@@ -8,7 +9,7 @@ tags:
 
 {{Non-standard_header()}}
 
-The **`msPutPropertyEnabled`** method sets whether a given property in the style object is enabled or disabled.
+The **`msPutPropertyEnabled()`** method sets whether a given property in the style object is enabled or disabled.
 
 This proprietary method is specific to Internet Explorer and Microsoft Edge.
 

--- a/files/en-us/web/api/cssstyledeclaration/msputpropertyenabled/index.md
+++ b/files/en-us/web/api/cssstyledeclaration/msputpropertyenabled/index.md
@@ -1,5 +1,5 @@
 ---
-title: msPutPropertyEnabled
+title: CSSStyleDeclaration.msPutPropertyEnabled()
 slug: Web/API/CSSStyleDeclaration/msPutPropertyEnabled
 page-type: web-api-instance-method
 tags:

--- a/files/en-us/web/api/document/mscapslockwarningoff/index.md
+++ b/files/en-us/web/api/document/mscapslockwarningoff/index.md
@@ -2,6 +2,9 @@
 title: Document.msCapsLockWarningOff
 slug: Web/API/Document/msCapsLockWarningOff
 page-type: web-api-instance-property
+tags:
+  - Property
+  - Non-standard
 ---
 {{APIRef("DOM")}}
 

--- a/files/en-us/web/api/document/mscapslockwarningoff/index.md
+++ b/files/en-us/web/api/document/mscapslockwarningoff/index.md
@@ -1,8 +1,9 @@
 ---
 title: msCapsLockWarningOff
-slug: Web/API/msCapsLockWarningOff
+slug: Web/API/Document/msCapsLockWarningOff
+page-type: web-api-instance-property
 ---
-{{APIRef("HTML DOM")}}
+{{APIRef("DOM")}}
 
 {{Non-standard_header()}}
 

--- a/files/en-us/web/api/document/mscapslockwarningoff/index.md
+++ b/files/en-us/web/api/document/mscapslockwarningoff/index.md
@@ -1,5 +1,5 @@
 ---
-title: msCapsLockWarningOff
+title: Document.msCapsLockWarningOff
 slug: Web/API/Document/msCapsLockWarningOff
 page-type: web-api-instance-property
 ---

--- a/files/en-us/web/api/document/msthumbnailclick_event/index.md
+++ b/files/en-us/web/api/document/msthumbnailclick_event/index.md
@@ -4,6 +4,8 @@ slug: Web/API/Document/msthumbnailclick_event
 page-type: web-api-event
 tags:
   - msthumbnailclick
+  - Event
+  - Non-standard
 ---
 {{APIRef("DOM")}}
 

--- a/files/en-us/web/api/document/msthumbnailclick_event/index.md
+++ b/files/en-us/web/api/document/msthumbnailclick_event/index.md
@@ -1,10 +1,11 @@
 ---
 title: msthumbnailclick event
-slug: Web/API/msthumbnailclick
+slug: Web/API/Document/msthumbnailclick_event
+page-type: web-api-event
 tags:
   - msthumbnailclick
 ---
-{{APIRef("HTMLMediaElement")}}
+{{APIRef("DOM")}}
 
 {{Non-standard_header()}}
 

--- a/files/en-us/web/api/document/msthumbnailclick_event/index.md
+++ b/files/en-us/web/api/document/msthumbnailclick_event/index.md
@@ -1,5 +1,5 @@
 ---
-title: msthumbnailclick event
+title: 'Document: msthumbnailclick event'
 slug: Web/API/Document/msthumbnailclick_event
 page-type: web-api-event
 tags:

--- a/files/en-us/web/api/msgestureevent/index.md
+++ b/files/en-us/web/api/msgestureevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: MSGestureEvent
 slug: Web/API/MSGestureEvent
+page-type: web-api-interface
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/msmanipulationevent/index.md
+++ b/files/en-us/web/api/msmanipulationevent/index.md
@@ -12,7 +12,7 @@ tags:
   - Non-standard
   - Reference
 ---
-{{APIRef("Microsoft Extensions")}}{{Non-standard_Header}}
+{{APIRef("UI Events")}}{{Non-standard_Header}}
 
 **`MSManipulationEvent`** provides contextual information when contact is made to the screen and an element is manipulated.
 

--- a/files/en-us/web/api/msmanipulationevent/index.md
+++ b/files/en-us/web/api/msmanipulationevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: MSManipulationEvent
 slug: Web/API/MSManipulationEvent
+page-type: web-api-interface
 tags:
   - API
   - API:Microsoft Extensions

--- a/files/en-us/web/api/msmanipulationevent/initmsmanipulationevent/index.md
+++ b/files/en-us/web/api/msmanipulationevent/initmsmanipulationevent/index.md
@@ -11,7 +11,7 @@ tags:
   - Reference
   - initMSManipulationEvent
 ---
-{{APIRef("Microsoft Extensions")}}{{Non-standard_Header}}{{Deprecated_Header}}
+{{APIRef("UI Events")}}{{Non-standard_Header}}{{Deprecated_Header}}
 
 The **`initMSManipulationEvent`** method is used to create a {{DOMxRef("MSManipulationEvent")}} that can be called from JavaScript.
 

--- a/files/en-us/web/api/msmanipulationevent/initmsmanipulationevent/index.md
+++ b/files/en-us/web/api/msmanipulationevent/initmsmanipulationevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: MSManipulationEvent.initMSManipulationEvent()
 slug: Web/API/MSManipulationEvent/initMSManipulationEvent
+page-type: web-api-instance-method
 tags:
   - API
   - API:Microsoft Extensions

--- a/files/en-us/web/api/mssitemodeevent/index.md
+++ b/files/en-us/web/api/mssitemodeevent/index.md
@@ -1,6 +1,7 @@
 ---
 title: MSSiteModeEvent
 slug: Web/API/MSSiteModeEvent
+page-type: web-api-interface
 ---
 {{Non-standard_header()}}
 

--- a/files/en-us/web/api/mssitemodeevent/index.md
+++ b/files/en-us/web/api/mssitemodeevent/index.md
@@ -3,7 +3,7 @@ title: MSSiteModeEvent
 slug: Web/API/MSSiteModeEvent
 page-type: web-api-interface
 ---
-{{Non-standard_header()}}
+{{APIRef("UI Events")}}{{Non-standard_header()}}
 
 **`MSSiteModeEvent`** provides event properties that are specific to pinned site events.
 

--- a/files/en-us/web/api/mswriteprofilermark/index.md
+++ b/files/en-us/web/api/mswriteprofilermark/index.md
@@ -1,6 +1,7 @@
 ---
 title: msWriteProfilerMark
 slug: Web/API/msWriteProfilerMark
+page-type: web-api-global-function
 tags:
   - msWriteProfilerMark
 ---

--- a/files/en-us/web/api/performancetiming/msfirstpaint/index.md
+++ b/files/en-us/web/api/performancetiming/msfirstpaint/index.md
@@ -1,10 +1,11 @@
 ---
 title: msFirstPaint
-slug: Web/API/MsFirstPaint
+slug: Web/API/PerformanceTiming/MsFirstPaint
+page-type: web-api-instance-property
 tags:
   - msFirstPaint
 ---
-{{APIRef("DOM")}}
+{{APIRef("Navigation timing API")}}
 
 {{Non-standard_header()}}
 

--- a/files/en-us/web/api/performancetiming/msfirstpaint/index.md
+++ b/files/en-us/web/api/performancetiming/msfirstpaint/index.md
@@ -1,5 +1,5 @@
 ---
-title: msFirstPaint
+title: PerformanceTiming.msFirstPaint
 slug: Web/API/PerformanceTiming/MsFirstPaint
 page-type: web-api-instance-property
 tags:

--- a/files/en-us/web/api/performancetiming/msfirstpaint/index.md
+++ b/files/en-us/web/api/performancetiming/msfirstpaint/index.md
@@ -4,6 +4,8 @@ slug: Web/API/PerformanceTiming/MsFirstPaint
 page-type: web-api-instance-property
 tags:
   - msFirstPaint
+  - Property
+  - Non-standard
 ---
 {{APIRef("Navigation timing API")}}
 


### PR DESCRIPTION
This is the first PR in a series to find homes and therefore page types for the proprietary MS features listed in https://github.com/mdn/content/issues/16255#issuecomment-1146469624.

Please refer to the linked sheet for the choices I've made about the filed changed in this PR. 

I'm trying to keep this pretty minimal and not spend time improving these pages. I just want to give them page types, so we don't have exceptions.