### PR TITLE
Uses Specifications instead of SpecName/Spec2

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-modal/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-modal/index.md
@@ -8,6 +8,7 @@ tags:
   - ARIA property
   - aria-modal
   - Reference
+spec-urls: https://w3c.github.io/aria/#aria-modal
 ---
 
 The `aria-modal` attribute indicates whether an element is modal when displayed.
@@ -98,9 +99,7 @@ Inherits into roles:
 
 ## Specifications
 
-| Specification | Status |
-| ------------- | ------  |
-| {{SpecName("ARIA","#aria-modal","ARIA: aria-modal Attribute")}}  | {{Spec2('ARIA')}} |
+{{Specifications}}
 
 ## See Also
 


### PR DESCRIPTION
`SpecName` and `Spec2` are deprecated in favour of Specifications and the `spec-url` YAML header.