### PR TITLE
In “Third-party APIs”, link to Mapquest example source, not live version

### DIFF
--- a/files/en-us/learn/javascript/client-side_web_apis/third_party_apis/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/third_party_apis/index.md
@@ -47,7 +47,7 @@ The APIs we've covered so far are built into the browser, but not all APIs are. 
 
 Third party APIs are APIs provided by third parties — generally companies such as Facebook, Twitter, or Google — to allow you to access their functionality via JavaScript and use it on your site. One of the most obvious examples is using mapping APIs to display custom maps on your pages.
 
-Let's look at a [Simple Mapquest API example](https://mdn.github.io/learning-area/javascript/apis/third-party-apis/mapquest/finished/), and use it to illustrate how third-party APIs differ from browser APIs.
+Let's look at a [Simple Mapquest API example](https://github.com/mdn/learning-area/tree/main/javascript/apis/third-party-apis/mapquest), and use it to illustrate how third-party APIs differ from browser APIs.
 
 > **Note:** You might want to just [get all our code examples](/en-US/docs/Learn#getting_our_code_examples) at once, in which case you can then just search the repo for the example files you need in each section.
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/18322