### PR TITLE
Fix accidental `` inline code sample

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/tabpanel_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/tabpanel_role/index.md
@@ -36,7 +36,7 @@ When a tabbed interface is initialized, one `tabpanel` is displayed and its asso
 
 If using `aria-hidden`, use CSS to hide the hidden tab panels. When a new `tab` is selected, remove the `hidden` attribute from the newly active panel or set the `aria-hidden` attribute to `false`, while adding `hidden` or `aria-hidden="true"` to the previously active `tabpanel`.
 
-The newly selected `tab` is considered "active" and should have it`s [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected) attribute set to`true` while all other tabs in the same `tablist` should have the `aria-selected` attribute set to `false`, or removed altogether. See [ARIA`tab` role](/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role) for move information.
+The newly selected `tab` is considered "active" and should have it's [`aria-selected`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-selected) attribute set to`true` while all other tabs in the same `tablist` should have the `aria-selected` attribute set to `false`, or removed altogether. See [ARIA`tab` role](/en-US/docs/Web/Accessibility/ARIA/Roles/tab_role) for move information.
 
 If the `tablist` precedes the `tabpanel` in source order, the user will expect to be able to step through the remaining tabs in focus order or select the <kbd>down arrow</kbd> to give focus to the visible tabpanel when navigating by keyboard.
 


### PR DESCRIPTION
#### Summary

Fixes some markdown syntax where a backtick was used in place of an apostrophe, thereby setting off an inline code sample where it shouldn't be. 

#### Motivation

Article was hard to read with this broken syntax

#### Supporting details
n/a

#### Related issues
n/a

#### Metadata
This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
