### PR TITLE
OpenType guide: font-variant-position is not mutually exclusive with <sup>/<sub>

### DIFF
--- a/files/en-us/web/css/css_fonts/opentype_fonts_guide/index.md
+++ b/files/en-us/web/css/css_fonts/opentype_fonts_guide/index.md
@@ -96,7 +96,7 @@ While more common in script typefaces, in the below example they are used to cre
 
 Associated CSS property: {{cssxref("font-variant-position")}}
 
-Position variants are used to enable typographic superscript and subscript glyphs. These are designed to work with the surrounding text without altering the baseline or line spacing. This is one of the key benefits over using the {{htmlelement("sub")}} or {{htmlelement("sup")}} elements.
+Position variants are used to enable typographic superscript and subscript glyphs. These are designed to work with the surrounding text without altering the baseline or line spacing. This is especially useful with the {{htmlelement("sub")}} or {{htmlelement("sup")}} elements.
 
 {{EmbedGHLiveSample("css-examples/font-features/font-variant-position.html", '100%', 550)}}
 


### PR DESCRIPTION
#### Summary

Change the following sentence from [OpenType fonts guide](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Fonts/OpenType_fonts_guide) regarding `font-variation-position`:

> This is one of the key benefits over using the `<sub>` or `<sup>` elements.

…to:

> This is especially useful with the `<sub>` or `<sup>` elements.

#### Motivation
As [the page on `font-variant-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-position) currently says, `font-variant-position` is typically used on `<sup>` and `<sub>` elements to improve their typographic display.

However, the [OpenType fonts guide](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Fonts/OpenType_fonts_guide) currently says, “Position variants are used to enable typographic superscript and subscript glyphs. These are designed to work with the surrounding text without altering the baseline or line spacing. This is one of the key benefits over using the `<sub>` or `<sup>` elements.” This is misleading; it seems to imply that `<sub>` and `<sup>` elements have to alter the baseline and line spacing and that `font-variant-position` is incompatible with them.

#### Related issues
In the future, we probably should alter [css-examples/font-features/font-variant-position.html](https://github.com/mdn/css-examples/blob/main/font-features/font-variant-position.html) to use `<sub>` and `<sup>` elements, since those are what the property is most useful with.

#### Metadata

This PR…

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error