### PR TITLE
Webassembly documentation fix for op codes global.get and global.set

### DIFF
--- a/files/en-us/webassembly/reference/variables/global_get/index.md
+++ b/files/en-us/webassembly/reference/variables/global_get/index.md
@@ -22,4 +22,4 @@ global.get $val
 
 | Instruction  | Binary opcode |
 | ------------ | ------------- |
-| `global.get` | `0x20`        |
+| `global.get` | `0x23`        |

--- a/files/en-us/webassembly/reference/variables/global_set/index.md
+++ b/files/en-us/webassembly/reference/variables/global_set/index.md
@@ -25,4 +25,4 @@ global.set $val
 
 | Instruction  | Binary opcode |
 | ------------ | ------------- |
-| `global.set` | `0x21`        |
+| `global.set` | `0x24`        |


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
This PR fixes the binary op codes in the webassembly `global.get` and `global.set` documentation pages. They currently are identical to `local.get`: `0x20` and `local.set`: `0x21`.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The correct binary op codes are `0x23` for `global.get` and `0x24` for `global.set`.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://github.com/WebAssembly/wabt/blob/8761c56038aa69e697315dc9898ba2b1cfa305f5/src/opcode.def#L66

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
