### PR TITLE
Drop mention of outdated macro in Writing Style Guide

### DIFF
--- a/files/en-us/mdn/guidelines/writing_style_guide/index.md
+++ b/files/en-us/mdn/guidelines/writing_style_guide/index.md
@@ -55,7 +55,6 @@ Page titles, on the other hand, may be as long as you like, within reason, and t
 
 When you need to add some articles about a topic or subject area, you will typically do so by creating a landing page, then adding subpages for each of the individual articles.
 The landing page should open with a paragraph or two describing the topic or technology, then provide a list of the subpages with descriptions of each page.
-You can automate the insertion of pages into the list using some macros we've created.
 
 For example, consider the [JavaScript](/en-US/docs/Web/JavaScript) guide, which is structured as follows:
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/1818

The sentence _“You can automate the insertion of pages into the list using some macros we've created”_ is no longer relevant to current editing of MDN content, so this change drops it.