### PR TITLE
Improve String.p.split description

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@split/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@split/index.md
@@ -13,8 +13,7 @@ browser-compat: javascript.builtins.RegExp.@@split
 ---
 {{JSRef}}
 
-The **`[@@split]()`** method splits a {{jsxref("String")}}
-object into an array of strings by separating the string into substrings.
+The **`[@@split]()`** method of a regular expression specifies how [`String.prototype.split`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) should behave when the regular expression is passed in as the separator.
 
 {{EmbedInteractiveExample("pages/js/regexp-prototype-@@split.html")}}
 
@@ -29,22 +28,15 @@ regexp[Symbol.split](str[, limit])
 - `str`
   - : The target of the split operation.
 - `limit` {{optional_inline}}
-  - : Integer specifying a limit on the number of splits to be found. The
-    `[@@split]()` method still splits on every match of `this`
-    RegExp pattern (or, in the Syntax above, `regexp`), until the
-    number of split items match the `limit` or the string falls
-    short of `this` pattern.
+  - : Integer specifying a limit on the number of splits to be found. The `[@@split]()` method still splits on every match of `this` RegExp pattern (or, in the Syntax above, `regexp`), until the number of split items match the `limit` or the string falls short of `this` pattern.
 
 ### Return value
 
-An {{jsxref("Array")}} containing substrings as its elements.
+An {{jsxref("Array")}} containing substrings as its elements. Capturing groups are included.
 
 ## Description
 
-This method is called internally in {{jsxref("String.prototype.split()")}} if its
-`separator` argument is an object that has a `@@split` method,
-such as a {{jsxref("RegExp")}}. For example, the following two examples return the same
-result.
+This method is called internally in {{jsxref("String.prototype.split()")}} when a `RegExp` is passed as the separator. For example, the following two examples return the same result.
 
 ```js
 'a-b-c'.split(/-/);
@@ -52,8 +44,16 @@ result.
 /-/[Symbol.split]('a-b-c');
 ```
 
-This method exists for customizing the behavior of `split()` in
-`RegExp` subclass.
+This method exists for customizing the behavior of `split()` in `RegExp` subclasses.
+
+The `RegExp.prototype.@@split` base method exhibits the following behaviors:
+
+- The regexp's `g` ("global") flag is ignored, and the `y` ("sticky") flag is always applied even when it was not originally present.
+- If the target string is empty, and the regexp can match empty strings (for example, `/a?/`), an empty array is returned. Otherwise, if the regexp can't match an empty string, `[""]` is returned.
+- The matching proceeds by continuously calling `this.exec()`. Since the regexp is always sticky, this will move along the string, each time yielding a matching string, index, and any capturing groups.
+- For each match, the substring between the last matched string's end and the current matched string's beginning is first appended to the result array. Then, the capturing groups' values are appended one-by-one.
+- If the regexp doesn't match the target string, the target string is returned as-is, wrapped in an array.
+- The returned array's length will never exceed the `limit` parameter, if provided, while trying to be as close as possible. Therefore, the last match and its capturing groups may not all be present in the returned array if the array is already filled.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/string/split/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/split/index.md
@@ -27,7 +27,7 @@ split(separator, limit)
 ### Parameters
 
 - `separator` {{optional_inline}}
-  - : The pattern describing where each split should occur. Can be a string or an object with a [`Symbol.split`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/split) method, the typical example being a {{jsxref("Global_Objects/RegExp", "regular expression", "", 1)}}. If undefined, the original target string is returned wrapped in an array.
+  - : The pattern describing where each split should occur. Can be a string or an object with a [`Symbol.split`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/split) method — the typical example being a {{jsxref("Global_Objects/RegExp", "regular expression", "", 1)}}. If undefined, the original target string is returned wrapped in an array.
 - `limit` {{optional_inline}}
   - : A non-negative integer specifying a limit on the number of substrings to be included in the array. If provided, splits the string at each occurrence of the specified `separator`, but stops when `limit` entries have been placed in the array. Any leftover text is not included in the array at all.
     - The array may contain fewer entries than `limit` if the end of the string is reached before the limit is reached.

--- a/files/en-us/web/javascript/reference/global_objects/string/split/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/split/index.md
@@ -12,10 +12,7 @@ browser-compat: javascript.builtins.String.split
 ---
 {{JSRef}}
 
-The **`split()`** method divides a
-{{jsxref("String")}} into an ordered list of substrings, puts these substrings into an
-array, and returns the array.  The division is done by searching for a pattern; where
-the pattern is provided as the first parameter in the method's call.
+The **`split()`** method takes a pattern and divides a {{jsxref("String")}} into an ordered list of substrings by searching for the pattern, puts these substrings into an array, and returns the array.
 
 {{EmbedInteractiveExample("pages/js/string-split.html", "taller")}}
 
@@ -30,64 +27,31 @@ split(separator, limit)
 ### Parameters
 
 - `separator` {{optional_inline}}
-
-  - : The pattern describing where each split should occur.
-     The `separator` can be a simple string or it can be a
-    {{jsxref("Global_Objects/RegExp", "regular expression", "", 1)}}.
-
-    - The simplest case is when `separator` is just a single
-      character; this is used to split a delimited string.  For example, a string
-      containing tab separated values (TSV) could be parsed by passing a tab character
-      as the separator, like this: `myString.split("\t")`.
-    - If `separator` contains multiple characters, that entire
-      character sequence must be found in order to split.
-    - If `separator` is omitted or does not occur in
-      `str`, the returned array contains one element consisting of
-      the entire string.
-    - If `separator` appears at the beginning (or end) of the
-      string, it still has the effect of splitting.  The result is an empty (i.e. zero
-      length) string, which appears at the first (or last) position of the returned
-      array.
-    - If `separator` is an empty string (`""`),
-      `str` is converted to an array of each of its UTF-16
-      "characters".
-
-    > **Warning:** When the empty string (`""`) is used as a
-    > separator, the string is **not** split by _user-perceived
-    > characters_ ([grapheme clusters](https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries))
-    > or unicode characters (codepoints), but by UTF-16 codeunits.
-    > This destroys [surrogate pairs](https://unicode.org/faq/utf_bom.html#utf16-2).
-    > See ["How do you get a string to a character array in JavaScript?" on StackOverflow](https://stackoverflow.com/questions/4547609/how-to-get-character-array-from-a-string/34717402).
-
+  - : The pattern describing where each split should occur. Can be a string or an object with a [`Symbol.split`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/split) method, the typical example being a {{jsxref("Global_Objects/RegExp", "regular expression", "", 1)}}. If undefined, the original target string is returned wrapped in an array.
 - `limit` {{optional_inline}}
-
-  - : A non-negative integer specifying a limit on the number of substrings to be
-    included in the array. If provided, splits the string at each occurrence of the
-    specified `separator`, but stops when
-    `limit` entries have been placed in the array. Any leftover
-    text is not included in the array at all.
-
-    - The array may contain fewer entries than `limit` if the end of the
-      string is reached before the limit is reached.
+  - : A non-negative integer specifying a limit on the number of substrings to be included in the array. If provided, splits the string at each occurrence of the specified `separator`, but stops when `limit` entries have been placed in the array. Any leftover text is not included in the array at all.
+    - The array may contain fewer entries than `limit` if the end of the string is reached before the limit is reached.
     - If `limit` is `0`, `[]` is returned.
 
 ### Return value
 
-An {{jsxref("Array")}} of strings, split at each point where the
-`separator` occurs in the given string.
+An {{jsxref("Array")}} of strings, split at each point where the `separator` occurs in the given string.
 
 ## Description
 
-When found, `separator` is removed from the string, and the
-substrings are returned in an array.
+If `separator` is a non-empty string, the target string is split by all matches of the `separator` without including `separator` in the results. For example, a string containing tab separated values (TSV) could be parsed by passing a tab character as the separator, like `myString.split("\t")`. If `separator` contains multiple characters, that entire character sequence must be found in order to split. If `separator` appears at the beginning (or end) of the string, it still has the effect of splitting, resulting in an empty (i.e. zero length) string appearing at the first (or last) position of the returned array. If `separator` does not occur in `str`, the returned array contains one element consisting of the entire string.
 
-If `separator` is a regular expression with capturing
-parentheses, then each time `separator` matches, the results
-(including any `undefined` results) of the capturing parentheses are spliced
-into the output array.
+If `separator` is an empty string (`""`), `str` is converted to an array of each of its UTF-16 "characters", without empty strings on either ends of the resulting string.
 
-If the separator is an array, then that Array is coerced to a String and used as a
-separator.
+> **Note:** `"".split("")` is therefore the only way to produce an empty array when a string is passed as `separator`.
+
+> **Warning:** When the empty string (`""`) is used as a separator, the string is **not** split by _user-perceived characters_ ([grapheme clusters](https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries)) or unicode characters (codepoints), but by UTF-16 codeunits. This destroys [surrogate pairs](https://unicode.org/faq/utf_bom.html#utf16-2). See ["How do you get a string to a character array in JavaScript?" on StackOverflow](https://stackoverflow.com/questions/4547609/how-to-get-character-array-from-a-string/34717402).
+
+If `separator` is a regular expression with capturing groups, then each time `separator` matches, the captured groups (including any `undefined` results) are spliced into the output array. This behavior is specified by the regexp's [`Symbol.split`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/split) method.
+
+If `separator` is an object with a [`Symbol.split`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/split) method, that method is called with the target string and `limit` as arguments, and `this` set to the object. Its return value becomes the return value of `split`.
+
+Any other value will be coerced to a string before being used as separator.
 
 ## Examples
 
@@ -213,6 +177,33 @@ This script displays the following:
 ```
 
 > **Note:** `\d` matches the [character class](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Character_Classes) for digits between 0 and 9.
+
+### Using a custom splitter
+
+An object with a `Symbol.split` method can be used as a splitter with custom behavior.
+
+```js
+const splitByNumber = {
+  [Symbol.split](str) {
+    let num = 1;
+    let pos = 0;
+    const result = [];
+    while (pos < str.length) {
+      const matchPos = str.indexOf(num, pos);
+      if (matchPos === -1) {
+        result.push(str.substring(pos));
+        break;
+      }
+      result.push(str.substring(pos, matchPos));
+      pos = matchPos + String(num).length;
+    }
+    return result;
+  }
+};
+
+const myString = "a1bc2c5d3e4f";
+console.log(myString.split(splitByNumber)); // [ "a", "bc", "c5d", "e", "f" ]
+```
 
 ## Specifications
 

--- a/files/en-us/web/javascript/reference/global_objects/string/split/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/split/index.md
@@ -45,7 +45,7 @@ If `separator` is an empty string (`""`), `str` is converted to an array of each
 
 > **Note:** `"".split("")` is therefore the only way to produce an empty array when a string is passed as `separator`.
 
-> **Warning:** When the empty string (`""`) is used as a separator, the string is **not** split by _user-perceived characters_ ([grapheme clusters](https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries)) or unicode characters (codepoints), but by UTF-16 codeunits. This destroys [surrogate pairs](https://unicode.org/faq/utf_bom.html#utf16-2). See ["How do you get a string to a character array in JavaScript?" on StackOverflow](https://stackoverflow.com/questions/4547609/how-to-get-character-array-from-a-string/34717402).
+> **Warning:** When the empty string (`""`) is used as a separator, the string is **not** split by _user-perceived characters_ ([grapheme clusters](https://unicode.org/reports/tr29/#Grapheme_Cluster_Boundaries)) or unicode characters (codepoints), but by UTF-16 codeunits. This destroys [surrogate pairs](https://unicode.org/faq/utf_bom.html#utf16-2). See ["How do you get a string to a character array in JavaScript?" on StackOverflow](https://stackoverflow.com/questions/4547609/how-to-get-character-array-from-a-string/34717402#34717402).
 
 If `separator` is a regular expression with capturing groups, then each time `separator` matches, the captured groups (including any `undefined` results) are spliced into the output array. This behavior is specified by the regexp's [`Symbol.split`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/split) method.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

It's less well-known that `"".split("")` is the only case for `split` to return an empty array when given a string. (e.g. https://github.com/microsoft/TypeScript/issues/49635) I decided to elaborate a bit on the behavior of `split` as well as `RegExp.p.@@split`.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
