### PR TITLE
unnecessary array is displayed in output

### DIFF
--- a/files/en-us/web/api/console/index.md
+++ b/files/en-us/web/api/console/index.md
@@ -100,7 +100,7 @@ console.log(someObject);
 The output looks something like this:
 
 ```bash
-[09:27:13.475] ({str:"Some text", id:5})
+{str:"Some text", id:5}
 ```
 
 #### Outputting multiple objects


### PR DESCRIPTION
array [09:27:13.475] is showing as an extra value.

Here is an output value
![image](https://user-images.githubusercontent.com/47469261/181182047-7933d439-6d12-47f9-a971-5abe4662dc58.png)

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
