### PR TITLE
Object destructuring reference fix

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/forms/create_genre_form/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/forms/create_genre_form/index.md
@@ -14,7 +14,7 @@ This sub article shows how we define our page to create `Genre` objects (this is
 
 To use the _express-validator_ in our controllers we have to _require_ the functions we want to use from the `'express-validator'` module.
 
-Open `/controllers/genreController.js`, and add the following line at the top of the file:
+Open **/controllers/genreController.js**, and add the following line at the top of the file:
 
 ```js
 const { body, validationResult } = require("express-validator");

--- a/files/en-us/learn/server-side/express_nodejs/forms/create_genre_form/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/forms/create_genre_form/index.md
@@ -24,8 +24,8 @@ const { body,validationResult } = require("express-validator");
 >
 > ```js
 > validator = require("express-validator");
-> body = validator.body();
-> validationResult = validator.validationResult();
+> body = validator.body;
+> validationResult = validator.validationResult;
 > ```
 
 ## Controller—get route

--- a/files/en-us/learn/server-side/express_nodejs/forms/create_genre_form/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/forms/create_genre_form/index.md
@@ -12,20 +12,20 @@ This sub article shows how we define our page to create `Genre` objects (this is
 
 ## Import validation and sanitization methods
 
-To use the _express-validator_ in our controllers we have to *require* the functions we want to use from the **'express-validator**' module.
+To use the _express-validator_ in our controllers we have to _require_ the functions we want to use from the `'express-validator'` module.
 
-Open **/controllers/genreController.js**, and add the following line at the top of the file:
+Open `/controllers/genreController.js`, and add the following line at the top of the file:
 
 ```js
-const { body,validationResult } = require("express-validator");
+const { body, validationResult } = require("express-validator");
 ```
 
 > **Note:** This syntax allows us to use `body` and `validationResult` as the associated middleware functions, as you will see in the post route section below. It is equivalent to:
 >
 > ```js
-> validator = require("express-validator");
-> body = validator.body;
-> validationResult = validator.validationResult;
+> const validator = require("express-validator");
+> const body = validator.body;
+> const validationResult = validator.validationResult;
 > ```
 
 ## Controller—get route


### PR DESCRIPTION
The syntax for copying the methods on the validator package caused an error for me when I tried to implement it. My change worked correctly.

The code in the 'Note' did not align with the Object destructuring it was referring to. Threw an error when I tried it out. My change did work when I last ran it. Hopefully this helps others as well going through the tutorial.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
