### PR TITLE
Fix typo located in setPointerCapture example

### DIFF
--- a/files/en-us/web/api/element/setpointercapture/index.md
+++ b/files/en-us/web/api/element/setpointercapture/index.md
@@ -60,7 +60,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 This example sets pointer capture on a {{HtmlElement("div")}} when you press down on
-it. This lets you slide the element horizontally, even when you pointer moves outside of
+it. This lets you slide the element horizontally, even when your pointer moves outside of
 its boundaries.
 
 ### HTML


### PR DESCRIPTION
Corrected a minor grammatical error.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The reason for this change is to fix a misspelling within the setPointerCapture example section to maintain grammatical consistency.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I'm making this change to help provide efficient communication for readers.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
