### PR TITLE
Add a reference for native toString() formats

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/date/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/index.md
@@ -165,6 +165,22 @@ const birthday = new Date(1995, 11, 17, 3, 24, 0)
 const birthday = new Date(628021800000)            // passing epoch timestamp
 ```
 
+### Formats of native toString methods
+
+```js
+const date = new Date("2020-05-12T23:50:21.817Z");
+date.toString()               // Tue May 12 2020 18:50:21 GMT-0500 (Central Daylight Time)
+date.toDateString()           // Tue May 12 2020
+date.toTimeString()           // 18:50:21 GMT-0500 (Central Daylight Time)
+date.toISOString()            // 2020-05-12T23:50:21.817Z
+date.toUTCString()            // Tue, 12 May 2020 23:50:21 GMT
+date.toGMTString()            // Tue, 12 May 2020 23:50:21 GMT
+date.toJSON()                 // 2020-05-12T23:50:21.817Z
+date.toLocaleString()         // 5/12/2020, 6:50:21 PM
+date.toLocaleDateString()     // 5/12/2020
+date.toLocaleTimeString()     // 6:50:21 PM
+```
+
 ### To get Date, Month and Year or Time
 
 ```js

--- a/files/en-us/web/javascript/reference/global_objects/date/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/index.md
@@ -165,7 +165,7 @@ const birthday = new Date(1995, 11, 17, 3, 24, 0)
 const birthday = new Date(628021800000)            // passing epoch timestamp
 ```
 
-### Formats of native toString methods
+### Formats of toString method return values
 
 ```js
 const date = new Date("2020-05-12T23:50:21.817Z");


### PR DESCRIPTION
It's difficult to remember which of the many toString() methods outputs which format.  I have a Stack Overflow issue I usually search for, but -- unable to find it this time -- it seemed logical to maybe be able to find it on MDN instead.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Add some example text displaying various toString formatting differences

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
It's a question I have every time I try to convert a date to a string

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
N/A

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
N/A

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
