### PR TITLE
Document MathML dir attribute

### DIFF
--- a/files/en-us/web/mathml/global_attributes/dir/index.md
+++ b/files/en-us/web/mathml/global_attributes/dir/index.md
@@ -48,7 +48,7 @@ The **`dir`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) is an
 >
 > - This attribute can be overridden by the CSS property {{ cssxref("direction") }}, if a CSS page is active and the element supports these properties.
 > - As the directionality of mathematics is semantically related to its content and not to its presentation, it is recommended that web developers use this attribute instead of the related CSS properties when possible. That way, the formulas will display correctly even on a browser that doesn't support CSS or has the CSS deactivated.
-> - The `dir` attribute is used to set the directionality of math formulas, which is often from right to left in Arabic speaking world. However, languages written from right to left often embed mathematical content written from left to right and so the [user agent stylesheet](/en-US/docs/Web/CSS/Cascade#user-agent_stylesheets) resets the direction property accordingly on the [`math`](/en-US/docs/Web/MathML/Element/math) element.
+> - The `dir` attribute is used to set the directionality of math formulas, which is often from right to left in Arabic speaking world. However, languages written from right to left often embed mathematical content written from left to right. Consequently, the `auto` keyword from the HTML `dir` attribute is not recognized and by default the [user agent stylesheet](/en-US/docs/Web/CSS/Cascade#user-agent_stylesheets) resets the direction property on the [`math`](/en-US/docs/Web/MathML/Element/math) element.
 
 ## Specifications
 
@@ -62,3 +62,4 @@ The **`dir`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) is an
 
 - All [global attributes](/en-US/docs/Web/MathML/Global_attributes).
 - {{cssxref("direction")}}
+- The HTML {{htmlattrxref("dir")}} global attribute

--- a/files/en-us/web/mathml/global_attributes/dir/index.md
+++ b/files/en-us/web/mathml/global_attributes/dir/index.md
@@ -26,7 +26,7 @@ The **`dir`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) is an
   </msup>
 </math>
 
-<!---- Maghreb/Machrek style -->
+<!-- Maghreb/Machrek style -->
 <math dir="rtl">
   <msqrt>
     <mi>س</mi>

--- a/files/en-us/web/mathml/global_attributes/dir/index.md
+++ b/files/en-us/web/mathml/global_attributes/dir/index.md
@@ -1,0 +1,64 @@
+---
+title: dir
+slug: Web/MathML/Global_attributes/dir
+tags:
+  - Global attributes
+  - MathML
+  - Reference
+browser-compat: mathml.global_attributes.dir
+---
+{{MathMLRef("Global_attributes")}}
+
+The **`dir`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) is an enumerated attribute that indicates the directionality of the MathML element.
+
+## Syntax
+
+```html
+<!-- Moroccan style -->
+<math dir="ltr">
+  <msqrt>
+    <mi>س</mi>
+  </msqrt>
+  <mo>=</mo>
+  <msup>
+    <mn>3</mn>
+    <mi>ب</mi>
+  </msup>
+</math>
+
+<!---- Maghreb/Machrek style -->
+<math dir="rtl">
+  <msqrt>
+    <mi>س</mi>
+  </msqrt>
+  <mo>=</mo>
+  <msup>
+    <mn>٣</mn>
+    <mi>ب</mi>
+  </msup>
+</math>
+```
+
+### Values
+
+- `ltr`, which means _left to right_ and is used to render mathematical expressions from the left to the right (e.g. English or Moroccan style);
+- `rtl`, which means _right to left_ and is used to render mathematical expressions from the right to the left (e.g. Maghreb or Machrek style);
+
+> **Note:**
+>
+> - This attribute can be overridden by the CSS property {{ cssxref("direction") }}, if a CSS page is active and the element supports these properties.
+> - As the directionality of mathematics is semantically related to its content and not to its presentation, it is recommended that web developers use this attribute instead of the related CSS properties when possible. That way, the formulas will display correctly even on a browser that doesn't support CSS or has the CSS deactivated.
+> - The `dir` attribute is used to set the directionality of math formulas, which is often from right to left in Arabic speaking world. However, languages written from right to left often embed mathematical content written from left to right and so the [user agent stylesheet](/en-US/docs/Web/CSS/Cascade#user-agent_stylesheets) resets the direction property accordingly on the [`math`](/en-US/docs/Web/MathML/Element/math) element.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- All [global attributes](/en-US/docs/Web/MathML/Global_attributes).
+- {{cssxref("direction")}}

--- a/files/en-us/web/mathml/global_attributes/index.md
+++ b/files/en-us/web/mathml/global_attributes/index.md
@@ -26,13 +26,12 @@ In addition to the basic MathML global attributes, the following global attribut
   - : A space-separated list of the classes of the element. Classes allows CSS and JavaScript to select and access specific elements via the [class selectors](/en-US/docs/Web/CSS/Class_selectors) or functions like the method {{DOMxRef("Document.getElementsByClassName()")}}.
 - [`data-*`](/en-US/docs/Web/HTML/Global_attributes/data-*)
   - : Forms a class of attributes, called custom data attributes, that allow proprietary information to be exchanged between the [MathML](/en-US/docs/Web/MathML) and its {{glossary("DOM")}} representation that may be used by scripts. All such custom data are available via the {{DOMxRef("MathMLElement")}} interface of the element the attribute is set on. The {{DOMxRef("HTMLElement.dataset")}} property gives access to them.
-- [`dir`](/en-US/docs/Web/HTML/Global_attributes/dir)
+- [`dir`](/en-US/docs/Web/MathML/Global_attributes/dir)
 
-  - : An enumerated attribute indicating the directionality of the element's text. It can have the following values:
+  - : An enumerated attribute indicating the directionality of the MathML element. It can have the following values:
 
-    - `ltr`, which means _left to right_ and is to be used for languages that are written from the left to the right (like English);
-    - `rtl`, which means _right to left_ and is to be used for languages that are written from the right to the left (like Arabic);
-    - `auto`, which lets the user agent decide. It uses a basic algorithm as it parses the characters inside the element until it finds a character with a strong directionality, then it applies that directionality to the whole element.
+    - `ltr`, which means _left to right_ and is used to render mathematical expressions from the left to the right (e.g. English or Moroccan style);
+    - `rtl`, which means _right to left_ and is used to render mathematical expressions from the right to the left (e.g. Maghreb or Machrek style);
 
 - [`displaystyle`](/en-US/docs/Web/MathML/Global_attributes/displaystyle):
   - : a boolean setting the [math-style](/en-US/docs/Web/CSS/math-style) for the element.


### PR DESCRIPTION
#### Summary

Add new article for the MathML dir attribute and fix the corresponding content in the article about MathML global attributes.

#### Motivation

The MathML `dir` attribute is slightly different from the HTML one (it does not support `auto`).
Also, this article will be linked from browser-compat-data.

#### Supporting details

https://w3c.github.io/mathml-core/#dfn-dir
https://github.com/mdn/browser-compat-data/pull/16995

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
