### PR TITLE
Comment out ellipsis in code blocks

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy-report-only/index.md
+++ b/files/en-us/web/http/headers/content-security-policy-report-only/index.md
@@ -102,7 +102,7 @@ The HTML of `signup.html` looks like this:
     <link rel="stylesheet" href="css/style.css">
   </head>
   <body>
-    ... Content ...
+    Page content
   </body>
 </html>
 ```

--- a/files/en-us/web/http/headers/content-security-policy/child-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/child-src/index.md
@@ -72,7 +72,7 @@ This {{HTMLElement("iframe")}} and worker are blocked and won't load:
 <iframe src="https://not-example.com"></iframe>
 
 <script>
-  var blockedWorker = new Worker("data:application/javascript,...");
+  var blockedWorker = new Worker("data:application/javascript,…");
 </script>
 ```
 

--- a/files/en-us/web/http/headers/content-security-policy/child-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/child-src/index.md
@@ -72,7 +72,7 @@ This {{HTMLElement("iframe")}} and worker are blocked and won't load:
 <iframe src="https://not-example.com"></iframe>
 
 <script>
-  var blockedWorker = new Worker("data:application/javascript,…");
+  const blockedWorker = new Worker("data:application/javascript,…");
 </script>
 ```
 

--- a/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/connect-src/index.md
@@ -87,7 +87,7 @@ The following connections are blocked and won't load:
 
   var es = new EventSource("https://not-example.com/");
 
-  navigator.sendBeacon("https://not-example.com/", { ... });
+  navigator.sendBeacon("https://not-example.com/", { /* … */ });
 </script>
 ```
 

--- a/files/en-us/web/http/headers/content-security-policy/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/index.md
@@ -153,7 +153,7 @@ Reporting directives control the reporting process of CSP violations. See also t
     > you can specify both **`report-uri`** and {{CSP("report-to")}}:
     >
     > ```html
-    > Content-Security-Policy: ...; report-uri https://endpoint.example.com; report-to groupname
+    > Content-Security-Policy: …; report-uri https://endpoint.example.com; report-to groupname
     > ```
     >
     > In browsers that support {{CSP("report-to")}},

--- a/files/en-us/web/http/headers/content-security-policy/report-to/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/report-to/index.md
@@ -18,7 +18,7 @@ The `Content-Security-Policy`
 instructs the user agent to store reporting endpoints for an origin.
 
 ```html
-Content-Security-Policy: ...; report-to groupname
+Content-Security-Policy: …; report-to groupname
 ```
 
 The directive has no effect in and of itself, but only gains meaning in combination
@@ -65,7 +65,7 @@ Report-To: { "group": "csp-endpoint",
               "endpoints": [
                 { "url": "https://example.com/hpkp-reports" }
               ] }
-Content-Security-Policy: ...; report-to csp-endpoint
+Content-Security-Policy: …; report-to csp-endpoint
 ```
 
 ```
@@ -76,13 +76,13 @@ Report-To: { "group": "endpoint-1",
                 { "url": "https://backup.com/reports" }
               ] }
 
-Content-Security-Policy: ...; report-to endpoint-1
+Content-Security-Policy: …; report-to endpoint-1
 ```
 
 ```
 Reporting-Endpoints: endpoint-1="https://example.com/reports"
 
-Content-Security-Policy: ...; report-to endpoint-1
+Content-Security-Policy: …; report-to endpoint-1
 ```
 
 ## Specifications

--- a/files/en-us/web/http/headers/content-security-policy/report-uri/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/report-uri/index.md
@@ -23,7 +23,7 @@ documents sent via an HTTP POST request to the specified URI.
 > you can specify both **`report-uri`** and {{CSP("report-to")}}:
 >
 > ```html
-> Content-Security-Policy: ...; report-uri https://endpoint.com; report-to groupname
+> Content-Security-Policy: …; report-uri https://endpoint.com; report-to groupname
 > ```
 >
 > In browsers that support {{CSP("report-to")}},

--- a/files/en-us/web/http/headers/content-security-policy/worker-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/worker-src/index.md
@@ -73,7 +73,7 @@ blocked and won't load:
 
 ```html
 <script>
-  var blockedWorker = new Worker("data:application/javascript,...");
+  var blockedWorker = new Worker("data:application/javascript,…");
   blockedWorker = new SharedWorker("https://not-example.com/");
   navigator.serviceWorker.register('https://not-example.com/sw.js');
 </script>

--- a/files/en-us/web/http/headers/content-security-policy/worker-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/worker-src/index.md
@@ -73,7 +73,7 @@ blocked and won't load:
 
 ```html
 <script>
-  var blockedWorker = new Worker("data:application/javascript,…");
+  const blockedWorker = new Worker("data:application/javascript,…");
   blockedWorker = new SharedWorker("https://not-example.com/");
   navigator.serviceWorker.register('https://not-example.com/sw.js');
 </script>

--- a/files/en-us/web/http/headers/index.md
+++ b/files/en-us/web/http/headers/index.md
@@ -395,8 +395,8 @@ _Learn more about CORS [here](CORS)._
   - : TBD
 - {{HTTPHeader("X-Requested-With")}}
   - : TBD
-- {{HTTPHeader("X-Robots-Tag")}} {{non-standard_inline}}
-  - : The [`X-Robots-Tag`](https://developers.google.com/search/docs/advanced/robots/robots_meta_tag) HTTP header is used to indicate how a web page is to be indexed within public search engine results. The header is effectively equivalent to `<meta name="robots" content="...">`.
+- {{HTTPHeader("X-Robots-Tag")}}{{non-standard_inline}}
+  - : The [`X-Robots-Tag`](https://developers.google.com/search/docs/advanced/robots/robots_meta_tag) HTTP header is used to indicate how a web page is to be indexed within public search engine results. The header is effectively equivalent to `<meta name="robots" content="…">`.
 - {{HTTPHeader("X-UA-Compatible")}} {{non-standard_inline}}
   - : Used by Internet Explorer to signal which document mode to use.
 

--- a/files/en-us/web/http/headers/save-data/index.md
+++ b/files/en-us/web/http/headers/save-data/index.md
@@ -84,7 +84,7 @@ Vary: Accept-Encoding, Save-Data
 Cache-Control: public, max-age=31536000
 Content-Type: image/jpeg
 
-[...]
+[…]
 ```
 
 ### Without `Save-Data`
@@ -105,7 +105,7 @@ Vary: Accept-Encoding, Save-Data
 Cache-Control: public, max-age=31536000
 Content-Type: image/jpeg
 
-[...]
+[…]
 ```
 
 ## Specifications

--- a/files/en-us/web/http/headers/x-frame-options/index.md
+++ b/files/en-us/web/http/headers/x-frame-options/index.md
@@ -83,7 +83,7 @@ To configure IIS to send the `X-Frame-Options` header, add this to your site's `
 
 ```xml
 <system.webServer>
-  ...
+  …
 
   <httpProtocol>
     <customHeaders>
@@ -91,7 +91,7 @@ To configure IIS to send the `X-Frame-Options` header, add this to your site's `
     </customHeaders>
   </httpProtocol>
 
-  ...
+  …
 </system.webServer>
 ```
 

--- a/files/en-us/web/http/overview/index.md
+++ b/files/en-us/web/http/overview/index.md
@@ -173,7 +173,7 @@ When a client wants to communicate with a server, either the final server or an 
    Content-Length: 29769
    Content-Type: text/html
 
-   <!DOCTYPE html… (here come the 29769 bytes of the requested web page)
+   <!DOCTYPE html>… (here come the 29769 bytes of the requested web page)
    ```
 
 4. Close or reuse the connection for further requests.

--- a/files/en-us/web/http/overview/index.md
+++ b/files/en-us/web/http/overview/index.md
@@ -173,7 +173,7 @@ When a client wants to communicate with a server, either the final server or an 
    Content-Length: 29769
    Content-Type: text/html
 
-   <!DOCTYPE html... (here come the 29769 bytes of the requested web page)
+   <!DOCTYPE html… (here come the 29769 bytes of the requested web page)
    ```
 
 4. Close or reuse the connection for further requests.

--- a/files/en-us/web/http/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.md
+++ b/files/en-us/web/http/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.md
@@ -13,7 +13,7 @@ A **Proxy Auto-Configuration (PAC)** file is a JavaScript function that determin
 
 ```js
 function FindProxyForURL(url, host) {
-  // ...
+  // …
 }
 ```
 
@@ -719,11 +719,9 @@ function FindProxyForURL(url, host) {
 For example:
 
 ```js
-// ...
 if (shExpMatch(url, "http:*")) {
   return "PROXY http-proxy.mydomain.com:8080";
 }
-// ...
 ```
 
 > **Note:** The autoconfig file can be output by a CGI script. This is useful, for example, when making the autoconfig file act differently based on the client IP address (the `REMOTE_ADDR` environment variable in CGI).

--- a/files/en-us/web/http/range_requests/index.md
+++ b/files/en-us/web/http/range_requests/index.md
@@ -18,7 +18,7 @@ If an HTTP response includes the {{HTTPHeader("Accept-Ranges")}} header and its 
 curl -I http://i.imgur.com/z4d4kWk.jpg
 
 HTTP/1.1 200 OK
-...
+…
 Accept-Ranges: bytes
 Content-Length: 146515
 ```
@@ -31,7 +31,7 @@ If sites omit the `Accept-Ranges` header, they likely don't support partial requ
 curl -I https://www.youtube.com/watch?v=EwTZ2xpQwpA
 
 HTTP/1.1 200 OK
-...
+…
 Accept-Ranges: none
 ```
 
@@ -63,7 +63,7 @@ The server responses with the {{HTTPStatus("206")}} `Partial Content` status:
 HTTP/1.1 206 Partial Content
 Content-Range: bytes 0-1023/146515
 Content-Length: 1024
-...
+…
 (binary content)
 ```
 

--- a/files/en-us/web/http/session/index.md
+++ b/files/en-us/web/http/session/index.md
@@ -120,7 +120,7 @@ Via: Moz-Cache-zlb05
 Connection: Keep-Alive
 Content-Length: 325 (the content contains a default page to display if the user-agent is not able to follow the link)
 
-<!DOCTYPE html… (contains a site-customized page helping the user to find the missing resource)
+<!DOCTYPE html>… (contains a site-customized page helping the user to find the missing resource)
 ```
 
 Notification that the requested resource doesn't exist:
@@ -142,7 +142,7 @@ X-XSS-Protection: 1; mode=block
 Vary: Accept-Encoding,Cookie
 X-Cache: Error from cloudfront
 
-<!DOCTYPE html… (contains a site-customized page helping the user to find the missing resource)
+<!DOCTYPE html>… (contains a site-customized page helping the user to find the missing resource)
 ```
 
 ### Response status codes

--- a/files/en-us/web/http/session/index.md
+++ b/files/en-us/web/http/session/index.md
@@ -120,7 +120,7 @@ Via: Moz-Cache-zlb05
 Connection: Keep-Alive
 Content-Length: 325 (the content contains a default page to display if the user-agent is not able to follow the link)
 
-<!DOCTYPE html... (contains a site-customized page helping the user to find the missing resource)
+<!DOCTYPE html… (contains a site-customized page helping the user to find the missing resource)
 ```
 
 Notification that the requested resource doesn't exist:
@@ -142,7 +142,7 @@ X-XSS-Protection: 1; mode=block
 Vary: Accept-Encoding,Cookie
 X-Cache: Error from cloudfront
 
-<!DOCTYPE html... (contains a site-customized page helping the user to find the missing resource)
+<!DOCTYPE html… (contains a site-customized page helping the user to find the missing resource)
 ```
 
 ### Response status codes

--- a/files/en-us/web/http/status/206/index.md
+++ b/files/en-us/web/http/status/206/index.md
@@ -39,7 +39,7 @@ Content-Range: bytes 21010-47021/47022
 Content-Length: 26012
 Content-Type: image/gif
 
-... 26012 bytes of partial image data ...
+# 26012 bytes of partial image data…
 ```
 
 A response containing several ranges:
@@ -55,12 +55,12 @@ Content-Type: multipart/byteranges; boundary=String_separator
 Content-Type: application/pdf
 Content-Range: bytes 234-639/8000
 
-...the first range...
+# the first range
 --String_separator
 Content-Type: application/pdf
 Content-Range: bytes 4590-7999/8000
 
-...the second range
+# the second range
 --String_separator--
 ```
 

--- a/files/en-us/web/javascript/a_re-introduction_to_javascript/index.md
+++ b/files/en-us/web/javascript/a_re-introduction_to_javascript/index.md
@@ -578,20 +578,20 @@ a.push(item);
 
 Arrays come with a number of methods. See also the [full documentation for array methods](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array).
 
-| Method name                                          | Description                                                                       |
-| ---------------------------------------------------- | --------------------------------------------------------------------------------- |
-| `a.toString()`                                       | Returns a string with the `toString()` of each element separated by commas.       |
-| `a.toLocaleString()`                                 | Returns a string with the `toLocaleString()` of each element separated by commas. |
-| `a.concat(item1[, item2[, ...[, itemN]]])`           | Returns a new array with the items added on to it.                                |
-| `a.join(sep)`                                        | Converts the array to a string — with values delimited by the `sep` param         |
-| `a.pop()`                                            | Removes and returns the last item.                                                |
-| `a.push(item1, ..., itemN)`                          | Appends items to the end of the array.                                            |
-| `a.shift()`                                          | Removes and returns the first item.                                               |
-| `a.unshift(item1[, item2[, ...[, itemN]]])`          | Prepends items to the start of the array.                                         |
-| `a.slice(start[, end])`                              | Returns a sub-array.                                                              |
-| `a.sort([cmpfn])`                                    | Takes an optional comparison function.                                            |
-| `a.splice(start, delcount[, item1[, ...[, itemN]]])` | Lets you modify an array by deleting a section and replacing it with more items.  |
-| `a.reverse()`                                        | Reverses the array.                                                               |
+| Method name                                        | Description                                                                       |
+|----------------------------------------------------| --------------------------------------------------------------------------------- |
+| `a.toString()`                                     | Returns a string with the `toString()` of each element separated by commas.       |
+| `a.toLocaleString()`                               | Returns a string with the `toLocaleString()` of each element separated by commas. |
+| `a.concat(item1, /* … ,*/ itemN)`                  | Returns a new array with the items added on to it.                                |
+| `a.join(sep)`                                      | Converts the array to a string — with values delimited by the `sep` param         |
+| `a.pop()`                                          | Removes and returns the last item.                                                |
+| `a.push(item1, /* … ,*/ itemN)`                    | Appends items to the end of the array.                                            |
+| `a.shift()`                                        | Removes and returns the first item.                                               |
+| `a.unshift(item1, /* … ,*/ itemN)`                 | Prepends items to the start of the array.                                         |
+| `a.slice(start[, end])`                            | Returns a sub-array.                                                              |
+| `a.sort([cmpfn])`                                  | Takes an optional comparison function.                                            |
+| `a.splice(start, delcount[, item1, /* … ,*/ itemN])` | Lets you modify an array by deleting a section and replacing it with more items.  |
+| `a.reverse()`                                      | Reverses the array.                                                               |
 
 ## Functions
 

--- a/files/en-us/web/javascript/data_structures/index.md
+++ b/files/en-us/web/javascript/data_structures/index.md
@@ -215,7 +215,7 @@ Additionally, arrays inherit from `Array.prototype`, which provides to them a ha
 | {{jsxref("Int32Array")}}         | `-2147483648` to `2147483647` | 4             | 32-bit two's complement signed integer                                       | `long`                | `int32_t`                       |
 | {{jsxref("Uint32Array")}}         | `0` to `4294967295`           | 4             | 32-bit unsigned integer                                                      | `unsigned long`       | `uint32_t`                      |
 | {{jsxref("Float32Array")}}     | `1.2E-38` to `3.4E38`         | 4             | 32-bit IEEE floating point number (7 significant digits e.g., `1.1234567`)   | `unrestricted float`  | `float`                         |
-| {{jsxref("Float64Array")}}     | `5E-324` to `1.8E308`         | 8             | 64-bit IEEE floating point number (16 significant digits e.g., `1.123...15`) | `unrestricted double` | `double`                        |
+| {{jsxref("Float64Array")}}     | `5E-324` to `1.8E308`         | 8             | 64-bit IEEE floating point number (16 significant digits e.g., `1.123…15`) | `unrestricted double` | `double`                        |
 | {{jsxref("BigInt64Array")}}     | `-2^63` to `2^63 - 1`         | 8             | 64-bit two's complement signed integer                                       | `bigint`              | `int64_t (signed long long)`    |
 | {{jsxref("BigUint64Array")}}     | `0` to `2^64 - 1`             | 8             | 64-bit unsigned integer                                                      | `bigint`              | `uint64_t (unsigned long long)` |
 

--- a/files/en-us/web/javascript/guide/control_flow_and_error_handling/index.md
+++ b/files/en-us/web/javascript/guide/control_flow_and_error_handling/index.md
@@ -131,7 +131,7 @@ if (condition_1) {
 
 In the case of multiple conditions, only the first logical condition which evaluates to
 `true` will be executed. To execute multiple statements, group them within a
-block statement (`{ … }`).
+block statement (`{ /* … */ }`).
 
 #### Best practice
 

--- a/files/en-us/web/javascript/guide/expressions_and_operators/index.md
+++ b/files/en-us/web/javascript/guide/expressions_and_operators/index.md
@@ -576,8 +576,8 @@ So, when the bitwise operators are applied to these values, the results are as f
 | `15 & 9`   | `9`    | `1111 & 1001 = 1001`                                  |
 | `15 \| 9`  | `15`   | `1111 \| 1001 = 1111`                                 |
 | `15 ^ 9`   | `6`    | `1111 ^ 1001 = 0110`                                  |
-| `~15`      | `-16`  | `~ 0000 0000 ... 0000 1111 = 1111 1111 ... 1111 0000` |
-| `~9`       | `-10`  | `~ 0000 0000 ... 0000 1001 = 1111 1111 ... 1111 0110` |
+| `~15`      | `-16`  | `~ 0000 0000 … 0000 1111 = 1111 1111 … 1111 0000` |
+| `~9`       | `-10`  | `~ 0000 0000 … 0000 1001 = 1111 1111 … 1111 0110` |
 
 Note that all 32 bits are inverted using the Bitwise NOT operator, and that values with
 the most significant (left-most) bit set to 1 represent negative numbers

--- a/files/en-us/web/javascript/guide/functions/index.md
+++ b/files/en-us/web/javascript/guide/functions/index.md
@@ -22,7 +22,7 @@ A **function definition** (also called a **function declaration**, or **function
 
 - The name of the function.
 - A list of parameters to the function, enclosed in parentheses and separated by commas.
-- The JavaScript statements that define the function, enclosed in curly brackets, `{...}`.
+- The JavaScript statements that define the function, enclosed in curly brackets, `{ /* … */ }`.
 
 For example, the following code defines a simple function named `square`:
 
@@ -164,7 +164,7 @@ Functions must be _in scope_ when they are called, but the function declaration 
 
 ```js
 console.log(square(5));
-/* ... */
+// …
 function square(n) {
   return n * n;
 }
@@ -504,7 +504,7 @@ In the code above, the `name` variable of the outer function is accessible to th
 
 ```js
 const getCode = (function () {
-  const apiCode = '0]Eal(eh&2';    // A code we do not want outsiders to be able to modify...
+  const apiCode = '0]Eal(eh&2';    // A code we do not want outsiders to be able to modify…
 
   return function () {
     return apiCode;

--- a/files/en-us/web/javascript/guide/grammar_and_types/index.md
+++ b/files/en-us/web/javascript/guide/grammar_and_types/index.md
@@ -339,7 +339,7 @@ let answer = 42;
 And later, you could assign the same variable a string value, for example:
 
 ```js
-answer = 'Thanks for all the fish...';
+answer = 'Thanks for all the fish!';
 ```
 
 Because JavaScript is dynamically typed, this assignment does not cause an error message.

--- a/files/en-us/web/javascript/guide/indexed_collections/index.md
+++ b/files/en-us/web/javascript/guide/indexed_collections/index.md
@@ -23,12 +23,12 @@ JavaScript does not have an explicit array data type. However, you can use the p
 The following statements create equivalent arrays:
 
 ```js
-const arr1 = new Array(element0, element1, ..., elementN)
-const arr2 = Array(element0, element1, ..., elementN)
-const arr3 = [element0, element1, ..., elementN]
+const arr1 = new Array(element0, element1, /* … ,*/ elementN)
+const arr2 = Array(element0, element1, /* … ,*/ elementN)
+const arr3 = [element0, element1, /* … ,*/ elementN]
 ```
 
-`element0, element1, ..., elementN` is a list of values for the array's elements. When these values are specified, the array is initialized with them as the array's elements. The array's `length` property is set to the number of arguments.
+`element0, element1, …, elementN` is a list of values for the array's elements. When these values are specified, the array is initialized with them as the array's elements. The array's `length` property is set to the number of arguments.
 
 The bracket syntax is called an "array literal" or "array initializer." It's shorter than other forms of array creation, and so is generally preferred. See [Array literals](/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#array_literals) for details.
 
@@ -52,11 +52,11 @@ In addition to a newly defined variable as shown above, arrays can also be assig
 
 ```js
 const obj = {}
-// ...
-obj.prop = [element0, element1, ..., elementN]
+// …
+obj.prop = [element0, element1, /* … ,*/ elementN]
 
 // OR
-const obj = {prop: [element0, element1, ...., elementN]}
+const obj = {prop: [element0, element1, /* … ,*/ elementN]}
 ```
 
 If you wish to initialize an array with a single element, and the element happens to be a `Number`, you must use the bracket syntax. When a single `Number` value is passed to the `Array()` constructor or function, it is interpreted as an `arrayLength`, not as a single element.
@@ -593,7 +593,7 @@ Typed array views have self descriptive names and provide views for all the usua
 | {{jsxref("Int32Array")}}         | `-2147483648` to `2147483647` | 4             | 32-bit two's complement signed integer                                       | `long`                | `int32_t`                       |
 | {{jsxref("Uint32Array")}}         | `0` to `4294967295`           | 4             | 32-bit unsigned integer                                                      | `unsigned long`       | `uint32_t`                      |
 | {{jsxref("Float32Array")}}     | `1.2E-38` to `3.4E38`         | 4             | 32-bit IEEE floating point number (7 significant digits e.g., `1.1234567`)   | `unrestricted float`  | `float`                         |
-| {{jsxref("Float64Array")}}     | `5E-324` to `1.8E308`         | 8             | 64-bit IEEE floating point number (16 significant digits e.g., `1.123...15`) | `unrestricted double` | `double`                        |
+| {{jsxref("Float64Array")}}     | `5E-324` to `1.8E308`         | 8             | 64-bit IEEE floating point number (16 significant digits e.g., `1.123…15`) | `unrestricted double` | `double`                        |
 | {{jsxref("BigInt64Array")}}     | `-2^63` to `2^63 - 1`         | 8             | 64-bit two's complement signed integer                                       | `bigint`              | `int64_t (signed long long)`    |
 | {{jsxref("BigUint64Array")}}     | `0` to `2^64 - 1`             | 8             | 64-bit unsigned integer                                                      | `bigint`              | `uint64_t (unsigned long long)` |
 

--- a/files/en-us/web/javascript/guide/keyed_collections/index.md
+++ b/files/en-us/web/javascript/guide/keyed_collections/index.md
@@ -80,7 +80,8 @@ function Public() {
 
 Public.prototype.method = function () {
   const me = privates.get(this);
-  // Do stuff with private data in `me`...
+  // Do stuff with private data in `me`
+  // …
 };
 
 module.exports = Public;

--- a/files/en-us/web/javascript/guide/loops_and_iteration/index.md
+++ b/files/en-us/web/javascript/guide/loops_and_iteration/index.md
@@ -61,7 +61,7 @@ When a `for` loop executes, the following occurs:
 
 1. The initializing expression `initialExpression`, if any, is executed. This expression usually initializes one or more loop counters, but the syntax allows an expression of any degree of complexity. This expression can also declare variables.
 2. The `conditionExpression` expression is evaluated. If the value of `conditionExpression` is true, the loop statements execute. Otherwise, the `for` loop terminates. (If the `conditionExpression` expression is omitted entirely, the condition is assumed to be true.)
-3. The `statement` executes. To execute multiple statements, use a [block statement](/en-US/docs/Web/JavaScript/Reference/Statements/block) (`{ ... }`) to group those statements.
+3. The `statement` executes. To execute multiple statements, use a [block statement](/en-US/docs/Web/JavaScript/Reference/Statements/block) (`{ }`) to group those statements.
 4. If present, the update expression `incrementExpression` is executed.
 5. Control returns to Step 2.
 
@@ -125,7 +125,7 @@ while (condition);
 ```
 
 _`statement`_ is always executed once before the condition is
-checked. (To execute multiple statements, use a block statement (`{ ... }`)
+checked. (To execute multiple statements, use a block statement (`{ }`)
 to group those statements.)
 
 If `condition` is `true`, the statement executes again. At the
@@ -167,7 +167,7 @@ and the _`condition`_ is tested again. If the condition returns
 `false`, execution stops, and control is passed to the statement following
 `while`.
 
-To execute multiple statements, use a block statement (`{ ... }`) to group
+To execute multiple statements, use a block statement (`{ }`) to group
 those statements.
 
 ### Example 1

--- a/files/en-us/web/javascript/guide/modules/index.md
+++ b/files/en-us/web/javascript/guide/modules/index.md
@@ -508,7 +508,7 @@ squareBtn.addEventListener('click', () => {
 });
 ```
 
-Note that, because the promise fulfillment returns a module object, the class is then made a subfeature of the object, hence we now need to access the constructor with `Module.` prepended to it, e.g. `Module.Square( )`.
+Note that, because the promise fulfillment returns a module object, the class is then made a subfeature of the object, hence we now need to access the constructor with `Module.` prepended to it, e.g. `Module.Square( /* … */ )`.
 
 Another advantage of dynamic imports is that they are always available, even in script environments. Therefore, if you have an existing `<script>` tag in your HTML that doesn't have `type="module"`, you can still reuse code distributed as modules by dynamically importing it.
 
@@ -564,7 +564,7 @@ import { Canvas } from './modules/canvas.js';
 
 let circleBtn = document.querySelector('.circle');
 
-…
+// …
 ```
 
 We'll use `colors` instead of the previously used strings when calling our shape functions:

--- a/files/en-us/web/javascript/guide/modules/index.md
+++ b/files/en-us/web/javascript/guide/modules/index.md
@@ -232,7 +232,7 @@ We could instead prepend `export default` onto the function and define it as an 
 
 ```js
 export default function(ctx) {
-  ...
+  // …
 }
 ```
 
@@ -387,14 +387,14 @@ You can see an example of our shape drawing module rewritten with ES classes in 
 ```js
 class Square {
   constructor(ctx, listId, length, x, y, color) {
-    ...
+    // …
   }
 
   draw() {
-    ...
+    // …
   }
 
-  ...
+  // …
 }
 ```
 
@@ -508,7 +508,7 @@ squareBtn.addEventListener('click', () => {
 });
 ```
 
-Note that, because the promise fulfillment returns a module object, the class is then made a subfeature of the object, hence we now need to access the constructor with `Module.` prepended to it, e.g. `Module.Square( ... )`.
+Note that, because the promise fulfillment returns a module object, the class is then made a subfeature of the object, hence we now need to access the constructor with `Module.` prepended to it, e.g. `Module.Square( )`.
 
 Another advantage of dynamic imports is that they are always available, even in script environments. Therefore, if you have an existing `<script>` tag in your HTML that doesn't have `type="module"`, you can still reuse code distributed as modules by dynamically importing it.
 
@@ -564,25 +564,17 @@ import { Canvas } from './modules/canvas.js';
 
 let circleBtn = document.querySelector('.circle');
 
-...
+…
 ```
 
 We'll use `colors` instead of the previously used strings when calling our shape functions:
 
 ```js
-...
-
 let square1 = new Module.Square(myCanvas.ctx, myCanvas.listId, 50, 50, 100, colors.blue);
-
-...
 
 let circle1 = new Module.Circle(myCanvas.ctx, myCanvas.listId, 75, 200, 100, colors.green);
 
-...
-
 let triangle1 = new Module.Triangle(myCanvas.ctx, myCanvas.listId, 100, 75, 190, colors.yellow);
-
-...
 ```
 
 This is useful because the code within [`main.js`](https://github.com/mdn/js-examples/blob/master/module-examples/top-level-await/main.js) won't execute until the code in [`getColors.js`](https://github.com/mdn/js-examples/blob/master/module-examples/top-level-await/modules/getColors.js) has run. However it won't block other modules being loaded. For instance our [`canvas.js`](https://github.com/mdn/js-examples/blob/master/module-examples/top-level-await/modules/canvas.js) module will continue to load while `colors` is being fetched.
@@ -620,7 +612,7 @@ In order to maximize the reusability of a module, it is often advised to make th
     // We are running in Node.js; use node-fetch
     globalThis.fetch = (await import("node-fetch")).default;
   }
-  // ...
+  // …
   ```
 
   The [`globalThis`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) variable is a global object that is available in every environment and is useful if you want to read or create global variables within modules.

--- a/files/en-us/web/javascript/guide/using_promises/index.md
+++ b/files/en-us/web/javascript/guide/using_promises/index.md
@@ -116,7 +116,7 @@ doSomething()
 ```js example-bad
 doSomething()
   .then((url) => {
-    // I forgot to return this…
+    // I forgot to return this
     fetch(url);
   })
   .then((result) => {
@@ -134,7 +134,7 @@ const listOfIngredients = [];
 
 doSomething()
   .then((url) => {
-    // I forgot to return this…
+    // I forgot to return this
     fetch(url)
       .then((res) => res.json())
       .then((data) => {

--- a/files/en-us/web/javascript/guide/using_promises/index.md
+++ b/files/en-us/web/javascript/guide/using_promises/index.md
@@ -116,7 +116,7 @@ doSomething()
 ```js example-bad
 doSomething()
   .then((url) => {
-    // I forgot to return this...
+    // I forgot to return this…
     fetch(url);
   })
   .then((result) => {
@@ -134,7 +134,7 @@ const listOfIngredients = [];
 
 doSomething()
   .then((url) => {
-    // I forgot to return this...
+    // I forgot to return this…
     fetch(url)
       .then((res) => res.json())
       .then((data) => {

--- a/files/en-us/web/javascript/guide/working_with_objects/index.md
+++ b/files/en-us/web/javascript/guide/working_with_objects/index.md
@@ -184,9 +184,8 @@ The syntax for an object using an object initializer is:
 
 ```js
 const obj = {
-  property_1:   value_1,   // property name may be an identifier...
-  2:            value_2,   // or a number...
-  // ...,
+  property_1:   value_1,   // property name may be an identifier
+  2:            value_2,   // or a number
   'property n': value_n    // or a string
 };
 ```
@@ -350,12 +349,12 @@ objectName.methodName = functionName;
 
 const myObj = {
   myMethod: function(params) {
-    // ...do something
+    // do something
   },
 
   // this works too!
   myOtherMethod(params) {
-    // ...do something else
+    // do something else
   }
 };
 ```

--- a/files/en-us/web/javascript/reference/classes/class_static_initialization_blocks/index.md
+++ b/files/en-us/web/javascript/reference/classes/class_static_initialization_blocks/index.md
@@ -25,7 +25,7 @@ This means that static blocks can also be used to share information between clas
 ## Syntax
 
 ```js
-static { /* ... */ }
+static { /* … */ }
 ```
 
 ## Description

--- a/files/en-us/web/javascript/reference/classes/constructor/index.md
+++ b/files/en-us/web/javascript/reference/classes/constructor/index.md
@@ -17,10 +17,10 @@ The `constructor` method is a special method of a {{jsxref("Statements/class", "
 ## Syntax
 
 ```js
-constructor() { /* ... */ }
-constructor(argument0) { /* ... */ }
-constructor(argument0, argument1) { /* ... */ }
-constructor(argument0, argument1, ... , argumentN) { /* ... */ }
+constructor() { /* … */ }
+constructor(argument0) { /* … */ }
+constructor(argument0, argument1) { /* … */ }
+constructor(argument0, argument1, /* … ,*/ argumentN) { /* … */ }
 ```
 
 ## Description

--- a/files/en-us/web/javascript/reference/classes/extends/index.md
+++ b/files/en-us/web/javascript/reference/classes/extends/index.md
@@ -19,7 +19,7 @@ create a class that is a child of another class.
 ## Syntax
 
 ```js
-class ChildClass extends ParentClass { /* ... */ }
+class ChildClass extends ParentClass { /* … */ }
 ```
 
 ## Description


### PR DESCRIPTION
Ellipsis in markdown code blocks are syntax errors.

In order to have smooth transition to Prettier and ESLint the PR comments out such bare ellipses. Refer the https://github.com/mdn/content/pull/18171#issuecomment-1179670484 for more context.