### PR TITLE
Add specification macro

### DIFF
--- a/files/en-us/web/css/font-variant-alternates/index.md
+++ b/files/en-us/web/css/font-variant-alternates/index.md
@@ -111,7 +111,7 @@ p {
 
 ## Specifications
 
-Not part of any standard.
+{{Specification}}
 
 ## Browser compatibility
 


### PR DESCRIPTION
This is now part of a standard and the URL is up-to-date in bcd. The macro will link to it.

Fixes #18081