### PR TITLE
Reword note on usage of "singular they" in writing style guide

### DIFF
--- a/files/en-us/mdn/guidelines/writing_style_guide/index.md
+++ b/files/en-us/mdn/guidelines/writing_style_guide/index.md
@@ -426,9 +426,9 @@ To fix this, use gender-neutral pronouns:
 
 _A confirmation dialog appears, asking the user if they allow the Web page to make use of their Web cam._
 
-> **Note:** MDN allows the use of this very common syntax (which is controversial among usage authorities) to make up for the lack of a neutral gender in English.
+> **Note:** MDN allows the use of the very common syntax known as "[singular 'they.'](https://en.wikipedia.org/wiki/Singular_they)"
 >
-> The use of the third-person plural as a gender neutral pronoun (that is, using "they," "them", "their," and "theirs") is an accepted practice, commonly known as "[singular 'they.'](https://en.wikipedia.org/wiki/Singular_they)"
+> The use of the third-person plural as a gender neutral pronoun (that is, using "they," "them", "their," and "theirs") is an accepted practice to make up for the lack of a neutral gender in English.
 
 Making the users plural:
 


### PR DESCRIPTION
The note now informs the reader what decision was made (allowing singular they) and then gives the reason why the decision was made (the lack of a gender neutral pronouns in English).

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The change reorders two sentence in the writing style guide. It also removes some extraneous information that can be found in the linked wiki article.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
In my experience, I didn't understand what the author was talking about till I reached the last sentence of the note. Upon reaching the last sentence I was able to reread the note and understand the authors intent (now that the 'goal' of the note was clear to me). I believe reordering the two sentences makes the note more concise and easier to understand.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
