### PR TITLE
comma separated, not space separated

### DIFF
--- a/files/en-us/web/html/global_attributes/exportparts/index.md
+++ b/files/en-us/web/html/global_attributes/exportparts/index.md
@@ -19,7 +19,7 @@ Rules present outside of the shadow tree, must use the {{CSSxRef("::part")}} pse
 
 The global attribute {{HTMLAttrxRef("part")}} makes the element visible on just a single level of depth. When the shadow tree is nested, parts will be visible only to the parent of the shadow tree but not to its ancestor. Exporting parts further down is exactly what `exportparts` attribute is for.
 
-Attribute `exportparts` must be placed on a _shadow Host_, which is the element to which the _shadow tree_ is attached. The value of the attribute should be a space-separated list of part names present in the shadow tree and which should be made available via a DOM outside of the current structure.
+Attribute `exportparts` must be placed on a _shadow Host_, which is the element to which the _shadow tree_ is attached. The value of the attribute should be a comma-separated list of part names present in the shadow tree and which should be made available via a DOM outside of the current structure.
 
 ## Specifications
 


### PR DESCRIPTION
https://drafts.csswg.org/css-shadow-parts/#element-attrdef-html-global-exportparts

> The exportparts attribute is parsed as a comma-separated list of part mappings.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
