### PR TITLE
Update BCD identifiers for Content Security Policy

### DIFF
--- a/files/en-us/web/http/csp/index.md
+++ b/files/en-us/web/http/csp/index.md
@@ -8,7 +8,7 @@ tags:
   - Guide
   - Security
   - access
-browser-compat: http.headers.csp
+browser-compat: http.headers.Content-Security-Policy
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/base-uri/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/base-uri/index.md
@@ -7,7 +7,7 @@ tags:
   - Document directive
   - HTTP
   - Security
-browser-compat: http.headers.csp.Content-Security-Policy.base-uri
+browser-compat: http.headers.Content-Security-Policy.base-uri
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/block-all-mixed-content/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/block-all-mixed-content/index.md
@@ -10,7 +10,7 @@ tags:
   - Reference
   - Security
   - block-all-mixed-content
-browser-compat: http.headers.csp.Content-Security-Policy.block-all-mixed-content
+browser-compat: http.headers.Content-Security-Policy.block-all-mixed-content
 ---
 {{HTTPSidebar}}{{deprecated_header}}
 

--- a/files/en-us/web/http/headers/content-security-policy/child-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/child-src/index.md
@@ -11,7 +11,7 @@ tags:
   - Security
   - child-src
   - source
-browser-compat: http.headers.csp.Content-Security-Policy.child-src
+browser-compat: http.headers.Content-Security-Policy.child-src
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
@@ -10,7 +10,7 @@ tags:
   - Security
   - connect-src
   - source
-browser-compat: http.headers.csp.Content-Security-Policy.connect-src
+browser-compat: http.headers.Content-Security-Policy.connect-src
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/default-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/default-src/index.md
@@ -11,7 +11,7 @@ tags:
   - default
   - default-src
   - source
-browser-compat: http.headers.csp.Content-Security-Policy.default-src
+browser-compat: http.headers.Content-Security-Policy.default-src
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/font-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/font-src/index.md
@@ -10,7 +10,7 @@ tags:
   - Security
   - font
   - source
-browser-compat: http.headers.csp.Content-Security-Policy.font-src
+browser-compat: http.headers.Content-Security-Policy.font-src
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/form-action/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/form-action/index.md
@@ -10,7 +10,7 @@ tags:
   - action
   - form
   - form-action
-browser-compat: http.headers.csp.Content-Security-Policy.form-action
+browser-compat: http.headers.Content-Security-Policy.form-action
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/frame-ancestors/index.md
@@ -10,7 +10,7 @@ tags:
   - HTTP
   - Security
   - frame-ancestors
-browser-compat: http.headers.csp.Content-Security-Policy.frame-ancestors
+browser-compat: http.headers.Content-Security-Policy.frame-ancestors
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/frame-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/frame-src/index.md
@@ -11,7 +11,7 @@ tags:
   - Security
   - frame-src
   - source
-browser-compat: http.headers.csp.Content-Security-Policy.frame-src
+browser-compat: http.headers.Content-Security-Policy.frame-src
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/img-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/img-src/index.md
@@ -11,7 +11,7 @@ tags:
   - Security
   - img-src
   - source
-browser-compat: http.headers.csp.Content-Security-Policy.img-src
+browser-compat: http.headers.Content-Security-Policy.img-src
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/index.md
@@ -8,7 +8,7 @@ tags:
   - Reference
   - Security
   - header
-browser-compat: http.headers.csp.Content-Security-Policy
+browser-compat: http.headers.Content-Security-Policy
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/manifest-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/manifest-src/index.md
@@ -11,7 +11,7 @@ tags:
   - Security
   - manifest-src
   - source
-browser-compat: http.headers.csp.Content-Security-Policy.manifest-src
+browser-compat: http.headers.Content-Security-Policy.manifest-src
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/media-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/media-src/index.md
@@ -11,7 +11,7 @@ tags:
   - Security
   - media-src
   - source
-browser-compat: http.headers.csp.Content-Security-Policy.media-src
+browser-compat: http.headers.Content-Security-Policy.media-src
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/navigate-to/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/navigate-to/index.md
@@ -9,7 +9,7 @@ tags:
   - Navigation
   - Reference
   - Security
-browser-compat: http.headers.csp.Content-Security-Policy.navigate-to
+browser-compat: http.headers.Content-Security-Policy.navigate-to
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/object-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/object-src/index.md
@@ -11,7 +11,7 @@ tags:
   - Security
   - object-src
   - source
-browser-compat: http.headers.csp.Content-Security-Policy.object-src
+browser-compat: http.headers.Content-Security-Policy.object-src
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/plugin-types/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/plugin-types/index.md
@@ -11,7 +11,7 @@ tags:
   - Plugin
   - Plugins
   - Security
-browser-compat: http.headers.csp.Content-Security-Policy.plugin-types
+browser-compat: http.headers.Content-Security-Policy.plugin-types
 ---
 {{HTTPSidebar}}{{deprecated_header}}
 

--- a/files/en-us/web/http/headers/content-security-policy/prefetch-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/prefetch-src/index.md
@@ -8,7 +8,7 @@ tags:
   - HTTP
   - Reference
   - prefetch-src
-browser-compat: http.headers.csp.Content-Security-Policy.prefetch-src
+browser-compat: http.headers.Content-Security-Policy.prefetch-src
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/referrer/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/referrer/index.md
@@ -10,7 +10,7 @@ tags:
   - Reference
   - Security
   - referrer
-browser-compat: http.headers.csp.Content-Security-Policy.referrer
+browser-compat: http.headers.Content-Security-Policy.referrer
 ---
 {{HTTPSidebar}} {{deprecated_header}}
 

--- a/files/en-us/web/http/headers/content-security-policy/report-to/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/report-to/index.md
@@ -9,7 +9,7 @@ tags:
   - Reporting
   - Security
   - report-to
-browser-compat: http.headers.csp.Content-Security-Policy.report-to
+browser-compat: http.headers.Content-Security-Policy.report-to
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/report-uri/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/report-uri/index.md
@@ -7,7 +7,7 @@ tags:
   - HTTP
   - Reference
   - Security
-browser-compat: http.headers.csp.Content-Security-Policy.report-uri
+browser-compat: http.headers.Content-Security-Policy.report-uri
 ---
 {{HTTPSidebar}}{{deprecated_header}}
 

--- a/files/en-us/web/http/headers/content-security-policy/require-sri-for/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/require-sri-for/index.md
@@ -9,7 +9,7 @@ tags:
   - Security
   - Subresource Integrity
   - require-sri-for
-browser-compat: http.headers.csp.Content-Security-Policy.require-sri-for
+browser-compat: http.headers.Content-Security-Policy.require-sri-for
 ---
 {{deprecated_header}}
 

--- a/files/en-us/web/http/headers/content-security-policy/require-trusted-types-for/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/require-trusted-types-for/index.md
@@ -6,7 +6,7 @@ tags:
   - Directive
   - HTTP
   - Security
-browser-compat: http.headers.csp.Content-Security-Policy.require-trusted-types-for
+browser-compat: http.headers.Content-Security-Policy.require-trusted-types-for
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/sandbox/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/sandbox/index.md
@@ -8,7 +8,7 @@ tags:
   - HTTP
   - Sandbox
   - Security
-browser-compat: http.headers.csp.Content-Security-Policy.sandbox
+browser-compat: http.headers.Content-Security-Policy.sandbox
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-attr/index.md
@@ -12,7 +12,7 @@ tags:
   - Security
   - script-src
   - source
-browser-compat: http.headers.csp.Content-Security-Policy.script-src-attr
+browser-compat: http.headers.Content-Security-Policy.script-src-attr
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src-elem/index.md
@@ -12,7 +12,7 @@ tags:
   - Security
   - script-src
   - source
-browser-compat: http.headers.csp.Content-Security-Policy.script-src-elem
+browser-compat: http.headers.Content-Security-Policy.script-src-elem
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/script-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/script-src/index.md
@@ -12,7 +12,7 @@ tags:
   - Security
   - script-src
   - source
-browser-compat: http.headers.csp.Content-Security-Policy.script-src
+browser-compat: http.headers.Content-Security-Policy.script-src
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-attr/index.md
@@ -13,7 +13,7 @@ tags:
   - source
   - style-src
   - style-src-attr
-browser-compat: http.headers.csp.Content-Security-Policy.style-src-attr
+browser-compat: http.headers.Content-Security-Policy.style-src-attr
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src-elem/index.md
@@ -13,7 +13,7 @@ tags:
   - source
   - style-src
   - style-src-elem
-browser-compat: http.headers.csp.Content-Security-Policy.style-src-elem
+browser-compat: http.headers.Content-Security-Policy.style-src-elem
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/style-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src/index.md
@@ -12,7 +12,7 @@ tags:
   - Style
   - source
   - style-src
-browser-compat: http.headers.csp.Content-Security-Policy.style-src
+browser-compat: http.headers.Content-Security-Policy.style-src
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/trusted-types/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/trusted-types/index.md
@@ -6,7 +6,7 @@ tags:
   - Directive
   - HTTP
   - Security
-browser-compat: http.headers.csp.Content-Security-Policy.trusted-types
+browser-compat: http.headers.Content-Security-Policy.trusted-types
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/upgrade-insecure-requests/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/upgrade-insecure-requests/index.md
@@ -11,7 +11,7 @@ tags:
   - Security
   - Upgrade
   - upgrade-insecure-requests
-browser-compat: http.headers.csp.Content-Security-Policy.upgrade-insecure-requests
+browser-compat: http.headers.Content-Security-Policy.upgrade-insecure-requests
 ---
 {{HTTPSidebar}}
 

--- a/files/en-us/web/http/headers/content-security-policy/worker-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/worker-src/index.md
@@ -8,7 +8,7 @@ tags:
   - HTTP
   - Reference
   - Security
-browser-compat: http.headers.csp.Content-Security-Policy.worker-src
+browser-compat: http.headers.Content-Security-Policy.worker-src
 ---
 {{HTTPSidebar}}
 


### PR DESCRIPTION
This PR updates all of the BCD keys for the Content-Security-Policy HTTP header to adhere to its move in https://github.com/mdn/browser-compat-data/pull/16980 (since it's the only subfeature of `http.headers.csp`, so it's redundant to have an additional parent of `csp`).
