### PR TITLE
fix: PUT may have a successful response body

### DIFF
--- a/files/en-us/web/http/methods/put/index.md
+++ b/files/en-us/web/http/methods/put/index.md
@@ -21,7 +21,7 @@ The difference between `PUT` and {{HTTPMethod("POST")}} is that `PUT` is idempot
     </tr>
     <tr>
       <th scope="row">Successful response has body</th>
-      <td>No</td>
+      <td>May</td>
     </tr>
     <tr>
       <th scope="row">{{Glossary("Safe/HTTP", "Safe")}}</th>


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Mark "body with successful responses" as "May" instead of "No".

#### Motivation

Neither RFC2616 nor RFC7231 are specific about not returning a successful response body.

This creates a bit of confusion as it is quite common to return a body with successful responses.

"May" seems to be more appropriate.

_Let me know if you'd prefer if I open an issue first. I just thought that it was better to ask for forgiveness than permission._
_In case you disagree, it would be nice to add a paragraph that explains why the response body isn't semantically correct and why/how it should be avoided._

#### Supporting details
https://opensource.zalando.com/restful-api-guidelines/#put 
https://stackoverflow.com/questions/797834/should-a-restful-put-operation-return-something

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
