### PR TITLE
Added section on using the MediaSession API to add controls to Picture-in-Picture overlays

### DIFF
--- a/files/en-us/web/api/picture-in-picture_api/index.md
+++ b/files/en-us/web/api/picture-in-picture_api/index.md
@@ -71,6 +71,10 @@ _The Picture-in-Picture API defines three events, which can be used to detect wh
 - {{domxref("PictureInPictureWindow.resize_event", "resize")}}
   - : Sent to a {{DOMxRef("PictureInPictureWindow")}} when it changes size.
 
+## Adding Controls
+
+If media action handlers have been set via the [Media Session API](/en-US/docs/Web/API/Media_Session_API), then appropriate controls for those actions will be added by the browser to the picture-in-picture overlay. For example, if a `"nexttrack"` action has been set, then a skip button might be displayed in the picture-in-picture view. There is no support for adding custom HTML buttons or controls.
+
 ## Controlling styling
 
 The [`:picture-in-picture`](/en-US/docs/Web/CSS/:picture-in-picture) [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) matches the video element currently in picture-in-picture mode, allowing you to configure your stylesheets to automatically adjust the size, style, or layout of content when a video switches back and forth between picture-in-picture and traditional presentation modes.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Added a section discussing the ability to add buttons to picture-in-picture overlays via the MediaSession API.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
It previously wasn't clear that it is possible to add buttons to picture-in-picture overlays, or that the MediaSession API has an effect on these overlays. I think that this is important/interesting behaviour to discuss.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
 * https://www.w3.org/TR/picture-in-picture/#media-session
 * https://web.dev/media-session/

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Slightly expands on an existing document

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
