### PR TITLE
Fix invalid anchor when rendering as HTML

### DIFF
--- a/files/en-us/web/http/status/index.md
+++ b/files/en-us/web/http/status/index.md
@@ -23,7 +23,7 @@ Responses are grouped in five classes:
 
 The below status codes are defined by [section 10 of RFC 2616](https://datatracker.ietf.org/doc/html/rfc2616#section-10). You can find an updated specification in [RFC 7231](https://datatracker.ietf.org/doc/html/rfc7231#section-6).
 
-> **Note:** If you receive a response that is not in [this list](#information-responses), it is a non-standard response, possibly custom to the server's software.
+> **Note:** If you receive a response that is not in [this list](#information_responses), it is a non-standard response, possibly custom to the server's software.
 
 ## Information responses
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

The anchor link on "this list" does not direct the user to the "Information responses" as expected.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

To avoid confusion from the broken link while browsing.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

The current link does not scroll to the intended anchor as can be tested below:
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#information-responses (does not scroll to the anchor)
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#information_responses (scroll to the correct anchor)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Fixes #17919

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
