### PR TITLE
ReadableStream constructor underlying source is only technically optional

### DIFF
--- a/files/en-us/web/api/readablestream/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/readablestream/index.md
@@ -13,7 +13,7 @@ browser-compat: api.ReadableStream.ReadableStream
 
 The **`ReadableStream()`** constructor creates and returns a readable stream object from the given handlers.
 
-Note that while parameters are technically optional, omitting the `underlyingSource` will result in a stream that has no source, and that can't be read from (readers return a promise that will never be resolved).
+Note that while all parameters are technically optional, omitting the `underlyingSource` will result in a stream that has no source, and that can't be read from (readers return a promise that will never be resolved).
 
 ## Syntax
 

--- a/files/en-us/web/api/readablestream/readablestream/index.md
+++ b/files/en-us/web/api/readablestream/readablestream/index.md
@@ -11,8 +11,9 @@ browser-compat: api.ReadableStream.ReadableStream
 ---
 {{APIRef("Streams")}}
 
-The **`ReadableStream()`** constructor creates
-and returns a readable stream object from the given handlers.
+The **`ReadableStream()`** constructor creates and returns a readable stream object from the given handlers.
+
+Note that while parameters are technically optional, omitting the `underlyingSource` will result in a stream that has no source, and that can't be read from (readers return a promise that will never be resolved).
 
 ## Syntax
 
@@ -26,8 +27,8 @@ new ReadableStream(underlyingSource, queuingStrategy)
 
 - `underlyingSource` {{optional_inline}}
 
-  - : An object containing methods and properties that define how the constructed stream
-    instance will behave. `underlyingSource` can contain the following:
+  - : An object containing methods and properties that define how the constructed stream instance will behave. 
+    `underlyingSource` can contain the following:
 
     - `start`(controller) {{optional_inline}}
       - : This is a method, called immediately when the object is constructed. The


### PR DESCRIPTION
You can create a ReadableStream with no source, but it isn't useful for anything since there is no way to get data into it.