### PR TITLE
fix(scroll-snap-align): update safari bug note

### DIFF
--- a/files/en-us/web/css/scroll-snap-align/index.md
+++ b/files/en-us/web/css/scroll-snap-align/index.md
@@ -41,7 +41,7 @@ scroll-snap-align: unset;
 - `center`
   - : The center alignment of this box's scroll snap area, within the scroll container's snapport is a snap position in this axis.
 
-Safari currently has the two value syntax in the wrong order, the first value being inline the second block. See [bug #191865](https://bugs.webkit.org/show_bug.cgi?id=191865).
+Safari had the two value syntax in the wrong order, the first value being inline the second block. See [bug #191865](https://bugs.webkit.org/show_bug.cgi?id=191865).
 
 ## Formal definition
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
The bug with the `scroll-snap-align` value syntax being in the wrong order in Safari is fixed. This PR reflects that.

#### Motivation
Update Safari 

#### Supporting details
Referenced Webkit ticket: https://bugs.webkit.org/show_bug.cgi?id=191865

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
