### PR TITLE
typofix: brackets/parenthesis parity for a syntax bloc

### DIFF
--- a/files/en-us/web/css/gradient/repeating-conic-gradient/index.md
+++ b/files/en-us/web/css/gradient/repeating-conic-gradient/index.md
@@ -29,7 +29,7 @@ The **`repeating-conic-gradient()`** [CSS](/en-US/docs/Web/CSS) [function](/en-U
 background: repeating-conic-gradient(
     from 3deg at 25% 25%,
     hsl(200, 100%, 50%) 0deg 15deg,
-    hsl(200, 100%, 60%) 10deg 30deg);
+    hsl(200, 100%, 60%) 10deg 30deg
 );
 ```
 


### PR DESCRIPTION

#### Summary
A typo in the syntax block, there was too much closing parenthesis

#### Motivation
Fixing a typo

#### Supporting details
https://www.w3.org/TR/CSS2/syndata.html#tokenization

#### Related issues
I didn't look for any existing. I'd assume it would have been fixed already, if any.

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

