### PR TITLE
bookmarks.onMoved indexing clarification

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
@@ -31,7 +31,7 @@ An {{jsxref("object")}} with the following properties:
   - : A {{jsxref("string")}} which uniquely identifies the node. Each ID is unique within the user's profile and remains unchanged across browser restarts.
 - `index` {{optional_inline}}
   - : A number which represents the zero-based position of this node within its parent folder, where zero represents the first entry.
-  > **Note:** If you create or move multiple bookmarks, because the {{WebExtAPIRef("bookmarks.create()")}} and {{WebExtAPIRef("bookmarks.move()")}} methods are asynchronous, the requests may get processed in any order. Consequently, the value of each bookmark's index may change or be unknown until all the requests are completed. If you want to obtain the index values after a move or create, you must wait for all the calls to resolve or reject before reading the index value.
+  > **Note:** If you create or move multiple bookmarks, because the {{WebExtAPIRef("bookmarks.create()")}} and {{WebExtAPIRef("bookmarks.move()")}} methods are asynchronous, the requests may get processed in any order. Consequently, the value of each bookmark's index may change or be unknown until all the requests are completed. If the index associated with a bookmark matters to your extension, then – when creating or moving multiple bookmarks – the extension should wait for each `bookmarks.create` or `bookmarks.move` call to complete before creating or moving the next bookmark. Waiting ensures that the index associated with each bookmark is not affected by a create or move call executing concurrently while the original call is in progress.
 - `parentId` {{optional_inline}}
   - : A {{jsxref("string")}} which specifies the ID of the parent folder. This property is not present in the root node.
 - `title`

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/bookmarktreenode/index.md
@@ -31,6 +31,7 @@ An {{jsxref("object")}} with the following properties:
   - : A {{jsxref("string")}} which uniquely identifies the node. Each ID is unique within the user's profile and remains unchanged across browser restarts.
 - `index` {{optional_inline}}
   - : A number which represents the zero-based position of this node within its parent folder, where zero represents the first entry.
+  > **Note:** If you create or move multiple bookmarks, because the {{WebExtAPIRef("bookmarks.create()")}} and {{WebExtAPIRef("bookmarks.move()")}} methods are asynchronous, the requests may get processed in any order. Consequently, the value of each bookmark's index may change or be unknown until all the requests are completed. If you want to obtain the index values after a move or create, you must wait for all the calls to resolve or reject before reading the index value.
 - `parentId` {{optional_inline}}
   - : A {{jsxref("string")}} which specifies the ID of the parent folder. This property is not present in the root node.
 - `title`

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/create/index.md
@@ -38,7 +38,7 @@ let createBookmark = browser.bookmarks.create(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a {{WebExtAPIRef('bookmarks.BookmarkTreeNode', 'BookmarkTreeNode')}} that describes the new bookmark node.
 
-> **Note:** If you create multiple bookmarks, because this API is asynchronous, the creates may get processed in any order. Consequently, the value of each bookmark's index returned in {{WebExtAPIRef('bookmarks.BookmarkTreeNode', 'BookmarkTreeNode')}} may change or be unknown until all the creates are completed. If you want to obtain the index values after a create, you must wait for all the calls to resolve or reject before reading the index values.
+> **Note:** If you create multiple bookmarks, because this API is asynchronous, the create calls may get processed in any order. Consequently, the value of each bookmark's index returned in {{WebExtAPIRef('bookmarks.BookmarkTreeNode', 'BookmarkTreeNode')}} may change or be unknown until all the create calls are completed. If the index associated with a bookmark matters to your extension, then – when creating multiple bookmarks – the extension should wait for each `bookmarks.create`call to complete before creating the next bookmark. Waiting ensures that the index associated with each bookmark is not affected by a create call executing concurrently while the original call is in progress.
 
 ## Examples
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/create/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/create/index.md
@@ -38,6 +38,8 @@ let createBookmark = browser.bookmarks.create(
 
 A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that will be fulfilled with a {{WebExtAPIRef('bookmarks.BookmarkTreeNode', 'BookmarkTreeNode')}} that describes the new bookmark node.
 
+> **Note:** If you create multiple bookmarks, because this API is asynchronous, the creates may get processed in any order. Consequently, the value of each bookmark's index returned in {{WebExtAPIRef('bookmarks.BookmarkTreeNode', 'BookmarkTreeNode')}} may change or be unknown until all the creates are completed. If you want to obtain the index values after a create, you must wait for all the calls to resolve or reject before reading the index values.
+
 ## Examples
 
 This example creates a bookmark for this page, placing it in the default folder ("Other Bookmarks" in Firefox and Chrome).

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/move/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/move/index.md
@@ -49,7 +49,7 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 
 If the node corresponding to the `id` parameter can't be found, the promise is rejected with an error message.
 
-> **Note:** If you move multiple bookmarks, because this API is asynchronous, the moves may get processed in any order. Consequently, the value of each bookmark's index returned in {{WebExtAPIRef('bookmarks.BookmarkTreeNode', 'BookmarkTreeNode')}} may change or be unknown until all the moves are completed. If you want to obtain the index values after a move, you must wait for all the calls to resolve or reject before reading the index values.
+> **Note:** If you move multiple bookmarks, because this API is asynchronous, the move calls may get processed in any order. Consequently, the value of each bookmark's index returned in {{WebExtAPIRef('bookmarks.BookmarkTreeNode', 'BookmarkTreeNode')}} may change or be unknown until all the move calls are completed. If the index associated with a bookmark matters to your extension, then – when moving multiple bookmarks – the extension should wait for each `bookmarks.move` call to complete before moving the next bookmark. Waiting ensures that the index associated with each bookmark is not affected by a move call executing concurrently while the original call is in progress.
 
 ## Examples
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/move/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/move/index.md
@@ -49,6 +49,8 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) that 
 
 If the node corresponding to the `id` parameter can't be found, the promise is rejected with an error message.
 
+> **Note:** If you move multiple bookmarks, because this API is asynchronous, the moves may get processed in any order. Consequently, the value of each bookmark's index returned in {{WebExtAPIRef('bookmarks.BookmarkTreeNode', 'BookmarkTreeNode')}} may change or be unknown until all the moves are completed. If you want to obtain the index values after a move, you must wait for all the calls to resolve or reject before reading the index values.
+
 ## Examples
 
 This example moves a bookmark so that it's the first bookmark in its current folder.

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onmoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onmoved/index.md
@@ -17,7 +17,7 @@ browser-compat: webextensions.api.bookmarks.onMoved
 
 Fired when a bookmark or folder is moved to a different parent folder or position within a folder.
 
-> **Note:** If you're moving multiple bookmarks, because this API is asynchronous, the moves may get processed in any order. Consequently, the value of each bookmark's index may change or be unknown until all the moves are completed. If you want to obtain the index values after a move, you must wait for all the calls to resolve or reject before reading the index values.
+> **Note:** If you're moving multiple bookmarks, because this API is asynchronous, the move calls may get processed in any order. Consequently, the value of each bookmark's index may change or be unknown until all the move calls are completed. If the index associated with a bookmark matters to your extension, then – when moving multiple bookmarks – the extension should wait for each `bookmarks.move` call to complete before moving the next bookmark. Waiting ensures that the index associated with each bookmark is not affected by a move call executing concurrently while the original call is in progress.
 
 ## Syntax
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onmoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/bookmarks/onmoved/index.md
@@ -15,7 +15,9 @@ browser-compat: webextensions.api.bookmarks.onMoved
 ---
 {{AddonSidebar()}}
 
-Fired when a bookmark or folder is moved to a different parent folder and/or position within a folder.
+Fired when a bookmark or folder is moved to a different parent folder or position within a folder.
+
+> **Note:** If you're moving multiple bookmarks, because this API is asynchronous, the moves may get processed in any order. Consequently, the value of each bookmark's index may change or be unknown until all the moves are completed. If you want to obtain the index values after a move, you must wait for all the calls to resolve or reject before reading the index values.
 
 ## Syntax
 


### PR DESCRIPTION
### Summary
Adds a note to clarify that if bookmark index values are required after a move, the calls must be allowed to resolve or reject before the index values are read.

#### Related issues
Fixes [Issue with "bookmarks.onMoved": Add bug with inconsistent indexing. #7227 ](https://github.com/mdn/content/issues/7227)

#### Metadata

This PR…

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
