### PR TITLE
Missing spaces batch 3

### DIFF
--- a/files/en-us/mdn/structures/macros/commonly-used_macros/index.md
+++ b/files/en-us/mdn/structures/macros/commonly-used_macros/index.md
@@ -224,7 +224,7 @@ They typically link back to the main page of the reference/guide/tutorial (this 
 Usage: `\{{Optional_Inline}}` or `\{{ReadOnlyInline}}`.
 Example:
 
-- `isCustomObject`{{ReadOnlyInline}}
+- `isCustomObject` {{ReadOnlyInline}}
   - : Indicates, if `true`, that the object is a custom one.
 - `parameterX` {{optional_inline}}
   - : Blah blah blah...

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/getcurrent/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/getcurrent/index.md
@@ -37,7 +37,7 @@ let gettingCurrent = browser.windows.getCurrent(
 
     - `populate` {{optional_inline}}
       - : `boolean`. If true, the {{WebExtAPIRef('windows.Window')}} object will have a `tabs` property that contains a list of {{WebExtAPIRef('tabs.Tab')}} objects representing the tabs in the window. The `Tab` objects only contain the `url`, `title` and `favIconUrl` properties if the extension's manifest file includes the `"tabs"` permission or [host permissions](/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions#host_permissions) that match the tab's URL.
-    - `windowTypes`{{deprecated_inline}}{{optional_inline}}
+    - `windowTypes` {{deprecated_inline}} {{optional_inline}}
       - : An `array` of `{{WebExtAPIRef('windows.WindowType')}}` objects. If set, the {{WebExtAPIRef('windows.Window')}} returned will be filtered based on its type. If unset the default filter is set to `['normal', 'panel', 'popup']`, with `'panel'` window types limited to the extension's own windows.
 
 > **Note:** If supplied, the `windowTypes` component of `getInfo` is ignored. The use of `windowTypes` has been deprecated as of Firefox 62.

--- a/files/en-us/web/api/canvasgradient/addcolorstop/index.md
+++ b/files/en-us/web/api/canvasgradient/addcolorstop/index.md
@@ -40,7 +40,7 @@ None ({{jsxref("undefined")}}).
 
 - `IndexSizeError` {{domxref("DOMException")}}
   - : Thrown if `offset` is not between 0 and 1 (both included).
-- `SyntaxError`{{domxref("DOMException")}}
+- `SyntaxError` {{domxref("DOMException")}}
   - : Thrown if `color` cannot be parsed as a CSS {{cssxref("&lt;color&gt;")}} value.
 
 ## Examples

--- a/files/en-us/web/api/clipboardevent/clipboardevent/index.md
+++ b/files/en-us/web/api/clipboardevent/clipboardevent/index.md
@@ -37,9 +37,9 @@ new ClipboardEvent(type, options)
   - : An object that, _in addition of the properties defined in {{domxref("Event/Event", "Event()")}}_, has the following properties:
     - `clipboardData` {{optional_inline}}
       - : A {{domxref("DataTransfer")}} object containing the data concerned by the clipboard event. It defaults to `null`.
-    - `dataType`{{non-standard_inline}} {{optional_inline}}
+    - `dataType` {{non-standard_inline}} {{optional_inline}}
       - : A string containing the MIME-type of the data contained in the `data` argument. It defaults to `""`.
-    - `data`{{non-standard_inline}} {{optional_inline}}
+    - `data` {{non-standard_inline}} {{optional_inline}}
       - : A string containing the data concerned by the clipboard event. It defaults to `""`.
 
 ### Return value

--- a/files/en-us/web/api/cssstylesheet/insertrule/index.md
+++ b/files/en-us/web/api/cssstylesheet/insertrule/index.md
@@ -56,7 +56,7 @@ The newly inserted rule's index within the stylesheet's rule-list.
   - : Thrown if `index` > `{{domxref("CSSRuleList", "", "", "1")}}.length`.
 - `HierarchyRequestError` {{domxref("DOMException")}}
   - : Thrown if `rule` cannot be inserted at `index` `0` due to some CSS constraint.
-- `SyntaxError`{{domxref("DOMException")}}
+- `SyntaxError` {{domxref("DOMException")}}
   - : Thrown if more than one rule is given in the `rule` parameter.
 - `HierarchyRequestError` {{domxref("DOMException")}}
   - : Thrown if trying to insert an {{cssxref("@import")}} at-rule after a style rule.

--- a/files/en-us/web/api/document/append/index.md
+++ b/files/en-us/web/api/document/append/index.md
@@ -47,7 +47,7 @@ None ({{jsxref("undefined")}}).
 ### Appending a root element to a document
 
 If you try to append an element to an existing HTML document,
-it might throw a `HierarchyRequestError`{{domxref("DOMException")}} given a {{HTMLElement("html")}} element already exists.
+it might throw a `HierarchyRequestError` {{domxref("DOMException")}} given a {{HTMLElement("html")}} element already exists.
 
 ```js
 let html = document.createElement("html");

--- a/files/en-us/web/api/filesystemwritablefilestream/truncate/index.md
+++ b/files/en-us/web/api/filesystemwritablefilestream/truncate/index.md
@@ -44,7 +44,7 @@ A {{jsxref('Promise')}} which returns undefined.
 
 ### Exceptions
 
-- `NotAllowedError`{{domxref("DOMException")}}
+- `NotAllowedError` {{domxref("DOMException")}}
   - : If the {{domxref('PermissionState')}} is not 'granted'.
 - {{jsxref("TypeError")}}
   - : If the size is undefined or not an unsigned long.

--- a/files/en-us/web/api/mouseevent/getmodifierstate/index.md
+++ b/files/en-us/web/api/mouseevent/getmodifierstate/index.md
@@ -28,7 +28,7 @@ getModifierState(key)
 
 - `key`
   - : A modifier key value.
-    The value must be one of the {{domxref("KeyboardEvent.key")}} values which represent modifier keys or `"Accel"`{{deprecated_inline}}.
+    The value must be one of the {{domxref("KeyboardEvent.key")}} values which represent modifier keys or `"Accel"` {{deprecated_inline}}.
     This is case-sensitive.
 
 ### Return value

--- a/files/en-us/web/api/msmanipulationevent/index.md
+++ b/files/en-us/web/api/msmanipulationevent/index.md
@@ -30,10 +30,10 @@ This proprietary method is specific to Internet Explorer.
 
 | Property                                      | Description                                                                          |
 | --------------------------------------------- | ------------------------------------------------------------------------------------ |
-| `currentState`{{ReadOnlyInline}}        | Returns the current state of a manipulation event.                                   |
-| `inertiaDestinationX`{{ReadOnlyInline}} | Represents the predicted horizontal scroll offset after the inertia phase completes. |
-| `inertiaDestinationY`{{ReadOnlyInline}} | Represents the predicted vertical scroll offset after the inertia phase completes.   |
-| `lastState`{{ReadOnlyInline}}           | Returns the last state after a manipulation change event.                            |
+| `currentState` {{ReadOnlyInline}}        | Returns the current state of a manipulation event.                                   |
+| `inertiaDestinationX` {{ReadOnlyInline}} | Represents the predicted horizontal scroll offset after the inertia phase completes. |
+| `inertiaDestinationY` {{ReadOnlyInline}} | Represents the predicted vertical scroll offset after the inertia phase completes.   |
+| `lastState` {{ReadOnlyInline}}           | Returns the last state after a manipulation change event.                            |
 
 ## Example
 

--- a/files/en-us/web/api/navigator/registerprotocolhandler/index.md
+++ b/files/en-us/web/api/navigator/registerprotocolhandler/index.md
@@ -65,7 +65,7 @@ None ({{jsxref("undefined")}}).
     - The browser requires that this function is called from a secure context.
     - The browser requires that the handler's URL be over HTTPS.
 
-- `SyntaxError`{{domxref("DOMException")}}
+- `SyntaxError` {{domxref("DOMException")}}
   - : The `%s` placeholder is missing from the handler URL.
 
 ## Permitted schemes

--- a/files/en-us/web/api/permissionstatus/index.md
+++ b/files/en-us/web/api/permissionstatus/index.md
@@ -24,7 +24,7 @@ The **`PermissionStatus`** interface of the [Permissions API](Permissions_API) p
   - : Returns the name of a requested permission, identical to the `name` passed to {{domxref("Permissions.query")}}.
 - {{domxref("PermissionStatus.state")}} {{readonlyinline}}
   - : Returns the state of a requested permission; one of `'granted'`, `'denied'`, or `'prompt'`.
-- `PermissionStatus.status`{{readonlyinline}} {{deprecated_inline}}
+- `PermissionStatus.status` {{readonlyinline}} {{deprecated_inline}}
   - : Returns the state of a requested permission; one of `'granted'`, `'denied'`, or `'prompt'`. Later versions of the specification replace this with {{domxref("PermissionStatus.state")}}.
 
 ### Events

--- a/files/en-us/web/css/list-style-type/index.md
+++ b/files/en-us/web/css/list-style-type/index.md
@@ -104,7 +104,7 @@ Note that:
   - : Han "Earthly Branch" ordinals.
 - `cjk-heavenly-stem`, `-moz-cjk-heavenly-stem`
   - : Han "Heavenly Stem" ordinals.
-- `cjk-ideographic`{{experimental_inline}}
+- `cjk-ideographic` {{experimental_inline}}
   - : Identical to `trad-chinese-informal`.
 - `devanagari`, `-moz-devanagari`
   - : Devanagari numbering.

--- a/files/en-us/web/css/mask-clip/index.md
+++ b/files/en-us/web/css/mask-clip/index.md
@@ -66,13 +66,13 @@ One or more of the keyword values listed below, separated by commas.
   - : Uses the nearest SVG viewport as reference box. If a [`viewBox`](/en-US/docs/Web/SVG/Attribute/viewBox) attribute is specified for the element creating the SVG viewport, the reference box is positioned at the origin of the coordinate system established by the `viewBox` attribute and the dimension of the reference box is set to the width and height values of the `viewBox` attribute.
 - `no-clip`
   - : The painted content is not clipped.
-- `border`{{non-standard_inline}}
+- `border` {{non-standard_inline}}
   - : This keyword behaves the same as `border-box`.
-- `padding`{{non-standard_inline}}
+- `padding` {{non-standard_inline}}
   - : This keyword behaves the same as `padding-box`.
-- `content`{{non-standard_inline}}
+- `content` {{non-standard_inline}}
   - : This keyword behaves the same as `content-box`.
-- `text`{{non-standard_inline}}
+- `text` {{non-standard_inline}}
   - : This keyword clips the mask image to the text of the element.
 
 ## Formal definition

--- a/files/en-us/web/css/mozilla_extensions/index.md
+++ b/files/en-us/web/css/mozilla_extensions/index.md
@@ -277,7 +277,7 @@ Property: {{CSSxRef("background-image")}}
 
 Property: {{CSSxRef("border-color")}}
 
-- `-moz-use-text-color`{{deprecated_inline}} (removed in {{bug(1306214)}}); use {{CSSxRef("color_value#currentcolor_keyword","currentcolor")}} instead.
+- `-moz-use-text-color` {{deprecated_inline}} (removed in {{bug(1306214)}}); use {{CSSxRef("color_value#currentcolor_keyword","currentcolor")}} instead.
 
 ### order-style and outline-style
 

--- a/files/en-us/web/css/user-select/index.md
+++ b/files/en-us/web/css/user-select/index.md
@@ -74,7 +74,7 @@ user-select: unset;
   - : The content of the element shall be selected atomically: If a selection would contain part of the element, then the selection must contain the entire element including all its descendants.  If a double-click or context-click occurred in sub-elements, the highest ancestor with this value will be selected.
 - `contain`
   - : Enables selection to start within the element; however, the selection will be contained by the bounds of that element.
-- `element`{{non-standard_inline}} (IE-specific alias)
+- `element` {{non-standard_inline}} (IE-specific alias)
   - : Same as `contain`. Supported only in Internet Explorer.
 
 > **Note:** CSS UI 4 [renames `user-select: element` to `contain`](https://github.com/w3c/csswg-drafts/commit/3f1d9db96fad8d9fc787d3ed66e2d5ad8cfadd05).

--- a/files/en-us/web/svg/attribute/dominant-baseline/index.md
+++ b/files/en-us/web/svg/attribute/dominant-baseline/index.md
@@ -90,11 +90,11 @@ text {
     If the computed {{SVGAttr("baseline-shift")}} value actually shifts the baseline, then the baseline-table font-size component is set to the value of the {{SVGAttr("font-size")}} attribute on the element on which the `dominant-baseline` attribute occurs, otherwise the baseline-table font-size remains the same as that of the element.
 
     If there is no parent text content element, the scaled-baseline-table value is constructed as above for {{SVGElement("text")}} elements.
-- `use-script`{{deprecated_inline}}
+- `use-script` {{deprecated_inline}}
   - : The dominant-baseline and the baseline-table components are set by determining the predominant script of the character data content. The {{SVGAttr("writing-mode")}}, whether horizontal or vertical, is used to select the appropriate set of baseline-tables and the dominant baseline is used to select the baseline-table that corresponds to that baseline. The baseline-table font-size component is set to the value of the {{SVGAttr("font-size")}} attribute on the element on which the `dominant-baseline` attribute occurs.
-- `no-change`{{deprecated_inline}}
+- `no-change` {{deprecated_inline}}
   - : The dominant-baseline, the baseline-table, and the baseline-table font-size remain the same as that of the parent text content element.
-- `reset-size`{{deprecated_inline}}
+- `reset-size` {{deprecated_inline}}
   - : The dominant-baseline and the baseline-table remain the same, but the baseline-table font-size is changed to the value of the {{SVGAttr("font-size")}} attribute on this element. This re-scales the baseline-table for the current {{SVGAttr("font-size")}}.
 - `ideographic`
   - : The baseline-identifier for the dominant-baseline is set to be `ideographic`, the derived baseline-table is constructed using the `ideographic` baseline-table in the font, and the baseline-table font-size is changed to the value of the {{SVGAttr("font-size")}} attribute on this element.


### PR DESCRIPTION
Added spaces after/before Markdown where appropriate.

{{deprecated_inline}}
{{experimental_inline}}
{{non-standard_inline}}

Does not result in bad rendering for text-browsers, but looks like it in
the markdown. Mostly it is with space so making it more uniform.

Others can give bad selection on "double-click" or rendering in text-browsers.

Also ref.  issue #18019

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Added missing spaces 

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

Improve readability, usability.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
