### PR TITLE
Fix typo in last listing

### DIFF
--- a/files/en-us/webassembly/c_to_wasm/index.md
+++ b/files/en-us/webassembly/c_to_wasm/index.md
@@ -160,7 +160,7 @@ If you have a function defined in your C code that you want to call as needed fr
           null,  // argument types
           null,  // arguments
         );
-      };
+      });
     ```
 
 This illustrates how `ccall()` is used to call the exported function.


### PR DESCRIPTION
The presented code:

    ```js
    document
      .getElementById("mybutton")
      .addEventListener("click", () => {
        alert("check console");
        const result = Module.ccall(
          "myFunction",  // name of C function
          null,  // return type
          null,  // argument types
          null,  // arguments
        );
      };
    ```

is missing a closing bracket, and as such is rejected by my browser. This commit adds the missing closing bracket.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
