### PR TITLE
Removes nonexistent class 'dummy'

### DIFF
--- a/files/en-us/web/api/broadcastchannel/message_event/index.md
+++ b/files/en-us/web/api/broadcastchannel/message_event/index.md
@@ -149,11 +149,11 @@ channel.addEventListener('message', event => {
 
 ### Result
 
-{{ EmbedLiveSample('Sender', '100%', '170px','' ,'' , 'dummy') }}
+{{ EmbedLiveSample('Sender', '100%', 220) }}
 
-{{ EmbedLiveSample('Receiver_1', '100%', '150px','' ,'' , 'dummy') }}
+{{ EmbedLiveSample('Receiver_1', '100%', 160) }}
 
-{{ EmbedLiveSample('Receiver_2', '100%', '150px','' ,'' , 'dummy') }}
+{{ EmbedLiveSample('Receiver_2', '100%', 160) }}
 
 ## Specifications
 


### PR DESCRIPTION
Due to the use of 'dummy' the required class 'sample-code-frame' is not being applied.