### PR TITLE
Remove Firefox-specific notes for the <math> element

### DIFF
--- a/files/en-us/web/mathml/element/math/index.md
+++ b/files/en-us/web/mathml/element/math/index.md
@@ -118,12 +118,6 @@ In addition to the following attributes, the `<math>` element accepts any attrib
 
 {{Compat}}
 
-## Firefox-specific notes
-
-Firefox 7 introduced support for accepting all MathML attributes on the top-level math element (i.e. the same behavior as a {{ MathMLElement("mstyle") }} element). However, the `displaystyle` attribute was not taken into account and [has been added](https://bugzilla.mozilla.org/show_bug.cgi?id=669719) in Firefox 8.
-
-A textual fall-back (`alttext`) or referring to an alternative image using the attributes `altimg`, `altimg-width`, `altimg-height` or `altimg-valign` is currently not implemented in Firefox.
-
 ## See also
 
 - HTML top-level element: {{ HTMLElement("html") }}


### PR DESCRIPTION
#### Summary

Remove Firefox-specific notes for the math element which
are not very relevant, or are confusing, for web developers.

#### Motivation

The first note essentially says that some mstyle attributes were
implemented on the math element in Firefox 7 and 8. Nowadays, these
are actually global attributes so they are no longer mentioned on the
specific article for the math tag. Moreover [1] currently says

"Prior to Firefox 70, the attribute was only accepted on a few elements,
as specified in MathML 3."

so that seems enough information, no need to be more specific about
when the attributes were implemented on the <math> tag.

The second note mentions alttext/altimg/altimg-width/altimg-height,
altimg-valign from MathML3. These are actually not part of MathML
Core, not implemented in browsers (they would instead expose an a11y
tree as described in [2]) and not even mentioned on the article itself.
We can add this back if it turns out that these are added in future
MathML Core versions, but for now let's remove them to avoid any
confusion for web developers.

#### Supporting details

[1] https://developer.mozilla.org/en-US/docs/Web/MathML/Global_attributes
[2] https://w3c.github.io/mathml-aam/

#### Related issues

N/A

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
