### PR TITLE
id in history.onTitleChanged

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/history/ontitlechanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/ontitlechanged/index.md
@@ -39,7 +39,7 @@ Events have three functions:
   - : Function that is called when this event occurs. The function is passed an object with these properties:
 
     - `id`
-      - : `String`. ID of the page visited.
+      - : `String`. The unique identifier for the {{WebExtAPIRef("history.HistoryItem")}} associated with this visit.
     - `url`
       - : `String`. URL of the page visited.
     - `title`

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/ontitlechanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/ontitlechanged/index.md
@@ -11,7 +11,7 @@ tags:
   - onTitleChanged
 browser-compat: webextensions.api.history.onTitleChanged
 ---
-{{AddonSidebar()}}Fired when the title of a page visited by the user is recorded.To listen for visits to a page you can use {{WebExtAPIRef("history.onVisited")}}. However, the {{WebExtAPIRef("history.HistoryItem")}} that this event passes to its listener does not include the page title, because the page title is typically not known at the time `history.onVisited` is sent.Instead, the stored {{WebExtAPIRef("history.HistoryItem")}} is updated with the page title after the page has loaded, once the title is known. The history.onTitleChanged event is fired at that time. So if you need to know the titles of pages as they are visited, listen for `history.onTitleChanged`.
+{{AddonSidebar()}}Fired when the title of a page visited by the user is recorded. To listen for visits to a page you use {{WebExtAPIRef("history.onVisited")}}. However, the {{WebExtAPIRef("history.HistoryItem")}} that this event passes to its listener does not include the page title, because the page title is typically not known at the time `history.onVisited` is sent. Instead, the stored {{WebExtAPIRef("history.HistoryItem")}} is updated with the page title after the page has loaded, once the title is known. The `history.onTitleChanged` event is fired at that time. So if you need to know the titles of pages as they are visited, listen for `history.onTitleChanged`.
 
 ## Syntax
 
@@ -36,8 +36,10 @@ Events have three functions:
 
 - `callback`
 
-  - : Function that will be called when this event occurs. The function will be passed an object with the following properties:
+  - : Function that is called when this event occurs. The function is passed an object with these properties:
 
+    - `id`
+      - : `String`. ID of the page visited.
     - `url`
       - : `String`. URL of the page visited.
     - `title`
@@ -49,10 +51,11 @@ Events have three functions:
 
 ## Examples
 
-Listen for title change events, and log the URL and title of the visited pages.
+Listen for title change events, and log the ID, URL, and title of the visited pages.
 
 ```js
 function handleTitleChanged(item) {
+  console.log(item.id);
   console.log(item.title);
   console.log(item.url);
 }

--- a/files/en-us/mozilla/firefox/releases/86/index.md
+++ b/files/en-us/mozilla/firefox/releases/86/index.md
@@ -76,6 +76,7 @@ _No changes._
 - [Host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) now grant access to privileged parts of the [tabs API](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs) ({{bug(1679688)}}).
 - `focused: false` is now ignored when set as an option in a [`windows.create()`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/windows/create) call ({{bug(1253129)}}).
 - {{WebExtAPIRef("identity.getRedirectURL")}} now supports a loopback address, see [Getting the redirect URL](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/identity#getting_the_redirect_url) for details ({{bug(1614919)}}).
+- The page ID is now returned as part of {{WebExtAPIRef("history.onTitleChanged")}} ({{bug(1678611)}}).
 
 ## Older versions
 


### PR DESCRIPTION
#### Summary
Adds the `id` parameter to the `history.onTitleChanged` event. Provides the content requested in [Bug 1756663](https://bugzilla.mozilla.org/show_bug.cgi?id=1756663).

Related BCD update: https://github.com/mdn/browser-compat-data/pull/16715

Fixes https://github.com/mdn/content/issues/13369

#### Metadata

This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error