### PR TITLE
Promise - improve eventual

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/promise/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/promise/index.md
@@ -27,9 +27,10 @@ A `Promise` is in one of these states:
 - _fulfilled_: meaning that the operation was completed successfully.
 - _rejected_: meaning that the operation failed.
 
-A pending promise can either be _fulfilled_ with a value or _rejected_ with a reason (error). When either of these options happens, the associated handlers queued up by a promise's `then` method are called. If the promise has already been fulfilled or rejected when a corresponding handler is attached, the handler will be called, so there is no race condition between an asynchronous operation completing and its handlers being attached.
+ The _eventual state_ of a pending promise can either be _fulfilled_ with a value or _rejected_ with a reason (error).
+ When either of these options occur, the associated handlers queued up by a promise's `then` method are called. If the promise has already been fulfilled or rejected when a corresponding handler is attached, the handler will be called, so there is no race condition between an asynchronous operation completing and its handlers being attached.
 
-A promise is said to be _settled_ if it is either fulfilled or rejected, but not pending. Its state at this instant is also called its _eventual state_, which can either be "fulfilled with some value" or "rejected with some reason".
+A promise is said to be _settled_ if it is either fulfilled or rejected, but not pending.
 
 ![](promises.png)
 


### PR DESCRIPTION
As discussed in https://github.com/mdn/content/pull/18169#issuecomment-1179946569, referring to the term eventual state as something that happens at a particular instant seems wrong. This just makes it clear that these are the states that the promise may "eventually" end up in.