### PR TITLE
Move 4 IE specific props under HTMLMediaElement

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -8700,6 +8700,10 @@
 /en-US/docs/Web/API/MsIsLayoutOptimalForPlayback	/en-US/docs/Web/API/HTMLVideoElement/msIsLayoutOptimalForPlayback
 /en-US/docs/Web/API/MsIsStereo3D	/en-US/docs/Web/API/HTMLVideoElement/msIsStereo3D
 /en-US/docs/Web/API/MsManipulationViewsEnabled	/en-US/docs/Web/API/Touch/MsManipulationViewsEnabled
+/en-US/docs/Web/API/MsPlayToDisabled	/en-US/docs/Web/API/HTMLMediaElement/msPlayToDisabled
+/en-US/docs/Web/API/MsPlayToPreferredSourceUri	/en-US/docs/Web/API/HTMLMediaElement/msPlayToPreferredSourceURI
+/en-US/docs/Web/API/MsPlayToPrimary	/en-US/docs/Web/API/HTMLMediaElement/msPlayToPrimary
+/en-US/docs/Web/API/MsPlayToSource	/en-US/docs/Web/API/HTMLMediaElement/msPlayToSource
 /en-US/docs/Web/API/MsSetVideoRectangle	/en-US/docs/Web/API/HTMLVideoElement/msSetVideoRectangle
 /en-US/docs/Web/API/MsStereo3DPackingMode	/en-US/docs/Web/API/HTMLVideoElement/msStereo3DPackingMode
 /en-US/docs/Web/API/MsStereo3DRenderMode	/en-US/docs/Web/API/HTMLVideoElement/msStereo3DRenderMode

--- a/files/en-us/_wikihistory.json
+++ b/files/en-us/_wikihistory.json
@@ -49059,6 +49059,34 @@
       "erikadoyle"
     ]
   },
+  "Web/API/HTMLMediaElement/msPlayToDisabled": {
+    "modified": "2019-03-18T21:32:36.239Z",
+    "contributors": [
+      "mattwojo",
+      "erikadoyle"
+    ]
+  },
+  "Web/API/HTMLMediaElement/msPlayToPreferredSourceURI": {
+    "modified": "2019-03-18T21:32:28.825Z",
+    "contributors": [
+      "mattwojo",
+      "erikadoyle"
+    ]
+  },
+  "Web/API/HTMLMediaElement/msPlayToPrimary": {
+    "modified": "2019-03-18T21:32:29.885Z",
+    "contributors": [
+      "mattwojo",
+      "erikadoyle"
+    ]
+  },
+  "Web/API/HTMLMediaElement/msPlayToSource": {
+    "modified": "2019-03-18T21:32:37.509Z",
+    "contributors": [
+      "mattwojo",
+      "erikadoyle"
+    ]
+  },
   "Web/API/HTMLMediaElement/muted": {
     "modified": "2020-10-15T21:38:15.940Z",
     "contributors": [
@@ -58035,34 +58063,6 @@
   },
   "Web/API/MsIsBoxed": {
     "modified": "2019-03-18T21:32:17.989Z",
-    "contributors": [
-      "mattwojo",
-      "erikadoyle"
-    ]
-  },
-  "Web/API/MsPlayToDisabled": {
-    "modified": "2019-03-18T21:32:36.239Z",
-    "contributors": [
-      "mattwojo",
-      "erikadoyle"
-    ]
-  },
-  "Web/API/MsPlayToPreferredSourceUri": {
-    "modified": "2019-03-18T21:32:28.825Z",
-    "contributors": [
-      "mattwojo",
-      "erikadoyle"
-    ]
-  },
-  "Web/API/MsPlayToPrimary": {
-    "modified": "2019-03-18T21:32:29.885Z",
-    "contributors": [
-      "mattwojo",
-      "erikadoyle"
-    ]
-  },
-  "Web/API/MsPlayToSource": {
-    "modified": "2019-03-18T21:32:37.509Z",
     "contributors": [
       "mattwojo",
       "erikadoyle"

--- a/files/en-us/web/api/htmlmediaelement/msplaytodisabled/index.md
+++ b/files/en-us/web/api/htmlmediaelement/msplaytodisabled/index.md
@@ -1,23 +1,19 @@
 ---
-title: msPlayToDisabled
-slug: Web/API/MsPlayToDisabled
+title: HTMLMediaElement.msPlayToDisabled
+slug: Web/API/HTMLMediaElement/msPlayToDisabled
 tags:
   - msPlayToDisabled
+  - Property
+  - Non-standard
 ---
-{{APIRef("DOM")}}
+{{APIRef("HTML DOM")}}
 
-{{Non-standard_header()}}
+{{Non-standard_header}}
 
 **`msPlayToDisabled`** is a read/write property which gets and
 sets if the _PlayTo_ device is enabled or disabled.
 
 This proprietary property is specific to Internet Explorer and Microsoft Edge.
-
-## Syntax
-
-```js
-ptr = object.msPlayToDisabled;
-```
 
 ## Value
 

--- a/files/en-us/web/api/htmlmediaelement/msplaytodisabled/index.md
+++ b/files/en-us/web/api/htmlmediaelement/msplaytodisabled/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.msPlayToDisabled
 slug: Web/API/HTMLMediaElement/msPlayToDisabled
+page-type: api-instance-property
 tags:
   - msPlayToDisabled
   - Property

--- a/files/en-us/web/api/htmlmediaelement/msplaytodisabled/index.md
+++ b/files/en-us/web/api/htmlmediaelement/msplaytodisabled/index.md
@@ -1,7 +1,7 @@
 ---
 title: HTMLMediaElement.msPlayToDisabled
 slug: Web/API/HTMLMediaElement/msPlayToDisabled
-page-type: api-instance-property
+page-type: web-api-instance-property
 tags:
   - msPlayToDisabled
   - Property

--- a/files/en-us/web/api/htmlmediaelement/msplaytopreferredsourceuri/index.md
+++ b/files/en-us/web/api/htmlmediaelement/msplaytopreferredsourceuri/index.md
@@ -1,7 +1,7 @@
 ---
 title: HTMLMediaElement.msPlayToPreferredSourceUri
 slug: Web/API/HTMLMediaElement/msPlayToPreferredSourceURI
-page-type: api-instance-property
+page-type: web-api-instance-property
 tags:
   - Non-standard
   - Property

--- a/files/en-us/web/api/htmlmediaelement/msplaytopreferredsourceuri/index.md
+++ b/files/en-us/web/api/htmlmediaelement/msplaytopreferredsourceuri/index.md
@@ -1,8 +1,11 @@
 ---
-title: msPlayToPreferredSourceUri
-slug: Web/API/MsPlayToPreferredSourceUri
+title: HTMLMediaElement.msPlayToPreferredSourceUri
+slug: Web/API/HTMLMediaElement/msPlayToPreferredSourceURI
+tags:
+  - Non-standard
+  - Property
 ---
-{{APIRef("DOM")}}
+{{APIRef("HTML DOM")}}
 
 {{Non-standard_header()}}
 
@@ -13,15 +16,9 @@ location, such as a cloud media server.
 
 This proprietary property is specific to Internet Explorer and Microsoft Edge.
 
-## Syntax
-
-```js
-ptr = object.msPlayToPreferredSourceUri;
-```
-
 ## Value
 
-**`msPlayToPreferredSourceUri`** enables a _PlayTo_
+`msPlayToPreferredSourceUri` enables a _PlayTo_
 reference (a URI or URL) for streaming content on the _PlayTo_ target device from
 a different location, such as a cloud media server. This enables web pages and Microsoft
 Store apps to play Digital Rights Management (DRM) protected content. The app specifies

--- a/files/en-us/web/api/htmlmediaelement/msplaytopreferredsourceuri/index.md
+++ b/files/en-us/web/api/htmlmediaelement/msplaytopreferredsourceuri/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.msPlayToPreferredSourceUri
 slug: Web/API/HTMLMediaElement/msPlayToPreferredSourceURI
+page-type: api-instance-property
 tags:
   - Non-standard
   - Property

--- a/files/en-us/web/api/htmlmediaelement/msplaytoprimary/index.md
+++ b/files/en-us/web/api/htmlmediaelement/msplaytoprimary/index.md
@@ -1,10 +1,12 @@
 ---
-title: msPlayToPrimary
-slug: Web/API/MsPlayToPrimary
+title: HTMLMediaElement.msPlayToPrimary
+slug: Web/API/HTMLMediaElement/msPlayToPrimary
 tags:
   - msPlayToPrimary
+  - Non-standard
+  - Property
 ---
-{{APIRef("DOM")}}
+{{APIRef("HTML DOM")}}
 
 {{Non-standard_header()}}
 
@@ -13,28 +15,10 @@ sets the primary DLNA _PlayTo_ device.
 
 This proprietary property is specific to Internet Explorer and Microsoft Edge.
 
-## Syntax
-
-```js
-ptr = object.msPlayToPrimary;
-```
-
 ## Value
 
 Boolean value set to _true_ indicates that the device is the primary DLNA
 _PlayTo_ device, otherwise false.
-
-## Example
-
-```html
-     // Microsoft extensions
-     interface HTMLImageElement : HTMLElement
-     {
-                  attribute boolean msPlayToDisabled;
-                  attribute boolean msPlayToPrimary;
-                  attribute DOMString msPlayToPreferredSourceUri;
-     };
-```
 
 ## See also
 

--- a/files/en-us/web/api/htmlmediaelement/msplaytoprimary/index.md
+++ b/files/en-us/web/api/htmlmediaelement/msplaytoprimary/index.md
@@ -1,7 +1,7 @@
 ---
 title: HTMLMediaElement.msPlayToPrimary
 slug: Web/API/HTMLMediaElement/msPlayToPrimary
-page-type: api-instance-property
+page-type: web-api-instance-property
 tags:
   - msPlayToPrimary
   - Non-standard

--- a/files/en-us/web/api/htmlmediaelement/msplaytoprimary/index.md
+++ b/files/en-us/web/api/htmlmediaelement/msplaytoprimary/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.msPlayToPrimary
 slug: Web/API/HTMLMediaElement/msPlayToPrimary
+page-type: api-instance-property
 tags:
   - msPlayToPrimary
   - Non-standard

--- a/files/en-us/web/api/htmlmediaelement/msplaytosource/index.md
+++ b/files/en-us/web/api/htmlmediaelement/msplaytosource/index.md
@@ -1,10 +1,12 @@
 ---
-title: msPlayToSource
-slug: Web/API/MsPlayToSource
+title: HTMLMediaElement.msPlayToSource
+slug: Web/API/HTMLMediaElement/msPlayToSource
 tags:
   - msPlayToSource
+  - Non-standard
+  - Property
 ---
-{{APIRef("DOM")}}
+{{APIRef("HTML DOM")}}
 
 {{Non-standard_header()}}
 
@@ -13,15 +15,9 @@ source associated with the media element for use by the [`PlayToManager`](https:
 
 This proprietary property is specific to Internet Explorer and Microsoft Edge.
 
-## Syntax
-
-```js
-ptr = object.msPlayToSource;
-```
-
 ## Value
 
-_PlayTo_ is a means through which an app can connect local playback/display for
+_PlayTo_ is a mean through which an app can connect local playback/display for
 audio, video, and img elements to a remote device. For more information, see the [Windows.Media.PlayTo](https://docs.microsoft.com/en-us/uwp/api/windows.media.playto?view=winrt-22000)
 APIs.
 

--- a/files/en-us/web/api/htmlmediaelement/msplaytosource/index.md
+++ b/files/en-us/web/api/htmlmediaelement/msplaytosource/index.md
@@ -18,7 +18,7 @@ This proprietary property is specific to Internet Explorer and Microsoft Edge.
 
 ## Value
 
-_PlayTo_ is a mean through which an app can connect local playback/display for
+_PlayTo_ enables an app can connect local playback/display for
 audio, video, and img elements to a remote device. For more information, see the [Windows.Media.PlayTo](https://docs.microsoft.com/en-us/uwp/api/windows.media.playto?view=winrt-22000)
 APIs.
 

--- a/files/en-us/web/api/htmlmediaelement/msplaytosource/index.md
+++ b/files/en-us/web/api/htmlmediaelement/msplaytosource/index.md
@@ -1,6 +1,7 @@
 ---
 title: HTMLMediaElement.msPlayToSource
 slug: Web/API/HTMLMediaElement/msPlayToSource
+page-type: api-instance-property
 tags:
   - msPlayToSource
   - Non-standard

--- a/files/en-us/web/api/htmlmediaelement/msplaytosource/index.md
+++ b/files/en-us/web/api/htmlmediaelement/msplaytosource/index.md
@@ -1,7 +1,7 @@
 ---
 title: HTMLMediaElement.msPlayToSource
 slug: Web/API/HTMLMediaElement/msPlayToSource
-page-type: api-instance-property
+page-type: web-api-instance-property
 tags:
   - msPlayToSource
   - Non-standard


### PR DESCRIPTION
These properties concern media elements and shouldn't be at the top level. (Part of #16255)