### PR TITLE
Added a missing detail

### DIFF
--- a/files/en-us/webassembly/c_to_wasm/index.md
+++ b/files/en-us/webassembly/c_to_wasm/index.md
@@ -132,7 +132,7 @@ If you have a function defined in your C code that you want to call as needed fr
 
     > **Note:** We are including the `#ifdef` blocks so that if you are trying to include this in C++ code, the example will still work. Due to C versus C++ name mangling rules, this would otherwise break, but here we are setting it so that it treats it as an external C function if you are using C++.
 
-2. Now add `html_template/shell_minimal.html` with `{{{ SCRIPT }}}` as content into this new directory too, just for convenience (you'd obviously put this in a central place in your real dev environment).
+2. Now add `html_template/shell_minimal.html` with `\{\{{ SCRIPT }}}` as content into this new directory too, just for convenience (you'd obviously put this in a central place in your real dev environment).
 3. Now let's run the compilation step again. From inside your latest directory (and while inside your Emscripten compiler environment terminal window), compile your C code with the following command. (Note that we need to compile with `NO_EXIT_RUNTIME`, which is necessary as otherwise when `main()` exits the runtime would be shut down — necessary for proper C emulation, e.g., atexits are called — and it wouldn't be valid to call compiled code.)
 
     ```bash

--- a/files/en-us/webassembly/c_to_wasm/index.md
+++ b/files/en-us/webassembly/c_to_wasm/index.md
@@ -132,7 +132,7 @@ If you have a function defined in your C code that you want to call as needed fr
 
     > **Note:** We are including the `#ifdef` blocks so that if you are trying to include this in C++ code, the example will still work. Due to C versus C++ name mangling rules, this would otherwise break, but here we are setting it so that it treats it as an external C function if you are using C++.
 
-2. Now add `html_template/shell_minimal.html` with <i>{<i>{<i>{ SCRIPT }</i>}</i>}</i> as content into this new directory too, just for convenience (you'd obviously put this in a central place in your real dev environment).
+2. Now add `html_template/shell_minimal.html` with <b>\{\{{ SCRIPT }}}</b> as content into this new directory too, just for convenience (you'd obviously put this in a central place in your real dev environment).
 3. Now let's run the compilation step again. From inside your latest directory (and while inside your Emscripten compiler environment terminal window), compile your C code with the following command. (Note that we need to compile with `NO_EXIT_RUNTIME`, which is necessary as otherwise when `main()` exits the runtime would be shut down — necessary for proper C emulation, e.g., atexits are called — and it wouldn't be valid to call compiled code.)
 
     ```bash

--- a/files/en-us/webassembly/c_to_wasm/index.md
+++ b/files/en-us/webassembly/c_to_wasm/index.md
@@ -132,7 +132,7 @@ If you have a function defined in your C code that you want to call as needed fr
 
     > **Note:** We are including the `#ifdef` blocks so that if you are trying to include this in C++ code, the example will still work. Due to C versus C++ name mangling rules, this would otherwise break, but here we are setting it so that it treats it as an external C function if you are using C++.
 
-2. Now add `html_template/shell_minimal.html` with <b>\{\{{ SCRIPT }}}</b> as content into this new directory too, just for convenience (you'd obviously put this in a central place in your real dev environment).
+2. Now add `html_template/shell_minimal.html` with \\{\\{\\{ SCRIPT }}} as content into this new directory too, just for convenience (you'd obviously put this in a central place in your real dev environment).
 3. Now let's run the compilation step again. From inside your latest directory (and while inside your Emscripten compiler environment terminal window), compile your C code with the following command. (Note that we need to compile with `NO_EXIT_RUNTIME`, which is necessary as otherwise when `main()` exits the runtime would be shut down — necessary for proper C emulation, e.g., atexits are called — and it wouldn't be valid to call compiled code.)
 
     ```bash

--- a/files/en-us/webassembly/c_to_wasm/index.md
+++ b/files/en-us/webassembly/c_to_wasm/index.md
@@ -132,7 +132,7 @@ If you have a function defined in your C code that you want to call as needed fr
 
     > **Note:** We are including the `#ifdef` blocks so that if you are trying to include this in C++ code, the example will still work. Due to C versus C++ name mangling rules, this would otherwise break, but here we are setting it so that it treats it as an external C function if you are using C++.
 
-2. Now add `html_template/shell_minimal.html` with `{{{ SCRIPT }}}` as content into this new directory too, just for convenience (you'd obviously put this in a central place in your real dev environment).
+2. Now add `html_template/shell_minimal.html` with <i>{<i>{<i>{ SCRIPT }</i>}</i>}</i> as content into this new directory too, just for convenience (you'd obviously put this in a central place in your real dev environment).
 3. Now let's run the compilation step again. From inside your latest directory (and while inside your Emscripten compiler environment terminal window), compile your C code with the following command. (Note that we need to compile with `NO_EXIT_RUNTIME`, which is necessary as otherwise when `main()` exits the runtime would be shut down — necessary for proper C emulation, e.g., atexits are called — and it wouldn't be valid to call compiled code.)
 
     ```bash

--- a/files/en-us/webassembly/c_to_wasm/index.md
+++ b/files/en-us/webassembly/c_to_wasm/index.md
@@ -132,7 +132,7 @@ If you have a function defined in your C code that you want to call as needed fr
 
     > **Note:** We are including the `#ifdef` blocks so that if you are trying to include this in C++ code, the example will still work. Due to C versus C++ name mangling rules, this would otherwise break, but here we are setting it so that it treats it as an external C function if you are using C++.
 
-2. Now add `html_template/shell_minimal.html` with \\{\\{\\{ SCRIPT }}} as content into this new directory too, just for convenience (you'd obviously put this in a central place in your real dev environment).
+2. Now add `html_template/shell_minimal.html` with `\\{\\{\\{ SCRIPT }}}` as content into this new directory too, just for convenience (you'd obviously put this in a central place in your real dev environment).
 3. Now let's run the compilation step again. From inside your latest directory (and while inside your Emscripten compiler environment terminal window), compile your C code with the following command. (Note that we need to compile with `NO_EXIT_RUNTIME`, which is necessary as otherwise when `main()` exits the runtime would be shut down — necessary for proper C emulation, e.g., atexits are called — and it wouldn't be valid to call compiled code.)
 
     ```bash

--- a/files/en-us/webassembly/c_to_wasm/index.md
+++ b/files/en-us/webassembly/c_to_wasm/index.md
@@ -132,7 +132,7 @@ If you have a function defined in your C code that you want to call as needed fr
 
     > **Note:** We are including the `#ifdef` blocks so that if you are trying to include this in C++ code, the example will still work. Due to C versus C++ name mangling rules, this would otherwise break, but here we are setting it so that it treats it as an external C function if you are using C++.
 
-2. Now add `html_template/shell_minimal.html` with `\\{\\{\\{ SCRIPT }}}` as content into this new directory too, just for convenience (you'd obviously put this in a central place in your real dev environment).
+2. Now add `html_template/shell_minimal.html` with `{{{ SCRIPT }}}` as content into this new directory too, just for convenience (you'd obviously put this in a central place in your real dev environment).
 3. Now let's run the compilation step again. From inside your latest directory (and while inside your Emscripten compiler environment terminal window), compile your C code with the following command. (Note that we need to compile with `NO_EXIT_RUNTIME`, which is necessary as otherwise when `main()` exits the runtime would be shut down — necessary for proper C emulation, e.g., atexits are called — and it wouldn't be valid to call compiled code.)
 
     ```bash

--- a/files/en-us/webassembly/c_to_wasm/index.md
+++ b/files/en-us/webassembly/c_to_wasm/index.md
@@ -132,7 +132,7 @@ If you have a function defined in your C code that you want to call as needed fr
 
     > **Note:** We are including the `#ifdef` blocks so that if you are trying to include this in C++ code, the example will still work. Due to C versus C++ name mangling rules, this would otherwise break, but here we are setting it so that it treats it as an external C function if you are using C++.
 
-2. Now add `html_template/shell_minimal.html` into this new directory too, just for convenience (you'd obviously put this in a central place in your real dev environment).
+2. Now add `html_template/shell_minimal.html` with `{{{ SCRIPT }}}` as content into this new directory too, just for convenience (you'd obviously put this in a central place in your real dev environment).
 3. Now let's run the compilation step again. From inside your latest directory (and while inside your Emscripten compiler environment terminal window), compile your C code with the following command. (Note that we need to compile with `NO_EXIT_RUNTIME`, which is necessary as otherwise when `main()` exits the runtime would be shut down — necessary for proper C emulation, e.g., atexits are called — and it wouldn't be valid to call compiled code.)
 
     ```bash


### PR DESCRIPTION
#### Summary
The shell HTML file needs to have `{{{ SCRIPT }}}` as content or the compiler will throw an AssertionError looking like this:
`AssertionError: HTML shell must contain  {{{ SCRIPT }}}  , see src/shell.html for an example`

#### Motivation
This will help them avoid this error when following the guide.

#### Supporting details
This detail has been pointed out in the section describing the `--shell-file` flag:
https://emscripten.org/docs/tools_reference/emcc.html

#### Metadata
This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error