### PR TITLE
cache venv with specific python version

### DIFF
--- a/.github/workflows/pr-review-companion.yml
+++ b/.github/workflows/pr-review-companion.yml
@@ -88,7 +88,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: yari/deployer/.venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ hashFiles('.github/workflows/pr-review-companion.yml') }}
+          # the trailing number is used to increase for getting
+          # a different cache key when this file changes
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ steps.setup-python.outputs.python-version }}-0
 
       - name: Install poetry dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'


### PR DESCRIPTION
#### Summary

When python version changed, the cached venv may be broken. So add python version to cache key.

#### Motivation

add python version to venv cache key.

#### Supporting details

mdn/translated-content#6805

#### Metadata

- [x] Fixes a typo, bug, or other error
