### PR TITLE
Add space between <code> and {{optional_inline}} - batch 2/2 (#18019)

### DIFF
--- a/files/en-us/mdn/structures/macros/commonly-used_macros/index.md
+++ b/files/en-us/mdn/structures/macros/commonly-used_macros/index.md
@@ -226,7 +226,7 @@ Example:
 
 - `isCustomObject`{{ReadOnlyInline}}
   - : Indicates, if `true`, that the object is a custom one.
-- `parameterX`{{Optional_Inline}}
+- `parameterX` {{optional_inline}}
   - : Blah blah blah...
 
 ## Status and compatibility indicators

--- a/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecache/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/browsingdata/removecache/index.md
@@ -30,7 +30,7 @@ let removing = browser.browsingData.removeCache(
 
 ### Parameters
 
-- `removalOptions`{{optional_inline}}
+- `removalOptions` {{optional_inline}}
   - : `object`. A {{WebExtAPIRef("browsingData.RemovalOptions")}} object. This parameter has no effect.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/contentscripts/register/index.md
@@ -37,25 +37,25 @@ let registering = browser.contentScripts.register(
 
     The `RegisteredContentScriptOptions` object has the following properties:
 
-    - `allFrames`{{optional_inline}}
+    - `allFrames` {{optional_inline}}
       - : Same as `all_frames` in the [`content_scripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) key.
     - `cookieStoreId` {{optional_inline}}
       - : A string or array of strings. Registers the content script in the tabs that belong to one or more cookie store IDs. This enables scripts to be registered for all default or non-contextual identity tabs, private browsing tabs (if extensions are enabled in private browsing), the tabs of a [contextual identity](/en-US/docs/Mozilla/Add-ons/WebExtensions/Work_with_contextual_identities), or a combination of these.
-    - `css`{{optional_inline}}
+    - `css` {{optional_inline}}
       - : An array of objects. Each object has either a property named `file`, which is a URL starting at the extension's manifest.json and pointing to a CSS file to register, or a property named `code`, which is some CSS code to register.
-    - `excludeGlobs`{{optional_inline}}
+    - `excludeGlobs` {{optional_inline}}
       - : Same as `exclude_globs` in the [`content_scripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) key.
-    - `excludeMatches`{{optional_inline}}
+    - `excludeMatches` {{optional_inline}}
       - : Same as `exclude_matches` in the [`content_scripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) key.
-    - `includeGlobs`{{optional_inline}}
+    - `includeGlobs` {{optional_inline}}
       - : Same as `include_globs` in the [`content_scripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) key.
-    - `js`{{optional_inline}}
+    - `js` {{optional_inline}}
       - : An array of objects. Each object has either a property named `file`, which is a URL starting at the extension's manifest.json and pointing to a JavaScript file to register, or a property named `code`, which is some JavaScript code to register.
-    - `matchAboutBlank`{{optional_inline}}
+    - `matchAboutBlank` {{optional_inline}}
       - : Same as `match_about_blank` in the [`content_scripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) key.
     - `matches`
       - : Same as `matches` in the [`content_scripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) key.
-    - `runAt`{{optional_inline}}
+    - `runAt` {{optional_inline}}
       - : Same as `run_at` in the [`content_scripts`](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/content_scripts) key.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/rule/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/rule/index.md
@@ -21,15 +21,15 @@ Description of a declarative rule for handling events.
 
 Values of this type are objects. They contain the following properties:
 
-- `id`{{optional_inline}}
+- `id` {{optional_inline}}
   - : `string`. Optional identifier that allows referencing this rule.
-- `tags`{{optional_inline}}
+- `tags` {{optional_inline}}
   - : `array` of `string`. Tags can be used to annotate rules and perform operations on sets of rules.
 - `conditions`
   - : `array` of `any`. List of conditions that can trigger the actions.
 - `actions`
   - : `array` of `any`. List of actions that are triggered if one of the conditions is fulfilled.
-- `priority`{{optional_inline}}
+- `priority` {{optional_inline}}
   - : `integer`. Optional priority of this rule. Defaults to 100.
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/urlfilter/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/urlfilter/index.md
@@ -25,7 +25,7 @@ Values of this type are objects. They contain the following properties:
 
 However, note that these last two patterns will not match the last component of the hostname, because no implicit dot is added at the end of the hostname. So for example, `"org."` will match "https\://borg.com" but not "https\://example.org". To match these patterns, use `hostSuffix`.
 
-- `hostContains`{{optional_inline}}
+- `hostContains` {{optional_inline}}
 
   - : `string`. Matches if the [hostname](/en-US/docs/Web/API/HTMLAnchorElement/hostname) of the URL (without protocol or port – see `schemes` and `ports`) contains the given string.
 
@@ -33,64 +33,64 @@ However, note that these last two patterns will not match the last component of 
     - To test whether a hostname component ends with "foo", use `"foo."`.
     - To test whether a hostname component exactly matches "foo", use `".foo."`.
 
-- `hostEquals`{{optional_inline}}
+- `hostEquals` {{optional_inline}}
 
   - : `string`. Matches if the hostname of the URL is equal to a specified string.
 
     - Example: `"www.example.com"` matches "http\://www\.example.com/" and "https\://www\.example.com/", but not "http\://example.com/".
 
-- `hostPrefix`{{optional_inline}}
+- `hostPrefix` {{optional_inline}}
   - : `string`. Matches if the hostname of the URL starts with a specified string.
-- `hostSuffix`{{optional_inline}}
+- `hostSuffix` {{optional_inline}}
 
   - : `string`. Matches if the hostname of the URL ends with a specified string.
 
     - Example: `".example.com"` matches "http\://www\.example.com/", but not "http\://example.com/".
     - Example: `"example.com"` matches "http\://www\.example.com/", and "http\://fakeexample.com/".
 
-- `pathContains`{{optional_inline}}
+- `pathContains` {{optional_inline}}
   - : `string`. Matches if the path segment of the URL contains a specified string.
-- `pathEquals`{{optional_inline}}
+- `pathEquals` {{optional_inline}}
   - : `string`. Matches if the path segment of the URL is equal to a specified string.
-- `pathPrefix`{{optional_inline}}
+- `pathPrefix` {{optional_inline}}
   - : `string`. Matches if the path segment of the URL starts with a specified string.
-- `pathSuffix`{{optional_inline}}
+- `pathSuffix` {{optional_inline}}
   - : `string`. Matches if the path segment of the URL ends with a specified string.
-- `queryContains`{{optional_inline}}
+- `queryContains` {{optional_inline}}
   - : `string`. Matches if the query segment of the URL contains a specified string.
-- `queryEquals`{{optional_inline}}
+- `queryEquals` {{optional_inline}}
   - : `string`. Matches if the query segment of the URL is equal to a specified string.
-- `queryPrefix`{{optional_inline}}
+- `queryPrefix` {{optional_inline}}
   - : `string`. Matches if the query segment of the URL starts with a specified string.
-- `querySuffix`{{optional_inline}}
+- `querySuffix` {{optional_inline}}
   - : `string`. Matches if the query segment of the URL ends with a specified string.
-- `urlContains`{{optional_inline}}
+- `urlContains` {{optional_inline}}
   - : `string`. Matches if the URL (without fragment identifier) contains a specified string. Port numbers are stripped from the URL if they match the default port number.
-- `urlEquals`{{optional_inline}}
+- `urlEquals` {{optional_inline}}
   - : `string`. Matches if the URL (without fragment identifier) is equal to a specified string. Port numbers are stripped from the URL if they match the default port number.
-- `urlMatches`{{optional_inline}}
+- `urlMatches` {{optional_inline}}
 
   - : `string`. Matches if the URL (without fragment identifier) matches a specified [regular expression](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions). Port numbers are stripped from the URL if they match the default port number.
 
     - For example: `urlMatches: "^[^:]*:(?://)?(?:[^/]*\\.)?mozilla\\.org/.*$"` matches "https\://mozilla.org/", "https\://developer.mozilla.org/", but not "https\://developer.fakemozilla.org/".
 
-- `originAndPathMatches`{{optional_inline}}
+- `originAndPathMatches` {{optional_inline}}
   - : `string`. Matches if the URL without query segment and fragment identifier matches a specified [regular expression](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions). Port numbers are stripped from the URL if they match the default port number.
-- `urlPrefix`{{optional_inline}}
+- `urlPrefix` {{optional_inline}}
 
   - : `string`. Matches if the URL (without fragment identifier) starts with a specified string. Port numbers are stripped from the URL if they match the default port number.
 
     - Example: `"https://developer"` matches "https\://developer.mozilla.org/" and "https\://developers.facebook.com/".
 
-- `urlSuffix`{{optional_inline}}
+- `urlSuffix` {{optional_inline}}
   - : `string`. Matches if the URL (without fragment identifier) ends with a specified string. Port numbers are stripped from the URL if they match the default port number. Note that an implicit forward slash "/" is added after the host, so `"com/"` matches "https\://example.com", but `"com"` does not.
-- `schemes`{{optional_inline}}
+- `schemes` {{optional_inline}}
 
   - : `array` of `string`. Matches if the scheme of the URL is equal to any of the schemes specified in the array. Because schemes are always converted to lowercase, this should always be given in lowercase or it will never match.
 
     - Example: `["https"]` will match only HTTPS URLs.
 
-- `ports`{{optional_inline}}
+- `ports` {{optional_inline}}
 
   - : `array` of (`integer` or (`array` of `integer`)). An array which may contain integers and arrays of integers. Integers are interpreted as port numbers, while arrays of integers are interpreted as port ranges. Matches if the port of the URL matches any port number or is contained in any ranges.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/getextensiontabs/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/getextensiontabs/index.md
@@ -31,7 +31,7 @@ This API is also available as `browser.extension.getExtensionTabs()`.
 
 ### Parameters
 
-- `windowId`{{optional_inline}}
+- `windowId` {{optional_inline}}
   - : `integer`.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/getviews/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/getviews/index.md
@@ -34,13 +34,13 @@ let windows = browser.extension.getViews(
 
 ### Parameters
 
-- `fetchProperties`{{optional_inline}}
+- `fetchProperties` {{optional_inline}}
 
   - : An object with the following properties:
 
-    - `type`{{optional_inline}}
+    - `type` {{optional_inline}}
       - : `string`. An {{WebExtAPIRef('extension.ViewType')}} indicating the type of view to get. If omitted, this function returns all views.
-    - `windowId`{{optional_inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. The window to restrict the search to. If omitted, this function returns all views. In Firefox version 92 and earlier, sidebar views are not matched and, therefore, not returned.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/sendrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/sendrequest/index.md
@@ -34,11 +34,11 @@ This API is also available as `browser.extension.sendRequest()` in a [version th
 
 ### Parameters
 
-- `extensionId`{{Optional_Inline}}
+- `extensionId` {{optional_inline}}
   - : `string`. The extension ID of the extension you want to connect to. If omitted, default is your own extension.
 - `request`
   - : `any`.
-- `responseCallback`{{Optional_Inline}}
+- `responseCallback` {{optional_inline}}
 
   - : `function`. The function is passed the following arguments:
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/find/find/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/find/find/index.md
@@ -38,7 +38,7 @@ browser.find.find(
 
 - `queryphrase`
   - : `string`. The text to search for.
-- `options`{{optional_inline}}
+- `options` {{optional_inline}}
 
   - : `object`. An object specifying additional options. It may take any of the following properties, all optional:
 
@@ -59,7 +59,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 
 - `count`
   - : `integer`. The number of results found.
-- `rangeData`{{optional_inline}}
+- `rangeData` {{optional_inline}}
 
   - : `array`. If `includeRangeData` was given in the `options` parameter, then this property will be included. It is provided as an array of `RangeData` objects, one for each match. Each `RangeData` object describes where in the DOM tree the match was found. This would enable, for example, an extension to get the text surrounding each match, so as to display context for the matches.
 
@@ -78,7 +78,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
     - `endOffset`
       - : The ordinal position of the end of the match within its text node.
 
-- `rectData`{{optional_inline}}
+- `rectData` {{optional_inline}}
 
   - : `array`. If `includeRectData` was given in the `options` parameter, then this property will be included. It is an array of `RectData` objects. It contains client rectangles for all the text matched in the search, relative to the top-left of the viewport. Extensions can use this to provide custom highlighting of the results.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/find/highlightresults/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/find/highlightresults/index.md
@@ -30,7 +30,7 @@ browser.find.highlightResults(
 
 ### Parameters
 
-- `options`{{optional_inline}}
+- `options` {{optional_inline}}
 
   - : `object`. An object specifying additional options. It may take any of the following properties, all optional:
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstall/index.md
@@ -32,7 +32,7 @@ let uninstalling = browser.management.uninstall(
 
 - `id`
   - : `string`. ID of the add-on to uninstall.
-- `options`{{optional_inline}}
+- `options` {{optional_inline}}
   - : `object`. Object which may contain a single property, `showConfirmDialog`. If `showConfirmDialog` is `true`, the browser will show a dialog asking the user to confirm that the add-on should be uninstalled.
 
 <!---->

--- a/files/en-us/mozilla/add-ons/webextensions/api/management/uninstallself/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/management/uninstallself/index.md
@@ -29,13 +29,13 @@ let uninstallingSelf = browser.management.uninstallSelf(
 
 ### Parameters
 
-- `options`{{optional_inline}}
+- `options` {{optional_inline}}
 
   - : `object`. Object which may two properties, both optional:
 
-    - `showConfirmDialog`{{optional_inline}}
+    - `showConfirmDialog` {{optional_inline}}
       - : Boolean. If `showConfirmDialog` is `true`, the browser will show a dialog asking the user to confirm that the add-on should be uninstalled. Defaults to `false`.
-    - `dialogMessage`{{optional_inline}}
+    - `dialogMessage` {{optional_inline}}
       - : String. An extra message that will be displayed in the confirmation dialog.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/connect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/connect/index.md
@@ -35,15 +35,15 @@ let port = browser.runtime.connect(
 
 ### Parameters
 
-- `extensionId`{{optional_inline}}
+- `extensionId` {{optional_inline}}
   - : `string`. The ID of the extension to connect to. If the target has set an ID explicitly using the [applications](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) key in manifest.json, then `extensionId` should have that value. Otherwise it should have the ID that was generated for the target.
-- `connectInfo`{{optional_inline}}
+- `connectInfo` {{optional_inline}}
 
   - : `object`. Details of the connection:
 
-    - `name`{{optional_inline}}
+    - `name` {{optional_inline}}
       - : `string`. Will be passed into {{WebExtAPIRef("runtime.onConnect")}} for processes that are listening for the connection event.
-    - `includeTlsChannelId`{{optional_inline}}
+    - `includeTlsChannelId` {{optional_inline}}
       - : `boolean`. Whether the TLS channel ID will be passed into {{WebExtAPIRef("runtime.onConnectExternal")}} for processes that are listening for the connection event.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/messagesender/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/messagesender/index.md
@@ -23,15 +23,15 @@ It is also a property of {{WebExtAPIRef("runtime.Port")}}, but only in the `Port
 
 Values of this type are objects. They contain the following properties:
 
-- `tab`{{optional_inline}}
+- `tab` {{optional_inline}}
   - : {{WebExtAPIRef('tabs.Tab')}}. The {{WebExtAPIRef('tabs.Tab')}} which opened the connection. This property will only be present when the connection was opened from a tab (including content scripts).
-- `frameId`{{optional_inline}}
+- `frameId` {{optional_inline}}
   - : `integer`. The frame that opened the connection. Zero for top-level frames, positive for child frames. This will only be set when `tab` is set.
-- `id`{{optional_inline}}
+- `id` {{optional_inline}}
 
   - : `string`. The ID of the extension that sent the message, if the message was sent by an extension. If the sender set an ID explicitly using the [applications](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) key in manifest.json, then `id` will have this value. Otherwise it will have the ID that was generated for the sender.
 
-- `url`{{optional_inline}}
+- `url` {{optional_inline}}
 
   - : `string`. The URL of the page or frame hosting the script that sent the message.
 
@@ -39,7 +39,7 @@ Values of this type are objects. They contain the following properties:
 
     \>If the sender is a script running in a web page (including content scripts as well as normal page scripts), then `url` will be the web page URL. If the script is running in an iframe, `url` will be the iframe's URL.
 
-- `tlsChannelId`{{optional_inline}}
+- `tlsChannelId` {{optional_inline}}
   - : `string`. The TLS channel ID of the page or frame that opened the connection, if requested by the extension, and if available.
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalled/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/oninstalled/index.md
@@ -48,9 +48,9 @@ Events have three functions:
 
       - : An object with the following properties:
 
-        - `id`{{optional_inline}}
+        - `id` {{optional_inline}}
           - : `string`. The ID of the imported shared module extension that updated. This is present only if the `reason` value is `shared_module_update`.
-        - `previousVersion`{{optional_inline}}
+        - `previousVersion` {{optional_inline}}
           - : `string`. The previous version of the extension just updated. This is only present if the `reason` value is `update`.
         - `reason`
           - : An {{WebExtAPIRef('runtime.OnInstalledReason')}} value, stating the reason that this event is being dispatched.

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/port/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/port/index.md
@@ -94,7 +94,7 @@ Values of this type are objects. They contain the following properties:
   - : `object`. This contains the `addListener()` and `removeListener()` functions common to all events for extensions built using WebExtension APIs. Listener functions will be called when the other end has sent this port a message. The listener will be passed the value that the other end sent.
 - `postMessage`
   - : `function`. Send a message to the other end. This takes one argument, which is a serializable value (see [Data cloning algorithm](/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities#data_cloning_algorithm)) representing the message to send. It will be delivered to any script listening to the port's `onMessage` event, or to the native application if this port is connected to a native application.
-- `sender`{{optional_inline}}
+- `sender` {{optional_inline}}
   - : {{WebExtAPIRef('runtime.MessageSender')}}. Contains information about the sender of the message. This property will only be present on ports passed to `onConnect`/`onConnectExternal` listeners.
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheck/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/requestupdatecheck/index.md
@@ -35,7 +35,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 
 - `status`
   - : A {{WebExtAPIRef('runtime.RequestUpdateCheckStatus')}} value — the result of the update check.
-- `details`{{optional_inline}}
+- `details` {{optional_inline}}
 
   - : `object`. If `status` is `update_available`, this contains more information about the update. It is an object containing a single property:
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/sendmessage/index.md
@@ -39,7 +39,7 @@ let sending = browser.runtime.sendMessage(
 
 ### Parameters
 
-- `extensionId`{{optional_inline}}
+- `extensionId` {{optional_inline}}
 
   - : `string`. The ID of the extension to send the message to. Include this to send the message to a different extension. If the intended recipient has set an ID explicitly using the [applications](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings) key in manifest.json, then `extensionId` should have that value. Otherwise it should have the ID that was generated for the intended recipient.
 
@@ -47,11 +47,11 @@ let sending = browser.runtime.sendMessage(
 
 - `message`
   - : `any`. An object that can be structured clone serialized (see [Data cloning algorithm](/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities#data_cloning_algorithm)).
-- `options`{{optional_inline}}
+- `options` {{optional_inline}}
 
   - : `object`.
 
-    - `includeTlsChannelId`{{optional_inline}}
+    - `includeTlsChannelId` {{optional_inline}}
 
       - : `boolean`. Whether the TLS channel ID will be passed into {{WebExtAPIRef('runtime.onMessageExternal')}} for processes that are listening for the connection event.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/search/get/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/search/get/index.md
@@ -38,9 +38,9 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
   - : `string`. The search engine's name.
 - `isDefault`
   - : `boolean`. `true` if the search engine is the default. Only one search engine can be the default at any given time.
-- `alias`{{optional_inline}}
+- `alias` {{optional_inline}}
   - : `string`. If a search engine has an alias, the user can search with a particular search engine by entering the alias in address bar before the search term. For example, if the Wikipedia engine has an alias "wk", the user can search Wikipedia for pandas by entering "wk pandas" in the address bar. The alias is sometimes also called a "keyword".
-- `favIconUrl`{{optional_inline}}
+- `favIconUrl` {{optional_inline}}
   - : `string`. The search engine's icon, as a data: URL.
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/search/search/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/search/search/index.md
@@ -37,9 +37,9 @@ browser.search.search(
 
     - `query`
       - : `string`. The search query.
-    - `engine`{{optional_inline}}
+    - `engine` {{optional_inline}}
       - : `string`. The name of the search engine. If the search engine name you specify doesn't exist, the function throws an error. If this property is omitted the default search engine will be used.
-    - `tabId`{{optional_inline}}
+    - `tabId` {{optional_inline}}
       - : `integer`. An optional identifier for the tab you want to execute the search in. If this property is omitted the search results will be displayed in a new tab.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturetab/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturetab/index.md
@@ -29,9 +29,9 @@ let capturing = browser.tabs.captureTab(
 
 ### Parameters
 
-- `tabId`{{optional_inline}}
+- `tabId` {{optional_inline}}
   - : `integer`. ID of the tab to capture. Defaults to the active tab in the current window.
-- `options`{{optional_inline}}
+- `options` {{optional_inline}}
   - : {{WebExtAPIRef('extensionTypes.ImageDetails')}}.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturevisibletab/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/capturevisibletab/index.md
@@ -30,9 +30,9 @@ let capturing = browser.tabs.captureVisibleTab(
 
 ### Parameters
 
-- `windowId`{{optional_inline}}
+- `windowId` {{optional_inline}}
   - : `integer`. The target window. Defaults to the current window.
-- `options`{{optional_inline}}
+- `options` {{optional_inline}}
   - : {{WebExtAPIRef('extensionTypes.ImageDetails')}}.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/connect/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/connect/index.md
@@ -34,13 +34,13 @@ browser.tabs.connect(
 
 - `tabId`
   - : `integer`. ID of the tab whose content scripts we want to connect to.
-- `connectInfo`{{optional_inline}}
+- `connectInfo` {{optional_inline}}
 
   - : An object with the following properties:
 
-    - `name`{{optional_inline}}
+    - `name` {{optional_inline}}
       - : `string`. Will be passed into {{WebExtAPIRef("runtime.onConnect")}} event listeners in content scripts belonging to this extension and running in the specified tab.
-    - `frameId`{{optional_inline}}
+    - `frameId` {{optional_inline}}
       - : `integer`. Open a port to a specific frame identified by `frameId` instead of all frames in the tab.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getallinwindow/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getallinwindow/index.md
@@ -32,7 +32,7 @@ let getting = browser.tabs.getAllInWindow(
 
 ### Parameters
 
-- `windowId`{{Optional_Inline}}
+- `windowId` {{optional_inline}}
   - : `integer`. Defaults to the current window.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getselected/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getselected/index.md
@@ -32,7 +32,7 @@ let gettingSelected = browser.tabs.getSelected(
 
 ### Parameters
 
-- `windowId`{{optional_inline}}
+- `windowId` {{optional_inline}}
   - : `integer`. Defaults to the current window.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getzoom/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getzoom/index.md
@@ -29,7 +29,7 @@ let gettingZoom = browser.tabs.getZoom(
 
 ### Parameters
 
-- `tabId`{{optional_inline}}
+- `tabId` {{optional_inline}}
   - : `integer`. The ID of the tab to get the current zoom factor from. Defaults to the active tab of the current window.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/getzoomsettings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/getzoomsettings/index.md
@@ -29,7 +29,7 @@ let gettingZoomSettings = browser.tabs.getZoomSettings(
 
 ### Parameters
 
-- `tabId`{{optional_inline}}
+- `tabId` {{optional_inline}}
   - : `integer`. The ID of the tab to get the current zoom settings from. Defaults to the active tab of the current window.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/goback/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/goback/index.md
@@ -29,9 +29,9 @@ let withGoingBack = browser.tabs.goBack(
 
 ### Parameters
 
-- `tabId`{{optional_inline}}
+- `tabId` {{optional_inline}}
   - : `integer`. The ID of the tab to navigate. Defaults to the active tab of the current window.
-- `callback`{{optional_inline}}
+- `callback` {{optional_inline}}
   - : `function`. When the page navigation finishes, this function is called without parameters.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/goforward/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/goforward/index.md
@@ -29,9 +29,9 @@ let goingForward = browser.tabs.goForward(
 
 ### Parameters
 
-- `tabId`{{optional_inline}}
+- `tabId` {{optional_inline}}
   - : `integer`. The ID of the tab to navigate. Defaults to the active tab of the current window.
-- `callback`{{optional_inline}}
+- `callback` {{optional_inline}}
   - : `function`. When the page navigation finishes, this function is called without parameters.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/highlight/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/highlight/index.md
@@ -31,9 +31,9 @@ let highlighting = browser.tabs.highlight(
 
   - : `object`.
 
-    - `windowId`{{optional_inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. ID of the window that contains the tabs.
-    - `populate`{{optional_inline}}
+    - `populate` {{optional_inline}}
 
       - : `boolean`. Defaults to `true`. If set to `false`, the {{WebExtAPIRef('windows.Window')}} object won't have a `tabs` property containing a list of {{WebExtAPIRef('tabs.Tab')}} objects representing the tabs open in the window.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/insertcss/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/insertcss/index.md
@@ -46,24 +46,24 @@ let inserting = browser.tabs.insertCSS(
 
   - : An object describing the CSS to insert. It contains the following properties:
 
-    - `allFrames`{{optional_inline}}
+    - `allFrames` {{optional_inline}}
       - : `boolean`. If `true`, the CSS will be injected into all frames of the current page. If it is `false`, CSS is only injected into the top frame. Defaults to `false`.
-    - `code`{{optional_inline}}
+    - `code` {{optional_inline}}
       - : `string`. Code to inject, as a text string.
-    - `cssOrigin`{{optional_inline}}
+    - `cssOrigin` {{optional_inline}}
 
       - : `string`. This can take one of two values: "user", to add the CSS as a user stylesheet or "author" to add it as an author stylesheet. If this option is omitted, the CSS is added as an author stylesheet.
 
         - "user" enables you to prevent websites from overriding the CSS you insert: see [Cascading order](/en-US/docs/Web/CSS/Cascade#cascading_order).
         - "author" stylesheets behave as if they appear after all author rules specified by the web page. This behavior includes any author stylesheets added dynamically by the page's scripts, even if that addition happens after the `insertCSS` call completes.
 
-    - `file`{{optional_inline}}
+    - `file` {{optional_inline}}
       - : `string`. Path to a file containing the code to inject. In Firefox, relative URLs are resolved relative to the current page URL. In Chrome, these URLs are resolved relative to the extension's base URL. To work cross-browser, you can specify the path as an absolute URL, starting at the extension's root, like this: `"/path/to/stylesheet.css"`.
-    - `frameId`{{optional_inline}}
+    - `frameId` {{optional_inline}}
       - : `integer`. The frame where the CSS should be injected. Defaults to `0` (the top-level frame).
-    - `matchAboutBlank`{{optional_inline}}
+    - `matchAboutBlank` {{optional_inline}}
       - : `boolean`. If `true`, the code will be injected into embedded "about:blank" and "about:srcdoc" frames if your extension has access to their parent document. The code cannot be inserted in top-level about: frames. Defaults to `false`.
-    - `runAt`{{optional_inline}}
+    - `runAt` {{optional_inline}}
       - : {{WebExtAPIRef('extensionTypes.RunAt')}}. The soonest that the code will be injected into the tab. Defaults to "document_idle".
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/move/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/move/index.md
@@ -38,7 +38,7 @@ let moving = browser.tabs.move(
 
   - : `object`. An object that specifies where to move the tab(s).
 
-    - `windowId`{{optional_inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. The ID of the window to which you want to move the tab(s). If you omit this, then each tab in `tabIds` will be moved to `index` in its current window. If you include this, and `tabIds` contains more than one tab, then the first tab in `tabIds` will be moved to `index`, and the other tabs will follow it in the order given in `tabIds`.
     - `index`
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/mutedinfo/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/mutedinfo/index.md
@@ -21,11 +21,11 @@ This object contains a boolean indicating whether the tab is muted, and the reas
 
 Values of this type are objects. They contain the following properties:
 
-- `extensionId`{{optional_inline}}
+- `extensionId` {{optional_inline}}
   - : `string`. The ID of the extension that last changed the muted state. Not set if an extension was not the reason the muted state last changed.
 - `muted`
   - : `boolean`. Whether the tab is currently muted. Equivalent to whether the muted audio indicator is showing.
-- `reason`{{optional_inline}}
+- `reason` {{optional_inline}}
   - : {{WebExtAPIRef('tabs.MutedInfoReason')}}. The reason the tab was muted or unmuted. Not set if the tab's muted state has never been changed.
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
@@ -53,7 +53,7 @@ Events have three functions:
     - `tab`
       - : {{WebExtAPIRef('tabs.Tab')}}. The new state of the tab.
 
-- `extraParameters`{{optional_inline}}
+- `extraParameters` {{optional_inline}}
 
   - : `object`. A set of filters that restricts the events that will be sent to this listener. This is an object which may have one or more of the following properties. Events will only be sent if they satisfy all the filters given.
 
@@ -91,25 +91,25 @@ Lists the changes to the state of the tab that was updated. To learn more about 
 
 - `attention` {{optional_inline}}
   - : `boolean`. Indicates whether the tab is drawing attention. For example, when the tab displays a modal dialog, `attention` will be `true`.
-- `audible`{{optional_inline}}
+- `audible` {{optional_inline}}
   - : `boolean`. The tab's new audible state.
 - `discarded` {{optional_inline}}
   - : `boolean`. Whether the tab is discarded. A discarded tab is one whose content has been unloaded from memory, but is still visible in the tab strip. Its content gets reloaded the next time it's activated.
-- `favIconUrl`{{optional_inline}}
+- `favIconUrl` {{optional_inline}}
   - : `string`. The tab's new favicon URL.
-- `hidden`{{optional_inline}}
+- `hidden` {{optional_inline}}
   - : `boolean`. True if the tab is {{WebExtAPIRef("tabs.hide()", "hidden")}}.
-- `isArticle`{{optional_inline}}
+- `isArticle` {{optional_inline}}
   - : `boolean`. True if the tab is an article and is therefore eligible for display in {{WebExtAPIRef("tabs.toggleReaderMode()", "Reader Mode")}}.
-- `mutedInfo`{{optional_inline}}
+- `mutedInfo` {{optional_inline}}
   - : {{WebExtAPIRef('tabs.MutedInfo')}}. The tab's new muted state and the reason for the change.
-- `pinned`{{optional_inline}}
+- `pinned` {{optional_inline}}
   - : `boolean`. The tab's new pinned state.
-- `status`{{optional_inline}}
+- `status` {{optional_inline}}
   - : `string`. The status of the tab. Can be either _loading_ or _complete_.
-- `title`{{optional_inline}}
+- `title` {{optional_inline}}
   - : `string`. The tab's new title.
-- `url`{{optional_inline}}
+- `url` {{optional_inline}}
   - : `string`. The tab's URL if it has changed.
 
 ## Examples

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/pagesettings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/pagesettings/index.md
@@ -30,13 +30,13 @@ For setting headers and footers, you can include certain special characters in t
 
 Values of this type are objects. They contain the following properties:
 
-- `edgeBottom`{{optional_inline}}
+- `edgeBottom` {{optional_inline}}
   - : `number`. The spacing between the bottom of the footers and the bottom edge of the paper (inches). Default: 0.
-- `edgeLeft`{{optional_inline}}
+- `edgeLeft` {{optional_inline}}
   - : `number`. The spacing between the left header/footer and the left edge of the paper (inches). Default: 0.
-- `edgeRight`{{optional_inline}}
+- `edgeRight` {{optional_inline}}
   - : `number`. The spacing between the right header/footer and the left edge of the paper (inches). Default: 0.
-- `edgeTop`{{optional_inline}}
+- `edgeTop` {{optional_inline}}
   - : `number`. The spacing between the top of the headers and the top edge of the paper (inches). Default: 0
 - `footerCenter` {{optional_inline}}
   - : `string`. The text for the page's center footer. Default: ''.
@@ -50,17 +50,17 @@ Values of this type are objects. They contain the following properties:
   - : `string`. The text for the page's left header. Default: '\&T'.
 - `headerRight` {{optional_inline}}
   - : `string`. The text for the page's right header. Default: '\&U'.
-- `marginBottom`{{optional_inline}}
+- `marginBottom` {{optional_inline}}
   - : `number`. The margin between the page content and the bottom edge of the paper (inches). Default: 0.5.
-- `marginLeft`{{optional_inline}}
+- `marginLeft` {{optional_inline}}
   - : `number`. The margin between the page content and the left edge of the paper (inches). Default: 0.5.
-- `marginRight`{{optional_inline}}
+- `marginRight` {{optional_inline}}
   - : `number`. The margin between the page content and the right edge of the paper (inches). Default: 0.5.
-- `marginTop`{{optional_inline}}
+- `marginTop` {{optional_inline}}
   - : `number`. The margin between the page content and the top edge of the paper (inches). Default: 0.5.
 - `orientation` {{optional_inline}}
   - : `integer`. Page orientation: 0 means "portrait", 1 means "landscape". Default: 0.
-- `paperHeight`{{optional_inline}}
+- `paperHeight` {{optional_inline}}
   - : `number`. The paper height in paper size units. Default: 11.0.
 - `paperSizeUnit` {{optional_inline}}
   - : `integer`. The paper size unit: 0 = inches, 1 = millimeters. Default: 0.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/query/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/query/index.md
@@ -33,39 +33,39 @@ let querying = browser.tabs.query(queryObj)
 
     See the {{WebExtAPIRef("tabs.Tab")}} documentation to learn more about these properties.
 
-    - `active`{{optional_inline}}
+    - `active` {{optional_inline}}
       - : `boolean`. Whether the tabs are active in their windows.
-    - `audible`{{optional_inline}}
+    - `audible` {{optional_inline}}
       - : `boolean`. Whether the tabs are audible.
-    - `autoDiscardable`{{optional_inline}}
+    - `autoDiscardable` {{optional_inline}}
       - : `boolean`. Whether the tabs can be discarded automatically by the browser when resources are low.
     - `cookieStoreId` {{optional_inline}}
       - : `string` or `array` of `string`. Use this to return tabs whose `tab.cookieStoreId` matches any of the `cookieStoreId` strings. This option is only available if the add-on has the `"cookies"` [permission](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions).
-    - `currentWindow`{{optional_inline}}
+    - `currentWindow` {{optional_inline}}
       - : `boolean`. Whether the tabs are in the current window.
-    - `discarded`{{optional_inline}}
+    - `discarded` {{optional_inline}}
       - : `boolean`. Whether the tabs are discarded. A discarded tab is one whose content has been unloaded from memory, but is still visible in the tab strip. Its content gets reloaded the next time it's activated.
-    - `hidden`{{optional_inline}}
+    - `hidden` {{optional_inline}}
       - : `boolean`. Whether the tabs are hidden.
-    - `highlighted`{{optional_inline}}
+    - `highlighted` {{optional_inline}}
       - : `boolean`. Whether the tabs are highlighted.
-    - `index`{{optional_inline}}
+    - `index` {{optional_inline}}
       - : `integer`. The position of the tabs within their windows.
-    - `muted`{{optional_inline}}
+    - `muted` {{optional_inline}}
       - : `boolean`. Whether the tabs are muted.
-    - `lastFocusedWindow`{{optional_inline}}
+    - `lastFocusedWindow` {{optional_inline}}
       - : `boolean`. Whether the tabs are in the last focused window.
-    - `pinned`{{optional_inline}}
+    - `pinned` {{optional_inline}}
       - : `boolean`. Whether the tabs are pinned.
-    - `status`{{optional_inline}}
+    - `status` {{optional_inline}}
       - : {{WebExtAPIRef('tabs.TabStatus')}}. Whether the tabs have completed loading.
-    - `title`{{optional_inline}}
+    - `title` {{optional_inline}}
       - : `string`. Match page titles against a pattern. Requires the "tabs" permission or [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) for the tab to match.
-    - `url`{{optional_inline}}
+    - `url` {{optional_inline}}
       - : `string` or `array` of `string`. Match tabs against one or more [match patterns](/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns). Note that fragment identifiers are not matched. Requires the "tabs" permission or [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) for the tab to match.
-    - `windowId`{{optional_inline}}
+    - `windowId` {{optional_inline}}
       - : `integer`. The `id` of the parent window, or {{WebExtAPIRef('windows.WINDOW_ID_CURRENT')}} for the current window.
-    - `windowType`{{optional_inline}}
+    - `windowType` {{optional_inline}}
       - : {{WebExtAPIRef('tabs.WindowType')}}. The type of window the tabs are in.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/reload/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/reload/index.md
@@ -30,13 +30,13 @@ let reloading = browser.tabs.reload(
 
 ### Parameters
 
-- `tabId`{{optional_inline}}
+- `tabId` {{optional_inline}}
   - : `integer`. The ID of the tab to reload. Defaults to the selected tab of the current window.
-- `reloadProperties`{{optional_inline}}
+- `reloadProperties` {{optional_inline}}
 
   - : An object with the following properties:
 
-    - `bypassCache`{{optional_inline}}
+    - `bypassCache` {{optional_inline}}
       - : `boolean`. Bypass the local web cache. Default is `false`.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/removecss/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/removecss/index.md
@@ -38,17 +38,17 @@ let removing = browser.tabs.removeCSS(
 
   - : An object describing the CSS to remove from the page. It contains the following properties:
 
-    - `allFrames`{{optional_inline}}
+    - `allFrames` {{optional_inline}}
       - : `boolean`. If `true`, the code will be removed from all frames of the current page. If it is `false`, code is only removed from the top frame. Defaults to `false`.
-    - `code`{{optional_inline}}
+    - `code` {{optional_inline}}
       - : `string`. CSS to remove, as a text string. This must exactly match a CSS string previously inserted into the page using {{WebExtAPIRef("tabs.insertCSS()")}}.
-    - `cssOrigin`{{optional_inline}}
+    - `cssOrigin` {{optional_inline}}
       - : `string`. This can take one of two values: "user", for CSS added as a user stylesheet, or "author" for CSS added as an author stylesheet. If this option was set previously by {{WebExtAPIRef("tabs.insertCSS()")}}, then it must exactly match.
-    - `file`{{optional_inline}}
+    - `file` {{optional_inline}}
       - : `string`. Path to a file containing the CSS to remove. This must exactly match a CSS file previously inserted into the page using {{WebExtAPIRef("tabs.insertCSS()")}}.
-    - `frameId`{{optional_inline}}
+    - `frameId` {{optional_inline}}
       - : `integer`. The frame from which to remove the CSS. Defaults to `0` (the top-level frame).
-    - `matchAboutBlank`{{optional_inline}}
+    - `matchAboutBlank` {{optional_inline}}
       - : `boolean`. If `true`, the CSS will be removed from embedded "about:blank" and "about:srcdoc" frames if your extension has access to their parent document. Defaults to `false`.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/setzoom/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/setzoom/index.md
@@ -30,7 +30,7 @@ let zooming = browser.tabs.setZoom(
 
 ### Parameters
 
-- `tabId`{{optional_inline}}
+- `tabId` {{optional_inline}}
   - : `integer`. The ID of the tab to zoom. Defaults to the active tab of the current window.
 - `zoomFactor`
   - : `number`. The new zoom factor. Use a value of 0 here to set the tab to its current default zoom factor. Otherwise, this must be a number between 0.3 and 5, specifying a zoom factor.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/setzoomsettings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/setzoomsettings/index.md
@@ -30,7 +30,7 @@ let settingZoomSettings = browser.tabs.setZoomSettings(
 
 ### Parameters
 
-- `tabId`{{optional_inline}}
+- `tabId` {{optional_inline}}
   - : `integer`. The ID of the tab to change the zoom settings for. Defaults to the active tab of the current window.
 - `zoomSettings`
   - : {{WebExtAPIRef('tabs.ZoomSettings')}}. Defines how zoom changes are handled and at what scope.

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/togglereadermode/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/togglereadermode/index.md
@@ -49,7 +49,7 @@ let toggling = browser.tabs.toggleReaderMode(
 
 ### Parameters
 
-- `tabId`{{optional_inline}}
+- `tabId` {{optional_inline}}
   - : `integer`. The ID of the tab to display in Reader Mode. Defaults to the selected tab of the current window.
 
 ### Return value

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/update/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/update/index.md
@@ -32,23 +32,23 @@ let updating = browser.tabs.update(
 
 ### Parameters
 
-- `tabId`{{optional_inline}}
+- `tabId` {{optional_inline}}
   - : `integer`. Defaults to the selected tab of the current window.
 - `updateProperties`
 
   - : `object`. The set of properties to update for this tab. To learn more about these properties, see the {{WebExtAPIRef("tabs.Tab")}} documentation.
 
-    - `active`{{optional_inline}}
+    - `active` {{optional_inline}}
       - : `boolean`. Whether the tab should become active. Does not affect whether the window is focused (see {{WebExtAPIRef('windows.update')}}). If `true`, non-active highlighted tabs will stop being highlighted. If `false`, does nothing.
-    - `autoDiscardable`{{optional_inline}}
+    - `autoDiscardable` {{optional_inline}}
       - : `boolean`. Whether the tab should be discarded automatically by the browser when resources are low.
-    - `highlighted`{{optional_inline}}
+    - `highlighted` {{optional_inline}}
 
       - : `boolean`. Adds or removes the tab from the current selection. If `true` and the tab is not highlighted, it will become active by default.
 
         If you only want to highlight the tab without activating it, Firefox accepts setting `highlighted` to `true` and `active` to `false`. Other browsers may activate the tab even in this case.
 
-    - `loadReplace`{{optional_inline}}
+    - `loadReplace` {{optional_inline}}
 
       - : `boolean`. Whether the new URL should replace the old URL in the tab's navigation history, as accessed via the "Back" button.
 
@@ -56,17 +56,17 @@ let updating = browser.tabs.update(
 
         Note though that the original URL will still appear in the browser's global history.
 
-    - `muted`{{optional_inline}}
+    - `muted` {{optional_inline}}
       - : `boolean`. Whether the tab should be muted.
-    - `openerTabId`{{optional_inline}}
+    - `openerTabId` {{optional_inline}}
       - : `integer`. The ID of the tab that opened this tab. If specified, the opener tab must be in the same window as this tab.
-    - `pinned`{{optional_inline}}
+    - `pinned` {{optional_inline}}
       - : `boolean`. Whether the tab should be pinned.
     - `selected` {{deprecated_inline}} {{optional_inline}}
       - : `boolean`. Whether the tab should be selected. This property has been replaced by `active` and `highlighted`.
     - `successorTabId` {{optional_inline}}
       - : `integer`. The id of the ID of the tab's successor.
-    - `url`{{optional_inline}}
+    - `url` {{optional_inline}}
 
       - : `string`. A URL to navigate the tab to.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettings/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/zoomsettings/index.md
@@ -21,11 +21,11 @@ Defines zoom settings for a tab: {{WebExtAPIRef("tabs.ZoomSettingsMode", "mode")
 
 Values of this type are objects. They contain the following properties:
 
-- `defaultZoomFactor`{{optional_inline}}
+- `defaultZoomFactor` {{optional_inline}}
   - : `number`. The default zoom level for the current tab. Note that this is only used in {{WebExtAPIRef("tabs.getZoomSettings")}}.
-- `mode`{{optional_inline}}
+- `mode` {{optional_inline}}
   - : {{WebExtAPIRef('tabs.ZoomSettingsMode')}}. Defines whether zoom changes are handled by the browser, by the extension, or are disabled.
-- `scope`{{optional_inline}}
+- `scope` {{optional_inline}}
   - : {{WebExtAPIRef('tabs.ZoomSettingsScope')}}. Defines whether zoom changes will persist for the page's origin, or only take effect in this tab.
 
 ## Browser compatibility

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/onupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/onupdated/index.md
@@ -50,7 +50,7 @@ Events have three functions:
 
         - `theme`
           - : `object`. If the event fired because an extension-supplied theme was removed, this will be an empty object. If it fired because an extension-supplied theme was applied, then it will be a {{WebExtAPIRef("theme.Theme")}} object representing the theme that was applied.
-        - `windowId`{{optional_inline}}
+        - `windowId` {{optional_inline}}
           - : `integer`. The ID of the window for which theme has been updated. If this property is not present, it means that the theme was updated globally.
 
 ## Browser compatibility

--- a/files/en-us/web/api/audiodata/allocationsize/index.md
+++ b/files/en-us/web/api/audiodata/allocationsize/index.md
@@ -26,9 +26,9 @@ allocationSize(options)
   - : An object containing the following:
     - `planeIndex`
       - : The index of the plane to return the size of.
-    - `frameOffset`{{optional_inline}}
+    - `frameOffset` {{optional_inline}}
       - : An integer giving an offset into the plane data indicating which plane to begin from. Defaults to `0`.
-    - `frameCount`{{optional_inline}}
+    - `frameCount` {{optional_inline}}
       - : An integer giving the number of frames to return the size of. If omitted then all frames in the plane will be used, beginning with the frame specified in `frameOffset`.
 
 ### Return value

--- a/files/en-us/web/api/audiodata/copyto/index.md
+++ b/files/en-us/web/api/audiodata/copyto/index.md
@@ -28,9 +28,9 @@ copyTo(destination, options)
   - : An object containing the following:
     - `planeIndex`
       - : The index of the plane to copy from.
-    - `frameOffset`{{optional_inline}}
+    - `frameOffset` {{optional_inline}}
       - : An integer giving an offset into the plane data indicating which plane to begin copying from. Defaults to `0`.
-    - `frameCount`{{optional_inline}}
+    - `frameCount` {{optional_inline}}
       - : An integer giving the number of frames to copy. If omitted then all frames in the plane will be copied, beginning with the frame specified in `frameOffset`.
 
 ### Return value

--- a/files/en-us/web/api/audiodecoder/configure/index.md
+++ b/files/en-us/web/api/audiodecoder/configure/index.md
@@ -30,7 +30,7 @@ configure(config)
       - : An integer representing the number of frame samples per second.
     - `numberOfChannels`
       - : An integer representing the number of audio channels.
-    - `description`{{Optional_Inline}}
+    - `description` {{optional_inline}}
       - : Aa {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, or a {{jsxref("DataView")}} containing a sequence of codec specific bytes, commonly known as extradata.
 
 > **Note:** The registrations in the [WebCodecs Codec Registry](https://www.w3.org/TR/webcodecs-codec-registry/#audio-codec-registry) link to a specification detailing whether and how to populate the optional `description` member.

--- a/files/en-us/web/api/audioencoder/audioencoder/index.md
+++ b/files/en-us/web/api/audioencoder/audioencoder/index.md
@@ -31,7 +31,7 @@ new AudioEncoder(init)
           - : An integer representing the number of frame samples per second.
         - `numberOfChannels`
           - : An integer representing the number of audio channels.
-        - `description`{{Optional_Inline}}
+        - `description` {{optional_inline}}
           - : An {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, or a {{jsxref("DataView")}} containing a sequence of codec specific bytes, commonly known as extradata.
     - `error`
       - : A callback which takes an {{jsxref("Error")}} object as its only argument.

--- a/files/en-us/web/api/audioencoder/configure/index.md
+++ b/files/en-us/web/api/audioencoder/configure/index.md
@@ -26,11 +26,11 @@ configure(config)
   - : A dictionary object containing the following members:
     - `codec`
       - : A string containing a [valid codec string](https://www.w3.org/TR/webcodecs-codec-registry/#audio-codec-registry).
-    - `sampleRate`{{Optional_Inline}}
+    - `sampleRate` {{optional_inline}}
       - : An integer representing the number of frame samples per second.
-    - `numberOfChannels`{{Optional_Inline}}
+    - `numberOfChannels` {{optional_inline}}
       - : An integer representing the number of audio channels.
-    - `bitrate`{{Optional_Inline}}
+    - `bitrate` {{optional_inline}}
       - : An integer representing the bitrate.
 
 ### Return value

--- a/files/en-us/web/api/backgroundfetchupdateuievent/updateui/index.md
+++ b/files/en-us/web/api/backgroundfetchupdateuievent/updateui/index.md
@@ -24,24 +24,24 @@ updateUI(options)
 
 ### Parameters
 
-- `options`{{optional_inline}}
+- `options` {{optional_inline}}
 
   - : An object containing any of the following:
 
-    - `icons`{{optional_inline}}
+    - `icons` {{optional_inline}}
 
       - : A list of one or more image resources, containing icons for use in the user interface. An image resource is an object containing:
 
         - `src`
           - : A string which is a URL of an image.
-        - `sizes`{{optional_inline}}
+        - `sizes` {{optional_inline}}
           - : A string which is equivalent to a {{htmlelement("link")}} `sizes` attribute.
-        - `type`{{optional_inline}}
+        - `type` {{optional_inline}}
           - : A string containing an image MIME type.
-        - `label`{{optional_inline}}
+        - `label` {{optional_inline}}
           - : A string providing a name for the associated image.
 
-    - `title`{{optional_inline}}
+    - `title` {{optional_inline}}
       - : A string containing the new title of the user interface.
 
 ### Return value

--- a/files/en-us/web/api/cookiestore/getall/index.md
+++ b/files/en-us/web/api/cookiestore/getall/index.md
@@ -24,9 +24,9 @@ getAll(options)
 
 ### Parameters
 
-- `name`{{Optional_Inline}}
+- `name` {{optional_inline}}
   - : A string with the name of a cookie.
-- `options`{{Optional_Inline}}
+- `options` {{optional_inline}}
 
   - : An object containing:
 

--- a/files/en-us/web/api/cssstylesheet/cssstylesheet/index.md
+++ b/files/en-us/web/api/cssstylesheet/cssstylesheet/index.md
@@ -27,15 +27,15 @@ new CSSStyleSheet(options)
 
 ### Parameters
 
-- `options`{{optional_inline}}
+- `options` {{optional_inline}}
 
   - : An object containing the following:
 
-    - `baseURL`{{optional_inline}}
+    - `baseURL` {{optional_inline}}
       - : A string containing the `baseURL` used to resolve relative URLs in the stylesheet.
-    - `media`{{optional_inline}}
+    - `media` {{optional_inline}}
       - : A {{domxref("MediaList")}} containing a list of media rules, or a string containing a single rule.
-    - `disabled`{{optional_inline}}
+    - `disabled` {{optional_inline}}
       - : A {{jsxref("Boolean")}} indicating whether the stylesheet is disabled. False by default.
 
 ## Examples

--- a/files/en-us/web/api/csstransformvalue/foreach/index.md
+++ b/files/en-us/web/api/csstransformvalue/foreach/index.md
@@ -44,9 +44,9 @@ forEach(function(currentValue, index, array) { /* ... */ }, thisArg)
 
     - `currentValue`
       - : The value of the current element being processed.
-    - `index`{{optional_inline}}
+    - `index` {{optional_inline}}
       - : The index of the current element being processed.
-    - `array`{{optional_inline}}
+    - `array` {{optional_inline}}
       - : The `CSSTransformValue` that `forEach()` is being called on.
 
 - `thisArg` {{Optional_inline}}

--- a/files/en-us/web/api/cssunparsedvalue/foreach/index.md
+++ b/files/en-us/web/api/cssunparsedvalue/foreach/index.md
@@ -48,9 +48,9 @@ forEach(function(currentValue, index, array) { /* ... */ }, thisArg)
 
     - `currentValue`
       - : The value of the current element being processed.
-    - `index`{{optional_inline}}
+    - `index` {{optional_inline}}
       - : The index of the current element being processed.
-    - `array`{{optional_inline}}
+    - `array` {{optional_inline}}
       - : The `CSSUnparsedValue` that `forEach()` is being called
         on.
 

--- a/files/en-us/web/api/element/animate/index.md
+++ b/files/en-us/web/api/element/animate/index.md
@@ -37,7 +37,7 @@ animate(keyframes, options)
   - : Either an **integer representing the animation's duration** (in
     milliseconds), **or** an Object containing one or more timing properties described in the [`KeyframeEffect()` options parameter](/en-US/docs/Web/API/KeyframeEffect/KeyframeEffect#parameters) and/or the following options:
 
-    - `id`{{optional_inline}}
+    - `id` {{optional_inline}}
       - : A property unique to `animate()`: a string
         with which to reference the animation.
 

--- a/files/en-us/web/api/element/getanimations/index.md
+++ b/files/en-us/web/api/element/getanimations/index.md
@@ -38,7 +38,7 @@ getAnimations(options)
 
 ### Parameters
 
-- `options`{{optional_inline}}
+- `options` {{optional_inline}}
 
   - : An options object containing the following property:
 

--- a/files/en-us/web/api/elementinternals/setformvalue/index.md
+++ b/files/en-us/web/api/elementinternals/setformvalue/index.md
@@ -25,7 +25,7 @@ setFormValue(value, state)
 
 - `value`
   - : A {{domxref("File")}}, a string, or a {{domxref("FormData")}} as the value to be submitted to the server.
-- `state`{{Optional_Inline}}
+- `state` {{optional_inline}}
   - : A {{domxref("File")}}, a string, or a {{domxref("FormData")}} representing the input made by the user.
     This allows the application to re-display the information that the user submitted, in the form that they submitted it, if required.
 

--- a/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.md
@@ -30,7 +30,7 @@ new ExtendableCookieChangeEvent(type, options)
 - `type`
   - : A string with the name of the event.
     It is case-sensitive and browsers always set it to `cookiechange`.
-- `options`{{Optional_Inline}}
+- `options` {{optional_inline}}
   - : An object that, _in addition of the properties defined in {{domxref("ExtendableEvent/ExtendableEvent", "ExtendableEvent()")}}_, can have the following properties:
     - `changed`
       - : An array containing a changed cookie.

--- a/files/en-us/web/api/hid/requestdevice/index.md
+++ b/files/en-us/web/api/hid/requestdevice/index.md
@@ -29,17 +29,17 @@ requestDevice(options)
 
   - : An object containing an array of filter objects for possible devices to pair with. Each filter object can have the following properties:
 
-    - `vendorId`{{Optional_Inline}}
+    - `vendorId` {{optional_inline}}
       - : An integer representing the vendorId of the requested HID device
-    - `productId`{{Optional_Inline}}
+    - `productId` {{optional_inline}}
       - : An integer representing the productId of the requested HID device.
-    - `usagePage`{{Optional_Inline}}
+    - `usagePage` {{optional_inline}}
 
       - : An integer representing the usage page component of the HID usage of the requested device. The usage for a top level collection is used to identify the device type.
 
         Standard HID usage values can be found in the [HID Usage Tables](https://usb.org/document-library/hid-usage-tables-13) document
 
-    - `usage`{{Optional_Inline}}
+    - `usage` {{optional_inline}}
       - : An integer representing the usage ID component of the HID usage of the requested device.
 
 > **Note:** The device filters are used to narrow the list of devices presented to the user. If no filters are present, all connected devices are shown. When one or more filters are included, a device is included if any filter matches. To match a filter, all of the rules included in that filter must match.

--- a/files/en-us/web/api/idledetector/start/index.md
+++ b/files/en-us/web/api/idledetector/start/index.md
@@ -28,7 +28,7 @@ start(options)
 
 ### Parameters
 
-- `options`{{optional_inline}}
+- `options` {{optional_inline}}
   - : An object with the following properties:
     - `threshold`
       - : The minimum number of idle milliseconds before reporting should begin.

--- a/files/en-us/web/api/imagedecoder/decode/index.md
+++ b/files/en-us/web/api/imagedecoder/decode/index.md
@@ -23,11 +23,11 @@ decode(options)
 
 ### Parameters
 
-- `options`{{Optional_Inline}}
+- `options` {{optional_inline}}
   - : An object containing the following members:
-    - `frameIndex`{{Optional_Inline}}
+    - `frameIndex` {{optional_inline}}
       - : An integer representing the index of the frame to decode. Defaults to `0` (the first frame).
-    - `completeFramesOnly`{{Optional_Inline}}
+    - `completeFramesOnly` {{optional_inline}}
       - : A {{jsxref("boolean")}} defaulting to `true`. When `false` indicates that for progressive images the decoder may output an image with reduced detail. When `false`, the promise returned by `decode()` will resolve exactly once for each new level of detail.
 
 ### Return value

--- a/files/en-us/web/api/imagedecoder/imagedecoder/index.md
+++ b/files/en-us/web/api/imagedecoder/imagedecoder/index.md
@@ -27,20 +27,20 @@ new ImageDecoder(init)
       - : A string containing the [MIME type](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) of the image file to be decoded.
     - `data`
       - : An {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, a {{jsxref("DataView")}}, or a {{domxref("ReadableStream")}} of bytes representing an encoded image type as described by `type`.
-    - `premultiplyAlpha`{{Optional_Inline}}
+    - `premultiplyAlpha` {{optional_inline}}
       - : Specifies whether the decoded image's color channels should be premultiplied by the alpha channel. If not provided set as `"default"`:
         - `"none"`
         - `"premultiply"`
         - `"default"`
-    - `colorSpaceConversion`{{Optional_Inline}}
+    - `colorSpaceConversion` {{optional_inline}}
       - : Specifies whether the image should be decoded using color space conversion. If not provided set as `"default"`. The value `"default"` indicates that implementation-specific behavior is used:
         - `"none"`
         - `"default"`
-    - `desiredWidth`{{Optional_Inline}}
+    - `desiredWidth` {{optional_inline}}
       - : An integer indicating the desired width for the decoded output. Has no effect unless the image codec supports variable resolution decoding.
-    - `desiredHeight`{{Optional_Inline}}
+    - `desiredHeight` {{optional_inline}}
       - : An integer indicating the desired height for the decoded output. Has no effect unless the image codec supports variable resolution decoding.
-    - `preferAnimation`{{Optional_Inline}}
+    - `preferAnimation` {{optional_inline}}
       - : A {{jsxref("Boolean")}} indicating whether the initial track selection should prefer an animated track.
 
 ## Examples

--- a/files/en-us/web/api/mediastreamtrackprocessor/mediastreamtrackprocessor/index.md
+++ b/files/en-us/web/api/mediastreamtrackprocessor/mediastreamtrackprocessor/index.md
@@ -25,7 +25,7 @@ new MediaStreamTrackProcessor(options)
   - : An object with the following properties:
     - `track`
       - : A {{domxref("MediaStreamTrack")}}.
-    - `maxBufferSize`{{Optional_Inline}}
+    - `maxBufferSize` {{optional_inline}}
       - : An integer specifying the maximum number of media frames to be buffered.
 
 ## Examples

--- a/files/en-us/web/api/midiconnectionevent/midiconnectionevent/index.md
+++ b/files/en-us/web/api/midiconnectionevent/midiconnectionevent/index.md
@@ -24,7 +24,7 @@ new MIDIConnectionEvent(type, midiConnectionEventInit)
 
 - `type`
   - : A string with one of `"connect"` or `"disconnect"`.
-- `midiConnectionEventInit`{{Optional_Inline}}
+- `midiConnectionEventInit` {{optional_inline}}
 
   - : A dictionary including the following fields:
 

--- a/files/en-us/web/api/midioutput/send/index.md
+++ b/files/en-us/web/api/midioutput/send/index.md
@@ -25,7 +25,7 @@ send(data, timestamp)
 
 - `data`
   - : A sequence of one or more [valid MIDI messages](https://www.midi.org/midi-articles/about-midi-part-3-midi-messages). Each entry represents a single byte of data.
-- `timestamp`{{Optional_Inline}}
+- `timestamp` {{optional_inline}}
   - : A {{domxref("DOMHighResTimestamp")}} with the time in milliseconds, which is the delay before sending the message.
 
 ### Return value

--- a/files/en-us/web/api/navigator/mslaunchuri/index.md
+++ b/files/en-us/web/api/navigator/mslaunchuri/index.md
@@ -28,9 +28,9 @@ msLaunchUri(uri, successCallback, noHandlerCallback)
 
 - `uri`
   - : A string specifying the URL containing including the protocol of the document or resource to be displayed.
-- `successCallback`{{Optional_Inline}}
+- `successCallback` {{optional_inline}}
   - : A function matching the signature of {{DOMxRef("MSLaunchUriCallback")}} to be executed if the protocol handler is present.
-- `noHandlerCallback`{{Optional_Inline}}
+- `noHandlerCallback` {{optional_inline}}
   - : A function matching {{DOMxRef("MSLaunchUriCallback")}} to be executed if the protocol handler is _not_ present.
 
 ### Return value

--- a/files/en-us/web/api/navigator/setappbadge/index.md
+++ b/files/en-us/web/api/navigator/setappbadge/index.md
@@ -24,7 +24,7 @@ setAppBadge(contents)
 
 ### Parameters
 
-- `contents`{{optional_inline}}
+- `contents` {{optional_inline}}
   - : A {{jsxref("number")}} which will be used as the value of the badge. If `contents` is `0` then the badge will be set to `nothing`, indicating a cleared badge.
 
 ### Return value

--- a/files/en-us/web/api/offscreencanvas/converttoblob/index.md
+++ b/files/en-us/web/api/offscreencanvas/converttoblob/index.md
@@ -30,7 +30,7 @@ convertToBlob(options)
 
 ### Parameters
 
-- `options`{{optional_inline}}
+- `options` {{optional_inline}}
 
   - : An object with the following properties:
     - `type`

--- a/files/en-us/web/api/remoteplayback/cancelwatchavailability/index.md
+++ b/files/en-us/web/api/remoteplayback/cancelwatchavailability/index.md
@@ -23,7 +23,7 @@ cancelWatchAvailability(id)
 
 ### Parameters
 
-- `id`{{Optional_Inline}}
+- `id` {{optional_inline}}
 
   - : The `callbackId` of a particular remote playback device.
 

--- a/files/en-us/web/api/serialport/open/index.md
+++ b/files/en-us/web/api/serialport/open/index.md
@@ -28,15 +28,15 @@ open(options)
 
     - `baudRate`
       - : A positive, non-zero value indicating the baud rate at which serial communication should be established.
-    - `bufferSize`{{optional_inline}}
+    - `bufferSize` {{optional_inline}}
       - : An unsigned long integer indicating the size of the read and write buffers that are to be established. If not passed, defaults to 255.
-    - `dataBits`{{optional_inline}}
+    - `dataBits` {{optional_inline}}
       - : An integer value of 7 or 8 indicating the number of data bits per frame. If not passed, defaults to 8.
-    - `flowControl`{{optional_inline}}
+    - `flowControl` {{optional_inline}}
       - : The flow control type, either `"none"` or `"hardware"`. The default value is `"none:`.
-    - `parity`{{optional_inline}}
+    - `parity` {{optional_inline}}
       - : The parity mode, either `"none"`, `"even"`, or `"odd"`. The default value is `"none"`.
-    - `stopBits`{{optional_inline}}
+    - `stopBits` {{optional_inline}}
       - : An integer value of 1 or 2 indicating the number of stop bits at the end of the frame. If not passed, defaults to 1.
 
 ### Return value

--- a/files/en-us/web/api/serialport/setsignals/index.md
+++ b/files/en-us/web/api/serialport/setsignals/index.md
@@ -23,7 +23,7 @@ setSignals(options)
 
 ### Parameters
 
-- `options`{{optional_inline}}
+- `options` {{optional_inline}}
 
   - : An object with any of the following values:
 

--- a/files/en-us/web/api/setinterval/index.md
+++ b/files/en-us/web/api/setinterval/index.md
@@ -49,7 +49,7 @@ setInterval(func, delay, arg0, arg1, /* ... ,*/ argN)
     compiled and executed every `delay` milliseconds. This syntax is _not
     recommended_ for the same reasons that make using {{jsxref("Global_Objects/eval", "eval()")}} a
     security risk.
-- `delay`{{optional_inline}}
+- `delay` {{optional_inline}}
   - : The time, in milliseconds (thousandths of a second), the timer should delay in
     between executions of the specified function or code. Defaults to 0 if not specified. See [Delay restrictions](#delay_restrictions)
     below for details on the permitted range of `delay` values.

--- a/files/en-us/web/api/stylepropertymapreadonly/foreach/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/foreach/index.md
@@ -45,9 +45,9 @@ forEach(function(currentValue, index, array) { /* ... */ }, thisArg)
 
     - `currentValue`
       - : The value of the current element being processed.
-    - `index`{{optional_inline}}
+    - `index` {{optional_inline}}
       - : The index of the current element being processed.
-    - `array`{{optional_inline}}
+    - `array` {{optional_inline}}
       - : The StylePropertyMapReadOnly that `forEach()` is being called on.
 
 - `thisArg` {{Optional_inline}}

--- a/files/en-us/web/api/textdecoder/textdecoder/index.md
+++ b/files/en-us/web/api/textdecoder/textdecoder/index.md
@@ -30,10 +30,10 @@ new TextDecoder(utfLabel, options)
 
 ### Parameters
 
-- `utfLabel`{{Optional_Inline}}
+- `utfLabel` {{optional_inline}}
   - : A string, defaulting to `"utf-8"`, containing the
     _label_ of the encoder. This may be [any valid label](/en-US/docs/Web/API/Encoding_API/Encodings).
-- `options`{{Optional_Inline}}
+- `options` {{optional_inline}}
 
   - : A `TextDecoderOptions` dictionary with the property:
 

--- a/files/en-us/web/api/touchevent/touchevent/index.md
+++ b/files/en-us/web/api/touchevent/touchevent/index.md
@@ -41,11 +41,11 @@ new TouchEvent(type, options)
       - : and defaulting to `[]`, of type `Touch[]`, that is a list of objects for every point of contact which contributed to the event.
     - `ctrlKey` {{optional_inline}}
       - : A boolean value, defaulting to `false`, indicating if the <kbd>ctrl</kbd> key was simultaneously pressed.
-    - `shiftKey`{{optional_inline}}
+    - `shiftKey` {{optional_inline}}
       - : A boolean value, defaulting to `false`, indicating if the <kbd>shift</kbd> key was simultaneously pressed.
-    - `altKey`{{optional_inline}}
+    - `altKey` {{optional_inline}}
       - : A boolean value, defaulting to `false`, indicating if the <kbd>alt</kbd> key was simultaneously pressed.
-    - `metaKey`{{optional_inline}}
+    - `metaKey` {{optional_inline}}
       - : A boolean value, defaulting to `false`, indicating if the <kbd>meta</kbd> key was simultaneously pressed.
 
 ### Return value

--- a/files/en-us/web/api/transformstream/transformstream/index.md
+++ b/files/en-us/web/api/transformstream/transformstream/index.md
@@ -24,7 +24,7 @@ new TransformStream(transformer, writableStrategy, readableStrategy)
 
 ### Parameters
 
-- `transformer`{{Optional_Inline}}
+- `transformer` {{optional_inline}}
 
   - : An object representing the `transformer`. If not supplied the resulting stream will be an **identity transform stream** which forwards all chunks written to its writable side to its readable side, without any changes.
 
@@ -37,7 +37,7 @@ new TransformStream(transformer, writableStrategy, readableStrategy)
     - `flush(controller)`
       - : Called after all chunks written to the writable side have been successfully transformed, and the writable side is about to be closed.
 
-- `writableStrategy`{{Optional_Inline}}
+- `writableStrategy` {{optional_inline}}
 
   - : An object that optionally defines a queuing strategy for the stream. This takes two
     parameters:
@@ -49,7 +49,7 @@ new TransformStream(transformer, writableStrategy, readableStrategy)
       - : A method containing a parameter `chunk`. This indicates the size to
         use for each chunk, in bytes.
 
-- `readableStrategy`{{Optional_Inline}}
+- `readableStrategy` {{optional_inline}}
 
   - : An object that optionally defines a queuing strategy for the stream. This takes two
     parameters:

--- a/files/en-us/web/api/trustedtypepolicy/createhtml/index.md
+++ b/files/en-us/web/api/trustedtypepolicy/createhtml/index.md
@@ -25,7 +25,7 @@ createHTML(input, args)
 
 - `input`
   - : A string containing the string to be sanitized by the policy.
-- `args`{{optional_inline}}
+- `args` {{optional_inline}}
   - : Additional arguments to be passed to the function represented by {{domxref("TrustedTypePolicy")}}.
 
 ### Return value

--- a/files/en-us/web/api/trustedtypepolicy/createscript/index.md
+++ b/files/en-us/web/api/trustedtypepolicy/createscript/index.md
@@ -25,7 +25,7 @@ createScript(input, args)
 
 - `input`
   - : A string containing the string to be sanitized by the policy.
-- `args`{{optional_inline}}
+- `args` {{optional_inline}}
   - : Additional arguments to be passed to the function represented by {{domxref("TrustedTypePolicy")}}.
 
 ### Return value

--- a/files/en-us/web/api/trustedtypepolicy/createscripturl/index.md
+++ b/files/en-us/web/api/trustedtypepolicy/createscripturl/index.md
@@ -25,7 +25,7 @@ createScriptURL(input, args)
 
 - `input`
   - : A string containing the string to be sanitized by the policy.
-- `args`{{optional_inline}}
+- `args` {{optional_inline}}
   - : Additional arguments to be passed to the function represented by {{domxref("TrustedTypePolicy")}}.
 
 ### Return value

--- a/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/createpolicy/index.md
@@ -32,7 +32,7 @@ createPolicy(policyName, policyOptions)
 
 - `policyName`
   - : A string with the name of the policy.
-- `policyOptions`{{optional_inline}}
+- `policyOptions` {{optional_inline}}
 
   - : User-defined functions for converting strings into trusted values.
 

--- a/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getattributetype/index.md
@@ -28,9 +28,9 @@ getAttributeType(tagName, attribute, elementNS, attrNS)
   - : A string containing the name of an HTML tag.
 - `attribute`
   - : A string containing an attribute.
-- `elementNS`{{optional_inline}}
+- `elementNS` {{optional_inline}}
   - : A string containing a namespace, if empty defaults to the HTML namespace.
-- `attrNS`{{optional_inline}}
+- `attrNS` {{optional_inline}}
   - : A string containing a namespace, if empty defaults to null.
 
 ### Return value

--- a/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.md
+++ b/files/en-us/web/api/trustedtypepolicyfactory/getpropertytype/index.md
@@ -27,7 +27,7 @@ getPropertyType(tagName, property, elementNS)
   - : A string containing the name of an HTML tag.
 - `property`
   - : A string containing a property, for example `"innerHTML"`.
-- `elementNS`{{optional_inline}}
+- `elementNS` {{optional_inline}}
   - : A string containing a namespace, if empty defaults to the HTML namespace.
 
 ### Return value

--- a/files/en-us/web/api/videocolorspace/videocolorspace/index.md
+++ b/files/en-us/web/api/videocolorspace/videocolorspace/index.md
@@ -24,25 +24,25 @@ new VideoColorSpace(init)
 
 All values default to `null` when they are not present.
 
-- `init`{{Optional_Inline}}
+- `init` {{optional_inline}}
   - : A dictionary object containing the following:
-    - `primaries`{{Optional_Inline}}
+    - `primaries` {{optional_inline}}
       - : One of the following strings:
         - `"bt709"`
         - `"bt470bg"`
         - `"smpte170m"`
-    - `transfer`{{Optional_Inline}}
+    - `transfer` {{optional_inline}}
       - : One of the following strings:
         - `"bt709"`
         - `"smpte170m"`
         - `"iec61966-2-1"`
-    - `matrix`{{Optional_Inline}}
+    - `matrix` {{optional_inline}}
       - : One of the following strings:
         - `"rgb"`
         - `"bt709"`
         - `"bt470bg"`
         - `"smpte170m"`
-    - `fullRange`{{Optional_Inline}}
+    - `fullRange` {{optional_inline}}
       - : A {{jsxref("Boolean")}}, `true` if full-range color values are used in the video.
 
 ## Examples

--- a/files/en-us/web/api/videodecoder/configure/index.md
+++ b/files/en-us/web/api/videodecoder/configure/index.md
@@ -26,15 +26,15 @@ configure(config)
   - : An object containing the following members:
     - `codec`
       - : A string containing a [valid codec string](https://www.w3.org/TR/webcodecs-codec-registry/#video-codec-registry).
-    - `description`{{Optional_Inline}}
+    - `description` {{optional_inline}}
       - : An {{jsxref("ArrayBuffer")}}, a {{jsxref("TypedArray")}}, or a {{jsxref("DataView")}} containing a sequence of codec specific bytes, commonly known as extradata.
-    - `codedWidth`{{Optional_Inline}}
+    - `codedWidth` {{optional_inline}}
       - : An integer representing the width of the {{domxref("VideoFrame")}} in pixels, including any non-visible padding, before any ratio adjustments.
-    - `codedHeight`{{Optional_Inline}}
+    - `codedHeight` {{optional_inline}}
       - : An integer representing the height of the {{domxref("VideoFrame")}} in pixels, including any non-visible padding, before any ratio adjustments.
-    - `displayAspectWidth`{{Optional_Inline}}
+    - `displayAspectWidth` {{optional_inline}}
       - : An integer representing the horizontal dimension of the {{domxref("VideoFrame")}} in pixels when displayed.
-    - `displayAspectHeight`{{Optional_Inline}}
+    - `displayAspectHeight` {{optional_inline}}
       - : An integer representing the vertical dimension of the {{domxref("VideoFrame")}} in pixels when displayed.
     - `colorSpace`
       - : An object. representing a {{domxref("VideoColorSpace")}}, containing the following members:

--- a/files/en-us/web/api/videoencoder/configure/index.md
+++ b/files/en-us/web/api/videoencoder/configure/index.md
@@ -26,13 +26,13 @@ configure(config)
   - : A dictionary object containing the following members:
     - `codec`
       - : A string containing a [valid codec string](https://www.w3.org/TR/webcodecs-codec-registry/#audio-codec-registry).
-    - `width`{{Optional_Inline}}
+    - `width` {{optional_inline}}
       - : An integer representing the width of each output {{domxref("EncodedVideoChunk")}} in pixels, before any ratio adjustments.
-    - `height`{{Optional_Inline}}
+    - `height` {{optional_inline}}
       - : An integer representing the height of each output {{domxref("EncodedVideoChunk")}} in pixels, before any ratio adjustments.
-    - `displayWidth`{{Optional_Inline}}
+    - `displayWidth` {{optional_inline}}
       - : An integer representing the intended display width of each output {{domxref("EncodedVideoChunk")}} in pixels when displayed.
-    - `displayHeight`{{Optional_Inline}}
+    - `displayHeight` {{optional_inline}}
       - : An integer representing the vertical dimension of each output {{domxref("EncodedVideoChunk")}} in pixels when displayed.
     - `hardwareAcceleration`
       - : A hint that configures the hardware acceleration method of this codec. One of:

--- a/files/en-us/web/api/videoencoder/encode/index.md
+++ b/files/en-us/web/api/videoencoder/encode/index.md
@@ -25,7 +25,7 @@ encode(frame, options)
 
 - `frame`
   - : A {{domxref("VideoFrame")}} object.
-- `options`{{Optional_Inline}}
+- `options` {{optional_inline}}
   - : An object containing the following member:
     - `keyFrame`
       - : A {{jsxref("boolean")}}, defaulting to `false` giving the user agent flexibility to decide if this frame should be encoded as a key frame. If `true` this indicates that the given frame must be encoded as a key frame.

--- a/files/en-us/web/api/videoencoder/isconfigsupported/index.md
+++ b/files/en-us/web/api/videoencoder/isconfigsupported/index.md
@@ -29,9 +29,9 @@ isConfigSupported(config)
 
 A {{jsxref("Promise")}} that resolves with an object containing the following members:
 
-- `supported`{{Optional_Inline}}
+- `supported` {{optional_inline}}
   - : A boolean value which is `true` if the given config is supported by the encoder.
-- `config`{{Optional_Inline}}
+- `config` {{optional_inline}}
   - : A copy of the given config with all the fields recognized by the encoder.
 
 ### Exceptions

--- a/files/en-us/web/api/videoframe/allocationsize/index.md
+++ b/files/en-us/web/api/videoframe/allocationsize/index.md
@@ -23,15 +23,15 @@ allocationSize(options)
 
 ### Parameters
 
-- `options`{{Optional_Inline}}
+- `options` {{optional_inline}}
   - : An object containing the following:
-    - `rect`{{Optional_Inline}}
+    - `rect` {{optional_inline}}
       - : The rectangle of pixels to copy from the `VideoFrame`. If unspecified the {{domxref("VideoFrame.visibleRect","visibleRect")}} will be used. This is in the format of a dictionary object containing:
         - `x`: The x-coordinate.
         - `y`: The y-coordinate.
         - `width`: The width of the frame.
         - `height`: The height of the frame.
-    - `layout`{{Optional_Inline}}
+    - `layout` {{optional_inline}}
       - : A list containing the following values for each plane in the `VideoFrame`. Planes may not overlap. If unspecified the planes will be tightly packed:
         - `offset`
           - : An integer representing the offset in bytes where the given plane begins.

--- a/files/en-us/web/api/videoframe/copyto/index.md
+++ b/files/en-us/web/api/videoframe/copyto/index.md
@@ -25,15 +25,15 @@ copyTo(destination, options)
 
 - `destination`
   - : An `ArrayBuffer`, a {{jsxref("TypedArray")}}, or a {{jsxref("DataView")}} to copy to.
-- `options`{{Optional_Inline}}
+- `options` {{optional_inline}}
   - : An object containing the following:
-    - `rect`{{Optional_Inline}}
+    - `rect` {{optional_inline}}
       - : The rectangle of pixels to copy from the `VideoFrame`. If unspecified, the {{domxref("VideoFrame.visibleRect","visibleRect")}} will be used. This is in the format of a dictionary object containing:
         - `x`: The x-coordinate.
         - `y`: The y-coordinate.
         - `width`: The width of the frame.
         - `height`: The height of the frame.
-    - `layout`{{Optional_Inline}}
+    - `layout` {{optional_inline}}
       - : A list containing the following values for each plane in the `VideoFrame`:
         - `offset`
           - : An integer representing the offset in bytes where the given plane begins.

--- a/files/en-us/web/api/videoframe/videoframe/index.md
+++ b/files/en-us/web/api/videoframe/videoframe/index.md
@@ -33,17 +33,17 @@ The first type of constructor (see above) creates a new {{domxref("VideoFrame")}
     an {{domxref("ImageBitmap")}},
     an {{domxref("OffscreenCanvas")}},
     or another {{domxref("VideoFrame")}}.
-- `init`{{Optional_Inline}}
+- `init` {{optional_inline}}
   - : A dictionary object containing the following:
-    - `duration`{{Optional_Inline}}
+    - `duration` {{optional_inline}}
       - : An integer representing the duration of the frame in microseconds.
     - `timestamp`
       - : An integer representing the timestamp of the frame in microseconds.
-    - `alpha`{{Optional_Inline}}
+    - `alpha` {{optional_inline}}
       - : A string, describing how the user agent should behave when dealing with alpha channels. The default value is "keep".
         - `"keep"`: Indicates that the user agent should preserve alpha channel data.
         - `"discard"`: Indicates that the user agent should ignore or remove alpha channel data.
-    - `visibleRect`{{Optional_Inline}}
+    - `visibleRect` {{optional_inline}}
       - : A dictionary representing the visible rectangle of the `VideoFrame`, containing the following:
         - `x`
           - : The x-coordinate.
@@ -53,9 +53,9 @@ The first type of constructor (see above) creates a new {{domxref("VideoFrame")}
           - : The width of the frame.
         - `height`
           - : The height of the frame.
-    - `displayWidth`{{Optional_Inline}}
+    - `displayWidth` {{optional_inline}}
       - : The width of the `VideoFrame` when displayed after applying aspect-ratio adjustments.
-    - `displayHeight`{{Optional_Inline}}
+    - `displayHeight` {{optional_inline}}
       - : The height of the `VideoFrame` when displayed after applying aspect-ratio adjustments.
 
 The second type of constructor (see above) creates a new {{domxref("VideoFrame")}} from an {{jsxref("ArrayBuffer")}}. Its parameters are:
@@ -81,16 +81,16 @@ The second type of constructor (see above) creates a new {{domxref("VideoFrame")
       - : Height of the `VideoFrame` in pixels, potentially including non-visible padding, and prior to considering potential ratio adjustments.
     - `timestamp`
       - : An integer representing the timestamp of the frame in microseconds.
-    - `duration`{{Optional_Inline}}
+    - `duration` {{optional_inline}}
       - : An integer representing the duration of the frame in microseconds.
-    - `layout`{{Optional_Inline}}
+    - `layout` {{optional_inline}}
       - : A list containing the following values for each plane in the `VideoFrame`:
         - `offset`
           - : An integer representing the offset in bytes where the given plane begins.
         - `stride`
           - : An integer representing the number of bytes, including padding, used by each row of the plane.
         Planes may not overlap. If no `layout` is specified, the planes will be tightly packed.
-    - `visibleRect`{{Optional_Inline}}
+    - `visibleRect` {{optional_inline}}
       - : A dictionary representing the visible rectangle of the `VideoFrame`, containing the following:
         - `x`
           - : The x-coordinate.
@@ -100,9 +100,9 @@ The second type of constructor (see above) creates a new {{domxref("VideoFrame")
           - : The width of the frame.
         - `height`
           - : The height of the frame.
-    - `displayWidth`{{Optional_Inline}}
+    - `displayWidth` {{optional_inline}}
       - : The width of the `VideoFrame` when displayed after applying aspect ratio adjustments.
-    - `displayHeight`{{Optional_Inline}}
+    - `displayHeight` {{optional_inline}}
       - : The height of the `VideoFrame` when displayed after applying aspect ratio adjustments.
     - `colorSpace`
       - : A dictionary representing the color space of the `VideoFrame`, containing the following:

--- a/files/en-us/web/api/window/getcomputedstyle/index.md
+++ b/files/en-us/web/api/window/getcomputedstyle/index.md
@@ -32,7 +32,7 @@ getComputedStyle(element, pseudoElt)
 
 - `element`
   - : The {{DOMxRef("Element")}} for which to get the computed style.
-- `pseudoElt`{{Optional_Inline}}
+- `pseudoElt` {{optional_inline}}
   - : A string specifying the pseudo-element to match. Omitted (or `null`) for
     real elements.
 

--- a/files/en-us/web/css/image/image-set/index.md
+++ b/files/en-us/web/css/image/image-set/index.md
@@ -32,9 +32,9 @@ where <image-set-option> = [ <image> | <string> ] <resolution> and
   - : The [`<image>`](/en-US/docs/Web/CSS/image) can be any image type except for an image set. The `image-set()` function may not be nested inside another `image-set()` function.
 - `<string>`
   - : A URL to an image.
-- `<resolution>`{{optional_inline}}
+- `<resolution>` {{optional_inline}}
   - : [`<resolution>`](/en-US/docs/Web/CSS/resolution) units include `x` or `dppx`, for dots per pixel unit, `dpi`, for dots per inch, and `dpcm` for dots per centimeter. Every image within an `image-set()` must have a unique resolution.
-- `type(<string>)`{{optional_inline}}
+- `type(<string>)` {{optional_inline}}
   - : A valid MIME type string, for example "image/jpeg".
 
 ## Examples

--- a/files/en-us/web/css/image/image/index.md
+++ b/files/en-us/web/css/image/image/index.md
@@ -22,11 +22,11 @@ The **`image()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_
 
 where:
 
-- `image-tags`{{Optional_Inline}}
+- `image-tags` {{optional_inline}}
   - : The directionality of the image, either `ltr` for left-to-right or `rtl` for right-to-left.
 - `image-src` {{Optional_Inline}}
   - : Zero or more {{CSSxRef("url", "url()")}}s or {{CSSxRef("&lt;string&gt;")}}s specifying the image sources, with optional image fragment identifiers.
-- `color`{{Optional_Inline}}
+- `color` {{optional_inline}}
   - : A color, specifying a solid background color to use as a fallback if no `image-src` is found, supported, or declared.
 
 ### Bi-directional awareness

--- a/files/en-us/web/exslt/regexp/match/index.md
+++ b/files/en-us/web/exslt/regexp/match/index.md
@@ -22,7 +22,7 @@ regexp:match(targetString, regExpString[, flagsString])
   - : The string to perform regular expression matching upon.
 - `regExpString`
   - : The JavaScript style regular expression to evaluate.
-- `flagsString`{{Optional_Inline}}
+- `flagsString` {{optional_inline}}
   - : An optional string containing character flags.
 
 The character flags are:

--- a/files/en-us/web/exslt/regexp/test/index.md
+++ b/files/en-us/web/exslt/regexp/test/index.md
@@ -22,7 +22,7 @@ regexp:test(testString, regExpString[, flagsString])
   - : The string to test.
 - `regExpString`
   - : The JavaScript style regular expression to evaluate.
-- `flagsString`{{Optional_Inline}}
+- `flagsString` {{optional_inline}}
   - : An optional string containing character flags.
 
 The character flags are:

--- a/files/en-us/web/http/headers/alt-svc/index.md
+++ b/files/en-us/web/http/headers/alt-svc/index.md
@@ -28,12 +28,12 @@ Alt-Svc: <protocol-id>=<alt-authority>; ma=<max-age>; persist=1
   - : The {{Glossary("ALPN")}} protocol identifier. Examples include `h2` for HTTP/2 and `h3-25` for draft 25 of the HTTP/3 protocol.
 - `<alt-authority>`
   - : The quoted string specifying the alternative authority which consists of an optional host override, a colon, and a mandatory port number.
-- `ma=<max-age>`{{Optional_Inline}}
+- `ma=<max-age>` {{optional_inline}}
   - : The number of seconds for which the alternative service is considered fresh.
     If omitted, it defaults to 24 hours.
     Alternative service entries can be cached for up to _\<max-age>_ seconds, minus the age of the response (from the {{httpheader("Age")}} header).
     Once the cached entry expires, the client can no longer use this alternative service for new connections.
-- `persist=1`{{Optional_Inline}}
+- `persist=1` {{optional_inline}}
   - : Usually cached alternative service entries are cleared on network configuration changes.
     Use of the `persist=1` parameter requests that the entry not be deleted by such changes.
 

--- a/files/en-us/web/javascript/reference/global_objects/aggregateerror/aggregateerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/aggregateerror/aggregateerror/index.md
@@ -25,7 +25,7 @@ new AggregateError(errors, message, options)
 
 - `errors`
   - : An iterable of errors, may not actually be {{JSxRef("Error")}} instances.
-- `message`{{optional_inline}}
+- `message` {{optional_inline}}
   - : An optional human-readable description of the aggregate error.
 - `options` {{optional_inline}}
   - : An object that has the following properties:

--- a/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
@@ -51,7 +51,7 @@ filter(function(element, index, array) { /* ... */ }, thisArg)
     - `array`
       - : The array on which `filter()` was called.
 
-- `thisArg`{{optional_inline}}
+- `thisArg` {{optional_inline}}
   - : Value to use as `this` when executing `callbackFn`.
 
 ### Return value

--- a/files/en-us/web/javascript/reference/global_objects/array/flatmap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/flatmap/index.md
@@ -50,7 +50,7 @@ flatMap(function(currentValue, index, array) { /* ... */ }, thisArg)
     - `array`
       - : The array `flatMap` was called upon.
 
-- `thisArg`{{optional_inline}}
+- `thisArg` {{optional_inline}}
   - : Value to use as `this` when executing `callbackFn`.
 
 ### Return value

--- a/files/en-us/web/javascript/reference/global_objects/array/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/map/index.md
@@ -54,7 +54,7 @@ map(function(element, index, array) { /* ... */ }, thisArg)
     - `array`
       - : The array `map` was called upon.
 
-- `thisArg`{{optional_inline}}
+- `thisArg` {{optional_inline}}
   - : Value to use as `this` when executing `callbackFn`.
 
 ### Return value

--- a/files/en-us/web/javascript/reference/global_objects/array/some/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/some/index.md
@@ -53,7 +53,7 @@ some(function(element, index, array) { /* ... */ }, thisArg)
     - `array`
       - : The array `some()` was called upon.
 
-- `thisArg`{{optional_inline}}
+- `thisArg` {{optional_inline}}
   - : A value to use as `this` when executing `callbackFn`.
 
 ### Return value

--- a/files/en-us/web/javascript/reference/global_objects/bigint/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint/tostring/index.md
@@ -25,7 +25,7 @@ toString(radix)
 
 ### Parameters
 
-- `radix`{{optional_inline}}
+- `radix` {{optional_inline}}
   - : Optional. An integer in the range 2 through 36 specifying the base to use for
     representing numeric values.
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/filter/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/filter/index.md
@@ -46,7 +46,7 @@ filter(function(element, index, array) { /* ... */ }, thisArg)
 
     The function is called with the following arguments: `(element, index, array)`.
     Return `true` to keep the element, `false` otherwise.
-- `thisArg`{{optional_inline}}
+- `thisArg` {{optional_inline}}
   - : Value to use as `this` when executing `callbackFn`.
 
 ### Return value


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Added missing space between `<code>` and `{{optional_inline}}` in markdown.
Ref #18019 

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

Improve usability

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
