### PR TITLE
Fixed inconsistency in the code example

### DIFF
--- a/files/en-us/learn/javascript/objects/basics/index.md
+++ b/files/en-us/learn/javascript/objects/basics/index.md
@@ -54,10 +54,10 @@ Congratulations, you've just created your first object. Job done! But this is an
 const person = {
   name: ['Bob', 'Smith'],
   age: 32,
-  bio: function() {
+  bio: function () {
     console.log(`${this.name[0]} ${this.name[1]} is ${this.age} years old.`);
   },
-  introduceSelf: function() {
+  introduceSelf: function () {
     console.log(`Hi! I'm ${this.name[0]}.`);
   }
 };
@@ -87,7 +87,7 @@ const objectName = {
 
 The value of an object member can be pretty much anything — in our person object we've got a number, an array, and two functions. The first two items are data items, and are referred to as the object's **properties**. The last two items are functions that allow the object to do something with that data, and are referred to as the object's **methods**.
 
-When the object's members are functions there's a simpler syntax. Instead of `bio: function()` we can write `bio()`. Like this:
+When the object's members are functions there's a simpler syntax. Instead of `bio: function ()` we can write `bio()`. Like this:
 
 ```js
 const person = {

--- a/files/en-us/learn/javascript/objects/basics/index.md
+++ b/files/en-us/learn/javascript/objects/basics/index.md
@@ -54,10 +54,10 @@ Congratulations, you've just created your first object. Job done! But this is an
 const person = {
   name: ['Bob', 'Smith'],
   age: 32,
-  bio() {
+  bio: function() {
     console.log(`${this.name[0]} ${this.name[1]} is ${this.age} years old.`);
   },
-  introduceSelf() {
+  introduceSelf: function() {
     console.log(`Hi! I'm ${this.name[0]}.`);
   }
 };


### PR DESCRIPTION
The shorthand of defining functions in an Object is used much earlier (in the code, on lines 57 and 60) than it is explained (on line 90).

#### Summary
I made a change in the first code example of creating a person Object - the function definition was not supposed to use the shorthand that was used until later after it was explained.

#### Motivation
When I read the first code example and then the next one, the explanation written before the second code example confused me because I did not see any difference between the two codes, which was supposed to be present. Hence I wanted to avoid future confusion for other people learning from / referring to this article.

#### Supporting details
None

#### Related issues
None

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
