### PR TITLE
Update msCaching description and browser compatibility

### DIFF
--- a/files/en-us/web/api/xmlhttprequest/mscaching/index.md
+++ b/files/en-us/web/api/xmlhttprequest/mscaching/index.md
@@ -11,7 +11,7 @@ tags:
 
 {{Non-standard_header()}}
 
-**`XMLHttpRequest.msCaching`** is a read/write property which specifies whether stream data downloaded using [XMLHttpRequest](/en-US/docs/Web/API/XMLHttpRequest) is cached to disk or not. On compatible browsers, if `msCaching` is not `disabled` instances of XMLHttpRequest will cache to disk regardless of if [cache-control](/en-US/docs/Web/HTTP/Headers/Cache-Control) is set to `no-cache`.
+**`msCaching`** is a read/write property which specifies whether stream data downloaded using [XMLHttpRequest](/en-US/docs/Web/API/XMLHttpRequest) is cached to disk or not. In compatible browsers, if `msCaching` is not `disabled`, then `XMLHttpRequest` instances will be cached to disk regardless of whether [cache-control](/en-US/docs/Web/HTTP/Headers/Cache-Control) is set to `no-cache`.
 
 ## Value
 

--- a/files/en-us/web/api/xmlhttprequest/mscaching/index.md
+++ b/files/en-us/web/api/xmlhttprequest/mscaching/index.md
@@ -11,7 +11,7 @@ tags:
 
 {{Non-standard_header()}}
 
-**`XMLHttpRequest.msCaching`** is a read/write property which specifies whether stream data downloaded using [XMLHttpRequest](/en-US/docs/Web/API/XMLHttpRequest) is cached to disk or not. On compatible browsers, if `msCaching` is not `disabled` XMLHttpRequest will cache to disk regardless of if [cache-control](/en-US/docs/Web/HTTP/Headers/Cache-Control) is set to `no-cache`.
+**`XMLHttpRequest.msCaching`** is a read/write property which specifies whether stream data downloaded using [XMLHttpRequest](/en-US/docs/Web/API/XMLHttpRequest) is cached to disk or not. On compatible browsers, if `msCaching` is not `disabled` instances of XMLHttpRequest will cache to disk regardless of if [cache-control](/en-US/docs/Web/HTTP/Headers/Cache-Control) is set to `no-cache`.
 
 ## Value
 

--- a/files/en-us/web/api/xmlhttprequest/mscaching/index.md
+++ b/files/en-us/web/api/xmlhttprequest/mscaching/index.md
@@ -11,7 +11,7 @@ tags:
 
 {{Non-standard_header()}}
 
-The **`msCaching`** read/write property specifies whether stream data downloaded using [XMLHttpRequest](/en-US/docs/Web/API/XMLHttpRequest)is cached to disk or not.
+**`XMLHttpRequest.msCaching`** is a read/write property which specifies whether stream data downloaded using [XMLHttpRequest](/en-US/docs/Web/API/XMLHttpRequest) is cached to disk or not. On compatible browsers, if `msCaching` is not `disabled` XMLHttpRequest will cache to disk regardless of if [cache-control](/en-US/docs/Web/HTTP/Headers/Cache-Control) is set to `no-cache`.
 
 ## Value
 
@@ -30,7 +30,7 @@ This feature is not part of any current specification. It is no longer on track 
 
 ## Browser compatibility
 
-This proprietary method is specific to Internet Explorer.
+This proprietary method is specific to Internet Explorer 11.
 
 ## See also
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
* Described default behavior of `msCaching` interacting with `cache-control` on response headers
* Specified the Internet Explorer version `msCaching` is available in

#### Motivation
The article did not originally mention that `msCaching` makes the default caching behavior different on IE (as opposed to WebKit, Chromium, etc). Thought it would be useful to note that disabling it results in typical `cache-control` behavior on XMLHttpRequests as in most browsers. Came up when targeting IE11/non-chromium Edge, for an application I am working on.

Additionally the original entry inaccurately implied that all versions of Internet Explorer implement this attribute on XMLHttpRequest.

#### Supporting details
[msCaching — Microsoft Internet Explorer 11 Documentation](https://docs.microsoft.com/en-us/previous-versions/dn255068(v=vs.85))
[Video — Microsoft Internet Explorer 11 Developer Guide](https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/dev-guides/bg182646(v=vs.85))

#### Metadata
- [ ] Adds a new document
- [X] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
