### PR TITLE
Fix width measurement

### DIFF
--- a/files/en-us/web/api/textmetrics/index.md
+++ b/files/en-us/web/api/textmetrics/index.md
@@ -103,8 +103,7 @@ const textMetrics = ctx.measureText(text);
 console.log(textMetrics.width);
 // 459.8833312988281
 
-console.log(Math.abs(textMetrics.actualBoundingBoxLeft) +
-            Math.abs(textMetrics.actualBoundingBoxRight));
+console.log(textMetrics.actualBoundingBoxRight + textMetrics.actualBoundingBoxLeft);
 // 462.8833333333333
 ```
 


### PR DESCRIPTION
> positive numbers indicating a distance going left from the given alignment point

Therefore, we should directly add `textMetrics.actualBoundingBoxRight` and `textMetrics.actualBoundingBoxLeft`. When the text is partly out of the left boundary, textMetrics.actualBoundingBoxLeft is positive. When the text doesn't touch the left boundary, the value is negative. 

When the text doesn't touch the left boundary, the original algorithm will report wrong answer. (Although I don't know if there will be a situation like this, but I think making it always right is better.)

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Fix width measurement
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The original one might report wrong answer. 
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Fixes #9834

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
