### PR TITLE
Add the global indexedDB to the correct sidebar

### DIFF
--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -750,7 +750,9 @@
       "overview": ["Intersection Observer API"],
       "interfaces": ["IntersectionObserver", "IntersectionObserverEntry"],
       "methods": [],
-      "properties": [],
+      "properties": [
+        "indexedDB"
+      ],
       "events": []
     },
     "Layout Instability API": {


### PR DESCRIPTION
The global property `indexedDB`, used to access any Indexed DB, is not listed on the IndexedDB sidebars.

This will add it.