### PR TITLE
caches/CacheStorate/Cache are not experimental

### DIFF
--- a/files/en-us/web/api/cache/add/index.md
+++ b/files/en-us/web/api/cache/add/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Cache
-  - Experimental
   - Method
   - Reference
   - Service Workers

--- a/files/en-us/web/api/cache/addall/index.md
+++ b/files/en-us/web/api/cache/addall/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Cache
-  - Experimental
   - Method
   - NeedsExample
   - Reference
@@ -17,15 +16,11 @@ browser-compat: api.Cache.addAll
 ---
 {{APIRef("Service Workers API")}}
 
-The **`addAll()`** method of the
-{{domxref("Cache")}} interface takes an array of URLs, retrieves them, and adds the
-resulting response objects to the given cache. The request objects created during
-retrieval become keys to the stored response operations.
+The **`addAll()`** method of the {{domxref("Cache")}} interface takes an array of URLs, retrieves them, and adds the resulting response objects to the given cache. The request objects created during retrieval become keys to the stored response operations.
 
 > **Note:** `addAll()` will overwrite any key/value pairs
 > previously stored in the cache that match the request, but will fail if a
-> resulting `put()` operation would overwrite a previous cache entry stored
-> by the same `addAll()` method.
+> resulting `put()` operation would overwrite a previous cache entry stored by the same `addAll()` method.
 
 ## Syntax
 

--- a/files/en-us/web/api/cache/delete/index.md
+++ b/files/en-us/web/api/cache/delete/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Cache
-  - Experimental
   - Method
   - NeedsContent
   - NeedsExample
@@ -17,11 +16,8 @@ browser-compat: api.Cache.delete
 ---
 {{APIRef("Service Workers API")}}
 
-The **`delete()`** method of the {{domxref("Cache")}} interface
-finds the {{domxref("Cache")}} entry whose key is the request, and if found, deletes the
-{{domxref("Cache")}} entry and returns a {{jsxref("Promise")}} that resolves to
-`true`. If no {{domxref("Cache")}} entry is found, it resolves
-to `false`.
+The **`delete()`** method of the {{domxref("Cache")}} interface finds the {{domxref("Cache")}} entry whose key is the request, and if found, deletes the {{domxref("Cache")}} entry and returns a {{jsxref("Promise")}} that resolves to `true`.
+If no {{domxref("Cache")}} entry is found, it resolves to `false`.
 
 ## Syntax
 
@@ -33,18 +29,16 @@ delete(request, options)
 ### Parameters
 
 - `request`
-  - : The {{domxref("Request")}} you are looking to delete. This can be a
-    `Request` object or a URL.
+  - : The {{domxref("Request")}} you are looking to delete.
+    This can be a `Request` object or a URL.
 - `options` {{optional_inline}}
 
-  - : An object whose properties control how matching is done in the `delete`
-    operation. The available options are:
+  - : An object whose properties control how matching is done in the `delete` operation.
+    The available options are:
 
     - `ignoreSearch`
-      - : A boolean value that specifies whether the
-        matching process should ignore the query string in the URL.  If set to
-        `true`, the `?value=bar` part of
-        `http://foo.com/?value=bar` would be ignored when performing a match.
+      - : A boolean value that specifies whether the matching process should ignore the query string in the URL.
+        If set to `true`, the `?value=bar` part of `http://foo.com/?value=bar` would be ignored when performing a match.
         It defaults to `false`.
     - `ignoreMethod`
       - : A boolean value that, when set to
@@ -58,9 +52,7 @@ delete(request, options)
         regardless of whether the {{domxref("Response")}} object has a `VARY`
         header. It defaults to `false`.
     - `cacheName`
-      - : A string that represents a specific
-        cache to search within. Note that this option is ignored by
-        `Cache.delete()`.
+      - : A string that represents a specific cache to search within. Note that this option is ignored by `Cache.delete()`.
 
 ### Return value
 

--- a/files/en-us/web/api/cache/index.md
+++ b/files/en-us/web/api/cache/index.md
@@ -6,7 +6,6 @@ tags:
   - API
   - Cache
   - Cache API
-  - Experimental
   - Interface
   - Offline
   - Reference

--- a/files/en-us/web/api/cache/keys/index.md
+++ b/files/en-us/web/api/cache/keys/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Cache
-  - Experimental
   - Method
   - Reference
   - Service Workers

--- a/files/en-us/web/api/cache/match/index.md
+++ b/files/en-us/web/api/cache/match/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Cache
-  - Experimental
   - Method
   - Reference
   - Service Workers
@@ -16,11 +15,8 @@ browser-compat: api.Cache.match
 ---
 {{APIRef("Service Workers API")}}
 
-The **`match()`** method of the
-{{domxref("Cache")}} interface returns a {{jsxref("Promise")}} that resolves to the
-{{domxref("Response")}} associated with the first matching request in the
-{{domxref("Cache")}} object. If no match is found, the {{jsxref("Promise")}} resolves
-to {{jsxref("undefined")}}.
+The **`match()`** method of the {{domxref("Cache")}} interface returns a {{jsxref("Promise")}} that resolves to the {{domxref("Response")}} associated with the first matching request in the {{domxref("Cache")}} object.
+If no match is found, the {{jsxref("Promise")}} resolves to {{jsxref("undefined")}}.
 
 ## Syntax
 
@@ -36,8 +32,8 @@ match(request, options)
     {{domxref("Cache")}}. This can be a {{domxref("Request")}} object or a URL.
 - `options` {{optional_inline}}
 
-  - : An object that sets options for the `match` operation. The available
-    options are:
+  - : An object that sets options for the `match` operation.
+     The available options are:
 
     - `ignoreSearch`
       - : A boolean value that specifies whether to

--- a/files/en-us/web/api/cache/matchall/index.md
+++ b/files/en-us/web/api/cache/matchall/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Cache
-  - Experimental
   - Method
   - Reference
   - Service Workers

--- a/files/en-us/web/api/cache/put/index.md
+++ b/files/en-us/web/api/cache/put/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Cache
-  - Experimental
   - Method
   - NeedsExample
   - Reference

--- a/files/en-us/web/api/caches/index.md
+++ b/files/en-us/web/api/caches/index.md
@@ -4,7 +4,6 @@ slug: Web/API/caches
 page-type: web-api-global-property
 tags:
   - API
-  - Experimental
   - Property
   - Read-only
   - Reference
@@ -13,12 +12,12 @@ tags:
   - Window
 browser-compat: api.caches
 ---
-{{APIRef()}}{{SeeCompatTable}}
+{{APIRef()}}
 
-The global **`caches`** read-only property returns the
-{{domxref("CacheStorage")}} object associated with the current context. This object
-enables functionality such as storing assets for offline use, and generating custom
-responses to requests.
+The global **`caches`** read-only property returns the {{domxref("CacheStorage")}} object associated with the current context.
+This object enables functionality such as storing assets for offline use, and generating custom responses to requests.
+
+{{securecontext_header}}
 
 ## Value
 
@@ -26,8 +25,7 @@ A {{domxref("CacheStorage")}} object.
 
 ## Examples
 
-The following example shows how you'd use a cache in a [service worker](/en-US/docs/Web/API/Service_Worker_API) context to store
-assets offline.
+The following example shows how you'd use a cache in a [service worker](/en-US/docs/Web/API/Service_Worker_API) context to store assets offline.
 
 ```js
 this.addEventListener('install', function(event) {

--- a/files/en-us/web/api/caches/index.md
+++ b/files/en-us/web/api/caches/index.md
@@ -12,7 +12,7 @@ tags:
   - Window
 browser-compat: api.caches
 ---
-{{APIRef()}}
+{{APIRef("Service Workers API")}}
 
 The global **`caches`** read-only property returns the {{domxref("CacheStorage")}} object associated with the current context.
 This object enables functionality such as storing assets for offline use, and generating custom responses to requests.

--- a/files/en-us/web/api/cachestorage/delete/index.md
+++ b/files/en-us/web/api/cachestorage/delete/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - CacheStorage
-  - Experimental
   - Method
   - Reference
   - Service Workers
@@ -15,14 +14,10 @@ browser-compat: api.CacheStorage.delete
 ---
 {{APIRef("Service Workers API")}}
 
-The **`delete()`** method of the
-{{domxref("CacheStorage")}} interface finds the {{domxref("Cache")}} object matching the
-`cacheName`, and if found, deletes the {{domxref("Cache")}} object and
-returns a {{jsxref("Promise")}} that resolves to `true`. If no
-{{domxref("Cache")}} object is found, it resolves to `false`.
+The **`delete()`** method of the {{domxref("CacheStorage")}} interface finds the {{domxref("Cache")}} object matching the `cacheName`, and if found, deletes the {{domxref("Cache")}} object and returns a {{jsxref("Promise")}} that resolves to `true`.
+If no {{domxref("Cache")}} object is found, it resolves to `false`.
 
-You can access `CacheStorage` through the global
-{{domxref("caches")}} property.
+You can access `CacheStorage` through the global {{domxref("caches")}} property.
 
 ## Syntax
 

--- a/files/en-us/web/api/cachestorage/has/index.md
+++ b/files/en-us/web/api/cachestorage/has/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - CacheStorage
-  - Experimental
   - Method
   - Reference
   - Service Workers
@@ -19,8 +18,7 @@ The **`has()`** method of the {{domxref("CacheStorage")}}
 interface returns a {{jsxref("Promise")}} that resolves to `true` if a
 {{domxref("Cache")}} object matches the `cacheName`.
 
-You can access `CacheStorage` through the global
-{{domxref("caches")}} property.
+You can access `CacheStorage` through the global {{domxref("caches")}} property.
 
 ## Syntax
 
@@ -31,8 +29,7 @@ has(cacheName)
 ### Parameters
 
 - `cacheName`
-  - : A string representing the name of the {{domxref("Cache")}} object
-    you are looking for in the {{domxref("CacheStorage")}}.
+  - : A string representing the name of the {{domxref("Cache")}} object you are looking for in the {{domxref("CacheStorage")}}.
 
 ### Return value
 

--- a/files/en-us/web/api/cachestorage/index.md
+++ b/files/en-us/web/api/cachestorage/index.md
@@ -5,14 +5,13 @@ page-type: web-api-interface
 tags:
   - API
   - CacheStorage
-  - Experimental
   - Interface
   - Reference
   - Service Workers
   - ServiceWorker
 browser-compat: api.CacheStorage
 ---
-{{APIRef("Service Workers API")}}{{SeeCompatTable}}
+{{APIRef("Service Workers API")}}
 
 The **`CacheStorage`** interface represents the storage for {{domxref("Cache")}} objects.
 
@@ -53,7 +52,8 @@ You can access `CacheStorage` through the global {{domxref("caches")}} property.
 
 ## Examples
 
-This code snippet is from the MDN [sw-test example](https://github.com/mdn/sw-test/) (see [sw-test running live](https://mdn.github.io/sw-test/).) This service worker script waits for an {{domxref("InstallEvent")}} to fire, then runs {{domxref("ExtendableEvent.waitUntil","waitUntil")}} to handle the install process for the app. This consists of calling {{domxref("CacheStorage.open")}} to create a new cache, then using {{domxref("Cache.addAll")}} to add a series of assets to it.
+This code snippet is from the MDN [sw-test example](https://github.com/mdn/sw-test/) (see [sw-test running live](https://mdn.github.io/sw-test/).)
+This service worker script waits for an {{domxref("InstallEvent")}} to fire, then runs {{domxref("ExtendableEvent.waitUntil","waitUntil")}} to handle the install process for the app. This consists of calling {{domxref("CacheStorage.open")}} to create a new cache, then using {{domxref("Cache.addAll")}} to add a series of assets to it.
 
 In the second code block, we wait for a {{domxref("FetchEvent")}} to fire. We construct a custom response like so:
 

--- a/files/en-us/web/api/cachestorage/keys/index.md
+++ b/files/en-us/web/api/cachestorage/keys/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - CacheStorage
-  - Experimental
   - Method
   - Reference
   - Service Workers
@@ -16,16 +15,10 @@ browser-compat: api.CacheStorage.keys
 ---
 {{APIRef("Service Workers API")}}
 
-The
-**`keys()`** method of the
-{{domxref("CacheStorage")}} interface returns a {{jsxref("Promise")}} that will
-resolve with an array containing strings corresponding to all of the named
-{{domxref("Cache")}} objects tracked by the {{domxref("CacheStorage")}} object in the
-order they were created. Use this method to iterate over a list of all
-{{domxref("Cache")}} objects.
+The **`keys()`** method of the {{domxref("CacheStorage")}} interface returns a {{jsxref("Promise")}} that will resolve with an array containing strings corresponding to all of the named {{domxref("Cache")}} objects tracked by the {{domxref("CacheStorage")}} object in the order they were created.
+Use this method to iterate over a list of all {{domxref("Cache")}} objects.
 
-You can access `CacheStorage` through the global
-{{domxref("caches")}} property.
+You can access `CacheStorage` through the global {{domxref("caches")}} property.
 
 ## Syntax
 
@@ -39,19 +32,14 @@ None.
 
 ### Return value
 
-a {{jsxref("Promise")}} that resolves with an array of the {{domxref("Cache")}} names
-inside the {{domxref("CacheStorage")}} object.
+a {{jsxref("Promise")}} that resolves with an array of the {{domxref("Cache")}} names inside the {{domxref("CacheStorage")}} object.
 
 ## Examples
 
-In this code snippet we wait for an {{domxref("ServiceWorkerGlobalScope.activate_event",
-  "activate")}} event, and then run a
-{{domxref("ExtendableEvent.waitUntil","waitUntil()")}} block that clears up any old,
-unused caches before a new service worker is activated. Here we have an allowlist
-containing the names of the caches we want to keep (`cacheAllowlist`). We
-return the keys of the caches in the {{domxref("CacheStorage")}} object using
-`keys()`, then check each key to see if it is in the allowlist. If not, we
-delete it using {{domxref("CacheStorage.delete()")}}.
+In this code snippet we wait for an {{domxref("ServiceWorkerGlobalScope.activate_event", "activate")}} event, and then run a {{domxref("ExtendableEvent.waitUntil","waitUntil()")}} block that clears up any old, unused caches before a new service worker is activated.
+Here we have an allowlist containing the names of the caches we want to keep (`cacheAllowlist`).
+We return the keys of the caches in the {{domxref("CacheStorage")}} object using `keys()`, then check each key to see if it is in the allowlist.
+If not, we delete it using {{domxref("CacheStorage.delete()")}}.
 
 ```js
 this.addEventListener('activate', function(event) {

--- a/files/en-us/web/api/cachestorage/match/index.md
+++ b/files/en-us/web/api/cachestorage/match/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - CacheStorage
-  - Experimental
   - Method
   - Reference
   - Service Workers
@@ -16,22 +15,16 @@ browser-compat: api.CacheStorage.match
 ---
 {{APIRef("Service Workers API")}}
 
-The **`match()`** method of the
-{{domxref("CacheStorage")}} interface checks if a given {{domxref("Request")}} or URL
-string is a key for a stored {{domxref("Response")}}. This method returns a
-{{jsxref("Promise")}} for a {{domxref("Response")}}, or a {{jsxref("Promise")}} which
-resolves to `undefined` if no match is found.
+The **`match()`** method of the {{domxref("CacheStorage")}} interface checks if a given {{domxref("Request")}} or URL string is a key for a stored {{domxref("Response")}}.
+This method returns a {{jsxref("Promise")}} for a {{domxref("Response")}}, or a {{jsxref("Promise")}} which resolves to `undefined` if no match is found.
 
 You can access `CacheStorage` through the global
 {{domxref("caches")}} property.
 
 `Cache` objects are searched in creation order.
 
-> **Note:** {{domxref("CacheStorage.match()",
-  "caches.match()")}} is a convenience method. Equivalent functionality is to call
-> {{domxref("cache.match()")}} on each cache (in the order returned by
-> {{domxref("CacheStorage.keys()", "caches.keys()")}}) until a {{domxref("Response")}} is
-> returned.
+> **Note:** {{domxref("CacheStorage.match()", "caches.match()")}} is a convenience method. 
+> Equivalent functionality is to call {{domxref("cache.match()")}} on each cache (in the order returned by {{domxref("CacheStorage.keys()", "caches.keys()")}}) until a {{domxref("Response")}} is returned.
 
 ## Syntax
 

--- a/files/en-us/web/api/cachestorage/open/index.md
+++ b/files/en-us/web/api/cachestorage/open/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - CacheStorage
-  - Experimental
   - Method
   - Reference
   - Service Workers


### PR DESCRIPTION
[CacheStorage](https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage), [Cache](https://developer.mozilla.org/en-US/docs/Web/API/Cache), and [caches](https://developer.mozilla.org/en-US/docs/Web/API/caches), are all supported in multiple browsers.

This removes the Experimental tag from all docs, and a few cases of the seecompat macro. It adds secure_context_header to the `caches` page as this is the entry point to the API.

There are no content changes. There area number of layout changes. If you agree that these APIs are not experimental this can be "rubber stamped"