### PR TITLE
muted property on tabs.create

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/create/index.md
@@ -41,6 +41,8 @@ let creating = browser.tabs.create(
       - : `boolean`. Whether the tab is created and made visible in the tab bar without any content loaded into memory, a state known as discarded. The tab's content is loaded when the tab is activated.
     - `index` {{optional_inline}}
       - : `integer`. The position the tab should take in the window. The provided value will be clamped to between zero and the number of tabs in the window.
+    - `muted` {{optional_inline}}
+      - : `boolean`. Whether the tab should be muted. Defaults to `false`.   
     - `openerTabId` {{optional_inline}}
       - : `integer`. The ID of the tab that opened this tab. If specified, the opener tab must be in the same window as the newly created tab.
     - `openInReaderMode` {{optional_inline}}

--- a/files/en-us/mozilla/firefox/releases/100/index.md
+++ b/files/en-us/mozilla/firefox/releases/100/index.md
@@ -51,7 +51,8 @@ No notable changes.
 
 ## Changes for add-on developers
 
-- The `color_scheme` and `content_color_scheme` properties are added to [theme](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme) manifest key and available in the{{WebExtAPIRef("theme")}} API. These properties enable a theme to override whether a light or dark color scheme is automatically applied to the chrome or content. ({{bug(1708105)}})
+- The `color_scheme` and `content_color_scheme` properties are added to [theme](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme) manifest key and available in the {{WebExtAPIRef("theme")}} API. These properties enable a theme to override whether a light or dark color scheme is automatically applied to the chrome or content ({{bug(1708105)}}).
+- You can now create a muted tab using {{WebExtAPIRef("tabs.create()")}} with the new `muted` property in the `createProperties` object ({{bug(1372100)}}).
 
 ## Older versions
 


### PR DESCRIPTION
#### Summary
Update to add `muted` to `createProperties` in the `tabs.create` API as implemented by [Bug 1372100](https://bugzilla.mozilla.org/show_bug.cgi?id=1372100).

[Related BCD](https://github.com/mdn/browser-compat-data/pull/16655).

#### Metadata

This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
