### PR TITLE
MediaRecorderErrorEvent gone; drop Specifications & add flags

### DIFF
--- a/files/en-us/web/api/mediarecordererrorevent/index.md
+++ b/files/en-us/web/api/mediarecordererrorevent/index.md
@@ -42,6 +42,9 @@ _Inherits properties from its parent interface, {{domxref("Event")}}_.
 
 _Inherits methods from its parent interface, {{domxref("Event")}}_.
 
+### Specifications
+
+This feature is no longer part of any specification, and longer on track to become standard.
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/mediarecordererrorevent/index.md
+++ b/files/en-us/web/api/mediarecordererrorevent/index.md
@@ -45,6 +45,7 @@ _Inherits methods from its parent interface, {{domxref("Event")}}_.
 ### Specifications
 
 This feature is no longer part of any specification, and longer on track to become standard.
+
 ## Browser compatibility
 
 {{Compat}}

--- a/files/en-us/web/api/mediarecordererrorevent/index.md
+++ b/files/en-us/web/api/mediarecordererrorevent/index.md
@@ -20,7 +20,7 @@ tags:
   - WebRTC
 browser-compat: api.MediaRecorderErrorEvent
 ---
-{{APIRef("MediaStream Recording")}}
+{{APIRef("MediaStream Recording")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The `MediaRecorderErrorEvent` interface represents errors returned by the [MediaStream Recording API.](/en-US/docs/Web/API/MediaStream_Recording_API) It is an {{domxref("Event")}} object that encapsulates a reference to a {{domxref("DOMException")}} describing the error that occurred.
 
@@ -41,10 +41,6 @@ _Inherits properties from its parent interface, {{domxref("Event")}}_.
 ## Methods
 
 _Inherits methods from its parent interface, {{domxref("Event")}}_.
-
-## Specifications
-
-{{Specifications}}
 
 ## Browser compatibility
 


### PR DESCRIPTION
https://github.com/w3c/mediacapture-record/pull/212 dropped `MediaRecorderErrorEvent` from the MediaStream Recording spec, so this change removes the Specifications section and adds the `{{Deprecated_Header}}` and `{{Non-standard_Header}}` macros.

Related BCD change: https://github.com/mdn/browser-compat-data/pull/16747