### PR TITLE
Deprecate MathML attributes scriptmize and scriptsizemultiplier

### DIFF
--- a/files/en-us/mozilla/firefox/releases/103/index.md
+++ b/files/en-us/mozilla/firefox/releases/103/index.md
@@ -19,6 +19,12 @@ This article provides information about the changes in Firefox 103 that will aff
 
 #### Removals
 
+### MathML
+
+#### Removals
+
+- The deprecated `scriptminsize` and `scriptsizemultipler` attributes have been removed ({{bug(1772697)}}).
+
 ### CSS
 
 #### Removals

--- a/files/en-us/web/mathml/attribute/index.md
+++ b/files/en-us/web/mathml/attribute/index.md
@@ -511,7 +511,7 @@ Notes:
       </td>
     </tr>
     <tr>
-      <td><code>scriptminsize</code></td>
+      <td><code>scriptminsize</code> {{deprecated_inline}}</td>
       <td>{{ MathMLElement("mstyle") }}</td>
       <td>
         Specifies a minimum font size allowed due to changes in
@@ -519,7 +519,7 @@ Notes:
       </td>
     </tr>
     <tr>
-      <td><code>scriptsizemultiplier</code></td>
+      <td><code>scriptsizemultiplier</code> {{deprecated_inline}}</td>
       <td>{{ MathMLElement("mstyle") }}</td>
       <td>
         Specifies the multiplier to be used to adjust font size due to changes

--- a/files/en-us/web/mathml/element/mstyle/index.md
+++ b/files/en-us/web/mathml/element/mstyle/index.md
@@ -16,9 +16,9 @@ The MathML `<mstyle>` element is used change the style of its children. It accep
 
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-- `scriptminsize`
+- `scriptminsize` {{deprecated_inline}}
   - : Specifies a minimum font size allowed due to changes in `scriptlevel`. The default value is 8pt.
-- `scriptsizemultiplier`
+- `scriptsizemultiplier` {{deprecated_inline}}
   - : Specifies the multiplier to be used to adjust font size due to changes in `scriptlevel`. The default value is 0.71.
 
 The `<mstyle>` element accepts [all attributes](/en-US/docs/Web/MathML/Attribute) of all presentation elements with the following exceptions:
@@ -70,16 +70,3 @@ Using `displaystyle` and `mathcolor` to effect style changes in the layout of th
 ## Browser compatibility
 
 {{Compat}}
-
-## Gecko-specific notes
-
-- Prior to Gecko 6.0 {{ geckoRelease("6.0") }} the implementation of `<mstyle>` was not complete and [has been corrected](https://bugzilla.mozilla.org/show_bug.cgi?id=569125). In particular, setting these attributes on `mstyle` had no effect to its children:
-
-  - The `bevelled` attribute on {{ MathMLElement("mfrac") }} elements.
-  - The `notation` attribute on {{ MathMLElement("menclose") }} elements.
-  - The `open`, `close` and `separators` attributes on {{ MathMLElement("mfenced") }} elements.
-  - The `accent` and `accentunder` attributes on {{ MathMLElement("mover") }}, {{ MathMLElement("munder") }} and {{ MathMLElement("munderover") }} elements.
-  - The `selection` attribute on {{ MathMLElement("maction") }} elements.
-  - The `mathvariant` attribute on {{ MathMLElement("mi") }} elements.
-
-- Starting with Gecko 29.0 {{geckoRelease("29.0")}}, the attributes accepted on the `<mstyle>` element have been restricted to those actually used in practice: `id, class, style, href, mathcolor, mathbackground, scriptlevel, displaystyle, scriptsizemultiplier, scriptminsize, dir, mathsize, mathvariant, fontfamily, fontweight, fontstyle, fontsize, color, background`.


### PR DESCRIPTION
#### Summary

Deprecate MathML attributes scriptmize and scriptsizemultiplier and document change in Firefox 103.

#### Motivation

These attributes have been removed from Firefox 103, not implemented in any other browsers and not part of MathML Core.

#### Supporting details

https://bugzilla.mozilla.org/show_bug.cgi?id=1772697
https://w3c.github.io/mathml-core/#style-change-mstyle

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
