### PR TITLE
Fix ambiguous description of private static fields

### DIFF
--- a/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
@@ -120,8 +120,8 @@ class ClassWithPrivateStaticField {
   }
 }
 
-console.log(ClassWithPrivateStaticField.publicStaticMethod() === 42);
-// true
+console.log(ClassWithPrivateStaticField.publicStaticMethod()); // 42
+console.log(new ClassWithPrivateStaticField().publicInstanceMethod()); // 42
 ```
 
 There is a restriction on private static fields: Only the class which

--- a/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
@@ -103,14 +103,18 @@ new SubClass();
 
 #### Private static fields
 
-Private static fields are added to the class constructor at class evaluation time.
-The limitation of static variables being called by only static methods still holds.
+Private static fields are added to the class constructor at class evaluation time. Like their public counterparts, private static fields are only accessible on the class itself or on the `this` context of static methods (although there are pitfalls — see below), but not on the `this` context of instance methods.
 
 ```js
 class ClassWithPrivateStaticField {
   static #PRIVATE_STATIC_FIELD;
 
   static publicStaticMethod() {
+    ClassWithPrivateStaticField.#PRIVATE_STATIC_FIELD = 42;
+    return ClassWithPrivateStaticField.#PRIVATE_STATIC_FIELD;
+  }
+
+  publicInstanceMethod() {
     ClassWithPrivateStaticField.#PRIVATE_STATIC_FIELD = 42;
     return ClassWithPrivateStaticField.#PRIVATE_STATIC_FIELD;
   }

--- a/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
@@ -103,7 +103,7 @@ new SubClass();
 
 #### Private static fields
 
-Private static fields are added to the class constructor at class evaluation time. Like their public counterparts, private static fields are only accessible on the class itself or on the `this` context of static methods (although there are pitfalls — see below), but not on the `this` context of instance methods.
+Private static fields are added to the class constructor at class evaluation time. Like their public counterparts, private static fields are only accessible on the class itself or on the `this` context of static methods, but not on the `this` context of instance methods.
 
 ```js
 class ClassWithPrivateStaticField {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation

Fix #15307.

Because there's another paragraph about the pitfalls of using `this.#staticPrivateField`, I did not elaborate too much here.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
