### PR TITLE
Fix comments in CSS code for "Backwards compatibility of Flexbox"

### DIFF
--- a/files/en-us/web/css/css_flexible_box_layout/backwards_compatibility_of_flexbox/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/backwards_compatibility_of_flexbox/index.md
@@ -103,7 +103,7 @@ You can use [feature queries](/en-US/docs/Web/CSS/@supports) to detect flexbox s
 
 ```css
 @supports (display: flex) {
-  // code for supporting browsers
+  /* code for supporting browsers */
 }
 ```
 
@@ -111,7 +111,7 @@ Note that Internet Explorer 11 does not support feature queries yet _does_ suppo
 
 ```css
 @supports (display: flex) or (display: -webkit-box) {
-  // code for supporting browsers
+  /* code for supporting browsers */
 }
 ```
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Corrects CSS comments to `/* ...comment... */`

#### Motivation
The syntax for comments in CSS is `/* ... */` (`// ...comment on one line...` is for JS)

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
