### PR TITLE
Fix `channelCount` semantics in `MediaStreamAudioSourceNode`.

### DIFF
--- a/files/en-us/web/api/mediastreamaudiosourcenode/index.md
+++ b/files/en-us/web/api/mediastreamaudiosourcenode/index.md
@@ -48,7 +48,7 @@ The number of channels output by the node matches the number of tracks found in 
     <tr>
       <th scope="row">Channel count</th>
       <td>
-        2 (but note that {{domxref("AudioNode.channelCount")}} is only used for up-mixing and down-mixing {{domxref("AudioNode")}} inputs, and {{domxref("MediaStreamAudioSourceNode")}} doesn't have any input.
+        2 (but note that {{domxref("AudioNode.channelCount")}} is only used for up-mixing and down-mixing {{domxref("AudioNode")}} inputs, and {{domxref("MediaStreamAudioSourceNode")}} doesn't have any input)
       </td>
     </tr>
   </tbody>

--- a/files/en-us/web/api/mediastreamaudiosourcenode/index.md
+++ b/files/en-us/web/api/mediastreamaudiosourcenode/index.md
@@ -48,7 +48,7 @@ The number of channels output by the node matches the number of tracks found in 
     <tr>
       <th scope="row">Channel count</th>
       <td>
-        2 (but note that {{domxref("AudioNode.channelCount")}} is only used for up-mixing and down-mixing {{domxref("AudioNode")}} inputs, and {{domxref("MediaStreamAudioSourceNode"}} doesn't have any input.
+        2 (but note that {{domxref("AudioNode.channelCount")}} is only used for up-mixing and down-mixing {{domxref("AudioNode")}} inputs, and {{domxref("MediaStreamAudioSourceNode")}} doesn't have any input.
       </td>
     </tr>
   </tbody>

--- a/files/en-us/web/api/mediastreamaudiosourcenode/index.md
+++ b/files/en-us/web/api/mediastreamaudiosourcenode/index.md
@@ -48,10 +48,7 @@ The number of channels output by the node matches the number of tracks found in 
     <tr>
       <th scope="row">Channel count</th>
       <td>
-        defined by the first audio {{domxref("MediaStreamTrack")}}
-        passed to the
-        {{domxref("AudioContext.createMediaStreamSource()")}}
-        method that created it.
+        2 (but note that {{domxref("AudioNode.channelCount")}} is only used for up-mixing and down-mixing {{domxref("AudioNode")}} inputs, and {{domxref("MediaStreamAudioSourceNode"}} doesn't have any input.
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
This sparked confusion, e.g. in https://github.com/WebAudio/web-audio-api/issues/2496.

#### Summary
The description of `channelCount` is wrong. This sparked confusion, e.g. in https://github.com/WebAudio/web-audio-api/issues/2496.

#### Supporting details
I am this specification's editor.

#### Related issues
Similar PR for `MediaElementAudioSourceNode`: https://github.com/mdn/content/pull/18473

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
