### PR TITLE
Rewrite MathML article for <mstyle>

### DIFF
--- a/files/en-us/web/mathml/element/mstyle/index.md
+++ b/files/en-us/web/mathml/element/mstyle/index.md
@@ -10,56 +10,68 @@ browser-compat: mathml.elements.mstyle
 ---
 {{MathMLRef}}
 
-The MathML `<mstyle>` element is used change the style of its children. It accepts all attributes of all MathML presentation elements with some exceptions and additional attributes listed below.
+The MathML `<mstyle>` element is used to change the style of its children.
+
+> **Note:** Historically, this element accepted almost all the MathML attributes and it was used to override the default attribute values of its descendants. It was later restricted to only a few relevant styling attributes that were used in existing web pages. Nowadays, these styling attributes are [common to all MathML elements](/en-US/docs/Web/MathML/Global_attributes) and so `<mstyle>` is really just equivalent to an [`<mrow>`](/en-US/docs/Web/MathML/Element/mrow) element. However, `<mstyle>` may still be relevant for compatibility with MathML implementations outside browsers.
 
 ## Attributes
 
-This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes) as well as the following deprecated attributes:
 
 - `scriptminsize` {{deprecated_inline}}
-  - : Specifies a minimum font size allowed due to changes in `scriptlevel`. The default value is 8pt.
+  - : Specifies a minimum font size allowed due to changes in `scriptlevel`. The default value is `8pt`.
 - `scriptsizemultiplier` {{deprecated_inline}}
-  - : Specifies the multiplier to be used to adjust font size due to changes in `scriptlevel`. The default value is 0.71.
-
-The `<mstyle>` element accepts [all attributes](/en-US/docs/Web/MathML/Attribute) of all presentation elements with the following exceptions:
-
-- `height`, `depth` or `width` do not apply to {{ MathMLElement("mpadded") }} or {{ MathMLElement("mtable") }}.
-- `rowalign`, `columnalign`, or `groupalign` do not apply to {{ MathMLElement("mtr") }}, {{ MathMLElement("mtd") }} or {{ MathMLElement("maligngroup") }}.
-- `lspace` or `voffset` do not apply to {{ MathMLElement("mpadded") }}.
-- `align` does not apply to {{ MathMLElement("mtable") }} or {{ MathMLElement("mstack") }}.
-- `index` cannot be set on `<mstyle>`.
-- `actiontype` on {{ MathMLElement("maction") }} cannot be set on `<mstyle>`.
+  - : Specifies the multiplier to be used to adjust font size due to changes in `scriptlevel`. The default value is `0.71`.
 
 ## Examples
 
-Using `displaystyle` and `mathcolor` to effect style changes in the layout of the whole sum.
+The following example uses [global attributes](/en-US/docs/Web/MathML/Global_attributes) `displaystyle` and `mathcolor` to respectively override the [`math-style`](/en-US/docs/Web/CSS/math-style) and [`color`](en-US/docs/Web/CSS/color) of the `<munder>` and `<munderover>` children:
 
 ```html
 <math>
-
   <mstyle displaystyle="true" mathcolor="teal">
-    <mrow>
-
-      <munderover>
-        <mo stretchy="true" form="prefix">&sum;</mo>
-        <mrow>
-          <mi>i</mi>
-          <mo form="infix">=</mo>
-          <mn>1</mn>
-        </mrow>
-        <mi>n</mi>
-      </munderover>
-
-      <mstyle displaystyle="true">
-        <mfrac>
-          <mn>1</mn>
-          <mi>n</mi>
-        </mfrac>
-      </mstyle>
-
-    </mrow>
+    <munder>
+      <mo>∑</mo>
+      <mi>I</mi>
+    </munder>
+    <munderover>
+      <mo>∏</mo>
+      <mrow>
+        <mi>i</mi>
+        <mo>=</mo>
+        <mn>1</mn>
+      </mrow>
+      <mi>N</mi>
+    </munderover>
   </mstyle>
+</math>
+```
 
+The following example shows a formula with [`font-size`](/en-US/docs/Web/CSS/font-size) set to `128pt`. It contains numbers that are placed in nested superscripts as well as an `<mstyle>` element with legacy attributes `scriptsizemultiplier` and `scriptminsize`. The `font-size` is multiplied by `0.5` when entering each superscript as long as that does not make it smaller than `16pt`.
+
+```html
+<math style="font-size: 128pt">
+  <mstyle scriptsizemultiplier="0.5" scriptminsize="16pt">
+    <msup>
+      <mn>2</mn>
+      <msup>
+        <mn>2</mn>
+        <msup>
+          <mn>2</mn>
+          <msup>
+            <mn>2</mn>
+            <msup>
+              <mn>2</mn>
+              <msup>
+                <mn>2</mn>
+                <mn>2</mn>
+              </msup>
+            </msup>
+          </msup>
+        </msup>
+      </msup>
+    </msup>
+  </mstyle>
 </math>
 ```
 


### PR DESCRIPTION
#### Summary

Rewrite the article, describing modern behavior in MathML Core and browsers and moving legacy behavior in a note.
Examples are also updated accordingly, clearly mentioning global attributes or legacy attributes.

#### Motivation

Article is a bit obsolete and confusing for web developers.

#### Supporting details

https://w3c.github.io/mathml-core/#style-change-mstyle

#### Related issues

On https://github.com/mdn/content/pull/17812 it was mentioned that the examples are confusing since they use global attributes not explicitly listed.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
