### PR TITLE
Removing duplicated CSSInfo

### DIFF
--- a/files/en-us/web/css/border-inline-end-color/index.md
+++ b/files/en-us/web/css/border-inline-end-color/index.md
@@ -35,8 +35,6 @@ border-inline-end-color: unset;
 
 Related properties are {{cssxref("border-block-start-color")}}, {{cssxref("border-block-end-color")}}, and {{cssxref("border-inline-start-color")}}, which define the other border colors of the element.
 
-{{cssinfo}}
-
 ### Values
 
 - `<'color'>`


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
 I removed the redundant, misplaced, extra CSSInfo element from the border-inline-end-color page.

#### Motivation
The border-inline-end-color page contained the CSSInfo element twice, one at the wrong location.

#### Supporting details
I kept the CSSInfo at the location it is on the partnering [border-inline-start-color](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-color)

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
