### PR TITLE
Remove return

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/index.md
@@ -52,14 +52,14 @@ There are two ways to access an individual character in a string. The first is t
 {{jsxref("String.prototype.charAt()", "charAt()")}} method:
 
 ```js
-return 'cat'.charAt(1) // returns "a"
+'cat'.charAt(1) // gives value "a"
 ```
 
 The other way (introduced in ECMAScript 5) is to treat the string as an array-like
 object, where individual characters correspond to a numerical index:
 
 ```js
-return 'cat'[1] // returns "a"
+'cat'[1] // gives value "a"
 ```
 
 When using bracket notation for character access, attempting to delete or assign a


### PR DESCRIPTION
#### Summary

I suppose, we can use simple literal here, no need `return` statement without a function.

#### Supporting details

By the way, we have the same issue in all languages. Is it ok to fix in English or we need to change all languages in one PR to be synchronized ?
