### PR TITLE
Update counters() example to use common layout

### DIFF
--- a/files/en-us/web/css/css_counter_styles/using_css_counters/index.md
+++ b/files/en-us/web/css/css_counter_styles/using_css_counters/index.md
@@ -92,11 +92,11 @@ For example, you might use this to lay out sections as shown:
 ```
 1 One
   1.1 Nested one
-  2.1 Nested two
+  1.2 Nested two
 2 Two
-  1.1 Nested one
-  2.1 Nested two
-  3.1 Nested three
+  2.1 Nested one
+  2.2 Nested two
+  2.3 Nested three
 3 Three
 ```
 


### PR DESCRIPTION
The initial example of using counters() has the counters ordered confusingly and different to the final more extensive example. This commit changes the earlier examples layout to be less confusing and to match the layout of the example at the end of the page.

#### Summary
The initial example of using counters() has the counters ordered confusingly and different to the final more extensive example. This commit changes the earlier examples layout to be less confusing and to match the layout of the example at the end of the page.

#### Motivation
The initial example confused me when I was reading the page.

#### Supporting details


#### Related issues

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
