### PR TITLE
Fix cache response headers in some sections

### DIFF
--- a/files/en-us/web/http/caching/index.md
+++ b/files/en-us/web/http/caching/index.md
@@ -581,13 +581,13 @@ Cache-Control: max-age=2592000
 
 ### Validation
 
-Don't forget to set the `If-Modified-Since` and `ETag` headers, so that you don't have to re-transmit a resource when reloading. It's easy to generate those headers for pre-built static files.
+Don't forget to set the `Last-Modified` and `ETag` headers, so that you don't have to re-transmit a resource when reloading. It's easy to generate those headers for pre-built static files.
 
 The `ETag` value here may be a hash of the file.
 
 ```http
 # response for bundle.v123.js
-If-Modified-Since: Tue, 22 Feb 2022 20:20:20 GMT
+Last-Modified: Tue, 22 Feb 2022 20:20:20 GMT
 ETag: YsAIAAAA-QG4G6kCMAMBAAAAAAAoK
 ```
 
@@ -601,7 +601,7 @@ The combined result is shown below.
 Content-Type: application/javascript
 Content-Length: 1024
 Cache-Control: public, max-age=31536000, immutable
-If-Modified-Since: Tue, 22 Feb 2022 20:20:20 GMT
+Last-Modified: Tue, 22 Feb 2022 20:20:20 GMT
 ETag: YsAIAAAA-QG4G6kCMAMBAAAAAAAoK
 ```
 
@@ -632,14 +632,14 @@ If the following HTML itself is stored, the latest version cannot be displayed e
 
 For that case, `no-cache` would be appropriate — rather than`no-store` — since we don't want to store HTML, but instead just want it to always be up-to-date.
 
-Furthermore, adding `If-Modified-Since` and `If-None-Match` will allow clients to send conditional requests, and a `304 Not Modified` can be returned if there have been no updates to the HTML:
+Furthermore, adding `Last-Modified` and `ETag` will allow clients to send conditional requests, and a `304 Not Modified` can be returned if there have been no updates to the HTML:
 
 ```http
 200 OK HTTP/1.1
 Content-Type: text/html
 Content-Length: 1024
 Cache-Control: no-cache
-If-Modified-Since: Tue, 22 Feb 2022 20:20:20 GMT
+Last-Modified: Tue, 22 Feb 2022 20:20:20 GMT
 ETag: AAPuIbAOdvAGEETbgAAAAAAABAAE
 ```
 
@@ -650,7 +650,7 @@ That setting is appropriate for non-personalized HTML — but for a response whi
 Content-Type: text/html
 Content-Length: 1024
 Cache-Control: no-cache, private
-If-Modified-Since: Tue, 22 Feb 2022 20:20:20 GMT
+Last-Modified: Tue, 22 Feb 2022 20:20:20 GMT
 ETag: AAPuIbAOdvAGEETbgAAAAAAABAAE
 Set-Cookie: __Host-SID=AHNtAyt3fvJrUL5g5tnGwER; Secure; Path=/; HttpOnly
 ```


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Fix cache response headers in sections 'Validation' and 'Main resources' of the 'HTTP caching' reference page.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Some cache-related response headers have been swapped with their matching request headers. Replace these with the correct response headers. 

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
[`If-Modified-Since`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Modified-Since) and [`If-None-Match`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match) are request headers, not response headers that should be inserted by the server.
Instead, [`Last-Modified`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified) and [`ETag`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag) are the ones to use.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
None.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
