### PR TITLE
Add sidebar for Compression Streams API

### DIFF
--- a/files/en-us/web/api/compressionstream/compressionstream/index.md
+++ b/files/en-us/web/api/compressionstream/compressionstream/index.md
@@ -9,7 +9,7 @@ tags:
   - CompressionStream
 browser-compat: api.CompressionStream.CompressionStream
 ---
-{{DefaultAPISidebar("Compression Streams API")}}
+{{APIRef("Compression Streams API")}}
 
 The **`CompressionStream()`** constructor creates a new {{domxref("CompressionStream")}} object which compresses a stream of data.
 

--- a/files/en-us/web/api/compressionstream/index.md
+++ b/files/en-us/web/api/compressionstream/index.md
@@ -9,7 +9,7 @@ tags:
   - CompressionStream
 browser-compat: api.CompressionStream
 ---
-{{DefaultAPISidebar("Compression Streams API")}}
+{{APIRef("Compression Streams API")}}
 
 The **`CompressionStream`** interface of the {{domxref('Compression Streams API','','',' ')}} is an API for compressing a stream of data.
 

--- a/files/en-us/web/api/compressionstream/readable/index.md
+++ b/files/en-us/web/api/compressionstream/readable/index.md
@@ -10,7 +10,7 @@ tags:
   - CompressionStream
 browser-compat: api.CompressionStream.readable
 ---
-{{DefaultAPISidebar("Compression Streams API")}}
+{{APIRef("Compression Streams API")}}
 
 The **`readable`** read-only property of the {{domxref("CompressionStream")}} interface returns a {{domxref("ReadableStream")}}.
 

--- a/files/en-us/web/api/compressionstream/writable/index.md
+++ b/files/en-us/web/api/compressionstream/writable/index.md
@@ -10,7 +10,7 @@ tags:
   - CompressionStream
 browser-compat: api.CompressionStream.writable
 ---
-{{DefaultAPISidebar("Compression Streams API")}}
+{{APIRef("Compression Streams API")}}
 
 The **`writable`** read-only property of the {{domxref("CompressionStream")}} interface returns a {{domxref("WritableStream")}}.
 

--- a/files/en-us/web/api/decompressionstream/decompressionstream/index.md
+++ b/files/en-us/web/api/decompressionstream/decompressionstream/index.md
@@ -9,7 +9,7 @@ tags:
   - DecompressionStream
 browser-compat: api.DecompressionStream.DecompressionStream
 ---
-{{DefaultAPISidebar("Compression Streams API")}}
+{{APIRef("Compression Streams API")}}
 
 The **`DecompressionStream()`** constructor creates a new {{domxref("DecompressionStream")}} object which decompresses a stream of data.
 

--- a/files/en-us/web/api/decompressionstream/index.md
+++ b/files/en-us/web/api/decompressionstream/index.md
@@ -9,7 +9,7 @@ tags:
   - DecompressionStream
 browser-compat: api.DecompressionStream
 ---
-{{DefaultAPISidebar("Compression Streams API")}}
+{{APIRef("Compression Streams API")}}
 
 The **`DecompressionStream`** interface of the {{domxref('Compression Streams API','','',' ')}} is an API for decompressing a stream of data.
 

--- a/files/en-us/web/api/decompressionstream/readable/index.md
+++ b/files/en-us/web/api/decompressionstream/readable/index.md
@@ -10,7 +10,7 @@ tags:
   - DecompressionStream
 browser-compat: api.DecompressionStream.readable
 ---
-{{DefaultAPISidebar("Compression Streams API")}}
+{{APIRef("Compression Streams API")}}
 
 The **`readable`** read-only property of the {{domxref("DecompressionStream")}} interface returns a {{domxref("ReadableStream")}}.
 

--- a/files/en-us/web/api/decompressionstream/writable/index.md
+++ b/files/en-us/web/api/decompressionstream/writable/index.md
@@ -10,7 +10,7 @@ tags:
   - DecompressionStream
 browser-compat: api.DecompressionStream.writable
 ---
-{{DefaultAPISidebar("Compression Streams API")}}
+{{APIRef("Compression Streams API")}}
 
 The **`writable`** read-only property of the {{domxref("DecompressionStream")}} interface returns a {{domxref("WritableStream")}}.
 

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -121,6 +121,16 @@
         "Element: paste"
       ]
     },
+    "Compression Streams API": {
+      "overview": ["Compression Streams API"],
+      "interfaces": [
+        "CompressionStream",
+        "DecompressionStream"
+      ],
+      "methods": [],
+      "properties": [],
+      "events": []
+    },
     "Contact Picker API": {
       "overview": ["Contact Picker API"],
       "interfaces": ["ContactsManager"],


### PR DESCRIPTION
_Compression Streams API_ was missing a sidebar. This PR:
- add an entry in `GroupData.json`
- fix the macro calls in the articles.