### PR TITLE
Replace obsoleted method in sample code

### DIFF
--- a/files/en-us/web/api/htmlcanvaselement/capturestream/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/capturestream/index.md
@@ -59,7 +59,7 @@ var stream = canvasElt.captureStream(25); // 25 FPS
 // Do things to the stream
 // E.g. Send it to another computer using an RTCPeerConnection
 //      pc is an RTCPeerConnection created elsewhere
-pc.addStream(stream);
+stream.getTracks().forEach(track => pc.addTrack(track, stream));
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
`RTCPeerConnection.addStream` is obsolete and should be replaced with `addTrack` to stream the content of a `MediaStream` over an `RTCPeerConnection`.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The sample code can be misleading by encouraging to use an obsolete method.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
`RTCPeerConnection.addStream` is obsolete:
https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addStream

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
