### PR TITLE
Fix typo: Document.createComment() returns none

### DIFF
--- a/files/en-us/web/api/document/createcomment/index.md
+++ b/files/en-us/web/api/document/createcomment/index.md
@@ -27,7 +27,7 @@ createComment(data)
 
 ### Return value
 
-A [Comment](/en-US/docs/Web/API/Comment) node.
+A new {{domxref("Comment")}} object.
 
 ## Examples
 

--- a/files/en-us/web/api/document/createcomment/index.md
+++ b/files/en-us/web/api/document/createcomment/index.md
@@ -27,7 +27,7 @@ createComment(data)
 
 ### Return value
 
-None ({{jsxref("undefined")}}).
+A [Comment](/en-US/docs/Web/API/Comment) node.
 
 ## Examples
 


### PR DESCRIPTION
#### Summary
Fix a typo in [Document.createComment()](https://developer.mozilla.org/en-US/docs/Web/API/Document/createComment) page.

#### Metadata
- [x] Fixes a typo
