### PR TITLE
Comment out ellipsis in code blocks

### DIFF
--- a/files/en-us/web/api/webgl2renderingcontext/deletetransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/deletetransformfeedback/index.md
@@ -39,7 +39,7 @@ None ({{jsxref("undefined")}}).
 ```js
 var transformFeedback = gl.createTransformFeedback();
 
-// ...
+// …
 
 gl.deleteTransformFeedback(transformFeedback);
 ```

--- a/files/en-us/web/api/webgl2renderingcontext/deletevertexarray/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/deletevertexarray/index.md
@@ -37,7 +37,7 @@ None ({{jsxref("undefined")}}).
 var vao = gl.createVertexArray();
 gl.bindVertexArray(vao);
 
-// ...
+// …
 
 gl.deleteVertexArray(vao);
 ```

--- a/files/en-us/web/api/webgl2renderingcontext/endquery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/endquery/index.md
@@ -48,7 +48,7 @@ None ({{jsxref("undefined")}}).
 var query = gl.createQuery();
 gl.beginQuery(gl.ANY_SAMPLES_PASSED, query);
 
-// ...
+// …
 
 gl.endQuery(gl.ANY_SAMPLES_PASSED);
 ```

--- a/files/en-us/web/api/webgl2renderingcontext/isquery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/isquery/index.md
@@ -39,7 +39,7 @@ A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether the given objec
 ```js
 var query = gl.createQuery();
 
-// ...
+// …
 
 gl.isQuery(query);
 ```

--- a/files/en-us/web/api/webgl2renderingcontext/issampler/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/issampler/index.md
@@ -39,7 +39,7 @@ A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether the given objec
 ```js
 var sampler = gl.createSampler();
 
-// ...
+// …
 
 gl.isSampler(sampler);
 ```

--- a/files/en-us/web/api/webgl2renderingcontext/issync/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/issync/index.md
@@ -39,7 +39,7 @@ objects are not available in WebGL 1.
 ```js
 var sync = gl.fenceSync(gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
 
-// ...
+// …
 
 gl.isSync(sync);
 ```

--- a/files/en-us/web/api/webgl2renderingcontext/istransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/istransformfeedback/index.md
@@ -41,7 +41,7 @@ A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether the given objec
 ```js
 var transformFeedback = gl.createTransformFeedback();
 
-// ...
+// …
 
 gl.isTransformFeedback(transformFeedback);
 ```

--- a/files/en-us/web/api/webgl2renderingcontext/isvertexarray/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/isvertexarray/index.md
@@ -39,7 +39,7 @@ A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether the given objec
 var vao = gl.createVertexArray();
 gl.bindVertexArray(vao);
 
-// ...
+// …
 
 gl.isVertexArray(vao);
 ```

--- a/files/en-us/web/api/webgl2renderingcontext/pausetransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/pausetransformfeedback/index.md
@@ -37,7 +37,7 @@ var transformFeedback = gl.createTransformFeedback();
 gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, transformFeedback);
 gl.beginTransformFeedback(gl.TRIANGLES);
 gl.pauseTransformFeedback();
-//...
+// …
 gl.resumeTransformFeedback();
 gl.drawArrays(gl.TRIANGLES, 0, 3);
 gl.endTransformFeedback();

--- a/files/en-us/web/api/webgl2renderingcontext/resumetransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/resumetransformfeedback/index.md
@@ -37,7 +37,7 @@ var transformFeedback = gl.createTransformFeedback();
 gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, transformFeedback);
 gl.beginTransformFeedback(gl.TRIANGLES);
 gl.pauseTransformFeedback();
-//...
+//…
 gl.resumeTransformFeedback();
 gl.drawArrays(gl.TRIANGLES, 0, 3);
 gl.endTransformFeedback();

--- a/files/en-us/web/api/webgl_api/matrix_math_for_the_web/index.md
+++ b/files/en-us/web/api/webgl_api/matrix_math_for_the_web/index.md
@@ -179,7 +179,7 @@ A really easy way to start using a matrix is to use the CSS {{cssxref("transform
 ```html
 <div id='move-me' class='transformable'>
   <h2>Move me with a matrix</h2>
-  <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit...</p>
+  <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit…</p>
 </div>
 ```
 

--- a/files/en-us/web/api/webgl_api/tutorial/creating_3d_objects_using_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/creating_3d_objects_using_webgl/index.md
@@ -70,7 +70,7 @@ Since we've added a z-component to our vertices, we need to update the `numCompo
 // buffer into the vertexPosition attribute
 {
   const numComponents = 3;
-  // ...
+  // …
   gl.vertexAttribPointer(
       programInfo.attribLocations.vertexPosition,
       numComponents,
@@ -157,7 +157,7 @@ Next we need to add code to our `drawScene()` function to draw using the cube's 
   // Tell WebGL which indices to use to index the vertices
   gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, buffers.indices);
 
-  // ...
+  // …
 
   {
     const vertexCount = 36;

--- a/files/en-us/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/lighting_in_webgl/index.md
@@ -92,7 +92,7 @@ The first thing we need to do is generate the array of normals for all the verti
   gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(vertexNormals),
                 gl.STATIC_DRAW);
 
-  // ...
+  // …
 
   return {
     position: positionBuffer,
@@ -135,7 +135,7 @@ Finally, we need to update the code that builds the uniform matrices to generate
   mat4.invert(normalMatrix, modelViewMatrix);
   mat4.transpose(normalMatrix, normalMatrix);
 
-  // ...
+  // …
 
   gl.uniformMatrix4fv(
       programInfo.uniformLocations.normalMatrix,

--- a/files/en-us/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/using_shaders_to_apply_color_in_webgl/index.md
@@ -21,7 +21,6 @@ Let's say we want to render a gradient in which each corner of the square is a d
 
 ```js
 function initBuffers(){
-  // ...
   const colors = [
     1.0,  1.0,  1.0,  1.0,    // white
     1.0,  0.0,  0.0,  1.0,    // red
@@ -100,8 +99,7 @@ Next, it's necessary to add code to look up the attribute location for the color
       vertexPosition: gl.getAttribLocation(shaderProgram, 'aVertexPosition'),
       vertexColor: gl.getAttribLocation(shaderProgram, 'aVertexColor'),
     },
-    // ...
-  }
+    // …
 ```
 
 Then, `drawScene()` can have the following added to it so it actually uses these colors when drawing the square:

--- a/files/en-us/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/using_textures_in_webgl/index.md
@@ -148,7 +148,7 @@ At this point, the texture is loaded and ready to use. But before we can use it,
   gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(textureCoordinates),
                 gl.STATIC_DRAW);
 
-  // ...
+  // …
   return {
     position: positionBuffer,
     textureCoord: textureCoordBuffer,
@@ -265,9 +265,9 @@ Lastly, add `texture` as a parameter to the `drawScene()` function, both where i
 
 ```js
 drawScene(gl, programInfo, buffers, texture, deltaTime);
-// ...
+// …
 function drawScene(gl, programInfo, buffers, texture, deltaTime) {
-  // ...
+  // …
 }
 ```
 

--- a/files/en-us/web/api/webgl_api/webgl_best_practices/index.md
+++ b/files/en-us/web/api/webgl_api/webgl_best_practices/index.md
@@ -443,7 +443,7 @@ Most texture uploads from DOM elements will incur a processing pass that will te
 In WebGL:
 
 ```
-    ...
+    …
     useProgram(prog1)
 <pipeline flush>
     bindFramebuffer(target)
@@ -451,13 +451,13 @@ In WebGL:
     bindTexture(webgl_texture)
     texImage2D(HTMLVideoElement)
     drawArrays()
-    ...
+    …
 ```
 
 Behind the scenes in the browser:
 
 ```
-    ...
+    …
     useProgram(prog1)
 <pipeline flush>
     bindFramebuffer(target)
@@ -474,7 +474,7 @@ Behind the scenes in the browser:
         +useProgram(prog1)
 <pipeline flush>
     drawArrays()
-    ...
+    …
 ```
 
 Prefer doing uploads before starting drawing, or at least between pipelines:
@@ -482,7 +482,7 @@ Prefer doing uploads before starting drawing, or at least between pipelines:
 In WebGL:
 
 ```
-    ...
+    …
     bindTexture(webgl_texture)
     texImage2D(HTMLVideoElement)
     useProgram(prog1)
@@ -491,13 +491,13 @@ In WebGL:
     drawArrays()
     bindTexture(webgl_texture)
     drawArrays()
-    ...
+    …
 ```
 
 Behind the scenes in the browser:
 
 ```
-    ...
+    …
     bindTexture(webgl_texture)
     -texImage2D(HTMLVideoElement):
         +useProgram(_internal_tex_tranform_prog)
@@ -513,7 +513,7 @@ Behind the scenes in the browser:
     drawArrays()
     bindTexture(webgl_texture)
     drawArrays()
-    ...
+    …
 ```
 
 ## Use texStorage to create textures

--- a/files/en-us/web/api/webgl_multi_draw/multidrawarraysinstancedwebgl/index.md
+++ b/files/en-us/web/api/webgl_multi_draw/multidrawarraysinstancedwebgl/index.md
@@ -92,9 +92,9 @@ None.
 ## Examples
 
 ```js
-// let firsts = new Int32Array(...);
-// let counts = new Int32Array(...);
-// let instanceCounts = new Int32Array(...);
+const firsts = new Int32Array(/* … */);
+const counts = new Int32Array(/* … */);
+const instanceCounts = new Int32Array(/* … */);
 ext.multiDrawArraysInstancedWEBGL(
    gl.TRIANGLES, firsts, 0, counts, 0, instanceCounts, 0, firsts.length);
 ```

--- a/files/en-us/web/api/webglrenderingcontext/checkframebufferstatus/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/checkframebufferstatus/index.md
@@ -77,7 +77,7 @@ var canvas = document.getElementById('canvas');
 var gl = canvas.getContext('webgl');
 var framebuffer = gl.createFramebuffer();
 
-// ...
+// …
 
 gl.checkFramebufferStatus(gl.FRAMEBUFFER);
 ```

--- a/files/en-us/web/api/webglrenderingcontext/commit/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/commit/index.md
@@ -39,7 +39,7 @@ var htmlCanvas = document.createElement('canvas');
 var offscreen = htmlCanvas.transferControlToOffscreen();
 var gl = offscreen.getContext('webgl');
 
-// ... some drawing using the gl context ...
+// Perform some drawing using the gl context
 
 // Push frames back to the original HTMLCanvasElement
 gl.commit();

--- a/files/en-us/web/api/webglrenderingcontext/deletebuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/deletebuffer/index.md
@@ -40,7 +40,7 @@ var canvas = document.getElementById('canvas');
 var gl = canvas.getContext('webgl');
 var buffer = gl.createBuffer();
 
-// ...
+// …
 
 gl.deleteBuffer(buffer);
 ```

--- a/files/en-us/web/api/webglrenderingcontext/deleteframebuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/deleteframebuffer/index.md
@@ -41,7 +41,7 @@ var canvas = document.getElementById('canvas');
 var gl = canvas.getContext('webgl');
 var framebuffer = gl.createFramebuffer();
 
-// ...
+// …
 
 gl.deleteFramebuffer(framebuffer);
 ```

--- a/files/en-us/web/api/webglrenderingcontext/deleteprogram/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/deleteprogram/index.md
@@ -41,7 +41,7 @@ var canvas = document.getElementById('canvas');
 var gl = canvas.getContext('webgl');
 var program = gl.createProgram();
 
-// ...
+// …
 
 gl.deleteProgram(program);
 ```

--- a/files/en-us/web/api/webglrenderingcontext/deleterenderbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/deleterenderbuffer/index.md
@@ -41,7 +41,7 @@ var canvas = document.getElementById('canvas');
 var gl = canvas.getContext('webgl');
 var renderbuffer = gl.createRenderbuffer();
 
-// ...
+// …
 
 gl.deleteRenderbuffer(renderbuffer);
 ```

--- a/files/en-us/web/api/webglrenderingcontext/deletetexture/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/deletetexture/index.md
@@ -42,7 +42,7 @@ var canvas = document.getElementById('canvas');
 var gl = canvas.getContext('webgl');
 var texture = gl.createTexture();
 
-// ...
+// …
 
 gl.deleteTexture(texture);
 ```

--- a/files/en-us/web/api/webglrenderingcontext/getsupportedextensions/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getsupportedextensions/index.md
@@ -37,7 +37,7 @@ var canvas = document.getElementById('canvas');
 gl = canvas.getContext('webgl');
 
 var extensions = gl.getSupportedExtensions();
-// Array [ 'ANGLE_instanced_arrays', 'EXT_blend_minmax', ... ]
+// Array [ 'ANGLE_instanced_arrays', 'EXT_blend_minmax', … ]
 ```
 
 See also the {{domxref("WebGLRenderingContext.getExtension()")}} method to get a

--- a/files/en-us/web/api/webglrenderingcontext/isprogram/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/isprogram/index.md
@@ -39,7 +39,7 @@ var canvas = document.getElementById('canvas');
 var gl = canvas.getContext('webgl');
 var program = gl.createProgram();
 
-// ...
+// …
 
 gl.isProgram(program);
 ```

--- a/files/en-us/web/api/webglrenderingcontext/isshader/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/isshader/index.md
@@ -39,7 +39,7 @@ var canvas = document.getElementById('canvas');
 var gl = canvas.getContext('webgl');
 var shader = gl.createShader(gl.VERTEX_SHADER);
 
-// ...
+// …
 
 gl.isShader(shader);
 ```

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/answer_a_call/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/answer_a_call/index.md
@@ -47,7 +47,7 @@ Now our users can make a call, but they can't answer one. Let's add the next pie
 
     - `call.answer(window.localStream)`: if `answerCall` is `true`, you'll want to call peerJS's `answer()` function on the call to create an answer, passing it the local stream.
     - `showCallContent`: Similar to what you did in the call button event listener, you want to ensure the person being called sees the correct HTML content.
-    - Everything in the `call.on('stream', function(){...}` block is exactly the same as it is in call button's event listener. The reason you need to add it here too is so that the browser is also updated for the person answering the call.
+    - Everything in the `call.on('stream', function(){ }` block is exactly the same as it is in call button's event listener. The reason you need to add it here too is so that the browser is also updated for the person answering the call.
     - If the person denies the call, we're just going to log a message to the console.
 
 3. The code you have now is enough for you to create a call and answer it. Refresh your browsers and test it out. You'll want to make sure that both browsers have the console open or else you won't get the prompt to answer the call. Click call, submit the peer ID for the other browser and then answer the call. The final page should look like this:

--- a/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/end_a_call/index.md
+++ b/files/en-us/web/api/webrtc_api/build_a_phone_with_peerjs/connect_peers/end_a_call/index.md
@@ -19,7 +19,7 @@ You've nearly finished! The last thing you want to do is ensure your callers hav
     })
     ```
 
-2. When the connection has been closed, you also want to display the correct HTML content so you can just call your `showCallContent()` function. Within the `call` event, you also want to ensure the remote browser is updated. To achieve this, add another event listener within the `peer.on('call', function(stream){...}` event listener, within the conditional block.
+2. When the connection has been closed, you also want to display the correct HTML content so you can just call your `showCallContent()` function. Within the `call` event, you also want to ensure the remote browser is updated. To achieve this, add another event listener within the `peer.on('call', function(stream){ }` event listener, within the conditional block.
 
     ```js
     conn.on('close', function (){

--- a/files/en-us/web/api/webrtc_api/signaling_and_video_calling/index.md
+++ b/files/en-us/web/api/webrtc_api/signaling_and_video_calling/index.md
@@ -242,7 +242,7 @@ When the user clicks on a username they want to call, the `invite()` function is
 ```js
 const mediaConstraints = {
   audio: true, // We want an audio track
-  video: true // ...and we want a video track
+  video: true // And we want a video track
 };
 
 function invite(evt) {


### PR DESCRIPTION
Ellipsis in markdown code blocks are syntax errors.

In order to have smooth transition to Prettier and ESLint the PR comments out such bare ellipses. Refer the https://github.com/mdn/content/pull/18171#issuecomment-1179670484 for more context.