### PR TITLE
Fix HTMLImageElement.decoding

### DIFF
--- a/files/en-us/web/api/htmlimageelement/decoding/index.md
+++ b/files/en-us/web/api/htmlimageelement/decoding/index.md
@@ -21,12 +21,13 @@ it should decode the image.
 
 A string representing the decoding hint. Possible values are:
 
-- **`sync`**: Decode the image synchronously for atomic
-  presentation with other content.
-- **`async`**: Decode the image asynchronously to reduce delay
-  in presenting other content.
-- **`auto`**: Default mode, which indicates no preference for
-  the decoding mode. The browser decides what is best for the user.
+- `sync`
+  - : Decode the image synchronously for atomic presentation with other content.
+- `async`
+  - : Decode the image asynchronously to reduce delay in presenting other content.
+- `auto`
+  - : Default mode, which indicates no preference for the decoding mode.
+    The browser decides what is best for the user.
 
 ## Usage notes
 
@@ -39,7 +40,7 @@ offscreen image objects.
 ## Examples
 
 ```js
-var img = new Image();
+const img = new Image();
 img.decoding = 'sync';
 img.src = 'img/logo.png';
 ```


### PR DESCRIPTION
This is the last of my small list to fix

- Remove a `var`, and change it to a `const`.
- Fixes the list of value to make it use a definition list.