### PR TITLE
FF103 caches global object secure context

### DIFF
--- a/files/en-us/mozilla/firefox/releases/103/index.md
+++ b/files/en-us/mozilla/firefox/releases/103/index.md
@@ -41,6 +41,10 @@ This article provides information about the changes in Firefox 103 that will aff
   After transferring, the original object cannot be used.
   See {{bug(1659025)}} for more details.
 
+- [`caches`](/en-US/docs/Web/API/caches), [`CacheStorage`](/en-US/docs/Web/API/CacheStorage), and [`Cache`](/en-US/docs/Web/API/Cache) now require a [secure context](/en-US/docs/Web/Security/Secure_Contexts); the properties/interfaces are not defined if used in an insecure context.
+  Previously `cache` would return a `CacheStorage` that would throw an exception if used outside of a secure context.
+  See {{bug(1112134)}} for more details.
+
 #### DOM
 
 #### Media, WebRTC, and Web Audio

--- a/files/en-us/web/api/cachestorage/index.md
+++ b/files/en-us/web/api/cachestorage/index.md
@@ -18,9 +18,6 @@ The **`CacheStorage`** interface represents the storage for {{domxref("Cache")}}
 The interface:
 
 - Provides a master directory of all the named caches that can be accessed by a {{domxref("ServiceWorker")}} or other type of worker or {{domxref("window")}} scope (you're not limited to only using it with service workers).
-
-  > **Note:** [Chrome and Safari only expose \`CacheStorage\` to the windowed context over HTTPS](https://bugs.chromium.org/p/chromium/issues/detail?id=1026063). {{domxref("caches")}} will be undefined unless an SSL certificate is configured.
-
 - Maintains a mapping of string names to corresponding {{domxref("Cache")}} objects.
 
 Use {{domxref("CacheStorage.open()")}} to obtain a {{domxref("Cache")}} instance.


### PR DESCRIPTION
FF103 makes `caches`, `CacheStorage` and `Caches` require a secure context in https://bugzilla.mozilla.org/show_bug.cgi?id=1112134#c57

What this means is that they aren't even defined in FF103 in an insecure context. So `caches` wouldn't exist and so you couldn't get a `CacheStorage` (and from it `Caches`). Previously `caches` would return the  `CacheStorage` but it would then throw if you tried to use it in an insecure context. Upshot, inconsistent behaviour that is confusing to developers when compared to all other APIs protected via a secure context.

Mostly this is just a release note update. NOte that I do not mention one other aspect here, which is that there is a pref you can enable to turn off secure context requirement. This is only provided to allow test code to run more easily, so I felt not relevant to most developers.

Other docs work can be tracked in #17475