### PR TITLE
webRequest API blocked requests clarification

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/index.md
@@ -20,7 +20,7 @@ Each event is fired at a particular stage of the request. The typical sequence o
 
 ![](webrequest-flow.png)
 
-{{WebExtAPIRef("webRequest.onErrorOccurred", "onErrorOccurred")}} can fire at any time during the request. Also, note that sometimes the sequence of events may differ from this. For example, in Firefox, on an [HSTS](/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) upgrade, the `onBeforeRedirect` event is triggered immediately after `onBeforeRequest`. `onErrorOccurred` is also fired if Firefox Tracking Protection blocks a request.
+{{WebExtAPIRef("webRequest.onErrorOccurred", "onErrorOccurred")}} can fire at any time during the request. Also, note that sometimes the sequence of events may differ from this. For example, in Firefox, on an [HSTS](/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) upgrade, the `onBeforeRedirect` event is triggered immediately after `onBeforeRequest`. `onErrorOccurred` is also fired if [Firefox Tracking Protection](https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-desktop) blocks a request.
 
 All events – _except_ `onErrorOccurred` – can take three arguments to `addListener()`:
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/index.md
@@ -20,9 +20,9 @@ Each event is fired at a particular stage of the request. The typical sequence o
 
 ![](webrequest-flow.png)
 
-{{WebExtAPIRef("webRequest.onErrorOccurred", "onErrorOccurred")}} can be fired at any time during the request. Also, note that sometimes the sequence of events may differ from this: for example, in Firefox, on an [HSTS](/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) upgrade, the `onBeforeRedirect` event will be triggered immediately after `onBeforeRequest`.
+{{WebExtAPIRef("webRequest.onErrorOccurred", "onErrorOccurred")}} can fire at any time during the request. Also, note that sometimes the sequence of events may differ from this. For example, in Firefox, on an [HSTS](/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) upgrade, the `onBeforeRedirect` event is triggered immediately after `onBeforeRequest`. `onErrorOccurred` is also fired if Firefox Tracking Protection blocks a request.
 
-All events—_except_ `onErrorOccurred`—can take three arguments to `addListener()`:
+All events – _except_ `onErrorOccurred` – can take three arguments to `addListener()`:
 
 - the listener itself
 - a {{WebExtAPIRef("webRequest.RequestFilter", "filter")}} object, so you can only be notified for requests made to particular URLs or for particular types of resource

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onerroroccurred/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onerroroccurred/index.md
@@ -141,16 +141,16 @@ Events have three functions:
     - `any_strict_tracking`: a meta flag that combines any tracking and fingerprinting flags, including `tracking_content` and `fingerprinting_content`.
     - `any_social_tracking`: a meta flag that combines any social tracking flags.
     
-    **Note** If Firefox Tracking Protection blocks the request an empty object is returned and `error` returns one of these descriptions:
-    - "The URI is malware"
-    - "The URI is phishing"
-    - "The URI is tracking"
-    - "The URI is unwanted"
-    - "The URI is blocked"
-    - "The URI is harmful"
-    - "The URI is fingerprinting"
-    - "The URI is cryptomining"
-    - "The URI is social tracking"
+    **Note** If Firefox Tracking Protection blocks the request an empty object is returned and `error` returns one of these codes:
+    - `NS_ERROR_MALWARE_URI` indicating a malware URI.
+    - `NS_ERROR_PHISHING_URI` indicating a phishing URI.
+    - `NS_ERROR_TRACKING_URI` indicating a tracking URI.
+    - `NS_ERROR_UNWANTED_URI` indicating a unwanted URI.
+    - `NS_ERROR_BLOCKED_URI` indicating a blocked URI.
+    - `NS_ERROR_HARMFUL_URI` indicating a harmful URI.
+    - `NS_ERROR_FINGERPRINTING` indicating a fingerprinting URI.
+    - `NS_ERROR_CRYPTOMINING_URI` indicating a cryptomining URI.
+    - `NS_ERROR_SOCIALTRACKING_URI` indicating a social tracking URI.
 
 ## Browser compatibility
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onerroroccurred/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onerroroccurred/index.md
@@ -125,7 +125,7 @@ Events have three functions:
   - : `string`. Target of the request.
 - `urlClassification`
 
-  - : `object`. The type of tracking associated with the request, if with the request has been classified by [Firefox Tracking Protection](https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-desktop). This is an object with the following properties:
+  - : `object`. The type of tracking associated with the request, if with the request has been classified by [Firefox Tracking Protection](https://support.mozilla.org/en-US/kb/enhanced-tracking-protection-firefox-desktop). This is an object with these properties:
 
     - `firstParty`
       - : `array` of `strings`. Classification flags for the request's first party.
@@ -140,6 +140,17 @@ Events have three functions:
     - `any_basic_tracking`: a meta flag that combines any tracking and fingerprinting flags, excluding `tracking_content` and `fingerprinting_content`.
     - `any_strict_tracking`: a meta flag that combines any tracking and fingerprinting flags, including `tracking_content` and `fingerprinting_content`.
     - `any_social_tracking`: a meta flag that combines any social tracking flags.
+    
+    **Note** If Firefox Tracking Protection blocks the request an empty object is returned and `error` returns one of these descriptions:
+    - "The URI is malware"
+    - "The URI is phishing"
+    - "The URI is tracking"
+    - "The URI is unwanted"
+    - "The URI is blocked"
+    - "The URI is harmful"
+    - "The URI is fingerprinting"
+    - "The URI is cryptomining"
+    - "The URI is social tracking"
 
 ## Browser compatibility
 


### PR DESCRIPTION
#### Summary
Adds a note about the details returned by `webRequest.onErrorOccurred` when Firefox Tracking Protection blocks a request. Provides the content requested in [Bug 1779770](https://bugzilla.mozilla.org/show_bug.cgi?id=1779770).

#### Metadata

This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error