### PR TITLE
Comment out ellipsis in code blocks, part 1

### DIFF
--- a/files/en-us/games/techniques/3d_on_the_web/webvr/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/webvr/index.md
@@ -90,7 +90,7 @@ function setView() {
     }
   }
 
-  ...
+  // …
 
 }
 ```

--- a/files/en-us/games/techniques/audio_for_web_games/index.md
+++ b/files/en-us/games/techniques/audio_for_web_games/index.md
@@ -234,35 +234,35 @@ To see this in action, let's lay out some separate tracks:
   <ul>
     <li data-loading="true">
       <a href="leadguitar.mp3" class="track">Lead Guitar</a>
-      <p class="loading-text">Loading...</p>
+      <p class="loading-text">Loading…</p>
       <button data-playing="false" aria-describedby="guitar-play-label">
         <span id="guitar-play-label">Play</span>
       </button>
     </li>
     <li data-loading="true">
       <a href="bassguitar.mp3" class="track">Bass Guitar</a>
-      <p class="loading-text">Loading...</p>
+      <p class="loading-text">Loading…</p>
       <button data-playing="false" aria-describedby="bass-play-label">
         <span id="bass-play-label">Play</span>
       </button>
     </li>
     <li data-loading="true">
       <a href="drums.mp3" class="track">Drums</a>
-      <p class="loading-text">Loading...</p>
+      <p class="loading-text">Loading…</p>
       <button data-playing="false" aria-describedby="drums-play-label">
         <span id="drums-play-label">Play</span>
       </button>
     </li>
     <li data-loading="true">
       <a href="horns.mp3" class="track">Horns</a>
-      <p class="loading-text">Loading...</p>
+      <p class="loading-text">Loading…</p>
       <button data-playing="false" aria-describedby="horns-play-label">
         <span id="horns-play-label">Play</span>
       </button>
     </li>
     <li data-loading="true">
       <a href="clav.mp3" class="track">Clavi</a>
-      <p class="loading-text">Loading...</p>
+      <p class="loading-text">Loading…</p>
       <button data-playing="false" aria-describedby="clavi-play-label">
         <span id="clavi-play-label">Play</span>
       </button>

--- a/files/en-us/games/techniques/control_mechanisms/desktop_with_gamepad/index.md
+++ b/files/en-us/games/techniques/control_mechanisms/desktop_with_gamepad/index.md
@@ -239,7 +239,7 @@ The `textGamepad` object holds the text saying a gamepad has been connected, and
 create() {
     // …
     var message = 'Gamepad connected! Press Y for controls';
-    var textGamepad = this.add.text(message, '…');
+    var textGamepad = this.add.text(0, 0, message);
     textGamepad.visible = false;
 }
 ```

--- a/files/en-us/games/techniques/control_mechanisms/desktop_with_gamepad/index.md
+++ b/files/en-us/games/techniques/control_mechanisms/desktop_with_gamepad/index.md
@@ -84,7 +84,7 @@ Next, in the `draw()` function we do two things — execute the `gamepadUpdateHa
 function draw() {
     ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-    // ...
+    // …
 
     gamepadUpdateHandler();
     if(gamepadButtonPressedHandler(0)) {
@@ -103,7 +103,7 @@ function draw() {
         alert('BOOM!');
     }
 
-    // ...
+    // …
 
     ctx.drawImage(img, playerX, playerY);
     requestAnimationFrame(draw);
@@ -237,9 +237,9 @@ The `textGamepad` object holds the text saying a gamepad has been connected, and
 
 ```js
 create() {
-    // ...
+    // …
     var message = 'Gamepad connected! Press Y for controls';
-    var textGamepad = this.add.text(message, ...);
+    var textGamepad = this.add.text(message, '…');
     textGamepad.visible = false;
 }
 ```
@@ -248,7 +248,7 @@ In the `update()` function, which is executed every frame, we can wait until the
 
 ```js
 update: function() {
-    // ...
+    // …
     if(GamepadAPI.active) {
         if(!this.textGamepad.visible) {
             this.textGamepad.visible = true;
@@ -284,7 +284,7 @@ When the game is started, some introductory text is shown that shows you availab
 
 ```js
 create() {
-    // ...
+    // …
     if(this.game.device.desktop) {
         if(GamepadAPI.active) {
             moveText = 'DPad or left Stick\nto move';

--- a/files/en-us/games/techniques/controls_gamepad_api/index.md
+++ b/files/en-us/games/techniques/controls_gamepad_api/index.md
@@ -168,7 +168,7 @@ buttonPressed: function(button, hold) {
   var newPress = false;
   // loop through pressed buttons
   for(var i=0,s=gamepadAPI.buttonsStatus.length; i<s; i++) {
-    // if we found the button we're looking for...
+    // if we found the button we're looking for…
     if(gamepadAPI.buttonsStatus[i] == button) {
       // set the boolean variable to true
       newPress = true;

--- a/files/en-us/games/techniques/efficient_animation_for_web_games/index.md
+++ b/files/en-us/games/techniques/efficient_animation_for_web_games/index.md
@@ -38,7 +38,7 @@ function doAnimation(timestamp) {
       progress = timestamp - startTime;
   }
 
-  // Do animation …
+  // Perform the animation
   if (progress < animationLength) {
       requestAnimationFrame(doAnimation);
   }

--- a/files/en-us/games/techniques/efficient_animation_for_web_games/index.md
+++ b/files/en-us/games/techniques/efficient_animation_for_web_games/index.md
@@ -55,7 +55,7 @@ To save battery life, it is best to only draw when there are things going on, so
 ```js
 function redraw() {
   drawPending = false;
-  // Do drawing …
+  // Perform the drawing
 }
 
 var drawPending = false;

--- a/files/en-us/games/techniques/efficient_animation_for_web_games/index.md
+++ b/files/en-us/games/techniques/efficient_animation_for_web_games/index.md
@@ -38,7 +38,7 @@ function doAnimation(timestamp) {
       progress = timestamp - startTime;
   }
 
-  // Do animation ...
+  // Do animation …
   if (progress < animationLength) {
       requestAnimationFrame(doAnimation);
   }
@@ -55,7 +55,7 @@ To save battery life, it is best to only draw when there are things going on, so
 ```js
 function redraw() {
   drawPending = false;
-  // Do drawing ...
+  // Do drawing …
 }
 
 var drawPending = false;

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/player_paddle_and_controls/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/player_paddle_and_controls/index.md
@@ -34,7 +34,7 @@ Then, in the `preload` function, load the `paddle` image by adding the following
 
 ```js
 function preload() {
-    // ...
+    // …
     game.load.image('ball', 'img/ball.png');
     game.load.image('paddle', 'img/paddle.png');
 }
@@ -103,14 +103,14 @@ If you haven't already done so, reload your `index.html` and try it out!
 
 ## Position the ball
 
-We have the paddle working as expected, so let's position the ball on it. It's very similar to positioning the paddle — we need to have it placed in the middle of the screen horizontally and at the bottom vertically with a little offset from the bottom. To place it exactly as we want it we will set the anchor to the exact middle of the ball. Find the existing `ball = game.add.sprite( ... )` line, and replace it with the following two lines:
+We have the paddle working as expected, so let's position the ball on it. It's very similar to positioning the paddle — we need to have it placed in the middle of the screen horizontally and at the bottom vertically with a little offset from the bottom. To place it exactly as we want it we will set the anchor to the exact middle of the ball. Find the existing `ball = game.add.sprite( … )` line, and replace it with the following two lines:
 
 ```js
 ball = game.add.sprite(game.world.width*0.5, game.world.height-25, 'ball');
 ball.anchor.set(0.5);
 ```
 
-The velocity stays almost the same — we're just changing the second parameter's value from 150 to -150, so the ball will start the game by moving up instead of down. Find the existing `ball.body.velocity.set( ... )` line and update it to the following:
+The velocity stays almost the same — we're just changing the second parameter's value from 150 to -150, so the ball will start the game by moving up instead of down. Find the existing `ball.body.velocity.set( … )` line and update it to the following:
 
 ```js
 ball.body.velocity.set(150, -150);

--- a/files/en-us/games/tutorials/2d_breakout_game_phaser/player_paddle_and_controls/index.md
+++ b/files/en-us/games/tutorials/2d_breakout_game_phaser/player_paddle_and_controls/index.md
@@ -103,14 +103,14 @@ If you haven't already done so, reload your `index.html` and try it out!
 
 ## Position the ball
 
-We have the paddle working as expected, so let's position the ball on it. It's very similar to positioning the paddle — we need to have it placed in the middle of the screen horizontally and at the bottom vertically with a little offset from the bottom. To place it exactly as we want it we will set the anchor to the exact middle of the ball. Find the existing `ball = game.add.sprite( … )` line, and replace it with the following two lines:
+We have the paddle working as expected, so let's position the ball on it. It's very similar to positioning the paddle — we need to have it placed in the middle of the screen horizontally and at the bottom vertically with a little offset from the bottom. To place it exactly as we want it we will set the anchor to the exact middle of the ball. Find the existing `ball = game.add.sprite()` line, and replace it with the following two lines:
 
 ```js
 ball = game.add.sprite(game.world.width*0.5, game.world.height-25, 'ball');
 ball.anchor.set(0.5);
 ```
 
-The velocity stays almost the same — we're just changing the second parameter's value from 150 to -150, so the ball will start the game by moving up instead of down. Find the existing `ball.body.velocity.set( … )` line and update it to the following:
+The velocity stays almost the same — we're just changing the second parameter's value from 150 to -150, so the ball will start the game by moving up instead of down. Find the existing `ball.body.velocity.set()` line and update it to the following:
 
 ```js
 ball.body.velocity.set(150, -150);

--- a/files/en-us/glossary/constructor/index.md
+++ b/files/en-us/glossary/constructor/index.md
@@ -16,7 +16,7 @@ function Default() {
 
 // This is an overloaded constructor class Overloaded
 // with parameter arguments
-function Overloaded(arg1, arg2, ..., argN){
+function Overloaded(arg1, arg2, …, argN){
 }
 ```
 

--- a/files/en-us/glossary/constructor/index.md
+++ b/files/en-us/glossary/constructor/index.md
@@ -16,7 +16,7 @@ function Default() {
 
 // This is an overloaded constructor class Overloaded
 // with parameter arguments
-function Overloaded(arg1, arg2, …, argN){
+function Overloaded(arg1, arg2, /* …, */ argN){
 }
 ```
 

--- a/files/en-us/glossary/pac/index.md
+++ b/files/en-us/glossary/pac/index.md
@@ -9,7 +9,7 @@ A Proxy Auto-Configuration file (**PAC file**) is a file which contains a functi
 
 ```js
 function FindProxyForURL(url, host) {
-  /* ... */
+  /* … */
 }
 
 ret = FindProxyForURL(url, host)

--- a/files/en-us/glossary/pac/index.md
+++ b/files/en-us/glossary/pac/index.md
@@ -9,7 +9,7 @@ A Proxy Auto-Configuration file (**PAC file**) is a file which contains a functi
 
 ```js
 function FindProxyForURL(url, host) {
-  /* … */
+  // …
 }
 
 ret = FindProxyForURL(url, host)

--- a/files/en-us/learn/accessibility/multimedia/index.md
+++ b/files/en-us/learn/accessibility/multimedia/index.md
@@ -316,7 +316,7 @@ This is the first subtitle.
 00:00:30.739 --> 00:00:34.074
 This is the second.
 
-...
+…
 ```
 
 To get this displayed along with the HTML media playback, you need to:

--- a/files/en-us/learn/accessibility/wai-aria_basics/index.md
+++ b/files/en-us/learn/accessibility/wai-aria_basics/index.md
@@ -128,9 +128,9 @@ WAI-ARIA adds the [`role` attribute](https://www.w3.org/TR/wai-aria-1.1/#role_de
 
 ```html
 <header>
-  <h1>...</h1>
+  <h1>…</h1>
   <nav>
-    <ul>...</ul>
+    <ul>…</ul>
     <form>
       <!-- search form  -->
     </form>
@@ -138,11 +138,11 @@ WAI-ARIA adds the [`role` attribute](https://www.w3.org/TR/wai-aria-1.1/#role_de
 </header>
 
 <main>
-  <article>...</article>
-  <aside>...</aside>
+  <article>…</article>
+  <aside>…</aside>
 </main>
 
-<footer>...</footer>
+<footer>…</footer>
 ```
 
 If you try testing the example with a screenreader in a modern browser, you'll already get some useful information. For example, VoiceOver gives you the following:
@@ -164,9 +164,9 @@ Let's improve it by the use of some ARIA features. First, we'll add some [`role`
 
 ```html
 <header>
-  <h1>...</h1>
+  <h1>…</h1>
   <nav role="navigation">
-    <ul>...</ul>
+    <ul>…</ul>
     <form role="search">
       <!-- search form  -->
     </form>
@@ -174,11 +174,11 @@ Let's improve it by the use of some ARIA features. First, we'll add some [`role`
 </header>
 
 <main>
-  <article role="article">...</article>
-  <aside role="complementary">...</aside>
+  <article role="article">…</article>
+  <aside role="complementary">…</aside>
 </main>
 
-<footer>...</footer>
+<footer>…</footer>
 ```
 
 We've also given you a bonus feature in this example — the {{htmlelement("input")}} element has been given the attribute [`aria-label`](https://www.w3.org/TR/wai-aria-1.1/#aria-label), which gives it a descriptive label to be read out by a screenreader, even though we haven't included a {{htmlelement("label")}} element. In cases like these, this is very useful — a search form like this one is a very common, easily recognized feature, and adding a visual label would spoil the page design.
@@ -371,13 +371,13 @@ To improve things, we've created a new version of the example called [aria-tabbe
 </ul>
 <div class="panels">
   <article class="active-panel" role="tabpanel" aria-hidden="false">
-    ...
+    …
   </article>
   <article role="tabpanel" aria-hidden="true">
-    ...
+    …
   </article>
   <article role="tabpanel" aria-hidden="true">
-    ...
+    …
   </article>
 </div>
 ```

--- a/files/en-us/learn/css/building_blocks/organizing/index.md
+++ b/files/en-us/learn/css/building_blocks/organizing/index.md
@@ -103,15 +103,15 @@ A good tip is to add a block of comments between logical sections in your styles
 ```css
 /* || General styles */
 
-...
+/* … */
 
 /* || Typography */
 
-...
+/* … */
 
 /* || Header and Main Navigation */
 
-...
+/* … */
 ```
 
 You don't need to comment every single thing in your CSS, as much of it will be self-explanatory. What you should comment are the things where you made a particular decision for a reason.
@@ -143,13 +143,13 @@ In this section of the stylesheet we are providing default styling for the type 
 ```css
 /* || GENERAL STYLES */
 
-body { ... }
+body { /* … */ }
 
-h1, h2, h3, h4 { ... }
+h1, h2, h3, h4 { /* … */ }
 
-ul { ... }
+ul { /* … */ }
 
-blockquote { ... }
+blockquote { /* … */ }
 ```
 
 After this section, we could define a few utility classes, for example, a class that removes the default list style for lists we're going to display as flex items or in some other way. If you have a few styling choices you know you will want to apply to lots of different elements, they can be put in this section.
@@ -163,7 +163,7 @@ After this section, we could define a few utility classes, for example, a class 
   padding: 0;
 }
 
-...
+/* … */
 ```
 
 Then we can add everything that is used sitewide. That might be things like the basic page layout, the header, navigation styling, and so on.
@@ -171,9 +171,9 @@ Then we can add everything that is used sitewide. That might be things like the 
 ```css
 /* || SITEWIDE */
 
-.main-nav { ... }
+.main-nav { /* … */ }
 
-.logo { ... }
+.logo { /* … */ }
 ```
 
 Finally, we will include CSS for specific things, broken down by the context, page, or even component in which they are used.
@@ -181,9 +181,9 @@ Finally, we will include CSS for specific things, broken down by the context, pa
 ```css
 /* || STORE PAGES */
 
-.product-listing { ... }
+.product-listing { /* … */ }
 
-.product-box { ... }
+.product-box { /* … */ }
 ```
 
 By ordering things in this way, we at least have an idea in which part of the stylesheet we will be looking for something that we want to change.

--- a/files/en-us/learn/css/css_layout/positioning/index.md
+++ b/files/en-us/learn/css/css_layout/positioning/index.md
@@ -385,7 +385,7 @@ You should now see the finished example:
 
 <p>I am a basic block level element. My adjacent block level elements sit on new lines below me.</p>
 
-<p class="positioned">I'm not positioned any more…</p>
+<p class="positioned">I'm not positioned any more.</p>
 
 <p>We are separated by our margins. Because of margin collapsing, we are separated by the width of one of our margins, not both.</p>
 

--- a/files/en-us/learn/css/css_layout/positioning/index.md
+++ b/files/en-us/learn/css/css_layout/positioning/index.md
@@ -51,7 +51,7 @@ Static positioning is the default that every element gets. It just means "put th
 To see this (and get your example set up for future sections) first add a `class` of `positioned` to the second {{htmlelement("p")}} in the HTML:
 
 ```html
-<p class="positioned"> ... </p>
+<p class="positioned"> … </p>
 ```
 
 Now add the following rule to the bottom of your CSS:
@@ -385,7 +385,7 @@ You should now see the finished example:
 
 <p>I am a basic block level element. My adjacent block level elements sit on new lines below me.</p>
 
-<p class="positioned">I'm not positioned any more...</p>
+<p class="positioned">I'm not positioned any more…</p>
 
 <p>We are separated by our margins. Because of margin collapsing, we are separated by the width of one of our margins, not both.</p>
 

--- a/files/en-us/learn/css/css_layout/practical_positioning_examples/index.md
+++ b/files/en-us/learn/css/css_layout/practical_positioning_examples/index.md
@@ -325,7 +325,7 @@ As a starting point, make a local copy of [hidden-info-panel-start.html](https:/
 <input type="checkbox" id="toggle">
 <aside>
 
-<!-- … -->
+…
 
 </aside>
 ```

--- a/files/en-us/learn/css/css_layout/practical_positioning_examples/index.md
+++ b/files/en-us/learn/css/css_layout/practical_positioning_examples/index.md
@@ -325,7 +325,7 @@ As a starting point, make a local copy of [hidden-info-panel-start.html](https:/
 <input type="checkbox" id="toggle">
 <aside>
 
-  ...
+<!-- … -->
 
 </aside>
 ```

--- a/files/en-us/learn/css/first_steps/how_css_is_structured/index.md
+++ b/files/en-us/learn/css/first_steps/how_css_is_structured/index.md
@@ -251,7 +251,7 @@ p {
 
 However, in the case of our earlier example with the conflict between the class selector and the element selector, the class prevails, rendering the paragraph text red. How can this happen even though a conflicting style appears later in the stylesheet? A class is rated as being more specific, as in having more **specificity** than the element selector, so it cancels the other conflicting style declaration.
 
-Try this experiment for yourself! Add HTML, then add the two `p { ... }` rules to your stylesheet. Next, change the first `p` selector to `.special` to see how it changes the styling.
+Try this experiment for yourself! Add HTML, then add the two `p { }` rules to your stylesheet. Next, change the first `p` selector to `.special` to see how it changes the styling.
 
 The rules of specificity and the cascade can seem complicated at first. These rules are easier to understand as you become more familiar with CSS. The [Cascade and inheritance](/en-US/docs/Learn/CSS/Building_blocks/Cascade_and_inheritance) section in the next module explains this in detail, including how to calculate specificity.
 

--- a/files/en-us/learn/forms/your_first_form/index.md
+++ b/files/en-us/learn/forms/your_first_form/index.md
@@ -295,7 +295,7 @@ Let's look at some of our form code again:
     <textarea id="msg" name="user_message"></textarea>
   </li>
 
-<!-- … -->
+…
 ```
 
 In our example, the form will send 3 pieces of data named "`user_name`", "`user_email`", and "`user_message`".

--- a/files/en-us/learn/forms/your_first_form/index.md
+++ b/files/en-us/learn/forms/your_first_form/index.md
@@ -295,7 +295,7 @@ Let's look at some of our form code again:
     <textarea id="msg" name="user_message"></textarea>
   </li>
 
-  ...
+<!-- … -->
 ```
 
 In our example, the form will send 3 pieces of data named "`user_name`", "`user_email`", and "`user_message`".

--- a/files/en-us/learn/server-side/django/development_environment/index.md
+++ b/files/en-us/learn/server-side/django/development_environment/index.md
@@ -232,7 +232,7 @@ At this point you should see a bunch of scripts being run as shown below:
 ```bash
 virtualenvwrapper.user_scripts creating /home/ubuntu/.virtualenvs/premkproject
 virtualenvwrapper.user_scripts creating /home/ubuntu/.virtualenvs/postmkproject
-...
+# …
 virtualenvwrapper.user_scripts creating /home/ubuntu/.virtualenvs/preactivate
 virtualenvwrapper.user_scripts creating /home/ubuntu/.virtualenvs/postactivate
 virtualenvwrapper.user_scripts creating /home/ubuntu/.virtualenvs/get_env_details
@@ -313,7 +313,7 @@ Now you can create a new virtual environment with the `mkvirtualenv` command. As
 $ mkvirtualenv my_django_environment
 
 Running virtualenv with interpreter /usr/bin/python3
-...
+# …
 virtualenvwrapper.user_scripts creating /home/ubuntu/.virtualenvs/t_env7/bin/get_env_details
 (my_django_environment) ubuntu@ubuntu:~$
 ```
@@ -389,7 +389,7 @@ We can run the _development web server_ from within this folder using **manage.p
 ```bash
 $ python3 manage.py runserver
 Watching for file changes with StatReloader
-Performing system checks...
+Performing system checks…
 
 System check identified no issues (0 silenced).
 

--- a/files/en-us/learn/server-side/django/django_assessment_blog/index.md
+++ b/files/en-us/learn/server-side/django/django_assessment_blog/index.md
@@ -301,7 +301,7 @@ We briefly talked about passing a context to the template in a class-based view 
 
 ```python
 class SomeView(generic.ListView):
-    ...
+    # …
 
     def get_context_data(self, **kwargs):
         # Call the base implementation first to get a context

--- a/files/en-us/learn/server-side/django/introduction/index.md
+++ b/files/en-us/learn/server-side/django/introduction/index.md
@@ -172,7 +172,8 @@ class Team(models.Model):
         ('U09', 'Under 09s'),
         ('U10', 'Under 10s'),
         ('U11', 'Under 11s'),
-        ...  #list other team levels
+        # …
+        # list other team levels
     )
     team_level = models.CharField(max_length=3, choices=TEAM_LEVELS, default='U11')
 ```

--- a/files/en-us/learn/server-side/django/models/index.md
+++ b/files/en-us/learn/server-side/django/models/index.md
@@ -80,7 +80,7 @@ class MyModelName(models.Model):
 
     # Fields
     my_field_name = models.CharField(max_length=20, help_text='Enter field documentation')
-    ...
+    # …
 
     # Metadata
     class Meta:

--- a/files/en-us/learn/server-side/node_server_without_framework/index.md
+++ b/files/en-us/learn/server-side/node_server_without_framework/index.md
@@ -97,7 +97,7 @@ Afterward is the function for creating the server. `https.createServer` returns 
 
 ```js
 http.createServer(function (request, response) {
-    ...
+    // …
 }).listen(8125);
 console.log('Server running at http://127.0.0.1:8125/');
 ```
@@ -143,7 +143,7 @@ Lastly, we respond to the client with the file information. This function reads 
 
 ```js
 fs.readFile(filePath, function(error, content) {
-    ...
+    // …
 });
 ```
 

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/html_and_css/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/html_and_css/index.md
@@ -179,7 +179,7 @@ The button has a number of declarations that style, but the two we are most inte
 
 ```css
 button {
-  ...
+  /* … */
 
   background-color: #ff0000;
   background-color: rgba(255,0,0,1);
@@ -232,7 +232,7 @@ It isn't that simple, however — you also need to create a copy of each element
 
 ```js
 const asideElem = document.createElement('aside');
- ...
+ /* … */
 ```
 
 This sounds like a pain to deal with, but fortunately there is a {{glossary("polyfill")}} available that does the necessary fixes for you, and more besides — see [HTML5Shiv](https://github.com/aFarkas/html5shiv) for all the details (see [manual installation](https://github.com/aFarkas/html5shiv#installation) for the simplest usage).

--- a/files/en-us/mdn/structures/compatibility_tables/index.md
+++ b/files/en-us/mdn/structures/compatibility_tables/index.md
@@ -233,7 +233,7 @@ There is a fourth, optional, member that can go inside the `__compat` member —
         }
       }
 
-      // … etc.
+      // …
     }
   }
 }
@@ -284,7 +284,7 @@ For an API, you've got the top two levels defined as `api.name-of-the-interface`
         }
       },
 
-      // … etc.
+      // …
 
     }
   }

--- a/files/en-us/mdn/structures/compatibility_tables/index.md
+++ b/files/en-us/mdn/structures/compatibility_tables/index.md
@@ -116,7 +116,7 @@ Let's look at an example. CSS property JSON files for example need the following
     "properties": {
       "border-width": {
         "__compat": {
-          ...
+          // …
         }
       }
     }
@@ -140,7 +140,7 @@ In HTML, CSS, and JS pages, you'll normally only need one feature. API interface
 
 Inside a feature `__compat` member, you need to include the following members:
 
-- `mdn_url`: Contains the URL of the reference page for this feature on MDN. Note that this needs to be written without the locale directory inside, e.g. `/docs/...` not `/en-US/docs/...`. This is added in by the macro when the data is put on the page, for localization purposes.
+- `mdn_url`: Contains the URL of the reference page for this feature on MDN. Note that this needs to be written without the locale directory inside, e.g. `/docs/…` not `/en-US/docs/…`. This is added in by the macro when the data is put on the page, for localization purposes.
 - `spec_url`: URL or array of URLs to specification(s) in which this feature is defined.
 - `support`: Contains members representing the browser support information for this feature in all the different browsers we want to report.
 - `status`: Contains members reporting the standards track status of this feature.
@@ -221,19 +221,19 @@ There is a fourth, optional, member that can go inside the `__compat` member —
   "api": {
     "AbortController": {
       "__compat": {
-        ...
+        // …
       },
       "AbortController": {
         "__compat": {
           "mdn_url": "https://developer.mozilla.org/docs/Web/API/AbortController/AbortController",
           "description": "<code>AbortController()</code> constructor",
           "support": {
-            ...
+            …
           }
         }
       }
 
-      ... etc.
+      // … etc.
     }
   }
 }
@@ -251,11 +251,11 @@ As an example, see the [compat data](https://github.com/mdn/browser-compat-data/
     "properties": {
       "background-color": {
         "__compat": {
-          ...
+          // …
         },
         "alpha_ch_for_hex": {
           "__compat": {
-            ...
+            // …
           },
         }
       }
@@ -271,20 +271,20 @@ For an API, you've got the top two levels defined as `api.name-of-the-interface`
   "api": {
     "VRDisplay": {
       "__compat": {
-        ...
+        // …
       },
       "cancelAnimationFrame": {
         "__compat": {
-          ...
+          // …
         }
       },
       "capabilities": {
         "__compat": {
-          ...
+          // …
         }
       },
 
-      ... etc.
+      // … etc.
 
     }
   }
@@ -478,7 +478,7 @@ For example, for the {{domxref("AbortController")}} this would be added as shown
 title: AbortController
 slug: Web/API/AbortController
 
-...
+…
 
 browser-compat: api.AbortController
 ---


### PR DESCRIPTION
Ellipsis in markdown code blocks are syntax errors.

In order to have smooth transition to Prettier and ESLint the PR comments out such bare ellipses. Refer the [discussion](https://github.com/mdn/content/pull/18171#issuecomment-1179670484) for more context.

@Josh-Cena, @teoli2003 will this changes make Prettier-ESLint happy?