### PR TITLE
fix typo and rephrase unclear sentence

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/introduction/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/introduction/index.md
@@ -480,9 +480,9 @@ For more information see [Database integration](https://expressjs.com/en/guide/d
 
 ### Rendering data (views)
 
-Template engines (referred to as "view engines" by _Express_) allow you to specify the _structure_ of an output document in a template, using placeholders for data that will be filled in when a page is generated. Templates are often used to create HTML, but can also create other types of documents. Express has support for [a number of template engines](https://github.com/expressjs/express/wiki#template-engines), and there is a useful comparison of the more popular engines here: [Comparing JavaScript Templating Engines: Jade, Mustache, Dust and More](https://strongloop.com/strongblog/compare-javascript-templates-jade-mustache-dust/).
+Template engines (also referred to as "view engines" by _Express_'s documentation) allow you to specify the _structure_ of an output document in a template, using placeholders for data that will be filled in when a page is generated. Templates are often used to create HTML, but can also create other types of documents. Express has support for [a number of template engines](https://github.com/expressjs/express/wiki#template-engines), and there is a useful comparison of the more popular engines here: [Comparing JavaScript Templating Engines: Jade, Mustache, Dust and More](https://strongloop.com/strongblog/compare-javascript-templates-jade-mustache-dust/).
 
-In your application settings code you set the template engine to use and the location where Express should look for templates using the 'views' and 'view engines' settings, as shown below (you will also have to install the package containing your template library too!)
+In your application settings code you set the template engine to use and the location where Express should look for templates using the 'views' and 'view engine' settings, as shown below (you will also have to install the package containing your template library too!)
 
 ```js
 const express = require('express');


### PR DESCRIPTION
there's an inconsistency between the article and code snippet, in favour of the code snippet (and the documentation: https://expressjs.com/en/api.html#app.settings.table)

also, it looks like current (?) express docs refer to template engines as view engines somewhat interchangeably with the former (or at least for me it isn't entirely clear whether any of these should convey something else)
https://expressjs.com/en/guide/using-template-engines.html
https://github.com/expressjs/express/wiki#template-engines
