### PR TITLE
Fixed property name of rotationAngle

### DIFF
--- a/files/en-us/web/api/touch/rotationangle/index.md
+++ b/files/en-us/web/api/touch/rotationangle/index.md
@@ -12,7 +12,7 @@ browser-compat: api.Touch.rotationAngle
 ---
 {{ APIRef("Touch Events") }}
 
-The **`radiusX`** read-only property of the {{domxref("Touch")}} interface returns the rotation angle, in degrees, of the contact area ellipse defined by {{ domxref("Touch.radiusX") }} and {{ domxref("Touch.radiusY") }}. The value may be between 0 and 90. Together, these three values describe an ellipse that approximates the size and shape of the area of contact between the user and the screen. This may be a relatively large ellipse representing the contact between a fingertip and the screen or a small area representing the tip of a stylus, for example.
+The **`rotationAngle`** read-only property of the {{domxref("Touch")}} interface returns the rotation angle, in degrees, of the contact area ellipse defined by {{ domxref("Touch.radiusX") }} and {{ domxref("Touch.radiusY") }}. The value may be between 0 and 90. Together, these three values describe an ellipse that approximates the size and shape of the area of contact between the user and the screen. This may be a relatively large ellipse representing the contact between a fingertip and the screen or a small area representing the tip of a stylus, for example.
 
 ## Value
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Fixed a typo where `rotationAngle` was named `radiusX`.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
It was a typo showing the wrong property name.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
