### PR TITLE
Fixed TypeError in the example code

### DIFF
--- a/files/en-us/web/javascript/reference/operators/this/index.md
+++ b/files/en-us/web/javascript/reference/operators/this/index.md
@@ -256,7 +256,7 @@ In global code, it will be set to the global object:
 
 ```js
 const globalObject = this;
-let foo = (() => this);
+const foo = (() => this);
 console.log(foo() === globalObject); // true
 ```
 
@@ -274,8 +274,8 @@ console.log(obj.func() === globalObject); // true
 console.log(foo.call(obj) === globalObject); // true
 
 // Attempt to set this using bind
-foo = foo.bind(obj);
-console.log(foo() === globalObject); // true
+const boundFoo = foo.bind(obj);
+console.log(boundFoo() === globalObject); // true
 ```
 
 No matter what, `foo`'s `this` is set to what it was when it was

--- a/files/en-us/web/javascript/reference/operators/this/index.md
+++ b/files/en-us/web/javascript/reference/operators/this/index.md
@@ -256,7 +256,7 @@ In global code, it will be set to the global object:
 
 ```js
 const globalObject = this;
-const foo = (() => this);
+let foo = (() => this);
 console.log(foo() === globalObject); // true
 ```
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Change `const foo` to the `let` declaration in the example code.
#### Motivation
This change fixes the "TypeError: Assignment to constant variable." error in [the "Arrow functions" example code](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/this#arrow_functions):

![Screenshot 2022-07-26 111037](https://user-images.githubusercontent.com/30019338/180958048-31bbe3b0-395e-4a53-971f-ca913da462f5.png)
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
