### PR TITLE
Deprecate nonPersistentCookies from privacy.websites.cookieConfig

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/privacy/websites/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/privacy/websites/index.md
@@ -35,7 +35,7 @@ Default values for these properties tend to vary across browsers.
       - "reject_trackers": reject tracking cookies
       - "reject_trackers_and_partition_foreign": reject trackers and partition third-party cookies.
 
-    - `nonPersistentCookies`: a boolean. If true, all cookies will be treated as session cookies.
+    - `nonPersistentCookies` {{deprecated_inline}}: a boolean. If true, all cookies will be treated as session cookies.
 
 - `firstPartyIsolate`
 

--- a/files/en-us/mozilla/firefox/releases/102/index.md
+++ b/files/en-us/mozilla/firefox/releases/102/index.md
@@ -62,6 +62,8 @@ This article provides information about the changes in Firefox 102 that will aff
 
 - The {{WebExtAPIRef("scripting")}} API, which provides features to execute script, insert and remove CSS, and manage the registration of content scripts is now available to Manifest V2 extensions ({{bug(1766615)}}).
 - With the introduction of support for the 'wasm-unsafe-eval' CSP keyword in Firefox ({{bug(1740263)}}), Manifest V3 extensions are now required to specify this keyword in the [content_security_policy](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_security_policy) manifest key to use [WebAssembly](/en-US/docs/WebAssembly). For backwards-compatibility, Manifest V2 extensions can still use WebAssembly without the keyword ({{bug(1766027)}}).
+- The `nonPersistentCookies` option of the {{WebExtAPIRef("privacy.websites")}} `cookieConfig` property has been deprecated ({{bug(1754924)}}).
+
 
 #### Removals
 


### PR DESCRIPTION
#### Summary
Update to address deprecation of `nonPersistentCookies` from `privacy.websites.cookieConfig` API implemented by [Bug 1754924](https://bugzilla.mozilla.org/show_bug.cgi?id=1754924) 


#### Metadata

This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
