### PR TITLE
Comment out ellipsis in code blocks

### DIFF
--- a/files/en-us/web/api/stylepropertymapreadonly/foreach/index.md
+++ b/files/en-us/web/api/stylepropertymapreadonly/foreach/index.md
@@ -22,19 +22,19 @@ provided function once for each element of {{domxref('StylePropertyMapReadOnly')
 
 ```js
 // Arrow function
-forEach((currentValue) => { /* ... */ } )
-forEach((currentValue, index) => { /* ... */ } )
-forEach((currentValue, index, array) => { /* ... */ } )
+forEach((currentValue) => { /* … */ } )
+forEach((currentValue, index) => { /* … */ } )
+forEach((currentValue, index, array) => { /* … */ } )
 
 // Callback function
 forEach(callbackFn)
 forEach(callbackFn, thisArg)
 
 // Inline callback function
-forEach(function(currentValue) { /* ... */ })
-forEach(function(currentValue, index) { /* ... */ })
-forEach(function(currentValue, index, array){ /* ... */ })
-forEach(function(currentValue, index, array) { /* ... */ }, thisArg)
+forEach(function(currentValue) { /* … */ })
+forEach(function(currentValue, index) { /* … */ })
+forEach(function(currentValue, index, array){ /* … */ })
+forEach(function(currentValue, index, array) { /* … */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/stylesheet/disabled/index.md
+++ b/files/en-us/web/api/stylesheet/disabled/index.md
@@ -28,9 +28,9 @@ A boolean.
 ## Examples
 
 ```js
-// If the stylesheet is disabled...
+// If the stylesheet is disabled
 if (stylesheet.disabled) {
-  // ... apply styles in-line.
+  // Apply styles in-line
 }
 ```
 

--- a/files/en-us/web/api/stylesheetlist/index.md
+++ b/files/en-us/web/api/stylesheetlist/index.md
@@ -49,7 +49,7 @@ const allCSS = [...document.styleSheets]
         .map(rule => rule.cssText)
         .join('');
     } catch (e) {
-      console.log('Access to stylesheet %s is denied. Ignoring...', styleSheet.href);
+      console.log('Access to stylesheet %s is denied. Ignoring…', styleSheet.href);
     }
   })
   .filter(Boolean)

--- a/files/en-us/web/api/subtlecrypto/derivebits/index.md
+++ b/files/en-us/web/api/subtlecrypto/derivebits/index.md
@@ -113,7 +113,7 @@ async function deriveSharedSecret(privateKey, publicKey) {
   sharedSecretValue.addEventListener("animationend", () => {
     sharedSecretValue.classList.remove("fade-in");
   });
-  sharedSecretValue.textContent = `${buffer}...[${sharedSecret.byteLength} bytes total]`;
+  sharedSecretValue.textContent = `${buffer}…[${sharedSecret.byteLength} bytes total]`;
 }
 
 // Generate 2 ECDH key pairs: one for Alice and one for Bob
@@ -197,7 +197,7 @@ async function getDerivedBits() {
   derivedBitsValue.addEventListener("animationend", () => {
     derivedBitsValue.classList.remove("fade-in");
   });
-  derivedBitsValue.textContent = `${buffer}...[${derivedBits.byteLength} bytes total]`;
+  derivedBitsValue.textContent = `${buffer}…[${derivedBits.byteLength} bytes total]`;
 }
 
 const deriveBitsButton = document.querySelector(".pbkdf2 .derive-bits-button");

--- a/files/en-us/web/api/touch/radiusx/index.md
+++ b/files/en-us/web/api/touch/radiusx/index.md
@@ -27,7 +27,7 @@ This example illustrates using the {{domxref("Touch")}} interface's {{domxref("T
 The following simple code snippet, registers a single handler for the {{domxref("Document/touchstart_event", "touchstart")}}, {{event("touchmove")}} and {{event("touchend")}} events. When the `src` element is touched, the element's width and height will be calculate based on the touch point's `radiusX` and `radiusY` values and the element will then be rotated using the touch point's `rotationAngle`.
 
 ```html
-<div id="src"> ... </div>
+<div id="src"> … </div>
 ```
 
 ```js

--- a/files/en-us/web/api/visualviewport/resize_event/index.md
+++ b/files/en-us/web/api/visualviewport/resize_event/index.md
@@ -34,7 +34,7 @@ You can use the `resize` event in an [`addEventListener`](/en-US/docs/Web/API/Ev
 
 ```js
 visualViewport.addEventListener('resize', function() {
-  /* ... */
+  // …
 });
 ```
 
@@ -42,7 +42,7 @@ Or use the `onresize` event handler property:
 
 ```js
 visualViewport.onresize = function() {
-  /* ... */
+  // …
 };
 ```
 

--- a/files/en-us/web/api/visualviewport/scroll_event/index.md
+++ b/files/en-us/web/api/visualviewport/scroll_event/index.md
@@ -34,7 +34,7 @@ You can use the `scroll` event in an [`addEventListener`](/en-US/docs/Web/API/Ev
 
 ```js
 visualViewport.addEventListener('scroll', function() {
-  /* ... */
+  // …
 });
 ```
 
@@ -42,7 +42,7 @@ Or use the `onscroll` event handler property:
 
 ```js
 visualViewport.onscroll = function() {
-  /* ... */
+  // …
 };
 ```
 

--- a/files/en-us/web/api/vrdisplay/cancelanimationframe/index.md
+++ b/files/en-us/web/api/vrdisplay/cancelanimationframe/index.md
@@ -93,7 +93,7 @@ function drawVRScene() {
   // WebVR: Request the next frame of the animation
   vrSceneFrame = vrDisplay.requestAnimationFrame(drawVRScene);
 
-  // ...
+  // …
 }
 ```
 

--- a/files/en-us/web/api/vrdisplay/getframedata/index.md
+++ b/files/en-us/web/api/vrdisplay/getframedata/index.md
@@ -94,7 +94,7 @@ function drawVRScene() {
     // draw the view for each eye
   }
 
-  // ...
+  // …
 
   // WebVR: Indicate that we are ready to present the rendered frame to the VR display
   vrDisplay.submitFrame();

--- a/files/en-us/web/api/vrdisplay/getpose/index.md
+++ b/files/en-us/web/api/vrdisplay/getpose/index.md
@@ -53,7 +53,7 @@ if(navigator.getVRDisplays) {
       // Return the current VRPose object for the display
       const pose = vrDisplay.getPose();
 
-      // ...
+      // …
 
     }
   });

--- a/files/en-us/web/api/vrdisplay/requestanimationframe/index.md
+++ b/files/en-us/web/api/vrdisplay/requestanimationframe/index.md
@@ -94,7 +94,7 @@ function drawVRScene() {
     // draw the view for each eye
   }
 
-  // ...
+  // …
 
   // WebVR: Indicate that we are ready to present the rendered frame to the VR display
   vrDisplay.submitFrame();

--- a/files/en-us/web/api/vrdisplay/submitframe/index.md
+++ b/files/en-us/web/api/vrdisplay/submitframe/index.md
@@ -92,7 +92,7 @@ function drawVRScene() {
     // draw the view for each eye
   }
 
-  // ...
+  // …
 
   // WebVR: Indicate that we are ready to present the rendered frame to the VR display
   vrDisplay.submitFrame();

--- a/files/en-us/web/api/vrframedata/timestamp/index.md
+++ b/files/en-us/web/api/vrframedata/timestamp/index.md
@@ -57,7 +57,7 @@ function drawVRScene() {
   // and do something with it
   framedata.timestamp
 
-  // ...
+  // …
 
   // WebVR: Indicates that we are ready to present the rendered frame to the VR display
   vrDisplay.submitFrame();

--- a/files/en-us/web/api/vrlayerinit/index.md
+++ b/files/en-us/web/api/vrlayerinit/index.md
@@ -52,7 +52,7 @@ if(navigator.getVRDisplays) {
           // Here it returns an array of VRLayerInit objects
           layers = vrDisplay.getLayers();
 
-          // ...
+          // …
         });
       });
     }
@@ -64,8 +64,8 @@ if(navigator.getVRDisplays) {
 
 ```
 {
-  leftBounds : [ ... ],
-  rightBounds: [ ... ],
+  leftBounds : [ /* … */ ],
+  rightBounds: [ /* … */ ],
   source: canvasReference
 }
 ```

--- a/files/en-us/web/api/vrpose/angularacceleration/index.md
+++ b/files/en-us/web/api/vrpose/angularacceleration/index.md
@@ -46,7 +46,7 @@ function drawVRScene() {
   const aaz = angAcc[2];
 
   // render the scene
-  // ...
+  // …
 
   // WebVR: submit the rendered frame to the VR display
   vrDisplay.submitFrame();

--- a/files/en-us/web/api/vrpose/angularvelocity/index.md
+++ b/files/en-us/web/api/vrpose/angularvelocity/index.md
@@ -46,7 +46,7 @@ function drawVRScene() {
   const avz = angVel[2];
 
   // render the scene
-  // ...
+  …
 
   // WebVR: submit the rendered frame to the VR display
   vrDisplay.submitFrame();

--- a/files/en-us/web/api/vrpose/linearacceleration/index.md
+++ b/files/en-us/web/api/vrpose/linearacceleration/index.md
@@ -46,7 +46,7 @@ function drawVRScene() {
   const laz = linAcc[2];
 
   // render the scene
-  // ...
+  // …
 
   // WebVR: submit the rendered frame to the VR display
   vrDisplay.submitFrame();

--- a/files/en-us/web/api/vrpose/linearvelocity/index.md
+++ b/files/en-us/web/api/vrpose/linearvelocity/index.md
@@ -46,7 +46,7 @@ function drawVRScene() {
   const lvz = linVel[2];
 
   // render the scene
-  // ...
+  // …
 
   // WebVR: submit the rendered frame to the VR display
   vrDisplay.submitFrame();

--- a/files/en-us/web/api/web_animations_api/using_the_web_animations_api/index.md
+++ b/files/en-us/web/api/web_animations_api/using_the_web_animations_api/index.md
@@ -342,15 +342,15 @@ const endGame = function() {
 
   if (aliceHeight <= .333){
     // Alice got smaller!
-    // ...
+    // …
 
   } else if (aliceHeight >= .666) {
     // Alice got bigger!
-    // ...
+    // …
 
   } else {
     // Alice didn't change significantly
-    // ...
+    // …
 
   }
 }
@@ -368,11 +368,11 @@ CSS Animations and Transitions have their own event listeners, and these are als
 Here we set the callbacks for the cake, bottle, and Alice to fire the `endGame` function:
 
 ```js
-// When the cake or bottle runs out...
+// When the cake or bottle runs out
 nommingCake.onfinish = endGame;
 drinking.onfinish = endGame;
 
-// ...or Alice reaches the end of her animation
+// Alice reaches the end of her animation
 aliceChange.onfinish = endGame;
 ```
 

--- a/files/en-us/web/api/web_audio_api/advanced_techniques/index.md
+++ b/files/en-us/web/api/web_audio_api/advanced_techniques/index.md
@@ -430,7 +430,7 @@ We can now use `setupSample()` like so:
 setupSample()
     .then((sample) => {
         // sample is our buffered file
-        // ...
+        // …
 });
 ```
 

--- a/files/en-us/web/api/web_audio_api/using_iir_filters/index.md
+++ b/files/en-us/web/api/web_audio_api/using_iir_filters/index.md
@@ -97,8 +97,7 @@ And the `click` event listener starts like so:
 playButton.addEventListener('click', function() {
     if (this.dataset.playing === 'false') {
         srcNode = playSourceNode(audioCtx, sample);
-        // ...
-    }   
+        // …
 }, false);
 ```
 
@@ -115,8 +114,7 @@ filterButton.addEventListener('click', function() {
     if (this.dataset.filteron === 'false') {
         srcNode.disconnect(audioCtx.destination);
         srcNode.connect(iirfilter).connect(audioCtx.destination);
-        // ...
-    }
+        // …
 }, false);
 ```
 

--- a/files/en-us/web/api/web_authentication_api/index.md
+++ b/files/en-us/web/api/web_authentication_api/index.md
@@ -180,7 +180,7 @@ navigator.credentials.create(createCredentialDefaultArgs)
         console.log("NEW CREDENTIAL", cred);
 
         // normally the credential IDs available for an account would come from a server
-        // but we can just copy them from above...
+        // but we can just copy them from above…
         const idList = [{
             id: cred.rawId,
             transports: ["usb", "nfc", "ble"],

--- a/files/en-us/web/api/web_speech_api/using_the_web_speech_api/index.md
+++ b/files/en-us/web/api/web_speech_api/using_the_web_speech_api/index.md
@@ -43,7 +43,7 @@ The HTML and CSS for the app is really trivial. We have a title, instructions pa
 <h1>Speech color changer</h1>
 <p>Tap/click then say a color to change the background color of the app.</p>
 <div>
-  <p class="output"><em>...diagnostic messages</em></p>
+  <p class="output"><em>…diagnostic messages</em></p>
 </div>
 ```
 
@@ -68,7 +68,7 @@ const SpeechRecognitionEvent = window.SpeechRecognitionEvent || webkitSpeechReco
 The next part of our code defines the grammar we want our app to recognize. The following variable is defined to hold our grammar:
 
 ```js
-const colors = [ 'aqua' , 'azure' , 'beige', 'bisque', 'black', 'blue', 'brown', 'chocolate', 'coral', /* ... */ ];
+const colors = [ 'aqua' , 'azure' , 'beige', 'bisque', 'black', 'blue', 'brown', 'chocolate', 'coral', /* … */ ];
 const grammar = '#JSGF V1.0; grammar colors; public <color> = ' + colors.join(' | ') + ' ;'
 ```
 

--- a/files/en-us/web/api/web_workers_api/using_web_workers/index.md
+++ b/files/en-us/web/api/web_workers_api/using_web_workers/index.md
@@ -44,9 +44,7 @@ For slightly more controlled error handling and backwards compatibility, it is a
 
 ```js
 if (window.Worker) {
-
-  // ...
-
+  // …
 }
 ```
 
@@ -606,9 +604,7 @@ There is not an "official" way to embed the code of a worker within a web page, 
 <script type="text/javascript">
   // This script WILL be parsed by JS engines because its MIME type is text/javascript.
 
-  // In the past...:
-  // blob builder existed
-  // ...but now we use Blob...:
+  // In the past blob builder existed, but now we use Blob
   const blob = new Blob(Array.prototype.map.call(document.querySelectorAll('script[type=\'text\/js-worker\']'), function (oScript) { return oScript.textContent; }),{type: 'text/javascript'});
 
   // Creating a new document.worker property containing all our "text/js-worker" scripts.

--- a/files/en-us/web/api/webgl2renderingcontext/beginquery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/beginquery/index.md
@@ -51,7 +51,7 @@ None ({{jsxref("undefined")}}).
 var query = gl.createQuery();
 gl.beginQuery(gl.ANY_SAMPLES_PASSED, query);
 
-// ...
+// …
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webgl2renderingcontext/bindvertexarray/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/bindvertexarray/index.md
@@ -37,10 +37,12 @@ None ({{jsxref("undefined")}}).
 var vao = gl.createVertexArray();
 gl.bindVertexArray(vao);
 
-// ...
+// …
+
 // calls to bindBuffer or vertexAttribPointer
 // which will be "recorded" in the VAO
-// ...
+
+// …
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webgl2renderingcontext/createvertexarray/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/createvertexarray/index.md
@@ -39,10 +39,12 @@ points to vertex array data.
 var vao = gl.createVertexArray();
 gl.bindVertexArray(vao);
 
-// ...
+// …
+
 // calls to bindBuffer or vertexAttribPointer
 // which will be "recorded" in the VAO
-// ...
+
+// …
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webgl2renderingcontext/deletequery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/deletequery/index.md
@@ -38,7 +38,7 @@ None ({{jsxref("undefined")}}).
 ```js
 var query = gl.createQuery();
 
-// ...
+// …
 
 gl.deleteQuery(query);
 ```

--- a/files/en-us/web/api/webgl2renderingcontext/deletesampler/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/deletesampler/index.md
@@ -39,7 +39,7 @@ None ({{jsxref("undefined")}}).
 ```js
 var sampler = gl.createSampler();
 
-// ...
+// …
 
 gl.deleteSampler(sampler);
 ```

--- a/files/en-us/web/api/webgl2renderingcontext/deletesync/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/deletesync/index.md
@@ -38,7 +38,7 @@ objects are not available in WebGL 1.
 ```js
 var sync = gl.fenceSync(gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
 
-// ...
+// …
 
 gl.deleteSync(sync);
 ```


### PR DESCRIPTION
Ellipsis in markdown code blocks are syntax errors.

In order to have smooth transition to Prettier and ESLint the PR comments out such bare ellipses. Refer the https://github.com/mdn/content/pull/18171#issuecomment-1179670484 for more context.