### PR TITLE
Fixes TextTrack default mode when `default` is set on HTMLTrackElement

### DIFF
--- a/files/en-us/web/api/texttrack/index.md
+++ b/files/en-us/web/api/texttrack/index.md
@@ -37,7 +37,7 @@ _This interface also inherits properties from {{domxref("EventTarget")}}._
 - {{domxref("TextTrack.language")}} {{readonlyInline}}
   - : A string which specifies the text language in which the text track's contents is written. The value must adhere to the format specified in {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}, just like the HTML {{htmlattrxref("lang")}} attribute. For example, this can be `"en-US"` for United States English or `"pt-BR"` for Brazilian Portuguese.
 - {{domxref("TextTrack.mode")}}
-  - : A string specifying the track's current mode, which must be one of the permitted values. Changing this property's value changes the track's current mode to match. The default is `disabled`, unless the {{HTMLElement("track")}} element's {{htmlattrxref("default", "track")}} Boolean attribute is set to `true`, in which case the default mode is `showing`.
+  - : A string specifying the track's current mode, which must be one of the permitted values. Changing this property's value changes the track's current mode to match. The default is `disabled`, unless the {{HTMLElement("track")}} element's {{htmlattrxref("default", "track")}} boolean attribute is set to `true` — in which case the default mode is `showing`.
 
 ## Methods
 

--- a/files/en-us/web/api/texttrack/index.md
+++ b/files/en-us/web/api/texttrack/index.md
@@ -37,7 +37,7 @@ _This interface also inherits properties from {{domxref("EventTarget")}}._
 - {{domxref("TextTrack.language")}} {{readonlyInline}}
   - : A string which specifies the text language in which the text track's contents is written. The value must adhere to the format specified in {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}, just like the HTML {{htmlattrxref("lang")}} attribute. For example, this can be `"en-US"` for United States English or `"pt-BR"` for Brazilian Portuguese.
 - {{domxref("TextTrack.mode")}}
-  - : A string specifying the track's current mode, which must be one of the permitted values. Changing this property's value changes the track's current mode to match. The default is `disabled`, unless the {{HTMLElement("track")}} element's {{htmlattrxref("default", "track")}} Boolean attribute is specified, in which case the default mode is `started`.
+  - : A string specifying the track's current mode, which must be one of the permitted values. Changing this property's value changes the track's current mode to match. The default is `disabled`, unless the {{HTMLElement("track")}} element's {{htmlattrxref("default", "track")}} Boolean attribute is set to `true`, in which case the default mode is `showing`.
 
 ## Methods
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fixes an error in how the `TextTrack.mode` default value is set

`TextTrack.mode` has only 3 possible values `disabled`, `hidden` and `showing` as per the specs (https://html.spec.whatwg.org/multipage/media.html#text-track-mode) `started` is not one of them. After some testing I come to the conclusion that when an `HTMLTrackElement.default` is set to true, its `TextTrack.mode` has the default `showing` value.

#### Motivation
The documentation did not match neither the specs nor my own testing 

#### Supporting details
https://html.spec.whatwg.org/multipage/media.html#text-track-mode

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

