### PR TITLE
Clarify what behavior of Date.parse is specified

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/date/date/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/date/index.md
@@ -59,20 +59,11 @@ There are five basic forms for the `Date()` constructor:
 
     - `dateString`
 
-      - : A string value representing a date, specified in a format recognized by the
-        {{jsxref("Date.parse()")}} method. (These formats are
-        [IETF-compliant RFC 2822 timestamps](https://datatracker.ietf.org/doc/html/rfc2822#page-14),
-        and also strings in a
-        [version of ISO8601](https://262.ecma-international.org/11.0/#sec-date.parse).)
+      - : A string value representing a date, in a format recognized by the {{jsxref("Date.parse()")}} method. (The ECMA262 spec specifies a [simplified version of ISO 8601](https://tc39.es/ecma262/#sec-date-time-string-format), but other formats can be implementation-defined, which commonly include [IETF-compliant RFC 2822 timestamps](https://datatracker.ietf.org/doc/html/rfc2822#page-14).)
 
-        > **Note:** Parsing of date strings with the `Date`
-        > constructor (and `Date.parse()`, which works the same way) is
-        > _strongly discouraged_ due to browser differences and inconsistencies.
-        >
-        > - Support for [RFC 2822](https://datatracker.ietf.org/doc/html/rfc2822)
-        >   format strings is by convention only.
-        > - Support for ISO 8601 formats differs in that date-only strings (e.g.
-        >   `"1970-01-01"`) are treated as UTC, not local.
+        > **Note:** When parsing date strings with the `Date` constructor (and `Date.parse`, they are equivalent), always make sure that the input conforms to the ISO 8601 format (`YYYY-MM-DDTHH:mm:ss.sssZ`) — the parsing behavior with other formats is implementation-defined and may not work across all browsers. Support for [RFC 2822](https://datatracker.ietf.org/doc/html/rfc2822) format strings is by convention only. A library can help if many different formats are to be accommodated.
+        > 
+        > Date-only strings (e.g. `"1970-01-01"`) are treated as UTC, while date-time strings (e.g. `"1970-01-01T12:00"`) are treated as local. You are therefore also advised to make sure the input format is consistent between the two types.
 
 4. Date object
 
@@ -128,17 +119,13 @@ Calling the `Date()` function (without the `new` keyword) returns a string repre
 
 The following examples show several ways to create JavaScript dates:
 
-> **Note:** Parsing of date strings with the `Date` constructor
-> (and `Date.parse`, they are equivalent) is strongly discouraged due to
-> browser differences and inconsistencies.
-
 ```js
-let today = new Date()
-let sameDay = new Date(today)
-let birthday = new Date('December 17, 1995 13:24:00')
-let birthday = new Date('1995-12-17T13:24:00')
-let birthday = new Date(1995, 11, 17)            // the month is 0-indexed
-let birthday = new Date(1995, 11, 17, 13, 24, 0)
+const today = new Date()
+const birthday = new Date('December 17, 1995 03:24:00') // DISCOURAGED: may not work in all runtimes
+const birthday = new Date('1995-12-17T03:24:00')   // This is ISO-8601-compliant and will work reliably
+const birthday = new Date(1995, 11, 17)            // the month is 0-indexed
+const birthday = new Date(1995, 11, 17, 3, 24, 0)
+const birthday = new Date(628021800000)            // passing epoch timestamp
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/date/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/index.md
@@ -154,15 +154,15 @@ In addition to methods to read and alter individual components of the local date
 
 The following examples show several ways to create JavaScript dates:
 
-> **Note:** Parsing of date strings with the `Date` constructor (and `Date.parse`, they are equivalent) is strongly discouraged due to browser differences and inconsistencies.
+> **Note:** When parsing date strings with the `Date` constructor (and `Date.parse`, they are equivalent), always make sure that the input conforms to the [ISO 8601 format](https://tc39.es/ecma262/#sec-date-time-string-format) (`YYYY-MM-DDTHH:mm:ss.sssZ`) — the parsing behavior with other formats is implementation-defined and may not work across all browsers. A library can help if many different formats are to be accommodated.
 
 ```js
-let today = new Date()
-let birthday = new Date('December 17, 1995 03:24:00')
-let birthday = new Date('1995-12-17T03:24:00')
-let birthday = new Date(1995, 11, 17)            // the month is 0-indexed
-let birthday = new Date(1995, 11, 17, 3, 24, 0)
-let birthday = new Date(628021800000)            // passing epoch timestamp
+const today = new Date()
+const birthday = new Date('December 17, 1995 03:24:00') // DISCOURAGED: may not work in all runtimes
+const birthday = new Date('1995-12-17T03:24:00')   // This is ISO8601-compliant and will work reliably
+const birthday = new Date(1995, 11, 17)            // the month is 0-indexed
+const birthday = new Date(1995, 11, 17, 3, 24, 0)
+const birthday = new Date(628021800000)            // passing epoch timestamp
 ```
 
 ### To get Date, Month and Year or Time

--- a/files/en-us/web/javascript/reference/global_objects/date/parse/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/parse/index.md
@@ -15,10 +15,7 @@ a date, and returns the number of milliseconds since January 1, 1970, 00:00:00 U
 `NaN` if the string is unrecognized or, in some cases, contains illegal date
 values (e.g. 2015-02-31).
 
-It is not recommended to use `Date.parse` as until ES5, parsing of strings
-was entirely implementation dependent. There are still many differences in how different
-hosts parse date strings, therefore date strings should be manually parsed (a library
-can help if many different formats are to be accommodated).
+As until ES5, parsing of strings was entirely implementation-dependent. After the ES5 spec, the [ISO 8601 format](https://tc39.es/ecma262/#sec-date-time-string-format) (`YYYY-MM-DDTHH:mm:ss.sssZ`) is explicitly specified, while other formats are still implementation-defined and may not work across all browsers. A library can help if many different formats are to be accommodated.
 
 {{EmbedInteractiveExample("pages/js/date-parse.html")}}
 
@@ -51,7 +48,7 @@ doesn't represent a valid date, {{jsxref("NaN")}} is returned.
 ## Description
 
 The `parse()` method takes a date string (such as
-"`2011-10-10T14:48:00`") and returns the number of milliseconds since January
+`"2011-10-10T14:48:00"`) and returns the number of milliseconds since January
 1, 1970, 00:00:00 UTC.
 
 This function is useful for setting date values based on string values, for example in
@@ -65,9 +62,9 @@ The standard string representation of a date time string is a simplification of 
 (See the section [Date Time String Format](https://tc39.es/ecma262/#sec-date-time-string-format)
 in the ECMAScript specification for more details.)
 
-For example, "`2011-10-10`" (_date-only_ form),
-"`2011-10-10T14:48:00`" (_date-time_ form), or
-"`2011-10-10T14:48:00.000+09:00`" (_date-time_ form with milliseconds
+For example, `"2011-10-10"` (_date-only_ form),
+`"2011-10-10T14:48:00"` (_date-time_ form), or
+`"2011-10-10T14:48:00.000+09:00"` (_date-time_ form with milliseconds
 and time zone) can be passed and will be parsed. When the time zone offset is absent,
 date-only forms are interpreted as a UTC time and date-time forms are interpreted as
 local time.
@@ -112,7 +109,7 @@ new Date('2014-25-23').toISOString();
 ```
 
 SpiderMonkey's implementation-specific heuristic can be found in [`jsdate.cpp`](https://searchfox.org/mozilla-central/source/js/src/jsdate.cpp?rev=64553c483cd1#889).
-The string "`10 06 2014`" is an example of a non-conforming ISO format and
+The string `"10 06 2014"` is an example of a non-conforming ISO format and
 thus falls back to a custom routine. See also this [rough outline](https://bugzilla.mozilla.org/show_bug.cgi?id=1023155#c6) on
 how the parsing works.
 
@@ -137,9 +134,9 @@ Date.parse('foo-bar 2014');
 > **Note:** This section contains implementation-specific behavior that can be inconsistent
 > across implementations.
 
-Given a non-standard date string of "`March 7, 2014`", `parse()`
+Given a non-standard date string of `"March 7, 2014"`, `parse()`
 assumes a local time zone, but given a simplification of the ISO 8601 calendar date
-extended format such as "`2014-03-07`", it will assume a time zone of UTC
+extended format such as `"2014-03-07"`, it will assume a time zone of UTC
 (ES5 and ECMAScript 2015). Therefore {{jsxref("Date")}} objects produced using those
 strings may represent different moments in time depending on the version of ECMAScript
 supported unless the system is set with a local time zone of UTC. This means that two


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

Fix #9605
Fix #9608

I think parsing ISO date strings is useful enough to not be completely discouraged.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
