### PR TITLE
Fix last example on Function.prototype.call page

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/function/call/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/call/index.md
@@ -148,7 +148,7 @@ first argument. If the first argument is not passed, the value of `this` is
 bound to the global object.
 
 ```js
-const sData = 'Wisen';
+var sData = 'Wisen';
 
 function display() {
   console.log('sData value is %s ', this.sData);
@@ -163,7 +163,7 @@ display.call();  // sData value is Wisen
 ```js
 'use strict';
 
-const sData = 'Wisen';
+var sData = 'Wisen';
 
 function display() {
   console.log('sData value is %s ', this.sData);


### PR DESCRIPTION
### Summary
The change in commit 37851e7 (#16481) inadvertently broke that last example, 
as const variables do not create properties on the global object, whilst var variables do

#### Rambling Details
<details>
<summary>I'm on the fence as to whether this should be fixed via a reversion to `var`, or a change to `window.`</summary>
On the one hand, `window.x = 42` is the Correct way to do it & helps avoid future wrongful "corrections".
OTOH, the fact that top-level `var` adds props. to the global object might not be common knowledge & thus this helps teach people that? (IDK, all i know is before today I was under the misimpression that using var *always* did the Right thing & this horrible revelation has me **SHOOK**)
</details>

### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
