### PR TITLE
fix the example to got the expected behavior

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/function/apply/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/apply/index.md
@@ -146,7 +146,7 @@ Function.prototype.construct = function(aArgs) {
 Example usage:
 
 ```js
-function MyConstructor(arguments) {
+function MyConstructor() {
   for (let nProp = 0; nProp < arguments.length; nProp++) {
     this['property' + nProp] = arguments[nProp];
   }


### PR DESCRIPTION
#### Summary

This problem is raised here: mdn/translated-content#6410. And the [`arguments`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments) should be an Array-like object accessible inside functions. I have made a mistake before.

#### Supporting details

run the following code, and got what's expected.

```js
Function.prototype.construct = function (aArgs) {
	let oNew = Object.create(this.prototype);
	this.apply(oNew, aArgs);
	return oNew;
}

function MyConstructor() {
	for (let nProp = 0; nProp < arguments.length; nProp++) {
		this['property' + nProp] = arguments[nProp];
	}
}

let myArray = [4, 'Hello world!', false];
let myInstance = MyConstructor.construct(myArray);

console.log(myInstance.property1);                // expected logs 'Hello world!'
console.log(myInstance instanceof MyConstructor); // expected  logs 'true'
console.log(myInstance.constructor);              // expected  logs 'MyConstructor'
```

#### Metadata

- [x] Fixes a typo, bug, or other error
