### PR TITLE
Link to iframe in GlobalEventHandlers.onload doc

### DIFF
--- a/files/en-us/web/api/globaleventhandlers/onload/index.md
+++ b/files/en-us/web/api/globaleventhandlers/onload/index.md
@@ -16,8 +16,8 @@ browser-compat: api.GlobalEventHandlers.onload
 
 The **`onload`** property of the
 {{domxref("GlobalEventHandlers")}} mixin is an [event handler](/en-US/docs/Web/Events/Event_handlers) that
-processes {{domxref("Window/load_event", "load")}} events on a {{domxref("Window")}},
-{{domxref("XMLHttpRequest")}}, {{htmlelement("img")}} element, etc.
+processes {{domxref("Window/load_event", "load")}} events on a {{domxref("Window")}}, 
+{{domxref("XMLHttpRequest")}}, {{htmlelement("iframe")}} and {{htmlelement("img")}} elements, etc.
 
 The `load` event fires when a given resource has loaded.
 


### PR DESCRIPTION
Nowhere in the docs is it stated that an `HTMLIFrameElement` emits a `load` event. While it *should* be obvious, it would be good to have a canonical resource to reference for this feature.
