### PR TITLE
Fix typo from "GitHub have" to "GitHub has"

### DIFF
--- a/files/en-us/mdn/contribute/github_beginners/index.md
+++ b/files/en-us/mdn/contribute/github_beginners/index.md
@@ -52,7 +52,7 @@ Before you get started with working on any particular repo, follow these steps:
 
 At this point you need to set up an SSH key on your GitHub account. This is basically a security mechanism that identifies you to GitHub, and means that you don't have to authenticate each time you use GitHub services.
 
-GitHub have created a useful guide to setting this up — see the starting point at [Connecting to GitHub with SSH](https://docs.github.com/en/authentication/connecting-to-github-with-ssh). Follow each of the steps here to get set up with SSH on GitHub.
+GitHub has created a useful guide to setting this up — see the starting point at [Connecting to GitHub with SSH](https://docs.github.com/en/authentication/connecting-to-github-with-ssh). Follow each of the steps here to get set up with SSH on GitHub.
 
 If you don't do this, you'll still be able to contribute to MDN, but you'll have to enter your username and password every time you interact with GitHub (e.g. whenever you submit a pull request, as seen below).
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
In GitHub for complete beginners <a href="https://developer.mozilla.org/en-US/docs/MDN/Contribute/GitHub_beginners#setting_up_ssh_authentication_on_github">article</a>, Github is singular, but it was not the case under <a href="https://developer.mozilla.org/en-US/docs/MDN/Contribute/GitHub_beginners#setting_up_ssh_authentication_on_github">"Setting up SSH authentication on GitHub"</a> section.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
This change will make the article more consistent by following the definition provided in <a href="https://developer.mozilla.org/en-US/docs/MDN/Contribute/GitHub_beginners#essential_concepts" >Essential Concepts.</a>

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
