### PR TITLE
Remove mentions of enum types of WebRTC that had no page

### DIFF
--- a/files/en-us/mdn/contribute/howto/write_an_api_reference/sidebars/index.md
+++ b/files/en-us/mdn/contribute/howto/write_an_api_reference/sidebars/index.md
@@ -117,7 +117,8 @@ These are all technically optional, but it is strongly encouraged that instead o
    > Where possible, these are now described as objects in the places where they are used.
 8. `"types"` — an array of typedefs and enumerated types defined by the API.
    You may choose to only list those that are of special importance or are referenced from multiple pages, in order to keep the list short.
-   "RTCSctpTransportState" creates a link to [https://developer.mozilla.org/en-US/docs/Web/API/RTCSctpTransportState](/en-US/docs/Web/API/RTCSctpTransport/state).
+   > **Note:** MDN is moving away from separately documenting typedefs.
+   > Where possible, these are now described as values in the places where they are used.
 9. `"callbacks"` — the value is an array containing a list of all the defined callback types for the API.
    You may find it unnecessary to use this group at all, even on APIs that include callback types, as often they are not useful to document separately.
 

--- a/files/en-us/web/api/rtcerror/errordetail/index.md
+++ b/files/en-us/web/api/rtcerror/errordetail/index.md
@@ -30,8 +30,7 @@ The {{domxref("RTCError")}} interface's read-only
 ## Value
 
 A read-only string whose value indicates the type of WebRTC-specific error that
-occurred on an {{domxref("RTCPeerConnection")}}. The possible values are taken from the
-`RTCErrorDetailType` enumeration:
+occurred on an {{domxref("RTCPeerConnection")}}. The possible values are:
 
 - `data-channel-failure`
   - : The connection's {{domxref("RTCDataChannel")}} has failed.

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/index.md
@@ -44,7 +44,7 @@ _The `RTCOutboundRtpStreamStats` dictionary includes the following properties in
 - {{domxref("RTCOutboundRtpStreamStats.qualityLimitationDurations", "qualityLimitationDurations")}}
   - : A record mapping each of the quality limitation reasons in the {{domxref("RTCRemoteInboundRtpStreamStats")}} enumeration to a floating-point value indicating the number of seconds the stream has spent with its quality limited for that reason.
 - {{domxref("RTCOutboundRtpStreamStats.qualityLimitationReason", "qualityLimitationReason")}}
-  - : A value from the {{domxref("RTCQualityLimitationReason")}} enumerated type explaining why the resolution and/or frame rate is being limited for this RTP stream. _Valid only for video streams_.
+  - : One of the string `none`, `cpu`, `bandwidth`, or `other`, explaining why the resolution and/or frame rate is being limited for this RTP stream. _Valid only for video streams_.
 - {{domxref("RTCOutboundRtpStreamStats.remoteId", "remoteId")}}
   - : A string which identifies the {{domxref("RTCRemoteInboundRtpStreamStats")}} object that provides statistics for the remote peer for this same SSRC. This ID is stable across multiple calls to `getStats()`.
 - {{domxref("RTCOutboundRtpStreamStats.retransmittedBytesSent", "retransmittedBytesSent")}}

--- a/files/en-us/web/api/rtcoutboundrtpstreamstats/qualitylimitationreason/index.md
+++ b/files/en-us/web/api/rtcoutboundrtpstreamstats/qualitylimitationreason/index.md
@@ -36,8 +36,7 @@ potential ways that can be done can be found in
 
 ## Value
 
-A {{jsxref("Map")}} whose keys are strings whose values come from the
-{{domxref("RTCQualityLimitationReason")}} enumerated type, and whose values are the
+A {{jsxref("Map")}} whose keys are strings whose values are `none`, `cpu`, `bandwidth`, or `other`, and whose values are the
 duration of the media, in seconds, whose quality was reduced for that reason.
 
 ## Examples

--- a/files/en-us/web/api/rtcrtpencodingparameters/index.md
+++ b/files/en-us/web/api/rtcrtpencodingparameters/index.md
@@ -29,8 +29,8 @@ This dictionary is used in the {{domxref("RTCRtpSendParameters")}} describing th
   - : If `true`, the described encoding is currently actively being used. That is, for RTP senders, the encoding is currently being used to send data, while for receivers, the encoding is being used to decode received data. The default value is `true`.
 - {{domxref("RTCRtpEncodingParameters.codecPayloadType", "codecPayloadType")}}
   - : When describing a codec for an {{domxref("RTCRtpSender")}}, `codecPayloadType` is a single 8-bit byte (or octet) specifying the codec to use for sending the stream; the value matches one from the owning {{domxref("RTCRtpParameters")}} object's {{domxref("RTCRtpParameters.codecs", "codecs")}} parameter. This value can only be set when creating the transceiver; after that, this value is read only.
-- {{domxref("RTCRtpEncodingParameters.dtx", "dtx")}}
-  - : Only used for an {{domxref("RTCRtpSender")}} whose {{domxref("MediaStreamTrack.kind", "kind")}} is `audio`, this property indicates whether or not to use discontinuous transmission (a feature by which a phone is turned off or the microphone muted automatically in the absence of voice activity). The value is taken from the enumerated string type {{domxref("RTCDtxStatus")}}.
+- {{domxref("RTCRtpEncodingParameters.dtx", "dtx")}} {{deprecated_inline}}
+  - : Only used for an {{domxref("RTCRtpSender")}} whose {{domxref("MediaStreamTrack.kind", "kind")}} is `audio`, this property indicates whether or not to use discontinuous transmission (a feature by which a phone is turned off or the microphone muted automatically in the absence of voice activity). The value is taken either `enabled` or `disabled`.
 - {{domxref("RTCRtpEncodingParameters.maxBitrate", "maxBitrate")}}
   - : An unsigned long integer indicating the maximum number of bits per second to allow for this encoding. Other parameters may further constrain the bit rate, such as the value of `maxFramerate` or transport or physical network limitations.
 - {{domxref("RTCRtpEncodingParameters.maxFramerate", "maxFramerate")}}
@@ -38,7 +38,7 @@ This dictionary is used in the {{domxref("RTCRtpSendParameters")}} describing th
 - {{domxref("RTCRtpEncodingParameters.ptime", "ptime")}}
   - : An unsigned long integer value indicating the preferred duration of a media packet in milliseconds. This is typically only relevant for audio encodings. The user agent will try to match this as well as it can, but there is no guarantee.
 - {{domxref("RTCRtpEncodingParameters.rid", "rid")}}
-  - : A string which, if set, specifies an **RTP stream ID** (**RID**) to be sent using the RID header extension. This parameter cannot be modified using {{domxref("RTCRtpSender.setParameters", "setParameters()")}}. Its value can only be set when the transceiver is first created.
+  - : A string which, if set, specifies an _RTP stream ID_ (_RID_) to be sent using the RID header extension. This parameter cannot be modified using {{domxref("RTCRtpSender.setParameters", "setParameters()")}}. Its value can only be set when the transceiver is first created.
 - {{domxref("RTCRtpEncodingParameters.scaleResolutionDownBy", "scaleResolutionDownBy")}}
   - : Only used for senders whose track's {{domxref("MediaStreamTrack.kind", "kind")}} is `video`, this is a double-precision floating-point value specifying a factor by which to scale down the video during encoding. The default value, 1.0, means that the sent video's size will be the same as the original. A value of 2.0 scales the video frames down by a factor of 2 in each dimension, resulting in a video 1/4 the size of the original. The value must not be less than 1.0 (you can't use this to scale the video up).
 

--- a/files/en-us/web/api/rtcrtpsender/setparameters/index.md
+++ b/files/en-us/web/api/rtcrtpsender/setparameters/index.md
@@ -52,9 +52,9 @@ setParameters(parameters)
     - `transactionId`
       - : A string containing a unique ID for the last set of parameters applied; this value is used to ensure that {{domxref("RTCRtpSender.setParameters", "setParameters()")}} can only be called to alter changes made by a specific previous call to {{domxref("RTCRtpSender.getParameters", "getParameters()")}}. Once this parameter is initially set, it cannot be changed.
     - `degradationPreference` {{deprecated_inline}}
-      - : Specifies the preferred way the WebRTC layer should handle optimizing bandwidth against quality in constrained-bandwidth situations; the value comes from the {{domxref("RTCDegradationPreference")}} enumerated string type, and the default is `balanced`.
+      - : Specifies the preferred way the WebRTC layer should handle optimizing bandwidth against quality in constrained-bandwidth situations; the possible values are `maintain-framerate`, `maintain-resolution`, or `balanced`. The default value is `balanced`.
     - `priority` {{deprecated_inline}}
-      - : A string from the {{domxref("RTCPriorityType")}} enumerated type which indicates the encoding's priority. The default value is `low`.
+      - : A string that indicates the encoding's priority. It is one of: `very-low`, `low`, `medium`, or `high`. The default value is `low`.
 
 ### Return value
 

--- a/files/en-us/web/api/rtcrtpsendparameters/index.md
+++ b/files/en-us/web/api/rtcrtpsendparameters/index.md
@@ -37,9 +37,9 @@ _In addition to the properties below, `RTCRtpSendParameters` inherits the proper
 ### Obsolete properties
 
 - {{domxref("RTCRtpSendParameters.degradationPreference", "degradationPreference")}} {{deprecated_inline}}
-  - : Specifies the preferred way the WebRTC layer should handle optimizing bandwidth against quality in constrained-bandwidth situations; the value comes from the {{domxref("RTCDegradationPreference")}} enumerated string type, and the default is `balanced`.
+  - : Specifies the preferred way the WebRTC layer should handle optimizing bandwidth against quality in constrained-bandwidth situations; the possible values are `maintain-framerate`, `maintain-resolution`, or `balanced`. The default value is `balanced`.
 - {{domxref("RTCRtpSendParameters,priority", "priority")}} {{deprecated_inline}}
-  - : A string from the {{domxref("RTCPriorityType")}} enumerated type which indicates the encoding's priority. The default value is `low`.
+  - : A string that indicates the encoding's priority.  It is one of: `very-low`, `low`, `medium`, or `high`. The default value is `low`.
 
 ## Specifications
 

--- a/files/en-us/web/api/rtcsctptransport/state/index.md
+++ b/files/en-us/web/api/rtcsctptransport/state/index.md
@@ -10,7 +10,6 @@ tags:
   - NeedsExample
   - Property
   - RTCSctpTransport
-  - RTCSctpTransportState
   - Read-only
   - Reference
   - WebRTC
@@ -21,12 +20,11 @@ browser-compat: api.RTCSctpTransport.state
 
 The **`state`** read-only property of the
 {{DOMxRef("RTCSctpTransport")}} interface provides information which describes a Stream
-Control Transmission Protocol (**{{Glossary("SCTP")}}**) transport state.
+Control Transmission Protocol ({{Glossary("SCTP")}}) transport state.
 
 ## Value
 
-A string whose value is taken from the `RTCSctpTransportState` enumerated
-type. Its value is one of the following:
+A string whose value is one of the following:
 
 - `connecting`
   - : The initial state when the connection is being established.

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -1915,12 +1915,6 @@
         "RTCRTPStreamStats"
       ],
       "types": [
-        "RTCPriorityType",
-        "RTCDtxStatus",
-        "RTCDegradationPreference",
-        "RTCSctpTransportState",
-        "RTCErrorDetailType",
-        "RTCQualityLimitationReason",
         "RTCStatsType"
       ],
       "methods": ["MediaDevices.getUserMedia()"],


### PR DESCRIPTION
A few WebRTC enum had mentions (red links) but no page.

As we remove the enum, I clean this (and GroupData that was listing them!)