### PR TITLE
Wrong information for hash algo for ECDSA

### DIFF
--- a/files/en-us/web/api/subtlecrypto/sign/index.md
+++ b/files/en-us/web/api/subtlecrypto/sign/index.md
@@ -68,7 +68,7 @@ Three of these algorithms — RSASSA-PKCS1-v1_5, RSA-PSS, and ECDSA — are
 key for signing and the public key for verification.
 These systems all use a [digest algorithm](/en-US/docs/Web/API/SubtleCrypto/digest#supported_algorithms)
 to hash the message to a short fixed size before signing.
-Except for ECDSA for which it is passed in the `algorithm` object, the choice of digest algorithm is passed into the
+Except for ECDSA (for which it is passed in the `algorithm` object), the choice of digest algorithm is passed into the
 {{domxref("SubtleCrypto.generateKey()", "generateKey()")}} or {{domxref("SubtleCrypto.importKey()", "importKey()")}} functions.
 
 The fourth algorithm — HMAC — uses the same algorithm and key for signing and for

--- a/files/en-us/web/api/subtlecrypto/sign/index.md
+++ b/files/en-us/web/api/subtlecrypto/sign/index.md
@@ -68,7 +68,7 @@ Three of these algorithms — RSASSA-PKCS1-v1_5, RSA-PSS, and ECDSA — are
 key for signing and the public key for verification.
 These systems all use a [digest algorithm](/en-US/docs/Web/API/SubtleCrypto/digest#supported_algorithms)
 to hash the message to a short fixed size before signing.
-The choice of digest algorithm is passed into the
+Except for ECDSA for which it is passed in the `algorithm` object, the choice of digest algorithm is passed into the
 {{domxref("SubtleCrypto.generateKey()", "generateKey()")}} or {{domxref("SubtleCrypto.importKey()", "importKey()")}} functions.
 
 The fourth algorithm — HMAC — uses the same algorithm and key for signing and for


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
The information about how the hash algorithm is given is wrong for ECDSA since it is given in the EcdsaParams object and not in the parameters for the EC key.
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
The API is complex so precise and correct information is better
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
