### PR TITLE
Fix broken link in index.md

### DIFF
--- a/files/en-us/web/api/file_and_directory_entries_api/introduction/index.md
+++ b/files/en-us/web/api/file_and_directory_entries_api/introduction/index.md
@@ -38,7 +38,7 @@ The File and Directory Entries API is an important API for the following reasons
 - It lets users of your web app directly edit a binary file that's in their local file directory.
 - It provides a storage API that is already familiar to your users, who are used to working with file systems.
 
-For examples of features you can create with this app, see the [Sample use cases](#sample-use-cases) section.
+For examples of features you can create with this app, see the [Sample use cases](#sample_use_cases) section.
 
 ### The File and Directory Entries API and other storage APIs
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fixing a broken link that I had tried to fix before.

#### Motivation
I tried this fix before in https://github.com/mdn/content/pull/10482 using `#sample-use-cases` but that seems wrong too - it should use underscores and read `#sample_use_cases`.

#### Supporting details

The current live link which is broken (because it uses dashes) is:

> https://developer.mozilla.org/en-US/docs/Web/API/File_and_Directory_Entries_API/Introduction#sample-use-cases

When this fix is merged, it should produce the following valid link (which uses underscores):

> https://developer.mozilla.org/en-US/docs/Web/API/File_and_Directory_Entries_API/Introduction#sample_use_cases

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
