### PR TITLE
Fix some details in the description of Number type

### DIFF
--- a/files/en-us/web/javascript/data_structures/index.md
+++ b/files/en-us/web/javascript/data_structures/index.md
@@ -58,11 +58,19 @@ ECMAScript has two built-in numeric types: [Number](#number-type) and [BigInt](#
 
 #### Number type
 
-The Number type is a [double-precision 64-bit binary format IEEE 754 value](https://en.wikipedia.org/wiki/Double_precision_floating-point_format). It is capable of storing floating-point numbers between 2^-1074 and 2^1024, but can only safely store integers in the range -(2^53 − 1) to 2^53 − 1. Values outside of the range from {{jsxref("Number.MIN_VALUE")}} to {{jsxref("Number.MAX_VALUE")}} are automatically converted to either `+Infinity` or `-Infinity`, which behave similarly to mathematical infinity, but with some slight differences; see {{jsxref("Number.POSITIVE_INFINITY")}} for details.
+The Number type is a [double-precision 64-bit binary format IEEE 754 value](https://en.wikipedia.org/wiki/Double_precision_floating-point_format). It is capable of storing positive floating-point numbers between 2^-1074 ({{jsxref("Number.MIN_VALUE")}}) and 2^1024 ({{jsxref("Number.MAX_VALUE")}}) as well as negative floating-point numbers between -(2^-1074) and -(2^1024). But it can only safely store integers in the range -(2^53 − 1) ({{jsxref("Number.MIN_SAFE_INTEGER")}}) to 2^53 − 1 ({{jsxref("Number.MAX_SAFE_INTEGER")}}).
 
-> **Note:** You can check if a number is in the double-precision floating-point number range using {{jsxref("Number.isSafeInteger()")}} Outside the range from {{jsxref("Number.MIN_SAFE_INTEGER")}} to {{jsxref("Number.MAX_SAFE_INTEGER")}}, JavaScript can no longer safely represent integers; they will instead be represented by a double-precision floating point approximation.
+> **Note:** You can check if a number is within the range of safe integers using {{jsxref("Number.isSafeInteger()")}}. Outside the range from {{jsxref("Number.MIN_SAFE_INTEGER")}} to {{jsxref("Number.MAX_SAFE_INTEGER")}}, JavaScript can no longer safely represent integers; they will instead be represented by a double-precision floating point approximation.
 
-The number type has only one integer with multiple representations: `0` is represented as both `-0` and `+0` (where `0` is an alias for `+0`). In practice, there is almost no difference between the different representations; for example, `+0 === -0` is `true`. However, you are able to notice this when you divide by zero:
+Values outside the range ±(2^-1074 to 2^1024) are automatically converted:
+- Positive values greater than {{jsxref("Number.MAX_VALUE")}} are converted to `+Infinity`.
+- Positive values smaller than {{jsxref("Number.MIN_VALUE")}} are converted to `+0`.
+- Negative values smaller than -{{jsxref("Number.MAX_VALUE")}} are converted to `-Infinity`.
+- Negative values greater than -{{jsxref("Number.MIN_VALUE")}} are converted to `-0`.
+
+`+Infinity` and `-Infinity` behave similarly to mathematical infinity, but with some slight differences; see {{jsxref("Number.POSITIVE_INFINITY")}} and {{jsxref("Number.NEGATIVE_INFINITY")}} for details.
+
+The Number type has only one integer with multiple representations: `0` is represented as both `-0` and `+0` (where `0` is an alias for `+0`). In practice, there is almost no difference between the different representations; for example, `+0 === -0` is `true`. However, you are able to notice this when you divide by zero:
 
 ```js
 > 42 / +0

--- a/files/en-us/web/javascript/data_structures/index.md
+++ b/files/en-us/web/javascript/data_structures/index.md
@@ -58,7 +58,7 @@ ECMAScript has two built-in numeric types: [Number](#number-type) and [BigInt](#
 
 #### Number type
 
-The Number type is a [double-precision 64-bit binary format IEEE 754 value](https://en.wikipedia.org/wiki/Double_precision_floating-point_format). It is capable of storing positive floating-point numbers between 2^-1074 ({{jsxref("Number.MIN_VALUE")}}) and 2^1024 ({{jsxref("Number.MAX_VALUE")}}) as well as negative floating-point numbers between -(2^-1074) and -(2^1024). But it can only safely store integers in the range -(2^53 − 1) ({{jsxref("Number.MIN_SAFE_INTEGER")}}) to 2^53 − 1 ({{jsxref("Number.MAX_SAFE_INTEGER")}}).
+The Number type is a [double-precision 64-bit binary format IEEE 754 value](https://en.wikipedia.org/wiki/Double_precision_floating-point_format). It is capable of storing positive floating-point numbers between 2^-1074 ({{jsxref("Number.MIN_VALUE")}}) and 2^1024 ({{jsxref("Number.MAX_VALUE")}}) as well as negative floating-point numbers between -(2^-1074) and -(2^1024), but it can only safely store integers in the range -(2^53 − 1) ({{jsxref("Number.MIN_SAFE_INTEGER")}}) to 2^53 − 1 ({{jsxref("Number.MAX_SAFE_INTEGER")}}).
 
 > **Note:** You can check if a number is within the range of safe integers using {{jsxref("Number.isSafeInteger()")}}. Outside the range from {{jsxref("Number.MIN_SAFE_INTEGER")}} to {{jsxref("Number.MAX_SAFE_INTEGER")}}, JavaScript can no longer safely represent integers; they will instead be represented by a double-precision floating point approximation.
 

--- a/files/en-us/web/javascript/guide/numbers_and_dates/index.md
+++ b/files/en-us/web/javascript/guide/numbers_and_dates/index.md
@@ -106,8 +106,8 @@ The following table summarizes the `Number` object's properties.
 
 | Property                                             | Description                                                                                                                                        |
 | ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| {{jsxref("Number.MAX_VALUE")}}             | The largest representable number (`±1.7976931348623157e+308`)                                                                                      |
-| {{jsxref("Number.MIN_VALUE")}}             | The smallest representable number (`±5e-324`)                                                                                                      |
+| {{jsxref("Number.MAX_VALUE")}}             | The largest positive representable number (`1.7976931348623157e+308`)                                                                                      |
+| {{jsxref("Number.MIN_VALUE")}}             | The smallest positive representable number (`5e-324`)                                                                                                      |
 | {{jsxref("Number.NaN")}}                     | Special "not a number" value                                                                                                                       |
 | {{jsxref("Number.NEGATIVE_INFINITY")}} | Special negative infinite value; returned on overflow                                                                                              |
 | {{jsxref("Number.POSITIVE_INFINITY")}} | Special positive infinite value; returned on overflow                                                                                              |


### PR DESCRIPTION
#### Summary
Add range for negative values of Number type.
Add rules for converting numbers to +0 and -0.
Fix range for Number.isSafeInteger().

#### Motivation
There are three statements concerning Number type in the current version of the article which I think are not entirely correct.

1. "The Number type is a double-precision 64-bit binary format IEEE 754 value. It is capable of storing floating-point numbers between 2^-1074 and 2^1024".

IEEE 754 double-precision binary format has a sign bit. So I believe it's better to point out that Number type is capable of storing not only positive numbers between 2^-1074 and 2^1024, but negative numbers between -(2^1024) and -(2^-1074) as well. And this will be more in line with the next existing statement which describes safe integer range with negative values in it: "...but can only safely store integers in the range -(2^53 − 1) to 2^53 − 1" .

2. "Values outside of the range from Number.MIN_VALUE to Number.MAX_VALUE are automatically converted to either +Infinity or -Infinity".

Positive values smaller then Number.MIN_VALUE (e.g. MIN_VALUE / 2) fall outside the range from Number.MIN_VALUE to Number.MAX_VALUE. But they are converted to +0 and not to +Infinity or -Infinity. Similar story with negative values greater than -Number.MIN_VALUE: they are converted to -0.
This conversion/replacement rule is described in the specification: https://tc39.es/ecma262/#number-value 

3. "You can check if a number is in the double-precision floating-point number range using Number.isSafeInteger()".

Number.isSafeInteger() checks if a number is within the narrow range -(2^53 − 1) to 2^53 − 1 and not only within the entire range of double-precision floating-point numbers. This is stated in the specification: https://tc39.es/ecma262/#sec-number.issafeinteger
As an example: Number.MAX_VALUE is in the double-precision floating-point number range, but it is not a safe integer (even though Number.MAX_VALUE is an integer value). So Number.isSafeInteger(Number.MAX_VALUE) returns false.

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
