### PR TITLE
The value of literalString is not a literal

### DIFF
--- a/files/en-us/web/javascript/reference/operators/instanceof/index.md
+++ b/files/en-us/web/javascript/reference/operators/instanceof/index.md
@@ -100,10 +100,10 @@ The following example shows the behavior of `instanceof` with `String` objects.
 let literalString = 'This is a literal string';
 let stringObject  = new String('String created with constructor');
 
-literalString instanceof String;  // false, string literal is not a String
+literalString instanceof String;  // false, string primitive is not a String
 stringObject  instanceof String;  // true
 
-literalString instanceof Object;  // false, string literal is not an Object
+literalString instanceof Object;  // false, string primitive is not an Object
 stringObject  instanceof Object;  // true
 
 stringObject  instanceof Date;    // false


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The value of a variable initialised with a string literal is a string primitive.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
 A literal is a syntactic term that exists only at parse time.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
