### PR TITLE
Fix EmbedLiveSample macro heights, part 1

### DIFF
--- a/files/en-us/web/api/abstractrange/index.md
+++ b/files/en-us/web/api/abstractrange/index.md
@@ -167,7 +167,7 @@ We then finish up by calling {{domxref("Range.cloneContents", "cloneContents()")
 
 The result looks like this:
 
-{{EmbedLiveSample("Example", 600, 80)}}
+{{ EmbedLiveSample("Example", 600, 112) }}
 
 ## Specifications
 

--- a/files/en-us/web/api/batterymanager/chargingchange_event/index.md
+++ b/files/en-us/web/api/batterymanager/chargingchange_event/index.md
@@ -46,7 +46,7 @@ navigator.getBattery().then(battery => {
 });
 ```
 
-{{ EmbedLiveSample('Example', '100%', 40) }}
+{{ EmbedLiveSample('Example', '100%', 100) }}
 
 ## Specifications
 

--- a/files/en-us/web/api/batterymanager/chargingtimechange_event/index.md
+++ b/files/en-us/web/api/batterymanager/chargingtimechange_event/index.md
@@ -47,7 +47,7 @@ navigator.getBattery().then(battery => {
 });
 ```
 
-{{ EmbedLiveSample('Example', '100%', 40) }}
+{{ EmbedLiveSample('Example', '100%', 100) }}
 
 ## Specifications
 

--- a/files/en-us/web/api/batterymanager/dischargingtimechange_event/index.md
+++ b/files/en-us/web/api/batterymanager/dischargingtimechange_event/index.md
@@ -47,7 +47,7 @@ navigator.getBattery().then(battery => {
 });
 ```
 
-{{ EmbedLiveSample('Example', '100%', 40) }}
+{{ EmbedLiveSample('Example', '100%', 100) }}
 
 ## Specifications
 

--- a/files/en-us/web/api/batterymanager/levelchange_event/index.md
+++ b/files/en-us/web/api/batterymanager/levelchange_event/index.md
@@ -54,7 +54,7 @@ navigator.getBattery().then(battery => {
 });
 ```
 
-{{ EmbedLiveSample('Example', '100%', 40) }}
+{{ EmbedLiveSample('Example', '100%', 100) }}
 
 ## Specifications
 

--- a/files/en-us/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
@@ -65,7 +65,7 @@ draw();
 
 The result looks like this:
 
-{{EmbedLiveSample("A_fillStyle_example", 160, 160, "canvas_fillstyle.png")}}
+{{ EmbedLiveSample("A_fillStyle_example", 160, 198, "canvas_fillstyle.png") }}
 
 ### A `strokeStyle` example
 
@@ -96,7 +96,7 @@ draw();
 
 The result looks like this:
 
-{{EmbedLiveSample("A_strokeStyle_example", "180", "180", "canvas_strokestyle.png")}}
+{{ EmbedLiveSample("A_strokeStyle_example", "180", 198, "canvas_strokestyle.png") }}
 
 ## Transparency
 
@@ -156,7 +156,7 @@ function draw() {
 draw();
 ```
 
-{{EmbedLiveSample("A_globalAlpha_example", "180", "180", "canvas_globalalpha.png")}}
+{{ EmbedLiveSample("A_globalAlpha_example", "180", 198, "canvas_globalalpha.png") }}
 
 ### An example using `rgba()`
 
@@ -194,7 +194,7 @@ function draw() {
 draw();
 ```
 
-{{EmbedLiveSample("An_example_using_rgba", "180", "180", "canvas_rgba.png")}}
+{{ EmbedLiveSample("An_example_using_rgba", "180", 198, "canvas_rgba.png") }}
 
 ## Line styles
 
@@ -246,7 +246,7 @@ function draw() {
 draw();
 ```
 
-{{EmbedLiveSample("A_lineWidth_example", "180", "180", "canvas_linewidth.png")}}
+{{ EmbedLiveSample("A_lineWidth_example", "180", 198, "canvas_linewidth.png") }}
 
 Obtaining crisp lines requires understanding how paths are stroked. In the images below, the grid represents the canvas coordinate grid. The squares between gridlines are actual on-screen pixels. In the first grid image below, a rectangle from (2,1) to (5,5) is filled. The entire area between them (light red) falls on pixel boundaries, so the resulting filled rectangle will have crisp edges.
 
@@ -314,7 +314,7 @@ function draw() {
 draw();
 ```
 
-{{EmbedLiveSample("A_lineCap_example", "180", "180", "Canvas_linecap.png")}}
+{{ EmbedLiveSample("A_lineCap_example", "180", 198, "Canvas_linecap.png") }}
 
 ### A `lineJoin` example
 
@@ -357,7 +357,7 @@ function draw() {
 draw();
 ```
 
-{{EmbedLiveSample("A_lineJoin_example", "180", "180", "Canvas_linejoin.png")}}
+{{ EmbedLiveSample("A_lineJoin_example", "180", 198, "Canvas_linejoin.png") }}
 
 ### A demo of the `miterLimit` property
 
@@ -432,7 +432,7 @@ document.getElementById('miterLimit').value = document.getElementById('canvas').
 draw();
 ```
 
-{{EmbedLiveSample("A_demo_of_the_miterLimit_property", "400", "180", "canvas_miterlimit.png")}}
+{{ EmbedLiveSample("A_demo_of_the_miterLimit_property", "400", 204, "canvas_miterlimit.png") }}
 
 ### Using line dashes
 
@@ -467,7 +467,7 @@ function march() {
 march();
 ```
 
-{{EmbedLiveSample("Using_line_dashes", "120", "120", "marching-ants.png")}}
+{{ EmbedLiveSample("Using_line_dashes", "120", 158, "marching-ants.png") }}
 
 ## Gradients
 
@@ -542,7 +542,7 @@ The first is a background gradient. As you can see, we assigned two colors at th
 
 In the second gradient, we didn't assign the starting color (at position 0.0) since it wasn't strictly necessary, because it will automatically assume the color of the next color stop. Therefore, assigning the black color at position 0.5 automatically makes the gradient, from the start to this stop, black.
 
-{{EmbedLiveSample("A_createLinearGradient_example", "180", "180", "canvas_lineargradient.png")}}
+{{ EmbedLiveSample("A_createLinearGradient_example", "180", 198, "canvas_lineargradient.png") }}
 
 ### A `createRadialGradient` example
 
@@ -597,7 +597,7 @@ In this case, we've offset the starting point slightly from the end point to ach
 
 The last color stop in each of the four gradients uses a fully transparent color. If you want to have a nice transition from this to the previous color stop, both colors should be equal. This isn't very obvious from the code because it uses two different CSS color methods as a demonstration, but in the first gradient `#019F62 = rgba(1,159,98,1)`.
 
-{{EmbedLiveSample("A_createRadialGradient_example", "180", "180", "canvas_radialgradient.png")}}
+{{ EmbedLiveSample("A_createRadialGradient_example", "180", 198, "canvas_radialgradient.png") }}
 
 ### A `createConicGradient` example
 
@@ -643,7 +643,7 @@ The first gradient is positioned in the center of the first rectangle and moves 
 
 The second gradient is also positioned at the center of it's second rectangle. This one has multiple color stops, alternating from black to white at each quarter of the rotation. This gives us the checkered effect.
 
-{{EmbedLiveSample("A_createConicGradient_example", "180", "180", "canvas_conicgrad.png")}}
+{{ EmbedLiveSample("A_createConicGradient_example", "180", 198, "canvas_conicgrad.png") }}
 
 ## Patterns
 
@@ -703,7 +703,7 @@ function draw() {
 draw();
 ```
 
-{{EmbedLiveSample("A_createPattern_example", "180", "180", "canvas_createpattern.png")}}
+{{ EmbedLiveSample("A_createPattern_example", "180", 198, "canvas_createpattern.png") }}
 
 ## Shadows
 
@@ -753,7 +753,7 @@ function draw() {
 draw();
 ```
 
-{{EmbedLiveSample("A_shadowed_text_example", "180", "100", "shadowed-string.png")}}
+{{ EmbedLiveSample("A_shadowed_text_example", "180", 128, "shadowed-string.png") }}
 
 We will look at the `font` property and `fillText` method in the next chapter about [drawing text](/en-US/docs/Web/API/Canvas_API/Tutorial/Drawing_text).
 
@@ -786,6 +786,6 @@ function draw() {
 draw();
 ```
 
-{{EmbedLiveSample("Canvas_fill_rules", "110", "110", "fill-rule.png")}}
+{{ EmbedLiveSample("Canvas_fill_rules", "110", 148,  "fill-rule.png") }}
 
 {{PreviousNext("Web/API/Canvas_API/Tutorial/Drawing_shapes", "Web/API/Canvas_API/Tutorial/Drawing_text")}}

--- a/files/en-us/web/api/canvas_api/tutorial/basic_usage/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_usage/index.md
@@ -115,7 +115,7 @@ The script includes a function called `draw()`, which is executed once the page 
 
 Here is how a template would look in action. As shown here, it is initially blank.
 
-{{EmbedLiveSample("A_skeleton_template", 160, 160)}}
+{{ EmbedLiveSample("A_skeleton_template", 160, 200) }}
 
 ## A simple example
 
@@ -149,6 +149,6 @@ To begin, let's take a look at a simple example that draws two intersecting rect
 
 This example looks like this:
 
-{{EmbedLiveSample("A_simple_example", 160, 160, "canvas_ex1.png")}}
+{{ EmbedLiveSample("A_simple_example", 160, 198, "canvas_ex1.png") }}
 
 {{PreviousNext("Web/API/Canvas_API/Tutorial", "Web/API/Canvas_API/Tutorial/Drawing_shapes")}}

--- a/files/en-us/web/api/canvas_api/tutorial/drawing_shapes/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/drawing_shapes/index.md
@@ -65,7 +65,7 @@ function draw() {
 
 This example's output is shown below.
 
-{{EmbedLiveSample("Rectangular_shape_example", 160, 160, "canvas_rect.png")}}
+{{ EmbedLiveSample("Rectangular_shape_example", 160, 198, "canvas_rect.png") }}
 
 The `fillRect()` function draws a large black square 100 pixels on each side. The `clearRect()` function then erases a 60x60 pixel square from the center, and then `strokeRect()` is called to create a rectangular outline 50x50 pixels within the cleared square.
 
@@ -133,7 +133,7 @@ function draw() {
 
 The result looks like this:
 
-{{EmbedLiveSample("Drawing_a_triangle", 110, 110, "triangle.png")}}
+{{ EmbedLiveSample("Drawing_a_triangle", 110, 148, "triangle.png") }}
 
 ### Moving the pen
 
@@ -175,7 +175,7 @@ function draw() {
 
 The result looks like this:
 
-{{EmbedLiveSample("Moving_the_pen", 160, 160, "canvas_smiley.png")}}
+{{ EmbedLiveSample("Moving_the_pen", 160, 198, "canvas_smiley.png") }}
 
 If you'd like to see the connecting lines, you can remove the lines that call `moveTo()`.
 
@@ -226,7 +226,7 @@ function draw() {
 
 This starts by calling `beginPath()` to start a new shape path. We then use the `moveTo()` method to move the starting point to the desired position. Below this, two lines are drawn which make up two sides of the triangle.
 
-{{EmbedLiveSample("Lines", 160, 160, "canvas_lineto.png")}}
+{{ EmbedLiveSample("Lines", 160, 198, "canvas_lineto.png") }}
 
 You'll notice the difference between the filled and stroked triangle. This is, as mentioned above, because shapes are automatically closed when a path is filled, but not when they are stroked. If we left out the `closePath()` for the stroked triangle, only two lines would have been drawn, not a complete triangle.
 
@@ -290,7 +290,7 @@ function draw() {
 }
 ```
 
-{{EmbedLiveSample("Arcs", 160, 210, "canvas_arc.png")}}
+{{ EmbedLiveSample("Arcs", 160, 248, "canvas_arc.png") }}
 
 ### Bezier and quadratic curves
 
@@ -342,7 +342,7 @@ function draw() {
 }
 ```
 
-{{EmbedLiveSample("Quadratic_Bezier_curves", 160, 160, "canvas_quadratic.png")}}
+{{ EmbedLiveSample("Quadratic_Bezier_curves", 160, 198, "canvas_quadratic.png") }}
 
 #### Cubic Bezier curves
 
@@ -376,7 +376,7 @@ function draw() {
 }
 ```
 
-{{EmbedLiveSample("Cubic_Bezier_curves", 160, 160, "canvas_bezier.png")}}
+{{ EmbedLiveSample("Cubic_Bezier_curves", 160, 198, "canvas_bezier.png") }}
 
 ### Rectangles
 
@@ -483,7 +483,7 @@ function roundedRect(ctx, x, y, width, height, radius) {
 
 The resulting image looks like this:
 
-{{EmbedLiveSample("Making_combinations", 160, 160, "combinations.png")}}
+{{ EmbedLiveSample("Making_combinations", 160, 198, "combinations.png") }}
 
 We won't go over this in detail, since it's actually surprisingly simple. The most important things to note are the use of the `fillStyle` property on the drawing context, and the use of a utility function (in this case `roundedRect()`). Using utility functions for bits of drawing you do often can be very helpful and reduce the amount of code you need, as well as its complexity.
 
@@ -540,7 +540,7 @@ function draw() {
 }
 ```
 
-{{EmbedLiveSample("Path2D_example", 130, 110, "path2d.png")}}
+{{ EmbedLiveSample("Path2D_example", 130, 148, "path2d.png") }}
 
 ### Using SVG paths
 

--- a/files/en-us/web/api/canvas_api/tutorial/drawing_text/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/drawing_text/index.md
@@ -41,7 +41,7 @@ function draw() {
 draw();
 ```
 
-{{EmbedLiveSample("A_fillText_example", 310, 110)}}
+{{ EmbedLiveSample("A_fillText_example", 310, 148) }}
 
 ### A `strokeText` example
 
@@ -63,7 +63,7 @@ function draw() {
 draw();
 ```
 
-{{EmbedLiveSample("A_strokeText_example", 310, 110)}}
+{{ EmbedLiveSample("A_strokeText_example", 310, 148) }}
 
 ## Styling text
 

--- a/files/en-us/web/api/canvas_api/tutorial/using_images/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/using_images/index.md
@@ -148,7 +148,7 @@ function draw() {
 
 The resulting graph looks like this:
 
-{{EmbedLiveSample("Example_A_simple_line_graph", 220, 160, "canvas_backdrop.png")}}
+{{ EmbedLiveSample("Example_A_simple_line_graph", 220, 198, "canvas_backdrop.png") }}
 
 ## Scaling
 
@@ -188,7 +188,7 @@ function draw() {
 
 The resulting canvas looks like this:
 
-{{EmbedLiveSample("Example_Tiling_an_image", 160, 160, "canvas_scale_image.png")}}
+{{ EmbedLiveSample("Example_Tiling_an_image", 160, 198, "canvas_scale_image.png") }}
 
 ## Slicing
 
@@ -237,7 +237,7 @@ function draw() {
 
 We took a different approach to loading the images this time. Instead of loading them by creating new {{domxref("HTMLImageElement")}} objects, we included them as {{HTMLElement("img")}} tags directly in our HTML source and retrieved the images from those. The images are hidden from output by setting the CSS property {{cssxref("display")}} to none for those images.
 
-{{EmbedLiveSample("Example_Framing_an_image", 160, 160, "canvas_drawimage2.jpg")}}
+{{ EmbedLiveSample("Example_Framing_an_image", 160, 198, "canvas_drawimage2.jpg") }}
 
 The script itself is very simple. Each {{HTMLElement("img")}} is assigned an ID attribute, which makes them easy to select using {{domxref("document.getElementById()")}}. We then use `drawImage()` to slice the rhino out of the first image and scale him onto the canvas, then draw the frame on top using a second `drawImage()` call.
 
@@ -323,7 +323,7 @@ function draw() {
 }
 ```
 
-{{EmbedLiveSample("Art_gallery_example", 725, 400)}}
+{{EmbedLiveSample("Art_gallery_example", 725, 510)}}
 
 ## Controlling image scaling behavior
 


### PR DESCRIPTION
Some of the `EmbedLiveSample` macro outputs got vertical scrollbars after the PR https://github.com/mdn/yari/pull/5337. Due to the shortened heights, the outputs are obscured.

The PR updates live samples that have vertical scrollbars due to their height falling short by small margin.
In order to include lower resolutions, the heights have been updated considering 600px wide iframe.

Note: Only the live samples with scrollbars have been targeted.