### PR TITLE
Add page type for VideoFrame.copyTo

### DIFF
--- a/files/en-us/web/api/videoframe/copyto/index.md
+++ b/files/en-us/web/api/videoframe/copyto/index.md
@@ -1,6 +1,7 @@
 ---
 title: VideoFrame.copyTo()
 slug: Web/API/VideoFrame/copyTo
+page-type: web-api-instance-method
 tags:
   - API
   - Method


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/16255. Add page types for the new VideoFrame.copyTo page.

I really need to add this to the meta-docs...