### PR TITLE
Printing events supported by all browsers

### DIFF
--- a/files/en-us/web/guide/printing/index.md
+++ b/files/en-us/web/guide/printing/index.md
@@ -29,7 +29,7 @@ Add the following to your {{HTMLElement("head")}} tag.
 
 ## Detecting print requests
 
-Browsers send `beforeprint` and `afterprint` events to let content determine when printing may have occurred. You can use this to adjust the user interface presented during printing (such as by displaying or hiding user interface elements during the print process).
+Browsers send {{domxref("Window/beforeprint_event", "beforeprint")}} and {{domxref("Window/afterprint_event", "afterprint")}} events to let content determine when printing may have occurred. You can use this to adjust the user interface presented during printing (such as by displaying or hiding user interface elements during the print process).
 
 ## Examples
 

--- a/files/en-us/web/guide/printing/index.md
+++ b/files/en-us/web/guide/printing/index.md
@@ -29,9 +29,7 @@ Add the following to your {{HTMLElement("head")}} tag.
 
 ## Detecting print requests
 
-Some browsers (including Firefox 6 and later and Internet Explorer) send `beforeprint` and `afterprint` events to let content determine when printing may have occurred. You can use this to adjust the user interface presented during printing (such as by displaying or hiding user interface elements during the print process).
-
-> **Note:** You can also use `window.onbeforeprint` and `window.onafterprint` to assign handlers for these events, but using {{domxref("EventTarget.addEventListener()")}} is preferred.
+Browsers send `beforeprint` and `afterprint` events to let content determine when printing may have occurred. You can use this to adjust the user interface presented during printing (such as by displaying or hiding user interface elements during the print process).
 
 ## Examples
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Printing events are now supported by all evergreen browsers.

Also removed note about possibility of using `window.on*` events, don't think it makes sense to have such a note every time the docs reference event listeners.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://caniuse.com/?search=Printing%20Events

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
