### PR TITLE
Remove Gecko-specific notes for semantics

### DIFF
--- a/files/en-us/web/mathml/element/semantics/index.md
+++ b/files/en-us/web/mathml/element/semantics/index.md
@@ -94,8 +94,3 @@ The following attributes can be set on `<annotation>` and `<annotation-xml>`:
 ## Browser compatibility
 
 {{Compat}}
-
-## Gecko-specific notes
-
-- The algorithm of determining the visible child in `<semantics>` has been corrected in {{geckoRelease("23")}} to match the MathML specification. In prior versions the first child element has been rendered.
-- In Gecko `<annotation>` and `<annotation-xml>` elements are ignored if the `src` attribute is set.


### PR DESCRIPTION
#### Summary

Remove Gecko-specific notes for semantics

#### Motivation

These are better handled as notes in browser-compat-data.

#### Supporting details

N/A

#### Related issues

https://github.com/mdn/browser-compat-data/pull/17065

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
