### PR TITLE
Guidance about GFM link styles

### DIFF
--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.md
@@ -30,7 +30,7 @@ This is the correct way to write GFM links on MDN:
 This is an incorrect way to write links on MDN:
 
 ```md example-bad
-[Macarons][macaron]  are delicious but tricky to make.
+[Macarons][macaron] are delicious but tricky to make.
 
 [macaron]: https://en.wikipedia.org/wiki/Macaron
 ```

--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.md
@@ -12,6 +12,29 @@ This page describes how we use Markdown to write documentation on MDN. We have c
 
 The baseline for MDN Markdown is GitHub-Flavored Markdown (GFM): <https://github.github.com/gfm/>. This means that for anything not otherwise specified in this page, you can refer to the GFM specification. GFM in turn is a superset of CommonMark ([https://spec.commonmark.org/](https://spec.commonmark.org/)).
 
+## Links
+
+The GFM specification defines two basic types of links:
+
+- [inline links](https://github.github.com/gfm/#inline-link), in which the destination is given immediately after the link text
+- [reference links](https://github.github.com/gfm/#reference-link), in which the destination is defined elsewhere in the document.
+
+On MDN we allow only inline links.
+
+This is the correct way to write GFM links on MDN:
+
+```md example-good
+[Macarons](https://en.wikipedia.org/wiki/Macaron) are delicious but tricky to make.
+```
+
+This is an incorrect way to write links on MDN:
+
+```md example-bad
+[Macarons][macaron]  are delicious but tricky to make.
+
+[macaron]: https://en.wikipedia.org/wiki/Macaron
+```
+
 ## Example code blocks
 
 In GFM and CommonMark, authors can use "code fences" to demarcate `<pre>` blocks. The opening code fence may be followed by some text that is called the "info string". From the spec:


### PR DESCRIPTION
Added guidance about GFM link styles, following the conversation at https://github.com/mdn/content/pull/17014#discussion_r889800542.