### PR TITLE
Fixes multiline markdown link text

### DIFF
--- a/files/en-us/web/api/xrreferencespace/getoffsetreferencespace/index.md
+++ b/files/en-us/web/api/xrreferencespace/getoffsetreferencespace/index.md
@@ -185,9 +185,7 @@ drawing a frame, immediately before fetching the viewer's pose using
 {{domxref("XRFrame.getViewerPose", "getViewerPose()")}}, and the rendering should be
 performed in this reference space.
 
-You can see code similar to this in use in our broader WebXR tutorial article called [Movement, orientation,
-and motion](/en-US/docs/Web/API/WebXR_Device_API/Movement_and_motion). In particular, check out the section called [Starting
-up the WebXR session](/en-US/docs/Web/API/WebXR_Device_API/Movement_and_motion#starting_up_the_webxr_session).
+You can see code similar to this in use in our broader WebXR tutorial article called [Movement, orientation, and motion](/en-US/docs/Web/API/WebXR_Device_API/Movement_and_motion). In particular, check out the section called [Starting up the WebXR session](/en-US/docs/Web/API/WebXR_Device_API/Movement_and_motion#starting_up_the_webxr_session).
 
 ## Specifications
 

--- a/files/en-us/web/api/xrrigidtransform/orientation/index.md
+++ b/files/en-us/web/api/xrrigidtransform/orientation/index.md
@@ -61,7 +61,6 @@ should be facing directly along the _y_ axis.
 
 ## See also
 
-- [Movement,
-  orientation, and motion](/en-US/docs/Web/API/WebXR_Device_API/Movement_and_motion)
+- [Movement, orientation, and motion](/en-US/docs/Web/API/WebXR_Device_API/Movement_and_motion)
 - {{interwiki("wikipedia", "versor", "Unit quaternions")}}
 - {{interwiki("wikipedia", "Quaternions and spatial rotation")}}

--- a/files/en-us/web/api/xrrigidtransform/xrrigidtransform/index.md
+++ b/files/en-us/web/api/xrrigidtransform/xrrigidtransform/index.md
@@ -94,8 +94,7 @@ Then {{domxref("XRSession.requestAnimationFrame", "requestAnimationFrame()")}} i
 called to ask for a new animation frame to draw into. The `drawFrame()`
 callback will be executed when the system is ready to draw the next frame.
 
-You can find more examples in [Movement, orientation,
-and motion](/en-US/docs/Web/API/WebXR_Device_API/Movement_and_motion).
+You can find more examples in [Movement, orientation, and motion](/en-US/docs/Web/API/WebXR_Device_API/Movement_and_motion).
 
 ## Specifications
 

--- a/files/en-us/web/api/xsltprocessor/index.md
+++ b/files/en-us/web/api/xsltprocessor/index.md
@@ -29,8 +29,7 @@ new XSLTProcessor()
 
 - [Throws] void {{domxref("XSLTProcessor.importStylesheet")}}({{domxref("Node")}} styleSheet)
   - : Imports the XSLT stylesheet. If the given node is a document node, you can pass in a
-    full XSL Transform or a [literal result element
-    transform](https://www.w3.org/TR/xslt/#result-element-stylesheet); otherwise, it must be an `<xsl:stylesheet>` or
+    full XSL Transform or a [literal result element transform](https://www.w3.org/TR/xslt/#result-element-stylesheet); otherwise, it must be an `<xsl:stylesheet>` or
     `<xsl:transform>` element.
 - [Throws] {{domxref("DocumentFragment")}}
   {{domxref("XSLTProcessor.transformToFragment")}}({{domxref("Node")}} source, {{domxref("Document")}} owner)

--- a/files/en-us/web/css/transform-function/matrix3d/index.md
+++ b/files/en-us/web/css/transform-function/matrix3d/index.md
@@ -259,5 +259,4 @@ body {
 
 - {{cssxref("transform")}}
 - {{cssxref("&lt;transform-function&gt;")}}
-- [Understanding the CSS
-  Transforms Matrix](https://dev.opera.com/articles/understanding-the-css-transforms-matrix/)
+- [Understanding the CSS Transforms Matrix](https://dev.opera.com/articles/understanding-the-css-transforms-matrix/)

--- a/files/en-us/web/css/transform-function/scale/index.md
+++ b/files/en-us/web/css/transform-function/scale/index.md
@@ -147,10 +147,8 @@ user has reduced animation specified in their system preferences.
 
 Find out more:
 
-- [MDN
-  Understanding WCAG, Guideline 2.3 explanations](/en-US/docs/Web/Accessibility/Understanding_WCAG/Operable#guideline_2.3_%e2%80%94_seizures_and_physical_reactions_do_not_design_content_in_a_way_that_is_known_to_cause_seizures_or_physical_reactions)
-- [Understanding Success Criterion
-  2.3.3 | W3C Understanding WCAG 2.1](https://www.w3.org/WAI/WCAG21/Understanding/animation-from-interactions)
+- [MDN Understanding WCAG, Guideline 2.3 explanations](/en-US/docs/Web/Accessibility/Understanding_WCAG/Operable#guideline_2.3_%e2%80%94_seizures_and_physical_reactions_do_not_design_content_in_a_way_that_is_known_to_cause_seizures_or_physical_reactions)
+- [Understanding Success Criterion 2.3.3 | W3C Understanding WCAG 2.1](https://www.w3.org/WAI/WCAG21/Understanding/animation-from-interactions)
 
 ## Examples
 

--- a/files/en-us/web/css/transform-function/scalex/index.md
+++ b/files/en-us/web/css/transform-function/scalex/index.md
@@ -18,8 +18,7 @@ x-axis (horizontally). Its result is a {{cssxref("&lt;transform-function&gt;")}}
 
 It modifies the abscissa of each element point by a constant factor, except when the scale factor is 1, in which case
 the function is the identity transform. The scaling is not isotropic, and the angles of the element are not conserved.
-`scaleX(-1)` defines an [axial
-symmetry](https://en.wikipedia.org/wiki/Axial_symmetry), with a vertical axis passing through the origin (as specified by the {{cssxref("transform-origin")}}
+`scaleX(-1)` defines an [axial symmetry](https://en.wikipedia.org/wiki/Axial_symmetry), with a vertical axis passing through the origin (as specified by the {{cssxref("transform-origin")}}
 property).
 
 > **Note:** `scaleX(sx)` is equivalent to

--- a/files/en-us/web/css/transform-function/scaley/index.md
+++ b/files/en-us/web/css/transform-function/scaley/index.md
@@ -18,8 +18,7 @@ y-axis (vertically). Its result is a {{cssxref("&lt;transform-function&gt;")}} d
 
 It modifies the ordinate of each element point by a constant factor, except when the scale factor is 1, in which case
 the function is the identity transform. The scaling is not isotropic, and the angles of the element are not conserved.
-`scaleY(-1)` defines an [axial
-symmetry](https://en.wikipedia.org/wiki/Axial_symmetry), with a horizontal axis passing through the origin (as specified by the {{cssxref("transform-origin")}}
+`scaleY(-1)` defines an [axial symmetry](https://en.wikipedia.org/wiki/Axial_symmetry), with a horizontal axis passing through the origin (as specified by the {{cssxref("transform-origin")}}
 property).
 
 > **Note:** `scaleY(sy)` is equivalent to

--- a/files/en-us/web/http/basics_of_http/resource_urls/index.md
+++ b/files/en-us/web/http/basics_of_http/resource_urls/index.md
@@ -35,8 +35,7 @@ loaded the next one:
 resource://<File-loader> -> <File-loaded>
 ```
 
-Please refer to [Identifying
-resources on the web](/en-US/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web) for more general details.
+Please refer to [Identifying resources on the web](/en-US/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web) for more general details.
 
 In this article, we focus on resource URIs, which are used internally by Firefox to
 point to built-in resources.
@@ -48,8 +47,7 @@ websites, a web page could run internal scripts and inspect internal resources o
 Firefox, including the default preferences, which could be a serious security and
 privacy issue.
 
-For example, [a script on
-Browserleaks](https://browserleaks.com/firefox) highlights what Firefox reveals when queried by a simple script
+For example, [a script on Browserleaks](https://browserleaks.com/firefox) highlights what Firefox reveals when queried by a simple script
 running on the site (you can find the code in <https://browserleaks.com/firefox#more>).
 
 The file firefox.js passes preference names and values to the pref() function. For
@@ -98,8 +96,6 @@ resource: is Firefox only.
 
 ## See also
 
-- [Identifying
-  resources on the Web](/en-US/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web)
+- [Identifying resources on the Web](/en-US/docs/Web/HTTP/Basics_of_HTTP/Identifying_resources_on_the_Web)
 - [What is a URL?](/en-US/docs/Learn/Common_questions/What_is_a_URL)
-- [IANA list
-  of URI schemes](https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml) (`resource:` is [covered here](https://www.iana.org/assignments/uri-schemes/prov/resource))
+- [IANA list of URI schemes](https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml) (`resource:` is [covered here](https://www.iana.org/assignments/uri-schemes/prov/resource))

--- a/files/en-us/web/http/cors/errors/corsalloworiginnotmatchingorigin/index.md
+++ b/files/en-us/web/http/cors/errors/corsalloworiginnotmatchingorigin/index.md
@@ -52,5 +52,4 @@ add_header 'Access-Control-Allow-Origin' 'origin'
 - [CORS errors](/en-US/docs/Web/HTTP/CORS/Errors)
 - Glossary: {{Glossary("CORS")}}
 - [CORS introduction](/en-US/docs/Web/HTTP/CORS)
-- [Enable CORS: I want to add CORS
-  support to my server](https://enable-cors.org/server.html)
+- [Enable CORS: I want to add CORS support to my server](https://enable-cors.org/server.html)

--- a/files/en-us/web/http/cors/errors/corsmultiplealloworiginnotallowed/index.md
+++ b/files/en-us/web/http/cors/errors/corsmultiplealloworiginnotallowed/index.md
@@ -37,5 +37,4 @@ null
 - [CORS errors](/en-US/docs/Web/HTTP/CORS/Errors)
 - Glossary: {{Glossary("CORS")}}
 - [CORS introduction](/en-US/docs/Web/HTTP/CORS)
-- [Enable CORS: I want to add CORS
-  support to my server](https://enable-cors.org/server.html)
+- [Enable CORS: I want to add CORS support to my server](https://enable-cors.org/server.html)

--- a/files/en-us/web/http/headers/accept-ranges/index.md
+++ b/files/en-us/web/http/headers/accept-ranges/index.md
@@ -43,8 +43,7 @@ Accept-Ranges: none
 - `<range-unit>`
   - : Defines the range unit that the server supports. Though `bytes` is the only
     range unit formally defined by {{RFC("7233")}}, additional range units may be
-    registered in the[
-    HTTP Range Unit Registry](https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#range-units).
+    registered in the[HTTP Range Unit Registry](https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#range-units).
 - `none`
   - : Indicates that no range unit is supported. This makes the header equivalent of its own absence
     and is therefore, rarely used. Although in some browsers, like IE9, this setting is used to
@@ -68,5 +67,4 @@ Accept-Ranges: bytes
 
 - {{HTTPHeader("If-Range")}}
 - {{HTTPHeader("Range")}}
-- [IANA
-  HTTP Range Unit Registry](https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#range-units)
+- [IANA HTTP Range Unit Registry](https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#range-units)

--- a/files/en-us/web/http/headers/access-control-allow-methods/index.md
+++ b/files/en-us/web/http/headers/access-control-allow-methods/index.md
@@ -37,12 +37,10 @@ Access-Control-Allow-Methods: *
 ## Directives
 
 - \<method>
-  - : A comma-delimited list of the allowed [HTTP
-    request methods](/en-US/docs/Web/HTTP/Methods).
+  - : A comma-delimited list of the allowed [HTTP request methods](/en-US/docs/Web/HTTP/Methods).
 - `*` (wildcard)
   - : The value "`*`" only counts as a special wildcard value for requests
-    without credentials (requests without [HTTP
-    cookies](/en-US/docs/Web/HTTP/Cookies) or HTTP authentication information). In requests with credentials, it is
+    without credentials (requests without [HTTP cookies](/en-US/docs/Web/HTTP/Cookies) or HTTP authentication information). In requests with credentials, it is
     treated as the literal method name "`*`" without special semantics.
 
 ## Examples

--- a/files/en-us/web/http/headers/content-location/index.md
+++ b/files/en-us/web/http/headers/content-location/index.md
@@ -11,8 +11,7 @@ browser-compat: http.headers.Content-Location
 
 The **`Content-Location`** header indicates an alternate
 location for the returned data. The principal use is to indicate the URL of a resource
-transmitted as the result of [content
-negotiation](/en-US/docs/Web/HTTP/Content_negotiation).
+transmitted as the result of [content negotiation](/en-US/docs/Web/HTTP/Content_negotiation).
 
 {{HTTPHeader("Location")}} and `Content-Location` are different.
 `Location` indicates the URL of a redirect, while
@@ -64,8 +63,7 @@ URLs for `Content-Location` depending on the request's
 | `Accept: text/plain, text/*`          | `Content-Location: /documents/foo.txt`  |
 
 These URLs are examples — the site could serve the different filetypes with any URL
-patterns it wishes, such as a [query string
-parameter](/en-US/docs/Web/API/HTMLAnchorElement/search): `/documents/foo?format=json`,
+patterns it wishes, such as a [query string parameter](/en-US/docs/Web/API/HTMLAnchorElement/search): `/documents/foo?format=json`,
 `/documents/foo?format=xml`, and so on.
 
 Then the client could remember that the JSON version is available at that particular

--- a/files/en-us/web/http/headers/content-security-policy/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/index.md
@@ -167,8 +167,7 @@ Reporting directives control the reporting process of CSP violations. See also t
 - {{CSP("require-sri-for")}}{{experimental_inline}}
   - : Requires the use of {{Glossary("SRI")}} for scripts or styles on the page.
 - {{CSP("require-trusted-types-for")}}{{experimental_inline}}
-  - : Enforces [Trusted
-    Types](https://w3c.github.io/webappsec-trusted-types/dist/spec/) at the DOM XSS injection sinks.
+  - : Enforces [Trusted Types](https://w3c.github.io/webappsec-trusted-types/dist/spec/) at the DOM XSS injection sinks.
 - {{CSP("trusted-types")}}{{experimental_inline}}
   - : Used to specify an allow-list of [Trusted Types](https://w3c.github.io/webappsec-trusted-types/dist/spec/)
     policies. Trusted Types allows applications to lock down DOM XSS injection sinks to
@@ -299,8 +298,7 @@ would have occurred:
 Content-Security-Policy-Report-Only: default-src https:; report-uri /csp-violation-report-endpoint/
 ```
 
-See [Mozilla
-Web Security Guidelines](https://infosec.mozilla.org/guidelines/web_security#Examples_5) for more examples.
+See [Mozilla Web Security Guidelines](https://infosec.mozilla.org/guidelines/web_security#Examples_5) for more examples.
 
 ## Specifications
 

--- a/files/en-us/web/http/headers/content-security-policy/plugin-types/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/plugin-types/index.md
@@ -55,8 +55,7 @@ Content-Security-Policy: plugin-types <type>/<subtype> <type>/<subtype>;
 ```
 
 - \<type>/\<subtype>
-  - : A valid [MIME
-    type](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types).
+  - : A valid [MIME type](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types).
 
 ## Examples
 

--- a/files/en-us/web/http/headers/content-security-policy/require-sri-for/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/require-sri-for/index.md
@@ -15,8 +15,7 @@ browser-compat: http.headers.csp.Content-Security-Policy.require-sri-for
 
 The [HTTP](/en-US/docs/Web/HTTP) {{HTTPHeader("Content-Security-Policy")}}
 **`require-sri-for`** directive instructs the client to require
-the use of [Subresource
-Integrity](/en-US/docs/Web/Security/Subresource_Integrity) for scripts or styles on the page.
+the use of [Subresource Integrity](/en-US/docs/Web/Security/Subresource_Integrity) for scripts or styles on the page.
 
 ## Syntax
 

--- a/files/en-us/web/http/headers/content-security-policy/sandbox/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/sandbox/index.md
@@ -60,8 +60,7 @@ where `<value>` can optionally be one of the following values:
 - `allow-orientation-lock`
   - : Allows the page to disable the ability to lock the screen orientation.
 - `allow-pointer-lock`
-  - : Allows the page to use the [Pointer Lock
-    API](/en-US/docs/Web/API/Pointer_Lock_API).
+  - : Allows the page to use the [Pointer Lock API](/en-US/docs/Web/API/Pointer_Lock_API).
 - `allow-popups`
   - : Allows popups (like from `window.open`, `target="_blank"`,
     `showModalDialog`). If this keyword is not used, that functionality will

--- a/files/en-us/web/http/headers/feature-policy/autoplay/index.md
+++ b/files/en-us/web/http/headers/feature-policy/autoplay/index.md
@@ -21,8 +21,7 @@ returned by {{domxref("HTMLMediaElement.play()")}} will reject with
 a {{domxref("DOMException")}}. The {{htmlattrxref("autoplay", "audio")}} attribute on
 {{HTMLElement("audio")}} and {{HTMLElement("video")}} elements will be ignored.
 
-For more details on autoplay and autoplay blocking, see the article [Autoplay guide for media and Web Audio
-APIs](/en-US/docs/Web/Media/Autoplay_guide).
+For more details on autoplay and autoplay blocking, see the article [Autoplay guide for media and Web Audio APIs](/en-US/docs/Web/Media/Autoplay_guide).
 
 ## Syntax
 
@@ -50,5 +49,4 @@ The default value in [Google Chrome](https://chromestatus.com/feature/5100524789
 
 - {{HTTPHeader("Feature-Policy")}} header
 - [Feature Policy](/en-US/docs/Web/HTTP/Feature_Policy)
-- [Using Feature
-  Policy](/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy)
+- [Using Feature Policy](/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy)

--- a/files/en-us/web/http/headers/feature-policy/gamepad/index.md
+++ b/files/en-us/web/http/headers/feature-policy/gamepad/index.md
@@ -68,5 +68,4 @@ iframe attributes can selectively enable features in certain frames, and not in 
 
 - {{HTTPHeader("Feature-Policy")}} header
 - [Feature Policy](/en-US/docs/Web/HTTP/Feature_Policy)
-- [Using Feature
-  Policy](/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy)
+- [Using Feature Policy](/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy)

--- a/files/en-us/web/http/headers/feature-policy/geolocation/index.md
+++ b/files/en-us/web/http/headers/feature-policy/geolocation/index.md
@@ -80,5 +80,4 @@ even if those frames contain documents from the same origin.
 
 - {{HTTPHeader("Feature-Policy")}} header
 - [Feature Policy](/en-US/docs/Web/HTTP/Feature_Policy)
-- [Using Feature
-  Policy](/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy)
+- [Using Feature Policy](/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy)

--- a/files/en-us/web/http/headers/feature-policy/microphone/index.md
+++ b/files/en-us/web/http/headers/feature-policy/microphone/index.md
@@ -43,5 +43,4 @@ Default allow list for `microphone` is `'self'`.
 
 - {{HTTPHeader("Feature-Policy")}} header
 - [Feature Policy](/en-US/docs/Web/HTTP/Feature_Policy)
-- [Using Feature
-  Policy](/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy)
+- [Using Feature Policy](/en-US/docs/Web/HTTP/Feature_Policy/Using_Feature_Policy)

--- a/files/en-us/web/http/headers/if-unmodified-since/index.md
+++ b/files/en-us/web/http/headers/if-unmodified-since/index.md
@@ -18,8 +18,7 @@ after the specified date, the response will be a {{HTTPStatus("412", "412 Precon
 The **`If-Unmodified-Since`** HTTP header is commonly used in the following situations:
 
 - In conjunction with non-{{Glossary("Safe/HTTP", "safe")}} methods, like {{HTTPMethod("POST")}},
-  this header can be used to implement an [optimistic
-  concurrency control](https://en.wikipedia.org/wiki/Optimistic_concurrency_control), as is done by some wikis: editions are rejected if the
+  this header can be used to implement an [optimistic concurrency control](https://en.wikipedia.org/wiki/Optimistic_concurrency_control), as is done by some wikis: editions are rejected if the
   stored document has been modified since the original was retrieved.
 - In conjunction with a range request using the {{HTTPHeader("Range")}} header, this header can
   be used to ensure that the new fragment requested comes from an unmodified document.

--- a/files/en-us/web/http/headers/large-allocation/index.md
+++ b/files/en-us/web/http/headers/large-allocation/index.md
@@ -61,8 +61,7 @@ Large-Allocation: 500
 ## Troubleshooting errors
 
 The `Large-Allocation` header throws warnings or error messages when used
-incorrectly. You'll encounter them in the [web
-console](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html).
+incorrectly. You'll encounter them in the [web console](https://firefox-source-docs.mozilla.org/devtools-user/web_console/index.html).
 
 - This page was loaded in a new process due to a `Large-Allocation` header.
   - : This message means that the browser saw the `Large-Allocation` header,

--- a/files/en-us/web/http/headers/proxy-authenticate/index.md
+++ b/files/en-us/web/http/headers/proxy-authenticate/index.md
@@ -41,10 +41,8 @@ Proxy-Authenticate: <type> realm=<realm>
 ## Directives
 
 - \<type>
-  - : [Authentication
-    type](/en-US/docs/Web/HTTP/Authentication#authentication_schemes). A common type is ["Basic"](/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme).
-    IANA maintains a [list
-    of authentication schemes](https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml).
+  - : [Authentication type](/en-US/docs/Web/HTTP/Authentication#authentication_schemes). A common type is ["Basic"](/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme).
+    IANA maintains a [list of authentication schemes](https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml).
 - realm=\<realm>
   - : A description of the protected area, the realm. If no realm is specified, clients
     often display a formatted host name instead.

--- a/files/en-us/web/http/headers/proxy-authorization/index.md
+++ b/files/en-us/web/http/headers/proxy-authorization/index.md
@@ -38,10 +38,8 @@ Proxy-Authorization: <type> <credentials>
 ## Directives
 
 - \<type>
-  - : [Authentication
-    type](/en-US/docs/Web/HTTP/Authentication#authentication_schemes). A common type is ["Basic"](/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme).
-    See also the [IANA
-    registry of Authentication schemes](https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml).
+  - : [Authentication type](/en-US/docs/Web/HTTP/Authentication#authentication_schemes). A common type is ["Basic"](/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme).
+    See also the [IANA registry of Authentication schemes](https://www.iana.org/assignments/http-authschemes/http-authschemes.xhtml).
 - \<credentials>
 
   - : The credentials are constructed like this:

--- a/files/en-us/web/http/headers/public-key-pins/index.md
+++ b/files/en-us/web/http/headers/public-key-pins/index.md
@@ -20,11 +20,9 @@ browser-compat: http.headers.Public-Key-Pins
 The HTTP **`Public-Key-Pins`** response header used to
 associate a specific cryptographic public {{Glossary("key")}} with a certain web server
 to decrease the risk of {{Glossary("MITM")}} attacks with forged certificates. However,
-it has been removed from modern browsers and is no longer supported. Use [Certificate
-Transparency](/en-US/docs/Web/Security/Certificate_Transparency) and {{HTTPHeader("Expect-CT")}} header instead.
+it has been removed from modern browsers and is no longer supported. Use [Certificate Transparency](/en-US/docs/Web/Security/Certificate_Transparency) and {{HTTPHeader("Expect-CT")}} header instead.
 
-For more information, see the [HTTP
-Public Key Pinning](/en-US/docs/Web/HTTP/Public_Key_Pinning) article.
+For more information, see the [HTTP Public Key Pinning](/en-US/docs/Web/HTTP/Public_Key_Pinning) article.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/http/headers/x-content-type-options/index.md
+++ b/files/en-us/web/http/headers/x-content-type-options/index.md
@@ -12,8 +12,7 @@ browser-compat: http.headers.X-Content-Type-Options
 
 The **`X-Content-Type-Options`** response HTTP header is a
 marker used by the server to indicate that the [MIME types](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) advertised in the
-{{HTTPHeader("Content-Type")}} headers should be followed and not be changed. The header allows you to avoid [MIME type
-sniffing](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#mime_sniffing) by saying that the MIME types are deliberately
+{{HTTPHeader("Content-Type")}} headers should be followed and not be changed. The header allows you to avoid [MIME type sniffing](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#mime_sniffing) by saying that the MIME types are deliberately
 configured.
 
 This header was introduced by Microsoft in IE 8 as a way for webmasters to block

--- a/files/en-us/web/http/headers/x-dns-prefetch-control/index.md
+++ b/files/en-us/web/http/headers/x-dns-prefetch-control/index.md
@@ -93,8 +93,7 @@ You can reverse this setting by setting `content` to "`on`".
 
 You can force the lookup of specific hostnames without providing specific anchors using
 that hostname by using the {{ htmlattrxref("rel","link") }} attribute on the {{
-  HTMLElement("link") }} element with a [link
-type](/en-US/docs/Web/HTML/Link_types) of `dns-prefetch`:
+  HTMLElement("link") }} element with a [link type](/en-US/docs/Web/HTML/Link_types) of `dns-prefetch`:
 
 ```html
 <link rel="dns-prefetch" href="https://www.mozilla.org/contribute/">

--- a/files/en-us/web/http/headers/x-forwarded-for/index.md
+++ b/files/en-us/web/http/headers/x-forwarded-for/index.md
@@ -100,8 +100,7 @@ X-Forwarded-For: 203.0.113.195,2001:db8:85a3:8d3:1319:8a2e:370:7348,150.172.238.
 Improper parsing of the `X-Forwarded-For` header can result in spoofed values being used
 for security-related purposes, resulting in the negative consequences mentioned above.
 
-There may be multiple `X-Forwarded-For` headers present in a request (per [RFC
-2616](https://datatracker.ietf.org/doc/html/rfc2616#section-4.2)). The IP addresses in
+There may be multiple `X-Forwarded-For` headers present in a request (per [RFC 2616](https://datatracker.ietf.org/doc/html/rfc2616#section-4.2)). The IP addresses in
 these headers must be treated as a single list, starting with the first IP address of the
 first header and continuing to the last IP address of the last header. There are two ways
 of making this single list:
@@ -122,8 +121,7 @@ When choosing the `X-Forwarded-For` client IP address closest to the client (unt
 and _not_ for security-related purposes), the first IP from the leftmost that is _a valid
 address_ and _not private/internal_ should be selected. ("Valid" because spoofed values
 may not be IP addresses at all; "not internal/private" because clients may have used
-proxies on their internal network, which may have added addresses from the [private IP
-space](https://en.wikipedia.org/wiki/Private_network).)
+proxies on their internal network, which may have added addresses from the [private IP space](https://en.wikipedia.org/wiki/Private_network).)
 
 When choosing the first _trustworthy_ `X-Forwarded-For` client IP address, additional
 configuration is required. There are two common methods:

--- a/files/en-us/web/http/status/101/index.md
+++ b/files/en-us/web/http/status/101/index.md
@@ -17,8 +17,7 @@ The protocol is specified in the {{HTTPHeader("Upgrade")}} request header receiv
 
 The server includes in this response an {{HTTPHeader("Upgrade")}} response header to
 indicate the protocol it switched to. The process is described in the following article:
-[Protocol upgrade
-mechanism](/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism).
+[Protocol upgrade mechanism](/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism).
 
 ## Status
 
@@ -42,8 +41,7 @@ Connection: Upgrade
 
 ## See also
 
-- [Protocol upgrade
-  mechanism](/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism)
+- [Protocol upgrade mechanism](/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism)
 - [WebSockets](/en-US/docs/Web/API/WebSockets_API)
 - {{HTTPHeader("Upgrade")}}
 - {{HTTPStatus("426")}} `Upgrade Required`

--- a/files/en-us/web/http/status/204/index.md
+++ b/files/en-us/web/http/status/204/index.md
@@ -38,8 +38,7 @@ A 204 response is cacheable by default (an {{HTTPHeader("ETag")}} header is incl
 
 - Although this status code is intended to describe a response with no body, servers
   may erroneously include data following the headers. The protocol allows user agents to
-  vary in how they process such responses ([discussion regarding this
-  specification text can be found here](https://github.com/httpwg/http-core/issues/26)). This is observable in persistent
+  vary in how they process such responses ([discussion regarding this specification text can be found here](https://github.com/httpwg/http-core/issues/26)). This is observable in persistent
   connections, where the invalid body may include a distinct response to a subsequent
   request.
 

--- a/files/en-us/web/javascript/reference/global_objects/math/sign/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/sign/index.md
@@ -73,8 +73,7 @@ Math.sign();      // NaN
 ## See also
 
 - [Polyfill of `Math.sign` in `core-js`](https://github.com/zloirock/core-js#ecmascript-math)
-- [A
-  polyfill](https://github.com/behnammodi/polyfill/blob/master/math.polyfill.js)
+- [A polyfill](https://github.com/behnammodi/polyfill/blob/master/math.polyfill.js)
 - {{jsxref("Math.abs()")}}
 - {{jsxref("Math.ceil()")}}
 - {{jsxref("Math.floor()")}}

--- a/files/en-us/web/javascript/reference/global_objects/math/trunc/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/trunc/index.md
@@ -97,8 +97,7 @@ Math.trunc();         // NaN
 ## See also
 
 - [Polyfill of `Math.trunc` in `core-js`](https://github.com/zloirock/core-js#ecmascript-math)
-- [A
-  polyfill](https://github.com/behnammodi/polyfill/blob/master/math.polyfill.js)
+- [A polyfill](https://github.com/behnammodi/polyfill/blob/master/math.polyfill.js)
 - {{jsxref("Math.abs()")}}
 - {{jsxref("Math.ceil()")}}
 - {{jsxref("Math.floor()")}}

--- a/files/en-us/web/javascript/reference/global_objects/string/padend/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/padend/index.md
@@ -68,5 +68,4 @@ A {{jsxref("String")}} of the specified `targetLength` with the
 
 - [Polyfill of `String.prototype.padEnd` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.padStart()")}}
-- [A
-  polyfill](https://github.com/behnammodi/polyfill/blob/master/string.polyfill.js)
+- [A polyfill](https://github.com/behnammodi/polyfill/blob/master/string.polyfill.js)

--- a/files/en-us/web/javascript/reference/global_objects/string/padstart/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/padstart/index.md
@@ -83,5 +83,4 @@ console.log(leftFillNum(num, 5));
 
 - [Polyfill of `String.prototype.padStart` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.padEnd()")}}
-- [A
-  polyfill](https://github.com/behnammodi/polyfill/blob/master/string.polyfill.js)
+- [A polyfill](https://github.com/behnammodi/polyfill/blob/master/string.polyfill.js)

--- a/files/en-us/web/privacy/state_partitioning/index.md
+++ b/files/en-us/web/privacy/state_partitioning/index.md
@@ -45,8 +45,7 @@ access to some storage APIs (e.g., cookies and localStorage) for certain
 domains under certain conditions. For example, our "block all third-party
 cookies" policy will prevent all domains from accessing certain storage APIs
 when loaded in a third-party context. Our current
-[default cookie policy
-](en-US/docs/Mozilla/Firefox/Privacy/Storage_access_policy)blocks access in a third-party context only for domains classified as
+[default cookie policy](en-US/docs/Mozilla/Firefox/Privacy/Storage_access_policy) blocks access in a third-party context only for domains classified as
 trackers.
 
 ## State Partitioning
@@ -75,8 +74,7 @@ identifier when embedded in other websites.
 
 ### Standardization
 
-The [Privacy Community
-Group](https://privacycg.github.io/) has a Work Item for
+The [Privacy Community Group](https://privacycg.github.io/) has a Work Item for
 [Client-Side Storage Partitioning](https://privacycg.github.io/storage-partitioning/). This serves as an overview of the
 standardization efforts for storage partitioning in the individual standards
 affected. We intend to align our state partitioning implementation with these
@@ -196,8 +194,7 @@ third-party integrations that are common on the web to continue to function.
 #### Storage Access API
 
 Third-party frames may use
-[`document.requestStorageAccess`
-](/en-US/docs/Web/API/Document/requestStorageAccess) to request unpartitioned storage access through the
+[`document.requestStorageAccess` ](/en-US/docs/Web/API/Document/requestStorageAccess) to request unpartitioned storage access through the
 [Storage Access API](/en-US/docs/Web/API/Storage_Access_API). Once
 granted, the requesting third-party will gain access to its first-party
 storage bucket (i.e., the storage it would have access to if visited as a
@@ -234,8 +231,7 @@ with storage in a third-party context. In the following examples,
 
 If a third-party iframe is granted storage access to the parent context,
 Firefox sets a permission. To revoke access you can clear the permission via
-the [Site
-Information Panel](https://support.mozilla.org/en-US/kb/site-information-panel) in the permissions section under "Cross-site Cookies".
+the [Site Information Panel](https://support.mozilla.org/en-US/kb/site-information-panel) in the permissions section under "Cross-site Cookies".
 
 #### Test Preferences
 
@@ -257,11 +253,9 @@ Features disabled by the pref include:
 - Automatic storage access grants:
   [document.requestStorageAccess](/en-US/docs/Web/API/Document/requestStorageAccess)
   will always prompt the user.
-- [SmartBlock's "unblock on opt-in"
-  feature](https://blog.mozilla.org/security/2021/07/13/smartblock-v2/), which
+- [SmartBlock's "unblock on opt-in" feature](https://blog.mozilla.org/security/2021/07/13/smartblock-v2/), which
   will allow certain trackers when users interact with them.
-- Any temporary [anti-tracking
-  exceptions](https://wiki.mozilla.org/Security/Anti_tracking_policy#Temporary_Web_Compatibility_Interventions)
+- Any temporary [anti-tracking exceptions](https://wiki.mozilla.org/Security/Anti_tracking_policy#Temporary_Web_Compatibility_Interventions)
   granted to websites via the skip-listing mechanism.
 
 ##### Disable Heuristics
@@ -270,12 +264,10 @@ The following preferences can be used to disable individual storage access
 heuristics via the
 [config editor](https://support.mozilla.org/en-US/kb/about-config-editor-firefox):
 
-- Enable / disable the [redirect
-  heuristics](#storage_access_redirect_heuristics):
+- Enable / disable the [redirect heuristics](#storage_access_redirect_heuristics):
   `privacy.restrict3rdpartystorage.heuristic.recently_visited`,
   `privacy.restrict3rdpartystorage.heuristic.redirect`
-- Enable / disable the [window
-  open heuristics](#storage_access_window_open_heuristics):
+- Enable / disable the [window open heuristics](#storage_access_window_open_heuristics):
   `privacy.restrict3rdpartystorage.heuristic.window_open`,
   `privacy.restrict3rdpartystorage.heuristic.opened_window_after_interaction`
 

--- a/files/en-us/web/privacy/storage_access_policy/errors/cookiepartitionedforeign/index.md
+++ b/files/en-us/web/privacy/storage_access_policy/errors/cookiepartitionedforeign/index.md
@@ -22,14 +22,12 @@ third-party context and storage partitioning is enabled.
 
 A request to access cookies or storage was _partitioned_ because it
 came from a third-party (a different origin) and
-[dynamic state partitioning
-](/en-US/docs/Web/Privacy/State_Partitioning#dynamic_state_partitioning)is enabled.
+[dynamic state partitioning](/en-US/docs/Web/Privacy/State_Partitioning#dynamic_state_partitioning)is enabled.
 
 With Dynamic State Partitioning enabled, Firefox provides embedded resources with a
 separate storage bucket for every top-level website. Embedded third-parties may
 request access to the top-level storage bucket via the [Storage Access API](/en-US/docs/Web/Privacy/State_Partitioning#storage_access_api).
-You can also [disable
-Dynamic State Partitioning](/en-US/docs/Web/Privacy/State_Partitioning#disable_dynamic_state_partitioning) with the
+You can also [disable Dynamic State Partitioning](/en-US/docs/Web/Privacy/State_Partitioning#disable_dynamic_state_partitioning) with the
 `network.cookie.cookieBehavior` pref.
 
 ## See also

--- a/files/en-us/web/webdriver/capabilities/firefoxoptions/index.md
+++ b/files/en-us/web/webdriver/capabilities/firefoxoptions/index.md
@@ -285,8 +285,7 @@ This runs the GeckoView example application as installed on the first Android em
 
 ## See also
 
-- [geckodriver's
-  documentation on supported Firefox capabilities](https://firefox-source-docs.mozilla.org/testing/geckodriver/Capabilities.html)
+- [geckodriver's documentation on supported Firefox capabilities](https://firefox-source-docs.mozilla.org/testing/geckodriver/Capabilities.html)
 - [Chrome-specific WebDriver capabilities](https://chromedriver.chromium.org/capabilities)
   (`goog:chromeOptions)`
 - [List of WebDriver capabilities](/en-US/docs/Web/WebDriver/Capabilities)

--- a/files/en-us/webassembly/existing_c_to_wasm/index.md
+++ b/files/en-us/webassembly/existing_c_to_wasm/index.md
@@ -173,8 +173,7 @@ api.free_result(resultPointer);
 
 Depending on the size of your image, you might run into an error where wasm can't grow the memory enough to accommodate both the input and the output image:
 
-![
-  Screenshot of the DevTools console showing an error.](error.png)
+![Screenshot of the DevTools console showing an error.](error.png)
 
 Luckily, the solution to this problem is in the error message. You just need to add `-s ALLOW_MEMORY_GROWTH=1` to your compilation command.
 


### PR DESCRIPTION
This is the last one.
All such links have been fixed.