### PR TITLE
CSS miscellaneous: change intro to reflect content

### DIFF
--- a/files/en-us/web/css/css_miscellaneous/index.md
+++ b/files/en-us/web/css/css_miscellaneous/index.md
@@ -9,7 +9,7 @@ tags:
 ---
 {{CSSRef}}
 
-These pages contain CSS properties that don't fit in any other categories, are experimental, or are supported in browsers though not included in a CSS specification.
+These pages contain CSS properties that are supported by browsers but either aren't included in a CSS specification, don't fit into any other CSS categories, or are experimental.
 
 ## Reference
 

--- a/files/en-us/web/css/css_miscellaneous/index.md
+++ b/files/en-us/web/css/css_miscellaneous/index.md
@@ -9,7 +9,7 @@ tags:
 ---
 {{CSSRef}}
 
-These pages contain CSS properties that are highly experimental or don't fit in any other categories.
+These pages contain CSS properties that don't fit in any other categories, are experimental, or are supported in browsers though not included in a CSS specification.
 
 ## Reference
 


### PR DESCRIPTION
all is supported, but not really categorizable.
text-rendering is supported, but in the SVG spec not a CSS spec.
the original text made it seem like the content would be experimental, so tried to play that part down.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
