### PR TITLE
Fixed typo in sub-heading

### DIFF
--- a/files/en-us/web/html/viewport_meta_tag/index.md
+++ b/files/en-us/web/html/viewport_meta_tag/index.md
@@ -20,7 +20,9 @@ Some mobile devices and other narrow screens render pages in a virtual window or
 
 This is done because not all pages are optimized for mobile and break (or at least look bad) when rendered at a small viewport width. This virtual viewport is a way to make non-mobile-optimized sites in general look better on narrow screen devices.
 
-However, this mechanism is not so good for pages that are optimized for narrow screens using [media queries](/en-US/docs/Web/CSS/Media_Queries) — if the virtual viewport is 980px for example, media queries that kick in at 640px or 480px or less will never be used, limiting the effectiveness of such responsive design techniques. The viewport meta tag mitigates this problem of virtual viewport on narrow screen devices.## Viewport basics
+However, this mechanism is not so good for pages that are optimized for narrow screens using [media queries](/en-US/docs/Web/CSS/Media_Queries) — if the virtual viewport is 980px for example, media queries that kick in at 640px or 480px or less will never be used, limiting the effectiveness of such responsive design techniques. The viewport meta tag mitigates this problem of virtual viewport on narrow screen devices.
+
+## Viewport basics
 
 A typical mobile-optimized site contains something like the following:
 


### PR DESCRIPTION
Viewport basics is a 'heading' but was previously, invalidly inserted into markup document, which is now being resolved

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
"viewport basics' markup was previously wrong but now is corrected

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
seem like an opportunity to contribute, by correcting proper sub heading markup on document

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
* added a new line to make sure 'viewport basics' sub heading is properly visible on article
