### PR TITLE
Fix TypeError in a live sample

### DIFF
--- a/files/en-us/web/api/css_typed_om_api/guide/index.md
+++ b/files/en-us/web/api/css_typed_om_api/guide/index.md
@@ -226,13 +226,7 @@ There are other types available:
 - A {{cssxref('transform')}} returns a `CSSTransformValue`.
 - A [custom property](/en-US/docs/Web/CSS/--*) returns a {{domxref('CSSUnparsedValue')}}.
 
-You can use a `CSSUnitValue` or `CSSKeywordValue` to create other objects. For example, the parameters for a {{domxref('CSSPositionValue')}} is one to two `CSSUnitValues` or `CSSKeywordValues`, or one of each:
-
-```js
-let position = new CSSPositionValue(
-    new CSSKeywordValue("center"),
-    new CSSUnitValue(10, "px"));
-```
+You can use a `CSSUnitValue` or `CSSKeywordValue` to create other objects.
 
 ## CSSStyleValue
 


### PR DESCRIPTION
The page throws error:
> TypeError: Failed to construct 'CSSPositionValue': parameter 1 is not of type 'CSSNumericValue'.

`CSSPositonValue` is deprecated(now only chromium has it) so we can simply remove the code block.