### PR TITLE
Correct imprecise info in `::backdrop`

### DIFF
--- a/files/en-us/web/css/_doublecolon_backdrop/index.md
+++ b/files/en-us/web/css/_doublecolon_backdrop/index.md
@@ -22,7 +22,7 @@ The **`::backdrop`** [CSS](/en-US/docs/Web/CSS) [pseudo-element](/en-US/docs/Web
 When multiple elements have been placed into fullscreen mode, the backdrop is drawn immediately beneath the frontmost such element, and on top of the older fullscreen elements.
 
 ```css
-/* Backdrop is only displayed when dialog is opened with dialog.showModal() */
+/* Backdrop is only displayed when dialog is opened with dialog.showModal() or dialog.show() */
 dialog::backdrop {
   background: rgba(255,0,0,.25);
 }


### PR DESCRIPTION
The `.show()` method allows for `dialog` elements' `::backdrop` to apply, in addition to `.showModal()`.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Mentioned that `.show()` shows the `::backdrop`, in addition to `.showModal()`.

#### Motivation
This is because `.show()` works like `.showModal()` to enable the `::backdrop`.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
