### PR TITLE
Remove Gecko-specific notes for menclose@notation

### DIFF
--- a/files/en-us/web/mathml/element/menclose/index.md
+++ b/files/en-us/web/mathml/element/menclose/index.md
@@ -61,11 +61,3 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 ## Browser compatibility
 
 {{Compat}}
-
-## Gecko-specific notes
-
-- Additional values for the `notation` attribute have been added in the following releases:
-
-  - `madruwb` in Gecko 2.0 {{GeckoRelease("2.0")}}.
-  - `updiagonalarrow` in Gecko 24.0 {{GeckoRelease("24.0")}}
-  - `phasorangle` in Gecko 32.0 {{GeckoRelease("32.0")}}


### PR DESCRIPTION
#### Summary

Remove Gecko-specific notes for menclose@notation

#### Motivation

These are better handled as `notes` in browser-compat-data.

#### Supporting details

N/A

#### Related issues

https://github.com/mdn/browser-compat-data/pull/17062

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
