### PR TITLE
Make code example valid

### DIFF
--- a/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.md
@@ -55,11 +55,9 @@ function makeDistortionCurve(amount) {
   const k = typeof amount === 'number' ? amount : 50,
     n_samples = 44100,
     curve = new Float32Array(n_samples),
-    deg = Math.PI / 180,
-    i = 0,
-    x;
-  for ( ; i < n_samples; ++i ) {
-    x = i * 2 / n_samples - 1;
+    deg = Math.PI / 180;
+  for (let i = 0; i < n_samples; ++i ) {
+    const x = i * 2 / n_samples - 1;
     curve[i] = ( 3 + k ) * x * 20 * deg / ( Math.PI + k * Math.abs(x) );
   }
   return curve;

--- a/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.md
@@ -52,10 +52,11 @@ const distortion = audioCtx.createWaveShaper();
 // …
 
 function makeDistortionCurve(amount) {
-  const k = typeof amount === 'number' ? amount : 50,
-    n_samples = 44100,
-    curve = new Float32Array(n_samples),
-    deg = Math.PI / 180;
+  const k = typeof amount === 'number' ? amount : 50;
+  const n_samples = 44100;
+  const curve = new Float32Array(n_samples);
+  const deg = Math.PI / 180;
+  
   for (let i = 0; i < n_samples; i++) {
     const x = i * 2 / n_samples - 1;
     curve[i] = (3 + k) * x * 20 * deg / (Math.PI + k * Math.abs(x));

--- a/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createwaveshaper/index.md
@@ -46,7 +46,7 @@ node. For applied examples/information, check out our [Voice-change-O-matic](htt
 > smoother sounding result. We found the below distortion curve code on [Stack Overflow](https://stackoverflow.com/questions/22312841/waveshaper-node-in-webaudio-how-to-emulate-distortion).
 
 ```js
-const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+const audioCtx = new AudioContext();
 const distortion = audioCtx.createWaveShaper();
 
 // …
@@ -56,9 +56,9 @@ function makeDistortionCurve(amount) {
     n_samples = 44100,
     curve = new Float32Array(n_samples),
     deg = Math.PI / 180;
-  for (let i = 0; i < n_samples; ++i ) {
+  for (let i = 0; i < n_samples; i++) {
     const x = i * 2 / n_samples - 1;
-    curve[i] = ( 3 + k ) * x * 20 * deg / ( Math.PI + k * Math.abs(x) );
+    curve[i] = (3 + k) * x * 20 * deg / (Math.PI + k * Math.abs(x));
   }
   return curve;
 };


### PR DESCRIPTION
I tried this code sample myself, even after this correction I'm not sure it works correctly, but at least now it can run at all.

#### Summary
Some variables were declared as `const` but were reassigned in the `for` loop. I'm assuming this was a "translation" of an old piece of code that used to use `var`.

#### Motivation
Now at least users can actually run the code.

#### Supporting details

#### Related issues

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
