### PR TITLE
Reduce chance that people will use wrong methods in a form

### DIFF
--- a/files/en-us/web/html/element/form/index.md
+++ b/files/en-us/web/html/element/form/index.md
@@ -145,7 +145,7 @@ The following attributes control behavior during form submission.
 - {{htmlattrdef("method")}}
 
   - : The [HTTP](/en-US/docs/Web/HTTP) method to submit the form with.
-    The only possible values are (case insensitive):
+    The only allowed methods/values are (case insensitive):
 
     - `post`: The [POST method](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.5); form data sent as the [request body](/en-US/docs/Web/API/Request/body).
     - `get`: The [GET method](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.3); form data appended to the `action` URL with a `?` separator. Use this method when the form [has no side-effects](/en-US/docs/Glossary/Idempotent).

--- a/files/en-us/web/html/element/form/index.md
+++ b/files/en-us/web/html/element/form/index.md
@@ -145,7 +145,7 @@ The following attributes control behavior during form submission.
 - {{htmlattrdef("method")}}
 
   - : The [HTTP](/en-US/docs/Web/HTTP) method to submit the form with.
-    The only possible (case insensitive) values are:
+    The only possible values are (case insensitive):
 
     - `post`: The [POST method](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.5); form data sent as the [request body](/en-US/docs/Web/API/Request/body).
     - `get`: The [GET method](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.3); form data appended to the `action` URL with a `?` separator. Use this method when the form [has no side-effects](/en-US/docs/Glossary/Idempotent).

--- a/files/en-us/web/html/element/form/index.md
+++ b/files/en-us/web/html/element/form/index.md
@@ -144,7 +144,8 @@ The following attributes control behavior during form submission.
 
 - {{htmlattrdef("method")}}
 
-  - : The [HTTP](/en-US/docs/Web/HTTP) method to submit the form with. Possible (case insensitive) values:
+  - : The [HTTP](/en-US/docs/Web/HTTP) method to submit the form with.
+    The only possible (case insensitive) values are:
 
     - `post`: The [POST method](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.5); form data sent as the [request body](/en-US/docs/Web/API/Request/body).
     - `get`: The [GET method](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.3); form data appended to the `action` URL with a `?` separator. Use this method when the form [has no side-effects](/en-US/docs/Glossary/Idempotent).


### PR DESCRIPTION
Related to discussion https://github.com/mdn/content/issues/18614#issuecomment-1194126404

The list of possible options for the method in the form is canonical. This makes it obvious that not only is it correct, but we really mean it :-)
