### PR TITLE
Update maximum string length in SpiderMonkey in error docs

### DIFF
--- a/files/en-us/web/javascript/reference/errors/resulting_string_too_large/index.md
+++ b/files/en-us/web/javascript/reference/errors/resulting_string_too_large/index.md
@@ -36,7 +36,7 @@ number. The range of allowed values can be described like this: \[0, +∞).
 
 The resulting string can also not be larger than the maximum string size, which can
 differ in JavaScript engines. In Firefox (SpiderMonkey) the maximum string size is
-2^28 - 1 (`0xFFFFFFF`).
+2^30 - 2 (`0x3FFFFFFD`).
 
 ## Examples
 
@@ -44,7 +44,7 @@ differ in JavaScript engines. In Firefox (SpiderMonkey) the maximum string size 
 
 ```js example-bad
 'abc'.repeat(Infinity); // RangeError
-'a'.repeat(2**28);      // RangeError
+'a'.repeat(2**30);      // RangeError
 ```
 
 ### Valid cases

--- a/files/en-us/web/javascript/reference/errors/resulting_string_too_large/index.md
+++ b/files/en-us/web/javascript/reference/errors/resulting_string_too_large/index.md
@@ -36,7 +36,7 @@ number. The range of allowed values can be described like this: \[0, +∞).
 
 The resulting string can also not be larger than the maximum string size, which can
 differ in JavaScript engines. In Firefox (SpiderMonkey) the maximum string size is
-2^30 - 2 (`0x3FFFFFFD`).
+2<sup>30</sup> - 2 (\~1GB).
 
 ## Examples
 


### PR DESCRIPTION
#### Summary
The maximum string length SpiderMonkey can handle was increased from `2^28 - 1` to `2^30 - 2` [in this 2018 CL](https://hg.mozilla.org/integration/autoland/rev/cafc30a40d9f).

#### Motivation
This updates the documentation to ensure it's accurate.

This PR…

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error
