### PR TITLE
Correct the expected result of the given code

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
@@ -64,7 +64,7 @@ The `finally()` method is very similar to calling
     `Promise.resolve(2).finally(() => 77)` will return a
     new resolved promise with the result `2`.
   - Similarly, unlike `Promise.reject(3).then(() => {}, () => 88)`
-    (which will return a rejected promise with the reason `88`),
+    (which will return a resolved promise with the reason `88`),
     `Promise.reject(3).finally(() => 88)` will return a rejected promise
     with the reason `3`.  
   - But, either `Promise.reject(3).finally(() => throw 99)` or

--- a/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
@@ -67,7 +67,7 @@ The `finally()` method is very similar to calling
     (which will return a resolved promise with the reason `88`),
     `Promise.reject(3).finally(() => 88)` will return a rejected promise
     with the reason `3`.  
-  - But, either `Promise.reject(3).finally(() => throw 99)` or
+  - But, either `Promise.reject(3).finally(() => {throw 99})` or
     `Promise.reject(3).finally(() => Promise.reject(99))` will reject the returned promise
     with the reason `99`.
 


### PR DESCRIPTION
In this commit I corrected the output of the below code.
```
Promise.reject(3).then(() => {}, () => 88)
```
as this returns a fulfilled/resolved promise

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Correcting the expected output of the code.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Fixing the doc [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #18082
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
