### PR TITLE
Change return type of Window.showSaveFilePicker() to Promise<FileSystemFileHandle>

### DIFF
--- a/files/en-us/web/api/window/showsavefilepicker/index.md
+++ b/files/en-us/web/api/window/showsavefilepicker/index.md
@@ -49,7 +49,7 @@ showSaveFilePicker()
 
 ### Return value
 
-A {{domxref('FileSystemFileHandle')}}.
+A {{jsxref("Promise")}} whose fulfillment handler receives a {{domxref('FileSystemFileHandle')}} object.
 
 ### Exceptions
 
@@ -69,7 +69,7 @@ function getNewFileHandle() {
       accept: {'text/plain': ['.txt']},
     }],
   };
-  return window.showSaveFilePicker(opts);
+  return await window.showSaveFilePicker(opts);
 }
 ```
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The documentation for `Window.showSaveFilePicker()` indicates a return type of `FileSystemFileHandler` when the actual return type should be `Promise<FileSystemFileHandler>`. This change updates the documentation to use the correct return type.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The incorrect return type can be confusing if you don't know much about the file system API.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
