### PR TITLE
Add parentheses for single-parameter arrow function

### DIFF
--- a/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.md
@@ -105,9 +105,9 @@ You could copy most of this from the property's summary on the corresponding API
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('NameOfTheEvent', event => { });
+addEventListener('NameOfTheEvent', (event) => {});
 
-onNameOfTheEvent = event => { };
+onNameOfTheEvent = (event) => { };
 ```
 
 ## Event type


### PR DESCRIPTION
Though technically correct, the lack of parentheses makes it slightly more complex to rid for beginners. So we put the parentheses in all cases, even in the case of a single parameter.