### PR TITLE
"The Symbol class" is changed into "The Symbol [global or built-in] object"

### DIFF
--- a/files/en-us/glossary/symbol/index.md
+++ b/files/en-us/glossary/symbol/index.md
@@ -64,7 +64,7 @@ alert(_Sym.description); // Sym
 
 ### Well-known symbols
 
-The {{jsxref("Symbol")}} class has constants for so-called _well-known symbols_. These symbols let you configure how JS treats an object, by using them as property keys.
+The {{jsxref("Symbol")}} [global or built-in] object has constants for so-called _well-known symbols_. These symbols let you configure how JS treats an object, by using them as property keys.
 
 Examples of well-known symbols are: {{jsxref("Symbol.iterator")}} for array-like objects, or {{jsxref("Symbol.search")}} for string objects.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
`The Symbol class` is changed into `The Symbol [global or built-in] object`

#### Related issues
🔨 Fixes #17666 

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
