### PR TITLE
Remove mention of enums

### DIFF
--- a/files/en-us/web/api/idbcursor/direction/index.md
+++ b/files/en-us/web/api/idbcursor/direction/index.md
@@ -25,48 +25,19 @@ section below for possible values.
 
 ## Value
 
-A string (defined by the [`IDBCursorDirection` enum](https://w3c.github.io/IndexedDB/#enumdef-idbcursordirection)) indicating the direction in which the cursor is traversing the data.
+A string indicating the direction in which the cursor is traversing the data.
 Possible values are:
 
-<table class="no-markdown">
-  <thead>
-    <tr>
-      <th scope="col">Value</th>
-      <th scope="col">Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>next</code></td>
-      <td>
-        This direction causes the cursor to be opened at the start of
-        the source.
-      </td>
-    </tr>
-    <tr>
-      <td><code>nextunique</code></td>
-      <td>
-        This direction causes the cursor to be opened at the start of
-        the source. For every key with duplicate values, only the first record
-        is yielded.
-      </td>
-    </tr>
-    <tr>
-      <td><code>prev</code></td>
-      <td>
-        This direction causes the cursor to be opened at the end of the source.
-      </td>
-    </tr>
-    <tr>
-      <td><code>prevunique</code></td>
-      <td>
-        This direction causes the cursor to be opened at the end of the source.
-        For every key with duplicate values, only the first record is
-        yielded.<br />
-      </td>
-    </tr>
-  </tbody>
-</table>
+- `next`
+  - : This direction causes the cursor to be opened at the start of the source.
+- `nextunique``
+  - : This direction causes the cursor to be opened at the start of the source.
+    For every key with duplicate values, only the first record is yielded.
+- `prev`
+  - : This direction causes the cursor to be opened at the end of the source.
+- `prevunique`
+  - : This direction causes the cursor to be opened at the end of the source.
+    For every key with duplicate values, only the first record is yielded.
 
 ## Examples
 

--- a/files/en-us/web/api/idbobjectstore/opencursor/index.md
+++ b/files/en-us/web/api/idbobjectstore/opencursor/index.md
@@ -40,9 +40,19 @@ openCursor(query, direction)
     this will default to a range containing only that key. If nothing is passed, this will
     default to a key range that selects all the records in this object store.
 - `direction` {{optional_inline}}
-  - : An [`IDBCursorDirection`](https://w3c.github.io/IndexedDB/#enumdef-idbcursordirection) telling the cursor what direction to travel.
-    Valid values are `"next"`, `"nextunique"`, `"prev"`,
-    and `"prevunique"`. The default is `"next"`.
+  - : A string telling the cursor which direction to travel. The default is `next`. Valid values are:
+    - `next`
+      - : The cursor is opened at the start of the store; then, the cursor returns all records, even duplicates,
+        in the increasing order of keys.
+    - `nextunique`
+      - : The cursor is opened at the start of the store; then, the cursor returns all records, that are not duplicates,
+        in the increasing order of keys.
+    - `prev`
+      - : The cursor is opened at the start of the store; then, the cursor returns all records, even duplicates,
+        in the decreasing order of keys.
+    - `prevunique`
+      - : The cursor is opened at the start of the store; then, the cursor returns all records, that are not duplicates,
+        in the increasing order of keys.
 
 ### Return value
 


### PR DESCRIPTION
A few occurrences where the enum name was a link to the enum _in the spec_. Removed this (as it is a spec details) and formatted the enum values in the modern way of doing it (a definition list)