### PR TITLE
Fix sectioning flaw

### DIFF
--- a/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
@@ -16,7 +16,6 @@ The page front matter in the pages on MDN Web Docs comprises of the YAML headers
 
 > **Note:** _Remove this whole explanatory note before publishing._
 >
-> The YAML at the top of the page is used to define "page metadata". The values should be updated appropriately for the particular interface.
 >
 > ```plain
 > ---

--- a/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
@@ -12,7 +12,7 @@ browser-compat: path.to.feature.NameOfTheInterface
 
 ## YAML headers
 
-> **Note:** _Remove this whole explanatory note before publishing.
+> **Note:** _Remove this whole explanatory note before publishing._
 >
 > The YAML at the top of the page is used to define "page metadata". The values should be updated appropriately for the particular interface.
 >
@@ -48,7 +48,7 @@ browser-compat: path.to.feature.NameOfTheInterface
 
 ## Top macros
 
-> **Note:** _Remove this whole explanatory note before publishing.
+> **Note:** _Remove this whole explanatory note before publishing._
 >
 > There are five macro calls at the top of the template by default. You should update or delete them according to the advice below:
 >

--- a/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
@@ -12,7 +12,7 @@ browser-compat: path.to.feature.NameOfTheInterface
 
 > **Note:** _Remove this whole explanatory note before publishing_
 >
-> ### Page front matter
+> **Page front matter**
 >
 > The frontmatter at the top of the page is used to define "page metadata". The values should be updated appropriately for the particular interface.
 >
@@ -46,7 +46,7 @@ browser-compat: path.to.feature.NameOfTheInterface
 >
 >     Note that you may first need to create/update an entry for the API method in our [Browser compat data repo](https://github.com/mdn/browser-compat-data), and the entry for the API will need to include specification information. See our [guide on how to do this](/en-US/docs/MDN/Structures/Compatibility_tables).
 >
-> ### Top macros
+> **Top macros**
 >
 > There are five macro calls at the top of the template by default. You should update or delete them according to the advice below:
 >

--- a/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
@@ -10,7 +10,7 @@ browser-compat: path.to.feature.NameOfTheInterface
 ---
 {{MDNSidebar}}
 
-## YAML header
+## YAML headers
 
 > **Note:** _Remove this whole explanatory note before publishing.
 >

--- a/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
@@ -10,11 +10,11 @@ browser-compat: path.to.feature.NameOfTheInterface
 ---
 {{MDNSidebar}}
 
-> **Note:** _Remove this whole explanatory note before publishing_
+## YAML header
+
+> **Note:** _Remove this whole explanatory note before publishing.
 >
-> **Page front matter**
->
-> The frontmatter at the top of the page is used to define "page metadata". The values should be updated appropriately for the particular interface.
+> The YAML at the top of the page is used to define "page metadata". The values should be updated appropriately for the particular interface.
 >
 > ```plain
 > ---
@@ -45,8 +45,10 @@ browser-compat: path.to.feature.NameOfTheInterface
 >   - : Replace the placeholder value `path.to.feature.NameOfTheMethod` with the query string for the method in the [Browser compat data repo](https://github.com/mdn/browser-compat-data). The toolchain automatically uses the key to populate the compatibility and specification sections (replacing the `\{{Compat}}` and `\{{Specifications}}` macros).
 >
 >     Note that you may first need to create/update an entry for the API method in our [Browser compat data repo](https://github.com/mdn/browser-compat-data), and the entry for the API will need to include specification information. See our [guide on how to do this](/en-US/docs/MDN/Structures/Compatibility_tables).
->
-> **Top macros**
+
+## Top macros
+
+> **Note:** _Remove this whole explanatory note before publishing.
 >
 > There are five macro calls at the top of the template by default. You should update or delete them according to the advice below:
 >

--- a/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
@@ -49,6 +49,7 @@ The page front matter in the pages on MDN Web Docs comprises of the YAML headers
 
 ## Top macros
 
+By default, there are five macro calls at the top of a template. You should update or delete them according to the advice below.
 > **Note:** _Remove this whole explanatory note before publishing._
 >
 >

--- a/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
@@ -51,7 +51,6 @@ The page front matter in the pages on MDN Web Docs comprises of the YAML headers
 
 > **Note:** _Remove this whole explanatory note before publishing._
 >
-> There are five macro calls at the top of the template by default. You should update or delete them according to the advice below:
 >
 > - `\{{APIRef("<em>GroupDataName</em>")}}` — this generates the left-hand reference sidebar showing quick reference links related to the current page. For example, every page in the [WebVR API](/en-US/docs/Web/API/WebVR_API) has the same sidebar, which points to the other pages in the API. To generate the correct sidebar for your API, you need to add a GroupData entry to our KumaScript GitHub repo, and include the entry's name inside the macro call in place of _GroupDataName_. See our [API reference sidebars](/en-US/docs/MDN/Contribute/Howto/Write_an_API_reference/Sidebars) guide for information on how to do this.
 > - `\{{SeeCompatTable}}` — this generates a **This is an experimental technology** banner that indicates the technology is [experimental](/en-US/docs/MDN/Guidelines/Conventions_definitions#experimental). If the technology you are documenting is not experimental, you can remove this. If it is experimental, and the technology is hidden behind a pref in Firefox, you should also fill in an entry for it in the [Experimental features in Firefox](/en-US/docs/Mozilla/Firefox/Experimental_features) page.

--- a/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
@@ -10,7 +10,9 @@ browser-compat: path.to.feature.NameOfTheInterface
 ---
 {{MDNSidebar}}
 
-## YAML headers
+## Page front matter
+
+The page front matter in the pages on MDN Web Docs comprises of the YAML headers listed and described below. This YAML content at the top of a page is used to define the "page front matter" or the "page metadata". The values should be updated appropriately when describing a particular interface.
 
 > **Note:** _Remove this whole explanatory note before publishing._
 >


### PR DESCRIPTION
h3-level headings cannot be used inside a note:

1. They don't show up in the generated document; they are not achieving the intended goals.
2. They generate a sectioning flaw.

This PR transform them into bold text, not ideal but better.