### PR TITLE
WebDriver conformance changes for Firefox 103

### DIFF
--- a/files/en-us/mozilla/firefox/releases/103/index.md
+++ b/files/en-us/mozilla/firefox/releases/103/index.md
@@ -74,7 +74,7 @@ This article provides information about the changes in Firefox 103 that will aff
 #### Marionette
 
 - Updated the `platformVersion` capability to be returned as `moz:platformVersion`  ({{bug(1771760)}}).
-- Removed support for `ChromeElement`, all elements are now serialized as `WebElement`  ({{bug(1775036)}} and {{bug(1775064)}}).
+- Removed support for `ChromeElement`; all elements are now serialized as `WebElement` ({{bug(1775036)}} and {{bug(1775064)}}).
 
 ## Changes for add-on developers
 

--- a/files/en-us/mozilla/firefox/releases/103/index.md
+++ b/files/en-us/mozilla/firefox/releases/103/index.md
@@ -64,7 +64,17 @@ This article provides information about the changes in Firefox 103 that will aff
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
-#### Removals
+#### WebDriver BiDi
+
+- Added a preference to disable experimental BiDi commands and events `remote.experimental.enabled`  ({{bug(1777951)}}).
+- Added a `script` module with an experimental implementation of the `evaluate` command. Only available if `remote.experimental.enabled` is set to `true`  ({{bug(1742979)}}).
+- Added serialization support for collections with simple values and complex objects, used for instance for the event data of `log.entryAdded` or the return value of `script.evaluate`  ({{bug(1770752)}}).
+- Fixed an edge case for `browsingContext.navigate` when navigating to a cached image  ({{bug(1763133)}}).
+
+#### Marionette
+
+- Updated the `platformVersion` capability to be returned as `moz:platformVersion`  ({{bug(1771760)}}).
+- Removed support for `ChromeElement`, all elements are now serialized as `WebElement`  ({{bug(1775036)}} and {{bug(1775064)}}).
 
 ## Changes for add-on developers
 

--- a/files/en-us/mozilla/firefox/releases/103/index.md
+++ b/files/en-us/mozilla/firefox/releases/103/index.md
@@ -66,14 +66,14 @@ This article provides information about the changes in Firefox 103 that will aff
 
 #### WebDriver BiDi
 
-- Added a preference to disable experimental BiDi commands and events `remote.experimental.enabled`  ({{bug(1777951)}}).
-- Added a `script` module with an experimental implementation of the `evaluate` command. Only available if `remote.experimental.enabled` is set to `true`  ({{bug(1742979)}}).
-- Added serialization support for collections with simple values and complex objects, used for instance for the event data of `log.entryAdded` or the return value of `script.evaluate`  ({{bug(1770752)}}).
-- Fixed an edge case for `browsingContext.navigate` when navigating to a cached image  ({{bug(1763133)}}).
+- Added a preference to disable experimental BiDi commands and events `remote.experimental.enabled` ({{bug(1777951)}}).
+- Added a `script` module with an experimental implementation of the `evaluate` command. Only available if `remote.experimental.enabled` is set to `true` ({{bug(1742979)}}).
+- Added serialization support for collections with simple values and complex objects, used for instance for the event data of `log.entryAdded` or the return value of `script.evaluate` ({{bug(1770752)}}).
+- Fixed an edge case for `browsingContext.navigate` when navigating to a cached image ({{bug(1763133)}}).
 
 #### Marionette
 
-- Updated the `platformVersion` capability to be returned as `moz:platformVersion`  ({{bug(1771760)}}).
+- Updated the `platformVersion` capability to be returned as `moz:platformVersion` ({{bug(1771760)}}).
 - Removed support for `ChromeElement`; all elements are now serialized as `WebElement` ({{bug(1775036)}} and {{bug(1775064)}}).
 
 ## Changes for add-on developers


### PR DESCRIPTION
The following PR contains all the user facing changes to Marionette for the Firefox 103 release. Here a [list of all the changes](https://bugzilla.mozilla.org/buglist.cgi?component=Agent&component=Marionette&component=WebDriver%20BiDi&v1=fixed&query_format=advanced&o1=equals&product=Remote%20Protocol&product=Testing&j_top=OR&resolution=FIXED&f1=cf_status_firefox103&list_id=16154414)

