### PR TITLE
Fixed anchor link for digest functions

### DIFF
--- a/files/en-us/web/api/ecdsaparams/index.md
+++ b/files/en-us/web/api/ecdsaparams/index.md
@@ -24,11 +24,11 @@ The **`EcdsaParams`** dictionary of the [Web Crypto API](/en-US/docs/Web/API/Web
 
   - : A string. An identifier for the [digest algorithm](/en-US/docs/Web/API/SubtleCrypto/digest) to use. This should be one of the following:
 
-    - `SHA-256`: selects the [SHA-256](/en-US/docs/Web/API/SubtleCrypto/digest#sha-256) algorithm.
-    - `SHA-384`: selects the [SHA-384](/en-US/docs/Web/API/SubtleCrypto/digest#sha-384) algorithm.
-    - `SHA-512`: selects the [SHA-512](/en-US/docs/Web/API/SubtleCrypto/digest#sha-512) algorithm.
+    - `SHA-256`: selects the [SHA-256](/en-US/docs/Web/API/SubtleCrypto/digest#supported_algorithms) algorithm.
+    - `SHA-384`: selects the [SHA-384](/en-US/docs/Web/API/SubtleCrypto/digest#supported_algorithms) algorithm.
+    - `SHA-512`: selects the [SHA-512](/en-US/docs/Web/API/SubtleCrypto/digest#supported_algorithms) algorithm.
 
-    > **Warning:** `SHA-1` is also supported here but the [SHA-1](/en-US/docs/Web/API/SubtleCrypto/digest#sha-1) algorithm is considered vulnerable and should no longer be used.
+    > **Warning:** `SHA-1` is also supported here but the [SHA-1](/en-US/docs/Web/API/SubtleCrypto/digest#supported_algorithms) algorithm is considered vulnerable and should no longer be used.
 
 ## Examples
 


### PR DESCRIPTION
#### Summary
I fixed the link for the digest functions to link to the anchor 'supported_algorithms', where the digest functions are listed on the 'digest' page.

#### Motivation
The link to the 'digest' page for the digest functions links to the non-existent 'SHA-1', 'SHA-256', 'SHA-384' & 'SHA-512' anchors. 

#### Related issues
#17317 and #18127 covered a similar problems.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
