### PR TITLE
MediaStream: ended is a value not a property

### DIFF
--- a/files/en-us/web/api/mediastream/active/index.md
+++ b/files/en-us/web/api/mediastream/active/index.md
@@ -18,8 +18,8 @@ The **`active`** read-only property of the
 {{domxref("MediaStream")}} interface returns a Boolean value which is
 `true` if the stream is currently active; otherwise, it returns
 `false`. A stream is considered **active** if at least one of
-its {{domxref("MediaStreamTrack")}}s is not in the {{domxref("MediaStreamTrack.ended")}}
-state. Once every track has ended, the stream's `active` property becomes
+its {{domxref("MediaStreamTrack")}}s does not have its property {{domxref("MediaStreamTrack.readyState")}}
+set to `ended`. Once every track has ended, the stream's `active` property becomes
 `false`.
 
 ## Value


### PR DESCRIPTION
#### Summary
I changed the wording because MediaStreamTrack.ended property does not exist according to specification

#### Motivation
It creates confusion

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://w3c.github.io/mediacapture-main/#dom-mediastreamtrack

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
