### PR TITLE
Pendantic: basic v. simple selector

### DIFF
--- a/files/en-us/web/api/document/queryselector/index.md
+++ b/files/en-us/web/api/document/queryselector/index.md
@@ -100,7 +100,7 @@ In this example, the first element in the document with the class
 var el = document.querySelector(".myclass");
 ```
 
-### A more complex selector
+### Complex selectors
 
 Selectors can also be really powerful, as demonstrated in the following example. Here,
 the first {{HTMLElement("input")}} element with the name "login"

--- a/files/en-us/web/css/_colon_first-of-type/index.md
+++ b/files/en-us/web/css/_colon_first-of-type/index.md
@@ -49,7 +49,7 @@ p:first-of-type {
 
 ### Nested elements
 
-This example shows how nested elements can also be targeted. Note that the [universal selector](/en-US/docs/Web/CSS/Universal_selectors) (`*`) is implied when no simple selector is written.
+This example shows how nested elements can also be targeted. Note that the [universal selector](/en-US/docs/Web/CSS/Universal_selectors) (`*`) is implied when no type selector is written.
 
 #### HTML
 

--- a/files/en-us/web/css/_colon_is/index.md
+++ b/files/en-us/web/css/_colon_is/index.md
@@ -36,28 +36,6 @@ footer p:hover {
 
 Pseudo-elements are not valid in the selector list for `:is()`.
 
-Note that older browsers support this functionality as `:matches()`, or through an older, prefixed pseudo-class — `:any()`, including older versions of Chrome, Firefox, and Safari. `:any()` works in exactly the same way as `:matches()`/`:is()`, except that it requires vendor prefixes and doesn't support [complex selectors](/en-US/docs/Learn/CSS/Building_blocks/Selectors).
-
-These legacy pseudo-classes can be used to provide backwards compatibility.
-
-```css
-/* Backwards-compatible version with :-*-any() and :matches()
-   (It is not possible to group selectors into single rule,
-   because presence of invalid selector would invalidate whole rule.) */
-:-webkit-any(header, main, footer) p:hover {
-  color: red;
-  cursor: pointer;
-}
-:-moz-any(header, main, footer) p:hover {
-  color: red;
-  cursor: pointer;
-}
-:matches(header, main, footer) p:hover {
-  color: red;
-  cursor: pointer;
-}
-```
-
 ### Difference between :is() and :where()
 
 The difference between the two is that `:is()` counts towards the specificity of the overall selector (it takes the specificity of its most specific argument), whereas [`:where()`](/en-US/docs/Web/CSS/:where) has a specificity value of 0. This is demonstrated by the [example on the `:where()` reference page](/en-US/docs/Web/CSS/:where#examples).

--- a/files/en-us/web/css/layout_cookbook/breadcrumb_navigation/index.md
+++ b/files/en-us/web/css/layout_cookbook/breadcrumb_navigation/index.md
@@ -36,7 +36,7 @@ The items typically display inline with a separator to indicate a hierarchy betw
 > }
 > ```
 >
-> This solution uses a more complex selector, but requires less rules. Feel free to choose the solution that you prefer.
+> This solution uses a more complicated selector, but requires fewer rules. Feel free to choose the solution that you prefer.
 
 ## Choices made
 

--- a/files/en-us/web/css/reference/index.md
+++ b/files/en-us/web/css/reference/index.md
@@ -81,7 +81,7 @@ The following are the various [selectors](/en-US/docs/Web/CSS/CSS_Selectors), wh
 
 ### Combinators
 
-Combinators are selectors that establish a relationship between two or more simple selectors, such as "`A` is a child of `B`" or "`A` is adjacent to `B`."
+Combinators are selectors that establish a relationship between two or more simple selectors, such as "`A` is a child of `B`" or "`A` is adjacent to `B`", creating a complex selector.
 
 - [Adjacent sibling combinator](/en-US/docs/Web/CSS/Adjacent_sibling_combinator) `A + B`
   - : Specifies that the elements selected by both `A` and `B` have the same parent and that the element selected by `B` immediately follows the element selected by `A` horizontally.

--- a/files/en-us/web/css/specificity/index.md
+++ b/files/en-us/web/css/specificity/index.md
@@ -208,7 +208,7 @@ You can also include the `id` or any part of a selector as a parameter in the `:
 
 ### Increasing specificity by duplicating selector
 
-As a special case for increasing specificity, you can duplicate weights from the _CLASS_ or _ID_ columns. Duplicating simple selectors will increase specificity when overriding very specific selectors over which you have no control.
+As a special case for increasing specificity, you can duplicate weights from the _CLASS_ or _ID_ columns. Duplicating id, class, pseudo-class or attribute selectors within a compound selector will increase specificity when overriding very specific selectors over which you have no control.
 
 ```css
 #myId#myId#myId span { /* 3-0-1 */}


### PR DESCRIPTION
We have been using the term simple and complex selector incorrectly. A simple selector is one that uses only one component, like `a` or `:nth-of-type(3n+2)`. A complex selector is selector that has a combinator, including just a space, such as `ul li`. A compound selector is one that has multiple components without a space, such as `div#myId.myClass`.

I am not sure if we want to clarify and be pedantic, but the term we've been using are not fully accurate.



<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
