### PR TITLE
HTML sanitizer - clarify the allow + disallow case

### DIFF
--- a/files/en-us/web/api/sanitizer/sanitizer/index.md
+++ b/files/en-us/web/api/sanitizer/sanitizer/index.md
@@ -31,20 +31,32 @@ new Sanitizer(config)
 
     - `allowElements` {{optional_inline}}
       - : An {{jsxref('Array')}} of {{jsxref('String','strings')}} indicating elements that the sanitizer should not remove.
+        All elements not in the array will be dropped.
     - `blockElements` {{optional_inline}}
       - : An {{jsxref('Array')}} of {{jsxref('String','strings')}} indicating elements that the sanitizer should remove, but keeping their child elements.
     - `dropElements` {{optional_inline}}
       - : An {{jsxref('Array')}} of {{jsxref('String','strings')}} indicating elements (including nested elements) that the sanitizer should remove.
     - `allowAttributes` {{optional_inline}}
-      - : An {{jsxref("Object")}} where each key is the attribute name and the value is an {{jsxref("Array")}} of allowed tag names. Matching attributes will not be removed.
+      - : An {{jsxref("Object")}} where each key is the attribute name and the value is an {{jsxref("Array")}} of allowed tag names.
+        Matching attributes will not be removed.
+        All attributes that are not in the array will be dropped.
     - `dropAttributes` {{optional_inline}}
-      - : An {{jsxref('Object')}} where each key is the attribute name and the value is an {{jsxref("Array")}} of dropped tag names. Matching attributes will be removed.
+      - : An {{jsxref('Object')}} where each key is the attribute name and the value is an {{jsxref("Array")}} of dropped tag names.
+        Matching attributes will be removed.
     - `allowCustomElements` {{optional_inline}}
       - : A {{jsxref('Boolean')}} value set to `false` (default) to remove custom elements and their children.
         If set to `true`, custom elements will be subject to built-in and custom configuration checks (and will be retained or dropped based on those checks).
     - `allowComments` {{optional_inline}}
       - : A {{jsxref('Boolean')}} value set to `false` (default) to remove HTML comments.
         Set to `true` in order to keep comments.
+
+> **Note:** `allowElements` creates a sanitizer that will drop any elements that are not in `allowElements`, while `blockElements` and `dropElements` create a sanitizer that will allow all elements except those in these properties.
+>
+> `blockElements` and `dropElements` are processed before `allowElements`.
+> If you specify both properties, the elements in `blockElements` or `dropElements` will be discarded first, followed by any elements not in `allowElements`.
+> So while it is possible to specify both types of properties at the same time, the intent can always be more clearly captured using just one type.
+>
+> The same applies to `allowAttributes` and `dropAttributes`.
 
 ## Examples
 
@@ -65,7 +77,7 @@ const sanitized =  new Sanitizer().sanitizeFor("div", unsanitized);
 // Result (innerHTML of 'sanitized'): script will be removed: "abc alert(1) def"
 ```
 
-<!-- Add other examples showing use of parameter when it is implemented somewhere -->
+<!-- Add other examples showing use of parameter -->
 
 ## Specifications
 


### PR DESCRIPTION
The HTML sanitizer docs did not specify what happens if the [config](https://developer.mozilla.org/en-US/docs/Web/API/Sanitizer/Sanitizer#parameters) uses both an allow and a drop list for elements/attributes at the same time. 

This clarifies that it is not recommended and shows what would happen.

This follows on from https://github.com/mdn/content/pull/18264 and the discussion in https://github.com/WICG/sanitizer-api/pull/166#issuecomment-1194825415