### PR TITLE
Remove extraneous 2nd arg in handler.ownKeys example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/proxy/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/proxy/index.md
@@ -406,7 +406,7 @@ const docCookies = new Proxy(docCookies, {
     if (!sKey in oTarget) { return false; }
     return oTarget.removeItem(sKey);
   },
-  ownKeys: function (oTarget, sKey) {
+  ownKeys: function (oTarget) {
     return oTarget.keys();
   },
   has: function (oTarget, sKey) {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation

Fix #11076. The `enumerate` trap was already removed in #11862.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
