### PR TITLE
Expand 'textual types' and 'numeric types' in <input> attribute table

### DIFF
--- a/files/en-us/web/html/element/input/index.md
+++ b/files/en-us/web/html/element/input/index.md
@@ -326,39 +326,39 @@ This section provides a table listing all the attributes with a brief descriptio
 
 Attributes for the `<input`> element include the [global HTML attributes](/en-US/docs/Web/HTML/Global_attributes) and additionally:
 
-| Attribute                           | Type or Types                    | Description                                                                           |
-| ----------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------- |
-| [`accept`](#accept)                 | `file`                           | Hint for expected file type in file upload controls                                   |
-| [`alt`](#alt)                       | `image`                          | alt attribute for the image type. Required for accessibility                          |
-| [`autocomplete`](#autocomplete)     | almost all                       | Hint for form autofill feature                                                        |
-| [`capture`](#capture)               | `file`                           | Media capture input method in file upload controls                                    |
-| [`checked`](#checked)               | `checkbox`, `radio`              | Whether the command or control is checked                                             |
-| [`dirname`](#dirname)               | `search`, `text`                 | Name of form field to use for sending the element's directionality in form submission |
-| [`disabled`](#disabled)             | all                              | Whether the form control is disabled                                                  |
-| [`form`](#form)                     | all                              | Associates the control with a form element                                            |
-| [`formaction`](#formaction)         | `image`, `submit`                | URL to use for form submission                                                        |
-| [`formenctype`](#formenctype)       | `image`, `submit`                | Form data set encoding type to use for form submission                                |
-| [`formmethod`](#formmethod)         | `image`, `submit`                | HTTP method to use for form submission                                                |
-| [`formnovalidate`](#formnovalidate) | `image`, `submit`                | Bypass form control validation for form submission                                    |
-| [`formtarget`](#formtarget)         | `image`, `submit`                | Browsing context for form submission                                                  |
-| [`height`](#height)                 | `image`                          | Same as height attribute for {{htmlelement('img')}}; vertical dimension               |
-| [`list`](#list)                     | almost all                       | Value of the id attribute of the {{htmlelement('datalist')}} of autocomplete options  |
-| [`max`](#max)                       | numeric types                    | Maximum value                                                                         |
-| [`maxlength`](#maxlength)           | textual types                    | Maximum length (number of characters) of `value`                                      |
-| [`min`](#min)                       | numeric types                    | Minimum value                                                                         |
-| [`minlength`](#minlength)           | textual types                    | Minimum length (number of characters) of `value`                                      |
-| [`multiple`](#multiple)             | `email`, `file`                  | Boolean. Whether to allow multiple values                                             |
-| [`name`](#name)                     | all                              | Name of the form control. Submitted with the form as part of a name/value pair        |
-| [`pattern`](#pattern)               | textual types                    | Pattern the `value` must match to be valid                                            |
-| [`placeholder`](#placeholder)       | textual types and `number`       | Text that appears in the form control when it has no value set                        |
-| [`readonly`](#readonly)             | almost all                       | Boolean. The value is not editable                                                    |
-| [`required`](#required)             | almost all                       | Boolean. A value is required or must be check for the form to be submittable          |
-| [`size`](#size)                     | textual types                    | Size of the control                                                                   |
-| [`src`](#src)                       | `image`                          | Same as `src` attribute for {{htmlelement('img')}}; address of image resource         |
-| [`step`](#step)                     | numeric types                    | Incremental values that are valid                                                     |
-| [`type`](#type)                     | all                              | Type of form control                                                                  |
-| [`value`](#value)                   | all                              | The initial value of the control                                                      |
-| [`width`](#width)                   | `image`                          | Same as `width` attribute for {{htmlelement('img')}}
+| Attribute                           | Type or Types                                                           | Description                                                                           |
+| ----------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| [`accept`](#accept)                 | `file`                                                                  | Hint for expected file type in file upload controls                                   |
+| [`alt`](#alt)                       | `image`                                                                 | alt attribute for the image type. Required for accessibility                          |
+| [`autocomplete`](#autocomplete)     | all except `checkbox`, `radio`, and buttons                             | Hint for form autofill feature                                                        |
+| [`capture`](#capture)               | `file`                                                                  | Media capture input method in file upload controls                                    |
+| [`checked`](#checked)               | `checkbox`, `radio`                                                     | Whether the command or control is checked                                             |
+| [`dirname`](#dirname)               | `search`, `text`                                                        | Name of form field to use for sending the element's directionality in form submission |
+| [`disabled`](#disabled)             | all                                                                     | Whether the form control is disabled                                                  |
+| [`form`](#form)                     | all                                                                     | Associates the control with a form element                                            |
+| [`formaction`](#formaction)         | `image`, `submit`                                                       | URL to use for form submission                                                        |
+| [`formenctype`](#formenctype)       | `image`, `submit`                                                       | Form data set encoding type to use for form submission                                |
+| [`formmethod`](#formmethod)         | `image`, `submit`                                                       | HTTP method to use for form submission                                                |
+| [`formnovalidate`](#formnovalidate) | `image`, `submit`                                                       | Bypass form control validation for form submission                                    |
+| [`formtarget`](#formtarget)         | `image`, `submit`                                                       | Browsing context for form submission                                                  |
+| [`height`](#height)                 | `image`                                                                 | Same as height attribute for {{htmlelement('img')}}; vertical dimension               |
+| [`list`](#list)                     | all except `hidden`, `password`, `checkbox`, `radio`, and buttons       | Value of the id attribute of the {{htmlelement('datalist')}} of autocomplete options  |
+| [`max`](#max)                       | `date`, `month`, `week`, `time`, `datetime-local`, `range`              | Maximum value                                                                         |
+| [`maxlength`](#maxlength)           | `text`, `search`, `url`, `tel`, `email`, `password`                     | Maximum length (number of characters) of `value`                                      |
+| [`min`](#min)                       | `date`, `month`, `week`, `time`, `datetime-local`, `range`              | Minimum value                                                                         |
+| [`minlength`](#minlength)           | `text`, `search`, `url`, `tel`, `email`, `password`                     | Minimum length (number of characters) of `value`                                      |
+| [`multiple`](#multiple)             | `email`, `file`                                                         | Boolean. Whether to allow multiple values                                             |
+| [`name`](#name)                     | all                                                                     | Name of the form control. Submitted with the form as part of a name/value pair        |
+| [`pattern`](#pattern)               | `text`, `search`, `url`, `tel`, `email`, `password`                     | Pattern the `value` must match to be valid                                            |
+| [`placeholder`](#placeholder)       | `text`, `search`, `url`, `tel`, `email`, `password`, `number`           | Text that appears in the form control when it has no value set                        |
+| [`readonly`](#readonly)             | all except `hidden`, `range`, `color`, `checkbox`, `radio`, and buttons | Boolean. The value is not editable                                                    |
+| [`required`](#required)             | all except `hidden`, `range`, `color`, and buttons                      | Boolean. A value is required or must be check for the form to be submittable          |
+| [`size`](#size)                     | `text`, `search`, `url`, `tel`, `email`, `password`                     | Size of the control                                                                   |
+| [`src`](#src)                       | `image`                                                                 | Same as `src` attribute for {{htmlelement('img')}}; address of image resource         |
+| [`step`](#step)                     | `date`, `month`, `week`, `time`, `datetime-local`, `range`              | Incremental values that are valid                                                     |
+| [`type`](#type)                     | all                                                                     | Type of form control                                                                  |
+| [`value`](#value)                   | all                                                                     | The initial value of the control                                                      |
+| [`width`](#width)                   | `image`                                                                 | Same as `width` attribute for {{htmlelement('img')}}                                  |
 
 A few additional non-standard attributes are listed following the descriptions of the standard attributes.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Follow up of #17346

#### Motivation
https://github.com/mdn/content/pull/17346#pullrequestreview-1020902633

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
