### PR TITLE
Add allow-top-navigation-to-custom-protocols CSP sandbox value

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy/sandbox/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/sandbox/index.md
@@ -88,7 +88,7 @@ where `<value>` can optionally be one of the following values:
   - : Lets the resource navigate the top-level browsing context, but only if initiated by
     a user gesture.
 - `allow-top-navigation-to-custom-protocols`
-  - :  Allows navigations toward non fetch schemes being handed off to external software.
+  - :  Allows navigations toward non-fetch schemes to be handed off to external software.
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/sandbox/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/sandbox/index.md
@@ -87,6 +87,8 @@ where `<value>` can optionally be one of the following values:
 - `allow-top-navigation-by-user-activation`
   - : Lets the resource navigate the top-level browsing context, but only if initiated by
     a user gesture.
+- `allow-top-navigation-to-custom-protocols`
+  - :  Allows navigations toward non fetch schemes being handed off to external software.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
The Content Security Policy `sandbox` directive allows `allow-top-navigation-to-custom-protocols` as a value

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-iframe-sandbox
https://html.spec.whatwg.org/multipage/origin.html#sandboxed-custom-protocols-navigation-browsing-context-flag

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
