### PR TITLE
provide link to MDN documentation for Number.prototype.toString()

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/tostring/index.md
@@ -54,7 +54,7 @@ This method is inherited by every object descended from `Object`, but can be ove
 
 ## Parameters
 
-By default `toString()` takes no parameters. However, objects that inherit from `Object` may override it with their own implementation that do take parameters. For example, the `toString()` methods implemented by {{jsxref("Number")}} and {{jsxref("BigInt")}} take an optional `radix` parameter, as can been seen [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString). 
+By default `toString()` takes no parameters. However, objects that inherit from `Object` may override it with their own implementation that do take parameters. For example, the [`Number.prototype.toString()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString) and [`BigInt.prototype.toString()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/toString) methods take an optional `radix` parameter. 
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/object/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/tostring/index.md
@@ -54,7 +54,7 @@ This method is inherited by every object descended from `Object`, but can be ove
 
 ## Parameters
 
-By default `toString()` takes no parameters. However, objects that inherit from `Object` may override it with their own implementation that do take parameters. For example, the [`Number.prototype.toString()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString) and [`BigInt.prototype.toString()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/toString) methods take an optional `radix` parameter. 
+By default `toString()` takes no parameters. However, objects that inherit from `Object` may override it with their own implementation that do take parameters. For example, the [`Number.prototype.toString()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString) and [`BigInt.prototype.toString()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/toString) methods take an optional `radix` parameter.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/object/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/tostring/index.md
@@ -54,7 +54,7 @@ This method is inherited by every object descended from `Object`, but can be ove
 
 ## Parameters
 
-By default `toString()` takes no parameters. However, objects that inherit from `Object` may override it with their own implementation that do take parameters. For example, the `toString()` methods implemented by {{jsxref("Number")}} and {{jsxref("BigInt")}} take an optional `radix` parameter.
+By default `toString()` takes no parameters. However, objects that inherit from `Object` may override it with their own implementation that do take parameters. For example, the `toString()` methods implemented by {{jsxref("Number")}} and {{jsxref("BigInt")}} take an optional `radix` parameter, as can been seen [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/toString). 
 
 ## Examples
 


### PR DESCRIPTION
Providing a link to the MDN documentation for Number.prototype.toString() in the Parameter section will make it easy for those looking for it, instead of manually having to navigate through the page for Number primitive wrapper object in search of it.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

Provide a link to the MDN documentation for Number.prototype.toString() in the Parameter section of Object.prototype.toString()

#### Motivation
I was looking for documentation for using toString(2) and expected it to be in the parameter section of this article but I couldn't find it and had to google it.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
