### PR TITLE
Add space between <code> and {{optional_inline}} - batch 1/2 (#18019)

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/action/disable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/disable/index.md
@@ -29,7 +29,7 @@ browser.action.disable(
 
 ### Parameters
 
-- `tabId`{{optional_inline}}
+- `tabId` {{optional_inline}}
   - : `integer`. The id of the tab for which you want to disable the browser action.
 
 ## Examples

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/enable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/enable/index.md
@@ -29,7 +29,7 @@ browser.action.enable(
 
 ### Parameters
 
-- `tabId`{{optional_inline}}
+- `tabId` {{optional_inline}}
   - : `integer`. The id of the tab for which you want to enable the browser action.
 
 ## Examples

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/getbadgebackgroundcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/getbadgebackgroundcolor/index.md
@@ -35,9 +35,9 @@ browser.action.getBadgeBackgroundColor(
 
   - : An object with the following properties:
 
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. Specifies the tab to get the badge background color from.
-    - `windowId`{{optional_inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. Specifies the window from which to get the badge background color.
 
 <!---->

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/getbadgetext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/getbadgetext/index.md
@@ -35,9 +35,9 @@ let gettingText = browser.action.getBadgeText(
 
   - : An object with the following properties:
 
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. Specifies the tab from which to get the badge text.
-    - `windowId`{{optional_inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. Specifies the window from which to get the badge text.
 
 <!---->

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/getbadgetextcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/getbadgetextcolor/index.md
@@ -38,9 +38,9 @@ browser.action.getBadgeTextColor(
 
   - : `object`.
 
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. Specifies the tab to get the badge text color from.
-    - `windowId`{{optional_inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. Specifies the window from which to get the badge text color.
 
 <!---->

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/getpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/getpopup/index.md
@@ -35,9 +35,9 @@ let gettingPopup = browser.action.getPopup(
 
   - : An object with the following properties:
 
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. The tab whose popup to get.
-    - `windowId`{{optional_inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. The windows whose popup to get.
 
 <!---->

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/gettitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/gettitle/index.md
@@ -37,9 +37,9 @@ let gettingTitle = browser.action.getTitle(
 
   - : An object with the following properties:
 
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. Specify the tab to get the title from.
-    - `windowId`{{optional_inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. Specify the window to get the title from.
 
 <!---->

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgebackgroundcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgebackgroundcolor/index.md
@@ -45,9 +45,9 @@ browser.action.setBadgeBackgroundColor(
         - a `{{WebExtAPIRef('action.ColorArray')}}` object.
         - `null`. If a `tabId` is specified, it removes the tab-specific badge background color so that the tab inherits the global badge background color. Otherwise it reverts the global badge background color to the default value.
 
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. Sets the badge background color only for the given tab. The color is reset when the user navigates this tab to a new page.
-    - `windowId`{{optional_inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. Sets the badge background color only for the given tab.
 
 <!---->

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgetext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgetext/index.md
@@ -47,9 +47,9 @@ This API is also available as `chrome.action.setBadgeText()`.
 
         If a `windowId` is specified, `null` removes the window-specific badge text so that the tab inherits the global badge text. Otherwise it reverts the global badge text to `""`.
 
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. Set the badge text only for the given tab. The text is reset when the user navigates this tab to a new page.
-    - `windowId`{{optional_inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. Set the badge text for the given window.
 
 <!---->

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgetextcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/setbadgetextcolor/index.md
@@ -40,9 +40,9 @@ browser.action.setBadgeTextColor(
         - a `{{WebExtAPIRef('action.ColorArray')}}` object.
         - `null`. If a `tabId` is specified, it removes the tab-specific badge text color so that the tab inherits the global badge text color. Otherwise it reverts the global badge text color to the default value.
 
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. Sets the badge text color only for the given tab. The color is reset when the user navigates this tab to a new page.
-    - `windowId`{{optional_inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. Sets the badge text color only for the given tab.
 
 <!---->

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/seticon/index.md
@@ -41,7 +41,7 @@ let settingIcon = browser.action.setIcon(
 
   - : `object`. An object containing either `imageData` or `path` properties, and optionally a `tabId` property.
 
-    - `imageData`{{optional_inline}}
+    - `imageData` {{optional_inline}}
 
       - : `{{WebExtAPIRef('action.ImageDataType')}}` or `object`. This is either a single `ImageData` object or a dictionary object.
 
@@ -56,7 +56,7 @@ let settingIcon = browser.action.setIcon(
 
         The browser will choose the image to use depending on the screen's pixel density. See [Choosing icon sizes](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action#choosing_icon_sizes) for more information on this.
 
-    - `path`{{optional_inline}}
+    - `path` {{optional_inline}}
 
       - : `string` or `object`. This is either a relative path to an icon file or it is a dictionary object.
 
@@ -71,9 +71,9 @@ let settingIcon = browser.action.setIcon(
 
         The browser will choose the image to use depending on the screen's pixel density. See [Choosing icon sizes](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action#choosing_icon_sizes) for more information on this.
 
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. Sets the icon only for the given tab. The icon is reset when the user navigates this tab to a new page.
-    - `windowId`{{optional_inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. Sets the icon for the given window.
 
 <!---->

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/setpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/setpopup/index.md
@@ -33,9 +33,9 @@ browser.action.setPopup(
 
   - : An object with the following properties:
 
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. Sets the popup only for a specific tab. The popup is reset when the user navigates this tab to a new page.
-    - `windowId`{{optional_inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. Sets the popup only for the specified window.
     - `popup`
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/action/settitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/action/settitle/index.md
@@ -44,9 +44,9 @@ browser.action.setTitle(
         - if `windowId` is specified, and the window has a window-specific title set, then the window will inherit the global title.
         - Otherwise, the global title will be reset to the manifest title.
 
-    - `tabId`{{Optional_Inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. Sets the title only for the given tab.
-    - `windowId`{{Optional_Inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. Sets the title for the given window.
 
 <!---->

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/alarm/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/alarm/index.md
@@ -25,7 +25,7 @@ Values of this type are objects. They contain the following properties:
   - : `string`. Name of this alarm. This is the name that was passed into the {{WebExtAPIRef('alarms.create()')}} call that created this alarm.
 - `scheduledTime`
   - : `double`. Time at which the alarm is scheduled to fire next, in [milliseconds since the epoch](https://en.wikipedia.org/wiki/Unix_time).
-- `periodInMinutes`{{optional_inline}}
+- `periodInMinutes` {{optional_inline}}
   - : `double`. If this is not `null`, then the alarm is periodic, and this represents its period in minutes.
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/clear/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/clear/index.md
@@ -29,7 +29,7 @@ let clearAlarm = browser.alarms.clear(
 
 ### Parameters
 
-- `name`{{optional_inline}}
+- `name` {{optional_inline}}
   - : `string`. The name of the alarm to clear. If you don't supply this, the empty string "" will be used.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/create/index.md
@@ -28,7 +28,7 @@ browser.alarms.create(
 
 ### Parameters
 
-- `name`{{optional_inline}}
+- `name` {{optional_inline}}
 
   - : `string`. A name for the alarm. Defaults to the empty string.
 
@@ -36,7 +36,7 @@ browser.alarms.create(
 
     Alarm names are unique within the scope of a single extension. If an alarm with an identical name exists, the existing alarm will be cleared and the alarm being created will replace it.
 
-- `alarmInfo`{{optional_inline}}
+- `alarmInfo` {{optional_inline}}
 
   - : `object`. You can use this to specify when the alarm will initially fire, either as an absolute value (`when`), or as a delay from the time the alarm is set (`delayInMinutes`). To make the alarm recur, specify `periodInMinutes`.
 
@@ -44,11 +44,11 @@ browser.alarms.create(
 
     The `alarmInfo` object may contain the following properties:
 
-    - `when`{{optional_inline}}
+    - `when` {{optional_inline}}
       - : `double`. The time the alarm will fire first, given as [milliseconds since the epoch](https://en.wikipedia.org/wiki/Unix_time). To get the number of milliseconds between the epoch and the current time, use [`Date.now()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now). If you specify `when`, don't specify `delayInMinutes`.
-    - `delayInMinutes`{{optional_inline}}
+    - `delayInMinutes` {{optional_inline}}
       - : `double`. The time the alarm will fire first, given as minutes from the time the alarm is set. If you specify `delayInMinutes`, don't specify `when`.
-    - `periodInMinutes`{{optional_inline}}
+    - `periodInMinutes` {{optional_inline}}
       - : `double`. If this is specified, the alarm will fire again every `periodInMinutes` after its initial firing. If you specify this value you may omit both `when` and `delayInMinutes`, and the alarm will then fire initially after `periodInMinutes`. If `periodInMinutes` is not specified, the alarm will only fire once.
 
 ## Examples

--- a/files/en-us/mozilla/add-ons/webextensions/api/alarms/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/alarms/get/index.md
@@ -29,7 +29,7 @@ let getAlarm = browser.alarms.get(
 
 ### Parameters
 
-- `name`{{optional_inline}}
+- `name` {{optional_inline}}
   - : `string`. The name of the alarm to get. If you don't supply this, the empty string "" will be used.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
@@ -35,7 +35,7 @@ An {{jsxref("object")}} with the following properties:
   - : A {{jsxref("string")}} which specifies the ID of the parent folder. This property is not present in the root node.
 - `title`
   - : A {{jsxref("string")}} which contains the text displayed for the node in menus and lists of bookmarks.
-- `type`{{optional_inline}}
+- `type` {{optional_inline}}
   - : A {{WebExtAPIRef("bookmarks.BookmarkTreeNodeType")}} object indicating whether this is a bookmark, a folder, or a separator. Defaults to `"bookmark"` unless `url` is omitted, in which case it defaults to `"folder"`.
 - `unmodifiable` {{optional_inline}}
   - : A {{jsxref("string")}} as described by the type {{WebExtAPIRef('bookmarks.BookmarkTreeNodeUnmodifiable')}}. Represents the reason that the node can't be changed. If the node can be changed, this is omitted.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/createdetails/index.md
@@ -27,7 +27,7 @@ An {{jsxref("object")}} containing some combination of the following fields:
   - : A {{jsxref("string")}} which indicates the ID of the parent folder into which to place the new bookmark or bookmark folder. On Chrome and Firefox, the default is the "Other Bookmarks" folder on the Bookmarks menu.
 - `title` {{optional_inline}}
   - : A {{jsxref("string")}} which specifies the title for the bookmark or the name of the folder to be created. If this isn't specified, the title is `""`.
-- `type`{{optional_inline}}
+- `type` {{optional_inline}}
   - : A {{WebExtAPIRef("bookmarks.BookmarkTreeNodeType")}} object indicating whether this is a bookmark, a folder, or a separator. Defaults to `"bookmark"` unless `url` is omitted, in which case it defaults to `"folder"`.
 - `url` {{optional_inline}}
   - : `string`. A {{jsxref("string")}} which specifies the URL of the page to bookmark. If this is omitted or is `null`, a folder is created instead of a bookmark.

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/disable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/disable/index.md
@@ -27,7 +27,7 @@ browser.browserAction.disable(
 
 ### Parameters
 
-- `tabId`{{optional_inline}}
+- `tabId` {{optional_inline}}
   - : `integer`. The id of the tab for which you want to disable the browser action.
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/enable/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/enable/index.md
@@ -27,7 +27,7 @@ browser.browserAction.enable(
 
 ### Parameters
 
-- `tabId`{{optional_inline}}
+- `tabId` {{optional_inline}}
   - : `integer`. The id of the tab for which you want to enable the browser action.
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgebackgroundcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgebackgroundcolor/index.md
@@ -33,9 +33,9 @@ browser.browserAction.getBadgeBackgroundColor(
 
   - : An object with the following properties:
 
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. Specifies the tab to get the badge background color from.
-    - `windowId`{{optional_inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. Specifies the window from which to get the badge background color.
 
 <!---->

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetext/index.md
@@ -33,9 +33,9 @@ let gettingText = browser.browserAction.getBadgeText(
 
   - : An object with the following properties:
 
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. Specifies the tab from which to get the badge text.
-    - `windowId`{{optional_inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. Specifies the window from which to get the badge text.
 
 <!---->

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetextcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getbadgetextcolor/index.md
@@ -36,9 +36,9 @@ browser.browserAction.getBadgeTextColor(
 
   - : `object`.
 
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. Specifies the tab to get the badge text color from.
-    - `windowId`{{optional_inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. Specifies the window from which to get the badge text color.
 
 <!---->

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/getpopup/index.md
@@ -33,9 +33,9 @@ let gettingPopup = browser.browserAction.getPopup(
 
   - : An object with the following properties:
 
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. The tab whose popup to get.
-    - `windowId`{{optional_inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. The windows whose popup to get.
 
 <!---->

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/gettitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/gettitle/index.md
@@ -35,9 +35,9 @@ let gettingTitle = browser.browserAction.getTitle(
 
   - : An object with the following properties:
 
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. Specify the tab to get the title from.
-    - `windowId`{{optional_inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. Specify the window to get the title from.
 
 <!---->

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgebackgroundcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgebackgroundcolor/index.md
@@ -43,9 +43,9 @@ browser.browserAction.setBadgeBackgroundColor(
         - a `{{WebExtAPIRef('browserAction.ColorArray')}}` object.
         - `null`. If a `tabId` is specified, it removes the tab-specific badge background color so that the tab inherits the global badge background color. Otherwise it reverts the global badge background color to the default value.
 
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. Sets the badge background color only for the given tab. The color is reset when the user navigates this tab to a new page.
-    - `windowId`{{optional_inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. Sets the badge background color only for the given tab.
 
 <!---->

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetext/index.md
@@ -45,9 +45,9 @@ This API is also available as `chrome.browserAction.setBadgeText()`.
 
         If a `windowId` is specified, `null` removes the window-specific badge text so that the tab inherits the global badge text. Otherwise it reverts the global badge text to `""`.
 
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. Set the badge text only for the given tab. The text is reset when the user navigates this tab to a new page.
-    - `windowId`{{optional_inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. Set the badge text for the given window.
 
 <!---->

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetextcolor/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setbadgetextcolor/index.md
@@ -38,9 +38,9 @@ browser.browserAction.setBadgeTextColor(
         - a `{{WebExtAPIRef('browserAction.ColorArray')}}` object.
         - `null`. If a `tabId` is specified, it removes the tab-specific badge text color so that the tab inherits the global badge text color. Otherwise it reverts the global badge text color to the default value.
 
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. Sets the badge text color only for the given tab. The color is reset when the user navigates this tab to a new page.
-    - `windowId`{{optional_inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. Sets the badge text color only for the given tab.
 
 <!---->

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/seticon/index.md
@@ -39,7 +39,7 @@ let settingIcon = browser.browserAction.setIcon(
 
   - : `object`. An object containing either `imageData` or `path` properties, and optionally a `tabId` property.
 
-    - `imageData`{{optional_inline}}
+    - `imageData` {{optional_inline}}
 
       - : `{{WebExtAPIRef('browserAction.ImageDataType')}}` or `object`. This is either a single `ImageData` object or a dictionary object.
 
@@ -54,7 +54,7 @@ let settingIcon = browser.browserAction.setIcon(
 
         The browser will choose the image to use depending on the screen's pixel density. See [Choosing icon sizes](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action#choosing_icon_sizes) for more information on this.
 
-    - `path`{{optional_inline}}
+    - `path` {{optional_inline}}
 
       - : `string` or `object`. This is either a relative path to an icon file or it is a dictionary object.
 
@@ -69,9 +69,9 @@ let settingIcon = browser.browserAction.setIcon(
 
         The browser will choose the image to use depending on the screen's pixel density. See [Choosing icon sizes](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action#choosing_icon_sizes) for more information on this.
 
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. Sets the icon only for the given tab. The icon is reset when the user navigates this tab to a new page.
-    - `windowId`{{optional_inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. Sets the icon for the given window.
 
 <!---->

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setpopup/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/setpopup/index.md
@@ -31,9 +31,9 @@ browser.browserAction.setPopup(
 
   - : An object with the following properties:
 
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. Sets the popup only for a specific tab. The popup is reset when the user navigates this tab to a new page.
-    - `windowId`{{optional_inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. Sets the popup only for the specified window.
     - `popup`
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/browseraction/settitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browseraction/settitle/index.md
@@ -42,9 +42,9 @@ browser.browserAction.setTitle(
         - if `windowId` is specified, and the window has a window-specific title set, then the window will inherit the global title.
         - Otherwise, the global title will be reset to the manifest title.
 
-    - `tabId`{{Optional_Inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. Sets the title only for the given tab.
-    - `windowId`{{Optional_Inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. Sets the title for the given window.
 
 <!---->

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/command/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/command/index.md
@@ -23,11 +23,11 @@ An array of these objects is returned from {{WebExtAPIRef('commands.getAll()')}}
 
 Values of this type are objects. They contain the following properties:
 
-- `name`{{optional_inline}}
+- `name` {{optional_inline}}
   - : `string`. Name of this command. This will be passed into the {{WebExtAPIRef('commands.onCommand')}} event listener.
-- `description`{{optional_inline}}
+- `description` {{optional_inline}}
   - : `string`. Description of this command. This is primarily used to explain to the user what this command does.
-- `shortcut`{{optional_inline}}
+- `shortcut` {{optional_inline}}
   - : `string`. Key(s) used to execute this command, specified as a string like "Ctrl+Shift+Y".
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/commands/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/commands/update/index.md
@@ -34,9 +34,9 @@ browser.commands.update(
 
     - `name`
       - : `string`. The name of the command to update. This must match the name of an existing command, as given for example in the `name` property of the {{WebExtAPIRef("commands.Command")}} object.
-    - `description`{{optional_inline}}
+    - `description` {{optional_inline}}
       - : `string`. A new description to set for the command.
-    - `shortcut`{{optional_inline}}
+    - `shortcut` {{optional_inline}}
 
       - : `string`. A new shortcut to set for the command. This can be:
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookie/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/cookie/index.md
@@ -23,7 +23,7 @@ Values of this type are objects, which can contain the following properties:
 
 - `domain`
   - : A `string` representing the domain the cookie belongs to (e.g. "www\.google.com", "example.com").
-- `expirationDate`{{optional_inline}}
+- `expirationDate` {{optional_inline}}
   - : A `number` representing the expiration date of the cookie as the number of seconds since the UNIX epoch. Not provided for session cookies.
 - `firstPartyDomain`
   - : A `string` representing the first-party domain associated with the cookie. This will be an empty string if the cookie was set while first-party isolation was off. See [First-party isolation](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#first-party_isolation).
@@ -33,7 +33,7 @@ Values of this type are objects, which can contain the following properties:
   - : A `boolean`, `true` if the cookie is marked as HttpOnly (i.e. the cookie is inaccessible to client-side scripts), or `false` otherwise.
 - `name`
   - : A `string` representing the name of the cookie.
-- `partitionKey`{{optional_inline}}
+- `partitionKey` {{optional_inline}}
 
   - : An `object` representing the description of the [storage partition](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#storage_partitioning) containing the cookie. This object is omitted (null) if the cookie is not in partitioned storage. This object contains the following properties:
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/get/index.md
@@ -35,18 +35,18 @@ let getting = browser.cookies.get(
 
   - : An `object` containing details that can be used to match a cookie to be retrieved. It can include the following properties:
 
-    - `firstPartyDomain`{{optional_inline}}
+    - `firstPartyDomain` {{optional_inline}}
       - : A `string` representing the first-party domain with which the cookie to retrieve is associated. This property must be supplied if the browser has first-party isolation enabled. See [First-party isolation](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#first-party_isolation).
     - `name`
       - : A `string` representing the name of the cookie to retrieve.
-    - `partitionKey`{{optional_inline}}
+    - `partitionKey` {{optional_inline}}
 
       - : An `object` representing the [storage partition](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#storage_partitioning) containing the cookie. Include this object with `topLevelSite` to obtain a cookie from partitioned storage. Otherwise, returns the cookie from unpartitioned storage. This object contains:
 
-        - `topLevelSite`{{optional_inline}}
+        - `topLevelSite` {{optional_inline}}
           - : A `string` representing the first-party URL of the top-level site storage partition containing the cookie.
 
-    - `storeId`{{optional_inline}}
+    - `storeId` {{optional_inline}}
       - : A `string` representing the ID of the {{WebExtAPIRef("cookies.CookieStore", "cookie store")}} in which to look for the cookie (as returned by {{WebExtAPIRef("cookies.getAllCookieStores()")}}). By default, the current execution context's cookie store will be used.
     - `url`
       - : A `string` representing the URL with which the cookie to retrieve is associated. This argument may be a full URL, in which case any data following the URL path (e.g. the query string) is ignored. If [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) for this URL are not specified in the extension's [manifest file](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json), the API call will fail.

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/getall/index.md
@@ -33,17 +33,17 @@ let getting = browser.cookies.getAll(
 
   - : An `object` containing details that can be used to match cookies to be retrieved. Included properties are as follows (see [Cookie type](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies/Cookie#type) for more information on these):
 
-    - `domain`{{optional_inline}}
+    - `domain` {{optional_inline}}
       - : A `string` representing a domain that cookies must be associated with (they can be associated either with this exact domain or one of its subdomains).
-    - `firstPartyDomain`{{optional_inline}}
+    - `firstPartyDomain` {{optional_inline}}
 
       - : A `string` representing the first-party domain with which the cookie to retrieve is associated.
 
         This property must be supplied if the browser has first-party isolation enabled. You can however pass `null` in this situation. If you do this, then cookies with any value for `firstPartyDomain`, as well as cookies which do not have `firstPartyDomain` set at all, will be included in the results. See [First-party isolation](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#first-party_isolation).
 
-    - `name`{{optional_inline}}
+    - `name` {{optional_inline}}
       - : A `string` representing a name that the cookies should have.
-    - `partitionKey`{{optional_inline}}
+    - `partitionKey` {{optional_inline}}
 
       - : An `object` defining which [storage partitions](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#storage_partitioning) to return cookies from:
 
@@ -53,18 +53,18 @@ let getting = browser.cookies.getAll(
 
         This object contains:
 
-        - `topLevelSite`{{optional_inline}}
+        - `topLevelSite` {{optional_inline}}
           - : A `string` representing the first-party URL of the top-level site storage partition containing the cookies.
 
-    - `path`{{optional_inline}}
+    - `path` {{optional_inline}}
       - : A `string` representing a path — the cookies' path must be identical to this one.
-    - `secure`{{optional_inline}}
+    - `secure` {{optional_inline}}
       - : A `boolean` — filters cookies by their `secure` property, allowing you to filter secure cookies vs. non-secure cookies.
-    - `session`{{optional_inline}}
+    - `session` {{optional_inline}}
       - : A `boolean`— filters the cookies by their `session` property, allowing you to filter session cookies vs. persistent cookies.
-    - `storeId`{{optional_inline}}
+    - `storeId` {{optional_inline}}
       - : A `string` representing the cookie store to retrieve cookies from. If omitted, the current execution context's cookie store will be used.
-    - `url`{{optional_inline}}
+    - `url` {{optional_inline}}
       - : A `string` representing a URL that the retrieved cookies must be associated with.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/remove/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/remove/index.md
@@ -35,18 +35,18 @@ let removing = browser.cookies.remove(
 
   - : An `object` containing information to identify the cookie to remove. It contains the following properties:
 
-    - `firstPartyDomain`{{optional_inline}}
+    - `firstPartyDomain` {{optional_inline}}
       - : A `string` representing the first-party domain with which the cookie to remove is associated. This property must be supplied if the browser has first-party isolation enabled. See [First-party isolation](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#first-party_isolation).
     - `name`
       - : A `string` representing the name of the cookie to remove.
-    - `partitionKey`{{optional_inline}}
+    - `partitionKey` {{optional_inline}}
 
       - : An `object` representing the [storage partition](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#storage_partitioning) containing the cookie. Include this object to remove a cookie from partitioned storage. This object contains:
 
-        - `topLevelSite`{{optional_inline}}
+        - `topLevelSite` {{optional_inline}}
           - : A `string` representing the first-party URL of the top-level site storage partition containing the cookie.
 
-    - `storeId`{{optional_inline}}
+    - `storeId` {{optional_inline}}
       - : A `string` representing the ID of the cookie store to find the cookie in. If unspecified, the cookie is looked for by default in the current execution context's cookie store.
     - `url`
       - : A `string` representing the URL associated with the cookie. If the extension does not have [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) for this URL, the API call will fail.

--- a/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/cookies/set/index.md
@@ -35,34 +35,34 @@ let setting = browser.cookies.set(
 
   - : An `object` containing the details of the cookie you wish to set. It can have the following properties:
 
-    - `domain`{{optional_inline}}
+    - `domain` {{optional_inline}}
       - : A `string` representing the domain of the cookie. If omitted, the cookie becomes a host-only cookie.
-    - `expirationDate`{{optional_inline}}
+    - `expirationDate` {{optional_inline}}
       - : A `number` that represents the expiration date of the cookie as the number of seconds since the UNIX epoch. If omitted, the cookie becomes a session cookie.
-    - `firstPartyDomain`{{optional_inline}}
+    - `firstPartyDomain` {{optional_inline}}
       - : A `string` representing the first-party domain with which the cookie to will be associated. This property must be supplied if the browser has first-party isolation enabled. See [First-party isolation](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#first-party_isolation).
-    - `httpOnly`{{optional_inline}}
+    - `httpOnly` {{optional_inline}}
       - : A `boolean` that specifies whether the cookie should be marked as HttpOnly (`true`), or not (false). If omitted, it defaults to false.
-    - `name`{{optional_inline}}
+    - `name` {{optional_inline}}
       - : A `string` representing the name of the cookie. If omitted, this is empty by default.
-    - `partitionKey`{{optional_inline}}
+    - `partitionKey` {{optional_inline}}
 
       - : An `object` representing the [storage partition](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies#storage_partitioning) to set the cookie in. Include this object to set a cookie in partitioned storage. This object contains:
 
-        - `topLevelSite`{{optional_inline}}
+        - `topLevelSite` {{optional_inline}}
           - : A `string` representing the first-party URL of the top-level site storage partition containing the cookie.
 
-    - `path`{{optional_inline}}
+    - `path` {{optional_inline}}
       - : A `string` representing the path of the cookie. If omitted, this defaults to the path portion of the URL parameter.
-    - `sameSite`{{optional_inline}}
+    - `sameSite` {{optional_inline}}
       - : A {{WebExtAPIRef("cookies.SameSiteStatus")}} value that indicates the SameSite state of the cookie. If omitted, it defaults to 0, 'no_restriction'.
-    - `secure`{{optional_inline}}
+    - `secure` {{optional_inline}}
       - : A `boolean` that specifies whether the cookie should be marked as secure (`true`), or not (false). If omitted, it defaults to false.
-    - `storeId`{{optional_inline}}
+    - `storeId` {{optional_inline}}
       - : A `string` representing the ID of the cookie store in which to set the cookie. If omitted, the cookie is set in the current execution context's cookie store by default.
     - `url`
       - : A `string` representing the request-URI to associate with the cookie. This value can affect the default domain and path values of the created cookie. If host permissions for this URL are not specified in the manifest file, the method call will fail.
-    - `value`{{optional_inline}}
+    - `value` {{optional_inline}}
       - : A `string` representing the value of the cookie. If omitted, this is empty by default.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/eval/index.md
@@ -54,13 +54,13 @@ let evaluating = browser.devtools.inspectedWindow.eval(
 
 - `expression`
   - : `string`. The JavaScript expression to evaluate. The string must evaluate to a object that can be represented as JSON, or an exception will be thrown. For example, `expression` must not evaluate to a function.
-- `options`{{optional_inline}}
+- `options` {{optional_inline}}
 
   - : `object`. Options for the function (Note that Firefox does not yet support this options), as follows:
 
-    - `frameURL`{{optional_inline}}
+    - `frameURL` {{optional_inline}}
       - : `string`. The URL of the frame in which to evaluate the expression. If this is omitted, the expression is evaluated in the main frame of the window.
-    - `useContentScriptContext`{{optional_inline}}
+    - `useContentScriptContext` {{optional_inline}}
       - : `boolean`. If `true`, evaluate the expression in the context of any content scripts that this extension has attached to the page. If you set this option, then you must have actually attached some content scripts to the page, or a Devtools error will be thrown.
     - `contextSecurityOrigin` {{optional_inline}}
       - : `string`. Evaluate the expression in the context of a content script attached by a different extension, whose origin matches the value given here. This overrides `useContentScriptContext`.

--- a/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/reload/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/devtools/inspectedwindow/reload/index.md
@@ -26,13 +26,13 @@ browser.devtools.inspectedWindow.reload(
 
 ### Parameters
 
-- `reloadOptions`{{optional_inline}}
+- `reloadOptions` {{optional_inline}}
 
   - : `object`. Options for the function, as follows:
 
-    - `ignoreCache`{{optional_inline}}
+    - `ignoreCache` {{optional_inline}}
       - : `boolean`. If true, this makes the reload ignore the browser cache (as if the user had pressed Shift+Ctrl+R).
-    - `userAgent`{{optional_inline}}
+    - `userAgent` {{optional_inline}}
       - : `string`. Set a custom user agent for the page. The string supplied here will be sent in the browser's [User-Agent](/en-US/docs/Web/HTTP/Headers/User-Agent) header, and will be returned by calls to [`navigator.userAgent`](/en-US/docs/Web/API/Navigator/userAgent) made by scripts running in the page.
     - `injectedScript` {{optional_inline}}
       - : `string`. Inject the given JavaScript expression into all frames in the page, before any other scripts.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/booleandelta/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/booleandelta/index.md
@@ -21,9 +21,9 @@ The `BooleanDelta` type of the {{WebExtAPIRef("downloads")}} API represents the 
 
 Values of this type are objects. They contain the following properties:
 
-- `current`{{optional_inline}}
+- `current` {{optional_inline}}
   - : A `boolean` representing the current boolean value.
-- `previous`{{optional_inline}}
+- `previous` {{optional_inline}}
   - : A `boolean` representing the previous boolean value.
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/doubledelta/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/doubledelta/index.md
@@ -21,9 +21,9 @@ The `DoubleDelta` type of the {{WebExtAPIRef("downloads")}} API represents the d
 
 Values of this type are objects. They contain the following properties:
 
-- `current`{{optional_inline}}
+- `current` {{optional_inline}}
   - : A `number` representing the current double value.
-- `previous`{{optional_inline}}
+- `previous` {{optional_inline}}
   - : A `number` representing the previous double value.
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/download/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/download/index.md
@@ -40,28 +40,28 @@ let downloading = browser.downloads.download(
 
   - : An `object` specifying what file you wish to download, and any other preferences you wish to set concerning the download. It can contain the following properties:
 
-    - `allowHttpErrors`{{optional_inline}}
+    - `allowHttpErrors` {{optional_inline}}
 
       - : A `boolean` flag that enables downloads to continue even if they encounter HTTP errors. Using this flag, for example, enables the download of server error pages. Default value `false`. When set to:
 
         - `false`, the download is canceled when it encounters an HTTP error.
         - `true`, the download continues when an HTTP error is encountered and the HTTP server error is not reported. However, if the download fails due to file-related, network-related, user-related, or other error, that error is reported.
 
-    - `body`{{optional_inline}}
+    - `body` {{optional_inline}}
       - : A `string` representing the post body of the request.
-    - `conflictAction`{{optional_inline}}
+    - `conflictAction` {{optional_inline}}
       - : A string representing the action you want taken if there is a filename conflict, as defined in the {{WebExtAPIRef('downloads.FilenameConflictAction')}} type (defaults to "uniquify" when it is not specified).
-    - `cookieStoreId`{{optional_inline}}
+    - `cookieStoreId` {{optional_inline}}
       - : The cookie store ID of the [contextual identity](/en-US/docs/Mozilla/Add-ons/WebExtensions/Work_with_contextual_identities) the download is associated with. If omitted, the default cookie store is used. Use requires the "cookies" [API permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#api_permissions).
-    - `filename`{{optional_inline}}
+    - `filename` {{optional_inline}}
       - : A `string` representing a file path relative to the default downloads directory — this provides the location where you want the file to be saved, and what filename you want to use. Absolute paths, empty paths, path components that start and/or end with a dot (.), and paths containing back-references (`../`) will cause an error. If omitted, this value will default to the filename already given to the download file, and a location immediately inside the downloads directory.
-    - `headers`{{optional_inline}}
+    - `headers` {{optional_inline}}
       - : If the URL uses the HTTP or HTTPS protocols, an `array` of `objects` representing additional HTTP headers to send with the request. Each header is represented as a dictionary object containing the keys `name` and either `value` or `binaryValue`. The headers that are forbidden by `XMLHttpRequest` and `fetch` cannot be specified, however, Firefox 70 and later enables the use of the `Referer` header. Attempting to use a forbidden header throws an error.
-    - `incognito`{{optional_inline}}
+    - `incognito` {{optional_inline}}
       - : A `boolean`: if present and set to true, then associate this download with a private browsing session. This means that it will only appear in the download manager for any private windows that are currently open.
-    - `method`{{optional_inline}}
+    - `method` {{optional_inline}}
       - : A `string` representing the HTTP method to use if the `url` uses the HTTP\[S] protocol. This may be either "GET" or "POST".
-    - `saveAs`{{optional_inline}}
+    - `saveAs` {{optional_inline}}
 
       - : A `boolean` that specifies whether to provide a file chooser dialog to allow the user to select a filename (`true`), or not (`false`).
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloaditem/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloaditem/index.md
@@ -21,23 +21,23 @@ The `DownloadItem` type of the {{WebExtAPIRef("downloads")}} API represents a do
 
 Values of this type are objects. They contain the following properties:
 
-- `byExtensionId`{{optional_inline}}
+- `byExtensionId` {{optional_inline}}
   - : A `string` representing the ID of the extension that triggered the download (if it was triggered by an extension). This does not change once set. If the download was not triggered by an extension this is undefined.
-- `byExtensionName`{{optional_inline}}
+- `byExtensionName` {{optional_inline}}
   - : A `string` representing the name of the extension that triggered the download (if it was triggered by an extension). This may change if the extension changes its name or the user changes their locale. If the download was not triggered by an extension this is undefined.
 - `bytesReceived`
   - : A `number` representing the number of bytes received so far from the host during the download; this does not take file compression into consideration.
 - `canResume`
   - : A `boolean` indicating whether a currently-interrupted (e.g. paused) download can be resumed from the point where it was interrupted (`true`), or not (`false`).
-- `cookieStoreId`{{optional_inline}}
+- `cookieStoreId` {{optional_inline}}
   - : The cookie store ID of the [contextual identity](/en-US/docs/Mozilla/Add-ons/WebExtensions/Work_with_contextual_identities) in which the download took place.
 - `danger`
   - : A string indicating whether this download is thought to be safe or known to be suspicious. Its possible values are defined in the {{WebExtAPIRef('downloads.DangerType')}} type.
-- `endTime`{{optional_inline}}
+- `endTime` {{optional_inline}}
   - : A `string` (in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format) representing the number of milliseconds between the UNIX epoch and when this download ended. This is undefined if the download has not yet finished.
-- `error`{{optional_inline}}
+- `error` {{optional_inline}}
   - : A string indicating why a download was interrupted. Possible values are defined in the {{WebExtAPIRef('downloads.InterruptReason')}} type. This is undefined if an error has not occurred.
-- `estimatedEndTime`{{optional_inline}}
+- `estimatedEndTime` {{optional_inline}}
   - : A `string` (in [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format) representing the estimated number of milliseconds between the UNIX epoch and when this download is estimated to be completed. This is undefined if it is not known (in particular, it is undefined in the `DownloadItem` that's passed into {{WebExtAPIRef("downloads.onCreated")}}).
 - `exists`
   - : A `boolean` indicating whether a downloaded file still exists (`true`) or not (`false`). This information might be out-of-date, as browsers do not automatically watch for file removal — to check whether a file exists, call the {{WebExtAPIRef('downloads.search()')}} method, filtering for the file in question.

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadquery/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/downloadquery/index.md
@@ -23,57 +23,57 @@ This type is used for example in {{WebExtAPIRef("downloads.search()")}} and {{We
 
 Values of this type are objects. They contain the following properties:
 
-- `cookieStoreId`{{optional_inline}}
+- `cookieStoreId` {{optional_inline}}
   - : The cookie store ID of the [contextual identity](/en-US/docs/Mozilla/Add-ons/WebExtensions/Work_with_contextual_identities) in which the download took place.
-- `query`{{optional_inline}}
+- `query` {{optional_inline}}
   - : An `array` of `string`s. Include only {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}} whose `filename` or `url` contains all of the given strings. You can also include terms beginning with a dash (-) — these terms **must not** be contained in the item's `filename` or `url` for it to be included.
-- `startedBefore`{{optional_inline}}
+- `startedBefore` {{optional_inline}}
   - : A {{WebExtAPIRef('downloads.DownloadTime', "DownloadTime")}}. Include only {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}} that started before the given time.
-- `startedAfter`{{optional_inline}}
+- `startedAfter` {{optional_inline}}
   - : A {{WebExtAPIRef('downloads.DownloadTime', "DownloadTime")}}. Include only {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}} that started after the given time.
-- `endedBefore`{{optional_inline}}
+- `endedBefore` {{optional_inline}}
   - : A {{WebExtAPIRef('downloads.DownloadTime', "DownloadTime")}}. Include only {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}} that ended before the given time.
-- `endedAfter`{{optional_inline}}
+- `endedAfter` {{optional_inline}}
   - : A {{WebExtAPIRef('downloads.DownloadTime', "DownloadTime")}}. Include only {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}} that ended after the given time.
-- `totalBytesGreater`{{optional_inline}}
+- `totalBytesGreater` {{optional_inline}}
   - : A `number` representing a number of bytes. Include only {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}} whose `totalBytes` is greater than the given number.
-- `totalBytesLess`{{optional_inline}}
+- `totalBytesLess` {{optional_inline}}
   - : A `number` representing a number of bytes. Include only {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}} whose `totalBytes` is less than the given number.
-- `filenameRegex`{{optional_inline}}
+- `filenameRegex` {{optional_inline}}
   - : A `string` representing a regular expression. Include only {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}} whose `filename` value matches the given regular expression.
-- `urlRegex`{{optional_inline}}
+- `urlRegex` {{optional_inline}}
   - : A `string` representing a regular expression. Include only {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}} whose `url` value matches the given regular expression.
-- `limit`{{optional_inline}}
+- `limit` {{optional_inline}}
   - : An `integer` representing a number of results. Include only the specified number of {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}}.
-- `orderBy`{{optional_inline}}
+- `orderBy` {{optional_inline}}
   - : An `array` of `string`s representing {{WebExtAPIRef("downloads.DownloadItem", "DownloadItem")}} properties the search results should be sorted by. For example, including `startTime` then `totalBytes` in the array would sort the {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}} by their start time, then total bytes — in ascending order. To specify sorting by a property in descending order, prefix it with a hyphen, for example `-startTime`.
-- `id`{{optional_inline}}
+- `id` {{optional_inline}}
   - : An `integer` representing the ID of the {{WebExtAPIRef("downloads.DownloadItem")}} you want to query.
-- `url`{{optional_inline}}
+- `url` {{optional_inline}}
   - : A `string` representing the absolute URL that the download was initiated from, before any redirects.
-- `filename`{{optional_inline}}
+- `filename` {{optional_inline}}
   - : A string representing the absolute local path of the download file you want to query.
-- `danger`{{optional_inline}}
+- `danger` {{optional_inline}}
   - : A string representing a {{WebExtAPIRef('downloads.DangerType')}} — include only {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}} with this `danger` value.
-- `mime`{{optional_inline}}
+- `mime` {{optional_inline}}
   - : A `string` representing a MIME type. Include only {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}} with this `mime` value.
-- `startTime`{{optional_inline}}
+- `startTime` {{optional_inline}}
   - : A `string` representing an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format time. Include only {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}} with this `startTime` value.
-- `endTime`{{optional_inline}}
+- `endTime` {{optional_inline}}
   - : A `string` representing an [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) format time. Include only will limited to {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}} with this `endTime` value.
-- `state`{{optional_inline}}
+- `state` {{optional_inline}}
   - : A `string` representing a download {{WebExtAPIRef('downloads.State')}} (`in_progress`, `interrupted`, or `complete`). Include only{{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}} with this `state` value.
-- `paused`{{optional_inline}}
+- `paused` {{optional_inline}}
   - : A `boolean` that indicates whether a download is paused — i.e. has stopped reading data from the host, but kept the connection open (`true`), or not (`false`). Include only {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}} with this `paused` value.
-- `error`{{optional_inline}}
+- `error` {{optional_inline}}
   - : A string representing an {{WebExtAPIRef('downloads.InterruptReason')}} — a reason why a download was interrupted. Include only {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}} with this `error` value.
-- `bytesReceived`{{optional_inline}}
+- `bytesReceived` {{optional_inline}}
   - : A `number` representing the number of bytes received so far from the host, without considering file compression. Include only {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}} with this `bytesReceived` value.
-- `totalBytes`{{optional_inline}}
+- `totalBytes` {{optional_inline}}
   - : A `number` representing the total number of bytes in the downloaded file, without considering file compression. Include only {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}} with this `totalBytes` value.
-- `fileSize`{{optional_inline}}
+- `fileSize` {{optional_inline}}
   - : `number`. Number of bytes in the whole file post-decompression, or -1 if unknown. A `number` representing the total number of bytes in the file after decompression. Include only {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}} with this `fileSize` value.
-- `exists`{{optional_inline}}
+- `exists` {{optional_inline}}
   - : A `boolean` indicating whether a downloaded file still exists (`true`) or not (`false`). Include only {{WebExtAPIRef("downloads.DownloadItem", "DownloadItems")}} with this `exists` value.
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/getfileicon/index.md
@@ -36,11 +36,11 @@ let gettingIcon = browser.downloads.getFileIcon(
 
 - `downloadId`
   - : An `integer` representing the ID of the download.
-- `options`{{optional_inline}}
+- `options` {{optional_inline}}
 
   - : An options `object` representing preferences for the icon to be retrieved. It can take the following properties:
 
-    - `size`{{optional_inline}}
+    - `size` {{optional_inline}}
       - : An `integer` representing the size of the icon. The returned icon's size will be the provided size squared (in pixels). If omitted, the default size for the icon is 32x32 pixels.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/onchanged/index.md
@@ -55,31 +55,31 @@ The `downloadDelta` object has the following properties available:
 
 - `id`
   - : An `integer` representing the `id` of the {{WebExtAPIRef('downloads.DownloadItem')}} that changed.
-- `url`{{optional_inline}}
+- `url` {{optional_inline}}
   - : A {{WebExtAPIRef('downloads.StringDelta')}} object describing a change in a {{WebExtAPIRef('downloads.DownloadItem')}}'s `url`.
-- `filename`{{optional_inline}}
+- `filename` {{optional_inline}}
   - : A {{WebExtAPIRef('downloads.StringDelta')}} object describing a change in a {{WebExtAPIRef('downloads.DownloadItem')}}'s `filename`.
-- `danger`{{optional_inline}}
+- `danger` {{optional_inline}}
   - : A {{WebExtAPIRef('downloads.StringDelta')}} object describing a change in a {{WebExtAPIRef('downloads.DownloadItem')}}'s `danger`.
-- `mime`{{optional_inline}}
+- `mime` {{optional_inline}}
   - : A {{WebExtAPIRef('downloads.StringDelta')}} object describing a change in a {{WebExtAPIRef('downloads.DownloadItem')}}'s `mime`.
-- `startTime`{{optional_inline}}
+- `startTime` {{optional_inline}}
   - : A {{WebExtAPIRef('downloads.StringDelta')}} object describing a change in a {{WebExtAPIRef('downloads.DownloadItem')}}'s `startTime`.
-- `endTime`{{optional_inline}}
+- `endTime` {{optional_inline}}
   - : A {{WebExtAPIRef('downloads.StringDelta')}} object describing a change in a {{WebExtAPIRef('downloads.DownloadItem')}}'s `endTime`.
-- `state`{{optional_inline}}
+- `state` {{optional_inline}}
   - : A {{WebExtAPIRef('downloads.StringDelta')}} object describing a change in a {{WebExtAPIRef('downloads.DownloadItem')}}'s `state`.
-- `canResume`{{optional_inline}}
+- `canResume` {{optional_inline}}
   - : A {{WebExtAPIRef('downloads.BooleanDelta')}} object describing a change in a {{WebExtAPIRef('downloads.DownloadItem')}}'s `canResume` status.
-- `paused`{{optional_inline}}
+- `paused` {{optional_inline}}
   - : A {{WebExtAPIRef('downloads.BooleanDelta')}} object describing a change in a {{WebExtAPIRef('downloads.DownloadItem')}}'s `paused` status.
-- `error`{{optional_inline}}
+- `error` {{optional_inline}}
   - : A {{WebExtAPIRef('downloads.StringDelta')}} object describing a change in a {{WebExtAPIRef('downloads.DownloadItem')}}'s `error` status.
-- `totalBytes`{{optional_inline}}
+- `totalBytes` {{optional_inline}}
   - : A {{WebExtAPIRef('downloads.DoubleDelta')}} object describing a change in a {{WebExtAPIRef('downloads.DownloadItem')}}'s `totalBytes`.
-- `fileSize`{{optional_inline}}
+- `fileSize` {{optional_inline}}
   - : A {{WebExtAPIRef('downloads.DoubleDelta')}} object describing a change in a {{WebExtAPIRef('downloads.DownloadItem')}}'s `fileSize`.
-- `exists`{{optional_inline}}
+- `exists` {{optional_inline}}
   - : A {{WebExtAPIRef('downloads.BooleanDelta')}} object describing a change in a {{WebExtAPIRef('downloads.DownloadItem')}}'s `exists` status.
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/downloads/stringdelta/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/downloads/stringdelta/index.md
@@ -21,9 +21,9 @@ The `StringDelta` type of the {{WebExtAPIRef("downloads")}} API represents the d
 
 Values of this type are objects. They contain the following properties:
 
-- `current`{{optional_inline}}
+- `current` {{optional_inline}}
   - : A `string` representing the current string value.
-- `previous`{{optional_inline}}
+- `previous` {{optional_inline}}
   - : A `string` representing the previous string value.
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imagedetails/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extensiontypes/imagedetails/index.md
@@ -21,11 +21,11 @@ Details about the format, quality, area and scale of a captured image.
 
 Values of this type are objects. They contain the following properties:
 
-- `format`{{optional_inline}}
+- `format` {{optional_inline}}
   - : {{WebExtAPIRef('extensionTypes.ImageFormat')}}. The format of the resulting image. Default is `"png"`.
-- `quality`{{optional_inline}}
+- `quality` {{optional_inline}}
   - : `integer`. When format is `"jpeg"`, this controls the quality of the resulting image. It is a number between 0 and 100, which is converted to a value between 0 and 1 and then used as the `encoderOptions` argument to [`HTMLCanvasElement.toDataURL()`](/en-US/docs/Web/API/HTMLCanvasElement/toDataURL). If it is omitted, 92 is used. As quality is decreased, the resulting image will have more visual artifacts, and the number of bytes needed to store it will decrease. This value is ignored for PNG images.
-- `rect`{{optional_inline}}
+- `rect` {{optional_inline}}
 
   - : An `object` specifying the area of the document to capture, in CSS pixels, relative to the page. All properties default to `0`. The properties are:
 
@@ -36,7 +36,7 @@ Values of this type are objects. They contain the following properties:
 
     This option was introduced in Firefox 82.  If omitted, the currently visible viewport is captured.
 
-- `scale`{{optional_inline}}
+- `scale` {{optional_inline}}
   - : `number`. The scale to render at, defaults to [`devicePixelRatio`](/en-US/docs/Web/API/Window/devicePixelRatio). This option was introduced in Firefox 82.
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/addurl/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/addurl/index.md
@@ -35,11 +35,11 @@ let addingUrl = browser.history.addUrl(
 
     - `url`
       - : `string`. The URL to add.
-    - `title`{{optional_inline}}
+    - `title` {{optional_inline}}
       - : string: The title of the page. If this is not supplied, the title will be recorded as `null`.
-    - `transition`{{optional_inline}}
+    - `transition` {{optional_inline}}
       - : {{WebExtAPIRef("history.TransitionType")}}. Describes how the browser navigated to the page on this occasion. If this is not supplied, a transition type of "link" will be recorded.
-    - `visitTime`{{optional_inline}}
+    - `visitTime` {{optional_inline}}
       - : `number` or `string` or `object`. A value indicating a date and time.  This can be represented as: a [`Date`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) object, an [ISO 8601 date string](https://www.iso.org/iso-8601-date-and-time-format.html), or the number of milliseconds since the epoch. Sets the visit time to this value. If this is not supplied, the current time will be recorded.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/history/visititem/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/history/visititem/index.md
@@ -25,7 +25,7 @@ Values of this type are objects. They contain the following properties:
   - : `string`. The unique identifier for the {{WebExtAPIRef("history.HistoryItem")}} associated with this visit.
 - `visitId`
   - : `string`. The unique identifier for this visit.
-- `visitTime`{{optional_inline}}
+- `visitTime` {{optional_inline}}
   - : `number`. When this visit occurred, represented in milliseconds since the epoch.
 - `referringVisitId`
   - : `string`. The visit ID of the referrer.

--- a/files/en-us/mozilla/add-ons/webextensions/api/i18n/getmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/i18n/getmessage/index.md
@@ -37,7 +37,7 @@ browser.i18n.getMessage(
     - Firefox returns "" and logs an error.
     - Chrome returns "" and does not log an error.
 
-- `substitutions`{{optional_inline}}
+- `substitutions` {{optional_inline}}
 
   - : `string` or `array` of `string`. A single substitution string, or an array of substitution strings.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/onclickdata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/onclickdata/index.md
@@ -51,7 +51,7 @@ Values of this type are objects. They contain the following properties:
   - : `string`. If some text was selected in the page, this contains the selected text.
 - `srcUrl` {{optional_inline}}
   - : `string`. If present, the `src` value for the media in the clicked element.
-- `targetElementId`{{optional_inline}}
+- `targetElementId` {{optional_inline}}
   - : `integer`. An identifier of the element, if any, over which the context menu was created. Use {{WebExtAPIRef("menus.getTargetElement()")}} in the content script to locate the element. Note that this is not the [id](/en-US/docs/Web/HTML/Global_attributes/id) attribute of the page element.
 - `viewType` {{optional_inline}}
   - : {{WebExtAPIRef("extension.ViewType", "ViewType")}}. The type of extension view.

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/overridecontext/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/overridecontext/index.md
@@ -35,11 +35,11 @@ browser.menus.overrideContext(
 
     - `showDefaults` {{optional_inline}}
       - : `boolean`. Whether to also include default menu items in the menu.
-    - `context`{{optional_inline}}
+    - `context` {{optional_inline}}
       - : `string`. ContextType to override, to allow menu items from other extensions in the menu. Currently only `'bookmark'` and `'tab'` are supported. `showDefaults` cannot be used with this option.
-    - `bookmarkId`{{optional_inline}}
+    - `bookmarkId` {{optional_inline}}
       - : `string`. Required when context is `'bookmark'`. Requires 'bookmark' permission.
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. Required when context is `'tab'`. Requires 'tabs' permission.
 
 ## Examples

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/create/index.md
@@ -36,7 +36,7 @@ let creating = browser.notifications.create(
 
 ### Parameters
 
-- `id`{{optional_inline}}
+- `id` {{optional_inline}}
   - : `string`. This is used to refer to this notification in {{WebExtAPIRef("notifications.update()")}}, {{WebExtAPIRef("notifications.clear()")}}, and event listeners. If you omit this argument or pass an empty string, then a new ID will be generated for this notification. If the ID you provide matches the ID of an existing notification from this extension, then the other notification will be cleared.
 - `options`
   - : {{WebExtAPIRef('notifications.NotificationOptions')}}. Defines the notification's content and behavior.

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/notificationoptions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/notificationoptions/index.md
@@ -32,21 +32,21 @@ The first three properties - `type`, `title`, `message` - are mandatory in {{Web
   - : `string`. The notification's main content.
 - `title`
   - : `string`. The notification's title.
-- `iconUrl`{{optional_inline}}
+- `iconUrl` {{optional_inline}}
   - : `string`. A URL pointing to an icon to display in the notification. The URL can be: a data URL, a blob URL, a http or https URL, or the [relative URL of a file within the extension.](/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities#relative_urls)
-- `contextMessage`{{optional_inline}}
+- `contextMessage` {{optional_inline}}
   - : `string`. Supplementary content to display.
-- `priority`{{optional_inline}}
+- `priority` {{optional_inline}}
   - : `number`. The notification's priority: may be 0, 1, or 2. Defaults to 0 if omitted.
-- `eventTime`{{optional_inline}}
+- `eventTime` {{optional_inline}}
   - : `number`. A timestamp for the notification in [milliseconds since the epoch](https://en.wikipedia.org/wiki/Unix_time).
-- `buttons`{{optional_inline}}
+- `buttons` {{optional_inline}}
 
   - : `array` of `button`. An array of up to 2 buttons to include in the notification. You can listen for button clicks using {{WebExtAPIRef("notifications.onButtonClicked")}}. Each button is specified as an object with the following properties:
 
     - `title`
       - : `string`. Title for the button.
-    - `iconUrl`{{optional_inline}}
+    - `iconUrl` {{optional_inline}}
       - : `string`. URL pointing to an icon for the button.
 
 - `imageUrl`

--- a/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pageaction/seticon/index.md
@@ -37,7 +37,7 @@ let settingIcon = browser.pageAction.setIcon(
 
   - : `object`. An object containing either `imageData` or `path` properties, and a `tabId` property.
 
-    - `imageData`{{optional_inline}}
+    - `imageData` {{optional_inline}}
 
       - : `{{WebExtAPIRef('pageAction.ImageDataType')}}` or `object`. This is either a single `ImageData` object or a dictionary object.
 
@@ -52,7 +52,7 @@ let settingIcon = browser.pageAction.setIcon(
 
         The browser will choose the image to use depending on the screen's pixel density. See [Choosing icon sizes](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action#choosing_icon_sizes) for more information on this.
 
-    - `path`{{optional_inline}}
+    - `path` {{optional_inline}}
 
       - : `string` or `object`. This is either a relative path to an icon file or a dictionary object.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/permissions/permissions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/permissions/permissions/index.md
@@ -18,9 +18,9 @@ A `Permissions` object represents a collection of permissions.
 
 An {{jsxref("object")}} with the following properties:
 
-- `origins`{{optional_inline}}
+- `origins` {{optional_inline}}
   - : An array of [match patterns](/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns), representing [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions).
-- `permissions`{{optional_inline}}
+- `permissions` {{optional_inline}}
   - : An array of named permissions, including [API permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#api_permissions) and [clipboard permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#clipboard_access).
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/installmodule/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/pkcs11/installmodule/index.md
@@ -31,7 +31,7 @@ let installing = browser.pkcs11.installModule(
 
 - `name`
   - : `string`. Name of the module to install. This must match the `name` property in the [PKCS #11 manifest](/en-US/docs/Mozilla/Add-ons/WebExtensions/Native_manifests#pkcs_11_manifests) for the module.
-- `flags`{{optional_inline}}
+- `flags` {{optional_inline}}
   - : `integer`. Flags to pass to the module.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/requestdetails/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/requestdetails/index.md
@@ -36,7 +36,7 @@ Values of this type are objects. They contain the following properties:
   - : `integer`. ID of the frame that contains the frame that sent the request. Set to -1 if no parent frame exists.
 - `requestId`
   - : `string`. The ID of the request. Request IDs are unique within a browser session, so you can use an ID to identify different events associated with the same request.
-- `requestHeaders`{{optional_inline}}
+- `requestHeaders` {{optional_inline}}
   - : {{WebExtAPIRef('webRequest.HttpHeaders')}}. The HTTP request headers that will be sent with this request. Note that this is only included if the `"requestHeaders"` option was passed into `addListener()`.
 - `tabId`
   - : `integer`. ID of the tab in which the request takes place. Set to -1 if the request is not related to a tab.

--- a/files/en-us/mozilla/add-ons/webextensions/api/proxy/settings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/proxy/settings/index.md
@@ -22,27 +22,27 @@ The underlying value is an object with the properties listed below.
 
 When setting this object, all properties are optional. Note that any properties that are omitted will be reset to their default value.
 
-- `autoConfigUrl`{{optional_inline}}
+- `autoConfigUrl` {{optional_inline}}
   - : `string`. A URL to use to configure the proxy.
-- `autoLogin`{{optional_inline}}
+- `autoLogin` {{optional_inline}}
   - : `boolean`. Do not prompt for authentication if the password is saved. Defaults to `false`.
-- `ftp`{{optional_inline}} {{Deprecated_Inline}}
+- `ftp` {{optional_inline}} {{Deprecated_Inline}}
   - : `string`. The address of the FTP proxy. Can include a port.
-- `http`{{optional_inline}}
+- `http` {{optional_inline}}
   - : `string`. The address of the HTTP proxy. Can include a port.
-- `httpProxyAll`{{optional_inline}}
+- `httpProxyAll` {{optional_inline}}
   - : `boolean`. Use the HTTP proxy server for all protocols. Defaults to `false`.
-- `passthrough`{{optional_inline}}
+- `passthrough` {{optional_inline}}
   - : `string`. A comma-separated list of hosts which should not be proxied. Defaults to "localhost, 127.0.0.1".
-- `proxyDNS`{{optional_inline}}
+- `proxyDNS` {{optional_inline}}
   - : `boolean`. Proxy DNS when using SOCKS5. Defaults to `false`.
-- `proxyType`{{optional_inline}}
+- `proxyType` {{optional_inline}}
   - : `string`. The type of proxy to use. This may take any one of the following values: "none", "autoDetect", "system", "manual", "autoConfig". Defaults to "system".
-- `socks`{{optional_inline}}
+- `socks` {{optional_inline}}
   - : `string`. The address of the SOCKS proxy. Can include a port.
-- `socksVersion`{{optional_inline}}
+- `socksVersion` {{optional_inline}}
   - : `integer`. The version of the SOCKS proxy. May be 4 or 5. Defaults to 5.
-- `ssl`{{optional_inline}}
+- `ssl` {{optional_inline}}
   - : `string`. The address of the SSL proxy. Can include a port.
 
 ## Examples

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/executescript/index.md
@@ -46,7 +46,7 @@ let results = await browser.scripting.executeScript(
       - : `array` of `string`. An array of path of the JS files to inject, relative to the extension's root directory. Exactly one of `files` and `func` must be specified.
     - `func`
       - : `function`. A JavaScript function to inject. This function is serialized and then deserialized for injection. This means that any bound parameters and execution context are lost. Exactly one of `files` and `func` must be specified.
-    - `injectImmediately`{{optional_inline}}
+    - `injectImmediately` {{optional_inline}}
       - : `boolean`. Whether the injection into the target is triggered as soon as possible, but not necessarily prior to page load.
     - `target`
       - : {{WebExtAPIRef("scripting.InjectionTarget")}}. Details specifying the target to inject the script into.
@@ -61,9 +61,9 @@ Each `InjectionResult` object has these properties:
 
 - `frameId`
   - : `number`. The frame ID associated with the injection.
-- `result`{{optional_inline}}
+- `result` {{optional_inline}}
   - : `any`. The result of the script execution.
-- `error`{{optional_inline}}
+- `error` {{optional_inline}}
   - : `object`. When the injection fails, details of the failure errors.
     - `message`
       - : `string`. A message explaining why the injection failed.

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/injectiontarget/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/injectiontarget/index.md
@@ -20,9 +20,9 @@ This object contains details specifying the injection target for CSS and JavaScr
 
 Values of this type are objects. They contain these properties:
 
-- `allFrames`{{optional_inline}}
+- `allFrames` {{optional_inline}}
   - : `boolean`. Whether the script or CSS is injected into all frames within the tab. Defaults to `false`. Cannot be `true` if `frameIds` is specified.
-- `frameIds`{{optional_inline}}
+- `frameIds` {{optional_inline}}
   - : `array` of `string`. Array of the IDs of the frames to inject into.
 - `tabId`
   - : `number`. The ID of the tab to inject into.

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/insertcss/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/insertcss/index.md
@@ -42,11 +42,11 @@ await browser.scripting.insertCSS(
 
   - : An object describing the CSS to insert and where to insert it. It contains the following properties:
 
-    - `css`{{optional_inline}}
+    - `css` {{optional_inline}}
       - : `string`. A string containing the CSS to inject. Either `css` or `files` must be specified.
-    - `files`{{optional_inline}}
+    - `files` {{optional_inline}}
       - : `array` of `string`. The path of a CSS files to inject, relative to the extension's root directory. Either `files` or `css` must be specified.
-    - `origin`{{optional_inline}}
+    - `origin` {{optional_inline}}
       - : `string`. The style origin for the injection, either `USER` or `AUTHOR`. Defaults to `AUTHOR`.
     - `target`
       - : {{WebExtAPIRef("scripting.InjectionTarget")}}. Details specifying the target to inject the CSS into.

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/registeredcontentscript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/registeredcontentscript/index.md
@@ -20,21 +20,21 @@ This object contains details of a script to be registered or that is registered.
 
 Values of this type are objects. They contain these properties:
 
-- `allFrames`{{optional_inline}}
+- `allFrames` {{optional_inline}}
   - : `boolean`. If specified `true`, the script is inject into all frames, even if the frame is not the top-most frame in the tab. Each frame is checked independently for URL requirements; it does not inject into child frames if the URL requirements are not met. Defaults to `false`, meaning that only the top frame is matched.
-- `css`{{optional_inline}}
+- `css` {{optional_inline}}
   - : `array` of `string`. The list of CSS files to be injected into matching pages. These are injected in the order they appear in this array.
-- `excludeMatches`{{optional_inline}}
+- `excludeMatches` {{optional_inline}}
   - : `array` of `string`. Array of pages that this content script is excluded from but would otherwise be injected into.
 - `id`
   - : `string`. The ID of the content script, specified in the API call.
-- `js`{{optional_inline}}
+- `js` {{optional_inline}}
   - : `array` of `string`. Array of path to JavaScript files in the extension package to inject into matching pages. Scripts are injected in the order they appear in this array.
-- `matches`{{optional_inline}}
+- `matches` {{optional_inline}}
   - : `array` of `string`. Array of the pages this content script is injected into. Must be specified for {{WebExtAPIRef("scripting.registerContentScripts()")}}.
-- `persistAcrossSessions`{{optional_inline}}
+- `persistAcrossSessions` {{optional_inline}}
   - : `boolean`. Specifies if this content script persists into future sessions. Defaults to `true`. Firefox does not support registering persistent scripts, see ({{bug("1751436")}}), so this flag must be set to `false` to register non-persistent scripts.
-- `runAt`{{optional_inline}}
+- `runAt` {{optional_inline}}
   - : {{WebExtAPIRef("extensionTypes.RunAt")}}. Specifies when JavaScript files are injected into the web page. The default value is `document_idle`. In Firefox, `runAt` also affects the point where the CSS is inserted. In Chrome, `runAt` does not affect the CSS insertion point.
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/removecss/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/removecss/index.md
@@ -36,11 +36,11 @@ await browser.scripting.removeCSS(
 
   - : An object describing the CSS to remove and where to remove it from. It contains the following properties:
 
-    - `css`{{optional_inline}}
+    - `css` {{optional_inline}}
       - : `string`. A string containing the CSS to inject. Either `css` or `files` must be specified and must match the stylesheet inserted through {{WebExtAPIRef("scripting.insertCSS()")}}.
-    - `files`{{optional_inline}}
+    - `files` {{optional_inline}}
       - : `array` of `string`. The path of a CSS files to inject, relative to the extension's root directory. Either `files` or `css` must be specified and must match the stylesheet inserted through {{WebExtAPIRef("scripting.insertCSS()")}}.
-    - `origin`{{optional_inline}}
+    - `origin` {{optional_inline}}
       - : `string`. The style origin for the injection, either `USER` or `AUTHOR`. Defaults to `AUTHOR`. Must match the origin of the stylesheet inserted through {{WebExtAPIRef("scripting.insertCSS()")}}.
     - `target`
       - : {{WebExtAPIRef("scripting.InjectionTarget")}}. Details specifying the target to remove the CSS from.

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/unregistercontentscripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/unregistercontentscripts/index.md
@@ -32,7 +32,7 @@ await browser.scripting.unregisterContentScripts(
 
 ### Parameters
 
-- `scripts`{{optional_inline}}
+- `scripts` {{optional_inline}}
   - : {{WebExtAPIRef("scripting.ContentScriptFilter")}}. A filter to identify the dynamic content scripts to unregistered. If not specified, all dynamic content scripts are unregistered.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/filter/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/filter/index.md
@@ -21,7 +21,7 @@ The `Filter` object enables you to restrict the number of {{WebExtAPIRef("sessio
 
 Values of this type are objects. They contain the following properties:
 
-- `maxResults`{{optional_inline}}
+- `maxResults` {{optional_inline}}
   - : `number`. The maximum number of results to return.
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/getrecentlyclosed/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/getrecentlyclosed/index.md
@@ -29,7 +29,7 @@ let gettingSessions = browser.sessions.getRecentlyClosed(
 
 ### Parameters
 
-- `filter`{{optional_inline}}
+- `filter` {{optional_inline}}
   - : `object`. A {{WebExtAPIRef("sessions.Filter")}} object that limits the set of sessions returned.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/sessions/session/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sessions/session/index.md
@@ -34,9 +34,9 @@ Values of this type are objects. They contain the following properties:
 
 - `lastModified`
   - : `number`. The time the tab or window was closed, in [milliseconds since the epoch](https://en.wikipedia.org/wiki/Unix_time).
-- `tab`{{optional_inline}}
+- `tab` {{optional_inline}}
   - : `object`. If the object represents a closed tab, then this property is present and will be a {{WebExtAPIRef("tabs.Tab")}} object. This will contain `url`, `title`, and `favIconUrl` only if the extension has the "tabs" [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions) or [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) to access the tab's URL.
-- `window`{{optional_inline}}
+- `window` {{optional_inline}}
   - : `object`. If the object represents a closed window, then this property is present and will be a {{WebExtAPIRef("windows.Window")}} object.
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/getpanel/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/getpanel/index.md
@@ -32,7 +32,7 @@ let gettingPanel = browser.sidebarAction.getPanel(
 
   - : `object`. An object with the following properties:
 
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. Get the panel for the sidebar specific to the given tab.
     - `windowId` {{optional_inline}}
       - : `integer`. Get the panel for the sidebar specific to the given window.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/gettitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/gettitle/index.md
@@ -34,7 +34,7 @@ let gettingTitle = browser.sidebarAction.getTitle(
 
   - : `object`. An object with the following properties:
 
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. Get the title for the sidebar specific to the given tab.
     - `windowId` {{optional_inline}}
       - : `integer`. Get the title for the sidebar specific to the given window.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/seticon/index.md
@@ -48,7 +48,7 @@ let settingIcon = browser.sidebarAction.setIcon(
 
   - : `object`. An object with the following properties:
 
-    - `imageData`{{optional_inline}}
+    - `imageData` {{optional_inline}}
 
       - : `{{WebExtAPIRef('sidebarAction.ImageDataType')}}` or `object`. This is either a single `ImageData` object or a dictionary object.
 
@@ -63,7 +63,7 @@ let settingIcon = browser.sidebarAction.setIcon(
 
         The browser will choose the image to use depending on the screen's pixel density. See [Choosing icon sizes](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_action#choosing_icon_sizes) for more information on this.
 
-    - `path`{{optional_inline}}
+    - `path` {{optional_inline}}
 
       - : `string` or `object`. This is either a relative path to an icon file or it is a dictionary object.
 
@@ -86,7 +86,7 @@ let settingIcon = browser.sidebarAction.setIcon(
 
         if `path` is `null`, and `tabId` was omitted, and there was a global icon set, it will be reset to the manifest icon.
 
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. Sets the icon only for the given tab.
     - `windowId` {{optional_inline}}
       - : `integer`. Sets the icon only for the given window.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/setpanel/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/setpanel/index.md
@@ -52,7 +52,7 @@ browser.sidebarAction.setPanel(
         - If `windowId` is specified, and the window has a window-specific panel set, then the window will inherit the global panel.
         - Otherwise, the global panel will be reset to the manifest panel.
 
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. Sets the panel only for the given tab.
     - `windowId` {{optional_inline}}
       - : `integer`. Sets the panel only for the given window.

--- a/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/settitle/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/sidebaraction/settitle/index.md
@@ -52,9 +52,9 @@ browser.sidebarAction.setTitle(
         - If `windowId` is specified, and the window has a window-specific title set, then the window will inherit the global title.
         - Otherwise, the global title will be reset to the manifest title.
 
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. Sets the title only for the given tab.
-    - `windowId`{{optional_inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. Sets the title only for the given window.
 
 <!---->

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagechange/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagechange/index.md
@@ -19,9 +19,9 @@ browser-compat: webextensions.api.storage.StorageChange
 
 `StorageChange` objects contain the following properties:
 
-- `oldValue`{{optional_inline}}
+- `oldValue` {{optional_inline}}
   - : The old value of the item, if there was an old value. This can be any data type.
-- `newValue`{{optional_inline}}
+- `newValue` {{optional_inline}}
   - : The new value of the item, if there is a new value. This can be any data type.
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/userscripts/userscriptoptions/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/userscripts/userscriptoptions/index.md
@@ -21,21 +21,21 @@ The UserScriptOptions object represents the content scripts to register. It has 
 
 The UserScriptOptions object has the following properties:
 
-- `allFrames`{{optional_inline}}
+- `allFrames` {{optional_inline}}
   - : Same as `all_frames` in the [`content_scripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) key.
-- `excludeGlobs`{{optional_inline}}
+- `excludeGlobs` {{optional_inline}}
   - : Same as `exclude_globs` in the [`content_scripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) key.
-- `excludeMatches`{{optional_inline}}
+- `excludeMatches` {{optional_inline}}
   - : Same as `exclude_matches` in the [`content_scripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) key.
-- `includeGlobs`{{optional_inline}}
+- `includeGlobs` {{optional_inline}}
   - : Same as `include_globs` in the [`content_scripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) key.
-- `js`{{optional_inline}}
+- `js` {{optional_inline}}
   - : An array of objects. Each object has either a property named `file`, which is a URL starting at the extension's manifest.json and pointing to a JavaScript file to register, or a property named `code`, which is some JavaScript code to register.
-- `matchAboutBlank`{{optional_inline}}
+- `matchAboutBlank` {{optional_inline}}
   - : Same as `match_about_blank` in the [`content_scripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) key.
 - `matches`
   - : Same as `matches` in the [`content_scripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) key.
-- `runAt`{{optional_inline}}
+- `runAt` {{optional_inline}}
   - : Same as `run_at` in the [`content_scripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) key.
 - `scriptMetadata` {{optional_inline}}
   - : A user script metadata value

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onbeforenavigate/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onbeforenavigate/index.md
@@ -48,7 +48,7 @@ Events have three functions:
     - `details`
       - : [`object`](#details). Details about the navigation event.
 
-- `filter`{{optional_inline}}
+- `filter` {{optional_inline}}
   - : `object`. An object containing a single property `url`, which is an `Array` of {{WebExtAPIRef("events.UrlFilter")}} objects. If you include this parameter, then the event will fire only for transitions to URLs which match at least one `UrlFilter` in the array. If you omit this parameter, the event will fire for all transitions.
 
 ## Additional objects

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncommitted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncommitted/index.md
@@ -48,7 +48,7 @@ Events have three functions:
     - `details`
       - : [`object`](#details). Details about the navigation event.
 
-- `filter`{{optional_inline}}
+- `filter` {{optional_inline}}
   - : `object`. An object containing a single property `url`, which is an `Array` of {{WebExtAPIRef("events.UrlFilter")}} objects. If you include this parameter, then the event will fire only for transitions to URLs which match at least one `UrlFilter` in the array. If you omit this parameter, the event will fire for all transitions.
 
 ## Additional objects

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncompleted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncompleted/index.md
@@ -48,7 +48,7 @@ Events have three functions:
     - `details`
       - : [`object`](#details). Details about the navigation event.
 
-- `filter`{{optional_inline}}
+- `filter` {{optional_inline}}
   - : `object`. An object containing a single property `url`, which is an `Array` of {{WebExtAPIRef("events.UrlFilter")}} objects. If you include this parameter, then the event will fire only for transitions to URLs which match at least one `UrlFilter` in the array. If you omit this parameter, the event will fire for all transitions.
 
 ## Additional objects

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncreatednavigationtarget/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/oncreatednavigationtarget/index.md
@@ -55,7 +55,7 @@ Events have three functions:
     - `details`
       - : [`object`](#details). Details about the navigation event. See [details](#details) below.
 
-- `filter`{{optional_inline}}
+- `filter` {{optional_inline}}
   - : `object`. An object containing a single property `url`, which is an `Array` of {{WebExtAPIRef("events.UrlFilter")}} objects. If you include this parameter, then the event will fire only for transitions to URLs which match at least one `UrlFilter` in the array. If you omit this parameter, the event will fire for all transitions. Note that `filter` is not supported in Firefox.
 
 ## Additional objects

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/ondomcontentloaded/index.md
@@ -48,7 +48,7 @@ Events have three functions:
     - `details`
       - : [`object`](#details). Details about the navigation event.
 
-- `filter`{{optional_inline}}
+- `filter` {{optional_inline}}
   - : `object`. An object containing a single property `url`, which is an {{jsxref("Array")}} of {{WebExtAPIRef("events.UrlFilter")}} objects. If you include this parameter, then the event will fire only for transitions to URLs which match at least one `UrlFilter` in the array. If you omit this parameter, the event will fire for all transitions.
 
 ## Additional objects

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onerroroccurred/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onerroroccurred/index.md
@@ -76,7 +76,7 @@ Events have three functions:
         - `error`
           - : `string`. The error code. This is an internal error code, and is not guaranteed to stay the same or be consistent from one browser to another.
 
-- `filter`{{optional_inline}}
+- `filter` {{optional_inline}}
 
   - : `object`. An object containing a single property `url`, which is an `Array` of {{WebExtAPIRef("events.UrlFilter")}} objects.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onhistorystateupdated/index.md
@@ -48,7 +48,7 @@ Events have three functions:
     - `details`
       - : [`object`](#details). Details about the navigation event.
 
-- `filter`{{optional_inline}}
+- `filter` {{optional_inline}}
   - : `object`. An object containing a single property `url`, which is an `Array` of {{WebExtAPIRef("events.UrlFilter")}} objects. If you include this parameter, then the event will fire only for transitions to URLs which match at least one `UrlFilter` in the array. If you omit this parameter, the event will fire for all transitions.
 
 ## Additional objects

--- a/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webnavigation/onreferencefragmentupdated/index.md
@@ -46,7 +46,7 @@ Events have three functions:
     - `details`
       - : [`object`](#details). Details about the navigation event.
 
-- `filter`{{optional_inline}}
+- `filter` {{optional_inline}}
   - : `object`. An object containing a single property `url`, which is an `Array` of {{WebExtAPIRef("events.UrlFilter")}} objects. If you include this parameter, then the event will fire only for transitions to URLs which match at least one `UrlFilter` in the array. If you omit this parameter, the event will fire for all transitions.
 
 ## Additional objects

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/blockingresponse/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/blockingresponse/index.md
@@ -25,7 +25,7 @@ Note that you can't set all this object's properties in every listener: the prop
 
 Values of this type are objects. They contain the following properties:
 
-- `authCredentials`{{optional_inline}}
+- `authCredentials` {{optional_inline}}
 
   - : `object`. If set, the request is made using the given credentials. You can only set this property in {{WebExtAPIRef("webRequest.onAuthRequired", "onAuthRequired")}}. The `authCredentials` property is an object with the following properties:
 
@@ -34,9 +34,9 @@ Values of this type are objects. They contain the following properties:
     - `password`
       - : `string`. Password to supply.
 
-- `cancel`{{optional_inline}}
+- `cancel` {{optional_inline}}
   - : `boolean`. If `true`, the request is cancelled. You can only set this property in {{WebExtAPIRef("webRequest.onBeforeRequest", "onBeforeRequest")}}, {{WebExtAPIRef("webRequest.onBeforeSendHeaders", "onBeforeSendHeaders")}}, {{WebExtAPIRef("webRequest.onHeadersReceived", "onHeadersReceived")}}, and {{WebExtAPIRef("webRequest.onAuthRequired", "onAuthRequired")}}.
-- `redirectUrl`{{optional_inline}}
+- `redirectUrl` {{optional_inline}}
 
   - : `string`. This is a URL, and if set, the original request is redirected to that URL. You can only set this property in {{WebExtAPIRef("webRequest.onBeforeRequest", "onBeforeRequest")}} or {{WebExtAPIRef("webRequest.onHeadersReceived", "onHeadersReceived")}}.
 
@@ -44,11 +44,11 @@ Values of this type are objects. They contain the following properties:
 
     If an extension wants to redirect a public (e.g. HTTPS) URL to an [extension page](/en-US/docs/Mozilla/Add-ons/WebExtensions/user_interface/Extension_pages), the extension's manifest.json file must contain a [web_accessible_resources](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/web_accessible_resources) key that lists the URL for the extension page.
 
-- `requestHeaders`{{optional_inline}}
+- `requestHeaders` {{optional_inline}}
   - : {{WebExtAPIRef('webRequest.HttpHeaders')}}. This is an {{WebExtAPIRef('webRequest.HttpHeaders', "HttpHeaders")}} object, an array in which each object represents a header. If set, the request is made with these headers rather than the original headers. You can only set this property in {{WebExtAPIRef("webRequest.onBeforeSendHeaders", "onBeforeSendHeaders")}} .
-- `responseHeaders`{{optional_inline}}
+- `responseHeaders` {{optional_inline}}
   - : {{WebExtAPIRef('webRequest.HttpHeaders')}}. This is an {{WebExtAPIRef('webRequest.HttpHeaders', "HttpHeaders")}} object, an array in which each object represents a header. If set, the server is assumed to have responded with these response headers instead of the originals. You can only set this property in {{WebExtAPIRef("webRequest.onHeadersReceived", "onHeadersReceived")}}. If multiple extensions attempt to set the same header (for example, `Content-Security-Policy`), only one of the changes will be successful.
-- `upgradeToSecure`{{optional_inline}}
+- `upgradeToSecure` {{optional_inline}}
   - : `boolean`. If set to `true` and the original request is an HTTP request, this will prevent the original request from being sent and instead make a secure (HTTPS) request. If any extension returns `redirectUrl` in `onBeforeRequest`, then `upgradeToSecure` will be ignored for that request. You can only set this property in {{WebExtAPIRef("webRequest.onBeforeRequest", "onBeforeRequest")}}.
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/httpheaders/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/httpheaders/index.md
@@ -23,9 +23,9 @@ An `array` of `object`s. Each object has the following properties:
 
 - `name`
   - : `string`. Name of the HTTP header.
-- `value`{{optional_inline}}
+- `value` {{optional_inline}}
   - : `string`. Value of the HTTP header if it can be represented by UTF-8. Either this property or `binaryValue` must be present.
-- `binaryValue`{{optional_inline}}
+- `binaryValue` {{optional_inline}}
   - : `array` of `integer`. Value of the HTTP header if it cannot be represented by UTF-8, represented as bytes (0..255). Either this property or `value` must be present.
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onauthrequired/index.md
@@ -93,7 +93,7 @@ Events have three functions:
 
 - `filter`
   - : {{WebExtAPIRef('webRequest.RequestFilter')}}. A filter that restricts the events that will be sent to this listener.
-- `extraInfoSpec`{{optional_inline}}
+- `extraInfoSpec` {{optional_inline}}
 
   - : `array` of `string`. Extra options for the event. You can pass any of the following values:
 
@@ -153,11 +153,11 @@ Events have three functions:
     - `failoverTimeout`
       - : `integer`. Failover timeout in seconds. If the connection fails to connect the proxy server after this number of seconds, the next proxy server in the array returned from [FindProxyForURL()](</en-US/docs/Mozilla/Add-ons/WebExtensions/API/proxy#findproxyforurl()_return_value>) will be used.
 
-- `realm`{{optional_inline}}
+- `realm` {{optional_inline}}
   - : `string`. The authentication [realm](https://datatracker.ietf.org/doc/html/rfc1945#section-11) provided by the server, if there is one.
 - `requestId`
   - : `string`. The ID of the request. Request IDs are unique within a browser session, so you can use them to relate different events associated with the same request.
-- `responseHeaders`{{optional_inline}}
+- `responseHeaders` {{optional_inline}}
   - : {{WebExtAPIRef('webRequest.HttpHeaders')}}. The HTTP response headers that were received along with this response.
 - `scheme`
   - : `string`. The authentication scheme: `"basic"` or `"digest`".

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforeredirect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforeredirect/index.md
@@ -53,7 +53,7 @@ Events have three functions:
 
 - `filter`
   - : {{WebExtAPIRef('webRequest.RequestFilter')}}. A filter that restricts the events that will be sent to this listener.
-- `extraInfoSpec`{{optional_inline}}
+- `extraInfoSpec` {{optional_inline}}
 
   - : `array` of `string`. Extra options for the event. You can pass just one value:
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
@@ -66,7 +66,7 @@ Events have three functions:
 
 - `filter`
   - : {{WebExtAPIRef('webRequest.RequestFilter')}}. A filter that restricts the events that will be sent to this listener.
-- `extraInfoSpec`{{optional_inline}}
+- `extraInfoSpec` {{optional_inline}}
 
   - : `array` of `string`. Extra options for the event. You can pass any of the following values:
 
@@ -130,19 +130,19 @@ Events have three functions:
     - `failoverTimeout`
       - : `integer`. Failover timeout in seconds. If the proxy connection fails, the proxy will not be used again for this period.
 
-- `requestBody`{{optional_inline}}
+- `requestBody` {{optional_inline}}
 
   - : `object`. Contains the HTTP request body data. Only provided if `extraInfoSpec` contains `"requestBody"`.
 
-    - `error`{{optional_inline}}
+    - `error` {{optional_inline}}
       - : `string`. This is set if any errors were encountered when obtaining request body data.
-    - `formData`{{optional_inline}}
+    - `formData` {{optional_inline}}
 
       - : `object`. This object is present if the request method is POST and the body is a sequence of key-value pairs encoded in UTF-8 as either "multipart/form-data" or "application/x-www-form-urlencoded".
 
         It is a dictionary in which each key contains the list of all values for that key. For example: `{'key': ['value1', 'value2']}`. If the data is of another media type, or if it is malformed, the object is not present.
 
-    - `raw`{{optional_inline}}
+    - `raw` {{optional_inline}}
       - : `array` of `{{WebExtAPIRef('webRequest.UploadData')}}`. If the request method is PUT or POST, and the body is not already parsed in `formData`, then this array contains the unparsed request body elements.
 
 - `requestId`

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforesendheaders/index.md
@@ -77,7 +77,7 @@ Events have three functions:
 
 - `filter`
   - : {{WebExtAPIRef('webRequest.RequestFilter')}}. A set of filters that restricts the events that will be sent to this listener.
-- `extraInfoSpec`{{optional_inline}}
+- `extraInfoSpec` {{optional_inline}}
 
   - : `array` of `string`. Extra options for the event. You can pass any of the following values:
 
@@ -132,7 +132,7 @@ Events have three functions:
     - `failoverTimeout`
       - : `integer`. Failover timeout in seconds. If the proxy connection fails, the proxy will not be used again for this period.
 
-- `requestHeaders`{{optional_inline}}
+- `requestHeaders` {{optional_inline}}
   - : {{WebExtAPIRef('webRequest.HttpHeaders')}}. The HTTP request headers that will be sent with this request.
 - `requestId`
   - : `string`. The ID of the request. Request IDs are unique within a browser session, so you can use them to relate different events associated with the same request.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/oncompleted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/oncompleted/index.md
@@ -53,7 +53,7 @@ Events have three functions:
 
 - `filter`
   - : {{WebExtAPIRef('webRequest.RequestFilter')}}. A filter that restricts the events that will be sent to this listener.
-- `extraInfoSpec`{{optional_inline}}
+- `extraInfoSpec` {{optional_inline}}
 
   - : `array` of `string`. Extra options for the event. You can pass just one value:
 
@@ -113,7 +113,7 @@ Events have three functions:
 
 - `requestId`
   - : `string`. The ID of the request. Request IDs are unique within a browser session, so you can use them to relate different events associated with the same request.
-- `responseHeaders`{{optional_inline}}
+- `responseHeaders` {{optional_inline}}
   - : {{WebExtAPIRef('webRequest.HttpHeaders')}}. The HTTP response headers that were received along with this response.
 - `statusCode`
   - : `integer`. Standard HTTP status code returned by the server.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onheadersreceived/index.md
@@ -63,7 +63,7 @@ Events have three functions:
 
 - `filter`
   - : {{WebExtAPIRef('webRequest.RequestFilter')}}. A set of filters that restricts the events that are sent to this listener.
-- `extraInfoSpec`{{optional_inline}}
+- `extraInfoSpec` {{optional_inline}}
 
   - : `array` of `string`. Extra options for the event. You can pass any of the following values:
 
@@ -133,7 +133,7 @@ Events have three functions:
 
 - `requestId`
   - : `string`. The ID of the request. Request IDs are unique within a browser session, so you can use them to relate different events associated with the same request.
-- `responseHeaders`{{optional_inline}}
+- `responseHeaders` {{optional_inline}}
   - : {{WebExtAPIRef('webRequest.HttpHeaders')}}. The HTTP response headers that were received for this request.
 - `statusCode`
   - : `integer`. Standard HTTP status code returned by the server.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onresponsestarted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onresponsestarted/index.md
@@ -53,7 +53,7 @@ Events have three functions:
 
 - `filter`
   - : {{WebExtAPIRef('webRequest.RequestFilter')}}. A filter that restricts the events that will be sent to this listener.
-- `extraInfoSpec`{{optional_inline}}
+- `extraInfoSpec` {{optional_inline}}
 
   - : `array` of `string`. Extra options for the event. You can pass just one value:
 
@@ -113,7 +113,7 @@ Events have three functions:
 
 - `requestId`
   - : `string`. The ID of the request. Request IDs are unique within a browser session, so you can use them to relate different events associated with the same request.
-- `responseHeaders`{{optional_inline}}
+- `responseHeaders` {{optional_inline}}
   - : {{WebExtAPIRef('webRequest.HttpHeaders')}}. The HTTP response headers that were received along with this response.
 - `statusCode`
   - : `integer`. Standard HTTP status code returned by the server.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onsendheaders/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onsendheaders/index.md
@@ -53,7 +53,7 @@ Events have three functions:
 
 - `filter`
   - : {{WebExtAPIRef('webRequest.RequestFilter')}}. A filter that restricts the events that will be sent to this listener.
-- `extraInfoSpec`{{optional_inline}}
+- `extraInfoSpec` {{optional_inline}}
 
   - : `array` of `string`. Extra options for the event. You can only pass one value here:
 
@@ -109,7 +109,7 @@ Events have three functions:
 
 - `requestId`
   - : `string`. The ID of the request. Request IDs are unique within a browser session, so you can use them to relate different events associated with the same request.
-- `requestHeaders`{{optional_inline}}
+- `requestHeaders` {{optional_inline}}
   - : {{WebExtAPIRef('webRequest.HttpHeaders')}}. The HTTP request headers that have been sent out with this request.
 - `tabId`
   - : `integer`. ID of the tab in which the request takes place. Set to -1 if the request isn't related to a tab.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/requestfilter/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/requestfilter/index.md
@@ -23,11 +23,11 @@ Values of this type are objects. They contain the following properties:
 
 - `urls`
   - : `array` of `string`. An array of [match patterns](/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns). The listener will only be called for requests whose targets match any of the given patterns. Only requests made using HTTP or HTTPS will trigger events, other protocols (such as data: and file:) supported by pattern matching do not trigger events. `view-source:` requests may be matched based on its inner URL.
-- `types`{{optional_inline}}
+- `types` {{optional_inline}}
   - : `array` of `{{WebExtAPIRef('webRequest.ResourceType')}}`. A list of resource types (for example, stylesheets, images, scripts). The listener will only be called for requests for resources which are one of the given types.
-- `tabId`{{optional_inline}}
+- `tabId` {{optional_inline}}
   - : `integer`. The listener will only be called for requests from the {{WebExtAPIRef("tabs.Tab", "tab")}} identified by this ID.
-- `windowId`{{optional_inline}}
+- `windowId` {{optional_inline}}
   - : `integer`. The listener will only be called for requests from the {{WebExtAPIRef("windows.Window", "window")}} identified by this ID.
 - `incognito` {{optional_inline}}
   - : `boolean`. If provided, requests that do not match the incognito state (`true` or `false`) will be filtered out.

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/uploaddata/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/uploaddata/index.md
@@ -21,9 +21,9 @@ Contains data uploaded in a URL request.
 
 Values of this type are objects. They contain the following properties:
 
-- `bytes`{{optional_inline}}
+- `bytes` {{optional_inline}}
   - : `any`. An ArrayBuffer with a copy of the data.
-- `file`{{optional_inline}}
+- `file` {{optional_inline}}
   - : `string`. A string with the file's path and name.
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/get/index.md
@@ -32,13 +32,13 @@ let getting = browser.windows.get(
 
 - `windowId`
   - : `integer`. The ID of the window object you want returned.
-- `getInfo`{{optional_inline}}
+- `getInfo` {{optional_inline}}
 
   - : `object`. Contains options to filter the type of window.
 
-    - `populate`{{optional_inline}}
+    - `populate` {{optional_inline}}
       - : `boolean`. If `true`, the {{WebExtAPIRef('windows.Window')}} object will have a `tabs` property that contains a list of {{WebExtAPIRef('tabs.Tab')}} objects representing the tabs open in the window. The `Tab` objects only contain the `url`, `title` and `favIconUrl` properties if the extension's manifest file includes the `"tabs"` permission or a matching [host permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions).
-    - `windowTypes`{{optional_inline}}
+    - `windowTypes` {{optional_inline}}
       - : `array` of {{WebExtAPIRef('windows.WindowType')}} objects. If set, the {{WebExtAPIRef('windows.Window')}} returned will be filtered based on its type. If unset the default filter is set to `['normal', 'panel', 'popup']`, with `'panel'` window types limited to the extension's own windows.
 
 > **Note:** If supplied, the `windowTypes` component of `getInfo` is ignored. The use of `windowTypes` has been deprecated as of Firefox 62.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getall/index.md
@@ -29,13 +29,13 @@ let gettingAll = browser.windows.getAll(
 
 ### Parameters
 
-- `getInfo`{{optional_inline}}
+- `getInfo` {{optional_inline}}
 
   - : `object`. This controls what {{WebExtAPIRef('windows.Window')}} objects are retrieved.
 
-    - `populate`{{optional_inline}}
+    - `populate` {{optional_inline}}
       - : `boolean`. Defaults to `false`. If set to `true`, each {{WebExtAPIRef('windows.Window')}} object will have a `tabs` property that contains a list of {{WebExtAPIRef('tabs.Tab')}} objects representing the tabs in that window. The `Tab` objects will contain the `url`, `title` and `favIconUrl` properties only if the extension's manifest file includes the `"tabs"` permission or [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) that match the tab's URL.
-    - `windowTypes`{{optional_inline}}
+    - `windowTypes` {{optional_inline}}
       - : An `array` of {{WebExtAPIRef('windows.WindowType')}} objects. If set, the {{WebExtAPIRef('windows.Window')}} objects returned will be filtered based on their type. If unset the default filter is set to `['normal', 'panel', 'popup']`, with `'panel'` window types limited to the extension's own windows.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getcurrent/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getcurrent/index.md
@@ -31,11 +31,11 @@ let gettingCurrent = browser.windows.getCurrent(
 
 ### Parameters
 
-- `getInfo`{{optional_inline}}
+- `getInfo` {{optional_inline}}
 
   - : `object`.
 
-    - `populate`{{optional_inline}}
+    - `populate` {{optional_inline}}
       - : `boolean`. If true, the {{WebExtAPIRef('windows.Window')}} object will have a `tabs` property that contains a list of {{WebExtAPIRef('tabs.Tab')}} objects representing the tabs in the window. The `Tab` objects only contain the `url`, `title` and `favIconUrl` properties if the extension's manifest file includes the `"tabs"` permission or [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) that match the tab's URL.
     - `windowTypes`{{deprecated_inline}}{{optional_inline}}
       - : An `array` of `{{WebExtAPIRef('windows.WindowType')}}` objects. If set, the {{WebExtAPIRef('windows.Window')}} returned will be filtered based on its type. If unset the default filter is set to `['normal', 'panel', 'popup']`, with `'panel'` window types limited to the extension's own windows.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getlastfocused/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getlastfocused/index.md
@@ -29,13 +29,13 @@ let gettingWindow = browser.windows.getLastFocused(
 
 ### Parameters
 
-- `getInfo`{{optional_inline}}
+- `getInfo` {{optional_inline}}
 
   - : `object`.
 
-    - `populate`{{optional_inline}}
+    - `populate` {{optional_inline}}
       - : `boolean`. If `true`, the {{WebExtAPIRef('windows.Window')}} object will have a `tabs` property that contains a list of {{WebExtAPIRef('tabs.Tab')}} objects representing the tabs in the window. The `Tab` objects only contain the `url`, `title` and `favIconUrl` properties if the extension's manifest file includes the `"tabs"` permission or [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) matching the tab's URL.
-    - `windowTypes`{{optional_inline}}
+    - `windowTypes` {{optional_inline}}
       - : An `array` of {{WebExtAPIRef('windows.WindowType')}} objects. If set, the {{WebExtAPIRef('windows.Window')}} returned will be filtered based on its type. If unset the default filter is set to `['normal', 'panel', 'popup']`, with `'panel'` window types limited to the extension's own windows.
 
 > **Note:** If supplied, the `windowTypes` component of `getInfo` is ignored. The use of `windowTypes` has been deprecated as of Firefox 62.

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/window/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/window/index.md
@@ -25,30 +25,30 @@ Values of this type are `objects`. They contain the following properties:
   - : `boolean`. Whether the window is set to be always on top.
 - `focused`
   - : `boolean`. Whether the window is currently the focused window.
-- `height`{{optional_inline}}
+- `height` {{optional_inline}}
   - : `integer`. The height of the window, including the frame, in pixels.
 
 <!---->
 
-- `id`{{optional_inline}}
+- `id` {{optional_inline}}
   - : `integer`. The ID of the window. Window IDs are unique within a browser session.
 - `incognito`
   - : `boolean`. Whether the window is incognito (private).
-- `left`{{optional_inline}}
+- `left` {{optional_inline}}
   - : `integer`. The offset of the window from the left edge of the screen in pixels.
-- `sessionId`{{optional_inline}}
+- `sessionId` {{optional_inline}}
   - : `string`. The session ID used to uniquely identify a Window obtained from the {{WebExtAPIRef('sessions')}} API.
-- `state`{{optional_inline}}
+- `state` {{optional_inline}}
   - : A {{WebExtAPIRef('windows.WindowState')}} value representing the state of this browser window — maximized, minimized, etc.
-- `tabs`{{optional_inline}}
+- `tabs` {{optional_inline}}
   - : Array of {{WebExtAPIRef('tabs.Tab')}} objects representing the current tabs in the window.
-- `title`{{optional_inline}}
+- `title` {{optional_inline}}
   - : The title of the browser window. Requires "tabs" permission or [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) for the active tab's URL. Read only.
-- `top`{{optional_inline}}
+- `top` {{optional_inline}}
   - : `integer`. The offset of the window from the top edge of the screen in pixels.
-- `type`{{optional_inline}}
+- `type` {{optional_inline}}
   - : A {{WebExtAPIRef('windows.WindowType')}} value representing the type of browser window this is — normal browser window, popup, etc.
-- `width`{{optional_inline}}
+- `width` {{optional_inline}}
   - : `integer`. The width of the window, including the frame, in pixels.
 
 ## Browser compatibility


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Added missing space between `<code>` and `{{optional_inline}}` in markdown.
Ref #18019 

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

Improve usability

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
