### PR TITLE
Adopt a different 'enhanced typeof' implementation

### DIFF
--- a/files/en-us/web/javascript/reference/operators/typeof/index.md
+++ b/files/en-us/web/javascript/reference/operators/typeof/index.md
@@ -226,7 +226,7 @@ function type(value) {
   }
 
   if (
-    Object.getPrototypeOf(obj) === Function.prototype &&
+    Object.getPrototypeOf(value) === Function.prototype &&
     /^class/.test(String(value))
   ) {
     return "class";

--- a/files/en-us/web/javascript/reference/operators/typeof/index.md
+++ b/files/en-us/web/javascript/reference/operators/typeof/index.md
@@ -18,11 +18,8 @@ of the unevaluated operand.
 
 ## Syntax
 
-The `typeof` operator is followed by its operand:
-
 ```js
 typeof operand
-typeof(operand)
 ```
 
 ### Parameters
@@ -41,10 +38,10 @@ more information about types and primitives, see also the [JavaScript data struc
 | [Null](/en-US/docs/Glossary/Null)                                                        | `"object"` (see [below](#typeof_null)) |
 | [Boolean](/en-US/docs/Glossary/Boolean)                                                  | `"boolean"`                            |
 | [Number](/en-US/docs/Glossary/Number)                                                    | `"number"`                             |
-| [BigInt](/en-US/docs/Glossary/BigInt) (new in ECMAScript 2020)                           | `"bigint"`                             |
+| [BigInt](/en-US/docs/Glossary/BigInt)                                                    | `"bigint"`                             |
 | [String](/en-US/docs/Glossary/String)                                                    | `"string"`                             |
-| [Symbol](/en-US/docs/Glossary/Symbol) (new in ECMAScript 2015)                           | `"symbol"`                             |
-| [Function](/en-US/docs/Glossary/Function) object (implements [[Call]] in ECMA-262 terms) | `"function"`                           |
+| [Symbol](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)                     | `"symbol"`                             |
+| [Function](/en-US/docs/Glossary/Function) (implements [[Call]] in ECMA-262 terms; [classes](/en-US/docs/Web/JavaScript/Reference/Statements/class) are functions as well) | `"function"`                           |
 | Any other object                                                                         | `"object"`                             |
 
 > **Note:** ECMAScript 2019 and older permitted implementations to have
@@ -62,7 +59,7 @@ more information about types and primitives, see also the [JavaScript data struc
 // Numbers
 typeof 37 === 'number';
 typeof 3.14 === 'number';
-typeof(42) === 'number';
+typeof 42 === 'number';
 typeof Math.LN2 === 'number';
 typeof Infinity === 'number';
 typeof NaN === 'number'; // Despite being "Not-A-Number"
@@ -96,7 +93,7 @@ typeof declaredButUndefinedVariable === 'undefined';
 typeof undeclaredVariable === 'undefined';
 
 // Objects
-typeof {a: 1} === 'object';
+typeof { a: 1 } === 'object';
 
 // use Array.isArray or Object.prototype.toString.call
 // to differentiate regular objects from arrays
@@ -116,7 +113,7 @@ typeof class C {} === 'function';
 typeof Math.sin === 'function';
 ```
 
-### `typeof null`
+### typeof null
 
 ```js
 // This stands since the beginning of JavaScript
@@ -133,26 +130,28 @@ A fix was proposed for ECMAScript (via an opt-in), but
 [was rejected](https://web.archive.org/web/20160331031419/http://wiki.ecmascript.org:80/doku.php?id=harmony:typeof_null).
 It would have resulted in `typeof null === 'null'`.
 
-### Using `new` operator
+### Using new operator
 
 ```js
 // All constructor functions, with the exception of the Function constructor, will always be typeof 'object'
-let str = new String('String');
-let num = new Number(100);
+const str = new String('String');
+const num = new Number(100);
 
 typeof str; // It will return 'object'
 typeof num; // It will return 'object'
 
-let func = new Function();
+const func = new Function();
 
 typeof func; // It will return 'function'
 ```
 
 ### Need for parentheses in Syntax
 
+The `typeof` operator has higher [precedence](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence) than binary operators like addition (`+`). Therefore, parentheses are needed to evaluate the type of an addition result.
+
 ```js
 // Parentheses can be used for determining the data type of expressions.
-let iData = 99;
+const iData = 99;
 
 typeof iData + ' Wisen'; // 'number Wisen'
 typeof (iData + ' Wisen'); // 'string'
@@ -209,34 +208,52 @@ requires those type tags to be different from the predefined ones. The case of
 `document.all` having type `'undefined'` is classified in the web
 standards as a "willful violation" of the original ECMA JavaScript standard.
 
-### Real-world usage
+### Custom method that gets a more specific type
 
 `typeof` is very useful, but it's not as versatile as might be required. For
-example, `typeof([])` , is `'object'`, as well as
-`typeof(new Date())`, `typeof(/abc/)`, etc.
+example, `typeof []` , is `'object'`, as well as
+`typeof new Date()`, `typeof /abc/`, etc.
 
-For greater specificity in checking types, a `typeof` wrapper for usage in
-production-level code would be as follows (provided `obj` exists):
+For greater specificity in checking types, here we present a custom `type(obj)` function, which mostly mimics the behavior of `typeof`, but for non-primitives (i.e. objects and functions), it returns a more granular type name where possible.
 
 ```js
-  function type(obj, showFullClass) {
-
-    // get toPrototypeString() of obj (handles all types)
-    if (showFullClass && typeof obj === "object") {
-        return Object.prototype.toString.call(obj);
-    }
-    if (obj == null) { return (obj + '').toLowerCase(); } // implicit toString() conversion
-
-    var deepType = Object.prototype.toString.call(obj).slice(8,-1).toLowerCase();
-    if (deepType === 'generatorfunction') { return 'function' }
-
-    // Prevent overspecificity (for example, [object HTMLDivElement], etc).
-    // Account for functionish Regexp (Android <=2.3), functionish <object> element (Chrome <=57, Firefox <=52), etc.
-    // String.prototype.match is universally supported.
-
-    return deepType.match(/^(array|bigint|date|error|function|generator|regexp|symbol)$/) ? deepType :
-       (typeof obj === 'object' || typeof obj === 'function') ? 'object' : typeof obj;
+function type(obj) {
+  if (typeof value !== "object" && typeof value !== "function") {
+    return typeof value;
   }
+  if (value === null) {
+    return "null";
+  }
+
+  if (
+    Object.getPrototypeOf(obj) === Function.prototype &&
+    /^class/.test(String(value))
+  ) {
+    return "class";
+  }
+
+  // Symbol.toStringTag often specifies the "display name" of the
+  // object's class.
+  if (
+    Symbol.toStringTag in value &&
+    typeof value[Symbol.toStringTag] === "string"
+  ) {
+    return value[Symbol.toStringTag];
+  }
+
+  // The name of the constructor, for example `Array`, `GeneratorFunction`,
+  // `Number`, `String`, `Boolean` or `MyCustomObject`
+  if (
+    typeof value.constructor.name === "string" &&
+    value.constructor.name !== ""
+  ) {
+    return value.constructor.name;
+  }
+
+  // At this point there's no robust way to get the type of value,
+  // so we use the base implementation.
+  return typeof value;
+}
 ```
 
 For checking non-existent variables that would otherwise throw

--- a/files/en-us/web/javascript/reference/operators/typeof/index.md
+++ b/files/en-us/web/javascript/reference/operators/typeof/index.md
@@ -214,7 +214,7 @@ standards as a "willful violation" of the original ECMA JavaScript standard.
 example, `typeof []` , is `'object'`, as well as
 `typeof new Date()`, `typeof /abc/`, etc.
 
-For greater specificity in checking types, here we present a custom `type(obj)` function, which mostly mimics the behavior of `typeof`, but for non-primitives (i.e. objects and functions), it returns a more granular type name where possible.
+For greater specificity in checking types, here we present a custom `type(value)` function, which mostly mimics the behavior of `typeof`, but for non-primitives (i.e. objects and functions), it returns a more granular type name where possible.
 
 ```js
 function type(obj) {

--- a/files/en-us/web/javascript/reference/operators/typeof/index.md
+++ b/files/en-us/web/javascript/reference/operators/typeof/index.md
@@ -241,7 +241,7 @@ function type(value) {
     return value[Symbol.toStringTag];
   }
 
-  // The name of the constructor, for example `Array`, `GeneratorFunction`,
+  // The name of the constructor; for example `Array`, `GeneratorFunction`,
   // `Number`, `String`, `Boolean` or `MyCustomObject`
   if (
     typeof value.constructor.name === "string" &&

--- a/files/en-us/web/javascript/reference/operators/typeof/index.md
+++ b/files/en-us/web/javascript/reference/operators/typeof/index.md
@@ -217,7 +217,7 @@ example, `typeof []` , is `'object'`, as well as
 For greater specificity in checking types, here we present a custom `type(value)` function, which mostly mimics the behavior of `typeof`, but for non-primitives (i.e. objects and functions), it returns a more granular type name where possible.
 
 ```js
-function type(obj) {
+function type(value) {
   if (typeof value !== "object" && typeof value !== "function") {
     return typeof value;
   }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

Fix #15772. I've adopted a largely different implementation, because we should never, ever, encourage parsing a function's `toString()` result. (I still used it for testing classes but that seems worth it.) Also used `Symbol.toStringTag`.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
