### PR TITLE
Fix macro name

### DIFF
--- a/files/en-us/web/api/content_index_api/index.md
+++ b/files/en-us/web/api/content_index_api/index.md
@@ -13,7 +13,7 @@ tags:
   - Experimental
 browser-compat: api.ContentIndex
 ---
-{{DefaultAPISidebar("Content Index API")}}{{SeeContentTable}}
+{{DefaultAPISidebar("Content Index API")}}{{SeeCompatTable}}
 
 The **Content Index API** allows developers to register their offline enabled content with the browser.
 


### PR DESCRIPTION
There was a typo in the macro name (detected via the flaws dashboard)