### PR TITLE
Remove confusing typeof check from event.button example

### DIFF
--- a/files/en-us/web/api/mouseevent/button/index.md
+++ b/files/en-us/web/api/mouseevent/button/index.md
@@ -53,26 +53,22 @@ Others may have many buttons mapped to different functions and button values.
 
 ```js
 let button = document.querySelector('#button');
-let log = document.querySelector('#log');
-button.addEventListener('mouseup', logMouseButton);
-
-function logMouseButton(e) {
-  if (typeof e === 'object') {
-    switch (e.button) {
-      case 0:
-        log.textContent = 'Left button clicked.';
-        break;
-      case 1:
-        log.textContent = 'Middle button clicked.';
-        break;
-      case 2:
-        log.textContent = 'Right button clicked.';
-        break;
-      default:
-        log.textContent = `Unknown button code: ${e.button}`;
-    }
+button.addEventListener('mouseup', e => {
+  let log = document.querySelector('#log');
+  switch (e.button) {
+    case 0:
+      log.textContent = 'Left button clicked.';
+      break;
+    case 1:
+      log.textContent = 'Middle button clicked.';
+      break;
+    case 2:
+      log.textContent = 'Right button clicked.';
+      break;
+    default:
+      log.textContent = `Unknown button code: ${e.button}`;
   }
-}
+});
 ```
 
 ### Result


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The event listener is always being passed the event object, so the `typeof` check is unnecessary and its existence may confuse readers.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
To avoid confusion over the potential type of an event listener.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
