### PR TITLE
Fix issue 17003: more syntax examples

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
@@ -35,6 +35,9 @@ The reducer walks through the array element-by-element, at each step adding the 
 reduce((previousValue, currentValue) => { /* ... */ } )
 reduce((previousValue, currentValue, currentIndex) => { /* ... */ } )
 reduce((previousValue, currentValue, currentIndex, array) => { /* ... */ } )
+
+reduce((previousValue, currentValue) => { /* ... */ } , initialValue)
+reduce((previousValue, currentValue, currentIndex) => { /* ... */ } , initialValue)
 reduce((previousValue, currentValue, currentIndex, array) => { /* ... */ }, initialValue)
 
 // Callback function
@@ -45,6 +48,9 @@ reduce(callbackFn, initialValue)
 reduce(function(previousValue, currentValue) { /* ... */ })
 reduce(function(previousValue, currentValue, currentIndex) { /* ... */ })
 reduce(function(previousValue, currentValue, currentIndex, array) { /* ... */ })
+
+reduce(function(previousValue, currentValue) { /* ... */ }, initialValue)
+reduce(function(previousValue, currentValue, currentIndex) { /* ... */ }, initialValue)
 reduce(function(previousValue, currentValue, currentIndex, array) { /* ... */ }, initialValue)
 ```
 


### PR DESCRIPTION
This attempts to fix https://github.com/mdn/content/issues/17003 by adding more syntax examples, to emphasise that the reducer function might not want to make use of all the arguments it's passed.
