### PR TITLE
Drop (for now) spec URL and BCD link for elementtiming HTML attribute

### DIFF
--- a/files/en-us/web/html/attributes/elementtiming/index.md
+++ b/files/en-us/web/html/attributes/elementtiming/index.md
@@ -8,7 +8,6 @@ tags:
   - elementtiming
   - Performance
   - Reference
-spec-urls: https://wicg.github.io/element-timing/forms.html#attr-label-for
 ---
 
 {{HTMLSidebar}}
@@ -37,14 +36,6 @@ Good contenders for elements you might want to observe are:
 
 <p elementtiming="important-text">Some very important information.</p">
 ```
-
-## Specifications
-
-{{Specifications}}
-
-## Browser compatibility
-
-{{Compat("html.elements.attribute.elementtiming")}}
 
 ## See also
 


### PR DESCRIPTION
There is no feature for the `elementtiming` HTML content attribute in BCD yet — not at `html.elements.attribute.elementtiming` no anywhere else in BCD — and it is as yet not actually defined in any spec; the spec URL https://wicg.github.io/element-timing/forms.html#attr-label-for is wrong — that spec has no forms.html page, and that `attr-label-for` anchor would anyway not be the right anchor for the feature.

https://github.com/whatwg/html/issues/8024 is a related issue for creating a normative spec definition for the feature. After the feature is actually defined in a spec and added then added to BCD, we could include the Specifications and Compat sections again.