### PR TITLE
Fixed anchor link for digest functions

### DIFF
--- a/files/en-us/web/api/rsahashedimportparams/index.md
+++ b/files/en-us/web/api/rsahashedimportparams/index.md
@@ -20,7 +20,7 @@ The **`RsaHashedImportParams`** dictionary of the [Web Crypto API](/en-US/docs/W
   - : A string. This should be set to `RSASSA-PKCS1-v1_5`, `RSA-PSS`, or `RSA-OAEP`, depending on the algorithm you want to use.
 - `hash`
 
-  - : A string representing the name of the [digest function](/en-US/docs/Web/API/SubtleCrypto#digest_algorithms) to use. This can be one of `SHA-256`, `SHA-384`, or `SHA-512`.
+  - : A string representing the name of the [digest function](/en-US/docs/Web/API/SubtleCrypto#supported_algorithms) to use. This can be one of `SHA-256`, `SHA-384`, or `SHA-512`.
 
     > **Warning:** Although you can technically pass `SHA-1` here, this is strongly discouraged as it is considered vulnerable.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
I fixed the link to the 'SubtleCrypto' page for the digest functions to link to the anchor 'supported_algorithms', where the digest functions are listed on that page.

#### Motivation
The link to the 'SubtleCrypto' page for the digest functions linked to the non-existent 'digest_algorithms' anchor.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
