### PR TITLE
Link private member documentation to weakmaps/closures

### DIFF
--- a/files/en-us/web/javascript/guide/details_of_the_object_model/index.md
+++ b/files/en-us/web/javascript/guide/details_of_the_object_model/index.md
@@ -29,9 +29,7 @@ In class-based languages, you define a class in a separate _class definition_. I
 
 JavaScript follows a similar model, but does not have a class definition separate from the constructor. Instead, you define a constructor function to create objects with a particular initial set of properties and values. Any JavaScript function can be used as a constructor. You use the `new` operator with a constructor function to create a new object.
 
-> **Note:** ECMAScript 2015 introduces a [class declaration](/en-US/docs/Web/JavaScript/Reference/Classes):
->
-> > JavaScript classes, introduced in ECMAScript 2015, are primarily syntactical sugar over JavaScript's existing prototype-based inheritance. The class syntax _does not_ introduce a new object-oriented inheritance model to JavaScript.
+> **Note:** ECMAScript 2015 introduces [class declarations](/en-US/docs/Web/JavaScript/Reference/Classes). JavaScript classes are primarily syntactical sugar over JavaScript's existing prototype-based inheritance. The class syntax _does not_ introduce a new object-oriented inheritance model to JavaScript — all patterns are convertible to prototype-based inheritance. More details can be found in the classes references.
 
 ### Subclasses and inheritance
 

--- a/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
@@ -14,7 +14,7 @@ Class fields are {{ jsxref('Classes/Public_class_fields','public') }} by default
 by using a hash `#` prefix. The privacy encapsulation of these class features is
 enforced by JavaScript itself.
 
-Private members are not native to the language before this syntax existed. In prototypical inheritance, its behavior may be emulated with [`WeakMap`s](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap#emulating_private_members) or [closures](/en-US/docs/Web/JavaScript/Closures#emulating_private_methods_with_closures), but they can't compare to the `#` syntax in terms of ergonomics.
+Private members are not native to the language before this syntax existed. In prototypical inheritance, its behavior may be emulated with [`WeakMap`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap#emulating_private_members) objects or [closures](/en-US/docs/Web/JavaScript/Closures#emulating_private_methods_with_closures), but they can't compare to the `#` syntax in terms of ergonomics.
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
@@ -14,6 +14,8 @@ Class fields are {{ jsxref('Classes/Public_class_fields','public') }} by default
 by using a hash `#` prefix. The privacy encapsulation of these class features is
 enforced by JavaScript itself.
 
+Private members are not native to the language before this syntax existed. In prototypical inheritance, its behavior may be emulated with [`WeakMap`s](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap#emulating_private_members) or [closures](//en-US/docs/Web/JavaScript/Closures#emulating_private_methods_with_closures), but they can't compare to the `#` syntax in terms of ergonomics.
+
 ## Syntax
 
 ```js

--- a/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
@@ -14,7 +14,7 @@ Class fields are {{ jsxref('Classes/Public_class_fields','public') }} by default
 by using a hash `#` prefix. The privacy encapsulation of these class features is
 enforced by JavaScript itself.
 
-Private members are not native to the language before this syntax existed. In prototypical inheritance, its behavior may be emulated with [`WeakMap`s](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap#emulating_private_members) or [closures](//en-US/docs/Web/JavaScript/Closures#emulating_private_methods_with_closures), but they can't compare to the `#` syntax in terms of ergonomics.
+Private members are not native to the language before this syntax existed. In prototypical inheritance, its behavior may be emulated with [`WeakMap`s](/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap#emulating_private_members) or [closures](/en-US/docs/Web/JavaScript/Closures#emulating_private_methods_with_closures), but they can't compare to the `#` syntax in terms of ergonomics.
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/weakmap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/weakmap/index.md
@@ -121,8 +121,8 @@ class ClearableWeakMap {
 Developers can use a {{jsxref("WeakMap")}} to associate private data to an object, with the following benefits:
 
 - Compared to a {{jsxref("Map")}}, a weakmap does not hold strong references to the object used as the key, so the metadata shares the same lifetime as the object itself, avoiding memory leaks.
-- Compared to using non-enumerable and/or {{jsxref("Symbol")}} properties, a weakmap is external to the object and there is no way for user code to retrieve the metadata through reflective methods like {{jsxref("Object.getOwnPropertyDescriptor")}}.
-- Compared to a [closure](/en-US/docs/Web/JavaScript/Closures), the same weakmap instance can be reused for all instances created from a constructor, making it more memory-efficient, and allows different instances of the same class to read the private members of each other.
+- Compared to using non-enumerable and/or {{jsxref("Symbol")}} properties, a weakmap is external to the object and there is no way for user code to retrieve the metadata through reflective methods like {{jsxref("Object.getOwnPropertySymbols")}}.
+- Compared to a [closure](/en-US/docs/Web/JavaScript/Closures), the same weakmap can be reused for all instances created from a constructor, making it more memory-efficient, and allows different instances of the same class to read the private members of each other.
 
 ```js
 let Thing;

--- a/files/en-us/web/javascript/reference/global_objects/weakmap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/weakmap/index.md
@@ -116,6 +116,81 @@ class ClearableWeakMap {
 }
 ```
 
+### Emulating private members
+
+Weakmaps allow one to associate private data to an object. Using a weakmap has the following benefits:
+
+- Compared to a {{jsxref("Map")}}, a weakmap does not hold strong references to the object used as the key, so the metadata shares the same lifetime as the object itself, avoiding memory leaks.
+- Compared to using non-enumerable and/or {{jsxref("Symbol")}} properties, a weakmap is external to the object and there is no way for user code to retrieve the metadata through reflective methods like {{jsxref("Object.getOwnPropertyDescriptor")}}.
+- Compared to a [closure](/en-US/docs/Web/JavaScript/Closures), the same weakmap instance can be reused for all instances created from a constructor, making it more memory-efficient, and allows different instances of the same class to read the private members of each other.
+
+```js
+let Thing;
+
+{
+  const privateScope = new WeakMap();
+  let counter = 0;
+
+  Thing = function() {
+    this.someProperty = 'foo';
+
+    privateScope.set(this, {
+      hidden: ++counter,
+    });
+  };
+
+  Thing.prototype.showPublic = function() {
+    return this.someProperty;
+  };
+
+  Thing.prototype.showPrivate = function() {
+    return privateScope.get(this).hidden;
+  };
+}
+
+console.log(typeof privateScope);
+// "undefined"
+
+const thing = new Thing();
+
+console.log(thing);
+// Thing {someProperty: "foo"}
+
+thing.showPublic();
+// "foo"
+
+thing.showPrivate();
+// 1
+```
+
+This is roughly equivalent to the following, using [private fields](/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields):
+
+```js
+class Thing {
+  static #counter = 0;
+  #hidden;
+  constructor() {
+    this.someProperty = 'foo';
+    this.#hidden = ++Thing.#counter;
+  }
+  showPublic() {
+    return this.someProperty;
+  }
+  showPrivate() {
+    return this.#hidden;
+  }
+}
+
+console.log(thing);
+// Thing {someProperty: "foo"}
+
+thing.showPublic();
+// "foo"
+
+thing.showPrivate();
+// 1
+```
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/global_objects/weakmap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/weakmap/index.md
@@ -118,7 +118,7 @@ class ClearableWeakMap {
 
 ### Emulating private members
 
-Weakmaps allow one to associate private data to an object. Using a weakmap has the following benefits:
+Developers can use a {{jsxref("WeakMap")}} to associate private data to an object, with the following benefits:
 
 - Compared to a {{jsxref("Map")}}, a weakmap does not hold strong references to the object used as the key, so the metadata shares the same lifetime as the object itself, avoiding memory leaks.
 - Compared to using non-enumerable and/or {{jsxref("Symbol")}} properties, a weakmap is external to the object and there is no way for user code to retrieve the metadata through reflective methods like {{jsxref("Object.getOwnPropertyDescriptor")}}.

--- a/files/en-us/web/javascript/reference/statements/let/index.md
+++ b/files/en-us/web/javascript/reference/statements/let/index.md
@@ -105,55 +105,6 @@ console.log(this.x); // "global"
 console.log(this.y); // undefined
 ```
 
-### Emulating private members
-
-In dealing with {{Glossary("Constructor", "constructors")}} it is possible to use the
-**`let`** bindings to share one or more private members without
-using [closures](/en-US/docs/Web/JavaScript/Closures):
-
-```js
-var Thing;
-
-{
-  let privateScope = new WeakMap();
-  let counter = 0;
-
-  Thing = function() {
-    this.someProperty = 'foo';
-
-    privateScope.set(this, {
-      hidden: ++counter,
-    });
-  };
-
-  Thing.prototype.showPublic = function() {
-    return this.someProperty;
-  };
-
-  Thing.prototype.showPrivate = function() {
-    return privateScope.get(this).hidden;
-  };
-}
-
-console.log(typeof privateScope);
-// "undefined"
-
-var thing = new Thing();
-
-console.log(thing);
-// Thing {someProperty: "foo"}
-
-thing.showPublic();
-// "foo"
-
-thing.showPrivate();
-// 1
-```
-
-The same privacy pattern with closures over local variables can be created with
-`var`, but those need a function scope (typically an {{Glossary("IIFE")}} in
-the module pattern) instead of just a block scope like in the example above.
-
 ### Redeclarations
 
 Redeclaring the same variable within the same function or block scope raises a


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

Fix #16104. This is related to #10301—we need to make the entire https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Details_of_the_Object_Model page more biased towards classes instead of pointing people everywhere.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
