### PR TITLE
Fix "string objects" in DocumentType

### DIFF
--- a/files/en-us/web/api/documenttype/after/index.md
+++ b/files/en-us/web/api/documenttype/after/index.md
@@ -13,9 +13,9 @@ browser-compat: api.DocumentType.after
 {{APIRef("DOM")}}
 
 The **`DocumentType.after()`** method inserts a set of
-{{domxref("Node")}} or string objects in the children list of the
+{{domxref("Node")}} objects or strings in the children list of the
 `DocumentType`'s parent, just after the `DocumentType`.
-String objects are inserted as equivalent {{domxref("Text")}} nodes.
+Strings are inserted as equivalent {{domxref("Text")}} nodes.
 
 ## Syntax
 
@@ -28,7 +28,7 @@ after(param1, param2, /* ... ,*/ paramN)
 ### Parameters
 
 - `param1`, …, `paramN`
-  - : A set of {{domxref("Node")}} or string objects to insert.
+  - : A set of {{domxref("Node")}} objects or strings to insert.
 
 ### Return value
 

--- a/files/en-us/web/api/documenttype/before/index.md
+++ b/files/en-us/web/api/documenttype/before/index.md
@@ -13,9 +13,9 @@ browser-compat: api.DocumentType.before
 {{APIRef("DOM")}}
 
 The **`DocumentType.before()`** method inserts a set of
-{{domxref("Node")}} or string objects in the children list of the
+{{domxref("Node")}} objects or strings in the children list of the
 `DocumentType`'s parent, just before the `DocumentType`.
-String objects are inserted as equivalent {{domxref("Text")}} nodes.
+Strings are inserted as equivalent {{domxref("Text")}} nodes.
 
 > **Note:** Putting nodes before the document's doctype will set the rendering mode to
 > [quirks mode](/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode)
@@ -32,7 +32,7 @@ before(param1, param2, /* ... ,*/ paramN)
 ### Parameters
 
 - `param1`, …, `paramN`
-  - : A set of {{domxref("Node")}} or string objects to insert.
+  - : A set of {{domxref("Node")}} objects or strings to insert.
 
 ### Return value
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
"String objects" is confusing in JavaScript because it looks like the `String` wrapper object.
So, correct it as "strings".

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
