### PR TITLE
remove a broken link

### DIFF
--- a/files/en-us/web/api/baseaudiocontext/samplerate/index.md
+++ b/files/en-us/web/api/baseaudiocontext/samplerate/index.md
@@ -27,7 +27,7 @@ second.
 ## Examples
 
 > **Note:** for a full Web Audio example implementation, see one of our
-> Web Audio Demos on the [MDN GitHub repo](https://github.com/orgs/mdn/repositories?q=audio). Try entering
+> Web Audio Demos on the [MDN GitHub repo](https://github.com/mdn/webaudio-examples). Try entering
 > `audioCtx.sampleRate` into your browser console.
 
 ```js

--- a/files/en-us/web/api/baseaudiocontext/samplerate/index.md
+++ b/files/en-us/web/api/baseaudiocontext/samplerate/index.md
@@ -27,7 +27,7 @@ second.
 ## Examples
 
 > **Note:** for a full Web Audio example implementation, see one of our
-> Web Audio Demos on the [MDN GitHub repo](https://github.com/mdn/), like [panner-node](https://github.com/mdn/panner-node). Try entering
+> Web Audio Demos on the [MDN GitHub repo](https://github.com/orgs/mdn/repositories?q=audio). Try entering
 > `audioCtx.sampleRate` into your browser console.
 
 ```js


### PR DESCRIPTION
Also provided a better link for audio repos under mdn.

We need to move web audio examples to mdn/dom-examples.