### PR TITLE
Fix syntax errors

### DIFF
--- a/files/en-us/web/api/blobbuilder/index.md
+++ b/files/en-us/web/api/blobbuilder/index.md
@@ -110,7 +110,7 @@ void append(
 Returns the {{domxref("Blob")}} object that has been constructed using the data passed
 through calls to [`append()`](#append).
 
-```js
+```
 Blob getBlob(
   in DOMString contentType // optional
 );
@@ -133,7 +133,7 @@ starting a new, empty blob.
 
 Returns a {{domxref("File")}} object.
 
-```js
+```
 File getFile(
   in DOMString name,
   [optional] in DOMString contentType

--- a/files/en-us/web/api/blobbuilder/index.md
+++ b/files/en-us/web/api/blobbuilder/index.md
@@ -112,7 +112,7 @@ through calls to [`append()`](#append).
 
 ```js
 Blob getBlob(
-  in DOMString contentType {{optional_inline}}
+  in DOMString contentType // optional
 );
 ```
 

--- a/files/en-us/web/api/rtcpeerconnection/getstats/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/getstats/index.md
@@ -69,7 +69,7 @@ the new promise-based version_. Check the [Browser compatibility](#browser_compa
 to verify the state of this method.
 
 ```js
-promise = rtcPeerConnection.getStats(selector, successCallback, failureCallback) {{deprecated_inline}}
+promise = rtcPeerConnection.getStats(selector, successCallback, failureCallback) // deprecated
 ```
 
 #### Parameters


### PR DESCRIPTION
Reported in https://github.com/orgs/mdn/discussions/158 (PR11)
The macro just prints `Deprected` and `Optional` in the code.

These were the only macro calls in code blocs.