### PR TITLE
Fix issue voices not ready on page load in Chrome

### DIFF
--- a/files/en-us/web/api/speechsynthesisutterance/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/index.md
@@ -82,11 +82,23 @@ const inputForm = document.querySelector('form');
 const inputTxt = document.querySelector('input');
 const voiceSelect = document.querySelector('select');
 
-for (let i = 0; i < voices.length; i++) {
-  const option = document.createElement('option');
-  option.textContent = voices[i].name + ' (' + voices[i].lang + ')';
-  option.value = i;
-  voiceSelect.appendChild(option);
+let voices;
+
+function loadVoices() {
+  voices = synth.getVoices();
+  for(let i = 0; i < voices.length; i++) {
+    const option = document.createElement('option');
+    option.textContent = voices[i].name + ' (' + voices[i].lang + ')';
+    option.value = i;
+    voiceSelect.appendChild(option);
+  }
+}
+
+// in Google Chrome the voices are not ready on page load
+if ('onvoiceschanged' in synth) {
+  synth.onvoiceschanged = loadVoices;
+} else {
+  loadVoices();
 }
 
 inputForm.onsubmit = function(event) {

--- a/files/en-us/web/api/speechsynthesisutterance/index.md
+++ b/files/en-us/web/api/speechsynthesisutterance/index.md
@@ -76,7 +76,6 @@ Inside the `inputForm.onsubmit` handler, we stop the form submitting with {{domx
 
 ```js
 const synth = window.speechSynthesis;
-const voices = synth.getVoices();
 
 const inputForm = document.querySelector('form');
 const inputTxt = document.querySelector('input');


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

Fix code snippet when voices are not ready on page loading in Chrome

#### Motivation
The code doesn't work when copy-paste in Google Chrome

#### Supporting details
IT's based on [Codepen Demo](https://codepen.io/jcubic/pen/rNdWjrR?editors=1010) but the if statement was similar to [Example](https://github.com/mdn/dom-examples/tree/master/web-speech-api/speak-easy-synthesis)

#### Related issues
This fixes #18359

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
