### PR TITLE
Fix a live sample

### DIFF
--- a/files/en-us/web/css/filter/index.md
+++ b/files/en-us/web/css/filter/index.md
@@ -687,7 +687,7 @@ table.standard-table td {
 ```html
 <svg style="position: absolute; top: -999999px" xmlns="http://www.w3.org/2000/svg">
   <filter id="svgHueRotate">
-    <feColorMatrix type="hueRotate" values="[angle]"/>
+    <feColorMatrix type="hueRotate" values="90"/>
   </filter>
 </svg>
 ```


### PR DESCRIPTION
The live sample throws following error:
Firefox
> Unexpected value [angle] parsing values attribute.

Chrome
> Error: <feColorMatrix> attribute values: Expected number, "[angle]".