### PR TITLE
Fix punctuation and update var declarations

### DIFF
--- a/files/en-us/web/api/console/index.md
+++ b/files/en-us/web/api/console/index.md
@@ -93,7 +93,7 @@ There are two ways to use each of the output methods; you can pass in a list of 
 The simplest way to use the logging methods is to output a single object:
 
 ```js
-var someObject = { str: "Some text", id: 5 };
+const someObject = { str: "Some text", id: 5 };
 console.log(someObject);
 ```
 
@@ -108,12 +108,12 @@ The output looks something like this:
 You can also output multiple objects by listing them when calling the logging method, like this:
 
 ```js
-var car = "Dodge Charger";
-var someObject = { str: "Some text", id: 5 };
+const car = "Dodge Charger";
+const someObject = { str: "Some text", id: 5 };
 console.info("My first car was a", car, ". The object is:", someObject);
 ```
 
-This output will look like this:
+The output will look like this:
 
 ```bash
 [09:28:22.711] My first car was a Dodge Charger . The object is: ({str:"Some text", id:5})
@@ -126,18 +126,18 @@ When passing a string to one of the `console` object's methods that accepts a st
 - `%o` or `%O`
   - : Outputs a JavaScript object. Clicking the object name opens more information about it in the inspector.
 - `%d` or `%i`
-  - : Outputs an integer. Number formatting is supported, for example `console.log("Foo %.2d", 1.1)` will output the number as two significant figures with a leading 0: `Foo 01`
+  - : Outputs an integer. Number formatting is supported, for example `console.log("Foo %.2d", 1.1)` will output the number as two significant figures with a leading 0: `Foo 01`.
 - `%s`
   - : Outputs a string.
 - `%f`
-  - : Outputs a floating-point value. Formatting is supported, for example `console.log("Foo %.2f", 1.1)` will output the number to 2 decimal places: `Foo 1.10`
+  - : Outputs a floating-point value. Formatting is supported, for example `console.log("Foo %.2f", 1.1)` will output the number to 2 decimal places: `Foo 1.10`.
 
-> **Note:** Precision formatting doesn't work in Chrome
+> **Note:** Precision formatting doesn't work in Chrome.
 
 Each of these pulls the next argument after the format string off the parameter list. For example:
 
 ```js
-for (var i=0; i<5; i++) {
+for (let i=0; i<5; i++) {
   console.log("Hello, %s. You've called me %d times.", "Bob", i+1);
 }
 ```
@@ -172,7 +172,7 @@ console.log("Multiple styles: %cred %corange", "color: red", "color: orange", "A
 
 The properties usable along with the `%c` syntax are as follows (at least, in Firefox — they may differ in other browsers):
 
-- {{cssxref("background")}} and its longhand equivalents.
+- {{cssxref("background")}} and its longhand equivalents
 - {{cssxref("border")}} and its longhand equivalents
 - {{cssxref("border-radius")}}
 - {{cssxref("box-decoration-break")}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Added missing periods at the end of the sentences and changed var keyword to const/let as appropriate. Also changed "This" to "The" and removed period from the list item as both of these things look out of place.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
