### PR TITLE
Remove bogus compat table

### DIFF
--- a/files/en-us/web/api/media_source_extensions_api/index.md
+++ b/files/en-us/web/api/media_source_extensions_api/index.md
@@ -68,10 +68,6 @@ There are numerous available free and open source tools for transcoding content 
 
 {{Specifications}}
 
-## Browser compatibility
-
-{{Compat}}
-
 ## See also
 
 - [Transcoding assets for Media Source Extensions](/en-US/docs/Web/API/Media_Source_Extensions_API/Transcoding_assets_for_MSE)


### PR DESCRIPTION
I think there is no bcd entry for this (and we use `spec-url` in YAML because of this)