### PR TITLE
Fixed anchor links for CSS Typed Object Model

### DIFF
--- a/files/en-us/web/api/stylepropertymap/index.md
+++ b/files/en-us/web/api/stylepropertymap/index.md
@@ -14,7 +14,7 @@ browser-compat: api.StylePropertyMap
 ---
 {{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}
 
-The **`StylePropertyMap`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model#css_typed_object_model) provides a representation of a CSS declaration block that is an alternative to {{DOMxRef("CSSStyleDeclaration")}}.
+The **`StylePropertyMap`** interface of the [CSS Typed Object Model API](/en-US/docs/Web/API/CSS_Object_Model#css_typed_object_model_experimental) provides a representation of a CSS declaration block that is an alternative to {{DOMxRef("CSSStyleDeclaration")}}.
 
 {{InheritanceDiagram}}
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
I fixed the anchor for the 'CSS Typed Object Model API'  link.

#### Motivation
The link to the 'CSS Typed Object Model API' page was broken because it pointed to an non-existent anchor. 

#### Related issues
 #16265 changed the link to all lower-case, but it still lacked the '_experimental' at the end

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
