### PR TITLE
Fix link in “Forbidden header name” glossary entry

### DIFF
--- a/files/en-us/glossary/forbidden_header_name/index.md
+++ b/files/en-us/glossary/forbidden_header_name/index.md
@@ -10,7 +10,7 @@ tags:
 ---
 A **forbidden header name** is the name of any [HTTP header](/en-US/docs/Web/HTTP/Headers) that cannot be modified programmatically; specifically, an HTTP **request** header name (in contrast with a {{Glossary("Forbidden response header name")}}).
 
-Modifying such headers is forbidden because the user agent retains full control over them. Names starting with `Sec-` are reserved for creating new headers safe from {{glossary("API","APIs")}} using [Fetch](/en-US/docs/Web/API/Fetch_API) that grant developers control over headers, such as {{domxref("XMLHttpRequest")}}.
+Modifying such headers is forbidden because the user agent retains full control over them. Names starting with `Sec-` are reserved for creating new headers safe from {{glossary("API","APIs")}} using the [fetch algorithm](https://fetch.spec.whatwg.org/#concept-fetch) that grant developers control over headers, such as {{domxref("XMLHttpRequest")}}.
 
 Forbidden header names start with `Proxy-` or `Sec-`, or are one of the following names:
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/17281

This text in the MDN article mirrors a note in the spec at https://fetch.spec.whatwg.org/#ref-for-header-name①④ — which links to https://fetch.spec.whatwg.org/#concept-fetch (the definition of the Fetch algorithm, not the Fetch/`fetch()` API).