### PR TITLE
fix issue-17308

### DIFF
--- a/files/en-us/web/html/element/input/index.md
+++ b/files/en-us/web/html/element/input/index.md
@@ -1040,7 +1040,7 @@ Specific attributes and their values can lead to a specific error {{domxref('Val
       </td>
     </tr>
     <tr>
-      <td><a href="#maxlength"><code>maxlength</code></a></td>
+      <td><a href="#maxlength"><code>minlength</code></a></td>
       <td>{{domxref('validityState.tooShort')}}</td>
       <td>
         Occurs when the number of characters is less than the number required by the <code>minlength</code> property


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Hello! 😀
I was reading mdn's documentation and found that **minlength was incorrectly written as maxlength.** The attribute associated with validityState.tooShort should be minlength, not maxlength.
 thank you for reading.😀

#### Motivation
To provide users with accurate information

#### Supporting details
![image](https://user-images.githubusercontent.com/78897803/173840352-d20df5e7-2f8f-45d3-b784-d914b8453cb6.png)
![image](https://user-images.githubusercontent.com/78897803/173840393-5db73c9d-c7de-492a-abb5-7bd0668b2b86.png)


#### Related issues
fix [issue-17308](https://github.com/mdn/content/issues/17308)

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
