### PR TITLE
update way of explaining how to add methods to prototypes

### DIFF
--- a/files/en-us/learn/javascript/objects/object_prototypes/index.md
+++ b/files/en-us/learn/javascript/objects/object_prototypes/index.md
@@ -197,7 +197,7 @@ Here we create:
 We then put the methods defined in `personPrototype` onto the `Person` function's `prototype` property using [Object.assign](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign).
 
 
-After this code, objects created using `Person()` will get `personPrototype` as their prototype.
+After this code, objects created using `Person()` will get `Person.prototype` as their prototype, which automatically contains the `greet` method.
 
 ```js
 const reuben = new Person('Reuben');

--- a/files/en-us/learn/javascript/objects/object_prototypes/index.md
+++ b/files/en-us/learn/javascript/objects/object_prototypes/index.md
@@ -194,7 +194,7 @@ Here we create:
 - an object `personPrototype`, which has a `greet()` method
 - a `Person()` constructor function which initializes the name of the person to create.
 
-We then set the `Person` function's `prototype` property to point to `personPrototype` using [Object.assign](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign) to put a new function inside the prototype.
+We then put the methods defined in `personPrototype` onto the `Person` function's `prototype` property using [Object.assign](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign).
 
 
 After this code, objects created using `Person()` will get `personPrototype` as their prototype.

--- a/files/en-us/learn/javascript/objects/object_prototypes/index.md
+++ b/files/en-us/learn/javascript/objects/object_prototypes/index.md
@@ -184,8 +184,9 @@ function Person(name) {
   this.name = name;
 }
 
-Person.prototype = personPrototype;
-Person.prototype.constructor = Person;
+Object.assign(Person.prototype, personPrototype);
+// or
+// Person.prototype.greet = personPrototype.greet;
 ```
 
 Here we create:
@@ -193,10 +194,8 @@ Here we create:
 - an object `personPrototype`, which has a `greet()` method
 - a `Person()` constructor function which initializes the name of the person to create.
 
-We then set the `Person` function's `prototype` property to point to `personPrototype`.
+We then set the `Person` function's `prototype` property to point to `personPrototype` using [Object.assign](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign) to put a new function inside the prototype.
 
-The last line (`Person.prototype.constructor = Person;`) sets the prototype's `constructor` property to the function used to create `Person` objects.
-This is required because after setting `Person.prototype = personPrototype;` the property points to the constructor for the `personPrototype`, which is `Object` rather than `Person` (because `personPrototype` was constructed as an object literal).
 
 After this code, objects created using `Person()` will get `personPrototype` as their prototype.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
update way of explaining how to add methods to prototypes

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The old code overwrites the entire prototype with an object overriding the old constructor, and then adds the constructor on another line. I, who was studying the subject found it quite complex, and there are simpler ways to do it without having to overriding a constructor and fix it, and explain superficially what is going on.

It's a suggestion to simplify and not have to address unnecessary things to the topic explained in the snippet. It's much easier to understand an Object.assign than to understand why you need two lines because of an overriding that was done.

