### PR TITLE
Protocol handlers in private browsing windows clarification

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/protocol_handlers/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/protocol_handlers/index.md
@@ -45,6 +45,8 @@ Use this key to register one or more web-based protocol handlers.
 
 A protocol handler is an application that knows how to handle particular types of links: for example, a mail client is a protocol handler for "mailto:" links. When the user clicks a "mailto:" link, the browser opens the application selected as the handler for the "mailto:" protocol (or offers them a choice of handlers, depending on their settings).
 
+> **Note:** By default, extensions do not run in private browsing windows. As protocol handlers are part of the extension, they don't work in private browsing windows by default. Whether an extension can access private browsing windows and its protocol handlers become active is under user control. For details, see [Extensions in Private Browsing](https://support.mozilla.org/en-US/kb/extensions-private-browsing). Your extension can check whether it can access private browsing windows using {{WebExtAPIRef("extension.isAllowedIncognitoAccess")}}.
+
 With this key, you can register a website as a handler for a particular protocol. The syntax and semantics of this key is very much like the [`Navigator.registerProtocolHandler()`](/en-US/docs/Web/API/Navigator/registerProtocolHandler) function, except that with `registerProtocolHandler()` a website can only register itself as a handler.
 
 Each protocol handler has three properties, all mandatory:


### PR DESCRIPTION

#### Summary
Adds a note to the description of the `protocol_handler` manifest.json key that the execution of protocol handlers in private windows is disabled by default (because web extensions are disabled by default) and that web extension access to private browser windows is under user control. Provides the content requested in [Bug 1521596](https://bugzilla.mozilla.org/show_bug.cgi?id=1521596).

#### Metadata

This PR…

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
