### PR TITLE
Updates a live sample

### DIFF
--- a/files/en-us/web/api/screenorientation/lock/index.md
+++ b/files/en-us/web/api/screenorientation/lock/index.md
@@ -120,7 +120,10 @@ unlock_btn.addEventListener('click', () => {
 const fullscreen_btn = document.querySelector('#fullscreen_button');
 fullscreen_btn.addEventListener('click', () => {
   log.textContent+='Fullscreen pressed \n';
-  document.querySelector("#example_container").requestFullscreen();
+  const container = document.querySelector("#example_container");
+  container.requestFullscreen().catch( error => {
+      log.textContent += `${error}\n`
+  });
 } );
 ```
 


### PR DESCRIPTION
When clicked on 'Fullscreen' button it throws `TypeError: fullscreen error`. And it's not being logged in the live sample.
The PR logs the error like it's been done for the 'Lock' handler.