### PR TITLE
fix a typo in the example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
@@ -61,7 +61,7 @@ The `finally()` method is very similar to calling
   So for example:
   - Unlike `Promise.resolve(2).then(() => 77, () => {})` (which
     will return a resolved promise with the result `77`),
-    `Promise.resolve(2).finally(() => {})` will return a
+    `Promise.resolve(2).finally(() => 77)` will return a
     new resolved promise with the result `2`.
   - Similarly, unlike `Promise.reject(3).then(() => {}, () => 88)`
     (which will return a rejected promise with the reason `88`),


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
fixed a typo in the example of using `finally` under **Description** section

As we are using numbers in the example it would be relatable to have a similar structure in the example instead of sending `undefined` in the return statement

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
It would avoid confusion for future readers

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
