### PR TITLE
Replace links to ARIA Authoring practices for grid role

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/grid_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/grid_role/index.md
@@ -13,7 +13,6 @@ tags:
   - NeedsContent
 spec-urls:
   - https://w3c.github.io/aria/#grid
-  - https://w3c.github.io/aria-practices/#grid
 ---
 The grid role is for a widget that contains one or more rows of cells. The position of each cell is significant and can be focused using keyboard input.
 
@@ -54,7 +53,7 @@ The `grid` role is a composite widget containing a collection of one or more row
 </table>
 ```
 
-A grid widget contains one or more rows with one or more cells of thematically related interactive content. While it does not imply a specific visual presentation, it implies a relationship among elements. Uses fall into two categories: presenting tabular information (data grids) and grouping other widgets (layout grids). Even though both data grids and layout grids employ the same ARIA roles, states, and properties, differences in their content and purpose surface factors that are important to consider in keyboard interaction design. See [ARIA Authoring practices](https://www.w3.org/TR/wai-aria-practices-1.2/#grid) for more details
+A grid widget contains one or more rows with one or more cells of thematically related interactive content. While it does not imply a specific visual presentation, it implies a relationship among elements. Uses fall into two categories: presenting tabular information (data grids) and grouping other widgets (layout grids). Even though both data grids and layout grids employ the same ARIA roles, states, and properties, differences in their content and purpose surface factors that are important to consider in keyboard interaction design. See [ARIA Authoring Practices Guide](https://www.w3.org/WAI/ARIA/apg/patterns/grid/) for more details
 
 Cell elements have the role [`gridcell`](/en-US/docs/Web/Accessibility/ARIA/Roles/gridcell_role), unless they are a row or column header. Then the elements are [`rowheader`](/en-US/docs/Web/Accessibility/ARIA/Roles/rowheader_role) and [`columnheader`](/en-US/docs/Web/Accessibility/ARIA/Roles/columnheader_role), respectively. Cell elements need to be owned by elements with a [`row`](/en-US/docs/Web/Accessibility/ARIA/Roles/row_role) role. Rows can be grouped using `rowgroups`.
 
@@ -583,8 +582,8 @@ document.querySelector('table').addEventListener("keydown", function(event) {
 
 ### More examples
 
-- [Data Grid Examples](https://www.w3.org/TR/wai-aria-practices-1.1/examples/grid/dataGrids.html)
-- [Layout Grids Examples](https://www.w3.org/TR/wai-aria-practices/examples/grid/LayoutGrids.html)
+- [Data Grid Examples](https://www.w3.org/WAI/ARIA/apg/example-index/grid/dataGrids.html)
+- [Layout Grids Examples](https://www.w3.org/WAI/ARIA/apg/example-index/grid/LayoutGrids.html)
 - [W3C/WAI Tutorial: Tables](https://www.w3.org/WAI/tutorials/tables/)
 
 ## Accessibility concerns


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
This document links to ARIA Authoring practices 1.2, but it is already retired from published as formal document.
They says the content of the document is continuously updated at here https://www.w3.org/WAI/ARIA/apg/

#### Motivation
Navigate to latest document.

#### Supporting details
https://www.w3.org/TR/wai-aria-practices-1.2/

```
Document moved
This version of WAI-ARIA Authoring Practices is published to retire it from the Working Group Note track. The content continues to be updated in a format that is more useful to developers:

https://www.w3.org/WAI/ARIA/apg/
```

#### Related issues
None

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
