### PR TITLE
Minor: add fieldsets, labels, and names to form controls

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/implement_a_settings_page/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/implement_a_settings_page/index.md
@@ -112,7 +112,7 @@ Next, because we've promised to provide `options.html`, let's create it. Create 
   <body>
 
     <form>
-        <label>Border color<input type="text" id="color" ></label>
+        <label>Border color <input type="text" id="color" name="color"></label>
         <button type="submit">Save</button>
     </form>
 

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/options_pages/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/options_pages/index.md
@@ -31,7 +31,7 @@ To create an options page, write an HTML file defining the page. This page can i
   <body>
     <form>
       <label>Favorite color</label>
-      <input type="text" id="color"/>
+      <input type="text" id="color" name="color"/>
       <button type="submit">Save</button>
     </form>
     <script src="options.js"></script>

--- a/files/en-us/web/accessibility/aria/annotations/index.md
+++ b/files/en-us/web/accessibility/aria/annotations/index.md
@@ -85,13 +85,17 @@ Simple descriptions basically just involve usage of `aria-description` on an ele
 
 ```html
 <section aria-description="Choose your favorite fruit — the fruit with the highest number of votes will be added to the lunch options next week.">
-  <p>Pick your favorite fruit:</p>
   <form>
-    <ul>
-      <li><label>Apple: <input type="radio" name="fruit" value="apple"></label></li>
-      <li><label>Orange: <input type="radio" name="fruit" value="orange"></label></li>
-      <li><label>Banana: <input type="radio" name="fruit" value="banana"></label></li>
-    </ul>
+    <fieldset>
+      <legend>
+        <p>Pick your favorite fruit:</p>
+      </legend>
+      <ul>
+        <li><label>Apple: <input type="radio" name="fruit" value="apple"></label></li>
+        <li><label>Orange: <input type="radio" name="fruit" value="orange"></label></li>
+        <li><label>Banana: <input type="radio" name="fruit" value="banana"></label></li>
+      </ul>
+    </fieldset>
   </form>
 </section>
 ```
@@ -103,11 +107,16 @@ If the descriptive text does appear in the UI (it should for this example), you 
 
 <section aria-describedby="fruit-desc">
   <form>
-    <ul>
-      <li><label>Apple: <input type="radio" name="fruit" value="apple"></label></li>
-      <li><label>Orange: <input type="radio" name="fruit" value="orange"></label></li>
-      <li><label>Banana: <input type="radio" name="fruit" value="banana"></label></li>
-    </ul>
+    <fieldset>
+      <legend>
+        <p>Pick your favorite fruit:</p>
+      </legend>
+      <ul>
+        <li><label>Apple: <input type="radio" name="fruit" value="apple"></label></li>
+        <li><label>Orange: <input type="radio" name="fruit" value="orange"></label></li>
+        <li><label>Banana: <input type="radio" name="fruit" value="banana"></label></li>
+      </ul>
+    </fieldset>
   </form>
 </section>
 ```

--- a/files/en-us/web/accessibility/understanding_wcag/text_labels_and_names/index.md
+++ b/files/en-us/web/accessibility/understanding_wcag/text_labels_and_names/index.md
@@ -166,10 +166,10 @@ The form element can be placed inside the {{htmlelement("label")}}, in which cas
 
 ```html
 <label>I agree to the terms and conditions.
-  <input type="checkbox" id="terms">
+  <input type="checkbox" id="terms" name="terms">
 </label>
 
-<input type="checkbox" id="emailoptin">
+<input type="checkbox" id="emailoptin" name="optin">
 <label for="emailoptin">Yes, please send me news about this product.</label>
 ```
 

--- a/files/en-us/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/applying_styles_and_colors/index.md
@@ -416,7 +416,7 @@ function draw() {
     <td><canvas id="canvas" width="150" height="150"></canvas></td>
     <td>Change the <code>miterLimit</code> by entering a new value below and clicking the redraw button.<br><br>
       <form onsubmit="return draw();">
-        <label>Miter limit</label>
+        <label for="miterLimit">Miter limit</label>
         <input type="number" size="3" id="miterLimit"/>
         <input type="submit" value="Redraw"/>
       </form>

--- a/files/en-us/web/api/document/domcontentloaded_event/index.md
+++ b/files/en-us/web/api/document/domcontentloaded_event/index.md
@@ -265,8 +265,8 @@ if (document.readyState === 'loading') {  // Loading hasn't finished yet
 </div>
 
 <div class="event-log">
-  <label>Event log:</label>
-  <textarea readonly class="event-log-contents" rows="8" cols="30"></textarea>
+  <label for="eventLog">Event log:</label>
+  <textarea readonly class="event-log-contents" rows="8" cols="30" id="leventLog"></textarea>
 </div>
 ```
 

--- a/files/en-us/web/api/document/mscapslockwarningoff/index.md
+++ b/files/en-us/web/api/document/mscapslockwarningoff/index.md
@@ -55,7 +55,7 @@ Fiddle: <https://jsfiddle.net/jonathansampson/mqcHA/1/>
     </script>
 </head>
 <body>
-<label>Type a password: input type="password" /></label><br />
+<label>Type a password: <input type="password" name="password"/></label><br />
 <button id="caps" onclick="capsOff();">Warning off</button>
 </body>
 </html>

--- a/files/en-us/web/api/document/readystatechange_event/index.md
+++ b/files/en-us/web/api/document/readystatechange_event/index.md
@@ -41,8 +41,8 @@ A generic {{domxref("Event")}}.
 </div>
 
 <div class="event-log">
-  <label>Event log:</label>
-  <textarea readonly class="event-log-contents" rows="8" cols="30"></textarea>
+  <label for="eventLog">Event log:</label>
+  <textarea readonly class="event-log-contents" rows="8" cols="30" id="eventLog"></textarea>
 </div>
 ```
 

--- a/files/en-us/web/api/element/compositionend_event/index.md
+++ b/files/en-us/web/api/element/compositionend_event/index.md
@@ -55,8 +55,8 @@ inputElement.addEventListener('compositionend', (event) => {
 </div>
 
 <div class="event-log">
-  <label>Event log:</label>
-  <textarea readonly class="event-log-contents" rows="8" cols="25"></textarea>
+  <label for="eventLog">Event log:</label>
+  <textarea readonly class="event-log-contents" rows="8" cols="25" id="eventLog"></textarea>
   <button class="clear-log">Clear</button>
 </div>
 ```

--- a/files/en-us/web/api/element/compositionstart_event/index.md
+++ b/files/en-us/web/api/element/compositionstart_event/index.md
@@ -58,8 +58,8 @@ inputElement.addEventListener('compositionstart', (event) => {
 </div>
 
 <div class="event-log">
-  <label>Event log:</label>
-  <textarea readonly class="event-log-contents" rows="8" cols="25"></textarea>
+  <label for="eventLog">Event log:</label>
+  <textarea readonly class="event-log-contents" rows="8" cols="25" id="eventLog"></textarea>
   <button class="clear-log">Clear</button>
 </div>
 ```

--- a/files/en-us/web/api/element/compositionupdate_event/index.md
+++ b/files/en-us/web/api/element/compositionupdate_event/index.md
@@ -55,8 +55,8 @@ inputElement.addEventListener('compositionupdate', (event) => {
 </div>
 
 <div class="event-log">
-  <label>Event log:</label>
-  <textarea readonly class="event-log-contents" rows="8" cols="25"></textarea>
+  <label for="eventLog">Event log:</label>
+  <textarea readonly class="event-log-contents" rows="8" cols="25" id="eventLog"></textarea>
   <button class="clear-log">Clear</button>
 </div>
 ```

--- a/files/en-us/web/api/element/error_event/index.md
+++ b/files/en-us/web/api/element/error_event/index.md
@@ -60,8 +60,8 @@ The event object is a {{domxref("UIEvent")}} instance if it was generated from a
 </div>
 
 <div class="event-log">
-  <label>Event log:</label>
-  <textarea readonly class="event-log-contents" rows="8" cols="30"></textarea>
+  <label for="eventLog">Event log:</label>
+  <textarea readonly class="event-log-contents" rows="8" cols="30" id="eventLog"></textarea>
 </div>
 ```
 

--- a/files/en-us/web/api/filereader/abort_event/index.md
+++ b/files/en-us/web/api/filereader/abort_event/index.md
@@ -64,8 +64,8 @@ _Also inherits properties from its parent {{domxref("Event")}}_.
     <img src="" class="preview" height="200" alt="Image preview">
 
     <div class="event-log">
-        <label>Event log:</label>
-        <textarea readonly class="event-log-contents"></textarea>
+        <label for="eventLog">Event log:</label>
+        <textarea readonly class="event-log-contents" id="eventLog"></textarea>
     </div>
 
   </div>

--- a/files/en-us/web/api/filereader/load_event/index.md
+++ b/files/en-us/web/api/filereader/load_event/index.md
@@ -62,8 +62,8 @@ _Also inherits properties from its parent {{domxref("Event")}}_.
     <img src="" class="preview" height="200" alt="Image preview">
 
     <div class="event-log">
-        <label>Event log:</label>
-        <textarea readonly class="event-log-contents"></textarea>
+        <label for="eventLog">Event log:</label>
+        <textarea readonly class="event-log-contents" id="eventLog"></textarea>
     </div>
 
   </div>

--- a/files/en-us/web/api/filereader/loadend_event/index.md
+++ b/files/en-us/web/api/filereader/loadend_event/index.md
@@ -63,8 +63,8 @@ _Also inherits properties from its parent {{domxref("Event")}}_.
     <img src="" class="preview" height="200" alt="Image preview">
 
     <div class="event-log">
-        <label>Event log:</label>
-        <textarea readonly class="event-log-contents"></textarea>
+        <label for="eventLog">Event log:</label>
+        <textarea readonly class="event-log-contents" id="eventLog"></textarea>
     </div>
 
   </div>

--- a/files/en-us/web/api/filereader/loadstart_event/index.md
+++ b/files/en-us/web/api/filereader/loadstart_event/index.md
@@ -63,8 +63,8 @@ _Also inherits properties from its parent {{domxref("Event")}}_.
     <img src="" class="preview" height="200" alt="Image preview">
 
     <div class="event-log">
-        <label>Event log:</label>
-        <textarea readonly class="event-log-contents"></textarea>
+        <label for="eventLog">Event log:</label>
+        <textarea readonly class="event-log-contents" id="eventLog"></textarea>
     </div>
 
   </div>

--- a/files/en-us/web/api/filereader/progress_event/index.md
+++ b/files/en-us/web/api/filereader/progress_event/index.md
@@ -64,8 +64,8 @@ _Also inherits properties from its parent {{domxref("Event")}}_.
     <img src="" class="preview" height="200" alt="Image preview">
 
     <div class="event-log">
-        <label>Event log:</label>
-        <textarea readonly class="event-log-contents"></textarea>
+        <label for="eventLog">Event log:</label>
+        <textarea readonly class="event-log-contents" id="eventLog"></textarea>
     </div>
 
   </div>

--- a/files/en-us/web/api/formdata/using_formdata_objects/index.md
+++ b/files/en-us/web/api/formdata/using_formdata_objects/index.md
@@ -81,9 +81,10 @@ You can also send files using `FormData`. Include an {{ HTMLElement("input") }} 
 
 ```html
 <form enctype="multipart/form-data" method="post" name="fileinfo">
-  <p><label>Your email address:
+  <p>
+    <label>Your email address:
       <input type="email" autocomplete="on" name="userid" placeholder="email" required size="32" maxlength="64" />
-      </label>
+    </label>
   </p>
   <p>
     <label>Custom file label:

--- a/files/en-us/web/api/formdata/using_formdata_objects/index.md
+++ b/files/en-us/web/api/formdata/using_formdata_objects/index.md
@@ -81,13 +81,23 @@ You can also send files using `FormData`. Include an {{ HTMLElement("input") }} 
 
 ```html
 <form enctype="multipart/form-data" method="post" name="fileinfo">
-  <label>Your email address:</label>
-  <input type="email" autocomplete="on" autofocus name="userid" placeholder="email" required size="32" maxlength="64" /><br />
-  <label>Custom file label:</label>
-  <input type="text" name="filelabel" size="12" maxlength="32" /><br />
-  <label>File to stash:</label>
-  <input type="file" name="file" required />
-  <input type="submit" value="Stash the file!" />
+  <p><label>Your email address:
+      <input type="email" autocomplete="on" name="userid" placeholder="email" required size="32" maxlength="64" />
+      </label>
+  </p>
+  <p>
+    <label>Custom file label:
+      <input type="text" name="filelabel" size="12" maxlength="32" />
+    </label>
+  </p>
+  <p>
+    <label>File to stash:
+      <input type="file" name="file" required />
+    </label>
+  </p>
+  <p>
+    <input type="submit" value="Stash the file!" />
+  </p>
 </form>
 <div></div>
 ```

--- a/files/en-us/web/api/htmlmediaelement/loadstart_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/loadstart_event/index.md
@@ -51,8 +51,8 @@ The **`loadstart`** event is fired when the browser has started to load a resour
     <video controls width="250"></video>
 
     <div class="event-log">
-        <label>Event log:</label>
-        <textarea readonly class="event-log-contents"></textarea>
+        <label for="eventLog">Event log:</label>
+        <textarea readonly class="event-log-contents" id="eventLog"></textarea>
     </div>
 
 </div>

--- a/files/en-us/web/api/htmlmediaelement/progress_event/index.md
+++ b/files/en-us/web/api/htmlmediaelement/progress_event/index.md
@@ -49,8 +49,8 @@ The **`progress`** event is fired periodically as the browser loads a resource.
     <video controls width="250"></video>
 
     <div class="event-log">
-        <label>Event log:</label>
-        <textarea readonly class="event-log-contents"></textarea>
+        <label for="eventLog">Event log:</label>
+        <textarea readonly class="event-log-contents" id="eventLog"></textarea>
     </div>
 
 </div>


### PR DESCRIPTION
Ensuring semantic HTML by:
* Add fieldset to radio group
* associate labels with form controls (implicitly and explicitly with for attribute)
* add names to form controls

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
