### PR TITLE
Fix demonstrating default behaviour twice

### DIFF
--- a/files/en-us/web/api/element/scrollintoviewifneeded/index.md
+++ b/files/en-us/web/api/element/scrollintoviewifneeded/index.md
@@ -40,8 +40,8 @@ None ({{jsxref("undefined")}}).
 ```js
 var element = document.getElementById("my-el");
 
-element.scrollIntoViewIfNeeded();
-element.scrollIntoViewIfNeeded(true); // Centers the element in the visible area
+element.scrollIntoViewIfNeeded(); // Centers the element in the visible area
+element.scrollIntoViewIfNeeded(false); // Aligns the element to the nearest edge in the visible area
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Demonstrate default and other behaviour of `scrollIntoViewIfNeeded` instead of default behaviour twice.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Understanding the function better.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Same doc mentions that the default is `true`.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
None.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
