### PR TITLE
Fix typo for CSS selector `:local-link`

### DIFF
--- a/files/en-us/web/css/_colon_local-link/index.md
+++ b/files/en-us/web/css/_colon_local-link/index.md
@@ -1,7 +1,7 @@
 ---
 title: ':local-link'
 slug: Web/CSS/:local-link
-spec-url: https://drafts.csswg.org/selectors/#local-link-pseudo
+spec-urls: https://drafts.csswg.org/selectors/#local-link-pseudo
 ---
 {{ CSSRef }}
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fixes a typo introduced in #17445.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
[The relevant MDN page](https://developer.mozilla.org/en-US/docs/Web/CSS/:local-link#specifications) doesn't render the "Specifications" macro.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
