### PR TITLE
Add referrer meta tag as a possible mitigation of the referrer problem

### DIFF
--- a/files/en-us/web/security/referer_header_colon__privacy_and_security_concerns/index.md
+++ b/files/en-us/web/security/referer_header_colon__privacy_and_security_concerns/index.md
@@ -33,6 +33,7 @@ You can also mitigate such risks using:
 - The {{httpheader("Referrer-Policy")}} header on your server to control what information is sent through the {{httpheader("Referer")}} header. For example, a directive of `no-referrer` would omit the Referer header entirely.
 - The `referrerpolicy` attribute on HTML elements that are in danger of leaking such information (such as {{HTMLElement("img")}} and {{HTMLElement("a")}}). This can for example be set to `no-referrer` to stop the `Referer` header being sent altogether.
 - The `rel` attribute set to `noreferrer` on HTML elements that are in danger of leaking such information (such as {{HTMLElement("img")}} and {{HTMLElement("a")}}). See [Link types](/en-US/docs/Web/HTML/Link_types) and search for `noreferrer` for more information.
+- A {{HTMLElement("meta")}} element with a [name](/en-US/docs/Web/HTML/Element/meta#attr-name) of `referrer` and the content set to `no-referrer` to disable the Referer header for the whole document. See [Referrer-Policy Integration with HTML](/en-US/docs/Web/HTTP/Headers/Referrer-Policy#integration_with_html).
 - The [Exit page](https://geekthis.net/post/hide-http-referer-headers/#exit-page-redirect) technique.
 
 Security-conscious server-side frameworks tend to have built in mitigations for such problems, for example:


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
A referrer meta tag has been added to the list of possible mitigations for the referer problem. A [different document](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy#integration_with_html) already documents the option, however it was not included in the list on the privacy and security concerns document.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I was looking for a way to disable the sending of the referer header for requests from my site in the html without adding an attribute to every link element. I first stumbled upon the privacy concerns list and had to search for an HTML element with the desired effect explicitly to find what I was looking for.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
