### PR TITLE
Add caveat that manual slot assignment needs to be enabled

### DIFF
--- a/files/en-us/web/api/htmlslotelement/assign/index.md
+++ b/files/en-us/web/api/htmlslotelement/assign/index.md
@@ -17,6 +17,8 @@ browser-compat: api.HTMLSlotElement.assign
 The **`assign()`** method of the
 {{domxref("HTMLSlotElement")}} interface sets the slot's **manually assigned nodes** to an ordered set of slottables. The manually assigned nodes set is initially empty until nodes are assigned using `assign()`.
 
+Please note that you cannot mix declarative and imperative slot assignment. Therefore, for this to work, the shadow tree needs to have been created with the `slotAssignment: "manual"` option.
+
 ## Syntax
 
 ```js


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Added caveat that manual slot assignment needs to be enabled.


[`Element.attachShadow()`](https://developer.mozilla.org/en-US/docs/Web/API/Element/attachShadow) also needs to be updated, but that's for another day.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Took me a good hour of head scratching to figure out why my code wasn't working, so trying to save any others down the same path.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Source: https://github.com/WICG/webcomponents/blob/gh-pages/proposals/Imperative-Shadow-DOM-Distribution-API.md

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
