### PR TITLE
Added missing "outline: none" declaration

### DIFF
--- a/files/en-us/learn/css/styling_text/styling_links/index.md
+++ b/files/en-us/learn/css/styling_text/styling_links/index.md
@@ -411,6 +411,7 @@ body,html {
 a {
   flex: 1;
   text-decoration: none;
+  outline: none;
   text-align: center;
   line-height: 3;
   color: black;


### PR DESCRIPTION
The declaration, "outline:none" was missing from the Styling links as buttons example's CSS as implied by the line: "Next, we turn off the default text-decoration and outline — we don't want those spoiling our look".

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Added missing "outline: none" declaration that was implied to missing by the line: "Next, we turn off the default text-decoration and outline — we don't want those spoiling our look". 

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
To allow the reader to know how it is done within the example being discussed.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
