### PR TITLE
Proxy authorization header https only

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/proxyinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/proxyinfo/index.md
@@ -47,7 +47,7 @@ Values of this type are objects. They contain the following properties:
     For instance, if you want to send "username" and "password" for "basic" authentication, you can set the `proxyAuthorizationHeader` property to `Basic dXNlcm5hbWU6cGFzc3dvcmQ=`
 
 - `connectionIsolationKey` {{optional_inline}}
-  - : `string.` An optional key used for additional isolation of this proxy connection.
+  - : `string.` An optional key used for additional isolation of this proxy connection. Applies to HTTPS proxies only.
 
 ## Browser compatibility
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/proxyinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/proxyinfo/index.md
@@ -42,7 +42,7 @@ Values of this type are objects. They contain the following properties:
   - : `number`. Failover timeout in seconds. If the connection fails to connect the proxy server after this number of seconds, the next proxy server in the array returned from the `proxy.onRequest` listener will be used.
 - `proxyAuthorizationHeader`
 
-  - : `string.` This string, if set to non-empty, is passed directly as a value to the {{httpheader("Proxy-Authorization")}} request header sent to HTTP proxies as part of plain HTTP requests and CONNECT requests. In other words, this can be used to directly authenticate to HTTP proxies requiring (non-challenging) authentication.
+  - : `string.` This string, if set to non-empty, is passed directly as a value to the {{httpheader("Proxy-Authorization")}} request header sent to HTTPS proxies as part of HTTPS and CONNECT requests. In other words, this can be used to directly authenticate to HTTPS proxies that allow (non-challenging) authentication.
 
     For instance, if you want to send "username" and "password" for "basic" authentication, you can set the `proxyAuthorizationHeader` property to `Basic dXNlcm5hbWU6cGFzc3dvcmQ=`
 

--- a/files/en-us/mozilla/firefox/releases/68/index.md
+++ b/files/en-us/mozilla/firefox/releases/68/index.md
@@ -173,6 +173,7 @@ _No changes._
 - When an add-on attempts to add a bookmark folder to the root folder, the resulting error message is now much more intuitive ({{bug(1512171)}}).
 - The promise returned by [`browser.tabs.duplicate()`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/duplicate) now resolves immediately, before the tabs are completely loaded ({{bug(1394376)}}).
 - Support has been added for chrome.storage.managed, allowing web extension settings to be implemented via enterprise policy ({{bug(1230802)}}).
+- `proxyAuthorization` and `connectionIsolation` in {{WebExtAPIRef("proxy.onRequest")}} now apply only to HTTPS proxies ({{bug(1549368)}}. 
 
 ### Manifest changes
 


### PR DESCRIPTION
#### Summary
Adds documentation that `proxyAuthorization` and `connectionIsolation` in `proxy.onRequest` only apply to HTTPS proxies. This covers the documentation requirements for the original bug [Bug 1549368](https://bugzilla.mozilla.org/show_bug.cgi?id=1549368) _Limit proxy.onRequest to set proxyAuthorization and connectionIsolation to apply only to https proxies_  and subsequent [Bug 1618494](https://bugzilla.mozilla.org/show_bug.cgi?id=1618494) _Returning proxyAuthorizationHeader from proxy.onRequest does not actually send Proxy-Authorization header_.

#### Metadata

This PR…

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
