### PR TITLE
Fix erroneous example in the best practice section of aria-keyshortcuts page

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-keyshortcuts/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-keyshortcuts/index.md
@@ -79,7 +79,7 @@ Unless you're creating an HTML version of a productivity application, you should
 
 #### Consider language and keyboard differences
 
-Take into account the diversity of available keyboards and the various keyboard language preferences. Modifier keys are often used to create language specific common punctuation symbols and number characters. For example, numbers, when the keyboard language preference is set to French, use the Control key.
+Take into account the diversity of available keyboards and the various keyboard language preferences. Modifier keys are often used to create language specific common punctuation symbols and number characters. For example, numbers, when the keyboard language preference is set to French (France), use the Shift key.
 
 #### **Don't** use HTML instead
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
In the "Consider language and keyboard differences" section of [aria-keyshortcuts](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-keyshortcuts) page, fixed the example based on the French keyboard as follows to be in accordance with reality:
1. Changed the modifier used to type numbers from `Control` to `Shift`
2. Specified explicitly "French (France)" keyboard layout instead of only "French", since not all French keyboard layout use `Shift` to type numbers (e.g. Switzerland, Canada)

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Current example in the page was erroneous: French  (France) keyboard layout use `Shift` modifier to type a number, not `Control`.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Discussion in #18580.
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

Fixes #18580

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
