### PR TITLE
serviceWorkers and indexedDB delete by hostname

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removaloptions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removaloptions/index.md
@@ -30,7 +30,7 @@ Values of this type are objects. They contain the following properties:
 
 - `hostnames` {{optional_inline}}
 
-  - : `Array` of `string`. This property applies to cookies, indexedDB, local storage, and service worker items. Remove only cookies, indexedDB, local storage, and service worker items associated with these hostnames.
+  - : `Array` of `string`. This property applies to cookie, indexedDB, local storage, and service worker registration items. Remove only cookie, indexedDB, local storage, and service worker registration items associated with these hostnames.
 
     You must pass in just a hostname here, without protocol (for example, "google.com" not "https\://google.com"). You can use the [`URL`](/en-US/docs/Web/API/URL) interface to parse a raw URL and retrieve the hostname. Items associated with subdomains of a given hostname are _not_ removed: you must explicitly list subdomains.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removaloptions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removaloptions/index.md
@@ -30,9 +30,9 @@ Values of this type are objects. They contain the following properties:
 
 - `hostnames` {{optional_inline}}
 
-  - : `Array` of `string`. This property only applies to cookies and local storage items. Only remove cookies and local storage items which are associated with these hostnames.
+  - : `Array` of `string`. This property applies to cookies, indexedDB, local storage, and service worker items. Remove only cookies, indexedDB, local storage, and service worker items associated with these hostnames.
 
-    You must pass in just a hostname here, without protocol (for example: "google.com" not https\://google.com"). You can use the [`URL`](/en-US/docs/Web/API/URL) interface to parse a raw URL and retrieve just the hostname. Items associated with subdomains of a given hostname will _not_ be removed: you must explicitly list subdomains.
+    You must pass in just a hostname here, without protocol (for example, "google.com" not "https\://google.com"). You can use the [`URL`](/en-US/docs/Web/API/URL) interface to parse a raw URL and retrieve the hostname. Items associated with subdomains of a given hostname are _not_ removed: you must explicitly list subdomains.
 
 - `originTypes` {{optional_inline}}
 


### PR DESCRIPTION
#### Summary
Adds details about the deletion of serviceWorkers and indexedDB by hostname in browsingData. Provides the content for:

- [Bug 1632990](https://bugzilla.mozilla.org/show_bug.cgi?id=1632990) Allow WebExtensions to clear ServiceWorkers by hostname
- [Bug 1551301](https://bugzilla.mozilla.org/show_bug.cgi?id=1551301) Allow WebExtensions to clear IndexedDB by hostname

(Release note changes were previously made in https://github.com/mdn/content/blob/94e04537fb2f29fc347865e84a0a12100f251b1c/files/en-us/mozilla/firefox/releases/77/index.md?plain=1#L61).

Related BCD changes provided in https://github.com/mdn/browser-compat-data/pull/16838

#### Metadata

This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error