### PR TITLE
Fix getHighEntropyValues(["fullVersionList"])

### DIFF
--- a/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.md
+++ b/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.md
@@ -54,7 +54,7 @@ A {{jsxref("Promise")}} that resolves to an object containing some or all of the
   - : A string containing the full browser version. For example, `"91.0.4472.124"`.
 - `fullVersionList`
   - : An array of brand information containing the browser name and full version.
-    For example, `"Chromium";v="91.0.4472.124","Google Chrome";v="91.0.4472.124"`.
+    For example, `{"brand": "Google Chrome", "version": "103.0.5060.134"}, {"brand": "Chromium", "version": "103.0.5060.134"}`.
 
 ### Exceptions
 
@@ -72,7 +72,7 @@ navigator.userAgentData.getHighEntropyValues(
   "model",
   "platformVersion",
   "fullVersionList"])
-  .then((ua) => { console.log(ua) });
+  .then(console.log);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.md
+++ b/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.md
@@ -72,7 +72,7 @@ navigator.userAgentData.getHighEntropyValues(
   "model",
   "platformVersion",
   "fullVersionList"])
-  .then(console.log);
+  .then((values) => console.log(values));
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Fix `fullVersionList`: it is an array of objects containing `brand` and `version`, not a single string.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Make documentation consistent with specification and Chromium implementation.

#### Supporting details
1. The spec says so [here](https://wicg.github.io/ua-client-hints/#dom-uadatavalues-fullversionlist): 
   `fullVersionList` defined as
   ```
   sequence<NavigatorUABrandVersion>
   ```
   and `NavigatorUABrandVersion` is defined as
   ```
   dictionary NavigatorUABrandVersion {
      [DOMString](https://webidl.spec.whatwg.org/#idl-DOMString) brand;
      [DOMString](https://webidl.spec.whatwg.org/#idl-DOMString) version;
   };
   ```
   At different points in time, this property had a different type (`FrozenArray<NavigatorUABrandVersion>`), different name (`versionList`), but it was never a string (`DOMString`).

2. When run provided example, Chromium returns the exact object I pasted into this document.

I think the original example was just a mistake in MDN so we can just update this example and do not need to document string type since it never existed, as far as I can tell.
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
#13461

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
