### PR TITLE
Comment out ellipsis in code blocks

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/sort/index.md
@@ -27,13 +27,13 @@ implementation.
 sort()
 
 // Arrow function
-sort((a, b) => { /* ... */ } )
+sort((a, b) => { /* … */ } )
 
 // Compare function
 sort(compareFn)
 
 // Inline compare function
-sort(function compareFn(a, b) { /* ... */ })
+sort(function compareFn(a, b) { /* … */ })
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/array/splice/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/splice/index.md
@@ -50,7 +50,7 @@ splice(start, deleteCount, item1, item2, itemN)
     If `deleteCount` is `0` or negative, no elements are removed.
     In this case, you should specify at least one new element (see below).
 
-- `item1, item2, ...` {{optional_inline}}
+- `item1`, …, `itemN` {{optional_inline}}
   - : The elements to add to the array, beginning from `start`.
 
     If you do not specify any elements, `splice()` will only remove elements from the array.

--- a/files/en-us/web/javascript/reference/global_objects/array/unshift/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/unshift/index.md
@@ -22,7 +22,7 @@ beginning of an array and returns the new length of the array.
 ```js
 unshift(element0)
 unshift(element0, element1)
-unshift(element0, element1, /* ... ,*/ elementN)
+unshift(element0, element1, /* … ,*/ elementN)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/boolean/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/boolean/index.md
@@ -39,8 +39,8 @@ if (x) {
 Do not use a `Boolean` object to convert a non-boolean value to a boolean value. To perform this task, instead, use `Boolean` as a function, or a [double NOT operator](/en-US/docs/Web/JavaScript/Reference/Operators/Logical_NOT#double_not_!!):
 
 ```js
-const x = Boolean(expression);     // use this...
-const x = !!(expression);          // ...or this
+const x = Boolean(expression);     // use this
+const x = !!(expression);          // or this
 const x = new Boolean(expression); // don't use this!
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/date/gettime/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/gettime/index.md
@@ -44,14 +44,14 @@ new Date().getTime();
 // 1519211809934
 // 1519211810362
 // 1519211811670
-// ...
+// …
 
 // reduced time precision with `privacy.resistFingerprinting` enabled
 new Date().getTime();
 // 1519129853500
 // 1519129858900
 // 1519129864400
-// ...
+// …
 ```
 
 In Firefox, you can also enable `privacy.resistFingerprinting`, the

--- a/files/en-us/web/javascript/reference/global_objects/date/now/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/date/now/index.md
@@ -42,14 +42,14 @@ Date.now()
 // 1519211809934
 // 1519211810362
 // 1519211811670
-// ...
+// …
 
 // reduced time precision with `privacy.resistFingerprinting` enabled
 Date.now();
 // 1519129853500
 // 1519129858900
 // 1519129864400
-// ...
+// …
 ```
 
 In Firefox, you can also enable `privacy.resistFingerprinting`, the

--- a/files/en-us/web/javascript/reference/global_objects/error/cause/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/cause/index.md
@@ -52,7 +52,7 @@ function makeRSA(p, q) {
       cause: { code: 'NonCoprime', values: [p, q] },
     })
   }
-  // rsa algorithm...
+  // rsa algorithm…
 }
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/error/error/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/error/index.md
@@ -46,10 +46,9 @@ When `Error` is used like a function, that is without {{JSxRef("Operators/new", 
 Therefore, a mere call to `Error` will produce the same output that constructing an `Error` object via the `new` keyword would.
 
 ```js
-// this...
 const x = Error('I was created using a function call!')
 
-// ...has the same functionality as this.
+// above has the same functionality as following
 const y = new Error('I was constructed via the "new" keyword!')
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/error/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/index.md
@@ -106,7 +106,7 @@ try {
   } else if (e instanceof RangeError) {
     console.error(e.name + ': ' + e.message)
   }
-  // ... etc
+  // etc.
 
   else {
     // If none of our cases matched leave the Error unhandled

--- a/files/en-us/web/javascript/reference/global_objects/eval/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/eval/index.md
@@ -42,7 +42,7 @@ The completion value of evaluating the given code. If the completion value is em
 
 The argument of the `eval()` function is a string. It will evaluate the source string as a script body, which means both statements and expressions are allowed. It returns the completion value of the code. For expressions, it's the value the expression evaluates to. Many statements and declarations have completion values as well, but the result may be surprising (for example, the completion value of an assignment is the assigned value, but the completion value of [`let`](/en-US/docs/Web/JavaScript/Reference/Statements/let) is undefined), so it's recommended to not rely on statements' completion values.
 
-There are two modes of `eval()` calls: _direct_ eval and _indirect_ eval. Direct eval only has one form: `eval(...)` (the invoked function's name is `eval` and its value is the global `eval` function). Everything else, including invoking it via an aliased variable, via a member access or other expression, or through the optional chaining [`?.`](/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) operator, is indirect.
+There are two modes of `eval()` calls: _direct_ eval and _indirect_ eval. Direct eval only has one form: `eval( )` (the invoked function's name is `eval` and its value is the global `eval` function). Everything else, including invoking it via an aliased variable, via a member access or other expression, or through the optional chaining [`?.`](/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) operator, is indirect.
 
 ```js
 // Indirect call using the comma operator to return eval
@@ -364,11 +364,11 @@ and objects' properties, and so on. Many DOM APIs are designed with this in mind
 can (and should) write:
 
 ```js
-// instead of setTimeout(" ... ", 1000) use:
-setTimeout(function() { /* ... */ }, 1000);
+// instead of setTimeout(" … ", 1000) use:
+setTimeout(function() { /* … */ }, 1000);
 
-// instead of elt.setAttribute("onclick", "...") use:
-elt.addEventListener('click', function() { /* ... */ } , false);
+// instead of elt.setAttribute("onclick", "…") use:
+elt.addEventListener('click', function() { /* … */ } , false);
 ```
 
 [Closures](/en-US/docs/Web/JavaScript/Closures) are also helpful as a way to

--- a/files/en-us/web/javascript/reference/global_objects/finalizationregistry/finalizationregistry/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/finalizationregistry/finalizationregistry/index.md
@@ -17,13 +17,13 @@ The **`FinalizationRegistry`** constructor creates a {{jsxref("FinalizationRegis
 
 ```js
 // Arrow callback function
-new FinalizationRegistry(heldValue => { /* ... */ } )
+new FinalizationRegistry(heldValue => { /* … */ } )
 
 // Callback function
 new FinalizationRegistry(callbackFn)
 
 // Inline callback function
-new FinalizationRegistry(function(heldValue) { /* ... */ })
+new FinalizationRegistry(function(heldValue) { /* … */ })
 ```
 
 ### Parameters
@@ -39,7 +39,7 @@ You create the registry passing in the callback:
 
 ```js
 const registry = new FinalizationRegistry(heldValue => {
-  // ....
+  // …
 });
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/finalizationregistry/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/finalizationregistry/index.md
@@ -22,7 +22,7 @@ You create the registry passing in the callback:
 
 ```js
 const registry = new FinalizationRegistry(heldValue => {
-  // ....
+  // …
 });
 ```
 
@@ -42,7 +42,9 @@ It's common to use the object itself as the unregister token, which is just fine
 
 ```js
 registry.register(theObject, "some value", theObject);
-// ...some time later, if you don't care about `theObject` anymore...
+// …
+
+// some time later, if you don't care about `theObject` anymore unregister it
 registry.unregister(theObject);
 ```
 
@@ -50,7 +52,9 @@ It doesn't have to be the same object, though; it can be a different one:
 
 ```js
 registry.register(theObject, "some value", tokenObject);
-// ...some time later, if you don't care about `theObject` anymore...
+// …
+
+// some time later
 registry.unregister(tokenObject);
 ```
 
@@ -101,7 +105,7 @@ You create the registry passing in the callback:
 
 ```js
 const registry = new FinalizationRegistry(heldValue => {
-  // ....
+  // …
 });
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/function/apply/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/apply/index.md
@@ -92,8 +92,8 @@ const numbers = [5, 6, 2, 3, 7];
 
 // using Math.min/Math.max apply
 let max = Math.max.apply(null, numbers);
-// This about equal to Math.max(numbers[0], ...)
-// or Math.max(5, 6, ...)
+// This about equal to Math.max(numbers[0], …)
+// or Math.max(5, 6, …)
 
 let min = Math.min.apply(null, numbers);
 

--- a/files/en-us/web/javascript/reference/global_objects/function/name/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/name/index.md
@@ -61,7 +61,7 @@ doSomething.name; // "doSomething"
 
 ### Function constructor name
 
-Functions created with the syntax `new Function(...)` or just `Function(...)` create {{jsxref("Function")}} objects and their name is "anonymous".
+Functions created with the syntax `new Function()` or just `Function()` create {{jsxref("Function")}} objects and their name is "anonymous".
 
 ```js
 (new Function).name; // "anonymous"

--- a/files/en-us/web/javascript/reference/global_objects/generator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/generator/index.md
@@ -64,7 +64,7 @@ const generator = infinite(); // "Generator { }"
 console.log(generator.next().value); // 0
 console.log(generator.next().value); // 1
 console.log(generator.next().value); // 2
-// ...
+// …
 ```
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/global_objects/intl/supportedvaluesof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/supportedvaluesof/index.md
@@ -63,7 +63,7 @@ You can then iterate through the returned array as shown below:
 
 ```js
 Intl.supportedValuesOf("calendar").forEach(function(calendar) {
-   // "buddhist", "chinese", "coptic", "dangi", ...
+   // "buddhist", "chinese", "coptic", "dangi", etc.
 });
 ```
 
@@ -73,23 +73,23 @@ The other values are all obtained in the same way:
 
 ```js
 Intl.supportedValuesOf("collation").forEach(function(collation) {
-   // "big5han", "compat", "dict", "emoji", ...
+   // "big5han", "compat", "dict", "emoji", etc.
 });
 
 Intl.supportedValuesOf("currency").forEach(function(currency) {
-   // "ADP", "AED", "AFA", "AFN", "ALK", "ALL", "AMD", ...
+   // "ADP", "AED", "AFA", "AFN", "ALK", "ALL", "AMD", etc.
 });
 
 Intl.supportedValuesOf("numberingSystem").forEach(function(numberingSystem) {
-   // "adlm", "ahom", "arab", "arabext", "bali", ...
+   // "adlm", "ahom", "arab", "arabext", "bali", etc.
 });
 
 Intl.supportedValuesOf("timeZone").forEach(function(timeZone) {
-   // "Africa/Abidjan", "Africa/Accra", "Africa/Addis_Ababa", "Africa/Algiers", ...
+   // "Africa/Abidjan", "Africa/Accra", "Africa/Addis_Ababa", "Africa/Algiers", etc.
 });
 
 Intl.supportedValuesOf("unit").forEach(function(unit) {
-   // "acre", "bit", "byte", "celsius", "centimeter", ...
+   // "acre", "bit", "byte", "celsius", "centimeter", etc.
 });
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/map/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/foreach/index.md
@@ -21,21 +21,21 @@ pair in the `Map` object, in insertion order.
 
 ```js
 // Arrow function
-forEach(() => { /* ... */ } )
-forEach((value) => { /* ... */ } )
-forEach((value, key) => { /* ... */ } )
-forEach((value, key, map) => { /* ... */ } )
+forEach(() => { /* … */ } )
+forEach((value) => { /* … */ } )
+forEach((value, key) => { /* … */ } )
+forEach((value, key, map) => { /* … */ } )
 
 // Callback function
 forEach(callbackFn)
 forEach(callbackFn, thisArg)
 
 // Inline callback function
-forEach(function() { /* ... */ })
-forEach(function(value) { /* ... */ })
-forEach(function(value, key) { /* ... */ })
-forEach(function(value, key, map) { /* ... */ })
-forEach(function(value, key, map) { /* ... */ }, thisArg)
+forEach(function() { /* … */ })
+forEach(function(value) { /* … */ })
+forEach(function(value, key) { /* … */ })
+forEach(function(value, key, map) { /* … */ })
+forEach(function(value, key, map) { /* … */ }, thisArg)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/math/ceil/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/ceil/index.md
@@ -66,13 +66,13 @@ Math.ceil(-7.004); // -7
    * @returns {Number} The adjusted value.
    */
   function decimalAdjust(type, value, exp) {
-    // If the exp is undefined or zero...
+    // If the exp is undefined or zero
     if (typeof exp === 'undefined' || +exp === 0) {
       return Math[type](value);
     }
     value = +value;
     exp = +exp;
-    // If the value is not a number or the exp is not an integer...
+    // If the value is not a number or the exp is not an integer
     if (isNaN(value) || !(typeof exp === 'number' && exp % 1 === 0)) {
       return NaN;
     }

--- a/files/en-us/web/javascript/reference/global_objects/math/floor/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/floor/index.md
@@ -63,13 +63,13 @@ Math.floor(-45.95); // -46
  * @returns {Number} The adjusted value.
  */
 function decimalAdjust(type, value, exp) {
-  // If the exp is undefined or zero...
+  // If the exp is undefined or zero
   if (typeof exp === 'undefined' || +exp === 0) {
     return Math[type](value);
   }
   value = +value;
   exp = +exp;
-  // If the value is not a number or the exp is not an integer...
+  // If the value is not a number or the exp is not an integer
   if (isNaN(value) || !(typeof exp === 'number' && exp % 1 === 0)) {
     return NaN;
   }

--- a/files/en-us/web/javascript/reference/global_objects/math/hypot/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/hypot/index.md
@@ -61,12 +61,12 @@ sum of squares of its arguments, that is:
 Math.hypot()
 Math.hypot(value0)
 Math.hypot(value0, value1)
-Math.hypot(value0, value1, ... , valueN)
+Math.hypot(value0, value1, /* … ,*/ valueN)
 ```
 
 ### Parameters
 
-- `value1, value2, ...`
+- `value1`, …, `valueN`
   - : Numbers.
 
 ### Return value
@@ -83,7 +83,7 @@ corresponding distance in 2 or more dimensions can be calculated by adding more 
 under the square root: `Math.sqrt(v1*v1 + v2*v2 + v3*v3 + v4*v4)`.
 
 This function makes this calculation easier and faster; you call
-`Math.hypot(v1, v2)` , or `Math.hypot(v1, v2, v3, v4, ...)`.
+`Math.hypot(v1, v2)` , or `Math.hypot(v1, /* … ,*/, vN)`.
 
 `Math.hypot` also avoids overflow/underflow problems if the magnitude of
 your numbers is very large. The largest number you can represent in JS is

--- a/files/en-us/web/javascript/reference/global_objects/math/max/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/max/index.md
@@ -25,7 +25,7 @@ The **`Math.max()`** function returns the largest of the zero or more numbers gi
 Math.max()
 Math.max(value0)
 Math.max(value0, value1)
-Math.max(value0, value1, /* ... ,*/ valueN)
+Math.max(value0, value1, /* … ,*/ valueN)
 ```
 
 ### Parameters

--- a/files/en-us/web/javascript/reference/global_objects/math/min/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/min/index.md
@@ -29,12 +29,12 @@ isn't a number and can't be converted into one.
 Math.min()
 Math.min(value0)
 Math.min(value0, value1)
-Math.min(value0, value1, ... , valueN)
+Math.min(value0, value1, /* … ,*/ valueN)
 ```
 
 ### Parameters
 
-- `value1, value2, ...`
+- `value1`, …, `valueN`
   - : Zero or more numbers among which the lowest value will be selected and returned.
 
 ### Return value

--- a/files/en-us/web/javascript/reference/global_objects/object/constructor/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/constructor/index.md
@@ -105,7 +105,7 @@ Every function constructor will have a `prototype` property, which will become t
 However, if `ConstructorFunction.prototype` is re-assigned, the `constructor` property will be lost. For example, the following is a common way to create an inheritance pattern:
 
 ```js
-function Parent() { /* ... */ }
+function Parent() { /* … */ }
 Parent.prototype.parentMethod = function parentMethod() {}
 
 function Child() {
@@ -118,7 +118,7 @@ Child.prototype = Object.create(Parent.prototype);
 The `constructor` of instances of `Child` will be `Parent` due to `Child.prototype` being re-assigned. Ensuring that `Child.prototype.constructor` always points to `Child` itself is crucial when you are using `constructor` to access the original class from an instance. Take the following case: the object has the `create()` method to create itself.
 
 ```js
-function Parent() { /* ... */ }
+function Parent() { /* … */ }
 function CreatedConstructor() {
   Parent.call(this);
 }
@@ -135,8 +135,8 @@ new CreatedConstructor().create().create(); // TypeError: new CreatedConstructor
 In the example above, an exception is thrown, since the `constructor` links to `Parent`. To avoid this, just assign the necessary constructor you are going to use.
 
 ```js
-function Parent() { /* ... */ }
-function CreatedConstructor() { /* ... */ }
+function Parent() { /* … */ }
+function CreatedConstructor() { /* … */ }
 
 CreatedConstructor.prototype = Object.create(Parent.prototype);
 // Return original constructor to Child
@@ -152,8 +152,8 @@ new CreatedConstructor().create().create(); // it's pretty fine
 However, even better, do not re-assign `ConstructorFunction.prototype` — instead, use [`Object.setPrototypeOf`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/setPrototypeOf) to manipulate the prototype chain.
 
 ```js
-function Parent() { /* ... */ }
-function CreatedConstructor() { /* ... */ }
+function Parent() { /* … */ }
+function CreatedConstructor() { /* … */ }
 
 Object.setPrototypeOf(CreatedConstructor.prototype, Parent.prototype);
 
@@ -200,11 +200,11 @@ new Child(1, 1).getOffsetByInitialPosition();
 For this example to work properly, we can reassign the `Parent`'s static properties to `Child`:
 
 ```js
-// ...
-Child = Object.assign(Child, ParentWithStatic); // Notice that we assign it before we create(...) a prototype below
+// …
+Child = Object.assign(Child, ParentWithStatic); // Notice that we assign it before we create() a prototype below
 Child.prototype = Object.create(ParentWithStatic.prototype);
 Child.prototype.constructor = Child;
-// ...
+// …
 ```
 
 But even better, we can make the constructor functions themselves extend each other, as classes' [`extends`](/en-US/docs/Web/JavaScript/Reference/Classes/extends) do.

--- a/files/en-us/web/javascript/reference/global_objects/object/create/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/create/index.md
@@ -131,7 +131,7 @@ Object.prototype.authenticated = true;
 
 // Unexpectedly allowing unauthenticated user to pass through
 if (user.authenticated) {
-  // access confidential data...
+  // access confidential data
 }
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md
@@ -137,7 +137,7 @@ function withValue(value) {
 
   return d;
 }
-// ... and ...
+// and
 Object.defineProperty(obj, 'key', withValue('static'));
 
 // if freeze is available, prevents adding or

--- a/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/hasown/index.md
@@ -98,7 +98,7 @@ To iterate over the enumerable properties of an object, you _should_ use:
 ```js
 const example = { foo: true, bar: true };
 for (const name of Object.keys(example)) {
-  // ...
+  // …
 }
 ```
 
@@ -108,7 +108,7 @@ But if you need to use `for...in`, you can use `Object.hasOwn()` to skip the inh
 const example = { foo: true, bar: true };
 for (const name in example) {
   if (Object.hasOwn(example, name)) {
-    // ...
+    // …
   }
 }
 ```

--- a/files/en-us/web/javascript/reference/global_objects/object/isextensible/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/isextensible/index.md
@@ -48,7 +48,7 @@ non-extensible using {{jsxref("Object.preventExtensions()")}},
 const empty = {};
 Object.isExtensible(empty); // === true
 
-// ...but that can be changed.
+// They can be made un-extensible
 Object.preventExtensions(empty);
 Object.isExtensible(empty); // === false
 

--- a/files/en-us/web/javascript/reference/global_objects/object/isfrozen/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/isfrozen/index.md
@@ -61,8 +61,7 @@ Object.isFrozen(oneProp); // === false
 Object.preventExtensions(oneProp);
 Object.isFrozen(oneProp); // === false
 
-// ...but then deleting that property makes the object
-// vacuously frozen.
+// Deleting that property makes the object vacuously frozen.
 delete oneProp.p;
 Object.isFrozen(oneProp); // === true
 
@@ -104,8 +103,7 @@ const accessor = { get food() { return 'yum'; } };
 Object.preventExtensions(accessor);
 Object.isFrozen(accessor); // === false
 
-// ...but make that property non-configurable
-// and it becomes frozen.
+// When we make that property non-configurable it becomes frozen.
 Object.defineProperty(accessor, 'food', {
   configurable: false
 });

--- a/files/en-us/web/javascript/reference/global_objects/object/preventextensions/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/preventextensions/index.md
@@ -69,7 +69,7 @@ obj === obj2; // true
 const empty = {};
 Object.isExtensible(empty); // === true
 
-// ...but that can be changed.
+// They can be made un-extensible
 Object.preventExtensions(empty);
 Object.isExtensible(empty); // === false
 

--- a/files/en-us/web/javascript/reference/global_objects/object/proto/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/proto/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Object.proto
 ---
 {{JSRef}}{{Deprecated_header}}
 
-> **Warning:** Changing the `[[Prototype]]` of an object is, by the nature of how modern JavaScript engines optimize property accesses, a very slow operation, in **_every_** browser and JavaScript engine. The effects on the performance of altering inheritance are subtle and far-flung, and are not limited to the time spent in `obj.__proto__ = ...` statements, but may extend to **_any_** code that has access to **_any_** object whose `[[Prototype]]` has been altered. If you care about performance you should avoid setting the `[[Prototype]]` of an object. Instead, create a new object with the desired `[[Prototype]]` using {{JSxRef("Object.create()")}}.
+> **Warning:** Changing the `[[Prototype]]` of an object is, by the nature of how modern JavaScript engines optimize property accesses, a very slow operation, in **_every_** browser and JavaScript engine. The effects on the performance of altering inheritance are subtle and far-flung, and are not limited to the time spent in `obj.__proto__ = …` statements, but may extend to **_any_** code that has access to **_any_** object whose `[[Prototype]]` has been altered. If you care about performance you should avoid setting the `[[Prototype]]` of an object. Instead, create a new object with the desired `[[Prototype]]` using {{JSxRef("Object.create()")}}.
 
 > **Warning:** While `Object.prototype.__proto__` is supported today in most browsers, its existence and exact behavior has only been standardized in the ECMAScript 2015 specification as a legacy feature to ensure compatibility for web browsers. For better support, use {{JSxRef("Object.getPrototypeOf()")}} instead.
 


### PR DESCRIPTION
Ellipsis in markdown code blocks are syntax errors.

In order to have smooth transition to Prettier and ESLint the PR comments out such bare ellipses. Refer the https://github.com/mdn/content/pull/18171#issuecomment-1179670484 for more context.