### PR TITLE
Add window.scheduler to Prioritized Task API sidebar

### DIFF
--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -1044,7 +1044,7 @@
       "guides": [],
       "interfaces": ["Scheduler", "TaskController", "TaskSignal", "AbortSignal", "TaskPriorityChangeEvent"],
       "methods": [],
-      "properties": [],
+      "properties": ["Window.scheduler"],
       "events": []
     },
     "Proximity Events": {


### PR DESCRIPTION
This is the last part of #15468

It add a missing property to the sidebar for Prioritized Task Scheduling (the global property used to access it - originally wasn't sure where it would live in the docs tree).