### PR TITLE
Comment out ellipsis in code blocks

### DIFF
--- a/files/en-us/web/javascript/reference/classes/public_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/public_class_fields/index.md
@@ -217,7 +217,7 @@ const instance = new Derived();
 // Derived constructor: 1
 ```
 
-Because class fields are added using the `[[Define]]` semantic (which is essentially {{jsxref("Global_Objects/Object/defineProperty", "Object.defineProperty()")}}), field declarations in derived classes do not invoke setters in the base class. This behavior differs from using `this.field = ...` in the constructor.
+Because class fields are added using the `[[Define]]` semantic (which is essentially {{jsxref("Global_Objects/Object/defineProperty", "Object.defineProperty()")}}), field declarations in derived classes do not invoke setters in the base class. This behavior differs from using `this.field = …` in the constructor.
 
 ```js
 class Base {

--- a/files/en-us/web/javascript/reference/classes/static/index.md
+++ b/files/en-us/web/javascript/reference/classes/static/index.md
@@ -24,7 +24,7 @@ Static methods are often utility functions, such as functions to create or clone
 ## Syntax
 
 ```js
-static methodName() { /* ... */ }
+static methodName() { /* … */ }
 static propertyName [= value];
 
 // Class static initialization block

--- a/files/en-us/web/javascript/reference/errors/delete_in_strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/errors/delete_in_strict_mode/index.md
@@ -46,7 +46,7 @@ Attempting to delete a plain variable, doesn't work in JavaScript and it throws 
 
 var x;
 
-// ...
+// …
 
 delete x;
 
@@ -61,7 +61,7 @@ To free the contents of a variable, you can set it to {{jsxref("null")}}:
 
 var x;
 
-// ...
+// …
 
 x = null;
 

--- a/files/en-us/web/javascript/reference/errors/invalid_const_assignment/index.md
+++ b/files/en-us/web/javascript/reference/errors/invalid_const_assignment/index.md
@@ -42,7 +42,7 @@ Assigning a value to the same constant name in the same block-scope will throw.
 ```js example-bad
 const COLUMNS = 80;
 
-// ...
+// …
 
 COLUMNS = 120; // TypeError: invalid assignment to const `COLUMNS'
 ```
@@ -73,7 +73,7 @@ global variable with
 ```js example-good
 let columns = 80;
 
-// ...
+// …
 
 columns = 120;
 ```

--- a/files/en-us/web/javascript/reference/functions/arguments/length/index.md
+++ b/files/en-us/web/javascript/reference/functions/arguments/length/index.md
@@ -23,7 +23,7 @@ The arguments.length property provides the number of arguments actually passed t
 In this example we define a function that can add two or more numbers together.
 
 ```js
-function adder(base /*, n2, ... */) {
+function adder(base /*, num1, …, numN */) {
   base = Number(base);
   for (let i = 1; i < arguments.length; i++) {
     base += Number(arguments[i]);

--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
@@ -199,8 +199,8 @@ const obj = { // does not create a new scope
   },
 }
 
-obj.b(); // prints undefined, Window {...} (or the global object)
-obj.c(); // prints 10, Object {...}
+obj.b(); // prints undefined, Window { } (or the global object)
+obj.c(); // prints 10, Object { }
 ```
 
 Arrow functions do not have their own `this`. Another example involving
@@ -215,7 +215,7 @@ const obj = {
 
 Object.defineProperty(obj, 'b', {
   get: () => {
-    console.log(this.a, typeof this.a, this); // undefined 'undefined' Window {...} (or the global object)
+    console.log(this.a, typeof this.a, this); // undefined 'undefined' Window { } (or the global object)
     return this.a + 10; // represents global object 'Window', therefore 'this.a' returns 'undefined'
   },
 });
@@ -541,7 +541,7 @@ simple(10); // 10
 
 const max = (a, b) => a > b ? a : b;
 
-// Easy array filtering, mapping, ...
+// Easy array filtering, mapping, etc.
 
 const arr = [5, 6, 13, 0, 1, 18, 23];
 
@@ -557,10 +557,10 @@ const double = arr.map(v => v * 2);
 // More concise promise chains
 promise
   .then(a => {
-  // ...
+  // …
   })
   .then(b => {
-    // ...
+    // …
   });
 
 // Parameterless arrow functions that are visually easier to parse

--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
@@ -215,7 +215,7 @@ const obj = {
 
 Object.defineProperty(obj, 'b', {
   get: () => {
-    console.log(this.a, typeof this.a, this); // undefined 'undefined' Window { } (or the global object)
+    console.log(this.a, typeof this.a, this); // undefined 'undefined' Window { /* … */ } (or the global object)
     return this.a + 10; // represents global object 'Window', therefore 'this.a' returns 'undefined'
   },
 });

--- a/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
+++ b/files/en-us/web/javascript/reference/functions/arrow_functions/index.md
@@ -199,8 +199,8 @@ const obj = { // does not create a new scope
   },
 }
 
-obj.b(); // prints undefined, Window { } (or the global object)
-obj.c(); // prints 10, Object { }
+obj.b(); // prints undefined, Window { /* … */ } (or the global object)
+obj.c(); // prints 10, Object { /* … */ }
 ```
 
 Arrow functions do not have their own `this`. Another example involving

--- a/files/en-us/web/javascript/reference/functions/default_parameters/index.md
+++ b/files/en-us/web/javascript/reference/functions/default_parameters/index.md
@@ -19,7 +19,7 @@ is passed.
 ## Syntax
 
 ```js
-function fnName(param1 = defaultValue1, ..., paramN = defaultValueN) { /* ... */ }
+function fnName(param1 = defaultValue1, /* … ,*/ paramN = defaultValueN) { /* … */ }
 ```
 
 ## Description

--- a/files/en-us/web/javascript/reference/functions/get/index.md
+++ b/files/en-us/web/javascript/reference/functions/get/index.md
@@ -61,7 +61,7 @@ Note the following when working with the `get` syntax:
 
   ```js example-bad
   {
-    x: …, get x() { }
+    x: /* … */, get x() { /* … */ }
   }
   ```
 

--- a/files/en-us/web/javascript/reference/functions/get/index.md
+++ b/files/en-us/web/javascript/reference/functions/get/index.md
@@ -20,8 +20,8 @@ that will be called when that property is looked up.
 ## Syntax
 
 ```js
-{get prop() { /* ... */ } }
-{get [expression]() { /* ... */ } }
+{get prop() { /* … */ } }
+{get [expression]() { /* … */ } }
 ```
 
 ### Parameters
@@ -61,7 +61,7 @@ Note the following when working with the `get` syntax:
 
   ```js example-bad
   {
-    x: ..., get x() { }
+    x: …, get x() { }
   }
   ```
 

--- a/files/en-us/web/javascript/reference/functions/rest_parameters/index.md
+++ b/files/en-us/web/javascript/reference/functions/rest_parameters/index.md
@@ -18,7 +18,7 @@ The **rest parameter** syntax allows a function to accept an indefinite number o
 
 ```js
 function f(a, b, ...theArgs) {
-  // ...
+  // …
 }
 ```
 

--- a/files/en-us/web/javascript/reference/functions/set/index.md
+++ b/files/en-us/web/javascript/reference/functions/set/index.md
@@ -51,7 +51,7 @@ Note the following when working with the `set` syntax:
 - It must not appear in an object literal with another `set` or with a
   data entry for the same property.
   ( `{ set x(v) { }, set x(v) { } }` and
-  `{ x: ..., set x(v) { } }` are forbidden )
+  `{ x: …, set x(v) { } }` are forbidden )
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/array/@@iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/@@iterator/index.md
@@ -90,7 +90,7 @@ object or a custom object.
 ```js
 function logIterable(it) {
   if (!(Symbol.iterator in it)) {
-    console.log(it, ' is not an iterable object...');
+    console.log(it, ' is not an iterable object…');
     return;
   }
 
@@ -113,7 +113,7 @@ logIterable('abc');
 // c
 
 logIterable(123);
-// 123 is not an iterable object...
+// 123 is not an iterable object…
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/array/@@iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/@@iterator/index.md
@@ -90,7 +90,7 @@ object or a custom object.
 ```js
 function logIterable(it) {
   if (!(Symbol.iterator in it)) {
-    console.log(it, ' is not an iterable object…');
+    console.log(it, ' is not an iterable object.');
     return;
   }
 

--- a/files/en-us/web/javascript/reference/global_objects/array/@@iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/@@iterator/index.md
@@ -113,7 +113,7 @@ logIterable('abc');
 // c
 
 logIterable(123);
-// 123 is not an iterable object…
+// 123 is not an iterable object.
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/array/array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/array/index.md
@@ -17,10 +17,10 @@ The **`Array()`** constructor is used to create
 
 ```js
 // literal constructor
-[element0, element1, /* ... ,*/ elementN]
+[element0, element1, /* … ,*/ elementN]
 
 // construct from elements
-new Array(element0, element1, /* ... ,*/ elementN)
+new Array(element0, element1, /* … ,*/ elementN)
 
 // construct from array length
 new Array(arrayLength)

--- a/files/en-us/web/javascript/reference/global_objects/array/concat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/concat/index.md
@@ -25,7 +25,7 @@ This method does not change the existing arrays, but instead returns a new array
 concat()
 concat(value0)
 concat(value0, value1)
-concat(value0, value1, ... , valueN)
+concat(value0, value1, /* … ,*/ valueN)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/every/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/every/index.md
@@ -22,19 +22,19 @@ returns a Boolean value.
 
 ```js
 // Arrow function
-every((element) => { /* ... */ } )
-every((element, index) => { /* ... */ } )
-every((element, index, array) => { /* ... */ } )
+every((element) => { /* … */ } )
+every((element, index) => { /* … */ } )
+every((element, index, array) => { /* … */ } )
 
 // Callback function
 every(callbackFn)
 every(callbackFn, thisArg)
 
 // Inline callback function
-every(function(element) { /* ... */ })
-every(function(element, index) { /* ... */ })
-every(function(element, index, array){ /* ... */ })
-every(function(element, index, array) { /* ... */ }, thisArg)
+every(function(element) { /* … */ })
+every(function(element, index) { /* … */ })
+every(function(element, index, array){ /* … */ })
+every(function(element, index, array) { /* … */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/filter/index.md
@@ -21,19 +21,19 @@ The **`filter()`** method creates a [shallow copy](/en-US/docs/Glossary/Shallow_
 
 ```js
 // Arrow function
-filter((element) => { /* ... */ } )
-filter((element, index) => { /* ... */ } )
-filter((element, index, array) => { /* ... */ } )
+filter((element) => { /* … */ } )
+filter((element, index) => { /* … */ } )
+filter((element, index, array) => { /* … */ } )
 
 // Callback function
 filter(callbackFn)
 filter(callbackFn, thisArg)
 
 // Inline callback function
-filter(function(element) { /* ... */ })
-filter(function(element, index) { /* ... */ })
-filter(function(element, index, array){ /* ... */ })
-filter(function(element, index, array) { /* ... */ }, thisArg)
+filter(function(element) { /* … */ })
+filter(function(element, index) { /* … */ })
+filter(function(element, index, array){ /* … */ })
+filter(function(element, index, array) { /* … */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/find/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/find/index.md
@@ -29,19 +29,19 @@ If no values satisfy the testing function, {{jsxref("undefined")}} is returned.
 
 ```js
 // Arrow function
-find((element) => { /* ... */ } )
-find((element, index) => { /* ... */ } )
-find((element, index, array) => { /* ... */ } )
+find((element) => { /* … */ } )
+find((element, index) => { /* … */ } )
+find((element, index, array) => { /* … */ } )
 
 // Callback function
 find(callbackFn)
 find(callbackFn, thisArg)
 
 // Inline callback function
-find(function(element) { /* ... */ })
-find(function(element, index) { /* ... */ })
-find(function(element, index, array){ /* ... */ })
-find(function(element, index, array) { /* ... */ }, thisArg)
+find(function(element) { /* … */ })
+find(function(element, index) { /* … */ })
+find(function(element, index, array){ /* … */ })
+find(function(element, index, array) { /* … */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/findindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/findindex/index.md
@@ -23,19 +23,19 @@ See also the {{jsxref("Array.find", "find()")}} method, which returns the first 
 
 ```js
 // Arrow function
-findIndex((element) => { /* ... */ } )
-findIndex((element, index) => { /* ... */ } )
-findIndex((element, index, array) => { /* ... */ } )
+findIndex((element) => { /* … */ } )
+findIndex((element, index) => { /* … */ } )
+findIndex((element, index, array) => { /* … */ } )
 
 // Callback function
 findIndex(callbackFn)
 findIndex(callbackFn, thisArg)
 
 // Inline callback function
-findIndex(function(element) { /* ... */ })
-findIndex(function(element, index) { /* ... */ })
-findIndex(function(element, index, array){ /* ... */ })
-findIndex(function(element, index, array) { /* ... */ }, thisArg)
+findIndex(function(element) { /* … */ })
+findIndex(function(element, index) { /* … */ })
+findIndex(function(element, index, array){ /* … */ })
+findIndex(function(element, index, array) { /* … */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/findlast/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/findlast/index.md
@@ -32,19 +32,19 @@ If you need to find:
 
 ```js
 // Arrow function
-findLast((element) => { /* ... */ } )
-findLast((element, index) => { /* ... */ } )
-findLast((element, index, array) => { /* ... */ } )
+findLast((element) => { /* … */ } )
+findLast((element, index) => { /* … */ } )
+findLast((element, index, array) => { /* … */ } )
 
 // Callback function
 findLast(callbackFn)
 findLast(callbackFn, thisArg)
 
 // Inline callback function
-findLast(function(element) { /* ... */ })
-findLast(function(element, index) { /* ... */ })
-findLast(function(element, index, array){ /* ... */ })
-findLast(function(element, index, array) { /* ... */ }, thisArg)
+findLast(function(element) { /* … */ })
+findLast(function(element, index) { /* … */ })
+findLast(function(element, index, array){ /* … */ })
+findLast(function(element, index, array) { /* … */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/findlastindex/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/findlastindex/index.md
@@ -23,19 +23,19 @@ See also the {{jsxref("Array.findLast()", "findLast()")}} method, which returns 
 
 ```js
 // Arrow function
-findLastIndex((element) => { /* ... */ } )
-findLastIndex((element, index) => { /* ... */ } )
-findLastIndex((element, index, array) => { /* ... */ } )
+findLastIndex((element) => { /* … */ } )
+findLastIndex((element, index) => { /* … */ } )
+findLastIndex((element, index, array) => { /* … */ } )
 
 // Callback function
 findLastIndex(callbackFn)
 findLastIndex(callbackFn, thisArg)
 
 // Inline callback function
-findLastIndex(function(element) { /* ... */ })
-findLastIndex(function(element, index) { /* ... */ })
-findLastIndex(function(element, index, array){ /* ... */ })
-findLastIndex(function(element, index, array) { /* ... */ }, thisArg)
+findLastIndex(function(element) { /* … */ })
+findLastIndex(function(element, index) { /* … */ })
+findLastIndex(function(element, index, array){ /* … */ })
+findLastIndex(function(element, index, array) { /* … */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/flatmap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/flatmap/index.md
@@ -22,19 +22,19 @@ The **`flatMap()`** method returns a new array formed by applying a given callba
 
 ```js
 // Arrow function
-flatMap((currentValue) => { /* ... */ } )
-flatMap((currentValue, index) => { /* ... */ } )
-flatMap((currentValue, index, array) => { /* ... */ } )
+flatMap((currentValue) => { /* … */ } )
+flatMap((currentValue, index) => { /* … */ } )
+flatMap((currentValue, index, array) => { /* … */ } )
 
 // Callback function
 flatMap(callbackFn)
 flatMap(callbackFn, thisArg)
 
 // Inline callback function
-flatMap(function(currentValue) { /* ... */ })
-flatMap(function(currentValue, index) { /* ... */ })
-flatMap(function(currentValue, index, array){ /* ... */ })
-flatMap(function(currentValue, index, array) { /* ... */ }, thisArg)
+flatMap(function(currentValue) { /* … */ })
+flatMap(function(currentValue, index) { /* … */ })
+flatMap(function(currentValue, index, array){ /* … */ })
+flatMap(function(currentValue, index, array) { /* … */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/foreach/index.md
@@ -22,19 +22,19 @@ for each array element.
 
 ```js
 // Arrow function
-forEach((element) => { /* ... */ })
-forEach((element, index) => { /* ... */ })
-forEach((element, index, array) => { /* ... */ })
+forEach((element) => { /* … */ })
+forEach((element, index) => { /* … */ })
+forEach((element, index, array) => { /* … */ })
 
 // Callback function
 forEach(callbackFn)
 forEach(callbackFn, thisArg)
 
 // Inline callback function
-forEach(function(element) { /* ... */ })
-forEach(function(element, index) { /* ... */ })
-forEach(function(element, index, array){ /* ... */ })
-forEach(function(element, index, array) { /* ... */ }, thisArg)
+forEach(function(element) { /* … */ })
+forEach(function(element, index) { /* … */ })
+forEach(function(element, index, array){ /* … */ })
+forEach(function(element, index, array) { /* … */ }, thisArg)
 ```
 
 ### Parameters
@@ -196,7 +196,7 @@ const logArrayElements = (element, index, array) => {
 };
 
 // Notice that index 2 is skipped, since there is no item at
-// that position in the array...
+// that position in the array.
 [2, 5,, 9].forEach(logArrayElements);
 // logs:
 // a[0] = 2

--- a/files/en-us/web/javascript/reference/global_objects/array/from/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/from/index.md
@@ -20,18 +20,18 @@ The **`Array.from()`** static method creates a new, shallow-copied `Array` insta
 
 ```js
 // Arrow function
-Array.from(arrayLike, (element) => { /* ... */ } )
-Array.from(arrayLike, (element, index) => { /* ... */ } )
+Array.from(arrayLike, (element) => { /* … */ } )
+Array.from(arrayLike, (element, index) => { /* … */ } )
 
 // Mapping function
 Array.from(arrayLike, mapFn)
 Array.from(arrayLike, mapFn, thisArg)
 
 // Inline mapping function
-Array.from(arrayLike, function mapFn(element) { /* ... */ })
-Array.from(arrayLike, function mapFn(element, index) { /* ... */ })
-Array.from(arrayLike, function mapFn(element) { /* ... */ }, thisArg)
-Array.from(arrayLike, function mapFn(element, index) { /* ... */ }, thisArg)
+Array.from(arrayLike, function mapFn(element) { /* … */ })
+Array.from(arrayLike, function mapFn(element, index) { /* … */ })
+Array.from(arrayLike, function mapFn(element) { /* … */ }, thisArg)
+Array.from(arrayLike, function mapFn(element, index) { /* … */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/group/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/group/index.md
@@ -24,19 +24,19 @@ If you need to group elements using a key that is some arbitrary value, use {{js
 
 ```js
 // Arrow function
-group((element) => { /* ... */ } )
-group((element, index) => { /* ... */ } )
-group((element, index, array) => { /* ... */ } )
+group((element) => { /* … */ } )
+group((element, index) => { /* … */ } )
+group((element, index, array) => { /* … */ } )
 
 // Callback function
 group(callbackFn)
 group(callbackFn, thisArg)
 
 // Inline callback function
-group(function(element) { /* ... */ })
-group(function(element, index) { /* ... */ })
-group(function(element, index, array){ /* ... */ })
-group(function(element, index, array) { /* ... */ }, thisArg)
+group(function(element) { /* … */ })
+group(function(element, index) { /* … */ })
+group(function(element, index, array){ /* … */ })
+group(function(element, index, array) { /* … */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/grouptomap/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/grouptomap/index.md
@@ -25,19 +25,19 @@ If the object is invariant, you might instead represent it using a string, and g
 
 ```js
 // Arrow function
-groupToMap((element) => { /* ... */ } )
-groupToMap((element, index) => { /* ... */ } )
-groupToMap((element, index, array) => { /* ... */ } )
+groupToMap((element) => { /* … */ } )
+groupToMap((element, index) => { /* … */ } )
+groupToMap((element, index, array) => { /* … */ } )
 
 // Callback function
 groupToMap(callbackFn)
 groupToMap(callbackFn, thisArg)
 
 // Inline callback function
-groupToMap(function(element) { /* ... */ })
-groupToMap(function(element, index) { /* ... */ })
-groupToMap(function(element, index, array){ /* ... */ })
-groupToMap(function(element, index, array) { /* ... */ }, thisArg)
+groupToMap(function(element) { /* … */ })
+groupToMap(function(element, index) { /* … */ })
+groupToMap(function(element, index, array){ /* … */ })
+groupToMap(function(element, index, array) { /* … */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/map/index.md
@@ -23,19 +23,19 @@ every element in the calling array.
 
 ```js
 // Arrow function
-map((element) => { /* ... */ })
-map((element, index) => { /* ... */ })
-map((element, index, array) => { /* ... */ })
+map((element) => { /* … */ })
+map((element, index) => { /* … */ })
+map((element, index, array) => { /* … */ })
 
 // Callback function
 map(callbackFn)
 map(callbackFn, thisArg)
 
 // Inline callback function
-map(function(element) { /* ... */ })
-map(function(element, index) { /* ... */ })
-map(function(element, index, array){ /* ... */ })
-map(function(element, index, array) { /* ... */ }, thisArg)
+map(function(element) { /* … */ })
+map(function(element, index) { /* … */ })
+map(function(element, index, array){ /* … */ })
+map(function(element, index, array) { /* … */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/of/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/of/index.md
@@ -34,7 +34,7 @@ Array(1, 2, 3);    // [1, 2, 3]
 ```js
 Array.of(element0)
 Array.of(element0, element1)
-Array.of(element0, element1, /* ... ,*/ elementN)
+Array.of(element0, element1, /* … ,*/ elementN)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/push/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/push/index.md
@@ -22,7 +22,7 @@ an array and returns the new length of the array.
 ```js
 push(element0)
 push(element0, element1)
-push(element0, element1, /* ... ,*/ elementN)
+push(element0, element1, /* … ,*/ elementN)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduce/index.md
@@ -32,26 +32,26 @@ The reducer walks through the array element-by-element, at each step adding the 
 
 ```js
 // Arrow function
-reduce((previousValue, currentValue) => { /* ... */ } )
-reduce((previousValue, currentValue, currentIndex) => { /* ... */ } )
-reduce((previousValue, currentValue, currentIndex, array) => { /* ... */ } )
+reduce((previousValue, currentValue) => { /* … */ } )
+reduce((previousValue, currentValue, currentIndex) => { /* … */ } )
+reduce((previousValue, currentValue, currentIndex, array) => { /* … */ } )
 
-reduce((previousValue, currentValue) => { /* ... */ } , initialValue)
-reduce((previousValue, currentValue, currentIndex) => { /* ... */ } , initialValue)
-reduce((previousValue, currentValue, currentIndex, array) => { /* ... */ }, initialValue)
+reduce((previousValue, currentValue) => { /* … */ } , initialValue)
+reduce((previousValue, currentValue, currentIndex) => { /* … */ } , initialValue)
+reduce((previousValue, currentValue, currentIndex, array) => { /* … */ }, initialValue)
 
 // Callback function
 reduce(callbackFn)
 reduce(callbackFn, initialValue)
 
 // Inline callback function
-reduce(function(previousValue, currentValue) { /* ... */ })
-reduce(function(previousValue, currentValue, currentIndex) { /* ... */ })
-reduce(function(previousValue, currentValue, currentIndex, array) { /* ... */ })
+reduce(function(previousValue, currentValue) { /* … */ })
+reduce(function(previousValue, currentValue, currentIndex) { /* … */ })
+reduce(function(previousValue, currentValue, currentIndex, array) { /* … */ })
 
-reduce(function(previousValue, currentValue) { /* ... */ }, initialValue)
-reduce(function(previousValue, currentValue, currentIndex) { /* ... */ }, initialValue)
-reduce(function(previousValue, currentValue, currentIndex, array) { /* ... */ }, initialValue)
+reduce(function(previousValue, currentValue) { /* … */ }, initialValue)
+reduce(function(previousValue, currentValue, currentIndex) { /* … */ }, initialValue)
+reduce(function(previousValue, currentValue, currentIndex, array) { /* … */ }, initialValue)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/reduceright/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reduceright/index.md
@@ -24,20 +24,20 @@ See also {{jsxref("Array.prototype.reduce()")}} for left-to-right.
 
 ```js
 // Arrow function
-reduceRight((accumulator, currentValue) => { /* ... */ } )
-reduceRight((accumulator, currentValue, index) => { /* ... */ } )
-reduceRight((accumulator, currentValue, index, array) => { /* ... */ } )
-reduceRight((accumulator, currentValue, index, array) => { /* ... */ }, initialValue)
+reduceRight((accumulator, currentValue) => { /* … */ } )
+reduceRight((accumulator, currentValue, index) => { /* … */ } )
+reduceRight((accumulator, currentValue, index, array) => { /* … */ } )
+reduceRight((accumulator, currentValue, index, array) => { /* … */ }, initialValue)
 
 // Callback function
 reduceRight(callbackFn)
 reduceRight(callbackFn, initialValue)
 
 // Callback reducer function
-reduceRight(function(accumulator, currentValue) { /* ... */ })
-reduceRight(function(accumulator, currentValue, index) { /* ... */ })
-reduceRight(function(accumulator, currentValue, index, array){ /* ... */ })
-reduceRight(function(accumulator, currentValue, index, array) { /* ... */ }, initialValue)
+reduceRight(function(accumulator, currentValue) { /* … */ })
+reduceRight(function(accumulator, currentValue, index) { /* … */ })
+reduceRight(function(accumulator, currentValue, index, array){ /* … */ })
+reduceRight(function(accumulator, currentValue, index, array) { /* … */ }, initialValue)
 ```
 
 ### Parameters
@@ -80,7 +80,7 @@ this:
 
 ```js
 arr.reduceRight(function(accumulator, currentValue, index, array) {
-  // ...
+  // …
 });
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/array/some/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/some/index.md
@@ -23,19 +23,19 @@ function. It returns true if, in the array, it finds an element for which the pr
 
 ```js
 // Arrow function
-some((element) => { /* ... */ } )
-some((element, index) => { /* ... */ } )
-some((element, index, array) => { /* ... */ } )
+some((element) => { /* … */ } )
+some((element, index) => { /* … */ } )
+some((element, index, array) => { /* … */ } )
 
 // Callback function
 some(callbackFn)
 some(callbackFn, thisArg)
 
 // Inline callback function
-some(function(element) { /* ... */ })
-some(function(element, index) { /* ... */ })
-some(function(element, index, array){ /* ... */ })
-some(function(element, index, array) { /* ... */ }, thisArg)
+some(function(element) { /* … */ })
+some(function(element, index) { /* … */ })
+some(function(element, index, array){ /* … */ })
+some(function(element, index, array) { /* … */ }, thisArg)
 ```
 
 ### Parameters


### PR DESCRIPTION
Ellipsis in markdown code blocks are syntax errors.

In order to have smooth transition to Prettier and ESLint the PR comments out such bare ellipses. Refer the https://github.com/mdn/content/pull/18171#issuecomment-1179670484 for more context.