### PR TITLE
Incorrectly formatted notes and warnings

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-rowindex/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-rowindex/index.md
@@ -26,7 +26,7 @@ If all of the rows are loaded and in the DOM, you don't need to include `aria-ro
 
 If the table with only a subset of rows has a cell that spans more than one row, both the row and cell need to have the `aria-rowspan`  set. If a cell spans more than one row－when a cell role includes the `aria-rowspan` attribute or HTML cell has a `rowspan` attribute set to a value greater than 1－include the row's `aria-rowindex` value on the spanning cell in addition to the appropriate row spanning attribute. The value should be the row index of the row where the span starts.
 
-> **Note**: The `aria-rowindex` must be added to each row, but is optional on the cells, except for cells that span rows: the `aria-rowindex` attribute is required on all spanning cells.
+> **Note:** The `aria-rowindex` must be added to each row, but is optional on the cells, except for cells that span rows: the `aria-rowindex` attribute is required on all spanning cells.
 
 ## Examples
 

--- a/files/en-us/web/accessibility/aria/roles/slider_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/slider_role/index.md
@@ -30,7 +30,8 @@ The `slider` role, similar to HTML's `input` of type `range`, [`<input type="ran
 
 While all three of these ranges have the same ARIA states and properties, the `slider` role is the only read-write range: it is the only one whose value changes via user interaction. As such, it must be able to receive focus. In addition, keyboard interaction, mouse clicks, and touch interaction must be supported.
 
-> **Warning** To change the slider value, touch-based assistive technologies need to respond to user gestures for increasing and decreasing the value by synthesizing key events. Fully test slider widgets using assistive technologies on devices where touch is a primary input mechanism before using the `slider` role (and all range widgets).
+> **Warning:** To change the slider value, touch-based assistive technologies need to respond to user gestures for increasing and decreasing the value by synthesizing key events.
+> Fully test slider widgets using assistive technologies on devices where touch is a primary input mechanism before using the `slider` role (and all range widgets).
 
 #### Common attributes
 

--- a/files/en-us/web/accessibility/aria/roles/spinbutton_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/spinbutton_role/index.md
@@ -39,7 +39,8 @@ The `slider` role, similar to HTML's `input` of type `range`, [`<input type="ran
 
 While all three of these ranges have the same ARIA states and properties, the `spinbutton` role is the only read-write range: it is the only one whose value changes via user interaction. As such, it must be able to receive focus. In addition, keyboard interaction, mouse clicks, and touch interaction must be supported.
 
-> **Warning** To change the spinbutton value, touch-based assistive technologies need to respond to user gestures for increasing and decreasing the value by synthesizing key events. Fully test spinbutton widgets using assistive technologies on devices where touch is a primary input mechanism before using the `spinbutton` role (and all range widgets).
+> **Warning:** To change the spinbutton value, touch-based assistive technologies need to respond to user gestures for increasing and decreasing the value by synthesizing key events.
+> Fully test spinbutton widgets using assistive technologies on devices where touch is a primary input mechanism before using the `spinbutton` role (and all range widgets).
 
 #### Common attributes
 

--- a/files/en-us/web/api/window/applicationcache/index.md
+++ b/files/en-us/web/api/window/applicationcache/index.md
@@ -16,7 +16,7 @@ browser-compat: api.SharedWorkerGlobalScope.applicationCache
 ---
 {{APIRef}}{{Deprecated_Header}}{{Non-standard_Header}}{{securecontext_header}}
 
-> **Warning**: Application cache is being removed from web platform. Consider using [service workers](/en-US/docs/Web/API/Service_Worker_API) instead.
+> **Warning:**: Application cache is being removed from web platform. Consider using [service workers](/en-US/docs/Web/API/Service_Worker_API) instead.
 
 Returns a reference to the application cache object for the window.
 


### PR DESCRIPTION
These were missing the `:` so did not render as intended. 