### PR TITLE
Wheel event demo also scrolled the page

### DIFF
--- a/files/en-us/web/api/element/wheel_event/index.md
+++ b/files/en-us/web/api/element/wheel_event/index.md
@@ -95,7 +95,7 @@ el.onwheel = zoom;
 The event handler can also be set up using the {{domxref("EventTarget/addEventListener", "addEventListener()")}} method:
 
 ```js
-el.addEventListener('wheel', zoom);
+el.addEventListener('wheel', zoom, { passive: false });
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Wheel event demo also scrolled the page, fixed by not using a passive event listener so that `event.preventDefault()` can actually work.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Makes it easier/more pleasant to actually test out the demo

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Wheel event listeners are passive by default in modern browsers, making the `preventDefault` in the demo inoperable. https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#improving_scrolling_performance_with_passive_listeners

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
