### PR TITLE
Element»scrollIntoView() doc: affects ancestor containers (not just parent)

### DIFF
--- a/files/en-us/web/api/element/scrollintoview/index.md
+++ b/files/en-us/web/api/element/scrollintoview/index.md
@@ -17,8 +17,8 @@ browser-compat: api.Element.scrollIntoView
 {{APIRef("DOM")}}
 
 The {{domxref("Element")}} interface's
-**`scrollIntoView()`** method scrolls the element's parent
-container such that the element on which `scrollIntoView()` is called is
+**`scrollIntoView()`** method scrolls the element's ancestor
+containers such that the element on which `scrollIntoView()` is called is
 visible to the user.
 
 ## Syntax


### PR DESCRIPTION
#### Summary
A simple edit that fixes a slightly misleading statement that `scrollIntoView()` only scrolls the parent.

#### Motivation
Otherwise people have to spend 2 extra minutes to confirm behaviour in the spec.

#### Supporting details
First 3 lines of [drafts.csswg.org/cssom-view/#scroll-an-element-into-view](https://drafts.csswg.org/cssom-view/#scroll-an-element-into-view)

#### Metadata

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error
