### PR TITLE
Add the "not required to call" description

### DIFF
--- a/files/en-us/web/api/webglrenderingcontext/deletebuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/deletebuffer/index.md
@@ -14,7 +14,7 @@ browser-compat: api.WebGLRenderingContext.deleteBuffer
 
 The **`WebGLRenderingContext.deleteBuffer()`** method of the [WebGL API](/en-US/docs/Web/API/WebGL_API) deletes a given
 {{domxref("WebGLBuffer")}}. This method has no effect if the buffer has already been
-deleted.
+deleted. Normally you don't need to call this method yourself, when the buffer object is dereferenced it will be marked as free.
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Add the "not required to call" description to WebGLRenderingContext.deleteBuffer

#### Motivation


#### Supporting details
https://registry.khronos.org/webgl/specs/latest/1.0/#5.14.5
```
void deleteBuffer(WebGLBuffer? buffer) ([OpenGL ES 2.0 §2.9](http://www.khronos.org/registry/gles/specs/2.0/es_full_spec_2.0.25.pdf#nameddest=section-2.9), similar to [glDeleteBuffers](http://www.khronos.org/opengles/sdk/2.0/docs/man/xhtml/glDeleteBuffers.xml))
If buffer was generated by a different WebGLRenderingContext than this one, generates an INVALID_OPERATION error.

Mark for deletion the buffer object contained in the passed WebGLBuffer, as if by calling glDeleteBuffers. If the object has already been marked for deletion, the call has no effect. Note that underlying GL object will be automatically marked for deletion when the JS object is destroyed, however this method allows authors to mark an object for deletion early.
```

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
