### PR TITLE
Replace link to tool that doesn't support IPv6

### DIFF
--- a/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/how_the_web_works/index.md
@@ -71,7 +71,7 @@ Real web addresses aren't the nice, memorable strings you type into your address
 
 This is called an {{Glossary("IP Address", "IP address")}}, and it represents a unique location on the web. However, it's not very easy to remember, is it? That's why Domain Name Servers were invented. These are special servers that match up a web address you type into your browser (like "mozilla.org") to the website's real (IP) address.
 
-Websites can be reached directly via their IP addresses. You can use a [DNS lookup tool](https://www.whatismyip.com/dns-lookup/) to find the IP address of a website.
+Websites can be reached directly via their IP addresses. You can use a [DNS lookup tool](https://www.nslookup.io/website-to-ip-lookup/) to find the IP address of a website.
 
 ## Packets explained
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
This PR replaces a link to a tool that doesn't support IPv6 with a tool that does.

#### Motivation
Many sites now listen to both IPv4 and IPv6 addresses. The MDN docs should promote IPv6 adoption.

#### Supporting details
Old link: 
![image](https://user-images.githubusercontent.com/1055478/174620282-61d0470a-3420-4b51-9c09-62d9f983195f.png)
New link:
![image](https://user-images.githubusercontent.com/1055478/174620317-8220649f-4bcf-41b1-8c59-109141d3b6bb.png)


#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
