### PR TITLE
Fix undefined return value

### DIFF
--- a/files/en-us/web/api/audiodecoder/decode/index.md
+++ b/files/en-us/web/api/audiodecoder/decode/index.md
@@ -27,7 +27,7 @@ decode(chunk)
 
 ### Return value
 
-{{jsxref("Undefined")}}.
+None ({{jsxref("undefined")}}).
 
 ### Exceptions
 

--- a/files/en-us/web/api/audiodecoder/reset/index.md
+++ b/files/en-us/web/api/audiodecoder/reset/index.md
@@ -26,7 +26,7 @@ None.
 
 ### Return value
 
-{{jsxref("Undefined")}}.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/audioencoder/encode/index.md
+++ b/files/en-us/web/api/audioencoder/encode/index.md
@@ -27,7 +27,7 @@ encode(data)
 
 ### Return value
 
-{{jsxref("Undefined")}}.
+None ({{jsxref("undefined")}}).
 
 ### Exceptions
 

--- a/files/en-us/web/api/audioencoder/reset/index.md
+++ b/files/en-us/web/api/audioencoder/reset/index.md
@@ -26,7 +26,7 @@ None.
 
 ### Return value
 
-{{jsxref("Undefined")}}.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/cookiestore/delete/index.md
+++ b/files/en-us/web/api/cookiestore/delete/index.md
@@ -42,7 +42,7 @@ This method requires one of the following:
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves with {{jsxref("Undefined")}} when deletion completes.
+A {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}} when deletion completes.
 
 ### Exceptions
 

--- a/files/en-us/web/api/cookiestore/set/index.md
+++ b/files/en-us/web/api/cookiestore/set/index.md
@@ -58,7 +58,7 @@ This method requires one of the following:
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves with {{jsxref("Undefined")}} when setting the cookie completes.
+A {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}} when setting the cookie completes.
 
 ### Exceptions
 

--- a/files/en-us/web/api/cookiestoremanager/subscribe/index.md
+++ b/files/en-us/web/api/cookiestoremanager/subscribe/index.md
@@ -33,7 +33,7 @@ subscribe(subscriptions)
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves with {{jsxref("Undefined")}} when the subscription completes.
+A {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}} when the subscription completes.
 
 ### Exceptions
 

--- a/files/en-us/web/api/cookiestoremanager/unsubscribe/index.md
+++ b/files/en-us/web/api/cookiestoremanager/unsubscribe/index.md
@@ -33,7 +33,7 @@ unsubscribe(subscriptions)
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves with {{jsxref("Undefined")}} when the subscription completes.
+A {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}} when the subscription completes.
 
 ### Exceptions
 

--- a/files/en-us/web/api/encodedaudiochunk/copyto/index.md
+++ b/files/en-us/web/api/encodedaudiochunk/copyto/index.md
@@ -27,7 +27,7 @@ copyTo(destination)
 
 ### Return value
 
-{{jsxref("Undefined")}}.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/encodedvideochunk/copyto/index.md
+++ b/files/en-us/web/api/encodedvideochunk/copyto/index.md
@@ -27,7 +27,7 @@ copyTo(destination)
 
 ### Return value
 
-{{jsxref("Undefined")}}.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/fontfaceset/clear/index.md
+++ b/files/en-us/web/api/fontfaceset/clear/index.md
@@ -26,7 +26,7 @@ None.
 
 ### Return value
 
-{{jsxref("Undefined")}}.
+None ({{jsxref("undefined")}}).
 
 ## Specifications
 

--- a/files/en-us/web/api/imagedecoder/reset/index.md
+++ b/files/en-us/web/api/imagedecoder/reset/index.md
@@ -26,7 +26,7 @@ None.
 
 ### Return value
 
-{{jsxref("Undefined")}}.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/imagetracklist/ready/index.md
+++ b/files/en-us/web/api/imagetracklist/ready/index.md
@@ -16,11 +16,11 @@ The **`ready`** property of the {{domxref("ImageTrackList")}} interface returns 
 
 ## Value
 
-A {{jsxref("Promise")}} that resolves with {{jsxref("Undefined")}}.
+A {{jsxref("Promise")}} that resolves with {{jsxref("undefined")}}.
 
 ## Examples
 
-The following example prints the value of `ready` to the console, this will be `Undefined` once the promise resolves.
+The following example prints the value of `ready` to the console, this will be `undefined` once the promise resolves.
 
 ```js
 let tracks = imageDecoder.tracks;

--- a/files/en-us/web/api/videodecoder/decode/index.md
+++ b/files/en-us/web/api/videodecoder/decode/index.md
@@ -27,7 +27,7 @@ decode(chunk)
 
 ### Return value
 
-{{jsxref("Undefined")}}.
+None ({{jsxref("undefined")}}).
 
 ### Exceptions
 

--- a/files/en-us/web/api/videodecoder/reset/index.md
+++ b/files/en-us/web/api/videodecoder/reset/index.md
@@ -26,7 +26,7 @@ None.
 
 ### Return value
 
-{{jsxref("Undefined")}}.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 

--- a/files/en-us/web/api/videoencoder/encode/index.md
+++ b/files/en-us/web/api/videoencoder/encode/index.md
@@ -32,7 +32,7 @@ encode(frame, options)
 
 ### Return value
 
-{{jsxref("Undefined")}}.
+None ({{jsxref("undefined")}}).
 
 ### Exceptions
 

--- a/files/en-us/web/api/videoencoder/reset/index.md
+++ b/files/en-us/web/api/videoencoder/reset/index.md
@@ -26,7 +26,7 @@ None.
 
 ### Return value
 
-{{jsxref("Undefined")}}.
+None ({{jsxref("undefined")}}).
 
 ## Examples
 


### PR DESCRIPTION
We have standardized the way to mark an _undefined_ return value.

These few pages were not fixed (likely because of the capital U). 

This PR fixes them.