### PR TITLE
Fix a live sample

### DIFF
--- a/files/en-us/web/api/svggeometryelement/ispointinfill/index.md
+++ b/files/en-us/web/api/svggeometryelement/ispointinfill/index.md
@@ -53,18 +53,35 @@ A boolean indicating whether the given point is within the fill or not.
 ### JavaScript
 
 ```js
-var circle = document.getElementById('circle');
+const circle = document.getElementById('circle');
 
-// Point is outside
-console.log('Point at 10,10:', circle.isPointInFill(new DOMPoint(10, 10)));
+try {
+  // Point is outside
+  console.log('Point at 10,10:', circle.isPointInFill(new DOMPoint(10, 10)));
 
-// Point is inside
-console.log('Point at 40,30:', circle.isPointInFill(new DOMPoint(40, 30)));
+  // Point is inside
+  console.log('Point at 40,30:', circle.isPointInFill(new DOMPoint(40, 30)));
+  
+} catch(e) {
+  // for the browsers that still support the deprecated interface SVGPoint
+  const svg = document.getElementsByTagName('svg')[0];
+  const point = svg.createSVGPoint();
+
+  // Point is outside
+  point.x = 10;
+  point.y = 10;
+  console.log('Point at 10,10: ', circle.isPointInFill(point));
+
+  // Point is inside
+  point.x = 40;
+  point.y = 30;
+  console.log('Point at 40,30: ', circle.isPointInFill(point));
+}
 ```
 
 ### Result
 
-{{EmbedLiveSample("Examples", "150", "150")}}
+{{EmbedLiveSample("Examples", "150", "155")}}
 
 ## Specifications
 


### PR DESCRIPTION
Chromium still uses the deprecated SVGPoint. And it throws following error:
> Uncaught TypeError: Failed to execute 'isPointInFill' on 'SVGGeometryElement': parameter 1 is not of type 'SVGPoint'.