### PR TITLE
Document macOS Thunderbird native manifest location

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/native_manifests/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/native_manifests/index.md
@@ -424,6 +424,36 @@ For per-user visibility, store the manifest in:
 ~/Library/Application Support/Mozilla/PKCS11Modules/<name>.json
 ```
 
+### macOS (Thunderbird)
+
+For global visibility, store the manifest in:
+
+```
+/Library/Application Support/Mozilla/NativeMessagingHosts/<name>.json
+```
+
+```
+/Library/Application Support/Mozilla/ManagedStorage/<name>.json
+```
+
+```
+/Library/Application Support/Mozilla/PKCS11Modules/<name>.json
+```
+
+For per-user visibility, store the manifest in:
+
+```
+~/Library/Mozilla/NativeMessagingHosts/<name>.json
+```
+
+```
+~/Library/Mozilla/ManagedStorage/<name>.json
+```
+
+```
+~/Library/Mozilla/PKCS11Modules/<name>.json
+```
+
 ### Linux
 
 For global visibility, store the manifest in either:


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

According to [1], Thunderbird under macOS looks for native manifests in
Library folder instead of Application Support folder.

[1] https://hg.mozilla.org/mozilla-central/file/012ceb5e65c2f22b19e921aedfe2aef311ea3631/toolkit/xre/nsXREDirProvider.cpp#l1347

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

At the moment this piece of info is very obscure. I was working on an
MailExtension which leveraged native messaging and Thunderbird just kept
complaining 'No such native application xxx' no matter where I put the
manifest file.

I ended up having to download Thunderbird's source code which led me to
[1] to finally get it working.

So since this MDN page doesn't seem to be Firefox-specific, I think it'd
be nice to document this case. And it'll be great if someone can help
update [2] as well.

[2] https://wiki.mozilla.org/WebExtensions/Native_Messaging

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

See [1].

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
