### PR TITLE
FF103 Native Error types are serializable

### DIFF
--- a/files/en-us/mozilla/firefox/releases/103/index.md
+++ b/files/en-us/mozilla/firefox/releases/103/index.md
@@ -28,7 +28,7 @@ This article provides information about the changes in Firefox 103 that will aff
 - Native Error types can now be serialized using the [structured clone algorithm](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
   This includes {{JSxRef("Error")}}, {{JSxRef("EvalError")}}, {{JSxRef("RangeError")}}, {{JSxRef("ReferenceError")}}, {{JSxRef("SyntaxError")}}, {{JSxRef("TypeError")}}, {{JSxRef("URIError")}} and {{JSxRef("AggregateError")}}.
   Serialized properties include the [`name`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/name), [`message`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/message), [`cause`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause), [`fileName`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/fileName), [`lineNumber`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/lineNumber) and [`columnNumber`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/columnNumber).
-  [`stack`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Stack) is only serialized in the nightly builds ({{bug(1774866)}}).
+  <!-- [`stack`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Stack) is only serialized in the nightly builds ({{bug(1774866)}}). -->
   For {{JSxRef("AggregateError")}} the `message`, `name`, `cause` and `errors` properties are serialized
   See {{bug(1556604)}} for more details.
 

--- a/files/en-us/mozilla/firefox/releases/103/index.md
+++ b/files/en-us/mozilla/firefox/releases/103/index.md
@@ -25,6 +25,13 @@ This article provides information about the changes in Firefox 103 that will aff
 
 ### JavaScript
 
+- Native Error types can now be serialized using the [structured clone algorithm](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
+  This includes {{JSxRef("Error")}}, {{JSxRef("EvalError")}}, {{JSxRef("RangeError")}}, {{JSxRef("ReferenceError")}}, {{JSxRef("SyntaxError")}}, {{JSxRef("TypeError")}}, {{JSxRef("URIError")}} and {{JSxRef("AggregateError")}}.
+  Serialized properties include the [`name`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/name), [`message`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/message), [`cause`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause), [`fileName`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/fileName), [`lineNumber`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/lineNumber) and [`columnNumber`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/columnNumber).
+  [`stack`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Stack) is only serialized in the nightly builds ({{bug(1774866)}}).
+  For {{JSxRef("AggregateError")}} the `message`, `name`, `cause` and `errors` properties are serialized
+  See {{bug(1556604)}} for more details.
+
 #### Removals
 
 ### HTTP

--- a/files/en-us/mozilla/firefox/releases/103/index.md
+++ b/files/en-us/mozilla/firefox/releases/103/index.md
@@ -29,7 +29,7 @@ This article provides information about the changes in Firefox 103 that will aff
   This includes {{JSxRef("Error")}}, {{JSxRef("EvalError")}}, {{JSxRef("RangeError")}}, {{JSxRef("ReferenceError")}}, {{JSxRef("SyntaxError")}}, {{JSxRef("TypeError")}}, {{JSxRef("URIError")}} and {{JSxRef("AggregateError")}}.
   Serialized properties include the [`name`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/name), [`message`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/message), [`cause`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause), [`fileName`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/fileName), [`lineNumber`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/lineNumber) and [`columnNumber`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/columnNumber).
   <!-- [`stack`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Stack) is only serialized in the nightly builds ({{bug(1774866)}}). -->
-  For {{JSxRef("AggregateError")}} the `message`, `name`, `cause` and `errors` properties are serialized
+  For {{JSxRef("AggregateError")}} the `message`, `name`, `cause` and `errors` properties are serialized.
   See {{bug(1556604)}} for more details.
 
 #### Removals

--- a/files/en-us/mozilla/firefox/releases/104/index.md
+++ b/files/en-us/mozilla/firefox/releases/104/index.md
@@ -25,6 +25,13 @@ This article provides information about the changes in Firefox 104 that will aff
 
 ### JavaScript
 
+- Native Error types can now be serialized using the [structured clone algorithm](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
+  This includes {{JSxRef("Error")}}, {{JSxRef("EvalError")}}, {{JSxRef("RangeError")}}, {{JSxRef("ReferenceError")}}, {{JSxRef("SyntaxError")}}, {{JSxRef("TypeError")}}, {{JSxRef("URIError")}} and {{JSxRef("AggregateError")}}.
+  Serialized properties include the [`name`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/name), [`message`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/message), [`cause`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause), [`fileName`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/fileName), [`lineNumber`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/lineNumber) and [`columnNumber`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/columnNumber).
+  [`stack`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Stack) is only serialized in the nightly builds ({{bug(1774866)}}).
+  For {{JSxRef("AggregateError")}} the `message`, `name`, `cause` and `errors` properties are serialized
+  See {{bug(1556604)}} for more details.
+
 #### Removals
 
 ### HTTP

--- a/files/en-us/mozilla/firefox/releases/104/index.md
+++ b/files/en-us/mozilla/firefox/releases/104/index.md
@@ -25,13 +25,6 @@ This article provides information about the changes in Firefox 104 that will aff
 
 ### JavaScript
 
-- Native Error types can now be serialized using the [structured clone algorithm](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
-  This includes {{JSxRef("Error")}}, {{JSxRef("EvalError")}}, {{JSxRef("RangeError")}}, {{JSxRef("ReferenceError")}}, {{JSxRef("SyntaxError")}}, {{JSxRef("TypeError")}}, {{JSxRef("URIError")}} and {{JSxRef("AggregateError")}}.
-  Serialized properties include the [`name`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/name), [`message`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/message), [`cause`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause), [`fileName`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/fileName), [`lineNumber`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/lineNumber) and [`columnNumber`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/columnNumber).
-  [`stack`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Stack) is only serialized in the nightly builds ({{bug(1774866)}}).
-  For {{JSxRef("AggregateError")}} the `message`, `name`, `cause` and `errors` properties are serialized
-  See {{bug(1556604)}} for more details.
-
 #### Removals
 
 ### HTTP

--- a/files/en-us/web/api/web_workers_api/structured_clone_algorithm/index.md
+++ b/files/en-us/web/api/web_workers_api/structured_clone_algorithm/index.md
@@ -109,7 +109,8 @@ It clones by recursing through the input object while maintaining a map of previ
     </tr>
     <tr>
       <td>{{domxref("DOMException")}}</td>
-      <td>Most browsers only clone the properties {{domxref("DOMException.name","name")}} and {{domxref("DOMException.message","message")}} (in theory stack traces and other attributes may also be cloned).</td>
+      <td>Browsers must serialize the properties {{domxref("DOMException.name","name")}} and {{domxref("DOMException.message","message")}}.
+      Other attributes may also be serialized/cloned.</td>
     </tr>
     <tr>
       <td><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error">Native <code>Error</code> types</a></td>

--- a/files/en-us/web/api/web_workers_api/structured_clone_algorithm/index.md
+++ b/files/en-us/web/api/web_workers_api/structured_clone_algorithm/index.md
@@ -116,7 +116,7 @@ It clones by recursing through the input object while maintaining a map of previ
       <td>
         <p>The error name must be one of: {{jsxref("Error")}}, {{JSxRef("EvalError")}}, {{JSxRef("RangeError")}}, {{JSxRef("ReferenceError")}}, {{JSxRef("SyntaxError")}}, {{JSxRef("TypeError")}}, {{JSxRef("URIError")}} (or will be set to "Error").</p>
         <p>Browsers must serialize the properties <code>name</code> and <code>message</code>, and are expected to serialise "interesting" other properties of the errors such as <code>stack</code>, <code>cause</code>, etc.</p>
-        <p>{{JSxRef("AggregateError")}} support is expected to be added to the specification in <a href="https://github.com/whatwg/html/pull/5749">whatwg/html/#5749</a> (and is already supported in some browsers).</p>
+        <p>{{JSxRef("AggregateError")}} support is expected to be added to the specification in <a href="https://github.com/whatwg/html/pull/5749">whatwg/html#5749</a> (and is already supported in some browsers).</p>
       </td>
     </tr>
   </tbody>

--- a/files/en-us/web/api/web_workers_api/structured_clone_algorithm/index.md
+++ b/files/en-us/web/api/web_workers_api/structured_clone_algorithm/index.md
@@ -27,9 +27,6 @@ It clones by recursing through the input object while maintaining a map of previ
     For example, if an object is marked readonly with a [property descriptor](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptor), it will be read/write in the duplicate, since that's the default.
   - The prototype chain is not walked or duplicated.
 
-> **Note:** Native {{jsxref("Error")}} types can be cloned in Chrome.
-> Firefox can clone {{domxref("DOMException")}}, and is [working on the other error types](https://bugzilla.mozilla.org/show_bug.cgi?id=1556604).
-
 ## Supported types
 
 <table class="no-markdown">
@@ -113,6 +110,14 @@ It clones by recursing through the input object while maintaining a map of previ
     <tr>
       <td>{{domxref("DOMException")}}</td>
       <td>Most browsers only clone the properties {{domxref("DOMException.name","name")}} and {{domxref("DOMException.message","message")}} (in theory stack traces and other attributes may also be cloned).</td>
+    </tr>
+    <tr>
+      <td><a href="/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error">Native <code>Error</code> types</a></td>
+      <td>
+        <p>The error name must be one of: {{jsxref("Error")}}, {{JSxRef("EvalError")}}, {{JSxRef("RangeError")}}, {{JSxRef("ReferenceError")}}, {{JSxRef("SyntaxError")}}, {{JSxRef("TypeError")}}, {{JSxRef("URIError")}} (or will be set to "Error").</p>
+        <p>Browsers must serialize the properties <code>name</code> and <code>message</code>, and are expected to serialise "interesting" other properties of the errors such as <code>stack</code>, <code>cause</code>, etc.</p>
+        <p>{{JSxRef("AggregateError")}} support is expected to be added to the specification in <a href="https://github.com/whatwg/html/pull/5749">whatwg/html/#5749</a> (and is already supported in some browsers).</p>
+      </td>
     </tr>
   </tbody>
 </table>

--- a/files/en-us/web/javascript/reference/global_objects/error/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/index.md
@@ -17,6 +17,8 @@ browser-compat: javascript.builtins.Error
 
 Runtime errors result in new `Error` objects being created and thrown.
 
+`Error` is a {{Glossary("serializable object")}}, so it can be cloned with {{domxref("structuredClone()")}} or copied between [Workers](/en-US/docs/Web/API/Worker) using {{domxref("Worker.postMessage()", "postMessage()")}}.
+
 ### Error types
 
 Besides the generic `Error` constructor, there are other core error constructors in JavaScript. For client-side exceptions, see [Exception handling statements](/en-US/docs/Web/JavaScript/Guide/Control_flow_and_error_handling#exception_handling_statements).

--- a/files/en-us/web/javascript/reference/global_objects/evalerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/evalerror/index.md
@@ -13,6 +13,8 @@ browser-compat: javascript.builtins.EvalError
 
 The **`EvalError`** object indicates an error regarding the global {{jsxref("Global_Objects/eval", "eval()")}} function. This exception is not thrown by JavaScript anymore, however the `EvalError` object remains for compatibility.
 
+`EvalError` is a {{Glossary("serializable object")}}, so it can be cloned with {{domxref("structuredClone()")}} or copied between [Workers](/en-US/docs/Web/API/Worker) using {{domxref("Worker.postMessage()", "postMessage()")}}.
+
 ## Constructor
 
 - {{jsxref("EvalError/EvalError", "EvalError()")}}

--- a/files/en-us/web/javascript/reference/global_objects/rangeerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/rangeerror/index.md
@@ -22,6 +22,8 @@ This can be encountered when:
 - when attempting to create an array of an illegal length with the {{jsxref("Array")}} constructor, or
 - when passing bad values to the numeric methods {{jsxref("Number.prototype.toExponential()")}}, {{jsxref("Number.prototype.toFixed()")}} or {{jsxref("Number.prototype.toPrecision()")}}.
 
+`RangeError` is a {{Glossary("serializable object")}}, so it can be cloned with {{domxref("structuredClone()")}} or copied between [Workers](/en-US/docs/Web/API/Worker) using {{domxref("Worker.postMessage()", "postMessage()")}}.
+
 ## Constructor
 
 - {{jsxref("RangeError/RangeError", "RangeError()")}}

--- a/files/en-us/web/javascript/reference/global_objects/referenceerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/referenceerror/index.md
@@ -13,6 +13,8 @@ browser-compat: javascript.builtins.ReferenceError
 
 The **`ReferenceError`** object represents an error when a variable that doesn't exist (or hasn't yet been initialized) in the current scope is referenced.
 
+`ReferenceError` is a {{Glossary("serializable object")}}, so it can be cloned with {{domxref("structuredClone()")}} or copied between [Workers](/en-US/docs/Web/API/Worker) using {{domxref("Worker.postMessage()", "postMessage()")}}.
+
 ## Constructor
 
 - {{jsxref("Global_Objects/ReferenceError/ReferenceError", "ReferenceError()")}}

--- a/files/en-us/web/javascript/reference/global_objects/syntaxerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/syntaxerror/index.md
@@ -13,6 +13,8 @@ browser-compat: javascript.builtins.SyntaxError
 
 The **`SyntaxError`** object represents an error when trying to interpret syntactically invalid code. It is thrown when the JavaScript engine encounters tokens or token order that does not conform to the syntax of the language when parsing code.
 
+`SyntaxError` is a {{Glossary("serializable object")}}, so it can be cloned with {{domxref("structuredClone()")}} or copied between [Workers](/en-US/docs/Web/API/Worker) using {{domxref("Worker.postMessage()", "postMessage()")}}.
+
 ## Constructor
 
 - {{jsxref("Global_Objects/SyntaxError/SyntaxError", "SyntaxError()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typeerror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typeerror/index.md
@@ -19,6 +19,8 @@ A `TypeError` may be thrown when:
 - when attempting to modify a value that cannot be changed; or
 - when attempting to use a value in an inappropriate way.
 
+`TypeError` is a {{Glossary("serializable object")}}, so it can be cloned with {{domxref("structuredClone()")}} or copied between [Workers](/en-US/docs/Web/API/Worker) using {{domxref("Worker.postMessage()", "postMessage()")}}.
+
 ## Constructor
 
 - {{jsxref("Global_Objects/TypeError/TypeError", "TypeError()")}}

--- a/files/en-us/web/javascript/reference/global_objects/urierror/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/urierror/index.md
@@ -13,6 +13,8 @@ browser-compat: javascript.builtins.URIError
 
 The **`URIError`** object represents an error when a global URI handling function was used in a wrong way.
 
+`URIError` is a {{Glossary("serializable object")}}, so it can be cloned with {{domxref("structuredClone()")}} or copied between [Workers](/en-US/docs/Web/API/Worker) using {{domxref("Worker.postMessage()", "postMessage()")}}.
+
 ## Constructor
 
 - {{jsxref("Global_Objects/URIError/URIError", "URIError()")}}


### PR DESCRIPTION
FF103 makes native error types serializable in https://bugzilla.mozilla.org/show_bug.cgi?id=1556604 - see https://bugzilla.mozilla.org/show_bug.cgi?id=1556604#c33 for some explanation of what is covered.
This includes the error types except for `InternalError`. It includes `AggregateError` (serializing this is pending an update to the spec being accepted). Stack is not serialised in 104 but is in nightly.

This adds cross linking info about support to the affected types and a release note.

Other docs work can be tracked in #18208