### PR TITLE
Fix broken links in "Enumerability and ownership of properties" table

### DIFF
--- a/files/en-us/web/javascript/enumerability_and_ownership_of_properties/index.md
+++ b/files/en-us/web/javascript/enumerability_and_ownership_of_properties/index.md
@@ -25,8 +25,8 @@ There are four built-in ways to query a property of an object. They all support 
 
 |  | Enumerable, own | Enumerable, inherited | Non-enumerable, own | Non-enumerable, inherited |
 |--|------------|-----------|------------|-----------|
-| [`propertyIsEnumerable()`]((/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable)) | `true ✅`  | `false ❌` | `false ❌` | `false ❌` |
-| [`hasOwnProperty()`]((/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty)) | `true ✅`  | `false ❌` | `true ✅`  | `false ❌` |
+| [`propertyIsEnumerable()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable) | `true ✅`  | `false ❌` | `false ❌` | `false ❌` |
+| [`hasOwnProperty()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty) | `true ✅`  | `false ❌` | `true ✅`  | `false ❌` |
 | [`Object.hasOwn()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn) | `true ✅`  | `false ❌` | `true ✅`  | `false ❌` |
 | [`in`](/en-US/docs/Web/JavaScript/Reference/Operators/in) | `true ✅`  | `true ✅`  | `true ✅`  | `true ✅`  |
 


### PR DESCRIPTION
#### Summary
There are two broken links in the [Enumerability and ownership of properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Enumerability_and_ownership_of_properties) article.

The broken links are present in the "Querying object properties" table:
- `propertyIsEnumerable`
- `hasOwnProperty`

![image](https://user-images.githubusercontent.com/2999604/180571963-cde0bf1b-eeba-4f10-b1d0-cc8b2e7ba21c.png)

#### Motivation
Clicking the property name is taking the users to the following URL: https://developer.mozilla.org/en-US/docs/Web/JavaScript/(/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/propertyIsEnumerable) which doesn't exist and shows a 404 page. 

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
