### PR TITLE
Typed arrays are always deep copies

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/typedarray/slice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/slice/index.md
@@ -61,7 +61,7 @@ A new typed array containing the extracted elements.
 
 ## Description
 
-The `slice` method does not alter the original typed array, but instead returns a copy of a portion of the original typed array. As typed arrays only store primitive values, the copy the `slice` method returns is always a [shallow copy](/en-US/docs/Glossary/Shallow_copy).
+The `slice` method does not alter the original typed array, but instead returns a copy of a portion of the original typed array. As typed arrays only store primitive values, the copy the `slice` method returns is always a [deep copy](/en-US/docs/Glossary/Deep_copy).
 
 If an element is changed in either typed array, the other typed array is not affected.
 


### PR DESCRIPTION
The original description indicates that typed arrays create shallow copies for a reason that means they should only create deep copies. 

Specifically, a typed array can only contain primitive values. Since primitives are always assigned unique values, a copy cannot have duplicate references. I presume the original text is a typo.

This comes out of the discussion in #17889