### PR TITLE
Document that all MathML elements accept global MathML attributes.

### DIFF
--- a/files/en-us/web/mathml/element/maction/index.md
+++ b/files/en-us/web/mathml/element/maction/index.md
@@ -14,6 +14,8 @@ The MathML **`<maction>`** element provides a possibility to bind actions to (su
 
 ## Attributes
 
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 - actiontype
 
   - : The action which specifies what happens for this element. Possible values are:

--- a/files/en-us/web/mathml/element/math/index.md
+++ b/files/en-us/web/mathml/element/math/index.md
@@ -13,6 +13,8 @@ The top-level element in MathML is `<math>`. Every valid MathML instance must be
 
 ## Attributes
 
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 In addition to the following attributes, the `<math>` element accepts any attributes of the {{ MathMLElement("mstyle") }} element.
 
 - display

--- a/files/en-us/web/mathml/element/menclose/index.md
+++ b/files/en-us/web/mathml/element/menclose/index.md
@@ -14,6 +14,8 @@ The MathML `<menclose>` element renders its content inside an enclosing notation
 
 ## Attributes
 
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 - notation
 
   - : A list of notations, separated by white space, to apply to the child elements. The symbols are each drawn as if the others are not present, and therefore may overlap. Possible values are:

--- a/files/en-us/web/mathml/element/merror/index.md
+++ b/files/en-us/web/mathml/element/merror/index.md
@@ -12,6 +12,10 @@ browser-compat: mathml.elements.merror
 
 The MathML `<merror>` element is used to display contents as error messages. In Firefox this error message is rendered similar to the typical XML error message. Note that this error is **not** thrown when your MathML markup is wrong or not well-formed XML. You will still get an XML parsing error (in case of the XHTML notation of MathML), which has nothing to do with `<merror>`.
 
+## Attributes
+
+This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 ## Examples
 
 ```html

--- a/files/en-us/web/mathml/element/mfenced/index.md
+++ b/files/en-us/web/mathml/element/mfenced/index.md
@@ -15,6 +15,8 @@ The deprecated MathML `<mfenced>` element used to provide the possibility to add
 
 ## Attributes
 
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 - `close`
   - : A string for the closing delimiter. The default value is `")`" and any white space is trimmed.
 - `open`

--- a/files/en-us/web/mathml/element/mfrac/index.md
+++ b/files/en-us/web/mathml/element/mfrac/index.md
@@ -20,6 +20,8 @@ The MathML `<mfrac>` element is used to display fractions.
 
 ## Attributes
 
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 - `bevelled`
   - : Specifies the way the fraction is displayed. If `true`, the fraction line is bevelled, which means that numerator and denominator are displayed side by side and separated by a slash (/). Otherwise, if set to `false` (which is the default value), numerator and denominator are on top of each other.
 - `denomalign` {{deprecated_inline}}

--- a/files/en-us/web/mathml/element/mi/index.md
+++ b/files/en-us/web/mathml/element/mi/index.md
@@ -12,6 +12,10 @@ browser-compat: mathml.elements.mi
 
 The MathML `<mi>` element indicates that the content should be rendered as an **identifier** such as function names, variables or symbolic constants. You can also have arbitrary text in it to mark up terms.
 
+## Attributes
+
+This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 ## Examples
 
 ```html

--- a/files/en-us/web/mathml/element/mmultiscripts/index.md
+++ b/files/en-us/web/mathml/element/mmultiscripts/index.md
@@ -26,8 +26,6 @@ After the base expression you can specify a postsubscript and a postsuperscript.
 
 ## Attributes
 
-## Attributes
-
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
 - `subscriptshift` {{deprecated_inline}}

--- a/files/en-us/web/mathml/element/mmultiscripts/index.md
+++ b/files/en-us/web/mathml/element/mmultiscripts/index.md
@@ -26,6 +26,10 @@ After the base expression you can specify a postsubscript and a postsuperscript.
 
 ## Attributes
 
+## Attributes
+
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 - `subscriptshift` {{deprecated_inline}}
   - : The minimum space by which to shift the subscript below the baseline of the expression, as a [CSS length](/en-US/docs/Web/CSS/length).
     This property is deprecated and will be removed in the future.

--- a/files/en-us/web/mathml/element/mn/index.md
+++ b/files/en-us/web/mathml/element/mn/index.md
@@ -12,6 +12,10 @@ browser-compat: mathml.elements.mn
 
 The MathML `<mn>` element represents a numeric literal which is normally a sequence of digits with a possible separator (a dot or a comma). However,  it is also allowed to have arbitrary text in it which is actually a numeric quantity, for example "eleven".
 
+## Attributes
+
+This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 ## Examples
 
 ```html

--- a/files/en-us/web/mathml/element/mo/index.md
+++ b/files/en-us/web/mathml/element/mo/index.md
@@ -14,6 +14,8 @@ The MathML `<mo>` element represents an operator in a broad sense. Besides opera
 
 ## Attributes
 
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 - accent
   - : If the operator is used as an [under](/en-US/docs/Web/MathML/Element/munder)- or [overscript](/en-US/docs/Web/MathML/Element/mover) this attribute specifies whether the operator should be treated as an accent.
     Allowed values are `true` or `false`.

--- a/files/en-us/web/mathml/element/mover/index.md
+++ b/files/en-us/web/mathml/element/mover/index.md
@@ -14,6 +14,8 @@ The MathML `<mover>` element is used to attach an accent or a limit over an expr
 
 ## Attributes
 
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 - accent
   - : If `true` the over-script is an _accent_, which is drawn closer to the base expression.
     If `false` (default value) the over-script is a _limit_ over the base expression.

--- a/files/en-us/web/mathml/element/mpadded/index.md
+++ b/files/en-us/web/mathml/element/mpadded/index.md
@@ -14,6 +14,8 @@ The MathML `<mpadded>` element is used to add extra padding and to set the gener
 
 ## Attributes
 
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 - depth
   - : Sets or increments the depth. Possible values: Any [length](/en-US/docs/Web/MathML/Attribute/Values#lengths) or an increment/decrement (a length prefixed with "+" or "-") .
 - height

--- a/files/en-us/web/mathml/element/mphantom/index.md
+++ b/files/en-us/web/mathml/element/mphantom/index.md
@@ -12,6 +12,10 @@ browser-compat: mathml.elements.mphantom
 
 The MathML `<mphantom>` element is rendered invisibly, but dimensions (such as height, width, and baseline position) are still kept.
 
+## Attributes
+
+This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 ## Examples
 
 Sample rendering: ![x+  z](mphantom.png)

--- a/files/en-us/web/mathml/element/mroot/index.md
+++ b/files/en-us/web/mathml/element/mroot/index.md
@@ -12,6 +12,10 @@ browser-compat: mathml.elements.mroot
 
 The MathML `<mroot>` element is used to display roots with an explicit index. Two arguments are accepted, which leads to the syntax: `<mroot> base index </mroot>`.
 
+## Attributes
+
+This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 ## Examples
 
 Sample Rendering: ![x](mroot.png)

--- a/files/en-us/web/mathml/element/mrow/index.md
+++ b/files/en-us/web/mathml/element/mrow/index.md
@@ -18,6 +18,10 @@ When writing a MathML expression, you should group elements within an `<mrow>` i
 - It allows for more intelligent line-breaking and indentation.
 - It simplifies the interpretation of the expression by automated systems such as computer algebra systems and audio renderers.
 
+## Attributes
+
+This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 ## Examples
 
 ```html

--- a/files/en-us/web/mathml/element/ms/index.md
+++ b/files/en-us/web/mathml/element/ms/index.md
@@ -14,6 +14,8 @@ The MathML `<ms>` element represents a _string literal_ meant to be interpreted 
 
 ## Attributes
 
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 - lquote
   - : The opening quote character (depends on [`dir`](#attr-dir)) to enclose the content. The default value is "`&quot;".`
 

--- a/files/en-us/web/mathml/element/mspace/index.md
+++ b/files/en-us/web/mathml/element/mspace/index.md
@@ -14,6 +14,8 @@ The MathML `<mspace>` element is used to display a blank space, whose size is se
 
 ## Attributes
 
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 - depth
   - : The desired depth (below the baseline) of the space (see [length](/en-US/docs/Web/MathML/Attribute/Values#lengths) for values and units).
 - height

--- a/files/en-us/web/mathml/element/msqrt/index.md
+++ b/files/en-us/web/mathml/element/msqrt/index.md
@@ -12,6 +12,10 @@ browser-compat: mathml.elements.msqrt
 
 The MathML `<msqrt>` element is used to display square roots (no index is displayed). The square root accepts only one argument, which leads to the following syntax: `<msqrt> base </msqrt>`.
 
+## Attributes
+
+This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 ## Examples
 
 Sample rendering: ![root-x](msqrt.png)

--- a/files/en-us/web/mathml/element/mstyle/index.md
+++ b/files/en-us/web/mathml/element/mstyle/index.md
@@ -14,6 +14,8 @@ The MathML `<mstyle>` element is used change the style of its children. It accep
 
 ## Attributes
 
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 - `infixlinebreakstyle`
   - : Specifies the default `linebreakstyle` to use for infix operators. The values `before`, `after` and `duplicate` are allowed.
 - `scriptminsize`

--- a/files/en-us/web/mathml/element/msub/index.md
+++ b/files/en-us/web/mathml/element/msub/index.md
@@ -16,6 +16,8 @@ It uses the following syntax: `<msub> base subscript </msub>`.
 
 ## Attributes
 
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 - `subscriptshift` {{deprecated_inline}}
   - : The minimum space by which to shift the subscript below the baseline of the expression, as a [length value](/en-US/docs/Web/MathML/Attribute/Values#lengths).
     This attribute is deprecated and will be removed in the future.

--- a/files/en-us/web/mathml/element/msubsup/index.md
+++ b/files/en-us/web/mathml/element/msubsup/index.md
@@ -16,6 +16,8 @@ It uses the following syntax: `<msubsup> base subscript superscript </msubsup>`.
 
 ## Attributes
 
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 - `subscriptshift` {{deprecated_inline}}
   - : The minimum space by which to shift the subscript below the baseline of the expression, as a [length value.](/en-US/docs/Web/MathML/Attribute/Values#lengths)
     This attribute is deprecated and will be removed in the future.

--- a/files/en-us/web/mathml/element/msup/index.md
+++ b/files/en-us/web/mathml/element/msup/index.md
@@ -16,6 +16,8 @@ It uses the following syntax: `<msup> base superscript </msup>`.
 
 ## Attributes
 
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 - `superscriptshift` {{deprecated_inline}}
   - : The minimum space by which to shift the superscript up from the baseline of the expression, as a [length value.](/en-US/docs/Web/MathML/Attribute/Values#lengths)
     This attribute is deprecated and will be removed in the future.

--- a/files/en-us/web/mathml/element/mtable/index.md
+++ b/files/en-us/web/mathml/element/mtable/index.md
@@ -16,6 +16,8 @@ The MathML `<mtable>` element allows you to create tables or matrices. Inside a 
 
 ## Attributes
 
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 - align
 
   - : Specifies the **vertical** alignment of the table with respect to its environment.

--- a/files/en-us/web/mathml/element/mtd/index.md
+++ b/files/en-us/web/mathml/element/mtd/index.md
@@ -14,6 +14,8 @@ The MathML `<mtd>` element represents a cell in a table or a matrix. It may only
 
 ## Attributes
 
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 - columnalign
   - : Specifies the horizontal alignment of this cell and overrides values specified by {{ MathMLElement("mtable") }} or {{ MathMLElement("mtr") }}.
     Possible values are: `left`, `center` and `right`.

--- a/files/en-us/web/mathml/element/mtext/index.md
+++ b/files/en-us/web/mathml/element/mtext/index.md
@@ -14,6 +14,10 @@ The MathML \<mtext> element is used to render arbitrary text with _no_ notationa
 
 To display text _with_ notational meaning, use {{ MathMLElement("mi") }} and {{ MathMLElement("mo") }} instead.
 
+## Attributes
+
+This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 ## Examples
 
 ```html

--- a/files/en-us/web/mathml/element/mtr/index.md
+++ b/files/en-us/web/mathml/element/mtr/index.md
@@ -14,6 +14,8 @@ The MathML `<mtr>` element represents a row in a table or a matrix. It may only 
 
 ## Attributes
 
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 - columnalign
   - : Overrides the horizontal alignment of cells specified by {{ MathMLElement("mtable") }} for this row.
     Possible values are: `left`, `center` and `right`.

--- a/files/en-us/web/mathml/element/munder/index.md
+++ b/files/en-us/web/mathml/element/munder/index.md
@@ -14,6 +14,8 @@ The MathML `<munder>` element is used to attach an accent or a limit under an ex
 
 ## Attributes
 
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 - accentunder
   - : If `true`, the element is an _accent_, which is drawn closer to the base expression.
     If `false` (default value), the element is a _limit_ under the base expression.

--- a/files/en-us/web/mathml/element/munderover/index.md
+++ b/files/en-us/web/mathml/element/munderover/index.md
@@ -16,6 +16,8 @@ It uses the following syntax: `<munderover> base underscript overscript </munder
 
 ## Attributes
 
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 - accent
   - : If `true`, the overscript is an _accent_, which is drawn closer to the base expression.
     If `false` (default value), the overscript is a _limit_ over the base expression.

--- a/files/en-us/web/mathml/element/semantics/index.md
+++ b/files/en-us/web/mathml/element/semantics/index.md
@@ -31,6 +31,8 @@ The rules of determining the visible child in a `<semantics>` element are the fo
 
 ## Attributes
 
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+
 The following attributes can be set on `<annotation>` and `<annotation-xml>`:
 
 - definitionURL


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
- Document that all MathML elements accept global MathML attributes.

#### Motivation
Global attributes have been moved to a dedicated article in https://github.com/mdn/content/pull/17812 ; we need to make sure each element's article still refer to them.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
