### PR TITLE
Rewrite description and example of mi element

### DIFF
--- a/files/en-us/web/mathml/element/mi/index.md
+++ b/files/en-us/web/mathml/element/mi/index.md
@@ -14,20 +14,21 @@ The MathML `<mi>` element indicates that the content should be rendered as an **
 
 ## Attributes
 
-This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+This element accepts the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes). For `<mi>` elements that contain a single character, the default value of the [`mathvariant`](/en-US/docs/Web/MathML/Global_attributes/mathvariant) attribute is `italic`.
 
 ## Examples
 
 ```html
 <math>
 
-  <mi>y</mi>
-
+  <!-- Multiple characters, default mathvariant is "normal". -->
   <mi>sin</mi>
 
-  <mi mathvariant="monospace">x</mi>
+  <!-- Single character, default mathvariant is "italic". -->
+  <mi>y</mi>
 
-  <mi mathvariant="bold">&pi;</mi>
+  <!-- Overriding default mathvariant. -->
+  <mi mathvariant="normal">F</mi>
 
 </math>
 ```


### PR DESCRIPTION
#### Summary

Rewrite description of mi to mention the particular case of mathvariant.

#### Motivation

`mathvariant` is a global attribute so in theory it does not make sense to have a specific example here. However, one particularity of `mi` is that its default mathvariant depends on whether it has 1 or more characters. So this need to be documented.

#### Supporting details

https://w3c.github.io/mathml-core/#identifier-mi

#### Related issues

This was discussed in review feedback of https://github.com/mdn/content/pull/17812

#### Metadata
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
