### PR TITLE
Fixed renamed variable not renamed in comments

### DIFF
--- a/files/en-us/web/javascript/guide/working_with_private_class_features/index.md
+++ b/files/en-us/web/javascript/guide/working_with_private_class_features/index.md
@@ -205,7 +205,7 @@ class Scalar {
   }
 
   add(s) {
-    // check the passed object defines #length
+    // check the passed object defines #total
     if (!(#total in s)) {
       throw new TypeError("Expected an instance of Scalar");
     }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Fixed renamed variable not renamed in comments
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
It's just wrong originally. It most likely was `#length` originally and the variable was renamed, but the renamer didn't change the comment.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Working_With_Private_Class_Features#checking_if_a_private_fieldmethod_exists
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
