### PR TITLE
Update what attributes are supported by each input types

### DIFF
--- a/files/en-us/web/html/element/input/index.md
+++ b/files/en-us/web/html/element/input/index.md
@@ -328,37 +328,37 @@ Attributes for the `<input`> element include the [global HTML attributes](/en-US
 
 | Attribute                           | Type or Types                    | Description                                                                           |
 | ----------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------- |
-| [`accept`](#accept)                 | file                             | Hint for expected file type in file upload controls                                   |
-| [`alt`](#alt)                       | image                            | alt attribute for the image type. Required for accessibility                          |
-| [`autocomplete`](#autocomplete)     | all                              | Hint for form autofill feature                                                        |
-| [`capture`](#capture)               | file                             | Media capture input method in file upload controls                                    |
-| [`checked`](#checked)               | radio, checkbox                  | Whether the command or control is checked                                             |
-| [`dirname`](#dirname)               | text, search                     | Name of form field to use for sending the element's directionality in form submission |
+| [`accept`](#accept)                 | `file`                           | Hint for expected file type in file upload controls                                   |
+| [`alt`](#alt)                       | `image`                          | alt attribute for the image type. Required for accessibility                          |
+| [`autocomplete`](#autocomplete)     | almost all                       | Hint for form autofill feature                                                        |
+| [`capture`](#capture)               | `file`                           | Media capture input method in file upload controls                                    |
+| [`checked`](#checked)               | `checkbox`, `radio`              | Whether the command or control is checked                                             |
+| [`dirname`](#dirname)               | `search`, `text`                 | Name of form field to use for sending the element's directionality in form submission |
 | [`disabled`](#disabled)             | all                              | Whether the form control is disabled                                                  |
 | [`form`](#form)                     | all                              | Associates the control with a form element                                            |
-| [`formaction`](#formaction)         | image, submit                    | URL to use for form submission                                                        |
-| [`formenctype`](#formenctype)       | image, submit                    | Form data set encoding type to use for form submission                                |
-| [`formmethod`](#formmethod)         | image, submit                    | HTTP method to use for form submission                                                |
-| [`formnovalidate`](#formnovalidate) | image, submit                    | Bypass form control validation for form submission                                    |
-| [`formtarget`](#formtarget)         | image, submit                    | Browsing context for form submission                                                  |
-| [`height`](#height)                 | image                            | Same as height attribute for {{htmlelement('img')}}; vertical dimension               |
+| [`formaction`](#formaction)         | `image`, `submit`                | URL to use for form submission                                                        |
+| [`formenctype`](#formenctype)       | `image`, `submit`                | Form data set encoding type to use for form submission                                |
+| [`formmethod`](#formmethod)         | `image`, `submit`                | HTTP method to use for form submission                                                |
+| [`formnovalidate`](#formnovalidate) | `image`, `submit`                | Bypass form control validation for form submission                                    |
+| [`formtarget`](#formtarget)         | `image`, `submit`                | Browsing context for form submission                                                  |
+| [`height`](#height)                 | `image`                          | Same as height attribute for {{htmlelement('img')}}; vertical dimension               |
 | [`list`](#list)                     | almost all                       | Value of the id attribute of the {{htmlelement('datalist')}} of autocomplete options  |
 | [`max`](#max)                       | numeric types                    | Maximum value                                                                         |
-| [`maxlength`](#maxlength)           | password, search, tel, text, url | Maximum length (number of characters) of `value`                                      |
+| [`maxlength`](#maxlength)           | textual types                    | Maximum length (number of characters) of `value`                                      |
 | [`min`](#min)                       | numeric types                    | Minimum value                                                                         |
-| [`minlength`](#minlength)           | password, search, tel, text, url | Minimum length (number of characters) of `value`                                      |
-| [`multiple`](#multiple)             | email, file                      | Boolean. Whether to allow multiple values                                             |
+| [`minlength`](#minlength)           | textual types                    | Minimum length (number of characters) of `value`                                      |
+| [`multiple`](#multiple)             | `email`, `file`                  | Boolean. Whether to allow multiple values                                             |
 | [`name`](#name)                     | all                              | Name of the form control. Submitted with the form as part of a name/value pair        |
-| [`pattern`](#pattern)               | password, text, tel              | Pattern the `value` must match to be valid                                            |
-| [`placeholder`](#placeholder)       | password, search, tel, text, url | Text that appears in the form control when it has no value set                        |
+| [`pattern`](#pattern)               | textual types                    | Pattern the `value` must match to be valid                                            |
+| [`placeholder`](#placeholder)       | textual types and `number`       | Text that appears in the form control when it has no value set                        |
 | [`readonly`](#readonly)             | almost all                       | Boolean. The value is not editable                                                    |
 | [`required`](#required)             | almost all                       | Boolean. A value is required or must be check for the form to be submittable          |
-| [`size`](#size)                     | email, password, tel, text, url  | Size of the control                                                                   |
-| [`src`](#src)                       | image                            | Same as `src` attribute for {{htmlelement('img')}}; address of image resource         |
+| [`size`](#size)                     | textual types                    | Size of the control                                                                   |
+| [`src`](#src)                       | `image`                          | Same as `src` attribute for {{htmlelement('img')}}; address of image resource         |
 | [`step`](#step)                     | numeric types                    | Incremental values that are valid                                                     |
 | [`type`](#type)                     | all                              | Type of form control                                                                  |
 | [`value`](#value)                   | all                              | The initial value of the control                                                      |
-| [`width`](#width)                   | image                            | Same as `width` attribute for {{htmlelement('img')}}
+| [`width`](#width)                   | `image`                          | Same as `width` attribute for {{htmlelement('img')}}
 
 A few additional non-standard attributes are listed following the descriptions of the standard attributes.
 
@@ -526,7 +526,7 @@ A few additional non-standard attributes are listed following the descriptions o
 
 - `pattern`
 
-  - : The `pattern` attribute, when specified, is a regular expression that the input's [`value`](#value) must match in order for the value to pass [constraint validation](/en-US/docs/Web/Guide/HTML/Constraint_validation). It must be a valid JavaScript regular expression, as used by the {{jsxref("RegExp")}} type, and as documented in our [guide on regular expressions](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions); the `'u'` flag is specified when compiling the regular expression, so that the pattern is treated as a sequence of Unicode code points, instead of as ASCII. No forward slashes should be specified around the pattern text.
+  - : Valid for `text`, `search`, `url`, `tel`, `email`, and `password`, the `pattern` attribute defines a regular expression that the input's [`value`](#value) must match in order for the value to pass [constraint validation](/en-US/docs/Web/Guide/HTML/Constraint_validation). It must be a valid JavaScript regular expression, as used by the {{jsxref("RegExp")}} type, and as documented in our [guide on regular expressions](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions); the `'u'` flag is specified when compiling the regular expression, so that the pattern is treated as a sequence of Unicode code points, instead of as ASCII. No forward slashes should be specified around the pattern text.
 
     If the `pattern` attribute is present but is not specified or is invalid, no regular expression is applied and this attribute is ignored completely. If the pattern attribute is valid and a non-empty value does not match the pattern, constraint validation will prevent form submission.
 
@@ -536,7 +536,7 @@ A few additional non-standard attributes are listed following the descriptions o
 
 - `placeholder`
 
-  - : The `placeholder` attribute is a string that provides a brief hint to the user as to what kind of information is expected in the field. It should be a word or short phrase that provides a hint as to the expected type of data, rather than an explanation or prompt. The text _must not_ include carriage returns or line feeds. So for example if a field is expected to capture a user's first name, and its label is "First Name", a suitable placeholder might be "e.g. Mustafa".
+  - : Valid for `text`, `search`, `url`, `tel`, `email`, `password`, and `number`, the `placeholder` attribute provides a brief hint to the user as to what kind of information is expected in the field. It should be a word or short phrase that provides a hint as to the expected type of data, rather than an explanation or prompt. The text _must not_ include carriage returns or line feeds. So for example if a field is expected to capture a user's first name, and its label is "First Name", a suitable placeholder might be "e.g. Mustafa".
 
     > **Note:** The `placeholder` attribute is not as semantically useful as other ways to explain your form, and can cause unexpected technical issues with your content. See [Labels](#labels) for more information.
 
@@ -554,14 +554,14 @@ A few additional non-standard attributes are listed following the descriptions o
 
 - `size`
 
-  - : Valid for `email`, `password`, `tel`, `url` and `text` `input` types only. Specifies how much of the input is shown. Basically creates same result as setting CSS `width` property with a few specialities. The actual unit of the value depends on the input type. For `password` and `text`, it is a number of characters (or `em` units) with a default value of `20`, and for others, it is `pixel`s. CSS width takes precedence over size attribute.
+  - : Valid for `email`, `password`, `tel`, `url`, and `text`, the `size` attribute specifies how much of the input is shown. Basically creates same result as setting CSS [`width`](/en-US/docs/CSS/width) property with a few specialities. The actual unit of the value depends on the input type. For `password` and `text`, it is a number of characters (or `em` units) with a default value of `20`, and for others, it is pixels (or `px` units). CSS `width` takes precedence over the `size` attribute.
 
 - `src`
   - : Valid for the `image` input button only, the `src` is string specifying the URL of the image file to display to represent the graphical submit button. See the {{HTMLElement("input/image", "image")}} input type.
 
 - `step`
 
-  - : Valid for the numeric input types, including `number`, date/time input types, and `range`, the [`step`](/en-US/docs/Web/HTML/Attributes/step) attribute is a number that specifies the granularity that the value must adhere to.
+  - : Valid for `date`, `month`, `week`, `time`, `datetime-local`, `number`, and `range`, the [`step`](/en-US/docs/Web/HTML/Attributes/step) attribute is a number that specifies the granularity that the value must adhere to.
 
     If not explicitly included:
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Updates `<input>` attribute table's type columns, and explicitly lists applicable input types under the `pattern` and `placeholder` attribute descriptions.

#### Motivation
The table doesn't match the spec.

#### Supporting details
https://html.spec.whatwg.org/multipage/input.html#do-not-apply

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
