### PR TITLE
Add release notes for scroll-snap-stop and backdrop-filter

### DIFF
--- a/files/en-us/mozilla/firefox/releases/103/index.md
+++ b/files/en-us/mozilla/firefox/releases/103/index.md
@@ -25,6 +25,9 @@ This article provides information about the changes in Firefox 103 that will aff
 
 ### CSS
 
+- The {{CSSxRef("backdrop-filter")}} property is now available by default. It was earlier behind a preference setting ({{bug(1578503)}}).
+- The {{CSSxRef("scroll-snap-stop")}} property is now available ({{bug(1312165)}}). You can use this property's `always` and `normal` values to specify whether or not to pass the snap points, even when scrolling fast.
+
 #### Removals
 
 ### JavaScript


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Motivation

In FF103:
- 'backdrop-filter' has been made available by default.
- 'scroll-snap-stop' has been implemented.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
- 'backdrop-filter': https://bugzilla.mozilla.org/show_bug.cgi?id=1578503
- 'scroll-snap-stop': https://bugzilla.mozilla.org/show_bug.cgi?id=1312165

#### Doc issue trackers
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
- 'backdrop-filter': https://github.com/mdn/content/issues/17474
- 'scroll-snap-stop': https://github.com/mdn/content/issues/17469

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [X] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
