### PR TITLE
Change AudioFrame to AudioData

### DIFF
--- a/files/en-us/web/api/mediastreamtrackgenerator/index.md
+++ b/files/en-us/web/api/mediastreamtrackgenerator/index.md
@@ -17,7 +17,7 @@ The object consumes a stream of media frames as input, which can be audio or vid
 ## Constructor
 
 - {{domxref("MediaStreamTrackGenerator.MediaStreamTrackGenerator", "MediaStreamTrackGenerator()")}}
-  - : Creates a new `MediaStreamTrackGenerator` object which accepts either {{domxref("VideoFrame")}} or {{domxref("AudioFrame")}} objects.
+  - : Creates a new `MediaStreamTrackGenerator` object which accepts either {{domxref("VideoFrame")}} or {{domxref("AudioData")}} objects.
 
 ## Properties
 


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
There is no AudioFrame object, instead this should reference AudioData: https://developer.mozilla.org/en-US/docs/Web/API/AudioData

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
The object used to be called AudioFrame, but it was updated to AudioData.

#### Related issues


#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
