### PR TITLE
Comment out ellipsis in code blocks

### DIFF
--- a/files/en-us/web/api/abstractrange/index.md
+++ b/files/en-us/web/api/abstractrange/index.md
@@ -81,11 +81,11 @@ To illustrate this, consider the HTML below:
   </div>
   <article>
     <section class="entry" id="entry1">
-      <h2>Section 1: An interesting thing...</h2>
-      <p>A <em>very</em> interesting thing happened on the way to the forum...</p>
+      <h2>Section 1: An interesting thing…</h2>
+      <p>A <em>very</em> interesting thing happened on the way to the forum…</p>
       <aside class="callout">
         <h2>Aside</h2>
-        <p>An interesting aside to share with you...</p>
+        <p>An interesting aside to share with you…</p>
       </aside>
     </section>
   </article>
@@ -99,7 +99,7 @@ After loading the HTML and constructing the DOM representation of the document, 
 
 In this diagram, the nodes representing HTML elements are shown in green. Eah row beneath them shows the next layer of depth into the DOM tree. Blue nodes are text nodes, containing the text that gets shown onscreen. Each element's contents are linked below it in the tree, potentially spawning a series of branches below as elements include other elements and text nodes.
 
-If you want to create a range that incorporates the contents of the {{HTMLElement("p")}} element whose contents are `"A <em>very</em> interesting thing happened on the way to the forum..."`, you can do so like this:
+If you want to create a range that incorporates the contents of the {{HTMLElement("p")}} element whose contents are `"A <em>very</em> interesting thing happened on the way to the forum…"`, you can do so like this:
 
 ```js
 let pRange = document.createRange();

--- a/files/en-us/web/api/analysernode/fftsize/index.md
+++ b/files/en-us/web/api/analysernode/fftsize/index.md
@@ -34,7 +34,7 @@ The following example shows basic usage of an {{domxref("AudioContext")}} to cre
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 const analyser = audioCtx.createAnalyser();
 
-  ...
+// …
 
 analyser.fftSize = 2048;
 const bufferLength = analyser.frequencyBinCount;

--- a/files/en-us/web/api/analysernode/frequencybincount/index.md
+++ b/files/en-us/web/api/analysernode/frequencybincount/index.md
@@ -31,7 +31,7 @@ const analyser = audioCtx.createAnalyser();
 analyser.minDecibels = -90;
 analyser.maxDecibels = -10;
 
-  ...
+// …
 
 analyser.fftSize = 256;
 const bufferLength = analyser.frequencyBinCount;

--- a/files/en-us/web/api/analysernode/getbytefrequencydata/index.md
+++ b/files/en-us/web/api/analysernode/getbytefrequencydata/index.md
@@ -44,7 +44,7 @@ The following example shows basic usage of an {{domxref("AudioContext")}} to cre
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 const analyser = audioCtx.createAnalyser();
 
-  ...
+// …
 
 analyser.fftSize = 256;
 const bufferLength = analyser.frequencyBinCount;

--- a/files/en-us/web/api/analysernode/getbytetimedomaindata/index.md
+++ b/files/en-us/web/api/analysernode/getbytetimedomaindata/index.md
@@ -40,7 +40,7 @@ The following example shows basic usage of an {{domxref("AudioContext")}} to cre
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 const analyser = audioCtx.createAnalyser();
 
-  ...
+// …
 
 analyser.fftSize = 2048;
 const bufferLength = analyser.fftSize;

--- a/files/en-us/web/api/analysernode/getfloattimedomaindata/index.md
+++ b/files/en-us/web/api/analysernode/getfloattimedomaindata/index.md
@@ -38,7 +38,7 @@ The following example shows basic usage of an {{domxref("AudioContext")}} to cre
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 const analyser = audioCtx.createAnalyser();
 
-  ...
+// …
 
 analyser.fftSize = 1024;
 const bufferLength = analyser.fftSize;

--- a/files/en-us/web/api/analysernode/index.md
+++ b/files/en-us/web/api/analysernode/index.md
@@ -89,7 +89,7 @@ The following example shows basic usage of an {{domxref("AudioContext")}} to cre
 ```js
 const audioCtx = new(window.AudioContext || window.webkitAudioContext)();
 
-// ...
+// …
 
 const analyser = audioCtx.createAnalyser();
 analyser.fftSize = 2048;

--- a/files/en-us/web/api/analysernode/maxdecibels/index.md
+++ b/files/en-us/web/api/analysernode/maxdecibels/index.md
@@ -36,7 +36,7 @@ const analyser = audioCtx.createAnalyser();
 analyser.minDecibels = -90;
 analyser.maxDecibels = -10;
 
-  ...
+// …
 
 analyser.fftSize = 256;
 const bufferLength = analyser.frequencyBinCount;

--- a/files/en-us/web/api/analysernode/mindecibels/index.md
+++ b/files/en-us/web/api/analysernode/mindecibels/index.md
@@ -33,7 +33,7 @@ const analyser = audioCtx.createAnalyser();
 analyser.minDecibels = -90;
 analyser.maxDecibels = -10;
 
-  ...
+// …
 
 analyser.fftSize = 256;
 const bufferLength = analyser.frequencyBinCount;

--- a/files/en-us/web/api/analysernode/smoothingtimeconstant/index.md
+++ b/files/en-us/web/api/analysernode/smoothingtimeconstant/index.md
@@ -38,7 +38,7 @@ analyser.minDecibels = -90;
 analyser.maxDecibels = -10;
 analyser.smoothingTimeConstant = 0.85;
 
-  ...
+// …
 
 analyser.fftSize = 256;
 const bufferLength = analyser.frequencyBinCount;

--- a/files/en-us/web/api/animationplaybackevent/currenttime/index.md
+++ b/files/en-us/web/api/animationplaybackevent/currenttime/index.md
@@ -33,14 +33,14 @@ playbackEvent.currentTime;
 // 23.404
 // 24.192
 // 25.514
-// ...
+// …
 
 // reduced time precision with `privacy.resistFingerprinting` enabled
 playbackEvent.currentTime;
 // 49.8
 // 50.6
 // 51.7
-// ...
+// …
 ```
 
 In Firefox, you can also enabled `privacy.resistFingerprinting`, the precision will be 100ms or the value of `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever is larger.

--- a/files/en-us/web/api/animationtimeline/currenttime/index.md
+++ b/files/en-us/web/api/animationtimeline/currenttime/index.md
@@ -34,14 +34,14 @@ animationTimeline.currentTime;
 // 23.404
 // 24.192
 // 25.514
-// ...
+// …
 
 // reduced time precision with `privacy.resistFingerprinting` enabled
 animationTimeline.currentTime;
 // 49.8
 // 50.6
 // 51.7
-// ...
+// …
 ```
 
 In Firefox, you can also enable `privacy.resistFingerprinting`; the precision will be 100ms or the value of `privacy.resistFingerprinting.reduceTimerPrecision.microseconds`, whichever is larger.

--- a/files/en-us/web/api/audiobuffersourcenode/loopend/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/loopend/index.md
@@ -81,7 +81,7 @@ function getData() {
   request.send();
 }
 
-  ...
+// …
 
 loopstartControl.oninput = function() {
   source.loopStart = loopstartControl.value;

--- a/files/en-us/web/api/audiobuffersourcenode/loopstart/index.md
+++ b/files/en-us/web/api/audiobuffersourcenode/loopstart/index.md
@@ -73,7 +73,7 @@ function getData() {
   request.send();
 }
 
-  ...
+// …
 
 loopstartControl.oninput = function() {
   source.loopStart = loopstartControl.value;

--- a/files/en-us/web/api/audioparam/value/index.md
+++ b/files/en-us/web/api/audioparam/value/index.md
@@ -43,7 +43,7 @@ not always exactly equal what you set it to.
 Consider this example:
 
 ```js
-const source = new AudioBufferSourceNode(...);
+const source = new AudioBufferSourceNode(/* … */);
 const rate = 5.3;
 source.playbackRate.value = rate;
 console.log(source.playbackRate.value === rate);
@@ -56,7 +56,7 @@ method, which returns the single-precision value equivalent to the 64-bit JavaSc
 value specified—when setting `value`, like this:
 
 ```js
-const source = new AudioBufferSourceNode(...);
+const source = new AudioBufferSourceNode(/* … */);
 const rate = Math.fround(5.3);
 source.playbackRate.value = rate;
 console.log(source.playbackRate.value === rate);

--- a/files/en-us/web/api/audioparamdescriptor/index.md
+++ b/files/en-us/web/api/audioparamdescriptor/index.md
@@ -49,7 +49,7 @@ class WhiteNoiseProcessor extends AudioWorkletProcessor {
     }]
   }
 
-...
+// …
 }
 ```
 

--- a/files/en-us/web/api/background_tasks_api/index.md
+++ b/files/en-us/web/api/background_tasks_api/index.md
@@ -97,7 +97,7 @@ In order to be oriented about what we're trying to accomplish, let's have a look
 </p>
 
 <div id="container">
-  <div class="label">Decoding quantum filament tachyon emissions...</div>
+  <div class="label">Decoding quantum filament tachyon emissions…</div>
 
   <progress id="progress" value="0"></progress>
 

--- a/files/en-us/web/api/baseaudiocontext/createanalyser/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createanalyser/index.md
@@ -51,7 +51,7 @@ examples/information, check out our [Voice-change-O-matic](https://mdn.github.io
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 const analyser = audioCtx.createAnalyser();
 
-  ...
+// …
 
 analyser.fftSize = 2048;
 const bufferLength = analyser.frequencyBinCount;

--- a/files/en-us/web/api/baseaudiocontext/createconvolver/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createconvolver/index.md
@@ -50,7 +50,7 @@ For applied examples/information, check out our [Voice-change-O-matic demo](http
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 const convolver = audioCtx.createConvolver();
 
-  ...
+// …
 
 // grab audio track via XHR for convolver node
 
@@ -71,7 +71,7 @@ ajaxRequest.onload = function() {
 
 ajaxRequest.send();
 
-  ...
+// …
 
 convolver.buffer = concertHallBuffer;
 ```

--- a/files/en-us/web/api/baseaudiocontext/createdelay/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createdelay/index.md
@@ -54,7 +54,7 @@ var audioCtx = new AudioContext();
 
 var synthDelay = audioCtx.createDelay(5.0);
 
-  ...
+// …
 
 var synthSource;
 
@@ -75,7 +75,7 @@ stopSynth.onclick = function() {
   playSynth.removeAttribute('disabled');
 }
 
-...
+// …
 
 var delay1;
 rangeSynth.oninput = function() {

--- a/files/en-us/web/api/baseaudiocontext/creategain/index.md
+++ b/files/en-us/web/api/baseaudiocontext/creategain/index.md
@@ -88,7 +88,7 @@ if (navigator.mediaDevices.getUserMedia) {
 source.connect(gainNode);
 gainNode.connect(audioCtx.destination);
 
-  ...
+// …
 
 mute.onclick = voiceMute;
 

--- a/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.md
@@ -49,7 +49,7 @@ node. For applied examples/information, check out our [Voice-change-O-matic](htt
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
 const distortion = audioCtx.createWaveShaper();
 
-  ...
+// …
 
 function makeDistortionCurve(amount) {
   const k = typeof amount === 'number' ? amount : 50,
@@ -65,7 +65,7 @@ function makeDistortionCurve(amount) {
   return curve;
 };
 
-  ...
+// …
 
 distortion.curve = makeDistortionCurve(400);
 distortion.oversample = '4x';

--- a/files/en-us/web/api/baseaudiocontext/currenttime/index.md
+++ b/files/en-us/web/api/baseaudiocontext/currenttime/index.md
@@ -29,7 +29,7 @@ var AudioContext = window.AudioContext || window.webkitAudioContext;
 var audioCtx = new AudioContext();
 // Older webkit/blink browsers require a prefix
 
-...
+// …
 
 console.log(audioCtx.currentTime);
 ```
@@ -47,14 +47,14 @@ audioCtx.currentTime;
 // 23.404
 // 24.192
 // 25.514
-// ...
+// …
 
 // reduced time precision with `privacy.resistFingerprinting` enabled
 audioCtx.currentTime;
 // 49.8
 // 50.6
 // 51.7
-// ...
+// …
 ```
 
 In Firefox, you can also enabled `privacy.resistFingerprinting`, the

--- a/files/en-us/web/api/baseaudiocontext/listener/index.md
+++ b/files/en-us/web/api/baseaudiocontext/listener/index.md
@@ -32,7 +32,7 @@ var AudioContext = window.AudioContext || window.webkitAudioContext;
 var audioCtx = new AudioContext();
 // Older webkit/blink browsers require a prefix
 
-...
+// …
 
 var myListener = audioCtx.listener;
 ```

--- a/files/en-us/web/api/baseaudiocontext/samplerate/index.md
+++ b/files/en-us/web/api/baseaudiocontext/samplerate/index.md
@@ -35,7 +35,7 @@ var AudioContext = window.AudioContext || window.webkitAudioContext;
 var audioCtx = new AudioContext();
 // Older webkit/blink browsers require a prefix
 
-...
+…
 
 console.log(audioCtx.sampleRate);
 ```

--- a/files/en-us/web/api/baseaudiocontext/state/index.md
+++ b/files/en-us/web/api/baseaudiocontext/state/index.md
@@ -56,7 +56,7 @@ function play() {
     audioCtx.resume().then(() => play());
     return;
   }
-  // ... rest of the play() function
+  // rest of the play() function
 }
 ```
 

--- a/files/en-us/web/api/beforeinstallpromptevent/prompt/index.md
+++ b/files/en-us/web/api/beforeinstallpromptevent/prompt/index.md
@@ -44,7 +44,7 @@ window.addEventListener("beforeinstallprompt", function(e) {
   }
 
   // The event was re-dispatched in response to our request
-  // ...
+  // …
 });
 ```
 

--- a/files/en-us/web/api/biquadfilternode/getfrequencyresponse/index.md
+++ b/files/en-us/web/api/biquadfilternode/getfrequencyresponse/index.md
@@ -102,7 +102,7 @@ biquadFilter.type = "lowshelf";
 biquadFilter.frequency.value = 1000;
 biquadFilter.gain.value = range.value;
 
-  ...
+// …
 
 function calcFrequencyResponse() {
   biquadFilter.getFrequencyResponse(myFrequencyArray,magResponseOutput,phaseResponseOutput);

--- a/files/en-us/web/api/blob/size/index.md
+++ b/files/en-us/web/api/blob/size/index.md
@@ -30,7 +30,7 @@ lengths in bytes.
 
 ```html
 <input type="file" id="input" multiple>
-<output id="output">Choose files...</output>
+<output id="output">Choose files…</output>
 ```
 
 ```css hidden

--- a/files/en-us/web/api/blob/type/index.md
+++ b/files/en-us/web/api/blob/type/index.md
@@ -28,7 +28,7 @@ sure it's one of a given set of image file types.
 
 ```html
 <input type="file" id="input" multiple>
-<output id="output">Choose image files...</output>
+<output id="output">Choose image files…</output>
 ```
 
 ```css hidden
@@ -51,7 +51,7 @@ input.addEventListener('change', (event) => {
   const files = event.target.files;
 
   if (files.length === 0) {
-    output.innerText = 'Choose image files...';
+    output.innerText = 'Choose image files…';
     return;
   }
 


### PR DESCRIPTION
Ellipsis in markdown code blocks are syntax errors.

In order to have smooth transition to Prettier and ESLint the PR comments out such bare ellipses. Refer the [discussion](https://github.com/mdn/content/pull/18171#issuecomment-1179670484) for more context.