### PR TITLE
Remove misleading log from micro task example

### DIFF
--- a/files/en-us/web/api/html_dom_api/microtask_guide/index.md
+++ b/files/en-us/web/api/html_dom_api/microtask_guide/index.md
@@ -290,7 +290,6 @@ log("Main program started");
 setTimeout(callback, 0);
 log(`10! equals ${doWork()}`);
 log("Main program exiting");
-log("Regular timeout callback has run");
 ```
 
 #### Result


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
The last example snippet on this page has a redundant log line at the end of the program,
which may create the impression that the `callback` function that is scheduled with `setTimeout`, is run *before* the `urgentCallback` scheduled with `queueMicrotask`.
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
Reduce confusion for readers.
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
None.
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
None.
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
