### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/web/api/element/matches/index.md
+++ b/files/en-us/web/api/element/matches/index.md
@@ -19,7 +19,7 @@ The **`matches()`** method of the {{domxref("Element")}} interface tests whether
 ## Syntax
 
 ```js
-matches(selectorString)
+matches(selectors)
 ```
 
 ### Parameters


### PR DESCRIPTION
The parameter in the Syntax section is called ”selectorString,” whereas the parameter in the Parameters sub-section is called “selectors.” The parameter in the Syntax section should preferably be called “selectors,” too, to avoid confusion. 

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Renamed a parameter from selectorString to selectors.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The parameter in the Syntax section is called ”selectorString,” whereas the parameter in the Parameters sub-section is called “selectors.” The parameter in the Syntax section should preferably be called “selectors,” too, to avoid confusion. 

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://developer.mozilla.org/en-US/docs/Web/API/Element/closest

The closest() method is somewhat similar to the matches() method, and the CSS selector string in the description of the closest() method is called ”selectors” in the Syntax and Parameters sections.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
