### PR TITLE
Fix links to the `is` attribute

### DIFF
--- a/files/en-us/web/web_components/index.md
+++ b/files/en-us/web/web_components/index.md
@@ -70,7 +70,7 @@ The basic approach for implementing a web component generally looks something li
 
   - : The following extensions are defined:
 
-    - The {{htmlattrxref("is")}} global HTML attribute: Allows you to specify that a standard HTML element should behave like a registered custom built-in element.
+    - The [`is`](/en-US/docs/Web/HTML/Global_attributes/is) global HTML attribute: Allows you to specify that a standard HTML element should behave like a registered custom built-in element.
     - The "is" option of the {{domxref("Document.createElement()")}} method: Allows you to create an instance of a standard HTML element that behaves like a given registered custom built-in element.
 
 - CSS pseudo-classes

--- a/files/en-us/web/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/web_components/using_custom_elements/index.md
@@ -54,7 +54,7 @@ You'll learn more about these in the [Using the lifecycle callbacks](#using_the_
 There are two types of custom elements:
 
 - **Autonomous custom elements** are standalone — they don't inherit from standard HTML elements. You use these on a page by literally writing them out as an HTML element. For example `<popup-info>`, or `document.createElement("popup-info")`.
-- **Customized built-in elements** inherit from basic HTML elements. To create one of these, you have to specify which element they extend (as implied in the examples above), and they are used by writing out the basic element but specifying the name of the custom element in the {{htmlattrxref("is")}} attribute (or property). For example `<p is="word-count">`, or `document.createElement("p", { is: "word-count" })`.
+- **Customized built-in elements** inherit from basic HTML elements. To create one of these, you have to specify which element they extend (as implied in the examples above), and they are used by writing out the basic element but specifying the name of the custom element in the [`is`](/en-US/docs/Web/HTML/Global_attributes/is) attribute (or property). For example `<p is="word-count">`, or `document.createElement("p", { is: "word-count" })`.
 
 ## Working through some simple examples
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary/Motivation
<!-- ✍️ In a sentence or two, describe your changes -->
Replaces `htmlattrxref` macros with the `is` attribute by links to the correct page (the macro points to `/Global_attributes#attr-is`, but the correct link is `/Global_attributes/is`)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #17890

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
