### PR TITLE
Fix broken wrapping in the ImageDecoder example.

### DIFF
--- a/files/en-us/web/api/imagedecoder/decode/index.md
+++ b/files/en-us/web/api/imagedecoder/decode/index.md
@@ -66,9 +66,9 @@ The following example decodes the first frame repeatedly until its complete:
 ```js
 let complete = false;
 while (!complete) {
-  // The promise returned by `decode()` will only resolve when a new level of
-  // detail is available or the frame is complete. I.e., calling `decode()` in a
-  // loop like this is won't needlessly spin.
+  // The promise returned by `decode()` will only resolve when a new
+  // level of detail is available or the frame is complete. I.e.,
+  // calling `decode()` in a loop like this is won't needlessly spin.
   let result = await imageDecode.decode({completeFramesOnly: false});
 
   // Do something with `result.image`.

--- a/files/en-us/web/api/imagedecoder/index.md
+++ b/files/en-us/web/api/imagedecoder/index.md
@@ -65,9 +65,9 @@ function renderImage(result) {
 
   const track = imageDecoder.tracks.selectedTrack;
 
-  // We check complete here since `frameCount` won't be stable until all data
-  // has been received. This may cause us to receive a RangeError during the
-  // decode() call below which needs to be handled.
+  // We check complete here since `frameCount` won't be stable until all
+  // data has been received. This may cause us to receive a RangeError
+  // during the decode() call below which needs to be handled.
   if (imageDecoder.complete) {
     if (track.frameCount == 1)
       return;
@@ -85,11 +85,13 @@ function renderImage(result) {
               },
               result.image.duration / 1000.0))
       .catch(e => {
-        // We can end up requesting an imageIndex past the end since we're using
-        // a ReadableStream from fetch(), when this happens just wrap around.
+        // We can end up requesting an imageIndex past the end since
+        // we're using a ReadableStream from fetch(), when this happens
+        // just wrap around.
         if (e instanceof RangeError) {
           imageIndex = 0;
-          imageDecoder.decode({frameIndex: imageIndex}).then(renderImage);
+          imageDecoder.decode({frameIndex: imageIndex})
+              .then(renderImage);
         } else {
           throw e;
         }
@@ -97,7 +99,8 @@ function renderImage(result) {
 }
 
 function decodeImage(imageByteStream) {
-  imageDecoder = new ImageDecoder({data: imageByteStream, type: 'image/gif'});
+  imageDecoder = new ImageDecoder(
+      {data: imageByteStream, type: 'image/gif'});
   imageDecoder.decode({frameIndex: imageIndex}).then(renderImage);
 }
 


### PR DESCRIPTION
Looks like 80 characters was too long.

#### Summary
Fixes text wrapping in example.

#### Motivation
Makes example more legible.

This PR…
- [x] Fixes a typo, bug, or other error
