### PR TITLE
Changed `focused` to `hovered`

### DIFF
--- a/files/en-us/web/web_components/using_shadow_dom/index.md
+++ b/files/en-us/web/web_components/using_shadow_dom/index.md
@@ -88,7 +88,7 @@ shadow.appendChild(para);
 
 ## Working through a simple example
 
-Now let's walk through a simple example to demonstrate the shadow DOM in action inside a custom element — [`<popup-info>`](https://github.com/mdn/web-components-examples/tree/main/popup-info-box-web-component) (see a [live example](https://mdn.github.io/web-components-examples/popup-info-box-web-component/) also). This takes an image icon and a text string, and embeds the icon into the page. When the icon is focused, it displays the text in a pop up information box to provide further in-context information. To begin with, in our JavaScript file we define a class called `PopUpInfo`, which extends `HTMLElement`:
+Now let's walk through a simple example to demonstrate the shadow DOM in action inside a custom element — [`<popup-info>`](https://github.com/mdn/web-components-examples/tree/main/popup-info-box-web-component) (see a [live example](https://mdn.github.io/web-components-examples/popup-info-box-web-component/) also). This takes an image icon and a text string, and embeds the icon into the page. When the icon is hovered, it displays the text in a pop up information box to provide further in-context information. To begin with, in our JavaScript file we define a class called `PopUpInfo`, which extends `HTMLElement`:
 
 ```js
 class PopUpInfo extends HTMLElement {


### PR DESCRIPTION
Hovered is better than focused because people usually hover the icon and see the description than focusing on it; although focus in on CSS
Also it can be `hovered or focused`

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
