### PR TITLE
Remove some notes for MathML global attributes.

### DIFF
--- a/files/en-us/web/mathml/global_attributes/displaystyle/index.md
+++ b/files/en-us/web/mathml/global_attributes/displaystyle/index.md
@@ -42,10 +42,6 @@ In this example, an [munder](/en-US/docs/Web/MathML/Element/munder) element is u
 - `false`
    -: Sets the display style to `compact`.
 
-## Notes on MathML versions
-
-- MathML Core relies on `math-style` to implement the `displaystyle` attribute, but implementations of older MathML versions may follow a different approach to implement similar behavior.
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/mathml/global_attributes/mathsize/index.md
+++ b/files/en-us/web/mathml/global_attributes/mathsize/index.md
@@ -32,8 +32,6 @@ The **`mathsize`** [global attribute](/en-US/docs/Web/MathML/Global_attributes) 
 - {{cssxref("&lt;percentage&gt;")}}
   - : A positive {{cssxref("&lt;percentage&gt;")}} value, relative to the parent element's font size.
 
-## Notes on MathML versions
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/mathml/global_attributes/mathvariant/index.md
+++ b/files/en-us/web/mathml/global_attributes/mathvariant/index.md
@@ -92,12 +92,6 @@ which are by convention italic, no special classes are used by default.
 - `stretched`
    -: Try and use stretched characters e.g. "𞹢".
 
-## Notes on MathML versions
-
-- `mathvariant` values other than `normal` were designed for backward compatibility. Authors are encouraged to instead directly use the corresponding Unicode characters from the [Mathematical Alphanumeric Symbols](https://en.wikipedia.org/wiki/Mathematical_Alphanumeric_Symbols).
-
-- MathML Core relies on `text-transform` to implement the `mathvariant` attribute, but implementations of older MathML versions may follow a different approach to implement similar behavior.
-
 ## Specifications
 
 {{Specifications}}
@@ -105,7 +99,6 @@ which are by convention italic, no special classes are used by default.
 ## Browser compatibility
 
 {{Compat}}
-On Firefox, some `mathvariant` values are only implemented starting with Firefox 28 and require appropriate [math fonts](/en-US/docs/Web/MathML/Fonts).
 
 ## See also
 

--- a/files/en-us/web/mathml/global_attributes/scriptlevel/index.md
+++ b/files/en-us/web/mathml/global_attributes/scriptlevel/index.md
@@ -52,10 +52,6 @@ If `<U>` is an unsigned [integer](/en-US/docs/Web/CSS/integer) (i.e. with prefix
       -: Sets the `math-depth` to value `add(-<U>)`. This will scale up
         `font-size` on the element `<U>` times.
 
-## Notes on MathML versions
-
-- MathML Core relies on `math-depth` to implement the `scriptlevel` attribute, but implementations of older MathML versions may follow a different approach to implement similar side-effect on the `font-size` within mathematical formulas.
-
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
#### Summary

This is a follow-up of [1]:

- Comments that displaystyle/scriptlevel/mathvariant
  are implemented via CSS are moved to
  browser-compat-data [2].

- mathsize: empty section is removed.

- mathvariant: recommendation to use Unicode characters is
  removed, since it's repeating a note above on the page.
  The vague statement about partial implementation in
  Firefox 28 as well as the comment to have appropriate
  fonts are removed, as they are not really important.

#### Motivation

Remove confusing notes for web developers and move
implementation-specific info to browser-compat-data.

#### Supporting details

[1] https://github.com/mdn/content/pull/17812
[2] https://github.com/mdn/browser-compat-data/pull/17067

#### Related issues

https://github.com/mdn/browser-compat-data/pull/17067

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
