### PR TITLE
Update examples guidance some more

### DIFF
--- a/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.md
@@ -127,7 +127,7 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 >
 > **Scenario 1:** If you have some examples on this page and some more examples on another page:
 >
-> Include an H3 heading for each example on this page and then a final H3 heading with the text "More examples", under which you can link to the examples on other pages. For example:
+> Include an H3 heading (`###`) for each example on this page and then a final H3 heading (`###`) with the text "More examples", under which you can link to the examples on other pages. For example:
 >
 >  ```md
 >  ## Examples

--- a/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_constructor_subpage_template/index.md
@@ -125,7 +125,8 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 
 > **Note:** Sometimes you will want to link to examples given on another page.
 >
-> Scenario 1: If you have some examples on this page and some more examples on another page
+> **Scenario 1:** If you have some examples on this page and some more examples on another page:
+>
 > Include an H3 heading for each example on this page and then a final H3 heading with the text "More examples", under which you can link to the examples on other pages. For example:
 >
 >  ```md
@@ -138,8 +139,9 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 >  ...links to more examples on other pages
 >  ```
 >
-> Scenario 2: If you _only_ have examples on another page and none on this page
-Don't add any H3 headings; just add the links directly under the H2 heading "Examples". For example:
+> **Scenario 2:** If you _only_ have examples on another page and none on this page:
+>
+> Don't add any H3 headings; just add the links directly under the H2 heading "Examples". For example:
 >
 >  ```md
 >   ## Examples

--- a/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.md
@@ -152,6 +152,32 @@ Each example must have an H3 heading (`###`) naming the example. The heading sho
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 
+> **Note:** Sometimes you will want to link to examples given on another page.
+>
+> **Scenario 1:** If you have some examples on this page and some more examples on another page:
+>
+> Include an H3 heading for each example on this page and then a final H3 heading with the text "More examples", under which you can link to the examples on other pages. For example:
+>
+>  ```md
+>  ## Examples
+>
+>  ### Using the fetch API
+>  ... example of Fetch
+>
+>  ### More examples
+>  ...links to more examples on other pages
+>  ```
+>
+> **Scenario 2:** If you _only_ have examples on another page and none on this page:
+>
+> Don't add any H3 headings; just add the links directly under the H2 heading "Examples". For example:
+>
+>  ```md
+>   ## Examples
+>
+>   For examples of this API, see [the page on fetch()](https://example.org).
+>
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.md
@@ -156,7 +156,7 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 >
 > **Scenario 1:** If you have some examples on this page and some more examples on another page:
 >
-> Include an H3 heading for each example on this page and then a final H3 heading with the text "More examples", under which you can link to the examples on other pages. For example:
+> Include an H3 heading (`###`) for each example on this page and then a final H3 heading (`###`) with the text "More examples", under which you can link to the examples on other pages. For example:
 >
 >  ```md
 >  ## Examples

--- a/files/en-us/mdn/structures/page_types/api_landing_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_landing_page_template/index.md
@@ -147,7 +147,7 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 >
 > **Scenario 1:** If you have some examples on this page and some more examples on another page:
 >
-> Include an H3 heading for each example on this page and then a final H3 heading with the text "More examples", under which you can link to the examples on other pages. For example:
+> Include an H3 heading (`###`) for each example on this page and then a final H3 heading (`###`) with the text "More examples", under which you can link to the examples on other pages. For example:
 >
 >  ```md
 >  ## Examples

--- a/files/en-us/mdn/structures/page_types/api_landing_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_landing_page_template/index.md
@@ -143,6 +143,32 @@ Each example must have an H3 heading naming the example. The heading should be d
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 
+> **Note:** Sometimes you will want to link to examples given on another page.
+>
+> **Scenario 1:** If you have some examples on this page and some more examples on another page:
+>
+> Include an H3 heading for each example on this page and then a final H3 heading with the text "More examples", under which you can link to the examples on other pages. For example:
+>
+>  ```md
+>  ## Examples
+>
+>  ### Using the fetch API
+>  ... example of Fetch
+>
+>  ### More examples
+>  ...links to more examples on other pages
+>  ```
+>
+> **Scenario 2:** If you _only_ have examples on another page and none on this page:
+>
+> Don't add any H3 headings; just add the links directly under the H2 heading "Examples". For example:
+>
+>  ```md
+>   ## Examples
+>
+>   For examples of this API, see [the page on fetch()](https://example.org).
+>
+
 ## Specifications
 
 {{Specifications("path.to.feature.Interface_1")}}

--- a/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.md
@@ -143,7 +143,7 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 >
 > **Scenario 1:** If you have some examples on this page and some more examples on another page:
 >
-> Include an H3 heading for each example on this page and then a final H3 heading with the text "More examples", under which you can link to the examples on other pages. For example:
+> Include an H3 heading (`###`) for each example on this page and then a final H3 heading (`###`) with the text "More examples", under which you can link to the examples on other pages. For example:
 >
 >  ```md
 >  ## Examples

--- a/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.md
@@ -139,6 +139,32 @@ Each example must have an H3 heading naming the example. The heading should be d
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 
+> **Note:** Sometimes you will want to link to examples given on another page.
+>
+> **Scenario 1:** If you have some examples on this page and some more examples on another page:
+>
+> Include an H3 heading for each example on this page and then a final H3 heading with the text "More examples", under which you can link to the examples on other pages. For example:
+>
+>  ```md
+>  ## Examples
+>
+>  ### Using the fetch API
+>  ... example of Fetch
+>
+>  ### More examples
+>  ...links to more examples on other pages
+>  ```
+>
+> **Scenario 2:** If you _only_ have examples on another page and none on this page:
+>
+> Don't add any H3 headings; just add the links directly under the H2 heading "Examples". For example:
+>
+>  ```md
+>   ## Examples
+>
+>   For examples of this API, see [the page on fetch()](https://example.org).
+>
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.md
@@ -103,6 +103,32 @@ Each example must have an H3 heading (`###`) naming the example. The heading sho
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 
+> **Note:** Sometimes you will want to link to examples given on another page.
+>
+> **Scenario 1:** If you have some examples on this page and some more examples on another page:
+>
+> Include an H3 heading for each example on this page and then a final H3 heading with the text "More examples", under which you can link to the examples on other pages. For example:
+>
+>  ```md
+>  ## Examples
+>
+>  ### Using the fetch API
+>  ... example of Fetch
+>
+>  ### More examples
+>  ...links to more examples on other pages
+>  ```
+>
+> **Scenario 2:** If you _only_ have examples on another page and none on this page:
+>
+> Don't add any H3 headings; just add the links directly under the H2 heading "Examples". For example:
+>
+>  ```md
+>   ## Examples
+>
+>   For examples of this API, see [the page on fetch()](https://example.org).
+>
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.md
@@ -107,7 +107,7 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 >
 > **Scenario 1:** If you have some examples on this page and some more examples on another page:
 >
-> Include an H3 heading for each example on this page and then a final H3 heading with the text "More examples", under which you can link to the examples on other pages. For example:
+> Include an H3 heading (`###`) for each example on this page and then a final H3 heading (`###`) with the text "More examples", under which you can link to the examples on other pages. For example:
 >
 >  ```md
 >  ## Examples

--- a/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
@@ -109,6 +109,32 @@ Each example must have an H3 heading (`###`) naming the example. The heading sho
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 
+> **Note:** Sometimes you will want to link to examples given on another page.
+>
+> **Scenario 1:** If you have some examples on this page and some more examples on another page:
+>
+> Include an H3 heading for each example on this page and then a final H3 heading with the text "More examples", under which you can link to the examples on other pages. For example:
+>
+>  ```md
+>  ## Examples
+>
+>  ### Using the fetch API
+>  ... example of Fetch
+>
+>  ### More examples
+>  ...links to more examples on other pages
+>  ```
+>
+> **Scenario 2:** If you _only_ have examples on another page and none on this page:
+>
+> Don't add any H3 headings; just add the links directly under the H2 heading "Examples". For example:
+>
+>  ```md
+>   ## Examples
+>
+>   For examples of this API, see [the page on fetch()](https://example.org).
+>
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
@@ -113,7 +113,7 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 >
 > **Scenario 1:** If you have some examples on this page and some more examples on another page:
 >
-> Include an H3 heading for each example on this page and then a final H3 heading with the text "More examples", under which you can link to the examples on other pages. For example:
+> Include an H3 heading (`###`) for each example on this page and then a final H3 heading (`###`) with the text "More examples", under which you can link to the examples on other pages. For example:
 >
 >  ```md
 >  ## Examples

--- a/files/en-us/mdn/structures/page_types/aria_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/aria_page_template/index.md
@@ -85,7 +85,7 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 >
 > **Scenario 1:** If you have some examples on this page and some more examples on another page:
 >
-> Include an H3 heading for each example on this page and then a final H3 heading with the text "More examples", under which you can link to the examples on other pages. For example:
+> Include an H3 heading (`###`) for each example on this page and then a final H3 heading (`###`) with the text "More examples", under which you can link to the examples on other pages. For example:
 >
 >  ```md
 >  ## Examples

--- a/files/en-us/mdn/structures/page_types/aria_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/aria_page_template/index.md
@@ -81,6 +81,32 @@ Each example must have an H3 heading (`###`) naming the example. The heading sho
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 
+> **Note:** Sometimes you will want to link to examples given on another page.
+>
+> **Scenario 1:** If you have some examples on this page and some more examples on another page:
+>
+> Include an H3 heading for each example on this page and then a final H3 heading with the text "More examples", under which you can link to the examples on other pages. For example:
+>
+>  ```md
+>  ## Examples
+>
+>  ### Using the fetch API
+>  ... example of Fetch
+>
+>  ### More examples
+>  ...links to more examples on other pages
+>  ```
+>
+> **Scenario 2:** If you _only_ have examples on another page and none on this page:
+>
+> Don't add any H3 headings; just add the links directly under the H2 heading "Examples". For example:
+>
+>  ```md
+>   ## Examples
+>
+>   For examples of this API, see [the page on fetch()](https://example.org).
+>
+
 ## Accessibility concerns
 
 Optionally, warn of any potential accessibility concerns that exist with using this property, and how to work around them. Remove this section if there are none to list.

--- a/files/en-us/mdn/structures/page_types/css_property_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/css_property_page_template/index.md
@@ -120,7 +120,7 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 >
 > **Scenario 1:** If you have some examples on this page and some more examples on another page:
 >
-> Include an H3 heading for each example on this page and then a final H3 heading with the text "More examples", under which you can link to the examples on other pages. For example:
+> Include an H3 heading (`###`) for each example on this page and then a final H3 heading (`###`) with the text "More examples", under which you can link to the examples on other pages. For example:
 >
 >  ```md
 >  ## Examples

--- a/files/en-us/mdn/structures/page_types/css_property_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/css_property_page_template/index.md
@@ -116,6 +116,32 @@ Each example must have an H3 heading (`###`) naming the example. The heading sho
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 
+> **Note:** Sometimes you will want to link to examples given on another page.
+>
+> **Scenario 1:** If you have some examples on this page and some more examples on another page:
+>
+> Include an H3 heading for each example on this page and then a final H3 heading with the text "More examples", under which you can link to the examples on other pages. For example:
+>
+>  ```md
+>  ## Examples
+>
+>  ### Using the fetch API
+>  ... example of Fetch
+>
+>  ### More examples
+>  ...links to more examples on other pages
+>  ```
+>
+> **Scenario 2:** If you _only_ have examples on another page and none on this page:
+>
+> Don't add any H3 headings; just add the links directly under the H2 heading "Examples". For example:
+>
+>  ```md
+>   ## Examples
+>
+>   For examples of this API, see [the page on fetch()](https://example.org).
+>
+
 ## Accessibility concerns
 
 Optionally, warn of any potential accessibility concerns that exist with using this property, and how to work around them. Remove this section if there are none to list.

--- a/files/en-us/mdn/structures/page_types/css_selector_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/css_selector_page_template/index.md
@@ -99,6 +99,32 @@ Each example must have an H3 heading (`###`) naming the example. The heading sho
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 
+> **Note:** Sometimes you will want to link to examples given on another page.
+>
+> **Scenario 1:** If you have some examples on this page and some more examples on another page:
+>
+> Include an H3 heading for each example on this page and then a final H3 heading with the text "More examples", under which you can link to the examples on other pages. For example:
+>
+>  ```md
+>  ## Examples
+>
+>  ### Using the fetch API
+>  ... example of Fetch
+>
+>  ### More examples
+>  ...links to more examples on other pages
+>  ```
+>
+> **Scenario 2:** If you _only_ have examples on another page and none on this page:
+>
+> Don't add any H3 headings; just add the links directly under the H2 heading "Examples". For example:
+>
+>  ```md
+>   ## Examples
+>
+>   For examples of this API, see [the page on fetch()](https://example.org).
+>
+
 ## Accessibility concerns
 
 Optionally, warn of any potential accessibility concerns that exist with using this selector, and how to work around them.

--- a/files/en-us/mdn/structures/page_types/css_selector_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/css_selector_page_template/index.md
@@ -103,7 +103,7 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 >
 > **Scenario 1:** If you have some examples on this page and some more examples on another page:
 >
-> Include an H3 heading for each example on this page and then a final H3 heading with the text "More examples", under which you can link to the examples on other pages. For example:
+> Include an H3 heading (`###`) for each example on this page and then a final H3 heading (`###`) with the text "More examples", under which you can link to the examples on other pages. For example:
 >
 >  ```md
 >  ## Examples

--- a/files/en-us/mdn/structures/page_types/html_element_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/html_element_page_template/index.md
@@ -117,7 +117,7 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 >
 > **Scenario 1:** If you have some examples on this page and some more examples on another page:
 >
-> Include an H3 heading for each example on this page and then a final H3 heading with the text "More examples", under which you can link to the examples on other pages. For example:
+> Include an H3 heading (`###`) for each example on this page and then a final H3 heading (`###`) with the text "More examples", under which you can link to the examples on other pages. For example:
 >
 >  ```md
 >  ## Examples

--- a/files/en-us/mdn/structures/page_types/html_element_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/html_element_page_template/index.md
@@ -113,6 +113,32 @@ Each example must have an H3 heading (`###`) naming the example. The heading sho
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 
+> **Note:** Sometimes you will want to link to examples given on another page.
+>
+> **Scenario 1:** If you have some examples on this page and some more examples on another page:
+>
+> Include an H3 heading for each example on this page and then a final H3 heading with the text "More examples", under which you can link to the examples on other pages. For example:
+>
+>  ```md
+>  ## Examples
+>
+>  ### Using the fetch API
+>  ... example of Fetch
+>
+>  ### More examples
+>  ...links to more examples on other pages
+>  ```
+>
+> **Scenario 2:** If you _only_ have examples on another page and none on this page:
+>
+> Don't add any H3 headings; just add the links directly under the H2 heading "Examples". For example:
+>
+>  ```md
+>   ## Examples
+>
+>   For examples of this API, see [the page on fetch()](https://example.org).
+>
+
 ## Accessibility concerns
 
 Optionally, warn of any potential accessibility concerns that exist with using this element, and how to work around them. Remove this section if there are none to list.

--- a/files/en-us/mdn/structures/page_types/http_header_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/http_header_page_template/index.md
@@ -135,7 +135,7 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 >
 > **Scenario 1:** If you have some examples on this page and some more examples on another page:
 >
-> Include an H3 heading for each example on this page and then a final H3 heading with the text "More examples", under which you can link to the examples on other pages. For example:
+> Include an H3 heading (`###`) for each example on this page and then a final H3 heading (`###`) with the text "More examples", under which you can link to the examples on other pages. For example:
 >
 >  ```md
 >  ## Examples

--- a/files/en-us/mdn/structures/page_types/http_header_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/http_header_page_template/index.md
@@ -131,6 +131,32 @@ Each example must have an H3 heading (`###`) naming the example. The heading sho
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 
+> **Note:** Sometimes you will want to link to examples given on another page.
+>
+> **Scenario 1:** If you have some examples on this page and some more examples on another page:
+>
+> Include an H3 heading for each example on this page and then a final H3 heading with the text "More examples", under which you can link to the examples on other pages. For example:
+>
+>  ```md
+>  ## Examples
+>
+>  ### Using the fetch API
+>  ... example of Fetch
+>
+>  ### More examples
+>  ...links to more examples on other pages
+>  ```
+>
+> **Scenario 2:** If you _only_ have examples on another page and none on this page:
+>
+> Don't add any H3 headings; just add the links directly under the H2 heading "Examples". For example:
+>
+>  ```md
+>   ## Examples
+>
+>   For examples of this API, see [the page on fetch()](https://example.org).
+>
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/mdn/structures/page_types/svg_element_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/svg_element_page_template/index.md
@@ -117,6 +117,32 @@ Each example must have an H3 heading (`###`) naming the example. The heading sho
 
 See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_examples) for more information.
 
+> **Note:** Sometimes you will want to link to examples given on another page.
+>
+> **Scenario 1:** If you have some examples on this page and some more examples on another page:
+>
+> Include an H3 heading for each example on this page and then a final H3 heading with the text "More examples", under which you can link to the examples on other pages. For example:
+>
+>  ```md
+>  ## Examples
+>
+>  ### Using the fetch API
+>  ... example of Fetch
+>
+>  ### More examples
+>  ...links to more examples on other pages
+>  ```
+>
+> **Scenario 2:** If you _only_ have examples on another page and none on this page:
+>
+> Don't add any H3 headings; just add the links directly under the H2 heading "Examples". For example:
+>
+>  ```md
+>   ## Examples
+>
+>   For examples of this API, see [the page on fetch()](https://example.org).
+>
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/mdn/structures/page_types/svg_element_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/svg_element_page_template/index.md
@@ -121,7 +121,7 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 >
 > **Scenario 1:** If you have some examples on this page and some more examples on another page:
 >
-> Include an H3 heading for each example on this page and then a final H3 heading with the text "More examples", under which you can link to the examples on other pages. For example:
+> Include an H3 heading (`###`) for each example on this page and then a final H3 heading (`###`) with the text "More examples", under which you can link to the examples on other pages. For example:
 >
 >  ```md
 >  ## Examples


### PR DESCRIPTION
Here's a follow-up to https://github.com/mdn/content/pull/15894, to add the note about "what to do if you have linked examples" to add templates.

I wish there weren't so much duplication, but don't want to try to fix that now.

Note that the markup in the original was broken at https://github.com/mdn/content/pull/15894/files#diff-b1c0fb6f4a1cbb1fd5bd80671f2bff8101854645d108aa2270039c110fcf3dcdR138 so I have redone it a bit.