### PR TITLE
fix: toDataURL type error

### DIFF
--- a/files/en-us/web/api/htmlcanvaselement/todataurl/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/todataurl/index.md
@@ -18,7 +18,7 @@ The desired file format and image quality may be specified.
 If the file format is not specified, or if the given format is not supported, then the data will be exported as `image/png`.
 In other words, if the returned value starts with `data:image/png` for any other requested `type`, then that format is not supported.
 
-Browsers are required to support `image/png`; many will support additional formats including `image/jpg` and `image/webp`.
+Browsers are required to support `image/png`; many will support additional formats including `image/jpeg` and `image/webp`.
 
 The created image data will have a resolution of 96dpi for file formats that support encoding resolution metadata.
 


### PR DESCRIPTION

#### Summary
'image/jpg' is not a valid type, so it will be treated as 'imag/png'.

#### Supporting details
https://www.w3.org/TR/2011/WD-html5-20110405/the-canvas-element.html#dom-canvas-todataurl

#### Metadata

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

