### PR TITLE
Remove Array.from polyfill, clarify iterator being prioritized over length

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/from/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/from/index.md
@@ -12,9 +12,7 @@ browser-compat: javascript.builtins.Array.from
 ---
 {{JSRef}}
 
-The **`Array.from()`** static method
-creates a new, shallow-copied `Array` instance from an array-like or
-iterable object.
+The **`Array.from()`** static method creates a new, shallow-copied `Array` instance from an iterable or array-like object.
 
 {{EmbedInteractiveExample("pages/js/array-from.html","shorter")}}
 
@@ -39,7 +37,7 @@ Array.from(arrayLike, function mapFn(element, index) { /* ... */ }, thisArg)
 ### Parameters
 
 - `arrayLike`
-  - : An array-like or iterable object to convert to an array.
+  - : An iterable or array-like object to convert to an array.
 - `mapFn` {{Optional_inline}}
   - : Map function to call on every element of the array.
 - `thisArg` {{Optional_inline}}
@@ -53,43 +51,29 @@ A new {{jsxref("Array")}} instance.
 
 `Array.from()` lets you create `Array`s from:
 
-- array-like objects (objects with a `length` property and indexed
-  elements); or
-- [iterable objects](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) (objects
-  such as {{jsxref("Map")}} and {{jsxref("Set")}}).
+- [iterable objects](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) (objects such as {{jsxref("Map")}} and {{jsxref("Set")}}); or, if the object is not iterable,
+- array-like objects (objects with a `length` property and indexed elements).
 
-`Array.from()` has an optional parameter `mapFn`,
-which allows you to execute a {{jsxref("Array.prototype.map()", "map()")}} function on
-each element of the array being created.
+`Array.from()` has an optional parameter `mapFn`, which allows you to execute a {{jsxref("Array.prototype.map()", "map()")}} function on each element of the array being created.
 
-More clearly,
-`Array.from(obj, mapFn, thisArg)`
-has the same result
-as `Array.from(obj).map(mapFn, thisArg)`,
-except that it does not create an intermediate array, and _mapFn_ only receives
-two arguments (_element_, _index_).
+More clearly, `Array.from(obj, mapFn, thisArg)` has the same result as `Array.from(obj).map(mapFn, thisArg)`, except that it does not create an intermediate array, and _mapFn_ only receives two arguments (_element_, _index_) without the whole array, because the array is still under construction.
 
-> **Note:** This is especially important for certain array subclasses, like [typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays), since the
-> intermediate array would necessarily have values truncated to fit into the appropriate
-> type.
+> **Note:** This is especially important for certain array subclasses, like [typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays), since the intermediate array would necessarily have values truncated to fit into the appropriate type.
 
 The `length` property of the `from()` method is `1`.
 
-In ES2015, the class syntax allows sub-classing of both built-in and user-defined
-classes. As a result, static methods such as `Array.from()` are "inherited"
-by subclasses of `Array`, and create new instances _of the
-subclass_, not `Array`.
+In ES2015, the class syntax allows sub-classing of both built-in and user-defined classes. As a result, static methods such as `Array.from()` are "inherited" by subclasses of `Array`, and create new instances _of the subclass_, not `Array`. The `Array.from()` method is also defined generically and can be defined on any constructor that accepts a single number argument.
 
 ## Examples
 
-### Array from a `String`
+### Array from a String
 
 ```js
 Array.from('foo');
 // [ "f", "o", "o" ]
 ```
 
-### Array from a `Set`
+### Array from a Set
 
 ```js
 const set = new Set(['foo', 'bar', 'baz', 'foo']);
@@ -97,7 +81,7 @@ Array.from(set);
 // [ "foo", "bar", "baz" ]
 ```
 
-### Array from a `Map`
+### Array from a Map
 
 ```js
 const map = new Map([[1, 2], [2, 4], [4, 8]]);
@@ -112,7 +96,7 @@ Array.from(mapper.keys());
 // ['1', '2'];
 ```
 
-### Array from a `NodeList`
+### Array from a NodeList
 
 ```js
 // Create an array based on a property of DOM Elements
@@ -133,7 +117,7 @@ f(1, 2, 3);
 // [ 1, 2, 3 ]
 ```
 
-### Using arrow functions and `Array.from()`
+### Using arrow functions and Array.from()
 
 ```js
 // Using an arrow function as the map function to
@@ -174,164 +158,6 @@ range('A'.charCodeAt(0), 'Z'.charCodeAt(0), 1).map(x => String.fromCharCode(x));
 ## Browser compatibility
 
 {{Compat}}
-
-## Polyfill
-
-`Array.from()` was added to the ECMA-262 standard in the 6th
-Edition (ES2015). As such, it may not be present in other implementations of the
-standard.
-
-You can work around this by inserting the following code at the beginning of your
-scripts, allowing use of `Array.from()` in implementations that don't
-natively support it.
-
-> **Note:** This algorithm is exactly as specified in
-> ECMA-6th> Edition (assuming `Object` and
-> `TypeError` have their original values and that
-> `callback.call()` evaluates to the original value of
-> {{jsxref("Function.prototype.call()")}}).
->
-> In addition, since true iterables cannot be polyfilled, this implementation does
-> not support generic iterables as defined in the 6th Edition of
-> ECMA-262.
-
-```js
-// Production steps of ECMA-262, Edition 6, 22.1.2.1
-if (!Array.from) {
-    Array.from = (function () {
-        var symbolIterator;
-        try {
-            symbolIterator = Symbol.iterator
-                ? Symbol.iterator
-                : 'Symbol(Symbol.iterator)';
-        } catch (e) {
-            symbolIterator = 'Symbol(Symbol.iterator)';
-        }
-
-        var toStr = Object.prototype.toString;
-        var isCallable = function (fn) {
-            return (
-                typeof fn === 'function' ||
-                toStr.call(fn) === '[object Function]'
-            );
-        };
-        var toInteger = function (value) {
-            var number = Number(value);
-            if (isNaN(number)) return 0;
-            if (number === 0 || !isFinite(number)) return number;
-            return (number > 0 ? 1 : -1) * Math.floor(Math.abs(number));
-        };
-        var maxSafeInteger = Math.pow(2, 53) - 1;
-        var toLength = function (value) {
-            var len = toInteger(value);
-            return Math.min(Math.max(len, 0), maxSafeInteger);
-        };
-
-        var setGetItemHandler = function setGetItemHandler(isIterator, items) {
-            var iterator = isIterator && items[symbolIterator]();
-            return function getItem(k) {
-                return isIterator ? iterator.next() : items[k];
-            };
-        };
-
-        var getArray = function getArray(
-            T,
-            A,
-            len,
-            getItem,
-            isIterator,
-            mapFn
-        ) {
-            // 16. Let k be 0.
-            var k = 0;
-
-            // 17. Repeat, while k < len… or while iterator is done (also steps a - h)
-            while (k < len || isIterator) {
-                var item = getItem(k);
-                var kValue = isIterator ? item.value : item;
-
-                if (isIterator && item.done) {
-                    return A;
-                } else {
-                    if (mapFn) {
-                        A[k] =
-                            typeof T === 'undefined'
-                                ? mapFn(kValue, k)
-                                : mapFn.call(T, kValue, k);
-                    } else {
-                        A[k] = kValue;
-                    }
-                }
-                k += 1;
-            }
-
-            if (isIterator) {
-                throw new TypeError(
-                    'Array.from: provided arrayLike or iterator has length more then 2 ** 52 - 1'
-                );
-            } else {
-                A.length = len;
-            }
-
-            return A;
-        };
-
-        // The length property of the from method is 1.
-        return function from(arrayLikeOrIterator /*, mapFn, thisArg */) {
-            // 1. Let C be the this value.
-            var C = this;
-
-            // 2. Let items be ToObject(arrayLikeOrIterator).
-            var items = Object(arrayLikeOrIterator);
-            var isIterator = isCallable(items[symbolIterator]);
-
-            // 3. ReturnIfAbrupt(items).
-            if (arrayLikeOrIterator == null && !isIterator) {
-                throw new TypeError(
-                    'Array.from requires an array-like object or iterator - not null or undefined'
-                );
-            }
-
-            // 4. If mapfn is undefined, then let mapping be false.
-            var mapFn = arguments.length > 1 ? arguments[1] : void undefined;
-            var T;
-            if (typeof mapFn !== 'undefined') {
-                // 5. else
-                // 5. a If IsCallable(mapfn) is false, throw a TypeError exception.
-                if (!isCallable(mapFn)) {
-                    throw new TypeError(
-                        'Array.from: when provided, the second argument must be a function'
-                    );
-                }
-
-                // 5. b. If thisArg was supplied, let T be thisArg; else let T be undefined.
-                if (arguments.length > 2) {
-                    T = arguments[2];
-                }
-            }
-
-            // 10. Let lenValue be Get(items, "length").
-            // 11. Let len be ToLength(lenValue).
-            var len = toLength(items.length);
-
-            // 13. If IsConstructor(C) is true, then
-            // 13. a. Let A be the result of calling the [[Construct]] internal method
-            // of C with an argument list containing the single item len.
-            // 14. a. Else, Let A be ArrayCreate(len).
-            var A = isCallable(C) ? Object(new C(len)) : new Array(len);
-
-            return getArray(
-                T,
-                A,
-                len,
-                setGetItemHandler(isIterator, items),
-                isIterator,
-                mapFn
-            );
-        };
-    })();
-}
-```
 
 ## See also
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

I heard we are removing polyfills from MDN; here's part of the effort. In addition, I've made a little clarification that `@@iterator` takes precedence over the `length` property.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
