### PR TITLE
Suggest proper pseudo-class for keyboard focus

### DIFF
--- a/files/en-us/web/accessibility/understanding_wcag/keyboard/index.md
+++ b/files/en-us/web/accessibility/understanding_wcag/keyboard/index.md
@@ -64,7 +64,7 @@ If the user can interact with an element (for example, using touch or a pointing
 
 ## Focusable element must have focus styling
 
-Any element that can receive keyboard focus should have visible styling that indicates when the element is focused. You can do this with the [`:focus`](/en-US/docs/Web/CSS/:focus) CSS pseudo-class.
+Any element that can receive keyboard focus should have visible styling that indicates when the element is focused. You can do this with the [`:focus-visible`](/en-US/docs/Web/CSS/:focus-visible) CSS pseudo-class.
 
 Standard focusable elements such as links and input fields are given special styling by the browser by default, so you might not need to specify focus styling for such elements, unless you want the focus styling to be more distinctive.
 

--- a/files/en-us/web/accessibility/understanding_wcag/keyboard/index.md
+++ b/files/en-us/web/accessibility/understanding_wcag/keyboard/index.md
@@ -64,7 +64,7 @@ If the user can interact with an element (for example, using touch or a pointing
 
 ## Focusable element must have focus styling
 
-Any element that can receive keyboard focus should have visible styling that indicates when the element is focused. You can do this with the [`:focus-visible`](/en-US/docs/Web/CSS/:focus-visible) CSS pseudo-class.
+Any element that can receive keyboard focus should have visible styling that indicates when the element is focused. You can do this with the [`:focus`](/en-US/docs/Web/CSS/:focus) and [`:focus-visible`](/en-US/docs/Web/CSS/:focus-visible) CSS pseudo-classes.
 
 Standard focusable elements such as links and input fields are given special styling by the browser by default, so you might not need to specify focus styling for such elements, unless you want the focus styling to be more distinctive.
 


### PR DESCRIPTION
The section [Focusable element must have focus styling](https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Keyboard#focusable_element_must_have_focus_styling) speaks about keyboard focus but suggests the adapt the styles using the `:focus` pseudo class. This however would modify the UI not just for keyboard access but also for tap, click and other means of interaction. `:focus-visible` however can help making this very distinction and hence should be promoted here.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Suggesting `:focus-visible` psdeudo-class rather than `:focus` for keyboard focus styling.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The `:focus-visible` pseudo-class isn't as well know as `:focus` but might be all it takes to style UI states for keyboard access. Developers for instance do not have to rely on a whole dependency like "what-input" which would bloat the file size unnecessarily.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Referring to MDN's own helpful resources here: https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
