### PR TITLE
Clarify RegExp syntax, add example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/regexp/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/index.md
@@ -22,8 +22,8 @@ For an introduction to regular expressions, read the [Regular Expressions chapte
 
 There are two ways to create a `RegExp` object: a _literal notation_ and a _constructor_.
 
-- **The literal notation** takes a pattern between two slashes and optional flags after the second slash.
-- **The constructor function** takes either a string or a `RegExp` Object as first parameter and a string of optional flags as second parameter. 
+- The _literal notation_ takes a pattern between two slashes, followed by optional flags, after the second slash.
+- The _constructor function_ takes either a string or a `RegExp` object as its first parameter and a string of optional flags as its second parameter. 
 
 The following three expressions create the same regular expression object:
 
@@ -33,9 +33,11 @@ let re = new RegExp('ab+c', 'i') // constructor with string pattern as first arg
 let re = new RegExp(/ab+c/, 'i') // constructor with regular expression literal as first argument (Starting with ECMAScript 6)
 ```
 
+Before regular expressions can be used, they have to be compiled. This process allows them to perform matches more efficiently. There are two ways to compile and get a `RegExp` object. 
+
 The literal notation results in compilation of the regular expression when the expression is evaluated. On the other hand, the constructor of the `RegExp` object, `new RegExp('ab+c')`, results in runtime compilation of the regular expression. 
 
-Use a string as the first argument to the RegExp constructor when you want to [build the regular expression from dynamic input](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#Building_a_regular_expression_from_dynamic_inputs).
+Use a string as the first argument to the `RegExp()` constructor when you want to [build the regular expression from dynamic input](#Building_a_regular_expression_from_dynamic_inputs).
 
 ### Flags in constructor
 
@@ -220,7 +222,7 @@ console.log(/^https?:\/\/(.+?)\./.exec(url)[1]); // logs 'xxx'
 const breakfasts = ['bacon', 'eggs', 'oatmeal', 'toast', 'cereal'];
 const order = 'Let me get some bacon and eggs, please';
 
-order.match(new RegExp('\\b(' + breakfasts.join('|') + ')\\b', 'g')); 
+order.match(new RegExp(`\\b(${breakfasts.join('|')})\\b`, 'g')); 
 // Returns ['bacon', 'eggs']
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/index.md
@@ -33,7 +33,7 @@ let re = new RegExp('ab+c', 'i') // constructor with string pattern as first arg
 let re = new RegExp(/ab+c/, 'i') // constructor with regular expression literal as first argument (Starting with ECMAScript 6)
 ```
 
-Before regular expressions can be used, they have to be compiled. This process allows them to perform matches more efficiently. There are two ways to compile and get a `RegExp` object. 
+Before regular expressions can be used, they have to be compiled. This process allows them to perform matches more efficiently. More about the process can be found in [dotnet docs](https://docs.microsoft.com/en-us/dotnet/standard/base-types/compilation-and-reuse-in-regular-expressions). 
 
 The literal notation results in compilation of the regular expression when the expression is evaluated. On the other hand, the constructor of the `RegExp` object, `new RegExp('ab+c')`, results in runtime compilation of the regular expression. 
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/index.md
@@ -22,8 +22,8 @@ For an introduction to regular expressions, read the [Regular Expressions chapte
 
 There are two ways to create a `RegExp` object: a _literal notation_ and a _constructor_.
 
-- **The literal notation's** parameters are enclosed between slashes and do not use quotation marks.
-- **The constructor function's** parameters are not enclosed between slashes but do use quotation marks.
+- **The literal notation** takes a pattern between two slashes and optional flags after the second slash.
+- **The constructor function** takes either a string or a `RegExp` Object as first parameter and a string of optional flags as second parameter. 
 
 The following three expressions create the same regular expression object:
 
@@ -33,9 +33,9 @@ let re = new RegExp('ab+c', 'i') // constructor with string pattern as first arg
 let re = new RegExp(/ab+c/, 'i') // constructor with regular expression literal as first argument (Starting with ECMAScript 6)
 ```
 
-The literal notation results in compilation of the regular expression when the expression is evaluated. Use literal notation when the regular expression will remain constant. For example, if you use literal notation to construct a regular expression used in a loop, the regular expression won't be recompiled on each iteration.
+The literal notation results in compilation of the regular expression when the expression is evaluated. On the other hand, the constructor of the `RegExp` object, `new RegExp('ab+c')`, results in runtime compilation of the regular expression. 
 
-The constructor of the regular expression object—for example, `new RegExp('ab+c')`—results in runtime compilation of the regular expression. Use the constructor function when you know the regular expression pattern will be changing, or you don't know the pattern and obtain it from another source, such as user input.
+Use a string as the first argument to the RegExp constructor when you want to [build the regular expression from dynamic input](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#Building_a_regular_expression_from_dynamic_inputs).
 
 ### Flags in constructor
 
@@ -213,6 +213,16 @@ console.log(/^https?:\/\/(.+?)\./.exec(url)[1]); // logs 'xxx'
 ```
 
 > **Note:** Instead of using regular expressions for parsing URLs, it is usually better to use the browsers built-in URL parser by using the [URL API](/en-US/docs/Web/API/URL_API).
+
+### Building a regular expression from dynamic inputs
+
+```js
+const breakfasts = ['bacon', 'eggs', 'oatmeal', 'toast', 'cereal'];
+const order = 'Let me get some bacon and eggs, please';
+
+order.match(new RegExp('\\b(' + breakfasts.join('|') + ')\\b', 'g')); 
+// Returns ['bacon', 'eggs']
+```
 
 ## Specifications
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/regexp/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/regexp/index.md
@@ -90,10 +90,8 @@ RegExp(pattern[, flags])
 There are two ways to create a `RegExp` object: a _literal notation_
 and a _constructor_.
 
-- **The literal notation's** parameters are enclosed between slashes and
-  do not use quotation marks.
-- **The constructor function's** parameters are not enclosed between
-  slashes but do use quotation marks.
+- The _literal notation_ takes a pattern between two slashes, followed by optional flags, after the second slash.
+- The _constructor function_ takes either a string or a `RegExp` object as its first parameter and a string of optional flags as its second parameter. 
 
 The following three expressions create the same regular expression:
 
@@ -103,16 +101,21 @@ new RegExp(/ab+c/, 'i') // literal notation
 new RegExp('ab+c', 'i') // constructor
 ```
 
-The literal notation results in compilation of the regular expression when the
-expression is evaluated. Use literal notation when the regular expression will remain
-constant. For example, if you use literal notation to construct a regular expression
-used in a loop, the regular expression won't be recompiled on each iteration.
+Before regular expressions can be used, they have to be compiled. This process allows them to perform matches more efficiently. There are two ways to compile and get a `RegExp` object. 
 
-The constructor of the regular expression object—for example,
-`new RegExp('ab+c')`—results in runtime compilation of the regular
-expression. Use the constructor function when you know the regular expression pattern
-will be changing, or you don't know the pattern and are getting it from another source,
-such as user input.
+The literal notation results in compilation of the regular expression when the expression is evaluated. On the other hand, the constructor of the `RegExp` object, `new RegExp('ab+c')`, results in runtime compilation of the regular expression. 
+
+Use a string as the first argument to the `RegExp()` constructor when you want to [build the regular expression from dynamic input](#Building_a_regular_expression_from_dynamic_inputs).
+
+### Building a regular expression from dynamic inputs
+
+```js
+const breakfasts = ['bacon', 'eggs', 'oatmeal', 'toast', 'cereal'];
+const order = 'Let me get some bacon and eggs, please';
+
+order.match(new RegExp(`\\b(${breakfasts.join('|')})\\b`, 'g')); 
+// Returns ['bacon', 'eggs']
+```
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
I have clarified the definition of literal notation and constructor of RegExp and added an example. I have also shortened some paragraphs regarding the usage of RegExp. 

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Fixing an Issue with RegExp literal notation parameter explanation #17641, which had a misleading definition regarding regular expression literal notation and constructor. Using terms such as "do not use quotations" is misleading and confusing to the reader because it has nothing to do with syntax. 

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes  #17641

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
