### PR TITLE
MathML elements: Use backticks when listing attributes

### DIFF
--- a/files/en-us/web/mathml/element/maction/index.md
+++ b/files/en-us/web/mathml/element/maction/index.md
@@ -16,7 +16,7 @@ The MathML **`<maction>`** element provides a possibility to bind actions to (su
 
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-- actiontype
+- `actiontype`
 
   - : The action which specifies what happens for this element. Possible values are:
 
@@ -26,7 +26,7 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
     - `tooltip`: When the pointer moves over the _expression_, a tooltip box with a _message_ is displayed near the expression.
       The syntax is: `<maction actiontype="tooltip"> expression message </maction>.`
 
-- selection
+- `selection`
   - : The child element which is addressed by the action. The default value is `1`, which is the first child element.
 
 ## Examples

--- a/files/en-us/web/mathml/element/math/index.md
+++ b/files/en-us/web/mathml/element/math/index.md
@@ -17,7 +17,7 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 
 In addition to the following attributes, the `<math>` element accepts any attributes of the {{ MathMLElement("mstyle") }} element.
 
-- display
+- `display`
 
   - : This enumerated attribute specifies how the enclosed MathML markup should be rendered. It can have one of the following values:
 
@@ -26,7 +26,7 @@ In addition to the following attributes, the `<math>` element accepts any attrib
 
     If not present, its default value is `inline`.
 
-- mode {{deprecated_inline}}
+- `mode` {{deprecated_inline}}
   - : Deprecated in favor of the [display attribute](#attr-display).
     Possible values are: `display` (which has the same effect as `display="block"`) and `inline`.
 

--- a/files/en-us/web/mathml/element/menclose/index.md
+++ b/files/en-us/web/mathml/element/menclose/index.md
@@ -16,7 +16,7 @@ The MathML `<menclose>` element renders its content inside an enclosing notation
 
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-- notation
+- `notation`
 
   - : A list of notations, separated by white space, to apply to the child elements. The symbols are each drawn as if the others are not present, and therefore may overlap. Possible values are:
 

--- a/files/en-us/web/mathml/element/mo/index.md
+++ b/files/en-us/web/mathml/element/mo/index.md
@@ -16,41 +16,41 @@ The MathML `<mo>` element represents an operator in a broad sense. Besides opera
 
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-- accent
+- `accent`
   - : If the operator is used as an [under](/en-US/docs/Web/MathML/Element/munder)- or [overscript](/en-US/docs/Web/MathML/Element/mover) this attribute specifies whether the operator should be treated as an accent.
     Allowed values are `true` or `false`.
-- fence
+- `fence`
   - : There is no visual effect for this attribute, but it specifies whether the operator is a fence (such as parentheses).
     Allowed values are `true` or `false`.
-- lspace
+- `lspace`
   - : The amount of space before the operator (see [length](/en-US/docs/Web/MathML/Attribute/Values#lengths) for values and units). The constant `thickmathspace` (5/18em) is the default value.
 
-- maxsize
+- `maxsize`
 
   - : If `stretchy` is `true`, this attribute specifies the maximum size of the operator. Allowed values are:
 
     - `infinity`
     - an arbitrary [length](/en-US/docs/Web/MathML/Attribute/Values#lengths)
 
-- minsize
+- `minsize`
 
   - : If `stretchy` is `true`, this attribute specifies the minimum size of the operator. Allowed values are:
 
     - `infinity`
     - an arbitrary [length](/en-US/docs/Web/MathML/Attribute/Values#lengths)
 
-- movablelimits
+- `movablelimits`
   - : Specifies whether attached under- and overscripts move to sub- and superscript positions when `displaystyle` is `false`.
     Allowed values are either `true` or `false.`
-- rspace
+- `rspace`
   - : The amount of space after the operator (see [length](/en-US/docs/Web/MathML/Attribute/Values#lengths) for values and units). The constant `thickmathspace` (5/18em) is the default value.
-- separator
+- `separator`
   - : There is no visual effect for this attribute, but it specifies whether the operator is a separator (such as commas).
     Allowed values are `true` or `false`.
-- stretchy
+- `stretchy`
   - : Specifies whether the operator stretches to the size of the adjacent element.
     Allowed values are `true` or `false`.
-- symmetric
+- `symmetric`
   - : If `stretchy` is `true`, this attribute specifies whether the operator should be vertically symmetric around the imaginary math axis (centered fraction line).
     The default value is `true` if **stretchy** is set to `true` and otherwise `false`. Allowed values are `true` or `false`.
 

--- a/files/en-us/web/mathml/element/mover/index.md
+++ b/files/en-us/web/mathml/element/mover/index.md
@@ -16,10 +16,10 @@ The MathML `<mover>` element is used to attach an accent or a limit over an expr
 
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-- accent
+- `accent`
   - : If `true` the over-script is an _accent_, which is drawn closer to the base expression.
     If `false` (default value) the over-script is a _limit_ over the base expression.
-- align {{deprecated_inline}}
+- `align` {{deprecated_inline}}
   - : The alignment of the over-script. Possible values are: `left`, `center`, and `right`.
     This attribute is deprecated and will be removed in the future. Use CSS [`text-align`](/en-US/docs/Web/CSS/text-align) instead.
 

--- a/files/en-us/web/mathml/element/mpadded/index.md
+++ b/files/en-us/web/mathml/element/mpadded/index.md
@@ -16,15 +16,15 @@ The MathML `<mpadded>` element is used to add extra padding and to set the gener
 
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-- depth
+- `depth`
   - : Sets or increments the depth. Possible values: Any [length](/en-US/docs/Web/MathML/Attribute/Values#lengths) or an increment/decrement (a length prefixed with "+" or "-") .
-- height
+- `height`
   - : Sets or increments the height. Possible values: Any [length](/en-US/docs/Web/MathML/Attribute/Values#lengths) or an increment/decrement (a length prefixed with "+" or "-") .
-- lspace
+- `lspace`
   - : Sets or increments the horizontal position. Possible values: Any [length](/en-US/docs/Web/MathML/Attribute/Values#lengths) or an increment/decrement (a length prefixed with "+" or "-") .
-- voffset
+- `voffset`
   - : Sets or increments the vertical position. Possible values: Any [length](/en-US/docs/Web/MathML/Attribute/Values#lengths) or an increment/decrement (a length prefixed with "+" or "-") .
-- width
+- `width`
   - : Sets or increments the width. Possible values: Any [length](/en-US/docs/Web/MathML/Attribute/Values#lengths) or an increment/decrement (a length prefixed with "+" or "-") .
 
 ### Pseudo-units

--- a/files/en-us/web/mathml/element/ms/index.md
+++ b/files/en-us/web/mathml/element/ms/index.md
@@ -16,10 +16,10 @@ The MathML `<ms>` element represents a _string literal_ meant to be interpreted 
 
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-- lquote
+- `lquote`
   - : The opening quote character (depends on [`dir`](#attr-dir)) to enclose the content. The default value is "`&quot;".`
 
-- rquote
+- `rquote`
   - : The closing quote mark (depends on [`dir`](#attr-dir)) to enclose the content. The default value is "`&quot;".`
 
 ## Examples

--- a/files/en-us/web/mathml/element/mspace/index.md
+++ b/files/en-us/web/mathml/element/mspace/index.md
@@ -16,11 +16,11 @@ The MathML `<mspace>` element is used to display a blank space, whose size is se
 
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-- depth
+- `depth`
   - : The desired depth (below the baseline) of the space (see [length](/en-US/docs/Web/MathML/Attribute/Values#lengths) for values and units).
-- height
+- `height`
   - : The desired height (above the baseline) of the space (see [length](/en-US/docs/Web/MathML/Attribute/Values#lengths) for values and units).
-- width
+- `width`
   - : The desired width of the space (see [length](/en-US/docs/Web/MathML/Attribute/Values#lengths) for values and units).
 
 Note that some common attributes like `mathcolor`, `mathvariant` or `dir` have no effect on `<mspace>`.

--- a/files/en-us/web/mathml/element/mtable/index.md
+++ b/files/en-us/web/mathml/element/mtable/index.md
@@ -18,7 +18,7 @@ The MathML `<mtable>` element allows you to create tables or matrices. Inside a 
 
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-- align
+- `align`
 
   - : Specifies the **vertical** alignment of the table with respect to its environment.
     Possible values are:
@@ -31,23 +31,23 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 
     In addition, values of the `align` attribute can end with a _rownumber_ (e.g. `align="center 3"`). This allows you to align the specified row of the table rather than the whole table. A negative Integer value counts rows from the bottom of the table. Starting with Gecko 8.0 {{ geckoRelease("8.0") }} the interpretation of _negative_ values has been corrected ({{ bug(601436) }}). In Gecko 17.0 {{geckoRelease("17.0")}} the parsing has been updated to treat whitespace correctly.
 
-- columnalign
+- `columnalign`
   - : Specifies the horizontal alignment of the cells. Multiple values separated by space are allowed and apply to the corresponding columns (e.g. `columnalign="left right center"`). Possible values are: `left`, `center` (default) and `right`.
-- columnlines
+- `columnlines`
   - : Specifies column borders. Multiple values separated by space are allowed and apply to the corresponding columns (e.g. `columnlines="none none solid"`). Possible values are: `none` (default), `solid` and `dashed`.
-- columnspacing
+- `columnspacing`
   - : Specifies the space between table columns.
-- frame
+- `frame`
   - : Specifies borders of the entire table. Possible values are: `none` (default), `solid` and `dashed`.
-- framespacing
+- `framespacing`
   - : Specifies additional space added between the table and frame.
-- rowalign
+- `rowalign`
   - : Specifies the vertical alignment of the cells. Multiple values separated by space are allowed and apply to the corresponding rows (e.g. `rowalign="top bottom axis"`). Possible values are: `axis`, `baseline` (default), `bottom`, `center` and `top`.
-- rowlines
+- `rowlines`
   - : Specifies row borders. Multiple values separated by space are allowed and apply to the corresponding rows (e.g. `rowlines="none none solid"`). Possible values are: `none` (default), `solid` and `dashed`.
 - {{ unimplemented_inline() }} rowspacing
   - : Specifies the space between table rows.
-- width
+- `width`
   - : Specifies the width of the entire table. Accepts [length values](/en-US/docs/Web/MathML/Attribute/Values#lengths).
 
 ## Examples

--- a/files/en-us/web/mathml/element/mtd/index.md
+++ b/files/en-us/web/mathml/element/mtd/index.md
@@ -16,15 +16,15 @@ The MathML `<mtd>` element represents a cell in a table or a matrix. It may only
 
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-- columnalign
+- `columnalign`
   - : Specifies the horizontal alignment of this cell and overrides values specified by {{ MathMLElement("mtable") }} or {{ MathMLElement("mtr") }}.
     Possible values are: `left`, `center` and `right`.
-- columnspan
+- `columnspan`
   - : A non-negative integer value that indicates on how many columns does the cell extend.
-- rowalign
+- `rowalign`
   - : Specifies the vertical alignment of this cell and overrides values specified by {{ MathMLElement("mtable") }} or {{ MathMLElement("mtr") }}.
     Possible values are: `axis`, `baseline`, `bottom`, `center` and `top`.
-- rowspan
+- `rowspan`
   - : A non-negative integer value that indicates on how many rows does the cell extend.
 
 ## Specifications

--- a/files/en-us/web/mathml/element/mtr/index.md
+++ b/files/en-us/web/mathml/element/mtr/index.md
@@ -16,10 +16,10 @@ The MathML `<mtr>` element represents a row in a table or a matrix. It may only 
 
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-- columnalign
+- `columnalign`
   - : Overrides the horizontal alignment of cells specified by {{ MathMLElement("mtable") }} for this row.
     Possible values are: `left`, `center` and `right`.
-- rowalign
+- `rowalign`
   - : Overrides the vertical alignment of cells specified by {{ MathMLElement("mtable") }} for this row.
     Possible values are: `axis`, `baseline`, `bottom`, `center` and `top`.
 

--- a/files/en-us/web/mathml/element/munder/index.md
+++ b/files/en-us/web/mathml/element/munder/index.md
@@ -16,10 +16,10 @@ The MathML `<munder>` element is used to attach an accent or a limit under an ex
 
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-- accentunder
+- `accentunder`
   - : If `true`, the element is an _accent_, which is drawn closer to the base expression.
     If `false` (default value), the element is a _limit_ under the base expression.
-- align {{deprecated_inline}}
+- `align` {{deprecated_inline}}
   - : The alignment of the underscript. Possible values are: `left`, `center`, and `right`.
     This attribute is deprecated and will be removed in the future. Use CSS [`text-align`](/en-US/docs/Web/CSS/text-align) instead.
 

--- a/files/en-us/web/mathml/element/munderover/index.md
+++ b/files/en-us/web/mathml/element/munderover/index.md
@@ -18,13 +18,13 @@ It uses the following syntax: `<munderover> base underscript overscript </munder
 
 This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
 
-- accent
+- `accent`
   - : If `true`, the overscript is an _accent_, which is drawn closer to the base expression.
     If `false` (default value), the overscript is a _limit_ over the base expression.
-- accentunder
+- `accentunder`
   - : If `true`, the underscript is an _accent_, which is drawn closer to the base expression.
     If `false` (default value), the underscript is a _limit_ under the base expression.
-- align {{deprecated_inline}}
+- `align` {{deprecated_inline}}
   - : The alignment of both underscript and overscript. Possible values are: `left`, `center`, and `right`.
     This attribute is deprecated and will be removed in the future. Use CSS [`text-align`](/en-US/docs/Web/CSS/text-align) instead.
 

--- a/files/en-us/web/mathml/element/semantics/index.md
+++ b/files/en-us/web/mathml/element/semantics/index.md
@@ -35,15 +35,15 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 
 The following attributes can be set on `<annotation>` and `<annotation-xml>`:
 
-- definitionURL
+- `definitionURL`
   - : The location of the annotation key symbol.
-- encoding
+- `encoding`
   - : The encoding of the semantic information in the annotation (e.g. "MathML-Content", "MathML-Presentation", "application/openmath+xml", "image/png")
-- cd
+- `cd`
   - : The content dictionary that contains the annotation key symbol.
-- name
+- `name`
   - : The name of the annotation key symbol.
-- src
+- `src`
   - : The location of an external source for semantic information.
 
 ## Example


### PR DESCRIPTION
#### Summary

On each page for MathML elements, use backticks when listing attributes.

#### Motivation

For clarify & consistency.

#### Supporting details

N/A

#### Related issues

Review feedback from https://github.com/mdn/content/pull/17812

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
