### PR TITLE
Minor: HTML: remove presentational elements

### DIFF
--- a/files/en-us/web/api/range/tostring/index.md
+++ b/files/en-us/web/api/range/tostring/index.md
@@ -38,7 +38,7 @@ A string.
 ### HTML
 
 ```html
-<p>This example logs <b>everything</b> between the bold <b>words</b>. Look at the output below.</p>
+<p>This example logs <em>everything</em> between the emphasized <em>words</em>. Look at the output below.</p>
 <p id="log"></p>
 ```
 
@@ -47,8 +47,8 @@ A string.
 ```js
 const range = document.createRange();
 
-range.setStartBefore(document.getElementsByTagName('b').item(0), 0);
-range.setEndAfter(document.getElementsByTagName('b').item(1), 0);
+range.setStartBefore(document.getElementsByTagName('em').item(0), 0);
+range.setEndAfter(document.getElementsByTagName('em').item(1), 0);
 document.getElementById('log').textContent = range.toString();
 ```
 

--- a/files/en-us/web/api/websockets_api/writing_websocket_client_applications/index.md
+++ b/files/en-us/web/api/websockets_api/writing_websocket_client_applications/index.md
@@ -181,13 +181,13 @@ exampleSocket.onmessage = function(event) {
       setUsername();
       break;
     case "username":
-      text = "<b>User <em>" + msg.name + "</em> signed in at " + timeStr + "</b><br>";
+      text = "User <em>" + msg.name + "</em> signed in at " + timeStr + "<br>";
       break;
     case "message":
-      text = "(" + timeStr + ") <b>" + msg.name + "</b>: " + msg.text + "<br>";
+      text = "(" + timeStr + ") " + msg.name + ": " + msg.text + "<br>";
       break;
     case "rejectusername":
-      text = "<b>Your username has been set to <em>" + msg.name + "</em> because the name you chose is in use.</b><br>"
+      text = "Your username has been set to <em>" + msg.name + "</em> because the name you chose is in use.<br>"
       break;
     case "userlist":
       var ul = "";

--- a/files/en-us/web/api/websockets_api/writing_websocket_client_applications/index.md
+++ b/files/en-us/web/api/websockets_api/writing_websocket_client_applications/index.md
@@ -181,7 +181,7 @@ exampleSocket.onmessage = function(event) {
       setUsername();
       break;
     case "username":
-      text = "User <em>" + msg.name + "</em> signed in at " + timeStr + "<br>";
+      text = `User <em>${msg.name}</em> signed in at ${timeStr}<br>`;
       break;
     case "message":
       text = "(" + timeStr + ") " + msg.name + ": " + msg.text + "<br>";

--- a/files/en-us/web/api/websockets_api/writing_websocket_client_applications/index.md
+++ b/files/en-us/web/api/websockets_api/writing_websocket_client_applications/index.md
@@ -18,14 +18,12 @@ WebSocket client applications use the [WebSocket API](/en-US/docs/Web/API/WebSoc
 
 {{AvailableInWorkers}}
 
-> **Note:** The example snippets in this article are taken from our
-> WebSocket chat client/server sample. [See the code](https://github.com/mdn/samples-server/tree/master/s/websocket-chat).
+> **Note:** The example snippets in this article are taken from our WebSocket chat client/server sample.
+> [See the code](https://github.com/mdn/samples-server/tree/master/s/websocket-chat).
 
 ## Creating a WebSocket object
 
-In order to communicate using the WebSocket protocol, you need to create a
-{{domxref("WebSocket")}} object; this will automatically attempt to open the connection
-to the server.
+In order to communicate using the WebSocket protocol, you need to create a {{domxref("WebSocket")}} object; this will automatically attempt to open the connection to the server.
 
 The WebSocket constructor accepts one required and one optional parameter:
 
@@ -34,70 +32,48 @@ webSocket = new WebSocket(url, protocols);
 ```
 
 - `url`
-  - : The URL to which to connect; this should be the URL to which the WebSocket server
-    will respond. This should use the URL scheme `wss://`, although some
-    software may allow you to use the insecure `ws://` for local connections.
+  - : The URL to which to connect; this should be the URL to which the WebSocket server will respond.
+    This should use the URL scheme `wss://`, although some software may allow you to use the insecure `ws://` for local connections.
 - `protocols` {{ optional_inline() }}
-  - : Either a single protocol string or an array of protocol strings. These strings are
-    used to indicate sub-protocols, so that a single server can implement multiple
-    WebSocket sub-protocols (for example, you might want one server to be able to handle
-    different types of interactions depending on the specified `protocol`). If
-    you don't specify a protocol string, an empty string is assumed.
+  - : Either a single protocol string or an array of protocol strings.
+    These strings are used to indicate sub-protocols, so that a single server can implement multiple WebSocket sub-protocols (for example, you might want one server to be able to handle different types of interactions depending on the specified `protocol`).
+    If you don't specify a protocol string, an empty string is assumed.
 
-The constructor will throw a `SecurityError` if the destination doesn't
-allow access. This may happen if you attempt to use an insecure connection (most
-{{Glossary("user agent", "user agents")}} now require a secure link for all WebSocket
-connections unless they're on the same device or possibly on the same network).
+The constructor will throw a `SecurityError` if the destination doesn't allow access.
+This may happen if you attempt to use an insecure connection (most {{Glossary("user agent", "user agents")}} now require a secure link for all WebSocket connections unless they're on the same device or possibly on the same network).
 
 ### Connection errors
 
-If an error occurs while attempting to connect, first a simple event with the name
-`error` is sent to the {{domxref("WebSocket")}} object (thereby invoking its
-{{domxref("WebSocket.onerror", "onerror")}} handler), and then the
-{{domxref("CloseEvent")}} is sent to the `WebSocket` object (thereby invoking
-its {{domxref("WebSocket.onclose", "onclose")}} handler) to indicate the reason for the
-connection's closing.
+If an error occurs while attempting to connect, first a simple event with the name `error` is sent to the {{domxref("WebSocket")}} object (thereby invoking its {{domxref("WebSocket.onerror", "onerror")}} handler), and then the {{domxref("CloseEvent")}} is sent to the `WebSocket` object (thereby invoking its {{domxref("WebSocket.onclose", "onclose")}} handler) to indicate the reason for the connection's closing.
 
-The browser may also output to its console a more descriptive error message as well as
-a closing code as defined in [RFC 6455, Section 7.4](https://datatracker.ietf.org/doc/html/rfc6455#section-7.4) through the
-{{domxref("CloseEvent")}}.
+The browser may also output to its console a more descriptive error message as well as a closing code as defined in [RFC 6455, Section 7.4](https://datatracker.ietf.org/doc/html/rfc6455#section-7.4) through the {{domxref("CloseEvent")}}.
 
 ### Examples
 
-This simple example creates a new WebSocket, connecting to the server at
-`wss://www.example.com/socketserver`. A custom
-protocol of "protocolOne" is named in the request for the socket in this example, though
-this can be omitted.
+This simple example creates a new WebSocket, connecting to the server at `wss://www.example.com/socketserver`.
+A custom protocol of "protocolOne" is named in the request for the socket in this example, though this can be omitted.
 
 ```js
 var exampleSocket = new WebSocket("wss://www.example.com/socketserver", "protocolOne");
 ```
 
-On return, {{domxref("WebSocket.readyState", "exampleSocket.readyState")}} is
-`CONNECTING`. The `readyState` will become `OPEN` once
+On return, {{domxref("WebSocket.readyState", "exampleSocket.readyState")}} is `CONNECTING`. The `readyState` will become `OPEN` once
 the connection is ready to transfer data.
 
-If you want to open a connection and are flexible about the protocols you support, you
-can specify an array of protocols:
+If you want to open a connection and are flexible about the protocols you support, you can specify an array of protocols:
 
 ```js
 var exampleSocket = new WebSocket("wss://www.example.com/socketserver", ["protocolOne", "protocolTwo"]);
 ```
 
-Once the connection is established (that is, `readyState` is
-`OPEN`), {{domxref("WebSocket.protocol", "exampleSocket.protocol")}} will
-tell you which protocol the server selected.
+Once the connection is established (that is, `readyState` is `OPEN`), {{domxref("WebSocket.protocol", "exampleSocket.protocol")}} will tell you which protocol the server selected.
 
-Establishing a WebSocket relies on the [HTTP Upgrade mechanism](/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism), so
-the request for the protocol upgrade is implicit when we address the web server as
-`ws://www.example.com` or
-`wss://www.example.com`.
+Establishing a WebSocket relies on the [HTTP Upgrade mechanism](/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism), so the request for the protocol upgrade is implicit when we address the web server as `ws://www.example.com` or `wss://www.example.com`.
 
 ## Sending data to the server
 
-Once you've opened your connection, you can begin transmitting data to the server. To
-do this, call the `WebSocket` object's {{domxref("WebSocket.send",
-  "send()")}} method for each message you want to send:
+Once you've opened your connection, you can begin transmitting data to the server.
+To do this, call the `WebSocket` object's {{domxref("WebSocket.send", "send()")}} method for each message you want to send:
 
 ```js
 exampleSocket.send("Here's some text that the server is urgently awaiting!");
@@ -105,11 +81,8 @@ exampleSocket.send("Here's some text that the server is urgently awaiting!");
 
 You can send data as a string, {{ domxref("Blob") }}, or {{jsxref("ArrayBuffer")}}.
 
-As establishing a connection is asynchronous and prone to failure there is no guarantee
-that calling the `send()` method immediately after creating a WebSocket
-object will be successful. We can at least be sure that attempting to send data only
-takes place once a connection is established by defining an
-{{domxref("WebSocket.onopen", "onopen")}} event handler to do the work:
+As establishing a connection is asynchronous and prone to failure there is no guarantee that calling the `send()` method immediately after creating a WebSocket object will be successful.
+We can at least be sure that attempting to send data only takes place once a connection is established by defining an {{domxref("WebSocket.onopen", "onopen")}} event handler to do the work:
 
 ```js
 exampleSocket.onopen = function (event) {
@@ -158,8 +131,7 @@ exampleSocket.onmessage = function (event) {
 
 ### Receiving and interpreting JSON objects
 
-Let's consider the chat client application first alluded to in [Using JSON to transmit objects](#using_json_to_transmit_objects). There are assorted types of data packets the client might
-receive, such as:
+Let's consider the chat client application first alluded to in [Using JSON to transmit objects](#using_json_to_transmit_objects). There are assorted types of data packets the client might receive, such as:
 
 - Login handshake
 - Message text
@@ -184,10 +156,10 @@ exampleSocket.onmessage = function(event) {
       text = `User <em>${msg.name}</em> signed in at ${timeStr}<br>`;
       break;
     case "message":
-      text = "(" + timeStr + ") " + msg.name + ": " + msg.text + "<br>";
+      text = `(${timeStr}) ${msg.name} : ${msg.text} <br>`;
       break;
     case "rejectusername":
-      text = "Your username has been set to <em>" + msg.name + "</em> because the name you chose is in use.<br>"
+      text = `Your username has been set to <em>${msg.name}</em> because the name you chose is in use.<br>`
       break;
     case "userlist":
       var ul = "";
@@ -205,8 +177,7 @@ exampleSocket.onmessage = function(event) {
 };
 ```
 
-Here we use {{jsxref("JSON.parse()")}} to convert the JSON object back into the
-original object, then examine and act upon its contents.
+Here we use {{jsxref("JSON.parse()")}} to convert the JSON object back into the original object, then examine and act upon its contents.
 
 ### Text data format
 
@@ -214,21 +185,16 @@ Text received over a WebSocket connection is in UTF-8 format.
 
 ## Closing the connection
 
-When you've finished using the WebSocket connection, call the WebSocket method
-{{domxref("WebSocket.close", "close()")}}:
+When you've finished using the WebSocket connection, call the WebSocket method {{domxref("WebSocket.close", "close()")}}:
 
 ```js
 exampleSocket.close();
 ```
 
-It may be helpful to examine the socket's {{domxref("WebSocket.bufferedAmount",
-  "bufferedAmount")}} attribute before attempting to close the connection to determine if
-any data has yet to be transmitted on the network. If this value isn't 0, there's
-pending data still, so you may wish to wait before closing the connection.
+It may be helpful to examine the socket's {{domxref("WebSocket.bufferedAmount", "bufferedAmount")}} attribute before attempting to close the connection to determine if any data has yet to be transmitted on the network.
+If this value isn't 0, there's pending data still, so you may wish to wait before closing the connection.
 
 ## Security considerations
 
-WebSockets should not be used in a mixed content environment; that is, you shouldn't
-open a non-secure WebSocket connection from a page loaded using HTTPS or vice-versa.
-Most browsers now only allow secure WebSocket connections, and no longer support using
-them in insecure contexts.
+WebSockets should not be used in a mixed content environment; that is, you shouldn't open a non-secure WebSocket connection from a page loaded using HTTPS or vice-versa.
+Most browsers now only allow secure WebSocket connections, and no longer support using them in insecure contexts.

--- a/files/en-us/web/css/_colon_first-of-type/index.md
+++ b/files/en-us/web/css/_colon_first-of-type/index.md
@@ -59,7 +59,7 @@ This example shows how nested elements can also be targeted. Note that the [univ
   <div>This <span>nested `span` is first</span>!</div>
   <div>This <em>nested `em` is first</em>, but this <em>nested `em` is last</em>!</div>
   <div>This <span>nested `span` gets styled</span>!</div>
-  <b>This `b` qualifies!</b>
+  <p>This `p` qualifies!</p>
   <div>This is the final `div`.</div>
 </article>
 ```

--- a/files/en-us/web/css/_colon_last-of-type/index.md
+++ b/files/en-us/web/css/_colon_last-of-type/index.md
@@ -58,7 +58,7 @@ This example shows how nested elements can also be targeted. Note that the [univ
   <div>This `div` is first.</div>
   <div>This <span>nested `span` is last</span>!</div>
   <div>This <em>nested `em` is first</em>, but this <em>nested `em` is last</em>!</div>
-  <b>This `b` qualifies!</b>
+  <p>This `p` qualifies!</p>
   <div>This is the final `div`!</div>
 </article>
 ```

--- a/files/en-us/web/css/css_positioning/understanding_z_index/adding_z-index/index.md
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/adding_z-index/index.md
@@ -42,31 +42,31 @@ In the following example, the layers' stacking order is rearranged using `z-inde
 
 ```html
 <div id="abs1">
-  <b>DIV #1</b>
+  <strong>DIV #1</strong>
   <br />position: absolute;
   <br />z-index: 5;
 </div>
 
 <div id="rel1">
-  <b>DIV #2</b>
+  <strong>DIV #2</strong>
   <br />position: relative;
   <br />z-index: 3;
 </div>
 
 <div id="rel2">
-  <b>DIV #3</b>
+  <strong>DIV #3</strong>
   <br />position: relative;
   <br />z-index: 2;
 </div>
 
 <div id="abs2">
-  <b>DIV #4</b>
+  <strong>DIV #4</strong>
   <br />position: absolute;
   <br />z-index: 1;
 </div>
 
 <div id="sta1">
-  <b>DIV #5</b>
+  <strong>DIV #5</strong>
   <br />no positioning
   <br />z-index: 8;
 </div>
@@ -81,7 +81,7 @@ div {
   text-align: center;
 }
 
-b {
+strong {
   font-family: sans-serif;
 }
 

--- a/files/en-us/web/css/css_positioning/understanding_z_index/stacking_and_float/index.md
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/stacking_and_float/index.md
@@ -38,24 +38,24 @@ Actually, as you can see in the example below, the background and border of the 
 
 ```html
 <div id="abs1">
-  <b>DIV #1</b><br />position: absolute;</div>
+  <strong>DIV #1</strong><br />position: absolute;</div>
 
 <div id="flo1">
-  <b>DIV #2</b><br />float: left;</div>
+  <strong>DIV #2</strong><br />float: left;</div>
 
 <div id="flo2">
-  <b>DIV #3</b><br />float: right;</div>
+  <strong>DIV #3</strong><br />float: right;</div>
 
 <br />
 
 <div id="sta1">
-  <b>DIV #4</b><br />no positioning</div>
+  <strong>DIV #4</strong><br />no positioning</div>
 
 <div id="abs2">
-  <b>DIV #5</b><br />position: absolute;</div>
+  <strong>DIV #5</strong><br />position: absolute;</div>
 
 <div id="rel1">
-  <b>DIV #6</b><br />position: relative;</div>
+  <strong>DIV #6</strong><br />position: relative;</div>
 ```
 
 ### CSS
@@ -66,7 +66,7 @@ div {
   text-align: center;
 }
 
-b {
+strong {
   font-family: sans-serif;
 }
 

--- a/files/en-us/web/css/css_positioning/understanding_z_index/stacking_without_z-index/index.md
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/stacking_without_z-index/index.md
@@ -31,21 +31,21 @@ In the example below, elements #1 through #4 are positioned elements. Element #5
 
 ```html
 <div id="abs1" class="absolute">
-  <b>DIV #1</b><br />position: absolute;</div>
+  <strong>DIV #1</strong><br />position: absolute;</div>
 <div id="rel1" class="relative">
-  <b>DIV #2</b><br />position: relative;</div>
+  <strong>DIV #2</strong><br />position: relative;</div>
 <div id="rel2" class="relative">
-  <b>DIV #3</b><br />position: relative;</div>
+  <strong>DIV #3</strong><br />position: relative;</div>
 <div id="abs2" class="absolute">
-  <b>DIV #4</b><br />position: absolute;</div>
+  <strong>DIV #4</strong><br />position: absolute;</div>
 <div id="sta1" class="static">
-  <b>DIV #5</b><br />position: static;</div>
+  <strong>DIV #5</strong><br />position: static;</div>
 ```
 
 ### CSS
 
 ```css
-b {
+strong {
   font-family: sans-serif;
 }
 

--- a/files/en-us/web/html/element/applet/index.md
+++ b/files/en-us/web/html/element/applet/index.md
@@ -108,7 +108,7 @@ Use of Java applets on the Web is deprecated; most browsers no longer support us
 ```html
 <applet code="game.class" align="left" archive="game.zip" height="250" width="350">
   <param name="difficulty" value="easy">
-  <b>Sorry, you need Java to play this game.</b>
+  <p>Sorry, you need Java to play this game.</p>
 </applet>
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formattoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/formattoparts/index.md
@@ -149,20 +149,20 @@ and {{jsxref("Array.prototype.join()")}}.
 ```js
 const dateString = formatter.formatToParts(date).map(({type, value}) => {
   switch (type) {
-    case 'dayPeriod': return `<b>${value}</b>`;
+    case 'dayPeriod': return `<em>${value}</em>`;
     default : return value;
   }
 }).join('');
 ```
 
-This will make the day period bold, when using the `formatToParts()` method.
+This will emphasize the day period when using the `formatToParts()` method.
 
 ```js
 console.log(formatter.format(date));
 // "Monday, 12/17/2012, 3:00:42.000 AM"
 
 console.log(dateString);
-// "Monday, 12/17/2012, 3:00:42.000 <b>AM</b>"
+// "Monday, 12/17/2012, 3:00:42.000 <em>AM</em>"
 ```
 
 ### Named Years and Mixed calendars

--- a/files/en-us/web/javascript/reference/global_objects/string/blink/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/blink/index.md
@@ -40,7 +40,7 @@ element: "`<blink>str</blink>`".
 
 ### Using blink()
 
-The following example uses string methods to change the formatting of a string:
+The following example uses deprecated string methods to change the formatting of a string:
 
 ```js
 const worldString = 'Hello, world';

--- a/files/en-us/web/javascript/reference/global_objects/string/bold/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/bold/index.md
@@ -36,7 +36,7 @@ The `bold()` method embeds a string in a `<b>` element:
 
 ### Using bold()
 
-The following example uses string methods to change the formatting of a string:
+The following example uses deprecated string methods to change the formatting of a string:
 
 ```js
 const worldString = 'Hello, world';

--- a/files/en-us/web/javascript/reference/global_objects/string/italics/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/italics/index.md
@@ -35,7 +35,7 @@ The `italics()` method embeds a string in an `<i>` element:
 
 ### Using italics()
 
-The following example uses string methods to change the formatting of a string:
+The following example uses deprecated string methods to change the formatting of a string:
 
 ```js
 const worldString = 'Hello, world';

--- a/files/en-us/web/javascript/reference/global_objects/string/strike/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/strike/index.md
@@ -35,7 +35,7 @@ element: "`<strike>str</strike>`".
 
 ### Using strike()
 
-The following example uses string methods to change the formatting of a string:
+The following example uses deprecated string methods to change the formatting of a string:
 
 ```js
 const worldString = 'Hello, world';


### PR DESCRIPTION
Improve semantics in code examples and explanations: 
* Discouraged use of presentational elements
* Ensure form controls have an id and associated label.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
