### PR TITLE
Correct browser.tabs permission requirements

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/index.md
@@ -22,7 +22,7 @@ You can use this API to get a list of opened tabs, filtered by various criteria,
 
 You can use most of this API without any special permission. However:
 
-- To access `Tab.url`, `Tab.title`, and `Tab.favIconUrl` (or to filter by these properties via {{WebExtAPIRef("tabs.query()")}}), you need to have the `"tabs"` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions), or have [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) that match `Tab.url`.
+- To access `Tab.url`, `Tab.title`, and `Tab.favIconUrl` (or to filter by these properties via {{WebExtAPIRef("tabs.query()")}}), you need to have [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) that match `Tab.url`. The `"tabs"` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) is optional.
 
   - Access to these properties by host permissions is supported since Firefox 86 and Chrome 50. In Firefox 85 and earlier, the "tabs" permission was required instead.
 


### PR DESCRIPTION
Developers MUST use the host permission. The tabs permission is optional. Source: personal experience (trust me bro); I was able to access tab.url without the tabs permission. Even with the tabs permission, the console complained that I didn't have host permissions. With just the host permission and no tabs permission, I can access tab.url. I am not sure about tab.title or favIconUrl, but I'd assume they'd work the same.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
I changed the permission requirements fo

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
It will help future readers easily use browser.tabs without figuring out why the browser wants different permissions. It took me a while to figure out what permissions I needed since the documentation was wrong.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Source is described in the first paragraph (no links)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
❌ None

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
