### PR TITLE
add link to updated HTTP spec for 422 response code

### DIFF
--- a/files/en-us/web/http/status/422/index.md
+++ b/files/en-us/web/http/status/422/index.md
@@ -8,9 +8,7 @@ tags:
   - Reference
   - Status code
   - WebDAV
-spec-urls: 
-  - https://www.rfc-editor.org/rfc/rfc9110#name-422-unprocessable-content
-  - https://www.rfc-editor.org/rfc/rfc4918#section-11.2
+spec-urls: https://httpwg.org/specs/rfc9110.html#status.422
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/status/422/index.md
+++ b/files/en-us/web/http/status/422/index.md
@@ -8,7 +8,9 @@ tags:
   - Reference
   - Status code
   - WebDAV
-spec-urls: https://www.rfc-editor.org/rfc/rfc4918#section-11.2
+spec-urls: 
+  - https://www.rfc-editor.org/rfc/rfc9110#name-422-unprocessable-content
+  - https://www.rfc-editor.org/rfc/rfc4918#section-11.2
 ---
 {{HTTPSidebar}}
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
The new HTTP spec (RFC 9110) defines the 422 Unprocessable Entity response code.

#### Motivation
The status code page currently states that this code is WebDAV only.

#### Supporting details
- https://www.rfc-editor.org/rfc/rfc9110#name-422-unprocessable-content

#### Related issues
N/A

#### Metadata
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
