### PR TITLE
Add custom replace rule to markdownlint configuration

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -102,5 +102,30 @@
     "style": "asterisk"
   },
   "MD051": false,
-  "MD052": false
+  "MD052": false,
+  "search-replace": {
+    "rules": [
+      {
+        "name": "curly-double-quotes",
+        "message": "Don't use curly double quotes.",
+        "searchPattern": "/“|”/g",
+        "replace": "\"",
+        "skipCode": true
+      },
+      {
+        "name": "curly-single-quotes",
+        "message": "Don't use curly single quotes.",
+        "searchPattern": "/‘|’/g",
+        "replace": "'",
+        "skipCode": true
+      },
+      {
+        "name": "m-dash",
+        "message": "Don't use '--'. Use m-dash — instead.",
+        "search": " -- ",
+        "replace": " — ",
+        "skipCode": true
+      }
+    ]
+  }
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -107,24 +107,38 @@
     "rules": [
       {
         "name": "curly-double-quotes",
-        "message": "Don't use curly double quotes.",
+        "message": "Don't use curly double quotes",
         "searchPattern": "/“|”/g",
         "replace": "\"",
         "skipCode": true
       },
       {
         "name": "curly-single-quotes",
-        "message": "Don't use curly single quotes.",
+        "message": "Don't use curly single quotes",
         "searchPattern": "/‘|’/g",
         "replace": "'",
         "skipCode": true
       },
       {
         "name": "m-dash",
-        "message": "Don't use '--'. Use m-dash — instead.",
+        "message": "Don't use '--'. Use m-dash — instead",
         "search": " -- ",
         "replace": " — ",
         "skipCode": true
+      },
+      {
+        "name": "relative-link",
+        "message": "Internal links should start with '/'",
+        "search": "(en-US/docs",
+        "replace": "(/en-US/docs",
+        "skipCode": true
+      },
+      {
+        "name": "trailing-spaces",
+        "message": "Avoid trailing spaces",
+        "searchPattern": "/  +$/gm",
+        "replace": "",
+        "skipCode": false
       }
     ]
   }

--- a/files/en-us/web/css/border/index.md
+++ b/files/en-us/web/css/border/index.md
@@ -15,13 +15,13 @@ browser-compat: css.properties.border
 
 The **`border`** [shorthand](/en-US/docs/Web/CSS/Shorthand_properties) [CSS](/en-US/docs/Web/CSS) property sets an element's border. It sets the values of {{Cssxref("border-width")}}, {{Cssxref("border-style")}}, and {{Cssxref("border-color")}}.
 
-{{EmbedInteractiveExample("pages/css/border.html")}}
+{{EmbedInteractiveExample("pages/css/border.html")}}  
 
 ## Constituent properties
 
 This property is a shorthand for the following CSS properties:
 
-- [`border-color`](/en-US/docs/Web/CSS/border-color)
+- [`border-color`](en-US/docs/Web/CSS/border-color)
 - [`border-style`](/en-US/docs/Web/CSS/border-style)
 - [`border-width`](/en-US/docs/Web/CSS/border-width)
 

--- a/files/en-us/web/css/border/index.md
+++ b/files/en-us/web/css/border/index.md
@@ -15,13 +15,13 @@ browser-compat: css.properties.border
 
 The **`border`** [shorthand](/en-US/docs/Web/CSS/Shorthand_properties) [CSS](/en-US/docs/Web/CSS) property sets an element's border. It sets the values of {{Cssxref("border-width")}}, {{Cssxref("border-style")}}, and {{Cssxref("border-color")}}.
 
-{{EmbedInteractiveExample("pages/css/border.html")}}  
+{{EmbedInteractiveExample("pages/css/border.html")}}
 
 ## Constituent properties
 
 This property is a shorthand for the following CSS properties:
 
-- [`border-color`](en-US/docs/Web/CSS/border-color)
+- [`border-color`](/en-US/docs/Web/CSS/border-color)
 - [`border-style`](/en-US/docs/Web/CSS/border-style)
 - [`border-width`](/en-US/docs/Web/CSS/border-width)
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "fix:md": "npm run lint:md -- --fix",
     "fix:yml": "prettier -w \"**/*.yml\"",
     "lint:json": "prettier -c \"**/*.json\"",
-    "lint:md": "markdownlint \"**/*.md\" -i node_modules",
+    "lint:md": "markdownlint \"**/*.md\" -i node_modules  -r markdownlint-rule-search-replace",
     "lint:yml": "prettier -c \"**/*.yml\"",
     "start": "yarn up-to-date-check && env-cmd --silent cross-env CONTENT_ROOT=files REACT_APP_DISABLE_AUTH=true BUILD_OUT_ROOT=build yari-server",
     "up-to-date-check": "node scripts/up-to-date-check.js"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "cross-env": "7.0.3",
     "env-cmd": "10.1.0",
     "markdownlint-cli": "0.32.2",
+    "markdownlint-rule-search-replace": "1.0.4",
     "prettier": "2.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "fix:md": "npm run lint:md -- --fix",
     "fix:yml": "prettier -w \"**/*.yml\"",
     "lint:json": "prettier -c \"**/*.json\"",
-    "lint:md": "markdownlint \"**/*.md\" -i node_modules  -r markdownlint-rule-search-replace",
+    "lint:md": "markdownlint \"**/*.md\" -i node_modules -r markdownlint-rule-search-replace",
     "lint:yml": "prettier -c \"**/*.yml\"",
     "start": "yarn up-to-date-check && env-cmd --silent cross-env CONTENT_ROOT=files REACT_APP_DISABLE_AUTH=true BUILD_OUT_ROOT=build yari-server",
     "up-to-date-check": "node scripts/up-to-date-check.js"
@@ -24,7 +24,7 @@
     "cross-env": "7.0.3",
     "env-cmd": "10.1.0",
     "markdownlint-cli": "0.32.2",
-    "markdownlint-rule-search-replace": "1.0.4",
+    "markdownlint-rule-search-replace": "1.0.5",
     "prettier": "2.7.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3065,10 +3065,22 @@ markdownlint-cli@0.32.2:
     minimatch "~5.1.0"
     run-con "~1.2.11"
 
+markdownlint-rule-helpers@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.16.0.tgz#c327f72782bd2b9475127a240508231f0413a25e"
+  integrity sha512-oEacRUVeTJ5D5hW1UYd2qExYI0oELdYK72k1TKGvIeYJIbqQWAz476NAc7LNixSySUhcNl++d02DvX0ccDk9/w==
+
 markdownlint-rule-helpers@~0.17.2:
   version "0.17.2"
   resolved "https://registry.yarnpkg.com/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.17.2.tgz#64d6e8c66e497e631b0e40cf1cef7ca622a0b654"
   integrity sha512-XaeoW2NYSlWxMCZM2B3H7YTG6nlaLfkEZWMBhr4hSPlq9MuY2sy83+Xr89jXOqZMZYjvi5nBCGoFh7hHoPKZmA==
+
+markdownlint-rule-search-replace@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/markdownlint-rule-search-replace/-/markdownlint-rule-search-replace-1.0.4.tgz#0fcbdced404409a63cb331fa5090b2819ed2eb38"
+  integrity sha512-VOgjmFrY1vVtURFpjo7QYOL3K9qAy8ari+jFA2KwlkopPhDatvH4tcIR1SexYXe5jqcEwZqOOATCrrYVN81qTg==
+  dependencies:
+    markdownlint-rule-helpers "^0.16.0"
 
 markdownlint@~0.26.2:
   version "0.26.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3065,22 +3065,17 @@ markdownlint-cli@0.32.2:
     minimatch "~5.1.0"
     run-con "~1.2.11"
 
-markdownlint-rule-helpers@^0.16.0:
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.16.0.tgz#c327f72782bd2b9475127a240508231f0413a25e"
-  integrity sha512-oEacRUVeTJ5D5hW1UYd2qExYI0oELdYK72k1TKGvIeYJIbqQWAz476NAc7LNixSySUhcNl++d02DvX0ccDk9/w==
-
 markdownlint-rule-helpers@~0.17.2:
   version "0.17.2"
   resolved "https://registry.yarnpkg.com/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.17.2.tgz#64d6e8c66e497e631b0e40cf1cef7ca622a0b654"
   integrity sha512-XaeoW2NYSlWxMCZM2B3H7YTG6nlaLfkEZWMBhr4hSPlq9MuY2sy83+Xr89jXOqZMZYjvi5nBCGoFh7hHoPKZmA==
 
-markdownlint-rule-search-replace@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/markdownlint-rule-search-replace/-/markdownlint-rule-search-replace-1.0.4.tgz#0fcbdced404409a63cb331fa5090b2819ed2eb38"
-  integrity sha512-VOgjmFrY1vVtURFpjo7QYOL3K9qAy8ari+jFA2KwlkopPhDatvH4tcIR1SexYXe5jqcEwZqOOATCrrYVN81qTg==
+markdownlint-rule-search-replace@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/markdownlint-rule-search-replace/-/markdownlint-rule-search-replace-1.0.5.tgz#20cc1681e3c162dd43d19614e3d1515e75cf0299"
+  integrity sha512-PXpHZuZrqaPA0kpkPSsTPVndxtoM+wgG95V9vzL5sZl+SQUp8hJIHSqOnNJOwd85ykgjbnripZYf0IN40ADkdw==
   dependencies:
-    markdownlint-rule-helpers "^0.16.0"
+    markdownlint-rule-helpers "~0.17.2"
 
 markdownlint@~0.26.2:
   version "0.26.2"


### PR DESCRIPTION
There are many unwanted characters that we've been replacing time to time. For example, https://github.com/mdn/content/pull/16324, https://github.com/mdn/content/pull/16770#issuecomment-1140765087, https://github.com/mdn/content/pull/17834#pullrequestreview-1025728726 are some of the PRs.
Because of some locales or keyboard settings contributors introduce such characters.

We want to handle cases such as:
- curly double quotes `“` to straight quotes `"` #16770
- curly single quotes `‘` and  `’` to straight quote `'`
- double hyphens `--` to m-dash `—` #17833
- three dots `...` to ellipsis `…`
- replace `(en-US/docs` with `(/en-US/docs` to avoid broken links https://github.com/mdn/content/pull/18670#issuecomment-1193056819
- remove trailing spaces. #19866
- and recently https://github.com/mdn/content/pull/18123#issuecomment-1179823977

The PR adds a custom markdownlint rule/plugin [markdownlint-rule-search-replace](https://github.com/OnkarRuikar/markdownlint-rule-search-replace) to address such issues.

With the `search-replace` rule in place we can run the linter like this:
```shell
# to flag the issues
yarn lint:md

# or to fix automatically
yarn fix:md
```
We can provide plain string or regex pattern to search and replace. So many complex cases can be handled.
Refer the rule [documentation](https://github.com/OnkarRuikar/markdownlint-rule-search-replace#using-markdownlintjson-config-file) for more information.

To see the plugin in action refer https://github.com/mdn/content/pull/18210.
***

cc/ @teoli2003 , @nschonni , @caugner 