### PR TITLE
There may be a punctuation missing here

### DIFF
--- a/files/en-us/web/api/textdecoderstream/ignorebom/index.md
+++ b/files/en-us/web/api/textdecoderstream/ignorebom/index.md
@@ -17,7 +17,7 @@ The **`ignoreBOM`** read-only property of the {{domxref("TextDecoderStream")}} i
 
 ## Value
 
-A {{jsxref("boolean")}}, initially `false`
+A {{jsxref("boolean")}}, initially `false`.
 
 ## Examples
 


### PR DESCRIPTION
Suggest adding a `.`

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
* There maybe a punctudtion missing here.

>A [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean), initially false
>
> no punctuation ends here

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

People are used to `.` endings.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ x ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
