### PR TITLE
fixes bug in `css:focus-visible`: replace the broken element in example

### DIFF
--- a/files/en-us/web/css/_colon_focus-visible/index.md
+++ b/files/en-us/web/css/_colon_focus-visible/index.md
@@ -62,16 +62,16 @@ input, button {
 A custom control, such as a custom element button, can use `:focus-visible` to selectively apply a focus indicator only on keyboard-focus. This matches the native focus behavior for controls like {{htmlelement("button")}}.
 
 ```html
-<custom-button tabindex="0" role="button">Click Me</custom-button>
+<button class="custom-button">Click Me</button>
 ```
 
 ```css
-custom-button {
+.custom-button {
   display: inline-block;
   margin: 10px;
 }
 
-custom-button:focus {
+.custom-button:focus {
   /* Provide a fallback style for browsers
      that don't support :focus-visible */
   outline: 2px solid red;
@@ -79,7 +79,7 @@ custom-button:focus {
 }
 
 @supports selector(:focus-visible) {
-  custom-button:focus {
+  .custom-button:focus {
     /* Remove the focus indicator on mouse-focus for browsers
        that do support :focus-visible */
     outline: none;
@@ -87,7 +87,7 @@ custom-button:focus {
   }
 }
 
-custom-button:focus-visible {
+.custom-button:focus-visible {
   /* Draw a very noticeable focus style for
      keyboard-focus on browsers that do support
      :focus-visible */


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
replace the element `<custom-button>` with `<button class="custom-button">` .
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The original element is broken.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
I don't keep the `role="button"` , it more uses in accessbility.
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #17881 
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
