### PR TITLE
MathML: updated communication links

### DIFF
--- a/files/en-us/web/mathml/index.md
+++ b/files/en-us/web/mathml/index.md
@@ -35,7 +35,6 @@ Below you will find links to documentation, examples, and tools to work with Mat
 - [W3C Math Home](https://www.w3.org/Math/)
 - [Raise issues on GitHub w3c/mathml repository](https://github.com/w3c/mathml/issues)
 - [www-math w3.org mail archive](https://lists.w3.org/Archives/Public/www-math/)
-- [Wiki used by Mozilla contributors](https://wiki.mozilla.org/MathML:Home_Page)
 
 ## Tools
 

--- a/files/en-us/web/mathml/index.md
+++ b/files/en-us/web/mathml/index.md
@@ -32,10 +32,10 @@ Below you will find links to documentation, examples, and tools to work with Mat
 
 ## Getting help from the community
 
-- [mozilla.dev.tech.mathml Google Group](https://groups.google.com/g/mozilla.dev.tech.mathml)
-- [Wiki used by Mozilla contributors](https://wiki.mozilla.org/MathML:Home_Page)
 - [W3C Math Home](https://www.w3.org/Math/)
+- [Raise issues on GitHub w3c/mathml repository](https://github.com/w3c/mathml/issues)
 - [www-math w3.org mail archive](https://lists.w3.org/Archives/Public/www-math/)
+- [Wiki used by Mozilla contributors](https://wiki.mozilla.org/MathML:Home_Page)
 
 ## Tools
 


### PR DESCRIPTION
There is no activity on google groups for years.
Sorted the list by most likely available/responsive.