### PR TITLE
Prevent ks to kick in for a macro in meta docs

### DIFF
--- a/files/en-us/web/css/layout_cookbook/contribute_a_recipe/cookbook_template/index.md
+++ b/files/en-us/web/css/layout_cookbook/contribute_a_recipe/cookbook_template/index.md
@@ -45,7 +45,7 @@ _Include this is there are any specific things to watch out for in regard to acc
 
 ## Browser compatibility
 
-_List the key properties you used in the `browser-compat` frontmatter metadata key. Then use the `{{Compat}}` macro in this section to automatically generate a compatibility table for the listed properties._
+_List the key properties you used in the `browser-compat` frontmatter metadata key. Then use the `\{{Compat}}` macro in this section to automatically generate a compatibility table for the listed properties._
 
 ## See also
 


### PR DESCRIPTION
The macro was generating a flaw because KS was trying to execute it. This is meta doc.