### PR TITLE
Array length need not be index of last element + 1

### DIFF
--- a/files/en-us/web/javascript/guide/indexed_collections/index.md
+++ b/files/en-us/web/javascript/guide/indexed_collections/index.md
@@ -137,7 +137,7 @@ let myArray = ['Mango', 'Apple', 'Orange']
 
 At the implementation level, JavaScript's arrays actually store their elements as standard object properties, using the array index as the property name.
 
-The `length` property is special. It always returns the index of the last element plus one. (In the example below, `'Dusty'` is indexed at `30`, so `cats.length` returns `30 + 1`).
+The `length` property is special. Its value is always a positive integer greater than the index of the last element if one exists. (In the example below, `'Dusty'` is indexed at `30`, so `cats.length` returns `30 + 1`).
 
 Remember, JavaScript Array indexes are 0-based: they start at `0`, not `1`. This means that the `length` property will be one more than the highest index stored in the array:
 


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Array length can be much greater than the index of the last element.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The current description is wrong.
Example: `[,] .length == 01` (but no elements), `[0,,].length == 02` (but the last element is at `0`)

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
