### PR TITLE
FF104 Relnote/Experimental features for Array.findLast() et al

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -559,47 +559,6 @@ The `groupBy` method should be used when strings can be used to represent elemen
   </tbody>
 </table>
 
-### Array findLast() and findLastIndex() methods
-
-The {{jsxref("Array.prototype.findLast()")}}, {{jsxref("Array.prototype.findLastIndex()")}}, {{jsxref("TypedArray.prototype.findLast()")}}, and {{jsxref("TypedArray.prototype.findLastIndex()")}} are used to find the value and index (respectively) of the last element in an array or TypedArray that matches a supplied test function.
-(See {{bug(1704385)}} for more details.)
-
-<table>
-  <thead>
-    <tr>
-      <th>Release channel</th>
-      <th>Version removed</th>
-      <th>Enabled by default?</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Nightly</th>
-      <td>103</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Developer Edition</th>
-      <td>103</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Beta</th>
-      <td>103</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Release</th>
-      <td>103</td>
-      <td>No</td>
-    </tr>
-    <tr>
-      <th>Preference name</th>
-      <td colspan="2"><code>javascript.options.experimental.array_find_last</code></td>
-    </tr>
-  </tbody>
-</table>
-
 ## APIs
 
 ### Graphics: Canvas, WebGL, and WebGPU

--- a/files/en-us/mozilla/firefox/releases/104/index.md
+++ b/files/en-us/mozilla/firefox/releases/104/index.md
@@ -25,6 +25,11 @@ This article provides information about the changes in Firefox 104 that will aff
 
 ### JavaScript
 
+- The methods {{jsxref("Array.prototype.findLast()")}}, {{jsxref("Array.prototype.findLastIndex()")}}, {{jsxref("TypedArray.prototype.findLast()")}}, and {{jsxref("TypedArray.prototype.findLastIndex()")}} are now supported.
+  These are used to find the value and index (respectively) of the last element in an {{jsxref("Array")}} or {{jsxref("TypedArray")}} that matches a supplied test function.
+  (See {{bug(1775026)}} for more details.)
+
+
 #### Removals
 
 ### HTTP


### PR DESCRIPTION
FF104 ships `Array.findLast` and `Array.findLastIndex` and the same methods in TypedArray in https://bugzilla.mozilla.org/show_bug.cgi?id=1775026. 

This adds release note and removes the feature from experimental features. No other work required because everything was updated last month.

Other docs work tracked in #18774