### PR TITLE
Make function names less ambiguous in “Strict mode” article

### DIFF
--- a/files/en-us/web/javascript/reference/strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/strict_mode/index.md
@@ -42,13 +42,13 @@ var v = "Hi! I'm a strict mode script!";
 Likewise, to invoke strict mode for a function, put the _exact_ statement `"use strict";` (or `'use strict';`) in the function's body before any other statements.
 
 ```js
-function Myfunc() {
+function myStrictFunction() {
   // Function-level strict mode syntax
   'use strict';
   function nested() { return 'And so am I!'; }
-  return "Hi!  I'm a strict mode function!  " + nested();
+  return "Hi! I'm a strict mode function! " + nested();
 }
-function notStrict() { return "I'm not strict."; }
+function myNotStrictFunction() { return "I'm not strict."; }
 ```
 
 In strict mode, starting with ES2015, functions inside blocks are scoped to that block. Prior to ES2015, block-level functions were forbidden in strict mode.
@@ -58,10 +58,10 @@ In strict mode, starting with ES2015, functions inside blocks are scoped to that
 ECMAScript 2015 introduced [JavaScript modules](/en-US/docs/Web/JavaScript/Reference/Statements/export) and therefore a 3rd way to enter strict mode. The entire contents of JavaScript modules are automatically in strict mode, with no statement needed to initiate it.
 
 ```js
-function strict() {
+function myStrictFunction() {
     // because this is a module, I'm strict by default
 }
-export default strict;
+export default myStrictFunction;
 ```
 
 ### Strict mode for classes

--- a/files/en-us/web/javascript/reference/strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/strict_mode/index.md
@@ -42,7 +42,7 @@ var v = "Hi! I'm a strict mode script!";
 Likewise, to invoke strict mode for a function, put the _exact_ statement `"use strict";` (or `'use strict';`) in the function's body before any other statements.
 
 ```js
-function strict() {
+function Myfunc() {
   // Function-level strict mode syntax
   'use strict';
   function nested() { return 'And so am I!'; }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
I am just learning git and contributing to OSP to help learn git. This fix of a function name clarification seemed like as easy fix. The demo had the function name of "strict" which may have confused readers thinking the name of the function had to be "strict" for it to be a strict function. I used the example name in the function post on MDN ("Myfunc") to clarify this point as well as be consistent with other MDN posts
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
