### PR TITLE
Correct type hierarchy flub in “RTCStats” doc

### DIFF
--- a/files/en-us/web/api/rtcstats/index.md
+++ b/files/en-us/web/api/rtcstats/index.md
@@ -12,7 +12,7 @@ tags:
   - Stats
   - WebRTC
   - rtc
-browser-compat: api.RTCStats
+spec-urls: https://w3c.github.io/webrtc-stats/#dom-rtcstats
 ---
 {{APIRef("WebRTC")}}
 
@@ -40,7 +40,7 @@ The various dictionaries that are used to define the contents of the objects tha
     - {{domxref("RTCReceivedRtpStreamStats")}} further adds statistics measured at the receiving end of an RTP stream, regardless of whether it's local or remote.
 
       - {{domxref("RTCInboundRtpStreamStats")}} contains statistics that can only be measured on a receiver at the local end of the RTP connection.
-      - {{domxref("RTCOutboundRtpStreamStats")}} contains statistics related to the receiver at the remote end of the RTP stream.
+      - {{domxref("RTCRemoteInboundRtpStreamStats")}} contains statistics relevant to the remote receiving end of an RTP stream — usually computed by combining local data with data received via an RTCP RR or XR block.
 
     - {{domxref("RTCSentRtpStreamStats")}} offers statistics related to the sending end of an RTP stream.
 
@@ -50,7 +50,3 @@ The various dictionaries that are used to define the contents of the objects tha
 ## Specifications
 
 {{Specifications}}
-
-## Browser compatibility
-
-{{Compat}}


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/17542. Without this change, the content is out of sync with the spec at https://w3c.github.io/webrtc-stats/#the-rtp-statistics-hierarchy