### PR TITLE
Fix link to "Examples" section

### DIFF
--- a/files/en-us/web/api/element/requestfullscreen/index.md
+++ b/files/en-us/web/api/element/requestfullscreen/index.md
@@ -103,7 +103,7 @@ be granted.
 
 You can determine whether or not your attempt to switch to fullscreen mode is
 successful by using the {{jsxref("Promise")}} returned by
-`requestFullscreen()`, as seen in the [Example](#example) below.
+`requestFullscreen()`, as seen in the [examples](#examples) below.
 
 To learn when other code has toggled fullscreen mode on and off, you should establish
 listeners for the {{event("fullscreenchange")}} event on the {{domxref("Document")}}.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fixed an incorrect link to the "Examples" section. Also removed the capital on "Example" (in favour of "example") for better flow (unless links to sections are by convention identical to the section title, case included)

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
