### PR TITLE
Fixed "ES 2O20" digit typo

### DIFF
--- a/files/en-us/web/javascript/reference/statements/export/index.md
+++ b/files/en-us/web/javascript/reference/statements/export/index.md
@@ -55,7 +55,7 @@ export { name1 as default, … };
 
 // Aggregating modules
 export * from …; // does not set the default export
-export * as name1 from …; // ECMAScript® 2O20
+export * as name1 from …; // ECMAScript® 2020
 export { name1, name2, …, nameN } from …;
 export { import1 as name1, import2 as name2, …, nameN } from …;
 export { default, … } from …;


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
In [this article](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/export#syntax) the year is written with an "O" char instead of the digit "0", so I replaced the letter with the digit.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The year is written with inconsistent symbols which is weird and confusing. Some people may mistakenly think that it's actually written with an "O"

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
ECMAscript yearly editions must be written with decimal digits

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
None, AFAIK

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
