### PR TITLE
let and id instead of var and class for WebAssembly example

### DIFF
--- a/files/en-us/webassembly/c_to_wasm/index.md
+++ b/files/en-us/webassembly/c_to_wasm/index.md
@@ -144,22 +144,21 @@ If you have a function defined in your C code that you want to call as needed fr
 6. Add a {{HTMLElement("button")}} element as shown below, just above the first opening `<script type='text/javascript'>` tag.
 
     ```html
-    <button class="mybutton">Run myFunction</button>
+    <button id="mybutton">Run myFunction</button>
     ```
 
 7. Now add the following code at the end of the first {{HTMLElement("script")}} element:
 
     ```js
-    document.querySelector('.mybutton')
-        .addEventListener('click', function() {
-            alert('check console');
-            var result = Module.ccall(
-                'myFunction',  // name of C function
-                null,  // return type
-                null,  // argument types
-                null  // arguments
-            );
-        });
+    document.getElementById("mybutton").onclick = () => {
+        alert('check console');
+        let result = Module.ccall(
+            'myFunction',  // name of C function
+            null,  // return type
+            null,  // argument types
+            null  // arguments
+        );
+    };
     ```
 
 This illustrates how `ccall()` is used to call the exported function.

--- a/files/en-us/webassembly/c_to_wasm/index.md
+++ b/files/en-us/webassembly/c_to_wasm/index.md
@@ -150,15 +150,17 @@ If you have a function defined in your C code that you want to call as needed fr
 7. Now add the following code at the end of the first {{HTMLElement("script")}} element:
 
     ```js
-    document.getElementById("mybutton").onclick = () => {
-      alert('check console');
-      let result = Module.ccall(
-        'myFunction',  // name of C function
-        null,  // return type
-        null,  // argument types
-        null,  // arguments
-      );
-    };
+    document
+      .getElementById("mybutton")
+      .addEventListener("click", () => {
+        alert('check console');
+        const result = Module.ccall(
+          'myFunction',  // name of C function
+          null,  // return type
+          null,  // argument types
+          null,  // arguments
+        );
+      };
     ```
 
 This illustrates how `ccall()` is used to call the exported function.

--- a/files/en-us/webassembly/c_to_wasm/index.md
+++ b/files/en-us/webassembly/c_to_wasm/index.md
@@ -151,13 +151,13 @@ If you have a function defined in your C code that you want to call as needed fr
 
     ```js
     document.getElementById("mybutton").onclick = () => {
-        alert('check console');
-        let result = Module.ccall(
-            'myFunction',  // name of C function
-            null,  // return type
-            null,  // argument types
-            null  // arguments
-        );
+      alert('check console');
+      let result = Module.ccall(
+        'myFunction',  // name of C function
+        null,  // return type
+        null,  // argument types
+        null,  // arguments
+      );
     };
     ```
 

--- a/files/en-us/webassembly/c_to_wasm/index.md
+++ b/files/en-us/webassembly/c_to_wasm/index.md
@@ -153,9 +153,9 @@ If you have a function defined in your C code that you want to call as needed fr
     document
       .getElementById("mybutton")
       .addEventListener("click", () => {
-        alert('check console');
+        alert("check console");
         const result = Module.ccall(
-          'myFunction',  // name of C function
+          "myFunction",  // name of C function
           null,  // return type
           null,  // argument types
           null,  // arguments


### PR DESCRIPTION
Using a cleaner and more modern example for [Compiling a New C/C++ Module to WebAssembly](https://developer.mozilla.org/en-US/docs/WebAssembly/C_to_wasm#calling_a_custom_function_defined_in_c).

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error