### PR TITLE
Adding fallback CSS vars example

### DIFF
--- a/files/en-us/web/css/var/index.md
+++ b/files/en-us/web/css/var/index.md
@@ -78,7 +78,7 @@ body {
 }
 
 body {
-  /* main-bg-color isn't set, it will fallback on backup-bg-color. If backup-bg-color isn't set it will fallback on white. */
+  /* main-bg-color isn't set, it will fall back to backup-bg-color. If backup-bg-color isn't set it will fall back to white. */
   color: var(--main-bg-color, var(--backup-bg-color, white));
 }
 ```

--- a/files/en-us/web/css/var/index.md
+++ b/files/en-us/web/css/var/index.md
@@ -35,7 +35,7 @@ The first argument to the function is the name of the custom property to be subs
 - `<custom-property-name>`
   - : A custom property's name represented by an identifier that starts with two dashes. Custom properties are solely for use by authors and users; CSS will never give them a meaning beyond what is presented here.
 - `<declaration-value>`
-  - : The custom property's fallback value, which is used in case the custom property is invalid in the used context. This value may contain any character except some characters with special meaning like newlines, unmatched closing brackets, i.e. `)`, `]`, or `}`, top-level semicolons, or exclamation marks.
+  - : The custom property's fallback value, which is used in case the custom property is invalid in the used context. This value may contain any character except some characters with special meaning like newlines, unmatched closing brackets, i.e. `)`, `]`, or `}`, top-level semicolons, or exclamation marks. The fallback value can itself be a custom property using the `var()` syntax.
 
 ## Examples
 
@@ -67,6 +67,19 @@ body {
 /* In the larger application's style: */
 .component {
   --text-color: #080;
+}
+```
+
+### Using a custom property as a fallback
+
+```css
+:root {
+  --backup-bg-color: teal;
+}
+
+body {
+  /* main-bg-color isn't set, it will fallback on backup-bg-color. If backup-bg-color isn't set it will fallback on white. */
+  color: var(--main-bg-color, var(--backup-bg-color, white));
 }
 ```
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Adding an example to the CSS var() page showing the use of a custom property as a fallback and updating the description of `<declaration-value>`. 

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Some users might not understand that CSS custom properties can be fallbacks.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
