### PR TITLE
chore(web/http/csp): use RFC2606 example domains for examples

### DIFF
--- a/files/en-us/web/http/csp/index.md
+++ b/files/en-us/web/http/csp/index.md
@@ -94,7 +94,7 @@ Content-Security-Policy: default-src 'self'
 A web site administrator wants to allow content from a trusted domain and all its subdomains (it doesn't have to be the same domain that the CSP is set on.)
 
 ```http
-Content-Security-Policy: default-src 'self' trusted.com *.trusted.com
+Content-Security-Policy: default-src 'self' example.com *.example.com
 ```
 
 ### Example 3
@@ -103,13 +103,13 @@ A web site administrator wants to allow users of a web application to include im
 but to restrict audio or video media to trusted providers, and all scripts only to a specific server that hosts trusted code.
 
 ```http
-Content-Security-Policy: default-src 'self'; img-src *; media-src media1.com media2.com; script-src userscripts.example.com
+Content-Security-Policy: default-src 'self'; img-src *; media-src example.org example.net; script-src userscripts.example.com
 ```
 
 Here, by default, content is only permitted from the document's origin, with the following exceptions:
 
 - Images may load from anywhere (note the "\*" wildcard).
-- Media is only allowed from media1.com and media2.com (and not from subdomains of those sites).
+- Media is only allowed from example.org and example.net (and not from subdomains of those sites).
 - Executable script is only allowed from userscripts.example.com.
 
 ### Example 4
@@ -117,17 +117,17 @@ Here, by default, content is only permitted from the document's origin, with the
 A web site administrator for an online banking site wants to ensure that all its content is loaded using TLS, in order to prevent attackers from eavesdropping on requests.
 
 ```http
-Content-Security-Policy: default-src https://onlinebanking.jumbobank.com
+Content-Security-Policy: default-src https://onlinebanking.example.com
 ```
 
-The server permits access only to documents being loaded specifically over HTTPS through the single origin onlinebanking.jumbobank.com.
+The server permits access only to documents being loaded specifically over HTTPS through the single origin onlinebanking.example.com.
 
 ### Example 5
 
 A web site administrator of a web mail site wants to allow HTML in email, as well as images loaded from anywhere, but not JavaScript or other potentially dangerous content.
 
 ```http
-Content-Security-Policy: default-src 'self' *.mailsite.com; img-src *
+Content-Security-Policy: default-src 'self' *.example.com; img-src *
 ```
 
 Note that this example doesn't specify a {{CSP("script-src")}}; with the example CSP,


### PR DESCRIPTION
#### Summary

As is the title.

#### Motivation

Some of the example domains in `web/http/csp` do not following RFC2606. Especially, `trusted.com` is exist domain. We should use example domains. 

#### Supporting details

N/A

#### Related issues

N/A

#### Metadata


- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

---

Thank you :)
