### PR TITLE
Remove reference to linebreaking attributes

### DIFF
--- a/files/en-us/web/mathml/element/mo/index.md
+++ b/files/en-us/web/mathml/element/mo/index.md
@@ -89,4 +89,3 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 ### Gecko-specific notes
 
 - Starting with Gecko 16.0 {{ geckoRelease("16.0") }} the default values for `lspace` and `rspace` have been corrected to match the MathML3 specification. They now default to the constant `thickmathspace` (5/18em).
-- Any [linebreaking](https://www.w3.org/TR/MathML3/chapter3.html#presm.lbattrs) or [indentation attributes](https://www.w3.org/TR/MathML3/chapter3.html#presm.lbindent.attrs) are not implemented yet. See {{ bug("534962") }}.

--- a/files/en-us/web/mathml/element/mstyle/index.md
+++ b/files/en-us/web/mathml/element/mstyle/index.md
@@ -16,8 +16,6 @@ The MathML `<mstyle>` element is used change the style of its children. It accep
 
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-- `infixlinebreakstyle`
-  - : Specifies the default `linebreakstyle` to use for infix operators. The values `before`, `after` and `duplicate` are allowed.
 - `scriptminsize`
   - : Specifies a minimum font size allowed due to changes in `scriptlevel`. The default value is 8pt.
 - `scriptsizemultiplier`


### PR DESCRIPTION
#### Summary

Remove reference to linebreaking attributes from mo and mstyle elements.

#### Motivation

These attributes are from MathML3 but they have never been implemented
in any browser and they are currently not part of MathML Core. It's not clear
if in the future linebreaking would actually follow the same design as
MathML3, so let's remove these for now to avoid confusing web developers.

#### Supporting details

N/A

#### Related issues

N/A

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
