### PR TITLE
`string.split` - Add new custom splitter example.

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/split/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/split/index.md
@@ -183,26 +183,40 @@ This script displays the following:
 An object with a `Symbol.split` method can be used as a splitter with custom behavior.
 
 ```js
-const splitByNumber = {
+// Character used to split the string.
+const DATE_DELIMITER = "/";
+
+// Split by the delimiter, but ignore any empty values.
+const splitDate = {
   [Symbol.split](str) {
-    let num = 1;
+    const results = [];
     let pos = 0;
-    const result = [];
-    while (pos < str.length) {
-      const matchPos = str.indexOf(num, pos);
-      if (matchPos === -1) {
-        result.push(str.substring(pos));
-        break;
+    let matchPos = str.indexOf(DATE_DELIMITER, pos);
+    
+    while (matchPos !== -1) {
+      let subString = str.substring(pos, matchPos);
+
+      // Ignore empty values.
+      if (subString.length > 0) {
+        results.push(subString);
       }
-      result.push(str.substring(pos, matchPos));
-      pos = matchPos + String(num).length;
+
+      pos = matchPos += DATE_DELIMITER.length;
+      matchPos = str.indexOf(DATE_DELIMITER, pos);
     }
-    return result;
+    
+    const lastSubString = str.substring(pos);
+
+    if (lastSubString.length > 0) {
+      results.push(lastSubString);
+    }
+
+    return results;
   }
 };
 
-const myString = "a1bc2c5d3e4f";
-console.log(myString.split(splitByNumber)); // [ "a", "bc", "c5d", "e", "f" ]
+const dateString = "/01/01/1970";
+console.log(dateString.split(splitDate)); // => ["01", "01", "1970"]
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/string/split/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/split/index.md
@@ -217,7 +217,7 @@ const DELIMITER = ";";
 const splitCommands = {
   [Symbol.split](str, lim) {
     const results = [];
-    let state = {
+    const state = {
       on: false,
       brightness: {
         current: 2,

--- a/files/en-us/web/javascript/reference/global_objects/string/split/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/split/index.md
@@ -229,7 +229,7 @@ const splitCommands = {
     let matchPos = str.indexOf(DELIMITER, pos);
 
     while (matchPos !== -1) {
-      let subString = str.slice(pos, matchPos).trim();
+      const subString = str.slice(pos, matchPos).trim();
 
       switch (subString) {
         case "light on":

--- a/files/en-us/web/javascript/reference/global_objects/string/split/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/split/index.md
@@ -208,7 +208,7 @@ const myString = "a1bc2c5d3e4f";
 console.log(myString.split(splitByNumber)); // => [ "a", "bc", "c5d", "e", "f" ]
 ```
 
-The following example uses an internal state to enforce certain behaviour, and to ensure a "valid" result is produced.
+The following example uses an internal state to enforce certain behavior, and to ensure a "valid" result is produced.
 
 ```js
 const DELIMITER = ";";


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Added a slightly more practical example for the custom splitter. This example splits by a date delimiter (`/`), but ignores empty sub-string values.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The current example does not actually produce the intended output (it is missing an increment for `num`), but also is a bit nebulous and impractical. The proposed changes are a simplified real world example, which I thought may be useful to have instead.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
