### PR TITLE
Note experimental status of ReadableStreams in Request.body

### DIFF
--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -74,7 +74,7 @@ fetch(resource, init)
       - : Any body that you want to add to your request:
         this can be a {{domxref("Blob")}}, an {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, a {{jsxref("DataView")}},
         a {{domxref("FormData")}}, a {{domxref("URLSearchParams")}}, string object or literal,
-        or a {{domxref("ReadableStream")}} object.
+        or a {{domxref("ReadableStream")}} object ([experimental](/en-US/docs/Web/API/Request#browser_compatibility)).
         Note that a request using the `GET` or `HEAD` method cannot have a body.
     - `mode`
       - : The mode you want to use for the request, e.g., `cors`,

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -74,7 +74,7 @@ fetch(resource, init)
       - : Any body that you want to add to your request:
         this can be a {{domxref("Blob")}}, an {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, a {{jsxref("DataView")}},
         a {{domxref("FormData")}}, a {{domxref("URLSearchParams")}}, string object or literal,
-        or a {{domxref("ReadableStream")}} object ([experimental](/en-US/docs/Web/API/Request#browser_compatibility)).
+        or a {{domxref("ReadableStream")}} object {{experimental_inline) ([info](/en-US/docs/Web/API/Request#browser_compatibility)).
         Note that a request using the `GET` or `HEAD` method cannot have a body.
     - `mode`
       - : The mode you want to use for the request, e.g., `cors`,

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -74,7 +74,7 @@ fetch(resource, init)
       - : Any body that you want to add to your request:
         this can be a {{domxref("Blob")}}, an {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, a {{jsxref("DataView")}},
         a {{domxref("FormData")}}, a {{domxref("URLSearchParams")}}, string object or literal,
-        or a {{domxref("ReadableStream")}} object {{experimental_inline) ([info](/en-US/docs/Web/API/Request#browser_compatibility)).
+        or a {{domxref("ReadableStream")}} object {{experimental_inline}} ([info](/en-US/docs/Web/API/Request#browser_compatibility)).
         Note that a request using the `GET` or `HEAD` method cannot have a body.
     - `mode`
       - : The mode you want to use for the request, e.g., `cors`,

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -74,7 +74,7 @@ fetch(resource, init)
       - : Any body that you want to add to your request:
         this can be a {{domxref("Blob")}}, an {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, a {{jsxref("DataView")}},
         a {{domxref("FormData")}}, a {{domxref("URLSearchParams")}}, string object or literal,
-        or a {{domxref("ReadableStream")}} object {{experimental_inline}} ([info](/en-US/docs/Web/API/Request#browser_compatibility)).
+        or a {{domxref("ReadableStream")}} object. This latest possibility is still experimental ([See compatibility info](/en-US/docs/Web/API/Request#browser_compatibility) to check if you can use it).
         Note that a request using the `GET` or `HEAD` method cannot have a body.
     - `mode`
       - : The mode you want to use for the request, e.g., `cors`,

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -74,7 +74,7 @@ fetch(resource, init)
       - : Any body that you want to add to your request:
         this can be a {{domxref("Blob")}}, an {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, a {{jsxref("DataView")}},
         a {{domxref("FormData")}}, a {{domxref("URLSearchParams")}}, string object or literal,
-        or a {{domxref("ReadableStream")}} object. This latest possibility is still experimental ([See compatibility info](/en-US/docs/Web/API/Request#browser_compatibility) to check if you can use it).
+        or a {{domxref("ReadableStream")}} object. This latest possibility is still experimental; check the [compatibility information](/en-US/docs/Web/API/Request#browser_compatibility) to verify you can use it.
         Note that a request using the `GET` or `HEAD` method cannot have a body.
     - `mode`
       - : The mode you want to use for the request, e.g., `cors`,


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

`ReadableStreams` support in `Request.body` is still experimental and largely unimplemented in most browsers. The listing does not currently point this out, as it lists it together with other, widely-supported `body` sources. The changes highlight the difference.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

MDN already has the support for sending `ReadableStreams` in `Request.body` tracked in a compatibility table, marked "experimental", but the `fetch` documentation is a much more trafficked page so exposing this better may help save people some confusion.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://developer.mozilla.org/en-US/docs/Web/API/Request#browser_compatibility

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Fixes mdn/browser-compat-data#16837

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
