### PR TITLE
Fix links to `item-*` attributes for `itemref`

### DIFF
--- a/files/en-us/web/html/global_attributes/itemref/index.md
+++ b/files/en-us/web/html/global_attributes/itemref/index.md
@@ -10,10 +10,9 @@ tags:
   - Reference
 browser-compat: html.global_attributes.itemref
 ---
-
 {{HTMLSidebar("Global_attributes")}}
 
-Properties that are not descendants of an element with the {{HTMLAttrxRef("itemscope")}} attribute can be associated with an item using the [global attribute](/en-US/docs/Web/HTML/Global_attributes) **`itemref`**.
+Properties that are not descendants of an element with the [`itemscope`](/en-US/docs/Web/HTML/Global_attributes/itemscope) attribute can be associated with an item using the [global attribute](/en-US/docs/Web/HTML/Global_attributes) **`itemref`**.
 
 `itemref` provides a list of element IDs (not `itemid`s) elsewhere in the document, with additional properties
 
@@ -66,10 +65,9 @@ This example uses microdata attributes to represent the following structured dat
 ## See also
 
 - [Other different global attributes](/en-US/docs/Web/HTML/Global_attributes)
-- Other, microdata related, global attributes:
+- Other microdata related global attributes:
 
-  - {{htmlattrxref("itemid")}}
-  - {{htmlattrxref("itemprop")}}
-  - {{htmlattrxref("itemref")}}
-  - {{htmlattrxref("itemscope")}}
-  - {{htmlattrxref("itemtype")}}
+  - [`itemid`](/en-US/docs/Web/HTML/Global_attributes/itemid)
+  - [`itemprop`](/en-US/docs/Web/HTML/Global_attributes/itemprop)
+  - [`itemscope`](/en-US/docs/Web/HTML/Global_attributes/itemscope)
+  - [`itemtype`](/en-US/docs/Web/HTML/Global_attributes/itemtype)


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary/Motivation

Changes `HTMLAttrxRef` macros to links since the macros lead to `/en-US/docs/Web/HTML/Global_attributes` + #`<attr-name>`, when the correct links should be `/en-US/docs/Web/HTML/Global_attributes/<attr-name>`.

It looks like this issue is also found on other `item-*` attribute pages, I also opened #17825 to fix those :)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Fixes #17823

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
