### PR TITLE
JavaScript - prefer dot notation over brackets

### DIFF
--- a/files/en-us/learn/javascript/objects/basics/index.md
+++ b/files/en-us/learn/javascript/objects/basics/index.md
@@ -179,7 +179,15 @@ It is no wonder that objects are sometimes called **associative arrays** — the
 
 Dot notation is generally preferred over bracket notation because it is more succint and easier to read.
 However there are some cases where you have to use brackets.
-For example, if an object property name is defined at runtime then you can't use dot notation to access the value, but you can pass the name as a variable inside brackets.
+For example, if an object property name is defined at runtime then you can't use dot notation to access the value, but you can pass the name as a variable inside brackets as shown with `input` below:
+
+```js
+const person = {
+  name: ['Bob', 'Smith'],
+  age: 32
+}
+const input = prompt('Get name or age?')
+console.log(person[input])
 
 ## Setting object members
 

--- a/files/en-us/learn/javascript/objects/basics/index.md
+++ b/files/en-us/learn/javascript/objects/basics/index.md
@@ -14,9 +14,7 @@ In this article, we'll look at fundamental JavaScript object syntax, and revisit
         Basic computer literacy, a basic understanding of HTML and CSS,
         familiarity with JavaScript basics (see
         <a href="/en-US/docs/Learn/JavaScript/First_steps">First steps</a> and
-        <a href="/en-US/docs/Learn/JavaScript/Building_blocks"
-          >Building blocks</a
-        >).
+        <a href="/en-US/docs/Learn/JavaScript/Building_blocks">Building blocks</a>).
       </td>
     </tr>
     <tr>
@@ -161,21 +159,27 @@ Otherwise, your methods will no longer work.
 
 ## Bracket notation
 
-There is another way to access object properties — using bracket notation. Instead of using these:
+Bracket notation provides an alternative way to access object properties.
+Instead of using [dot notation](#dot_notation) like this:
 
 ```js
 person.age
 person.name.first
 ```
 
-You can use
+You can instead use brackets:
 
 ```js
 person['age']
 person['name']['first']
 ```
 
-This looks very similar to how you access the items in an array, and it is basically the same thing — instead of using an index number to select an item, you are using the name associated with each member's value. It is no wonder that objects are sometimes called **associative arrays** — they map strings to values in the same way that arrays map numbers to values.
+This looks very similar to how you access the items in an array, and it is basically the same thing — instead of using an index number to select an item, you are using the name associated with each member's value.
+It is no wonder that objects are sometimes called **associative arrays** — they map strings to values in the same way that arrays map numbers to values.
+
+Dot notation is generally preferred over bracket notation because it is more succint and easier to read.
+However there are some cases where you have to use brackets.
+For example, if an object property name is defined at runtime then you can't use dot notation to access the value, but you can pass the name as a variable inside brackets.
 
 ## Setting object members
 


### PR DESCRIPTION
This follows on from the discussion in https://github.com/mdn/content/pull/17740#issuecomment-1178392811

Essentially ESLINT prefers dot notation for property accessors. This adds some reasoning when talking about bracket notation, and a case where brackets are preferred.

FYI @teoli2003 