### PR TITLE
Source Macro: Update broken urls

### DIFF
--- a/files/en-us/mozilla/firefox/releases/3/updating_extensions/index.md
+++ b/files/en-us/mozilla/firefox/releases/3/updating_extensions/index.md
@@ -150,7 +150,7 @@ Extensions that attempt to overlay onto the "appcontent" box try to float chrome
 _Add simple changes you had to make while updating your extension to work with Firefox 3 here._
 
 - `chrome://browser/base/utilityOverlay.js` is no longer supported for security reasons. If you were previously using this, you should switch to `chrome://browser/content/utilityOverlay.js`.
-- `nsIAboutModule` implementations are now required to support the `getURIFlags` method. See {{ Source("netwerk/protocol/about/public/nsIAboutModule.idl", "nsIAboutModule.idl") }} for documentation. This affects extensions that provide new `about:` URIs. ({{ Bug(337746) }})
+- `nsIAboutModule` implementations are now required to support the `getURIFlags` method. See {{ Source("netwerk/protocol/about/nsIAboutModule.idl", "nsIAboutModule.idl") }} for documentation. This affects extensions that provide new `about:` URIs. ({{ Bug(337746) }})
 - The [`<xul:tabbrowser>`](/en-US/docs/Mozilla/Tech/XUL/tabbrowser) element is no longer part of "toolkit" ({{ Bug(339964) }}). This means this element is no longer available to XUL applications and extensions. It continues to be used in the main Firefox window (browser.xul).
 - Changes to `nsISupports_proxies` and possibly to threading-related interfaces need to be documented.
 - If you use XML processing instructions, such as `<?xml-stylesheet ?>` in your XUL files, be aware of the changes made in {{ Bug(319654) }}:

--- a/files/en-us/web/api/xsltprocessor/index.md
+++ b/files/en-us/web/api/xsltprocessor/index.md
@@ -99,10 +99,10 @@ and not exposed to Web content:
 _Not part of any specification._ This is a proprietary interface that originated
 in Gecko.
 
-## Gecko IDL
+## Gecko Code
 
 - `{{ Source("dom/webidl/XSLTProcessor.webidl", "XSLTProcessor.webidl") }}`
-- `{{ Source("dom/xslt/nsIXSLTProcessor.idl", "nsIXSLTProcessor.idl") }}`
+- `{{ Source("dom/xslt/xslt/txXSLTProcessor.cpp", "txXSLTProcessor.cpp") }}`
 
 ## Browser compatibility
 

--- a/files/en-us/web/xslt/using_the_mozilla_javascript_interface_to_xsl_transformations/index.md
+++ b/files/en-us/web/xslt/using_the_mozilla_javascript_interface_to_xsl_transformations/index.md
@@ -83,8 +83,8 @@ The {{domxref("XSLTProcessor")}} object also implements a {{domxref("XSLTProcess
 
 The following reflect the interface of the {{domxref("XSLTProcessor")}} object:
 
-- {{ Source("dom/xslt/nsIXSLTProcessor.idl", "nsIXSLTProcessor.idl") }}
 - {{ Source("dom/webidl/XSLTProcessor.webidl", "XSLTProcessor.webidl") }}
+- {{ Source("dom/xslt/xslt/txXSLTProcessor.cpp", "txXSLTProcessor.cpp") }}
 
 ### Using XSLTProcessor from XPCOM components
 


### PR DESCRIPTION
The PR updates broken links related to the `Source` macro.
It is hard to track macro generated links as they can only be checked by crawling the hosted site.

@teoli2003 There are only 11 occurrences of the macro in 6 files left in the entire mdn/content. Should we deprecate the macro and convert the links to markdown format?