### PR TITLE
Complete self-closing tag

### DIFF
--- a/files/en-us/learn/server-side/django/authentication/index.md
+++ b/files/en-us/learn/server-side/django/authentication/index.md
@@ -311,7 +311,7 @@ This is the form used to get the user's email address (for sending the password 
     \{{ form.email.errors }}
   {% endif %}
       <p>\{{ form.email }}</p>
-    <input type="submit" class="btn btn-default btn-lg" value="Reset password">
+    <input type="submit" class="btn btn-default btn-lg" value="Reset password" />
   </form>
 {% endblock %}
 ```


### PR DESCRIPTION
#### Summary
Adds a missing slash for a self-closing tag.

#### Motivation
Just a minor fix to clean the code.

#### Supporting details
I checked and this issue doesn't appear in the [locallibrary tutorial directory](https://github.com/mdn/django-locallibrary-tutorial/blob/master/templates/registration/password_reset_form.html).

#### Related issues
None

#### Metadata
This PR…
- [x] Fixes a typo, bug, or other error
