### PR TITLE
Fix typo in YAML

### DIFF
--- a/files/en-us/web/css/_colon_local-link/index.md
+++ b/files/en-us/web/css/_colon_local-link/index.md
@@ -1,7 +1,7 @@
 ---
 title: ':local-link'
 slug: Web/CSS/:local-link
-spec-url: https://drafts.csswg.org/selectors/#local-link-pseudo
+spec-urls: https://drafts.csswg.org/selectors/#local-link-pseudo
 ---
 {{ CSSRef }}
 


### PR DESCRIPTION
YAML header is `spec-urls` not `spec-url`.

(Detected via the flaws dashboard)