### PR TITLE
TLS min/max in browserSettings

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/index.md
@@ -51,6 +51,8 @@ To use this API you need to have the "browserSettings" [permission](/en-US/docs/
   - : Controls whether to override the browser theme (light or dark) when setting pages' preferred color scheme.
 - {{WebExtAPIRef("browserSettings.overrideDocumentColors")}}
   - : Controls whether the user-chosen colors override the page's colors.
+- {{WebExtAPIRef("browserSettings.tlsVersionRestrictionConfig")}}
+  - : Read the highest and lowest versions of TLS supported by the browser.
 - {{WebExtAPIRef("browserSettings.useDocumentFonts")}}
   - : Controls whether the browser will use the fonts specified by a web page or use only built-in fonts.
 - {{WebExtAPIRef("browserSettings.webNotificationsDisabled")}}

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/tlsversionrestrictionconfig/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsersettings/tlsversionrestrictionconfig/index.md
@@ -1,0 +1,42 @@
+---
+title: browserSettings.tlsVersionRestrictionConfig
+slug: Mozilla/Add-ons/WebExtensions/API/browserSettings/tlsVersionRestrictionConfig
+tags:
+  - API
+  - Add-ons
+  - Extensions
+  - Property
+  - Reference
+  - WebExtensions
+  - browserSettings
+  - tlsVersionRestrictionConfig
+browser-compat: webextensions.api.browserSettings.tlsVersionRestrictionConfig
+---
+{{AddonSidebar()}}
+
+A {{WebExtAPIRef("types.BrowserSetting", "BrowserSetting")}} object used to read the highest and lowest versions of TLS supported by the browser.
+
+The object has these properties:
+
+- `minimum`
+  - : The lowest TLS version supported by the browser. Valid values are `TLSv1`, `TLSv1.1`, `TLSv1.2`, `TLSv1.3`, and `unknown`.
+- `maximum`
+  - : The highest TLS version supported by the browser. Valid values are `TLSv1`, `TLSv1.1`, `TLSv1.2`, `TLSv1.3`, and `unknown`.
+
+This is a read-only setting. 
+
+## Browser compatibility
+
+{{Compat}}
+
+## Examples
+
+Get the highest TLS version supported by the browser:
+
+```js
+browser.browserSettings.tlsVersionRestrictionConfig.maximum.get({}).then(result => {
+  console.log(`Highest TLS version supported: ${result}`);
+});
+```
+
+{{WebExtExamples}}

--- a/files/en-us/mozilla/firefox/releases/72/index.md
+++ b/files/en-us/mozilla/firefox/releases/72/index.md
@@ -128,6 +128,7 @@ _No changes._
 - The [`BrowserSetting.onChange`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/types/BrowserSetting/onChange) event has been implemented ({{bug(1410412)}}).
 - The [`captivePortal.canonicalURL`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/captivePortal/canonicalURL) property has been implemented ({{bug(1592932)}}).
 - The callback functions for the [`browserAction.onClicked`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/onClicked) and [`pageAction.onClicked`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/pageAction/onClicked) events now include a `OnClickData` property containing an object whose properties describe the mouse button pressed along with any keyboard modifiers ({{bug(1405031)}}). This allows support for additional types of mouse click.
+- The {{WebExtAPIRef("browserSettings.tlsVersionRestrictionConfig")}} property has been implemented and enables the highest and lowest versions of TLS supported by the browser to be read ({{bug(1593635)}}). 
 
 ### Manifest changes
 


### PR DESCRIPTION
#### Summary
Adds the `tlsVersionRestrictionConfig` property to the `browserSettings` API, includes API and release notes updates. Provides the content for [Bug 1593635](https://bugzilla.mozilla.org/show_bug.cgi?id=1593635).

Related BCD in https://github.com/mdn/browser-compat-data/pull/16836.

#### Metadata

This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
