### PR TITLE
Good Example after >>Now, you can use `restartIce()` to do this much …

### DIFF
--- a/files/en-us/web/api/webrtc_api/perfect_negotiation/index.md
+++ b/files/en-us/web/api/webrtc_api/perfect_negotiation/index.md
@@ -395,9 +395,18 @@ This has a number of reliability issues and outright bugs (such as failing if th
 Now, you can use `restartIce()` to do this much more cleanly:
 
 ```js example-good
+let makingOffer = false;
+
 pc.onnegotiationneeded = async () => {
-  await pc.setLocalDescription();
-  signaler.send({ description: pc.localDescription });
+  try {
+    makingOffer = true;
+    await pc.setLocalDescription();
+    signaler.send({ description: pc.localDescription });
+  } catch(err) {
+    console.error(err);
+  } finally {
+    makingOffer = false;
+  }
 };
 pc.oniceconnectionstatechange = () => {
   if (pc.iceConnectionState === "failed") {


### PR DESCRIPTION
Good Example after >>Now, you can use `restartIce()` to do this much more cleanly:<< shows wrong onnegotiationneeded code

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
