### PR TITLE
Remove all polyfills in JS docs

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/fill/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/fill/index.md
@@ -50,52 +50,6 @@ The modified array, filled with `value`.
 > To use `Array.prototype.fill()` when declaring an array, make sure to assign slots to the array.
 > [See example](#using_fill_to_populate_an_empty_array).
 
-## Polyfill
-
-```js
-if (!Array.prototype.fill) {
-  Object.defineProperty(Array.prototype, 'fill', {
-    value: function(value) {
-
-      // Steps 1-2.
-      if (this == null) {
-        throw new TypeError('this is null or not defined');
-      }
-
-      let O = Object(this);
-
-      // Steps 3-5.
-      const len = O.length >>> 0;
-
-      // Steps 6-7.
-      const start = arguments[1];
-      const relativeStart = start >> 0;
-
-      // Step 8.
-      let k = relativeStart < 0 ? Math.max(len + relativeStart, 0) : Math.min(relativeStart, len);
-
-      // Steps 9-10.
-      const end = arguments[2];
-      const relativeEnd = end === undefined ? len : end >> 0;
-
-      // Step 11.
-      const finalValue = relativeEnd < 0 ? Math.max(len + relativeEnd, 0) : Math.min(relativeEnd, len);
-
-      // Step 12.
-      while (k < finalValue) {
-        O[k] = value;
-        k++;
-      }
-
-      // Step 13.
-      return O;
-    }
-  });
-}
-```
-
-If you need to support truly obsolete JavaScript engines that don't support {{jsxref("Object.defineProperty")}}, it's best not to polyfill `Array.prototype` methods at all, as you can't make them non-enumerable.
-
 ## Examples
 
 ### Using fill

--- a/files/en-us/web/javascript/reference/global_objects/math/acosh/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/acosh/index.md
@@ -81,37 +81,6 @@ Math.acosh(2);   // 1.3169578969248166
 
 For values less than 1 `Math.acosh()` returns {{jsxref("NaN")}}.
 
-## Polyfill
-
-For all <math><semantics><mrow><mi>x</mi>
-<mo>≥</mo>
-<mn>1</mn>
-</mrow><annotation encoding="TeX">x \geq 1</annotation>
-</semantics></math>, we have <math>
-<semantics><mrow><mo lspace="0em" rspace="thinmathspace">arcosh</mo>
-<mo stretchy="false">(</mo>
-<mi>x</mi>
-<mo stretchy="false">)</mo>
-<mo>=</mo>
-<mo lspace="0em" rspace="0em">ln</mo>
-<mrow><mo>(</mo>
-<mrow><mi>x</mi>
-<mo>+</mo>
-<msqrt><mrow><msup><mi>x</mi>
-<mn>2</mn>
-</msup><mo>-</mo>
-<mn>1</mn>
-</mrow></msqrt></mrow><mo>)</mo>
-</mrow></mrow><annotation encoding="TeX">\operatorname {arcosh} (x) = \ln \left(x + \sqrt{x^{2} -
-1} \right)</annotation>
-</semantics></math> and so this can be emulated with the following function:
-
-```js
-Math.acosh = Math.acosh || function(x) {
-  return Math.log(x + Math.sqrt(x * x - 1));
-};
-```
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/global_objects/math/asinh/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/asinh/index.md
@@ -68,29 +68,6 @@ Math.asinh(1);  // 0.881373587019543
 Math.asinh(0);  // 0
 ```
 
-## Polyfill
-
-`Math.asinh` can be emulated with the following function:
-
-```js
-if (!Math.asinh) Math.asinh = function(x) {
-    var absX = Math.abs(x), w
-    if (absX < 3.725290298461914e-9) // |x| < 2^-28
-        return x
-    if (absX > 268435456) // |x| > 2^28
-        w = Math.log(absX) + Math.LN2
-    else if (absX > 2) // 2^28 >= |x| > 2
-        w = Math.log(2 * absX + 1 / (Math.sqrt(x * x + 1) + absX))
-    else
-        var t = x * x, w = Math.log1p(absX + t / (1 + Math.sqrt(1 + t)))
-
-    return x > 0 ? w : -w
-}
-```
-
-`Math.log1p` may also have to be polyfilled; see [Math.log1p](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/log1p)
-for details.
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/global_objects/math/atanh/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/atanh/index.md
@@ -84,40 +84,6 @@ Math.atanh(2);   // NaN
 
 For values greater than 1 or less than -1, {{jsxref("NaN")}} is returned.
 
-## Polyfill
-
-For <math><semantics><mrow><mrow><mo>|</mo>
-<mi>x</mi>
-<mo>|</mo>
-</mrow><mo>&#x3C;</mo>
-<mn>1</mn>
-</mrow><annotation encoding="TeX">\left|x\right| &#x3C; 1</annotation>
-</semantics></math>, we have <math><semantics><mrow><mo lspace="0em" rspace="thinmathspace">artanh</mo>
-<mo stretchy="false">(</mo>
-<mi>x</mi>
-<mo stretchy="false">)</mo>
-<mo>=</mo>
-<mfrac><mn>1</mn>
-<mn>2</mn>
-</mfrac><mo lspace="0em" rspace="0em">ln</mo>
-<mrow><mo>(</mo>
-<mfrac><mrow><mn>1</mn>
-<mo>+</mo>
-<mi>x</mi>
-</mrow><mrow><mn>1</mn>
-<mo>-</mo>
-<mi>x</mi>
-</mrow></mfrac><mo>)</mo>
-</mrow></mrow><annotation encoding="TeX">\operatorname {artanh} (x) = \frac{1}{2}\ln \left(
-\frac{1 + x}{1 - x} \right)</annotation>
-</semantics></math> so this can be emulated by the following function:
-
-```js
-Math.atanh = Math.atanh || function(x) {
-  return Math.log((1+x)/(1-x)) / 2;
-};
-```
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/global_objects/math/cbrt/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/cbrt/index.md
@@ -63,33 +63,6 @@ Because `cbrt()` is a static method of `Math`, you always use it
 as `Math.cbrt()`, rather than as a method of a `Math` object you
 created (`Math` is not a constructor).
 
-## Polyfill
-
-For all <math><semantics><mrow><mi>x</mi>
-<mo>≥</mo>
-<mn>0</mn>
-</mrow><annotation encoding="TeX">x \geq 0</annotation>
-</semantics></math>, have <math><semantics><mrow><mroot><mi>x</mi>
-<mn>3</mn>
-</mroot><mo>=</mo>
-<msup><mi>x</mi>
-<mrow><mn>1</mn>
-<mo>/</mo>
-<mn>3</mn>
-</mrow></msup></mrow><annotation encoding="TeX">\sqrt[3]{x} = x^{1/3}</annotation>
-</semantics></math> so this can be emulated by the following function:
-
-```js
-if (!Math.cbrt) {
-  Math.cbrt = (function(pow) {
-    return function cbrt(x){
-      // ensure negative numbers remain negative:
-      return x < 0 ? -pow(-x, 1/3) : pow(x, 1/3);
-    };
-  })(Math.pow); // localize Math.pow to increase efficiency
-}
-```
-
 ## Examples
 
 ### Using Math.cbrt()

--- a/files/en-us/web/javascript/reference/global_objects/math/clz32/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/clz32/index.md
@@ -170,26 +170,6 @@ Math.clz32(true);        // 31
 Math.clz32(3.5);         // 30
 ```
 
-## Polyfill
-
-The following polyfill is the most efficient.
-
-```js
-if (!Math.clz32) Math.clz32 = (function(log, LN2){
-  return function(x) {
-    // Let n be ToUint32(x).
-    // Let p be the number of leading zero bits in
-    // the 32-bit binary representation of n.
-    // Return p.
-    var asUint = x >>> 0;
-    if (asUint === 0) {
-      return 32;
-    }
-    return 31 - (log(asUint) / LN2 | 0) |0; // the "| 0" acts like math.floor
-  };
-})(Math.log, Math.LN2);
-```
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/global_objects/math/cosh/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/cosh/index.md
@@ -59,25 +59,6 @@ Math.cosh(1);  // 1.5430806348152437
 Math.cosh(-1); // 1.5430806348152437
 ```
 
-## Polyfill
-
-This can be emulated with the help of the {{jsxref("Math.exp()")}} function:
-
-```js
-Math.cosh = Math.cosh || function(x) {
-  return (Math.exp(x) + Math.exp(-x)) / 2;
-}
-```
-
-or using only one call to the {{jsxref("Math.exp()")}} function:
-
-```js
-Math.cosh = Math.cosh || function(x) {
-  var y = Math.exp(x);
-  return (y + 1 / y) / 2;
-};
-```
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/global_objects/math/hypot/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/hypot/index.md
@@ -121,44 +121,6 @@ Math.hypot(3, 4, '5');     // 7.0710678118654755, +'5' => 5
 Math.hypot(-3);            // 3, the same as Math.abs(-3)
 ```
 
-## Polyfill
-
-A naive approach that does not handle overflow/underflow issues:
-
-```js
-if (!Math.hypot) Math.hypot = function() {
-  var y = 0, i = arguments.length, containsInfinity = false;
-  while (i--) {
-    var arg = arguments[i];
-    if (arg === Infinity || arg === -Infinity)
-      containsInfinity = true
-    y += arg * arg
-  }
-  return containsInfinity ? Infinity : Math.sqrt(y)
-}
-```
-
-A polyfill that avoids underflows and overflows:
-
-```js
-if (!Math.hypot) Math.hypot = function () {
-  var max = 0;
-  var s = 0;
-  var containsInfinity = false;
-  for (var i = 0; i < arguments.length; ++i) {
-    var arg = Math.abs(Number(arguments[i]));
-    if (arg === Infinity)
-      containsInfinity = true
-    if (arg > max) {
-      s *= (max / arg) * (max / arg);
-      max = arg;
-    }
-    s += arg === 0 && max === 0 ? 0 : (arg / max) * (arg / max);
-  }
-  return containsInfinity ? Infinity : (max === 1 / 0 ? 1 / 0 : max * Math.sqrt(s));
-};
-```
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/global_objects/math/imul/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/imul/index.md
@@ -64,42 +64,6 @@ Math.imul(0xffffffff, 5); // -5
 Math.imul(0xfffffffe, 5); // -10
 ```
 
-## Polyfill
-
-This can be emulated with the following function:
-
-```js
-if (!Math.imul) Math.imul = function(a, b) {
-  var aHi = (a >>> 16) & 0xffff;
-  var aLo = a & 0xffff;
-  var bHi = (b >>> 16) & 0xffff;
-  var bLo = b & 0xffff;
-  // the shift by 0 fixes the sign on the high part
-  // the final |0 converts the unsigned value into a signed value
-  return ((aLo * bLo) + (((aHi * bLo + aLo * bHi) << 16) >>> 0) | 0);
-};
-```
-
-However, the following function is more performant because it is likely that browsers
-in which this polyfill would be used do not optimize with an internal integer type in
-JavaScript, instead using floating points for all numbers.
-
-```js
-if (!Math.imul) Math.imul = function(opA, opB) {
-  opB |= 0; // ensure that opB is an integer. opA will automatically be coerced.
-  // floating points give us 53 bits of precision to work with plus 1 sign bit
-  // automatically handled for our convenience:
-  // 1. 0x003fffff /*opA & 0x000fffff*/ * 0x7fffffff /*opB*/ = 0x1fffff7fc00001
-  //    0x1fffff7fc00001 < Number.MAX_SAFE_INTEGER /*0x1fffffffffffff*/
-  var result = (opA & 0x003fffff) * opB;
-  // 2. We can remove an integer coercion from the statement above because:
-  //    0x1fffff7fc00001 + 0xffc00000 = 0x1fffffff800001
-  //    0x1fffffff800001 < Number.MAX_SAFE_INTEGER /*0x1fffffffffffff*/
-  if (opA & 0xffc00000 /*!== 0*/) result += (opA & 0xffc00000) * opB |0;
-  return result |0;
-};
-```
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/global_objects/math/log10/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/log10/index.md
@@ -83,16 +83,6 @@ Math.log10(-2);     // NaN
 Math.log10(100000); // 5
 ```
 
-## Polyfill
-
-This can be emulated with the following function:
-
-```js
-Math.log10 = Math.log10 || function(x) {
-  return Math.log(x) * Math.LOG10E;
-};
-```
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/global_objects/math/log2/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/log2/index.md
@@ -71,18 +71,6 @@ created (`Math` is not a constructor).
 This function is the equivalent of Math.log(x) / Math.log(2). For log2(e) use the
 constant {{jsxref("Math.LOG2E")}} which is 1 / {{jsxref("Math.LN2")}}.
 
-## Polyfill
-
-This Polyfill emulates the `Math.log2` function. Note that it returns
-imprecise values on some inputs (like 1 << 29), wrap into
-{{jsxref("Math.round()")}} if working with bit masks.
-
-```js
-if (!Math.log2) Math.log2 = function(x) {
-  return Math.log(x) * Math.LOG2E;
-};
-```
-
 ## Examples
 
 ### Using Math.log2()

--- a/files/en-us/web/javascript/reference/global_objects/math/sinh/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/sinh/index.md
@@ -50,25 +50,6 @@ Because `sinh()` is a static method of `Math`, you always use it
 as `Math.sinh()`, rather than as a method of a `Math` object you
 created (`Math` is not a constructor).
 
-## Polyfill
-
-This can be emulated with the help of the {{jsxref("Math.exp()")}} function:
-
-```js
-Math.sinh = Math.sinh || function(x) {
-  return (Math.exp(x) - Math.exp(-x)) / 2;
-}
-```
-
-or using only one call to the {{jsxref("Math.exp()")}} function:
-
-```js
-Math.sinh = Math.sinh || function(x) {
-  var y = Math.exp(x);
-  return (y - 1 / y) / 2;
-}
-```
-
 ## Examples
 
 ### Using Math.sinh()

--- a/files/en-us/web/javascript/reference/global_objects/math/tanh/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/tanh/index.md
@@ -72,17 +72,6 @@ Because `tanh()` is a static method of `Math`, you always use it
 as `Math.tanh()`, rather than as a method of a `Math` object you
 created (`Math` is not a constructor).
 
-## Polyfill
-
-This can be emulated with the help of the {{jsxref("Math.exp()")}} function:
-
-```js
-Math.tanh = Math.tanh || function(x){
-    var a = Math.exp(+x), b = Math.exp(-x);
-    return a == Infinity ? 1 : b == Infinity ? -1 : (a - b) / (a + b);
-}
-```
-
 ## Examples
 
 ### Using Math.tanh()

--- a/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/epsilon/index.md
@@ -32,14 +32,6 @@ z = 0.1;
 equal = (Math.abs(x - y + z) < Number.EPSILON);
 ```
 
-## Polyfill
-
-```js
-if (Number.EPSILON === undefined) {
-    Number.EPSILON = Math.pow(2, -52);
-}
-```
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/global_objects/number/isfinite/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/isfinite/index.md
@@ -57,14 +57,6 @@ Number.isFinite(null);      // false, would've been true with
                             // global isFinite(null)
 ```
 
-## Polyfill
-
-```js
-if (Number.isFinite === undefined) Number.isFinite = function(value) {
-    return typeof value === 'number' && isFinite(value);
-}
-```
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/global_objects/number/isnan/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/isnan/index.md
@@ -74,17 +74,6 @@ Number.isNaN('');
 Number.isNaN(' ');
 ```
 
-## Polyfill
-
-The following works because NaN is the only value in JavaScript which is not equal to
-itself.
-
-```js
-Number.isNaN = Number.isNaN || function isNaN(input) {
-    return typeof input === 'number' && input !== input;
-}
-```
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/global_objects/number/issafeinteger/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/issafeinteger/index.md
@@ -54,14 +54,6 @@ Number.isSafeInteger(testValue)
 The boolean value `true` if the given value is a number that is a
 safe integer. Otherwise `false`.
 
-## Polyfill
-
-```js
-Number.isSafeInteger = Number.isSafeInteger || function (value) {
-   return Number.isInteger(value) && Math.abs(value) <= Number.MAX_SAFE_INTEGER;
-};
-```
-
 ## Examples
 
 ### Using isSafeInteger

--- a/files/en-us/web/javascript/reference/global_objects/number/max_safe_integer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/max_safe_integer/index.md
@@ -27,14 +27,6 @@ This field does not exist in old browsers. Using it without checking its existen
 
 Because `MAX_SAFE_INTEGER` is a static property of {{jsxref("Number")}}, you always use it as `Number.MAX_SAFE_INTEGER`, rather than as a property of a {{jsxref("Number")}} object you created.
 
-## Polyfill
-
-```js
-if (!Number.MAX_SAFE_INTEGER) {
-    Number.MAX_SAFE_INTEGER = 9007199254740991; // Math.pow(2, 53) - 1;
-}
-```
-
 ## Examples
 
 ### Return value of MAX_SAFE_INTEGER

--- a/files/en-us/web/javascript/reference/global_objects/object/defineproperties/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/defineproperties/index.md
@@ -96,76 +96,6 @@ Object.defineProperties(obj, {
 });
 ```
 
-## Polyfill
-
-Assuming a pristine execution environment with all names and properties referring to
-their initial values, `Object.defineProperties` is almost completely
-equivalent (note the comment in `isCallable`) to the following
-reimplementation in JavaScript:
-
-```js
-function defineProperties(obj, properties) {
-  function convertToDescriptor(desc) {
-    function hasProperty(obj, prop) {
-      return Object.prototype.hasOwnProperty.call(obj, prop);
-    }
-
-    function isCallable(v) {
-      // NB: modify as necessary if other values than functions are callable.
-      return typeof v === 'function';
-    }
-
-    if (typeof desc !== 'object' || desc === null)
-      throw new TypeError('bad desc');
-
-    var d = {};
-
-    if (hasProperty(desc, 'enumerable'))
-      d.enumerable = !!desc.enumerable;
-    if (hasProperty(desc, 'configurable'))
-      d.configurable = !!desc.configurable;
-    if (hasProperty(desc, 'value'))
-      d.value = desc.value;
-    if (hasProperty(desc, 'writable'))
-      d.writable = !!desc.writable;
-    if (hasProperty(desc, 'get')) {
-      var g = desc.get;
-
-      if (!isCallable(g) && typeof g !== 'undefined')
-        throw new TypeError('bad get');
-      d.get = g;
-    }
-    if (hasProperty(desc, 'set')) {
-      var s = desc.set;
-      if (!isCallable(s) && typeof s !== 'undefined')
-        throw new TypeError('bad set');
-      d.set = s;
-    }
-
-    if (('get' in d || 'set' in d) && ('value' in d || 'writable' in d))
-      throw new TypeError('identity-confused descriptor');
-
-    return d;
-  }
-
-  if (typeof obj !== 'object' || obj === null)
-    throw new TypeError('bad obj');
-
-  properties = Object(properties);
-
-  var keys = Object.keys(properties);
-  var descs = [];
-
-  for (var i = 0; i < keys.length; i++)
-    descs.push([keys[i], convertToDescriptor(properties[keys[i]])]);
-
-  for (var i = 0; i < descs.length; i++)
-    Object.defineProperty(obj, descs[i][0], descs[i][1]);
-
-  return obj;
-}
-```
-
 ## Specifications
 
 {{Specifications}}
@@ -176,6 +106,7 @@ function defineProperties(obj, properties) {
 
 ## See also
 
+- [Polyfill of `Object.defineProperties` in `core-js`](https://github.com/zloirock/core-js#ecmascript-object)
 - {{jsxref("Object.defineProperty()")}}
 - {{jsxref("Object.keys()")}}
 - [Enumerability and ownership of properties](/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties)

--- a/files/en-us/web/javascript/reference/global_objects/object/entries/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/entries/index.md
@@ -50,35 +50,6 @@ to the enumerable string-keyed property `[key, value]`
 pairs found directly upon `object`. The ordering of the properties is the
 same as that given by looping over the property values of the object manually.
 
-## Polyfill
-
-To add compatible `Object.entries()` support in older environments that do
-not natively support it, you can use any of the following:
-
-- a demonstration implementation of `Object.entries` in the [tc39/proposal-object-values-entries](https://github.com/tc39/proposal-object-values-entries) (if
-  you don't need any support for IE);
-- a polyfill in the [es-shims/Object.entries](https://github.com/es-shims/Object.entries)
-  repositories;
-- or, you can use the simple, ready-to-deploy polyfill listed below:
-
-```js
-if (!Object.entries) {
-  Object.entries = function( obj ){
-    var ownProps = Object.keys( obj ),
-        i = ownProps.length,
-        resArray = new Array(i); // preallocate the Array
-    while (i--)
-      resArray[i] = [ownProps[i], obj[ownProps[i]]];
-
-    return resArray;
-  };
-}
-```
-
-For the above polyfill code snippet, if you need support for IE<9, then you will
-also need an `Object.keys()` polyfill (such as the one found on the
-{{jsxref("Object.keys")}} page).
-
 ## Examples
 
 ```js

--- a/files/en-us/web/javascript/reference/global_objects/object/is/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/is/index.md
@@ -95,30 +95,6 @@ Object.is(NaN, 0/0);              // true
 Object.is(NaN, Number.NaN)        // true
 ```
 
-## Polyfill
-
-```js
-if (!Object.is) {
-  Object.defineProperty(Object, "is", {
-    value: function (x, y) {
-      // SameValue algorithm
-      if (x === y) {
-        // return true if x and y are not 0, OR
-        // if x and y are both 0 of the same sign.
-        // This checks for cases 1 and 2 above.
-        return x !== 0 || 1 / x === 1 / y;
-      } else {
-        // return true if both x AND y evaluate to NaN.
-        // The only possibility for a variable to not be strictly equal to itself
-        // is when that variable evaluates to NaN (example: Number.NaN, 0/0, NaN).
-        // This checks for case 3.
-        return x !== x && y !== y;
-      }
-    }
-  });
-}
-```
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/global_objects/object/setprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/setprototypeof/index.md
@@ -180,34 +180,6 @@ george(); // 'Hello guys!!'
 const dict = Object.setPrototypeOf({}, null);
 ```
 
-## Polyfill
-
-Using the older {{jsxref("Object.prototype.__proto__")}} property, we can easily define
-`Object.setPrototypeOf` if it isn't available already:
-
-```js
-if (!Object.setPrototypeOf) {
-    // Only works in Chrome and FireFox, does not work in IE:
-     Object.prototype.setPrototypeOf = function(obj, proto) {
-         if(obj.__proto__) {
-             obj.__proto__ = proto;
-             return obj;
-         } else {
-             // If you want to return prototype of Object.create(null):
-             var Fn = function() {
-                 for (var key in obj) {
-                     Object.defineProperty(this, key, {
-                         value: obj[key],
-                     });
-                 }
-             };
-             Fn.prototype = proto;
-             return new Fn();
-         }
-     }
-}
-```
-
 ## Specifications
 
 {{Specifications}}
@@ -218,6 +190,7 @@ if (!Object.setPrototypeOf) {
 
 ## See also
 
+- [Polyfill of `Object.setPrototypeOf` in `core-js`](https://github.com/zloirock/core-js#ecmascript-object)
 - {{jsxref("Reflect.setPrototypeOf()")}}
 - {{jsxref("Object.prototype.isPrototypeOf()")}}
 - {{jsxref("Object.getPrototypeOf()")}}

--- a/files/en-us/web/javascript/reference/global_objects/object/values/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/values/index.md
@@ -40,13 +40,6 @@ An array containing the given object's own enumerable property values.
 property values found on the object. The ordering of the properties is the same as that
 given by looping over the property values of the object manually.
 
-## Polyfill
-
-To add compatible `Object.values` support in older environments that do not
-natively support it, you can find a Polyfill in the [tc39/proposal-object-values-entries](https://github.com/tc39/proposal-object-values-entries)
-or in the [es-shims/Object.values](https://github.com/es-shims/Object.values)
-repositories.
-
 ## Examples
 
 ### Using Object.values

--- a/files/en-us/web/javascript/reference/global_objects/regexp/flags/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/flags/index.md
@@ -33,19 +33,6 @@ Flags in the `flags` property are sorted alphabetically (from left to right, e.g
 /bar/myu.flags;  // "muy"
 ```
 
-## Polyfill
-
-```js
-if (RegExp.prototype.flags === undefined) {
-  Object.defineProperty(RegExp.prototype, 'flags', {
-    configurable: true,
-    get: function() {
-      return this.toString().match(/[gimsuy]*$/)[0];
-    }
-  });
-}
-```
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/global_objects/string/codepointat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/codepointat/index.md
@@ -75,68 +75,6 @@ for (let codePoint of '\ud83d\udc0e\ud83d\udc71\u2764') {
 // '1f40e', '1f471', '2764'
 ```
 
-## Polyfill
-
-The following extends Strings to include the `codePointAt()` function as
-specified in ECMAScript 2015 for browsers without native support.
-
-```js
-/*! https://mths.be/codepointat v0.2.0 by @mathias */
-if (!String.prototype.codePointAt) {
-  (function() {
-    'use strict'; // needed to support `apply`/`call` with `undefined`/`null`
-    var defineProperty = (function() {
-      // IE 8 only supports `Object.defineProperty` on DOM elements
-      try {
-        var object = {};
-        var $defineProperty = Object.defineProperty;
-        var result = $defineProperty(object, object, object) && $defineProperty;
-      } catch(error) {}
-      return result;
-    }());
-    var codePointAt = function(position) {
-      if (this == null) {
-        throw TypeError();
-      }
-      var string = String(this);
-      var size = string.length;
-      // `ToInteger`
-      var index = position ? Number(position) : 0;
-      if (index != index) { // better `isNaN`
-        index = 0;
-      }
-      // Account for out-of-bounds indices:
-      if (index < 0 || index >= size) {
-        return undefined;
-      }
-      // Get the first code unit
-      var first = string.charCodeAt(index);
-      var second;
-      if ( // check if it's the start of a surrogate pair
-        first >= 0xD800 && first <= 0xDBFF && // high surrogate
-        size > index + 1 // there is a next code unit
-      ) {
-        second = string.charCodeAt(index + 1);
-        if (second >= 0xDC00 && second <= 0xDFFF) { // low surrogate
-          // https://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
-          return (first - 0xD800) * 0x400 + second - 0xDC00 + 0x10000;
-        }
-      }
-      return first;
-    };
-    if (defineProperty) {
-      defineProperty(String.prototype, 'codePointAt', {
-        'value': codePointAt,
-        'configurable': true,
-        'writable': true
-      });
-    } else {
-      String.prototype.codePointAt = codePointAt;
-    }
-  }());
-}
-```
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/global_objects/string/endswith/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/endswith/index.md
@@ -55,23 +55,6 @@ console.log(str.endsWith('to be'))      // false
 console.log(str.endsWith('to be', 19))  // true
 ```
 
-## Polyfill
-
-This method has been added to the ECMAScript 6 specification and may not be available
-in all JavaScript implementations yet. However, you can polyfill
-`String.prototype.endsWith()` with the following snippet:
-
-```js
-if (!String.prototype.endsWith) {
-  String.prototype.endsWith = function(search, this_len) {
-    if (this_len === undefined || this_len > this.length) {
-      this_len = this.length;
-    }
-    return this.substring(this_len - search.length, this_len) === search;
-  };
-}
-```
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/global_objects/string/fromcodepoint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/fromcodepoint/index.md
@@ -49,51 +49,6 @@ Because `fromCodePoint()` is a static method of {{jsxref("String")}}, you
 must call it as `String.fromCodePoint()`, rather than as a method of a
 {{jsxref("String")}} object you created.
 
-## Polyfill
-
-The `String.fromCodePoint()` method has been added to ECMAScript 2015 and
-may not be supported in all web browsers or environments yet.
-
-Use the code below for a polyfill:
-
-```js
-if (!String.fromCodePoint) (function(stringFromCharCode) {
-    var fromCodePoint = function(_) {
-      var codeUnits = [], codeLen = 0, result = "";
-      for (var index=0, len = arguments.length; index !== len; ++index) {
-        var codePoint = +arguments[index];
-        // correctly handles all cases including `NaN`, `-Infinity`, `+Infinity`
-        // The surrounding `!(...)` is required to correctly handle `NaN` cases
-        // The (codePoint>>>0) === codePoint clause handles decimals and negatives
-        if (!(codePoint < 0x10FFFF && (codePoint>>>0) === codePoint))
-          throw RangeError("Invalid code point: " + codePoint);
-        if (codePoint <= 0xFFFF) { // BMP code point
-          codeLen = codeUnits.push(codePoint);
-        } else { // Astral code point; split in surrogate halves
-          // https://mathiasbynens.be/notes/javascript-encoding#surrogate-formulae
-          codePoint -= 0x10000;
-          codeLen = codeUnits.push(
-            (codePoint >> 10) + 0xD800,  // highSurrogate
-            (codePoint % 0x400) + 0xDC00 // lowSurrogate
-          );
-        }
-        if (codeLen >= 0x3fff) {
-          result += stringFromCharCode.apply(null, codeUnits);
-          codeUnits.length = 0;
-        }
-      }
-      return result + stringFromCharCode.apply(null, codeUnits);
-    };
-    try { // IE 8 only supports `Object.defineProperty` on DOM elements
-      Object.defineProperty(String, "fromCodePoint", {
-        "value": fromCodePoint, "configurable": true, "writable": true
-      });
-    } catch(e) {
-      String.fromCodePoint = fromCodePoint;
-    }
-}(String.fromCharCode));
-```
-
 ## Examples
 
 ### Using fromCodePoint()

--- a/files/en-us/web/javascript/reference/global_objects/string/repeat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/repeat/index.md
@@ -59,54 +59,6 @@ A new string containing the specified number of copies of the given string.
 // 'abcabc' (repeat() is a generic method)
 ```
 
-## Polyfill
-
-This method has been added to the ECMAScript 2015 specification and may not be
-available in all JavaScript implementations yet. However, you can polyfill
-`String.prototype.repeat()` with the following snippet:
-
-```js
-if (!String.prototype.repeat) {
-  String.prototype.repeat = function(count) {
-    'use strict';
-    if (this == null)
-      throw new TypeError('can\'t convert ' + this + ' to object');
-
-    var str = '' + this;
-    // To convert string to integer.
-    count = +count;
-    // Check NaN
-    if (count != count)
-      count = 0;
-
-    if (count < 0)
-      throw new RangeError('repeat count must be non-negative');
-
-    if (count == Infinity)
-      throw new RangeError('repeat count must be less than infinity');
-
-    count = Math.floor(count);
-    if (str.length == 0 || count == 0)
-      return '';
-
-    // Ensuring count is a 31-bit integer allows us to heavily optimize the
-    // main part. But anyway, most current (August 2014) browsers can't handle
-    // strings 1 << 28 chars or longer, so:
-    if (str.length * count >= 1 << 28)
-      throw new RangeError('repeat count must not overflow maximum string size');
-
-    var maxCount = str.length * count;
-    count = Math.floor(Math.log(count) / Math.log(2));
-    while (count) {
-       str += str;
-       count--;
-    }
-    str += str.substring(0, maxCount - str.length);
-    return str;
-  }
-}
-```
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/global_objects/string/startswith/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/startswith/index.md
@@ -57,26 +57,6 @@ console.log(str.startsWith('not to be'))      // false
 console.log(str.startsWith('not to be', 10))  // true
 ```
 
-## Polyfill
-
-This method has been added to the ECMAScript 2015 specification and may not be
-available in all JavaScript implementations yet. However, you can polyfill
-`String.prototype.startsWith()` with the following snippet:
-
-```js
-if (!String.prototype.startsWith) {
-    Object.defineProperty(String.prototype, 'startsWith', {
-        value: function(search, rawPos) {
-            var pos = rawPos > 0 ? rawPos|0 : 0;
-            return this.substring(pos, pos + search.length) === search;
-        }
-    });
-}
-```
-
-A more robust (fully ES2015 specification compliant), but less performant and
-compact, Polyfill is available [on GitHub by Mathias Bynens](https://github.com/mathiasbynens/String.prototype.startsWith).
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/global_objects/string/substr/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/substr/index.md
@@ -58,33 +58,6 @@ A new string containing the specified part of the given string.
 - For both `start` and `length`,
   {{jsxref("NaN")}} is treated as `0`.
 
-## Polyfill
-
-Microsoft's JScript does not support negative values for the start index. To use this
-feature in JScript, you can use the following code:
-
-```js
-// only run when the substr() function is broken
-if ('ab'.substr(-1) != 'b') {
-  /**
-   *  Get the substring of a string
-   *  @param  {integer}  start   where to start the substring
-   *  @param  {integer}  length  how many characters to return
-   *  @return {string}
-   */
-  String.prototype.substr = function(substr) {
-    return function(start, length) {
-      // call the original method
-      return substr.call(this,
-        // did we get a negative start, calculate how much it is from the beginning of the string
-        // adjust the start parameter for negative value
-        start < 0 ? this.length + start : start,
-        length)
-    }
-  }(String.prototype.substr);
-}
-```
-
 ## Examples
 
 ### Using substr()

--- a/files/en-us/web/javascript/reference/global_objects/string/trimstart/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/trimstart/index.md
@@ -58,43 +58,6 @@ console.log(str.length); // 5
 console.log(str);        // 'foo  '
 ```
 
-## Polyfill
-
-```js
-//https://github.com/FabioVergani/js-Polyfill_String-trimStart
-
-(function(w){
-    var String=w.String, Proto=String.prototype;
-
-    (function(o,p){
-        if(p in o?o[p]?false:true:true){
-            var r=/^\s+/;
-            o[p]=o.trimLeft||function(){
-                return this.replace(r,'')
-            }
-        }
-    })(Proto,'trimStart');
-
-})(window);
-
-/*
-ES6:
-(w=>{
-    const String=w.String, Proto=String.prototype;
-
-    ((o,p)=>{
-        if(p in o?o[p]?false:true:true){
-            const r=/^\s+/;
-            o[p]=o.trimLeft||function(){
-                return this.replace(r,'')
-            }
-        }
-    })(Proto,'trimStart');
-
-})(window);
-*/
-```
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/findindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/findindex/index.md
@@ -118,44 +118,6 @@ console.log(uint8.findIndex(isPrime)); // -1, not found
 console.log(uint16.findIndex(isPrime)); // 2
 ```
 
-## Polyfill
-
-```js
-TypedArray.prototype.findIndex = Array.prototype.findIndex = Array.prototype.findIndex || function(evaluator, thisArg) {
-        'use strict';
-        if (!this) {
-          throw new TypeError('Array.prototype.some called on null or undefined');
-        }
-
-        if (typeof(evaluator) !== 'function') {
-            if (typeof(evaluator) === 'string') {
-                // Attempt to convert it to a function
-                if ( ! (evaluator = eval(evaluator)) ){
-                    throw new TypeError();
-                }
-            } else {
-                throw new TypeError();
-            }
-        }
-
-        var i;
-        if (thisArg === undefined) {  // Optimize for thisArg
-            for (i in this) {
-                if (evaluator(this[i], i, this)) {
-                    return i;
-                }
-            }
-            return -1;
-        }
-        for (i in this) {
-            if (evaluator.call(thisArg, this[i], i, this)) {
-                return i;
-            }
-        }
-        return -1;
-};
-```
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/join/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/join/index.md
@@ -49,24 +49,6 @@ uint8.join(' / '); // '1 / 2 / 3'
 uint8.join('');    // '123'
 ```
 
-## Polyfill
-
-Since there is no global object with the name _TypedArray_, polyfilling must be
-done on an "as needed" basis.
-
-```js
-// https://tc39.github.io/ecma262/#sec-%typedarray%.prototype.join
-if (!Uint8Array.prototype.join) {
-  Object.defineProperty(Uint8Array.prototype, 'join', {
-    value: Array.prototype.join
-  });
-}
-```
-
-If you need to support truly obsolete JavaScript engines that don't support
-{{jsxref("Object.defineProperty")}}, it's best not to polyfill
-`Array.prototype` methods at all, as you can't make them non-enumerable.
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/reduce/index.md
@@ -102,12 +102,6 @@ const total = new Uint8Array([0, 1, 2, 3]).reduce(function(a, b) {
 // total == 6
 ```
 
-## Polyfill
-
-This method uses the same algorithm as {{jsxref("Array.prototype.reduce()")}}, so the
-same polyfill can be used here: replace `Array.prototype.reduce` with
-`TypedArray.prototype.reduce`.
-
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

No more polyfills in JS docs. I've made sure they all have `core-js` links.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
