### PR TITLE
Remove some old elements from MathML3

### DIFF
--- a/files/en-us/web/mathml/element/index.md
+++ b/files/en-us/web/mathml/element/index.md
@@ -22,8 +22,6 @@ MathML elements implement the {{domxref("MathMLElement")}} class.
 ### A
 
 - {{MathMLElement("maction")}} (Bound actions to sub-expressions)
-- {{MathMLElement("maligngroup")}} (Alignment group)
-- {{MathMLElement("malignmark")}} (Alignment points)
 
 ### E
 
@@ -38,10 +36,6 @@ MathML elements implement the {{domxref("MathMLElement")}} class.
 ### I
 
 - {{MathMLElement("mi")}} (Identifier)
-
-### L
-
-- {{MathMLElement("mlongdiv")}} (Long division notation)
 
 ### M
 
@@ -69,14 +63,8 @@ MathML elements implement the {{domxref("MathMLElement")}} class.
 ### S
 
 - {{MathMLElement("ms")}} (String literal)
-- {{MathMLElement("mscarries")}} (Annotations such as carries)
-- {{MathMLElement("mscarry")}} (Single carry, child element of {{MathMLElement("mscarries")}})
-- {{MathMLElement("msgroup")}} (Grouped rows of {{MathMLElement("mstack")}} and {{MathMLElement("mlongdiv")}} elements)
-- {{MathMLElement("msline")}} (Horizontal lines inside {{MathMLElement("mstack")}} elements)
 - {{MathMLElement("mspace")}} (Space)
 - {{MathMLElement("msqrt")}} (Square root without an index)
-- {{MathMLElement("msrow")}} (Rows in {{MathMLElement("mstack")}} elements)
-- {{MathMLElement("mstack")}} (Stacked alignment)
 - {{MathMLElement("mstyle")}} (Style change)
 - {{MathMLElement("msub")}} (Subscript)
 - {{MathMLElement("msup")}} (Superscript)
@@ -142,21 +130,9 @@ MathML elements implement the {{domxref("MathMLElement")}} class.
 
 ### Tabular math
 
-- {{MathMLElement("maligngroup")}}
-- {{MathMLElement("malignmark")}}
 - {{MathMLElement("mtable")}}
 - {{MathMLElement("mtd")}}
 - {{MathMLElement("mtr")}}
-
-### Elementary math
-
-- {{MathMLElement("mlongdiv")}}
-- {{MathMLElement("mscarries")}}
-- {{MathMLElement("mscarry")}}
-- {{MathMLElement("msgroup")}}
-- {{MathMLElement("msline")}}
-- {{MathMLElement("msrow")}}
-- {{MathMLElement("mstack")}}
 
 ### Uncategorized elements
 


### PR DESCRIPTION
#### Summary

This commit removes the following elements from MathML3:

maligngroup, malignmark, mlongdiv, mscarries, mscarry, msgroup, msline,
msrow and mstack

None of them have never been implemented in browsers and there is no
plan to do it. They are not part of MathML Core. They didn't have any
dedicated MDN article.

#### Motivation

We are migrating the MathML doc towards browser-specific documentation so
do a bit of cleanup for elements that are not relevant for the web.

#### Supporting details

<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
