### PR TITLE
Modernize JS in basic-concepts and improve text

### DIFF
--- a/files/en-us/web/api/web_audio_api/basic_concepts_behind_web_audio_api/index.md
+++ b/files/en-us/web/api/web_audio_api/basic_concepts_behind_web_audio_api/index.md
@@ -16,83 +16,95 @@ tags:
 
 {{DefaultAPISidebar("Web Audio API")}}
 
-This article explains some of the audio theory behind how the features of the Web Audio API work, to help you make informed decisions while designing how audio is routed through your app. If you are not already a sound engineer, it will give you enough background to understand why the Web Audio API works as it does.
+This article explains some of the audio theory behind how the features of the Web Audio API work to help you make informed decisions while designing how your app routes audio. If you are not already a sound engineer, it will give you enough background to understand why the Web Audio API works as it does.
 
 ## Audio graphs
 
-The [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) involves handling audio operations inside an [audio context](/en-US/docs/Web/API/AudioContext), and has been designed to allow **modular routing**. Basic audio operations are performed with [audio nodes](/en-US/docs/Web/API/AudioNode), which are linked together to form an **audio routing graph**. Several sources — with different types of channel layout — are supported, even within a single context. This modular design provides the flexibility to create complex audio functions with dynamic effects.
+The [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) involves handling audio operations inside an [audio context](/en-US/docs/Web/API/AudioContext), and has been designed to allow _modular routing_.  Each [audio node](/en-US/docs/Web/API/AudioNode), which are linked together to form an _audio routing graph_, perform a basic audio operation. Several sources with different channel layouts are supported, even within a single context. This modular design provides the flexibility to create complex audio functions with dynamic effects.
 
-Audio nodes are linked via their inputs and outputs, forming a chain that starts with one or more sources, goes through one or more nodes, then ends up at a destination. Although, you don't have to provide a destination if you, say, just want to visualize some audio data. A simple, typical workflow for web audio would look something like this:
+Audio nodes are linked via their inputs and outputs, forming a chain that starts with one or more sources, goes through one or more nodes, then ends up at a destination. Although, you don't have to provide a destination if you only want to visualize some audio data. A simple, typical workflow for web audio would look something like this:
 
 1. Create the audio context.
 2. Create audio sources inside the context (such as {{HTMLElement("audio")}}, an oscillator, or stream).
 3. Create audio effects (such as the reverb, biquad filter, panner, or compressor nodes).
 4. Choose the final destination for the audio (such as the user's computer speakers).
-5. Connect the source nodes to zero or more effect nodes, and then to the chosen destination.
+5. Connect the source nodes to zero or more effect nodes and then to the chosen destination.
 
-> **Note:** The number of audio channels available on a signal is frequently presented in a numeric format, such as 2.0 or 5.1. This is called {{interwiki("wikipedia", "Surround_sound#Channel_notation", "channel notation")}}. The first number is the number of full frequency range audio channels that the signal includes. The number after the period indicates the number of those channels which are reserved for low-frequency effect (LFE) outputs; these are often referred to as **subwoofers**.
+> **Note:** The [channel notation](https://en.wikipedia.org/wiki/Surround_sound#Channel_notation) is a numeric value, such as _2.0_ or _5.1_, representing the number of audio channels available on a signal. The first number is the number of full frequency range audio channels the signal includes. The number appearing after the period indicates the number of those channels reserved for low-frequency effect (LFE) outputs; these are often called **subwoofers**.
 
-![A simple box diagram with an outer box labeled Audio context, and three inner boxes labeled Sources, Effects and Destination. The three inner boxes have arrow between them pointing from left to right, indicating the flow of audio information.](webaudioapi_en.svg)
+![A simple box diagram with an outer box labeled Audio context and three inner boxes labeled Sources, Effects, and Destination. The three inner boxes have arrows between them pointing from left to right, indicating the flow of audio information.](webaudioapi_en.svg)
 
 Each input or output is composed of one or more audio **channels**, which together represent a specific audio layout. Any discrete channel structure is supported, including _mono_, _stereo_, _quad_, _5.1_, and so on.
 
-![Show the ability of AudioNodes to connect via their inputs and outputs and the channels inside these inputs/outputs.](mdn.png)
+![Show the ability of audio nodes to connect via their inputs and outputs and the channels inside these inputs/outputs.](mdn.png)
 
-Audio sources can be obtained in a number of ways:
+You have several ways to obtain audio:
 
 - Sound can be generated directly in JavaScript by an audio node (such as an oscillator).
-- Created from raw [PCM](https://en.wikipedia.org/wiki/Pulse-code_modulation) data (such as .WAV files or other formats supported by {{domxref("BaseAudioContext/decodeAudioData", "AudioContext.decodeAudioData()")}}).
-- Taken from HTML media elements (such as {{HTMLElement("video")}} or {{HTMLElement("audio")}}).
-- Taken directly from a [WebRTC](/en-US/docs/Web/API/WebRTC_API) {{domxref("MediaStream")}} (such as a webcam or microphone).
+- It can be created from raw [PCM](https://en.wikipedia.org/wiki/Pulse-code_modulation) data (such as .WAV files or other formats supported by {{domxref("BaseAudioContext/decodeAudioData", "decodeAudioData()")}}).
+- It can be generated from HTML media elements, such as {{HTMLElement("video")}} or {{HTMLElement("audio")}}.
+- It can be obtained from a [WebRTC](/en-US/docs/Web/API/WebRTC_API) {{domxref("MediaStream")}}, such as a webcam or microphone.
 
 ## Audio data: what's in a sample
 
-When an audio signal is processed, **sampling** means the conversion of a [continuous signal](https://en.wikipedia.org/wiki/Continuous_signal) to a [discrete signal](https://en.wikipedia.org/wiki/Discrete_signal); or put another way, a continuous sound wave, such as a band playing live, is converted to a sequence of digital samples (a discrete-time signal) that allow a computer to handle the audio in distinct blocks.
+When an audio signal is processed, sampling happens. **Sampling** is the conversion of a [continuous signal](https://en.wikipedia.org/wiki/Continuous_signal) to a [discrete signal](https://en.wikipedia.org/wiki/Discrete_signal). Put another way, a continuous sound wave, such as a band playing live, is converted into a sequence of digital samples (a discrete-time signal) that allows a computer to handle the audio in distinct blocks.
 
-A lot more information can be found on the Wikipedia page [Sampling (signal processing)](https://en.wikipedia.org/wiki/Sampling_%28signal_processing%29).
+You'll find more information on the Wikipedia page [_Sampling (signal processing)_](https://en.wikipedia.org/wiki/Sampling_%28signal_processing%29).
 
 ## Audio buffers: frames, samples, and channels
 
-An {{domxref("AudioBuffer")}} takes as its parameters, a number of channels (1 for mono, 2 for stereo, etc.), a length, meaning the number of sample frames inside the buffer, and a sample rate, which is the number of sample frames played per second.
+An {{domxref("AudioBuffer")}} is defined with three parameters:
 
-A sample is a single 32-bit floating point value that represents the value of the audio stream at each specific point in time, in a specific channel (left or right, if in the case of stereo). A frame, or sample frame, is the set of all values for all channels that will play at a specific point in time: all the samples of all the channels that play at the same time (two for a stereo sound, six for 5.1, etc.).
+- the number of channels (1 for mono, 2 for stereo, etc.),
+- its length, meaning the number of sample frames inside the buffer,
+- and the sample rate, the number of sample frames played per second.
 
-The sample rate is the number of those samples (or frames, since all samples of a frame play at the same time) that will play in one second, measured in Hz. The higher the sample rate, the better the sound quality.
+A _sample_ is a single 32-bit floating point value representing the value of the audio stream at each specific moment in time within a particular channel (left or right, if in the case of stereo). A _frame_, or _sample frame_, is the set of all values for all channels that will play at a specific moment in time: all the samples of all the channels that play at the same time (two for a stereo sound, six for 5.1, etc.).
+
+The _sample rate_ is the quantity of those samples (or frames, since all samples of a frame play at the same time) that will play in one second, measured in Hz. The higher the sample rate, the better the sound quality.
 
 Let's look at a _mono_ and a _stereo_ audio buffer, each one second long at a rate of 44100Hz:
 
-- The _mono_ buffer will have 44100 samples, and 44100 frames. The `length` property will be 44100.
-- The _stereo_ buffer will have 88200 samples, but still 44100 frames. The `length` property will still be 44100 since it's equal to the number of frames.
+- The _mono_ buffer will have 44,100 samples and 44,100 frames. The `length` property will be 44,100.
+- The _stereo_ buffer will have 88,200 samples but still 44,100 frames. The `length` property will still be 44100 since it equals the number of frames.
 
 ![A diagram showing several frames in an audio buffer in a long line, each one containing two samples, as the buffer has two channels, it is stereo.](sampleframe-english.png)
 
-When a buffer plays, you will first hear the leftmost sample frame, then the one right next to it, then the next, _and so on_, until the end of the buffer. In the case of stereo, you will hear both channels at the same time. Sample frames are very useful because they are independent of the number of channels and they represent time in a ideal way for doing precise audio manipulation.
+When a buffer plays, you will first hear the leftmost sample frame, then the one right next to it, then the next, _and so on_, until the end of the buffer. In the case of stereo, you will hear both channels simultaneously. Sample frames are handy because they are independent of the number of channels and represent time in an ideal way for precise audio manipulation.
 
-> **Note:** To get a time in seconds from a frame count, divide the number of frames by the sample rate. To get a number of frames from a number of samples, divide by the channel count.
+> **Note:** To get a time in seconds from a frame count, divide the number of frames by the sample rate. To get the number of frames from the number of samples, you only need to divide the latter value by the channel count.
 
 Here are a couple of simple examples:
 
 ```js
-var context = new AudioContext();
-var buffer = context.createBuffer(2, 22050, 44100);
+const context = new AudioContext();
+const buffer = new AudioBuffer(context, {
+  numberOfChannels: 2, 
+  length: 22050, 
+  sampleRate: 44100
+});
 ```
 
-> **Note:** In [digital audio](https://en.wikipedia.org/wiki/Digital_audio), **44,100 [Hz](https://en.wikipedia.org/wiki/Hertz)** (alternately represented as **44.1 kHz**) is a common [sampling frequency](https://en.wikipedia.org/wiki/Sampling_frequency). Why 44.1kHz?
+> **Note:** In [digital audio](https://en.wikipedia.org/wiki/Digital_audio), **44,100 [Hz](https://en.wikipedia.org/wiki/Hertz)** (alternately represented as **44.1 kHz**) is a common [sampling frequency](https://en.wikipedia.org/wiki/Sampling_frequency). Why 44.1 kHz?
 >
 > Firstly, because the [hearing range](https://en.wikipedia.org/wiki/Hearing_range) of human ears is roughly 20 Hz to 20,000 Hz. Via the [Nyquist–Shannon sampling theorem](https://en.wikipedia.org/wiki/Nyquist%E2%80%93Shannon_sampling_theorem), the sampling frequency must be greater than twice the maximum frequency one wishes to reproduce. Therefore, the sampling rate has to be _greater_ than 40,000 Hz.
 >
-> Secondly, signals must be [low-pass filtered](https://en.wikipedia.org/wiki/Low-pass_filter "Low-pass filter") before sampling, otherwise [aliasing](https://en.wikipedia.org/wiki/Aliasing) occurs. While an ideal low-pass filter would perfectly pass frequencies below 20 kHz (without attenuating them) and perfectly cut off frequencies above 20 kHz, in practice a [transition band](https://en.wikipedia.org/wiki/Transition_band) is necessary, where frequencies are partly attenuated. The wider this transition band is, the easier and more economical it is to make an [anti-aliasing filter](https://en.wikipedia.org/wiki/Anti-aliasing_filter). The 44.1 kHz sampling frequency allows for a 2.05 kHz transition band.
+> Secondly, signals must be [low-pass filtered](https://en.wikipedia.org/wiki/Low-pass_filter "Low-pass filter") before sampling, otherwise [aliasing](https://en.wikipedia.org/wiki/Aliasing) occurs. While an ideal low-pass filter would perfectly pass frequencies below 20 kHz (without attenuating them) and perfectly cut off frequencies above 20 kHz, in practice, a [transition band](https://en.wikipedia.org/wiki/Transition_band) is necessary, where frequencies are partly attenuated. The wider this transition band is, the easier and more economical it is to make an [anti-aliasing filter](https://en.wikipedia.org/wiki/Anti-aliasing_filter). The 44.1 kHz sampling frequency allows for a 2.05 kHz transition band.
 
-If you use this call above, you will get a stereo buffer with two channels, that when played back on an {{domxref("AudioContext")}} running at 44100Hz (very common, most normal sound cards run at this rate), will last for 0.5 seconds: 22050 frames/44100Hz = 0.5 seconds.
+If you use this call above, you will get a stereo buffer with two channels that, when played back on an {{domxref("AudioContext")}} running at 44100 Hz (very common, most normal sound cards run at this rate), will last for 0.5 seconds: 22,050 frames/44,100 Hz = 0.5 seconds.
 
 ```js
-var context = new AudioContext();
-var buffer = context.createBuffer(1, 22050, 22050);
+const context = new AudioContext();
+const buffer = new AudioBuffer(context, {
+  numberOfChannels: 1, 
+  length: 22050, 
+  sampleRate: 22050
+});
 ```
 
-If you use this call, you will get a mono buffer (single-channel buffer) that, when played back on an {{domxref("AudioContext")}} running at 44100Hz, will be automatically _resampled_ to 44100Hz (and therefore yield 44100 frames), and last for 1.0 second: 44100 frames/44100Hz = 1 second.
+If you use this call, you will get a mono buffer (single-channel buffer) that, when played back on an {{domxref("AudioContext")}} running at 44,100 Hz, will be automatically _resampled_ to 44,100 Hz (and therefore yield 44,100 frames), and last for 1.0 second: 44,100 frames/44,100 Hz = 1 second.
 
-> **Note:** Audio resampling is very similar to image resizing. Say you've got a 16 x 16 image, but you want it to fill a 32 x 32 area. You resize (or resample) it. The result has less quality (it can be blurry or edgy, depending on the resizing algorithm), but it works, with the resized image taking up less space. Resampled audio is exactly the same: you save space, but, in practice, you will be unable to properly reproduce high frequency content, or treble sound.
+> **Note:** Audio resampling is very similar to image resizing. Say you've got a 16 x 16 image but want it to fill a 32 x 32 area. You resize (or resample) it. The result has less quality (it can be blurry or edgy, depending on the resizing algorithm), but it works, with the resized image taking up less space. Resampled audio is the same: you save space, but, in practice, you cannot correctly reproduce high-frequency content or treble sound.
 
 ### Planar versus interleaved buffers
 
@@ -102,7 +114,7 @@ The Web Audio API uses a planar buffer format. The left and right channels are s
 LLLLLLLLLLLLLLLLRRRRRRRRRRRRRRRR (for a buffer of 16 frames)
 ```
 
-This is very common in audio processing as it makes it easy to process each channel independently.
+This structure is widespread in audio processing, making it easy to process each channel independently.
 
 The alternative is to use an interleaved buffer format:
 
@@ -110,13 +122,13 @@ The alternative is to use an interleaved buffer format:
 LRLRLRLRLRLRLRLRLRLRLRLRLRLRLRLR (for a buffer of 16 frames)
 ```
 
-This format is very common for storing and playing back audio without much processing, for example: .WAV files or a decoded MP3 stream.
+This format is prevalent for storing and playing back audio without much processing, for example: .WAV files or a decoded MP3 stream.
 
-The Web Audio API exposes **only** planar buffers, because it's made for processing. It works with planar, but converts the audio to interleaved when it is sent to the sound card for playback. Conversely, when an MP3 is decoded, it starts off in interleaved format, but is converted to planar for processing.
+Because the Web Audio API is designed for processing, it exposes _only_ planar buffers. It uses the planar format but converts the audio to the interleaved format when it sends it to the sound card for playback. Conversely, when the API decodes an MP3, it starts with the interleaved format and converts it to the planar format for processing.
 
 ## Audio channels
 
-Different audio buffers contain different numbers of channels; from the more basic mono (only one channel) and stereo (left and right channels) making up the majority of modern audio devices, to the more complex "surround sound" sets like quad and 5.1, which can lead to a richer sound experience by virtue of their high channel count. The channels are usually represented by the standard abbreviations detailed in the table below:
+Each audio buffer may contain different numbers of channels. Most modern audio devices use the basic _mono_ (only one channel) and _stereo_ (left and right channels) settings. Some more complex sets support _surround sound_ settings (like _quad_ and _5.1_), which can lead to a richer sound experience thanks to their high channel count. We usually represent the channels with the standard abbreviations detailed in the table below:
 
 | Name     | Channels                                                                                           |
 | -------- | -------------------------------------------------------------------------------------------------- |
@@ -127,7 +139,7 @@ Different audio buffers contain different numbers of channels; from the more bas
 
 ### Up-mixing and down-mixing
 
-When the number of channels doesn't match between an input and an output, up- or down-mixing happens according the following rules. This can be somewhat controlled by setting the {{domxref("AudioNode.channelInterpretation")}} property to `speakers` or `discrete`:
+When the numbers of channels of the input and the output don't match, up-mixing, or down-mixing, must be done. The following rules, controlled by setting the {{domxref("AudioNode.channelInterpretation")}} property to `speakers` or `discrete`, apply:
 
 <table class="standard-table">
   <thead>
@@ -267,7 +279,7 @@ When the number of channels doesn't match between an input and an output, up- or
         <em>Down-mix from 5.1 to mono.</em><br />The left (<code>L</code> and
         <code>SL</code>), right (<code>R</code> and <code>SR</code>) and central
         channels are all mixed together. The surround channels are slightly
-        attenuated and the regular lateral channels are power-compensated to
+        attenuated, and the regular lateral channels are power-compensated to
         make them count as a single channel by multiplying by <code>√2/2</code>.
         The subwoofer (<code>LFE</code>) channel is lost.<br /><code
           >output.M = 0.7071 * (input.L + input.R) + input.C + 0.5 * (input.SL +
@@ -284,7 +296,7 @@ When the number of channels doesn't match between an input and an output, up- or
           >SL</code
         >
         or <code>SR</code>) and mixed to each lateral channel. As it is mixed
-        down to two channels, it is mixed at a lower power: in each case it is
+        down to two channels, it is mixed at a lower power: in each case, it is
         multiplied by <code>√2/2</code>. The subwoofer (<code>LFE</code>)
         channel is lost.<br /><code
           >output.L = input.L + 0.7071 * (input.C + input.SL)<br />output.R =
@@ -299,7 +311,7 @@ When the number of channels doesn't match between an input and an output, up- or
         <em>Down-mix from 5.1 to quad.</em><br />The central (<code>C</code>) is
         mixed with the lateral non-surround channels (<code>L</code> and
         <code>R</code>). As it is mixed down to two channels, it is mixed at a
-        lower power: in each case it is multiplied by <code>√2/2</code>. The
+        lower power: in each case, it is multiplied by <code>√2/2</code>. The
         surround channels are passed unchanged. The subwoofer (<code>LFE</code>)
         channel is lost.<br /><code
           >output.L = input.L + 0.7071 * input.C<br />output.R = input.R +
@@ -311,12 +323,9 @@ When the number of channels doesn't match between an input and an output, up- or
     <tr>
       <td colspan="2">Other, non-standard layouts</td>
       <td>
-        Non-standard channel layouts are handled as if
+        Non-standard channel layouts behave as if
         <code>channelInterpretation</code> is set to
-        <code>discrete</code>.<br />The specification explicitly allows the
-        future definition of new speaker layouts. This fallback is therefore not
-        future proof as the behavior of the browsers for a specific number of
-        channels may change in the future.
+        <code>discrete</code>.<br />The specification explicitly allows the future definition of new speaker layouts. Therefore, this fallback is not future-proof as the behavior of the browsers for a specific number of channels may change in the future.
       </td>
     </tr>
     <tr>
@@ -343,9 +352,9 @@ When the number of channels doesn't match between an input and an output, up- or
 
 ## Visualizations
 
-In general, audio visualizations are achieved by accessing an output of audio data over time, usually gain or frequency data, and then using a graphical technology to turn that into a visual output, such as a graph. The Web Audio API has an {{domxref("AnalyserNode")}} available that doesn't alter the audio signal passing through it. Instead, it outputs audio data that can be passed to a visualization technology such as {{htmlelement("canvas")}}.
+In general, we get the output over time to produce audio visualizations, usually reading its gain or frequency data. Then, using a graphical tool, we turn the obtained data into a visual representation, such as a graph. The Web Audio API has an {{domxref("AnalyserNode")}} available that doesn't alter the audio signal passing through it. Additionally, it outputs the audio data allowing us to process it via a technology such as {{htmlelement("canvas")}}.
 
-![Without modifying the audio stream, the node allows to get the frequency and time-domain data associated to it, using an FFT.](fttaudiodata_en.svg)
+![Without modifying the audio stream, the node allows to get the frequency and time-domain data associated with it, using an FFT.](fttaudiodata_en.svg)
 
 You can grab data using the following methods:
 
@@ -364,11 +373,11 @@ You can grab data using the following methods:
 
 Audio spatialization allows us to model the position and behavior of an audio signal at a certain point in physical space, simulating the listener hearing that audio. In the Web Audio API, spatialization is handled by the {{domxref("PannerNode")}} and the {{domxref("AudioListener")}}.
 
-The panner uses right-hand Cartesian coordinates to describe the audio source's _position_ as a vector and its _orientation_ as a 3D directional cone. The cone can be very large, e.g. for omnidirectional sources.
+The panner uses right-hand Cartesian coordinates to describe the audio source's _position_ as a vector and its _orientation_ as a 3D directional cone. The cone can be pretty large, for example, for omnidirectional sources.
 
 ![The PannerNode defines a spatial position and orientation for a given signal.](pannernode_en.svg)
 
-The listener is similarly described using right-hand Cartesian coordinates, with their _position_ as a vector (implicitly representing the "center" of their head), and their _orientation_ as two direction vectors: _up_ and _front_. Respectively, these vectors define the direction of the top of the listener's head, and the direction the listener's nose is pointing. The vectors are perpendicular to one another.
+Similarly, the Web Audio API describes the listener using right-hand Cartesian coordinates: their _position_ as one vector and their _orientation_ as two direction vectors, _up_ and _front_. These vectors define the direction of the top of the listener's head and the direction the listener's nose is pointing. The vectors are perpendicular to one another.
 
 ![We see the position, up, and front vectors of an AudioListener, with the up and front vectors at 90° from the other.](webaudiolistenerreduced.png)
 


### PR DESCRIPTION
There was a factory method used. I transformed it into the constructor, to match what we do in the examples.

Made a pass through the text.