### PR TITLE
Move background-image starting point

### DIFF
--- a/files/en-us/web/css/css_images/implementing_image_sprites_in_css/index.md
+++ b/files/en-us/web/css/css_images/implementing_image_sprites_in_css/index.md
@@ -42,7 +42,7 @@ A background position can be added either as two x, y values after the {{cssxref
 }
 ```
 
-This would move the element with the ID 'btn1' 20 pixels to the left and the element with the ID 'btn2' 40 pixels to the left (assuming they have the class `toolbtn` assigned and are affected by the image rule above).
+This would slide the starting point of the background image for the element with the ID 'btn1' 20 pixels to the left and the element with the ID 'btn2' 40 pixels to the left (assuming they have the class `toolbtn` assigned and are affected by the image rule above).
 
 Similarly, you can also make hover states with:
 

--- a/files/en-us/web/css/css_images/implementing_image_sprites_in_css/index.md
+++ b/files/en-us/web/css/css_images/implementing_image_sprites_in_css/index.md
@@ -42,7 +42,7 @@ A background position can be added either as two x, y values after the {{cssxref
 }
 ```
 
-This would slide the starting point of the background image for the element with the ID 'btn1' 20 pixels to the left and the element with the ID 'btn2' 40 pixels to the left (assuming they have the class `toolbtn` assigned and are affected by the image rule above).
+This would slide the starting point of the background image for the element with the ID `btn1` 20 pixels to the left and the element with the ID `btn2` 40 pixels to the left (assuming they have the class `toolbtn` assigned and are affected by the image rule above).
 
 Similarly, you can also make hover states with:
 


### PR DESCRIPTION
The element is not being moved at all. Only its bg starting point is moved. This basically hides the images in the left.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
