### PR TITLE
Refine description of backdrop-filter in FF 103 release notes

### DIFF
--- a/files/en-us/mozilla/firefox/releases/103/index.md
+++ b/files/en-us/mozilla/firefox/releases/103/index.md
@@ -25,6 +25,8 @@ This article provides information about the changes in Firefox 103 that will aff
 
 ### CSS
 
+The [`backdrop-filter`](/en-US/docs/Web/CSS/backdrop-filter) property that can be used to apply graphical effects such as blurring or color shifting to the area behind an element is now available by default ({{bug(1578503)}}).
+
 #### Removals
 
 ### JavaScript

--- a/files/en-us/mozilla/firefox/releases/103/index.md
+++ b/files/en-us/mozilla/firefox/releases/103/index.md
@@ -25,7 +25,7 @@ This article provides information about the changes in Firefox 103 that will aff
 
 ### CSS
 
-The [`backdrop-filter`](/en-US/docs/Web/CSS/backdrop-filter) property that can be used to apply graphical effects such as blurring or color shifting to the area behind an element is now available by default ({{bug(1578503)}}).
+- The [`backdrop-filter`](/en-US/docs/Web/CSS/backdrop-filter) property that can be used to apply graphical effects such as blurring or color shifting to the area behind an element is now available by default ({{bug(1578503)}}).
 
 #### Removals
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

This CSS property was enabled by default in v103 so I would like to add this to the changelog

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

It informs readers of the changelog that backdrop-filter has been enabled by default in Firefox 103.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://bugzilla.mozilla.org/show_bug.cgi?id=1578503

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
