### PR TITLE
Improve description in “Timing element visibility with the Intersection Observer API” doc

### DIFF
--- a/files/en-us/web/api/intersection_observer_api/timing_element_visibility/index.md
+++ b/files/en-us/web/api/intersection_observer_api/timing_element_visibility/index.md
@@ -582,7 +582,7 @@ The new ad's element object is returned to the caller in case it's needed.
 
 ### Result
 
-The resulting page looks like this. Try experimenting with scrolling around and watch how visibility changes affect the timers in each ad. Also note that each ad is replaced after one minute of visibility, and how the timers pause while the document is tabbed into the background.
+The resulting page looks like this. Try experimenting by scrolling up and down and notice how changes in the visibility affect the timers in each ad. Also note that each ad is replaced after one minute of visibility (but the ad must first be scrolled out of view and back again), and how the timers pause while the document is tabbed into the background. However, covering the browser with another window does not pause the timers.
 
 {{EmbedLiveSample("Building_the_site", 750, 800)}}
 


### PR DESCRIPTION
#### Motivation

It was not immediately obvious how the resulting page (demo code) works, so the added description describes the behavior more fully.

#### Suggestion to shorten length of ad display in demo code

I think it would also be a good idea to shorten the length of time an ad stays on screen to, say, 10 seconds, for this demonstration. However, I don't think the article needs to be changed, a minute is more reasonable for the use case, however, I assume that production code would have variable length ads.

I am not sure where the Building_the_site code is so I cannot make a PR on that.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
