### PR TITLE
Fix markdownlint errors and rephrase content

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/deployment/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/deployment/index.md
@@ -261,7 +261,9 @@ There are a lot of ways to work with git. One easy workflow is to first set up a
     - Choose your preferred license in the _Add license_ selection list.
     - Check **Initialize this repository with a README**.
 
-> **Warning:** The default “Public” will make *all* the code you submit public—including your database username and password! Either select “Private” or, if you’re hoping to show off your library project, configure the database so that it *only* reads from the environment variables, and does not have the database URI hard-coded in the app.
+    > **Warning:** The default “Public” access will make *all* the source code — including your database username and password —  visible to anyone on the internet! Make sure the source code reads all the credentials *only* from environment variables, and does not have any credentials hard-coded.
+    >
+    > Otherwise, select the “Private” option to allow only selected people to see the source code.
 
 4. Press **Create repository**.
 5. Click the green "**Clone or download**" button on your new repo page.

--- a/files/en-us/learn/server-side/express_nodejs/deployment/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/deployment/index.md
@@ -261,9 +261,9 @@ There are a lot of ways to work with git. One easy workflow is to first set up a
     - Choose your preferred license in the _Add license_ selection list.
     - Check **Initialize this repository with a README**.
 
-    > **Warning:** The default “Public” access will make *all* the source code — including your database username and password —  visible to anyone on the internet! Make sure the source code reads all the credentials *only* from environment variables, and does not have any credentials hard-coded.
+    > **Warning:** The default "Public" access will make _all_ source code — including your database username and password — visible to anyone on the internet! Make sure the source code reads credentials _only_ from environment variables and does not have any credentials hard-coded.
     >
-    > Otherwise, select the “Private” option to allow only selected people to see the source code.
+    > Otherwise, select the "Private" option to allow only selected people to see the source code.
 
 4. Press **Create repository**.
 5. Click the green "**Clone or download**" button on your new repo page.


### PR DESCRIPTION
Markdown linter was complaining about the indentation.

Also, I think intention of the PR "[encourage the reader to consider a private repo](https://github.com/mdn/content/pull/17513/files)" was to warn the developers about the pitfall. Not to encourage them to start having private repos just to protect credentials.
We should be promoting public repos to keep opensource alive. The private option needs to be used only when the entire work needs to be kept private.
