### PR TITLE
Add missing item for ServiceWorker.state

### DIFF
--- a/files/en-us/web/api/serviceworker/index.md
+++ b/files/en-us/web/api/serviceworker/index.md
@@ -29,7 +29,7 @@ _The `ServiceWorker` interface inherits properties from its parent, {{domxref("E
 - {{domxref("ServiceWorker.scriptURL")}} {{readonlyinline}}
   - : Returns the `ServiceWorker` serialized script URL defined as part of {{domxref("ServiceWorkerRegistration")}}. The URL must be on the same origin as the document that registers the `ServiceWorker`.
 - {{domxref("ServiceWorker.state")}} {{readonlyinline}}
-  - : Returns the state of the service worker. It returns one of the following values: `installing`, `installed,` `activating`, `activated`, or `redundant`.
+  - : Returns the state of the service worker. It returns one of the following values: `parsed`, `installing`, `installed,` `activating`, `activated`, or `redundant`.
 
 ## Methods
 

--- a/files/en-us/web/api/serviceworker/state/index.md
+++ b/files/en-us/web/api/serviceworker/state/index.md
@@ -15,7 +15,7 @@ browser-compat: api.ServiceWorker.state
 
 The **`state`** read-only property of the
 {{domxref("ServiceWorker")}} interface returns a string representing the current state
-of the service worker. It can be one of the following values: `installing`,
+of the service worker. It can be one of the following values: `parsed`, `installing`,
 `installed,` `activating`, `activated`, or
 `redundant`.
 
@@ -23,6 +23,8 @@ of the service worker. It can be one of the following values: `installing`,
 
 A {{jsxref("String")}} that can take one of the following values:
 
+- `"parsed"`
+  - : The initial state of a service worker after it is downloaded and confirmed to be runable. A service worker is never updated to this state meaning it will never be the value of the {{DOMxRef("ServiceWorker.statechange_event")}}
 - `"installing"`
   - : The service worker in this state is considered an installing worker. During this state, {{DOMxRef("ExtendableEvent.waitUntil()")}} can be called inside the `install` event handler to extend the life of the installing worker until the passed promise resolves successfully. This is primarily used to ensure that the service worker is not active until all of the core caches are populated.
 - `"installed"`

--- a/files/en-us/web/api/serviceworker/state/index.md
+++ b/files/en-us/web/api/serviceworker/state/index.md
@@ -24,7 +24,8 @@ of the service worker. It can be one of the following values: `parsed`, `install
 A {{jsxref("String")}} that can take one of the following values:
 
 - `"parsed"`
-  - : The initial state of a service worker after it is downloaded and confirmed to be runable. A service worker is never updated to this state meaning it will never be the value of the {{DOMxRef("ServiceWorker.statechange_event")}}
+  - : The initial state of a service worker after it is downloaded and confirmed to be runnable.
+    A service worker is never updated to this state, so this will never be the value of the {{DOMxRef("ServiceWorker.statechange_event")}}
 - `"installing"`
   - : The service worker in this state is considered an installing worker. During this state, {{DOMxRef("ExtendableEvent.waitUntil()")}} can be called inside the `install` event handler to extend the life of the installing worker until the passed promise resolves successfully. This is primarily used to ensure that the service worker is not active until all of the core caches are populated.
 - `"installed"`


### PR DESCRIPTION
https://w3c.github.io/ServiceWorker/#enumdef-serviceworkerstate

This is basically for completeness. Since this value can show up on someone's debugging or logging, they shouldn't need to dig to learn about it.