### PR TITLE
Wrap the throw statement in curly brackets to avoid execution error

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
@@ -67,7 +67,7 @@ The `finally()` method is very similar to calling
     (which will return a rejected promise with the reason `88`),
     `Promise.reject(3).finally(() => 88)` will return a rejected promise
     with the reason `3`.  
-  - But, either `Promise.reject(3).finally(() => throw 99)` or
+  - But, either `Promise.reject(3).finally(() => {throw 99})` or
     `Promise.reject(3).finally(() => Promise.reject(99))` will reject the returned promise
     with the reason `99`.
 


### PR DESCRIPTION
In this commit I wrap the below code's throw statement in curly brackets
```
Promise.reject(3).finally(() => throw 99)
```
as this return below error
```
Uncaught SyntaxError: Unexpected token 'throw'
```
and this needs to be written inside curly brackets for successful execution.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Fixes the doc mentioned here
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally

<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #18082

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
