### PR TITLE
Change the response type of DOMTokenList.item()

### DIFF
--- a/files/en-us/web/api/domtokenlist/index.md
+++ b/files/en-us/web/api/domtokenlist/index.md
@@ -23,7 +23,7 @@ A `DOMTokenList` is indexed beginning with `0` as with JavaScript {{jsxref("Arra
 ## Methods
 
 - {{domxref("DOMTokenList.item()")}}
-  - : Returns the item in the list by its index, or `undefined` if the index is greater than or equal to the list's `length`.
+  - : Returns the item in the list by its index, or `null` if the index is greater than or equal to the list's `length`.
 - {{domxref("DOMTokenList.contains()")}}
   - : Returns `true` if the list contains the given token, otherwise `false`.
 - {{domxref("DOMTokenList.add()")}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
The [https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList](https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList) page claims that `DOMTokenList.item()` returns `undefined` on out of bounds access.
In reality, `document.body.classList.item(100)` returns `null` (tested in Firefox and Chrome).

#### Motivation
Change the documentation to reflect correct return type

#### Supporting details
Run `document.body.classList.item(100)` in the DevTools' console

#### Metadata
This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
