### PR TITLE
Fix remaining links to `item-*` attributes on other pages

### DIFF
--- a/files/en-us/web/html/element/meta/index.md
+++ b/files/en-us/web/html/element/meta/index.md
@@ -30,7 +30,7 @@ The **`<meta>`** [HTML](/en-US/docs/Web/HTML) element represents {{Glossary("Met
       <td>
         <a href="/en-US/docs/Web/Guide/HTML/Content_categories#metadata_content"
           >Metadata content</a
-        >. If the {{htmlattrxref("itemprop")}} attribute is present:
+        >. If the <a href="/en-US/docs/Web/HTML/Global_attributes/itemprop"><code>itemprop</code></a> attribute is present:
         <a href="/en-US/docs/Web/Guide/HTML/Content_categories#flow_content"
           >flow content</a
         >,
@@ -108,13 +108,13 @@ The type of metadata provided by the `<meta>` element can be one of the followin
 - If the {{htmlattrxref("name", "meta")}} attribute is set, the `<meta>` element provides _document-level metadata_, applying to the whole page.
 - If the {{htmlattrxref("http-equiv", "meta")}} attribute is set, the `<meta>` element is a _pragma directive_, providing information equivalent to what can be given by a similarly-named HTTP header.
 - If the {{htmlattrxref("charset", "meta")}} attribute is set, the `<meta>` element is a _charset declaration_, giving the character encoding in which the document is encoded.
-- If the {{htmlattrxref("itemprop")}} attribute is set, the `<meta>` element provides _user-defined metadata_.
+- If the [`itemprop`](/en-US/docs/Web/HTML/Global_attributes/itemprop) attribute is set, the `<meta>` element provides _user-defined metadata_.
 
 ## Attributes
 
 This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attributes).
 
-> **Note:** the attribute {{htmlattrxref("name", "meta")}} has a specific meaning for the `<meta>` element, and the {{htmlattrxref("itemprop")}} attribute must not be set on the same `<meta>` element that has any existing {{htmlattrxref("name", "meta")}}, {{htmlattrxref("http-equiv", "meta")}} or {{htmlattrxref("charset", "meta")}} attributes.
+> **Note:** the attribute {{htmlattrxref("name", "meta")}} has a specific meaning for the `<meta>` element, and the [`itemprop`](/en-US/docs/Web/HTML/Global_attributes/itemprop) attribute must not be set on the same `<meta>` element that has any existing {{htmlattrxref("name", "meta")}}, {{htmlattrxref("http-equiv", "meta")}} or {{htmlattrxref("charset", "meta")}} attributes.
 
 - {{htmlattrdef("charset")}}
   - : This attribute declares the document's character encoding. If the attribute is present, its value must be an ASCII case-insensitive match for the string "`utf-8`", because UTF-8 is the only valid encoding for HTML5 documents. `<meta>` elements which declare a character encoding must be located entirely within the first 1024 bytes of the document.

--- a/files/en-us/web/html/global_attributes/index.md
+++ b/files/en-us/web/html/global_attributes/index.md
@@ -86,9 +86,9 @@ In addition to the basic HTML global attributes, the following global attributes
 - [`itemref`](/en-US/docs/Web/HTML/Global_attributes/itemref)
   - : Properties that are not descendants of an element with the `itemscope` attribute can be associated with the item using an `itemref`. It provides a list of element ids (not `itemid`s) with additional properties elsewhere in the document.
 - [`itemscope`](/en-US/docs/Web/HTML/Global_attributes/itemscope)
-  - : `itemscope` (usually) works along with {{HTMLAttrxRef("itemtype")}} to specify that the HTML contained in a block is about a particular item. `itemscope` creates the Item and defines the scope of the `itemtype` associated with it. `itemtype` is a valid URL of a vocabulary (such as [schema.org](https://schema.org/)) that describes the item and its properties context.
+  - : `itemscope` (usually) works along with [`itemtype`](/en-US/docs/Web/HTML/Global_attributes/itemtype) to specify that the HTML contained in a block is about a particular item. `itemscope` creates the Item and defines the scope of the `itemtype` associated with it. `itemtype` is a valid URL of a vocabulary (such as [schema.org](https://schema.org/)) that describes the item and its properties context.
 - [`itemtype`](/en-US/docs/Web/HTML/Global_attributes/itemtype)
-  - : Specifies the URL of the vocabulary that will be used to define `itemprop`s (item properties) in the data structure. {{HTMLAttrxRef("itemscope")}} is used to set the scope of where in the data structure the vocabulary set by `itemtype` will be active.
+  - : Specifies the URL of the vocabulary that will be used to define `itemprop`s (item properties) in the data structure. [`itemscope`](/en-US/docs/Web/HTML/Global_attributes/itemscope) is used to set the scope of where in the data structure the vocabulary set by `itemtype` will be active.
 - [`lang`](/en-US/docs/Web/HTML/Global_attributes/lang)
   - : Helps define the language of an element: the language that non-editable elements are in, or the language that editable elements should be written in by the user. The attribute contains one "language tag" (made of hyphen-separated "language subtags") in the format defined in {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}. [**xml:lang**](#attr-xml:lang) has priority over it.
 - [`nonce`](/en-US/docs/Web/HTML/Global_attributes/nonce)

--- a/files/en-us/web/html/global_attributes/itemid/index.md
+++ b/files/en-us/web/html/global_attributes/itemid/index.md
@@ -16,7 +16,7 @@ browser-compat: html.global_attributes.itemid
 
 The **`itemid`** [global attribute](/en-US/docs/Web/HTML/Global_attributes) provides microdata in the form of a unique, global identifier of an item.
 
-An `itemid` attribute can only be specified for an element that has both {{htmlattrxref("itemscope")}} and {{htmlattrxref("itemtype")}} attributes. Also, `itemid` can only be specified on elements that possess an `itemscope` attribute whose corresponding `itemtype` refers to or defines a vocabulary that supports global identifiers.
+An `itemid` attribute can only be specified for an element that has both [`itemscope`](/en-US/docs/Web/HTML/Global_attributes/itemscope) and [`itemtype`](/en-US/docs/Web/HTML/Global_attributes/itemtype) attributes. Also, `itemid` can only be specified on elements that possess an `itemscope` attribute whose corresponding `itemtype` refers to or defines a vocabulary that supports global identifiers.
 
 The exact meaning of an `itemtype`'s global identifier is provided by the definition of that identifier within the specified vocabulary. The vocabulary defines whether several items with the same global identifier can coexist and, if so, how items with the same identifier are handled.
 
@@ -87,10 +87,9 @@ This example uses microdata attributes to represent the following structured dat
 ## See also
 
 - All [global attributes](/en-US/docs/Web/HTML/Global_attributes).
-- Other, microdata related, global attributes:
+- Other microdata related global attributes:
 
-  - {{htmlattrxref("itemid")}}
-  - {{htmlattrxref("itemprop")}}
-  - {{htmlattrxref("itemref")}}
-  - {{htmlattrxref("itemscope")}}
-  - {{htmlattrxref("itemtype")}}
+  - [`itemprop`](/en-US/docs/Web/HTML/Global_attributes/itemprop)
+  - [`itemref`](/en-US/docs/Web/HTML/Global_attributes/itemref)
+  - [`itemscope`](/en-US/docs/Web/HTML/Global_attributes/itemscope)
+  - [`itemtype`](/en-US/docs/Web/HTML/Global_attributes/itemtype)

--- a/files/en-us/web/html/global_attributes/itemprop/index.md
+++ b/files/en-us/web/html/global_attributes/itemprop/index.md
@@ -451,10 +451,9 @@ This example uses microdata attributes to represent the following structured dat
 ## See also
 
 - [Other different global attributes](/en-US/docs/Web/HTML/Global_attributes)
-- Other, microdata related, global attributes:
+- Other microdata related global attributes:
 
-  - {{htmlattrxref("itemid")}}
-  - {{htmlattrxref("itemprop")}}
-  - {{htmlattrxref("itemref")}}
-  - {{htmlattrxref("itemscope")}}
-  - {{htmlattrxref("itemtype")}}
+  - [`itemid`](/en-US/docs/Web/HTML/Global_attributes/itemid)
+  - [`itemref`](/en-US/docs/Web/HTML/Global_attributes/itemref)
+  - [`itemscope`](/en-US/docs/Web/HTML/Global_attributes/itemscope)
+  - [`itemtype`](/en-US/docs/Web/HTML/Global_attributes/itemtype)

--- a/files/en-us/web/html/global_attributes/itemscope/index.md
+++ b/files/en-us/web/html/global_attributes/itemscope/index.md
@@ -15,7 +15,7 @@ browser-compat: html.global_attributes.itemscope
 
 **`itemscope`** is a boolean [global attribute](/en-US/docs/Web/HTML/Global_attributes) that defines the scope of associated metadata. Specifying the **`itemscope`** attribute for an element creates a new item, which results in a number of name-value pairs that are associated with the element.
 
-A related attribute, {{htmlattrxref("itemtype")}}, is used to specify the valid URL of a vocabulary (such as [schema.org](https://schema.org/)) that describes the item and its properties context. In each of the following examples, the vocabulary is from [schema.org](https://schema.org/).
+A related attribute, [`itemtype`](/en-US/docs/Web/HTML/Global_attributes/itemtype), is used to specify the valid URL of a vocabulary (such as [schema.org](https://schema.org/)) that describes the item and its properties context. In each of the following examples, the vocabulary is from [schema.org](https://schema.org/).
 
 Every HTML element may have an `itemscope` attribute specified. An `itemscope` element that does not have an associated `itemtype` must have an associated `itemref`.
 
@@ -255,9 +255,9 @@ There are four `itemscope` attributes in the following example. Each `itemscope`
 ## See also
 
 - [Other different global attributes](/en-US/docs/Web/HTML/Global_attributes)
-- Other, microdata related, global attributes:
+- Other microdata related global attributes:
 
-  - {{htmlattrxref("itemid")}}
-  - {{htmlattrxref("itemprop")}}
-  - {{htmlattrxref("itemref")}}
-  - {{htmlattrxref("itemtype")}}
+  - [`itemid`](/en-US/docs/Web/HTML/Global_attributes/itemid)
+  - [`itemprop`](/en-US/docs/Web/HTML/Global_attributes/itemprop)
+  - [`itemref`](/en-US/docs/Web/HTML/Global_attributes/itemref)
+  - [`itemtype`](/en-US/docs/Web/HTML/Global_attributes/itemtype)

--- a/files/en-us/web/html/global_attributes/itemtype/index.md
+++ b/files/en-us/web/html/global_attributes/itemtype/index.md
@@ -15,7 +15,7 @@ browser-compat: html.global_attributes.itemtype
 
 The [global attribute](/en-US/docs/Web/HTML/Global_attributes) **`itemtype`** specifies the URL of the vocabulary that will be used to define `itemprop`'s (item properties) in the data structure.
 
-{{htmlattrxref("itemscope")}} is used to set the scope of where in the data structure the vocabulary set by `itemtype` will be active.
+[`itemscope`](/en-US/docs/Web/HTML/Global_attributes/itemscope) is used to set the scope of where in the data structure the vocabulary set by `itemtype` will be active.
 
 Google and other major search engines support the [schema.org](https://schema.org/) vocabulary for structured data. This vocabulary defines a standard set of type names and property names. For example, `MusicEvent` indicates a concert performance, with [`startDate`](https://schema.org/startDate) and [`location`](https://schema.org/location) properties specifying the concert's key details. In this case, [`MusicEvent`](https://schema.org/MusicEvent)would be the URL used by `itemtype`, with `startDate` and location as `itemprop`'s which [`MusicEvent`](https://schema.org/MusicEvent) defines.
 
@@ -189,10 +189,9 @@ This example uses microdata attributes to represent structured data for a produc
 ## See also
 
 - [Other different global attributes](/en-US/docs/Web/HTML/Global_attributes)
-- Other, microdata related, global attributes:
+- Other microdata related global attributes:
 
-  - {{htmlattrxref("itemid")}}
-  - {{htmlattrxref("itemprop")}}
-  - {{htmlattrxref("itemref")}}
-  - {{htmlattrxref("itemscope")}}
-  - {{htmlattrxref("itemtype")}}
+  - [`itemid`](/en-US/docs/Web/HTML/Global_attributes/itemid)
+  - [`itemprop`](/en-US/docs/Web/HTML/Global_attributes/itemprop)
+  - [`itemref`](/en-US/docs/Web/HTML/Global_attributes/itemref)
+  - [`itemscope`](/en-US/docs/Web/HTML/Global_attributes/itemscope)


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary/Motivation
<!-- ✍️ In a sentence or two, describe your changes -->

- Changes `HTMLAttrxRef` macros to links since the macros lead to `/en-US/docs/Web/HTML/Global_attributes` + #`<attr-name>`, when the correct links should be `/en-US/docs/Web/HTML/Global_attributes/<attr-name>`
- Removes links that point to the same page
- Small typography/"grammar" change

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

These incorrect links were found thanks to #17824 (and the issue that PR fixes).

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
