### PR TITLE
Fix a link in “Namespaces crash course”

### DIFF
--- a/files/en-us/web/svg/namespaces_crash_course/index.md
+++ b/files/en-us/web/svg/namespaces_crash_course/index.md
@@ -184,7 +184,7 @@ The [DOM Level 1](https://www.w3.org/TR/REC-DOM-Level-1/) recommendation was cre
     </tr>
     <tr>
       <td>
-        <a href="https://www.w3.org/TR/REC-DOM-Level-1/level-one-core.html#"
+        <a href="https://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-ElHasAttr"
           >hasAttribute</a
         >
       </td>


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/17580

`hasAttribute` was (I think) first implemented browsers as part of DOM Level 1 — even though it was not part of the DOM Level 1 spec. It didn’t get specified formally until DOM Level 2.

Given all that, it’s not inaccurate to list it in the table in the “Namespaces crash course” page as a DOM Level 1 element — while linking to the DOM Level 2 spec for its definition.

So that’s what this change does.