### PR TITLE
clarify interpolation of startTime parameter

### DIFF
--- a/files/en-us/web/api/audioparam/setvalueattime/index.md
+++ b/files/en-us/web/api/audioparam/setvalueattime/index.md
@@ -31,8 +31,7 @@ setValueAtTime(value, startTime)
     given time.
 - `startTime`
   - : A double representing the time (in seconds) after the {{domxref("AudioContext")}}
-    was first created that the change in value will happen. A {{jsxref("TypeError")}} is
-    thrown if this value is negative.
+    was first created that the change in value will happen. If the time is less than {{domxref("BaseAudioContext/currentTime", "AudioContext.currentTime")}}, the change happens immediately. A {{jsxref("TypeError")}} is thrown if this value is negative.
 
 ### Return value
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Ran into this somewhat unexpected behavior of setValueAtTime() while chasing down a bug, figured it would be a good idea to clarify it here.

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
