### PR TITLE
Add guidance about not asking for extraneous changes in a PR review

### DIFF
--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -80,6 +80,12 @@ inappropriate, than it is to follow every guideline to the letter.
    - Alternatively, you can edit files using the GitHub UI — go to the pull
      request's "Files changed" tab, find the file you want to edit, and
      choose "three dot" menu (...) > Edit file.
+1. If a pull request is fine in itself, is a clear improvement to the content,
+   and makes the change it claims to make in the description, you should as a
+   rule merge it, even if you can see other improvements that could be made in
+   the same file. If you want to ensure that these other improvements will
+   be taken care of, file a follow-up issue or pull request of your own to
+   address them.
 1. If you don't understand a content change that you've been selected to
    review, or feel that it is too large and complex for you to deal with,
    don't panic! Feel free to reach out to someone else to ask for help,


### PR DESCRIPTION
This PR attempts to add guidance to PR reviewers that discourages them from asking for extra changes to PRs that are already fine and that address the issues that they claim to address.