### PR TITLE
Remove misleading section on aspect-ratio

### DIFF
--- a/files/en-us/web/css/aspect-ratio/index.md
+++ b/files/en-us/web/css/aspect-ratio/index.md
@@ -55,20 +55,6 @@ aspect-ratio: 16 / 9;
 aspect-ratio: 0.5;
 ```
 
-## Mapping width and height to aspect-ratio
-
-Browsers have added an internal `aspect-ratio` property that applies to [replaced elements](/en-US/docs/Web/CSS/Replaced_element) and other related elements that accept `width` and `height` attributes. This appears in the browser's internal UA stylesheet.
-
-In Firefox, the internal stylesheet rule looks like this:
-
-```css
-img, input[type="image"], video, embed, iframe, marquee, object, table {
-  aspect-ratio: attr(width) / attr(height);
-}
-```
-
-You can read more about this feature in [Setting Height And Width On Images Is Important Again](https://www.smashingmagazine.com/2020/03/setting-height-width-images-important-again/).
-
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

What this section describes isn't how the spec is written, and isn't how implementations work.

#### Motivation

It leads to confusion and misunderstandings https://twitter.com/jensimmons/status/1544372136172613632

#### Supporting details

Here's the Firefox UA stylesheets https://searchfox.org/mozilla-central/source/layout/style/res. The claim made in the deleted section is factually incorrect.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
