### PR TITLE
Add mention of module/block scope in closures

### DIFF
--- a/files/en-us/glossary/scope/index.md
+++ b/files/en-us/glossary/scope/index.md
@@ -6,7 +6,6 @@ tags:
   - Glossary
   - JavaScript
 ---
-
 The current context of execution. The context in which {{glossary("value","values")}} and **expressions** are "visible" or can be referenced. If a **{{glossary("variable")}}** or other expression is not "in the current scope," then it is unavailable for use. Scopes can also be layered in a hierarchy, so that child scopes have access to parent scopes, but not vice versa.
 
 JavaScript has the following kinds of scopes:

--- a/files/en-us/glossary/scope/index.md
+++ b/files/en-us/glossary/scope/index.md
@@ -6,15 +6,26 @@ tags:
   - Glossary
   - JavaScript
 ---
+
 The current context of execution. The context in which {{glossary("value","values")}} and **expressions** are "visible" or can be referenced. If a **{{glossary("variable")}}** or other expression is not "in the current scope," then it is unavailable for use. Scopes can also be layered in a hierarchy, so that child scopes have access to parent scopes, but not vice versa.
 
-A **{{glossary("function")}}** serves as a **closure** in {{glossary("JavaScript")}}, and thus creates a scope, so that (for example) a variable defined exclusively within the function cannot be accessed from outside the function or within other functions. For instance, the following is invalid:
+JavaScript has the following kinds of scopes:
+
+- **Global Scope**: The default scope for all code running in script mode.
+- **Module Scope**: The scope for code running in module mode.
+- **Function Scope**: The scope created with a **{{glossary("function")}}**.
+
+In addition, variables declared with [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let) or [`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const) can have an additional scope:
+
+- **Block Scope**: The scope created with a pair of curly braces (a [block](/en-US/docs/Web/JavaScript/Reference/Statements/block)).
+
+A **{{glossary("function")}}** creates a scope, so that (for example) a variable defined exclusively within the function cannot be accessed from outside the function or within other functions. For instance, the following is invalid:
 
 ```js
 function exampleFunction() {
-    var x = "declared inside function";  // x can only be used in exampleFunction
-    console.log("Inside function");
-    console.log(x);
+  var x = "declared inside function";  // x can only be used in exampleFunction
+  console.log("Inside function");
+  console.log(x);
 }
 
 console.log(x);  // Causes error
@@ -28,12 +39,28 @@ var x = "declared outside function";
 exampleFunction();
 
 function exampleFunction() {
-    console.log("Inside function");
-    console.log(x);
+  console.log("Inside function");
+  console.log(x);
 }
 
 console.log("Outside function");
 console.log(x);
+```
+
+Blocks only scope `let` and `const` declarations, but not `var` declarations.
+
+```js
+{
+  var x = 1;
+}
+console.log(x); // 1
+```
+
+```js
+{
+  const x = 1;
+}
+console.log(x); // ReferenceError: x is not defined
 ```
 
 ## See also

--- a/files/en-us/glossary/scope/index.md
+++ b/files/en-us/glossary/scope/index.md
@@ -6,19 +6,19 @@ tags:
   - Glossary
   - JavaScript
 ---
-The current context of execution. The context in which {{glossary("value","values")}} and **expressions** are "visible" or can be referenced. If a **{{glossary("variable")}}** or other expression is not "in the current scope," then it is unavailable for use. Scopes can also be layered in a hierarchy, so that child scopes have access to parent scopes, but not vice versa.
+The **scope** is the current context of execution in which {{glossary("value","values")}} and expressions are "visible" or can be referenced. If a {{glossary("variable")}} or expression is not in the current scope, it will not be available for use. Scopes can also be layered in a hierarchy, so that child scopes have access to parent scopes, but not vice versa.
 
 JavaScript has the following kinds of scopes:
 
-- **Global Scope**: The default scope for all code running in script mode.
-- **Module Scope**: The scope for code running in module mode.
-- **Function Scope**: The scope created with a **{{glossary("function")}}**.
+- Global scope: The default scope for all code running in script mode.
+- Module scope: The scope for code running in module mode.
+- Function scope: The scope created with a {{glossary("function")}}.
 
-In addition, variables declared with [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let) or [`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const) can have an additional scope:
+In addition, variables declared with [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let) or [`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const) can belong to an additional scope:
 
-- **Block Scope**: The scope created with a pair of curly braces (a [block](/en-US/docs/Web/JavaScript/Reference/Statements/block)).
+- Block scope: The scope created with a pair of curly braces (a [block](/en-US/docs/Web/JavaScript/Reference/Statements/block)).
 
-A **{{glossary("function")}}** creates a scope, so that (for example) a variable defined exclusively within the function cannot be accessed from outside the function or within other functions. For instance, the following is invalid:
+A {{glossary("function")}} creates a scope, so that (for example) a variable defined exclusively within the function cannot be accessed from outside the function or within other functions. For instance, the following is invalid:
 
 ```js
 function exampleFunction() {

--- a/files/en-us/web/javascript/closures/index.md
+++ b/files/en-us/web/javascript/closures/index.md
@@ -309,7 +309,7 @@ Closures can capture variables in block scopes and module scopes as well. For ex
 ```js
 function outer() {
   const x = 5;
-  if (true) {
+  if (Math.random() > 0.5) {
     const y = 6;
     return () => console.log(x, y);
   }

--- a/files/en-us/web/javascript/closures/index.md
+++ b/files/en-us/web/javascript/closures/index.md
@@ -50,7 +50,7 @@ console.log(x);
 
 For people from other languages (e.g. C, Java) where blocks create scopes, the above code should throw an error on the `console.log` line, because we are outside the scope of `x` in either block. However, because blocks don't create scopes for `var`, the `var` statements here actually create a global variable. There is also [a practical example](#creating_closures_in_loops_a_common_mistake) introduced below that illustrates how this can cause actual bugs when combined with closures.
 
-In ES6, JavaScript introduced the `let` and `const` declarations, which, among other things like [temporary dead zones](/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz), allow you to create block-scoped variables.
+In ES6, JavaScript introduced the `let` and `const` declarations, which, among other things like [temporal dead zones](/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz), allow you to create block-scoped variables.
 
 ```js
 if (Math.random() > 0.5) {
@@ -140,7 +140,7 @@ Here's the JavaScript:
 ```js
 function makeSizer(size) {
   return function () {
-    document.body.style.fontSize = size + 'px';
+    document.body.style.fontSize = `${size}px`;
   };
 }
 

--- a/files/en-us/web/javascript/closures/index.md
+++ b/files/en-us/web/javascript/closures/index.md
@@ -20,7 +20,8 @@ Consider the following example code:
 ```js
 function init() {
   var name = 'Mozilla'; // name is a local variable created by init
-  function displayName() { // displayName() is the inner function, a closure
+  function displayName() {
+    // displayName() is the inner function, a closure
     alert(name); // use variable declared in the parent function
   }
   displayName();
@@ -30,7 +31,37 @@ init();
 
 `init()` creates a local variable called `name` and a function called `displayName()`. The `displayName()` function is an inner function that is defined inside `init()` and is available only within the body of the `init()` function. Note that the `displayName()` function has no local variables of its own. However, since inner functions have access to the variables of outer functions, `displayName()` can access the variable `name` declared in the parent function, `init()`.
 
-Run the code using [this JSFiddle link](https://jsfiddle.net/xAFs9/3/) and notice that the `alert()` statement within the `displayName()` function successfully displays the value of the `name` variable, which is declared in its parent function. This is an example of _lexical_ _scoping_, which describes how a parser resolves variable names when functions are nested. The word *lexical* refers to the fact that lexical scoping uses the location where a variable is declared within the source code to determine where that variable is available. Nested functions have access to variables declared in their outer scope.
+Run the code using [this JSFiddle link](https://jsfiddle.net/xAFs9/3/) and notice that the `alert()` statement within the `displayName()` function successfully displays the value of the `name` variable, which is declared in its parent function. This is an example of _lexical scoping_, which describes how a parser resolves variable names when functions are nested. The word _lexical_ refers to the fact that lexical scoping uses the location where a variable is declared within the source code to determine where that variable is available. Nested functions have access to variables declared in their outer scope.
+
+In this particular example, the scope is called a _function scope_, because the variable is accessible and only accessible within the function body where it's declared.
+
+### Scoping with let and const
+
+Traditionally (before ES6), JavaScript only had two kinds of scopes: _function scope_ and _global scope_. Variables declared with `var` are either function-scoped or global-scoped, depending on whether they are declared within a function or outside a function. This can be tricky, because blocks with curly braces do not create scopes:
+
+```js
+if (Math.random() > 0.5) {
+  var x = 1;
+} else {
+  var x = 2;
+}
+console.log(x);
+```
+
+For people from other languages (e.g. C, Java) where blocks create scopes, the above code should throw an error on the `console.log` line, because we are outside the scope of `x` in either block. However, because blocks don't create scopes for `var`, the `var` statements here actually create a global variable. There is also [a practical example](#creating_closures_in_loops_a_common_mistake) introduced below that illustrates how this can cause actual bugs when combined with closures.
+
+In ES6, JavaScript introduced the `let` and `const` declarations, which, among other things like [temporary dead zones](/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz), allow you to create block-scoped variables.
+
+```js
+if (Math.random() > 0.5) {
+  const x = 1;
+} else {
+  const x = 2;
+}
+console.log(x); // ReferenceError: x is not defined
+```
+
+In essence, blocks are finally treated as scopes in ES6, but only if you declare variables with `let` or `const`. In addition, ES6 introduced [modules](/en-US/docs/Web/JavaScript/Guide/Modules), which introduced another kind of scope. Closures are able to capture variables in all these scopes, which we will introduce later.
 
 ## Closure
 
@@ -38,14 +69,14 @@ Consider the following code example:
 
 ```js
 function makeFunc() {
-  var name = 'Mozilla';
+  const name = 'Mozilla';
   function displayName() {
     alert(name);
   }
   return displayName;
 }
 
-var myFunc = makeFunc();
+const myFunc = makeFunc();
 myFunc();
 ```
 
@@ -59,15 +90,15 @@ Here's a slightly more interesting example—a `makeAdder` function:
 
 ```js
 function makeAdder(x) {
-  return function(y) {
+  return function (y) {
     return x + y;
   };
 }
 
-var add5 = makeAdder(5);
-var add10 = makeAdder(10);
+const add5 = makeAdder(5);
+const add10 = makeAdder(10);
 
-console.log(add5(2));  // 7
+console.log(add5(2)); // 7
 console.log(add10(2)); // 12
 ```
 
@@ -108,14 +139,14 @@ Here's the JavaScript:
 
 ```js
 function makeSizer(size) {
-  return function() {
+  return function () {
     document.body.style.fontSize = size + 'px';
   };
 }
 
-var size12 = makeSizer(12);
-var size14 = makeSizer(14);
-var size16 = makeSizer(16);
+const size12 = makeSizer(12);
+const size14 = makeSizer(14);
+const size16 = makeSizer(16);
 ```
 
 `size12`, `size14`, and `size16` are now functions that resize the body text to 12, 14, and 16 pixels, respectively. You can attach them to buttons (in this case hyperlinks) as demonstrated in the following code example.
@@ -138,40 +169,40 @@ Run the code using [JSFiddle](https://jsfiddle.net/vnkuZ/7726/).
 
 Languages such as Java allow you to declare methods as private, meaning that they can be called only by other methods in the same class.
 
-JavaScript previously didn't have a native way of declaring [private methods](/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields#private_methods), but it was possible to emulate private methods using closures. Private methods aren't just useful for restricting access to code. They also provide a powerful way of managing your global namespace.
+JavaScript, prior to [classes](/en-US/docs/Web/JavaScript/Reference/Classes), didn't have a native way of declaring [private methods](/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields#private_methods), but it was possible to emulate private methods using closures. Private methods aren't just useful for restricting access to code. They also provide a powerful way of managing your global namespace.
 
 The following code illustrates how to use closures to define public functions that can access private functions and variables. Note that these closures follow the [Module Design Pattern](https://www.google.com/search?q=javascript+module+pattern).
 
 ```js
-var counter = (function() {
-  var privateCounter = 0;
+const counter = (function () {
+  let privateCounter = 0;
   function changeBy(val) {
     privateCounter += val;
   }
 
   return {
-    increment: function() {
+    increment() {
       changeBy(1);
     },
 
-    decrement: function() {
+    decrement() {
       changeBy(-1);
     },
 
-    value: function() {
+    value() {
       return privateCounter;
-    }
+    },
   };
 })();
 
-console.log(counter.value());  // 0.
+console.log(counter.value()); // 0.
 
 counter.increment();
 counter.increment();
-console.log(counter.value());  // 2.
+console.log(counter.value()); // 2.
 
 counter.decrement();
-console.log(counter.value());  // 1.
+console.log(counter.value()); // 1.
 ```
 
 In previous examples, each closure had its own lexical environment. Here though, there is a single lexical environment that is shared by the three functions: `counter.increment`, `counter.decrement`, and `counter.value`.
@@ -181,30 +212,30 @@ The shared lexical environment is created in the body of an anonymous function, 
 Those three public functions are closures that share the same lexical environment. Thanks to JavaScript's lexical scoping, they each have access to the `privateCounter` variable and the `changeBy` function.
 
 ```js
-var makeCounter = function() {
-  var privateCounter = 0;
+const makeCounter = function () {
+  let privateCounter = 0;
   function changeBy(val) {
     privateCounter += val;
   }
   return {
-    increment: function() {
+    increment() {
       changeBy(1);
     },
 
-    decrement: function() {
+    decrement() {
       changeBy(-1);
     },
 
-    value: function() {
+    value() {
       return privateCounter;
-    }
-  }
+    },
+  };
 };
 
-var counter1 = makeCounter();
-var counter2 = makeCounter();
+const counter1 = makeCounter();
+const counter2 = makeCounter();
 
-alert(counter1.value());  // 0.
+alert(counter1.value()); // 0.
 
 counter1.increment();
 counter1.increment();
@@ -224,52 +255,115 @@ Notice how the two counters maintain their independence from one another. Each c
 Every closure has three scopes:
 
 - Local Scope (Own scope)
-- Outer Functions Scope
+- Enclosing Scope (can be block, function, or module scope)
 - Global Scope
 
 A common mistake is not realizing that in the case where the outer function is itself a nested function, access to the outer function's scope includes the enclosing scope of the outer function—effectively creating a chain of function scopes. To demonstrate, consider the following example code.
 
 ```js
 // global scope
-var e = 10;
-function sum(a){
-  return function(b){
-    return function(c){
+const e = 10;
+function sum(a) {
+  return function (b) {
+    return function (c) {
       // outer functions scope
-      return function(d){
+      return function (d) {
         // local scope
         return a + b + c + d + e;
-      }
-    }
-  }
+      };
+    };
+  };
 }
 
 console.log(sum(1)(2)(3)(4)); // log 20
+```
 
-// You can also write without anonymous functions:
+You can also write without anonymous functions:
 
+```js
 // global scope
-var e = 10;
-function sum(a){
-  return function sum2(b){
-    return function sum3(c){
+const e = 10;
+function sum(a) {
+  return function sum2(b) {
+    return function sum3(c) {
       // outer functions scope
-      return function sum4(d){
+      return function sum4(d) {
         // local scope
         return a + b + c + d + e;
-      }
-    }
-  }
+      };
+    };
+  };
 }
 
-var sum2 = sum(1);
-var sum3 = sum2(2);
-var sum4 = sum3(3);
-var result = sum4(4);
-console.log(result) //log 20
+const sum2 = sum(1);
+const sum3 = sum2(2);
+const sum4 = sum3(3);
+const result = sum4(4);
+console.log(result); //log 20
 ```
 
 In the example above, there's a series of nested functions, all of which have access to the outer functions' scope. In this context, we can say that closures have access to _all_ outer function scopes.
+
+Closures can capture variables in block scopes and module scopes as well. For example, the following creates a closure over the block-scoped variable `y`:
+
+```js
+function outer() {
+  const x = 5;
+  if (true) {
+    const y = 6;
+    return () => console.log(x, y);
+  }
+}
+
+outer()(); // logs 5 6
+```
+
+Closures over modules can be more interesting.
+
+```js
+// myModule.js
+let x = 5;
+export const getX = () => x;
+export const setX = (val) => {
+  x = val;
+}
+```
+
+Here, the module exports a pair of getter-setter functions, which close over the module-scoped variable `x`. Even when `x` is not directly accessible from other modules, it can be read and written with the functions.
+
+```js
+import { getX, setX } from "./myModule.js";
+
+console.log(getX()); // 5
+setX(6);
+console.log(getX()); // 6
+```
+
+Closures can close over imported values as well, which are regarded as _live bindings_, because when the original value changes, the imported one changes accordingly.
+
+```js
+// myModule.js
+export let x = 1;
+export const setX = (val) => {
+  x = val;
+}
+```
+
+```js
+// closureCreator.js
+import { x } from "./myModule.js";
+
+export const getX = () => x; // Close over an imported live binding
+```
+
+```js
+import { getX } from "./closureCreator.js";
+import { setX } from "./myModule.js";
+
+console.log(getX()); // 1
+setX(2);
+console.log(getX()); // 2
+```
 
 ## Creating closures in loops: A common mistake
 
@@ -289,16 +383,17 @@ function showHelp(help) {
 
 function setupHelp() {
   var helpText = [
-      {'id': 'email', 'help': 'Your e-mail address'},
-      {'id': 'name', 'help': 'Your full name'},
-      {'id': 'age', 'help': 'Your age (you must be over 16)'}
-    ];
+    { id: 'email', help: 'Your e-mail address' },
+    { id: 'name', help: 'Your full name' },
+    { id: 'age', help: 'Your age (you must be over 16)' },
+  ];
 
   for (var i = 0; i < helpText.length; i++) {
+    // Culprit is the use of `var` on this line
     var item = helpText[i];
-    document.getElementById(item.id).onfocus = function() {
+    document.getElementById(item.id).onfocus = function () {
       showHelp(item.help);
-    }
+    };
   }
 }
 
@@ -321,17 +416,17 @@ function showHelp(help) {
 }
 
 function makeHelpCallback(help) {
-  return function() {
+  return function () {
     showHelp(help);
   };
 }
 
 function setupHelp() {
   var helpText = [
-      {'id': 'email', 'help': 'Your e-mail address'},
-      {'id': 'name', 'help': 'Your full name'},
-      {'id': 'age', 'help': 'Your age (you must be over 16)'}
-    ];
+    { id: 'email', help: 'Your e-mail address' },
+    { id: 'name', help: 'Your full name' },
+    { id: 'age', help: 'Your age (you must be over 16)' },
+  ];
 
   for (var i = 0; i < helpText.length; i++) {
     var item = helpText[i];
@@ -355,17 +450,17 @@ function showHelp(help) {
 
 function setupHelp() {
   var helpText = [
-      {'id': 'email', 'help': 'Your e-mail address'},
-      {'id': 'name', 'help': 'Your full name'},
-      {'id': 'age', 'help': 'Your age (you must be over 16)'}
-    ];
+    { id: 'email', help: 'Your e-mail address' },
+    { id: 'name', help: 'Your full name' },
+    { id: 'age', help: 'Your age (you must be over 16)' },
+  ];
 
   for (var i = 0; i < helpText.length; i++) {
-    (function() {
-       var item = helpText[i];
-       document.getElementById(item.id).onfocus = function() {
-         showHelp(item.help);
-       }
+    (function () {
+      var item = helpText[i];
+      document.getElementById(item.id).onfocus = function () {
+        showHelp(item.help);
+      };
     })(); // Immediate event listener attachment with the current value of item (preserved until iteration).
   }
 }
@@ -373,7 +468,7 @@ function setupHelp() {
 setupHelp();
 ```
 
-If you don't want to use more closures, you can use the [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let) keyword introduced in ES2015 :
+If you don't want to use more closures, you can use the [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let) or [`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const) keyword introduced in ES6:
 
 ```js
 function showHelp(help) {
@@ -381,24 +476,24 @@ function showHelp(help) {
 }
 
 function setupHelp() {
-  var helpText = [
-      {'id': 'email', 'help': 'Your e-mail address'},
-      {'id': 'name', 'help': 'Your full name'},
-      {'id': 'age', 'help': 'Your age (you must be over 16)'}
-    ];
+  const helpText = [
+    { id: 'email', help: 'Your e-mail address' },
+    { id: 'name', help: 'Your full name' },
+    { id: 'age', help: 'Your age (you must be over 16)' },
+  ];
 
   for (let i = 0; i < helpText.length; i++) {
-    let item = helpText[i];
-    document.getElementById(item.id).onfocus = function() {
+    const item = helpText[i];
+    document.getElementById(item.id).onfocus = function () {
       showHelp(item.help);
-    }
+    };
   }
 }
 
 setupHelp();
 ```
 
-This example uses `let` instead of `var`, so every closure binds the block-scoped variable, meaning that no additional closures are required.
+This example uses `const` instead of `var`, so every closure binds the block-scoped variable, meaning that no additional closures are required.
 
 Another alternative could be to use `forEach()` to iterate over the `helpText` array and attach a listener to each [`<input>`](/en-US/docs/Web/HTML/Element/input), as shown:
 
@@ -409,15 +504,15 @@ function showHelp(help) {
 
 function setupHelp() {
   var helpText = [
-      {'id': 'email', 'help': 'Your e-mail address'},
-      {'id': 'name', 'help': 'Your full name'},
-      {'id': 'age', 'help': 'Your age (you must be over 16)'}
-    ];
+    { id: 'email', help: 'Your e-mail address' },
+    { id: 'name', help: 'Your full name' },
+    { id: 'age', help: 'Your age (you must be over 16)' },
+  ];
 
-  helpText.forEach(function(text) {
-    document.getElementById(text.id).onfocus = function() {
+  helpText.forEach(function (text) {
+    document.getElementById(text.id).onfocus = function () {
       showHelp(text.help);
-    }
+    };
   });
 }
 
@@ -426,7 +521,7 @@ setupHelp();
 
 ## Performance considerations
 
-It is unwise to unnecessarily create functions within other functions if closures are not needed for a particular task, as it will negatively affect script performance both in terms of processing speed and memory consumption.
+As mentioned previously, each function instance manages its own scope and closure. Therefore, it is unwise to unnecessarily create functions within other functions if closures are not needed for a particular task, as it will negatively affect script performance both in terms of processing speed and memory consumption.
 
 For instance, when creating a new object/class, methods should normally be associated to the object's prototype rather than defined into the object constructor. The reason is that whenever the constructor is called, the methods would get reassigned (that is, for every object creation).
 
@@ -436,11 +531,11 @@ Consider the following case:
 function MyObject(name, message) {
   this.name = name.toString();
   this.message = message.toString();
-  this.getName = function() {
+  this.getName = function () {
     return this.name;
   };
 
-  this.getMessage = function() {
+  this.getMessage = function () {
     return this.message;
   };
 }
@@ -454,12 +549,12 @@ function MyObject(name, message) {
   this.message = message.toString();
 }
 MyObject.prototype = {
-  getName: function() {
+  getName() {
     return this.name;
   },
-  getMessage: function() {
+  getMessage() {
     return this.message;
-  }
+  },
 };
 ```
 
@@ -470,10 +565,10 @@ function MyObject(name, message) {
   this.name = name.toString();
   this.message = message.toString();
 }
-MyObject.prototype.getName = function() {
+MyObject.prototype.getName = function () {
   return this.name;
 };
-MyObject.prototype.getMessage = function() {
+MyObject.prototype.getMessage = function () {
   return this.message;
 };
 ```

--- a/files/en-us/web/javascript/closures/index.md
+++ b/files/en-us/web/javascript/closures/index.md
@@ -22,7 +22,7 @@ function init() {
   var name = 'Mozilla'; // name is a local variable created by init
   function displayName() {
     // displayName() is the inner function, a closure
-    alert(name); // use variable declared in the parent function
+    console.log(name); // use variable declared in the parent function
   }
   displayName();
 }
@@ -31,7 +31,7 @@ init();
 
 `init()` creates a local variable called `name` and a function called `displayName()`. The `displayName()` function is an inner function that is defined inside `init()` and is available only within the body of the `init()` function. Note that the `displayName()` function has no local variables of its own. However, since inner functions have access to the variables of outer functions, `displayName()` can access the variable `name` declared in the parent function, `init()`.
 
-Run the code using [this JSFiddle link](https://jsfiddle.net/xAFs9/3/) and notice that the `alert()` statement within the `displayName()` function successfully displays the value of the `name` variable, which is declared in its parent function. This is an example of _lexical scoping_, which describes how a parser resolves variable names when functions are nested. The word _lexical_ refers to the fact that lexical scoping uses the location where a variable is declared within the source code to determine where that variable is available. Nested functions have access to variables declared in their outer scope.
+Run the code using [this JSFiddle link](https://jsfiddle.net/3dxck52m/) and notice that the `console.log()` statement within the `displayName()` function successfully displays the value of the `name` variable, which is declared in its parent function. This is an example of _lexical scoping_, which describes how a parser resolves variable names when functions are nested. The word _lexical_ refers to the fact that lexical scoping uses the location where a variable is declared within the source code to determine where that variable is available. Nested functions have access to variables declared in their outer scope.
 
 In this particular example, the scope is called a _function scope_, because the variable is accessible and only accessible within the function body where it's declared.
 
@@ -71,7 +71,7 @@ Consider the following code example:
 function makeFunc() {
   const name = 'Mozilla';
   function displayName() {
-    alert(name);
+    console.log(name);
   }
   return displayName;
 }
@@ -84,7 +84,7 @@ Running this code has exactly the same effect as the previous example of the `in
 
 At first glance, it might seem unintuitive that this code still works. In some programming languages, the local variables within a function exist for just the duration of that function's execution. Once `makeFunc()` finishes executing, you might expect that the `name` variable would no longer be accessible. However, because the code still works as expected, this is obviously not the case in JavaScript.
 
-The reason is that functions in JavaScript form closures. A _closure_ is the combination of a function and the lexical environment within which that function was declared. This environment consists of any local variables that were in-scope at the time the closure was created. In this case, `myFunc` is a reference to the instance of the function `displayName` that is created when `makeFunc` is run. The instance of `displayName` maintains a reference to its lexical environment, within which the variable `name` exists. For this reason, when `myFunc` is invoked, the variable `name` remains available for use, and "Mozilla" is passed to `alert`.
+The reason is that functions in JavaScript form closures. A _closure_ is the combination of a function and the lexical environment within which that function was declared. This environment consists of any local variables that were in-scope at the time the closure was created. In this case, `myFunc` is a reference to the instance of the function `displayName` that is created when `makeFunc` is run. The instance of `displayName` maintains a reference to its lexical environment, within which the variable `name` exists. For this reason, when `myFunc` is invoked, the variable `name` remains available for use, and "Mozilla" is passed to `console.log`.
 
 Here's a slightly more interesting example—a `makeAdder` function:
 
@@ -235,28 +235,28 @@ const makeCounter = function () {
 const counter1 = makeCounter();
 const counter2 = makeCounter();
 
-alert(counter1.value()); // 0.
+console.log(counter1.value()); // 0.
 
 counter1.increment();
 counter1.increment();
-alert(counter1.value()); // 2.
+console.log(counter1.value()); // 2.
 
 counter1.decrement();
-alert(counter1.value()); // 1.
-alert(counter2.value()); // 0.
+console.log(counter1.value()); // 1.
+console.log(counter2.value()); // 0.
 ```
 
 Notice how the two counters maintain their independence from one another. Each closure references a different version of the `privateCounter` variable through its own closure. Each time one of the counters is called, its lexical environment changes by changing the value of this variable. Changes to the variable value in one closure don't affect the value in the other closure.
 
 > **Note:** Using closures in this way provides benefits that are normally associated with object-oriented programming. In particular, _data hiding_ and _encapsulation_.
 
-## Closure Scope Chain
+## Closure scope chain
 
 Every closure has three scopes:
 
-- Local Scope (Own scope)
-- Enclosing Scope (can be block, function, or module scope)
-- Global Scope
+- Local scope (Own scope)
+- Enclosing scope (can be block, function, or module scope)
+- Global scope
 
 A common mistake is not realizing that in the case where the outer function is itself a nested function, access to the outer function's scope includes the enclosing scope of the outer function—effectively creating a chain of function scopes. To demonstrate, consider the following example code.
 
@@ -468,7 +468,7 @@ function setupHelp() {
 setupHelp();
 ```
 
-If you don't want to use more closures, you can use the [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let) or [`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const) keyword introduced in ES6:
+If you don't want to use more closures, you can use the [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let) or [`const`](/en-US/docs/Web/JavaScript/Reference/Statements/const) keyword:
 
 ```js
 function showHelp(help) {
@@ -484,7 +484,7 @@ function setupHelp() {
 
   for (let i = 0; i < helpText.length; i++) {
     const item = helpText[i];
-    document.getElementById(item.id).onfocus = function () {
+    document.getElementById(item.id).onfocus = () => {
       showHelp(item.help);
     };
   }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

Fix #3587 (with a minor reprise of the scope management issue; I don't know how we can better fix this. We can reopen if that requires further action.)
Fix #9075

#### Motivation

In addition to adding module/block, I'm also converting `var` to `let`/`const`. This is tricky because some `var` here is for illustration purposes, so it has to be done with caution. I decided to keep `var` statements in the section about "common mistake" here, because with `let` declarations, this becomes a non-problem, but the solutions here still seem intriguing for pre-ES6 archeology purposes.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
