### PR TITLE
Update error reference message formats

### DIFF
--- a/files/en-us/web/javascript/reference/errors/already_has_pragma/index.md
+++ b/files/en-us/web/javascript/reference/errors/already_has_pragma/index.md
@@ -14,7 +14,7 @@ The JavaScript warning "-file- is being assigned a //# sourceMappingURL, but alr
 
 ## Message
 
-```html
+```
 Warning: -file- is being assigned a //# sourceMappingURL, but already has one.
 ```
 

--- a/files/en-us/web/javascript/reference/errors/array_sort_argument/index.md
+++ b/files/en-us/web/javascript/reference/errors/array_sort_argument/index.md
@@ -13,9 +13,10 @@ The JavaScript exception "invalid Array.prototype.sort argument" occurs when the
 
 ## Message
 
-```html
-TypeError: argument is not a function object (Edge)
+```
+TypeError: The comparison function must be either a function or undefined (V8-based)
 TypeError: invalid Array.prototype.sort argument (Firefox)
+TypeError: Array.prototype.sort requires the comparator argument to be a function or undefined (Safari)
 ```
 
 ## Error type

--- a/files/en-us/web/javascript/reference/errors/bad_octal/index.md
+++ b/files/en-us/web/javascript/reference/errors/bad_octal/index.md
@@ -16,9 +16,8 @@ as an octal number.
 
 ## Message
 
-```js
+```
 Warning: SyntaxError: 08 is not a legal ECMA-262 octal constant.
-Warning: SyntaxError: 09 is not a legal ECMA-262 octal constant.
 ```
 
 ## Error type

--- a/files/en-us/web/javascript/reference/errors/bad_radix/index.md
+++ b/files/en-us/web/javascript/reference/errors/bad_radix/index.md
@@ -17,10 +17,9 @@ and 36.
 
 ## Message
 
-```js
-RangeError: invalid argument (Edge)
+```
+RangeError: toString() radix argument must be between 2 and 36 (V8-based & Safari)
 RangeError: radix must be an integer at least 2 and no greater than 36 (Firefox)
-RangeError: toString() radix argument must be between 2 and 36 (Chrome)
 ```
 
 ## Error type

--- a/files/en-us/web/javascript/reference/errors/bad_regexp_flag/index.md
+++ b/files/en-us/web/javascript/reference/errors/bad_regexp_flag/index.md
@@ -14,10 +14,10 @@ It may also be raised if the expression contains more than one instance of a val
 
 ## Message
 
-```js
-SyntaxError: Syntax error in regular expression (Edge)
-SyntaxError: invalid regular expression flag "x" (Firefox)
-SyntaxError: Invalid regular expression flags (Chrome)
+```
+SyntaxError: Invalid regular expression flags (V8-based)
+SyntaxError: invalid regular expression flag x (Firefox)
+SyntaxError: Invalid regular expression: invalid flags (Safari)
 ```
 
 ## Error type
@@ -75,8 +75,8 @@ Below is an example showing the use of some invalid flags `b`, `a` and `r`:
 The code below is incorrect, because `W`, `e` and `b` are not valid flags.
 
 ```js example-bad
-let obj = {
-  url: /docs/Web
+const obj = {
+  url: /docs/Web,
 };
 
 // SyntaxError: invalid regular expression flag "W"
@@ -86,8 +86,8 @@ An expression containing two slashes is interpreted as a regular expression lite
 Most likely the intent was to create a string literal, using single or double quotes as shown below:
 
 ```js example-good
-let obj = {
-  url: '/docs/Web'
+const obj = {
+  url: '/docs/Web',
 };
 ```
 

--- a/files/en-us/web/javascript/reference/errors/bad_return_or_yield/index.md
+++ b/files/en-us/web/javascript/reference/errors/bad_return_or_yield/index.md
@@ -16,10 +16,10 @@ statement is called outside of a [function](/en-US/docs/Web/JavaScript/Guide/Fun
 
 ## Message
 
-```js
-SyntaxError: 'return' statement outside of function (Edge)
+```
+SyntaxError: Illegal return statement (V8-based)
 SyntaxError: return not in function (Firefox)
-SyntaxError: yield not in function (Firefox)
+SyntaxError: Return statements are only valid inside functions. (Safari)
 ```
 
 ## Error type

--- a/files/en-us/web/javascript/reference/errors/bigint_division_by_zero/index.md
+++ b/files/en-us/web/javascript/reference/errors/bigint_division_by_zero/index.md
@@ -14,7 +14,7 @@ The JavaScript exception "BigInt division by zero" occurs when a {{jsxref("BigIn
 ## Message
 
 ```
-RangeError: Division by zero (Chromium-based)
+RangeError: Division by zero (V8-based)
 RangeError: BigInt division by zero (Firefox)
 RangeError: 0 is an invalid divisor value. (Safari)
 ```

--- a/files/en-us/web/javascript/reference/errors/bigint_negative_exponent/index.md
+++ b/files/en-us/web/javascript/reference/errors/bigint_negative_exponent/index.md
@@ -14,7 +14,7 @@ The JavaScript exception "BigInt negative exponent" occurs when a {{jsxref("BigI
 ## Message
 
 ```
-RangeError: Exponent must be positive (Chromium-based)
+RangeError: Exponent must be positive (V8-based)
 RangeError: BigInt negative exponent (Firefox)
 RangeError: Negative exponent is not allowed (Safari)
 ```

--- a/files/en-us/web/javascript/reference/errors/called_on_incompatible_type/index.md
+++ b/files/en-us/web/javascript/reference/errors/called_on_incompatible_type/index.md
@@ -15,12 +15,13 @@ the type expected by the function.
 
 ## Message
 
-```js
-TypeError: 'this' is not a Set object (Edge)
+```
+TypeError: Method Set.prototype.add called on incompatible receiver undefined (V8-based)
+TypeError: Bind must be called on a function (V8-based)
 TypeError: Function.prototype.toString called on incompatible object (Firefox)
 TypeError: Function.prototype.bind called on incompatible target (Firefox)
-TypeError: Method Set.prototype.add called on incompatible receiver undefined (Chrome)
-TypeError: Bind must be called on a function (Chrome)
+TypeError: Type error (Safari)
+TypeError: undefined is not an object (Safari)
 ```
 
 ## Error type

--- a/files/en-us/web/javascript/reference/errors/cant_access_lexical_declaration_before_init/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_access_lexical_declaration_before_init/index.md
@@ -14,9 +14,10 @@ This happens within any block statement, when [`let`](/en-US/docs/Web/JavaScript
 
 ## Message
 
-```plain
-ReferenceError: Cannot access 'X' before initialization (Chrome and Edge)
+```
+ReferenceError: Cannot access 'X' before initialization (V8-based)
 ReferenceError: can't access lexical declaration 'X' before initialization (Firefox)
+ReferenceError: Cannot access uninitialized variable. (Safari)
 ```
 
 ## Error type
@@ -43,7 +44,7 @@ At this point is has not been initialized with a value, so accessing the variabl
 ```js example-bad
 function test() {
   // Accessing the 'const' variable foo before it's declared
-  console.log(foo);     // ReferenceError: foo is not initialized
+  console.log(foo);       // ReferenceError: foo is not initialized
   const foo = 33;         // 'foo' is declared and initialized here using the 'const' keyword
 }
 
@@ -55,10 +56,10 @@ test();
 In the following example, we correctly declare a variable using the `const` keyword before accessing it.
 
 ```js example-good
-function test(){
-   // Declaring variable foo
-   const foo = 33;
-   console.log(foo);    // 33
+function test() {
+  // Declaring variable foo
+  const foo = 33;
+  console.log(foo);    // 33
 }
 test();
 ```

--- a/files/en-us/web/javascript/reference/errors/cant_access_property/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_access_property/index.md
@@ -14,17 +14,15 @@ operated on {{jsxref("undefined")}} or {{jsxref("null")}} values.
 
 ## Message
 
-```js
-TypeError: Unable to get property {x} of undefined or null reference (Edge)
-TypeError: can't access property {x} of {y} (Firefox)
-TypeError: {y} is undefined, can't access property {x} of it (Firefox)
-TypeError: {y} is null, can't access property {x} of it (Firefox)
-
-Examples:
-TypeError: x is undefined, can't access property "prop" of it
-TypeError: x is null, can't access property "prop" of it
-TypeError: can't access property "prop" of undefined
-TypeError: can't access property "prop" of null
+```
+TypeError: Cannot read properties of undefined (reading 'x') (V8-based)
+TypeError: Cannot read properties of null (reading 'a') (V8-based)
+TypeError: undefined has no properties (Firefox)
+TypeError: null has no properties (Firefox)
+TypeError: x is undefined (Firefox)
+TypeError: x is null (Firefox)
+TypeError: undefined is not an object (evaluating 'obj.x') (Safari)
+TypeError: null is not an object (evaluating 'obj.x') (Safari)
 ```
 
 ## Error type
@@ -43,10 +41,10 @@ value.
 ```js example-bad
 // undefined and null cases on which the substring method won't work
 const foo = undefined;
-foo.substring(1); // TypeError: x is undefined, can't access property "substring" of it
+foo.substring(1); // TypeError: foo is undefined
 
-const foo = null;
-foo.substring(1); // TypeError: x is null, can't access property "substring" of it
+const foo2 = null;
+foo2.substring(1); // TypeError: foo is null
 ```
 
 ### Fixing the issue

--- a/files/en-us/web/javascript/reference/errors/cant_assign_to_property/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_assign_to_property/index.md
@@ -15,9 +15,10 @@ such as a [symbol](/en-US/docs/Glossary/Symbol), a [string](/en-US/docs/Glossary
 
 ## Message
 
-```js
-TypeError: can't assign to property "x" on {y}: not an object (Firefox)
-TypeError: Cannot create property 'x' on {y} (Chrome)
+```
+TypeError: Cannot create property 'x' on number '1' (V8-based)
+TypeError: can't assign to property "x" on 1: not an object (Firefox)
+TypeError: Attempted to assign to readonly property. (Safari)
 ```
 
 ## Error type

--- a/files/en-us/web/javascript/reference/errors/cant_be_converted_to_bigint_because_it_isnt_an_integer/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_be_converted_to_bigint_because_it_isnt_an_integer/index.md
@@ -14,7 +14,7 @@ The JavaScript exception "x can't be converted to BigInt because it isn't an int
 ## Message
 
 ```
-RangeError: The number 1.5 cannot be converted to a BigInt because it is not an integer (Chromium-based & Firefox)
+RangeError: The number 1.5 cannot be converted to a BigInt because it is not an integer (V8-based & Firefox)
 RangeError: Not an integer (Safari)
 ```
 

--- a/files/en-us/web/javascript/reference/errors/cant_convert_bigint_to_number/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_convert_bigint_to_number/index.md
@@ -14,8 +14,8 @@ The JavaScript exception "can't convert BigInt to number" occurs when an arithme
 ## Message
 
 ```
-TypeError: Cannot mix BigInt and other types, use explicit conversions (Chromium-based)
-TypeError: BigInts have no unsigned right shift, use >> instead (Chromium-based)
+TypeError: Cannot mix BigInt and other types, use explicit conversions (V8-based)
+TypeError: BigInts have no unsigned right shift, use >> instead (V8-based)
 TypeError: can't convert BigInt to number (Firefox)
 TypeError: Invalid mix of BigInt and other type in addition/multiplication/…. (Safari)
 TypeError: BigInt does not support >>> operator (Safari)

--- a/files/en-us/web/javascript/reference/errors/cant_convert_x_to_bigint/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_convert_x_to_bigint/index.md
@@ -14,7 +14,7 @@ The JavaScript exception "x can't be converted to BigInt" occurs when attempting
 ## Message
 
 ```
-TypeError: Cannot convert null to a BigInt (Chromium-based)
+TypeError: Cannot convert null to a BigInt (V8-based)
 TypeError: can't convert null to BigInt (Firefox)
 TypeError: Invalid argument type in ToBigInt operation (Safari)
 ```

--- a/files/en-us/web/javascript/reference/errors/cant_define_property_object_not_extensible/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_define_property_object_not_extensible/index.md
@@ -16,10 +16,11 @@ as non-extensible.
 
 ## Message
 
-```js
-TypeError: Cannot create property for a non-extensible object (Edge)
-TypeError: can't define property "x": "obj" is not extensible (Firefox)
-TypeError: Cannot define property: "x", object is not extensible. (Chrome)
+```
+TypeError: Cannot add property x, object is not extensible (V8-based)
+TypeError: Cannot define property x, object is not extensible (V8-based)
+TypeError: can't define property "x": Object is not extensible (Firefox)
+TypeError: Attempting to define property on object that is not extensible. (Safari)
 ```
 
 ## Error type
@@ -49,7 +50,7 @@ const obj = {};
 Object.preventExtensions(obj);
 
 obj.x = 'foo';
-// TypeError: can't define property "x": "obj" is not extensible
+// TypeError: can't define property "x": Object is not extensible
 ```
 
 In both, [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode) and
@@ -60,10 +61,8 @@ property to a non-extensible object.
 const obj = { };
 Object.preventExtensions(obj);
 
-Object.defineProperty(obj,
-  'x', { value: "foo" }
-);
-// TypeError: can't define property "x": "obj" is not extensible
+Object.defineProperty(obj, 'x', { value: "foo" });
+// TypeError: can't define property "x": Object is not extensible
 ```
 
 To fix this error, you will either need to remove the call to

--- a/files/en-us/web/javascript/reference/errors/cant_delete/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_delete/index.md
@@ -15,10 +15,10 @@ when it was attempted to delete a property, but that property is [non-configurab
 
 ## Message
 
-```js
-TypeError: Calling delete on 'x' is not allowed in strict mode (Edge)
-TypeError: property "x" is non-configurable and can't be deleted. (Firefox)
-TypeError: Cannot delete property 'x' of #<Object> (Chrome)
+```
+TypeError: Cannot delete property 'x' of #<Object> (V8-based)
+TypeError: property "x" is non-configurable and can't be deleted (Firefox)
+TypeError: Unable to delete property. (Safari)
 ```
 
 ## Error type

--- a/files/en-us/web/javascript/reference/errors/cant_redefine_property/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_redefine_property/index.md
@@ -14,10 +14,10 @@ attempted to redefine a property, but that property is [non-configurable](/en-US
 
 ## Message
 
-```js
-TypeError: Cannot modify non-writable property {x} (Edge)
+```
+TypeError: Cannot redefine property: "x" (V8-based)
 TypeError: can't redefine non-configurable property "x" (Firefox)
-TypeError: Cannot redefine property: "x" (Chrome)
+TypeError: Attempting to change value of a readonly property. (Safari)
 ```
 
 ## Error type

--- a/files/en-us/web/javascript/reference/errors/cyclic_object_value/index.md
+++ b/files/en-us/web/javascript/reference/errors/cyclic_object_value/index.md
@@ -15,10 +15,10 @@ to solve them and fails accordingly.
 
 ## Message
 
-```js
+```
+TypeError: Converting circular structure to JSON (V8-based)
 TypeError: cyclic object value (Firefox)
-TypeError: Converting circular structure to JSON (Chrome and Opera)
-TypeError: Circular reference in value argument not supported (Edge)
+TypeError: JSON.stringify cannot serialize cyclic structures. (Safari)
 ```
 
 ## Error type

--- a/files/en-us/web/javascript/reference/errors/dead_object/index.md
+++ b/files/en-us/web/javascript/reference/errors/dead_object/index.md
@@ -15,7 +15,7 @@ destroyed to improve in memory usage and to prevent memory leaks.
 
 ## Message
 
-```js
+```
 TypeError: can't access dead object
 ```
 

--- a/files/en-us/web/javascript/reference/errors/delete_in_strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/errors/delete_in_strict_mode/index.md
@@ -15,10 +15,10 @@ The JavaScript [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode)-o
 
 ## Message
 
-```js
-SyntaxError: Calling delete on expression not allowed in strict mode (Edge)
-SyntaxError: applying the 'delete' operator to an unqualified name is deprecated (Firefox)
+```
 SyntaxError: Delete of an unqualified identifier in strict mode. (Chrome)
+SyntaxError: applying the 'delete' operator to an unqualified name is deprecated (Firefox)
+SyntaxError: Cannot delete unqualified property 'a' in strict mode. (Safari)
 ```
 
 ## Error type


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

This is part of a bigger effort to renovate the error reference pages' error messages.

For example, because Edge now uses Chromium, we can remove the Edge error messages. I also changed "Chromium-based" to "V8-based" to include Node as well. I wonder if we should do the same for Firefox and Safari, considering [JavaScriptCore is now also used outside Safari](https://bun.sh/).

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
