### PR TITLE
Mention that TypedArray#set throws a RangeError if the target is too large to fit in the target

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/typedarray/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/set/index.md
@@ -46,8 +46,8 @@ set(typedarray, targetOffset)
 
 - {{jsxref("RangeError")}}
   - : Thrown if one of the two conditions is met:
-    - The `array` or `typedarray` is too large to fit in the typed array.  
-    - The `targetOffset` is set such as it would store beyond the end of the typed array.
+    - An element will be stored beyond the end of the typed array, either because `targetOffset` is too large or because `array` or `typedarray` is too large.
+    - `targetOffset` is negative.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/set/index.md
@@ -44,6 +44,8 @@ set(typedarray, targetOffset)
 
 ### Exceptions
 
+A {{jsxref("RangeError")}}, if the `array` or `typedarray` is too large to
+fit in the typed array.  
 A {{jsxref("RangeError")}}, if the `targetOffset` is set such as it would store
 beyond the end of the typed array.
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/set/index.md
@@ -44,10 +44,10 @@ set(typedarray, targetOffset)
 
 ### Exceptions
 
-A {{jsxref("RangeError")}}, if the `array` or `typedarray` is too large to
-fit in the typed array.  
-A {{jsxref("RangeError")}}, if the `targetOffset` is set such as it would store
-beyond the end of the typed array.
+- {{jsxref("RangeError")}}
+  - : Thrown if one of the two conditions is met:
+    - The `array` or `typedarray` is too large to fit in the typed array.  
+    - The `targetOffset` is set such as it would store beyond the end of the typed array.
 
 ## Examples
 


### PR DESCRIPTION
#### Summary
This adds a line to the "Exceptions" section of the page about `TypedArray.prototype.set()` that mentions that it throws an exception if the target array is smaller than the source array + the offset.

#### Motivation
I had expected the method to simply ignore any extraneous data. Instead, it threw an exception. I think this surprising behaviour should be mentioned on the documentation page.