### PR TITLE
Add Web USB API sidebar

### DIFF
--- a/files/en-us/web/api/usb/connect_event/index.md
+++ b/files/en-us/web/api/usb/connect_event/index.md
@@ -8,6 +8,7 @@ tags:
   - Reference
   - USB
   - WebUSB
+  - Experimental
 browser-compat: api.USB.connect_event
 ---
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/usb/disconnect_event/index.md
+++ b/files/en-us/web/api/usb/disconnect_event/index.md
@@ -8,6 +8,7 @@ tags:
   - Reference
   - USB
   - WebUSB
+  - Experimental
 browser-compat: api.USB.disconnect_event
 ---
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/usb/getdevices/index.md
+++ b/files/en-us/web/api/usb/getdevices/index.md
@@ -10,6 +10,7 @@ tags:
   - WebUSB
   - WebUSB API
   - getDevices()
+  - Experimental
 browser-compat: api.USB.getDevices
 ---
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}{{securecontext_header}}

--- a/files/en-us/web/api/usb/index.md
+++ b/files/en-us/web/api/usb/index.md
@@ -9,6 +9,7 @@ tags:
   - USB
   - WebUSB
   - WebUSB API
+  - Experimental
 browser-compat: api.USB
 ---
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}{{securecontext_header}}

--- a/files/en-us/web/api/usb/requestdevice/index.md
+++ b/files/en-us/web/api/usb/requestdevice/index.md
@@ -10,6 +10,7 @@ tags:
   - WebUSB
   - WebUSB API
   - getDevices()
+  - Experimental
 browser-compat: api.USB.requestDevice
 ---
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}{{securecontext_header}}

--- a/files/en-us/web/api/usbalternateinterface/index.md
+++ b/files/en-us/web/api/usbalternateinterface/index.md
@@ -13,7 +13,7 @@ tags:
   - WebUSB API
 browser-compat: api.USBAlternateInterface
 ---
-{{securecontext_header}}{{APIRef("WebUSB API")}}
+{{securecontext_header}}{{APIRef("WebUSB API")}}{{SeeCompatTable}}
 
 The `USBAlternateInterface` interface of the [WebUSB API](/en-US/docs/Web/API/WebUSB_API) provides information about a particular configuration of an interface provided by the USB device. An interface includes one or more alternate settings which can configure a set of endpoints based on the operating mode of the device.
 

--- a/files/en-us/web/api/usbconfiguration/configurationname/index.md
+++ b/files/en-us/web/api/usbconfiguration/configurationname/index.md
@@ -11,9 +11,10 @@ tags:
   - WebUSB
   - WebUSB API
   - configurationName
+  - Experimental
 browser-compat: api.USBConfiguration.configurationName
 ---
-{{securecontext_header}}{{APIRef("WebUSB API")}}
+{{securecontext_header}}{{APIRef("WebUSB API")}}{{SeeCompatTable}}
 
 The **`configurationName`** read-only property
 of the {{domxref("USBConfiguration")}} interface returns the name provided by the device

--- a/files/en-us/web/api/usbconfiguration/configurationname/index.md
+++ b/files/en-us/web/api/usbconfiguration/configurationname/index.md
@@ -13,7 +13,7 @@ tags:
   - configurationName
 browser-compat: api.USBConfiguration.configurationName
 ---
-{{securecontext_header}}{{APIRef("")}}
+{{securecontext_header}}{{APIRef("WebUSB API")}}
 
 The **`configurationName`** read-only property
 of the {{domxref("USBConfiguration")}} interface returns the name provided by the device

--- a/files/en-us/web/api/usbconfiguration/configurationvalue/index.md
+++ b/files/en-us/web/api/usbconfiguration/configurationvalue/index.md
@@ -11,9 +11,10 @@ tags:
   - WebUSB
   - WebUSB API
   - configurationValue
+  - Experimental
 browser-compat: api.USBConfiguration.configurationValue
 ---
-{{securecontext_header}}{{APIRef("WebUSB API")}}
+{{securecontext_header}}{{APIRef("WebUSB API")}}{{SeeCompatTable}}
 
 The **`configurationValue`** read-only property
 of the {{domxref("USBConfiguration")}} interface null

--- a/files/en-us/web/api/usbconfiguration/configurationvalue/index.md
+++ b/files/en-us/web/api/usbconfiguration/configurationvalue/index.md
@@ -13,7 +13,7 @@ tags:
   - configurationValue
 browser-compat: api.USBConfiguration.configurationValue
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebUSB API")}}
+{{securecontext_header}}{{APIRef("WebUSB API")}}
 
 The **`configurationValue`** read-only property
 of the {{domxref("USBConfiguration")}} interface null

--- a/files/en-us/web/api/usbconfiguration/index.md
+++ b/files/en-us/web/api/usbconfiguration/index.md
@@ -12,7 +12,7 @@ tags:
   - WebUSB API
 browser-compat: api.USBConfiguration
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebUSB API")}}
+{{securecontext_header}}{{APIRef("WebUSB API")}}
 
 The `USBConfiguration` interface of the [WebUSB API](/en-US/docs/Web/API/WebUSB_API) provides information about a particular configuration of a USB device and the interfaces that it supports.
 

--- a/files/en-us/web/api/usbconfiguration/index.md
+++ b/files/en-us/web/api/usbconfiguration/index.md
@@ -10,9 +10,10 @@ tags:
   - USBConfiguration
   - WebUSB
   - WebUSB API
+  - Experimental
 browser-compat: api.USBConfiguration
 ---
-{{securecontext_header}}{{APIRef("WebUSB API")}}
+{{securecontext_header}}{{APIRef("WebUSB API")}}{{SeeCompatTable}}
 
 The `USBConfiguration` interface of the [WebUSB API](/en-US/docs/Web/API/WebUSB_API) provides information about a particular configuration of a USB device and the interfaces that it supports.
 

--- a/files/en-us/web/api/usbconfiguration/interfaces/index.md
+++ b/files/en-us/web/api/usbconfiguration/interfaces/index.md
@@ -13,7 +13,7 @@ tags:
   - WebUSB API
 browser-compat: api.USBConfiguration.interfaces
 ---
-{{securecontext_header}}{{DefaultAPISidebar("")}}
+{{securecontext_header}}{{APIRef("WebUSB API")}}
 
 The **`interfaces`** read-only property of the
 {{domxref("USBConfiguration")}} interface returns an array containing instances of the

--- a/files/en-us/web/api/usbconfiguration/interfaces/index.md
+++ b/files/en-us/web/api/usbconfiguration/interfaces/index.md
@@ -11,9 +11,10 @@ tags:
   - USBConfiguration
   - WebUSB
   - WebUSB API
+  - Experimental
 browser-compat: api.USBConfiguration.interfaces
 ---
-{{securecontext_header}}{{APIRef("WebUSB API")}}
+{{securecontext_header}}{{APIRef("WebUSB API")}}{{SeeCompatTable}}
 
 The **`interfaces`** read-only property of the
 {{domxref("USBConfiguration")}} interface returns an array containing instances of the

--- a/files/en-us/web/api/usbconfiguration/usbconfiguration/index.md
+++ b/files/en-us/web/api/usbconfiguration/usbconfiguration/index.md
@@ -14,7 +14,7 @@ tags:
   - WebUSB API
 browser-compat: api.USBConfiguration.USBConfiguration
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebUSB API")}}
+{{securecontext_header}}{{APIRef("WebUSB API")}}
 
 The **`USBConfiguration()`** constructor
 creates a new {{domxref("USBConfiguration")}} object which contains information about

--- a/files/en-us/web/api/usbconfiguration/usbconfiguration/index.md
+++ b/files/en-us/web/api/usbconfiguration/usbconfiguration/index.md
@@ -14,7 +14,7 @@ tags:
   - WebUSB API
 browser-compat: api.USBConfiguration.USBConfiguration
 ---
-{{securecontext_header}}{{APIRef("WebUSB API")}}
+{{securecontext_header}}{{APIRef("WebUSB API")}}{{SeeCompatTable}}
 
 The **`USBConfiguration()`** constructor
 creates a new {{domxref("USBConfiguration")}} object which contains information about

--- a/files/en-us/web/api/usbconnectionevent/device/index.md
+++ b/files/en-us/web/api/usbconnectionevent/device/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - device
   - USBConnectionEvent
+  - Experimental
 browser-compat: api.USBConnectionEvent.device
 ---
-{{securecontext_header}}{{APIRef("WebUSB API")}}
+{{securecontext_header}}{{APIRef("WebUSB API")}}{{SeeCompatTable}}
 
 The **`device`** read-only property of the {{domxref("USBConnectionEvent")}} interface returns a {{domxref("USBDevice")}} object representing the device being connected or disconnected.
 

--- a/files/en-us/web/api/usbconnectionevent/device/index.md
+++ b/files/en-us/web/api/usbconnectionevent/device/index.md
@@ -10,7 +10,7 @@ tags:
   - USBConnectionEvent
 browser-compat: api.USBConnectionEvent.device
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebUSB API")}}
+{{securecontext_header}}{{APIRef("WebUSB API")}}
 
 The **`device`** read-only property of the {{domxref("USBConnectionEvent")}} interface returns a {{domxref("USBDevice")}} object representing the device being connected or disconnected.
 

--- a/files/en-us/web/api/usbconnectionevent/index.md
+++ b/files/en-us/web/api/usbconnectionevent/index.md
@@ -7,9 +7,10 @@ tags:
   - Interface
   - Reference
   - USBConnectionEvent
+  - Experimental
 browser-compat: api.USBConnectionEvent
 ---
-{{securecontext_header}}{{APIRef("WebUSB API")}}
+{{securecontext_header}}{{APIRef("WebUSB API")}}{{SeeCompatTable}}
 
 The **`USBConnectionEvent`** interface of the {{domxref('WebUSB API','','',' ')}} is the event type passed to {{domxref("USB.onconnect")}} and {{domxref("USB.ondisconnect")}} when the user agent detects that a new USB device has been connected or disconnected.
 

--- a/files/en-us/web/api/usbconnectionevent/index.md
+++ b/files/en-us/web/api/usbconnectionevent/index.md
@@ -9,7 +9,7 @@ tags:
   - USBConnectionEvent
 browser-compat: api.USBConnectionEvent
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebUSB API")}}
+{{securecontext_header}}{{APIRef("WebUSB API")}}
 
 The **`USBConnectionEvent`** interface of the {{domxref('WebUSB API','','',' ')}} is the event type passed to {{domxref("USB.onconnect")}} and {{domxref("USB.ondisconnect")}} when the user agent detects that a new USB device has been connected or disconnected.
 

--- a/files/en-us/web/api/usbconnectionevent/usbconnectionevent/index.md
+++ b/files/en-us/web/api/usbconnectionevent/usbconnectionevent/index.md
@@ -7,6 +7,7 @@ tags:
   - Constructor
   - Reference
   - USBConnectionEvent
+  - Experimental
 browser-compat: api.USBConnectionEvent.USBConnectionEvent
 ---
 {{securecontext_header}}{{APIRef("WebUSB API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/usbdevice/claiminterface/index.md
+++ b/files/en-us/web/api/usbdevice/claiminterface/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - claimInterface
+  - Experimental
 browser-compat: api.USBDevice.claimInterface
 ---
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/usbdevice/clearhalt/index.md
+++ b/files/en-us/web/api/usbdevice/clearhalt/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - clearHalt
+  - Experimental
 browser-compat: api.USBDevice.clearHalt
 ---
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/usbdevice/close/index.md
+++ b/files/en-us/web/api/usbdevice/close/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - close
+  - Experimental
 browser-compat: api.USBDevice.close
 ---
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/usbdevice/configuration/index.md
+++ b/files/en-us/web/api/usbdevice/configuration/index.md
@@ -11,6 +11,7 @@ tags:
   - USBDevice
   - WebUSB
   - WebUSB API
+  - Experimental
 browser-compat: api.USBDevice.configuration
 ---
 {{SeeCompatTable}}{{APIRef("WebUSB API")}}

--- a/files/en-us/web/api/usbdevice/configurations/index.md
+++ b/files/en-us/web/api/usbdevice/configurations/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - configurations
+  - Experimental
 browser-compat: api.USBDevice.configurations
 ---
 {{SeeCompatTable}}{{APIRef("WebUSB API")}}

--- a/files/en-us/web/api/usbdevice/controltransferin/index.md
+++ b/files/en-us/web/api/usbdevice/controltransferin/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - controlTransferIn
+  - Experimental
 browser-compat: api.USBDevice.controlTransferIn
 ---
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/usbdevice/controltransferout/index.md
+++ b/files/en-us/web/api/usbdevice/controltransferout/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - controlTransferOut
+  - Experimental
 browser-compat: api.USBDevice.controlTransferOut
 ---
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/usbdevice/deviceclass/index.md
+++ b/files/en-us/web/api/usbdevice/deviceclass/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - deviceClass
+  - Experimental
 browser-compat: api.USBDevice.deviceClass
 ---
 {{SeeCompatTable}}{{APIRef("WebUSB API")}}

--- a/files/en-us/web/api/usbdevice/deviceprotocol/index.md
+++ b/files/en-us/web/api/usbdevice/deviceprotocol/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - deviceProtocol
+  - Experimental
 browser-compat: api.USBDevice.deviceProtocol
 ---
 {{SeeCompatTable}}{{APIRef("WebUSB API")}}

--- a/files/en-us/web/api/usbdevice/devicesubclass/index.md
+++ b/files/en-us/web/api/usbdevice/devicesubclass/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - deviceSubclass
+  - Experimental
 browser-compat: api.USBDevice.deviceSubclass
 ---
 {{SeeCompatTable}}{{APIRef("WebUSB API")}}

--- a/files/en-us/web/api/usbdevice/deviceversionmajor/index.md
+++ b/files/en-us/web/api/usbdevice/deviceversionmajor/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - deviceVersionMajor
+  - Experimental
 browser-compat: api.USBDevice.deviceVersionMajor
 ---
 {{SeeCompatTable}}{{APIRef("WebUSB API")}}

--- a/files/en-us/web/api/usbdevice/deviceversionminor/index.md
+++ b/files/en-us/web/api/usbdevice/deviceversionminor/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - deviceVersionMinor
+  - Experimental
 browser-compat: api.USBDevice.deviceVersionMinor
 ---
 {{SeeCompatTable}}{{APIRef("WebUSB API")}}

--- a/files/en-us/web/api/usbdevice/deviceversionsubminor/index.md
+++ b/files/en-us/web/api/usbdevice/deviceversionsubminor/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - deviceVersionSubminor
+  - Experimental
 browser-compat: api.USBDevice.deviceVersionSubminor
 ---
 {{SeeCompatTable}}{{APIRef("WebUSB API")}}

--- a/files/en-us/web/api/usbdevice/index.md
+++ b/files/en-us/web/api/usbdevice/index.md
@@ -9,6 +9,7 @@ tags:
   - USBDevice
   - WebUSB
   - WebUSB API
+  - Experimental
 browser-compat: api.USBDevice
 ---
 {{SeeCompatTable}}{{APIRef("WebUSB API")}}

--- a/files/en-us/web/api/usbdevice/isochronoustransferin/index.md
+++ b/files/en-us/web/api/usbdevice/isochronoustransferin/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - isochronousTransferIn
+  - Experimental
 browser-compat: api.USBDevice.isochronousTransferIn
 ---
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/usbdevice/isochronoustransferout/index.md
+++ b/files/en-us/web/api/usbdevice/isochronoustransferout/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - isochronousTransferOut
+  - Experimental
 browser-compat: api.USBDevice.isochronousTransferOut
 ---
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/usbdevice/manufacturername/index.md
+++ b/files/en-us/web/api/usbdevice/manufacturername/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - manufacturerName
+  - Experimental
 browser-compat: api.USBDevice.manufacturerName
 ---
 {{SeeCompatTable}}{{APIRef("WebUSB API")}}

--- a/files/en-us/web/api/usbdevice/open/index.md
+++ b/files/en-us/web/api/usbdevice/open/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - open
+  - Experimental
 browser-compat: api.USBDevice.open
 ---
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/usbdevice/opened/index.md
+++ b/files/en-us/web/api/usbdevice/opened/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - opened
+  - Experimental
 browser-compat: api.USBDevice.opened
 ---
 {{SeeCompatTable}}{{APIRef("WebUSB API")}}

--- a/files/en-us/web/api/usbdevice/productid/index.md
+++ b/files/en-us/web/api/usbdevice/productid/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - productID
+  - Experimental
 browser-compat: api.USBDevice.productId
 ---
 {{SeeCompatTable}}{{APIRef("WebUSB API")}}

--- a/files/en-us/web/api/usbdevice/productname/index.md
+++ b/files/en-us/web/api/usbdevice/productname/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - productName
+  - Experimental
 browser-compat: api.USBDevice.productName
 ---
 {{SeeCompatTable}}{{APIRef("WebUSB API")}}

--- a/files/en-us/web/api/usbdevice/releaseinterface/index.md
+++ b/files/en-us/web/api/usbdevice/releaseinterface/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - releaseInterface
+  - Experimental
 browser-compat: api.USBDevice.releaseInterface
 ---
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/usbdevice/reset/index.md
+++ b/files/en-us/web/api/usbdevice/reset/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - reset
+  - Experimental
 browser-compat: api.USBDevice.reset
 ---
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/usbdevice/selectalternateinterface/index.md
+++ b/files/en-us/web/api/usbdevice/selectalternateinterface/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - selectAlternateInterface
+  - Experimental
 browser-compat: api.USBDevice.selectAlternateInterface
 ---
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/usbdevice/selectconfiguration/index.md
+++ b/files/en-us/web/api/usbdevice/selectconfiguration/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - selectConfiguration
+  - Experimental
 browser-compat: api.USBDevice.selectConfiguration
 ---
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/usbdevice/serialnumber/index.md
+++ b/files/en-us/web/api/usbdevice/serialnumber/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - serialNumber
+  - Experimental
 browser-compat: api.USBDevice.serialNumber
 ---
 {{SeeCompatTable}}{{APIRef("WebUSB API")}}

--- a/files/en-us/web/api/usbdevice/transferin/index.md
+++ b/files/en-us/web/api/usbdevice/transferin/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - transferIn
+  - Experimental
 browser-compat: api.USBDevice.transferIn
 ---
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/usbdevice/transferout/index.md
+++ b/files/en-us/web/api/usbdevice/transferout/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - transferOut
+  - Experimental
 browser-compat: api.USBDevice.transferOut
 ---
 {{APIRef("WebUSB API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/usbdevice/usbversionmajor/index.md
+++ b/files/en-us/web/api/usbdevice/usbversionmajor/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - usbVersionMajor
+  - Experimental
 browser-compat: api.USBDevice.usbVersionMajor
 ---
 {{SeeCompatTable}}{{APIRef("WebUSB API")}}

--- a/files/en-us/web/api/usbdevice/usbversionminor/index.md
+++ b/files/en-us/web/api/usbdevice/usbversionminor/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - usbVersionMinor
+  - Experimental
 browser-compat: api.USBDevice.usbVersionMinor
 ---
 {{SeeCompatTable}}{{APIRef("WebUSB API")}}

--- a/files/en-us/web/api/usbdevice/usbversionsubminor/index.md
+++ b/files/en-us/web/api/usbdevice/usbversionsubminor/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - usbVersionSubminor
+  - Experimental
 browser-compat: api.USBDevice.usbVersionSubminor
 ---
 {{SeeCompatTable}}{{APIRef("WebUSB API")}}

--- a/files/en-us/web/api/usbdevice/vendorid/index.md
+++ b/files/en-us/web/api/usbdevice/vendorid/index.md
@@ -11,6 +11,7 @@ tags:
   - WebUSB
   - WebUSB API
   - vendorID
+  - Experimental
 browser-compat: api.USBDevice.vendorId
 ---
 {{SeeCompatTable}}{{APIRef("WebUSB API")}}

--- a/files/en-us/web/api/usbendpoint/index.md
+++ b/files/en-us/web/api/usbendpoint/index.md
@@ -11,10 +11,7 @@ tags:
   - Web USB API
 browser-compat: api.USBEndpoint
 ---
-
-{{APIRef("Web USB API")}}
-
-{{securecontext_header}}
+{{APIRef("WebUSB API")}}{{securecontext_header}}
 
 The `USBEndpoint` interface of the [WebUSB API](/en-US/docs/Web/API/WebUSB_API) provides information about an endpoint provided by the USB device. An endpoint represents a unidirectional data stream into or out of a device.
 

--- a/files/en-us/web/api/usbendpoint/index.md
+++ b/files/en-us/web/api/usbendpoint/index.md
@@ -9,9 +9,10 @@ tags:
   - USB
   - USBEndpoint
   - Web USB API
+  - Experimental
 browser-compat: api.USBEndpoint
 ---
-{{APIRef("WebUSB API")}}{{securecontext_header}}
+{{APIRef("WebUSB API")}}{{securecontext_header}}{{SeeCompatTable}}
 
 The `USBEndpoint` interface of the [WebUSB API](/en-US/docs/Web/API/WebUSB_API) provides information about an endpoint provided by the USB device. An endpoint represents a unidirectional data stream into or out of a device.
 

--- a/files/en-us/web/api/usbinterface/index.md
+++ b/files/en-us/web/api/usbinterface/index.md
@@ -13,7 +13,7 @@ tags:
   - WebUSB API
 browser-compat: api.USBInterface
 ---
-{{securecontext_header}}{{APIRef("WebUSB API")}}
+{{securecontext_header}}{{APIRef("WebUSB API")}}{{SeeCompatTable}}
 
 The `USBInterface` interface of the [WebUSB API](/en-US/docs/Web/API/WebUSB_API) provides information about an interface provided by the USB device. An interface represents a feature of the device which implements a particular protocol and may contain endpoints for bidirectional communication.
 

--- a/files/en-us/web/api/usbintransferresult/index.md
+++ b/files/en-us/web/api/usbintransferresult/index.md
@@ -13,7 +13,7 @@ tags:
   - WebUSB API
 browser-compat: api.USBInTransferResult
 ---
-{{securecontext_header}}{{APIRef("WebUSB API")}}
+{{securecontext_header}}{{APIRef("WebUSB API")}}{{SeeCompatTable}}
 
 The `USBInTransferResult` interface of the [WebUSB API](/en-US/docs/Web/API/WebUSB_API) provides the result from a call to the `transferIn()` and `controlTransferIn()` methods of the `USBDevice` interface. It represents the result from requesting a transfer of data from the USB device to the USB host.
 

--- a/files/en-us/web/api/usbisochronousintransferpacket/index.md
+++ b/files/en-us/web/api/usbisochronousintransferpacket/index.md
@@ -13,7 +13,7 @@ tags:
   - WebUSB API
 browser-compat: api.USBIsochronousInTransferPacket
 ---
-{{securecontext_header}}{{APIRef("WebUSB API")}}
+{{securecontext_header}}{{APIRef("WebUSB API")}}{{SeeCompatTable}}
 
 The `USBIsochronousInTransferPacket` interface of the [WebUSB API](/en-US/docs/Web/API/WebUSB_API) is part of the response from a call to the `isochronousTransferIn()` method of the `USBDevice` interface. It represents the status of an individual packet from a request to transfer data from the USB device to the USB host over an isochronous endpoint.
 

--- a/files/en-us/web/api/usbisochronousintransferresult/index.md
+++ b/files/en-us/web/api/usbisochronousintransferresult/index.md
@@ -13,7 +13,7 @@ tags:
   - WebUSB API
 browser-compat: api.USBIsochronousInTransferResult
 ---
-{{securecontext_header}}{{APIRef("WebUSB API")}}
+{{securecontext_header}}{{APIRef("WebUSB API")}}{{SeeCompatTable}}
 
 The `USBIsochronousInTransferResult` interface of the [WebUSB API](/en-US/docs/Web/API/WebUSB_API) provides the result from a call to the `isochronousTransferIn()` method of the `USBDevice` interface. It represents the result from requesting a transfer of data from the USB device to the USB host.
 

--- a/files/en-us/web/api/usbisochronousouttransferpacket/index.md
+++ b/files/en-us/web/api/usbisochronousouttransferpacket/index.md
@@ -13,7 +13,7 @@ tags:
   - WebUSB API
 browser-compat: api.USBIsochronousOutTransferPacket
 ---
-{{securecontext_header}}{{APIRef("WebUSB API")}}
+{{securecontext_header}}{{APIRef("WebUSB API")}}{{SeeCompatTable}}
 
 The `USBIsochronousOutTransferPacket` interface of the [WebUSB API](/en-US/docs/Web/API/WebUSB_API) is part of the response from a call to the `isochronousTransferOut()` method of the `USBDevice` interface. It represents the status of an individual packet from a request to transfer data from the USB host to the USB device over an isochronous endpoint.
 

--- a/files/en-us/web/api/usbisochronousouttransferresult/index.md
+++ b/files/en-us/web/api/usbisochronousouttransferresult/index.md
@@ -13,7 +13,7 @@ tags:
   - WebUSB API
 browser-compat: api.USBIsochronousOutTransferResult
 ---
-{{securecontext_header}}{{APIRef("WebUSB API")}}
+{{securecontext_header}}{{APIRef("WebUSB API")}}{{SeeCompatTable}}
 
 The `USBIsochronousOutTransferResult` interface of the [WebUSB API](/en-US/docs/Web/API/WebUSB_API) provides the result from a call to the `isochronousTransferOut()` method of the `USBDevice` interface. It represents the result from requesting a transfer of data from the USB host to the USB device.
 

--- a/files/en-us/web/api/usbouttransferresult/index.md
+++ b/files/en-us/web/api/usbouttransferresult/index.md
@@ -14,7 +14,7 @@ tags:
   - WebUSB API
 browser-compat: api.USBOutTransferResult
 ---
-{{securecontext_header}}{{APIRef("WebUSB API")}}
+{{securecontext_header}}{{APIRef("WebUSB API")}}{{SeeCompatTable}}
 
 The `USBOutTransferResult` interface of the [WebUSB API](/en-US/docs/Web/API/WebUSB_API) provides the result from a call to the `transferOut()` and `controlTransferOut()` methods of the `USBDevice` interface. It represents the result from requesting a transfer of data from the USB host to the USB device.
 

--- a/files/en-us/web/api/webusb_api/index.md
+++ b/files/en-us/web/api/webusb_api/index.md
@@ -7,9 +7,10 @@ tags:
   - Web USB
   - Overview
   - Reference
+  - Experimental
 spec-urls: https://wicg.github.io/webusb/
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebUSB API")}}
+{{securecontext_header}}{{DefaultAPISidebar("WebUSB API")}}{{SeeCompatTable}}
 
 The **WebUSB API** provides a way to expose non-standard Universal Serial Bus (USB) compatible devices services to the web, to make USB safer and easier to use.
 

--- a/files/en-us/web/api/webusb_api/index.md
+++ b/files/en-us/web/api/webusb_api/index.md
@@ -9,7 +9,7 @@ tags:
   - Reference
 spec-urls: https://wicg.github.io/webusb/
 ---
-{{securecontext_header}}{{DefaultAPISidebar("Web USB API")}}
+{{securecontext_header}}{{DefaultAPISidebar("WebUSB API")}}
 
 The **WebUSB API** provides a way to expose non-standard Universal Serial Bus (USB) compatible devices services to the web, to make USB safer and easier to use.
 

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -2023,6 +2023,27 @@
       "properties": [],
       "events": []
     },
+    "WebUSB API": {
+      "overview": ["WebUSB API"],
+      "interfaces": [
+        "USB",
+        "USBAlternateInterface",
+        "USBConfiguration",
+        "USBConnectionEvent",
+        "USBDevice",
+        "USBEndPoint",
+        "USBInterface",
+        "USBInTransferResult",
+        "USBIsochronousInTransferPacket",
+        "USBIsochronousInTransferResult",
+        "USBIsochronousOutTransferPacket",
+        "USBIsochronousOutTransferResult",
+        "USBOutTransferResult"
+      ],
+      "methods": [],
+      "properties": [],
+      "events": []
+    },
     "WebVR API": {
       "overview": ["WebVR API"],
       "guides": [


### PR DESCRIPTION
The Web USB API pages had no sidebar. This PR fixes it.

It also add the experimental tag and banner when it was missing it.