### PR TITLE
fix: keep the callout the same as the rendered

### DIFF
--- a/files/en-us/mdn/contribute/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/contribute/markdown_in_mdn/index.md
@@ -175,7 +175,7 @@ This HTML will be rendered as a highlighted box, like:
 ##### Callouts
 
 ```plain
-> **Callout:** **This is how you write a callout**.
+> **Callout:** **This is how you write a callout.**
 >
 > It can have multiple paragraphs.
 ```


### PR DESCRIPTION
#### Summary

keep the callout the same as the rendered content.

See line 196

![image](https://user-images.githubusercontent.com/15844309/172574582-fd7cfbe1-139e-4589-a472-eb1d87205882.png)

#### Metadata

- [x] Fixes a typo, bug, or other error
