### PR TITLE
Additional info on close and disconnect webRequest.filterResponseData()

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/filterresponsedata/index.md
@@ -52,6 +52,8 @@ filter.ondata = event => {
 filter.onstop = event => {
   // The extension should always call filter.close() or filter.disconnect()
   // after creating the StreamFilter, otherwise the response is kept alive forever.
+  // If processing of the response data is finished, use close. If any remaining 
+  // response data should be processed by Firefox, use disconnect.
   filter.close();
 };
 ```


### PR DESCRIPTION
#### Summary
Adds information to the commented example  on webRequest.filterResponseData() to clarify the use of close and disconnect. This is in addition to the information provided on [webRequest.StreamFilter](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter). Provides the content requested in [Bug 1431649](https://bugzilla.mozilla.org/show_bug.cgi?id=1431649).

#### Metadata
This PR…

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error