### PR TITLE
Remove Gecko-specific notes for mspace

### DIFF
--- a/files/en-us/web/mathml/element/mspace/index.md
+++ b/files/en-us/web/mathml/element/mspace/index.md
@@ -45,10 +45,6 @@ Note that some common attributes like `mathcolor`, `mathvariant` or `dir` have n
 
 {{Compat}}
 
-## Gecko-specific notes
-
-- Support for negative values for the `width` attribute has been implemented in Gecko 23.0 {{geckoRelease("23.0")}}.
-
 ## See also
 
 - {{ MathMLElement("mpadded") }}


### PR DESCRIPTION
#### Summary

Remove Gecko-specific notes for mspace

#### Motivation

These are better handled as notes in browser-compat-data.

#### Supporting details

N/A

#### Related issues

N/A

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
