### PR TITLE
ReadableStream reader - releasing lock throws pending read

### DIFF
--- a/files/en-us/mozilla/firefox/releases/102/index.md
+++ b/files/en-us/mozilla/firefox/releases/102/index.md
@@ -32,7 +32,7 @@ No notable changes.
 - [Transform streams](/en-US/docs/Web/API/TransformStream) are now supported, allowing you to pipe from {{domxref("ReadableStream")}} to a {{domxref("WritableStream")}}, executing a transformation on the chunks.
   The update includes the new interfaces [`TransformStream`](/en-US/docs/Web/API/TransformStream) and [`TransformStreamDefaultController`](/en-US/docs/Web/API/TransformStreamDefaultController) and the method [`ReadableStream.pipeThrough()`](/en-US/docs/Web/API/ReadableStream/pipeThrough) ({{bug(1767507)}}).
 
-- [Readable byte streams](/en-US/docs/Web/API/Streams_API#bytestream-related_interfaces) are now supported, allowing efficient zero-byte transfer of data from an underlying byte source to a consumer (bypassing the stream's internal queues).
+- [Readable byte streams](/en-US/docs/Web/API/Streams_API/Using_readable_byte_streams) are now supported, allowing efficient zero-byte transfer of data from an underlying byte source to a consumer (bypassing the stream's internal queues).
   The new interfaces are {{domxref("ReadableStreamBYOBReader")}}, {{domxref("ReadableByteStreamController")}} and {{domxref("ReadableStreamBYOBRequest")}} ({{bug(1767342)}}).
 
 #### DOM

--- a/files/en-us/web/api/readablestreambyobreader/read/index.md
+++ b/files/en-us/web/api/readablestreambyobreader/read/index.md
@@ -18,13 +18,13 @@ A request for data will be statisfied from the stream's internal queues if there
 If the stream queues are empty, the request may be supplied as a zero-copy transfer from the underlying byte source.
 
 The method takes as an argument a view on a buffer that supplied data is to be read into, and returns a {{jsxref("Promise")}}.
-The promise resolves with an object that has properties `value` and `done` when data comes available, or if the stream is cancelled.
+The promise fulfills with an object that has properties `value` and `done` when data comes available, or if the stream is cancelled.
 If the stream is errored, the promise will be rejected with the relevant error object.
 
 If a chunk of data is supplied, the `value` property will contain a new view.
 This will be a view over the same buffer/backing memory (and of the same type) as the original `view` passed to the `read()` method, now populated with the new chunk of data.
-Note that once the promise resolves, the original `view` passed to the method will be detached and no longer usable.
-The promise will resolve with a `value: undefined` if the stream has been cancelled.
+Note that once the promise fulfills, the original `view` passed to the method will be detached and no longer usable.
+The promise will fulfill with a `value: undefined` if the stream has been cancelled.
 In this case the backing memory region of `view` is discarded and not returned to the caller (all previously read data in the view's buffer is lost).
 
 The `done` property indicates whether or not more data is expected.
@@ -43,11 +43,11 @@ read(view)
 
 ### Return value
 
-A {{jsxref("Promise")}}, which resolves/rejects with a result depending on the state of the stream.
+A {{jsxref("Promise")}}, which fulfills/rejects with a result depending on the state of the stream.
 
 The following are possible:
 
-- If a chunk is available and the stream is still active, the promise resolves with an object of the form:
+- If a chunk is available and the stream is still active, the promise fulfills with an object of the form:
 
   ```js
   { value: theChunk, done: false }
@@ -57,7 +57,7 @@ The following are possible:
   This is a view of the same type and over the same backing memory as the `view` passed to the `read()` method.
   The original `view` will be detached and no longer usable.
   
-- If the stream is closed, the promise resolves with an object of the form (where `theChunk` has the same properties as above):
+- If the stream is closed, the promise fulfills with an object of the form (where `theChunk` has the same properties as above):
 
   ```js
   { value: theChunk, done: true }
@@ -77,7 +77,7 @@ The following are possible:
 ### Exceptions
 
 - {{jsxref("TypeError")}}
-  - : The source object is not a `ReadableStreamBYOBReader`, the stream has no owner, the view is not an object or has become detached, or the view's length is 0.
+  - : The source object is not a `ReadableStreamBYOBReader`, the stream has no owner, the view is not an object or has become detached, the view's length is 0, or {{domxref("ReadableStreamBYOBReader.releaseLock()")}} is called (when there's is a pending read request).
 
 ## Examples
 
@@ -104,7 +104,7 @@ function readStream(reader) {
   let offset =  0;
 
   while (offset < buffer.byteLength) {    
-    // read() returns a promise that resolves when a value has been received
+    // read() returns a promise that fulfills when a value has been received
     reader.read( new Uint8Array(buffer, offset, buffer.byteLength - offset) ).then(function processBytes({ done, value }) {
       // Result objects contain two properties:
         // done  - true if the stream has already given all its data.
@@ -127,7 +127,7 @@ function readStream(reader) {
 }
 ```
 
-When there is no more data in the stream, the `read()` method resolves with an object with the property `done` set to `true`, and the function returns.
+When there is no more data in the stream, the `read()` method fulfills with an object with the property `done` set to `true`, and the function returns.
 
 ## Specifications
 

--- a/files/en-us/web/api/readablestreambyobreader/releaselock/index.md
+++ b/files/en-us/web/api/readablestreambyobreader/releaselock/index.md
@@ -38,7 +38,7 @@ None ({{jsxref("undefined")}}).
 ### Exceptions
 
 - {{jsxref("TypeError")}}
-  - : Thrown if the source object is not a `ReadableStreamBYOBReader`, or a read request is pending.
+  - : Thrown if the source object is not a `ReadableStreamBYOBReader`.
 
 ## Examples
 

--- a/files/en-us/web/api/readablestreamdefaultreader/read/index.md
+++ b/files/en-us/web/api/readablestreamdefaultreader/read/index.md
@@ -45,7 +45,7 @@ The different possibilities are as follows:
 
 This example shows the basic API usage, but doesn't try to deal with complications like stream chunks not ending on line boundaries for example.
 
-In this example `stream` is a previously-created custom `ReadableStream`.
+In this example, `stream` is a previously-created custom `ReadableStream`.
 It is read using a {{domxref("ReadableStreamDefaultReader")}} created using `getReader()`.
 (see our [Simple random stream example](https://mdn.github.io/dom-examples/streams/simple-random-stream/) for the full code).
 Each chunk is read sequentially and output to the UI as an array of UTF-8 bytes, until the stream has finished being read, at which point we return out of the recursive function and print the entire stream to another part of the UI.

--- a/files/en-us/web/api/readablestreamdefaultreader/read/index.md
+++ b/files/en-us/web/api/readablestreamdefaultreader/read/index.md
@@ -37,7 +37,7 @@ The different possibilities are as follows:
 ### Exceptions
 
 - {{jsxref("TypeError")}}
-  - : The source object is not a `ReadableStreamDefaultReader`, the stream has no owner, or {{domxref("ReadableStreamDefaultReader.releaseLock()")}} is called (when there's is a pending read request).
+  - : The source object is not a `ReadableStreamDefaultReader`, the stream has no owner, or {{domxref("ReadableStreamDefaultReader.releaseLock()")}} is called (when there's a pending read request).
 
 ## Examples
 

--- a/files/en-us/web/api/readablestreamdefaultreader/read/index.md
+++ b/files/en-us/web/api/readablestreamdefaultreader/read/index.md
@@ -13,9 +13,7 @@ browser-compat: api.ReadableStreamDefaultReader.read
 ---
 {{APIRef("Streams")}}
 
-The **`read()`** method of the
-{{domxref("ReadableStreamDefaultReader")}} interface returns a {{jsxref("Promise")}} providing access
-to the next chunk in the stream's internal queue.
+The **`read()`** method of the {{domxref("ReadableStreamDefaultReader")}} interface returns a {{jsxref("Promise")}} providing access to the next chunk in the stream's internal queue.
 
 ## Syntax
 
@@ -29,42 +27,35 @@ None.
 
 ### Return value
 
-A {{jsxref("Promise")}}, which fulfills/rejects with a result depending on the state of
-the stream. The different possibilities are as follows:
+A {{jsxref("Promise")}}, which fulfills/rejects with a result depending on the state of the stream.
+The different possibilities are as follows:
 
-- If a chunk is available, the promise will be fulfilled with an object of the form
-  `{ value: theChunk, done: false }`.
-- If the stream becomes closed, the promise will be fulfilled with an object of the
-  form `{ value: undefined, done: true }`.
+- If a chunk is available, the promise will be fulfilled with an object of the form `{ value: theChunk, done: false }`.
+- If the stream becomes closed, the promise will be fulfilled with an object of the form `{ value: undefined, done: true }`.
 - If the stream becomes errored, the promise will be rejected with the relevant error.
 
 ### Exceptions
 
 - {{jsxref("TypeError")}}
-  - : The source object is not a `ReadableStreamDefaultReader`, or the stream
-    has no owner.
+  - : The source object is not a `ReadableStreamDefaultReader`, the stream has no owner, or {{domxref("ReadableStreamDefaultReader.releaseLock()")}} is called (when there's is a pending read request).
 
 ## Examples
 
 ### Example 1 - simple example
 
-This example shows the basic API usage, but doesn't try to deal with complications like
-stream chunks not ending on line boundaries for example.
+This example shows the basic API usage, but doesn't try to deal with complications like stream chunks not ending on line boundaries for example.
 
-In this example `stream` is a previously-created custom
-`ReadableStream`. It is read using a
-{{domxref("ReadableStreamDefaultReader")}} created using `getReader()`. (see
-our [Simple random stream example](https://mdn.github.io/dom-examples/streams/simple-random-stream/) for the full code). Each chunk is read sequentially and
-output to the UI as an array of UTF-8 bytes, until the stream has finished being read,
-at which point we return out of the recursive function and print the entire stream to
-another part of the UI.
+In this example `stream` is a previously-created custom `ReadableStream`.
+It is read using a {{domxref("ReadableStreamDefaultReader")}} created using `getReader()`.
+(see our [Simple random stream example](https://mdn.github.io/dom-examples/streams/simple-random-stream/) for the full code).
+Each chunk is read sequentially and output to the UI as an array of UTF-8 bytes, until the stream has finished being read, at which point we return out of the recursive function and print the entire stream to another part of the UI.
 
 ```js
 function fetchStream() {
   const reader = stream.getReader();
   let charsReceived = 0;
 
-  // read() returns a promise that resolves
+  // read() returns a promise that fulfills
   // when a value has been received
   reader.read().then(function processText({ done, value }) {
     // Result objects contain two properties:
@@ -93,9 +84,8 @@ function fetchStream() {
 
 ### Example 2 - handling text line by line
 
-This example shows how you might fetch a text file and handle it as a stream of text
-lines. It deals with stream chunks not ending on line boundaries and converting from
-Uint8Array to strings.
+This example shows how you might fetch a text file and handle it as a stream of text lines.
+It deals with stream chunks not ending on line boundaries and converting from `Uint8Array` to strings.
 
 ```js
 async function* makeTextFileLineIterator(fileURL) {

--- a/files/en-us/web/api/readablestreamdefaultreader/read/index.md
+++ b/files/en-us/web/api/readablestreamdefaultreader/read/index.md
@@ -85,7 +85,7 @@ function fetchStream() {
 ### Example 2 - handling text line by line
 
 This example shows how you might fetch a text file and handle it as a stream of text lines.
-It deals with stream chunks not ending on line boundaries and converting from `Uint8Array` to strings.
+It deals with stream chunks not ending on line boundaries, and with converting from `Uint8Array` to strings.
 
 ```js
 async function* makeTextFileLineIterator(fileURL) {

--- a/files/en-us/web/api/readablestreamdefaultreader/releaselock/index.md
+++ b/files/en-us/web/api/readablestreamdefaultreader/releaselock/index.md
@@ -37,7 +37,7 @@ None ({{jsxref("undefined")}}).
 ### Exceptions
 
 - {{jsxref("TypeError")}}
-  - : Thrown if the source object is not a `ReadableStreamDefaultReader`, or a read request is pending.
+  - : Thrown if the source object is not a `ReadableStreamDefaultReader`.
 
 ## Examples
 


### PR DESCRIPTION
This does two main things:
1. Fixes up FF102 release note to point to the guide on using readable byte streams
2. Fixes up the readable stream reader `releaseLock()` and `read()` interfaces to make it clear that if releaseLock is called and there is a pending read then it is the read() promise that is rejected (formerly `releaseLock()` would throw. 

This is due to a spec change in https://github.com/whatwg/streams/pull/1168.

I also removed a bunch of cases where we referred to "resolves" when we mean fulfills.