### PR TITLE
Fix text to be aligned with the `top` property

### DIFF
--- a/files/en-us/web/css/bottom/index.md
+++ b/files/en-us/web/css/bottom/index.md
@@ -17,7 +17,7 @@ The **`bottom`** [CSS](/en-US/docs/Web/CSS) property participates in setting the
 
 The effect of `bottom` depends on how the element is positioned (i.e., the value of the {{cssxref("position")}} property):
 
-- When `position` is set to `absolute` or `fixed`, the `bottom` property specifies the distance between the element's bottom edge and the bottom edge of its containing block.
+- When `position` is set to `absolute` or `fixed`, the `bottom` property specifies the distance between the element's outer margin of bottom edge and the inner border of the bottom edge of its containing block.
 - When `position` is set to `relative`, the `bottom` property specifies the distance the element's bottom edge is moved above its normal position.
 - When `position` is set to `sticky`, the `bottom` property is used to compute the sticky-constraint rectangle.
 - When `position` is set to `static`, the `bottom` property has _no effect_.


### PR DESCRIPTION
The explanation for the `absolute` / `fixed` position should be aligned with the same explanation of the [top property](https://developer.mozilla.org/en-US/docs/Web/CSS/top#:~:text=When%20position%20is%20set%20to%20absolute%20or%20fixed%2C%20the%20top%20property%20specifies%20the%20distance%20between%20the%20element%27s%20outer%20margin%20of%20top%20edge%20and%20the%20inner%20border%20of%20the%20top%20edge%20of%20its%20containing%20block.)