### PR TITLE
Add `"deflate-raw"` as valid compression format

### DIFF
--- a/files/en-us/web/api/compressionstream/compressionstream/index.md
+++ b/files/en-us/web/api/compressionstream/compressionstream/index.md
@@ -27,6 +27,7 @@ new CompressionStream(format)
 
     - `"gzip"`
     - `"deflate"`
+    - `"deflate-raw"`
 
 ## Exceptions
 

--- a/files/en-us/web/api/decompressionstream/decompressionstream/index.md
+++ b/files/en-us/web/api/decompressionstream/decompressionstream/index.md
@@ -27,6 +27,7 @@ new DecompressionStream(format)
 
     - `"gzip"`
     - `"deflate"`
+    - `"deflate-raw"`
 
 ## Exceptions
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

The spec page linked at the bottom lists three compression formats, whereas current MDN only shows two. This adds the third one!

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

To match the spec!

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://wicg.github.io/compression/#supported-formats

Afaik, Deno is currently the only one to actually support this format: https://github.com/denoland/deno/pull/14863

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
