### PR TITLE
Fix typo located in releasePointerCapture example

### DIFF
--- a/files/en-us/web/api/element/releasepointercapture/index.md
+++ b/files/en-us/web/api/element/releasepointercapture/index.md
@@ -46,7 +46,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 This example sets pointer capture on a {{HtmlElement("div")}} when you press down on
-it. This lets you slide the element horizontally, even when you pointer moves outside of
+it. This lets you slide the element horizontally, even when your pointer moves outside of
 its boundaries.
 
 ### HTML


### PR DESCRIPTION
#### Summary
Corrected a misspelling of 'your' spotted inside of releasePointerCapture's example section.

#### Motivation
 Concise and efficient grammatical context for readers is the motivation for my change.

#### Supporting details

#### Related issues

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

