### PR TITLE
fix description of ImageData dataArray

### DIFF
--- a/files/en-us/web/api/imagedata/imagedata/index.md
+++ b/files/en-us/web/api/imagedata/imagedata/index.md
@@ -42,7 +42,7 @@ new ImageData(dataArray, width, height, settings)
 - `colorSpace`
   - : One of `"srgb"`, `"rec2020"`, or `"display-p3"`.
 - `dataArray`
-  - : A {{jsxref("Uint8ClampedArray")}} array containing the underlying pixel representation of the image. If no such array is given, an image with a transparent black rectangle of the specified `width` and `height` will be created.
+  - : A {{jsxref("Uint8ClampedArray")}} containing the underlying pixel representation of the image. If no such array is given, an image with a transparent black rectangle of the specified `width` and `height` will be created.
 
 ### Return value
 

--- a/files/en-us/web/api/imagedata/imagedata/index.md
+++ b/files/en-us/web/api/imagedata/imagedata/index.md
@@ -42,7 +42,7 @@ new ImageData(dataArray, width, height, settings)
 - `colorSpace`
   - : One of `"srgb"`, `"rec2020"`, or `"display-p3"`.
 - `dataArray`
-  - : An array containing the underlying pixel representation of the image, one of {{jsxref("Uint8ClampedArray")}}, {{jsxref("Uint16Array")}}, or {{jsxref("Float32Array")}}. If no such array is given, an image with a transparent black rectangle of the specified `width` and `height` will be created.
+  - : A {{jsxref("Uint8ClampedArray")}} array containing the underlying pixel representation of the image. If no such array is given, an image with a transparent black rectangle of the specified `width` and `height` will be created.
 
 ### Return value
 


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
ImageData can only take a Uint8ClampedArray as the dataArray. No other TypedArray is allowed.


#### Supporting details
https://html.spec.whatwg.org/multipage/canvas.html#dom-imagedata-dev

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
