### PR TITLE
Fix order in exception definition list

### DIFF
--- a/files/en-us/web/api/cookiestore/set/index.md
+++ b/files/en-us/web/api/cookiestore/set/index.md
@@ -64,7 +64,7 @@ A {{jsxref("Promise")}} that resolves with {{jsxref("Undefined")}} when setting 
 
 - {{jsxref("TypeError")}}
   - : Thrown if setting the cookie with the given values fails.
-- {{domxref("DOMException")}} `SecurityError`
+- `SecurityError` {{domxref("DOMException")}}
   - : Thrown if the origin does not {{glossary("serialize")}} to a URL.
 
 ## Examples

--- a/files/en-us/web/api/cssstylesheet/replace/index.md
+++ b/files/en-us/web/api/cssstylesheet/replace/index.md
@@ -35,10 +35,10 @@ A {{jsxref("Promise")}} that resolves with a {{domxref("CSSStyleSheet")}}.
 
 ### Exceptions
 
-- {{domxref("DOMException")}} `NotAllowedError`
-  - : Thrown if the stylesheet was not created using the {{domxref("CSSStyleSheet.CSSStyleSheet()","CSSStyleSheet()")}} constructor.
-- {{domxref("DOMException")}} `NotAllowedError`
-  - : If the stylesheet is flagged as unmodifiable.
+- `NotAllowedError` {{domxref("DOMException")}}
+  - : Thrown if one of these two conditions is met:
+    - The stylesheet was not created using the {{domxref("CSSStyleSheet.CSSStyleSheet()","CSSStyleSheet()")}} constructor.
+    - The stylesheet is flagged as unmodifiable.
 
 ## Examples
 

--- a/files/en-us/web/api/cssstylesheet/replacesync/index.md
+++ b/files/en-us/web/api/cssstylesheet/replacesync/index.md
@@ -35,7 +35,7 @@ Undefined.
 
 ### Exceptions
 
-- {{domxref("DOMException")}} `NotAllowedError`
+- `NotAllowedError` {{domxref("DOMException")}}
   - : Thrown if the stylesheet was not created using the {{domxref("CSSStyleSheet.CSSStyleSheet()","CSSStyleSheet()")}} constructor or if the stylesheet is flagged as unmodifiable.
 
 ## Examples

--- a/files/en-us/web/api/customelementregistry/define/index.md
+++ b/files/en-us/web/api/customelementregistry/define/index.md
@@ -214,7 +214,7 @@ customElements.define('word-count', WordCount, { extends: 'p' });
 
 ### Creating an element which disables the ability to attach a shadow root
 
-If the class used for the element contains the static property `disabledFeatures` returning the string \`shadow\` this will cause {{domxref("Element.attachShadow()")}} to return a {{domxref("DOMException")}} `NotSupportedError`.
+If the class used for the element contains the static property `disabledFeatures` returning the string \`shadow\` this will cause {{domxref("Element.attachShadow()")}} to return a `NotSupportedError` {{domxref("DOMException")}}.
 
 ```js
 class PopUpInfo extends HTMLElement {

--- a/files/en-us/web/api/fontfaceset/add/index.md
+++ b/files/en-us/web/api/fontfaceset/add/index.md
@@ -31,7 +31,7 @@ A new {{domxref("FontFaceSet")}}.
 
 ### Exceptions
 
-- {{domxref("DOMException")}} `InvalidModificationError`
+- `InvalidModificationError` {{domxref("DOMException")}}
   - : Thrown if this font is already included via the CSS {{cssxref("@font-face")}} rule.
 
 ## Examples

--- a/files/en-us/web/api/hid/requestdevice/index.md
+++ b/files/en-us/web/api/hid/requestdevice/index.md
@@ -49,7 +49,7 @@ A {{jsxref("Promise")}} that resolves with an array of connected {{domxref("HIDD
 
 ### Exceptions
 
-- {{domxref("DOMException")}} `SecurityError`
+- `SecurityError` {{domxref("DOMException")}}
   - : Thrown if the page does not allow access to the HID feature.
 
 ## Examples

--- a/files/en-us/web/api/hiddevice/receivefeaturereport/index.md
+++ b/files/en-us/web/api/hiddevice/receivefeaturereport/index.md
@@ -33,7 +33,7 @@ A {{jsxref("Promise")}} which resolves with a {{jsxref("DataView")}} object cont
 
 ### Exceptions
 
-- {{domxref("DOMException")}} `NotAllowedError`
+- `NotAllowedError` {{domxref("DOMException")}}
   - : Thrown if receiving the report fails for any reason.
 
 ## Examples

--- a/files/en-us/web/api/hiddevice/sendfeaturereport/index.md
+++ b/files/en-us/web/api/hiddevice/sendfeaturereport/index.md
@@ -35,7 +35,7 @@ A {{jsxref("Promise")}} that resolves with `undefined` once the report has been 
 
 ### Exceptions
 
-- {{domxref("DOMException")}} `NotAllowedError`
+- `NotAllowedError` {{domxref("DOMException")}}
   - : Thrown if sending the report fails for any reason.
 
 ## Examples

--- a/files/en-us/web/api/hiddevice/sendreport/index.md
+++ b/files/en-us/web/api/hiddevice/sendreport/index.md
@@ -35,7 +35,7 @@ A {{jsxref("Promise")}} that resolves with `undefined` once the report has been 
 
 ### Exceptions
 
-- {{domxref("DOMException")}} `NotAllowedError`
+- `NotAllowedError` {{domxref("DOMException")}}
   - : Thrown if sending the report fails for any reason.
 
 ## Examples

--- a/files/en-us/web/api/midiport/open/index.md
+++ b/files/en-us/web/api/midiport/open/index.md
@@ -34,7 +34,7 @@ A {{jsxref("Promise")}} which resolves once access to the port has been successf
 
 ### Exceptions
 
-- {{domxref("DOMException")}} `InvalidAccessError`
+- `InvalidAccessError` {{domxref("DOMException")}}
   - : The promise is rejected with this error if the port is unavailable and cannot be opened.
 
 ## Examples

--- a/files/en-us/web/api/ndefrecord/torecords/index.md
+++ b/files/en-us/web/api/ndefrecord/torecords/index.md
@@ -33,7 +33,7 @@ A list of {{DOMxRef("NDEFRecord")}}s.
 
 ## Exceptions
 
-- {{domxref("DOMException")}} `"NotSupported"`
+- `NotSupported` {{domxref("DOMException")}}
   - : Indicates that the {{Glossary("User Agent")}} does not know how to parse this combination of
     {{DOMxRef("NDEFRecord.data")}} and {{DOMxRef("NDEFRecord.recordType")}}.
 

--- a/files/en-us/web/api/serial/getports/index.md
+++ b/files/en-us/web/api/serial/getports/index.md
@@ -30,7 +30,7 @@ A {{jsxref("Promise")}} that resolves with an array of {{domxref("SerialPort")}}
 
 ### Exceptions
 
-- {{domxref("DOMException")}} `"SecurityError"`
+- `SecurityError` {{domxref("DOMException")}}
   - : The returned `Promise` rejects with this error if a [Feature Policy](/en-US/docs/Web/HTTP/Feature_Policy) restricts use of this API or a permission to use it has not granted via a user gesture.
 
 ## Examples

--- a/files/en-us/web/api/serial/requestport/index.md
+++ b/files/en-us/web/api/serial/requestport/index.md
@@ -42,9 +42,9 @@ A {{jsxref("Promise")}} that resolves with an instance of {{domxref("SerialPort"
 
 ### Exceptions
 
-- {{domxref("DOMException")}} `"SecurityError"`
+- `SecurityError` {{domxref("DOMException")}}
   - : The returned `Promise` rejects with this error if a [Feature Policy](/en-US/docs/Web/HTTP/Feature_Policy) restricts use of this API or a permission to use it has not granted via a user gesture.
-- {{domxref("DOMException")}} `"AbortError"`
+- `AbortError` {{domxref("DOMException")}}
   - : The returned `Promise` rejects with this if the user does not select a port when prompted.
 
 ## Examples

--- a/files/en-us/web/api/svgpointlist/appenditem/index.md
+++ b/files/en-us/web/api/svgpointlist/appenditem/index.md
@@ -31,7 +31,7 @@ The {{domxref("SVGPoint")}} object that was appended.
 
 ### Exceptions
 
-- {{domxref("DOMException")}} `NoModificationAllowedError`
+- `NoModificationAllowedError` {{domxref("DOMException")}}
   - : Thrown if the list is read-only.
 
 ## Examples

--- a/files/en-us/web/api/svgpointlist/clear/index.md
+++ b/files/en-us/web/api/svgpointlist/clear/index.md
@@ -30,7 +30,7 @@ None ({{jsxref("undefined")}}).
 
 ### Exceptions
 
-- {{domxref("DOMException")}} `NoModificationAllowedError`
+- `NoModificationAllowedError` {{domxref("DOMException")}}
   - : Thrown if the list is read-only.
 
 ## Examples

--- a/files/en-us/web/api/svgpointlist/initialize/index.md
+++ b/files/en-us/web/api/svgpointlist/initialize/index.md
@@ -31,7 +31,7 @@ The added {{domxref("SVGPoint")}} object.
 
 ### Exceptions
 
-- {{domxref("DOMException")}} `NoModificationAllowedError`
+- `NoModificationAllowedError` {{domxref("DOMException")}}
   - : Thrown if the list is read-only.
 
 ## Examples

--- a/files/en-us/web/api/svgpointlist/insertitembefore/index.md
+++ b/files/en-us/web/api/svgpointlist/insertitembefore/index.md
@@ -33,7 +33,7 @@ The {{domxref("SVGPoint")}} object that was inserted.
 
 ### Exceptions
 
-- {{domxref("DOMException")}} `NoModificationAllowedError`
+- `NoModificationAllowedError` {{domxref("DOMException")}}
   - : Thrown if the list is read-only.
 
 ## Examples


### PR DESCRIPTION
We have unified the way we write exception definition terms (`DOMException` in second)

This PR fixes the few cases where this wasn't the case.