### PR TITLE
Drop outdated info from “Introduction to the server side” doc

### DIFF
--- a/files/en-us/learn/server-side/first_steps/introduction/index.md
+++ b/files/en-us/learn/server-side/first_steps/introduction/index.md
@@ -146,10 +146,7 @@ A deeper analysis of user habits can be used to anticipate their interests and f
 
 Server-side programming allows sites to restrict access to authorized users and serve only the information that a user is permitted to see.
 
-Real world examples include:
-
-- Social networks like Facebook allow users to fully control their own data but only allow their friends to view or comment on it. The user determines who can see their data, and by extension, whose data appears in their feed —  authorization is a central part of the user experience!
-- The site you are on right now controls access to content: articles are visible to everyone, but only users who have logged in can edit them. To try this, click on the **Edit** button at the top of this page — if you are logged in you will be shown the edit view; if you are not logged in you will be taken to the sign-up page.
+Real-world examples include social-networking sites which allow users to determine who can see the content they post to the site, and whose content appears in their feed.
 
 > **Note:** Consider other real examples where access to content is controlled. For example, what can you see if you go to the online site for your bank? Log in to your account — what additional information can you see and modify? What information can you see that only the bank can change?
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/17867

Also, try to salvage some better text from the other existing real-world example of “Controlled access to content” — which, among other problems, mentions Facebook as a site that “allow users to fully control their own data” (not a great choice of wording — even though it apparently means “content” rather “data”).