### PR TITLE
Updates broken links

### DIFF
--- a/files/en-us/glossary/class/index.md
+++ b/files/en-us/glossary/class/index.md
@@ -9,7 +9,7 @@ In {{glossary("OOP","object-oriented programming")}}, a _class_ defines an {{glo
 
 ## See also
 
-- [Class-based vs. prototype-based programming languages](/en-US/docs/Web/JavaScript/Guide/Details_of_the_Object_Model#class-based_vs._prototype-based_languages) (like JavaScript)
 - [Using functions as classes in JavaScript](/en-US/docs/Learn/JavaScript/Objects#the_class)
+- [Inheritance and the prototype chain](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain)
 - [Class-based programming](https://en.wikipedia.org/wiki/Class-based_programming) on Wikipedia
 - [Object-oriented programming](https://en.wikipedia.org/wiki/Object-oriented_programming) on Wikipedia

--- a/files/en-us/glossary/oop/index.md
+++ b/files/en-us/glossary/oop/index.md
@@ -8,9 +8,10 @@ tags:
 ---
 **OOP** (Object-Oriented Programming) is an approach in programming in which data is encapsulated within **{{glossary("object","objects")}}** and the object itself is operated on, rather than its component parts.
 
-{{glossary("JavaScript")}} is heavily object-oriented. It follows a **prototype**-based model ([as opposed to class-based](/en-US/docs/Web/JavaScript/Guide/Details_of_the_Object_Model#class-based_vs._prototype-based_languages)).
+{{glossary("JavaScript")}} is heavily object-oriented. It follows a **prototype**-based model.
 
 ## See also
 
 - {{Interwiki("wikipedia", "Object-oriented programming")}} on Wikipedia
 - [Introduction to object-oriented JavaScript](/en-US/docs/Learn/JavaScript/Objects)
+- [Inheritance and the prototype chain](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain)

--- a/files/en-us/glossary/oop/index.md
+++ b/files/en-us/glossary/oop/index.md
@@ -8,7 +8,7 @@ tags:
 ---
 **OOP** (Object-Oriented Programming) is an approach in programming in which data is encapsulated within **{{glossary("object","objects")}}** and the object itself is operated on, rather than its component parts.
 
-{{glossary("JavaScript")}} is heavily object-oriented. It follows a **prototype**-based model.
+{{glossary("JavaScript")}} is heavily object-oriented. It follows a [**prototype**-based model](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain), but it also offers a [class syntax](/en-US/docs/Web/JavaScript/Guide/Using_Classes) to enable typical OOP paradigms.
 
 ## See also
 

--- a/files/en-us/mdn/guidelines/writing_style_guide/index.md
+++ b/files/en-us/mdn/guidelines/writing_style_guide/index.md
@@ -60,8 +60,8 @@ For example, consider the [JavaScript](/en-US/docs/Web/JavaScript) guide, which 
 
 - [JavaScript/Guide](/en-US/docs/Web/JavaScript/Guide) – Main table-of-contents page
 - [JavaScript/Guide/JavaScript Overview](/en-US/docs/Web/JavaScript/Guide/Introduction)
-- [JavaScript/Guide/Functions](/en-US/docs/Web/JavaScript/Guide/Functions)
-- [JavaScript/Guide/Details of the Object Model](/en-US/docs/Web/JavaScript/Guide/Details_of_the_Object_Model)
+- [JavaScript/Guide/Grammar and types](/en-US/docs/Web/JavaScript/Guide/Grammar_and_types)
+- …
 
 Try to avoid putting your article at the top of the hierarchy, which slows the site down and makes search and site navigation less effective.
 

--- a/files/en-us/web/javascript/a_re-introduction_to_javascript/index.md
+++ b/files/en-us/web/javascript/a_re-introduction_to_javascript/index.md
@@ -756,7 +756,7 @@ Note that JavaScript functions are themselves objects — like everything else i
 ## Custom objects
 
 > **Note:** The content in this section does not cover modern JavaScript features, including support for [Classes](/en-US/docs/Web/JavaScript/Reference/Classes).
-> For a more detailed discussion of object-oriented programming in JavaScript, see [Introducing JavaScript objects](/en-US/docs/Learn/JavaScript/Objects) and [Details of the object model](/en-US/docs/Web/JavaScript/Guide/Details_of_the_Object_Model).
+> For a more detailed discussion of object-oriented programming in JavaScript, see [Introducing JavaScript objects](/en-US/docs/Learn/JavaScript/Objects) and [Inheritance and the prototype chain](/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain).
 
 In classic object-oriented programming, objects are collections of data and methods that operate on that data.
 JavaScript uses functions as classes.


### PR DESCRIPTION
The URL `Details_of_the_Object_Model` redirects to `Inheritance_and_the_prototype_chain`.
Also, the fragment `class-based_vs._prototype-based_languages` doesn't exist on the new page.