### PR TITLE
Make KeyboardEvent.Code page keyboard accessible

### DIFF
--- a/files/en-us/web/api/keyboardevent/code/index.md
+++ b/files/en-us/web/api/keyboardevent/code/index.md
@@ -39,7 +39,7 @@ The code values for Windows, Linux, and macOS are list on the [KeyboardEvent: co
 ```html
 <p>Press keys on the keyboard to see what the KeyboardEvent's key and code
    values are for each one.</p>
-<div id="output">
+<div id="output" tabindex="0">
 </div>
 ```
 
@@ -49,8 +49,13 @@ The code values for Windows, Linux, and macOS are list on the [KeyboardEvent: co
 #output {
   font-family: Arial, Helvetica, sans-serif;
   border: 1px solid black;
+  width: 95%;
+  margin: auto;
 }
-```
+#output:focus-visible {
+  outline: 3px solid dodgerblue;
+}
+```		
 
 #### JavaScript
 
@@ -59,12 +64,13 @@ window.addEventListener("keydown", function(event) {
   const p = document.createElement("p");
   p.textContent = `KeyboardEvent: key='${event.key}' | code='${event.code}'`;
   document.getElementById("output").appendChild(p);
+  window.scrollTo(0, document.body.scrollHeight);
 }, true);
 ```
 
 #### Try it out
 
-To ensure that keystrokes go to the sample, click in the output box below before pressing keys.
+To ensure that keystrokes go to the sample, click or focus the output box below before pressing keys.
 
 {{ EmbedLiveSample('Exercising_KeyboardEvent', 600, 300) }}
 
@@ -76,7 +82,7 @@ This example establishes an event listener for {{event("keydown")}} events that 
 
 ```html
 <p>Use the WASD (ZQSD on AZERTY) keys to move and steer.</p>
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" class="world">
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" class="world" tabindex="0">
   <polygon id="spaceship" points="15,0 0,30 30,30"/>
 </svg>
 ```
@@ -91,7 +97,9 @@ This example establishes an event listener for {{event("keydown")}} events that 
   width: 400px;
   height: 400px;
 }
-
+.world:focus-visible {
+  outline: 5px solid dodgerblue;
+}
 #spaceship {
   fill: orange;
   stroke: red;
@@ -190,14 +198,18 @@ window.addEventListener("keydown", function(event) {
 
   refresh();
 
-  // Consume the event so it doesn't get handled twice
-  event.preventDefault();
+  if (event.code !== "Tab")
+  {
+    // Consume the event so it doesn't get handled twice,
+    // as long as the user isn't trying to move focus away
+    event.preventDefault();
+  }
 }, true);
 ```
 
 #### Try it out
 
-To ensure that keystrokes go to the sample code, click inside the black game play field below before pressing keys.
+To ensure that keystrokes go to the sample code, click or focus the black game play field below before pressing keys.
 
 {{EmbedLiveSample("Handle_keyboard_events_in_a_game", 420, 460)}}
 


### PR DESCRIPTION
### Summary
The examples inside of the [KeyboardEvent.Code page](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code) were previously not keyboard accessible in Chromium browsers. We will now explicitly make the elements inside the examples keyboard focusable.

### Motivation
Keyboard-only users can now interact with the examples in browsers which don't make iframes focusable by default.

### Supporting details
Chromium browsers don't make iframes focusable by default. This shouldn't be a Chromium issue because the [HTML specifications](https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute) don't have a normative "default tab index" for iframes as far as I'm aware.

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error