### PR TITLE
fix: update the key to comply with Result

### DIFF
--- a/files/en-us/web/api/htmloptionelement/option/index.md
+++ b/files/en-us/web/api/htmloptionelement/option/index.md
@@ -86,13 +86,13 @@ var options = [ 'zero', 'one', 'two' ];
 
 options.forEach(function(element, key) {
   if (element == 'zero') {
-    s[s.options.length] = new Option(element, s.options.length, false, false);
+    s[key] = new Option(element, s.options.length, false, false);
   }
   if (element == 'one') {
-    s[s.options.length] = new Option(element, s.options.length, true, false); // Will add the "selected" attribute
+    s[key] = new Option(element, s.options.length, true, false); // Will add the "selected" attribute
   }
   if (element == 'two') {
-    s[s.options.length] = new Option(element, s.options.length, false, true); // Just will be selected in "view"
+    s[key] = new Option(element, s.options.length, false, true); // Just will be selected in "view"
   }
 });
 


### PR DESCRIPTION
This PR fixes the second example, as it was displaying the following result

```
<select id="s">
    <option>First</option>
    <option>Second</option>
    <option>Third</option>
    <option value="0">zero</option>
    <option value="1" selected="">one</option>
    <option value="2">two</option>
</select>
```
instead of 

```
<select id="s">
    <option value="0">zero</option>
    <option value="1" selected="">one</option>
    <option value="2">two</option>
</select>
```