### PR TITLE
Comment out ellipsis in code blocks, part 5

### DIFF
--- a/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_event_subpage_template/index.md
@@ -162,10 +162,10 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 >  ## Examples
 >
 >  ### Using the fetch API
->  ... example of Fetch
+>  Example of Fetch
 >
 >  ### More examples
->  ...links to more examples on other pages
+>  Links to more examples on other pages
 >  ```
 >
 > **Scenario 2:** If you _only_ have examples on another page and none on this page:

--- a/files/en-us/mdn/structures/page_types/api_landing_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_landing_page_template/index.md
@@ -153,10 +153,10 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 >  ## Examples
 >
 >  ### Using the fetch API
->  ... example of Fetch
+>  Example of Fetch
 >
 >  ### More examples
->  ...links to more examples on other pages
+>  Links to more examples on other pages
 >  ```
 >
 > **Scenario 2:** If you _only_ have examples on another page and none on this page:

--- a/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_method_subpage_template/index.md
@@ -149,10 +149,10 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 >  ## Examples
 >
 >  ### Using the fetch API
->  ... example of Fetch
+>  Example of Fetch
 >
 >  ### More examples
->  ...links to more examples on other pages
+>  Links to more examples on other pages
 >  ```
 >
 > **Scenario 2:** If you _only_ have examples on another page and none on this page:

--- a/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_property_subpage_template/index.md
@@ -113,10 +113,10 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 >  ## Examples
 >
 >  ### Using the fetch API
->  ... example of Fetch
+>  Example of Fetch
 >
 >  ### More examples
->  ...links to more examples on other pages
+>  Links to more examples on other pages
 >  ```
 >
 > **Scenario 2:** If you _only_ have examples on another page and none on this page:

--- a/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/api_reference_page_template/index.md
@@ -119,10 +119,10 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 >  ## Examples
 >
 >  ### Using the fetch API
->  ... example of Fetch
+>  Example of Fetch
 >
 >  ### More examples
->  ...links to more examples on other pages
+>  Links to more examples on other pages
 >  ```
 >
 > **Scenario 2:** If you _only_ have examples on another page and none on this page:

--- a/files/en-us/mdn/structures/page_types/aria_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/aria_page_template/index.md
@@ -91,10 +91,10 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 >  ## Examples
 >
 >  ### Using the fetch API
->  ... example of Fetch
+>  Example of Fetch
 >
 >  ### More examples
->  ...links to more examples on other pages
+>  Links to more examples on other pages
 >  ```
 >
 > **Scenario 2:** If you _only_ have examples on another page and none on this page:

--- a/files/en-us/mdn/structures/page_types/css_property_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/css_property_page_template/index.md
@@ -126,10 +126,10 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 >  ## Examples
 >
 >  ### Using the fetch API
->  ... example of Fetch
+>  Example of Fetch
 >
 >  ### More examples
->  ...links to more examples on other pages
+>  Links to more examples on other pages
 >  ```
 >
 > **Scenario 2:** If you _only_ have examples on another page and none on this page:

--- a/files/en-us/mdn/structures/page_types/css_selector_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/css_selector_page_template/index.md
@@ -109,10 +109,10 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 >  ## Examples
 >
 >  ### Using the fetch API
->  ... example of Fetch
+>  Example of Fetch
 >
 >  ### More examples
->  ...links to more examples on other pages
+>  Links to more examples on other pages
 >  ```
 >
 > **Scenario 2:** If you _only_ have examples on another page and none on this page:

--- a/files/en-us/mdn/structures/page_types/html_element_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/html_element_page_template/index.md
@@ -123,10 +123,10 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 >  ## Examples
 >
 >  ### Using the fetch API
->  ... example of Fetch
+>  Example of Fetch
 >
 >  ### More examples
->  ...links to more examples on other pages
+>  Links to more examples on other pages
 >  ```
 >
 > **Scenario 2:** If you _only_ have examples on another page and none on this page:

--- a/files/en-us/mdn/structures/page_types/http_header_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/http_header_page_template/index.md
@@ -141,10 +141,10 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 >  ## Examples
 >
 >  ### Using the fetch API
->  ... example of Fetch
+>  Example of Fetch
 >
 >  ### More examples
->  ...links to more examples on other pages
+>  Links to more examples on other pages
 >  ```
 >
 > **Scenario 2:** If you _only_ have examples on another page and none on this page:

--- a/files/en-us/mdn/structures/page_types/svg_element_page_template/index.md
+++ b/files/en-us/mdn/structures/page_types/svg_element_page_template/index.md
@@ -127,10 +127,10 @@ See our guide on how to add [code examples](/en-US/docs/MDN/Structures/Code_exam
 >  ## Examples
 >
 >  ### Using the fetch API
->  ... example of Fetch
+>  Example of Fetch
 >
 >  ### More examples
->  ...links to more examples on other pages
+>  Links to more examples on other pages
 >  ```
 >
 > **Scenario 2:** If you _only_ have examples on another page and none on this page:

--- a/files/en-us/mdn/structures/syntax_sections/index.md
+++ b/files/en-us/mdn/structures/syntax_sections/index.md
@@ -131,19 +131,19 @@ For methods with a callback function, the syntax for arrow functions, functions,
 
 ```js
 // Arrow function
-filter((currentValue) => { /* ... */ } )
-filter((currentValue, index) => { /* ... */ } )
-filter((currentValue, index, array) => { /* ... */ } )
+filter((currentValue) => { /* … */ } )
+filter((currentValue, index) => { /* … */ } )
+filter((currentValue, index, array) => { /* … */ } )
 
 // Callback function
 filter(callbackFn)
 filter(callbackFn, thisArg)
 
 // Inline callback function
-filter(function(currentValue) { /* ... */ })
-filter(function(currentValue, index) { /* ... */ })
-filter(function(currentValue, index, array){ /* ... */ })
-filter(function(currentValue, index, array) { /* ... */ }, thisArg)
+filter(function(currentValue) { /* … */ })
+filter(function(currentValue, index) { /* … */ })
+filter(function(currentValue, index, array){ /* … */ })
+filter(function(currentValue, index, array) { /* … */ }, thisArg)
 ```
 
 ##### Syntax for arbitrary number of parameters
@@ -153,7 +153,7 @@ For methods that accept an arbitrary number of parameters, the syntax block is w
 ```js
 unshift(element0)
 unshift(element0, element1)
-unshift(element0, element1, /* ... ,*/ elementN)
+unshift(element0, element1, /* … ,*/ elementN)
 ```
 
 #### Parameters section

--- a/files/en-us/mdn/tools/kumascript/index.md
+++ b/files/en-us/mdn/tools/kumascript/index.md
@@ -59,7 +59,7 @@ Hello #2
 Macro syntax takes the following general form:
 
 ```js
-\{{templateName("arg0", "arg1", ..., "argN")}}
+\{{templateName("arg0", "arg1", /* …, */ "argN")}}
 ```
 
 Macro syntax follows these rules:
@@ -110,7 +110,7 @@ KumaScript templates are processed by an [embedded JavaScript template engine](h
   <% } %>
   ```
 
-  Note how the JavaScript code is contained in `<% ... %>`, and output happens in the space between `%> ... <%`. The `for` loop in JS can begin with one `<% %>` block, transition to output mode, and finish up in a second `<% %>` JS block.
+  Note how the JavaScript code is contained in `<% … %>`, and output happens in the space between `%> … <%`. The `for` loop in JS can begin with one `<% %>` block, transition to output mode, and finish up in a second `<% %>` JS block.
 
 - For more details on EJS syntax, [check out the upstream module documentation](https://ejs.co).
 
@@ -201,7 +201,7 @@ This manually-maintained documentation is likely to fall out of date with the co
 
 - `md5(string)`
   - : Returns an MD5 hex digest of the given string.
-- `template("name", ["arg0", "arg1", ..., "argN"])`
+- `template("name", ["arg0", "arg1", …, "argN"])`
 
   - : Executes and returns the result of the named template with the given list of parameters.
 
@@ -321,7 +321,7 @@ Syntax error at line 436, column 461: Expected valid JSON object as the paramete
 If you edit the page, you'll probably see a macro like this at the bottom of the page:
 
 ```plain
-\{{ wiki.languages({ "zh-tw": "zh_tw/Core_JavaScript_1.5_教學/JavaScript_概要", ... }) }}
+\{{ wiki.languages({ "zh-tw": "zh_tw/Core_JavaScript_1.5_教學/JavaScript_概要", … }) }}
 ```
 
 To fix the problem, just delete the macro. Or, replace the curly braces on either side with HTML comments `<!-- -->` to preserve the information, like so:

--- a/files/en-us/mozilla/add-ons/webextensions/api/events/urlfilter/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/events/urlfilter/index.md
@@ -15,7 +15,7 @@ browser-compat: webextensions.api.events.UrlFilter
 ---
 {{AddonSidebar()}}
 
-Describes various criteria for filtering URLs. If all of the criteria specified in the filter's properties match the URL, then the filter matches. Filters are often provided to API methods in an [Array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) of UrlFilters. For example, [webNavigation](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation) listeners can be added with a filter which is an object with a single `url` property that is an [Array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) of UrlFilters, e.g. `{url:[UrlFilter,UrlFilter,...]}`. If any filter within the Array of UrlFilters matches, then it is considered a match for the Array. Effectively, the criteria specified within a single filter are AND'ed together, while all of the individual filters within an Array are OR'ed.
+Describes various criteria for filtering URLs. If all of the criteria specified in the filter's properties match the URL, then the filter matches. Filters are often provided to API methods in an [Array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) of UrlFilters. For example, [webNavigation](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webNavigation) listeners can be added with a filter which is an object with a single `url` property that is an [Array](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) of UrlFilters, e.g. `{url:[UrlFilter, UrlFilter, …]}`. If any filter within the Array of UrlFilters matches, then it is considered a match for the Array. Effectively, the criteria specified within a single filter are AND'ed together, while all of the individual filters within an Array are OR'ed.
 
 All criteria are case sensitive.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequestexternal/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/onrequestexternal/index.md
@@ -25,8 +25,8 @@ Fired when a request is sent from another extension.
 chrome.extension.onRequestExternal.addListener(function(
   request,         // optional any
   sender,          // runtime.MessageSender
-  function() {...} // function
-) {...})
+  function() { } // function
+) { })
 chrome.extension.onRequestExternal.removeListener(listener)
 chrome.extension.onRequestExternal.hasListener(listener)
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/sendrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/sendrequest/index.md
@@ -26,7 +26,7 @@ Sends a single request to other listeners within the extension. Similar to {{Web
 chrome.extension.sendRequest(
   extensionId,             // optional string
   request,                 // any
-  function(response) {...} // optional function
+  function(response) { } // optional function
 )
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/menus/create/index.md
@@ -26,7 +26,7 @@ For compatibility with other browsers, Firefox makes this method available via t
 ```js
 browser.menus.create(
   createProperties, // object
-  function() {...}  // optional function
+  function() { }  // optional function
 )
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/index.md
@@ -129,7 +129,7 @@ For complete example extensions, see [Example extensions](/en-US/docs/Mozilla/Ad
 
   "default_locale": "en",
 
-  "description": "...",
+  "description": "…",
 
   "icons": {
     "48": "icon.png",
@@ -138,7 +138,7 @@ For complete example extensions, see [Example extensions](/en-US/docs/Mozilla/Ad
 
   "manifest_version": 2,
 
-  "name": "...",
+  "name": "…",
 
   "page_action": {
     "default_icon": {

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/version/format/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/version/format/index.md
@@ -36,7 +36,7 @@ When two version strings are compared, their version parts are compared left to 
 
 If at some point a version part of one version string is greater than the corresponding version part of another version string, then the first version string is greater than the other one.
 
-Otherwise, the version strings are equal. Note, that since missing version parts are treated as if they were `0`, the following version strings are equal: `1`, `1.0`, `1.0.`, `1.0.0`, and even `1.0…`
+Otherwise, the version strings are equal. Note that since missing version parts are treated as if they were `0`, the following version strings are equal: `1`, `1.0`, `1.0.`, `1.0.0`, and even `1.0..`.
 
 ### Comparing version parts
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/version/format/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/version/format/index.md
@@ -36,7 +36,7 @@ When two version strings are compared, their version parts are compared left to 
 
 If at some point a version part of one version string is greater than the corresponding version part of another version string, then the first version string is greater than the other one.
 
-Otherwise, the version strings are equal. Note, that since missing version parts are treated as if they were `0`, the following version strings are equal: `1`, `1.0`, `1.0.`, `1.0.0`, and even `1.0...`
+Otherwise, the version strings are equal. Note, that since missing version parts are treated as if they were `0`, the following version strings are equal: `1`, `1.0`, `1.0.`, `1.0.0`, and even `1.0…`
 
 ### Comparing version parts
 

--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/web_accessible_resources/index.md
@@ -64,7 +64,7 @@ In Manifest V3, the `web_accessible_resources` key is an array of objects like t
 
 ```
 {
-  ...
+  // …
   "web_accessible_resources": [
     {
       "resources": [ "test1.png", "test2.png" ],
@@ -75,7 +75,7 @@ In Manifest V3, the `web_accessible_resources` key is an array of objects like t
       "use_dynamic_url": true
     }
   ],
-  ...
+  // …
 }
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
@@ -284,8 +284,8 @@ You can quickly get started sending and receiving messages with this NodeJS code
             flushChunksQueue();
 
             const json = JSON.parse(contentWithoutSize);
-            // Do something with the data...
-            }
+            // Do something with the data…
+         }
     };
 
     process.stdin.on('readable', () => {

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/context_menu_items/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/context_menu_items/index.md
@@ -42,7 +42,7 @@ browser.contextMenus.onClicked.addListener(function(info, tab) {
     case "log-selection":
       console.log(info.selectionText);
       break;
-    ...
+    // …
   }
 })
 ```

--- a/files/en-us/mozilla/firefox/releases/20/index.md
+++ b/files/en-us/mozilla/firefox/releases/20/index.md
@@ -24,7 +24,7 @@ Firefox 20 was released on April, 2nd 2013. This article provides information ab
 - Support for the `WeakMap.prototype.clear()` method, recently added to the Harmony (EcmaScript 2015) draft proposal has been added ({{bug("814562")}}).
 - Support for the [`Math.imul()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/imul) method, a C-style 32-bit multiplication function. Though proposed for Harmony (EcmaScript 2015) it has not yet accepted and still is non-standard ({{bug("808148")}}).
 - Web apps using draggable text with Kinetic 3.x are working, even when using the Cairo canvas backend ({{bug("835064")}}).
-- The [`for each…in`](/en-US/docs/JavaScript/Reference/Statements/for_each...in) statement has been deprecated and should not be used. Consider using the new [`for…of`](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) statement ({{Bug("804834")}}).
+- The [`for each...in`](/en-US/docs/JavaScript/Reference/Statements/for_each...in) statement has been deprecated and should not be used. Consider using the new [`for...of`](/en-US/docs/Web/JavaScript/Reference/Statements/for...of) statement ({{Bug("804834")}}).
 - Support for the {{jsxref("Map.prototype.keys()")}}, {{jsxref("Map.prototype.values()")}}, and {{jsxref("Map.prototype.entries()")}} has been added ({{bug("817368")}}).
 
 ### CSS
@@ -50,7 +50,7 @@ Firefox 20 was released on April, 2nd 2013. This article provides information ab
 - The third, optional, `transfer` argument of {{domxref("Window.postMessage")}} is now supported. It allows to transfer a sequence of {{domxref("Transferable")}} objects to the destination ({{bug("822094")}}).
 - The non-standard {{domxref("Window.sizeToContent()")}} method now clamps the minimal size: the window cannot be forced anymore to small sizes preventing the user to interact with ({{bug(764240)}}).
 - Blend modes, such as `overlay`, `color-burn`, `hue`, etc. have been added to the Canvas {{domxref("CanvasRenderingContext2D.globalCompositeOperation")}} property ({{bug(748433)}}).
-- The prefixed version of [`window.indexedDB`](/en-US/docs/Web/API/indexedDB) — `window.mozIndexedDB` — was reintroduced to Gecko, so that bad cross-browser prefixing code (such as `var indexedDB = window.indexedDB || window.webkitIndexedDB ...`) doesn't break in Firefox. A better approach is `window.indexedDB = window.indexedDB || window.webkitIndexedDB ...` (see {{bug("770844")}}.)
+- The prefixed version of [`window.indexedDB`](/en-US/docs/Web/API/indexedDB) — `window.mozIndexedDB` — was reintroduced to Gecko, so that bad cross-browser prefixing code (such as `var indexedDB = window.indexedDB || window.webkitIndexedDB …`) doesn't break in Firefox. A better approach is `window.indexedDB = window.indexedDB || window.webkitIndexedDB …` (see {{bug("770844")}}.)
 
 ### SVG
 

--- a/files/en-us/mozilla/firefox/releases/3/updating_web_applications/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/updating_web_applications/index.md
@@ -26,13 +26,13 @@ Firefox 3 closes a security bug in frames and iframes that allowed them to inher
 The `<script>` element in `text/html` documents now requires a closing `</script>` in HTML 4 documents, even if you're not including any content in between. While in previous versions of Firefox, you could do:
 
 ```html
-<script/>
+<script … />
 ```
 
 Now the markup must comply with the HTML specifications (if it's actually HTML), and hence you must actually close it, like this:
 
 ```html
-<script></script>
+<script …></script>
 ```
 
 This improves both compatibility and security.

--- a/files/en-us/mozilla/firefox/releases/3/updating_web_applications/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/updating_web_applications/index.md
@@ -26,13 +26,13 @@ Firefox 3 closes a security bug in frames and iframes that allowed them to inher
 The `<script>` element in `text/html` documents now requires a closing `</script>` in HTML 4 documents, even if you're not including any content in between. While in previous versions of Firefox, you could do:
 
 ```html
-<script ... />
+<script/>
 ```
 
 Now the markup must comply with the HTML specifications (if it's actually HTML), and hence you must actually close it, like this:
 
 ```html
-<script ...></script>
+<script></script>
 ```
 
 This improves both compatibility and security.

--- a/files/en-us/mozilla/firefox/releases/5/updating_add-ons/index.md
+++ b/files/en-us/mozilla/firefox/releases/5/updating_add-ons/index.md
@@ -57,9 +57,9 @@ To fix this, move your instantiation of these services into your `load` event ha
 var MyObject = {
   comp : null,
   init: function() {
-    this.comp = Components.classes[...].getService(...);
+    this.comp = Components.classes["…"].getService(/* … */);
   },
-  ...
+  // …
 }
 window.addEventListener("load", function() { MyObject.init(); }, false);
 ```

--- a/files/en-us/related/imsc/index.md
+++ b/files/en-us/related/imsc/index.md
@@ -21,7 +21,7 @@ Each IMSC document is self-contained and combines content, timing, layout and st
 IMSC differs from HTML in a number of ways:
 
 - IMSC uses [namespaces](/en-US/docs/Related/IMSC/Namespaces), so that `tts:fontSize` is not the same as `fontSize`, and namespace declarations are required, like
-  `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:tts="http://www.w3.org/ns/ttml#styling" ...>`
+  `<tt xmlns="http://www.w3.org/ns/ttml" xmlns:tts="http://www.w3.org/ns/ttml#styling" …>`
 - IMSC has stricter rules, for instance `<p>` elements can only be present within `<div>` elements, and cannot be direct children of `<body>` elements.
 
 While attributes names and syntax are similar, styling differs from CSS in a couple of ways:

--- a/files/en-us/related/imsc/mapping_video_time_codes_to_imsc/index.md
+++ b/files/en-us/related/imsc/mapping_video_time_codes_to_imsc/index.md
@@ -51,7 +51,7 @@ The two attributes that must be included to use the frames method are `frameRate
 
 ```xml
 <tt ttp:frameRate="24" ttp:frameRateMultiplier="1000 1001">
-  <!-- … -->
+  …
 </tt>
 ```
 

--- a/files/en-us/related/imsc/mapping_video_time_codes_to_imsc/index.md
+++ b/files/en-us/related/imsc/mapping_video_time_codes_to_imsc/index.md
@@ -50,8 +50,8 @@ That said, there is actually a different approach to describing the time express
 The two attributes that must be included to use the frames method are `frameRate` and `frameRateMultiplier`. The frame rate describes how many frames are in one second, and the multiplier is applied to the `frameRate` to describe the actual frame rate in real time seconds. To describe a frame rate of 23.976fps, the following values would be used:
 
 ```xml
-<tt ... ttp:frameRate="24" ttp:frameRateMultiplier="1000 1001">
-  ...
+<tt ttp:frameRate="24" ttp:frameRateMultiplier="1000 1001">
+  <!-- … -->
 </tt>
 ```
 

--- a/files/en-us/web/accessibility/aria/annotations/index.md
+++ b/files/en-us/web/accessibility/aria/annotations/index.md
@@ -52,7 +52,7 @@ We have already alluded to the difference between these two above — `aria-desc
 `aria-describedby` is appropriate for associating an element with a simple text description, where you don't have much in the way of meaningful semantics contained within. For example:
 
 ```html
-<p id="description-id">An extended text description of some kind…</p>
+<p id="description-id">An extended text description of some kind.</p>
 
 <div aria-describedby="description-id">
   <!-- Some kind of UI feature that needs an accessible description  -->

--- a/files/en-us/web/accessibility/aria/annotations/index.md
+++ b/files/en-us/web/accessibility/aria/annotations/index.md
@@ -52,7 +52,7 @@ We have already alluded to the difference between these two above — `aria-desc
 `aria-describedby` is appropriate for associating an element with a simple text description, where you don't have much in the way of meaningful semantics contained within. For example:
 
 ```html
-<p id="description-id">An extended text description of some kind...</p>
+<p id="description-id">An extended text description of some kind…</p>
 
 <div aria-describedby="description-id">
   <!-- Some kind of UI feature that needs an accessible description  -->
@@ -65,7 +65,7 @@ We have already alluded to the difference between these two above — `aria-desc
 <div id="detail-id">
   <h2>A heading</h2>
   <p>An extended text description of some kind…</p>
-  <p><time datetime="...">A timestamp</time></p>
+  <p><time datetime="…">A timestamp</time></p>
 </div>
 
 <div aria-details="detail-id">

--- a/files/en-us/web/accessibility/aria/aria_live_regions/index.md
+++ b/files/en-us/web/accessibility/aria/aria_live_regions/index.md
@@ -105,7 +105,7 @@ Here is a screenshot of VoiceOver on Mac announcing the update (via subtitles) t
 
 ## Roles with implicit live region attributes
 
-Elements with the following [`role="..."`](/en-US/docs/Web/Accessibility/ARIA/Roles) values act as live regions by default:
+Elements with the following [`role="…"`](/en-US/docs/Web/Accessibility/ARIA/Roles) values act as live regions by default:
 
 <table style="width: 100%;">
  <thead>
@@ -196,7 +196,7 @@ One way around this would be to first clear all the contents of the live region 
 
 ```html
 <div id="clock" role="timer" aria-live="polite" aria-atomic="true">
-  ...
+  …
 </div>
 ```
 

--- a/files/en-us/web/accessibility/aria/attributes/aria-colcount/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-colcount/index.md
@@ -62,7 +62,7 @@ The first rule of ARIA use is "if you can use a native feature with the semantic
       <td>New York</td>
       <td>14127</td>
     </tr>
-    ...
+    …
   </tbody>
 </table>
 ```


### PR DESCRIPTION
Adding to #18206.

Ellipsis in markdown code blocks are syntax errors.
In order to have smooth transition to Prettier and ESLint the PR comments out such bare ellipses.