### PR TITLE
`Window.showDirectoryPicker()`: Add `mode`

### DIFF
--- a/files/en-us/web/api/window/showdirectorypicker/index.md
+++ b/files/en-us/web/api/window/showdirectorypicker/index.md
@@ -9,9 +9,10 @@ tags:
   - Method
   - Window
   - working with files
+  - Experimental
 browser-compat: api.Window.showDirectoryPicker
 ---
-{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
+{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}{{SeeCompatTable}}
 
 The **`showDirectoryPicker()`** method of the
 {{domxref("Window")}} interface displays a directory picker which allows the user to

--- a/files/en-us/web/api/window/showdirectorypicker/index.md
+++ b/files/en-us/web/api/window/showdirectorypicker/index.md
@@ -30,7 +30,7 @@ var FileSystemDirectoryHandle = window.showDirectoryPicker();
   - : An object containing options, which are as follows:
 
     - `mode`
-      - : A string that defaults to `read` for read-only access or `readwrite` for read
+      - : A string that defaults to `"read"` for read-only access or `"readwrite"` for read
         and write access to the directory.
 
 ### Return value

--- a/files/en-us/web/api/window/showdirectorypicker/index.md
+++ b/files/en-us/web/api/window/showdirectorypicker/index.md
@@ -25,7 +25,13 @@ var FileSystemDirectoryHandle = window.showDirectoryPicker();
 
 ### Parameters
 
-None.
+- `options` {{optional_inline}}
+
+  - : An object containing options, which are as follows:
+
+    - `mode`
+      - : A string that defaults to `read` for read-only access or `readwrite` for read
+        and write access to the directory.
 
 ### Return value
 

--- a/files/en-us/web/api/window/showdirectorypicker/index.md
+++ b/files/en-us/web/api/window/showdirectorypicker/index.md
@@ -29,9 +29,16 @@ var FileSystemDirectoryHandle = window.showDirectoryPicker();
 
   - : An object containing options, which are as follows:
 
+    - `id`
+      - : By specifying an ID, the browser can remember different directories for different
+        IDs. If the same ID is used for another picker, the picker opens in the same
+        directory.
     - `mode`
       - : A string that defaults to `"read"` for read-only access or `"readwrite"` for read
         and write access to the directory.
+    - `startIn`
+      - : A `FileSystemHandle` or a well known directory (`"desktop"`, `"documents"`,
+        `"downloads"`, `"music"`, `"pictures"`, or `"videos"`) to open the dialog in.
 
 ### Return value
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Add `mode` to directory picker.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

Document API improvement.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://bugs.chromium.org/p/chromium/issues/detail?id=1115632

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [X] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
