### PR TITLE
Correct code output and fix typo

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
@@ -64,7 +64,7 @@ The `finally()` method is very similar to calling
     `Promise.resolve(2).finally(() => 77)` will return a
     new resolved promise with the result `2`.
   - Similarly, unlike `Promise.reject(3).then(() => {}, () => 88)`
-    (which will return a rejected promise with the reason `88`),
+    (which will return a resolved promise with the reason `88`),
     `Promise.reject(3).finally(() => 88)` will return a rejected promise
     with the reason `3`.  
   - But, either `Promise.reject(3).finally(() => throw 99)` or

--- a/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
@@ -29,20 +29,19 @@ This lets you avoid duplicating code in both the promise's {{jsxref("Promise.the
 promise.finally(onFinally);
 
 promise.finally(() => {
-   // Code that will run after promise is settled (fulfilled or rejected)
+  // Code that will run after promise is settled (fulfilled or rejected)
 });
 ```
 
 ### Parameters
 
 - `onFinally`
-  - : A {{jsxref("Function")}} called when the `Promise` is settled.
+  - : A {{jsxref("Function")}} called when the `Promise` is settled. This handler receives no parameters.
 
 ### Return value
 
 Returns an equivalent {{jsxref("Promise")}} with its `finally` handler set to the specified function.
-If the handler throws an error, that promise will be rejected
-with that value instead.
+If the handler throws an error or returns a rejected promise, the promise returned by `finally()` will be rejected with that value instead. Otherwise, the return value of the handler does not affect the state of the original promise.
 
 ## Description
 
@@ -53,7 +52,7 @@ The `finally()` method is very similar to calling
 `.then(onFinally, onFinally)`, however, there are a couple of differences:
 
 - When creating a function inline, you can pass it once, instead of being forced to
-  either declare it twice, or create a variable for it
+  either declare it twice, or create a variable for it.
 - A `finally` callback will not receive any argument. This use case
   is for precisely when you _do not care_ about the rejection reason, or the
   fulfillment value, and so there's no need to provide it.
@@ -62,11 +61,11 @@ The `finally()` method is very similar to calling
   - Unlike `Promise.resolve(2).then(() => 77, () => {})` (which
     will return a resolved promise with the result `77`),
     `Promise.resolve(2).finally(() => 77)` will return a
-    new resolved promise with the result `2`.
+    new fulfilled promise with the result `2`.
   - Similarly, unlike `Promise.reject(3).then(() => {}, () => 88)`
-    (which will return a resolved promise with the reason `88`),
+    (which will return a fulfilled promise with the value `88`),
     `Promise.reject(3).finally(() => 88)` will return a rejected promise
-    with the reason `3`.  
+    with the reason `3`.
   - But, both `Promise.reject(3).finally(() => {throw 99})` and
     `Promise.reject(3).finally(() => Promise.reject(99))` will reject the returned promise
     with the reason `99`.

--- a/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
@@ -67,7 +67,7 @@ The `finally()` method is very similar to calling
     (which will return a resolved promise with the reason `88`),
     `Promise.reject(3).finally(() => 88)` will return a rejected promise
     with the reason `3`.  
-  - But, either `Promise.reject(3).finally(() => throw 99)` or
+  - But, either `Promise.reject(3).finally(() => {throw 99})` or
     `Promise.reject(3).finally(() => Promise.reject(99))` will reject the returned promise
     with the reason `99`.
 

--- a/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/finally/index.md
@@ -67,7 +67,7 @@ The `finally()` method is very similar to calling
     (which will return a resolved promise with the reason `88`),
     `Promise.reject(3).finally(() => 88)` will return a rejected promise
     with the reason `3`.  
-  - But, either `Promise.reject(3).finally(() => {throw 99})` or
+  - But, both `Promise.reject(3).finally(() => {throw 99})` and
     `Promise.reject(3).finally(() => Promise.reject(99))` will reject the returned promise
     with the reason `99`.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
I have made 3 changes as 
#### 1. corrected the output of the below code.
```
Promise.reject(3).then(() => {}, () => 88)
```
as this returns a fulfilled/resolved promise

#### 2. Wrap the throw statement in curly brackets
```
Promise.reject(3).finally(() => throw 99)
```
to ensue successful execution

#### 3. Rephase sentence to account for both outputs
This below line should be changed.
_But, either `Promise.reject(3).finally(() => {throw 99})` or_
After correcting the code in previous PR. It is found that both will reject the returned promise

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Fixes at https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #18082
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
