### PR TITLE
Use Element browser compat data for copy/cut/paste events

### DIFF
--- a/files/en-us/web/api/document/copy_event/index.md
+++ b/files/en-us/web/api/document/copy_event/index.md
@@ -10,7 +10,7 @@ tags:
   - Reference
   - Web
   - copy
-browser-compat: api.Document.copy_event
+browser-compat: api.Element.copy_event
 ---
 {{APIRef}}
 

--- a/files/en-us/web/api/document/cut_event/index.md
+++ b/files/en-us/web/api/document/cut_event/index.md
@@ -10,7 +10,7 @@ tags:
   - Reference
   - Web
   - cut
-browser-compat: api.Document.cut_event
+browser-compat: api.Element.cut_event
 ---
 {{APIRef}}
 

--- a/files/en-us/web/api/document/paste_event/index.md
+++ b/files/en-us/web/api/document/paste_event/index.md
@@ -10,7 +10,7 @@ tags:
   - Reference
   - Web
   - paste
-browser-compat: api.Document.paste_event
+browser-compat: api.Element.paste_event
 ---
 {{APIRef}}
 

--- a/files/en-us/web/api/htmlelement/copy_event/index.md
+++ b/files/en-us/web/api/htmlelement/copy_event/index.md
@@ -10,7 +10,7 @@ tags:
   - Reference
   - Web
   - copy
-browser-compat: api.HTMLElement.copy_event
+browser-compat: api.Element.copy_event
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/en-us/web/api/htmlelement/cut_event/index.md
+++ b/files/en-us/web/api/htmlelement/cut_event/index.md
@@ -10,7 +10,7 @@ tags:
   - Reference
   - Web
   - cut
-browser-compat: api.HTMLElement.cut_event
+browser-compat: api.Element.cut_event
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/en-us/web/api/htmlelement/paste_event/index.md
+++ b/files/en-us/web/api/htmlelement/paste_event/index.md
@@ -10,7 +10,7 @@ tags:
   - Reference
   - Web
   - paste
-browser-compat: api.HTMLElement.paste_event
+browser-compat: api.Element.paste_event
 ---
 {{ APIRef("HTML DOM") }}
 

--- a/files/en-us/web/api/svggraphicselement/copy_event/index.md
+++ b/files/en-us/web/api/svggraphicselement/copy_event/index.md
@@ -8,7 +8,7 @@ tags:
   - Reference
   - SVG
   - SVG OM
-browser-compat: api.SVGGraphicsElement.copy_event
+browser-compat: api.Element.copy_event
 ---
 {{APIRef}}
 

--- a/files/en-us/web/api/svggraphicselement/cut_event/index.md
+++ b/files/en-us/web/api/svggraphicselement/cut_event/index.md
@@ -9,7 +9,7 @@ tags:
   - Reference
   - SVG
   - SVG OM
-browser-compat: api.SVGGraphicsElement.cut_event
+browser-compat: api.Element.cut_event
 ---
 {{APIRef}}
 

--- a/files/en-us/web/api/svggraphicselement/paste_event/index.md
+++ b/files/en-us/web/api/svggraphicselement/paste_event/index.md
@@ -8,7 +8,7 @@ tags:
   - Reference
   - SVG
   - SVG OM
-browser-compat: api.SVGGraphicsElement.paste_event
+browser-compat: api.Element.paste_event
 ---
 {{APIRef}}
 

--- a/files/en-us/web/api/window/copy_event/index.md
+++ b/files/en-us/web/api/window/copy_event/index.md
@@ -10,7 +10,7 @@ tags:
   - Web
   - Window
   - copy
-browser-compat: api.Window.copy_event
+browser-compat: api.Element.copy_event
 ---
 {{APIRef}}
 

--- a/files/en-us/web/api/window/cut_event/index.md
+++ b/files/en-us/web/api/window/cut_event/index.md
@@ -10,7 +10,7 @@ tags:
   - Reference
   - Web
   - Window
-browser-compat: api.Window.cut_event
+browser-compat: api.Element.cut_event
 ---
 {{APIRef}}
 

--- a/files/en-us/web/api/window/paste_event/index.md
+++ b/files/en-us/web/api/window/paste_event/index.md
@@ -9,7 +9,7 @@ tags:
   - Web
   - Window
   - paste
-browser-compat: api.Window.paste_event
+browser-compat: api.Element.paste_event
 ---
 {{APIRef}}
 


### PR DESCRIPTION
These events bubble, but there's really only one of each.

Note that the SVGGraphicsElement entries were actually not in BCD.

