### PR TITLE
fix: let -> const

### DIFF
--- a/files/en-us/web/api/mediastreamaudiodestinationnode/mediastreamaudiodestinationnode/index.md
+++ b/files/en-us/web/api/mediastreamaudiodestinationnode/mediastreamaudiodestinationnode/index.md
@@ -31,8 +31,9 @@ new MediaStreamAudioDestinationNode(context, options)
   - : An object defining the properties you want the `MediaStreamAudioDestinationNode` to have:
 
     - `channelCount`
-      - : An integer used to determine how many channels are used when [up-mixing
-        and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing) connections to any inputs to the node. (See
+      - : An integer used to determine how many channels are used when 
+        [up-mixing and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing) 
+        connections to any inputs to the node. (See
         {{domxref("AudioNode.channelCount")}} for more information.) Its usage and precise
         definition depend on the value of `channelCountMode`.
     - `channelCountMode`
@@ -40,19 +41,18 @@ new MediaStreamAudioDestinationNode(context, options)
         the node's inputs and outputs. (See {{domxref("AudioNode.channelCountMode")}} for more
         information including default values.)
     - `channelInterpretation`
-      - : A string describing the meaning of the channels. This
-        interpretation will define how audio [up-mixing
-        and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing) will happen.
-        The possible values are `"speakers"` or `"discrete"`. (See
+      - : A string describing the meaning of the channels. This interpretation will define how audio 
+        [up-mixing and down-mixing](/en-US/docs/Web/API/Web_Audio_API/Basic_concepts_behind_Web_Audio_API#up-mixing_and_down-mixing) 
+        will happen. The possible values are `"speakers"` or `"discrete"`. (See
         {{domxref("AudioNode.channelCountMode")}} for more information including default
         values.)
 
 ## Examples
 
 ```js
-let ac = new AudioContext();
+const ac = new AudioContext();
 
-let myDestination = new MediaStreamAudioDestinationNode(ac);
+const myDestination = new MediaStreamAudioDestinationNode(ac);
 ```
 
 ## Specifications


### PR DESCRIPTION
Also, we do not split markdown link text on multiple lines.