### PR TITLE
Change "Generator functions" example default `end` argument to Infinity

### DIFF
--- a/files/en-us/web/javascript/guide/iterators_and_generators/index.md
+++ b/files/en-us/web/javascript/guide/iterators_and_generators/index.md
@@ -85,7 +85,7 @@ The function can be called as many times as desired, and returns a new Generator
 We can now adapt the example from above. The behavior of this code is identical, but the implementation is much easier to write and read.
 
 ```js
-function* makeRangeIterator(start = 0, end = 100, step = 1) {
+function* makeRangeIterator(start = 0, end = Infinity, step = 1) {
     let iterationCount = 0;
     for (let i = start; i < end; i += step) {
         iterationCount++;


### PR DESCRIPTION
See https://github.com/mdn/content/issues/18066

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Under Change "Generator functions", the code example makeRangeIterator has its default `end` argument is changed from 100 to Infinity.

#### Motivation
 This it to make the example consistent with the Iterators makeRangeIterator example.

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
