### PR TITLE
Remove Gecko-specific note for mo@lspace and mo@rspace

### DIFF
--- a/files/en-us/web/mathml/element/mo/index.md
+++ b/files/en-us/web/mathml/element/mo/index.md
@@ -85,7 +85,3 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 ## Browser compatibility
 
 {{Compat}}
-
-### Gecko-specific notes
-
-- Starting with Gecko 16.0 {{ geckoRelease("16.0") }} the default values for `lspace` and `rspace` have been corrected to match the MathML3 specification. They now default to the constant `thickmathspace` (5/18em).


### PR DESCRIPTION
#### Summary

Remove Gecko-specific note for mo@lspace and mo@rspace

#### Motivation

These are better handled as notes in browser-compat-data.

#### Supporting details

N/A

#### Related issues

https://github.com/mdn/browser-compat-data/pull/17063

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
