### PR TITLE
Fix interactive example heights

### DIFF
--- a/files/en-us/web/html/element/a/index.md
+++ b/files/en-us/web/html/element/a/index.md
@@ -22,7 +22,7 @@ The **`<a>`** [HTML](/en-US/docs/Web/HTML) element (or _anchor_ element), with [
 
 Content within each `<a>` **should** indicate the link's destination. If the `href` attribute is present, pressing the enter key while focused on the `<a>` element will activate it.
 
-{{EmbedInteractiveExample("pages/tabbed/a.html")}}
+{{EmbedInteractiveExample("pages/tabbed/a.html", "tabbed-shorter")}}
 
 ## Attributes
 

--- a/files/en-us/web/html/element/link/index.md
+++ b/files/en-us/web/html/element/link/index.md
@@ -18,7 +18,7 @@ browser-compat: html.elements.link
 The **`<link>`** [HTML](/en-US/docs/Web/HTML) element specifies relationships between the current document and an external resource.
 This element is most commonly used to link to {{Glossary("CSS", "stylesheets")}}, but is also used to establish site icons (both "favicon" style icons and icons for the home screen and apps on mobile devices) among other things.
 
-{{EmbedInteractiveExample("pages/tabbed/link.html")}}
+{{EmbedInteractiveExample("pages/tabbed/link.html", "tabbed-shorter")}}
 
 To link an external stylesheet, you'd include a `<link>` element inside your {{HTMLElement("head")}} like this:
 

--- a/files/en-us/web/javascript/reference/classes/static/index.md
+++ b/files/en-us/web/javascript/reference/classes/static/index.md
@@ -19,7 +19,7 @@ Static methods are often utility functions, such as functions to create or clone
 
 > **Note:** In the context of classes, MDN Web Docs content uses the terms properties and [fields](/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields) interchangeably.
 
-{{EmbedInteractiveExample("pages/js/classes-static.html")}}
+{{EmbedInteractiveExample("pages/js/classes-static.html", "taller")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/functions/rest_parameters/index.md
+++ b/files/en-us/web/javascript/reference/functions/rest_parameters/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.functions.rest_parameters
 
 The **rest parameter** syntax allows a function to accept an indefinite number of arguments as an array, providing a way to represent [variadic functions](https://en.wikipedia.org/wiki/Variadic_function) in JavaScript.
 
-{{EmbedInteractiveExample("pages/js/functions-restparameters.html")}}
+{{EmbedInteractiveExample("pages/js/functions-restparameters.html", "taller")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/date/settime/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/settime/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Date.setTime
 The **`setTime()`** method sets the {{jsxref("Date")}} object
 to the time represented by a number of milliseconds since January 1, 1970, 00:00:00 UTC.
 
-{{EmbedInteractiveExample("pages/js/date-settime.html")}}
+{{EmbedInteractiveExample("pages/js/date-settime.html", "taller")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/datetimeformat/index.md
@@ -15,7 +15,7 @@ browser-compat: javascript.builtins.Intl.DateTimeFormat
 
 The **`Intl.DateTimeFormat`** object enables language-sensitive date and time formatting.
 
-{{EmbedInteractiveExample("pages/js/intl-datetimeformat.html")}}
+{{EmbedInteractiveExample("pages/js/intl-datetimeformat.html", "taller")}}
 
 <!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/locale/minimize/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/locale/minimize/index.md
@@ -17,7 +17,7 @@ The
 remove information about the locale that would be added by calling
 {{jsxref("Intl/Locale/maximize", "Locale.maximize()")}}.
 
-{{EmbedInteractiveExample("pages/js/intl-locale-prototype-minimize.html", "taller")}}
+{{EmbedInteractiveExample("pages/js/intl-locale-prototype-minimize.html")}}
 
 <!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/segmenter/supportedlocalesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/segmenter/supportedlocalesof/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Intl.Segmenter.supportedLocalesOf
 
 The **`Intl.Segmenter.supportedLocalesOf()`** method returns an array containing those of the provided locales that are supported without having to fall back to the runtime's default locale.
 
-{{EmbedInteractiveExample("pages/js/intl-segmenter-supportedlocalesof.html")}}
+{{EmbedInteractiveExample("pages/js/intl-segmenter-supportedlocalesof.html", "shorter")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/intl/supportedvaluesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/supportedvaluesof/index.md
@@ -19,7 +19,7 @@ Duplicates are omitted and the array is sorted in ascending alphabetic order (or
 The method can be used to feature-test whether values are supported in a particular implementation and download a polyfill only if necessary.
 It can also be used to build UIs that allow users to select their preferred localized values, for example when the UI is created from WebGL or server-side.
 
-{{EmbedInteractiveExample("pages/js/intl-supportedvaluesof.html")}}
+{{EmbedInteractiveExample("pages/js/intl-supportedvaluesof.html", "taller")}}
 
 <!-- The source for this interactive example is stored in a GitHub repository. If you'd like to contribute to the interactive examples project, please clone https://github.com/mdn/interactive-examples and send us a pull request. -->
 

--- a/files/en-us/web/javascript/reference/global_objects/number/nan/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/nan/index.md
@@ -11,7 +11,7 @@ browser-compat: javascript.builtins.Number.NaN
 
 The **`Number.NaN`** property represents Not-A-Number. Equivalent of {{jsxref("NaN")}}.
 
-{{EmbedInteractiveExample("pages/js/number-nan.html")}}
+{{EmbedInteractiveExample("pages/js/number-nan.html", "taller")}}
 
 You do not have to create a {{jsxref("Number")}} object to access this static property (use `Number.NaN`).
 

--- a/files/en-us/web/javascript/reference/global_objects/object/getprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/getprototypeof/index.md
@@ -15,7 +15,7 @@ The **`Object.getPrototypeOf()`** method returns the prototype
 (i.e. the value of the internal `[[Prototype]]` property) of the specified
 object.
 
-{{EmbedInteractiveExample("pages/js/object-getprototypeof.html")}}
+{{EmbedInteractiveExample("pages/js/object-getprototypeof.html", "shorter")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/match/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/match/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Symbol.match
 
 The **`Symbol.match`** well-known symbol specifies the matching of a regular expression against a string. This function is called by the {{jsxref("String.prototype.match()")}} method.
 
-{{EmbedInteractiveExample("pages/js/symbol-match.html")}}
+{{EmbedInteractiveExample("pages/js/symbol-match.html", "taller")}}
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/map/index.md
@@ -19,7 +19,7 @@ has the same algorithm as {{jsxref("Array.prototype.map()")}}_._
 _TypedArray_ is one of the
 [typed array types](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#typedarray_objects) here.
 
-{{EmbedInteractiveExample("pages/js/typedarray-map.html")}}
+{{EmbedInteractiveExample("pages/js/typedarray-map.html", "shorter")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/operators/bitwise_and/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_and/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.operators.bitwise_and
 The bitwise AND operator (`&`) returns a `1` in each bit
 position for which the corresponding bits of both operands are `1`s.
 
-{{EmbedInteractiveExample("pages/js/expressions-bitwise-and.html")}}
+{{EmbedInteractiveExample("pages/js/expressions-bitwise-and.html", "shorter")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/operators/bitwise_and_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_and_assignment/index.md
@@ -15,7 +15,7 @@ The bitwise AND assignment operator (`&=`) uses the binary
 representation of both operands, does a bitwise AND operation on them and assigns the
 result to the variable.
 
-{{EmbedInteractiveExample("pages/js/expressions-bitwise-and-assignment.html")}}
+{{EmbedInteractiveExample("pages/js/expressions-bitwise-and-assignment.html", "shorter")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/operators/bitwise_or/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_or/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.operators.bitwise_or
 The bitwise OR operator (`|`) returns a `1` in each bit position
 for which the corresponding bits of either or both operands are `1`s.
 
-{{EmbedInteractiveExample("pages/js/expressions-bitwise-or.html")}}
+{{EmbedInteractiveExample("pages/js/expressions-bitwise-or.html", "shorter")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/operators/bitwise_or_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_or_assignment/index.md
@@ -15,7 +15,7 @@ The bitwise OR assignment operator (`|=`) uses the binary representation of
 both operands, does a bitwise OR operation on them and assigns the result to the
 variable.
 
-{{EmbedInteractiveExample("pages/js/expressions-bitwise-or-assignment.html")}}
+{{EmbedInteractiveExample("pages/js/expressions-bitwise-or-assignment.html", "shorter")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/operators/bitwise_xor/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_xor/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.operators.bitwise_xor
 The bitwise XOR operator (`^`) returns a `1` in each bit position
 for which the corresponding bits of either but not both operands are `1`s.
 
-{{EmbedInteractiveExample("pages/js/expressions-bitwise-xor.html")}}
+{{EmbedInteractiveExample("pages/js/expressions-bitwise-xor.html", "shorter")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/operators/bitwise_xor_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/bitwise_xor_assignment/index.md
@@ -15,7 +15,7 @@ The bitwise XOR assignment operator (`^=`) uses the binary representation of
 both operands, does a bitwise XOR operation on them and assigns the result to the
 variable.
 
-{{EmbedInteractiveExample("pages/js/expressions-bitwise-xor-assignment.html")}}
+{{EmbedInteractiveExample("pages/js/expressions-bitwise-xor-assignment.html", "shorter")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/operators/left_shift/index.md
+++ b/files/en-us/web/javascript/reference/operators/left_shift/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.operators.left_shift
 
 The **left shift operator (`<<`)** shifts the first operand the specified number of bits, modulo 32, to the left. Excess bits shifted off to the left are discarded. Zero bits are shifted in from the right.
 
-{{EmbedInteractiveExample("pages/js/expressions-left-shift.html")}}
+{{EmbedInteractiveExample("pages/js/expressions-left-shift.html", "shorter")}}
 
 ## Syntax
 

--- a/files/en-us/web/javascript/reference/operators/left_shift_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/left_shift_assignment/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.operators.left_shift_assignment
 
 The left shift assignment operator (`<<=`) moves the specified amount of bits to the left and assigns the result to the variable.
 
-{{EmbedInteractiveExample("pages/js/expressions-left-shift-assignment.html")}}
+{{EmbedInteractiveExample("pages/js/expressions-left-shift-assignment.html", "shorter")}}
 
 ## Syntax
 

--- a/files/en-us/webassembly/reference/numeric/truncate_float_to_float/index.md
+++ b/files/en-us/webassembly/reference/numeric/truncate_float_to_float/index.md
@@ -16,7 +16,7 @@ The **`trunc`** instructions, short for *truncate*, are used for getting the val
 
 There's another [**`trunc`**](/en-US/docs/WebAssembly/Reference/Numeric/Truncate_float_to_int) instruction that truncates the fractional part of a floating point and converts it to an integer.
 
-{{EmbedInteractiveExample("pages/wat/trunc_float_to_float.html", "tabbed-standard")}}
+{{EmbedInteractiveExample("pages/wat/trunc_float_to_float.html", "tabbed-taller")}}
 
 ## Syntax
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
This PR fixes invalid height of few interactive examples like [keyword static](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/static). There are also 2 pages with interactive example commented out, but those examples don't exist: [reportError](https://developer.mozilla.org/en-US/docs/Web/API/reportError) & [groupToMap](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/groupToMap). Can I remove them?
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
