### PR TITLE
Nit: Some grammatical changes to the prose

### DIFF
--- a/files/en-us/web/svg/attribute/x/index.md
+++ b/files/en-us/web/svg/attribute/x/index.md
@@ -1154,9 +1154,9 @@ For {{SVGElement('svg')}}, `x` defines the x coordinate of the upper left corner
 
 ## text
 
-For {{SVGElement('text')}}, if it contain a single value, `x` defines the x coordinate on where the *content text position* must be placed. The *content text position* is usually a point on the baseline of the first line of text. The exact *content text position* is influenced by some properties like {{SVGAttr('text-anchor')}}, or {{cssxref('direction')}}.
+For {{SVGElement('text')}}, if it contains a single value, `x` defines the x coordinate where the *content text position* must be placed. The *content text position* is usually a point on the baseline of the first line of text. The exact *content text position* is influenced by other properties, such as {{SVGAttr('text-anchor')}} or {{cssxref('direction')}}.
 
-If there are multiple values, `x` defines the x coordinate of each individual glyph from the text. If there are less values than glyphs, the remaining glyphs are placed in the continuity of the last positioned glyph. If there are more values than glyphs, extra values are ignored.
+If it contains multiple values, `x` defines the x coordinate of each individual glyph from the text. If there are fewer values than glyphs, the remaining glyphs are placed in line with the last positioned glyph. If there are more values than glyphs, the extra values are ignored.
 
 <table class="properties">
   <tbody>
@@ -1229,9 +1229,9 @@ line {
 
 > **Warning:** As of SVG2 {{SVGElement('tref')}} is deprecated and shouldn't be used.
 
-For {{SVGElement('tref')}}, if it contain a single value, `x` defines the x coordinate on where the *content text position* must be placed. The *content text position* is usually a point on the baseline of the first line of text. The exact *content text position* is influenced by some properties like {{SVGAttr('text-anchor')}}, or {{cssxref('direction')}}.
+For {{SVGElement('tref')}}, if it contains a single value, `x` defines the x coordinate where the *content text position* must be placed. The *content text position* is usually a point on the baseline of the first line of text. The exact *content text position* is influenced by other properties, such as {{SVGAttr('text-anchor')}} or {{cssxref('direction')}}.
 
-If there are multiple values, `x` defines the x coordinate of each individual glyph from the text. If there are less values than glyphs, the remaining glyphs are placed in the continuity of the last positioned glyph. If there are more values than glyphs, extra values are ignored.
+If it contains multiple values, `x` defines the x coordinate of each individual glyph from the text. If there are fewer values than glyphs, the remaining glyphs are placed in line with the last positioned glyph. If there are more values than glyphs, the extra values are ignored.
 
 <table class="properties">
   <tbody>
@@ -1264,9 +1264,9 @@ If there are multiple values, `x` defines the x coordinate of each individual gl
 
 ## tspan
 
-For {{SVGElement('tspan')}}, if it contain a single value, `x` defines the x coordinate on where the *content text position* must be placed. The *content text position* is usually a point on the baseline of the first line of text. The exact *content text position* is influenced by some properties like {{SVGAttr('text-anchor')}}, or {{cssxref('direction')}}.
+For {{SVGElement('tspan')}}, if it contains a single value, `x` defines the x coordinate where the *content text position* must be placed. The *content text position* is usually a point on the baseline of the first line of text. The exact *content text position* is influenced by other properties, such as  {{SVGAttr('text-anchor')}} or {{cssxref('direction')}}.
 
-If there are multiple values, `x` defines the x coordinate of each individual glyph from the text. If there are less values than glyphs, the remaining glyphs are placed in the continuity of the last positioned glyph. If there are more values than glyphs, extra values are ignored.
+If it contains multiple values, `x` defines the x coordinate of each individual glyph from the text. If there are fewer values than glyphs, the remaining glyphs are placed in line with the last positioned glyph. If there are more values than glyphs, the extra values are ignored.
 
 <table class="properties">
   <tbody>


### PR DESCRIPTION
#### Summary
I altered the grammar of some of the paragraphs on this page so they would read better.

#### Motivation
Some of the paragraphs on this page did not read very well to me.

#### Related issues
I made similar changes to the `y` SVG Attribute page in #17276

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
