### PR TITLE
Fix fetch of forbidden header name

### DIFF
--- a/files/en-us/glossary/forbidden_header_name/index.md
+++ b/files/en-us/glossary/forbidden_header_name/index.md
@@ -10,7 +10,7 @@ tags:
 ---
 A **forbidden header name** is the name of any [HTTP header](/en-US/docs/Web/HTTP/Headers) that cannot be modified programmatically; specifically, an HTTP **request** header name (in contrast with a {{Glossary("Forbidden response header name")}}).
 
-Modifying such headers is forbidden because the user agent retains full control over them. Names starting with `Sec-` are reserved for creating new headers safe from {{glossary("API","APIs")}} using [Fetch](/en-US/docs/Web/API/Fetch_API) that grant developers control over headers, such as {{domxref("XMLHttpRequest")}}.
+Modifying such headers is forbidden because the user agent retains full control over them. Names starting with `Sec-` are reserved for creating new headers safe from APIs using [fetch](https://fetch.spec.whatwg.org/#concept-fetch), not {{DOMxRef("fetch", "fetch()")}}, that allow control over headers by developers, such as {{domxref("XMLHttpRequest")}}.
 
 Forbidden header names start with `Proxy-` or `Sec-`, or are one of the following names:
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Fix the content and the link of `fetch` of `Glossary/Forbidden_header_name`.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

I find that [`fetch()`](https://fetch.spec.whatwg.org/#dom-global-fetch) and [`fetch`](https://fetch.spec.whatwg.org/#concept-fetch) are different. And it seems to be used wrong here.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

[whatwg forbidden-header-name](https://fetch.spec.whatwg.org/#forbidden-header-name)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
