### PR TITLE
fix(ui-pseudo-classes): fix readonly css example

### DIFF
--- a/files/en-us/learn/forms/ui_pseudo-classes/index.md
+++ b/files/en-us/learn/forms/ui_pseudo-classes/index.md
@@ -463,7 +463,7 @@ If you try the live example, you'll see that the top set of form elements are no
 }
 
 :is(textarea:-moz-read-write, textarea:read-write) {
-   box-shadow: inset 1px 1px 3px #ccc;
+  box-shadow: inset 1px 1px 3px #ccc;
   border-radius: 5px;
 }
 ```

--- a/files/en-us/learn/forms/ui_pseudo-classes/index.md
+++ b/files/en-us/learn/forms/ui_pseudo-classes/index.md
@@ -463,7 +463,6 @@ If you try the live example, you'll see that the top set of form elements are no
 }
 
 :is(textarea:-moz-read-write, textarea:read-write) {
-  -webkit-box-shadow: inset 1px 1px 3px #ccc;
           box-shadow: inset 1px 1px 3px #ccc;
   border-radius: 5px;
 }

--- a/files/en-us/learn/forms/ui_pseudo-classes/index.md
+++ b/files/en-us/learn/forms/ui_pseudo-classes/index.md
@@ -458,7 +458,7 @@ If you try the live example, you'll see that the top set of form elements are no
 ```css
 :is(input:read-only, input:-moz-read-only, textarea:-moz-read-only, textarea:read-only) {
   border: 0;
-          box-shadow: none;
+  box-shadow: none;
   background-color: white;
 }
 

--- a/files/en-us/learn/forms/ui_pseudo-classes/index.md
+++ b/files/en-us/learn/forms/ui_pseudo-classes/index.md
@@ -463,7 +463,7 @@ If you try the live example, you'll see that the top set of form elements are no
 }
 
 :is(textarea:-moz-read-write, textarea:read-write) {
-          box-shadow: inset 1px 1px 3px #ccc;
+   box-shadow: inset 1px 1px 3px #ccc;
   border-radius: 5px;
 }
 ```

--- a/files/en-us/learn/forms/ui_pseudo-classes/index.md
+++ b/files/en-us/learn/forms/ui_pseudo-classes/index.md
@@ -458,7 +458,6 @@ If you try the live example, you'll see that the top set of form elements are no
 ```css
 :is(input:read-only, input:-moz-read-only, textarea:-moz-read-only, textarea:read-only) {
   border: 0;
-  -webkit-box-shadow: none;
           box-shadow: none;
   background-color: white;
 }

--- a/files/en-us/learn/forms/ui_pseudo-classes/index.md
+++ b/files/en-us/learn/forms/ui_pseudo-classes/index.md
@@ -456,16 +456,29 @@ A fragment of the HTML is as follows — note the readonly attribute:
 If you try the live example, you'll see that the top set of form elements are not focusable, however, the values are submitted when the form is submitted. We've styled the form controls using the `:read-only` and `:read-write` pseudo-classes, like so:
 
 ```css
-input:-moz-read-only, textarea:-moz-read-only,
-input:read-only, textarea:read-only {
+input:-moz-read-only,
+textarea:-moz-read-only {
   border: 0;
   box-shadow: none;
   background-color: white;
 }
 
-textarea:-moz-read-write,
-textarea:read-write {
+input:read-only,
+textarea:read-only {
+  border: 0;
+  -webkit-box-shadow: none;
+          box-shadow: none;
+  background-color: white;
+}
+
+textarea:-moz-read-write {
   box-shadow: inset 1px 1px 3px #ccc;
+  border-radius: 5px;
+}
+
+textarea:read-write {
+  -webkit-box-shadow: inset 1px 1px 3px #ccc;
+          box-shadow: inset 1px 1px 3px #ccc;
   border-radius: 5px;
 }
 ```

--- a/files/en-us/learn/forms/ui_pseudo-classes/index.md
+++ b/files/en-us/learn/forms/ui_pseudo-classes/index.md
@@ -456,27 +456,14 @@ A fragment of the HTML is as follows — note the readonly attribute:
 If you try the live example, you'll see that the top set of form elements are not focusable, however, the values are submitted when the form is submitted. We've styled the form controls using the `:read-only` and `:read-write` pseudo-classes, like so:
 
 ```css
-input:-moz-read-only,
-textarea:-moz-read-only {
-  border: 0;
-  box-shadow: none;
-  background-color: white;
-}
-
-input:read-only,
-textarea:read-only {
+:is(input:read-only, input:-moz-read-only, textarea:-moz-read-only, textarea:read-only) {
   border: 0;
   -webkit-box-shadow: none;
           box-shadow: none;
   background-color: white;
 }
 
-textarea:-moz-read-write {
-  box-shadow: inset 1px 1px 3px #ccc;
-  border-radius: 5px;
-}
-
-textarea:read-write {
+:is(textarea:-moz-read-write, textarea:read-write) {
   -webkit-box-shadow: inset 1px 1px 3px #ccc;
           box-shadow: inset 1px 1px 3px #ccc;
   border-radius: 5px;


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
- fix CSS error in `:read-only` example

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
- `:read-only` CSS is not working properly in Chorme.
- `-moz-` prefix won't work with Chome browser.
- Chome ignores whole CSS block with invalid prefix.

*As-Is*
<img width="542" alt="image" src="https://user-images.githubusercontent.com/73219421/173220104-f2087f86-74f2-4fd5-b6db-40822c16b4a4.png">
*To-Be*
<img width="532" alt="image" src="https://user-images.githubusercontent.com/73219421/173220087-4c6fec46-0c80-4450-b07d-a14b1d43117b.png">

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
> A selector always goes together with a declaration block.
> When a user agent cannot parse the selector (i.e., it is not valid CSS 2.1),
> it must ignore the selector and the following declaration block (if any) as well.
> &mdash; [4.1.7 Rule sets, declaration blocks, and selectors](<https://www.w3.org/TR/CSS21/syndata.html#rule-sets:~:text=A%20selector%20always%20goes%20together%20with%20a%20declaration%20block.%20When%20a%20user%20agent%20cannot%20parse%20the%20selector%20(i.e.%2C%20it%20is%20not%20valid%20CSS%C2%A02.1)%2C%20it%20must%20ignore%20the%20selector%20and%20the%20following%20declaration%20block%20(if%20any)%20as%20well.>)

- [autoprefixer](https://autoprefixer.github.io/) result
```css
/* input */
input:read-only,
textarea:read-only {
  border: 0;
  box-shadow: none;
  background-color: white;
}
```

```css
/* output */
input:-moz-read-only, textarea:-moz-read-only {
  border: 0;
  box-shadow: none;
  background-color: white;
}
input:read-only,
textarea:read-only {
  border: 0;
  -webkit-box-shadow: none;
          box-shadow: none;
  background-color: white;
}
```

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
