### PR TITLE
Add effectiveType to NetworkInformation properties sidebar

### DIFF
--- a/files/en-us/web/api/networkinformation/effectivetype/index.md
+++ b/files/en-us/web/api/networkinformation/effectivetype/index.md
@@ -7,6 +7,8 @@ tags:
   - Experimental
   - Network Information API
   - NetworkInformation
+  - Property
+  - Read-only
   - Reference
   - effectiveType
 browser-compat: api.NetworkInformation.effectiveType


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Add `effectiveType` to `NetworkInformation` properties sidebar.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

I realized that `effectiveType` was missing from the sidebar but was listed as [a property of `NetworkInformation`](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation#properties), and it got me confused for a second.

| Before | After |
| - | - |
| <img width="313" alt="Screen Shot 2022-07-19 at 2 08 29 PM" src="https://user-images.githubusercontent.com/7189823/179820428-b4637be1-3f3a-44d5-a532-4f13956e9e69.png"> | <img width="311" alt="Screen Shot 2022-07-19 at 2 07 59 PM" src="https://user-images.githubusercontent.com/7189823/179820435-cda8ef0c-726d-4ef6-ab9c-bdaef1fbcee2.png"> |

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
