### PR TITLE
Fix description of Blob and File constructor parameter

### DIFF
--- a/files/en-us/web/api/blob/blob/index.md
+++ b/files/en-us/web/api/blob/blob/index.md
@@ -30,7 +30,7 @@ new Blob(array, options)
     object such as an {{jsxref("Array")}}, having {{jsxref("ArrayBuffer")}}s,
     {{jsxref("TypedArray")}}s, {{jsxref("DataView")}}s, {{domxref("Blob")}}s, strings,
     or a mix of any of such elements, that will be put inside the {{domxref("Blob")}}.
-    Note that strings here are encoded as UTF-8, unlike the usual JS UTF-16 strings.
+    Note that strings here are encoded as UTF-8, unlike the usual JavaScript UTF-16 strings.
 
 - `options` {{optional_inline}}
   - : An object which may specify any of the following properties:

--- a/files/en-us/web/api/blob/blob/index.md
+++ b/files/en-us/web/api/blob/blob/index.md
@@ -26,10 +26,11 @@ new Blob(array, options)
 ### Parameters
 
 - `array`
-  - : An {{jsxref("Array")}} of {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, a {{jsxref("DataView")}},
-    a {{domxref("Blob")}}, string objects, or a mix of any of such
-    objects, that will be put inside the {{domxref("Blob")}}.
-    Note that strings objects here are encoded as UTF-8, unlike the usual JS UTF-16 strings.
+  - : An [iterable](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol)
+    object such as an {{jsxref("Array")}}, having {{jsxref("ArrayBuffer")}}s,
+    {{jsxref("TypedArray")}}s, {{jsxref("DataView")}}s, {{domxref("Blob")}}s, strings,
+    or a mix of any of such elements, that will be put inside the {{domxref("Blob")}}.
+    Note that strings here are encoded as UTF-8, unlike the usual JS UTF-16 strings.
 
 - `options` {{optional_inline}}
   - : An object which may specify any of the following properties:

--- a/files/en-us/web/api/file/file/index.md
+++ b/files/en-us/web/api/file/file/index.md
@@ -28,7 +28,7 @@ new File(bits, name, options)
     object such as an {{jsxref("Array")}}, having {{jsxref("ArrayBuffer")}}s,
     {{jsxref("TypedArray")}}s, {{jsxref("DataView")}}s, {{domxref("Blob")}}s, strings,
     or a mix of any of such elements, that will be put inside the {{domxref("File")}}.
-    Note that strings here are encoded as UTF-8, unlike the usual JS UTF-16 strings.
+    Note that strings here are encoded as UTF-8, unlike the usual JavaScript UTF-16 strings.
 - `name`
   - : A string representing the file name or the path to the file.
 - `options` {{optional_inline}}

--- a/files/en-us/web/api/file/file/index.md
+++ b/files/en-us/web/api/file/file/index.md
@@ -24,10 +24,11 @@ new File(bits, name, options)
 ### Parameters
 
 - `bits`
-  - : An {{jsxref("Array")}} of {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, a {{jsxref("DataView")}},
-    a {{domxref("Blob")}}, string literals or objects, or a mix of any of such
-    objects, that will be put inside the {{domxref("File")}}.
-    Note that strings objects here are encoded as UTF-8, unlike the usual JS UTF-16 strings.
+  - : An [iterable](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_iterable_protocol)
+    object such as an {{jsxref("Array")}}, having {{jsxref("ArrayBuffer")}}s,
+    {{jsxref("TypedArray")}}s, {{jsxref("DataView")}}s, {{domxref("Blob")}}s, strings,
+    or a mix of any of such elements, that will be put inside the {{domxref("File")}}.
+    Note that strings here are encoded as UTF-8, unlike the usual JS UTF-16 strings.
 - `name`
   - : A string representing the file name or the path to the file.
 - `options` {{optional_inline}}


### PR DESCRIPTION
#### Summary

This PR adjusts description of `Blob()` and `File()` constructors.

#### Motivation

Old decription sounds misleading, reading as `(An Array of ArrayBuffer), a TypedArray, a DataView, ...`
Parameter doesn't have to be an array. It can be any iterable sequence, e.g. `new Blob((function*(){ yield'a'; yield{}; })())`
Term "string objects" implies [`String`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String) while technically it's [`USVString`](https://webidl.spec.whatwg.org/#idl-USVString) so arbitrary values are coerced to primitive strings.

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
