### PR TITLE
private window access clarification in incognito key

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/incognito/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/incognito/index.md
@@ -37,7 +37,9 @@ browser-compat: webextensions.manifest.incognito
 
 Use the `incognito` key to control how the extension works with private browsing windows.
 
-This is a string which may take any of the following values:
+> **Note:** By default, extensions do not run in private browsing windows. Whether an extension can access private browsing windows is under user control. For details, see [Extensions in Private Browsing](https://support.mozilla.org/en-US/kb/extensions-private-browsing). Your extension can check whether it can access private browsing windows using {{WebExtAPIRef("extension.isAllowedIncognitoAccess")}}.
+
+This is a string that can take any of these values:
 
 - "spanning" (the default): the extension will see events from private and non-private windows and tabs. Windows and tabs will get an `incognito` property in the [`Window`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/windows/Window) or [`Tab`](/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/Tab) that represents them. This property indicates whether or not the object is private:
 


### PR DESCRIPTION
#### Summary
Adds a note about the execution of extensions in private windows being under user control to the description of the `incognito` manifest.json key. Provides the content requested in [Bug 1555649](https://bugzilla.mozilla.org/show_bug.cgi?id=1555649).

#### Metadata

This PR…

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
