### PR TITLE
Fixed anchor link for digest functions

### DIFF
--- a/files/en-us/web/api/rsapssparams/index.md
+++ b/files/en-us/web/api/rsapssparams/index.md
@@ -22,7 +22,7 @@ The **`RsaPssParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/We
 
   - : A `long` integer representing the length of the random salt to use, in bytes.
 
-    [RFC 3447](https://datatracker.ietf.org/doc/html/rfc3447) says that "Typical salt lengths" are either 0 or the length of the output of the [digest algorithm](/en-US/docs/Web/API/SubtleCrypto#digest_algorithms) that was selected when this key was [generated](/en-US/docs/Web/API/SubtleCrypto/generateKey). For example, if you use [SHA-256](/en-US/docs/Web/API/SubtleCrypto#sha-256) as the digest algorithm, this could be 32.
+    [RFC 3447](https://datatracker.ietf.org/doc/html/rfc3447) says that "Typical salt lengths" are either 0 or the length of the output of the [digest algorithm](/en-US/docs/Web/API/SubtleCrypto#supported_algorithms) that was selected when this key was [generated](/en-US/docs/Web/API/SubtleCrypto/generateKey). For example, if you use [SHA-256](/en-US/docs/Web/API/SubtleCrypto/digest#supported_algorithms) as the digest algorithm, this could be 32.
 
     The maximum size of `saltLength` is given by:
 


### PR DESCRIPTION
#### Summary
I fixed the link for the digest functions to link to the anchor 'supported_algorithms', where the digest functions are listed on that page, and the link for SHA-256 to the anchor 'supported_algorithms' on the 'digest' page  where it's described

#### Motivation
 The link to the 'SubtleCrypto' page for digest functions and SHA-256 linked to the non-existent 'digest_algorithms' anchor. 

#### Related issues
#17317 covered a similar problem.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
