### PR TITLE
Remove Experimental tag from oklab() and oklch()

### DIFF
--- a/files/en-us/web/css/color_value/oklab/index.md
+++ b/files/en-us/web/css/color_value/oklab/index.md
@@ -9,7 +9,6 @@ tags:
   - Web
   - color
   - oklab
-  - Experimental
 browser-compat: css.types.color.oklab
 ---
 {{CSSRef}}

--- a/files/en-us/web/css/color_value/oklch/index.md
+++ b/files/en-us/web/css/color_value/oklch/index.md
@@ -9,7 +9,6 @@ tags:
   - Web
   - color
   - oklch
-  - Experimental
 browser-compat: css.types.color.oklch
 ---
 {{CSSRef}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

I removed `Experimental` tag from `oklch()` and `oklab()` tags.

#### Motivation

1. `lch()` from the same spec does not have `Experimental` tag
2. We have implementation in stable Safari version (even a few versions already 15.4 and 15.5).
3. @jensimmons (Safari & WebKit Evangelist) [also think](https://github.com/Fyrd/caniuse/issues/6124#issuecomment-1161038884) that it is not experimental

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
