### PR TITLE
Docs for VideoEncoder.isConfigSupported()

### DIFF
--- a/files/en-us/web/api/videoencoder/index.md
+++ b/files/en-us/web/api/videoencoder/index.md
@@ -32,6 +32,8 @@ The **`VideoEncoder`** interface of the {{domxref('WebCodecs API','','','true')}
   - : Enqueues a control message to encode a given {{domxref("VideoFrame")}}.
 - {{domxref("VideoEncoder.flush()")}}
   - : Returns a promise that resolves once all pending messages in the queue have been completed.
+- {{domxref("VideoEncoder.isConfigSupported()")}}
+  - : Returns a promise indicating whether the provided VideoEncoderConfig is supported.
 - {{domxref("VideoEncoder.reset()")}}
   - : Resets all states including configuration, control messages in the control message queue, and all pending callbacks.
 - {{domxref("VideoEncoder.close()")}}

--- a/files/en-us/web/api/videoencoder/index.md
+++ b/files/en-us/web/api/videoencoder/index.md
@@ -33,7 +33,7 @@ The **`VideoEncoder`** interface of the {{domxref('WebCodecs API','','','true')}
 - {{domxref("VideoEncoder.flush()")}}
   - : Returns a promise that resolves once all pending messages in the queue have been completed.
 - {{domxref("VideoEncoder.isConfigSupported()")}}
-  - : Returns a promise indicating whether the provided VideoEncoderConfig is supported.
+  - : Returns a promise indicating whether the provided `VideoEncoderConfig` is supported.
 - {{domxref("VideoEncoder.reset()")}}
   - : Resets all states including configuration, control messages in the control message queue, and all pending callbacks.
 - {{domxref("VideoEncoder.close()")}}

--- a/files/en-us/web/api/videoencoder/isconfigsupported/index.md
+++ b/files/en-us/web/api/videoencoder/isconfigsupported/index.md
@@ -28,9 +28,9 @@ isConfigSupported(config)
 ### Return value
 
 A {{jsxref("Promise")}} that resolves with an object containing the following members:
-  - `supported`{{Optional_Inline}}
+  - `supported`
     - : A boolean value which is `true` if the given config is supported by the encoder.
-  - `config`{{Optional_Inline}}
+  - `config`
     - : A copy of the given config with all the fields recognized by the encoder.
 
 ### Exceptions

--- a/files/en-us/web/api/videoencoder/isconfigsupported/index.md
+++ b/files/en-us/web/api/videoencoder/isconfigsupported/index.md
@@ -31,7 +31,7 @@ A {{jsxref("Promise")}} that resolves with an object containing the following me
   - `supported`{{Optional_Inline}}
     - : A boolean value which is `true` if the given config is supported by the encoder.
   - `config`{{Optional_Inline}}
-    - : An copy of the given config with all the field recognized by the encoder.
+    - : A copy of the given config with all the field recognized by the encoder.
 
 ### Exceptions
 

--- a/files/en-us/web/api/videoencoder/isconfigsupported/index.md
+++ b/files/en-us/web/api/videoencoder/isconfigsupported/index.md
@@ -23,7 +23,7 @@ isConfigSupported(config)
 ### Parameters
 
 - `config`
-  - : The dictionary object accepted by {{jsxref("VideoEncoder.configure")}}
+  - : The dictionary object accepted by {{domxref("VideoEncoder.configure")}}
 
 ### Return value
 

--- a/files/en-us/web/api/videoencoder/isconfigsupported/index.md
+++ b/files/en-us/web/api/videoencoder/isconfigsupported/index.md
@@ -31,7 +31,7 @@ A {{jsxref("Promise")}} that resolves with an object containing the following me
   - `supported`{{Optional_Inline}}
     - : A boolean value which is `true` if the given config is supported by the encoder.
   - `config`{{Optional_Inline}}
-    - : A copy of the given config with all the field recognized by the encoder.
+    - : A copy of the given config with all the fields recognized by the encoder.
 
 ### Exceptions
 

--- a/files/en-us/web/api/videoencoder/isconfigsupported/index.md
+++ b/files/en-us/web/api/videoencoder/isconfigsupported/index.md
@@ -1,0 +1,82 @@
+---
+title: VideoEncoder.isConfigSupported()
+slug: Web/API/VideoEncoder/isConfigSupported
+page-type: web-api-static-method
+tags:
+  - API
+  - Method
+  - Reference
+  - isConfigSupported
+  - VideoEncoder
+browser-compat: api.VideoEncoder.isConfigSupported
+---
+{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+
+The **`isConfigSupported()`** static method of the {{domxref("VideoEncoder")}} interface that checks if the given config is supported.
+
+That is, if it can successfully configure {{domxref("VideoEncoder")}} objects with this the same config.
+
+## Syntax
+
+```js
+isConfigSupported(config)
+```
+
+### Parameters
+
+- `config`
+  - : The dictionary object accepted by {{jsxref("VideoEncoder.configure")}}
+
+### Return value
+
+A {{jsxref("Promise")}} that resolves with an object containing the following members:
+  - `supported`{{Optional_Inline}}
+    - : A Boolean value which is `true` if the given config is supported by the encoder.
+  - `config`{{Optional_Inline}}
+    - : An copy of the given config with all the field recognized by the encoder.
+
+### Exceptions
+
+- {{jsxref("TypeError")}}
+  - : Thrown if the provided `config` is invalid, i.e. doesn't have required
+  values (such as an empty `codec` filed) or has invalid values (such as a
+  negative `width`)
+
+## Examples
+
+The following example tests if the browser supports accelerated and un-accelerated
+versions of several video codecs.
+
+```js
+let codecs = ['avc1.42001E', 'vp8', 'vp09.00.10.08', 'av01.0.04M.08'];
+let accelerations = ['prefer-hardware', 'prefer-software']
+
+let configs = [];
+for (let codec of codecs) {
+  for (let acceleration of accelerations) {
+    configs.push({
+      codec: codec,
+      hardwareAcceleration: acceleration,
+      width: 1280,
+      height: 720,
+      bitrate: 2_000_000,
+      bitrateMode: 'constant',
+      framerate: 30,
+      not_supported_field: 123
+    });
+  }
+}
+
+for (let config of configs) {
+  let support = await VideoEncoder.isConfigSupported(config);
+  console.log(`VideoEncoder's config ${JSON.stringify(support.config)} support: ${support.supported}`);
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/videoencoder/isconfigsupported/index.md
+++ b/files/en-us/web/api/videoencoder/isconfigsupported/index.md
@@ -36,8 +36,8 @@ A {{jsxref("Promise")}} that resolves with an object containing the following me
 ### Exceptions
 
 - {{jsxref("TypeError")}}
-  - : Thrown if the provided `config` is invalid, i.e. doesn't have required
-  values (such as an empty `codec` filed) or has invalid values (such as a
+  - : Thrown if the provided `config` is invalid; that is, if doesn't have required
+  values (such as an empty `codec` field) or has invalid values (such as a
   negative `width`)
 
 ## Examples

--- a/files/en-us/web/api/videoencoder/isconfigsupported/index.md
+++ b/files/en-us/web/api/videoencoder/isconfigsupported/index.md
@@ -29,7 +29,7 @@ isConfigSupported(config)
 
 A {{jsxref("Promise")}} that resolves with an object containing the following members:
   - `supported`{{Optional_Inline}}
-    - : A Boolean value which is `true` if the given config is supported by the encoder.
+    - : A boolean value which is `true` if the given config is supported by the encoder.
   - `config`{{Optional_Inline}}
     - : An copy of the given config with all the field recognized by the encoder.
 

--- a/files/en-us/web/api/videoencoder/isconfigsupported/index.md
+++ b/files/en-us/web/api/videoencoder/isconfigsupported/index.md
@@ -12,9 +12,7 @@ browser-compat: api.VideoEncoder.isConfigSupported
 ---
 {{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
 
-The **`isConfigSupported()`** static method of the {{domxref("VideoEncoder")}} interface that checks if the given config is supported.
-
-That is, if it can successfully configure {{domxref("VideoEncoder")}} objects with this the same config.
+The **`isConfigSupported()`** static method of the {{domxref("VideoEncoder")}} interface checks if the given config is supported (that is, if {{domxref("VideoEncoder")}} objects can be successfully configured with the given config.
 
 ## Syntax
 

--- a/files/en-us/web/api/videoencoder/isconfigsupported/index.md
+++ b/files/en-us/web/api/videoencoder/isconfigsupported/index.md
@@ -12,7 +12,7 @@ browser-compat: api.VideoEncoder.isConfigSupported
 ---
 {{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
 
-The **`isConfigSupported()`** static method of the {{domxref("VideoEncoder")}} interface checks if the given config is supported (that is, if {{domxref("VideoEncoder")}} objects can be successfully configured with the given config.
+The **`isConfigSupported()`** static method of the {{domxref("VideoEncoder")}} interface checks if the given config is supported (that is, if {{domxref("VideoEncoder")}} objects can be successfully configured with the given config).
 
 ## Syntax
 


### PR DESCRIPTION
#### Summary
Adding docs for VideoEncoder.isConfigSupported()

#### Motivation
Undocumented method 

#### Supporting details
https://www.w3.org/TR/webcodecs/#dom-videoencoder-isconfigsupported

#### Metadata
This PR…
- [x ] Adds a new document
