### PR TITLE
Django: Remove closing backslash in self closing tags

### DIFF
--- a/files/en-us/learn/server-side/django/authentication/index.md
+++ b/files/en-us/learn/server-side/django/authentication/index.md
@@ -247,8 +247,8 @@ Create a new HTML file called /**locallibrary/templates/registration/login.html*
         <td>\{{ form.password }}</td>
       </tr>
     </table>
-    <input type="submit" value="login" />
-    <input type="hidden" name="next" value="\{{ next }}" />
+    <input type="submit" value="login">
+    <input type="hidden" name="next" value="\{{ next }}">
   </form>
 
   {# Assumes you setup the password_reset view in your URLconf #}
@@ -362,7 +362,7 @@ This page is where you enter your new password after clicking the link in the pa
                 </tr>
                 <tr>
                     <td></td>
-                    <td><input type="submit" value="Change my password" /></td>
+                    <td><input type="submit" value="Change my password"></td>
                 </tr>
             </table>
         </form>

--- a/files/en-us/learn/server-side/django/web_application_security/index.md
+++ b/files/en-us/learn/server-side/django/web_application_security/index.md
@@ -91,12 +91,12 @@ They would then send the file to all the Librarians and suggest that they open t
 
 <form action="http://127.0.0.1:8000/catalog/author/create/" method="post" name='EvilForm'>
   <table>
-    <tr><th><label for="id_first_name">First name:</label></th><td><input id="id_first_name" maxlength="100" name="first_name" type="text" value="Mad" required /></td></tr>
-    <tr><th><label for="id_last_name">Last name:</label></th><td><input id="id_last_name" maxlength="100" name="last_name" type="text" value="Man" required /></td></tr>
-    <tr><th><label for="id_date_of_birth">Date of birth:</label></th><td><input id="id_date_of_birth" name="date_of_birth" type="text" /></td></tr>
-    <tr><th><label for="id_date_of_death">Died:</label></th><td><input id="id_date_of_death" name="date_of_death" type="text" value="12/10/2016" /></td></tr>
+    <tr><th><label for="id_first_name">First name:</label></th><td><input id="id_first_name" maxlength="100" name="first_name" type="text" value="Mad" required></td></tr>
+    <tr><th><label for="id_last_name">Last name:</label></th><td><input id="id_last_name" maxlength="100" name="last_name" type="text" value="Man" required></td></tr>
+    <tr><th><label for="id_date_of_birth">Date of birth:</label></th><td><input id="id_date_of_birth" name="date_of_birth" type="text"></td></tr>
+    <tr><th><label for="id_date_of_death">Died:</label></th><td><input id="id_date_of_death" name="date_of_death" type="text" value="12/10/2016"></td></tr>
   </table>
-  <input type="submit" value="Submit" />
+  <input type="submit" value="Submit">
 </form>
 
 </body>
@@ -108,7 +108,7 @@ Run the development web server, and log in with your superuser account. Copy the
 The way the protection is enabled is that you include the `{% csrf_token %}` template tag in your form definition. This token is then rendered in your HTML as shown below, with a value that is specific to the user on the current browser.
 
 ```html
-<input type='hidden' name='csrfmiddlewaretoken' value='0QRWHnYVg776y2l66mcvZqp8alrv4lb8S8lZ4ZJUWGZFA5VHrVfL2mpH29YZ39PW' />
+<input type='hidden' name='csrfmiddlewaretoken' value='0QRWHnYVg776y2l66mcvZqp8alrv4lb8S8lZ4ZJUWGZFA5VHrVfL2mpH29YZ39PW'>
 ```
 
 Django generates a user/browser specific key and will reject forms that do not contain the field, or that contain an incorrect field value for the user/browser.


### PR DESCRIPTION
A number of self closing tags in django examples had a trailing backslash. This is not needed in HTML5.

Corresponding changes in https://github.com/mdn/django-locallibrary-tutorial/pull/106

As discussed in #17138