### PR TITLE
Fix autoboxing example mutating a string

### DIFF
--- a/files/en-us/glossary/primitive/index.md
+++ b/files/en-us/glossary/primitive/index.md
@@ -21,8 +21,7 @@ For example, below it looks like `toUpperCase()` and `length` are methods and pr
 
 ```js
 let mystring = "lower case string";
-mystring.toUpperCase();
-console.log(mystring);
+console.log(mystring.toUpperCase());
 // 'LOWER CASE STRING'
 console.log(mystring.length)
 // 17

--- a/files/en-us/glossary/primitive/index.md
+++ b/files/en-us/glossary/primitive/index.md
@@ -21,9 +21,9 @@ For example, below it looks like `toUpperCase()` and `length` are methods and pr
 
 ```js
 let mystring = "lower case string";
-console.log(mystring.toUpperCase());
-// 'LOWER CASE STRING'
-console.log(mystring.length)
+console.log(mystring.toUpperCase()); // 'LOWER CASE STRING'
+console.log(mystring); // Still 'lower case string' as toUpperCase() didn't modify mystring.
+console.log(mystring.length);
 // 17
 ```
 


### PR DESCRIPTION



<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fix autoboxing example showing that `toLowerCase()` could mutate a string, which is not the case.

#### Motivation

The example shows that `toLowerCase()` could mutate a string but it's not the case. While the goal of the example is to show that it's possible to call functions on primitives (thanks to autoboxing), I think the example should still be correct.

Instead of fixing the comment, I decided to fix the code so it produces the upper case output. This makes it clearer that the function has been called (otherwise it would not have any visible effect).

While I think it would be cleaner to put the result of `toLowerCase()` in a variable and then show it, I decided against it to keep the example simple.

#### Supporting details
![image](https://user-images.githubusercontent.com/11044507/174325228-9d9ce0f9-e4e2-4a0f-9167-51bba8317dd8.png)

#### Related issues
This seems related to #14626 but it is *not*

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
