### PR TITLE
adding the word "syntatically" to the sentence

### DIFF
--- a/files/en-us/learn/css/building_blocks/selectors/index.md
+++ b/files/en-us/learn/css/building_blocks/selectors/index.md
@@ -87,7 +87,7 @@ In the live example below try combining the two selectors which have identical d
 
 {{EmbedGHLiveSample("css-examples/learn/selectors/selector-list.html", '100%', 1100)}}
 
-When you group selectors in this way, if any selector is invalid the whole rule will be ignored.
+When you group selectors in this way, if any selector is syntatically invalid the whole rule will be ignored.
 
 In the following example, the invalid class selector rule will be ignored, whereas the `h1` would still be styled.
 

--- a/files/en-us/learn/css/building_blocks/selectors/index.md
+++ b/files/en-us/learn/css/building_blocks/selectors/index.md
@@ -87,7 +87,7 @@ In the live example below try combining the two selectors which have identical d
 
 {{EmbedGHLiveSample("css-examples/learn/selectors/selector-list.html", '100%', 1100)}}
 
-When you group selectors in this way, if any selector is syntatically invalid the whole rule will be ignored.
+When you group selectors in this way, if any selector is syntactically invalid, the whole rule will be ignored.
 
 In the following example, the invalid class selector rule will be ignored, whereas the `h1` would still be styled.
 


### PR DESCRIPTION
This makes it clear that semantic errors do not affect "grouped selectors".

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
