### PR TITLE
Fix incorrect link to `:host()`

### DIFF
--- a/files/en-us/web/css/_colon_host-context/index.md
+++ b/files/en-us/web/css/_colon_host-context/index.md
@@ -94,4 +94,4 @@ The `:host-context(h1) { font-style: italic; }` and `:host-context(h1):after { c
 
 - [Web components](/en-US/docs/Web/Web_Components)
 - {{cssxref(":host")}}
-- {{cssxref(":host", ":host()")}}
+- {{cssxref(":host_function", ":host()")}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

Fix broken link to the `:host()` page.

#### Motivation

NA

#### Supporting details

NA

#### Related issues

NA

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
