### PR TITLE
Invoke previously defined command instead of running node directly

### DIFF
--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/build_the_server/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/build_the_server/index.md
@@ -61,7 +61,7 @@ In this article we'll set up the server for our phone app. The server file will 
     console.log('Listening on: ' + port);
     ```
 
-5. You should be able to connect to your app via `localhost` (in our `server.js` we're using port 8000 (defined on line 7) but you may be using another port number). Run `node .` in your terminal and visit `localhost:8000` in your browser and you should see a page that looks like this:
+5. You should be able to connect to your app via `localhost` (in our `server.js` we're using port 8000 (defined on line 7) but you may be using another port number). Run `yarn start` (where `start` refers to the script you declared in `package.json` on the previous page) in your terminal. Visit `localhost:8000` in your browser and you should see a page that looks like this:
 
     ![A cream background with the words 'phone a friend' in bold, dark green font as the heading. 'Connecting...' is immediately below that and 'please use headphones!' below that. Following on, a big dark green button with 'Call' written in the same cream color of the background. ](1ic3evvgnzvg1koquxo0mmw.png)
 

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/setup/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/setup/index.md
@@ -22,7 +22,6 @@ So let's get started by setting up the basis for our WebRTC-powered phone app.
       "name": "audio_app",
       "version": "1.0.0",
       "description": "An audio app using WebRTC",
-      "main": "server.js",
       "scripts": {
         "start": "node server.js",
         "test": "echo \"Error: no test specified\" && exit 1"
@@ -37,8 +36,6 @@ So let's get started by setting up the basis for our WebRTC-powered phone app.
       }
     }
     ```
-
-    If your file has \`"main": "index.js"\`, you'll want to change it so that it says \`"main": "server.js"\` instead so that it's pointing to the correct file.
 
 4. To finish the setup, you'll want to copy the following [HTML](https://gist.github.com/lolaodelola/578d692e4700dfe2c9d239c80bbdbabc) and [CSS](https://gist.github.com/lolaodelola/b4498288b86ddce995603546a64abb29) files into the root of your project folder. You can name both files 'index', so the HTML file will be 'index.html' and the CSS file will be 'index.css'. You won't need to modify these much in the articles that follow.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

Fix #10972; supersedes #17642

#### Motivation

It's generally recommended to avoid running `node`, especially when using Yarn PnP since it simply doesn't work. For any slightly non-trivial task, including starting a server, abstraction with a custom command is recommended, and since we already have a command, let's use it instead.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
