### PR TITLE
Simplify is_overdue with bool()

### DIFF
--- a/files/en-us/learn/server-side/django/authentication/index.md
+++ b/files/en-us/learn/server-side/django/authentication/index.md
@@ -503,12 +503,20 @@ from datetime import date
 
 Now add the following property definition to the `BookInstance` class:
 
+> **Note:** The following uses Python's `bool()` function, which evaluates an object or the resulting object of an expression and returns True unless:
+> The object is empty, like [], (), {}
+> The object is False
+> The object is 0
+> The object is None
+> 
+> `bool()` returns False in the above cases. This is a very "pythonic" way of returning boolean values from expressions.  
+
 ```python
 @property
 def is_overdue(self):
     if self.due_back and date.today() > self.due_back:
-        return True
-    return False
+    """Derives whether the book is overdue given due data and current date."""
+    return bool(self.due_back and date.today() > self.due_back)
 ```
 
 > **Note:** We first verify whether `due_back` is empty before making a comparison. An empty `due_back` field would cause Django to throw an error instead of showing the page: empty values are not comparable. This is not something we would want our users to experience!

--- a/files/en-us/learn/server-side/django/authentication/index.md
+++ b/files/en-us/learn/server-side/django/authentication/index.md
@@ -503,18 +503,13 @@ from datetime import date
 
 Now add the following property definition to the `BookInstance` class:
 
-> **Note:** The following uses Python's `bool()` function, which evaluates an object or the resulting object of an expression and returns True unless:
-> The object is empty, like [], (), {}
-> The object is False
-> The object is 0
-> The object is None
-> 
-> `bool()` returns False in the above cases. This is a very "pythonic" way of returning boolean values from expressions.  
+> **Note:** The following code uses Python's `bool()` function, which evaluates an object or the resulting object of an expression, and returns `True` unless the result is "falsy", in which case it returns `False`.
+> In Python an object is _falsy_ (evaluates as `False`) if it is: empty (like `[]`, `()`, `{}`), `0`, `None` or if it is `False`.
 
 ```python
 @property
 def is_overdue(self):
-    """Derives whether the book is overdue given due data and current date."""
+    """Determines if the book is overdue based on due date and current date."""
     return bool(self.due_back and date.today() > self.due_back)
 ```
 

--- a/files/en-us/learn/server-side/django/authentication/index.md
+++ b/files/en-us/learn/server-side/django/authentication/index.md
@@ -514,7 +514,6 @@ Now add the following property definition to the `BookInstance` class:
 ```python
 @property
 def is_overdue(self):
-    if self.due_back and date.today() > self.due_back:
     """Derives whether the book is overdue given due data and current date."""
     return bool(self.due_back and date.today() > self.due_back)
 ```


### PR DESCRIPTION
#### Summary
Simplifies the function `is_overdue` to use `bool()` for more "pythonic" code, and adds a note above to teach the reader about it. I put the note above as there's already a note below and I wanted to avoid having two in a row.

#### Motivation
To use this section of the guide as an opportunity to teach readers about an interesting and useful function while reinforcing Python conventions.

#### Related issues
The change to the Django tutorial repo is https://github.com/mdn/django-locallibrary-tutorial/pull/105.