### PR TITLE
Missing spaces, batch 4

### DIFF
--- a/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
@@ -74,7 +74,7 @@ The summary paragraph — start by naming the interface, saying what API it is p
 
 _Also inherits properties from its parent interface, {{DOMxRef("NameOfParentInterface")}}._ (Note: If the interface doesn't inherit from another interface, remove this whole line.)
 
-- {{DOMxRef("NameOfTheInterface.property1")}}{{ReadOnlyInline}} {{Deprecated_Inline}}
+- {{DOMxRef("NameOfTheInterface.property1")}} {{ReadOnlyInline}} {{Deprecated_Inline}}
   - : Include a brief description of the property and what it does here. Include one term and definition for each property. If the property is not readonly/experimental/deprecated, remove the relevant macro calls.
 - {{DOMxRef("NameOfTheInterface.property2")}}
   - : etc.

--- a/files/en-us/mdn/structures/page_types/html_element_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/html_element_page_template/index.md
@@ -90,7 +90,7 @@ Further information — at this point, include a few more paragraphs explaining 
 
 This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attributes).
 
-- {{htmlattrdef("attribute1")}}{{Deprecated_inline}}{{experimental_inline}}
+- {{htmlattrdef("attribute1")}} {{Deprecated_inline}} {{experimental_inline}}
   - : Include description here of what the attribute does. Include one term and definition for each attribute. If the attribute is not experimental/deprecated, remove the relevant macro calls.
 - {{htmlattrdef("attribute2")}}
   - : etc.

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/index.md
@@ -24,7 +24,7 @@ Utilities related to your extension. Get URLs to resources packages with your ex
 
 ## Properties
 
-- {{WebExtAPIRef("extension.lastError")}}{{deprecated_inline}}
+- {{WebExtAPIRef("extension.lastError")}} {{deprecated_inline}}
   - : Set for the lifetime of a callback if an asynchronous extension API has resulted in an error. If no error has occurred, `lastError` will be {{jsxref("undefined")}}.
 - {{WebExtAPIRef("extension.inIncognitoContext")}}
   - : `True` for content scripts running inside incognito tabs, and for extension pages running inside an incognito process. (The latter only applies to extensions with '`split`' `incognito_behavior`.)

--- a/files/en-us/mozilla/add-ons/webextensions/api/notifications/templatetype/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/notifications/templatetype/index.md
@@ -27,9 +27,9 @@ Values of this type are strings. Possible values are:
 
   - a title (`NotificationOptions.title`)
   - a message (`NotificationOptions.message`)
-  - an icon (`NotificationOptions.iconUrl`){{optional_inline}}
-  - an extra message (`NotificationOptions.contextMessage`){{optional_inline}}
-  - up to two buttons (`NotificationOptions.buttons`){{optional_inline}}
+  - an icon (`NotificationOptions.iconUrl`) {{optional_inline}}
+  - an extra message (`NotificationOptions.contextMessage`) {{optional_inline}}
+  - up to two buttons (`NotificationOptions.buttons`) {{optional_inline}}
 
 - `"image"`: everything in `"basic"` and also:
 

--- a/files/en-us/web/api/attr/index.md
+++ b/files/en-us/web/api/attr/index.md
@@ -39,7 +39,7 @@ _This interface also inherits the properties of its parent interfaces, {{domxref
   - : The {{domxref("Element")}} the attribute belongs to.
 - {{domxref("Attr.prefix", "prefix")}} {{readOnlyInline}}
   - : A string representing the namespace prefix of the attribute, or `null` if a namespace without prefix or no namespace are specified.
-- {{domxref("Attr.specified", "specified")}} {{readOnlyInline}}{{deprecated_inline}}
+- {{domxref("Attr.specified", "specified")}} {{readOnlyInline}} {{deprecated_inline}}
   - : This property always returns `true`.
 - {{domxref("Attr.value", "value")}}
   - : The attribute's value, a string that can be set and get using this property.

--- a/files/en-us/web/api/audiodata/index.md
+++ b/files/en-us/web/api/audiodata/index.md
@@ -38,17 +38,17 @@ In planar format, the number of planes is equal to {{domxref("AudioData.numberOf
 
 ## Properties
 
-- {{domxref("AudioData.format")}}{{ReadOnlyInline}}
+- {{domxref("AudioData.format")}} {{ReadOnlyInline}}
   - : Returns the sample format of the audio.
-- {{domxref("AudioData.sampleRate")}}{{ReadOnlyInline}}
+- {{domxref("AudioData.sampleRate")}} {{ReadOnlyInline}}
   - : Returns the sample rate of the audio in Hz.
-- {{domxref("AudioData.numberOfFrames")}}{{ReadOnlyInline}}
+- {{domxref("AudioData.numberOfFrames")}} {{ReadOnlyInline}}
   - : Returns the number of frames.
-- {{domxref("AudioData.numberOfChannels")}}{{ReadOnlyInline}}
+- {{domxref("AudioData.numberOfChannels")}} {{ReadOnlyInline}}
   - : Returns the number of audio channels.
-- {{domxref("AudioData.duration")}}{{ReadOnlyInline}}
+- {{domxref("AudioData.duration")}} {{ReadOnlyInline}}
   - : Returns the duration of the audio in microseconds.
-- {{domxref("AudioData.timestamp")}}{{ReadOnlyInline}}
+- {{domxref("AudioData.timestamp")}} {{ReadOnlyInline}}
   - : Returns the timestamp of the audio in microseconds.
 
 ## Methods

--- a/files/en-us/web/api/audiodecoder/index.md
+++ b/files/en-us/web/api/audiodecoder/index.md
@@ -20,9 +20,9 @@ The **`AudioDecoder`** interface of the {{domxref('WebCodecs API','','',' ')}} d
 
 ## Properties
 
-- {{domxref("AudioDecoder.decodeQueueSize")}}{{ReadOnlyInline}}
+- {{domxref("AudioDecoder.decodeQueueSize")}} {{ReadOnlyInline}}
   - : An integer representing the number of decode queue requests.
-- {{domxref("AudioDecoder.state")}}{{ReadOnlyInline}}
+- {{domxref("AudioDecoder.state")}} {{ReadOnlyInline}}
   - : Represents the state of the underlying codec and whether it is configured for decoding.
 
 ## Methods

--- a/files/en-us/web/api/audioencoder/index.md
+++ b/files/en-us/web/api/audioencoder/index.md
@@ -19,9 +19,9 @@ The **`AudioEncoder`** interface of the [WebCodecs API](/en-US/docs/Web/API/WebC
 
 ## Properties
 
-- {{domxref("AudioEncoder.encodeQueueSize")}}{{ReadOnlyInline}}
+- {{domxref("AudioEncoder.encodeQueueSize")}} {{ReadOnlyInline}}
   - : An integer representing the number of encode queue requests.
-- {{domxref("AudioEncoder.state")}}{{ReadOnlyInline}}
+- {{domxref("AudioEncoder.state")}} {{ReadOnlyInline}}
   - : Represents the state of the underlying codec and whether it is configured for encoding.
 
 ## Methods

--- a/files/en-us/web/api/authenticatorassertionresponse/index.md
+++ b/files/en-us/web/api/authenticatorassertionresponse/index.md
@@ -24,13 +24,13 @@ This interface inherits from {{domxref("AuthenticatorResponse")}}.
 
 ## Properties
 
-- `AuthenticatorAssertionResponse.clientDataJSON` {{securecontext_inline}}{{readonlyinline}}
+- `AuthenticatorAssertionResponse.clientDataJSON` {{securecontext_inline}} {{readonlyinline}}
   - : The client data for the authentication, such as origin and challenge. The {{domxref("AuthenticatorAttestationResponse.clientDataJSON","clientDataJSON")}} property is inherited from the {{domxref("AuthenticatorResponse")}}.
-- {{domxref("AuthenticatorAssertionResponse.authenticatorData")}} {{securecontext_inline}}{{readonlyinline}}
+- {{domxref("AuthenticatorAssertionResponse.authenticatorData")}} {{securecontext_inline}} {{readonlyinline}}
   - : An {{jsxref("ArrayBuffer")}} containing information from the authenticator such as the Relying Party ID Hash (rpIdHash), a signature counter, test of user presence and user verification flags, and any extensions processed by the authenticator.
-- {{domxref("AuthenticatorAssertionResponse.signature")}} {{securecontext_inline}}{{readonlyinline}}
+- {{domxref("AuthenticatorAssertionResponse.signature")}} {{securecontext_inline}} {{readonlyinline}}
   - : An assertion signature over {{domxref("AuthenticatorAssertionResponse.authenticatorData")}} and {{domxref("AuthenticatorResponse.clientDataJSON")}}. The assertion signature is created with the private key of keypair that was created during the {{domxref("CredentialsContainer.create()","navigator.credentials.create()")}} call and verified using the public key of that same keypair.
-- {{domxref("AuthenticatorAssertionResponse.userHandle")}} {{securecontext_inline}}{{readonlyinline}}
+- {{domxref("AuthenticatorAssertionResponse.userHandle")}} {{securecontext_inline}} {{readonlyinline}}
   - : An {{jsxref("ArrayBuffer")}} containing an opaque user identifier.
 
 ## Methods

--- a/files/en-us/web/api/authenticatorattestationresponse/index.md
+++ b/files/en-us/web/api/authenticatorattestationresponse/index.md
@@ -24,14 +24,14 @@ This interface inherits from {{domxref("AuthenticatorResponse")}}.
 
 ## Properties
 
-- `AuthenticatorAttestationResponse.clientDataJSON` {{securecontext_inline}}{{readonlyinline}}
+- `AuthenticatorAttestationResponse.clientDataJSON` {{securecontext_inline}} {{readonlyinline}}
   - : Client data for the authentication, such as origin and challenge. The {{domxref("AuthenticatorResponse.clientDataJSON","clientDataJSON")}} property is inherited from the {{domxref("AuthenticatorResponse")}}.
-- {{domxref("AuthenticatorAttestationResponse.attestationObject")}} {{securecontext_inline}}{{readonlyinline}}
+- {{domxref("AuthenticatorAttestationResponse.attestationObject")}} {{securecontext_inline}} {{readonlyinline}}
   - : An {{jsxref("ArrayBuffer")}} containing authenticator data and an attestation statement for a newly-created key pair.
 
 ## Methods
 
-- {{domxref("AuthenticatorAttestationResponse.getTransports()")}}{{securecontext_inline}}
+- {{domxref("AuthenticatorAttestationResponse.getTransports()")}} {{securecontext_inline}}
   - : Returns an {{jsxref("Array")}} of strings describing which transport methods (e.g. `usb`, `nfc`) are believed to be supported with the authenticator. The array may be empty if the information is not available.
 
 ## Examples

--- a/files/en-us/web/api/backgroundfetchevent/index.md
+++ b/files/en-us/web/api/backgroundfetchevent/index.md
@@ -26,7 +26,7 @@ It is the event type passed to `onbackgroundfetchabort` and `onbackgroundfetchcl
 
 _Inherits properties from its ancestor, {{domxref("Event")}}_.
 
-- {{domxref("BackgroundFetchEvent.registration")}}{{ReadOnlyInline}}
+- {{domxref("BackgroundFetchEvent.registration")}} {{ReadOnlyInline}}
   - : Returns the {{domxref("BackgroundFetchRegistration")}} that the event was initialized to.
 
 ### Event handlers

--- a/files/en-us/web/api/backgroundfetchrecord/index.md
+++ b/files/en-us/web/api/backgroundfetchrecord/index.md
@@ -19,9 +19,9 @@ There will be one `BackgroundFetchRecord` for each resource requested by `fetch(
 
 ## Properties
 
-- {{domxref("BackgroundFetchRecord.request","request")}}{{ReadOnlyInline}}
+- {{domxref("BackgroundFetchRecord.request","request")}} {{ReadOnlyInline}}
   - : Returns a {{domxref("Request")}}.
-- {{domxref("BackgroundFetchRecord.responseReady","responseReady")}}{{ReadOnlyInline}}
+- {{domxref("BackgroundFetchRecord.responseReady","responseReady")}} {{ReadOnlyInline}}
   - : Returns a promise that resolves with a {{domxref("Response")}}.
 
 ## Examples

--- a/files/en-us/web/api/backgroundfetchregistration/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/index.md
@@ -21,19 +21,19 @@ A `BackgroundFetchRegistration` instance is returned by the {{domxref("Backgroun
 
 The following properties are available synchronously, as convenience properties copied from those in the `BackgroundFetchRegistration` instance.
 
-- {{domxref("BackgroundFetchRegistration.id")}}{{ReadOnlyInline}}
+- {{domxref("BackgroundFetchRegistration.id")}} {{ReadOnlyInline}}
   - : A string containing the background fetch's ID.
-- {{domxref("BackgroundFetchRegistration.uploadTotal")}}{{ReadOnlyInline}}
+- {{domxref("BackgroundFetchRegistration.uploadTotal")}} {{ReadOnlyInline}}
   - : A {{jsxref("number")}} containing the total number of bytes to be uploaded.
-- {{domxref("BackgroundFetchRegistration.uploaded")}}{{ReadOnlyInline}}
+- {{domxref("BackgroundFetchRegistration.uploaded")}} {{ReadOnlyInline}}
   - : A {{jsxref("number")}} containing the size in bytes successfully sent, initially `0`.
-- {{domxref("BackgroundFetchRegistration.downloadTotal")}}{{ReadOnlyInline}}
+- {{domxref("BackgroundFetchRegistration.downloadTotal")}} {{ReadOnlyInline}}
   - : A {{jsxref("number")}} containing the total size in bytes of this download. This is the value set when the background fetch was registered, or `0`.
-- {{domxref("BackgroundFetchRegistration.downloaded")}}{{ReadOnlyInline}}
+- {{domxref("BackgroundFetchRegistration.downloaded")}} {{ReadOnlyInline}}
   - : A {{jsxref("number")}} containing the size in bytes that has been downloaded, initially `0`.
-- {{domxref("BackgroundFetchRegistration.result")}}{{ReadOnlyInline}}
+- {{domxref("BackgroundFetchRegistration.result")}} {{ReadOnlyInline}}
   - : Returns an empty string initially, on completion either the string `"success"` or `"failure"`.
-- {{domxref("BackgroundFetchRegistration.failureReason")}}{{ReadOnlyInline}}
+- {{domxref("BackgroundFetchRegistration.failureReason")}} {{ReadOnlyInline}}
 
   - : One of the following strings:
 
@@ -50,7 +50,7 @@ The following properties are available synchronously, as convenience properties 
     - `"download-total-exceeded"`
       - : The provided `downloadTotal` was exceeded. This value was set when the background fetch was registered.
 
-- {{domxref("BackgroundFetchRegistration.recordsAvailable")}}{{ReadOnlyInline}}
+- {{domxref("BackgroundFetchRegistration.recordsAvailable")}} {{ReadOnlyInline}}
   - : A {{jsxref("boolean")}} indicating whether the `recordsAvailable` flag is set.
 
 ## Methods

--- a/files/en-us/web/api/barprop/index.md
+++ b/files/en-us/web/api/barprop/index.md
@@ -30,7 +30,7 @@ The `BarProp` interface is not accessed directly, but via one of these elements.
 
 ## Properties
 
-- {{domxref("BarProp.visible")}}{{ReadOnlyInline}}
+- {{domxref("BarProp.visible")}} {{ReadOnlyInline}}
   - : A {{jsxref("Boolean")}}, which is true if the bar represented by the used interface element is visible.
 
 ## Examples

--- a/files/en-us/web/api/battery_status_api/index.md
+++ b/files/en-us/web/api/battery_status_api/index.md
@@ -23,7 +23,7 @@ The **Battery Status API**, more often referred to as the **Battery API**, provi
 
 - {{domxref("BatteryManager")}}
   - : Provides information about the system's battery charge level.
-- {{domxref("navigator.getBattery()")}}{{readonlyInline}}
+- {{domxref("navigator.getBattery()")}} {{readonlyInline}}
   - : Returns a {{JSxRef("Promise")}} that resolves with a {{DOMxRef("BatteryManager")}} object.
 
 ## Example

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/index.md
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/index.md
@@ -20,23 +20,23 @@ This interface is returned by calling {{DOMxRef("BluetoothRemoteGATTCharacterist
 
 ## Properties
 
-- {{DOMxRef("BluetoothCharacteristicProperties.authenticatedSignedWrites","authenticatedSignedWrites")}}{{ReadOnlyInline}}
+- {{DOMxRef("BluetoothCharacteristicProperties.authenticatedSignedWrites","authenticatedSignedWrites")}} {{ReadOnlyInline}}
   - : Returns a `boolean` that is `true` if signed writing to the characteristic value is permitted.
-- {{DOMxRef("BluetoothCharacteristicProperties.broadcast", "broadcast")}}{{ReadOnlyInline}}
+- {{DOMxRef("BluetoothCharacteristicProperties.broadcast", "broadcast")}} {{ReadOnlyInline}}
   - : Returns a `boolean` that is `true` if the broadcast of the characteristic value is permitted using the Server Characteristic Configuration Descriptor.
-- {{DOMxRef("BluetoothCharacteristicProperties.indicate","indicate")}}{{ReadOnlyInline}}
+- {{DOMxRef("BluetoothCharacteristicProperties.indicate","indicate")}} {{ReadOnlyInline}}
   - : Returns a `boolean` that is `true` if indications of the characteristic value with acknowledgement is permitted.
-- {{DOMxRef("BluetoothCharacteristicProperties.notify","notify")}}{{ReadOnlyInline}}
+- {{DOMxRef("BluetoothCharacteristicProperties.notify","notify")}} {{ReadOnlyInline}}
   - : Returns a `boolean` that is `true` if notifications of the characteristic value without acknowledgement is permitted.
-- {{DOMxRef("BluetoothCharacteristicProperties.read", "read")}}{{ReadOnlyInline}}
+- {{DOMxRef("BluetoothCharacteristicProperties.read", "read")}} {{ReadOnlyInline}}
   - : Returns a `boolean` that is `true` if the reading of the characteristic value is permitted.
-- {{DOMxRef("BluetoothCharacteristicProperties.reliableWrite","reliableWrite")}}{{ReadOnlyInline}}
+- {{DOMxRef("BluetoothCharacteristicProperties.reliableWrite","reliableWrite")}} {{ReadOnlyInline}}
   - : Returns a `boolean` that is `true` if reliable writes to the characteristic is permitted.
-- {{DOMxRef("BluetoothCharacteristicProperties.writableAuxiliaries","writableAuxiliaries")}}{{ReadOnlyInline}}
+- {{DOMxRef("BluetoothCharacteristicProperties.writableAuxiliaries","writableAuxiliaries")}} {{ReadOnlyInline}}
   - : Returns a `boolean` that is `true` if reliable writes to the characteristic descriptor is permitted.
-- {{DOMxRef("BluetoothCharacteristicProperties.write","write")}}{{ReadOnlyInline}}
+- {{DOMxRef("BluetoothCharacteristicProperties.write","write")}} {{ReadOnlyInline}}
   - : Returns a `boolean` that is `true` if the writing to the characteristic with response is permitted.
-- {{DOMxRef("BluetoothCharacteristicProperties.writeWithoutResponse","writeWithoutResponse")}}{{ReadOnlyInline}}
+- {{DOMxRef("BluetoothCharacteristicProperties.writeWithoutResponse","writeWithoutResponse")}} {{ReadOnlyInline}}
   - : Returns a `boolean` that is `true` if the writing to the characteristic without response is permitted.
 
 ## Examples

--- a/files/en-us/web/api/bluetoothdevice/index.md
+++ b/files/en-us/web/api/bluetoothdevice/index.md
@@ -21,11 +21,11 @@ environment.
 
 ## Properties
 
-- {{DOMxRef("BluetoothDevice.id")}} {{Experimental_Inline}}{{ReadOnlyInline}}
+- {{DOMxRef("BluetoothDevice.id")}} {{Experimental_Inline}} {{ReadOnlyInline}}
   - : A string that uniquely identifies a device.
-- {{DOMxRef("BluetoothDevice.name")}} {{Experimental_Inline}}{{ReadOnlyInline}}
+- {{DOMxRef("BluetoothDevice.name")}} {{Experimental_Inline}} {{ReadOnlyInline}}
   - : A string that provides a human-readable name for the device.
-- {{DOMxRef("BluetoothDevice.gatt")}} {{Experimental_Inline}}{{ReadOnlyInline}}
+- {{DOMxRef("BluetoothDevice.gatt")}} {{Experimental_Inline}} {{ReadOnlyInline}}
   - : A reference to the device's {{DOMxRef("BluetoothRemoteGATTServer")}}.
 
 ## Methods

--- a/files/en-us/web/api/bluetoothremotegattcharacteristic/index.md
+++ b/files/en-us/web/api/bluetoothremotegattcharacteristic/index.md
@@ -20,13 +20,13 @@ The `BluetoothRemoteGattCharacteristic` interface of the [Web Bluetooth API](/en
 
 ## Properties
 
-- {{DOMxRef("BluetoothRemoteGATTCharacteristic.service")}}{{ReadOnlyInline}}
+- {{DOMxRef("BluetoothRemoteGATTCharacteristic.service")}} {{ReadOnlyInline}}
   - : Returns the {{DOMxRef("BluetoothRemoteGATTService")}} this characteristic belongs to.
-- {{DOMxRef("BluetoothRemoteGATTCharacteristic.uuid")}}{{ReadOnlyInline}}
+- {{DOMxRef("BluetoothRemoteGATTCharacteristic.uuid")}} {{ReadOnlyInline}}
   - : Returns a string containing the UUID of the characteristic, for example `'00002a37-0000-1000-8000-00805f9b34fb'` for the Heart Rate Measurement characteristic.
-- {{DOMxRef("BluetoothRemoteGATTCharacteristic.properties")}}{{ReadOnlyInline}}
+- {{DOMxRef("BluetoothRemoteGATTCharacteristic.properties")}} {{ReadOnlyInline}}
   - : Returns the properties of this characteristic.
-- {{DOMxRef("BluetoothRemoteGATTCharacteristic.value")}}{{ReadOnlyInline}}
+- {{DOMxRef("BluetoothRemoteGATTCharacteristic.value")}} {{ReadOnlyInline}}
   - : The currently cached characteristic value. This value gets updated when the value of the characteristic is read or updated via a notification or indication.
 
 ### Events

--- a/files/en-us/web/api/bluetoothremotegattdescriptor/index.md
+++ b/files/en-us/web/api/bluetoothremotegattdescriptor/index.md
@@ -19,14 +19,14 @@ which provides further information about a characteristic's value.
 
 ## Properties
 
-- {{DOMxRef("BluetoothRemoteGATTDescriptor.characteristic")}}{{ReadOnlyInline}}
+- {{DOMxRef("BluetoothRemoteGATTDescriptor.characteristic")}} {{ReadOnlyInline}}
   - : Returns the {{DOMxRef("BluetoothRemoteGATTCharacteristic")}} this descriptor belongs
     to.
-- {{DOMxRef("BluetoothRemoteGATTDescriptor.uuid")}}{{ReadOnlyInline}}
+- {{DOMxRef("BluetoothRemoteGATTDescriptor.uuid")}} {{ReadOnlyInline}}
   - : Returns the UUID of the characteristic descriptor, for
     example '`00002902-0000-1000-8000-00805f9b34fb`' for theClient
     Characteristic Configuration descriptor.
-- {{DOMxRef("BluetoothRemoteGATTDescriptor.value")}}{{ReadOnlyInline}}
+- {{DOMxRef("BluetoothRemoteGATTDescriptor.value")}} {{ReadOnlyInline}}
   - : Returns the currently cached descriptor value. This value gets updated when the
     value of the descriptor is read.
 

--- a/files/en-us/web/api/bluetoothremotegattserver/index.md
+++ b/files/en-us/web/api/bluetoothremotegattserver/index.md
@@ -19,11 +19,11 @@ Server on a remote device.
 
 ## Properties
 
-- {{DOMxRef("BluetoothRemoteGATTServer.connected")}}{{ReadOnlyInline}}
+- {{DOMxRef("BluetoothRemoteGATTServer.connected")}} {{ReadOnlyInline}}
   - : A boolean value that returns true while this script execution environment is
     connected to `this.device`. It can be false while the user agent is
     physically connected.
-- {{DOMxRef("BluetoothRemoteGATTServer.device")}}{{ReadOnlyInline}}
+- {{DOMxRef("BluetoothRemoteGATTServer.device")}} {{ReadOnlyInline}}
   - : A reference to the {{DOMxRef("BluetoothDevice")}} running the server.
 
 ## Methods

--- a/files/en-us/web/api/bluetoothremotegattservice/index.md
+++ b/files/en-us/web/api/bluetoothremotegattservice/index.md
@@ -23,13 +23,13 @@ and a list of the characteristics of this service.
 
 ## Properties
 
-- {{domxref("BluetoothRemoteGATTService.device")}}{{readonlyinline}}
+- {{domxref("BluetoothRemoteGATTService.device")}} {{readonlyinline}}
   - : Returns information about a Bluetooth device through an instance of
     {{domxref("BluetoothDevice")}}.
-- {{domxref("BluetoothRemoteGATTService.isPrimary")}}{{readonlyinline}}
+- {{domxref("BluetoothRemoteGATTService.isPrimary")}} {{readonlyinline}}
   - : Returns a boolean value indicating whether this is a primary or secondary
     service.
-- {{domxref("BluetoothRemoteGATTService.uuid")}}{{readonlyinline}}
+- {{domxref("BluetoothRemoteGATTService.uuid")}} {{readonlyinline}}
   - : Returns a string representing the UUID of this service.
 
 ## Methods

--- a/files/en-us/web/api/closeevent/index.md
+++ b/files/en-us/web/api/closeevent/index.md
@@ -26,11 +26,11 @@ A `CloseEvent` is sent to clients using {{Glossary("WebSockets")}} when the conn
 
 _This interface also inherits properties from its parent, {{domxref("Event")}}._
 
-- {{domxref("CloseEvent.code")}}{{readOnlyInline}}
+- {{domxref("CloseEvent.code")}} {{readOnlyInline}}
   - : Returns an `unsigned short` containing the close code sent by the server.
-- {{domxref("CloseEvent.reason")}}{{readOnlyInline}}
+- {{domxref("CloseEvent.reason")}} {{readOnlyInline}}
   - : Returns a string indicating the reason the server closed the connection. This is specific to the particular server and sub-protocol.
-- {{domxref("CloseEvent.wasClean")}}{{readOnlyInline}}
+- {{domxref("CloseEvent.wasClean")}} {{readOnlyInline}}
   - : Returns a boolean value that Indicates whether or not the connection was cleanly closed.
 
 ## Methods

--- a/files/en-us/web/api/cookiechangeevent/index.md
+++ b/files/en-us/web/api/cookiechangeevent/index.md
@@ -33,9 +33,9 @@ Cookie changes that will cause the `CookieChangeEvent` to be dispatched are:
 
 _This interface also inherits properties from {{domxref("Event")}}._
 
-- {{domxref("CookieChangeEvent.changed")}}{{ReadOnlyInline}}
+- {{domxref("CookieChangeEvent.changed")}} {{ReadOnlyInline}}
   - : Returns an array containing one or more changed cookies.
-- {{domxref("CookieChangeEvent.deleted")}}{{ReadOnlyInline}}
+- {{domxref("CookieChangeEvent.deleted")}} {{ReadOnlyInline}}
   - : Returns an array containing one or more deleted cookies.
 
 ## Examples

--- a/files/en-us/web/api/credentialscontainer/index.md
+++ b/files/en-us/web/api/credentialscontainer/index.md
@@ -27,13 +27,13 @@ None.
 
 ## Methods
 
-- {{domxref("CredentialsContainer.create()")}}{{securecontext_inline}}
+- {{domxref("CredentialsContainer.create()")}} {{securecontext_inline}}
   - : Returns a {{jsxref("Promise")}} that resolves with a new {{domxref("Credential")}} instance based on the provided options, or `null` if no `Credential` object can be created. In exceptional circumstances, the {{jsxref("Promise")}} may reject.
-- {{domxref("CredentialsContainer.get()")}}{{securecontext_inline}}
+- {{domxref("CredentialsContainer.get()")}} {{securecontext_inline}}
   - : Returns a {{jsxref("Promise")}} that resolves with the {{domxref("Credential")}} instance that matches the provided parameters.
-- {{domxref("CredentialsContainer.preventSilentAccess()")}}{{securecontext_inline}}
+- {{domxref("CredentialsContainer.preventSilentAccess()")}} {{securecontext_inline}}
   - : Sets a flag that specifies whether automatic log in is allowed for future visits to the current origin, then returns an empty {{jsxref("Promise")}}. For example, you might call this, after a user signs out of a website to ensure that they aren't automatically signed in on the next site visit. Earlier versions of the spec called this method `requireUserMediation()`. See [Browser compatibility](#browser_compatibility) for support details.
-- {{domxref("CredentialsContainer.store()")}}{{securecontext_inline}}
+- {{domxref("CredentialsContainer.store()")}} {{securecontext_inline}}
   - : Stores a set of credentials for a user, inside a provided {{domxref("Credential")}} instance and returns that instance in a {{jsxref("Promise")}}.
 
 ## Examples

--- a/files/en-us/web/api/css/index.md
+++ b/files/en-us/web/api/css/index.md
@@ -20,7 +20,7 @@ _The CSS interface is a utility interface and no object of this type can be crea
 
 ### Static properties
 
-- {{DOMxRef("CSS.paintWorklet")}} {{Experimental_Inline}}{{SecureContext_Inline}}
+- {{DOMxRef("CSS.paintWorklet")}} {{Experimental_Inline}} {{SecureContext_Inline}}
   - : Provides access to the Worklet responsible for all the classes related to painting.
 
 ## Methods

--- a/files/en-us/web/api/cssanimation/index.md
+++ b/files/en-us/web/api/cssanimation/index.md
@@ -20,7 +20,7 @@ The **`CSSAnimation`** interface of the {{domxref('Web Animations API','','',' '
 
 Inherits methods from its ancestor {{domxref("Animation")}} and adds {{domxref("animationName")}}.
 
-- {{domxref("CSSAnimation.animationName")}}{{readonlyinline}}
+- {{domxref("CSSAnimation.animationName")}} {{readonlyinline}}
   - : Returns the animation name as a string.
 
 ### Event handlers

--- a/files/en-us/web/api/cssfontfacerule/index.md
+++ b/files/en-us/web/api/cssfontfacerule/index.md
@@ -20,7 +20,7 @@ The **`CSSFontFaceRule`** interface represents an {{cssxref("@font-face")}} [at-
 
 _Inherits properties from its ancestor {{domxref("CSSRule")}}._
 
-- {{domxref("CSSFontFaceRule.style")}}{{readonlyinline}}
+- {{domxref("CSSFontFaceRule.style")}} {{readonlyinline}}
   - : Returns a {{domxref("CSSStyleDeclaration")}}.
 
 ## Methods

--- a/files/en-us/web/api/cssgroupingrule/index.md
+++ b/files/en-us/web/api/cssgroupingrule/index.md
@@ -19,7 +19,7 @@ The **`CSSGroupingRule`** interface of the [CSS Object Model](/en-US/docs/Web/AP
 
 _This interface also inherits properties from {{domxref("CSSRule")}}._
 
-- {{domxref("CSSGroupingRule.cssRules")}}{{readonlyinline}}
+- {{domxref("CSSGroupingRule.cssRules")}} {{readonlyinline}}
   - : Returns a {{domxref("CSSRuleList")}} of the CSS rules in the media rule.
 
 ## Methods

--- a/files/en-us/web/api/cssimportrule/index.md
+++ b/files/en-us/web/api/cssimportrule/index.md
@@ -19,11 +19,11 @@ The **`CSSImportRule`** interface represents an {{cssxref("@import")}} [at-rule]
 
 _Inherits properties from its ancestor {{domxref("CSSRule")}}._
 
-- {{domxref("CSSImportRule.href")}}{{readonlyinline}}
+- {{domxref("CSSImportRule.href")}} {{readonlyinline}}
   - : Returns the URL specified by the {{cssxref("@import")}} rule.
 - {{domxref("CSSImportRule.media")}}
   - : Returns the value of the `media` attribute of the associated stylesheet.
-- {{domxref("CSSImportRule.styleSheet")}}{{readonlyinline}}
+- {{domxref("CSSImportRule.styleSheet")}} {{readonlyinline}}
   - : Returns the associated stylesheet.
 
 ## Methods

--- a/files/en-us/web/api/csskeyframerule/index.md
+++ b/files/en-us/web/api/csskeyframerule/index.md
@@ -22,7 +22,7 @@ _Inherits properties from its ancestor {{domxref("CSSRule")}}._
 
 - {{domxref("CSSKeyframeRule.keyText")}}
   - : Represents the key of the keyframe, like `'10%'`, `'75%'`. The `from` keyword maps to `'0%'` and the `to` keyword maps to `'100%'`.
-- {{domxref("CSSKeyframeRule.style")}}{{readOnlyInline}}
+- {{domxref("CSSKeyframeRule.style")}} {{readOnlyInline}}
   - : Returns a {{domxref("CSSStyleDeclaration")}} of the CSS style associated with the keyframe.
 
 ## Methods


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/18019.
Continuing PR #18123.

Cases found and fixed using markdownlint plugin [markdownlint-rule-search-replace](https://www.npmjs.com/package/markdownlint-rule-search-replace). For more info refer #17988. 

***

We can add following config to the `.markdownlint.json` to solve the issue permanently:
```json
  "search-replace": {
    "rules": [
      {
        "name": "space-around-macros",
        "message": "Have spaces around macros.",
        "searchPattern": "/([^\\s`_\\\\>(\"\\*])(\\{\\{.+?inline}})/ig",
        "replace": "$1 $2",
        "skipCode": true
      }
    ]
  }
```

For this to work, we need to merge #17988 and #18009 to handle such simple stuffs. @schalkneethling, @hamishwillee wdyt?
