### PR TITLE
Update the interpretation of the example of the Adjacent sibling comb…

### DIFF
--- a/files/en-us/web/css/css_selectors/index.md
+++ b/files/en-us/web/css/css_selectors/index.md
@@ -69,7 +69,7 @@ spec-urls: https://drafts.csswg.org/selectors/
 - [Adjacent sibling combinator](/en-US/docs/Web/CSS/Adjacent_sibling_combinator)
   - : The `+` combinator matches the second element only if it _immediately_ follows the first element.
     **Syntax:** `A + B`
-    **Example:** `h2 + p` will match all {{HTMLElement("p")}} elements that _immediately_ follow an {{HTMLElement("h2")}} element.
+    **Example:** `h2 + p` will match the first {{HTMLElement("p")}} element that _immediately_ follow an {{HTMLElement("h2")}} element.
 
 - [Column combinator](/en-US/docs/Web/CSS/Column_combinator) {{Experimental_Inline}}
   - : The `||` combinator selects nodes which belong to a column.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
The `+` combinator matches the second element only if it _immediately_ follows the first element, that means matching one instead of multiple(all).

#### Motivation
Maybe make the interpretation of the example more accurate.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
