### PR TITLE
Makes references to `Intl.Locale()` consistent

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/calendar/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/calendar/index.md
@@ -66,7 +66,7 @@ The `calendar` property returns the part of the `Locale` that indicates the `Loc
 
 ### Adding a calendar in the Locale string
 
-Calendar eras fall under the category of locale key "extension keys". These keys add additional data about the locale, and are added to locale identifiers by using the `-u` extension. Thus, the calendar era type can be added to the initial locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Intl.Locale")}} constructor. To add the calendar type, first add the `-u` extension to the string. Next, add the `-ca` extension to indicate that you are adding a calendar type. Finally, add the calendar era to the string.
+Calendar eras fall under the category of locale key "extension keys". These keys add additional data about the locale, and are added to locale identifiers by using the `-u` extension. Thus, the calendar era type can be added to the initial locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. To add the calendar type, first add the `-u` extension to the string. Next, add the `-ca` extension to indicate that you are adding a calendar type. Finally, add the calendar era to the string.
 
 ```js
 let locale = new Intl.Locale("fr-FR-u-ca-buddhist");
@@ -75,7 +75,7 @@ console.log(locale.calendar); // Prints "buddhist"
 
 ### Adding a calendar with a configuration object
 
-The {{jsxref("Intl/Locale/Locale", "Intl.Locale")}} constructor has an optional configuration object argument, which can contain any of several extension types, including calendars. Set the `calendar` property of the configuration object to your desired calendar era, and then pass it into the constructor.
+The {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor has an optional configuration object argument, which can contain any of several extension types, including calendars. Set the `calendar` property of the configuration object to your desired calendar era, and then pass it into the constructor.
 
 ```js
 let locale = new Intl.Locale("fr-FR", { calendar: "buddhist" });

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/casefirst/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/casefirst/index.md
@@ -43,7 +43,7 @@ console.log(locale.caseFirst); // Prints "upper"
 
 ### Setting the caseFirst value via the configuration object argument
 
-The {{jsxref("Intl/Locale/Locale", "Intl.Locale")}} constructor has an optional configuration object argument, which can be used to pass extension types. Set the `caseFirst` property of the configuration object to your desired `caseFirst` value, and then pass it into the constructor.
+The {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor has an optional configuration object argument, which can be used to pass extension types. Set the `caseFirst` property of the configuration object to your desired `caseFirst` value, and then pass it into the constructor.
 
 ```js
 let locale = new Intl.Locale("en-Latn-US", { caseFirst: "lower" });

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/collation/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/collation/index.md
@@ -197,7 +197,7 @@ Like other locale subtags, the collation type can be added to the {{jsxref("Intl
 
 ### Adding a collation type via the locale string
 
-In the [Unicode locale string spec](https://www.unicode.org/reports/tr35/), collation types are locale key "extension subtags". These subtags add additional data about the locale, and are added to locale identifiers by using the `-u` extension. Thus, the collation type can be added to the initial locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Locale")}} constructor. To add the collation type, first add the `-u` extension to the string. Next, add the `-co` extension to indicate that you are adding a collation type. Finally, add the collation to the string.
+In the [Unicode locale string spec](https://www.unicode.org/reports/tr35/), collation types are locale key "extension subtags". These subtags add additional data about the locale, and are added to locale identifiers by using the `-u` extension. Thus, the collation type can be added to the initial locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. To add the collation type, first add the `-u` extension to the string. Next, add the `-co` extension to indicate that you are adding a collation type. Finally, add the collation to the string.
 
 ```js
 let locale = new Intl.Locale("zh-Hant-u-co-zhuyin");
@@ -206,7 +206,7 @@ console.log(locale.collation); // Prints "zhuyin"
 
 ### Adding a collation type via the configuration object argument
 
-The {{jsxref("Intl/Locale/Locale", "Intl.Locale")}} constructor has an optional configuration object argument, which can contain any of several extension types, including collation types. Set the `collation` property of the configuration object to your desired collation type, and then pass it into the constructor.
+The {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor has an optional configuration object argument, which can contain any of several extension types, including collation types. Set the `collation` property of the configuration object to your desired collation type, and then pass it into the constructor.
 
 ```js
 let locale = new Intl.Locale("zh-Hant", { collation: "zhuyin" });

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/hourcycle/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/hourcycle/index.md
@@ -35,7 +35,7 @@ These examples will show you how to add hour cycle data to your {{jsxref("Intl/L
 
 ### Adding an hour cycle via the locale string
 
-In the [Unicode locale string spec](https://www.unicode.org/reports/tr35/), the hour cycle is a locale string "extension subtag". These subtags add additional data about the locale, and are added to locale identifiers by using the `-u` extension key. Thus, the hour cycle type can be added to the initial locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Locale")}} constructor. To add the hour cycle type, first add the `-u` extension key to the string. Next, add the `-hc` extension key to indicate that you are adding an hour cycle. Finally, add the hour cycle type to the string.
+In the [Unicode locale string spec](https://www.unicode.org/reports/tr35/), the hour cycle is a locale string "extension subtag". These subtags add additional data about the locale, and are added to locale identifiers by using the `-u` extension key. Thus, the hour cycle type can be added to the initial locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. To add the hour cycle type, first add the `-u` extension key to the string. Next, add the `-hc` extension key to indicate that you are adding an hour cycle. Finally, add the hour cycle type to the string.
 
 ```js
 let locale = new Intl.Locale("fr-FR-u-hc-h23");
@@ -44,7 +44,7 @@ console.log(locale.hourCycle); // Prints "h23"
 
 ### Adding an hour cycle via the configuration object argument
 
-The {{jsxref("Intl/Locale/Locale", "Intl.Locale")}} constructor has an optional configuration object argument, which can contain any of several extension types, including hour cycle types. Set the `hourCycle` property of the configuration object to your desired hour cycle type, and then pass it into the constructor.
+The {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor has an optional configuration object argument, which can contain any of several extension types, including hour cycle types. Set the `hourCycle` property of the configuration object to your desired hour cycle type, and then pass it into the constructor.
 
 ```js
 let locale = new Intl.Locale("en-US", { hourCycle: "h12" });

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/index.md
@@ -77,7 +77,7 @@ Traditionally, the Intl API used strings to represent locales, just as Unicode d
 
 ### Basic usage
 
-At its very simplest, the {{jsxref("Intl/Locale/Locale", "Intl.Locale")}} constructor takes a locale identifier string as its argument:
+At its very simplest, the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor takes a locale identifier string as its argument:
 
 ```js
 let us = new Intl.Locale('en-US');

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/language/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/language/index.md
@@ -24,7 +24,7 @@ Language is one of the core features of a locale. The Unicode specification trea
 
 ### Setting the language in the locale identifier string argument
 
-In order to be a valid Unicode locale identifier, a string must start with the language subtag. The main argument to the {{jsxref("Intl/Locale/Locale", "Locale")}} constructor must be a valid Unicode locale identifier, so whenever the constructor is used, it must be passed an identifier with a language subtag.
+In order to be a valid Unicode locale identifier, a string must start with the language subtag. The main argument to the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor must be a valid Unicode locale identifier, so whenever the constructor is used, it must be passed an identifier with a language subtag.
 
 ```js
 let locale = new Intl.Locale("en-Latn-US");
@@ -33,7 +33,7 @@ console.log(locale.language); // Prints "en"
 
 ### Overriding language via the configuration object
 
-While the language subtag must be specified, the {{jsxref("Intl/Locale/Locale", "Locale()")}} constructor takes a configuration object, which can override the language subtag.
+While the language subtag must be specified, the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor takes a configuration object, which can override the language subtag.
 
 ```js
 let locale = new Intl.Locale("en-Latn-US", { language: "es" });

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/locale/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/locale/index.md
@@ -39,7 +39,7 @@ new Intl.Locale(tag, options)
 
 ### Basic usage
 
-At its very simplest, the {{jsxref("Intl/Locale/Locale", "Intl.Locale")}} constructor takes
+At its very simplest, the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor takes
 a locale identifier string as its argument:
 
 ```js

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/numberingsystem/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/numberingsystem/index.md
@@ -114,7 +114,7 @@ A numeral system is a system for expressing numbers. The `numberingSystem` prope
 
 ### Setting the `numberingSystem` value via the locale string
 
-In the [Unicode locale string spec](https://www.unicode.org/reports/tr35/), the values that `numberingSystem` represents correspond to the key `nu`. `nu` is considered a locale string "extension subtag". These subtags add additional data about the locale, and are added to locale identifiers by first adding the `-u` key. To set the `numberingSystem` value via the string argument to the {{jsxref("Intl/Locale/Locale", "Locale")}} constructor, first add the `-u` extension key. Next, add the `-nu` extension key to indicate that you are adding a value for `numberingSystem`. Finally, add the `numberingSystem` value to the string.
+In the [Unicode locale string spec](https://www.unicode.org/reports/tr35/), the values that `numberingSystem` represents correspond to the key `nu`. `nu` is considered a locale string "extension subtag". These subtags add additional data about the locale, and are added to locale identifiers by first adding the `-u` key. To set the `numberingSystem` value via the string argument to the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor, first add the `-u` extension key. Next, add the `-nu` extension key to indicate that you are adding a value for `numberingSystem`. Finally, add the `numberingSystem` value to the string.
 
 ```js
 let locale = new Intl.Locale("fr-Latn-FR-u-nu-mong");
@@ -123,7 +123,7 @@ console.log(locale.numberingSystem); // Prints "mong"
 
 ### Setting the `numberingSystem` value via the configuration object argument
 
-The {{jsxref("Intl/Locale/Locale", "Intl.Locale")}} constructor has an optional configuration object argument, which can be used to pass extension types. Set the `numberingSystem` property of the configuration object to your desired `numberingSystem` value and pass it into the constructor.
+The {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor has an optional configuration object argument, which can be used to pass extension types. Set the `numberingSystem` property of the configuration object to your desired `numberingSystem` value and pass it into the constructor.
 
 ```js
 let locale = new Intl.Locale("en-Latn-US", { numberingSystem: "latn" });

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/numberingsystems/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/numberingsystems/index.md
@@ -114,7 +114,7 @@ A numeral system is a system for expressing numbers. The `numberingSystem` prope
 
 ### Obtaining supported `numberingSystem` values via the locale string
 
-In the [Unicode locale string spec](https://www.unicode.org/reports/tr35/), the values that `numberingSystem` represents correspond to the key `nu`. `nu` is considered a locale string "extension subtag". These subtags add additional data about the locale, and are added to locale identifiers by first adding the `-u` key. To set the `numberingSystem` value via the string argument to the {{jsxref("Intl/Locale/Locale", "Locale")}} constructor, first add the `-u` extension key. Next, add the `-nu` extension key to indicate that you are adding a value for `numberingSystem`. Finally, add the `numberingSystem` value to the string.
+In the [Unicode locale string spec](https://www.unicode.org/reports/tr35/), the values that `numberingSystem` represents correspond to the key `nu`. `nu` is considered a locale string "extension subtag". These subtags add additional data about the locale, and are added to locale identifiers by first adding the `-u` key. To set the `numberingSystem` value via the string argument to the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor, first add the `-u` extension key. Next, add the `-nu` extension key to indicate that you are adding a value for `numberingSystem`. Finally, add the `numberingSystem` value to the string.
 
 List supported number system for a given `Locale`.
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/numeric/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/numeric/index.md
@@ -24,7 +24,7 @@ Like {{jsxref("Intl/Locale/caseFirst", "Intl.Locale.caseFirst")}}, `numeric` rep
 
 ### Setting the numeric value via the locale string
 
-In the [Unicode locale string spec](https://www.unicode.org/reports/tr35/), the values that `numeric` represents correspond to the key `kn`. `kn` is considered a locale string "extension subtag". These subtags add additional data about the locale, and are added to locale identifiers by using the `-u` extension key. Thus, the `numeric` value can be added to the initial locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Locale")}} constructor. To set the `numeric` value, first add the `-u` extension key to the string. Next, add the `-kn` extension key to indicate that you are adding a value for `numeric`. Finally, add the `numeric` value to the string. If you want to set `numeric` to `true`, adding the `kn` key will suffice. To set the value to `false`, you must specify in by adding "`false`" after the `kn` key.
+In the [Unicode locale string spec](https://www.unicode.org/reports/tr35/), the values that `numeric` represents correspond to the key `kn`. `kn` is considered a locale string "extension subtag". These subtags add additional data about the locale, and are added to locale identifiers by using the `-u` extension key. Thus, the `numeric` value can be added to the initial locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. To set the `numeric` value, first add the `-u` extension key to the string. Next, add the `-kn` extension key to indicate that you are adding a value for `numeric`. Finally, add the `numeric` value to the string. If you want to set `numeric` to `true`, adding the `kn` key will suffice. To set the value to `false`, you must specify in by adding "`false`" after the `kn` key.
 
 ```js
 let locale = new Intl.Locale("fr-Latn-FR-u-kn-false");
@@ -33,7 +33,7 @@ console.log(locale.numeric); // Prints "false"
 
 ### Setting the `numeric` value via the configuration object argument
 
-The {{jsxref("Intl/Locale/Locale", "Intl.Locale")}} constructor has an optional configuration object argument, which can be used to pass extension types. Set the `numeric` property of the configuration object to your desired `numeric` value and pass it into the constructor.
+The {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor has an optional configuration object argument, which can be used to pass extension types. Set the `numeric` property of the configuration object to your desired `numeric` value and pass it into the constructor.
 
 ```js
 let locale = new Intl.Locale("en-Latn-US", { numeric: true });

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/region/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/region/index.md
@@ -24,7 +24,7 @@ The region is an essential part of the locale identifier, as it places the local
 
 ### Setting the region in the locale identifier string argument
 
-The region is the third part of a valid Unicode language identifier string, and can be set by adding it to the locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Locale")}} constructor. The region is a mandatory part of a
+The region is the third part of a valid Unicode language identifier string, and can be set by adding it to the locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. The region is a mandatory part of a
 
 ```js
 let locale = new Intl.Locale("en-Latn-US");
@@ -33,7 +33,7 @@ console.log(locale.region); // Prints "US"
 
 ### Setting the region via the configuration object
 
-The {{jsxref("Intl/Locale/Locale", "Locale")}} constructor takes a configuration object, which can be used to set the region subtag and property.
+The {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor takes a configuration object, which can be used to set the region subtag and property.
 
 ```js
 let locale = new Intl.Locale("fr-Latn", { region: "FR" });

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/script/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/script/index.md
@@ -24,7 +24,7 @@ A script, sometimes called writing system, is one of the core attributes of a lo
 
 ### Setting the script in the locale identifier string argument
 
-The script is the second part of a valid Unicode language identifier string, and can be set by adding it to the locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Locale")}} constructor. Note that the script is not a required part of a locale identifier.
+The script is the second part of a valid Unicode language identifier string, and can be set by adding it to the locale identifier string that is passed into the {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor. Note that the script is not a required part of a locale identifier.
 
 ```js
 let locale = new Intl.Locale("en-Latn-US");
@@ -33,7 +33,7 @@ console.log(locale.script); // Prints "Latn"
 
 ### Setting the script via the configuration object
 
-The {{jsxref("Intl/Locale/Locale", "Locale")}} constructor takes a configuration object, which can be used to set the script subtag and property.
+The {{jsxref("Intl/Locale/Locale", "Intl.Locale()")}} constructor takes a configuration object, which can be used to set the script subtag and property.
 
 ```js
 let locale = new Intl.Locale("fr-FR", { script: "Latn" });


### PR DESCRIPTION
The link texts used for `Intl.Locale()` constructor are different in many places.
The PR makes sure `{{jsxref("Intl/Locale/Locale", "Intl.Locale()")}}` is used everywhere.