### PR TITLE
Added lossless case for image/webp and quality 1 for canvas toBlob and toDataURL

### DIFF
--- a/files/en-us/web/api/htmlcanvaselement/toblob/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/toblob/index.md
@@ -40,6 +40,7 @@ toBlob(callback, type, quality)
 - `quality` {{optional_inline}}
   - : A {{jsxref("Number")}} between `0` and `1` indicating the image quality to be used when creating images using file formats that support lossy compression (such as `image/jpeg` or `image/webp`).
     A user agent will use its default quality value if this option is not specified, or if the number is outside the allowed range.
+  - : A {{jsxref("Number")}} of `1` will use lossless compression for `image/webp`.
 
 ### Return value
 

--- a/files/en-us/web/api/htmlcanvaselement/todataurl/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/todataurl/index.md
@@ -38,6 +38,7 @@ toDataURL(type, encoderOptions)
 - `encoderOptions` {{optional_inline}}
   - : A {{jsxref("Number")}} between `0` and `1` indicating the image quality to be used when creating images using file formats that support lossy compression (such as `image/jpeg` or `image/webp`).
     A user agent will use its default quality value if this option is not specified, or if the number is outside the allowed range.
+  - : A {{jsxref("Number")}} of `1` will use lossless compression for `image/webp`.
 
 ### Return value
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Added lossless compression will be used for image/webp when quality is 1 for canvas toBlob and toDataURL

#### Motivation
Existing text isn't clear if lossless compression was available for image/webp.

#### Supporting details
Lossless image/webp is implemented https://bugs.chromium.org/p/chromium/issues/detail?id=523098

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
