### PR TITLE
Remove a useless dictionary name

### DIFF
--- a/files/en-us/web/api/svggeometryelement/ispointinstroke/index.md
+++ b/files/en-us/web/api/svggeometryelement/ispointinstroke/index.md
@@ -29,7 +29,7 @@ isPointInStroke(point)
 ### Parameters
 
 - `point`
-  - : A DOMPointInit object interpreted as a point in the local coordinate system
+  - : An object interpreted as a point in the local coordinate system
     of the element.
 
 ### Return value


### PR DESCRIPTION
Remove a useless (and not visible in browser consoles…) dictionary name.