### PR TITLE
Updates and corrections to the ARIA radio doc

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/radio_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/radio_role/index.md
@@ -64,7 +64,7 @@ Each radio element is labelled by its content, has a visible label referenced by
 
 As `radio` is an interactive control; it must be focusable and keyboard accessible. If the role is applied to a non-focusable element, use the [`tabindex`](/en-US/docs/Web/HTML/Global_attributes/tabindex) attribute to change this. The expected keyboard shortcut for activating a radio is the <kbd>Space</kbd> key. Use JavaScript to toggle the `aria-checked` attribute to `true` when a radio becomes checked while ensuing that all the other radio roles in the group are set to `aria-checked="false"`.
 
-To programmatically indicate that a radio button must be chosen from a radio group, then the [`aria-required`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) attribute, with a value of `true`, must be specified on the `radiogroup` element. It is not expected to use the `aria-required` attribute on individual ARIA radio buttons.  
+To programmatically indicate that a radio button must be chosen from a radio group the [`aria-required`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) attribute, with a value of `true`, must be specified on the `radiogroup` element. It is not expected to use the `aria-required` attribute on individual ARIA radio buttons.  
 
 ### All descendants are presentational
 

--- a/files/en-us/web/accessibility/aria/roles/radio_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/radio_role/index.md
@@ -17,20 +17,18 @@ A radio button is a checkable input that when associated with other radio button
 ```html
 <div role="radiogroup" aria-labelledby="legend25" id="radiogroup25">
   <p id="legend25">Ipsum and lorem?</p>
-  <ul>
-    <li>
-      <span role="radio" aria-checked="false" tabindex="0" aria-labelledby="q25_radio1-label" data-value="True"></span>
-      <label id="q25_radio1-label">True</label>
-    </li>
-    <li>
-      <span role="radio" aria-checked="false" tabindex="0" aria-labelledby="q25_radio2-label" data-value="False"></span>
-      <label id="q25_radio2-label">False</label>
-    </li>
-    <li>
-      <span role="radio" aria-checked="true" tabindex="0" aria-labelledby="q25_radio3-label" data-value="huh?"></span>
-      <label id="q25_radio3-label">What is the question?</label>
-    </li>
-  </ul>
+  <div>
+    <span role="radio" aria-checked="false" tabindex="0" aria-labelledby="q25_radio1-label" data-value="True"></span>
+    <label id="q25_radio1-label">True</label>
+  </div>
+  <div>
+    <span role="radio" aria-checked="false" tabindex="0" aria-labelledby="q25_radio2-label" data-value="False"></span>
+    <label id="q25_radio2-label">False</label>
+  </div>
+  <div>
+    <span role="radio" aria-checked="true" tabindex="0" aria-labelledby="q25_radio3-label" data-value="huh?"></span>
+    <label id="q25_radio3-label">What is the question?</label>
+  </div>
 </div>
 ```
 
@@ -41,20 +39,18 @@ The `role` attribute only adds semantics; all of the functionality that comes na
 ```html
 <fieldset>
   <legend>Ipsum and lorem?</legend>
-  <ul>
-    <li>
-      <input type="radio" value="True" id="q25_radio1" name="q25">
-      <label for="q25_radio1">True</label>
-    </li>
-    <li>
-      <input type="radio" value="False" id="q25_radio2" name="q25">
-      <label for="q25_radio2">False</label>
-    </li>
-    <li>
-      <input type="radio" value="huh?" id="q25_radio3"  name="q25" checked>
-      <label for="q25_radio3">What is the question?</label>
-    </li>
-  </ul>
+  <div>
+    <input type="radio" value="True" id="q25_radio1" name="q25">
+    <label for="q25_radio1">True</label>
+  </div>
+  <div>
+    <input type="radio" value="False" id="q25_radio2" name="q25">
+    <label for="q25_radio2">False</label>
+  </div>
+  <div>
+    <input type="radio" value="huh?" id="q25_radio3"  name="q25" checked>
+    <label for="q25_radio3">What is the question?</label>
+  </div>
 </fieldset>
 ```
 

--- a/files/en-us/web/accessibility/aria/roles/radio_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/radio_role/index.md
@@ -54,7 +54,7 @@ The `role` attribute only adds semantics; all of the functionality that comes na
 </fieldset>
 ```
 
-The native HTML radio ([`<input type="radio">`](/en-US/docs/Web/HTML/Element/input/radio)) form control has two states ("checked" or "not checked"). Similarly, an element with `role="radio"` can expose two states through the [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) attribute: `true` representing the checked state, and `false` representing the unchecked state. The `aria-checked` value of `mixed` is not valid to use for a radio button.
+The native HTML radio form control ([`<input type="radio">`](/en-US/docs/Web/HTML/Element/input/radio)) has two states ("checked" or "not checked"). Similarly, an element with `role="radio"` can expose two states through the [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) attribute: `true` representing the checked state, and `false` representing the unchecked state. The `aria-checked` value of `mixed` is not valid to use for a radio button.
 
 If a radio button is checked, the radio element has `aria-checked` set to `true`. If it is not checked, it has `aria-checked` set to `false`.
 

--- a/files/en-us/web/accessibility/aria/roles/radio_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/radio_role/index.md
@@ -8,11 +8,11 @@ tags:
   - ARIA widget
   - Reference
 ---
-The `radio` role is one of a group of checkable buttons, in a `radiogroup`, where no more than one of the buttons can be checked at a time.
+The `radio` role is one of a group of checkable radio buttons, in a `radiogroup`, where no more than a single radio button can be checked at a time.
 
 ## Description
 
-A radio element is a checkable input in a group of role elements, of which only one of which can be checked at a time. The radio elements must be grouped together in a ['radiogroup`](/en-US/docs/web/accessibility/aria/roles/radiogroup_role) to indicate which ones affect the same value.
+A radio button is a checkable input that when associated with other radio buttons, only one of which can be checked at a time. The radio buttons must be grouped together in a ['radiogroup`](/en-US/docs/web/accessibility/aria/roles/radiogroup_role) to indicate which ones affect the same value.
 
 ```html
 <div role="radiogroup" aria-labelledby="legend25" id="radiogroup25">
@@ -36,39 +36,39 @@ A radio element is a checkable input in a group of role elements, of which only 
 
 The `role` attribute only adds semantics; all of the functionality that comes natively with the [HTML radio](/en-US/docs/Web/HTML/Element/input/radio) needs to be added with JavaScript and the HTML [`tabindex`](/en-US/docs/Web/HTML/Global_attributes/tabindex) attribute.
 
-> **Note:** The first rule of ARIA is if a native HTML element or attribute has the semantics and behavior you require, use it instead of re-purposing an element and adding ARIA. Instead use the native [HTML radio](/en-US/docs/Web/HTML/Element/input/radio) of [`<input type="radio">`](/en-US/docs/Web/HTML/Element/input/radio) (with an associated {{HTMLElement('label')}}, which natively provides all the functionality required:
+> **Note:** The first rule of ARIA is if a native HTML element or attribute has the semantics and behavior you require, use it instead of re-purposing an element and adding ARIA. Instead use the native [HTML `<input type="radio">`](/en-US/docs/Web/HTML/Element/input/radio) (with an associated {{HTMLElement('label')}}, which natively provides all the functionality required:
 
 ```html
 <fieldset>
   <legend>Ipsum and lorem?</legend>
   <ul>
     <li>
-      <input type="radio" value="True" id="q25_radio1" name="q25" />
+      <input type="radio" value="True" id="q25_radio1" name="q25">
       <label for="q25_radio1">True</label>
     </li>
     <li>
-      <input type="radio" value="False" id="q25_radio2" name="q25" />
+      <input type="radio" value="False" id="q25_radio2" name="q25">
       <label for="q25_radio2">False</label>
     </li>
     <li>
-      <input type="radio" value="huh?" id="q25_radio3"  name="q25" checked />
+      <input type="radio" value="huh?" id="q25_radio3"  name="q25" checked>
       <label for="q25_radio3">What is the question?</label>
     </li>
   </ul>
 </fieldset>
 ```
 
-The native HTML radio ([`<input type="radio">`](/en-US/docs/Web/HTML/Element/input/radio)) form control had two states ("checked" or "not checked"). Similarly, an element with `role="radio"` can expose two states through the [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) attribute: `true` and `false`. The value of `mixed` correlates to the  `indeterminate` value of HTML `checked` attribute, meaning neither checked nor unchecked. While `mixed` is valid on both radios and checkboxes, it is rarely useful for a radio button.
+The native HTML radio ([`<input type="radio">`](/en-US/docs/Web/HTML/Element/input/radio)) form control has two states ("checked" or "not checked"). Similarly, an element with `role="radio"` can expose two states through the [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked) attribute: `true` representing the checked state, and `false` representing the unchecked state. The `aria-checked` value of `mixed` is not valid to use for a radio button.
 
 If a radio button is checked, the radio element has `aria-checked` set to `true`. If it is not checked, it has `aria-checked` set to `false`.
 
-Each radio button element has role `radio`. The radio role should always be nested with other radios in a `radiogroup`. If it is not possible to nest the radio button within a radio group, use the `id` of the non-grouped radio in a space separated list of values as the value of the [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-owns) attribute on the `radiogroup` element to indicate the relationship of the `radiogroup` to its radio members.
+Each radio button element has role `radio`. The radio role should always be nested with other associated radios in a `radiogroup`. If it is not possible to nest the radio button within a radio group, use the `id` of the non-grouped radio in a space separated list of values as the value of the [`aria-owns`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-owns) attribute on the `radiogroup` element to indicate the relationship of the `radiogroup` to its radio members.
 
-Each radio element is labelled by its content, has a visible label referenced by `aria-labelledby`, or has a label specified with `aria-label`. The containing radiogroup element should either have a visible label referenced by `aria-labelledby` or a label specified with `aria-label`. If elements providing additional information about either the radio group or each radio button are present, those elements should be referenced by the radiogroup element or radio elements with the [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) property.
+Each radio element is labelled by its content, has a visible label referenced by `aria-labelledby`, or has a label specified with `aria-label`. The containing `radiogroup` element should either have a visible label referenced by `aria-labelledby` or a label specified with `aria-label`. If elements providing additional information about either the radio group or each radio button are present, those elements should be referenced by the `radiogroup` element or radio elements with the [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) property.
 
 As `radio` is an interactive control; it must be focusable and keyboard accessible. If the role is applied to a non-focusable element, use the [`tabindex`](/en-US/docs/Web/HTML/Global_attributes/tabindex) attribute to change this. The expected keyboard shortcut for activating a radio is the <kbd>Space</kbd> key. Use JavaScript to toggle the `aria-checked` attribute to `true` when a radio becomes checked while ensuing that all the other radio roles in the group are set to `aria-checked="false"`.
 
-If any of the radio roles in a group has `aria-required="true"` set, it is as if all of the radios in the group had the attribute making the selection of one of the radios in the radiogroup being required to be valid;  though not necessarily the one that has the [`aria-required`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) attribute set.
+To programmatically indicate that a radio button must be chosen from a radio group, then the [`aria-required`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) attribute, with a value of `true`, must be specified on the `radiogroup` element. It is not expected to use the `aria-required` attribute on individual ARIA radio buttons.  
 
 ### All descendants are presentational
 
@@ -77,13 +77,13 @@ There are some types of user interface components that, when represented in a pl
 For example, consider the following `radio` element, which contains a heading.
 
 ```html
-<div role="radio"><h6>name of my radio</h6></li>
+<div role="radio"><h6>name of my radio</h6></div>
 ```
 
 Because descendants of `radio` are presentational, the following code is equivalent:
 
 ```html
-<div role="radio"><h6 role="presentation">name of my radio</h6></li>
+<div role="radio"><h6 role="presentation">name of my radio</h6></div>
 ```
 
 From the assistive technology user's perspective, the heading does not exist since the previous code snippets are equivalent to the following in the [accessibility tree](/en-US/docs/Glossary/Accessibility_tree):
@@ -95,37 +95,36 @@ From the assistive technology user's perspective, the heading does not exist sin
 ## Associated WAI-ARIA Roles, States, and Properties
 
 - ['radiogroup`](/en-US/docs/web/accessibility/aria/roles/radiogroup_role) role
-  - : The radio buttons are contained in or owned by an element with role `radiogroup`. If unable to be nested within a radiogroup within the markup, the `aria-owns` attribute of the `radiogroup` contains the `id` values of the non-nested radio buttons in the group.
+  - : The radio buttons are contained in or owned by an element with role `radiogroup`. If unable to be nested within a `radiogroup` within the markup, the `aria-owns` attribute of the `radiogroup` contains the `id` values of the non-nested radio buttons in the group.
 
 - [`aria-checked`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-checked)
 
-  - : The value of `aria-checked` defines the state of a radio. This attribute has one of three possible values:
+  - : The value of `aria-checked` defines the state of a radio. When used with radio elements, the attribute has one of two possible values:
 
     - `true`
       - : The radio is checked.
     - `false`
       - : The radio is not checked.
 
-- [`tabindex="0"`](/en-US/docs/Web/HTML/Global_attributes/tabindex)
-  - : Used to make it focusable so the assistive technology user can tab to it and start reading right away.
+> **Note:** use the [`tabindex` attribute](/en-US/docs/Web/HTML/Global_attributes/tabindex) if the `role="radio"` is used on an element that does not natively accept keyboard focus. E.g., a `<div>` or `<span>`.
 
 ## Keyboard interactions
 
 - <kbd>Tab</kbd> + <kbd>Shift</kbd>
-  - : Move focus into and out of the radio group. When focus moves into a radio group. If a radio button is checked, focus is set on the checked button. If none of the radio buttons are checked, focus is set on the first radio button in the group.
+  - : Move focus into and out of the radio group. When focus moves into a radio group, and a radio button is already checked, focus is set on the checked button. If none of the radio buttons are checked, focus is set on the first radio button in the group.
 
 - <kbd>Space</kbd>
-  - : Checks the radio if not already checked. Unchecks all the others in the radiogroup. |
+  - : Checks the radio if not already checked. Unchecks a previously checked radio button in the radio group. 
 
 - <kbd>Right Arrow</kbd> and <kbd>Down Arrow</kbd>
-  - : Move focus to the next radio button in the group, unchecking the previously focused button, and checking the newly focused button. If focus is on the last button, focus moves to the first button.
+  - : Move focus to and checks the next radio button in the group, unchecking the previously focused radio button. If focus is on the last radio button, focus moves to the first radio button.
 
 - <kbd>Left Arrow</kbd> and <kbd>Up Arrow</kbd>
-  - : Move focus to the previous radio button in the group, unchecking the previously focused button, and checking the newly focused button. If focus is on the first button, focus moves to the last button.
+  - : Move focus to and checks the previous radio button in the group, unchecking the previously focused radio button. If focus is on the first radio button, focus moves to the last radio button.
 
 ### Radios in a toolbar
 
-Because arrow keys are used to navigate among elements of a toolbar and the Tab key moves focus in and out of a toolbar, when a radio group is nested inside a toolbar, the keyboard interaction of the radio group is slightly different from that of a radio group that is not inside of a toolbar. See [`radiogroup` keyboard interactions](/en-US/docs/web/accessibility/aria/roles/radiogroup_role#keyboard_interactions) for more information
+Because arrow keys are used to navigate among elements of a toolbar and the <kbd>Tab</kbd> key moves focus in and out of a toolbar, when a radio group is nested inside a toolbar, the keyboard interaction of the radio group is slightly different from that of a radio group that is not inside of a toolbar. See [`radiogroup` keyboard interactions](/en-US/docs/web/accessibility/aria/roles/radiogroup_role#keyboard_interactions) for more information
 
 ## Required JavaScript
 
@@ -133,28 +132,24 @@ Because arrow keys are used to navigate among elements of a toolbar and the Tab 
   - : Handle mouse clicks on both the radio and the associated label that will change the state of the radio by changing the value of the `aria-checked` attribute and the appearance of the radio so it appears checked or unchecked to the sighted user
 - `onKeyPress`
   - : Handle the case where the user presses the <kbd>Space</kbd> key to change the state of the radio by changing the value of the `aria-checked` attribute and the appearance of the radio so it appears checked or unchecked to the sighted user
-- `onFocus`
-- `onBlur`
 
 ## Examples
 
-The following example creates an otherwise non-semantic radio element using CSS and JavaScript to handle the checked or unchecked status of the element.
+The following example uses ARIA to modify otherwise generic elements to be exposed as radio buttons. CSS and JavaScript are used to visually and programmatically modify the checked or unchecked state of the element.
 
 ### HTML
 
 ```html
 <div role="radiogroup" aria-labelledby="legend" id="radiogroup">
-  <p id="legend">Should you be using the <code>radio</code> role or <code>&lt;input type="radio"><code>?</p>
-  <ul>
-    <li>
-      <span role="radio" aria-checked="true" tabindex="0" aria-labelledby="ariaLabel" data-value="True"></span>
-      <label id="ariaLabel">ARIA role</label>
-    </li>
-    <li>
-      <span role="radio" aria-checked="false" tabindex="0" aria-labelledby="htmllabel" data-value="False"></span>
-      <label id="htmllabel">HTML <code>&lt;input type="radio"><code></label>
-    </li>
-  </ul>
+  <p id="legend">Should you be using the <code>radio</code> role or <code>&lt;input type="radio"></code>?</p>
+  <div>
+    <span role="radio" aria-checked="true" tabindex="0" aria-labelledby="ariaLabel" data-value="True"></span>
+    <label id="ariaLabel">ARIA role</label>
+  </div>
+  <div>
+    <span role="radio" aria-checked="false" tabindex="0" aria-labelledby="htmllabel" data-value="False"></span>
+    <label id="htmllabel">HTML <code>&lt;input type="radio"></code></label>
+  </div>
 </div>
 ```
 
@@ -162,7 +157,7 @@ The following example creates an otherwise non-semantic radio element using CSS 
 
 ```css
 [role="radio"] {
-    padding:5px;
+    padding: 5px;
 }
 
 [role="radio"][aria-checked="true"]::before {
@@ -181,8 +176,6 @@ The following example creates an otherwise non-semantic radio element using CSS 
 A lot of JavaScript is required to make radio buttons out of non-semantic HTML.
 
 ```js
-
-
 // initialize all the radio role elements
 
 let radioGroups = document.querySelectorAll('[role="radiogroup"]');
@@ -256,23 +249,21 @@ No JavaScript (or even CSS) would be needed had we used semantic HTML element wi
 
 ```html
 <fieldset>
-  <legend>Should you be using the <code>radio</code> role or <code>&lt;input type="radio"><code>?</legend>
-  <ul>
-    <li>
-      <input type="radio" name="bestPractices" id="ariaLabel" value="True" />
-      <label for="ariaLabel">ARIA role</label>
-    </li>
-    <li>
-      <input type="radio" name="bestPractices" id="htmllabel" value="False" />
-      <label for="htmllabel">HTML <code>&lt;input type="radio"><code></label>
-    </li>
-  </ul>
+  <legend>Should you be using the <code>radio</code> role or <code>&lt;input type="radio"></code>?</legend>
+  <div>
+    <input type="radio" name="bestPractices" id="ariaLabel" value="True" />
+    <label for="ariaLabel">ARIA role</label>
+  </div>
+  <div>
+    <input type="radio" name="bestPractices" id="htmllabel" value="False" />
+    <label for="htmllabel">HTML <code>&lt;input type="radio"></code></label>
+  </div>
 </fieldset>
 ```
 
 ## Best practices
 
-The first rule of ARIA is: if a native HTML element or attribute has the semantics and behavior you require, use it instead of re-purposing an element and adding an ARIA role, state or property to make it accessible. As such, it is recommended to use the native [HTML radio](/en-US/docs/Web/HTML/Element/input/radio) using form controls instead of recreating a radio's functionality with JavaScript and ARIA.
+The first rule of ARIA is: if a native HTML element or attribute has the semantics and behavior you require, use it instead of re-purposing an element and adding an ARIA role, state or property to make it accessible. As such, it is recommended to use native [HTML radio button](/en-US/docs/Web/HTML/Element/input/radio) form controls instead of recreating a radio's functionality with JavaScript and ARIA.
 
 ## See also
 


### PR DESCRIPTION
Upon reviewing the merged #17924, I noticed some additional typos in some of the markup examples. Those have been fixed in this PR.

Additionally, there were some instances of inaccurate information which have now also been corrected.
For instance: 
- removes the mention of using `aria-checked=mixed`. This is not valid for radio buttons.
- revises the section on how to indicate a required radio group. ARIA does not presently allow for the use of `aria-required` on individual `role=radio` elements. 
- changed the mention of `tabindex` in the Associated WAI-ARIA Roles, States, and Properties section to be a note - because it's not an ARIA attribute, so it didn't make sense to include it in the listing of ARIA attributes.
- Changed the examples to use `<div>` elements to group the radio/labels, rather than list items.  The use of list items would add extra enumeration to the radio buttons.  Being associated with each other, the radio buttons already announce an x of y... so the list items just add noise.
- Removed the mention of `onFocus` and `onBlur` from the required JavaScript section.  They had nothing written about them, so it didn't make sense for them to be there.