### PR TITLE
Remove whitespace in MathML token elements

### DIFF
--- a/files/en-us/web/mathml/element/menclose/index.md
+++ b/files/en-us/web/mathml/element/menclose/index.md
@@ -46,9 +46,9 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 <math>
 
   <menclose notation="circle box">
-    <mi> x </mi>
-    <mo> + </mo>
-    <mi> y </mi>
+    <mi>x</mi>
+    <mo>+</mo>
+    <mi>y</mi>
   </menclose>
 
 </math>

--- a/files/en-us/web/mathml/element/merror/index.md
+++ b/files/en-us/web/mathml/element/merror/index.md
@@ -23,10 +23,10 @@ This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Globa
 
 <merror>
   <mrow>
-    <mtext> Division by zero: </mtext>
+    <mtext>Division by zero:</mtext>
     <mfrac>
-      <mn> 1 </mn>
-      <mn> 0 </mn>
+      <mn>1</mn>
+      <mn>0</mn>
     </mfrac>
   </mrow>
 </merror>

--- a/files/en-us/web/mathml/element/mfrac/index.md
+++ b/files/en-us/web/mathml/element/mfrac/index.md
@@ -38,18 +38,18 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 
 Sample rendering: ![(a/b)/(c/d)](mfrac.png)
 
-Your browser rendering: <math><mfrac bevelled="true"><mfrac><mi>a </mi><mi>b </mi></mfrac><mfrac><mi>c </mi><mi>d</mi></mfrac></mfrac></math>
+Your browser rendering: <math><mfrac bevelled="true"><mfrac><mi>a</mi><mi>b</mi></mfrac><mfrac><mi>c</mi><mi>d</mi></mfrac></mfrac></math>
 
 ```html
 <math>
   <mfrac bevelled="true">
      <mfrac>
-        <mi> a </mi>
-        <mi> b </mi>
+        <mi>a</mi>
+        <mi>b</mi>
      </mfrac>
      <mfrac>
-        <mi> c </mi>
-        <mi> d </mi>
+        <mi>c</mi>
+        <mi>d</mi>
      </mfrac>
   </mfrac>
 </math>

--- a/files/en-us/web/mathml/element/mi/index.md
+++ b/files/en-us/web/mathml/element/mi/index.md
@@ -21,13 +21,13 @@ This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Globa
 ```html
 <math>
 
-  <mi> y </mi>
+  <mi>y</mi>
 
-  <mi> sin </mi>
+  <mi>sin</mi>
 
-  <mi mathvariant="monospace"> x </mi>
+  <mi mathvariant="monospace">x</mi>
 
-  <mi mathvariant="bold"> &pi; </mi>
+  <mi mathvariant="bold">&pi;</mi>
 
 </math>
 ```

--- a/files/en-us/web/mathml/element/mn/index.md
+++ b/files/en-us/web/mathml/element/mn/index.md
@@ -21,15 +21,15 @@ This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Globa
 ```html
 <math>
 
-  <mn> 0 </mn>
+  <mn>0</mn>
 
-  <mn> 1.337 </mn>
+  <mn>1.337</mn>
 
-  <mn> twelve </mn>
+  <mn>twelve</mn>
 
-  <mn> XVI </mn>
+  <mn>XVI</mn>
 
-  <mn> 2e10 </mn>
+  <mn>2e10</mn>
 
 </math>
 ```

--- a/files/en-us/web/mathml/element/mo/index.md
+++ b/files/en-us/web/mathml/element/mo/index.md
@@ -66,13 +66,13 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 </mrow>
 
 <mrow>
-  <mo> [ </mo> <!-- default form value: prefix -->
+  <mo>[</mo> <!-- default form value: prefix -->
   <mrow>
-    <mn> 0 </mn>
-    <mo> ; </mo> <!-- default form value: infix -->
-    <mn> 1 </mn>
+    <mn>0</mn>
+    <mo>;</mo> <!-- default form value: infix -->
+    <mn>1</mn>
   </mrow>
-  <mo> ) </mo> <!-- default form value: postfix -->
+  <mo>)</mo> <!-- default form value: postfix -->
 </mrow>
 
 </math>

--- a/files/en-us/web/mathml/element/mover/index.md
+++ b/files/en-us/web/mathml/element/mover/index.md
@@ -27,20 +27,20 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 
 Sample rendering: ![x+y+z](mover.png)
 
-Rendering in your browser: <math><mover accent="true"><mrow><mi>x </mi><mo>+ </mo><mi>y </mi><mo>+ </mo><mi>z </mi></mrow><mo>⏞</mo></mover></math>
+Rendering in your browser: <math><mover accent="true"><mrow><mi>x</mi><mo>+</mo><mi>y</mi><mo>+</mo><mi>z</mi></mrow><mo>⏞</mo></mover></math>
 
 ```html
 <math>
 
 <mover accent="true">
   <mrow>
-    <mi> x </mi>
-    <mo> + </mo>
-    <mi> y </mi>
-    <mo> + </mo>
-    <mi> z </mi>
+    <mi>x</mi>
+    <mo>+</mo>
+    <mi>y</mi>
+    <mo>+</mo>
+    <mi>z</mi>
   </mrow>
-  <mo> &#x23DE; <!--TOP CURLY BRACKET--> </mo>
+  <mo>&#x23DE;<!--TOP CURLY BRACKET--></mo>
 </mover>
 
 </math>

--- a/files/en-us/web/mathml/element/mpadded/index.md
+++ b/files/en-us/web/mathml/element/mpadded/index.md
@@ -38,9 +38,9 @@ Prior to Gecko 7.0 {{ geckoRelease("7.0") }} the MathML2 pseudo-unit `lspace` wa
 <math>
 
   <mpadded height="+150px" width="100px" lspace="2height">
-    <mi> x </mi>
-    <mo> + </mo>
-    <mi> y </mi>
+    <mi>x</mi>
+    <mo>+</mo>
+    <mi>y</mi>
   </mpadded>
 
 </math>

--- a/files/en-us/web/mathml/element/mphantom/index.md
+++ b/files/en-us/web/mathml/element/mphantom/index.md
@@ -20,19 +20,19 @@ This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Globa
 
 Sample rendering: ![x+  z](mphantom.png)
 
-Rendering in your browser: <math><mrow><mi>x </mi><mo>+ </mo><mphantom><mi>y </mi><mo>+ </mo></mphantom><mi>z</mi></mrow></math>
+Rendering in your browser: <math><mrow><mi>x</mi><mo>+</mo><mphantom><mi>y</mi><mo>+</mo></mphantom><mi>z</mi></mrow></math>
 
 ```html
 <math>
 
 <mrow>
-  <mi> x </mi>
-  <mo> + </mo>
+  <mi>x</mi>
+  <mo>+</mo>
   <mphantom>
-    <mi> y </mi>
-    <mo> + </mo>
+    <mi>y</mi>
+    <mo>+</mo>
   </mphantom>
-  <mi> z </mi>
+  <mi>z</mi>
 </mrow>
 
 </math>

--- a/files/en-us/web/mathml/element/mrow/index.md
+++ b/files/en-us/web/mathml/element/mrow/index.md
@@ -27,19 +27,19 @@ This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Globa
 <math>
 
   <mrow>
-    <mn> 1 </mn>
-    <mo> + </mo>
-    <mn> 1 </mn>
+    <mn>1</mn>
+    <mo>+</mo>
+    <mn>1</mn>
   </mrow>
 
   <mrow>
-    <mo> ( </mo>
+    <mo>(</mo>
     <mrow>
-      <mi> x </mi>
-      <mo> , </mo>
-      <mi> y </mi>
+      <mi>x</mi>
+      <mo>,</mo>
+      <mi>y</mi>
     </mrow>
-    <mo> ) </mo>
+    <mo>)</mo>
   </mrow>
 
 </math>

--- a/files/en-us/web/mathml/element/ms/index.md
+++ b/files/en-us/web/mathml/element/ms/index.md
@@ -27,7 +27,7 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 ```html
 <math>
 
-  <ms lquote="„" rquote="""> abc </ms>
+  <ms lquote="„" rquote=""">abc</ms>
 
 </math>
 ```

--- a/files/en-us/web/mathml/element/msubsup/index.md
+++ b/files/en-us/web/mathml/element/msubsup/index.md
@@ -29,15 +29,15 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 
 Sample rendering: ![x1](msubsup.png)
 
-Rendering in your browser: <math><msubsup><mo>∫</mo> <mn>0 </mn><mn>1</mn></msubsup></math>
+Rendering in your browser: <math><msubsup><mo>∫</mo><mn>0</mn><mn>1</mn></msubsup></math>
 
 ```html
 <math displaystyle="true">
 
   <msubsup>
-    <mo> &#x222B;<!--Integral --> </mo>
-    <mn> 0 </mn>
-    <mn> 1 </mn>
+    <mo>&#x222B;<!--Integral --></mo>
+    <mn>0</mn>
+    <mn>1</mn>
   </msubsup>
 
 </math>

--- a/files/en-us/web/mathml/element/mtext/index.md
+++ b/files/en-us/web/mathml/element/mtext/index.md
@@ -23,9 +23,9 @@ This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Globa
 ```html
 <math>
 
-  <mtext> Theorem of Pythagoras </mtext>
+  <mtext>Theorem of Pythagoras</mtext>
 
-  <mtext> /* comment here */ </mtext>
+  <mtext>/* comment here */</mtext>
 
 </math>
 ```

--- a/files/en-us/web/mathml/element/munder/index.md
+++ b/files/en-us/web/mathml/element/munder/index.md
@@ -27,20 +27,20 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 
 Sample rendering: ![x+y+z](munder.png)
 
-Rendering in your browser: <math><munder accentunder="true"><mrow><mi>x </mi><mo>+ </mo><mi>y </mi><mo>+ </mo><mi>z </mi></mrow><mo>⏟</mo></munder></math>
+Rendering in your browser: <math><munder accentunder="true"><mrow><mi>x</mi><mo>+</mo><mi>y</mi><mo>+</mo><mi>z</mi></mrow><mo>⏟</mo></munder></math>
 
 ```html
 <math>
 
 <munder accentunder="true">
   <mrow>
-    <mi> x </mi>
-    <mo> + </mo>
-    <mi> y </mi>
-    <mo> + </mo>
-    <mi> z </mi>
+    <mi>x</mi>
+    <mo>+</mo>
+    <mi>y</mi>
+    <mo>+</mo>
+    <mi>z</mi>
   </mrow>
-  <mo> &#x23DF; <!--BOTTOM CURLY BRACKET--> </mo>
+  <mo>&#x23DF;<!--BOTTOM CURLY BRACKET--></mo>
 </munder>
 
 </math>

--- a/files/en-us/web/mathml/element/munderover/index.md
+++ b/files/en-us/web/mathml/element/munderover/index.md
@@ -32,15 +32,15 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 
 Sample rendering: ![integral-0-infinity](munderover.png)
 
-Rendering in your browser: <math><munderover><mo>∫ </mo><mn>0 </mn><mi>∞</mi></munderover></math>
+Rendering in your browser: <math><munderover><mo>∫</mo><mn>0</mn><mi>∞</mi></munderover></math>
 
 ```html
 <math displaystyle="true">
 
   <munderover >
-    <mo> &#x222B; <!--INTEGRAL--> </mo>
-    <mn> 0 </mn>
-    <mi> &#x221E; <!--INFINITY--> </mi>
+    <mo>&#x222B;<!--INTEGRAL--></mo>
+    <mn>0</mn>
+    <mi>&#x221E;<!--INFINITY--></mi>
   </munderover>
 
 </math>


### PR DESCRIPTION
#### Summary

For ms, mi, mn, mtext and mo elements, do not use whitespace around their text content.

#### Motivation

- Consistency: Some examples don't use whitespace, let's do that for all of them.

- Browsers compat: Some browsers implement that behavior (as per MathML3) others do not (as per MathML Core). Make sure examples work in all browsers.

#### Supporting details

N/A

#### Related issues

N/A

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
