### PR TITLE
feat: tell range for confidence in speechrecognitionalternative page

### DIFF
--- a/files/en-us/web/api/speechrecognitionalternative/index.md
+++ b/files/en-us/web/api/speechrecognitionalternative/index.md
@@ -22,7 +22,7 @@ The **`SpeechRecognitionAlternative`** interface of the [Web Speech API](/en-US/
 - {{domxref("SpeechRecognitionAlternative.transcript")}} {{readonlyinline}}
   - : Returns a string containing the transcript of the recognized word.
 - {{domxref("SpeechRecognitionAlternative.confidence")}} {{readonlyinline}}
-  - : Returns a numeric estimate of how confident the speech recognition system is that the recognition is correct.
+  - : Returns a numeric estimate between 0 and 1 of how confident the speech recognition system is that the recognition is correct.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

Tells the range for the `confidence` property in the `SpeechRecognitionAlternative` page.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

It's a basic piece of information that I should know when reading the property instead of clicking on it and scrolling down to find the range.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Just takes info from https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognitionAlternative/confidence#value and adds to https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognitionAlternative#speechrecognitionalternative.confidence also.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

N/A

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
