### PR TITLE
Update NavigatorUAData.getHighEntropyValues()

### DIFF
--- a/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.md
+++ b/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.md
@@ -34,7 +34,6 @@ getHighEntropyValues(hints)
     - `"architecture"`
     - `"bitness"`
     - `"model"`
-    - `"platform"`
     - `"platformVersion"`
     - `"uaFullVersion"` {{deprecated_inline}}
     - `"fullVersionList"`

--- a/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.md
+++ b/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.md
@@ -41,6 +41,7 @@ getHighEntropyValues(hints)
 ### Return value
 
 A {{jsxref("Promise")}} that resolves to an object containing some or all of the following values (based on the hints requested):
+
 - `brands`
   - : A low-entropy hint provided automatically, for details see {{domxref("NavigatorUAData.brands")}}.
 - `mobile`

--- a/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.md
+++ b/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.md
@@ -34,6 +34,7 @@ getHighEntropyValues(hints)
     - `"architecture"`
     - `"bitness"`
     - `"model"`
+    - `"platform"`
     - `"platformVersion"`
     - `"uaFullVersion"` {{deprecated_inline}}
     - `"fullVersionList"`
@@ -41,20 +42,26 @@ getHighEntropyValues(hints)
 ### Return value
 
 A {{jsxref("Promise")}} that resolves to an object containing some or all of the following values (based on the hints requested):
-
+- `brands`
+  - : A low-entropy hint provided automatically, for details see {{domxref("NavigatorUAData.brands")}}.
+- `mobile`
+  - : A low-entropy hint provided automatically, for details see {{domxref("NavigatorUAData.mobile")}}.
+- `platform`
+  - : A low-entropy hint provided automatically, for details see {{domxref("NavigatorUAData.platform")}}.
 - `architecture`
   - : A string containing the platform architecture. For example, `"x86"`.
 - `bitness`
   - : A string containing the architecture bitness. For example, `"64"`.
 - `model`
-  - : A string containing the device model. For example, `"Pixel 2XL"`.
+  - : A string containing the device model. For example, `"Pixel 2XL"` or `""` if device model is not known.
 - `platformVersion`
-  - : A string containing the platform version. For example, `"10.0"`.
+  - : A string containing the platform version. Platform name itself is always available as low-entropy hint `platform`. For example, `"10.0"`.
 - `uaFullVersion` {{deprecated_inline}}
   - : A string containing the full browser version. For example, `"91.0.4472.124"`.
 - `fullVersionList`
-  - : An array of brand information containing the browser name and full version.
+  - : An array of objects with properties `"brand"` and `"version"` representing the browser name and full version respectively.
     For example, `{"brand": "Google Chrome", "version": "103.0.5060.134"}, {"brand": "Chromium", "version": "103.0.5060.134"}`.
+    Please note that one object may intentionally contain invalid information to prevent sites from relying on a fixed list of browsers.
 
 ### Exceptions
 
@@ -82,3 +89,15 @@ navigator.userAgentData.getHighEntropyValues(
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+ - These values are also alaviable as via HTTP request headers:
+   - {{HTTPHeader("Sec-CH-UA")}}
+   - {{HTTPHeader("Sec-CH-UA-Arch")}}
+   - {{HTTPHeader("Sec-CH-UA-Bitness")}}
+   - {{HTTPHeader("Sec-CH-UA-Full-Version")}}
+   - {{HTTPHeader("Sec-CH-UA-Mobile")}}
+   - {{HTTPHeader("Sec-CH-UA-Model")}}
+   - {{HTTPHeader("Sec-CH-UA-Platform")}}
+   - {{HTTPHeader("Sec-CH-UA-Platform-Version")}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Add more details about `NavigatorUAData.getHighEntropyValues`, add cross-links to client hint HTTP headers.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Clarify some stuff add details to make docs more useful and discoverable.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
I noted that `getHighEntropyValues()` automatically provides low-entropy values `brands`, `mobile`, and `platform`. This is described in the spec[1] and Google Chrome returns them when I run example already provided on MDN.[2]

[1] https://wicg.github.io/ua-client-hints/#getHighEntropyValues
[2] https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/getHighEntropyValues#examples

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
This PR is inspired by [this comment](https://github.com/mdn/content/pull/18687#discussion_r928329497) which highlighted that some text was not clear.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
