### PR TITLE
Fix TypeError in a live sample

### DIFF
--- a/files/en-us/web/api/document/cookie/index.md
+++ b/files/en-us/web/api/document/cookie/index.md
@@ -174,7 +174,7 @@ document.cookie = "test2=World; SameSite=None; Secure";
 const cookieValue = document.cookie
   .split('; ')
   .find(row => row.startsWith('test2='))
-  .split('=')[1];
+  ?.split('=')[1];
 
 function showCookieValue() {
   const output = document.getElementById('cookie-value')


### PR DESCRIPTION
The live sample throws following error in console if third party cookies are disabled:
> TypeError: Cannot read properties of undefined (reading 'split')

The PR resolves the error.