### PR TITLE
Elaborate on sort comparator formal rules

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
@@ -97,7 +97,7 @@ More formally, the comparator is expected to have the following properties, in o
 - _Pure_: The comparator does not mutate the objects being compared or any external state. (This is important because there's no guarantee _when_ and _how_ the comparator will be called, so any particular call should not produce visible effects to the outside.)
 - _Stable_: The comparator returns the same result with the same pair of input.
 - _Reflexive_: `compare(a, a) === 0`.
-- _Symmetric_: `Math.sign(compare(a, b)) === -1 * Math.sign(compare(b, a))`.
+- _Symmetric_: `compare(a, b)` and `compare(b, a)` must both be `0` or have opposite signs.
 - _Transitive_: For every given `a, b, c` true that if `Math.sign(compare(a, b)) !== -1 * Math.sign(compare(b, c))` than `Math.sign(compare(a, b) + compare(b, c)) === Math.sign(compare(a, c))` (e.g. `a<b<c` than `a<c` and `a=b<c` than `a<c`, etc.)
 
 A comparator conforming to the rules above will always be able to return all of `1`, `0`, and `-1`. For example, if a comparator only returns `1` and 0`, or only returns `0` and `-1`, it will not be able to sort reliably because _symmetry_ is broken.

--- a/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
@@ -100,7 +100,7 @@ More formally, the comparator is expected to have the following properties, in o
 - _Symmetric_: `compare(a, b)` and `compare(b, a)` must both be `0` or have opposite signs.
 - _Transitive_: For every given `a, b, c` true that if `Math.sign(compare(a, b)) !== -1 * Math.sign(compare(b, c))` than `Math.sign(compare(a, b) + compare(b, c)) === Math.sign(compare(a, c))` (e.g. `a<b<c` than `a<c` and `a=b<c` than `a<c`, etc.)
 
-A comparator conforming to the constraints above will always be able to return all of `1`, `0`, and `-1`, or consistently return `0`. For example, if a comparator only returns `1` and `0`, or only returns `0` and `-1`, it will not be able to sort reliably because _symmetry_ is broken. Comparators always returning `0` will cause the array to not be changed at all, but is reliable nonetheless.
+A comparator conforming to the constraints above will always be able to return all of `1`, `0`, and `-1`, or consistently return `0`. For example, if a comparator only returns `1` and `0`, or only returns `0` and `-1`, it will not be able to sort reliably because _symmetry_ is broken. A comparator that always returns `0` will cause the array to not be changed at all, but is reliable nonetheless.
 
 The default lexicographic comparator satisfies all constraints above.
 

--- a/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
@@ -100,7 +100,7 @@ More formally, the comparator is expected to have the following properties, in o
 - _Symmetric_: `compare(a, b)` and `compare(b, a)` must both be `0` or have opposite signs.
 - _Transitive_: For every given `a, b, c` true that if `Math.sign(compare(a, b)) !== -1 * Math.sign(compare(b, c))` than `Math.sign(compare(a, b) + compare(b, c)) === Math.sign(compare(a, c))` (e.g. `a<b<c` than `a<c` and `a=b<c` than `a<c`, etc.)
 
-A comparator conforming to the rules above will always be able to return all of `1`, `0`, and `-1`. For example, if a comparator only returns `1` and 0`, or only returns `0` and `-1`, it will not be able to sort reliably because _symmetry_ is broken.
+A comparator conforming to the rules above will always be able to return all of `1`, `0`, and `-1`. For example, if a comparator only returns `1` and `0`, or only returns `0` and `-1`, it will not be able to sort reliably because _symmetry_ is broken.
 
 The default lexicographic comparator satisfies all constraints above.
 

--- a/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
@@ -335,7 +335,7 @@ const compare = (a, b) => a > b ? 1 : 0;
 arr.sort(compare);
 ```
 
-The `compare` function here is not well-formed, because it does not satisfy symmetry: if `a > b`, it returns `1`; but by swapping `a` and `b`, it returns `0` instead of a negative value. Therefore, the resulting array will be different across engines. For example, V8 (used by Chrome, Node.js, etc.) and JavaScriptCore (used by Safari) would not sort the array at all, and return `[3, 1, 4, 1, 5, 9]`, while SpiderMonkey (used by Firefox) will return the array sorted ascendingly, as `[1, 1, 3, 4, 5, 9]`.
+The `compare` function here is not well-formed, because it does not satisfy symmetry: if `a > b`, it returns `1`; but by swapping `a` and `b`, it returns `0` instead of a negative value. Therefore, the resulting array will be different across engines. For example, V8 (used by Chrome, Node.js, etc.) and JavaScriptCore (used by Safari) would not sort the array at all and return `[3, 1, 4, 1, 5, 9]`, while SpiderMonkey (used by Firefox) will return the array sorted ascendingly, as `[1, 1, 3, 4, 5, 9]`.
 
 However, if the `compare` function is changed slightly so that it returns `-1` or `0`:
 

--- a/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
@@ -97,8 +97,10 @@ More formally, the comparator is expected to have the following properties, in o
 - _Pure_: The comparator does not mutate the objects being compared or any external state. (This is important because there's no guarantee _when_ and _how_ the comparator will be called, so any particular call should not produce visible effects to the outside.)
 - _Stable_: The comparator returns the same result with the same pair of input.
 - _Reflexive_: `compare(a, a) === 0`.
-- _Symmetric_: If `compare(a, b) === 0`, then `compare(b, a) === 0`.
-- _Transitive_: If `compare(a, b)` and `compare(b, c)` are both positive, zero, or negative, then `compare(a, c)` has the same positivity as the previous two.
+- _Symmetric_: `Math.sign(compare(a, b)) === -1 * Math.sign(compare(b, a))`.
+- _Transitive_: For every given `a, b, c` true that if `Math.sign(compare(a, b)) !== -1 * Math.sign(compare(b, c))` than `Math.sign(compare(a, b) + compare(b, c)) === Math.sign(compare(a, c))` (e.g. `a<b<c` than `a<c` and `a=b<c` than `a<c`, etc.)
+
+Your sort method is probably wrong, if it only contains `1, 0` or `0, -1` as return values, because it will break the _Symmetric_ behaviour (altough the `1, 0` will seem to work in some environments).
 
 The default lexicographic comparator satisfies all constraints above.
 

--- a/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
@@ -100,7 +100,7 @@ More formally, the comparator is expected to have the following properties, in o
 - _Symmetric_: `Math.sign(compare(a, b)) === -1 * Math.sign(compare(b, a))`.
 - _Transitive_: For every given `a, b, c` true that if `Math.sign(compare(a, b)) !== -1 * Math.sign(compare(b, c))` than `Math.sign(compare(a, b) + compare(b, c)) === Math.sign(compare(a, c))` (e.g. `a<b<c` than `a<c` and `a=b<c` than `a<c`, etc.)
 
-Your sort method is probably wrong, if it only contains `1, 0` or `0, -1` as return values, because it will break the _Symmetric_ behaviour (altough the `1, 0` will seem to work in some environments).
+A comparator conforming to the rules above will always be able to return all of `1`, `0`, and `-1`. For example, if a comparator only returns `1` and 0`, or only returns `0` and `-1`, it will not be able to sort reliably because _symmetry_ is broken.
 
 The default lexicographic comparator satisfies all constraints above.
 

--- a/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
@@ -100,7 +100,7 @@ More formally, the comparator is expected to have the following properties, in o
 - _Symmetric_: `compare(a, b)` and `compare(b, a)` must both be `0` or have opposite signs.
 - _Transitive_: For every given `a, b, c` true that if `Math.sign(compare(a, b)) !== -1 * Math.sign(compare(b, c))` than `Math.sign(compare(a, b) + compare(b, c)) === Math.sign(compare(a, c))` (e.g. `a<b<c` than `a<c` and `a=b<c` than `a<c`, etc.)
 
-A comparator conforming to the rules above will always be able to return all of `1`, `0`, and `-1`. For example, if a comparator only returns `1` and `0`, or only returns `0` and `-1`, it will not be able to sort reliably because _symmetry_ is broken.
+A comparator conforming to the constraints above will always be able to return all of `1`, `0`, and `-1`, or consistently return `0`. For example, if a comparator only returns `1` and `0`, or only returns `0` and `-1`, it will not be able to sort reliably because _symmetry_ is broken. Comparators always returning `0` will cause the array to not be changed at all, but is reliable nonetheless.
 
 The default lexicographic comparator satisfies all constraints above.
 

--- a/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
@@ -98,7 +98,7 @@ More formally, the comparator is expected to have the following properties, in o
 - _Stable_: The comparator returns the same result with the same pair of input.
 - _Reflexive_: `compare(a, a) === 0`.
 - _Symmetric_: `compare(a, b)` and `compare(b, a)` must both be `0` or have opposite signs.
-- _Transitive_: For every given `a, b, c` true that if `Math.sign(compare(a, b)) !== -1 * Math.sign(compare(b, c))` than `Math.sign(compare(a, b) + compare(b, c)) === Math.sign(compare(a, c))` (e.g. `a<b<c` than `a<c` and `a=b<c` than `a<c`, etc.)
+- _Transitive_: If `compare(a, b)` and `compare(b, c)` are both positive, zero, or negative, then `compare(a, c)` has the same positivity as the previous two.
 
 A comparator conforming to the constraints above will always be able to return all of `1`, `0`, and `-1`, or consistently return `0`. For example, if a comparator only returns `1` and `0`, or only returns `0` and `-1`, it will not be able to sort reliably because _symmetry_ is broken. A comparator that always returns `0` will cause the array to not be changed at all, but is reliable nonetheless.
 
@@ -322,6 +322,32 @@ Before version 10 (or EcmaScript 2019), sort stability was not guaranteed, meani
   { name: "Alex",   grade: 15 }  // original order not maintained
 ];
 ```
+
+### Sorting with non-well-formed comparator
+
+If a comparing function does not satisfy all of purity, stability, reflexivity, symmetry, and transitivity rules, as explained in the [description](#description), the program's behavior is not well-defined.
+
+For example, consider this code:
+
+```js
+const arr = [3, 1, 4, 1, 5, 9];
+const compare = (a, b) => a > b ? 1 : 0;
+arr.sort(compare);
+```
+
+The `compare` function here is not well-formed, because it does not satisfy symmetry: if `a > b`, it returns `1`; but by swapping `a` and `b`, it returns `0` instead of a negative value. Therefore, the resulting array will be different across engines. For example, V8 (used by Chrome, Node.js, etc.) and JavaScriptCore (used by Safari) would not sort the array at all, and return `[3, 1, 4, 1, 5, 9]`, while SpiderMonkey (used by Firefox) will return the array sorted ascendingly, as `[1, 1, 3, 4, 5, 9]`.
+
+However, if the `compare` function is changed slightly so that it returns `-1` or `0`:
+
+```js
+const arr = [3, 1, 4, 1, 5, 9];
+const compare = (a, b) => a > b ? -1 : 0;
+arr.sort(compare);
+```
+
+Then V8 and JavaScriptCore sorts it descendingly, as `[9, 5, 4, 3, 1, 1]`, while SpiderMonkey returns it as-is: `[3, 1, 4, 1, 5, 9]`.
+
+Due to this implementation inconsistency, you are always advised to make your comparator well-formed by following the five constraints.
 
 ## Specifications
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
I made the formal rules mathematically more correct + added a note about the return values.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
This sorted my array `return [...prevState, s].sort((a, b) => (a.type === 'bs' && b.type !== a.type) ? 1 : 0 )`, but this not `return [...prevState, s].sort((a, b) => (a.type === 'bs' && b.type !== a.type) ? -1 : 0 )` and I needed about 10 mins to figure out that they are not symmetric.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
