### PR TITLE
Remove continuity descriptions from `steps(...)`

### DIFF
--- a/files/en-us/web/css/easing-function/index.md
+++ b/files/en-us/web/css/easing-function/index.md
@@ -109,11 +109,11 @@ where:
   - : Is a strictly positive {{cssxref("&lt;integer&gt;")}}, representing the amount of equidistant treads composing the stepping function.
 - _direction_
 
-  - : Is a keyword indicating if it the function is [left- or right-continuous](https://en.wikipedia.org/wiki/Left-continuous#Directional_and_semi-continuity):
+  - : Is a keyword indicating when the jumps occur:
 
-    - `jump-start` denotes a left-continuous function, so that the first step or jump happens when the interpolation begins;
-    - `jump-end` denotes a right-continuous function, so that the last step or jump happens when the interpolation ends;
-    - `jump-both` denotes a right and left continuous function, includes pauses at both the 0% and 100% marks, effectively adding a step during the interpolation iteration;
+    - `jump-start` denotes that the first step or jump happens when the interpolation begins;
+    - `jump-end` denotes that the last step or jump happens when the interpolation ends;
+    - `jump-both` denotes that jumps occur at both the 0% and 100% marks, effectively adding a step during the interpolation iteration;
     - `jump-none` There is no jump on either end. Instead, holding at both the 0% mark and the 100% mark, each for 1/n of the duration
     - `start` is the equivalent of `jump-start`
     - `end` is the equivalent of `jump-end`


### PR DESCRIPTION
#### Summary
Remove references to left- and right-discontinuity from the section describing `direction` keyword of `steps(...)` easing function

#### Motivation
Current description of `steps(...)` `direction` keyword include references to left and right-discontinuity. However, examining Figure 5 in the relevant spec, they all seem to be right-continuous. Therefore, as it stands, references to left- and right-discontinuity cause confusion.

#### Supporting details
https://drafts.csswg.org/css-easing/#step-easing-functions

#### Related issues
N/A

#### Metadata

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
