### PR TITLE
Fix broken link

### DIFF
--- a/files/en-us/learn/html/tables/advanced/index.md
+++ b/files/en-us/learn/html/tables/advanced/index.md
@@ -350,7 +350,7 @@ This section of the article provides further techniques for making tables as acc
 
 Screenreaders will identify all headers and use them to make programmatic associations between those headers and the cells they relate to. The combination of column and row headers will identify and interpret the data in each cell so that screenreader users can interpret the table similarly to how a sighted user does.
 
-We already covered headers in our previous article — see [Adding headers with \<th> elements](/en-US/docs/Learn/HTML/Tables/Basics#adding_headers_with_%3cth%3e_elements).
+We already covered headers in our previous article — see [Adding headers with \<th> elements](/en-US/docs/Learn/HTML/Tables/Basics#adding_headers_with_th_elements).
 
 ### The scope attribute
 


### PR DESCRIPTION
Fixed a partially broken link in the **Using column and row headers** section.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Previously the link pointed to `https://developer.mozilla.org/en-US/docs/Learn/HTML/Tables/Basics#adding_headers_with_%3cth%3e_elements`

Where it should point to `https://developer.mozilla.org/en-US/docs/Learn/HTML/Tables/Basics#adding_headers_with_th_elements`

Only the `<>` or `%3c` & `%3e` around the `th` is only removed.
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
Updating the link will enable browser to scroll to the specific section when it goes to that page.
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
