### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/web/api/range/getboundingclientrect/index.md
+++ b/files/en-us/web/api/range/getboundingclientrect/index.md
@@ -62,8 +62,8 @@ p {
 
 ```js
 const range = document.createRange();
-range.setStartBefore(document.getElementsByTagName('b').item(0), 0);
-range.setEndAfter(document.getElementsByTagName('b').item(1), 0);
+range.setStartBefore(document.getElementsByTagName('b').item(0));
+range.setEndAfter(document.getElementsByTagName('b').item(1));
 
 const clientRect = range.getBoundingClientRect();
 const highlight = document.getElementById('highlight');


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
The `Range.setStartBefore` and `Range.setEndAfter` do not require offset values per MDN documentation for those methods. This is perhaps confused with the `setStart` and `setEnd` methods that do in fact require offset as a second argument.

#### Motivation
Clarification.

#### Supporting details

[MDN Docs for setStartBefore](https://developer.mozilla.org/en-US/docs/Web/API/Range/setStartBefore
)


This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
