### PR TITLE
replacement function params order error

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/replace/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/replace/index.md
@@ -181,7 +181,7 @@ transform the case and concatenate the hyphen before returning.
 
 ```js
 function styleHyphenFormat(propertyName) {
-  function upperToHyphenLower(match, string, offset) {
+  function upperToHyphenLower(match, offset, string) {
     return (offset > 0 ? '-' : '') + match.toLowerCase();
   }
   return propertyName.replace(/[A-Z]/g, upperToHyphenLower);


### PR DESCRIPTION
offset before string

#### Summary
switch the order of params

#### Motivation
the function can't work

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ✅ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
