### PR TITLE
Comment out ellipsis in code blocks

### DIFF
--- a/files/en-us/web/api/element/after/index.md
+++ b/files/en-us/web/api/element/after/index.md
@@ -22,7 +22,7 @@ String objects are inserted as equivalent {{domxref("Text")}} nodes.
 ```js
 after(node1)
 after(node1, node2)
-after(node1, node2, /* ... ,*/ nodeN)
+after(node1, node2, /* … ,*/ nodeN)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/element/append/index.md
+++ b/files/en-us/web/api/element/append/index.md
@@ -33,7 +33,7 @@ Differences from {{domxref("Node.appendChild()")}}:
 ```js
 append(param1)
 append(param1, param2)
-append(param1, param2, /* ... ,*/ paramN)
+append(param1, param2, /* … ,*/ paramN)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/element/ariaposinset/index.md
+++ b/files/en-us/web/api/element/ariaposinset/index.md
@@ -25,8 +25,8 @@ A string containing an integer.
 In this example the `aria-posinset` attribute on the element with an ID of `article2` is set to "2". Using `ariaPosInSet` we update the value to "3".
 
 ```html
-<article id="article1" aria-posinset="1"> ... </article>
-<article id="article2" aria-posinset="2"> ... </article>
+<article id="article1" aria-posinset="1"> … </article>
+<article id="article2" aria-posinset="2"> … </article>
 ```
 
 ```js

--- a/files/en-us/web/api/element/ariaroledescription/index.md
+++ b/files/en-us/web/api/element/ariaroledescription/index.md
@@ -25,7 +25,7 @@ A string.
 In this example the `aria-roledescription` attribute on the element with an ID of `myApplication` has been set. Using `ariaRoleDescription` we can update the value.
 
 ```html
-<div id="myApplication" role="application" aria-roledescription="a description of this widget">...</div>
+<div id="myApplication" role="application" aria-roledescription="a description of this widget">…</div>
 ```
 
 ```js

--- a/files/en-us/web/api/element/before/index.md
+++ b/files/en-us/web/api/element/before/index.md
@@ -22,7 +22,7 @@ String objects are inserted as equivalent {{domxref("Text")}} nodes.
 ```js
 before(param1)
 before(param1, param2)
-before(param1, param2, /* ... ,*/ paramN)
+before(param1, param2, /* … ,*/ paramN)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/element/copy_event/index.md
+++ b/files/en-us/web/api/element/copy_event/index.md
@@ -51,8 +51,8 @@ It's possible to construct and dispatch a [synthetic](/en-US/docs/Web/Events/Cre
 #### HTML
 
 ```html
-<div class="source" contenteditable="true">Try copying text from this box...</div>
-<div class="target" contenteditable="true">...and pasting it into this one</div>
+<div class="source" contenteditable="true">Copy text from this box.</div>
+<div class="target" contenteditable="true">And paste it into this one.</div>
 ```
 
 ```css hidden

--- a/files/en-us/web/api/element/cut_event/index.md
+++ b/files/en-us/web/api/element/cut_event/index.md
@@ -56,8 +56,8 @@ It's possible to construct and dispatch a [synthetic](/en-US/docs/Web/Events/Cre
 #### HTML
 
 ```html
-<div class="source" contenteditable="true">Try cutting text from this box...</div>
-<div class="target" contenteditable="true">...and pasting it into this one</div>
+<div class="source" contenteditable="true">Cut text from this box.</div>
+<div class="target" contenteditable="true">And paste it into this one.</div>
 ```
 
 ```css hidden

--- a/files/en-us/web/api/element/haspointercapture/index.md
+++ b/files/en-us/web/api/element/haspointercapture/index.md
@@ -45,7 +45,7 @@ capture, `false` if it doesn't.
       // Element 'target' will receive/capture further events
       el.setPointerCapture(ev.pointerId);
 
-      /* ... */
+      // …
 
       // Check whether element still has pointer capture
       let pointerCap = el.hasPointerCapture(ev.pointerId);

--- a/files/en-us/web/api/element/innerhtml/index.md
+++ b/files/en-us/web/api/element/innerhtml/index.md
@@ -114,7 +114,7 @@ const list = document.getElementById("list");
 list.innerHTML += `<li><a href="#">Item ${list.children.length + 1}</a></li>`;
 ```
 
-Please note that using `innerHTML` to append HTML elements (e.g. `el.innerHTML += "<a href='...'>link</a>"`) will result in the removal of any previously set event listeners.
+Please note that using `innerHTML` to append HTML elements (e.g. `el.innerHTML += "<a href='…'>link</a>"`) will result in the removal of any previously set event listeners.
 That is, after you append any HTML element that way you won't be able to listen to the previously set event listeners.
 
 ### Security considerations
@@ -171,7 +171,7 @@ function log(msg) {
   logElem.innerHTML += timeStr + ": " + msg + "<br/>";
 }
 
-log("Logging mouse events inside this container...");
+log("Logging mouse events inside this container…");
 ```
 
 The `log()` function creates the log output by getting the current time from a {{jsxref("Date")}} object using

--- a/files/en-us/web/api/element/paste_event/index.md
+++ b/files/en-us/web/api/element/paste_event/index.md
@@ -49,8 +49,8 @@ It's possible to construct and dispatch a [synthetic](/en-US/docs/Web/Events/Cre
 #### HTML
 
 ```html
-<div class="source" contenteditable="true">Try copying text from this box...</div>
-<div class="target" contenteditable="true">...and pasting it into this one</div>
+<div class="source" contenteditable="true">Copy text from this box.</div>
+<div class="target" contenteditable="true">And paste it into this one.</div>
 ```
 
 ```css hidden

--- a/files/en-us/web/api/element/prepend/index.md
+++ b/files/en-us/web/api/element/prepend/index.md
@@ -24,7 +24,7 @@ equivalent {{domxref("Text")}} nodes.
 ```js
 prepend(param1)
 prepend(param1, param2)
-prepend(param1, param2, /* ... ,*/ paramN)
+prepend(param1, param2, /* … ,*/ paramN)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/element/replacechildren/index.md
+++ b/files/en-us/web/api/element/replacechildren/index.md
@@ -23,7 +23,7 @@ can be string or {{domxref("Node")}} objects.
 ```js
 replaceChildren(param1)
 replaceChildren(param1, param2)
-replaceChildren(param1, param2, /* ... ,*/ paramN)
+replaceChildren(param1, param2, /* … ,*/ paramN)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/element/replacewith/index.md
+++ b/files/en-us/web/api/element/replacewith/index.md
@@ -22,7 +22,7 @@ objects are inserted as equivalent {{domxref("Text")}} nodes.
 ```js
 replaceWith(param1)
 replaceWith(param1, param2)
-replaceWith(param1, param2, /* ... ,*/ paramN)
+replaceWith(param1, param2, /* … ,*/ paramN)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/element/tagname/index.md
+++ b/files/en-us/web/api/element/tagname/index.md
@@ -47,7 +47,7 @@ inherits from {{domxref("Node")}}.
 ### HTML
 
 ```html
-<span id="born">When I was born...</span>
+<span id="born">When I was born…</span>
 ```
 
 ### JavaScript

--- a/files/en-us/web/api/elementinternals/index.md
+++ b/files/en-us/web/api/elementinternals/index.md
@@ -146,7 +146,7 @@ class CustomCheckbox extends HTMLElement {
     this.internals_ = this.attachInternals();
   }
 
-  /* ... */
+  // …
 }
 
 window.customElements.define('custom-checkbox', CustomCheckbox);

--- a/files/en-us/web/api/elementinternals/validity/index.md
+++ b/files/en-us/web/api/elementinternals/validity/index.md
@@ -35,7 +35,7 @@ class CustomCheckbox extends HTMLElement {
     super();
     this.internals_ = this.attachInternals();
 
-    /* ... */
+    // …
 
   }
   window.customElements.define("custom-checkbox", CustomCheckbox);

--- a/files/en-us/web/api/elementinternals/willvalidate/index.md
+++ b/files/en-us/web/api/elementinternals/willvalidate/index.md
@@ -37,7 +37,7 @@ class CustomCheckbox extends HTMLElement {
     super();
     this.internals_ = this.attachInternals();
 
-    /* ... */
+    // …
 
   }
   window.customElements.define("custom-checkbox", CustomCheckbox);

--- a/files/en-us/web/api/event/bubbles/index.md
+++ b/files/en-us/web/api/event/bubbles/index.md
@@ -22,9 +22,9 @@ A boolean value, which is `true` if the event bubbles up through the DOM tree.
 
 ```js
 function handleInput(e) {
-  // Checks whether the event bubbles and…
+  // Check whether the event bubbles
   if (!e.bubbles) {
-    // ... passes the event along if does not
+    // Passes the event along
     passItOn(e);
   }
 

--- a/files/en-us/web/api/event/bubbles/index.md
+++ b/files/en-us/web/api/event/bubbles/index.md
@@ -22,9 +22,8 @@ A boolean value, which is `true` if the event bubbles up through the DOM tree.
 
 ```js
 function handleInput(e) {
-  // Check whether the event bubbles
+  // Check whether the event bubbles passes the event along
   if (!e.bubbles) {
-    // Passes the event along
     passItOn(e);
   }
 

--- a/files/en-us/web/api/event/defaultprevented/index.md
+++ b/files/en-us/web/api/event/defaultprevented/index.md
@@ -42,7 +42,7 @@ function logClick(event) {
       log.innerText = 'Sorry, but you cannot visit this link!\n' + log.innerText;
     }
     else {
-      log.innerText = 'Visiting link...\n' + log.innerText;
+      log.innerText = 'Visiting link…\n' + log.innerText;
     }
   }
 }

--- a/files/en-us/web/api/eventtarget/addeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.md
@@ -576,7 +576,7 @@ occurrence of `this` within the code represents a reference to the element.
 
 ```html
 <table id="my_table" onclick="console.log(this.id);"><!-- `this` refers to the table; logs 'my_table' -->
-  ...
+  …
 </table>
 ```
 
@@ -589,7 +589,7 @@ shown in the following example:
   function logID() { console.log(this.id); }
 </script>
 <table id="my_table" onclick="logID();"><!-- when called, `this` will refer to the global object -->
-  ...
+  …
 </table>
 ```
 
@@ -637,10 +637,10 @@ const Something = function(element) {
     console.log(this.name); // 'Something Good', as this is bound to newly created object
     switch(event.type) {
       case 'click':
-        // some code here...
+        // some code here…
         break;
       case 'dblclick':
-        // some code here...
+        // some code here…
         break;
     }
   };
@@ -676,10 +676,10 @@ class SomeClass {
     console.log(this.name);
     switch(e.keyCode) {
       case 5:
-        // some code here...
+        // some code here…
         break;
       case 6:
-        // some code here...
+        // some code here…
         break;
     }
   }

--- a/files/en-us/web/api/ext_disjoint_timer_query/beginqueryext/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/beginqueryext/index.md
@@ -40,7 +40,7 @@ var ext = gl.getExtension('EXT_disjoint_timer_query');
 var query = ext.createQueryEXT();
 ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, query);
 
-// ...
+// …
 ```
 
 ## Specifications

--- a/files/en-us/web/api/ext_disjoint_timer_query/deletequeryext/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/deletequeryext/index.md
@@ -37,7 +37,7 @@ None ({{jsxref("undefined")}}).
 var ext = gl.getExtension('EXT_disjoint_timer_query');
 var query = ext.createQueryEXT();
 
-// ...
+// …
 
 ext.deleteQueryEXT(query);
 ```

--- a/files/en-us/web/api/ext_disjoint_timer_query/endqueryext/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/endqueryext/index.md
@@ -38,7 +38,7 @@ var ext = gl.getExtension('EXT_disjoint_timer_query');
 var query = ext.createQueryEXT();
 ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, query);
 
-// ...
+// …
 
 ext.endQueryEXT(ext.TIME_ELAPSED_EXT);
 ```

--- a/files/en-us/web/api/ext_disjoint_timer_query/getqueryobjectext/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/getqueryobjectext/index.md
@@ -46,7 +46,7 @@ const ext = gl.getExtension('EXT_disjoint_timer_query');
 const query = ext.createQueryEXT();
 ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, query);
 
-// ... drawing ...
+// drawing…
 
 ext.endQueryEXT(ext.TIME_ELAPSED_EXT);
 

--- a/files/en-us/web/api/ext_disjoint_timer_query/getqueryobjectext/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/getqueryobjectext/index.md
@@ -46,8 +46,7 @@ const ext = gl.getExtension('EXT_disjoint_timer_query');
 const query = ext.createQueryEXT();
 ext.beginQueryEXT(ext.TIME_ELAPSED_EXT, query);
 
-// drawing…
-
+// Draw
 ext.endQueryEXT(ext.TIME_ELAPSED_EXT);
 
 // At some point in the future, after returning control to the browser

--- a/files/en-us/web/api/ext_disjoint_timer_query/isqueryext/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/isqueryext/index.md
@@ -39,7 +39,7 @@ A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether the given objec
 var ext = gl.getExtension('EXT_disjoint_timer_query');
 var query = ext.createQueryEXT();
 
-// ...
+// …
 
 ext.isQueryEXT(query);
 ```

--- a/files/en-us/web/api/ext_disjoint_timer_query/querycounterext/index.md
+++ b/files/en-us/web/api/ext_disjoint_timer_query/querycounterext/index.md
@@ -42,7 +42,7 @@ var startQuery = ext.createQueryEXT();
 var endQuery = ext.createQueryEXT();
 ext.queryCounterEXT(startQuery, ext.TIMESTAMP_EXT);
 
-// ...
+// …
 
 ext.queryCounterEXT(endQuery, ext.TIMESTAMP_EXT);
 ```

--- a/files/en-us/web/api/fetchevent/request/index.md
+++ b/files/en-us/web/api/fetchevent/request/index.md
@@ -52,7 +52,7 @@ self.addEventListener('fetch', function(event) {
 
         return response;
       }
-      console.log('No response found in cache. About to fetch from network...');
+      console.log('No response found in cache. About to fetch from network…');
 
       return fetch(event.request).then(function(response) {
         console.log('Response from network is:', response);

--- a/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
+++ b/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
@@ -480,7 +480,7 @@ if (isset($_FILES['myFile'])) {
 </head>
 <body>
     <div>
-        <div id="dropzone" style="margin:30px; width:500px; height:300px; border:1px dotted grey;">Drag & drop your file here…</div>
+        <div id="dropzone" style="margin:30px; width:500px; height:300px; border:1px dotted grey;">Drag & drop your file here</div>
     </div>
 </body>
 </html>

--- a/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
+++ b/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
@@ -480,7 +480,7 @@ if (isset($_FILES['myFile'])) {
 </head>
 <body>
     <div>
-        <div id="dropzone" style="margin:30px; width:500px; height:300px; border:1px dotted grey;">Drag & drop your file here...</div>
+        <div id="dropzone" style="margin:30px; width:500px; height:300px; border:1px dotted grey;">Drag & drop your file here…</div>
     </div>
 </body>
 </html>

--- a/files/en-us/web/api/filereader/abort_event/index.md
+++ b/files/en-us/web/api/filereader/abort_event/index.md
@@ -61,7 +61,7 @@ _Also inherits properties from its parent {{domxref("Event")}}_.
                accept="image/png, image/jpeg">
     </div>
 
-    <img src="" class="preview" height="200" alt="Image preview...">
+    <img src="" class="preview" height="200" alt="Image preview…">
 
     <div class="event-log">
         <label>Event log:</label>

--- a/files/en-us/web/api/filereader/abort_event/index.md
+++ b/files/en-us/web/api/filereader/abort_event/index.md
@@ -61,7 +61,7 @@ _Also inherits properties from its parent {{domxref("Event")}}_.
                accept="image/png, image/jpeg">
     </div>
 
-    <img src="" class="preview" height="200" alt="Image preview…">
+    <img src="" class="preview" height="200" alt="Image preview">
 
     <div class="event-log">
         <label>Event log:</label>

--- a/files/en-us/web/api/filereader/load_event/index.md
+++ b/files/en-us/web/api/filereader/load_event/index.md
@@ -59,7 +59,7 @@ _Also inherits properties from its parent {{domxref("Event")}}_.
                accept="image/png, image/jpeg">
     </div>
 
-    <img src="" class="preview" height="200" alt="Image preview...">
+    <img src="" class="preview" height="200" alt="Image preview…">
 
     <div class="event-log">
         <label>Event log:</label>

--- a/files/en-us/web/api/filereader/load_event/index.md
+++ b/files/en-us/web/api/filereader/load_event/index.md
@@ -59,7 +59,7 @@ _Also inherits properties from its parent {{domxref("Event")}}_.
                accept="image/png, image/jpeg">
     </div>
 
-    <img src="" class="preview" height="200" alt="Image preview…">
+    <img src="" class="preview" height="200" alt="Image preview">
 
     <div class="event-log">
         <label>Event log:</label>

--- a/files/en-us/web/api/treewalker/index.md
+++ b/files/en-us/web/api/treewalker/index.md
@@ -69,7 +69,9 @@ _This interface doesn't inherit any method._
     let walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ALL);
     let node = walker.firstChild(); // nodeName: "#text"
     ```
+
     But if we do:
+
     ```js
     let walker = document.createTreeWalker(document.body, NodeFilter.SHOW_ELEMENT);
     let node = walker.firstChild(); // nodeName: "DIV"

--- a/files/en-us/web/javascript/reference/global_objects/asyncgeneratorfunction/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/asyncgeneratorfunction/index.md
@@ -47,7 +47,7 @@ Async generator function objects created with the `AsyncGeneratorFunction` const
 All arguments passed to the function, except the last, are treated as the names of the identifiers of the parameters in the function to be created, in the order in which they are passed.
 
 > **Note:** Async generator functions created with the `AsyncGeneratorFunction` constructor do not create closures to their creation contexts; they are always created in the global scope.
-> 
+>
 > When running them, they will only be able to access their own local variables and global ones, not the ones from the scope in which the `AsyncGeneratorFunction` constructor was called.
 >
 > This is different from using {{jsxref("Global_Objects/eval", "eval")}} with code for an async generator function expression.


### PR DESCRIPTION
Ellipsis in markdown code blocks are syntax errors.

In order to have smooth transition to Prettier and ESLint the PR comments out such bare ellipses. Refer the [discussion](https://github.com/mdn/content/pull/18171#issuecomment-1179670484) for more context.
