### PR TITLE
Remove spaces inside string template expressions

### DIFF
--- a/files/en-us/web/api/animation/commitstyles/index.md
+++ b/files/en-us/web/api/animation/commitstyles/index.md
@@ -36,7 +36,7 @@ const divElem = document.querySelector('div');
 
 document.body.addEventListener('mousemove', evt => {
   let anim = divElem.animate(
-    { transform: `translate(${ evt.clientX}px, ${evt.clientY}px)` },
+    { transform: `translate(${evt.clientX}px, ${evt.clientY}px)` },
     { duration: 500, fill: 'forwards' }
   );
 

--- a/files/en-us/web/api/animation/persist/index.md
+++ b/files/en-us/web/api/animation/persist/index.md
@@ -38,7 +38,7 @@ const divElem = document.querySelector('div');
 
 document.body.addEventListener('mousemove', evt => {
   let anim = divElem.animate(
-    { transform: `translate(${ evt.clientX}px, ${evt.clientY}px)` },
+    { transform: `translate(${evt.clientX}px, ${evt.clientY}px)` },
     { duration: 500, fill: 'forwards' }
   );
 

--- a/files/en-us/web/api/animation/remove_event/index.md
+++ b/files/en-us/web/api/animation/remove_event/index.md
@@ -45,7 +45,7 @@ const divElem = document.querySelector('div');
 
 document.body.addEventListener('mousemove', evt => {
   let anim = divElem.animate(
-    { transform: `translate(${ evt.clientX}px, ${evt.clientY}px)` },
+    { transform: `translate(${evt.clientX}px, ${evt.clientY}px)` },
     { duration: 500, fill: 'forwards' }
   );
 

--- a/files/en-us/web/api/animation/replacestate/index.md
+++ b/files/en-us/web/api/animation/replacestate/index.md
@@ -35,7 +35,7 @@ const divElem = document.querySelector('div');
 
 document.body.addEventListener('mousemove', evt => {
   let anim = divElem.animate(
-    { transform: `translate(${ evt.clientX}px, ${evt.clientY}px)` },
+    { transform: `translate(${evt.clientX}px, ${evt.clientY}px)` },
     { duration: 500, fill: 'forwards' }
   );
 

--- a/files/en-us/web/api/cachestorage/index.md
+++ b/files/en-us/web/api/cachestorage/index.md
@@ -110,7 +110,7 @@ This snippet shows how the API can be used outside of a service worker context, 
 // Try to get data from the cache, but fall back to fetching it live.
 async function getData() {
    const cacheVersion = 1;
-   const cacheName    = `myapp-${ cacheVersion }`;
+   const cacheName    = `myapp-${cacheVersion}`;
    const url          = 'https://jsonplaceholder.typicode.com/todos/1';
    let cachedData     = await getCachedData( cacheName, url );
 

--- a/files/en-us/web/api/element/getboundingclientrect/index.md
+++ b/files/en-us/web/api/element/getboundingclientrect/index.md
@@ -110,7 +110,7 @@ let rect = elem.getBoundingClientRect();
 for (var key in rect) {
   if(typeof rect[key] !== 'function') {
     let para = document.createElement('p');
-    para.textContent  = `${ key } : ${ rect[key] }`;
+    para.textContent  = `${key} : ${rect[key]}`;
     document.body.appendChild(para);
   }
 }
@@ -158,7 +158,7 @@ function update() {
   for (let key in rect) {
     if(typeof rect[key] !== 'function') {
       let para = document.createElement('p');
-      para.textContent  = `${ key } : ${ rect[key] }`;
+      para.textContent  = `${key} : ${rect[key]}`;
       container.appendChild(para);
     }
   }

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -279,7 +279,7 @@ const myRequest = new Request('flowers.jpg');
 fetch(myRequest)
   .then((response) => {
     if (!response.ok) {
-      throw new Error(`HTTP error! Status: ${ response.status }`);
+      throw new Error(`HTTP error! Status: ${response.status}`);
     }
 
     return response.blob();

--- a/files/en-us/web/api/htmlareaelement/hostname/index.md
+++ b/files/en-us/web/api/htmlareaelement/hostname/index.md
@@ -38,8 +38,8 @@ const area1 = document.getElementById("area1");
 const area2 = document.getElementById("area2");
 
 const log = document.getElementById("log");
-log.textContent = `area1 hostname: ${ area1.hostname } \n`; // 'developer.mozilla.org'
-log.textContent += `area2 hostname: ${ area2.hostname }`;  // 'coolexample.com'
+log.textContent = `area1 hostname: ${area1.hostname} \n`; // 'developer.mozilla.org'
+log.textContent += `area2 hostname: ${area2.hostname}`;  // 'coolexample.com'
 ```
 
 {{EmbedLiveSample("Examples")}}

--- a/files/en-us/web/api/navigator/mimetypes/index.md
+++ b/files/en-us/web/api/navigator/mimetypes/index.md
@@ -41,7 +41,7 @@ if ('application/pdf' in navigator.mimeTypes) {
   // browser supports inline viewing of PDF files.
 
   const { description, suffixes } = navigator.mimeTypes['application/pdf'];
-  console.log(`Description: ${ description }, Suffix: ${ suffixes }`);
+  console.log(`Description: ${description}, Suffix: ${suffixes}`);
   // expected output: Description: Portable Document Format, Suffix: pdf
 }
 ```

--- a/files/en-us/web/api/touch_events/index.md
+++ b/files/en-us/web/api/touch_events/index.md
@@ -100,7 +100,7 @@ function handleStart(evt) {
     log(`touchstart: ${i}.`);
     ongoingTouches.push(copyTouch(touches[i]));
     const color = colorForTouch(touches[i]);
-    log(`color of touch with id ${ touches[i].identifier } = ${ color }`);
+    log(`color of touch with id ${touches[i].identifier} = ${color}`);
     ctx.beginPath();
     ctx.arc(touches[i].pageX, touches[i].pageY, 4, 0, 2 * Math.PI, false);  // a circle at the start
     ctx.fillStyle = color;
@@ -129,11 +129,11 @@ function handleMove(evt) {
     const idx = ongoingTouchIndexById(touches[i].identifier);
 
     if (idx >= 0) {
-      log(`continuing touch ${ idx }`);
+      log(`continuing touch ${idx}`);
       ctx.beginPath();
-      log(`ctx.moveTo( ${ ongoingTouches[idx].pageX }, ${ ongoingTouches[idx].pageY } );`);
+      log(`ctx.moveTo( ${ongoingTouches[idx].pageX}, ${ongoingTouches[idx].pageY} );`);
       ctx.moveTo(ongoingTouches[idx].pageX, ongoingTouches[idx].pageY);
-      log(`ctx.lineTo( ${ touches[i].pageX }, ${ touches[i].pageY } );`);
+      log(`ctx.lineTo( ${touches[i].pageX}, ${touches[i].pageY} );`);
       ctx.lineTo(touches[i].pageX, touches[i].pageY);
       ctx.lineWidth = 4;
       ctx.strokeStyle = color;
@@ -262,7 +262,7 @@ function ongoingTouchIndexById(idToFind) {
 ```js
 function log(msg) {
   const container = document.getElementById('log');
-  container.textContent = `${ msg } \n${ container.textContent }`;
+  container.textContent = `${msg} \n${container.textContent}`;
 }
 
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
This PR ensures that code samples comply with the [`template-curly-spacing`](https://eslint.org/docs/latest/rules/template-curly-spacing) ESLint rule.

#### Motivation
This is in preparation of https://github.com/orgs/mdn/discussions/143#discussioncomment-3193114 where I'm going to let ESLint automatically fix `prefer-template`. However, running `prefer-template` directly causes changes like this:

```js
console.log('Download error: ' + e.message);
```
--->
```js
console.log(`Download error: ${  e.message}`);
```

(Note the extra space inside the template expression.)
According to [this comment](https://github.com/eslint/eslint/issues/8520#issuecomment-297872379), ESLint does this on purpose:

> [...] the rule preserves spacing there so that it doesn't end up removing any comments that might appear on either side of the operator. You can use [template-curly-spacing](http://eslint.org/docs/rules/template-curly-spacing) if you want the whitespace there to be automatically removed.

Long story short, this PR fixes all *existing* violations of `template-curly-spacing` to make further PRs easier to review.

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
