### PR TITLE
Fix "repository of wavetables" text's broken link

### DIFF
--- a/files/en-us/web/api/web_audio_api/advanced_techniques/index.md
+++ b/files/en-us/web/api/web_audio_api/advanced_techniques/index.md
@@ -99,7 +99,7 @@ First of all, we'll create our periodic wave. To do so, We need to pass real and
 const wave = audioCtx.createPeriodicWave(wavetable.real, wavetable.imag);
 ```
 
-> **Note:** In our example the wavetable is held in a separate JavaScript file (`wavetable.js`), because there are _so_ many values. It is taken from a [repository of wavetables](https://github.com/GoogleChromeLabs/web-audio-samples/tree/main/archive/demos/wave-tables), which can be found in the [Web Audio API examples from Google Chrome Labs](https://github.com/GoogleChromeLabs/web-audio-samples/).
+> **Note:** In our example the wavetable is held in a separate JavaScript file (`wavetable.js`), because there are _so_ many values. It is taken from a [repository of wavetables](https://github.com/GoogleChromeLabs/web-audio-samples/tree/main/src/demos/wavetable-synth/wave-tables), which can be found in the [Web Audio API examples from Google Chrome Labs](https://github.com/GoogleChromeLabs/web-audio-samples/).
 
 ### The Oscillator
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fixed "repository of wavetables" hyperlinked-text's broken link.

**Please Note:** My updated link is associated with the "wavetables" folder on the "_main_" branch, **instead of** with a specific folder on the "_archive_" branch. If however, the intention of the author of the original hyperlinked-text was to have it link to the "wavetables" folder on the "_archive_" branch, then _perhaps_ the link **should instead** be **updated to one of the following URL's**:
1. [The URL for the "_archive_" branch's "wavetables" folder: https://github.com/GoogleChromeLabs/web-audio-samples/tree/archive/archive/demos/wave-tables](https://github.com/GoogleChromeLabs/web-audio-samples/tree/archive/archive/demos/wave-tables)
2. [The URL for the "_archive_" branch's "original" folder found _under_ its "wavetables" folder: https://github.com/GoogleChromeLabs/web-audio-samples/tree/archive/archive/demos/wave-tables/original](https://github.com/GoogleChromeLabs/web-audio-samples/tree/archive/archive/demos/wave-tables/original)

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Upon clicking the original hyperlinked-text, I was taken to GitHub's 404 "Page not found" Webpage.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
This broken link fix is for the "repository of wavetables" hyperlinked-text found on the MDN Web Docs webpage which can be viewed at: [https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Advanced_techniques](https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API/Advanced_techniques).

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
