### PR TITLE
Fix description of negated character class

### DIFF
--- a/files/en-us/web/javascript/guide/regular_expressions/character_classes/index.md
+++ b/files/en-us/web/javascript/guide/regular_expressions/character_classes/index.md
@@ -65,7 +65,7 @@ Character classes distinguish kinds of characters such as, for example, distingu
           A negated or complemented character class. That is, it matches
           anything that is not enclosed in the brackets. You can specify a range
           of characters by using a hyphen, but if the hyphen appears as the
-          first or last character enclosed in the square brackets, it is taken as
+          first character after the `^` or the last character enclosed in the square brackets, it is taken as
           a literal hyphen to be included in the character class as a normal
           character. For example, <code>[^abc]</code> is the same as
           <code>[^a-c]</code>. They initially match "o" in "bacon" and "h" in


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Change `first` to `second`.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

Because if `-` is the second character after `[` in negated character class, it will be taken as a literal hyphen. Not first character. For example, `[^-abcd]`.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
