### PR TITLE
Tweak MathML examples

### DIFF
--- a/files/en-us/web/mathml/examples/deriving_the_quadratic_formula/index.md
+++ b/files/en-us/web/mathml/examples/deriving_the_quadratic_formula/index.md
@@ -10,151 +10,450 @@ tags:
   - MathML
   - NeedsBeginnerUpdate
 ---
-This page outlines the derivation of the Quadratic Formula.
+This page outlines the derivation of the [Quadratic Formula](https://en.wikipedia.org/wiki/Quadratic_formula).
 
 We take a quadratic equation in its general form, and solve for x:
 
-<math><mtable columnalign="left"><mtr><mtd><mrow><mrow><mrow><mrow><mi>a</mi>
-<mo>⁢</mo>
-<msup><mi>x</mi>
-<mn>2</mn>
-</msup></mrow><mo>+ </mo><mi>b</mi>
-<mo>⁢</mo>
-<mi>x</mi>
-</mrow><mo>+ </mo><mi>c</mi>
-</mrow><mo>=</mo>
-<mn>0</mn>
-</mrow></mtd></mtr><mtr><mtd><mrow><mrow><mspace depth="1ex" height="0.5ex" width="2.5ex"></mspace><mi>a</mi>
-<mo>⁢</mo>
-<msup><mi>x</mi>
-<mn>2</mn>
-</msup></mrow><mo>+ </mo><mi>b</mi>
-<mo>⁢</mo>
-<mi>x</mi>
-<mspace depth="1ex" height="0.5ex" width="2.5ex"></mspace></mrow><mo>=</mo>
-<mo>-</mo>
-<mi>c</mi>
-<mspace depth="1ex" height="0.5ex" width="2.5ex"></mspace></mtd></mtr><mtr><mtd><mrow><mrow><mspace depth="1ex" height="0.5ex" width="2.5ex"></mspace><msup><mi>x</mi>
-<mn>2</mn>
-</msup></mrow><mo>+ </mo><mfrac><mrow><mi>b</mi>
-</mrow><mi>a</mi>
-</mfrac><mo>⁤</mo>
-<mi>x</mi>
-</mrow><mspace depth="1ex" height="0.5ex" width="2.5ex"></mspace><mo>=</mo>
-<mfrac><mrow><mo>-</mo>
-<mi>c</mi>
-</mrow><mi>a</mi>
-</mfrac><mspace depth="1ex" height="0.5ex" width="2ex"></mspace><mrow><mtext mathcolor="red" mathsize="10pt">Divide out leading coefficient.</mtext>
-</mrow></mtd></mtr><mtr><mtd><mrow><mrow><mrow><mspace depth="1ex" height="0.5ex" width="2.5ex"></mspace><msup><mi>x</mi>
-<mn>2</mn>
-</msup></mrow><mo>+ </mo><mfrac><mrow><mi>b</mi>
-</mrow><mi>a</mi>
-</mfrac><mo>⁤</mo>
-<mi>x</mi>
-<mo>+ </mo><msup><mrow><mo>(</mo><mfrac><mrow><mi>b</mi>
-</mrow><mrow><mn>2</mn>
-<mi>a</mi>
-</mrow></mfrac><mo>)</mo></mrow><mn>2</mn>
-</msup></mrow><mo>=</mo>
-<mfrac><mrow><mo>-</mo>
-<mi>c</mi>
-<mo>(</mo>
-<mn>4</mn>
-<mi>a</mi>
-<mo>)</mo>
-</mrow><mrow><mi>a</mi>
-<mo>(</mo>
-<mn>4</mn>
-<mi>a</mi>
-<mo>)</mo>
-</mrow></mfrac></mrow><mo>+ </mo><mfrac><mrow><msup><mi>b</mi>
-<mn>2</mn>
-</msup></mrow><mrow><mn>4</mn>
-<msup><mi>a</mi>
-<mn>2</mn>
-</msup></mrow></mfrac><mspace depth="1ex" height="0.5ex" width="2ex"></mspace><mrow><mtext mathcolor="red" mathsize="10pt">Complete the square.</mtext>
-</mrow></mtd></mtr><mtr><mtd><mrow><mrow><mspace depth="1ex" height="0.5ex" width="2.5ex"></mspace><mo>(</mo>
-<mi>x</mi>
-<mo>+ </mo><mfrac><mrow><mi>b</mi>
-</mrow><mrow><mn>2</mn>
-<mi>a</mi>
-</mrow></mfrac><mo>)</mo>
-<mo>(</mo>
-<mi>x</mi>
-<mo>+ </mo><mfrac><mrow><mi>b</mi>
-</mrow><mrow><mn>2</mn>
-<mi>a</mi>
-</mrow></mfrac><mo>)</mo>
-<mo>=</mo>
-<mfrac><mrow><msup><mi>b</mi>
-<mn>2</mn>
-</msup><mo>- </mo><mn>4</mn>
-<mi>a</mi>
-<mi>c</mi>
-</mrow><mrow><mn>4</mn>
-<msup><mi>a</mi>
-<mn>2</mn>
-</msup></mrow></mfrac></mrow><mspace depth="1ex" height="0.5ex" width="2ex"></mspace><mrow><mtext mathcolor="red" mathsize="10pt">Discriminant revealed.</mtext>
-</mrow></mrow></mtd></mtr><mtr><mtd><mrow><mrow><mspace depth="1ex" height="0.5ex" width="2.5ex"></mspace><msup><mrow><mo>(</mo>
-<mi>x</mi>
-<mo>+ </mo><mfrac><mrow><mi>b</mi>
-</mrow><mrow><mn>2</mn>
-<mi>a</mi>
-</mrow></mfrac><mo>)</mo>
-</mrow><mn>2</mn>
-</msup><mo>=</mo>
-<mfrac><mrow><msup><mi>b</mi>
-<mn>2</mn>
-</msup><mo>- </mo><mn>4</mn>
-<mi>a</mi>
-<mi>c</mi>
-</mrow><mrow><mn>4</mn>
-<msup><mi>a</mi>
-<mn>2</mn>
-</msup></mrow></mfrac></mrow><mspace depth="1ex" height="0.5ex" width="2ex"></mspace><mrow><mtext mathcolor="red" mathsize="10pt"></mtext></mrow></mrow></mtd></mtr><mtr><mtd><mrow><mrow><mspace depth="1ex" height="0.5ex" width="2.5ex"></mspace><mrow><mi>x</mi>
-<mo>+ </mo><mfrac><mrow><mi>b</mi>
-</mrow><mrow><mn>2</mn>
-<mi>a</mi>
-</mrow></mfrac></mrow><mo>=</mo>
-<msqrt><mfrac><mrow><msup><mi>b</mi>
-<mn>2</mn>
-</msup><mo>- </mo><mn>4</mn>
-<mi>a</mi>
-<mi>c</mi>
-</mrow><mrow><mn>4</mn>
-<msup><mi>a</mi>
-<mn>2</mn>
-</msup></mrow></mfrac></msqrt></mrow><mspace depth="1ex" height="0.5ex" width="2ex"></mspace><mrow><mtext mathcolor="red" mathsize="10pt"></mtext></mrow></mrow></mtd></mtr><mtr><mtd><mrow><mrow><mspace depth="1ex" height="0.5ex" width="2.5ex"></mspace><mrow><mi>x</mi>
-</mrow><mo>=</mo>
-<mfrac><mrow><mo>-</mo>
-<mi>b</mi>
-</mrow><mrow><mn>2</mn>
-<mi>a</mi>
-</mrow></mfrac><mo>±</mo>
-<mrow><mo>{</mo>
-<mi>C</mi>
-<mo>}</mo>
-</mrow><msqrt><mfrac><mrow><msup><mi>b</mi>
-<mn>2</mn>
-</msup><mo>- </mo><mn>4</mn>
-<mi>a</mi>
-<mi>c</mi>
-</mrow><mrow><mn>4</mn>
-<msup><mi>a</mi>
-<mn>2</mn>
-</msup></mrow></mfrac></msqrt></mrow><mspace depth="1ex" height="0.5ex" width="2ex"></mspace><mrow><mtext mathcolor="red" mathsize="10pt">There's the vertex formula.</mtext>
-</mrow></mrow></mtd></mtr><mtr><mtd><mrow><mrow><mspace depth="1ex" height="0.5ex" width="2.5ex"></mspace><mrow><mi>x</mi>
-</mrow><mo>=</mo>
-<mfrac><mrow><mo>-</mo>
-<mi>b</mi>
-<mo>±</mo>
-<mrow><mo>{</mo>
-<mi>C</mi>
-<mo>}</mo>
-</mrow><msqrt><msup><mi>b</mi>
-<mn>2</mn>
-</msup><mo>- </mo><mn>4</mn>
-<mi>a</mi>
-<mi>c</mi>
-</msqrt></mrow><mrow><mn>2</mn>
-<mi>a</mi></mrow></mfrac></mrow><mspace depth="1ex" height="0.5ex" width="2ex"></mspace><mrow><mtext mathcolor="red" mathsize="10pt"></mtext></mrow></mrow></mtd></mtr></mtable></math>
+<math>
+  <mtable>
+    <mtr>
+      <mtd>
+        <mrow>
+          <mrow>
+            <mrow>
+              <mrow>
+                <mi>a</mi>
+                <mo>&#x2062;<!-- INVISIBLE TIMES --></mo>
+                <msup>
+                  <mi>x</mi>
+                  <mn>2</mn>
+                </msup>
+              </mrow>
+              <mo>+</mo>
+              <mi>b</mi>
+              <mo>&#x2062;<!-- INVISIBLE TIMES --></mo>
+              <mi>x</mi>
+            </mrow>
+            <mo>+</mo>
+            <mi>c</mi>
+          </mrow>
+        </mrow>
+      </mtd>
+      <mtd>
+        <mo>=</mo>
+      </mtd>
+      <mtd>
+        <mn>0</mn>
+      </mtd>
+    </mtr>
+    <mtr>
+      <mtd>
+        <mrow>
+          <mrow>
+            <mi>a</mi>
+            <mo>&#x2062;<!-- INVISIBLE TIMES --></mo>
+            <msup>
+              <mi>x</mi>
+              <mn>2</mn>
+            </msup>
+          </mrow>
+          <mo>+</mo>
+          <mi>b</mi>
+          <mo>&#x2062;<!-- INVISIBLE TIMES --></mo>
+          <mi>x</mi>
+        </mrow>
+      </mtd>
+      <mtd>
+        <mo>=</mo>
+      </mtd>
+      <mtd>
+        <mo>−</mo>
+        <mi>c</mi>
+      </mtd>
+    </mtr>
+    <mtr>
+      <mtd>
+        <mrow>
+          <mrow>
+            <msup>
+              <mi>x</mi>
+              <mn>2</mn>
+            </msup>
+          </mrow>
+          <mo>+</mo>
+          <mfrac>
+            <mi>b</mi>
+            <mi>a</mi>
+          </mfrac>
+          <mo>⁤</mo>
+          <mi>x</mi>
+        </mrow>
+      </mtd>
+      <mtd>
+        <mo>=</mo>
+      </mtd>
+      <mtd>
+        <mfrac>
+          <mrow>
+            <mo>−</mo>
+            <mi>c</mi>
+          </mrow>
+          <mi>a</mi>
+        </mfrac>
+      </mtd>
+      <mtd>
+        <mrow>
+          <mtext style="color: red; font-size: 10pt;">Divide out leading coefficient.</mtext>
+        </mrow>
+      </mtd>
+    </mtr>
+    <mtr>
+      <mtd>
+        <mrow>
+          <mrow>
+            <mrow>
+              <msup>
+                <mi>x</mi>
+                <mn>2</mn>
+              </msup>
+            </mrow>
+            <mo>+</mo>
+            <mfrac>
+              <mrow>
+                <mi>b</mi>
+              </mrow>
+              <mi>a</mi>
+            </mfrac>
+            <mo>⁤</mo>
+            <mi>x</mi>
+            <mo>+</mo>
+            <msup>
+              <mrow>
+                <mo>(</mo>
+                <mfrac>
+                  <mrow>
+                    <mi>b</mi>
+                  </mrow>
+                  <mrow>
+                    <mn>2</mn>
+                    <mi>a</mi>
+                  </mrow>
+                </mfrac>
+                <mo>)</mo>
+              </mrow>
+              <mn>2</mn>
+            </msup>
+          </mrow>
+        </mrow>
+      </mtd>
+      <mtd>
+        <mo>=</mo>
+      </mtd>
+      <mtd>
+        <mrow>
+          <mfrac>
+            <mrow>
+              <mo>−</mo>
+              <mi>c</mi>
+              <mo>(</mo>
+              <mn>4</mn>
+              <mi>a</mi>
+              <mo>)</mo>
+            </mrow>
+            <mrow>
+              <mi>a</mi>
+              <mo>(</mo>
+              <mn>4</mn>
+              <mi>a</mi>
+              <mo>)</mo>
+            </mrow>
+          </mfrac>
+          <mo>+</mo>
+          <mfrac>
+            <mrow>
+              <msup>
+                <mi>b</mi>
+                <mn>2</mn>
+              </msup>
+            </mrow>
+            <mrow>
+              <mn>4</mn>
+              <msup>
+                <mi>a</mi>
+                <mn>2</mn>
+              </msup>
+            </mrow>
+          </mfrac>
+        </mrow>
+      </mtd>
+      <mtd>
+        <mrow>
+          <mtext style="color: red; font-size: 10pt;">Complete the square.</mtext>
+        </mrow>
+      </mtd>
+    </mtr>
+    <mtr>
+      <mtd>
+        <mrow>
+          <mrow>
+            <mo>(</mo>
+            <mi>x</mi>
+            <mo>+</mo>
+            <mfrac>
+              <mrow>
+                <mi>b</mi>
+              </mrow>
+              <mrow>
+                <mn>2</mn>
+                <mi>a</mi>
+              </mrow>
+            </mfrac>
+            <mo>)</mo>
+            <mo>(</mo>
+            <mi>x</mi>
+            <mo>+</mo>
+            <mfrac>
+              <mrow>
+                <mi>b</mi>
+              </mrow>
+              <mrow>
+                <mn>2</mn>
+                <mi>a</mi>
+              </mrow>
+            </mfrac>
+            <mo>)</mo>
+          </mrow>
+        </mrow>
+      </mtd>
+      <mtd>
+        <mo>=</mo>
+      </mtd>
+      <mtd>
+        <mfrac>
+          <mrow>
+            <msup>
+              <mi>b</mi>
+              <mn>2</mn>
+            </msup>
+            <mo>−</mo>
+            <mn>4</mn>
+            <mi>a</mi>
+            <mi>c</mi>
+          </mrow>
+          <mrow>
+            <mn>4</mn>
+            <msup>
+              <mi>a</mi>
+              <mn>2</mn>
+            </msup>
+          </mrow>
+        </mfrac>
+      </mtd>
+      <mtd>
+        <mrow>
+          <mtext style="color: red; font-size: 10pt;">Discriminant revealed.</mtext>
+        </mrow>
+      </mtd>
+    </mtr>
+    <mtr>
+      <mtd>
+        <mrow>
+          <mrow>
+            <msup>
+              <mrow>
+                <mo>(</mo>
+                <mi>x</mi>
+                <mo>+</mo>
+                <mfrac>
+                  <mrow>
+                    <mi>b</mi>
+                  </mrow>
+                  <mrow>
+                    <mn>2</mn>
+                    <mi>a</mi>
+                  </mrow>
+                </mfrac>
+                <mo>)</mo>
+              </mrow>
+              <mn>2</mn>
+            </msup>
+          </mrow>
+        </mrow>
+      </mtd>
+      <mtd>
+        <mo>=</mo>
+      </mtd>
+      <mtd>
+        <mfrac>
+          <mrow>
+            <msup>
+              <mi>b</mi>
+              <mn>2</mn>
+            </msup>
+            <mo>−</mo>
+            <mn>4</mn>
+            <mi>a</mi>
+            <mi>c</mi>
+          </mrow>
+          <mrow>
+            <mn>4</mn>
+            <msup>
+              <mi>a</mi>
+              <mn>2</mn>
+            </msup>
+          </mrow>
+        </mfrac>
+      </mtd>
+      <mtd>
+        <mrow>
+          <mtext style="color: red; font-size: 10pt;"></mtext>
+        </mrow>
+      </mtd>
+    </mtr>
+    <mtr>
+      <mtd>
+        <mrow>
+          <mrow>
+            <mrow>
+              <mi>x</mi>
+              <mo>+</mo>
+              <mfrac>
+                <mrow>
+                  <mi>b</mi>
+                </mrow>
+                <mrow>
+                  <mn>2</mn>
+                  <mi>a</mi>
+                </mrow>
+              </mfrac>
+            </mrow>
+          </mrow>
+        </mrow>
+      </mtd>
+      <mtd>
+        <mo>=</mo>
+      </mtd>
+      <mtd>
+        <msqrt>
+          <mfrac>
+            <mrow>
+              <msup>
+                <mi>b</mi>
+                <mn>2</mn>
+              </msup>
+              <mo>−</mo>
+              <mn>4</mn>
+              <mi>a</mi>
+              <mi>c</mi>
+            </mrow>
+            <mrow>
+              <mn>4</mn>
+              <msup>
+                <mi>a</mi>
+                <mn>2</mn>
+              </msup>
+            </mrow>
+          </mfrac>
+        </msqrt>
+      </mtd>
+      <mtd>
+        <mrow>
+          <mtext style="color: red; font-size: 10pt;"></mtext>
+        </mrow>
+      </mtd>
+    </mtr>
+    <mtr>
+      <mtd>
+        <mi>x</mi>
+      </mtd>
+      <mtd>
+        <mo>=</mo>
+      </mtd>
+      <mtd>
+        <mfrac>
+          <mrow>
+            <mo>−</mo>
+            <mi>b</mi>
+          </mrow>
+          <mrow>
+            <mn>2</mn>
+            <mi>a</mi>
+          </mrow>
+        </mfrac>
+        <mo>±</mo>
+        <mrow>
+          <mo>{</mo>
+          <mi>C</mi>
+          <mo>}</mo>
+        </mrow>
+        <msqrt>
+          <mfrac>
+            <mrow>
+              <msup>
+                <mi>b</mi>
+                <mn>2</mn>
+              </msup>
+              <mo>−</mo>
+              <mn>4</mn>
+              <mi>a</mi>
+              <mi>c</mi>
+            </mrow>
+            <mrow>
+              <mn>4</mn>
+              <msup>
+                <mi>a</mi>
+                <mn>2</mn>
+              </msup>
+            </mrow>
+          </mfrac>
+        </msqrt>
+      </mtd>
+      <mtd>
+        <mrow>
+          <mtext style="color: red; font-size: 10pt;">There's the vertex formula.</mtext>
+        </mrow>
+      </mtd>
+    </mtr>
+    <mtr>
+      <mtd>
+        <mi>x</mi>
+      </mtd>
+      <mtd>
+        <mo>=</mo>
+      </mtd>
+      <mtd>
+        <mfrac>
+          <mrow>
+            <mo>−</mo>
+            <mi>b</mi>
+            <mo>±</mo>
+            <mrow>
+              <mo>{</mo>
+              <mi>C</mi>
+              <mo>}</mo>
+            </mrow>
+            <msqrt>
+              <msup>
+                <mi>b</mi>
+                <mn>2</mn>
+              </msup>
+              <mo>−</mo>
+              <mn>4</mn>
+              <mi>a</mi>
+              <mi>c</mi>
+            </msqrt>
+          </mrow>
+          <mrow>
+            <mn>2</mn>
+            <mi>a</mi>
+          </mrow>
+        </mfrac>
+      </mtd>
+      <mtd>
+        <mrow>
+          <mtext style="color: red; font-size: 10pt;"></mtext>
+        </mrow>
+      </mtd>
+    </mtr>
+  </mtable>
+</math>

--- a/files/en-us/web/mathml/examples/mathml_pythagorean_theorem/index.md
+++ b/files/en-us/web/mathml/examples/mathml_pythagorean_theorem/index.md
@@ -10,27 +10,123 @@ tags:
   - MathML
   - NeedsBeginnerUpdate
 ---
-We will now prove the Pythagorean theorem:
+We will now prove the [Pythagorean theorem](https://en.wikipedia.org/wiki/Pythagorean_theorem):
 
-**Statement**: In a right angled triangle, the square of the hypotenuse is equal to the sum of the
-squares of the other two sides.
+**Statement**: In a right triangle, the square of the hypotenuse is equal to
+the sum of the squares of the other two sides.
 
-i.e, If a and b are the legs and c is the hypotenuse then<math>
-<mrow><msup><mi>  a </mi><mn>2</mn>
-</msup><mo>+ </mo><msup><mi>b </mi><mn>2</mn>
-</msup><mo>= </mo><msup><mi>c </mi><mn>2</mn>
-</msup></mrow></math>.
+i.e, If a and b are the legs and c is the hypotenuse then
+<math>
+  <mrow>
+    <msup>
+      <mi>a</mi>
+      <mn>2</mn>
+    </msup>
+    <mo>+</mo>
+    <msup>
+      <mi>b</mi>
+      <mn>2</mn>
+    </msup>
+    <mo>=</mo>
+    <msup>
+      <mi>c</mi>
+      <mn>2</mn>
+    </msup>
+  </mrow>
+</math>.
 
-**Proof:**  We can prove the theorem algebraically by showing that the area of the big square
-equals the area of the inner square (hypotenuse squared) plus the area of the four triangles:
+**Proof:**  We can prove the theorem algebraically by showing that on
+[this figure](http://www.cut-the-knot.org/pythagoras/proof31.gif)
+the area of the big square equals the area of the inner square (hypotenuse
+squared) plus the area of the four triangles:
 
-<math><mtable columnalign="right center left"><mtr><mtd><msup><mrow><mo>( </mo><mi>a </mi><mo>+ </mo><mi>b </mi><mo>) </mo></mrow><mn>2 </mn></msup></mtd><mtd><mo>= </mo></mtd><mtd><msup><mi>c </mi><mn>2</mn>
-</msup><mo>+ </mo><mn>4 </mn><mo>⋅ </mo><mo>(</mo>
-<mfrac><mn>1 </mn><mn>2 </mn></mfrac><mi>a </mi><mi>b </mi><mo>)</mo>
-</mtd></mtr><mtr><mtd><msup><mi>a </mi><mn>2</mn>
-</msup><mo>+ </mo><mn>2 </mn><mi>a </mi><mi>b </mi><mo>+ </mo><msup><mi>b </mi><mn>2</mn>
-</msup></mtd><mtd><mo>= </mo></mtd><mtd><msup><mi>c </mi><mn>2</mn>
-</msup><mo>+ </mo><mn>2 </mn><mi>a </mi><mi>b</mi>
-</mtd></mtr><mtr><mtd><msup><mi>a </mi><mn>2</mn>
-</msup><mo>+ </mo><msup><mi>b </mi><mn>2</mn>
-</msup></mtd><mtd><mo>= </mo></mtd><mtd><msup><mi>c </mi><mn>2</mn></msup></mtd></mtr></mtable></math>
+<math display="block">
+  <mtable>
+    <mtr>
+      <mtd>
+        <msup>
+          <mrow>
+            <mo>(</mo>
+            <mi>a</mi>
+            <mo>+</mo>
+            <mi>b</mi>
+            <mo>)</mo>
+          </mrow>
+          <mn>2</mn>
+        </msup>
+      </mtd>
+      <mtd>
+        <mo>=</mo>
+      </mtd>
+      <mtd>
+        <msup>
+          <mi>c</mi>
+          <mn>2</mn>
+        </msup>
+        <mo>+</mo>
+        <mn>4</mn>
+        <mo>⋅</mo>
+        <mo>(</mo>
+        <mfrac>
+          <mn>1</mn>
+          <mn>2</mn>
+        </mfrac>
+        <mi>a</mi>
+        <mi>b</mi>
+        <mo>)</mo>
+      </mtd>
+    </mtr>
+    <mtr>
+      <mtd>
+        <msup>
+          <mi>a</mi>
+          <mn>2</mn>
+        </msup>
+        <mo>+</mo>
+        <mn>2</mn>
+        <mi>a</mi>
+        <mi>b</mi>
+        <mo>+</mo>
+        <msup>
+          <mi>b</mi>
+          <mn>2</mn>
+        </msup>
+      </mtd>
+      <mtd>
+        <mo>=</mo>
+      </mtd>
+      <mtd>
+        <msup>
+          <mi>c</mi>
+          <mn>2</mn>
+        </msup>
+        <mo>+</mo>
+        <mn>2</mn>
+        <mi>a</mi>
+        <mi>b</mi>
+      </mtd>
+    </mtr>
+    <mtr>
+      <mtd>
+        <msup>
+          <mi>a</mi>
+          <mn>2</mn>
+        </msup>
+        <mo>+</mo>
+        <msup>
+          <mi>b</mi>
+          <mn>2</mn>
+        </msup>
+      </mtd>
+      <mtd>
+        <mo>=</mo>
+      </mtd>
+      <mtd>
+        <msup>
+          <mi>c</mi>
+          <mn>2</mn>
+        </msup>
+      </mtd>
+    </mtr>
+  </mtable>
+</math>


### PR DESCRIPTION
#### Summary

This patch tweak a bit MathML examples so they are aligned with MathML
Core [1] and render better with Chromium Canary (e.g. using U+2212
MINUS SIGN, removing white spaces within token elements, replacing
mathcolor/mathsize with CSS, removing mtable@columalign...). MathML
source code is also reformatted for better readability (valided with
[2]) and minor changes to the examples' text have been made.

#### Motivation

- Use syntax allowed by MathML Core, to avoid that people use legacy content.
- Make examples render better in Chromium.

#### Supporting details

[1] https://w3c.github.io/mathml-core
[2] https://validator.w3.org/nu

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
