### PR TITLE
Fix broken link to promise docs

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/displaying_data/flow_control_using_async/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/displaying_data/flow_control_using_async/index.md
@@ -10,7 +10,7 @@ tags:
 ---
 The controller code for some of our _LocalLibrary_ pages will depend on the results of multiple asynchronous requests, which may be required to run either in some particular order or in parallel. In order to manage flow control, and render pages when we have all the required information available, we'll use the popular node [async](https://www.npmjs.com/package/async) module.
 
-> **Note:** There are a number of other ways to manage asynchronous behavior and flow control in JavaScript, including relatively recent JavaScript language features like [Promises](/en-US/docs/Archive/Add-ons/Techniques/Promises).
+> **Note:** There are a number of other ways to manage asynchronous behavior and flow control in JavaScript, including relatively recent JavaScript language features like [Promises](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).
 
 Async has a lot of useful methods (check out [the documentation](https://caolan.github.io/async/v3/docs.html)). Some of the more important functions are:
 


### PR DESCRIPTION
The link gives and error: 
"Page not found
Sorry, the page /en-US/docs/Archive/Add-ons/Techniques/Promises could not be found."

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
