### PR TITLE
Use let instead of const in let reference

### DIFF
--- a/files/en-us/web/javascript/reference/statements/let/index.md
+++ b/files/en-us/web/javascript/reference/statements/let/index.md
@@ -207,8 +207,8 @@ However due to lexical scoping this value is not available inside the block: the
 The expression `(foo + 55)` throws a `ReferenceError` because initialization of `let foo` has not completed — it is still in the temporal dead zone.
 
 This phenomenon can be confusing in a situation like the following.
-The instruction `const n of n.a` is already inside the private scope of the for loop's block.
-So, the identifier `n.a` is resolved to the property '`a`' of the '`n`' object located in the first part of the instruction itself (`const n`).
+The instruction `let n of n.a` is already inside the private scope of the for loop's block.
+So, the identifier `n.a` is resolved to the property '`a`' of the '`n`' object located in the first part of the instruction itself (`let n`).
 
 This is still in the temporal dead zone as its declaration statement has not been reached and terminated.
 
@@ -217,7 +217,7 @@ function go(n) {
   // n here is defined!
   console.log(n); // Object {a: [1,2,3]}
 
-  for (const n of n.a) { // ReferenceError
+  for (let n of n.a) { // ReferenceError
     console.log(n);
   }
 }


### PR DESCRIPTION
#### Summary

This is a document related with `let`, so use `let` instead of `const` (even through there could be `const`).

#### Metadata

- [x] Fixes a typo, bug, or other error
