### PR TITLE
Fix attribute name

### DIFF
--- a/files/en-us/web/api/customelementregistry/define/index.md
+++ b/files/en-us/web/api/customelementregistry/define/index.md
@@ -156,7 +156,7 @@ customElements.define('popup-info', PopUpInfo);
 ```
 
 ```html
-<popup-info img="img/alt.png" text="Your card validation code (CVC) is an extra
+<popup-info img="img/alt.png" data-text="Your card validation code (CVC) is an extra
                                     security feature — it is the last 3 or 4
                                     numbers on the back of your card.">
 ```


### PR DESCRIPTION
#### Summary
Attribute name `[data-text="..."]` should match selector `this.getAttribute('data-text')`

#### Motivation
Otherwise attribute selector will return `null` and popup example will display empty popup

#### Supporting details

Demo with error: https://stackblitz.com/edit/js-kjvfq4?file=index.html

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
