### PR TITLE
Clarify Clipboard availability

### DIFF
--- a/files/en-us/web/api/clipboard/index.md
+++ b/files/en-us/web/api/clipboard/index.md
@@ -45,13 +45,9 @@ _`Clipboard` is based on the {{domxref("EventTarget")}} interface, and includes 
 
 ## Clipboard availability
 
-The asynchronous clipboard API is a relatively recent addition, and the process of implementing it in browsers is not yet complete. Due to both potential security concerns and technical complexities, the process of integrating this API is happening gradually in most browsers.
+The asynchronous clipboard API is a relatively recent addition, and the process of implementing it in browsers is not yet complete. Due to both potential security concerns and technical complexities, the process of integrating this API is happening gradually in most browsers. See the [browser compatibility](#browser_compatibility) section below for more information.
 
-For example, Firefox does not yet support the `'clipboard-read'` and `'clipboard-write'` permissions, so access to the methods that access and change the contents of the clipboard are restricted in other ways.
-
-For Firefox WebExtensions, you can request the `'clipboardRead'` and `'clipboardWrite'` permissions to be able to use {{domxref("Clipboard.readText", "readText()")}} and {{domxref("Clipboard.writeText", "writeText()")}}. Content scripts applied on HTTP sites do not have access to the clipboard object. See [extensions in Firefox 63](https://blog.mozilla.org/addons/2018/08/31/extensions-in-firefox-63/).
-
-In addition to these, {{domxref("Clipboard.read", "read()")}} and {{domxref("Clipboard.write", "write()")}} are disabled by default in Firefox and require changing a preference to enable them. Check the compatibility tables for each method before using it.
+In browser extensions, you can access the system clipboard using the WebExtension [`clipboard`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/clipboard) API.
 
 ## Specifications
 

--- a/files/en-us/web/api/clipboard/index.md
+++ b/files/en-us/web/api/clipboard/index.md
@@ -24,16 +24,11 @@ The **`Clipboard`** interface implements the [Clipboard API](/en-US/docs/Web/API
 
 The system clipboard is exposed through the global {{domxref("Navigator.clipboard")}} property.
 
-Calls to the methods of the `Clipboard` object will not succeed if the user hasn't granted the needed permissions using the [Permissions API](/en-US/docs/Web/API/Permissions_API) and the `"clipboard-read"` or `"clipboard-write"` permission as appropriate.
+Calls to the methods of the `Clipboard` object will not succeed if the user hasn't granted the needed permissions using the [Permissions API](/en-US/docs/Web/API/Permissions_API) and the `'clipboard-read'` or `'clipboard-write'` permission as appropriate.
 
 > **Note:** In reality, at this time browser requirements for access to the clipboard vary significantly. Please see the section [Clipboard availability](#clipboard_availability) for details.
 
 All of the Clipboard API methods operate asynchronously; they return a {{jsxref("Promise")}} which is resolved once the clipboard access has been completed. The promise is rejected if clipboard access is denied.
-
-> **Note:** The **clipboard** is a data buffer that is used for short-term, data storage and/or data transfers, this can be between documents or applications
-> It is usually implemented as an anonymous, temporary [data buffer](https://en.wikipedia.org/wiki/Data_buffer), sometimes called the paste buffer, that can be accessed from most or all programs within the environment via defined [programming interfaces](https://en.wikipedia.org/wiki/Application_programming_interface).
->
-> A typical application accesses clipboard functionality by mapping [user input](https://en.wikipedia.org/wiki/User_input) such as [keybindings](https://en.wikipedia.org/wiki/Keybinding), [menu selections](<https://en.wikipedia.org/wiki/Menu_(computing)>), etc. to these interfaces.
 
 ## Methods
 
@@ -52,11 +47,11 @@ _`Clipboard` is based on the {{domxref("EventTarget")}} interface, and includes 
 
 The asynchronous clipboard API is a relatively recent addition, and the process of implementing it in browsers is not yet complete. Due to both potential security concerns and technical complexities, the process of integrating this API is happening gradually in most browsers.
 
-For example, Firefox does not yet support the `"clipboard-read"` and `"clipboard-write"` permissions, so access to the methods that access and change the contents of the clipboard are restricted in other ways.
+For example, Firefox does not yet support the `'clipboard-read'` and `'clipboard-write'` permissions, so access to the methods that access and change the contents of the clipboard are restricted in other ways.
 
-For WebExtensions, you can request the clipboardRead and clipboardWrite permissions to be able to use clipboard.readText() and clipboard.writeText(). Content scripts applied on HTTP sites do not have access to the clipboard object. See [extensions in Firefox 63](https://blog.mozilla.org/addons/2018/08/31/extensions-in-firefox-63/).
+For Firefox WebExtensions, you can request the `'clipboardRead'` and `'clipboardWrite'` permissions to be able to use {{domxref("Clipboard.readText", "readText()")}} and {{domxref("Clipboard.writeText", "writeText()")}}. Content scripts applied on HTTP sites do not have access to the clipboard object. See [extensions in Firefox 63](https://blog.mozilla.org/addons/2018/08/31/extensions-in-firefox-63/).
 
-In addition, {{domxref("Clipboard.read", "read()")}} and {{domxref("Clipboard.write", "write()")}} are disabled by default and require changing a preference to enable them. Check the compatibility tables for each method before using it.
+In addition to these, {{domxref("Clipboard.read", "read()")}} and {{domxref("Clipboard.write", "write()")}} are disabled by default in Firefox and require changing a preference to enable them. Check the compatibility tables for each method before using it.
 
 ## Specifications
 

--- a/files/en-us/web/api/clipboard_api/index.md
+++ b/files/en-us/web/api/clipboard_api/index.md
@@ -24,6 +24,11 @@ The **Clipboard API** provides the ability to respond to clipboard commands (cut
 
 This API is designed to supersede accessing the clipboard using {{domxref("document.execCommand()")}}.
 
+> **Note:** The **clipboard** is a data buffer that is used for short-term, data storage and/or data transfers, this can be between documents or applications
+> It is usually implemented as an anonymous, temporary [data buffer](https://en.wikipedia.org/wiki/Data_buffer), sometimes called the paste buffer, that can be accessed from most or all programs within the environment via defined [programming interfaces](https://en.wikipedia.org/wiki/Application_programming_interface).
+>
+> A typical application accesses clipboard functionality by mapping [user input](https://en.wikipedia.org/wiki/User_input) such as [keybindings](https://en.wikipedia.org/wiki/Keybinding), [menu selections](<https://en.wikipedia.org/wiki/Menu_(computing)>), etc. to these interfaces.
+
 ## Accessing the clipboard
 
 Instead of creating a `Clipboard` object through instantiation, you access the system clipboard through the {{domxref("Navigator.clipboard")}} global:


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Clarifies that the quarks listed in the page is for Firefox only. Also removes a note describing "clipboard" as a general term.

#### Motivation
> In addition, {{domxref("Clipboard.read", "read()")}} and {{domxref("Clipboard.write", "write()")}} are disabled by default ...

Yes, but only in Firefox. I have no idea about WebExtensions, but based on the compat table and the Mozilla blog post link, I think it's just for Firefox as well?

Now I have a question whether it's worth it to dedicate three paragraphs to Firefox only but in this PR I decided not to go too far.

Also for the deleted note, I believe it doesn't belong here.

#### Supporting details
The compat table.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
