### PR TITLE
fix: variable declaration in example

### DIFF
--- a/files/en-us/learn/forms/form_validation/index.md
+++ b/files/en-us/learn/forms/form_validation/index.md
@@ -782,8 +782,8 @@ function addEvent(element, event, callback) {
       output = previousEventCallBack(e);
       if(output === false) return false;
     }
-  }
-};
+  };
+}
 
 // Now we can rebuild our validation constraint
 // Because we do not rely on CSS pseudo-class, we have to

--- a/files/en-us/learn/forms/form_validation/index.md
+++ b/files/en-us/learn/forms/form_validation/index.md
@@ -772,7 +772,7 @@ const emailRegExp = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z
 function addEvent(element, event, callback) {
   let previousEventCallBack = element["on"+event];
   element["on"+event] = function (e) {
-    const output = callback(e);
+    let output = callback(e);
 
     // A callback that returns `false` stops the callback chain
     // and interrupts the execution of the event callback.


### PR DESCRIPTION
Fix variable declaration in example with create form's validation for old browsers without Constraint Validation API.
![Screenshot_2022-06-18_22-04-33](https://user-images.githubusercontent.com/81531000/174449130-8f441679-2624-4dfa-ba87-c629305ffe43.png)

Error in the example will be reproduced if you hang several event listeners of the same type on the same element.
For example:
![image](https://user-images.githubusercontent.com/81531000/174449008-8c39da0d-8122-49a4-a8e6-138239efad7c.png)

In a case with `const output = callback(e);` it will:
![image](https://user-images.githubusercontent.com/81531000/174449054-3ef3f001-454c-4371-9674-fa4496d9a332.png)


**UPD**:  add semicolon for function expression and remove semicolon for function declaration.
![image](https://user-images.githubusercontent.com/81531000/174451001-d47504a4-6202-4d32-aaf5-87bdaee166a6.png)

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
