### PR TITLE
FF103 Relnotes - remove commented line about stack

### DIFF
--- a/files/en-us/mozilla/firefox/releases/103/index.md
+++ b/files/en-us/mozilla/firefox/releases/103/index.md
@@ -28,7 +28,6 @@ This article provides information about the changes in Firefox 103 that will aff
 - Native Error types can now be serialized using the [structured clone algorithm](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
   This includes {{JSxRef("Error")}}, {{JSxRef("EvalError")}}, {{JSxRef("RangeError")}}, {{JSxRef("ReferenceError")}}, {{JSxRef("SyntaxError")}}, {{JSxRef("TypeError")}}, {{JSxRef("URIError")}} and {{JSxRef("AggregateError")}}.
   Serialized properties include the [`name`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/name), [`message`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/message), [`cause`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause), [`fileName`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/fileName), [`lineNumber`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/lineNumber) and [`columnNumber`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/columnNumber).
-  <!-- [`stack`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Stack) is only serialized in the nightly builds ({{bug(1774866)}}). -->
   For {{JSxRef("AggregateError")}} the `message`, `name`, `cause` and `errors` properties are serialized.
   See {{bug(1556604)}} for more details.
 


### PR DESCRIPTION
FF103 does not support serialization of Error.stack. This comes in FF104 - though I'll wait for FF103 to be released before adding a note - see https://github.com/mdn/browser-compat-data/pull/17008#issuecomment-1187617924

This just removes the hidden line where I was keeping the unconfirmed information.