### PR TITLE
Replace {{event}} for `ended` events

### DIFF
--- a/files/en-us/learn/javascript/client-side_web_apis/video_and_audio_apis/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/video_and_audio_apis/index.md
@@ -283,7 +283,7 @@ Let's implement probably the most important control — the play/pause button.
     media.addEventListener('ended', stopMedia);
     ```
 
-    The {{domxref("Element/click_event", "click")}} event is obvious — we want to stop the video by running our `stopMedia()` function when the stop button is clicked. We do however also want to stop the video when it finishes playing — this is marked by the {{event("ended")}} event firing, so we also set up a listener to run the function on that event firing too.
+    The {{domxref("Element/click_event", "click")}} event is obvious — we want to stop the video by running our `stopMedia()` function when the stop button is clicked. We do however also want to stop the video when it finishes playing — this is marked by the {{domxref("HTMLMediaElement/ended_event", "ended")}} event firing, so we also set up a listener to run the function on that event firing too.
 
 2. Next, let's define `stopMedia()` — add the following function below `playPauseMedia()`:
 

--- a/files/en-us/web/api/htmlmediaelement/seektonextframe/index.md
+++ b/files/en-us/web/api/htmlmediaelement/seektonextframe/index.md
@@ -33,7 +33,7 @@ This method returns immediately, returning a {{jsxref("Promise")}}, whose fulfil
 handler is called when the seek operation is complete. In addition, a
 {{event("seeked")}} event is sent to let interested parties know that a seek has taken
 place. If the seek fails because the media is already at the last frame, a
-{{event("seeked")}} event occurs, followed immediately by an {{event("ended")}} event.
+{{event("seeked")}} event occurs, followed immediately by an {{domxref("HTMLMediaElement/ended_event", "ended")}} event.
 
 If there is no video on the media element, or the media isn't seekable, nothing
 happens.

--- a/files/en-us/web/api/media_streams_api/index.md
+++ b/files/en-us/web/api/media_streams_api/index.md
@@ -56,7 +56,7 @@ Early versions of the Media Capture and Streams API specification included separ
 ## Events
 
 - {{event("addtrack")}}
-- {{event("ended")}}
+- {{domxref("MediaStreamTrack/ended_event", "ended")}}
 - {{event("muted")}}
 - {{domxref("MediaStreamTrack.overconstrained_event", "overconstrained")}}
 - {{event("removetrack")}}

--- a/files/en-us/web/api/mediastreamtrack/stop/index.md
+++ b/files/en-us/web/api/mediastreamtrack/stop/index.md
@@ -89,4 +89,4 @@ Finally, `srcObject` is set to `null` to sever the link to the
 
 - {{domxref("MediaStreamTrack")}}, the interface it belongs to.
 - {{domxref("MediaStreamTrack.readyState")}}
-- {{event("ended")}}
+- {{domxref("MediaStreamTrack/ended_event", "ended")}}

--- a/files/en-us/web/api/oscillatornode/index.md
+++ b/files/en-us/web/api/oscillatornode/index.md
@@ -61,7 +61,7 @@ _Inherits properties from its parent, {{domxref("AudioScheduledSourceNode")}}, a
 ### Event handlers
 
 - {{domxref("OscillatorNode.onended")}}
-  - : Sets the event handler for the {{event("ended")}} event, which fires when the tone has stopped playing.
+  - : Sets the event handler for the {{domxref("AudioScheduledSourceNode/ended_event", "ended")}} event, which fires when the tone has stopped playing.
 
 ## Methods
 

--- a/files/en-us/web/api/web_audio_api/index.md
+++ b/files/en-us/web/api/web_audio_api/index.md
@@ -76,7 +76,7 @@ General containers and definitions that shape audio graphs in Web Audio API usag
   - : Provides a map-like interface to a group of {{domxref("AudioParam")}} interfaces, which means it provides the methods `forEach()`, `get()`, `has()`, `keys()`, and `values()`, as well as a `size` property.
 - {{domxref("BaseAudioContext")}}
   - : The **`BaseAudioContext`** interface acts as a base definition for online and offline audio-processing graphs, as represented by {{domxref("AudioContext")}} and {{domxref("OfflineAudioContext")}} respectively. You wouldn't use `BaseAudioContext` directly — you'd use its features via one of these two inheriting interfaces.
-- The {{event("ended")}} event
+- The {{domxerf("AudioScheduledSourceNode/ended_event", "ended")}} event
   - : The `ended` event is fired when playback has stopped because the end of the media was reached.
 
 ### Defining audio sources


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Replace {{event}} for `ended` events.
They should be replaced different references because there are three `ended` events:
- `HTMLMediaElement`
- `MediaStreamTrack`
- `AudioScheduledSourceNode`

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
