### PR TITLE
FF102 Relnote: Readable byte streams

### DIFF
--- a/files/en-us/mozilla/firefox/releases/102/index.md
+++ b/files/en-us/mozilla/firefox/releases/102/index.md
@@ -44,6 +44,10 @@ The [`update`](/en-US/docs/Web/CSS/@media/update-frequency) media feature that c
 - [Transform streams](/en-US/docs/Web/API/TransformStream) are now supported, allowing you to pipe from a {{domxref("ReadableStream")}} to a {{domxref("WritableStream")}}, executing a transformation on the chunks.
   The update includes the new interfaces [`TransformStream`](/en-US/docs/Web/API/TransformStream) and [`TransformStreamDefaultController`](/en-US/docs/Web/API/TransformStreamDefaultController), and the method [`ReadableStream.pipeThrough()`](/en-US/docs/Web/API/ReadableStream/pipeThrough) ({{bug(1767507)}}).
 
+- [Readable byte streams](/en-US/docs/Web/API/Streams_API#bytestream-related_interfaces) are now supported, allowing efficient zero-byte transfer of data from an underlying byte source to a consumer (bypassing the stream's internal queues).
+  The new interfaces are {{domxref("ReadableStreamBYOBReader")}}, {{domxref("ReadableByteStreamController")}}, and {{domxref("ReadableStreamBYOBRequest")}}.
+  ({{bug(1767342)}}).
+
 #### DOM
 
 - The Firefox-only property {{domxref("Window.sidebar")}} has been moved behind a preference, and is planned for removal ({{bug(1768486)}}).


### PR DESCRIPTION
This is the release note indicating support for readable byte streams in FF102, as added in https://bugzilla.mozilla.org/show_bug.cgi?id=1767342 and tracked in #16816

The underlying docs are not quite complete and will need careful expert review (under construction in #16818). As this will not complete before release, this is a placeholder release note that will need to be updated with a link to the new use guide when it is accepted. That's going to be done in #16818