### PR TITLE
Fix flaws in VideoFrame

### DIFF
--- a/files/en-us/web/api/videoframe/index.md
+++ b/files/en-us/web/api/videoframe/index.md
@@ -11,7 +11,7 @@ browser-compat: api.VideoFrame
 ---
 {{DefaultAPISidebar("Web Codecs API")}}
 
-The **`VideoFrame`** interface of the {{domxref('Web Codecs API','','',' ')}} represents a frame of a video.
+The **`VideoFrame`** interface of the [Web Codecs API](/en-US/docs/Web/API/WebCodecs_API) represents a frame of a video.
 
 `VideoFrame` is a {{glossary("Transferable objects","transferable object")}}.
 

--- a/files/en-us/web/api/videoframe/videoframe/index.md
+++ b/files/en-us/web/api/videoframe/videoframe/index.md
@@ -1,5 +1,5 @@
 ---
-title: VideoFrame.VideoFrame()
+title: VideoFrame()
 slug: Web/API/VideoFrame/VideoFrame
 page-type: web-api-constructor
 tags:
@@ -52,10 +52,10 @@ The first type of constructor (see above) creates a new {{domxref("VideoFrame")}
     - `displayHeight`{{Optional_Inline}}
       - : The height of the `VideoFrame` when displayed after applying aspect-ratio adjustments.
 
-The second type of constructor (see above) creates a new {{domxref("VideoFrame")}} from an {{domxref("ArrayBuffer")}}. Its parameters are:
+The second type of constructor (see above) creates a new {{domxref("VideoFrame")}} from an {{jsxref("ArrayBuffer")}}. Its parameters are:
 
 - `data`
-  - : An {{domxref("ArrayBuffer")}} containing the data for the new `VideoFrame`.
+  - : An {{jsxref("ArrayBuffer")}} containing the data for the new `VideoFrame`.
 - `init`
   - : A dictionary object containing the following:
     - `format`


### PR DESCRIPTION
There are a few oddities in `VideoFrame`:

- Constructor name was incorrect
- Bad typography of the link to the overview page (Web Codecs API)
- 2 broken links (`ArrayBuffer` is a JS feature, not a Web API)

This PR fixes these.