### PR TITLE
Drop the “Text formatting and styles” section from Writing Style Guide

### DIFF
--- a/files/en-us/mdn/guidelines/writing_style_guide/index.md
+++ b/files/en-us/mdn/guidelines/writing_style_guide/index.md
@@ -227,17 +227,6 @@ We have created a short numbered list that provides instructive steps to produce
 Note how the items in numbered lists read like short paragraphs.
 Because numbered lists are routinely used for instructional purposes, or to walk someone through an orderly procedure, be sure to keep each item focused: one numbered item per step.
 
-### Text formatting and styles
-
-Use the **"Formatting Styles"** drop-down list to apply predefined styles to selected content.
-
-> **Note:** The **"Note Box"** style is used to call out important notes, like this one.
-
-> **Warning:** Similarly, the **"Warning Box"** style creates warning boxes like this.
-
-Unless specifically instructed, _do not_ use the HTML `style` attribute to manually apply a style.
-If you can't do it using a predefined class, ask for help in the [MDN discussion forum](https://discourse.mozilla.org/c/mdn/236).
-
 ### Code sample style and formatting
 
 > **Note:** This section deals with the styling/formatting of code as it appears on an MDN article.


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/1821

This section as currently written is wholly irrelevant to current editing of MDN content — because we don’t have a custom editing UI any longer, and we also don’t author in HTML any more (and so don’t need to inform authors to avoid using the `style` attribute.