### PR TITLE
[Web API] beforeinput doesn't fire on <select>

### DIFF
--- a/files/en-us/web/api/htmlelement/beforeinput_event/index.md
+++ b/files/en-us/web/api/htmlelement/beforeinput_event/index.md
@@ -14,7 +14,7 @@ browser-compat: api.HTMLElement.beforeinput_event
 ---
 {{APIRef}}
 
-The DOM **`beforeinput`** event fires when the value of an {{HTMLElement("input")}}, {{HTMLElement("select")}}, or {{HTMLElement("textarea")}} element is about to be modified. The event also applies to elements with {{domxref("HTMLElement.contentEditable", "contenteditable")}} enabled, and to any element when {{domxref("Document.designMode", "designMode")}} is turned on.
+The DOM **`beforeinput`** event fires when the value of an {{HTMLElement("input")}}, or {{HTMLElement("textarea")}} element is about to be modified. The event also applies to elements with {{domxref("HTMLElement.contentEditable", "contenteditable")}} enabled, and to any element when {{domxref("Document.designMode", "designMode")}} is turned on.
 
 This allows web apps to override text edit behavior before the browser modifies the DOM tree, and provides more control over input events to improve performance.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
This PR removes the mention of `<select>` firing the beforeinput event.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The current page apparently copied the summary from the input event but these are actually different. The input event indeed does fire on `<select>` elements but not the beforeinput one. 
Readers got confused seeing the event didn't fire in any browser.   
(W3C-UI-Events specs open-wording doesn't help in letting the user determine what should really happen...)
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
See https://stackoverflow.com/questions/72688184/should-the-html-select-element-dispatch-beforeinput-events
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
N/A
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
