### PR TITLE
fix: cannot assign to const property

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md
@@ -389,7 +389,7 @@ entry.
 
 ```js
 function Archiver() {
-  const temperature = null;
+  let temperature = null;
   const archive = [];
 
   Object.defineProperty(this, 'temperature', {


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

```
function Archiver() {
  let temperature = null;  // this cannot be const; we are assigning to it in the temperature property setter
  const archive = [];

  Object.defineProperty(this, 'temperature', {
    get() {
      console.log('get!');
      return temperature;
    },
    set(value) {
      temperature = value;
      archive.push({ val: temperature });
    }
  });

  this.getArchive = function() { return archive; };
}
```

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

Updated to let so variable can be assigned to - makes this code run.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
