### PR TITLE
Add missing parentheses in titles

### DIFF
--- a/files/en-us/web/api/navigator/mssaveblob/index.md
+++ b/files/en-us/web/api/navigator/mssaveblob/index.md
@@ -1,5 +1,5 @@
 ---
-title: Navigator.msSaveBlob
+title: Navigator.msSaveBlob()
 slug: Web/API/Navigator/msSaveBlob
 page-type: web-api-instance-method
 browser-compat: api.Navigator.msSaveBlob

--- a/files/en-us/web/api/navigator/mssaveoropenblob/index.md
+++ b/files/en-us/web/api/navigator/mssaveoropenblob/index.md
@@ -1,5 +1,5 @@
 ---
-title: Navigator.msSaveOrOpenBlob
+title: Navigator.msSaveOrOpenBlob()
 slug: Web/API/Navigator/msSaveOrOpenBlob
 page-type: web-api-instance-method
 browser-compat: api.Navigator.msSaveOrOpenBlob

--- a/files/en-us/web/api/paintworklet/registerpaint/index.md
+++ b/files/en-us/web/api/paintworklet/registerpaint/index.md
@@ -1,5 +1,5 @@
 ---
-title: PaintWorkletGlobalScope.registerPaint
+title: PaintWorkletGlobalScope.registerPaint()
 slug: Web/API/PaintWorklet/registerPaint
 page-type: web-api-instance-method
 tags:

--- a/files/en-us/web/api/paymentmethodchangeevent/paymentmethodchangeevent/index.md
+++ b/files/en-us/web/api/paymentmethodchangeevent/paymentmethodchangeevent/index.md
@@ -1,5 +1,5 @@
 ---
-title: PaymentMethodChangeEvent
+title: PaymentMethodChangeEvent()
 slug: Web/API/PaymentMethodChangeEvent/PaymentMethodChangeEvent
 page-type: web-api-constructor
 tags:

--- a/files/en-us/web/api/presentationconnectionavailableevent/presentationconnectionavailableevent/index.md
+++ b/files/en-us/web/api/presentationconnectionavailableevent/presentationconnectionavailableevent/index.md
@@ -1,5 +1,5 @@
 ---
-title: PresentationConnectionAvailableEvent
+title: PresentationConnectionAvailableEvent()
 slug: Web/API/PresentationConnectionAvailableEvent/PresentationConnectionAvailableEvent
 page-type: web-api-constructor
 tags:


### PR DESCRIPTION
A few occurrences of missing parentheses for methods and ctors, in the YAML title entries.