### PR TITLE
Fix `channelCount` semantics.

### DIFF
--- a/files/en-us/web/api/mediaelementaudiosourcenode/index.md
+++ b/files/en-us/web/api/mediaelementaudiosourcenode/index.md
@@ -33,10 +33,7 @@ A `MediaElementAudioSourceNode` has no inputs and exactly one output, and is cre
     <tr>
       <th scope="row">Channel count</th>
       <td>
-        defined by the media in the {{domxref("HTMLMediaElement")}}
-        passed to the
-        {{domxref("AudioContext.createMediaElementSource")}}
-        method that created it.
+        2 (but note that {{domxref("AudioNode.channelCount")}} is only used for up-mixing and down-mixing {{domxref("AudioNode")}} inputs, and {{domxref("MediaElementAudioSourceNode"}} doesn't have any input.
       </td>
     </tr>
   </tbody>

--- a/files/en-us/web/api/mediaelementaudiosourcenode/index.md
+++ b/files/en-us/web/api/mediaelementaudiosourcenode/index.md
@@ -33,7 +33,7 @@ A `MediaElementAudioSourceNode` has no inputs and exactly one output, and is cre
     <tr>
       <th scope="row">Channel count</th>
       <td>
-        2 (but note that {{domxref("AudioNode.channelCount")}} is only used for up-mixing and down-mixing {{domxref("AudioNode")}} inputs, and {{domxref("MediaElementAudioSourceNode")}} doesn't have any input.
+        2 (but note that {{domxref("AudioNode.channelCount")}} is only used for up-mixing and down-mixing {{domxref("AudioNode")}} inputs, and {{domxref("MediaElementAudioSourceNode")}} doesn't have any input)
       </td>
     </tr>
   </tbody>

--- a/files/en-us/web/api/mediaelementaudiosourcenode/index.md
+++ b/files/en-us/web/api/mediaelementaudiosourcenode/index.md
@@ -33,7 +33,7 @@ A `MediaElementAudioSourceNode` has no inputs and exactly one output, and is cre
     <tr>
       <th scope="row">Channel count</th>
       <td>
-        2 (but note that {{domxref("AudioNode.channelCount")}} is only used for up-mixing and down-mixing {{domxref("AudioNode")}} inputs, and {{domxref("MediaElementAudioSourceNode"}} doesn't have any input.
+        2 (but note that {{domxref("AudioNode.channelCount")}} is only used for up-mixing and down-mixing {{domxref("AudioNode")}} inputs, and {{domxref("MediaElementAudioSourceNode")}} doesn't have any input.
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
The description of `channelCount` is wrong. This sparked confusion, e.g. in https://github.com/WebAudio/web-audio-api/issues/2496.

#### Supporting details
I am this specification's editor.

#### Related issues
Similar PR for `MediaStreamAudioSourceNode`: https://github.com/mdn/content/pull/18472

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
