### PR TITLE
Revert "matches can be used with array as a parameter (#17010)"

### DIFF
--- a/files/en-us/web/api/element/matches/index.md
+++ b/files/en-us/web/api/element/matches/index.md
@@ -14,27 +14,27 @@ browser-compat: api.Element.matches
 ---
 {{APIRef("DOM")}}
 
-The **`matches()`** method of the {{domxref("Element")}} interface tests whether the element would be selected by the specified [selectors](/en-US/docs/Learn/CSS/Building_blocks/Selectors).
+The **`matches()`** method of the {{domxref("Element")}} interface tests whether the element would be selected by the specified [CSS selector](/en-US/docs/Learn/CSS/Building_blocks/Selectors).
 
 ## Syntax
 
 ```js
-matches(selectors)
+matches(selectorString)
 ```
 
 ### Parameters
 
 - `selectors`
-  - : A [selectors](/en-US/docs/Learn/CSS/Building_blocks/Selectors) string, or an array of [selectors](/en-US/docs/Learn/CSS/Building_blocks/Selectors) strings.
+  - : A string of valid [CSS selector](/en-US/docs/Learn/CSS/Building_blocks/Selectors) to test the {{domxref("Element")}} against.
 
 ### Return value
 
-`true` if the {{domxref("Element")}} matches the `selectors` value. Otherwise, `false`.
+`true` if the {{domxref("Element")}} matches the `selectors`. Otherwise, `false`.
 
 ### Exceptions
 
 - `SyntaxError` {{domxref("DOMException")}}
-  - : Thrown if `selectors` is not valid.
+  - : Thrown if the `selectors` is not a valid CSS selector.
 
 ## Examples
 
@@ -42,42 +42,26 @@ matches(selectors)
 
 ```html
 <ul id="birds">
-  <li class="amazon">Orange-winged parrot</li>
-  <li class="pacific">Philippine eagle</li>
-  <li class="europe asia africa">Great white pelican</li>
+  <li>Orange-winged parrot</li>
+  <li class="endangered">Philippine eagle</li>
+  <li>Great white pelican</li>
 </ul>
-<p></p>
 ```
 
 ### JavaScript
 
 ```js
 const birds = document.querySelectorAll('li');
-const p = document.querySelector('p');
-const results = [];
 
-p.append(`Amazon: `);
 for (const bird of birds) {
-  // the 'matches()' argument can be a string
-  if (bird.matches('.amazon')) {
-    results.push(`${bird.textContent}`);
+  if (bird.matches('.endangered')) {
+    console.log(`The ${bird.textContent} is endangered!`);
   }
 }
-p.append(`${results.join(', ')}. `);
-
-results.length = 0;
-p.append(`Asia and Pacific regions: `);
-for (const bird of birds) {
-  // the 'matches()' argument can be an array of strings
-  if (bird.matches(['.asia', '.pacific'])) {
-    results.push(`${bird.textContent}`);
-  }
-}
-p.append(`${results.join(', ')}. `);
-
 ```
 
-{{EmbedLiveSample("Examples")}}
+This will log "The Philippine eagle is endangered!" to the console, since the element
+has indeed a `class` attribute with value `endangered`.
 
 ## Specifications
 

--- a/files/en-us/web/api/element/matches/index.md
+++ b/files/en-us/web/api/element/matches/index.md
@@ -34,7 +34,7 @@ matches(selectorString)
 ### Exceptions
 
 - `SyntaxError` {{domxref("DOMException")}}
-  - : Thrown if the `selectors` is not a valid CSS selector.
+  - : Thrown if `selectors` cannot be parsed as a CSS selector list.
 
 ## Examples
 

--- a/files/en-us/web/api/element/matches/index.md
+++ b/files/en-us/web/api/element/matches/index.md
@@ -25,7 +25,7 @@ matches(selectorString)
 ### Parameters
 
 - `selectors`
-  - : A string of valid [CSS selector](/en-US/docs/Learn/CSS/Building_blocks/Selectors) to test the {{domxref("Element")}} against.
+  - : A string containing valid [CSS selectors](/en-US/docs/Learn/CSS/Building_blocks/Selectors) to test the {{domxref("Element")}} against.
 
 ### Return value
 


### PR DESCRIPTION
Reverts the edits made in #17010

The Selector spec does not have any logic for handling arrays. It implicitly coerces its argument to string. In the case of a CSS selector, the default behavior of an array (join using comma delimiter) works out pretty well, but this isn't a documented facet of the selector API at all, merely a coincidence.

For example, if you had a custom array that joined with `;` instead of `,`, that array can't be used to do selection and in fact will crash:
```js
class MyCustomArray extends Array {
    toString() { return this.join(";"); }
}
const c = new MyCustomArray();
c.push('body');
c.push('body');
// Crashes: the selectory "body;body" is not legal
document.body.matches(c);
```