### PR TITLE
Minor: Removed 62.5 font sizing

### DIFF
--- a/files/en-us/web/css/font-size/index.md
+++ b/files/en-us/web/css/font-size/index.md
@@ -114,7 +114,7 @@ One important fact to keep in mind: em values compound. Take the following HTML 
 
 ```css
 html {
-  font-size: 62.5%; /* 1em = 10px, if the default browser font-size is 16px. (62.5% of 16 = 10) */
+  font-size: 100% 
 }
 span {
   font-size: 1.6em;
@@ -129,9 +129,9 @@ span {
 
 The result is:
 
-{{EmbedLiveSample("Ems", 400, 75)}}
+{{EmbedLiveSample("Ems", 400, 100)}}
 
-Assuming that the browser's default `font-size` is 16px, the words "outer" would be rendered at 16px, but the word "inner" would be rendered at 25.6px. This is because the inner {{HTMLElement("span")}}'s `font-size` is 1.6em which is relative to its parent's `font-size`, which is in turn relative to its parent's `font-size`. This is often called **compounding**.
+Assuming that the browser's default `font-size` is 16px, the words "outer" would be rendered at 25.6px, but the word "inner" would be rendered at 40.96px. This is because the inner {{HTMLElement("span")}}'s `font-size` is 1.6em which is relative to its parent's `font-size`, which is in turn relative to its parent's `font-size`. This is often called **compounding**.
 
 ### Rems
 
@@ -141,7 +141,7 @@ The CSS below is nearly identical to the previous example. The only exception is
 
 ```css
 html {
-  font-size: 62.5%; /* font-size 1rem = 10px on default browser settings */
+  font-size: 100%; 
 }
 span {
   font-size: 1.6rem;
@@ -154,9 +154,9 @@ Then we apply this CSS to the same HTML, which looks like this:
 <span>Outer <span>inner</span> outer</span>
 ```
 
-{{EmbedLiveSample("Rems", 400, 75)}}
+{{EmbedLiveSample("Rems", 400, 100)}}
 
-In this example, the words "outer inner outer" are all displayed at 16px (assuming that the browser's `font-size` has been left at the default value of 16px).
+In this example, the words "outer inner outer" are all displayed at 25.6px (assuming that the browser's `font-size` has been left at the default value of 16px).
 
 ### Ex
 


### PR DESCRIPTION
That is from 2006 YUI. No longer the norm.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
