### PR TITLE
var -> const

### DIFF
--- a/files/en-us/web/javascript/reference/statements/do...while/index.md
+++ b/files/en-us/web/javascript/reference/statements/do...while/index.md
@@ -47,11 +47,11 @@ In the following example, the `do...while` loop iterates at least once and
 reiterates until `i` is no longer less than 5.
 
 ```js
-var result = '';
-var i = 0;
+let result = '';
+let i = 0;
 do {
-   i += 1;
-   result += i + ' ';
+  i += 1;
+  result += i + ' ';
 }
 while (i > 0 && i < 5);
 // Despite i == 0 this will still loop as it starts off without the test

--- a/files/en-us/web/javascript/reference/statements/export/index.md
+++ b/files/en-us/web/javascript/reference/statements/export/index.md
@@ -115,8 +115,10 @@ console.log(m);        // will log 12
 You can also rename named exports to avoid naming conflicts:
 
 ```js
-export { myFunction as function1,
-         myVariable as variable };
+export {
+  myFunction as function1,
+  myVariable as variable,
+};
 ```
 
 ### Re-exporting / Aggregating
@@ -128,23 +130,23 @@ single module concentrating various exports from various modules.
 This can be achieved with the "export from" syntax:
 
 ```js
-export { default as function1,
-         function2 } from 'bar.js';
+export {
+  default as function1,
+  function2,
+} from 'bar.js';
 ```
 
 Which is comparable to a combination of import and export:
 
 ```js
-import { default as function1,
-         function2 } from 'bar.js';
+import { default as function1, function2 } from 'bar.js';
 export { function1, function2 };
 ```
 
 But where `function1` and `function2` do not become available
 inside the current module.
 
-> **Note:** The following is syntactically invalid despite its import
-> equivalent:
+> **Note:** The following is syntactically invalid despite its import equivalent:
 
 ```js
 import DefaultExport from 'bar.js'; // Valid
@@ -181,15 +183,15 @@ function cube(x) {
 
 const foo = Math.PI + Math.SQRT2;
 
-var graph = {
+const graph = {
   options: {
-      color:'white',
-      thickness:'2px'
+    color: 'white',
+    thickness: '2px',
   },
-  draw: function() {
-      console.log('From graph draw function');
+  draw() {
+    console.log('From graph draw function');
   }
-}
+};
 
 export { cube, foo, graph };
 ```
@@ -200,8 +202,8 @@ Then in the top-level module included in your HTML page, we could have:
 import { cube, foo, graph } from './my-module.js';
 
 graph.options = {
-    color:'blue',
-    thickness:'3px'
+  color: 'blue',
+  thickness: '3px',
 };
 
 graph.draw();
@@ -251,15 +253,15 @@ This is what it would look like using code snippets:
 
 ```js
 // In childModule1.js
-let myFunction = ...; // assign something useful to myFunction
-let myVariable = ...; // assign something useful to myVariable
-export {myFunction, myVariable};
+const myFunction = ...; // assign something useful to myFunction
+const myVariable = ...; // assign something useful to myVariable
+export { myFunction, myVariable };
 ```
 
 ```js
 // In childModule2.js
-let myClass = ...; // assign something useful to myClass
-export myClass;
+const myClass = ...; // assign something useful to myClass
+export { myClass };
 ```
 
 ```js

--- a/files/en-us/web/javascript/reference/statements/for...in/index.md
+++ b/files/en-us/web/javascript/reference/statements/for...in/index.md
@@ -138,7 +138,7 @@ Prior to Firefox 40, it was possible to use an initializer expression
 (`i=0`) in a `for...in` loop:
 
 ```js example-bad
-var obj = {a: 1, b: 2, c: 3};
+const obj = { a: 1, b: 2, c: 3 };
 for (var i = 0 in obj) {
   console.log(obj[i]);
 }

--- a/files/en-us/web/javascript/reference/statements/function/index.md
+++ b/files/en-us/web/javascript/reference/statements/function/index.md
@@ -116,7 +116,7 @@ hoisted:
 notHoisted(); // TypeError: notHoisted is not a function
 
 var notHoisted = function() {
-   console.log('bar');
+  console.log('bar');
 };
 ```
 

--- a/files/en-us/web/javascript/reference/statements/if...else/index.md
+++ b/files/en-us/web/javascript/reference/statements/if...else/index.md
@@ -94,7 +94,7 @@ string (`""`), and any object, including a Boolean object whose value is
 example:
 
 ```js
-var b = new Boolean(false);
+const b = new Boolean(false);
 if (b) // this condition is truthy
 ```
 

--- a/files/en-us/web/javascript/reference/statements/return/index.md
+++ b/files/en-us/web/javascript/reference/statements/return/index.md
@@ -35,7 +35,7 @@ where `x` is a number.
 function square(x) {
    return x * x;
 }
-var demo = square(3);
+const demo = square(3);
 // demo will equal 9
 ```
 
@@ -90,13 +90,13 @@ A function immediately stops at the point where `return` is called.
 
 ```js
 function counter() {
-  for (var count = 1; ; count++) {  // infinite loop
+  for (let count = 1; ; count++) {  // infinite loop
     console.log(count + 'A'); // until 5
-      if (count === 5) {
-        return;
-      }
-      console.log(count + 'B');  // until 4
+    if (count === 5) {
+      return;
     }
+    console.log(count + 'B');  // until 4
+  }
   console.log(count + 'C');  // never appears
 }
 
@@ -123,7 +123,7 @@ function magic() {
   return function calc(x) { return x * 42; };
 }
 
-var answer = magic();
+const answer = magic();
 answer(1337); // 56154
 ```
 

--- a/files/en-us/web/javascript/reference/statements/switch/index.md
+++ b/files/en-us/web/javascript/reference/statements/switch/index.md
@@ -130,7 +130,7 @@ criterion was met**.
 See example here:
 
 ```js
-var foo = 0;
+const foo = 0;
 switch (foo) {
   case -1:
     console.log('negative 1');
@@ -155,7 +155,7 @@ Yes, you can! JavaScript will drop you back to the `default` if it can't
 find a match:
 
 ```js
-var foo = 5;
+const foo = 5;
 switch (foo) {
   case 2:
     console.log(2);
@@ -185,7 +185,7 @@ This is an example of a single operation sequential `case` statement, where
 four different values perform exactly the same.
 
 ```js
-var Animal = 'Giraffe';
+const Animal = 'Giraffe';
 switch (Animal) {
   case 'Cow':
   case 'Giraffe':
@@ -208,8 +208,8 @@ not have to be numerically sequential. In JavaScript, you can even mix in defini
 strings into these `case` statements as well.
 
 ```js
-var foo = 1;
-var output = 'Output: ';
+const foo = 1;
+let output = 'Output: ';
 switch (foo) {
   case 0:
     output += 'So ';

--- a/files/en-us/web/javascript/reference/statements/throw/index.md
+++ b/files/en-us/web/javascript/reference/statements/throw/index.md
@@ -59,7 +59,7 @@ function UserException(message) {
 }
 function getMonthName(mo) {
   mo = mo - 1; // Adjust month number for array index (1 = Jan, 12 = Dec)
-  var months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul',
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul',
     'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
   if (months[mo] !== undefined) {
     return months[mo];
@@ -68,10 +68,12 @@ function getMonthName(mo) {
   }
 }
 
+let monthName;
+
 try {
   // statements to try
-  var myMonth = 15; // 15 is out of bound to raise the exception
-  var monthName = getMonthName(myMonth);
+  const myMonth = 15; // 15 is out of bound to raise the exception
+  monthName = getMonthName(myMonth);
 } catch (e) {
   monthName = 'unknown';
   console.error(e.message, e.name); // pass exception object to err handler

--- a/files/en-us/web/javascript/reference/statements/while/index.md
+++ b/files/en-us/web/javascript/reference/statements/while/index.md
@@ -45,8 +45,8 @@ The following `while` loop iterates as long as `n` is less than
 three.
 
 ```js
-var n = 0;
-var x = 0;
+let n = 0;
+let x = 0;
 
 while (n < 3) {
   n++;
@@ -72,7 +72,9 @@ Consider the following example, which iterates over a document's comments, loggi
 
 ```js example-bad
 const iterator = document.createNodeIterator(
-  document, NodeFilter.SHOW_COMMENT);
+  document,
+  NodeFilter.SHOW_COMMENT,
+);
 let currentNode;
 while (currentNode = iterator.nextNode()) {
   console.log(currentNode.textContent.trim());

--- a/files/en-us/web/javascript/reference/strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/strict_mode/index.md
@@ -34,7 +34,7 @@ To invoke strict mode for an entire script, put the _exact_ statement `"use stri
 ```js
 // Whole-script strict mode syntax
 'use strict';
-var v = "Hi! I'm a strict mode script!";
+const v = "Hi! I'm a strict mode script!";
 ```
 
 ### Strict mode for functions
@@ -97,16 +97,16 @@ var undefined = 5; // throws a TypeError
 var Infinity = 5; // throws a TypeError
 
 // Assignment to a non-writable property
-var obj1 = {};
+const obj1 = {};
 Object.defineProperty(obj1, 'x', { value: 42, writable: false });
 obj1.x = 9; // throws a TypeError
 
 // Assignment to a getter-only property
-var obj2 = { get x() { return 17; } };
+const obj2 = { get x() { return 17; } };
 obj2.x = 5; // throws a TypeError
 
 // Assignment to a new property on a non-extensible object
-var fixed = {};
+const fixed = {};
 Object.preventExtensions(fixed);
 fixed.newProp = 'ohai'; // throws a TypeError
 ```
@@ -130,18 +130,18 @@ function sum(a, a, c) { // !!! syntax error
 Fifth, a strict mode in ECMAScript 5 [forbids a `0`-prefixed octal literal or octal escape sequence](/en-US/docs/Web/JavaScript/Reference/Errors/Deprecated_octal). Outside strict mode, a number beginning with a `0`, such as `0644`, is interpreted as an octal number (`0644 === 420`), if all digits are smaller than 8. Octal escape sequences, such as `"\45"`, which is equal to `"%"`, can be used to represent characters by extended-ASCII character code numbers in octal. In strict mode, this is a syntax error. In ECMAScript 2015, octal literals are supported by prefixing a number with "`0o`"; for example:
 
 ```js
-var a = 0o10; // ES2015: Octal
+const a = 0o10; // ES2015: Octal
 ```
 
 Novice developers sometimes believe a leading zero prefix has no semantic meaning, so they might use it as an alignment device — but this changes the number's meaning! A leading zero syntax for the octal is rarely useful and can be mistakenly used, so strict mode makes it a syntax error:
 
 ```js
 'use strict';
-var sum = 015 + // !!! syntax error
-          197 +
-          142;
+const sum = 015 + // !!! syntax error
+            197 +
+            142;
 
-var sumWithOctal = 0o10 + 8;
+const sumWithOctal = 0o10 + 8;
 console.log(sumWithOctal); // 16
 ```
 
@@ -162,7 +162,7 @@ In ECMAScript 5 strict-mode code, duplicate property names were considered a {{j
 
 ```js
 'use strict';
-var o = { p: 1, p: 2 }; // syntax error prior to ECMAScript 2015
+const o = { p: 1, p: 2 }; // syntax error prior to ECMAScript 2015
 ```
 
 ### Simplifying variable uses
@@ -173,9 +173,9 @@ First, strict mode prohibits [`with`](/en-US/docs/Web/JavaScript/Reference/State
 
 ```js
 'use strict';
-var x = 17;
+const x = 17;
 with (obj) { // !!! syntax error
-  // If this weren't strict mode, would this be var x, or
+  // If this weren't strict mode, would this be const x, or
   // would it instead be obj.x?  It's impossible in general
   // to say without running the code, so the name can't be
   // optimized.
@@ -243,13 +243,13 @@ First, the names `eval` and `arguments` can't be bound or assigned in language s
 eval = 17;
 arguments++;
 ++eval;
-var obj = { set p(arguments) { } };
-var eval;
+const obj = { set p(arguments) { } };
+let eval;
 try { } catch (arguments) { }
 function x(eval) { }
 function arguments() { }
-var y = function eval() { };
-var f = new Function('arguments', "'use strict'; return 17;");
+const y = function eval() { };
+const f = new Function('arguments', "'use strict'; return 17;");
 ```
 
 Second, strict mode code doesn't alias properties of `arguments` objects created within it. In normal code within a function whose first argument is `arg`, setting `arg` also sets `arguments[0]`, and vice versa (unless no arguments were provided or `arguments[0]` is deleted). `arguments` objects for strict mode functions store the original arguments when the function was invoked. `arguments[i]` does not track the value of the corresponding named argument, nor does a named argument track the value in the corresponding `arguments[i]`.
@@ -260,7 +260,7 @@ function f(a) {
   a = 42;
   return [a, arguments[0]];
 }
-var pair = f(17);
+const pair = f(17);
 console.assert(pair[0] === 42);
 console.assert(pair[1] === 17);
 ```
@@ -269,7 +269,7 @@ Third, `arguments.callee` is no longer supported. In normal code `arguments.call
 
 ```js
 'use strict';
-var f = function() { return arguments.callee; };
+const f = function() { return arguments.callee; };
 f(); // throws a TypeError
 ```
 
@@ -320,7 +320,7 @@ if (true) {
   f();
 }
 
-for (var i = 0; i < 5; i++) {
+for (let i = 0; i < 5; i++) {
   function f2() { } // !!! syntax error
   f2();
 }

--- a/files/en-us/web/javascript/reference/strict_mode/transitioning_to_strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/strict_mode/transitioning_to_strict_mode/index.md
@@ -22,7 +22,7 @@ Strict mode has been designed so that the transition to it can be made gradually
 
 When adding `'use strict';`, the following cases will throw a {{jsxref("SyntaxError")}} before the script is executing:
 
-- Octal syntax `var n = 023;`
+- Octal syntax `const n = 023;`
 - [`with`](/en-US/docs/Web/JavaScript/Reference/Statements/with) statement
 - Using [`delete`](/en-US/docs/Web/JavaScript/Reference/Operators/delete) on a variable name `delete myVariable`;
 - Using [`eval`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval) or [`arguments`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments) as variable or function argument name
@@ -43,7 +43,7 @@ JavaScript used to silently fail in contexts where what was done was an error. S
 ```js
 function f(x) {
   'use strict';
-  var a = 12;
+  const a = 12;
   b = a + x * 35; // error!
 }
 f(42);
@@ -52,11 +52,11 @@ f(42);
 This used to change a value on the global object which is rarely the expected effect. If you really want to set a value to the global object, pass it as an argument and explicitly assign it as a property:
 
 ```js
-var global = this; // in the top-level context, "this" always
+const global = this; // in the top-level context, "this" always
                    // refers to the global object
 function f(x) {
   'use strict';
-  var a = 12;
+  const a = 12;
   global.b = a + x * 35;
 }
 f(42);
@@ -77,13 +77,14 @@ Accessing `arguments.callee`, `arguments.caller`, `anyFunction.caller`, or `anyF
 
 ```js
 // example taken from vanillajs: http://vanilla-js.com/
-var s = document.getElementById('thing').style;
+const s = document.getElementById('thing').style;
 s.opacity = 1;
 (function() {
-  if ((s.opacity-=.1) < 0)
+  if ((s.opacity -= .1) < 0) {
     s.display = 'none';
-  else
+  } else {
     setTimeout(arguments.callee, 40);
+  }
 })();
 ```
 
@@ -91,13 +92,14 @@ which can be rewritten as:
 
 ```js
 'use strict';
-var s = document.getElementById('thing').style;
+const s = document.getElementById('thing').style;
 s.opacity = 1;
 (function fadeOut() { // name the function
-  if((s.opacity-=.1) < 0)
+  if ((s.opacity -= .1) < 0) {
     s.display = 'none';
-  else
+  } else {
     setTimeout(fadeOut, 40); // use the name of the function
+  }
 })();
 ```
 
@@ -126,7 +128,7 @@ A potential "downside" of moving strict code to strict mode is that the semantic
 
     1. `eval`: use it only if you know what you're doing
     2. `arguments`: always access function arguments via their name or perform a copy of the arguments object using:
-        `var args = Array.prototype.slice.call(arguments)`
+        `const args = Array.prototype.slice.call(arguments)`
         as the first line of your function
     3. `this`: only use `this` when it refers to an object you created.
 

--- a/files/en-us/web/javascript/reference/trailing_commas/index.md
+++ b/files/en-us/web/javascript/reference/trailing_commas/index.md
@@ -40,7 +40,7 @@ function parameters and to named imports and named exports.
 JavaScript ignores trailing commas in arrays:
 
 ```js
-var arr = [
+const arr = [
   1,
   2,
   3,
@@ -56,7 +56,7 @@ iterating arrays for example with {{jsxref("Array.prototype.forEach()")}} or
 {{jsxref("Array.prototype.map()")}}, array holes are skipped.
 
 ```js
-var arr = [1, 2, 3,,,];
+const arr = [1, 2, 3,,,];
 arr.length; // 5
 ```
 
@@ -65,7 +65,7 @@ arr.length; // 5
 Starting with ECMAScript 5, trailing commas in object literals are legal as well:
 
 ```js
-var object = {
+const object = {
   foo: "bar",
   baz: "qwerty",
   age: 42,
@@ -98,7 +98,7 @@ class C {
   two(a, b,) {}
 }
 
-var obj = {
+const obj = {
   one(a,) {},
   two(a, b,) {},
 };
@@ -140,17 +140,17 @@ A trailing comma is also allowed on the left-hand side when using
 [a, b,] = [1, 2];
 
 // object destructuring with trailing comma
-var o = {
+const o = {
   p: 42,
   q: true,
 };
-var {p, q,} = o;
+const {p, q,} = o;
 ```
 
 Again, when using a rest element, a {{jsxref("SyntaxError")}} will be thrown:
 
 ```js example-bad
-var [a, ...b,] = [1, 2, 3];
+const [a, ...b,] = [1, 2, 3];
 // SyntaxError: rest element may not have a trailing comma
 ```
 

--- a/files/en-us/web/javascript/the_performance_hazards_of_prototype_mutation/index.md
+++ b/files/en-us/web/javascript/the_performance_hazards_of_prototype_mutation/index.md
@@ -23,8 +23,8 @@ function Landmark(lat, lon, desc) {
   this.location = { lat: lat, long: lon };
   this.description = desc;
 }
-var lm1 = new Landmark(-90, 0, "South Pole");
-var lm2 = new Landmark(-24.3756466, -128.311018, "Pitcairn Islands");
+const lm1 = new Landmark(-90, 0, "South Pole");
+const lm2 = new Landmark(-24.3756466, -128.311018, "Pitcairn Islands");
 ```
 
 Every `Landmark` has properties `location` and `description` in that order.  Each object literal storing latitude/longitude information has properties `lat` and long in that order.  Subsequent code _could_ delete a property.  But it's unlikely, so engines can produce less-optimal code in such cases.  In SpiderMonkey, the JavaScript engine in Firefox, a particular ordering of properties (and some aspects of those properties, _not_ including values) is called a _shape_.  (V8's name for the concept is _structure ID_.) If two objects share a shape, their properties are stored identically.
@@ -60,13 +60,13 @@ If an engine knows an object has a particular shape, it can assume _all_ propert
 Many properties don't exist _directly_ on the object: lookups often find properties on the prototype chain.  Accesses to properties on prototypes is just extra "hops" through the `prototype` field to the object containing the property.  Optimizing _correctly_ requires that no object along the way have the property, so every hop must check that object's shape.
 
 ```js
-var d = new Date();
+const d = new Date();
 d.toDateString(); // Date.prototype.toDateString
 
 function Pair(x, y) { this.x = x; this.y = y; }
 Pair.prototype.sum = function() { return this.x + this.y; };
 
-var p = new Pair(3, 7);
+const p = new Pair(3, 7);
 p.sum(); // Pair.prototype.sum
 ```
 
@@ -81,26 +81,26 @@ Predictable property accesses _usually_ find the property a constant number of h
   - : In this case, a shape match must imply that no intervening object's `[[Prototype]]` has been modified.  Therefore, when an object's `[[Prototype]]` is mutated, every object along its `[[Prototype]]` chain must also have its shape changed.
 
     ```js
-        var obj1 = {};
-        var obj2 = Object.create(obj1);
-        var obj3 = Object.create(obj2);
+    const obj1 = {};
+    const obj2 = Object.create(obj1);
+    const obj3 = Object.create(obj2);
 
-        // Objects whose shapes would change: obj3, obj2, obj1, Object.prototype
-        obj3.__proto__ = {};
-        ```
+    // Objects whose shapes would change: obj3, obj2, obj1, Object.prototype
+    Object.setPrototypeOf(obj3, {});
+    ```
 
 - The shape of the object initially accessed can be checked.
 
   - : Every object that might inherit through a changed-`[[Prototype]]` object must change, reflecting the `[[Prototype]]` mutation having happened
 
     ```js
-        var obj1 = {};
-        var obj2 = Object.create(obj1);
-        var obj3 = Object.create(obj2);
+    const obj1 = {};
+    const obj2 = Object.create(obj1);
+    const obj3 = Object.create(obj2);
 
-        // Objects whose shapes would change: obj1, obj2, obj3
-        obj1.__proto__ = {};
-        ```
+    // Objects whose shapes would change: obj1, obj2, obj3
+    Object.setPrototypeOf(obj1, {});
+    ```
 
 ## Pernicious effects of `[[Prototype]]` mutation
 
@@ -115,26 +115,28 @@ While the spec considers mutating `[[Prototype]]` to be modifying a single hidde
 The bad effects of `[[Prototype]]` mutation don't end once the mutation is complete.  Because so many property-examination operations implicitly depend on `[[Prototype]]` chains not changing, when engines observe a mutation, _an object with mutated `[[Prototype]] "taints" all code the object flows through`_.  This tainting flows through all code that ever observes a mutated-`[[Prototype]]` object.  As a near-worst-case illustration, consider these patterns of behavior:
 
 ```js
-var obj = {};
-obj.__proto__ = { x: 3 }; // gratuitous mutation
+const obj = {};
+Object.setPrototypeOf(obj, { x: 3 }); // gratuitous mutation
 
-var arr = [obj];
-for (var i = 0; i < 5; i++)
+const arr = [obj];
+for (let i = 0; i < 5; i++) {
   arr.push({ x: i });
+}
 
 function f(v, i) {
-  var elt = v[i];
-  var r =  elt.x > 2 // pessimized
+  const elt = v[i];
+  const r = elt.x > 2 // pessimized
            ? elt
            : { x: elt.x + 1 };
   return r;
 }
-var c = f(arr, 0);
+
+let c = f(arr, 0);
 c.x; // pessimized: return value has unknown properties
 c = f(arr, 1);
 c.x; // still pessimized!
 
-var arr2 = [c];
+const arr2 = [c];
 arr2[0].x; // pessimized
 ```
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

`var` -> `const` in JS references is tricky because some of the use-cases are intended, so I'll be doing this myself.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues

Part of #16614 

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
