### PR TITLE
Add missing mention of the constructor

### DIFF
--- a/files/en-us/web/api/audioprocessingevent/index.md
+++ b/files/en-us/web/api/audioprocessingevent/index.md
@@ -19,6 +19,11 @@ The [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) `AudioProcessingEvent` re
 
 {{InheritanceDiagram}}
 
+## Constructor
+
+- `AudioProcessingEvent()`
+  - : Creates a new `AudioProcessingEvent` object.
+
 ## Properties
 
 _Also implements the properties inherited from its parent, {{domxref("Event")}}_.


### PR DESCRIPTION
There is a constructor on Chromium for this deprecated property. As it is listed in bcd, let's list it there too.