### PR TITLE
Mediacapture sidebar

### DIFF
--- a/files/en-us/web/api/blobevent/blobevent/index.md
+++ b/files/en-us/web/api/blobevent/blobevent/index.md
@@ -12,7 +12,7 @@ tags:
   - Reference
 browser-compat: api.BlobEvent.BlobEvent
 ---
-{{APIRef("Media Capture and Streams")}}
+{{APIRef("Media Recorder API")}}
 
 The **`BlobEvent()`** constructor returns a newly created
 {{domxref("BlobEvent")}} object with an associated {{domxref("Blob")}}.

--- a/files/en-us/web/api/blobevent/data/index.md
+++ b/files/en-us/web/api/blobevent/data/index.md
@@ -7,15 +7,14 @@ tags:
   - BlobEvent
   - DOM
   - DOM Reference
-  - Media Stream Recording
+  - Media Recorder API
   - Property
   - Reference
 browser-compat: api.BlobEvent.data
 ---
-{{ apiref("Media Capture and Streams") }}
+{{APIRef("Media Recorder API")}}
 
-The **`BlobEvent.data`** read-only property represents a
-{{domxref("Blob")}} associated with the event.
+The **`BlobEvent.data`** read-only property represents a {{domxref("Blob")}} associated with the event.
 
 ## Value
 

--- a/files/en-us/web/api/blobevent/index.md
+++ b/files/en-us/web/api/blobevent/index.md
@@ -18,8 +18,7 @@ browser-compat: api.BlobEvent
 ---
 {{APIRef("Media Recorder API")}}
 
-The **`BlobEvent`** interface represents events associated with a {{domxref("Blob")}}.
-These blobs are typically, but not necessarily, associated with media content.
+The **`BlobEvent`** interface represents events associated with a {{domxref("Blob")}}. These blobs are typically, but not necessarily,  associated with media content.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/blobevent/index.md
+++ b/files/en-us/web/api/blobevent/index.md
@@ -16,9 +16,10 @@ tags:
   - events
 browser-compat: api.BlobEvent
 ---
-{{APIRef("Media Capture and Streams")}}
+{{APIRef("Media Recorder API")}}
 
-The **`BlobEvent`** interface represents events associated with a {{domxref("Blob")}}. These blobs are typically, but not necessarily,  associated with media content.
+The **`BlobEvent`** interface represents events associated with a {{domxref("Blob")}}.
+These blobs are typically, but not necessarily, associated with media content.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/blobevent/timecode/index.md
+++ b/files/en-us/web/api/blobevent/timecode/index.md
@@ -13,7 +13,7 @@ browser-compat: api.BlobEvent.timecode
 ---
 {{SeeCompatTable}}{{APIRef("Media Recorder API")}}
 
-The **`timecode`** read only property of the {{domxref("BlobEvent")}} interface indicates the difference between the timestamp of the first chunk in data, and the timestamp of the first chunk in the first `BlobEvent` produced by this recorder.
+The **`timecode`** read only property of the {{domxref("BlobEvent")}} interface indicates the difference between the timestamp of the first chunk of data, and the timestamp of the first chunk in the first `BlobEvent` produced by this recorder.
 
 Note that the `timecode` in the first produced `BlobEvent` does not need to be zero.
 

--- a/files/en-us/web/api/blobevent/timecode/index.md
+++ b/files/en-us/web/api/blobevent/timecode/index.md
@@ -6,21 +6,16 @@ tags:
   - API
   - BlobEvent
   - Media
-  - Media Stream Recording
+  - Media Recorder API
   - Property
   - Reference
 browser-compat: api.BlobEvent.timecode
 ---
-{{SeeCompatTable}}{{APIRef("Media Capture and Streams")}}
+{{SeeCompatTable}}{{APIRef("Media Recorder API")}}
 
-The **`timecode`** readonlyinline
-property of the {{domxref("BlobEvent")}} interface a
-{{domxref("DOMHighResTimeStamp")}} indicating the difference between the timestamp of
-the first chunk in data, and the timestamp of the first chunk in the first BlobEvent
-produced by this recorder.
+The **`timecode`** read only property of the {{domxref("BlobEvent")}} interface indicates the difference between the timestamp of the first chunk in data, and the timestamp of the first chunk in the first `BlobEvent` produced by this recorder.
 
-Note that the timecode in the first produced
-BlobEvent does not need to be zero.
+Note that the `timecode` in the first produced `BlobEvent` does not need to be zero.
 
 ## Value
 

--- a/files/en-us/web/api/canvascapturemediastreamtrack/index.md
+++ b/files/en-us/web/api/canvascapturemediastreamtrack/index.md
@@ -13,7 +13,7 @@ tags:
   - Web
 browser-compat: api.CanvasCaptureMediaStreamTrack
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`CanvasCaptureMediaStreamTrack`** interface represents the video track contained in a {{domxref("MediaStream")}} being generated from a {{HTMLElement("canvas")}} following a call to {{domxref("HTMLCanvasElement.captureStream()")}}.
 

--- a/files/en-us/web/api/canvascapturemediastreamtrack/requestframe/index.md
+++ b/files/en-us/web/api/canvascapturemediastreamtrack/requestframe/index.md
@@ -14,7 +14,7 @@ tags:
   - requestFrame
 browser-compat: api.CanvasCaptureMediaStreamTrack.requestFrame
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("CanvasCaptureMediaStreamTrack")}} method
 **`requestFrame()`** requests that a frame be captured from

--- a/files/en-us/web/api/htmlcanvaselement/capturestream/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/capturestream/index.md
@@ -16,7 +16,7 @@ tags:
   - captureStream
 browser-compat: api.HTMLCanvasElement.captureStream
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("HTMLCanvasElement")}} **`captureStream()`** method returns a {{domxref("MediaStream")}}
 which includes a {{domxref("CanvasCaptureMediaStreamTrack")}} containing a real-time video capture of the canvas's contents.

--- a/files/en-us/web/api/media_streams_api/index.md
+++ b/files/en-us/web/api/media_streams_api/index.md
@@ -32,7 +32,6 @@ The output of the `MediaStream` object is linked to a **consumer**. It can be a 
 
 In these reference articles, you'll find the fundamental information you'll need to know about each of the interfaces that make up the Media Capture and Streams API.
 
-- {{domxref("BlobEvent")}}
 - {{domxref("CanvasCaptureMediaStreamTrack")}}
 - {{domxref("InputDeviceInfo")}}
 - {{domxref("MediaDeviceKind")}}

--- a/files/en-us/web/api/mediadevices/getsupportedconstraints/index.md
+++ b/files/en-us/web/api/mediadevices/getsupportedconstraints/index.md
@@ -14,7 +14,7 @@ tags:
   - getSupportedConstraints
 browser-compat: api.MediaDevices.getSupportedConstraints
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The
 **`getSupportedConstraints()`**

--- a/files/en-us/web/api/mediadevices/index.md
+++ b/files/en-us/web/api/mediadevices/index.md
@@ -20,7 +20,7 @@ tags:
   - WebRTC
 browser-compat: api.MediaDevices
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`MediaDevices`** interface provides access to connected media input devices like cameras and microphones, as well as screen sharing. In essence, it lets you obtain access to any hardware source of media data.
 

--- a/files/en-us/web/api/mediastream/active/index.md
+++ b/files/en-us/web/api/mediastream/active/index.md
@@ -12,7 +12,7 @@ tags:
   - active
 browser-compat: api.MediaStream.active
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`active`** read-only property of the
 {{domxref("MediaStream")}} interface returns a Boolean value which is

--- a/files/en-us/web/api/mediastream/addtrack/index.md
+++ b/files/en-us/web/api/mediastream/addtrack/index.md
@@ -11,7 +11,7 @@ tags:
   - addTrack
 browser-compat: api.MediaStream.addTrack
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`MediaStream.addTrack()`** method adds a new track to the
 stream. The track is specified as a parameter of type {{domxref("MediaStreamTrack")}}.

--- a/files/en-us/web/api/mediastream/addtrack_event/index.md
+++ b/files/en-us/web/api/mediastream/addtrack_event/index.md
@@ -6,7 +6,7 @@ tags:
   - Event
 browser-compat: api.MediaStream.addtrack_event
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The `addtrack` event is fired when a new [`MediaStreamTrack`](/en-US/docs/Web/API/MediaStreamTrack) object has been added to a [`MediaStream`](/en-US/docs/Web/API/MediaStream).
 

--- a/files/en-us/web/api/mediastream/clone/index.md
+++ b/files/en-us/web/api/mediastream/clone/index.md
@@ -12,7 +12,7 @@ tags:
   - clone
 browser-compat: api.MediaStream.clone
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`clone()`** method of the {{domxref("MediaStream")}}
 interface creates a duplicate of the `MediaStream`. This new

--- a/files/en-us/web/api/mediastream/getaudiotracks/index.md
+++ b/files/en-us/web/api/mediastream/getaudiotracks/index.md
@@ -17,7 +17,7 @@ tags:
   - track
 browser-compat: api.MediaStream.getAudioTracks
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`getAudioTracks()`** method of the
 {{domxref("MediaStream")}} interface returns a sequence that represents all the

--- a/files/en-us/web/api/mediastream/gettrackbyid/index.md
+++ b/files/en-us/web/api/mediastream/gettrackbyid/index.md
@@ -12,7 +12,7 @@ tags:
   - getTrackById
 browser-compat: api.MediaStream.getTrackById
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`MediaStream.getTrackById()`** method returns a
 {{domxref("MediaStreamTrack")}} object representing the track with the specified ID

--- a/files/en-us/web/api/mediastream/gettracks/index.md
+++ b/files/en-us/web/api/mediastream/gettracks/index.md
@@ -13,7 +13,7 @@ tags:
   - getTracks
 browser-compat: api.MediaStream.getTracks
 ---
-{{APIRef("Media Capture and Streams")}}{{SeeCompatTable}}
+{{DefaultAPISidebar("Media Capture and Streams")}}{{SeeCompatTable}}
 
 The **_`getTracks()`_** method of the
 {{domxref("MediaStream")}} interface returns a sequence that represents all the

--- a/files/en-us/web/api/mediastream/getvideotracks/index.md
+++ b/files/en-us/web/api/mediastream/getvideotracks/index.md
@@ -16,7 +16,7 @@ tags:
   - track
 browser-compat: api.MediaStream.getVideoTracks
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`getVideoTracks()`** method of the
 {{domxref("MediaStream")}} interface returns a sequence of

--- a/files/en-us/web/api/mediastream/id/index.md
+++ b/files/en-us/web/api/mediastream/id/index.md
@@ -10,7 +10,7 @@ tags:
   - Web
 browser-compat: api.MediaStream.id
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`MediaStream.id`** read-only property is a
 string containing 36 characters denoting a unique identifier (GUID)

--- a/files/en-us/web/api/mediastream/index.md
+++ b/files/en-us/web/api/mediastream/index.md
@@ -11,7 +11,7 @@ tags:
   - WebRTC
 browser-compat: api.MediaStream
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`MediaStream`** interface represents a stream of media content. A stream consists of several **tracks**, such as video or audio tracks. Each track is specified as an instance of {{domxref("MediaStreamTrack")}}.
 

--- a/files/en-us/web/api/mediastream/mediastream/index.md
+++ b/files/en-us/web/api/mediastream/mediastream/index.md
@@ -18,7 +18,7 @@ tags:
   - streaming
 browser-compat: api.MediaStream.MediaStream
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`MediaStream()`** constructor
 returns a newly-created {{domxref("MediaStream")}}, which serves as a collection of

--- a/files/en-us/web/api/mediastream/removetrack_event/index.md
+++ b/files/en-us/web/api/mediastream/removetrack_event/index.md
@@ -6,7 +6,7 @@ tags:
   - Event
 browser-compat: api.MediaStream.removetrack_event
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The `removetrack` event is fired when a new [`MediaStreamTrack`](/en-US/docs/Web/API/MediaStreamTrack) object has been removed from a [`MediaStream`](/en-US/docs/Web/API/MediaStream).
 

--- a/files/en-us/web/api/mediastreamtrack/applyconstraints/index.md
+++ b/files/en-us/web/api/mediastreamtrack/applyconstraints/index.md
@@ -12,7 +12,7 @@ tags:
   - applyConstraints
 browser-compat: api.MediaStreamTrack.applyConstraints
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The
 **`applyConstraints()`** method

--- a/files/en-us/web/api/mediastreamtrack/clone/index.md
+++ b/files/en-us/web/api/mediastreamtrack/clone/index.md
@@ -12,7 +12,7 @@ tags:
   - clone
 browser-compat: api.MediaStreamTrack.clone
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`clone()`** method of the {{domxref("MediaStreamTrack")}}
 interface creates a duplicate of the `MediaStreamTrack`. This new

--- a/files/en-us/web/api/mediastreamtrack/enabled/index.md
+++ b/files/en-us/web/api/mediastreamtrack/enabled/index.md
@@ -14,7 +14,7 @@ tags:
   - enabled
 browser-compat: api.MediaStreamTrack.enabled
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`enabled`** property on the
 {{domxref("MediaStreamTrack")}} interface is a Boolean value which is

--- a/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
+++ b/files/en-us/web/api/mediastreamtrack/getcapabilities/index.md
@@ -12,7 +12,7 @@ tags:
   - getCapabilities
 browser-compat: api.MediaStreamTrack.getCapabilities
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`getCapabilities()`** method of
 the {{domxref("MediaStreamTrack")}} interface returns a

--- a/files/en-us/web/api/mediastreamtrack/getconstraints/index.md
+++ b/files/en-us/web/api/mediastreamtrack/getconstraints/index.md
@@ -12,7 +12,7 @@ tags:
   - getConstraints
 browser-compat: api.MediaStreamTrack.getConstraints
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`getConstraints()`** method of
 the {{domxref("MediaStreamTrack")}} interface returns a

--- a/files/en-us/web/api/mediastreamtrack/getsettings/index.md
+++ b/files/en-us/web/api/mediastreamtrack/getsettings/index.md
@@ -11,7 +11,7 @@ tags:
   - Reference
 browser-compat: api.MediaStreamTrack.getSettings
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`getSettings()`** method of the
 {{domxref("MediaStreamTrack")}} interface returns a {{domxref("MediaTrackSettings")}}

--- a/files/en-us/web/api/mediastreamtrack/id/index.md
+++ b/files/en-us/web/api/mediastreamtrack/id/index.md
@@ -11,7 +11,7 @@ tags:
   - WebRTC
 browser-compat: api.MediaStreamTrack.id
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`MediaStreamTrack.id`** read-only property returns a
 string containing a unique identifier (GUID) for the track, which is

--- a/files/en-us/web/api/mediastreamtrack/index.md
+++ b/files/en-us/web/api/mediastreamtrack/index.md
@@ -15,7 +15,7 @@ tags:
   - WebRTC
 browser-compat: api.MediaStreamTrack
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`MediaStreamTrack`** interface represents a single media track within a stream; typically, these are audio or video tracks, but other track types may exist as well.
 

--- a/files/en-us/web/api/mediastreamtrack/kind/index.md
+++ b/files/en-us/web/api/mediastreamtrack/kind/index.md
@@ -12,7 +12,7 @@ tags:
   - WebRTC
 browser-compat: api.MediaStreamTrack.kind
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`MediaStreamTrack.kind`**
 read-only property returns a string set to `"audio"` if

--- a/files/en-us/web/api/mediastreamtrack/label/index.md
+++ b/files/en-us/web/api/mediastreamtrack/label/index.md
@@ -12,7 +12,7 @@ tags:
   - WebRTC
 browser-compat: api.MediaStreamTrack.label
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`MediaStreamTrack.label`**
 read-only property returns a string containing a {{glossary("user

--- a/files/en-us/web/api/mediastreamtrack/mute_event/index.md
+++ b/files/en-us/web/api/mediastreamtrack/mute_event/index.md
@@ -14,7 +14,7 @@ tags:
   - mute
 browser-compat: api.MediaStreamTrack.mute_event
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`mute`** event is sent to a {{domxref("MediaStreamTrack")}} when the track's source is temporarily unable to provide media data.
 

--- a/files/en-us/web/api/mediastreamtrack/muted/index.md
+++ b/files/en-us/web/api/mediastreamtrack/muted/index.md
@@ -12,7 +12,7 @@ tags:
   - muted
 browser-compat: api.MediaStreamTrack.muted
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`muted`** read-only property of the
 {{domxref("MediaStreamTrack")}} interface returns a boolean value

--- a/files/en-us/web/api/mediastreamtrack/readystate/index.md
+++ b/files/en-us/web/api/mediastreamtrack/readystate/index.md
@@ -12,7 +12,7 @@ tags:
   - Reference
 browser-compat: api.MediaStreamTrack.readyState
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`MediaStreamTrack.readyState`** read-only property
 returns an enumerated value giving the status of the track.

--- a/files/en-us/web/api/mediastreamtrack/remote/index.md
+++ b/files/en-us/web/api/mediastreamtrack/remote/index.md
@@ -11,7 +11,7 @@ tags:
   - WebRTC
 browser-compat: api.MediaStreamTrack.remote
 ---
-{{APIRef("Media Capture and Streams")}}{{deprecated_header}}
+{{DefaultAPISidebar("Media Capture and Streams")}}{{deprecated_header}}
 
 The **`MediaStreamTrack.remote`** read-only property allows
 Javascript to know whether a WebRTC MediaStreamTrack is from a remote source or a local

--- a/files/en-us/web/api/mediastreamtrack/stop/index.md
+++ b/files/en-us/web/api/mediastreamtrack/stop/index.md
@@ -15,7 +15,7 @@ tags:
   - stop
 browser-compat: api.MediaStreamTrack.stop
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`MediaStreamTrack.stop()`** method stops the track.
 

--- a/files/en-us/web/api/mediastreamtrack/unmute_event/index.md
+++ b/files/en-us/web/api/mediastreamtrack/unmute_event/index.md
@@ -14,7 +14,7 @@ tags:
   - unmute
 browser-compat: api.MediaStreamTrack.unmute_event
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`unmute`** event is sent to a {{domxref("MediaStreamTrack")}} when the track's source is once again able to provide media data after a period of not being able to do so.
 

--- a/files/en-us/web/api/mediatrackconstraints/aspectratio/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/aspectratio/index.md
@@ -16,7 +16,7 @@ tags:
   - getusermedia
 browser-compat: api.MediaTrackConstraints.aspectRatio
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackConstraints")}} dictionary's
 **`aspectRatio`** property is a [`ConstrainDouble`](/en-US/docs/Web/API/MediaTrackConstraints#constraindouble)

--- a/files/en-us/web/api/mediatrackconstraints/autogaincontrol/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/autogaincontrol/index.md
@@ -14,7 +14,7 @@ tags:
   - autoGainControl
 browser-compat: api.MediaTrackConstraints.autoGainControl
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackConstraints")}} dictionary's
 **`autoGainControl`** property is a

--- a/files/en-us/web/api/mediatrackconstraints/channelcount/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/channelcount/index.md
@@ -15,7 +15,7 @@ tags:
   - channelCount
 browser-compat: api.MediaTrackConstraints.channelCount
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackConstraints")}} dictionary's
 **`channelCount`** property is a [`ConstrainULong`](/en-US/docs/Web/API/MediaTrackConstraints#constrainulong)

--- a/files/en-us/web/api/mediatrackconstraints/deviceid/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/deviceid/index.md
@@ -16,7 +16,7 @@ tags:
   - getusermedia
 browser-compat: api.MediaTrackConstraints.deviceId
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackConstraints")}} dictionary's
 **`deviceId`** property is a [`ConstrainDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#constraindomstring)

--- a/files/en-us/web/api/mediatrackconstraints/displaysurface/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/displaysurface/index.md
@@ -21,7 +21,7 @@ tags:
   - screen
 browser-compat: api.MediaTrackConstraints.displaySurface
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackConstraints")}} dictionary's
 **`displaySurface`** property is a

--- a/files/en-us/web/api/mediatrackconstraints/echocancellation/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/echocancellation/index.md
@@ -15,7 +15,7 @@ tags:
   - echoCancellation
 browser-compat: api.MediaTrackConstraints.echoCancellation
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackConstraints")}} dictionary's
 **`echoCancellation`** property is a

--- a/files/en-us/web/api/mediatrackconstraints/facingmode/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/facingmode/index.md
@@ -17,7 +17,7 @@ tags:
   - getusermedia
 browser-compat: api.MediaTrackConstraints.facingMode
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackConstraints")}} dictionary's
 **`facingMode`** property is a [`ConstrainDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#constraindomstring)

--- a/files/en-us/web/api/mediatrackconstraints/framerate/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/framerate/index.md
@@ -16,7 +16,7 @@ tags:
   - frameRate
 browser-compat: api.MediaTrackConstraints.frameRate
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackConstraints")}} dictionary's
 **`frameRate`** property is a [`ConstrainDouble`](/en-US/docs/Web/API/MediaTrackConstraints#constraindouble)

--- a/files/en-us/web/api/mediatrackconstraints/groupid/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/groupid/index.md
@@ -16,7 +16,7 @@ tags:
   - groupId
 browser-compat: api.MediaTrackConstraints.groupId
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackConstraints")}} dictionary's
 **`groupId`** property is a [`ConstrainDOMString`](/en-US/docs/Web/API/MediaTrackConstraints#constraindomstring)

--- a/files/en-us/web/api/mediatrackconstraints/height/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/height/index.md
@@ -15,7 +15,7 @@ tags:
   - height
 browser-compat: api.MediaTrackConstraints.height
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackConstraints")}} dictionary's
 **`height`** property is a [`ConstrainULong`](/en-US/docs/Web/API/MediaTrackConstraints#constrainulong)

--- a/files/en-us/web/api/mediatrackconstraints/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/index.md
@@ -19,7 +19,7 @@ tags:
   - screen
 browser-compat: api.MediaTrackConstraints
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`MediaTrackConstraints`** dictionary is used to describe a set of capabilities and the value or values each can take on. A constraints dictionary is passed into {{domxref("MediaStreamTrack.applyConstraints", "applyConstraints()")}} to allow a script to establish a set of exact (required) values or ranges and/or preferred values or ranges of values for the track, and the most recently-requested set of custom constraints can be retrieved by calling {{domxref("MediaStreamTrack.getConstraints", "getConstraints()")}}.
 

--- a/files/en-us/web/api/mediatrackconstraints/latency/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/latency/index.md
@@ -16,7 +16,7 @@ tags:
   - latency
 browser-compat: api.MediaTrackConstraints.latency
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackConstraints")}} dictionary's
 **`latency`** property is a [`ConstrainDouble`](/en-US/docs/Web/API/MediaTrackConstraints#constraindouble)

--- a/files/en-us/web/api/mediatrackconstraints/logicalsurface/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/logicalsurface/index.md
@@ -21,7 +21,7 @@ tags:
   - screen
 browser-compat: api.MediaTrackConstraints.logicalSurface
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackConstraints")}} dictionary's
 **`logicalSurface`** property is a

--- a/files/en-us/web/api/mediatrackconstraints/noisesuppression/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/noisesuppression/index.md
@@ -14,7 +14,7 @@ tags:
   - noiseSuppression
 browser-compat: api.MediaTrackConstraints.noiseSuppression
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackConstraints")}} dictionary's
 **`noiseSuppression`** property is a

--- a/files/en-us/web/api/mediatrackconstraints/samplerate/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/samplerate/index.md
@@ -16,7 +16,7 @@ tags:
   - sampleRate
 browser-compat: api.MediaTrackConstraints.sampleRate
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackConstraints")}} dictionary's
 **`sampleRate`** property is a [`ConstrainULong`](/en-US/docs/Web/API/MediaTrackConstraints#constrainulong)

--- a/files/en-us/web/api/mediatrackconstraints/samplesize/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/samplesize/index.md
@@ -15,7 +15,7 @@ tags:
   - sampleSize
 browser-compat: api.MediaTrackConstraints.sampleSize
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackConstraints")}} dictionary's
 **`sampleSize`** property is a [`ConstrainULong`](/en-US/docs/Web/API/MediaTrackConstraints#constrainulong)

--- a/files/en-us/web/api/mediatrackconstraints/volume/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/volume/index.md
@@ -17,7 +17,7 @@ tags:
   - getusermedia
 browser-compat: api.MediaTrackConstraints.volume
 ---
-{{APIRef("Media Capture and Streams")}}{{deprecated_header}}
+{{DefaultAPISidebar("Media Capture and Streams")}}{{deprecated_header}}
 
 The {{domxref("MediaTrackConstraints")}} dictionary's
 **`volume`** property is a [`ConstrainDouble`](/en-US/docs/Web/API/MediaTrackConstraints#constraindouble)

--- a/files/en-us/web/api/mediatrackconstraints/width/index.md
+++ b/files/en-us/web/api/mediatrackconstraints/width/index.md
@@ -15,7 +15,7 @@ tags:
   - width
 browser-compat: api.MediaTrackConstraints.width
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackConstraints")}} dictionary's
 **`width`** property is a [`ConstrainULong`](/en-US/docs/Web/API/MediaTrackConstraints#constrainulong)

--- a/files/en-us/web/api/mediatracksettings/aspectratio/index.md
+++ b/files/en-us/web/api/mediatracksettings/aspectratio/index.md
@@ -16,7 +16,7 @@ tags:
   - aspectRatio
 browser-compat: api.MediaTrackSettings.aspectRatio
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSettings")}} dictionary's
 **`aspectRatio`** property is a double-precision floating-point

--- a/files/en-us/web/api/mediatracksettings/autogaincontrol/index.md
+++ b/files/en-us/web/api/mediatracksettings/autogaincontrol/index.md
@@ -14,7 +14,7 @@ tags:
   - autoGainControl
 browser-compat: api.MediaTrackSettings.autoGainControl
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSettings")}} dictionary's
 **`autoGainControl`** property is a Boolean value whose value

--- a/files/en-us/web/api/mediatracksettings/channelcount/index.md
+++ b/files/en-us/web/api/mediatracksettings/channelcount/index.md
@@ -16,7 +16,7 @@ tags:
   - channelCount
 browser-compat: api.MediaTrackSettings.channelCount
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSettings")}} dictionary's
 **`channelCount`** property is an integer indicating how many

--- a/files/en-us/web/api/mediatracksettings/cursor/index.md
+++ b/files/en-us/web/api/mediatracksettings/cursor/index.md
@@ -20,7 +20,7 @@ tags:
   - screen
 browser-compat: api.MediaTrackSettings.cursor
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSettings")}} dictionary's
 **`cursor`** property indicates whether or not the cursor

--- a/files/en-us/web/api/mediatracksettings/deviceid/index.md
+++ b/files/en-us/web/api/mediatracksettings/deviceid/index.md
@@ -15,7 +15,7 @@ tags:
   - deviceId
 browser-compat: api.MediaTrackSettings.deviceId
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSettings")}} dictionary's
 **`deviceId`** property is a string which

--- a/files/en-us/web/api/mediatracksettings/displaysurface/index.md
+++ b/files/en-us/web/api/mediatracksettings/displaysurface/index.md
@@ -22,7 +22,7 @@ tags:
   - screen
 browser-compat: api.MediaTrackSettings.displaySurface
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSettings")}} dictionary's
 **`displaySurface`** property indicates the type of display

--- a/files/en-us/web/api/mediatracksettings/echocancellation/index.md
+++ b/files/en-us/web/api/mediatracksettings/echocancellation/index.md
@@ -15,7 +15,7 @@ tags:
   - echoCancellation
 browser-compat: api.MediaTrackSettings.echoCancellation
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSettings")}} dictionary's
 **`echoCancellation`** property is a Boolean value whose value

--- a/files/en-us/web/api/mediatracksettings/facingmode/index.md
+++ b/files/en-us/web/api/mediatracksettings/facingmode/index.md
@@ -16,7 +16,7 @@ tags:
   - facingMode
 browser-compat: api.MediaTrackSettings.facingMode
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSettings")}} dictionary's
 **`facingMode`** property is a string

--- a/files/en-us/web/api/mediatracksettings/framerate/index.md
+++ b/files/en-us/web/api/mediatracksettings/framerate/index.md
@@ -16,7 +16,7 @@ tags:
   - frameRate
 browser-compat: api.MediaTrackSettings.frameRate
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSettings")}} dictionary's
 **`frameRate`** property is a double-precision floating-point

--- a/files/en-us/web/api/mediatracksettings/groupid/index.md
+++ b/files/en-us/web/api/mediatracksettings/groupid/index.md
@@ -15,7 +15,7 @@ tags:
   - groupId
 browser-compat: api.MediaTrackSettings.groupId
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSettings")}} dictionary's
 **`groupId`** property is a browsing-session unique

--- a/files/en-us/web/api/mediatracksettings/height/index.md
+++ b/files/en-us/web/api/mediatracksettings/height/index.md
@@ -16,7 +16,7 @@ tags:
   - height
 browser-compat: api.MediaTrackSettings.height
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSettings")}} dictionary's **`height`**
 property is an integer indicating the number of pixels tall

--- a/files/en-us/web/api/mediatracksettings/index.md
+++ b/files/en-us/web/api/mediatracksettings/index.md
@@ -17,7 +17,7 @@ tags:
   - Video
 browser-compat: api.MediaTrackSettings
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`MediaTrackSettings`** dictionary is used to return the current values configured for each of a {{domxref("MediaStreamTrack")}}'s settings. These values will adhere as closely as possible to any constraints previously described using a {{domxref("MediaTrackConstraints")}} object and set using {{domxref("MediaStreamTrack.applyConstraints", "applyConstraints()")}}, and will adhere to the default constraints for any properties whose constraints haven't been changed, or whose customized constraints couldn't be matched.
 

--- a/files/en-us/web/api/mediatracksettings/latency/index.md
+++ b/files/en-us/web/api/mediatracksettings/latency/index.md
@@ -16,7 +16,7 @@ tags:
   - latency
 browser-compat: api.MediaTrackSettings.latency
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSettings")}} dictionary's
 **`latency`** property is a double-precision floating-point

--- a/files/en-us/web/api/mediatracksettings/logicalsurface/index.md
+++ b/files/en-us/web/api/mediatracksettings/logicalsurface/index.md
@@ -22,7 +22,7 @@ tags:
   - Property
 browser-compat: api.MediaTrackSettings.logicalSurface
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSettings")}} dictionary's
 **`logicalSurface`** property indicates whether or not the

--- a/files/en-us/web/api/mediatracksettings/noisesuppression/index.md
+++ b/files/en-us/web/api/mediatracksettings/noisesuppression/index.md
@@ -14,7 +14,7 @@ tags:
   - noiseSuppression
 browser-compat: api.MediaTrackSettings.noiseSuppression
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSettings")}} dictionary's
 **`noiseSuppression`** property is a Boolean value whose value

--- a/files/en-us/web/api/mediatracksettings/samplerate/index.md
+++ b/files/en-us/web/api/mediatracksettings/samplerate/index.md
@@ -16,7 +16,7 @@ tags:
   - sampleRate
 browser-compat: api.MediaTrackSettings.sampleRate
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSettings")}} dictionary's
 **`sampleRate`** property is an integer indicating how many

--- a/files/en-us/web/api/mediatracksettings/samplesize/index.md
+++ b/files/en-us/web/api/mediatracksettings/samplesize/index.md
@@ -16,7 +16,7 @@ tags:
   - sampleSize
 browser-compat: api.MediaTrackSettings.sampleSize
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSettings")}} dictionary's
 **`sampleSize`** property is an integer indicating the linear

--- a/files/en-us/web/api/mediatracksettings/volume/index.md
+++ b/files/en-us/web/api/mediatracksettings/volume/index.md
@@ -15,7 +15,7 @@ tags:
   - WebRTC
 browser-compat: api.MediaTrackSettings.volume
 ---
-{{APIRef("Media Capture and Streams")}}{{deprecated_header}}
+{{DefaultAPISidebar("Media Capture and Streams")}}{{deprecated_header}}
 
 The {{domxref("MediaTrackSettings")}} dictionary's **`volume`**
 property is a double-precision floating-point number indicating the volume of the

--- a/files/en-us/web/api/mediatracksettings/width/index.md
+++ b/files/en-us/web/api/mediatracksettings/width/index.md
@@ -16,7 +16,7 @@ tags:
   - width
 browser-compat: api.MediaTrackSettings.width
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSettings")}} dictionary's **`width`**
 property is an integer indicating the number of pixels wide

--- a/files/en-us/web/api/mediatracksupportedconstraints/aspectratio/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/aspectratio/index.md
@@ -16,7 +16,7 @@ tags:
   - aspectRatio
 browser-compat: api.MediaTrackSupportedConstraints.aspectRatio
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSupportedConstraints")}} dictionary's
 **`aspectRatio`** property is a read-only Boolean value which is

--- a/files/en-us/web/api/mediatracksupportedconstraints/autogaincontrol/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/autogaincontrol/index.md
@@ -18,7 +18,7 @@ tags:
   - autoGainControl
 browser-compat: api.MediaTrackSupportedConstraints.autoGainControl
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSupportedConstraints")}} dictionary's
 **`autoGainControl`** property is a read-only Boolean value

--- a/files/en-us/web/api/mediatracksupportedconstraints/channelcount/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/channelcount/index.md
@@ -16,7 +16,7 @@ tags:
   - channelCount
 browser-compat: api.MediaTrackSupportedConstraints.channelCount
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSupportedConstraints")}} dictionary's
 **`channelCount`** property is a read-only Boolean value which

--- a/files/en-us/web/api/mediatracksupportedconstraints/deviceid/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/deviceid/index.md
@@ -16,7 +16,7 @@ tags:
   - deviceId
 browser-compat: api.MediaTrackSupportedConstraints.deviceId
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSupportedConstraints")}} dictionary's
 **`deviceId`** property is a read-only Boolean value which is

--- a/files/en-us/web/api/mediatracksupportedconstraints/displaysurface/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/displaysurface/index.md
@@ -21,7 +21,7 @@ tags:
   - screen
 browser-compat: api.MediaTrackSupportedConstraints.displaySurface
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSupportedConstraints")}} dictionary's
 **`displaySurface`** property indicates whether or not the

--- a/files/en-us/web/api/mediatracksupportedconstraints/echocancellation/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/echocancellation/index.md
@@ -15,7 +15,7 @@ tags:
   - echoCancellation
 browser-compat: api.MediaTrackSupportedConstraints.echoCancellation
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSupportedConstraints")}} dictionary's
 **`echoCancellation`** property is a read-only Boolean value

--- a/files/en-us/web/api/mediatracksupportedconstraints/facingmode/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/facingmode/index.md
@@ -15,7 +15,7 @@ tags:
   - facingMode
 browser-compat: api.MediaTrackSupportedConstraints.facingMode
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSupportedConstraints")}} dictionary's
 **`facingMode`** property is a read-only Boolean value which is

--- a/files/en-us/web/api/mediatracksupportedconstraints/framerate/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/framerate/index.md
@@ -16,7 +16,7 @@ tags:
   - frameRate
 browser-compat: api.MediaTrackSupportedConstraints.frameRate
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSupportedConstraints")}} dictionary's
 **`frameRate`** property is a read-only Boolean value which is

--- a/files/en-us/web/api/mediatracksupportedconstraints/groupid/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/groupid/index.md
@@ -15,7 +15,7 @@ tags:
   - groupId
 browser-compat: api.MediaTrackSupportedConstraints.groupId
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSupportedConstraints")}} dictionary's
 **`groupId`** property is a read-only Boolean value which is

--- a/files/en-us/web/api/mediatracksupportedconstraints/height/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/height/index.md
@@ -15,7 +15,7 @@ tags:
   - height
 browser-compat: api.MediaTrackSupportedConstraints.height
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSupportedConstraints")}} dictionary's
 **`height`** property is a read-only Boolean value which is

--- a/files/en-us/web/api/mediatracksupportedconstraints/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/index.md
@@ -17,7 +17,7 @@ tags:
   - screen
 browser-compat: api.MediaTrackSupportedConstraints
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`MediaTrackSupportedConstraints`** dictionary establishes the list of constrainable properties recognized by the {{Glossary("user agent")}} or browser in its implementation of the {{domxref("MediaStreamTrack")}} object. An object conforming to `MediaTrackSupportedConstraints` is returned by {{domxref("MediaDevices.getSupportedConstraints()")}}.
 

--- a/files/en-us/web/api/mediatracksupportedconstraints/latency/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/latency/index.md
@@ -16,7 +16,7 @@ tags:
   - latency
 browser-compat: api.MediaTrackSupportedConstraints.latency
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSupportedConstraints")}} dictionary's
 **`latency`** property is a read-only Boolean value which is

--- a/files/en-us/web/api/mediatracksupportedconstraints/logicalsurface/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/logicalsurface/index.md
@@ -19,7 +19,7 @@ tags:
   - screen
 browser-compat: api.MediaTrackSupportedConstraints.logicalSurface
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSupportedConstraints")}} dictionary's
 **`logicalSurface`** property indicates whether or not the

--- a/files/en-us/web/api/mediatracksupportedconstraints/noisesuppression/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/noisesuppression/index.md
@@ -15,7 +15,7 @@ tags:
   - noiseSuppression
 browser-compat: api.MediaTrackSupportedConstraints.noiseSuppression
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSupportedConstraints")}} dictionary's
 **`noiseSuppression`** property is a read-only Boolean value

--- a/files/en-us/web/api/mediatracksupportedconstraints/samplerate/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/samplerate/index.md
@@ -15,7 +15,7 @@ tags:
   - sampleRate
 browser-compat: api.MediaTrackSupportedConstraints.sampleRate
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSupportedConstraints")}} dictionary's
 **`sampleRate`** property is a read-only Boolean value which is

--- a/files/en-us/web/api/mediatracksupportedconstraints/samplesize/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/samplesize/index.md
@@ -15,7 +15,7 @@ tags:
   - sampleSize
 browser-compat: api.MediaTrackSupportedConstraints.sampleSize
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSupportedConstraints")}} dictionary's
 **`sampleSize`** property is a read-only Boolean value which is

--- a/files/en-us/web/api/mediatracksupportedconstraints/volume/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/volume/index.md
@@ -15,7 +15,7 @@ tags:
   - WebRTC
 browser-compat: api.MediaTrackSupportedConstraints.volume
 ---
-{{APIRef("Media Capture and Streams")}}{{deprecated_header}}
+{{DefaultAPISidebar("Media Capture and Streams")}}{{deprecated_header}}
 
 The {{domxref("MediaTrackSupportedConstraints")}} dictionary's
 **`volume`** property is a read-only Boolean value which is

--- a/files/en-us/web/api/mediatracksupportedconstraints/width/index.md
+++ b/files/en-us/web/api/mediatracksupportedconstraints/width/index.md
@@ -4,7 +4,7 @@ slug: Web/API/MediaTrackSupportedConstraints/width
 page-type: web-api-instance-property
 browser-compat: api.MediaTrackSupportedConstraints.width
 ---
-{{APIRef("Media Capture and Streams")}}
+{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The {{domxref("MediaTrackSupportedConstraints")}} dictionary's
 **`width`** property is a read-only Boolean value which is

--- a/files/en-us/web/api/navigator/getusermedia/index.md
+++ b/files/en-us/web/api/navigator/getusermedia/index.md
@@ -15,7 +15,7 @@ tags:
   - getusermedia
 browser-compat: api.Navigator.getUserMedia
 ---
-{{APIRef("Media Capture and Streams")}}{{deprecated_header}}
+{{DefaultAPISidebar("Media Capture and Streams")}}{{deprecated_header}}
 
 The deprecated **`Navigator.getUserMedia()`** method prompts
 the user for permission to use up to one video input device (such as a camera or shared

--- a/files/en-us/web/api/navigator/mediadevices/index.md
+++ b/files/en-us/web/api/navigator/mediadevices/index.md
@@ -14,7 +14,7 @@ tags:
   - Web
 browser-compat: api.Navigator.mediaDevices
 ---
-{{securecontext_header}}{{APIRef("Media Capture and Streams")}}
+{{securecontext_header}}{{DefaultAPISidebar("Media Capture and Streams")}}
 
 The **`Navigator.mediaDevices`** read-only property returns a
 {{domxref("MediaDevices")}} object, which provides access to connected media input

--- a/files/en-us/web/api/overconstrainederror/index.md
+++ b/files/en-us/web/api/overconstrainederror/index.md
@@ -14,7 +14,7 @@ tags:
   - Video
 browser-compat: api.OverconstrainedError
 ---
-{{securecontext_header}}{{APIRef("Media Capture and Streams")}}{{SeeCompatTable}}
+{{securecontext_header}}{{DefaultAPISidebar("Media Capture and Streams")}}{{SeeCompatTable}}
 
 The **`OverconstrainedError`** interface of the [Media Capture and Streams API](/en-US/docs/Web/API/Media_Streams_API) indicates that the set of desired capabilities for the current {{domxref('MediaStreamTrack')}} cannot currently be met. When this event is thrown on a MediaStreamTrack, it is muted until either the current constraints can be established or until satisfiable constraints are applied.
 

--- a/files/en-us/web/api/overconstrainederror/overconstrainederror/index.md
+++ b/files/en-us/web/api/overconstrainederror/overconstrainederror/index.md
@@ -14,7 +14,7 @@ tags:
   - Video
 browser-compat: api.OverconstrainedError.OverconstrainedError
 ---
-{{securecontext_header}}{{APIRef("Media Capture and Streams")}}{{SeeCompatTable}}
+{{securecontext_header}}{{DefaultAPISidebar("Media Capture and Streams")}}{{SeeCompatTable}}
 
 The **`OverconstrainedError`** constructor
 creates a new {{domxref("OverconstrainedError")}} object which indicates that the set of

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -790,13 +790,12 @@
       "dictionaries": []
     },
     "Media Capture and Streams": {
-      "overview": ["Media Streams API"],
+      "overview": ["Media Capture and Streams API"],
       "guides": [
         "/docs/Web/API/Media_Streams_API/Constraints",
         "/docs/Web/API/Media_Streams_API/Taking_still_photos"
       ],
       "interfaces": [
-        "BlobEvent",
         "CanvasCaptureMediaStreamTrack",
         "MediaDevices",
         "MediaStream",


### PR DESCRIPTION
This does two things.
1. BlobEvent is part of Media Recorder API, but was wrongly put in "Media Capture and Streams. This fixes up the BlobEvent and its parts. Also the sidebar
2. Replaces `{{APIRef("Media Capture and Streams")}}` in heaps of pages with `{{DefaultAPISidebar("Media Capture and Streams")}}`. I still don't really get the difference, but the second one "works".

