### PR TITLE
correct the description about `SameSite` attribute

### DIFF
--- a/files/en-us/web/http/headers/set-cookie/index.md
+++ b/files/en-us/web/http/headers/set-cookie/index.md
@@ -132,7 +132,7 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
 
     - `Strict`
       - : means that the browser sends the cookie only for same-site requests, that is, requests originating from the same site that set the cookie.
-        If a request originates from a domain different from the current one, no cookies with the `SameSite=Strict` attribute are sent.
+        If a request originates from a different domain or scheme (even with the same domain), no cookies with the `SameSite=Strict` attribute are sent.
 
     - `Lax`
       - : means that the cookie is not sent on cross-site requests, such as on requests to load images or frames, but is sent when a user is navigating to the origin site from an external site (for example, when following a link).

--- a/files/en-us/web/http/headers/set-cookie/index.md
+++ b/files/en-us/web/http/headers/set-cookie/index.md
@@ -132,7 +132,7 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
 
     - `Strict`
       - : means that the browser sends the cookie only for same-site requests, that is, requests originating from the same site that set the cookie.
-        If a request originates from a URL different from the current one, no cookies with the `SameSite=Strict` attribute are sent.
+        If a request originates from a domain different from the current one, no cookies with the `SameSite=Strict` attribute are sent.
 
     - `Lax`
       - : means that the cookie is not sent on cross-site requests, such as on requests to load images or frames, but is sent when a user is navigating to the origin site from an external site (for example, when following a link).

--- a/files/en-us/web/http/headers/set-cookie/index.md
+++ b/files/en-us/web/http/headers/set-cookie/index.md
@@ -125,7 +125,7 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
     This mitigates attacks against cross-site scripting ({{Glossary("Cross-site_scripting", "XSS")}}).
 - `SameSite=<samesite-value>` {{optional_inline}}
 
-  - : Controls whether or not a cookie is sent with cross-origin requests,
+  - : Controls whether or not a cookie is sent with cross-site requests,
     providing some protection against cross-site request forgery attacks ({{Glossary("CSRF")}}).
 
     The possible attribute values are:


### PR DESCRIPTION
#### Summary

the `SamteSite` attribute is used to control cross-site or not (not cross-origin which is stricter than cross-site).

#### Motivation

`cross-origin` ---> `cross-site`

#### Supporting details

see also: #15893

#### Metadata

- [x] Fixes a typo, bug, or other error
