### PR TITLE
Remove `var`s from `Uint16array` constructor page

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/uint16array/uint16array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint16array/uint16array/index.md
@@ -69,13 +69,13 @@ constructed with a {{jsxref("Operators/new", "new")}} operator. Calling a
 a {{jsxref("TypeError")}} from now on.
 
 ```js example-bad
-var dv = Uint16Array([1, 2, 3]);
+const dv = Uint16Array([1, 2, 3]);
 // TypeError: calling a builtin Uint16Array constructor
 // without new is forbidden
 ```
 
 ```js example-good
-var dv = new Uint16Array([1, 2, 3]);
+const dv = new Uint16Array([1, 2, 3]);
 ```
 
 ## Examples
@@ -84,28 +84,28 @@ var dv = new Uint16Array([1, 2, 3]);
 
 ```js
 // From a length
-var uint16 = new Uint16Array(2);
+const uint16 = new Uint16Array(2);
 uint16[0] = 42;
 console.log(uint16[0]); // 42
 console.log(uint16.length); // 2
 console.log(uint16.BYTES_PER_ELEMENT); // 2
 
 // From an array
-var arr = new Uint16Array([21,31]);
+const arr = new Uint16Array([21,31]);
 console.log(arr[1]); // 31
 
 // From another TypedArray
-var x = new Uint16Array([21, 31]);
-var y = new Uint16Array(x);
+const x = new Uint16Array([21, 31]);
+const y = new Uint16Array(x);
 console.log(y[0]); // 21
 
 // From an ArrayBuffer
-var buffer = new ArrayBuffer(8);
-var z = new Uint16Array(buffer, 0, 4);
+const buffer = new ArrayBuffer(8);
+const z = new Uint16Array(buffer, 0, 4);
 
 // From an iterable
-var iterable = function*(){ yield* [1,2,3]; }();
-var uint16 = new Uint16Array(iterable);
+const iterable = function*(){ yield* [1,2,3]; }();
+const uint16_from_iterable = new Uint16Array(iterable);
 // Uint16Array[1, 2, 3]
 ```
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Replaces `var` by `const` and changes a variable name to avoid errors.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

Updates per ES6. I noticed these when reviewing at `translated-content` and I thought I would create a PR here to remove `var`.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

This seems related to #16614

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
