### PR TITLE
Port explanation of Math.log1p to Math.expm1; wording fixes

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/math/exp/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/exp/index.md
@@ -40,6 +40,8 @@ Because `exp()` is a static method of `Math`, you always use it
 as `Math.exp()`, rather than as a method of a `Math` object you
 created (`Math` is not a constructor).
 
+Beware that `e` to the power of a number very close to 0 will be very close to 1 and suffer from loss of precision. In this case, you may want to use {{jsxref("Math.expm1")}} instead, and obtain a much higher-precision fractional part of the answer.
+
 ## Examples
 
 ### Using Math.exp()

--- a/files/en-us/web/javascript/reference/global_objects/math/expm1/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/expm1/index.md
@@ -11,9 +11,7 @@ browser-compat: javascript.builtins.Math.expm1
 ---
 {{JSRef}}
 
-The **`Math.expm1()`** function returns
-`e^x - 1`, where `x` is the argument, and
-{{jsxref("Math.E", "e", "", 1)}} the base of the natural logarithms.
+The **`Math.expm1()`** function returns `e^x - 1`, where `x` is the argument, and {{jsxref("Math.E", "e", "", 1)}} is the base of natural logarithms.
 
 {{EmbedInteractiveExample("pages/js/math-expm1.html")}}
 
@@ -30,14 +28,15 @@ Math.expm1(x)
 
 ### Return value
 
-A number representing `e^x - 1`, where `e` is
-{{jsxref("Math.E", "Euler's number", "", 1)}} and `x` is the argument.
+A number representing `e^x - 1`, where `e` is {{jsxref("Math.E", "the base of natural logarithms", "", 1)}} and `x` is the argument.
 
 ## Description
 
-Because `expm1()` is a static method of `Math`, you always use it
-as `Math.expm1()`, rather than as a method of a `Math` object you
-created (`Math` is not a constructor).
+For very small values of _x_, adding 1 can reduce or eliminate precision. The double floats used in JS give you about 15 digits of precision. 1 + 1e-15 \= 1.000000000000001, but 1 + 1e-16 = 1.000000000000000 and therefore exactly 1.0 in that arithmetic, because digits past 15 are rounded off.
+
+When you calculate <math display="inline"><semantics><msup><mrow><mi mathvariant="normal">e</mi></mrow><mi>x</mi></msup><annotation encoding="TeX">\mathrm{e}^x</annotation></semantics></math> where x is a number very close to 0, you should get an answer very close to 1 + x, because <math display="inline"><semantics><mrow><munder><mo movablelimits="true" form="prefix">lim</mo><mrow><mi>x</mi><mo stretchy="false">→</mo><mn>0</mn></mrow></munder><mfrac><msup><mrow><mi mathvariant="normal">e</mi></mrow><mi>x</mi></msup><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow></mfrac><mo>=</mo><mn>1</mn></mrow><annotation encoding="TeX">\lim_{x \to 0} \frac{\mathrm{e}^x}{x+1} = 1</annotation></semantics></math>. If you calculate `Math.exp(1.1111111111e-15) - 1`, you should get an answer close to `1.1111111111e-15`. Instead, due to the highest significant figure in the result of `Math.exp` being the units digit `1`, the final value ends up being `1.1102230246251565e-15`, with only 3 correct digits. If, instead, you calculate `Math.exp1m(1.1111111111e-15)`, you will get a much more accurate answer `1.1111111111000007e-15`, with 11 correct digits of precision.
+
+Because `expm1()` is a static method of `Math`, you always use it as `Math.expm1()`, rather than as a method of a `Math` object you created (`Math` is not a constructor).
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/math/log/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/log/index.md
@@ -77,6 +77,8 @@ If you need the natural log of 2 or 10, use the constants {{jsxref("Math.LN2")}}
 other bases, use Math.log(x) / Math.log(otherBase) as in the example below; you might
 want to precalculate 1 / Math.log(otherBase).
 
+Beware that positive numbers very close to 1 can suffer from loss of precision and make its natural logarithm less accurate. In this case, you may want to use {{jsxref("Math.log1p")}} instead.
+
 ## Examples
 
 ### Using Math.log()

--- a/files/en-us/web/javascript/reference/global_objects/math/log1p/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/log1p/index.md
@@ -49,7 +49,7 @@ Math.log1p(x)
 
 ### Return value
 
-The natural logarithm (base {{jsxref("Math.E", "e")}}) of **1** plus the given number. If the number is less than **-1**, {{jsxref("NaN")}} is returned.
+The natural logarithm (base {{jsxref("Math.E", "e")}}) of `1` plus the given number. If the number is less than `-1`, {{jsxref("NaN")}} is returned.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/math/log1p/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/log1p/index.md
@@ -12,8 +12,7 @@ browser-compat: javascript.builtins.Math.log1p
 ---
 {{JSRef}}
 
-The **`Math.log1p()`** function returns the natural logarithm
-(base {{jsxref("Math.E", "e")}}) of 1 + a number, that is
+The **`Math.log1p()`** function returns the natural logarithm (base {{jsxref("Math.E", "e")}}) of `1 + x`, where `x` is the argument. That is
 
 <math display="block"><semantics><mrow><mo>∀</mo>
 <mi>x</mi>
@@ -50,32 +49,17 @@ Math.log1p(x)
 
 ### Return value
 
-The natural logarithm (base {{jsxref("Math.E", "e")}}) of **1** plus the
-given number. If the number is less than **-1**, {{jsxref("NaN")}} is
-returned.
+The natural logarithm (base {{jsxref("Math.E", "e")}}) of **1** plus the given number. If the number is less than **-1**, {{jsxref("NaN")}} is returned.
 
 ## Description
 
-For very small values of _x_, adding 1 can reduce or eliminate precision.  The
-double floats used in JS give you about 15 digits of precision.  1 + 1e-15
-\= 1.000000000000001, but 1 + 1e-16 = 1.000000000000000 and therefore exactly 1.0 in
-that arithmetic, because digits past 15 are rounded off.
+For very small values of _x_, adding 1 can reduce or eliminate precision. The double floats used in JS give you about 15 digits of precision.  1 + 1e-15 \= 1.000000000000001, but 1 + 1e-16 = 1.000000000000000 and therefore exactly 1.0 in that arithmetic, because digits past 15 are rounded off.
 
-When you calculate log(1 + x), you should get an answer very close to x, if x is small
-(that's why these are called 'natural' logarithms).  If you calculate Math.log(1 +
-1.1111111111e-15) you should get an answer close to 1.1111111111e-15.  Instead,
-you will end up taking the logarithm of 1.00000000000000111022 (the roundoff is in binary so
-sometimes it gets ugly), so you get the answer 1.11022...e-15, with only 3
-correct digits.  If, instead, you calculate Math.log1p(1.1111111111e-15) you will get a
-much more accurate answer 1.1111111110999995e-15 with 15 correct digits of
-precision (actually 16 in this case).
+When you calculate log(1 + x) where x is a small positive number, you should get an answer very close to x, because <math display="inline"><semantics><mrow><munder><mo movablelimits="true" form="prefix">lim</mo><mrow ><mi>x</mi><mo stretchy="false">→</mo><mn>0</mn></mrow></munder><mfrac><mrow><mi>log</mi><mo>⁡</mo><mo stretchy="false">(</mo><mn>1</mn><mo>+</mo><mi>x</mi><mo stretchy="false">)</mo></mrow><mi>x</mi></mfrac><mo>=</mo><mn>1</mn></mrow><annotation encoding="TeX">\lim_{x \to 0} \frac{\log(1+x)}{x} = 1</annotation></semantics></math>. If you calculate `Math.log(1 + 1.1111111111e-15)`, you should get an answer close to `1.1111111111e-15`. Instead, you will end up taking the logarithm of `1.00000000000000111022` (the roundoff is in binary, so sometimes it gets ugly), and get the answer 1.11022...e-15, with only 3 correct digits. If, instead, you calculate `Math.log1p(1.1111111111e-15)`, you will get a much more accurate answer `1.1111111110999995e-15`, with 15 correct digits of precision (actually 16 in this case).
 
-If the value of `x` is less than -1, the return value is always
-{{jsxref("NaN")}}.
+If the value of `x` is less than -1, the return value is always {{jsxref("NaN")}}.
 
-Because `log1p()` is a static method of `Math`, you always use it
-as `Math.log1p()`, rather than as a method of a `Math` object
-you created (`Math` is not a constructor).
+Because `log1p()` is a static method of `Math`, you always use it as `Math.log1p()`, rather than as a method of a `Math` object you created (`Math` is not a constructor).
 
 ## Examples
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation

When I was looking at `expm1`, I had little idea what it's for, until I found the explanation in `log1p`. It would be beneficial to synchronize the two pages. In addition, the notion:

> When you calculate log(1 + x), you should get an answer very close to x, if x is small (that's why these are called 'natural' logarithms)

is incorrect: at least I don't think that's what "natural" logarithm is "natural" about—I could be wrong—so I made it more mathematical.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
