### PR TITLE
Add page types for drag events

### DIFF
--- a/files/en-us/web/api/htmlelement/dragend_event/index.md
+++ b/files/en-us/web/api/htmlelement/dragend_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: dragend event'
 slug: Web/API/HTMLElement/dragend_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/htmlelement/dragenter_event/index.md
+++ b/files/en-us/web/api/htmlelement/dragenter_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: dragenter event'
 slug: Web/API/HTMLElement/dragenter_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/htmlelement/dragleave_event/index.md
+++ b/files/en-us/web/api/htmlelement/dragleave_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: dragleave event'
 slug: Web/API/HTMLElement/dragleave_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/htmlelement/dragover_event/index.md
+++ b/files/en-us/web/api/htmlelement/dragover_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: dragover event'
 slug: Web/API/HTMLElement/dragover_event
+page-type: web-api-event
 tags:
   - API
   - DOM

--- a/files/en-us/web/api/htmlelement/dragstart_event/index.md
+++ b/files/en-us/web/api/htmlelement/dragstart_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: dragstart event'
 slug: Web/API/HTMLElement/dragstart_event
+page-type: web-api-event
 tags:
   - DOM
   - Event

--- a/files/en-us/web/api/htmlelement/drop_event/index.md
+++ b/files/en-us/web/api/htmlelement/drop_event/index.md
@@ -1,6 +1,7 @@
 ---
 title: 'HTMLElement: drop event'
 slug: Web/API/HTMLElement/drop_event
+page-type: web-api-event
 tags:
   - DOM
   - Drag Event


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/16255. Add page types for drag events, which were inexplicably missed.
