### PR TITLE
Update a broken link

### DIFF
--- a/files/en-us/web/api/console/timestamp/index.md
+++ b/files/en-us/web/api/console/timestamp/index.md
@@ -14,8 +14,7 @@ browser-compat: api.console.timeStamp
 ---
 {{APIRef("Console API")}}{{Non-standard_header}}
 
-The **`console.timeStamp`** method adds a single marker to the browser's [Performance](https://developer.chrome.com/docs/devtools/evaluate-performance/reference/)
-or [Waterfall](https://firefox-source-docs.mozilla.org/devtools-user/performance/waterfall/index.html) tool. This lets you
+The **`console.timeStamp`** method adds a single marker to the browser's Performance tool ([Firefox](https://profiler.firefox.com/docs/#/), [Chrome](https://developer.chrome.com/docs/devtools/evaluate-performance/reference/)). This lets you
 correlate a point in your code with the other events recorded in the timeline, such as
 layout and paint events.
 

--- a/files/en-us/web/api/console/timestamp/index.md
+++ b/files/en-us/web/api/console/timestamp/index.md
@@ -46,4 +46,4 @@ None ({{jsxref("undefined")}}).
 
 - {{domxref("console.time()")}}
 - {{domxref("console.timeEnd()")}}
-- [Adding timestamps to the waterfall](https://firefox-source-docs.mozilla.org/devtools-user/performance/waterfall/index.html#timestamp-markers)
+- [Adding markers with the console API](https://web.archive.org/web/20211207010020/https://firefox-source-docs.mozilla.org/devtools-user/performance/waterfall/index.html#adding-markers-with-the-console-api)


### PR DESCRIPTION
Firefox's profiler tool documentation has moved to a new location.