### PR TITLE
A tiny typo fix

### DIFF
--- a/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
@@ -91,7 +91,7 @@ If we want to start making this more grid-like we need to add column tracks.
 
 ## Grid tracks
 
-We define rows and columns on our grid with the {{cssxref("grid-template-columns")}} and {{cssxref("grid-template-rows")}} properties. These define grid tracks. A _grid track_ is the space between any two lines on the grid. In the below image you can see a track highlighted – this is the first row track in our grid.
+We define rows and columns on our grid with the {{cssxref("grid-template-rows")}} and {{cssxref("grid-template-columns")}} properties. These define grid tracks. A _grid track_ is the space between any two lines on the grid. In the below image you can see a track highlighted – this is the first row track in our grid.
 
 ![](1_grid_track.png)
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
While explaining grid track, 

If we say row and then column, Then follow the same order while relating the properties will make sense.

Instead of
```diff
- We define rows and columns on our grid with the `grid-template-columns` and `grid-template-rows` properties.
```
Recommend to
```diff
+ We define rows and columns on our grid with the `grid-template-rows` and `grid-template-columns` properties.
```

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
While explaining things, Order does matter which avoids confusion. It will make sense while switch `grid-template-rows` then `grid-template-columns`.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout#grid_tracks:~:text=We%20define%20rows%20and%20columns%20on%20our%20grid%20with%20the%20grid%2Dtemplate%2Dcolumns%20and%20grid%2Dtemplate%2Drows%20properties.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
