### PR TITLE
Fix a live sample

### DIFF
--- a/files/en-us/web/api/svggeometryelement/ispointinstroke/index.md
+++ b/files/en-us/web/api/svggeometryelement/ispointinstroke/index.md
@@ -55,18 +55,39 @@ A boolean indicating whether the given point is within the stroke or not.
 ### JavaScript
 
 ```js
-var circle = document.getElementById('circle');
+const circle = document.getElementById('circle');
 
-// Point not in circle
-console.log('Point at 10,10:', circle.isPointInStroke(new DOMPoint(10, 10)));
+try {
+  // Point not in circle
+  console.log('Point at 10,10:', circle.isPointInStroke(new DOMPoint(10, 10)));
 
-// Point in circle but not stroke
-console.log('Point at 40,30:', circle.isPointInStroke(new DOMPoint(40, 30)));
+  // Point in circle but not stroke
+  console.log('Point at 40,30:', circle.isPointInStroke(new DOMPoint(40, 30)));
 
-// Point in circle stroke
-console.log('Point at 83,17:', circle.isPointInStroke(new DOMPoint(83, 17)));
+  // Point in circle stroke
+  console.log('Point at 83,17:', circle.isPointInStroke(new DOMPoint(83, 17)));
+  
+} catch(e) {
+  // for the browsers that still support the deprecated interface SVGPoint
+  const svg = document.getElementsByTagName('svg')[0];
+  const point = svg.createSVGPoint();
+
+  // Point not in circle
+  point.x = 10;
+  point.y = 10;
+  console.log('Point at 10,10:', circle.isPointInStroke(point));
+
+  // Point in circle but not stroke
+  point.x = 40;
+  point.y = 30;
+  console.log('Point at 40,30:', circle.isPointInStroke(point));
+
+  // Point in circle stroke
+  point.x = 83;
+  point.y = 17;
+  console.log('Point at 83,17:', circle.isPointInStroke(point));
+}
 ```
-
 ### Result
 
 {{EmbedLiveSample("Examples", "150", "150")}}


### PR DESCRIPTION
Same as #17326

Chromium still uses the deprecated SVGPoint. And it throws following error:
> Uncaught TypeError: Failed to execute 'isPointInStroke' on 'SVGGeometryElement': parameter 1 is not of type 'SVGPoint'.
