### PR TITLE
Meta tag: include media attribute

### DIFF
--- a/files/en-us/web/html/element/meta/name/index.md
+++ b/files/en-us/web/html/element/meta/name/index.md
@@ -100,7 +100,7 @@ The HTML specification defines the following set of standard metadata names:
   > - Dynamically inserting `<meta name="referrer">` (with {{domxref("Document.write", "document.write()")}} or {{domxref("Node.appendChild", "appendChild()")}}) makes the referrer behavior unpredictable.
   > - When several conflicting policies are defined, the `no-referrer` policy is applied.
 
-- [`theme-color`](/en-US/docs/Web/HTML/Element/meta/name/theme-color): indicates a suggested color that user agents should use to customize the display of the page or of the surrounding user interface. The `content` attribute contains a valid CSS {{cssxref("&lt;color&gt;")}}.
+- [`theme-color`](/en-US/docs/Web/HTML/Element/meta/name/theme-color): indicates a suggested color that user agents should use to customize the display of the page or of the surrounding user interface. The `content` attribute contains a valid CSS {{cssxref("&lt;color&gt;")}}. The `media` attribute with a valid media query list can be included to set the media the theme color metadata applies to.
 - `color-scheme`: specifies one or more color schemes with which the document is compatible.
 
   The browser will use this information in tandem with the user's browser or device settings to determine what colors to use for everything from background and foregrounds to form controls and scrollbars. The primary use for `<meta name="color-scheme">` is to indicate compatibility with—and order of preference for—light and dark color modes.


### PR DESCRIPTION
#### Summary

The media attribute is ONLY valid on meta tags when the name value is set to color scheme. Otherwise, the media value is ignored. 

#### Motivation

Media attribute was missing, but is limited in scope

#### Supporting details

https://html.spec.whatwg.org/multipage/semantics.html#meta-theme-color
https://html.spec.whatwg.org/multipage/semantics.html#the-meta-element - see content attributes section
https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-media


- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
