### PR TITLE
Fix typo

### DIFF
--- a/files/en-us/web/http/headers/set-cookie/index.md
+++ b/files/en-us/web/http/headers/set-cookie/index.md
@@ -63,7 +63,7 @@ Set-Cookie: <cookie-name>=<cookie-value>; Domain=<domain-value>; Secure; HttpOnl
     A cookie definition begins with a name-value pair.
 
     A `<cookie-name>` can contain any US-ASCII characters except for: the control character, space, or a tab.
-    It also must not contain a separator characters like the following: `( ) < > @ , ; : \ " / [ ] ? = { }`.
+    It also must not contain separator characters like the following: `( ) < > @ , ; : \ " / [ ] ? = { }`.
 
     A `<cookie-value>` can optionally be wrapped in double quotes and include any US-ASCII character excluding a control character, {{glossary("Whitespace")}}, double quotes, comma, semicolon, and backslash.
 


### PR DESCRIPTION
Remove stray 'a' in "contain a separator characters like the following" -> "contain separator characters like the following"

#### Summary
Fix typo/remove stray 'a'

#### Motivation
I noticed this typo while reading about set-cookie and I just figured you'd like to know.

No other motivation besides that - I found it slightly disturbing to read, so I thought I'd help fix it.

#### Supporting details
It's just a typo...

#### Related issues


#### Metadata


This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
