### PR TITLE
Add spec-url for CSS `:local-link`

### DIFF
--- a/files/en-us/web/css/_colon_local-link/index.md
+++ b/files/en-us/web/css/_colon_local-link/index.md
@@ -2,6 +2,7 @@
 title: ':local-link'
 slug: Web/CSS/:local-link
 browser-compat: css.selectors.local-link
+spec-url: https://drafts.csswg.org/selectors/#local-link-pseudo
 ---
 {{ CSSRef }}
 

--- a/files/en-us/web/css/_colon_local-link/index.md
+++ b/files/en-us/web/css/_colon_local-link/index.md
@@ -1,7 +1,6 @@
 ---
 title: ':local-link'
 slug: Web/CSS/:local-link
-browser-compat: css.selectors.local-link
 spec-url: https://drafts.csswg.org/selectors/#local-link-pseudo
 ---
 {{ CSSRef }}
@@ -48,7 +47,7 @@ a:local-link {
 
 ## Browser compatibility
 
-{{Compat}}
+This feature is a proposal integrated into the specification. Currently, no browser supports it.
 
 ## See also
 


### PR DESCRIPTION
See mdn/browser-compat-data#15253

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Added spec-url for the CSS `:local-link` pseudo selector.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
This PR clears up confusion regarding the `:local-link` CSS feature.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
- **MDN URL**: https://developer.mozilla.org/en-US/docs/Web/CSS/:local-link
- **Spec URL**: https://drafts.csswg.org/selectors/#local-link-pseudo

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
- mdn/browser-compat-data#15253
- mdn/browser-compat-data#13029

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
