### PR TITLE
showopenfilepicker API: add that the method is async

### DIFF
--- a/files/en-us/web/api/window/showopenfilepicker/index.md
+++ b/files/en-us/web/api/window/showopenfilepicker/index.md
@@ -48,7 +48,7 @@ showOpenFilePicker()
 
 ### Return value
 
-A {{jsxref('Array')}} of {{domxref('FileSystemFileHandle')}} objects.
+A {{jsxref("Promise")}} whose fulfillment handler receives an {{jsxref('Array')}} of {{domxref('FileSystemFileHandle')}} objects.
 
 ### Exceptions
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Correct the **Return** section of the Syntax to specify that the return value is actually a Promise (and not an array).
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
As far as I know, the API is async, this means that the `return` value is actually a Promise and not an Array.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
<img width="481" alt="image" src="https://user-images.githubusercontent.com/36935593/178852297-795d7f03-3755-4cc7-9e39-f6549d686d16.png">

You also state it here: https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Asynchronous/Introducing#:~:text=Asking%20a%20user%20to%20select%20files%20using%20showOpenFilePicker()

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
