### PR TITLE
Elaborate on super behavior; document Reflect.set receiver parameter behavior

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/reflect/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/set/index.md
@@ -33,8 +33,7 @@ Reflect.set(target, propertyKey, value, receiver)
 - `value`
   - : The value to set.
 - `receiver` {{optional_inline}}
-  - : The value of `this` provided for the call to
-    `target` if a setter is encountered.
+  - : The value of `this` provided for the call to the setter for `propertyKey` on `target`. If provided and `target` does not have a setter for `propertyKey`, the property will be set on `receiver` instead.
 
 ### Return value
 
@@ -75,6 +74,27 @@ let obj = {}
 Reflect.set(obj)  // true
 Reflect.getOwnPropertyDescriptor(obj, 'undefined')
 // { value: undefined, writable: true, enumerable: true, configurable: true }
+```
+
+### Different target and receiver
+
+When the `target` and `receiver` are different, `Reflect.set` will use the property descriptor of `target` (to find the setter or determine if the property is writable), but set the property on `receiver`.
+
+```js
+const target = {};
+const receiver = {};
+Reflect.set(target, "a", 2, receiver); // true
+// target is {}; receiver is { a: 2 }
+
+const target = { a: 1 };
+const receiver = {};
+Reflect.set(target, "a", 2, receiver); // true
+// target is { a: 1 }; receiver is { a: 2 }
+
+const target = { set a(v) { this.b = v; } };
+const receiver = {};
+Reflect.set(target, "a", 2, receiver); // true
+// target is { a: [Setter] }; receiver is { b: 2 }
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/operators/super/index.md
+++ b/files/en-us/web/javascript/reference/operators/super/index.md
@@ -12,35 +12,45 @@ browser-compat: javascript.operators.super
 ---
 {{jsSidebar("Operators")}}
 
-The **super** keyword is used to access and call functions on an object's
-parent.
+The **super** keyword is used to access properties on an object literal or class's [[Prototype]], or invoke a superclass's constructor.
 
-The `super.prop` and `super[expr]` expressions are valid in any
-[method definition](/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions)
-in both [classes](/en-US/docs/Web/JavaScript/Reference/Classes) and
-[object literals](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer).
+The `super.prop` and `super[expr]` expressions are valid in any [method definition](/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions) in both [classes](/en-US/docs/Web/JavaScript/Reference/Classes) and [object literals](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer). The `super(...args)` expression is valid in class constructors.
 
 ## Syntax
 
 ```js
-super([arguments]); // calls the parent constructor.
-super.functionOnParent([arguments]);
+super([arguments]) // calls the parent constructor.
+super.propertyOnParent
+super[expression]
 ```
 
 ## Description
 
-When used in a constructor, the `super` keyword appears alone and must be
-used before the `this` keyword is used. The `super` keyword can
-also be used to call functions on a parent object.
+The `super` keyword can be used in two ways: as a "function call" (`super(...args)`), or as a "property lookup" (`super.prop` and `super[expr]`).
+
+> **Note:** `super` is a keyword and these are special syntactic constructs. `super` is not a variable that points to the prototype object. Attempting to read `super` itself is a {{jsxref("SyntaxError")}}.
+> 
+> ```js example-bad
+> const child = {
+>   myParent() {
+>     console.log(super); // SyntaxError: 'super' keyword unexpected here
+>   },
+> };
+> ```
+
+In the constructor body of a derived class (with `extends`), the `super` keyword may appear as a "function call" (`super(...args)`), which must be called before the `this` keyword is used, and before the constructor returns. It calls the parent class's constructor and binds the parent class's public fields, after which the derived class's constructor can further access and modify `this`.
+
+The "property lookup" form can be used to access methods and properties of an object literal's or class's [[Prototype]]. Within a class's body, the reference of `super` can be either the superclass's constructor itself, or the constructor's `prototype`, depending on whether the execution context is instance creation or class initialization. See the Examples section for more details.
+
+Note that the reference of `super` is determined by the class or object literal `super` was declared in, not the object the method is called on. Therefore, unbinding or re-binding a method doesn't change the reference of `super` in it (although they do change the reference of [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this)). You can see `super` as a variable in the class or object literal scope, which the methods create a closure over. (But also beware that it's not actually not a variable, as explained above.)
+
+When setting properties through `super`, the property is set on `this` instead.
 
 ## Examples
 
-### Using `super` in classes
+### Using super in classes
 
-This code snippet is taken from the [classes sample](https://github.com/GoogleChrome/samples/blob/gh-pages/classes-es6/index.html)
-([live demo](https://googlechrome.github.io/samples/classes-es6/index.html)).
-Here `super()` is called to avoid duplicating the constructor parts' that are
-common between `Rectangle` and `Square`.
+This code snippet is taken from the [classes sample](https://github.com/GoogleChrome/samples/blob/gh-pages/classes-es6/index.html) ([live demo](https://googlechrome.github.io/samples/classes-es6/index.html)). Here `super()` is called to avoid duplicating the constructor parts' that are common between `Rectangle` and `Square`.
 
 ```js
 class Rectangle {
@@ -94,6 +104,38 @@ class Square extends Rectangle {
 Square.logDescription(); // 'I have 4 sides which are all equal'
 ```
 
+### Accessing super in class field declaration
+
+`super` can also be accessed during class field initialization. The reference of `super` depends on whether the current field is an instance field or a static field.
+
+```js
+class Base {
+  static baseStaticField = 90;
+  baseMethod() {
+    return 10;
+  }
+}
+
+class Extended extends Base {
+  extendedField = super.baseMethod(); // 10
+  static extendedStaticField = super.baseStaticField; // 90
+}
+```
+
+Note that instance fields are set on the instance instead of the constructor's `prototype`, so you can't use `super` to access the instance field of a superclass.
+
+```js example-bad
+class Base {
+  baseField = 10;
+}
+
+class Extended extends Base {
+  extendedField = super.baseField; // undefined
+}
+```
+
+Here, `extendedField` is `undefined` instead of 10, because `baseField` is defined as an own property of the `Base` instance, instead of `Base.prototype`. `super`, in this context, only looks up properties on `Base.prototype`, because that's the [[Prototype]] of `Extended.prototype`.
+
 ### Deleting super properties will throw an error
 
 You cannot use the [delete operator](/en-US/docs/Web/JavaScript/Reference/Operators/delete) and
@@ -113,53 +155,18 @@ class Derived extends Base {
 new Derived().delete(); // ReferenceError: invalid delete involving 'super'.
 ```
 
-### `super.prop` cannot overwrite non-writable properties
+### Using super.prop in object literals
 
-When defining non-writable properties with e.g. {{jsxref("Object.defineProperty")}},
-`super` cannot overwrite the value of the property.
-
-```js
-class X {
-  constructor() {
-    Object.defineProperty(this, 'prop', {
-      configurable: true,
-      writable: false,
-      value: 1
-    });
-  }
-}
-
-class Y extends X {
-  constructor() {
-    super();
-  }
-  foo() {
-    super.prop = 2;   // Cannot overwrite the value.
-  }
-}
-
-var y = new Y();
-y.foo(); // TypeError: "prop" is read-only
-console.log(y.prop); // 1
-```
-
-### Using `super.prop` in object literals
-
-Super can also be used in the [object initializer / literal](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer)
-notation. In this example, two objects define a method. In
-the second object, `super` calls the first object's method. This works with
-the help of {{jsxref("Object.setPrototypeOf()")}} with which we are able to set the
-prototype of `obj2` to `obj1`, so that `super` is able
-to find `method1` on `obj1`.
+Super can also be used in the [object initializer / literal](/en-US/docs/Web/JavaScript/Reference/Operators/Object_initializer) notation. In this example, two objects define a method. In the second object, `super` calls the first object's method. This works with the help of {{jsxref("Object.setPrototypeOf()")}} with which we are able to set the prototype of `obj2` to `obj1`, so that `super` is able to find `method1` on `obj1`.
 
 ```js
-var obj1 = {
+const obj1 = {
   method1() {
     console.log('method 1');
   }
 }
 
-var obj2 = {
+const obj2 = {
   method2() {
     super.method1();
   }
@@ -169,7 +176,29 @@ Object.setPrototypeOf(obj2, obj1);
 obj2.method2(); // logs "method 1"
 ```
 
-Note that the reference of `super` is determined by the object literal `super` was declared in, not the object the method is called on. Therefore, unbinding or re-binding a method doesn't change the reference of `super` in it (although they do change the reference of [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this)). You can see `super` as a variable in the object literal scope, which the methods create a closure over. (But also beware that it's not actually not a variable — see below)
+### Methods that read super.prop do not behave differently when bound to other objects
+
+Accessing `super.x` behaves like `Reflect.get(Object.getPrototypeOf(objectLiteral), "x", this)`, which means the property is always seeked on the object literal/class declaration's prototype, and unbinding and re-binding a method won't change the reference of `super`.
+
+```js
+class Base {
+  baseGetX() {
+    return 1;
+  }
+}
+class Extended extends Base {
+  getX() {
+    return super.baseGetX();
+  }
+}
+
+const e = new Extended();
+console.log(e.getX()); // 1
+const { getX } = e;
+console.log(getX()); // 1
+```
+
+The same happens in object literals.
 
 ```js
 const parent1 = { prop: 1 };
@@ -191,14 +220,87 @@ const anotherChild = { __proto__: parent2, myParent };
 anotherChild.myParent(); // still logs "1"
 ```
 
-Note also that `super.prop` is a special syntax for property lookup on the prototype, but `super` itself is not a variable that points to the prototype.
+Only resetting the entire inheritance chain will change the reference of `super`.
 
 ```js
-const child = {
-  myParent() {
-    console.log(super); // SyntaxError: 'super' keyword unexpected here
-  },
-};
+class Base {
+  baseGetX() { return 1; }
+  static staticBaseGetX() { return 3; }
+}
+class AnotherBase {
+  baseGetX() { return 2; }
+  static staticBaseGetX() { return 4; }
+}
+class Extended extends Base {
+  getX() { return super.baseGetX(); }
+  static staticGetX() { return super.staticBaseGetX(); }
+}
+
+const e = new Extended();
+// Reset instance inheritance
+Object.setPrototypeOf(Extended.prototype, AnotherBase.prototype);
+console.log(e.getX()); // Logs "2" instead of "1", because the prototype chain has changed
+console.log(Extended.staticGetX()); // Still logs "3", because we haven't modified the static part yet
+// Reset static inheritance
+Object.setPrototypeOf(Extended, AnotherBase);
+console.log(Extended.staticGetX()); // Now logs "4"
+```
+
+### Setting super.prop will set the property on this instead
+
+Setting properties of `super`, such as `super.x = 1`, behaves like `Reflect.set(Object.getPrototypeOf(objectLiteral), "x", 1, this)`. This is one of the cases where understanding `super` as simply "reference of the prototype object" falls short, because it actually sets the property on `this` instead.
+
+```js
+class A {}
+class B extends A {
+  setX() {
+    super.x = 1;
+  }
+}
+
+const b = new B();
+b.setX();
+console.log(b); // B { x: 1 }
+console.log(Object.hasOwn(b, "x")); // true
+```
+
+`super.x = 1` will look for the property descriptor of `x` on `A.prototype` (and invoke the setters defined there), but the `this` value will be set to `this`, which is `b` in this context. You can read [`Reflect.set`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Reflect/set) for more details on the case when `target` and `receiver` differ.
+
+This means that while methods that _get_ `super.prop` are usually not susceptible to changes in the `this` context, those that _set_ `super.prop` are.
+
+```js example-bad
+/* Reusing same declarations as above */
+
+const b2 = new B();
+b2.setX.call(null); // TypeError: Cannot assign to read only property 'x' of object 'null'
+```
+
+However, `super.x = 1` still consults the property descriptor of the prototype object, which means you cannot rewrite non-writable properties, and setters will be invoked.
+
+```js
+class X {
+  constructor() {
+    // Create a non-writable property
+    Object.defineProperty(this, 'prop', {
+      configurable: true,
+      writable: false,
+      value: 1,
+    });
+  }
+}
+
+class Y extends X {
+  constructor() {
+    super();
+  }
+  foo() {
+    super.prop = 2;   // Cannot overwrite the value.
+  }
+}
+
+const y = new Y();
+y.foo(); // TypeError: "prop" is read-only
+console.log(y.prop); // 1
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation

Fix #208 
Fix #14744

After #16291, I spent much more time digging into `super`, and found it to be a lot more complicated than I thought. This PR attempts to describe all the nuances of `super` behavior as a getter/setter.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
