### PR TITLE
Remove inline event handlers `HTMLElement.focus()` examples

### DIFF
--- a/files/en-us/web/api/htmlelement/focus/index.md
+++ b/files/en-us/web/api/htmlelement/focus/index.md
@@ -53,17 +53,16 @@ None ({{jsxref("undefined")}}).
 #### JavaScript
 
 ```js
-focusMethod = function getFocus() {
+document.getElementById("focusButton").addEventListener("click", () => {
   document.getElementById("myTextField").focus();
-}
+});
 ```
 
 #### HTML
 
 ```html
-<input type="text" id="myTextField" value="Text field.">
-<p></p>
-<button type="button" onclick="focusMethod()">Click me to focus on the text field!</button>
+<input id="myTextField" value="Text field.">
+<button id="focusButton">Click me to focus on the text field!</button>
 ```
 
 #### Result
@@ -75,17 +74,16 @@ focusMethod = function getFocus() {
 #### JavaScript
 
 ```js
-focusMethod = function getFocus() {
+document.getElementById("focusButton").addEventListener("click", () => {
   document.getElementById("myButton").focus();
-}
+});
 ```
 
 #### HTML
 
 ```html
-<button type="button" id="myButton">Click Me!</button>
-<p></p>
-<button type="button" onclick="focusMethod()">Click me to focus on the button!</button>
+<button id="myButton">Click Me!</button>
+<button id="focusButton">Click me to focus on the button!</button>
 ```
 
 #### Result


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Removes some inline event handlers on html elements in some examples on the `HTMLElement.focus()` page.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
> You should never use the HTML event handler attributes — those are outdated, and using them is bad practice.
> https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Building_blocks/Events#inline_event_handlers_%E2%80%94_dont_use_these

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
