### PR TITLE
Change 'nodes' link to link directly to DOM nodes

### DIFF
--- a/files/en-us/glossary/shadow_tree/index.md
+++ b/files/en-us/glossary/shadow_tree/index.md
@@ -7,7 +7,7 @@ tags:
   - Shadow Tree
   - shadow DOM
 ---
-A **shadow tree** is a tree of DOM {{Glossary("node", "nodes")}} whose topmost node is a **shadow root**; that is, the topmost node within a **shadow DOM**. A shadow tree is a hidden set of standard DOM nodes which is attached to a standard DOM node that serves as a host. The hidden nodes are not directly visible using regular DOM functionality, but require the use of a special [Shadow DOM API](/en-US/docs/Web/Web_Components/Using_shadow_DOM) to access.
+A **shadow tree** is a tree of DOM [nodes](/en-US/docs/Glossary/Node/DOM) whose topmost node is a **shadow root**; that is, the topmost node within a **shadow DOM**. A shadow tree is a hidden set of standard DOM nodes which is attached to a standard DOM node that serves as a host. The hidden nodes are not directly visible using regular DOM functionality, but require the use of a special [Shadow DOM API](/en-US/docs/Web/Web_Components/Using_shadow_DOM) to access.
 
 Nodes within the shadow tree are not affected by anything applied outside the shadow tree, and vice versa. This provides a way to encapsulate implementation details, which is especially useful for custom elements and other advanced design paradigms.
 


### PR DESCRIPTION
#### Summary
I changed the link to DOM 'nodes' to directly link to the DOM nodes page.

#### Motivation
The link to DOM 'nodes' currently links to the 'nodes' glossary page, which seems unnecessary given DOM nodes are specifically being discussed.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
