### PR TITLE
Clarify offsetParent description in case of ancestor table elements

### DIFF
--- a/files/en-us/web/api/htmlelement/offsetparent/index.md
+++ b/files/en-us/web/api/htmlelement/offsetparent/index.md
@@ -14,9 +14,9 @@ browser-compat: api.HTMLElement.offsetParent
 
 The **`HTMLElement.offsetParent`** read-only property returns a
 reference to the element which is the closest (nearest in the containment hierarchy)
-positioned ancestor element. If there is no positioned ancestor element, the nearest
-ancestor `td`, `th`, `table` will be returned, or the
-`body` if there are no ancestor table elements either.
+positioned (non-static) ancestor element.
+
+If there is no positioned ancestor the nearest ancestor `td`, `th`, `table` will be returned (only if the element is static positioned), otherwise the `body` will be returned.
 
 > **Note:** `offsetParent` returns `null` in the following
 > situations:

--- a/files/en-us/web/api/htmlelement/offsetparent/index.md
+++ b/files/en-us/web/api/htmlelement/offsetparent/index.md
@@ -16,7 +16,7 @@ The **`HTMLElement.offsetParent`** read-only property returns a
 reference to the element which is the closest (nearest in the containment hierarchy)
 positioned (non-static) ancestor element.
 
-If there is no positioned ancestor the nearest ancestor `td`, `th`, `table` will be returned (only if the element is static positioned), otherwise the `body` will be returned.
+If there is no positioned ancestor element, the nearest ancestor `td`, `th`, `table` will be returned (**note**: only if the element is static positioned), otherwise the `body` will be returned.
 
 > **Note:** `offsetParent` returns `null` in the following
 > situations:

--- a/files/en-us/web/api/htmlelement/offsetparent/index.md
+++ b/files/en-us/web/api/htmlelement/offsetparent/index.md
@@ -14,9 +14,13 @@ browser-compat: api.HTMLElement.offsetParent
 
 The **`HTMLElement.offsetParent`** read-only property returns a
 reference to the element which is the closest (nearest in the containment hierarchy)
-positioned (non-static) ancestor element.
+positioned ancestor element.
 
-If there is no positioned ancestor element, the nearest ancestor `td`, `th`, `table` will be returned (**note**: only if the element is static positioned), otherwise the `body` will be returned.
+A positioned ancestor is either:
+- an element a non-static position
+- `td`, `th`, `table` in case the element itself is static positioned
+
+If there is no positioned ancestor element, the `body` will be returned.
 
 > **Note:** `offsetParent` returns `null` in the following
 > situations:

--- a/files/en-us/web/api/htmlelement/offsetparent/index.md
+++ b/files/en-us/web/api/htmlelement/offsetparent/index.md
@@ -17,7 +17,7 @@ reference to the element which is the closest (nearest in the containment hierar
 positioned ancestor element.
 
 A positioned ancestor is either:
-- an element a non-static position
+- an element with a non-static position
 - `td`, `th`, `table` in case the element itself is static positioned
 
 If there is no positioned ancestor element, the `body` will be returned.

--- a/files/en-us/web/api/htmlelement/offsetparent/index.md
+++ b/files/en-us/web/api/htmlelement/offsetparent/index.md
@@ -18,9 +18,9 @@ positioned ancestor element.
 
 A positioned ancestor is either:
 - an element with a non-static position
-- `td`, `th`, `table` in case the element itself is static positioned
+- `td`, `th`, `table` in case the element itself is static positioned.
 
-If there is no positioned ancestor element, the `body` will be returned.
+If there is no positioned ancestor element, the `body` is returned.
 
 > **Note:** `offsetParent` returns `null` in the following
 > situations:


### PR DESCRIPTION
#### Summary
Clarifies `offsetParent` description in case of ancestor table elements.

#### Motivation
The current description says `If there is no positioned ancestor element, the nearest ancestor td, th, table will be returned`.
This is true only if the element itself is static positioned and only if there are no nearest positioned ancestor in between.

#### Supporting details
https://drafts.csswg.org/cssom-view/#dom-htmlelement-offsetparent

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
