### PR TITLE
Use &ldquo;, &rdquo, and &rsquo; for curly quotes when needed

### DIFF
--- a/files/en-us/glossary/unicode/index.md
+++ b/files/en-us/glossary/unicode/index.md
@@ -8,7 +8,11 @@ Unicode is a standard {{Glossary("Character set","character set")}} that numbers
 
 By assigning each character a number, programmers can create {{Glossary("Character encoding","character encodings")}}, to let computers store, process, and transmit any combination of languages in the same file or program.
 
+<!-- markdownlint-disable search-replace -->
+
 Before Unicode, it was difficult and error-prone to mix languages in the same data. For example, one character set would store Japanese characters, and another would store the Arabic alphabet. If it was not clearly marked which parts of the data were in which character set, other programs and computers would display the text incorrectly, or damage it during processing. If you've ever seen text where characters like curly quotes (`“”`) were replaced with gibberish like `Ã‚Â£`, then you've seen this problem, known as [Mojibake](https://en.wikipedia.org/wiki/Mojibake).
+
+<!-- markdownlint-enable search-replace -->
 
 The most common Unicode character encoding on the Web is {{Glossary("UTF-8")}}. Other encodings exist, like UTF-16 or the obsolete UCS-2, but UTF-8 is recommended.
 

--- a/files/en-us/glossary/unicode/index.md
+++ b/files/en-us/glossary/unicode/index.md
@@ -8,11 +8,7 @@ Unicode is a standard {{Glossary("Character set","character set")}} that numbers
 
 By assigning each character a number, programmers can create {{Glossary("Character encoding","character encodings")}}, to let computers store, process, and transmit any combination of languages in the same file or program.
 
-<!-- markdownlint-disable search-replace -->
-
-Before Unicode, it was difficult and error-prone to mix languages in the same data. For example, one character set would store Japanese characters, and another would store the Arabic alphabet. If it was not clearly marked which parts of the data were in which character set, other programs and computers would display the text incorrectly, or damage it during processing. If you've ever seen text where characters like curly quotes (&ldquo;&rdquo) were replaced with gibberish like `Ã‚Â£`, then you've seen this problem, known as [Mojibake](https://en.wikipedia.org/wiki/Mojibake).
-
-<!-- markdownlint-enable search-replace -->
+Before Unicode, it was difficult and error-prone to mix languages in the same data. For example, one character set would store Japanese characters, and another would store the Arabic alphabet. If it was not clearly marked which parts of the data were in which character set, other programs and computers would display the text incorrectly, or damage it during processing. If you've ever seen text where characters like curly quotes (&ldquo;&rdquo;) were replaced with gibberish like `Ã‚Â£`, then you've seen this problem, known as [Mojibake](https://en.wikipedia.org/wiki/Mojibake).
 
 The most common Unicode character encoding on the Web is {{Glossary("UTF-8")}}. Other encodings exist, like UTF-16 or the obsolete UCS-2, but UTF-8 is recommended.
 

--- a/files/en-us/glossary/unicode/index.md
+++ b/files/en-us/glossary/unicode/index.md
@@ -10,7 +10,7 @@ By assigning each character a number, programmers can create {{Glossary("Charact
 
 <!-- markdownlint-disable search-replace -->
 
-Before Unicode, it was difficult and error-prone to mix languages in the same data. For example, one character set would store Japanese characters, and another would store the Arabic alphabet. If it was not clearly marked which parts of the data were in which character set, other programs and computers would display the text incorrectly, or damage it during processing. If you've ever seen text where characters like curly quotes (`“”`) were replaced with gibberish like `Ã‚Â£`, then you've seen this problem, known as [Mojibake](https://en.wikipedia.org/wiki/Mojibake).
+Before Unicode, it was difficult and error-prone to mix languages in the same data. For example, one character set would store Japanese characters, and another would store the Arabic alphabet. If it was not clearly marked which parts of the data were in which character set, other programs and computers would display the text incorrectly, or damage it during processing. If you've ever seen text where characters like curly quotes (&ldquo;&rdquo) were replaced with gibberish like `Ã‚Â£`, then you've seen this problem, known as [Mojibake](https://en.wikipedia.org/wiki/Mojibake).
 
 <!-- markdownlint-enable search-replace -->
 

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/index.md
@@ -265,12 +265,16 @@ Use English-style plurals, not the Latin- or Greek-influenced forms.
 - **Correct**: syllabuses, octopuses
 - **Incorrect**: syllabi, octopi
 
+<!-- markdownlint-disable search-replace -->
+
 ### Apostrophes and quotation marks
 
 Do not use "curly" quotes and quotation marks. On MDN Web Docs, we only use straight quotes and apostrophes. This is because we need to choose one or the other for consistency. If curly quotes or apostrophes make their way into code snippets, even inline ones, readers may copy and paste them, expecting them to function (which they will not).
 
 - **Correct**: Please don't use "curly quotes."
 - **Incorrect**: Please don’t use “curly quotes.”
+
+<!-- markdownlint-enable search-replace -->
 
 ### Commas
 

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/index.md
@@ -272,7 +272,7 @@ Use English-style plurals, not the Latin- or Greek-influenced forms.
 Do not use "curly" quotes and quotation marks. On MDN Web Docs, we only use straight quotes and apostrophes. This is because we need to choose one or the other for consistency. If curly quotes or apostrophes make their way into code snippets, even inline ones, readers may copy and paste them, expecting them to function (which they will not).
 
 - **Correct**: Please don't use "curly quotes."
-- **Incorrect**: Please don’t use “curly quotes.”
+- **Incorrect**: Please don&rsquo;t use &ldquo;curly quotes.&rdquo;
 
 <!-- markdownlint-enable search-replace -->
 

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/index.md
@@ -265,16 +265,12 @@ Use English-style plurals, not the Latin- or Greek-influenced forms.
 - **Correct**: syllabuses, octopuses
 - **Incorrect**: syllabi, octopi
 
-<!-- markdownlint-disable search-replace -->
-
 ### Apostrophes and quotation marks
 
 Do not use "curly" quotes and quotation marks. On MDN Web Docs, we only use straight quotes and apostrophes. This is because we need to choose one or the other for consistency. If curly quotes or apostrophes make their way into code snippets, even inline ones, readers may copy and paste them, expecting them to function (which they will not).
 
 - **Correct**: Please don't use "curly quotes."
 - **Incorrect**: Please don&rsquo;t use &ldquo;curly quotes.&rdquo;
-
-<!-- markdownlint-enable search-replace -->
 
 ### Commas
 


### PR DESCRIPTION
We don not use curly quotes on MDN. [[ref](https://pr18009.content.dev.mdn.mozit.cloud/en-US/docs/MDN/Writing_guidelines/Writing_style_guide#apostrophes_and_quotation_marks)]

Use HTML codes for curly quotes if required.
`&ldquo;`  **&ldquo;**
`&rdquo;`  **&rdquo;**
`&rsquo;`  **&rsquo;**

This saves them from getting flagged by our [customized linter](https://github.com/mdn/content/pull/17988).