### PR TITLE
Add deprecation header for maction/mfenced

### DIFF
--- a/files/en-us/web/mathml/element/maction/index.md
+++ b/files/en-us/web/mathml/element/maction/index.md
@@ -9,12 +9,13 @@ tags:
 browser-compat: mathml.elements.maction
 ---
 {{MathMLRef}}
+{{deprecated_header}}
 
-The MathML **`<maction>`** element provides a possibility to bind actions to (sub-) expressions. The action itself is specified by the `actiontype` attribute, which accepts several values. To specify which child elements are addressed by the action, you can make use of the `selection` attribute.
+The deprecated MathML **`<maction>`** element used to provide a possibility to bind an actions to mathematical expressions. Nowadays, it is recommended to rely on [JavaScript](/en-US/docs/Web/JavaScript) and other Web technologies to implement this use case. Some browsers will just render the first child of an `<maction>` element and ignore its `actiontype` and `selection` attributes.
 
 ## Attributes
 
-This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes).
+This element's attributes include the [global MathML attributes](/en-US/docs/Web/MathML/Global_attributes) as well as the following attributes:
 
 - `actiontype`
 
@@ -27,7 +28,7 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
       The syntax is: `<maction actiontype="tooltip"> expression message </maction>.`
 
 - `selection`
-  - : The child element which is addressed by the action. The default value is `1`, which is the first child element.
+  - : The child element currently visible, only taken into account for `actiontype="toggle"` or non-standard `actiontype` values. The default value is `1`, which is the first child element.
 
 ## Examples
 

--- a/files/en-us/web/mathml/element/maction/index.md
+++ b/files/en-us/web/mathml/element/maction/index.md
@@ -6,6 +6,7 @@ tags:
   - MathML Reference
   - MathML:Element
   - MathML:Enlivening Expressions
+  - Deprecated
 browser-compat: mathml.elements.maction
 ---
 {{MathMLRef}}

--- a/files/en-us/web/mathml/element/mfenced/index.md
+++ b/files/en-us/web/mathml/element/mfenced/index.md
@@ -10,6 +10,7 @@ tags:
 browser-compat: mathml.elements.mfenced
 ---
 {{MathMLRef}}
+{{deprecated_header}}
 
 The deprecated MathML `<mfenced>` element used to provide the possibility to add custom opening and closing parentheses (such as brackets) and separators (such as commas or semicolons) to an expression. It has been removed from the latest MathML standard and modern browsers no longer support it. Use the {{MathMLElement("mrow")}} and {{MathMLElement("mo")}} elements instead.
 


### PR DESCRIPTION
#### Summary

Add deprecation header for maction/mfenced. Also tweak a bit the description for maction.

#### Motivation

These elements are deprecated, so make clear to web developers they should avoid it.

#### Supporting details

MathML Core: https://w3c.github.io/mathml-core/#dfn-maction

#### Related issues

N/A

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
