### PR TITLE
Add togglemicrophone, togglecamera, hangup to MediaSession setActionHandler

### DIFF
--- a/files/en-us/web/api/mediasession/index.md
+++ b/files/en-us/web/api/mediasession/index.md
@@ -62,6 +62,10 @@ if ('mediaSession' in navigator) {
   navigator.mediaSession.setActionHandler('previoustrack', function() { /* Code excerpted. */ });
   navigator.mediaSession.setActionHandler('nexttrack', function() { /* Code excerpted. */ });
   navigator.mediaSession.setActionHandler('skipad', function() { /* Code excerpted. */ });
+  navigator.mediaSession.setActionHandler('togglecamera', function() { /* Code excerpted. */ });
+  navigator.mediaSession.setActionHandler('togglemicrophone', function() { /* Code excerpted. */ });
+  navigator.mediaSession.setActionHandler('hangup', function() { /* Code excerpted. */ });
+
 }
 ```
 

--- a/files/en-us/web/api/mediasession/setactionhandler/index.md
+++ b/files/en-us/web/api/mediasession/setactionhandler/index.md
@@ -57,10 +57,10 @@ setActionHandler(type, callback)
         This action may or may not be available, depending on the platform and {{Glossary("user agent")}}, or may be disabled due to subscription level or other circumstances.
     - `stop`
       - : Halts playback entirely.
-    - `togglemicrophone`
-      - : Mute or unmute the user’s microphone.
     - `togglecamera`
       - : Turn the user’s active camera on or off.
+    - `togglemicrophone`
+      - : Mute or unmute the user’s microphone.
 - `callback`
   - : A function to call when the specified action type is invoked. The callback should not return a value. The callback receives a dictionary containing the following properties:
     - `action`

--- a/files/en-us/web/api/mediasession/setactionhandler/index.md
+++ b/files/en-us/web/api/mediasession/setactionhandler/index.md
@@ -31,6 +31,8 @@ setActionHandler(type, callback)
 - `type`
   - : A string representing an action type to listen for. It will be one
     of the following:
+    - `hangup`
+      - : End a call.
     - `nexttrack`
       - : Advances playback to the next track.
     - `pause`
@@ -55,6 +57,10 @@ setActionHandler(type, callback)
         This action may or may not be available, depending on the platform and {{Glossary("user agent")}}, or may be disabled due to subscription level or other circumstances.
     - `stop`
       - : Halts playback entirely.
+    - `togglemicrophone`
+      - : Mute or unmute the user’s microphone.
+    - `togglecamera`
+      - : Turn the user’s active camera on or off.
 - `callback`
   - : A function to call when the specified action type is invoked. The callback should not return a value. The callback receives a dictionary containing the following properties:
     - `action`

--- a/files/en-us/web/api/mediasession/setcameraactive/index.md
+++ b/files/en-us/web/api/mediasession/setcameraactive/index.md
@@ -50,7 +50,7 @@ let cameraActive = false;
 
 navigator.mediaSession.setCameraActive(cameraActive);
 
-navigator.mediaSession.setCameraActive('togglecamera', () => {
+navigator.mediaSession.setActionHandler('togglecamera', () => {
   cameraActive = !cameraActive;
   navigator.mediaSession.setCameraActive(cameraActive);
 });

--- a/files/en-us/web/api/mediasession/setcameraactive/index.md
+++ b/files/en-us/web/api/mediasession/setcameraactive/index.md
@@ -1,0 +1,65 @@
+---
+title: MediaSession.setCameraActive()
+slug: Web/API/MediaSession/setCameraActive
+page-type: web-api-instance-method
+tags:
+  - API
+  - Audio
+  - Media
+  - Media Session API
+  - MediaSession
+  - Method
+  - Reference
+  - UX
+  - Video
+  - setActionHandler
+  - setCameraActive
+browser-compat: api.MediaSession.setCameraActive
+---
+{{APIRef("Media Session API")}}
+
+The {{domxref("MediaSession")}} method **`setCameraActive()`** is used to indicate to the user agent whether the user's camera is considered to be active.
+
+Call this method on the `navigator` object's
+{{domxref("navigator.mediaSession", "mediaSession")}} object.
+
+Note that the status of the camera is not tracked in the {{domxref("MediaSession")}} itself, but must be tracked separately.
+
+## Syntax
+
+```js
+setCameraActive(active)
+```
+
+### Parameters
+
+- `active`
+  - : A boolean indicating whether the camera is considered active or not.
+
+### Return value
+
+None ({{jsxref("undefined")}}).
+
+## Examples
+
+Below is an example of updating the camera active state of the current
+{{domxref('MediaSession')}}, as well as listening to requests to change the camera status with {{domxref("navigator.mediaSession.setActionHandler", "setActionHandler")}}.
+
+```js
+let cameraActive = false;
+
+navigator.mediaSession.setCameraActive(cameraActive);
+
+navigator.mediaSession.setCameraActive('togglecamera', () => {
+  cameraActive = !cameraActive;
+  navigator.mediaSession.setCameraActive(cameraActive);
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/mediasession/setmicrophoneactive/index.md
+++ b/files/en-us/web/api/mediasession/setmicrophoneactive/index.md
@@ -1,0 +1,65 @@
+---
+title: MediaSession.setMicrophoneActive()
+slug: Web/API/MediaSession/setMicrophoneActive
+page-type: web-api-instance-method
+tags:
+  - API
+  - Audio
+  - Media
+  - Media Session API
+  - MediaSession
+  - Method
+  - Reference
+  - UX
+  - Video
+  - setActionHandler
+  - setMicrophoneActive
+browser-compat: api.MediaSession.setMicrophoneActive
+---
+{{APIRef("Media Session API")}}
+
+The {{domxref("MediaSession")}} method **`setMicrophoneActive()`** is used to indicate to the user agent whether the user's microphone is considered to be currently muted.
+
+Call this method on the `navigator` object's
+{{domxref("navigator.mediaSession", "mediaSession")}} object.
+
+Note that the status of the microphone is not tracked in the {{domxref("MediaSession")}} itself, but must be tracked separately.
+
+## Syntax
+
+```js
+setMicrophoneActive(active)
+```
+
+### Parameters
+
+- `active`
+  - : A boolean indicating whether the microphone is considered muted or not.
+
+### Return value
+
+None ({{jsxref("undefined")}}).
+
+## Examples
+
+Below is an example of updating the microphone mute state of the current
+{{domxref('MediaSession')}}, as well as listening to requests to change the mute status with {{domxref("navigator.mediaSession.setActionHandler", "setActionHandler")}}.
+
+```js
+let microphoneActive = false;
+
+navigator.mediaSession.setMicrophoneActive(microphoneActive);
+
+navigator.mediaSession.setActionHandler('togglemicrophone', () => {
+  microphoneActive = !microphoneActive;
+  navigator.mediaSession.setMicrophoneActive(microphoneActive);
+});
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

`togglemicrophone`, `togglecamera`, and `hangup` are listed in [the mediasession standard](https://w3c.github.io/mediasession/#enumdef-mediasessionaction), as well as [`setMicrophoneActive` and `setCameraActive`](https://w3c.github.io/mediasession/#dom-mediasession-setmicrophoneactive)

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

I wanted to use these, but couldn't find any information about them until I read the standard.

We use these in a video conferencing app to add mute/unmute and hangup buttons to a picture-in-picture window.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://w3c.github.io/mediasession/#enumdef-mediasessionaction

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

These are not supported in Safari. See https://github.com/mdn/browser-compat-data/pull/17044

`setMicrophoneActive` / `setCameraActive` are already listed as unsupported by Safari in `browser-compat-data`:

https://github.com/mdn/browser-compat-data/blob/3ac24b90b7d3013538857dbda8616eb1a5c8383d/api/MediaSession.json#L219-L288

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
