### PR TITLE
Added grammar changes to history.pushState

### DIFF
--- a/files/en-us/web/api/history/pushstate/index.md
+++ b/files/en-us/web/api/history/pushstate/index.md
@@ -52,7 +52,7 @@ pushState(state, unused, url)
   - : This parameter exists for historical reasons, and cannot be omitted; passing an empty string is safe against future changes to the method.
 
 - `url` {{optional_inline}}
-  - : The new history entry's URL is given with this parameter. Note that the browser won't
+  - : The new history entry's URL. Note that the browser won't
     attempt to load this URL after a call to `pushState()`, but it may
     attempt to load the URL later, for instance, after the user restarts the browser. The
     new URL does not need to be absolute; if it's relative, it's resolved relative to the

--- a/files/en-us/web/api/history/pushstate/index.md
+++ b/files/en-us/web/api/history/pushstate/index.md
@@ -49,12 +49,12 @@ pushState(state, unused, url)
     "sessionStorage")}} and/or {{domxref("Window.localStorage", "localStorage")}}.
 
 - `unused`
-  - : This parameter exists for historical reasons, and cannot be omitted; passing the empty string is safe against future changes to the method.
+  - : This parameter exists for historical reasons, and cannot be omitted; passing an empty string is safe against future changes to the method.
 
 - `url` {{optional_inline}}
-  - : The new history entry's URL is given by this parameter. Note that the browser won't
-    attempt to load this URL after a call to `pushState()`, but it might
-    attempt to load the URL later, for instance after the user restarts the browser. The
+  - : The new history entry's URL is given with this parameter. Note that the browser won't
+    attempt to load this URL after a call to `pushState()`, but it may
+    attempt to load the URL later, for instance, after the user restarts the browser. The
     new URL does not need to be absolute; if it's relative, it's resolved relative to the
     current URL. The new URL must be of the same {{glossary("origin")}} as the current
     URL; otherwise, `pushState()` will throw an exception. If this parameter
@@ -74,7 +74,7 @@ But `pushState()` has a few advantages:
 - The new URL can be any URL in the same origin as the current URL. In contrast,
   setting {{domxref("window.location")}} keeps you at the same document only if you
   modify only the hash.
-- You don't have to change the URL if you don't want to. In contrast,
+- Changing the page's URL is optional. In contrast,
   setting `window.location = "#foo";` only creates a new history entry if the
   current hash isn't `#foo`.
 - You can associate arbitrary data with your new history entry. With the hash-based


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Attempted to make the page look a bit more formal and corrected grammar in some locations, such as "passing the empty string is safe" to "passing an empty string is safe", and "You don't have to change the URL if you don't want to" to "Changing the page's URL is optional."

#### Motivation
I was reading about how to use the pushState feature for an upcoming website, and came across this minor bug. I thought I should spend my time doing that instead of work.

This PR…

- [ X ] Rewrites (or significantly expands) a document
- [ X ] Fixes a typo, bug, or other error

