### PR TITLE
Add page-type to templates

### DIFF
--- a/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.md
@@ -1,6 +1,7 @@
 ---
 title: API constructor subpage template
 slug: MDN/Structures/Page_types/API_constructor_subpage_template
+page-type: web-api-constructor
 tags:
   - API
   - Constructor
@@ -24,6 +25,7 @@ browser-compat: path.to.feature.NameOfTheConstructor
 > ---
 > title: NameOfTheConstructor()
 > slug: Web/API/NameOfTheParentInterface/NameOfTheParentInterface
+> page-type: web-api-constructor
 > tags:
 >   - API
 >   - Constructor
@@ -43,6 +45,8 @@ browser-compat: path.to.feature.NameOfTheConstructor
 >   - : The end of the URL path after `https://developer.mozilla.org/en-US/docs/`).
 >     This will be formatted like `Web/API/NameOfTheParentInterface/NameOfTheParentInterface`.
 >     Note that the name of the constructor function in the slug omits the parenthesis (it ends in `NameOfTheParentInterface` not `NameOfTheParentInterface()`).
+> - **page-type**
+>   - : The `page-type` key for Web/API constructors is always `web-api-constructor`.
 > - **tags**
 >   - : Always include the following tags: **API**, **Reference**, **Constructor**,  the _name of the API_ (e.g. **WebVR**), the name of the _parent interface_ (e.g. **IDBIndex**).
 >

--- a/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.md
@@ -1,6 +1,7 @@
 ---
 title: API event subpage template
 slug: MDN/Structures/Page_types/API_event_subpage_template
+page-type: web-api-event
 tags:
   - API
   - Event
@@ -24,6 +25,7 @@ browser-compat: path.to.feature.NameOfTheEvent_event
 > ---
 > title: 'NameOfTheParentInterface: NameOfTheEvent event'
 > slug: Web/API/NameOfTheParentInterface/NameOfTheEventHandler_event
+> page-type: web-api-event
 > tags:
 >   - NameOfTheEvent
 >   - API
@@ -42,6 +44,8 @@ browser-compat: path.to.feature.NameOfTheEvent_event
 > - **slug**
 >   - : The end of the URL path after `https://developer.mozilla.org/en-US/docs/`).
 >     This will be formatted like `Web/API/NameOfTheParentInterface/NameOfTheEventHandler_event`.
+> - **page-type**
+>   - : The `page-type` key for Web/API events is always `web-api-event`.
 > - **tags**
 >   - : Always include the following tags: **API**, **Reference**, **Event**,  the _name of the event_, the name of the _parent interface_ (e.g. **Window**).
 >

--- a/files/en-us/mdn/structures/page_types/api_landing_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_landing_page_template/index.md
@@ -1,6 +1,7 @@
 ---
 title: API landing page template
 slug: MDN/Structures/Page_types/API_landing_page_template
+page-type: web-api-overview
 tags:
   - API
   - Landing
@@ -21,6 +22,7 @@ tags:
 > ---
 > title: NameOfTheAPI API
 > slug: Web/API/NameOfTheAPI_API
+> page-type: web-api-overview
 > tags:
 >   - API
 >   - NameOfTheAPI API
@@ -40,6 +42,8 @@ tags:
 >   - : The end of the URL path after `https://developer.mozilla.org/en-US/docs/`).
 >     This will be formatted like `Web/API/NameOfTheAPI_API`.
 >     For example, the [WebXR Device API](/en-US/docs/Web/API/WebVR_API)'s slug is `Web/API/WebXR_Device_API`.
+> - **page-type**
+>   - : The `page-type` key for Web/API landing pages is always `web-api-overview`.
 > - **tags**
 >   - : Always include the following tags: **API**, **Reference**, **Landing**,  the _name of the API_ (e.g. **WebXR Device API**).
 >

--- a/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.md
@@ -1,6 +1,7 @@
 ---
 title: API method subpage template
 slug: MDN/Structures/Page_types/API_method_subpage_template
+page-type: web-api-instance-method OR web-api-static-method
 tags:
   - API
   - Method
@@ -24,6 +25,7 @@ browser-compat: path.to.feature.NameOfTheMethod
 > ---
 > title: NameOfTheParentInterface.NameOfTheMethod()
 > slug: Web/API/NameOfTheParentInterface/NameOfTheMethod
+> page-type: web-api-instance-method OR web-api-static-method
 > tags:
 >   - NameOfTheMethod
 >   - API
@@ -44,6 +46,8 @@ browser-compat: path.to.feature.NameOfTheMethod
 >   - : The end of the URL path after `https://developer.mozilla.org/en-US/docs/`).
 >     This will be formatted like `Web/API/NameOfTheParentInterface/NameOfTheMethod`.
 >     Note that the name of the method in the slug omits the parenthesis (it ends in `NameOfTheMethod` not `NameOfTheMethod()`).
+> - **page-type**
+>   - : The `page-type` key for Web/API methods is either `web-api-instance-method` (for instance methods) or `web-api-static-method` (for static methods).
 > - **tags**
 >   - : Always include the following tags: **API**, **Reference**, **Method**,  the _name of the API_ (e.g. **WebVR**), the name of the _parent interface_ (e.g. **IDBIndex**), the name of the method (e.g. **count()**).
 >

--- a/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.md
@@ -1,6 +1,7 @@
 ---
 title: API property subpage template
 slug: MDN/Structures/Page_types/API_property_subpage_template
+page-type: web-api-instance-property OR web-api-static-property
 tags:
   - API
   - Property
@@ -24,6 +25,7 @@ browser-compat: path.to.feature.NameOfTheProperty
 > ---
 > title: NameOfTheParentInterface.NameOfTheProperty
 > slug: Web/API/NameOfTheParentInterface/NameOfTheProperty
+> page-type: web-api-instance-property OR web-api-static-property
 > tags:
 >   - NameOfTheProperty
 >   - API
@@ -43,6 +45,8 @@ browser-compat: path.to.feature.NameOfTheProperty
 > - **slug**
 >   - : The end of the URL path after `https://developer.mozilla.org/en-US/docs/`).
 >     This will be formatted like `Web/API/NameOfTheParentInterface/NameOfTheProperty`.
+> - **page-type**
+>   - : The `page-type` key for Web/API properties is either `web-api-instance-property` (for instance properties) or `web-api-static-property` (for static properties).
 > - **tags**
 >   - : Always include the following tags: **API**, **Reference**, **Property**,  the _name of the API_ (e.g. **WebVR**), the name of the _parent interface_ (e.g. **IDBIndex**), the name of the property (e.g. **capabilities**).
 >

--- a/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
@@ -1,6 +1,7 @@
 ---
 title: API reference page template
 slug: MDN/Structures/Page_types/API_reference_page_template
+page-type: web-api-interface
 tags:
   - API
   - Template
@@ -9,54 +10,51 @@ browser-compat: path.to.feature.NameOfTheInterface
 ---
 {{MDNSidebar}}
 
-<!-- Remove div below here before publishing -->
-
-### Page front matter
-
-The frontmatter at the top of the page is used to define "page metadata". The values should be updated appropriately for the particular interface.
-
-```plain
----
-title: NameOfTheInterface
-slug: Web/API/NameOfTheInterface
-tags:
-  - API
-  - NameOfTheInterface
-  - NameOfTheAPI
-  - Reference
-  - Experimental
-
-browser-compat: path.to.feature.NameOfTheInterface
----
-```
-
-- **title**
-  - : Title heading displayed at top of page. This is just the name of the interface. For example, the [Request](/en-US/docs/Web/API/Request) interface page has a _title_ of _Request_.
-- slug
-  - : The end of the URL path after `https://developer.mozilla.org/en-US/docs/`). This will be formatted like `Web/API/NameOfTheParentInterface`. For example, [Request](/en-US/docs/Web/API/Request) slug is "Web/API/Request".
-- tags
-
-  - : Include the following tags: **API**, **Reference**, **Interface**, _the name of the API_ (e.g. **WebVR**), the name of the interface (e.g. **Request**), **Experimental** (if the technology is [experimental](/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental)), **Secure context** (if it is available in a secure context only), and **Deprecated** (if it is [deprecated](/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete)).
-
-    Optionally, you can elect to include some other tags that represent terms people might search for when looking for information on that technology. For example on WebVR interface pages we include **VR** and **Virtual reality**.
-
-- browser-compat
-
-  - : Replace the placeholder value `path.to.feature.NameOfTheMethod` with the query string for the method in the [Browser compat data repo](https://github.com/mdn/browser-compat-data). The toolchain automatically uses the key to populate the compatibility and specification sections (replacing the `\{{Compat}}` and `\{{Specifications}}` macros).
-
-    Note that you may first need to create/update an entry for the API method in our [Browser compat data repo](https://github.com/mdn/browser-compat-data), and the entry for the API will need to include specification information. See our [guide on how to do this](/en-US/docs/MDN/Structures/Compatibility_tables).
-
-### Top macros
-
-There are five macro calls at the top of the template by default. You should update or delete them according to the advice below:
-
-- `\{{APIRef("<em>GroupDataName</em>")}}` — this generates the left-hand reference sidebar showing quick reference links related to the current page. For example, every page in the [WebVR API](/en-US/docs/Web/API/WebVR_API) has the same sidebar, which points to the other pages in the API. To generate the correct sidebar for your API, you need to add a GroupData entry to our KumaScript GitHub repo, and include the entry's name inside the macro call in place of _GroupDataName_. See our [API reference sidebars](/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Sidebars) guide for information on how to do this.
-- `\{{SeeCompatTable}}` — this generates a **This is an experimental technology** banner that indicates the technology is [experimental](/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental). If the technology you are documenting is not experimental, you can remove this. If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
-- `\{{SecureContext_Header}}` — this generates a **Secure context** banner that indicates the technology is only available in a [secure context](/en-US/docs/Web/Security/Secure_Contexts). If it isn't, then you can remove the macro call. If it is, then you should also fill in an entry for it in the [Features restricted to secure contexts](/en-US/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts) page.
-- `\{{Deprecated_Header}}` — this generates a **Deprecated** banner that indicates the technology is [deprecated](/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete). If it isn't, then you can remove the macro call.
-- `\{{Interface_Overview("<em>GroupDataName</em>")}} {{Experimental_Inline}}` — this generates the main body of the page (Constructor, Properties, Methods and Events).
-
-<!-- Remove div above here before publishing -->
+> **Note:** _Remove this whole explanatory note before publishing_
+>
+> ### Page front matter
+>
+> The frontmatter at the top of the page is used to define "page metadata". The values should be updated appropriately for the particular interface.
+>
+> ```plain
+> ---
+> title: NameOfTheInterface
+> slug: Web/API/NameOfTheInterface
+> page-type: web-api-interface
+> tags:
+>   - API
+>   - NameOfTheInterface
+>   - NameOfTheAPI
+>   - Reference
+>   - Experimental
+>
+> browser-compat: path.to.feature.NameOfTheInterface
+> ---
+> ```
+>
+> - **title**
+>   - : Title heading displayed at top of page. This is just the name of the interface. For example, the [Request](/en-US/docs/Web/API/Request) interface page has a _title_ of _Request_.
+> - **slug**
+>   - : The end of the URL path after `https://developer.mozilla.org/en-US/docs/`). This will be formatted like `Web/API/NameOfTheParentInterface`. For example, [Request](/en-US/docs/Web/API/Request) slug is "Web/API/Request".
+> - **page-type**
+>   - : The `page-type` key for Web/API interfaces is always `web-api-interface`.
+> - **tags**
+>   - : Include the following tags: **API**, **Reference**, **Interface**, _the name of the API_ (e.g. **WebVR**), the name of the interface (e.g. **Request**), **Experimental** (if the technology is [experimental](/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental)), **Secure context** (if it is available in a secure context only), and **Deprecated** (if it is [deprecated](/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete)).
+>     Optionally, you can elect to include some other tags that represent terms people might search for when looking for information on that technology. For example on WebVR interface pages we include **VR** and **Virtual reality**.
+> - **browser-compat**
+>   - : Replace the placeholder value `path.to.feature.NameOfTheMethod` with the query string for the method in the [Browser compat data repo](https://github.com/mdn/browser-compat-data). The toolchain automatically uses the key to populate the compatibility and specification sections (replacing the `\{{Compat}}` and `\{{Specifications}}` macros).
+>
+>     Note that you may first need to create/update an entry for the API method in our [Browser compat data repo](https://github.com/mdn/browser-compat-data), and the entry for the API will need to include specification information. See our [guide on how to do this](/en-US/docs/MDN/Structures/Compatibility_tables).
+>
+> ### Top macros
+>
+> There are five macro calls at the top of the template by default. You should update or delete them according to the advice below:
+>
+> - `\{{APIRef("<em>GroupDataName</em>")}}` — this generates the left-hand reference sidebar showing quick reference links related to the current page. For example, every page in the [WebVR API](/en-US/docs/Web/API/WebVR_API) has the same sidebar, which points to the other pages in the API. To generate the correct sidebar for your API, you need to add a GroupData entry to our KumaScript GitHub repo, and include the entry's name inside the macro call in place of _GroupDataName_. See our [API reference sidebars](/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Sidebars) guide for information on how to do this.
+> - `\{{SeeCompatTable}}` — this generates a **This is an experimental technology** banner that indicates the technology is [experimental](/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental). If the technology you are documenting is not experimental, you can remove this. If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.
+> - `\{{SecureContext_Header}}` — this generates a **Secure context** banner that indicates the technology is only available in a [secure context](/en-US/docs/Web/Security/Secure_Contexts). If it isn't, then you can remove the macro call. If it is, then you should also fill in an entry for it in the [Features restricted to secure contexts](/en-US/docs/Web/Security/Secure_Contexts/features_restricted_to_secure_contexts) page.
+> - `\{{Deprecated_Header}}` — this generates a **Deprecated** banner that indicates the technology is [deprecated](/en-US/docs/MDN/Guidelines/Conventions_definitions#deprecated_and_obsolete). If it isn't, then you can remove the macro call.
+> - `\{{Interface_Overview("<em>GroupDataName</em>")}} {{Experimental_Inline}}` — this generates the main body of the page (Constructor, Properties, Methods and Events).
 
 {{APIRef("GroupDataName")}}{{SeeCompatTable}}{{SecureContext_Header}}{{Deprecated_Header}}
 

--- a/files/en-us/mdn/structures/page_types/index.md
+++ b/files/en-us/mdn/structures/page_types/index.md
@@ -23,6 +23,10 @@ There are three broad categories of page types on MDN, though some page types fa
 
 To create new pages on MDN, you need to use GitHub — have a look at our [content repo README](https://github.com/mdn/content#adding-a-new-document) for more instructions.
 
+## The page-type front matter key
+
+We're currently in the process of adding a `page-type` key to the front matter of MDN pages, that describes the page type in an unambiguous way. The sections below describing each page type list the `page-type` values to use for that type, and the templates also include the correct `page-type` value to use.
+
 ## How to use the templates
 
 When creating a new page you can ensure that you've used the right page structure/contents by referring to one of our page templates — see the sections below.
@@ -60,6 +64,10 @@ For example, the [Generic Sensor API](https://www.w3.org/TR/generic-sensor/) cov
 In such cases, many of the high level concepts are the same, so it makes no sense to repeat those over multiple landing pages.
 In such a case, it would make more sense in terms of repetition and findability to cover them all under a single "Web sensors" landing page.
 
+### page-type value
+
+API landing pages have the `page-type` key set to `web-api-overview`.
+
 ### Example
 
 - [WebVR API](/en-US/docs/Web/API/WebVR_API)
@@ -76,6 +84,10 @@ An **API reference page** lists all the methods, properties, events, and so fort
 It provides an overview of what the class or interface does or is used for, and gives links to the documentation for each of these members.
 It is more granular than an API landing page, which typically links to multiple API reference pages.
 
+### page-type value
+
+API reference pages have the `page-type` key set to `web-api-interface`.
+
 ### Example
 
 - [Request interface](/en-US/docs/Web/API/Request) of the [Fetch API](/en-US/docs/Web/API/Fetch_API).
@@ -88,6 +100,17 @@ It is more granular than an API landing page, which typically links to multiple 
 
 An **API reference subpage** is a child of an API reference page.
 It documents a single interface member in detail.
+
+### page-type value
+
+API reference subpages have one of the following `page-type` values, depending on the page:
+
+- `web-api-constructor`
+- `web-api-event`
+- `web-api-instance-method`
+- `web-api-instance-property`
+- `web-api-static-method`
+- `web-api-static-property`
 
 ### Examples
 
@@ -107,6 +130,10 @@ It documents a single interface member in detail.
 
 An **HTML reference page** lists all the attributes that are available on an HTML element, explains the element's purpose and usage, and provides examples, browser compatibility information, and other important data.
 
+### page-type value
+
+Not yet defined.
+
 ### Example
 
 - [`<video>` element](/en-US/docs/Web/HTML/Element/video)
@@ -119,6 +146,10 @@ An **HTML reference page** lists all the attributes that are available on an HTM
 
 An **SVG reference page** lists all the attributes that are available on an SVG element, explains the element's purpose and usage, and provides examples, browser compatibility information, and other important data.
 
+### page-type value
+
+Not yet defined.
+
 ### Example
 
 - [\<g> element](/en-US/docs/Web/SVG/Element/g)
@@ -130,6 +161,10 @@ An **SVG reference page** lists all the attributes that are available on an SVG 
 ## CSS feature reference page
 
 A **CSS reference page** lists all the available syntax for a CSS feature such as a selector or property, and explains the feature's purpose and usage. It also provides examples, browser compatibility information, and other important data.
+
+### page-type value
+
+Not yet defined.
 
 ### Examples
 
@@ -147,6 +182,10 @@ A **CSS reference page** lists all the available syntax for a CSS feature such a
 An **HTTP header reference page** lists all the available directives that an HTTP header can contain, and explains the header's purpose and usage.
 It also provides examples, browser compatibility information, and other important explanations.
 
+### page-type value
+
+Not yet defined.
+
 ### Example
 
 - [Cache-Control header](/en-US/docs/Web/HTTP/Headers/Cache-Control)
@@ -161,6 +200,10 @@ A **conceptual page** is a _guide_ page that explains or teaches something.
 Generally, if a page contains primarily prose, and doesn't fall into another page type, it's probably a conceptual page.
 An extended discussion of a topic might be spread across multiple conceptual pages, and linked using [Next](https://github.com/mdn/yari/blob/main/kumascript/macros/Next.ejs) and [Previous](https://github.com/mdn/yari/blob/main/kumascript/macros/Previous.ejs) macros.
 
+### page-type value
+
+Conceptual pages have a `page-type` value of `guide`.
+
 ### Examples
 
 - [Using the WebVR API](/en-US/docs/Web/API/WebVR_API/Using_the_WebVR_API)
@@ -173,6 +216,10 @@ A **glossary page** contains a brief explanation of a term, topic, or concept.
 The first paragraph should be a simple, self-contained description of the term, no more than a couple sentences.
 This can be followed by links to further information in the **Learn more** section.
 If the page grows to more than a screenful or so, it's too long and should be converted to a conceptual page. See [How to write and reference an entry in the glossary](/en-US/docs/MDN/Contribute/Howto/Write_a_new_entry_in_the_Glossary) for more details.
+
+### page-type value
+
+Not yet defined.
 
 ### Examples
 
@@ -191,6 +238,10 @@ A landing page layout is typically used for the root page of a tree of pages abo
 It opens with a brief summary of the topic, then presents a structured list of links to its subpages, and optionally, additional material that be useful to the reader.
 
 The list of subpages can be generated automatically using the templates [`SubpagesWithSummaries`](https://github.com/mdn/yari/blob/main/kumascript/macros/SubpagesWithSummaries.ejs), [`SubpageMenuByCategories`](https://github.com/mdn/yari/tree/main/kumascript/macros/SubpageMenuByCategories.ejs), and [`LandingPageListSubpages`](https://github.com/mdn/yari/blob/main/kumascript/macros/LandingPageListSubpages.ejs). However, in more complex cases, the list may need to be created (and maintained!) by hand.
+
+### page-type value
+
+Conceptual pages have a `page-type` value of `landing-page`.
 
 ### Examples
 

--- a/files/en-us/mdn/structures/page_types/index.md
+++ b/files/en-us/mdn/structures/page_types/index.md
@@ -23,10 +23,6 @@ There are three broad categories of page types on MDN, though some page types fa
 
 To create new pages on MDN, you need to use GitHub — have a look at our [content repo README](https://github.com/mdn/content#adding-a-new-document) for more instructions.
 
-## The page-type front matter key
-
-We're currently in the process of adding a `page-type` key to the front matter of MDN pages, that describes the page type in an unambiguous way. The sections below describing each page type list the `page-type` values to use for that type, and the templates also include the correct `page-type` value to use.
-
 ## How to use the templates
 
 When creating a new page you can ensure that you've used the right page structure/contents by referring to one of our page templates — see the sections below.
@@ -64,10 +60,6 @@ For example, the [Generic Sensor API](https://www.w3.org/TR/generic-sensor/) cov
 In such cases, many of the high level concepts are the same, so it makes no sense to repeat those over multiple landing pages.
 In such a case, it would make more sense in terms of repetition and findability to cover them all under a single "Web sensors" landing page.
 
-### page-type value
-
-API landing pages have the `page-type` key set to `web-api-overview`.
-
 ### Example
 
 - [WebVR API](/en-US/docs/Web/API/WebVR_API)
@@ -84,10 +76,6 @@ An **API reference page** lists all the methods, properties, events, and so fort
 It provides an overview of what the class or interface does or is used for, and gives links to the documentation for each of these members.
 It is more granular than an API landing page, which typically links to multiple API reference pages.
 
-### page-type value
-
-API reference pages have the `page-type` key set to `web-api-interface`.
-
 ### Example
 
 - [Request interface](/en-US/docs/Web/API/Request) of the [Fetch API](/en-US/docs/Web/API/Fetch_API).
@@ -100,17 +88,6 @@ API reference pages have the `page-type` key set to `web-api-interface`.
 
 An **API reference subpage** is a child of an API reference page.
 It documents a single interface member in detail.
-
-### page-type value
-
-API reference subpages have one of the following `page-type` values, depending on the page:
-
-- `web-api-constructor`
-- `web-api-event`
-- `web-api-instance-method`
-- `web-api-instance-property`
-- `web-api-static-method`
-- `web-api-static-property`
 
 ### Examples
 
@@ -130,10 +107,6 @@ API reference subpages have one of the following `page-type` values, depending o
 
 An **HTML reference page** lists all the attributes that are available on an HTML element, explains the element's purpose and usage, and provides examples, browser compatibility information, and other important data.
 
-### page-type value
-
-Not yet defined.
-
 ### Example
 
 - [`<video>` element](/en-US/docs/Web/HTML/Element/video)
@@ -146,10 +119,6 @@ Not yet defined.
 
 An **SVG reference page** lists all the attributes that are available on an SVG element, explains the element's purpose and usage, and provides examples, browser compatibility information, and other important data.
 
-### page-type value
-
-Not yet defined.
-
 ### Example
 
 - [\<g> element](/en-US/docs/Web/SVG/Element/g)
@@ -161,10 +130,6 @@ Not yet defined.
 ## CSS feature reference page
 
 A **CSS reference page** lists all the available syntax for a CSS feature such as a selector or property, and explains the feature's purpose and usage. It also provides examples, browser compatibility information, and other important data.
-
-### page-type value
-
-Not yet defined.
 
 ### Examples
 
@@ -182,10 +147,6 @@ Not yet defined.
 An **HTTP header reference page** lists all the available directives that an HTTP header can contain, and explains the header's purpose and usage.
 It also provides examples, browser compatibility information, and other important explanations.
 
-### page-type value
-
-Not yet defined.
-
 ### Example
 
 - [Cache-Control header](/en-US/docs/Web/HTTP/Headers/Cache-Control)
@@ -200,10 +161,6 @@ A **conceptual page** is a _guide_ page that explains or teaches something.
 Generally, if a page contains primarily prose, and doesn't fall into another page type, it's probably a conceptual page.
 An extended discussion of a topic might be spread across multiple conceptual pages, and linked using [Next](https://github.com/mdn/yari/blob/main/kumascript/macros/Next.ejs) and [Previous](https://github.com/mdn/yari/blob/main/kumascript/macros/Previous.ejs) macros.
 
-### page-type value
-
-Conceptual pages have a `page-type` value of `guide`.
-
 ### Examples
 
 - [Using the WebVR API](/en-US/docs/Web/API/WebVR_API/Using_the_WebVR_API)
@@ -216,10 +173,6 @@ A **glossary page** contains a brief explanation of a term, topic, or concept.
 The first paragraph should be a simple, self-contained description of the term, no more than a couple sentences.
 This can be followed by links to further information in the **Learn more** section.
 If the page grows to more than a screenful or so, it's too long and should be converted to a conceptual page. See [How to write and reference an entry in the glossary](/en-US/docs/MDN/Contribute/Howto/Write_a_new_entry_in_the_Glossary) for more details.
-
-### page-type value
-
-Not yet defined.
 
 ### Examples
 
@@ -238,10 +191,6 @@ A landing page layout is typically used for the root page of a tree of pages abo
 It opens with a brief summary of the topic, then presents a structured list of links to its subpages, and optionally, additional material that be useful to the reader.
 
 The list of subpages can be generated automatically using the templates [`SubpagesWithSummaries`](https://github.com/mdn/yari/blob/main/kumascript/macros/SubpagesWithSummaries.ejs), [`SubpageMenuByCategories`](https://github.com/mdn/yari/tree/main/kumascript/macros/SubpageMenuByCategories.ejs), and [`LandingPageListSubpages`](https://github.com/mdn/yari/blob/main/kumascript/macros/LandingPageListSubpages.ejs). However, in more complex cases, the list may need to be created (and maintained!) by hand.
-
-### page-type value
-
-Conceptual pages have a `page-type` value of `landing-page`.
 
 ### Examples
 


### PR DESCRIPTION
Part of https://github.com/mdn/content/issues/15539.

This PR adds `page-type` values we have defined so far.

I don't at all like the way the templates are real pages with real front matter that doesn't make sense for what they are, but I'm assuming that since all this content is soon being reworked and moved that it will be gone before this becomes a real problem (e.g. before we start validating `page-type`).