### PR TITLE
Fixing link to tabindex HTML global attribute

### DIFF
--- a/files/en-us/web/api/htmlelement/focus/index.md
+++ b/files/en-us/web/api/htmlelement/focus/index.md
@@ -128,7 +128,7 @@ focusNoScrollMethod = function getFocusWithoutScrolling() {
   must call `event.preventDefault()` to keep the focus from leaving the
   `HTMLElement`
 - Behavior of the focus in relation to different HTML features like
-  {{HTMLAttrxRef("tabindex")}} or {{Glossary("shadow tree","shadow dom", 1)}},
+  [`tabindex`](/en-US/docs/Web/HTML/Global_attributes/tabindex) or {{Glossary("shadow tree","shadow dom", 1)}},
   which previously remained under-specified, were recently updated (as October
   of 2019). Checkout [WHATWG blog](https://blog.whatwg.org/focusing-on-focus) for more info.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
I replaced the link to the non-existent `tabindex` anchor on the HTML global attribute page with a link to the `tabindex` HTML global attribute page.

#### Motivation
The link to the `tabindex` HTML global attribute went to a non-existent anchor. 

#### Related issues
#15725 and #16660 were similar issues.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
