### PR TITLE
Use strict equality comparison when comparing to string literal or null

### DIFF
--- a/files/en-us/games/techniques/control_mechanisms/desktop_with_mouse_and_keyboard/index.md
+++ b/files/en-us/games/techniques/control_mechanisms/desktop_with_mouse_and_keyboard/index.md
@@ -260,7 +260,7 @@ To skip the how to play screen, we can listen for any key being pressed and move
 
 ```js
 this.input.keyboard.onDownCallback = function() {
-    if(this.stateStatus === 'intro') {
+    if (this.stateStatus === 'intro') {
         this.hideIntro();
     }
 };

--- a/files/en-us/games/techniques/control_mechanisms/desktop_with_mouse_and_keyboard/index.md
+++ b/files/en-us/games/techniques/control_mechanisms/desktop_with_mouse_and_keyboard/index.md
@@ -260,7 +260,7 @@ To skip the how to play screen, we can listen for any key being pressed and move
 
 ```js
 this.input.keyboard.onDownCallback = function() {
-    if(this.stateStatus == 'intro') {
+    if(this.stateStatus === 'intro') {
         this.hideIntro();
     }
 };

--- a/files/en-us/glossary/literal/index.md
+++ b/files/en-us/glossary/literal/index.md
@@ -42,7 +42,7 @@ The following is an example of an object literal. The first element of the `car`
 var sales = 'BMW';
 
 function carTypes(name) {
-  if (name == 'Honda') {
+  if (name === 'Honda') {
     return name;
   } else {
     return "Sorry, we don't sell " + name + ".";

--- a/files/en-us/glossary/literal/index.md
+++ b/files/en-us/glossary/literal/index.md
@@ -45,7 +45,7 @@ function carTypes(name) {
   if (name === 'Honda') {
     return name;
   } else {
-    return "Sorry, we don't sell " + name + ".";
+    return `Sorry, we don't sell ${name}.";
   }
 }
 

--- a/files/en-us/learn/forms/sending_and_retrieving_form_data/index.md
+++ b/files/en-us/learn/forms/sending_and_retrieving_form_data/index.md
@@ -230,7 +230,7 @@ def form():
 def hello():
     return render_template('greeting.html', say=request.form['say'], to=request.form['to'])
 
-if __name__ === "__main__":
+if __name__ == "__main__":
     app.run()
 ```
 

--- a/files/en-us/learn/forms/sending_and_retrieving_form_data/index.md
+++ b/files/en-us/learn/forms/sending_and_retrieving_form_data/index.md
@@ -230,7 +230,7 @@ def form():
 def hello():
     return render_template('greeting.html', say=request.form['say'], to=request.form['to'])
 
-if __name__ == "__main__":
+if __name__ === "__main__":
     app.run()
 ```
 

--- a/files/en-us/learn/getting_started_with_the_web/javascript_basics/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/javascript_basics/index.md
@@ -234,7 +234,7 @@ An `{{Glossary("operator")}}` is a mathematical symbol that produces a result ba
         This performs a test to see if two values are equal. It returns a
         <code>true</code>/<code>false</code> (Boolean) result.
       </td>
-      <td><code> ===</code></td>
+      <td><code>===</code></td>
       <td>
         <code>let myVariable = 3;<br />myVariable === 4;</code>
       </td>

--- a/files/en-us/learn/getting_started_with_the_web/javascript_basics/index.md
+++ b/files/en-us/learn/getting_started_with_the_web/javascript_basics/index.md
@@ -234,7 +234,7 @@ An `{{Glossary("operator")}}` is a mathematical symbol that produces a result ba
         This performs a test to see if two values are equal. It returns a
         <code>true</code>/<code>false</code> (Boolean) result.
       </td>
-      <td><code>===</code></td>
+      <td><code> ===</code></td>
       <td>
         <code>let myVariable = 3;<br />myVariable === 4;</code>
       </td>

--- a/files/en-us/learn/javascript/first_steps/a_first_splash/index.md
+++ b/files/en-us/learn/javascript/first_steps/a_first_splash/index.md
@@ -231,7 +231,7 @@ When we are running true/false tests (for example inside conditionals — see [b
       <th scope="col">Example</th>
     </tr>
     <tr>
-      <td><code>===</code></td>
+      <td><code> ===</code></td>
       <td>Strict equality (is it exactly the same?)</td>
       <td>
         <pre class="brush: js">

--- a/files/en-us/learn/javascript/first_steps/a_first_splash/index.md
+++ b/files/en-us/learn/javascript/first_steps/a_first_splash/index.md
@@ -231,7 +231,7 @@ When we are running true/false tests (for example inside conditionals — see [b
       <th scope="col">Example</th>
     </tr>
     <tr>
-      <td><code> ===</code></td>
+      <td><code>===</code></td>
       <td>Strict equality (is it exactly the same?)</td>
       <td>
         <pre class="brush: js">

--- a/files/en-us/mozilla/add-ons/webextensions/background_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/background_scripts/index.md
@@ -188,9 +188,9 @@ Message ports cannot prevent an event page from shutting down. If an extension u
 
 ```js
 browser.runtime.onMessage.addListener(function(message, callback) {
-  if (message == 'hello') {
+  if (message === 'hello') {
     sendResponse({greeting: 'welcome!'})
-  } else if (message == 'goodbye') {
+  } else if (message === 'goodbye') {
     browser.runtime.Port.disconnect();
   }
 });

--- a/files/en-us/mozilla/add-ons/webextensions/work_with_contextual_identities/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/work_with_contextual_identities/index.md
@@ -148,7 +148,7 @@ function eventHandler(event) {
 If the user clicks the option to create a tab for an identity, one is opened using tabs.create by passing the identity's cookie store ID.
 
 ```js
-  if (event.target.dataset.action == 'create') {
+  if (event.target.dataset.action === 'create') {
     browser.tabs.create({
       url: 'about:blank',
       cookieStoreId: event.target.dataset.identity
@@ -159,7 +159,7 @@ If the user clicks the option to create a tab for an identity, one is opened usi
 If the user selects the option to close all tabs for the identity, the script performs a tabs.query for all tabs that are using the identity's cookie store. The script then passes this list of tabs to `tabs.remove`.
 
 ```js
-  if (event.target.dataset.action == 'close-all') {
+  if (event.target.dataset.action === 'close-all') {
     browser.tabs.query({
       cookieStoreId: event.target.dataset.identity
     }).then((tabs) => {

--- a/files/en-us/web/accessibility/aria/roles/grid_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/grid_role/index.md
@@ -300,7 +300,7 @@ row = row + 1;
 
 function moveto(newrow, newcol) {
 var tgt = document.querySelector('[data-row="' + newrow + '"][data-col="' + newcol + '"]');
-if (tgt &#x26;&#x26; (tgt.getAttribute('role') ==='gridcell') ) {
+if (tgt &#x26;&#x26; (tgt.getAttribute('role')==='gridcell') ) {
 Array.prototype.forEach.call(document.querySelectorAll('[role=gridcell]'), function(el, i){
 el.setAttribute('tabindex', '-1');
 });
@@ -497,7 +497,7 @@ Array.prototype.forEach.call(trs, function(gridrow, i){
 
 function moveto(newrow, newcol) {
   var tgt = document.querySelector('[data-row="' + newrow + '"][data-col="' + newcol + '"]');
-  if (tgt && (tgt.getAttribute('role') ==='gridcell') ) {
+  if (tgt && (tgt.getAttribute('role') === 'gridcell') ) {
     Array.prototype.forEach.call(document.querySelectorAll('[role=gridcell]'), function(el, i){
       el.setAttribute('tabindex', '-1');
     });

--- a/files/en-us/web/accessibility/aria/roles/grid_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/grid_role/index.md
@@ -300,7 +300,7 @@ row = row + 1;
 
 function moveto(newrow, newcol) {
 var tgt = document.querySelector('[data-row="' + newrow + '"][data-col="' + newcol + '"]');
-if (tgt &#x26;&#x26; (tgt.getAttribute('role')==='gridcell') ) {
+if (tgt &#x26;&#x26; (tgt.getAttribute('role') ==='gridcell') ) {
 Array.prototype.forEach.call(document.querySelectorAll('[role=gridcell]'), function(el, i){
 el.setAttribute('tabindex', '-1');
 });
@@ -497,7 +497,7 @@ Array.prototype.forEach.call(trs, function(gridrow, i){
 
 function moveto(newrow, newcol) {
   var tgt = document.querySelector('[data-row="' + newrow + '"][data-col="' + newcol + '"]');
-  if (tgt && (tgt.getAttribute('role')==='gridcell') ) {
+  if (tgt && (tgt.getAttribute('role') ==='gridcell') ) {
     Array.prototype.forEach.call(document.querySelectorAll('[role=gridcell]'), function(el, i){
       el.setAttribute('tabindex', '-1');
     });

--- a/files/en-us/web/accessibility/aria/roles/switch_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/switch_role/index.md
@@ -118,7 +118,7 @@ document.querySelectorAll(".switch").forEach(function(theSwitch) {
 function handleClickEvent(evt) {
   let el = evt.target;
 
-  if (el.getAttribute("aria-checked") == "true") {
+  if (el.getAttribute("aria-checked") === "true") {
       el.setAttribute("aria-checked", "false");
   } else {
       el.setAttribute("aria-checked", "true");

--- a/files/en-us/web/api/abortsignal/throwifaborted/index.md
+++ b/files/en-us/web/api/abortsignal/throwifaborted/index.md
@@ -103,7 +103,7 @@ startSpinner();
 myCoolPromiseAPI({ /* … ,*/ signal })
   .then((result) => { })
   .catch((err) => {
-    if (err.name == 'AbortError') return;
+    if (err.name === 'AbortError') return;
     showUserErrorMessage();
   })
   .then(() => stopSpinner());

--- a/files/en-us/web/api/absoluteorientationsensor/index.md
+++ b/files/en-us/web/api/absoluteorientationsensor/index.md
@@ -57,7 +57,7 @@ sensor.addEventListener('reading', () => {
   model.quaternion.fromArray(sensor.quaternion).inverse();
 });
 sensor.addEventListener('error', (error) => {
-  if (event.error.name == 'NotReadableError') {
+  if (event.error.name === 'NotReadableError') {
     console.log("Sensor is not available.");
   }
 });

--- a/files/en-us/web/api/background_synchronization_api/index.md
+++ b/files/en-us/web/api/background_synchronization_api/index.md
@@ -86,7 +86,7 @@ The following example shows how to respond to a background sync event in the ser
 
 ```js
 self.addEventListener('sync', (event) => {
-  if (event.tag == 'sync-messages') {
+  if (event.tag === 'sync-messages') {
     event.waitUntil(sendOutboxMessages());
   }
 });

--- a/files/en-us/web/api/baseaudiocontext/createdynamicscompressor/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createdynamicscompressor/index.md
@@ -66,14 +66,14 @@ source.connect(audioCtx.destination);
 
 button.onclick = function() {
   const active = button.getAttribute('data-active');
-  if(active == 'false') {
+  if(active === 'false') {
     button.setAttribute('data-active', 'true');
     button.textContent = 'Remove compression';
 
     source.disconnect(audioCtx.destination);
     source.connect(compressor);
     compressor.connect(audioCtx.destination);
-  } else if(active == 'true') {
+  } else if(active === 'true') {
     button.setAttribute('data-active', 'false');
     button.textContent = 'Add compression';
 

--- a/files/en-us/web/api/baseaudiocontext/createdynamicscompressor/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createdynamicscompressor/index.md
@@ -64,16 +64,16 @@ compressor.release.setValueAtTime(0.25, audioCtx.currentTime);
 // connect the AudioBufferSourceNode to the destination
 source.connect(audioCtx.destination);
 
-button.onclick = function() {
+button.onclick = () => {
   const active = button.getAttribute('data-active');
-  if(active === 'false') {
+  if (active === 'false') {
     button.setAttribute('data-active', 'true');
     button.textContent = 'Remove compression';
 
     source.disconnect(audioCtx.destination);
     source.connect(compressor);
     compressor.connect(audioCtx.destination);
-  } else if(active === 'true') {
+  } else if (active === 'true') {
     button.setAttribute('data-active', 'false');
     button.textContent = 'Add compression';
 

--- a/files/en-us/web/api/baseaudiocontext/creategain/index.md
+++ b/files/en-us/web/api/baseaudiocontext/creategain/index.md
@@ -82,7 +82,7 @@ if (navigator.mediaDevices.getUserMedia) {
    }
   );
 } else {
-   console.error('getUserMedia not supported on your browser!');
+  console.error('getUserMedia not supported on your browser!');
 }
 
 source.connect(gainNode);

--- a/files/en-us/web/api/baseaudiocontext/creategain/index.md
+++ b/files/en-us/web/api/baseaudiocontext/creategain/index.md
@@ -93,7 +93,7 @@ gainNode.connect(audioCtx.destination);
 mute.onclick = voiceMute;
 
 function voiceMute() {
-  if(mute.id == "") {
+  if(mute.id === "") {
     // 0 means mute. If you still hear something, make sure you haven't
     // connected your source into the output in addition to using the GainNode.
     gainNode.gain.setValueAtTime(0, audioCtx.currentTime);

--- a/files/en-us/web/api/baseaudiocontext/creategain/index.md
+++ b/files/en-us/web/api/baseaudiocontext/creategain/index.md
@@ -58,10 +58,10 @@ The below snippet wouldn't work as is — for a complete working example, check 
 ```
 
 ```js
-var audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-var gainNode = audioCtx.createGain();
-var mute = document.querySelector('.mute');
-var source;
+const audioCtx = new AudioContext();
+const gainNode = audioCtx.createGain();
+const mute = document.querySelector('.mute');
+let source;
 
 if (navigator.mediaDevices.getUserMedia) {
  navigator.mediaDevices.getUserMedia (
@@ -71,18 +71,18 @@ if (navigator.mediaDevices.getUserMedia) {
    },
 
    // Success callback
-   function(stream) {
+   (stream) => {
      source = audioCtx.createMediaStreamSource(stream);
 
    },
 
    // Error callback
-   function(err) {
-     console.log(`The following gUM error occurred: ${err}`);
+   (err) => {
+     console.error(`The following gUM error occurred: ${err}`);
    }
   );
 } else {
-   console.log('getUserMedia not supported on your browser!');
+   console.error('getUserMedia not supported on your browser!');
 }
 
 source.connect(gainNode);
@@ -90,10 +90,8 @@ gainNode.connect(audioCtx.destination);
 
 // …
 
-mute.onclick = voiceMute;
-
-function voiceMute() {
-  if(mute.id === "") {
+mute.onclick = () => {
+  if (mute.id === "") {
     // 0 means mute. If you still hear something, make sure you haven't
     // connected your source into the output in addition to using the GainNode.
     gainNode.gain.setValueAtTime(0, audioCtx.currentTime);

--- a/files/en-us/web/api/clients/index.md
+++ b/files/en-us/web/api/clients/index.md
@@ -46,7 +46,7 @@ addEventListener('notificationclick', (event) => {
     for (const client of allClients) {
       const url = new URL(client.url);
 
-      if (url.pathname == '/chat/') {
+      if (url.pathname === '/chat/') {
         // Excellent, let's use it!
         client.focus();
         chatClient = client;

--- a/files/en-us/web/api/cssstylesheet/insertrule/index.md
+++ b/files/en-us/web/api/cssstylesheet/insertrule/index.md
@@ -166,7 +166,7 @@ to the default native `insertRule()`.
         // Works by if the char code is a backslash, then isEscaped
         // gets flipped (XOR-ed by 1), and if it is not a backslash
         // then isEscaped gets XORed by itself, zeroing it
-        isEscaped ^= newCharCode ===92?1:isEscaped; // 92 = "\\".charCodeAt(0)
+        isEscaped ^= newCharCode===92?1:isEscaped; // 92 = "\\".charCodeAt(0)
       }
       // Else, there is no unescaped bracket
       return originalInsertRule.call(this, selectorAndRule, "", arguments[2]);

--- a/files/en-us/web/api/cssstylesheet/insertrule/index.md
+++ b/files/en-us/web/api/cssstylesheet/insertrule/index.md
@@ -151,7 +151,7 @@ to the default native `insertRule()`.
             if (!isEscaped && (newCharCode === 125)) { // 125 = "}".charCodeAt(0)
               closeBracketPos = i;
             }
-            isEscaped ^= newCharCode===92?1:isEscaped; // 92 = "\\".charCodeAt(0)
+            isEscaped ^= newCharCode ===92?1:isEscaped; // 92 = "\\".charCodeAt(0)
           }
 
           if (closeBracketPos === -1) break a; // No closing bracket was found!
@@ -166,7 +166,7 @@ to the default native `insertRule()`.
         // Works by if the char code is a backslash, then isEscaped
         // gets flipped (XOR-ed by 1), and if it is not a backslash
         // then isEscaped gets XORed by itself, zeroing it
-        isEscaped ^= newCharCode===92?1:isEscaped; // 92 = "\\".charCodeAt(0)
+        isEscaped ^= newCharCode ===92?1:isEscaped; // 92 = "\\".charCodeAt(0)
       }
       // Else, there is no unescaped bracket
       return originalInsertRule.call(this, selectorAndRule, "", arguments[2]);

--- a/files/en-us/web/api/cssstylesheet/insertrule/index.md
+++ b/files/en-us/web/api/cssstylesheet/insertrule/index.md
@@ -151,7 +151,7 @@ to the default native `insertRule()`.
             if (!isEscaped && (newCharCode === 125)) { // 125 = "}".charCodeAt(0)
               closeBracketPos = i;
             }
-            isEscaped ^= newCharCode ===92?1:isEscaped; // 92 = "\\".charCodeAt(0)
+            isEscaped ^= newCharCode===92?1:isEscaped; // 92 = "\\".charCodeAt(0)
           }
 
           if (closeBracketPos === -1) break a; // No closing bracket was found!

--- a/files/en-us/web/api/datatransferitem/getasfile/index.md
+++ b/files/en-us/web/api/datatransferitem/getasfile/index.md
@@ -45,21 +45,21 @@ function drop_handler(ev) {
  ev.preventDefault();
  const data = ev.dataTransfer.items;
  for (let i = 0; i < data.length; i += 1) {
-   if ((data[i].kind == 'string') &&
+   if ((data[i].kind === 'string') &&
        (data[i].type.match('^text/plain'))) {
      // This item is the target node
      data[i].getAsString(function (s){
        ev.target.appendChild(document.getElementById(s));
      });
-   } else if ((data[i].kind == 'string') &&
+   } else if ((data[i].kind === 'string') &&
               (data[i].type.match('^text/html'))) {
      // Drag data item is HTML
      console.log("… Drop: HTML");
-   } else if ((data[i].kind == 'string') &&
+   } else if ((data[i].kind === 'string') &&
               (data[i].type.match('^text/uri-list'))) {
      // Drag data item is URI
      console.log("… Drop: URI");
-   } else if ((data[i].kind == 'file') &&
+   } else if ((data[i].kind === 'file') &&
               (data[i].type.match('^image/'))) {
      // Drag data item is an image file
      const f = data[i].getAsFile();

--- a/files/en-us/web/api/datatransferitem/getasstring/index.md
+++ b/files/en-us/web/api/datatransferitem/getasstring/index.md
@@ -55,21 +55,21 @@ function drop_handler(ev) {
  ev.preventDefault();
  const data = ev.dataTransfer.items;
  for (let i = 0; i < data.length; i += 1) {
-   if ((data[i].kind == 'string') &&
+   if ((data[i].kind === 'string') &&
        (data[i].type.match('^text/plain'))) {
      // This item is the target node
      data[i].getAsString(function (s){
        ev.target.appendChild(document.getElementById(s));
      });
-   } else if ((data[i].kind == 'string') &&
+   } else if ((data[i].kind === 'string') &&
               (data[i].type.match('^text/html'))) {
      // Drag data item is HTML
      console.log("… Drop: HTML");
-   } else if ((data[i].kind == 'string') &&
+   } else if ((data[i].kind === 'string') &&
               (data[i].type.match('^text/uri-list'))) {
      // Drag data item is URI
      console.log("… Drop: URI");
-   } else if ((data[i].kind == 'file') &&
+   } else if ((data[i].kind === 'file') &&
               (data[i].type.match('^image/'))) {
      // Drag data item is an image file
      const f = data[i].getAsFile();

--- a/files/en-us/web/api/datatransferitem/kind/index.md
+++ b/files/en-us/web/api/datatransferitem/kind/index.md
@@ -39,17 +39,17 @@ function drop_handler(ev) {
  ev.preventDefault();
  const data = event.dataTransfer.items;
  for (let i = 0; i < data.length; i += 1) {
-   if ((data[i].kind == 'string') &&
+   if ((data[i].kind === 'string') &&
        (data[i].type.match('^text/plain'))) {
      // This item is the target node
      data[i].getAsString(function (s){
        ev.target.appendChild(document.getElementById(s));
      });
-   } else if ((data[i].kind == 'string') &&
+   } else if ((data[i].kind === 'string') &&
               (data[i].type.match('^text/html'))) {
      // Drag data item is HTML
      console.log("… Drop: HTML");
-   } else if ((data[i].kind == 'file') &&
+   } else if ((data[i].kind === 'file') &&
               (data[i].type.match('^image/'))) {
      // Drag data item is an image file
      const f = data[i].getAsFile();

--- a/files/en-us/web/api/datatransferitem/type/index.md
+++ b/files/en-us/web/api/datatransferitem/type/index.md
@@ -36,21 +36,21 @@ function drop_handler(ev) {
  ev.preventDefault();
  const data = ev.dataTransfer.items;
  for (let i = 0; i < data.length; i += 1) {
-   if ((data[i].kind == 'string') &&
+   if ((data[i].kind === 'string') &&
        (data[i].type.match('^text/plain'))) {
      // This item is the target node
      data[i].getAsString(function (s){
        ev.target.appendChild(document.getElementById(s));
      });
-   } else if ((data[i].kind == 'string') &&
+   } else if ((data[i].kind === 'string') &&
               (data[i].type.match('^text/html'))) {
      // Drag data item is HTML
      console.log("… Drop: HTML");
-   } else if ((data[i].kind == 'string') &&
+   } else if ((data[i].kind === 'string') &&
               (data[i].type.match('^text/uri-list'))) {
      // Drag data item is URI
      console.log("… Drop: URI");
-   } else if ((data[i].kind == 'file') &&
+   } else if ((data[i].kind === 'file') &&
               (data[i].type.match('^image/'))) {
      // Drag data item is an image file
      const f = data[i].getAsFile();

--- a/files/en-us/web/api/datatransferitemlist/add/index.md
+++ b/files/en-us/web/api/datatransferitemlist/add/index.md
@@ -101,17 +101,17 @@ function drop_handler(ev) {
   const data = event.dataTransfer.items;
   // Loop through the dropped items and log their data
   for (let i = 0; i < data.length; i++) {
-    if ((data[i].kind == 'string') && (data[i].type.match('^text/plain'))) {
+    if ((data[i].kind === 'string') && (data[i].type.match('^text/plain'))) {
       // This item is the target node
       data[i].getAsString(function (s){
         ev.target.appendChild(document.getElementById(s));
       });
-    } else if ((data[i].kind == 'string') && (data[i].type.match('^text/html'))) {
+    } else if ((data[i].kind === 'string') && (data[i].type.match('^text/html'))) {
       // Drag data item is HTML
       data[i].getAsString(function (s){
         console.log(`… Drop: HTML = ${s}`);
       });
-    } else if ((data[i].kind == 'string') && (data[i].type.match('^text/uri-list'))) {
+    } else if ((data[i].kind === 'string') && (data[i].type.match('^text/uri-list'))) {
       // Drag data item is URI
       data[i].getAsString(function (s){
         console.log(`… Drop: URI = ${s}`);

--- a/files/en-us/web/api/datatransferitemlist/clear/index.md
+++ b/files/en-us/web/api/datatransferitemlist/clear/index.md
@@ -85,17 +85,17 @@ function drop_handler(ev) {
   const data = event.dataTransfer.items;
   // Loop through the dropped items and log their data
   for (let i = 0; i < data.length; i++) {
-    if ((data[i].kind == 'string') && (data[i].type.match('^text/plain'))) {
+    if ((data[i].kind === 'string') && (data[i].type.match('^text/plain'))) {
       // This item is the target node
       data[i].getAsString(function (s){
         ev.target.appendChild(document.getElementById(s));
       });
-    } else if ((data[i].kind == 'string') && (data[i].type.match('^text/html'))) {
+    } else if ((data[i].kind === 'string') && (data[i].type.match('^text/html'))) {
       // Drag data item is HTML
       data[i].getAsString(function (s){
         console.log(`… Drop: HTML = ${s}`);
       });
-    } else if ((data[i].kind == 'string') && (data[i].type.match('^text/uri-list'))) {
+    } else if ((data[i].kind === 'string') && (data[i].type.match('^text/uri-list'))) {
       // Drag data item is URI
       data[i].getAsString(function (s){
         console.log(`… Drop: URI = ${s}`);

--- a/files/en-us/web/api/datatransferitemlist/index.md
+++ b/files/en-us/web/api/datatransferitemlist/index.md
@@ -60,17 +60,17 @@ function drop_handler(ev) {
   const data = ev.dataTransfer.items;
   // Loop through the dropped items and log their data
   for (let i = 0; i < data.length; i++) {
-    if ((data[i].kind == 'string') && (data[i].type.match('^text/plain'))) {
+    if ((data[i].kind === 'string') && (data[i].type.match('^text/plain'))) {
       // This item is the target node
       data[i].getAsString(function (s){
         ev.target.appendChild(document.getElementById(s));
       });
-    } else if ((data[i].kind == 'string') && (data[i].type.match('^text/html'))) {
+    } else if ((data[i].kind === 'string') && (data[i].type.match('^text/html'))) {
       // Drag data item is HTML
       data[i].getAsString(function (s){
         console.log(`… Drop: HTML = ${s}`);
       });
-    } else if ((data[i].kind == 'string') && (data[i].type.match('^text/uri-list'))) {
+    } else if ((data[i].kind === 'string') && (data[i].type.match('^text/uri-list'))) {
       // Drag data item is URI
       data[i].getAsString(function (s){
         console.log(`… Drop: URI = ${s}`);

--- a/files/en-us/web/api/datatransferitemlist/length/index.md
+++ b/files/en-us/web/api/datatransferitemlist/length/index.md
@@ -51,17 +51,17 @@ function drop_handler(ev) {
   const data = ev.dataTransfer.items;
   // Loop through the dropped items and log their data
   for (let i = 0; i < data.length; i++) {
-    if ((data[i].kind == 'string') && (data[i].type.match('^text/plain'))) {
+    if ((data[i].kind === 'string') && (data[i].type.match('^text/plain'))) {
       // This item is the target node
       data[i].getAsString(function (s){
         ev.target.appendChild(document.getElementById(s));
       });
-    } else if ((data[i].kind == 'string') && (data[i].type.match('^text/html'))) {
+    } else if ((data[i].kind === 'string') && (data[i].type.match('^text/html'))) {
       // Drag data item is HTML
       data[i].getAsString(function (s){
         console.log(`… Drop: HTML = ${s}`);
       });
-    } else if ((data[i].kind == 'string') && (data[i].type.match('^text/uri-list'))) {
+    } else if ((data[i].kind === 'string') && (data[i].type.match('^text/uri-list'))) {
       // Drag data item is URI
       data[i].getAsString(function (s){
         console.log(`… Drop: URI = ${s}`);

--- a/files/en-us/web/api/datatransferitemlist/remove/index.md
+++ b/files/en-us/web/api/datatransferitemlist/remove/index.md
@@ -97,19 +97,19 @@ function drop_handler(ev) {
   const data = event.dataTransfer.items;
   // Loop through the dropped items and log their data
   for (const item of data) {
-    if ((item.kind == 'string') &&
+    if ((item.kind === 'string') &&
         (item.type.match('^text/plain'))) {
       // This item is the target node
       item.getAsString(function (s){
         ev.target.appendChild(document.getElementById(s));
       });
-    } else if ((item.kind == 'string') &&
+    } else if ((item.kind === 'string') &&
                (item.type.match('^text/html'))) {
       // Drag data item is HTML
       item.getAsString(function (s){
         console.log(`… Drop: HTML = ${s}`);
       });
-    } else if ((item.kind == 'string') &&
+    } else if ((item.kind === 'string') &&
                (item.type.match('^text/uri-list'))) {
       // Drag data item is URI
       item.getAsString(function (s){

--- a/files/en-us/web/api/document/compatmode/index.md
+++ b/files/en-us/web/api/document/compatmode/index.md
@@ -30,7 +30,7 @@ An enumerated value that can be:
 ## Examples
 
 ```js
-if (document.compatMode == "BackCompat") {
+if (document.compatMode === "BackCompat") {
   // in Quirks mode
 }
 ```

--- a/files/en-us/web/api/document/dragover_event/index.md
+++ b/files/en-us/web/api/document/dragover_event/index.md
@@ -108,7 +108,7 @@ document.addEventListener("drop", (event) => {
   // prevent default action (open as link for some elements)
   event.preventDefault();
   // move dragged element to the selected drop target
-  if (event.target.className == "dropzone") {
+  if (event.target.className === "dropzone") {
     dragged.parentNode.removeChild(dragged);
     event.target.appendChild(dragged);
   }

--- a/files/en-us/web/api/document/drop_event/index.md
+++ b/files/en-us/web/api/document/drop_event/index.md
@@ -105,7 +105,7 @@ document.addEventListener("drop", (event) => {
   // prevent default action (open as link for some elements)
   event.preventDefault();
   // move dragged element to the selected drop target
-  if (event.target.className == "dropzone") {
+  if (event.target.className === "dropzone") {
     dragged.parentNode.removeChild(dragged);
     event.target.appendChild(dragged);
   }

--- a/files/en-us/web/api/document/fullscreenelement/index.md
+++ b/files/en-us/web/api/document/fullscreenelement/index.md
@@ -43,7 +43,7 @@ that the video is in fullscreen mode.
 
 ```js
 function isVideoInFullscreen() {
-  if (document.fullscreenElement && document.fullscreenElement.nodeName == 'VIDEO') {
+  if (document.fullscreenElement && document.fullscreenElement.nodeName === 'VIDEO') {
     return true;
   }
   return false;

--- a/files/en-us/web/api/document/fullscreenelement/index.md
+++ b/files/en-us/web/api/document/fullscreenelement/index.md
@@ -43,7 +43,7 @@ that the video is in fullscreen mode.
 
 ```js
 function isVideoInFullscreen() {
-  if (document.fullscreenElement && document.fullscreenElement.nodeName === 'VIDEO') {
+  if (document.fullscreenElement?.nodeName === 'VIDEO') {
     return true;
   }
   return false;

--- a/files/en-us/web/api/document/images/index.md
+++ b/files/en-us/web/api/document/images/index.md
@@ -43,7 +43,7 @@ This example looks through the list of images and finds one whose name is
 var ilist = document.images;
 
 for(var i = 0; i < ilist.length; i++) {
-    if(ilist[i].src == 'banner.gif') {
+    if(ilist[i].src === 'banner.gif') {
         // found the banner
     }
 }

--- a/files/en-us/web/api/document/xmlversion/index.md
+++ b/files/en-us/web/api/document/xmlversion/index.md
@@ -18,7 +18,7 @@ Returns the version number as specified in the XML declaration (e.g., `<?xml ver
 This attribute was never really useful, since it always returned 1.0, and has been removed in DOM Level 4. As such, Firefox 10 no longer implements it. Its primary use in the past was to detect whether or not the document was being rendered as XML rather than HTML. To detect this, you can create an element with its name in lower case, then check to see if it gets converted into all upper case (in which case the document is in the non-XML HTML mode):
 
 ```js
-if (document.createElement("foo").tagName == "FOO") {
+if (document.createElement("foo").tagName === "FOO") {
   /* Document is not XML */
 }
 ```

--- a/files/en-us/web/api/document_object_model/introduction/index.md
+++ b/files/en-us/web/api/document_object_model/introduction/index.md
@@ -226,7 +226,7 @@ const table = document.getElementById("table");
 const tableAttrs = table.attributes; // Node/Element interface
 for (let i = 0; i < tableAttrs.length; i++) {
   // HTMLTableElement interface: border attribute
-  if(tableAttrs[i].nodeName.toLowerCase() == "border")
+  if(tableAttrs[i].nodeName.toLowerCase() === "border")
     table.border = "1";
 }
 // HTMLTableElement interface: summary attribute

--- a/files/en-us/web/api/document_object_model/introduction/index.md
+++ b/files/en-us/web/api/document_object_model/introduction/index.md
@@ -226,7 +226,7 @@ const table = document.getElementById("table");
 const tableAttrs = table.attributes; // Node/Element interface
 for (let i = 0; i < tableAttrs.length; i++) {
   // HTMLTableElement interface: border attribute
-  if(tableAttrs[i].nodeName.toLowerCase() === "border")
+  if (tableAttrs[i].nodeName.toLowerCase() === "border")
     table.border = "1";
 }
 // HTMLTableElement interface: summary attribute

--- a/files/en-us/web/api/element/getattributenode/index.md
+++ b/files/en-us/web/api/element/getattributenode/index.md
@@ -34,7 +34,7 @@ An `Attr` node for the attribute.
 // html: <div id="top" />
 let t = document.getElementById("top");
 let idAttr = t.getAttributeNode("id");
-alert(idAttr.value == "top")
+alert(idAttr.value === "top")
 ```
 
 ## Notes

--- a/files/en-us/web/api/element/getelementsbytagnamens/index.md
+++ b/files/en-us/web/api/element/getelementsbytagnamens/index.md
@@ -46,7 +46,7 @@ const cells = table.getElementsByTagNameNS("http://www.w3.org/1999/xhtml", "td")
 
 for (let i = 0; i < cells.length; i++) {
     const axis = cells[i].getAttribute("axis");
-    if (axis == "year") {
+    if (axis === "year") {
         // grab the data
     }
 }

--- a/files/en-us/web/api/element/namespaceuri/index.md
+++ b/files/en-us/web/api/element/namespaceuri/index.md
@@ -28,8 +28,8 @@ and the `localName` returns "browser", then the node is understood to be a
 XUL `<browser/>`.
 
 ```js
-if (element.localName == "browser" &&
-    element.namespaceURI == "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul") {
+if (element.localName === "browser" &&
+    element.namespaceURI === "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul") {
   // this is a XUL browser
 }
 ```

--- a/files/en-us/web/api/eventtarget/addeventlistener/index.md
+++ b/files/en-us/web/api/eventtarget/addeventlistener/index.md
@@ -124,7 +124,7 @@ For example, an event handler callback that can be used to handle both
 
 ```js
 function eventHandler(event) {
-  if (event.type == 'fullscreenchange') {
+  if (event.type === 'fullscreenchange') {
     /* handle a full screen toggle */
   } else /* fullscreenerror */ {
     /* handle a full screen toggle error */
@@ -229,7 +229,7 @@ clicks on an element.
 // Function to change the content of t2
 function modifyText() {
   const t2 = document.getElementById("t2");
-  if (t2.firstChild.nodeValue == "three") {
+  if (t2.firstChild.nodeValue === "three") {
     t2.firstChild.nodeValue = "two";
   } else {
     t2.firstChild.nodeValue = "three";
@@ -273,7 +273,7 @@ el.addEventListener("click", modifyText, { signal: controller.signal } );
 // Function to change the content of t2
 function modifyText() {
   const t2 = document.getElementById("t2");
-  if (t2.firstChild.nodeValue == "three") {
+  if (t2.firstChild.nodeValue === "three") {
     t2.firstChild.nodeValue = "two";
   } else {
     t2.firstChild.nodeValue = "three";

--- a/files/en-us/web/api/gamepad_api/using_the_gamepad_api/index.md
+++ b/files/en-us/web/api/gamepad_api/using_the_gamepad_api/index.md
@@ -165,7 +165,7 @@ After all this is done, we use our `requestAnimationFrame()` to request the next
 
 ```js
 function buttonPressed(b) {
-  if (typeof(b) === "object") {
+  if (typeof b === "object") {
     return b.pressed;
   }
   return b == 1.0;

--- a/files/en-us/web/api/gamepad_api/using_the_gamepad_api/index.md
+++ b/files/en-us/web/api/gamepad_api/using_the_gamepad_api/index.md
@@ -165,7 +165,7 @@ After all this is done, we use our `requestAnimationFrame()` to request the next
 
 ```js
 function buttonPressed(b) {
-  if (typeof(b) == "object") {
+  if (typeof(b) === "object") {
     return b.pressed;
   }
   return b == 1.0;
@@ -279,7 +279,7 @@ function updateStatus() {
       const b = buttons[i];
       let val = controller.buttons[i];
       let pressed = val == 1.0;
-      if (typeof(val) == "object") {
+      if (typeof(val) === "object") {
         pressed = val.pressed;
         val = val.value;
       }

--- a/files/en-us/web/api/gamepad_api/using_the_gamepad_api/index.md
+++ b/files/en-us/web/api/gamepad_api/using_the_gamepad_api/index.md
@@ -279,7 +279,7 @@ function updateStatus() {
       const b = buttons[i];
       let val = controller.buttons[i];
       let pressed = val == 1.0;
-      if (typeof(val) === "object") {
+      if (typeof val === "object") {
         pressed = val.pressed;
         val = val.value;
       }

--- a/files/en-us/web/api/history_api/example/index.md
+++ b/files/en-us/web/api/history_api/example/index.md
@@ -14,7 +14,7 @@ This is an example of an AJAX website composed only of three pages (_first_page.
     $page_title = "First page";
 
     $as_json = false;
-    if (isset($_GET["view_as"]) && $_GET["view_as"] === "json") {
+    if (isset($_GET["view_as"]) && $_GET["view_as"] == "json") {
         $as_json = true;
         ob_start();
     } else {
@@ -62,7 +62,7 @@ This is an example of an AJAX website composed only of three pages (_first_page.
     $page_title = "Second page";
 
     $as_json = false;
-    if (isset($_GET["view_as"]) && $_GET["view_as"] === "json") {
+    if (isset($_GET["view_as"]) && $_GET["view_as"] == "json") {
         $as_json = true;
         ob_start();
     } else {
@@ -110,7 +110,7 @@ This is an example of an AJAX website composed only of three pages (_first_page.
     $page_title = "Third page";
     $page_content = "<p>This is the content of <strong>third_page.php</strong>. This content is stored into a PHP variable.</p>";
 
-    if (isset($_GET["view_as"]) && $_GET["view_as"] === "json") {
+    if (isset($_GET["view_as"]) && $_GET["view_as"] == "json") {
         echo json_encode(array("page" => $page_title, "content" => $page_content));
     } else {
 ?>

--- a/files/en-us/web/api/history_api/example/index.md
+++ b/files/en-us/web/api/history_api/example/index.md
@@ -14,7 +14,7 @@ This is an example of an AJAX website composed only of three pages (_first_page.
     $page_title = "First page";
 
     $as_json = false;
-    if (isset($_GET["view_as"]) && $_GET["view_as"] == "json") {
+    if (isset($_GET["view_as"]) && $_GET["view_as"] === "json") {
         $as_json = true;
         ob_start();
     } else {
@@ -62,7 +62,7 @@ This is an example of an AJAX website composed only of three pages (_first_page.
     $page_title = "Second page";
 
     $as_json = false;
-    if (isset($_GET["view_as"]) && $_GET["view_as"] == "json") {
+    if (isset($_GET["view_as"]) && $_GET["view_as"] === "json") {
         $as_json = true;
         ob_start();
     } else {
@@ -110,7 +110,7 @@ This is an example of an AJAX website composed only of three pages (_first_page.
     $page_title = "Third page";
     $page_content = "<p>This is the content of <strong>third_page.php</strong>. This content is stored into a PHP variable.</p>";
 
-    if (isset($_GET["view_as"]) && $_GET["view_as"] == "json") {
+    if (isset($_GET["view_as"]) && $_GET["view_as"] === "json") {
         echo json_encode(array("page" => $page_title, "content" => $page_content));
     } else {
 ?>

--- a/files/en-us/web/api/html_drag_and_drop_api/recommended_drag_types/index.md
+++ b/files/en-us/web/api/html_drag_and_drop_api/recommended_drag_types/index.md
@@ -190,7 +190,7 @@ dataProvider.prototype = {
     throw Components.results.NS_NOINTERFACE;
   },
   getFlavorData(aTransferable, aFlavor, aData, aDataLen) {
-    if (aFlavor == 'application/x-moz-file-promise') {
+    if (aFlavor === 'application/x-moz-file-promise') {
 
        const urlPrimitive = {};
        const dataSize = {};

--- a/files/en-us/web/api/htmlanchorelement/host/index.md
+++ b/files/en-us/web/api/htmlanchorelement/host/index.md
@@ -26,14 +26,14 @@ A string.
 const anchor = document.createElement("a");
 
 anchor.href = "https://developer.mozilla.org/en-US/HTMLAnchorElement"
-anchor.host == "developer.mozilla.org"
+anchor.host === "developer.mozilla.org"
 
 anchor.href = "https://developer.mozilla.org:443/en-US/HTMLAnchorElement"
-anchor.host == "developer.mozilla.org"
+anchor.host === "developer.mozilla.org"
 // The port number is not included because 443 is the scheme's default port
 
 anchor.href = "https://developer.mozilla.org:4097/en-US/HTMLAnchorElement"
-anchor.host == "developer.mozilla.org:4097"
+anchor.host === "developer.mozilla.org:4097"
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlareaelement/host/index.md
+++ b/files/en-us/web/api/htmlareaelement/host/index.md
@@ -26,14 +26,14 @@ A string.
 const area = document.createElement("area");
 
 area.href = "https://developer.mozilla.org/en-US/HTMLAreaElement"
-area.host == "developer.mozilla.org"
+area.host === "developer.mozilla.org"
 
 area.href = "https://developer.mozilla.org:443/en-US/HTMLAreaElement"
-area.host == "developer.mozilla.org"
+area.host === "developer.mozilla.org"
 // The port number is not included because 443 is the scheme's default port
 
 area.href = "https://developer.mozilla.org:4097/en-US/HTMLAreaElement"
-area.host == "developer.mozilla.org:4097"
+area.host === "developer.mozilla.org:4097"
 ```
 
 ## Specifications

--- a/files/en-us/web/api/htmlcanvaselement/mozopaque/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/mozopaque/index.md
@@ -38,7 +38,7 @@ Given this {{HTMLElement("canvas")}} element:
 ```
 
 You can get or set the `mozOpaque` property. For example, you could
-conditionally set it to `true` if `mimeType == 'image/jpeg'`, or
+conditionally set it to `true` if `mimeType === 'image/jpeg'`, or
 similar, to gain performance in your application when translucency is not needed.
 
 ```js

--- a/files/en-us/web/api/htmldialogelement/returnvalue/index.md
+++ b/files/en-us/web/api/htmldialogelement/returnvalue/index.md
@@ -69,7 +69,7 @@ dialog.
       }
 
       function handleUserInput(returnValue) {
-        if (returnValue === 'Cancel' || returnValue === '') {
+        if (!returnValue || returnValue === 'Cancel') {
           // User canceled the dialog, do nothing
         } else if (returnValue === 'Confirm') {
           // User chose a favorite animal, do something with it

--- a/files/en-us/web/api/htmldialogelement/returnvalue/index.md
+++ b/files/en-us/web/api/htmldialogelement/returnvalue/index.md
@@ -69,7 +69,7 @@ dialog.
       }
 
       function handleUserInput(returnValue) {
-        if (returnValue === 'Cancel' || returnValue == null) {
+        if (returnValue === 'Cancel' || returnValue === null) {
           // User canceled the dialog, do nothing
         } else if (returnValue === 'Confirm') {
           // User chose a favorite animal, do something with it

--- a/files/en-us/web/api/htmldialogelement/returnvalue/index.md
+++ b/files/en-us/web/api/htmldialogelement/returnvalue/index.md
@@ -69,7 +69,7 @@ dialog.
       }
 
       function handleUserInput(returnValue) {
-        if (returnValue === 'Cancel' || returnValue === null) {
+        if (returnValue === 'Cancel' || returnValue === '') {
           // User canceled the dialog, do nothing
         } else if (returnValue === 'Confirm') {
           // User chose a favorite animal, do something with it

--- a/files/en-us/web/api/htmlelement/dragover_event/index.md
+++ b/files/en-us/web/api/htmlelement/dragover_event/index.md
@@ -110,7 +110,7 @@ target.addEventListener("drop", (event) => {
   // prevent default action (open as link for some elements)
   event.preventDefault();
   // move dragged element to the selected drop target
-  if (event.target.className == "dropzone") {
+  if (event.target.className === "dropzone") {
     dragged.parentNode.removeChild(dragged);
     event.target.appendChild(dragged);
   }

--- a/files/en-us/web/api/htmlelement/drop_event/index.md
+++ b/files/en-us/web/api/htmlelement/drop_event/index.md
@@ -107,7 +107,7 @@ target.addEventListener("drop", (event) => {
   // prevent default action (open as link for some elements)
   event.preventDefault();
   // move dragged element to the selected drop target
-  if (event.target.className == "dropzone") {
+  if (event.target.className === "dropzone") {
     dragged.parentNode.removeChild(dragged);
     event.target.appendChild(dragged);
   }

--- a/files/en-us/web/api/htmloptionelement/option/index.md
+++ b/files/en-us/web/api/htmloptionelement/option/index.md
@@ -85,13 +85,13 @@ var s = document.getElementById('s');
 var options = [ 'zero', 'one', 'two' ];
 
 options.forEach(function(element, key) {
-  if (element == 'zero') {
+  if (element === 'zero') {
     s[key] = new Option(element, s.options.length, false, false);
   }
-  if (element == 'one') {
+  if (element === 'one') {
     s[key] = new Option(element, s.options.length, true, false); // Will add the "selected" attribute
   }
-  if (element == 'two') {
+  if (element === 'two') {
     s[key] = new Option(element, s.options.length, false, true); // Just will be selected in "view"
   }
 });

--- a/files/en-us/web/api/htmlscriptelement/supports/index.md
+++ b/files/en-us/web/api/htmlscriptelement/supports/index.md
@@ -55,7 +55,7 @@ The code below shows how to check if `HTMLScriptElement.supports()` is defined, 
 ```
 
 ```js
-if (typeof HTMLScriptElement.supports == 'undefined') {
+if (typeof HTMLScriptElement.supports === 'undefined') {
   //Check if method is defined
   console.log("HTMLScriptElement.supports() method is not supported");
 }

--- a/files/en-us/web/api/indexeddb_api/checking_when_a_deadline_is_due/index.md
+++ b/files/en-us/web/api/indexeddb_api/checking_when_a_deadline_is_due/index.md
@@ -40,7 +40,7 @@ When the form's submit button is pressed, we run the `addData()` function, which
 function addData(e) {
   e.preventDefault();
 
-  if(title.value === '' || hours.value === null || minutes.value === null || day.value === '' || month.value === '' || year.value === null) {
+  if (title.value === '' || hours.value === null || minutes.value === null || day.value === '' || month.value === '' || year.value === null) {
     note.innerHTML += '<li>Data not submitted — form incomplete.</li>';
     return;
   }

--- a/files/en-us/web/api/indexeddb_api/checking_when_a_deadline_is_due/index.md
+++ b/files/en-us/web/api/indexeddb_api/checking_when_a_deadline_is_due/index.md
@@ -40,7 +40,7 @@ When the form's submit button is pressed, we run the `addData()` function, which
 function addData(e) {
   e.preventDefault();
 
-  if(title.value == '' || hours.value == null || minutes.value == null || day.value == '' || month.value == '' || year.value == null) {
+  if(title.value === '' || hours.value === null || minutes.value === null || day.value === '' || month.value === '' || year.value === null) {
     note.innerHTML += '<li>Data not submitted — form incomplete.</li>';
     return;
   }
@@ -169,7 +169,7 @@ The first thing we do is convert the month names we have stored in the database 
          +(cursor.value.day) == dayCheck &&
          monthNumber == monthCheck &&
          cursor.value.year == yearCheck &&
-         notified == "no") {
+         notified === "no") {
 
         // If the numbers all do match, run the createNotification()
         // function to create a system notification
@@ -181,7 +181,7 @@ With the current time and date segments that we want to check against the Indexe
 
 The `+` operator in this case converts numbers with leading zeros into their non leading zero equivalents, e.g. 09 -> 9. This is needed because JavaScript `Date` number values never have leading zeros, but our data might.
 
-The `notified == "no"` check is designed to make sure you will only get one notification per to-do item. When a notification is fired for each item object, its `notification` property is set to `"yes"` so this check will not pass on the next iteration, via the following code inside the `createNotification()` function (read [Using IndexedDB](/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB) for an explanation):
+The `notified === "no"` check is designed to make sure you will only get one notification per to-do item. When a notification is fired for each item object, its `notification` property is set to `"yes"` so this check will not pass on the next iteration, via the following code inside the `createNotification()` function (read [Using IndexedDB](/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB) for an explanation):
 
 ```js
     // now we need to update the value of notified to "yes" in this particular data object, so the

--- a/files/en-us/web/api/indexeddb_api/checking_when_a_deadline_is_due/index.md
+++ b/files/en-us/web/api/indexeddb_api/checking_when_a_deadline_is_due/index.md
@@ -40,7 +40,7 @@ When the form's submit button is pressed, we run the `addData()` function, which
 function addData(e) {
   e.preventDefault();
 
-  if (title.value === '' || hours.value === null || minutes.value === null || day.value === '' || month.value === '' || year.value === null) {
+  if (title.value === '' || hours.value === '' || minutes.value === '' || day.value === '' || month.value === '' || year.value === '') {
     note.innerHTML += '<li>Data not submitted — form incomplete.</li>';
     return;
   }

--- a/files/en-us/web/api/indexeddb_api/checking_when_a_deadline_is_due/index.md
+++ b/files/en-us/web/api/indexeddb_api/checking_when_a_deadline_is_due/index.md
@@ -40,7 +40,7 @@ When the form's submit button is pressed, we run the `addData()` function, which
 function addData(e) {
   e.preventDefault();
 
-  if (title.value === '' || hours.value === '' || minutes.value === '' || day.value === '' || month.value === '' || year.value === '') {
+  if (!title.value || !hours.value || !minutes.value || !day.value || !month.value || !year.value) {
     note.innerHTML += '<li>Data not submitted — form incomplete.</li>';
     return;
   }

--- a/files/en-us/web/api/location/host/index.md
+++ b/files/en-us/web/api/location/host/index.md
@@ -26,14 +26,14 @@ A string.
 const anchor = document.createElement("a");
 
 anchor.href = "https://developer.mozilla.org/en-US/Location.host";
-console.log(anchor.host == "developer.mozilla.org");
+console.log(anchor.host === "developer.mozilla.org");
 
 anchor.href = "https://developer.mozilla.org:443/en-US/Location.host";
-console.log(anchor.host == "developer.mozilla.org");
+console.log(anchor.host === "developer.mozilla.org");
 // The port number is not included because 443 is the scheme's default port
 
 anchor.href = "https://developer.mozilla.org:4097/en-US/Location.host";
-console.log(anchor.host == "developer.mozilla.org:4097");
+console.log(anchor.host === "developer.mozilla.org:4097");
 ```
 
 ## Specifications

--- a/files/en-us/web/api/media_streams_api/constraints/index.md
+++ b/files/en-us/web/api/media_streams_api/constraints/index.md
@@ -488,7 +488,7 @@ This code adds simple support for tabs to the {{HTMLElement("textarea")}} elemen
 
 ```js
 function keyDownHandler(event) {
-  if (event.key == "Tab") {
+  if (event.key === "Tab") {
     let elem = event.target;
     let str = elem.value;
 

--- a/files/en-us/web/api/mediastream_recording_api/index.md
+++ b/files/en-us/web/api/mediastream_recording_api/index.md
@@ -102,7 +102,7 @@ navigator.mediaDevices.enumerateDevices()
 .then(function(devices) {
   devices.forEach(function(device) {
     const menu = document.getElementById("inputdevices");
-    if (device.kind == "audioinput") {
+    if (device.kind === "audioinput") {
       const item = document.createElement("option");
       item.innerText = device.label;
       item.value = device.deviceId;

--- a/files/en-us/web/api/mediastream_recording_api/recording_a_media_element/index.md
+++ b/files/en-us/web/api/mediastream_recording_api/recording_a_media_element/index.md
@@ -173,7 +173,11 @@ function startRecording(stream, lengthInMS) {
   });
 
   let recorded = wait(lengthInMS).then(
-    () => recorder.state === "recording" && recorder.stop()
+    () => {
+      if (recorder.state === "recording") {
+        recorder.stop();
+      }
+    },
   );
 
   return Promise.all([

--- a/files/en-us/web/api/mediastream_recording_api/recording_a_media_element/index.md
+++ b/files/en-us/web/api/mediastream_recording_api/recording_a_media_element/index.md
@@ -173,7 +173,7 @@ function startRecording(stream, lengthInMS) {
   });
 
   let recorded = wait(lengthInMS).then(
-    () => recorder.state == "recording" && recorder.stop()
+    () => recorder.state === "recording" && recorder.stop()
   );
 
   return Promise.all([

--- a/files/en-us/web/api/namednodemap/setnameditemns/index.md
+++ b/files/en-us/web/api/namednodemap/setnameditemns/index.md
@@ -63,7 +63,7 @@ const one = warning.attributes.removeNamedItemNS("http://www.example.com/ob", "o
 attrMap.setNamedItemNS(one);
 result += `The '<span>' element now contains ${span.attributes.length} attributes:\n\n`;
 result += "Prefix\tLocal name\tQualified name\n";
-result += "=========================================\n";
+result += " =========================================\n";
 for(let attr of attrMap) {
   result += `${attr.prefix}\t${attr.localName}\t\t${attr.name}\n`;
 }

--- a/files/en-us/web/api/namednodemap/setnameditemns/index.md
+++ b/files/en-us/web/api/namednodemap/setnameditemns/index.md
@@ -63,7 +63,7 @@ const one = warning.attributes.removeNamedItemNS("http://www.example.com/ob", "o
 attrMap.setNamedItemNS(one);
 result += `The '<span>' element now contains ${span.attributes.length} attributes:\n\n`;
 result += "Prefix\tLocal name\tQualified name\n";
-result += " =========================================\n";
+result += "=========================================\n";
 for(let attr of attrMap) {
   result += `${attr.prefix}\t${attr.localName}\t\t${attr.name}\n`;
 }

--- a/files/en-us/web/api/ndefrecord/torecords/index.md
+++ b/files/en-us/web/api/ndefrecord/torecords/index.md
@@ -61,16 +61,16 @@ const ndefReader = new NDEFReader();
 await ndefReader.scan();
 ndefReader.onreading = (event) => {
   const externalRecord = event.message.records.find(
-    (record) => record.type == "example.com:smart-poster"
+    (record) => record.type === "example.com:smart-poster"
   );
 
   let action, text;
 
   for (const record of externalRecord.toRecords()) {
-    if (record.recordType == "text") {
+    if (record.recordType === "text") {
       const decoder = new TextDecoder(record.encoding);
       text = decoder.decode(record.data);
-    } else if (record.recordType == ":act") {
+    } else if (record.recordType === ":act") {
       action = record.data.getUint8(0);
     }
   }

--- a/files/en-us/web/api/notificationevent/index.md
+++ b/files/en-us/web/api/notificationevent/index.md
@@ -56,7 +56,7 @@ self.addEventListener('notificationclick', function(event) {
   }).then(function(clientList) {
     for (let i = 0; i < clientList.length; i++) {
       const client = clientList[i];
-      if (client.url == '/' && 'focus' in client)
+      if (client.url === '/' && 'focus' in client)
         return client.focus();
     }
     if (clients.openWindow)

--- a/files/en-us/web/api/notificationevent/index.md
+++ b/files/en-us/web/api/notificationevent/index.md
@@ -53,8 +53,8 @@ self.addEventListener('notificationclick', function(event) {
   // focuses if it is
   event.waitUntil(clients.matchAll({
     type: "window"
-  }).then((clientsList) => {
-    for (const client of clientsList) {
+  }).then((clientList) => {
+    for (const client of clientList) {
       if (client.url === '/' && 'focus' in client)
         return client.focus();
     }

--- a/files/en-us/web/api/notificationevent/index.md
+++ b/files/en-us/web/api/notificationevent/index.md
@@ -53,9 +53,8 @@ self.addEventListener('notificationclick', function(event) {
   // focuses if it is
   event.waitUntil(clients.matchAll({
     type: "window"
-  }).then(function(clientList) {
-    for (let i = 0; i < clientList.length; i++) {
-      const client = clientList[i];
+  }).then((clientsList) => {
+    for (const client of clientsList) {
       if (client.url === '/' && 'focus' in client)
         return client.focus();
     }

--- a/files/en-us/web/api/notificationevent/notification/index.md
+++ b/files/en-us/web/api/notificationevent/notification/index.md
@@ -40,7 +40,7 @@ self.addEventListener('notificationclick', function(event) {
   }).then(function(clientList) {
     for (let i = 0; i < clientList.length; i++) {
       const client = clientList[i];
-      if (client.url == '/' && 'focus' in client)
+      if (client.url === '/' && 'focus' in client)
         return client.focus();
     }
     if (clients.openWindow)

--- a/files/en-us/web/api/notificationevent/notification/index.md
+++ b/files/en-us/web/api/notificationevent/notification/index.md
@@ -37,9 +37,8 @@ self.addEventListener('notificationclick', function(event) {
   // focuses if it is
   event.waitUntil(clients.matchAll({
     type: "window"
-  }).then(function(clientList) {
-    for (let i = 0; i < clientList.length; i++) {
-      const client = clientList[i];
+  }).then((clientList) => {
+    for (const client of clientList) {
       if (client.url === '/' && 'focus' in client)
         return client.focus();
     }

--- a/files/en-us/web/api/orientationsensor/index.md
+++ b/files/en-us/web/api/orientationsensor/index.md
@@ -54,7 +54,7 @@ sensor.addEventListener('reading', () => {
   model.quaternion.fromArray(sensor.quaternion).inverse();
 });
 sensor.addEventListener('error', (error) => {
-   if (event.error.name == 'NotReadableError') {
+   if (event.error.name === 'NotReadableError') {
     console.log("Sensor is not available.");
   }
 });

--- a/files/en-us/web/api/performance/clearresourcetimings/index.md
+++ b/files/en-us/web/api/performance/clearresourcetimings/index.md
@@ -49,7 +49,7 @@ function clear_performance_timings() {
   // Create a resource timing performance entry by loading an image
   load_resource();
 
-  const supported = typeof performance.clearResourceTimings == "function";
+  const supported = typeof performance.clearResourceTimings === "function";
   if (supported) {
     console.log("Run: performance.clearResourceTimings()");
     performance.clearResourceTimings();

--- a/files/en-us/web/api/performance/setresourcetimingbuffersize/index.md
+++ b/files/en-us/web/api/performance/setresourcetimingbuffersize/index.md
@@ -46,7 +46,7 @@ function setResourceTimingBufferSize(maxSize) {
     log("Browser does not support Web Performance");
     return;
   }
-  const supported = typeof performance.setResourceTimingBufferSize == "function";
+  const supported = typeof performance.setResourceTimingBufferSize === "function";
   if (supported) {
     console.log("… Performance.setResourceTimingBufferSize() = Yes");
     performance.setResourceTimingBufferSize(maxSize);

--- a/files/en-us/web/api/performanceentry/duration/index.md
+++ b/files/en-us/web/api/performanceentry/duration/index.md
@@ -91,7 +91,7 @@ function check_PerformanceEntry(obj) {
   }
   for (let i=0; i < methods.length; i++) {
     // check each method
-    const supported = typeof obj[methods[i]] == "function";
+    const supported = typeof obj[methods[i]] === "function";
     if (supported) {
       const js = obj[methods[i]]();
       console.log(`…${methods[i]}() = ${JSON.stringify(js)}`);

--- a/files/en-us/web/api/performanceentry/name/index.md
+++ b/files/en-us/web/api/performanceentry/name/index.md
@@ -119,7 +119,7 @@ function check_PerformanceEntry(obj) {
   }
   for (let i=0; i < methods.length; i++) {
     // check each method
-    const supported = typeof obj[methods[i]] == "function";
+    const supported = typeof obj[methods[i]] === "function";
     if (supported) {
       const js = obj[methods[i]]();
       console.log(`…${methods[i]}() = ${JSON.stringify(js)}`);

--- a/files/en-us/web/api/performanceentry/starttime/index.md
+++ b/files/en-us/web/api/performanceentry/starttime/index.md
@@ -86,7 +86,7 @@ function check_PerformanceEntry(obj) {
   }
   for (let i=0; i < methods.length; i++) {
     // check each method
-    const supported = typeof obj[methods[i]] == "function";
+    const supported = typeof obj[methods[i]] === "function";
     if (supported) {
       const js = obj[methods[i]]();
       console.log(`…${methods[i]}() = ${JSON.stringify(js)}`);

--- a/files/en-us/web/api/performanceentry/tojson/index.md
+++ b/files/en-us/web/api/performanceentry/tojson/index.md
@@ -69,7 +69,7 @@ function check_PerformanceEntry(obj) {
   }
   for (let i=0; i < methods.length; i++) {
     // check each method
-    const supported = typeof obj[methods[i]] == "function";
+    const supported = typeof obj[methods[i]] === "function";
     if (supported) {
       const js = obj[methods[i]]();
       console.log(`…${methods[i]}() = ${JSON.stringify(js)}`);

--- a/files/en-us/web/api/periodicsyncevent/index.md
+++ b/files/en-us/web/api/periodicsyncevent/index.md
@@ -41,7 +41,7 @@ The following example shows how to respond to a periodic sync event in the servi
 
 ```js
 self.addEventListener('periodicsync', (event) => {
-  if (event.tag == 'get-latest-news') {
+  if (event.tag === 'get-latest-news') {
     event.waitUntil(fetchAndCacheLatestNews());
   }
 });

--- a/files/en-us/web/api/permissions/query/index.md
+++ b/files/en-us/web/api/permissions/query/index.md
@@ -66,9 +66,9 @@ A {{jsxref("Promise")}} that resolves to a {{domxref("PermissionStatus")}} objec
 
 ```js
 navigator.permissions.query({name:'geolocation'}).then(function(result) {
- if (result.state == 'granted') {
+ if (result.state === 'granted') {
    showLocalNewsWithGeolocation();
- } else if (result.state == 'prompt') {
+ } else if (result.state === 'prompt') {
    showButtonToEnableLocalNews();
  }
  // Don't do anything if the permission was denied.

--- a/files/en-us/web/api/permissions_api/using_the_permissions_api/index.md
+++ b/files/en-us/web/api/permissions_api/using_the_permissions_api/index.md
@@ -55,14 +55,14 @@ In our example, the Permissions functionality is handled by one function — `ha
 ```js
 function handlePermission() {
   navigator.permissions.query({name:'geolocation'}).then(function(result) {
-    if (result.state == 'granted') {
+    if (result.state === 'granted') {
       report(result.state);
       geoBtn.style.display = 'none';
-    } else if (result.state == 'prompt') {
+    } else if (result.state === 'prompt') {
       report(result.state);
       geoBtn.style.display = 'none';
       navigator.geolocation.getCurrentPosition(revealPosition,positionDenied,geoSettings);
-    } else if (result.state == 'denied') {
+    } else if (result.state === 'denied') {
       report(result.state);
       geoBtn.style.display = 'inline';
     }

--- a/files/en-us/web/api/presentation_api/index.md
+++ b/files/en-us/web/api/presentation_api/index.md
@@ -219,7 +219,7 @@ Example codes below highlight the usage of main features of the Presentation API
 <script>
   const addConnection = function(connection) {
     this.onmessage = function (message) {
-      if (message.data == "say hello")
+      if (message.data === "say hello")
         this.send("hello");
     };
   };

--- a/files/en-us/web/api/promiserejectionevent/promise/index.md
+++ b/files/en-us/web/api/promiserejectionevent/promise/index.md
@@ -40,7 +40,7 @@ been handled.
 
 ```js
 window.onunhandledrejection = function(event) {
-  if (event.reason.code && event.reason.code == "Module not ready") {
+  if (event.reason.code && event.reason.code === "Module not ready") {
     window.requestIdleCallback(function(deadline) {
       loadModule(event.reason.moduleName)
         .then(performStartup);

--- a/files/en-us/web/api/relativeorientationsensor/index.md
+++ b/files/en-us/web/api/relativeorientationsensor/index.md
@@ -59,7 +59,7 @@ sensor.addEventListener('reading', () => {
   model.quaternion.fromArray(sensor.quaternion).inverse();
 });
 sensor.addEventListener('error', (error) => {
-  if (event.error.name == 'NotReadableError') {
+  if (event.error.name === 'NotReadableError') {
     console.log("Sensor is not available.");
   }
 });

--- a/files/en-us/web/api/remoteplayback/watchavailability/index.md
+++ b/files/en-us/web/api/remoteplayback/watchavailability/index.md
@@ -41,7 +41,7 @@ A {{jsxref("Promise")}} that resolves with an integer. This is the `callbackId` 
 In the following example, after checking that there is no currently connected device, `watchAvailability()` is used to watch for remote devices becoming available. [See the working example](https://beaufortfrancois.github.io/sandbox/media/remote-playback.html) (Requires a supported device and a connected remote playback device).
 
 ```js
- if (video.remote.state == 'disconnected') {
+ if (video.remote.state === 'disconnected') {
   video.remote.watchAvailability(handleAvailabilityChange)
   .then((id) => {
     log(`> Started watching remote device availability: ${id}`);

--- a/files/en-us/web/api/reporterror/index.md
+++ b/files/en-us/web/api/reporterror/index.md
@@ -45,7 +45,7 @@ None ({{jsxref("undefined")}}).
 Feature test for the method using:
 
 ```js
-if (typeof self.reportError == 'function') {
+if (typeof self.reportError === 'function') {
   // function is defined
 }
 ```

--- a/files/en-us/web/api/resource_timing_api/using_the_resource_timing_api/index.md
+++ b/files/en-us/web/api/resource_timing_api/using_the_resource_timing_api/index.md
@@ -147,7 +147,7 @@ function clear_resource_timings() {
   }
   // Check if Performance.clearResourceTiming() is supported
   console.log ("= Print performance.clearResourceTimings()");
-  const supported = typeof performance.clearResourceTimings == "function";
+  const supported = typeof performance.clearResourceTimings === "function";
   if (supported) {
     console.log("… Performance.clearResourceTimings() = supported");
     performance.clearResourceTimings();
@@ -170,7 +170,7 @@ function set_resource_timing_buffer_size(n) {
   }
   // Check if Performance.setResourceTimingBufferSize() is supported
   console.log ("= performance.setResourceTimingBufferSize()");
-  const supported = typeof performance.setResourceTimingBufferSize == "function";
+  const supported = typeof performance.setResourceTimingBufferSize === "function";
   if (supported) {
     console.log("… Performance.setResourceTimingBufferSize() = supported");
     performance.setResourceTimingBufferSize(n);

--- a/files/en-us/web/api/rtcicecandidate/component/index.md
+++ b/files/en-us/web/api/rtcicecandidate/component/index.md
@@ -58,9 +58,9 @@ This code snippet examines a candidate's component type and dispatches the candi
 different handlers depending on the value.
 
 ```js
-if (candidate.component == "rtp") {
+if (candidate.component === "rtp") {
   handleRTPCandidate(candidate);
-} else if (candidate.component == "rtcp") {
+} else if (candidate.component === "rtcp") {
   handleRTCPCandidate(candidate);
 } else {
   handleUnknownCandidate(candidate);

--- a/files/en-us/web/api/rtcicecandidate/protocol/index.md
+++ b/files/en-us/web/api/rtcicecandidate/protocol/index.md
@@ -55,8 +55,8 @@ look at the value of {{domxref("RTCIceCandidate.tcpType", "tcpType")}} to see if
 **simultaneous-open** (**S-O**) candidate.
 
 ```js
-if (candidate.protocol == "tcp") {
-  if (candidate.tcpType == "so") {
+if (candidate.protocol === "tcp") {
+  if (candidate.tcpType === "so") {
     adjustForSimultaneousOpen(candidate);
   }
 }

--- a/files/en-us/web/api/rtcicecandidate/tcptype/index.md
+++ b/files/en-us/web/api/rtcicecandidate/tcptype/index.md
@@ -43,7 +43,7 @@ In this example, the candidate's {{domxref("RTCIceCandidate.protocol", "protocol
 and `tcpType` are used to adjust the user interface for simultaneous-open TCP candidates.
 
 ```js
-if (candidate.protocol == "tcp" && candidate.tcpType == "so") {
+if (candidate.protocol === "tcp" && candidate.tcpType === "so") {
     adjustForSimultaneousOpen(candidate);
 }
 ```

--- a/files/en-us/web/api/rtcicecandidate/type/index.md
+++ b/files/en-us/web/api/rtcicecandidate/type/index.md
@@ -50,7 +50,7 @@ present a modified user interface for host candidates (those where the
 an intermediary).
 
 ```js
-if (candidate.type == "host") {
+if (candidate.type === "host") {
   showHostControls();
 } else {
   hideHostControls();

--- a/files/en-us/web/api/rtcicecandidatestats/index.md
+++ b/files/en-us/web/api/rtcicecandidatestats/index.md
@@ -49,7 +49,7 @@ The WebRTC API's **`RTCIceCandidateStats`** dictionary provides statistics relat
 In this example, the candidate's {{domxref("RTCIceCandidate.type", "type")}} is used to present a modified user interface for host candidates (those where the {{domxref("RTCIceCandidate/address", "ip")}} refers directly to the remote peer, rather than an intermediary).
 
 ```js
-if (candidate.type == "host") {
+if (candidate.type === "host") {
   showHostControls();
 } else {
   hideHostControls();

--- a/files/en-us/web/api/rtcsessiondescription/index.md
+++ b/files/en-us/web/api/rtcsessiondescription/index.md
@@ -51,7 +51,7 @@ signalingChannel.onmessage = function (evt) {
       new RTCSessionDescription(message),
       function () {
         // if we received an offer, we need to answer
-        if (pc.remoteDescription.type == "offer")
+        if (pc.remoteDescription.type === "offer")
           pc.createAnswer(localDescCreated, logError);
       },
       logError

--- a/files/en-us/web/api/serviceworker/statechange_event/index.md
+++ b/files/en-us/web/api/serviceworker/statechange_event/index.md
@@ -60,9 +60,9 @@ changed. For example:
 
 ```js
 navigator.serviceWorker.register("/sw.js").then(function(swr) {
-  swr.installing.state == "installing"
+  swr.installing.state === "installing"
   swr.installing.onstatechange = function() {
-    swr.installing == null;
+    swr.installing === null;
     // At this point, swr.waiting OR swr.active might be true. This is because the statechange
     // event gets queued, meanwhile the underlying worker may have gone into the waiting
     // state and will be immediately activated if possible.

--- a/files/en-us/web/api/serviceworker/statechange_event/index.md
+++ b/files/en-us/web/api/serviceworker/statechange_event/index.md
@@ -60,7 +60,7 @@ changed. For example:
 
 ```js
 navigator.serviceWorker.register("/sw.js").then(function(swr) {
-  swr.installing.state === "installing"
+  swr.installing.state = "installing";
   swr.installing.onstatechange = function() {
     swr.installing = null;
     // At this point, swr.waiting OR swr.active might be true. This is because the statechange

--- a/files/en-us/web/api/serviceworker/statechange_event/index.md
+++ b/files/en-us/web/api/serviceworker/statechange_event/index.md
@@ -62,7 +62,7 @@ changed. For example:
 navigator.serviceWorker.register("/sw.js").then(function(swr) {
   swr.installing.state === "installing"
   swr.installing.onstatechange = function() {
-    swr.installing === null;
+    swr.installing = null;
     // At this point, swr.waiting OR swr.active might be true. This is because the statechange
     // event gets queued, meanwhile the underlying worker may have gone into the waiting
     // state and will be immediately activated if possible.

--- a/files/en-us/web/api/serviceworkerglobalscope/notificationclick_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/notificationclick_event/index.md
@@ -57,7 +57,7 @@ self.addEventListener('notificationclick', function(event) {
     type: "window"
   }).then(function(clientList) {
     for (const client of clientList) {
-      if (client.url == '/' && 'focus' in client)
+      if (client.url === '/' && 'focus' in client)
         return client.focus();
     }
     if (clients.openWindow)
@@ -79,7 +79,7 @@ self.onnotificationclick = function(event) {
     type: "window"
   }).then(function(clientList) {
     for (const client of clientList) {
-      if (client.url == '/' && 'focus' in client)
+      if (client.url === '/' && 'focus' in client)
         return client.focus();
     }
     if (clients.openWindow)

--- a/files/en-us/web/api/serviceworkerglobalscope/periodicsync_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/periodicsync_event/index.md
@@ -45,7 +45,7 @@ The following example shows how to respond to a periodic sync event in the servi
 
 ```js
 self.addEventListener('periodicsync', (event) => {
-  if (event.tag == 'get-latest-news') {
+  if (event.tag === 'get-latest-news') {
     event.waitUntil(fetchAndCacheLatestNews());
   }
 });

--- a/files/en-us/web/api/serviceworkerglobalscope/sync_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/sync_event/index.md
@@ -47,7 +47,7 @@ The following example shows how to respond to a sync event in the service worker
 
 ```js
 self.addEventListener('sync', (event) => {
-  if (event.tag == 'sync-messages') {
+  if (event.tag === 'sync-messages') {
     event.waitUntil(sendOutboxMessages());
   }
 });

--- a/files/en-us/web/api/sourcebuffer/mode/index.md
+++ b/files/en-us/web/api/sourcebuffer/mode/index.md
@@ -72,7 +72,7 @@ in which media segments are appended.
 
 ```js
 var curMode = sourceBuffer.mode;
-if (curMode == 'segments') {
+if (curMode === 'segments') {
   sourceBuffer.mode = 'sequence';
 }
 ```

--- a/files/en-us/web/api/sourcebuffer/mode/index.md
+++ b/files/en-us/web/api/sourcebuffer/mode/index.md
@@ -71,7 +71,7 @@ is currently set to `'segments'`, thus setting the play order to the sequence
 in which media segments are appended.
 
 ```js
-var curMode = sourceBuffer.mode;
+const curMode = sourceBuffer.mode;
 if (curMode === 'segments') {
   sourceBuffer.mode = 'sequence';
 }

--- a/files/en-us/web/api/touch_events/index.md
+++ b/files/en-us/web/api/touch_events/index.md
@@ -291,7 +291,7 @@ Since calling `preventDefault()` on a {{domxref("Element/touchstart_event", "tou
 ```js
 function onTouch(evt) {
   evt.preventDefault();
-  if (evt.touches.length > 1 || (evt.type == "touchend" && evt.touches.length > 0))
+  if (evt.touches.length > 1 || (evt.type === "touchend" && evt.touches.length > 0))
     return;
 
   const newEvt = document.createEvent("MouseEvents");

--- a/files/en-us/web/api/usbendpoint/index.md
+++ b/files/en-us/web/api/usbendpoint/index.md
@@ -80,9 +80,9 @@ for (const { alternates } of device.configuration.interfaces) {
       continue;
     }
 
-    if (endpoint.direction == "in") {
+    if (endpoint.direction === "in") {
       inEndpoint = endpoint.endpointNumber;
-    } else if (endpoint.direction == "out") {
+    } else if (endpoint.direction === "out") {
       outEndpoint = endpoint.endpointNumber;
     }
   }

--- a/files/en-us/web/api/user_timing_api/using_the_user_timing_api/index.md
+++ b/files/en-us/web/api/user_timing_api/using_the_user_timing_api/index.md
@@ -60,7 +60,7 @@ function display_marks(ev) {
   let entries = performance.getEntries();
   let j=0;
   for (let i = 0; i < entries.length; i++) {
-    if (entries[i].entryType == "mark") {
+    if (entries[i].entryType === "mark") {
       if (j == 0) { log("= getEntries()", 0); j++ }
       log(`... [${i}] = ${entries[i].name}`, 0);
     }
@@ -99,7 +99,7 @@ function clear_marks(obj) {
   }
   log("Clear marks", 0);
 
-  if (typeof obj == "string") {
+  if (typeof obj === "string") {
     log(`... cleared '${obj}' mark(s)`, 0);
     performance.clearMarks(obj);
   } else {
@@ -166,7 +166,7 @@ function display_measures(ev) {
   let entries = performance.getEntries();
   let j=0;
   for (let i = 0; i < entries.length; i++) {
-    if (entries[i].entryType == "measure") {
+    if (entries[i].entryType === "measure") {
       if (j == 0) { log("= getEntries()", 1); j++ }
       log(`... [${i}] = ${entries[i].name}`, 1);
     }
@@ -205,7 +205,7 @@ function clear_measures(obj) {
   }
   log("Clear measures", 1);
 
-  if (typeof obj == "string") {
+  if (typeof obj === "string") {
     log(`... cleared '${obj}' measure(s)`, 1);
     performance.clearMeasures(obj);
   } else {

--- a/files/en-us/web/api/web_audio_api/migrating_from_webkitaudiocontext/index.md
+++ b/files/en-us/web/api/web_audio_api/migrating_from_webkitaudiocontext/index.md
@@ -163,7 +163,7 @@ osc.type = "square";     // square waveform
 osc.type = "sawtooth";   // sawtooth waveform
 osc.type = "triangle";   // triangle waveform
 osc.setPeriodicWave(table);  // Note: setWaveTable has been renamed to setPeriodicWave!
-const isCustom = (osc.type == "custom"); // isCustom will be true
+const isCustom = (osc.type === "custom"); // isCustom will be true
 ```
 
 ### BiquadFilterNode.type

--- a/files/en-us/web/api/web_audio_api/simple_synth/index.md
+++ b/files/en-us/web/api/web_audio_api/simple_synth/index.md
@@ -494,7 +494,7 @@ function playTone(freq) {
 
   let type = wavePicker.options[wavePicker.selectedIndex].value;
 
-  if (type == "custom") {
+  if (type === "custom") {
     osc.setPeriodicWave(customWaveform);
   } else {
     osc.type = type;

--- a/files/en-us/web/api/web_periodic_background_synchronization_api/index.md
+++ b/files/en-us/web/api/web_periodic_background_synchronization_api/index.md
@@ -99,7 +99,7 @@ The following example shows how to respond to a periodic sync event in the servi
 
 ```js
 self.addEventListener('periodicsync', (event) => {
-  if (event.tag == 'get-latest-news') {
+  if (event.tag === 'get-latest-news') {
     event.waitUntil(fetchAndCacheLatestNews());
   }
 });

--- a/files/en-us/web/api/webrtc_api/perfect_negotiation/index.md
+++ b/files/en-us/web/api/webrtc_api/perfect_negotiation/index.md
@@ -159,7 +159,7 @@ let ignoreOffer = false;
 signaler.onmessage = async ({ data: { description, candidate } }) => {
   try {
     if (description) {
-      const offerCollision = (description.type == "offer") &&
+      const offerCollision = (description.type === "offer") &&
                              (makingOffer || pc.signalingState != "stable");
 
       ignoreOffer = !polite && offerCollision;
@@ -168,7 +168,7 @@ signaler.onmessage = async ({ data: { description, candidate } }) => {
       }
 
       await pc.setRemoteDescription(description);
-      if (description.type == "offer") {
+      if (description.type === "offer") {
         await pc.setLocalDescription();
         signaler.send({ description: pc.localDescription })
       }
@@ -272,7 +272,7 @@ Using the previous API to implement incoming negotiation messages during perfect
 signaler.onmessage = async ({data: { description, candidate }}) => {
   try {
     if (description) {
-      if (description.type == "offer" && pc.signalingState != "stable") {
+      if (description.type === "offer" && pc.signalingState != "stable") {
         if (!polite) {
           return;
         }
@@ -285,7 +285,7 @@ signaler.onmessage = async ({data: { description, candidate }}) => {
         await pc.setRemoteDescription(description);
       }
 
-      if (description.type == "offer") {
+      if (description.type === "offer") {
         await pc.setLocalDescription(await pc.createAnswer());
         signaler.send({ description: pc.localDescription });
       }
@@ -326,7 +326,7 @@ let ignoreOffer = false;
 signaler.onmessage = async ({ data: { description, candidate } }) => {
   try {
     if (description) {
-      const offerCollision = (description.type == "offer") &&
+      const offerCollision = (description.type === "offer") &&
                              (makingOffer || pc.signalingState != "stable");
 
       ignoreOffer = !polite && offerCollision;
@@ -335,7 +335,7 @@ signaler.onmessage = async ({ data: { description, candidate } }) => {
       }
 
       await pc.setRemoteDescription(description);
-      if (description.type == "offer") {
+      if (description.type === "offer") {
         await pc.setLocalDescription();
         signaler.send({ description: pc.localDescription });
       }

--- a/files/en-us/web/api/webxr_device_api/movement_and_motion/index.md
+++ b/files/en-us/web/api/webxr_device_api/movement_and_motion/index.md
@@ -262,7 +262,7 @@ function sessionStarted(session) {
     baseLayer: new XRWebGLLayer(xrSession, gl)
   });
 
-  if (SESSION_TYPE == "immersive-vr") {
+  if (SESSION_TYPE === "immersive-vr") {
     refSpaceType = "local";
   } else {
     refSpaceType = "viewer";

--- a/files/en-us/web/api/window/prompt/index.md
+++ b/files/en-us/web/api/window/prompt/index.md
@@ -45,7 +45,7 @@ A string containing the text entered by the user, or `null`.
 ```js
 let sign = prompt("What's your sign?");
 
-if (sign.toLowerCase() == "scorpio") {
+if (sign.toLowerCase() === "scorpio") {
   alert("Wow! I'm a Scorpio too!");
 }
 

--- a/files/en-us/web/api/windowclient/focus/index.md
+++ b/files/en-us/web/api/windowclient/focus/index.md
@@ -47,7 +47,7 @@ self.addEventListener('notificationclick', function(event) {
     type: "window"
   }).then(function(clientList) {
     for (const client of clientList) {
-      if (client.url == '/' && 'focus' in client)
+      if (client.url === '/' && 'focus' in client)
         return client.focus();
     }
     if (clients.openWindow)

--- a/files/en-us/web/api/windowclient/focused/index.md
+++ b/files/en-us/web/api/windowclient/focused/index.md
@@ -36,7 +36,7 @@ self.addEventListener('notificationclick', function(event) {
     type: "window"
   }).then(function(clientList) {
     for (const client of clientList) {
-      if (client.url == '/' && 'focus' in client) {
+      if (client.url === '/' && 'focus' in client) {
         if (!client.focused) return client.focus();
       }
     }

--- a/files/en-us/web/api/windowclient/index.md
+++ b/files/en-us/web/api/windowclient/index.md
@@ -50,7 +50,7 @@ self.addEventListener('notificationclick', function(event) {
     type: "window"
   }).then(function(clientList) {
     for (const client of clientList) {
-      if (client.url == '/' && 'focus' in client) {
+      if (client.url === '/' && 'focus' in client) {
         client.focus();
         break;
       }

--- a/files/en-us/web/api/windowclient/visibilitystate/index.md
+++ b/files/en-us/web/api/windowclient/visibilitystate/index.md
@@ -32,7 +32,7 @@ event.waitUntil(clients.matchAll({
   }).then(function(clientList) {
     for (let i = 0; i < clientList.length; i++) {
       let client = clientList[i];
-      if (client.url == '/' && 'focus' in client) {
+      if (client.url === '/' && 'focus' in client) {
         if (client.visibilityState === 'hidden') return client.focus();
       }
     }

--- a/files/en-us/web/api/xmlhttprequest/html_in_xmlhttprequest/index.md
+++ b/files/en-us/web/api/xmlhttprequest/html_in_xmlhttprequest/index.md
@@ -85,7 +85,7 @@ function detectHtmlInXhr(callback) {
   xhr.onreadystatechange = function() {
     if (this.readyState == 4 && !done) {
       done = true;
-      callback(!!(this.responseXML && this.responseXML.title && this.responseXML.title == "&&<"));
+      callback(!!(this.responseXML && this.responseXML.title && this.responseXML.title === "&&<"));
     }
   }
   xhr.onabort = xhr.onerror = function() {

--- a/files/en-us/web/api/xrinputsource/targetraymode/index.md
+++ b/files/en-us/web/api/xrinputsource/targetraymode/index.md
@@ -69,7 +69,7 @@ function updateInputSources(session, frame, refSpace) {
     let targetRayPose = frame.getPose(inputSource.targetRaySpace, refSpace);
 
     if (targetRayPose) {
-      if (source.targetRayMode == "tracked-pointer") {
+      if (source.targetRayMode === "tracked-pointer") {
         myRenderTargetRayAsBeam(targetRayPose);
       }
     }

--- a/files/en-us/web/api/xrinputsource/targetrayspace/index.md
+++ b/files/en-us/web/api/xrinputsource/targetrayspace/index.md
@@ -88,7 +88,7 @@ function updateInputSources(session, frame, refSpace) {
     let targetRayPose = frame.getPose(inputSource.targetRaySpace, refSpace);
 
     if (targetRayPose) {
-      if (source.targetRayMode == "tracked-pointer") {
+      if (source.targetRayMode === "tracked-pointer") {
         myRenderTargetRayAsBeam(targetRayPose);
       }
     }

--- a/files/en-us/web/api/xrinputsourceevent/inputsource/index.md
+++ b/files/en-us/web/api/xrinputsourceevent/inputsource/index.md
@@ -50,7 +50,7 @@ input devices. The device type is identified by looking at the
 xrSession.onselect = (event) => {
   let source = event.inputSource;
 
-  if (source.targetRayMode == "gaze") {
+  if (source.targetRayMode === "gaze") {
     /* handle selection using a gaze input */
   }
 };

--- a/files/en-us/web/api/xrinputsourceschangeevent/added/index.md
+++ b/files/en-us/web/api/xrinputsourceschangeevent/added/index.md
@@ -43,12 +43,12 @@ removed devices whose {{domxref("XRInputSource.targetRayMode", "targetRayMode")}
 ```js
 xrSession.oninputsourcescchange = (event) => {
   for (let input of event.added) {
-    if (input.targetRayMode == "tracked-pointer") {
+    if (input.targetRayMode === "tracked-pointer") {
       addedPointerDevice(input);
     }
   }
   for (let input of event.removed) {
-    if (input.targetRayMode == "tracked-pointer") {
+    if (input.targetRayMode === "tracked-pointer") {
       removedPointerDevice(input);
     }
   }

--- a/files/en-us/web/api/xrinputsourceschangeevent/index.md
+++ b/files/en-us/web/api/xrinputsourceschangeevent/index.md
@@ -61,7 +61,7 @@ xrSession.addEventListener("inputsourceschange", onInputSourcesChange);
 
 function onInputSourcesChange(event) {
   for (let input of event.added) {
-    if (input.targetRayMode == "tracked-pointer") {
+    if (input.targetRayMode === "tracked-pointer") {
       loadControllerMesh(input);
     }
   }

--- a/files/en-us/web/api/xrpose/transform/index.md
+++ b/files/en-us/web/api/xrpose/transform/index.md
@@ -53,7 +53,7 @@ xrSession.addEventListener("select", (event) => {
   let targetRayPose = frame.getPose(source.targetRaySpace, myRefSpace);
   let targetObject = findTargetUsingRay(targetRay.transform.matrix);
 
-  if (source.targetRayMode == "tracked-pointer") {
+  if (source.targetRayMode === "tracked-pointer") {
     if (source.handedness == user.handedness) {
       targetObject.primaryAction();
     } else {

--- a/files/en-us/web/api/xrsession/inputsourceschange_event/index.md
+++ b/files/en-us/web/api/xrsession/inputsourceschange_event/index.md
@@ -62,7 +62,7 @@ xrSession.addEventListener("inputsourceschange", onInputSourcesChange);
 
 function onInputSourcesChange(event) {
   for (let input of event.added) {
-    if (input.targetRayMode == "tracked-pointer") {
+    if (input.targetRayMode === "tracked-pointer") {
       loadControllerMesh(input);
     }
   }

--- a/files/en-us/web/api/xrsession/interactionmode/index.md
+++ b/files/en-us/web/api/xrsession/interactionmode/index.md
@@ -38,7 +38,7 @@ Possible values are:
 ## Examples
 
 ```js
-if (xrSession.interactionMode == "world-space") {
+if (xrSession.interactionMode === "world-space") {
   // draw UI in the world
 } else {
   // draw UI directly to the screen

--- a/files/en-us/web/api/xrsession/select_event/index.md
+++ b/files/en-us/web/api/xrsession/select_event/index.md
@@ -60,7 +60,7 @@ The following example uses {{domxref("EventTarget.addEventListener", "addEventLi
 
 ```js
 xrSession.addEventListener("select", (event) => {
-  if (event.inputSource.targetRayMode == "tracked-pointer") {
+  if (event.inputSource.targetRayMode === "tracked-pointer") {
     let targetRayPose = event.frame.getPose(event.inputSource.targetRaySpace,
                               myRefSpace);
     if (targetRayPose) {
@@ -74,7 +74,7 @@ You can also set up a handler for `select` events by setting the {{domxref("XRSe
 
 ```js
 xrSession.onselect = (event) => {
-  if (event.inputSource.targetRayMode == "tracked-pointer") {
+  if (event.inputSource.targetRayMode === "tracked-pointer") {
     let targetRayPose = event.frame.getPose(event.inputSource.targetRaySpace,
                               myRefSpace);
     if (targetRayPose) {

--- a/files/en-us/web/api/xrsession/squeeze_event/index.md
+++ b/files/en-us/web/api/xrsession/squeeze_event/index.md
@@ -78,7 +78,7 @@ This code treats the squeeze as an instantaneous action that doesn't involve tra
 
 ```js
 xrSession.addEventListener("squeeze", (event) => {
-  if (event.inputSource.targetRayMode == "tracked-pointer") {
+  if (event.inputSource.targetRayMode === "tracked-pointer") {
     let targetRayPose = event.frame.getPose(event.inputSource.targetRaySpace,
                               myRefSpace);
     if (targetRayPose) {
@@ -92,7 +92,7 @@ You can also set up a handler for `squeeze` events by setting the {{domxref("XRS
 
 ```js
 xrSession.onsqueeze = (event) => {
-  if (event.inputSource.targetRayMode == "tracked-pointer") {
+  if (event.inputSource.targetRayMode === "tracked-pointer") {
     let targetRayPose = event.frame.getPose(event.inputSource.targetRaySpace,
                               myRefSpace);
     if (targetRayPose) {

--- a/files/en-us/web/api/xrview/eye/index.md
+++ b/files/en-us/web/api/xrview/eye/index.md
@@ -58,7 +58,7 @@ gl.clearColor(0,0, 0, 1.0);
 gl.clearDepth(1.0);
 gl.clear(gl.COLOR_BUFFER_BIT, gl.DEPTH_BUFFER_BIT);
 
-for (let view of xrPose.views) {
+for (const view of xrPose.views) {
   let skipView = false;
 
   if (view.eye === "left" && body.leftEye.injured) {

--- a/files/en-us/web/api/xrview/eye/index.md
+++ b/files/en-us/web/api/xrview/eye/index.md
@@ -61,9 +61,9 @@ gl.clear(gl.COLOR_BUFFER_BIT, gl.DEPTH_BUFFER_BIT);
 for (let view of xrPose.views) {
   let skipView = false;
 
-  if (view.eye == "left" && body.leftEye.injured) {
+  if (view.eye === "left" && body.leftEye.injured) {
     skipView = updateInjury(body.leftEye);
-  } else if (view.eye == "right" && body.rightEye.injured) {
+  } else if (view.eye === "right" && body.rightEye.injured) {
     skipView = updateInjury(body.rightEye);
   }
 

--- a/files/en-us/web/css/counters/index.md
+++ b/files/en-us/web/css/counters/index.md
@@ -87,7 +87,7 @@ li::marker {
    content:  counters(listCounter, '.', upper-roman) ') ';
 }
 li::before {
-  content:  counters(listCounter, ".") " == " counters(listCounter, ".", lower-roman) ;
+  content:  counters(listCounter, ".") " === " counters(listCounter, ".", lower-roman) ;
 }
 ```
 
@@ -138,7 +138,7 @@ li::marker {
    content: counters(count, '.', upper-alpha) ') ';
 }
 li::before {
-  content: counters(count, ".", decimal-leading-zero) " == " counters(count, ".", lower-alpha);
+  content: counters(count, ".", decimal-leading-zero) " === " counters(count, ".", lower-alpha);
 }
 ```
 

--- a/files/en-us/web/css/counters/index.md
+++ b/files/en-us/web/css/counters/index.md
@@ -87,7 +87,7 @@ li::marker {
    content:  counters(listCounter, '.', upper-roman) ') ';
 }
 li::before {
-  content:  counters(listCounter, ".") " === " counters(listCounter, ".", lower-roman) ;
+  content:  counters(listCounter, ".") " == " counters(listCounter, ".", lower-roman) ;
 }
 ```
 
@@ -138,7 +138,7 @@ li::marker {
    content: counters(count, '.', upper-alpha) ') ';
 }
 li::before {
-  content: counters(count, ".", decimal-leading-zero) " === " counters(count, ".", lower-alpha);
+  content: counters(count, ".", decimal-leading-zero) " == " counters(count, ".", lower-alpha);
 }
 ```
 

--- a/files/en-us/web/css/flex/index.md
+++ b/files/en-us/web/css/flex/index.md
@@ -225,9 +225,9 @@ By default flex items don't shrink below their minimum content size. To change t
 ```
 
 ```js hidden
-var flex = document.getElementById("flex");
-var raw = document.getElementById("raw");
-flex.addEventListener("click", function() {
+const flex = document.getElementById("flex");
+const raw = document.getElementById("raw");
+flex.addEventListener("click", () => {
   raw.style.display = raw.style.display === "none" ? "block" : "none";
 });
 ```

--- a/files/en-us/web/css/flex/index.md
+++ b/files/en-us/web/css/flex/index.md
@@ -228,7 +228,7 @@ By default flex items don't shrink below their minimum content size. To change t
 var flex = document.getElementById("flex");
 var raw = document.getElementById("raw");
 flex.addEventListener("click", function() {
-  raw.style.display = raw.style.display == "none" ? "block" : "none";
+  raw.style.display = raw.style.display === "none" ? "block" : "none";
 });
 ```
 

--- a/files/en-us/web/guide/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
+++ b/files/en-us/web/guide/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
@@ -204,7 +204,8 @@ Initially the menu is hidden by default, so an event listener needs to be added 
 ```js
 subtitles.addEventListener('click', function(e) {
    if (subtitlesMenu) {
-      subtitlesMenu.style.display = (subtitlesMenu.style.display === 'block' ? 'none' : 'block');
+      subtitlesMenu.style.display =
+        subtitlesMenu.style.display === 'block' ? 'none' : 'block';
    }
 });
 ```

--- a/files/en-us/web/guide/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
+++ b/files/en-us/web/guide/audio_and_video_delivery/adding_captions_and_subtitles_to_html5_video/index.md
@@ -204,7 +204,7 @@ Initially the menu is hidden by default, so an event listener needs to be added 
 ```js
 subtitles.addEventListener('click', function(e) {
    if (subtitlesMenu) {
-      subtitlesMenu.style.display = (subtitlesMenu.style.display == 'block' ? 'none' : 'block');
+      subtitlesMenu.style.display = (subtitlesMenu.style.display === 'block' ? 'none' : 'block');
    }
 });
 ```

--- a/files/en-us/web/guide/audio_and_video_delivery/video_player_styling_basics/index.md
+++ b/files/en-us/web/guide/audio_and_video_delivery/video_player_styling_basics/index.md
@@ -253,7 +253,7 @@ Now that the buttons actually look like buttons and have images that indicate wh
 ```js
 var changeButtonState = function(type) {
    // Play/Pause button
-   if (type == 'playpause') {
+   if (type === 'playpause') {
       if (video.paused || video.ended) {
          playpause.setAttribute('data-state', 'play');
       }
@@ -262,7 +262,7 @@ var changeButtonState = function(type) {
       }
    }
    // Mute button
-   else if (type == 'mute') {
+   else if (type === 'mute') {
       mute.setAttribute('data-state', video.muted ? 'unmute' : 'mute');
    }
 }

--- a/files/en-us/web/javascript/equality_comparisons_and_sameness/index.md
+++ b/files/en-us/web/javascript/equality_comparisons_and_sameness/index.md
@@ -24,7 +24,7 @@ There are four equality algorithms in JavaScript:
 
 JavaScript provides three different value-comparison operations:
 
-- [ ===](/en-US/docs/Web/JavaScript/Reference/Operators#identity) — IsStrictlyEqual ("strict equality", "identity", "triple equals")
+- [===](/en-US/docs/Web/JavaScript/Reference/Operators#identity) — IsStrictlyEqual ("strict equality", "identity", "triple equals")
 - [==](/en-US/docs/Web/JavaScript/Reference/Operators#equality_operators) — IsLooselyEqual ("loose equality", "double equals")
 - {{jsxref("Object.is")}} — SameValue.
 
@@ -127,7 +127,7 @@ Similar to same-value equality, but +0 and -0 are considered equal.
 
 ## A model for understanding equality comparisons?
 
-People often compare double equals and triple equals by saying one is an "enhanced" version of the other. For example, double equals could be said as an extended version of triple equals, because the former does everything that the latter does, but with type conversion on its operands — for example, `6 === "6"`. Alternatively, it can be claimed that double equals is the baseline, and triple equals is an enhanced version, because it requires the two operands to be the same type, so it adds an extra constraint.
+People often compare double equals and triple equals by saying one is an "enhanced" version of the other. For example, double equals could be said as an extended version of triple equals, because the former does everything that the latter does, but with type conversion on its operands — for example, `6 == "6"`. Alternatively, it can be claimed that double equals is the baseline, and triple equals is an enhanced version, because it requires the two operands to be the same type, so it adds an extra constraint.
 
 However, this way of thinking implies that the equality comparisons form a one-dimensional "spectrum" where "totally strict" lies on one end and "totally loose" lies on the other. This model falls short with {{jsxref("Object.is")}}, because it isn't "looser" than double equals or "stricter" than triple equals, nor does it fit somewhere in between (i.e., being both stricter than double equals, but looser than triple equals). We can see from the sameness comparisons table below that this is due to the way that {{jsxref("Object.is")}} handles {{jsxref("NaN")}}. Notice that if `Object.is(NaN, NaN)` evaluated to `false`, we _could_ say that it fits on the loose/strict spectrum as an even stricter form of triple equals, one that distinguishes between `-0` and `+0`. The {{jsxref("NaN")}} handling means this is untrue, however. Unfortunately, {{jsxref("Object.is")}} has to be thought of in terms of its specific characteristics, rather than its looseness or strictness with regard to the equality operators.
 

--- a/files/en-us/web/javascript/equality_comparisons_and_sameness/index.md
+++ b/files/en-us/web/javascript/equality_comparisons_and_sameness/index.md
@@ -24,7 +24,7 @@ There are four equality algorithms in JavaScript:
 
 JavaScript provides three different value-comparison operations:
 
-- [===](/en-US/docs/Web/JavaScript/Reference/Operators#identity) — IsStrictlyEqual ("strict equality", "identity", "triple equals")
+- [ ===](/en-US/docs/Web/JavaScript/Reference/Operators#identity) — IsStrictlyEqual ("strict equality", "identity", "triple equals")
 - [==](/en-US/docs/Web/JavaScript/Reference/Operators#equality_operators) — IsLooselyEqual ("loose equality", "double equals")
 - {{jsxref("Object.is")}} — SameValue.
 
@@ -127,7 +127,7 @@ Similar to same-value equality, but +0 and -0 are considered equal.
 
 ## A model for understanding equality comparisons?
 
-People often compare double equals and triple equals by saying one is an "enhanced" version of the other. For example, double equals could be said as an extended version of triple equals, because the former does everything that the latter does, but with type conversion on its operands — for example, `6 == "6"`. Alternatively, it can be claimed that double equals is the baseline, and triple equals is an enhanced version, because it requires the two operands to be the same type, so it adds an extra constraint.
+People often compare double equals and triple equals by saying one is an "enhanced" version of the other. For example, double equals could be said as an extended version of triple equals, because the former does everything that the latter does, but with type conversion on its operands — for example, `6 === "6"`. Alternatively, it can be claimed that double equals is the baseline, and triple equals is an enhanced version, because it requires the two operands to be the same type, so it adds an extra constraint.
 
 However, this way of thinking implies that the equality comparisons form a one-dimensional "spectrum" where "totally strict" lies on one end and "totally loose" lies on the other. This model falls short with {{jsxref("Object.is")}}, because it isn't "looser" than double equals or "stricter" than triple equals, nor does it fit somewhere in between (i.e., being both stricter than double equals, but looser than triple equals). We can see from the sameness comparisons table below that this is due to the way that {{jsxref("Object.is")}} handles {{jsxref("NaN")}}. Notice that if `Object.is(NaN, NaN)` evaluated to `false`, we _could_ say that it fits on the loose/strict spectrum as an even stricter form of triple equals, one that distinguishes between `-0` and `+0`. The {{jsxref("NaN")}} handling means this is untrue, however. Unfortunately, {{jsxref("Object.is")}} has to be thought of in terms of its specific characteristics, rather than its looseness or strictness with regard to the equality operators.
 

--- a/files/en-us/web/javascript/guide/functions/index.md
+++ b/files/en-us/web/javascript/guide/functions/index.md
@@ -299,7 +299,7 @@ However, some algorithms cannot be simple iterative loops. For example, getting 
 
 ```js
 function walkTree(node) {
-  if (node == null) {
+  if (node === null) {
     return;
   }
   // do something with node

--- a/files/en-us/web/javascript/reference/errors/deprecated_caller_or_arguments_usage/index.md
+++ b/files/en-us/web/javascript/reference/errors/deprecated_caller_or_arguments_usage/index.md
@@ -45,7 +45,7 @@ are deprecated (see the reference articles for more information).
 'use strict';
 
 function myFunc() {
-  if (myFunc.caller == null) {
+  if (myFunc.caller === null) {
     return 'The function was called from the top!';
   } else {
     return 'This function\'s caller was ' + myFunc.caller;

--- a/files/en-us/web/javascript/reference/errors/reduce_of_empty_array_with_no_initial_value/index.md
+++ b/files/en-us/web/javascript/reference/errors/reduce_of_empty_array_with_no_initial_value/index.md
@@ -84,14 +84,14 @@ let name_list1 = "";
 if (names1.length >= 1) {
   name_list1 = Array.prototype.reduce.call(names, (acc, name) => acc + ", " + name);
 }
-// name_list1 == "" when names is empty.
+// name_list1 === "" when names is empty.
 
 const name_list2 = Array.prototype.reduce.call(names, (acc, name) => {
-  if (acc == "") // initial value
+  if (acc === "") // initial value
     return name;
   return acc + ", " + name;
 }, "");
-// name_list2 == "" when names is empty.
+// name_list2 === "" when names is empty.
 ```
 
 ## See also

--- a/files/en-us/web/javascript/reference/global_objects/function/caller/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/function/caller/index.md
@@ -63,7 +63,7 @@ The following code checks the value a function's `caller` property.
 
 ```js
 function myFunc() {
-  if (myFunc.caller == null) {
+  if (myFunc.caller === null) {
     return 'The function was called from the top!';
   } else {
     return 'This function\'s caller was ' + myFunc.caller;

--- a/files/en-us/web/javascript/reference/global_objects/number/tolocalestring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/number/tolocalestring/index.md
@@ -93,7 +93,7 @@ options for `Number.prototype.toLocaleString` directly:
 
 ```js
 function toLocaleStringSupportsOptions() {
-  return !!(typeof Intl == 'object' && Intl && typeof Intl.NumberFormat == 'function');
+  return !!(typeof Intl === 'object' && Intl && typeof Intl.NumberFormat === 'function');
 }
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/string/fromcharcode/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/fromcharcode/index.md
@@ -90,7 +90,7 @@ Supplementary characters, in UTF-16, require two code units (i.e. a surrogate pa
 
 ```js
 String.fromCharCode(0xD83C, 0xDF03); // Code Point U+1F303 "Night with
-String.fromCharCode(55356, 57091);   // Stars" == "\uD83C\uDF03"
+String.fromCharCode(55356, 57091);   // Stars" === "\uD83C\uDF03"
 
 String.fromCharCode(0xD834, 0xDF06, 0x61, 0xD834, 0xDF07); // "\uD834\uDF06a\uD834\uDF07"
 ```

--- a/files/en-us/web/javascript/reference/global_objects/string/fromcodepoint/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/fromcodepoint/index.md
@@ -58,7 +58,7 @@ Valid input:
 ```js
 String.fromCodePoint(42);       // "*"
 String.fromCodePoint(65, 90);   // "AZ"
-String.fromCodePoint(0x404);    // "\u0404" == "Є"
+String.fromCodePoint(0x404);    // "\u0404" === "Є"
 String.fromCodePoint(0x2F804);  // "\uD87E\uDC04"
 String.fromCodePoint(194564);   // "\uD87E\uDC04"
 String.fromCodePoint(0x1D306, 0x61, 0x1D307); // "\uD834\uDF06a\uD834\uDF07"
@@ -84,7 +84,7 @@ character:
 
 ```js
 String.fromCharCode(0xD83C, 0xDF03); // Code Point U+1F303 "Night with
-String.fromCharCode(55356, 57091);   // Stars" == "\uD83C\uDF03"
+String.fromCharCode(55356, 57091);   // Stars" === "\uD83C\uDF03"
 ```
 
 `String.fromCodePoint()`, on the other hand, can return 4-byte supplementary

--- a/files/en-us/web/javascript/reference/global_objects/symbol/toprimitive/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/toprimitive/index.md
@@ -36,10 +36,10 @@ console.log(obj1 + ''); // "[object Object]"
 // An object with Symbol.toPrimitive property.
 const obj2 = {
   [Symbol.toPrimitive](hint) {
-    if (hint == 'number') {
+    if (hint === 'number') {
       return 10;
     }
-    if (hint == 'string') {
+    if (hint === 'string') {
       return 'hello';
     }
     return true;

--- a/files/en-us/web/javascript/reference/operators/equality/index.md
+++ b/files/en-us/web/javascript/reference/operators/equality/index.md
@@ -48,7 +48,7 @@ Loose equality is _symmetric_: `A == B` always has identical semantics to `B == 
 
 The most notable difference between this operator and the [strict equality](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality) (`===`) operator is that the strict equality operator does not attempt type conversion. Instead, the strict equality operator always considers operands of different types to be different. The strict equality operator essentially carries out only step 1, and then returns `false` for all other cases.
 
-There's a "willful violation" of the above algorithm: if one of the operands is [`document.all`](/en-US/docs/Web/API/Document/all), it is treated as if it's `undefined`. This means that `document.all == null` is `true`, but `document.all === undefined && document.all === null` is `false`.
+There's a "willful violation" of the above algorithm: if one of the operands is [`document.all`](/en-US/docs/Web/API/Document/all), it is treated as if it's `undefined`. This means that `document.all === null` is `true`, but `document.all === undefined && document.all === null` is `false`.
 
 ## Examples
 
@@ -65,7 +65,7 @@ There's a "willful violation" of the above algorithm: if one of the operands is 
 "1" ==  1;            // true
 1 == "1";             // true
 0 == false;           // true
-0 == null;            // false
+0 === null;            // false
 0 == undefined;       // false
 0 == !!null;          // true, look at Logical NOT operator
 0 == !!undefined;     // true, look at Logical NOT operator

--- a/files/en-us/web/javascript/reference/operators/equality/index.md
+++ b/files/en-us/web/javascript/reference/operators/equality/index.md
@@ -48,7 +48,7 @@ Loose equality is _symmetric_: `A == B` always has identical semantics to `B == 
 
 The most notable difference between this operator and the [strict equality](/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality) (`===`) operator is that the strict equality operator does not attempt type conversion. Instead, the strict equality operator always considers operands of different types to be different. The strict equality operator essentially carries out only step 1, and then returns `false` for all other cases.
 
-There's a "willful violation" of the above algorithm: if one of the operands is [`document.all`](/en-US/docs/Web/API/Document/all), it is treated as if it's `undefined`. This means that `document.all === null` is `true`, but `document.all === undefined && document.all === null` is `false`.
+There's a "willful violation" of the above algorithm: if one of the operands is [`document.all`](/en-US/docs/Web/API/Document/all), it is treated as if it's `undefined`. This means that `document.all == null` is `true`, but `document.all === undefined && document.all === null` is `false`.
 
 ## Examples
 
@@ -65,7 +65,7 @@ There's a "willful violation" of the above algorithm: if one of the operands is 
 "1" ==  1;            // true
 1 == "1";             // true
 0 == false;           // true
-0 === null;            // false
+0 == null;            // false
 0 == undefined;       // false
 0 == !!null;          // true, look at Logical NOT operator
 0 == !!undefined;     // true, look at Logical NOT operator

--- a/files/en-us/web/javascript/reference/operators/null/index.md
+++ b/files/en-us/web/javascript/reference/operators/null/index.md
@@ -55,7 +55,7 @@ typeof undefined     // "undefined"
 null === undefined   // false
 null  == undefined   // true
 null === null        // true
-null === null        // true
+null  == null        // true
 !null                // true
 isNaN(1 + null)      // false
 isNaN(1 + undefined) // true

--- a/files/en-us/web/javascript/reference/operators/null/index.md
+++ b/files/en-us/web/javascript/reference/operators/null/index.md
@@ -55,7 +55,7 @@ typeof undefined     // "undefined"
 null === undefined   // false
 null  == undefined   // true
 null === null        // true
-null  == null        // true
+null === null        // true
 !null                // true
 isNaN(1 + null)      // false
 isNaN(1 + undefined) // true

--- a/files/en-us/web/javascript/reference/operators/void/index.md
+++ b/files/en-us/web/javascript/reference/operators/void/index.md
@@ -38,8 +38,8 @@ parentheses can help clarify the resolution of the expression following the
 `void` operator:
 
 ```js
-void 2 === '2';   // (void 2) === '2', returns false
-void (2 === '2'); // void (2 === '2'), returns undefined
+void 2 == '2';   // (void 2) == '2', returns false
+void (2 == '2'); // void (2 == '2'), returns undefined
 ```
 
 ## Examples

--- a/files/en-us/web/javascript/reference/operators/void/index.md
+++ b/files/en-us/web/javascript/reference/operators/void/index.md
@@ -38,8 +38,8 @@ parentheses can help clarify the resolution of the expression following the
 `void` operator:
 
 ```js
-void 2 == '2';   // (void 2) == '2', returns false
-void (2 == '2'); // void (2 == '2'), returns undefined
+void 2 === '2';   // (void 2) === '2', returns false
+void (2 === '2'); // void (2 === '2'), returns undefined
 ```
 
 ## Examples

--- a/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.md
+++ b/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.md
@@ -26,7 +26,7 @@ const xpathResult = document.evaluate(xpathExpression, contextNode, namespaceRes
 
 ### Parameters
 
-The [evaluate()](/en-US/docs/Web/API/Document/evaluate) method takes a total of five parameters:
+The [`evaluate()`](/en-US/docs/Web/API/Document/evaluate) method takes a total of five parameters:
 
 - `xpathExpression`: A string containing the XPath expression to be evaluated.
 - `contextNode`: A node in the document against which the `xpathExpression` should be evaluated, including any and all of its child nodes. The [document](/en-US/docs/Web/API/Document) node is the most commonly used.

--- a/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.md
+++ b/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.md
@@ -16,17 +16,17 @@ This document describes the interface for using [XPath](/en-US/docs/Web/XPath) i
 
 The main interface to using XPath is the [evaluate](/en-US/docs/Web/API/Document/evaluate) function of the [document](/en-US/docs/Web/API/Document) object.
 
-## document.evaluate
+## document.evaluate()
 
 This method evaluates [XPath](/en-US/docs/Web/XPath) expressions against an [XML](/en-US/docs/Glossary/XML) based document (including HTML documents), and returns a [`XPathResult`](/en-US/docs/Web/API/XPathResult) object, which can be a single node or a set of nodes. The existing documentation for this method is located at [document.evaluate](/en-US/docs/Web/API/Document/evaluate), but it is rather sparse for our needs at the moment; a more comprehensive examination will be given below.
 
 ```js
-var xpathResult = document.evaluate( xpathExpression, contextNode, namespaceResolver, resultType, result );
+const xpathResult = document.evaluate( xpathExpression, contextNode, namespaceResolver, resultType, result );
 ```
 
 ### Parameters
 
-The [evaluate](/en-US/docs/Web/API/Document/evaluate) function takes a total of five parameters:
+The [evaluate()](/en-US/docs/Web/API/Document/evaluate) method takes a total of five parameters:
 
 - `xpathExpression`: A string containing the XPath expression to be evaluated.
 - `contextNode`: A node in the document against which the `xpathExpression` should be evaluated, including any and all of its child nodes. The [document](/en-US/docs/Web/API/Document) node is the most commonly used.
@@ -48,14 +48,14 @@ Returns `xpathResult`, which is an `XPathResult` object of the type [specified](
 We create a namespace resolver using the `createNSResolver` method of the [document](/en-US/docs/Web/API/Document) object.
 
 ```js
-var nsResolver = document.createNSResolver( contextNode.ownerDocument === null ? contextNode.documentElement : contextNode.ownerDocument.documentElement );
+const nsResolver = document.createNSResolver(contextNode.ownerDocument === null ? contextNode.documentElement : contextNode.ownerDocument.documentElement);
 ```
 
 Or alternatively by using the `createNSResolver` method of a `XPathEvaluator` object.
 
 ```js
-var xpEvaluator = new XPathEvaluator();
-var nsResolver = xpEvaluator.createNSResolver( contextNode.ownerDocument === null ? contextNode.documentElement : contextNode.ownerDocument.documentElement );
+const xpEvaluator = new XPathEvaluator();
+const nsResolver = xpEvaluator.createNSResolver(contextNode.ownerDocument === null ? contextNode.documentElement : contextNode.ownerDocument.documentElement);
 ```
 
 And then pass `document.evaluate`, the `nsResolver` variable as the `namespaceResolver` parameter.
@@ -89,17 +89,17 @@ We obtain the returned value of the expression by accessing the following proper
 The following uses the XPath expression [`count(//p)`](/en-US/docs/Web/XPath/Functions/count) to obtain the number of `<p>` elements in an HTML document:
 
 ```js
-var paragraphCount = document.evaluate( 'count(//p)', document, null, XPathResult.ANY_TYPE, null );
+const paragraphCount = document.evaluate('count(//p)', document, null, XPathResult.ANY_TYPE, null);
 
-alert( 'This document contains ' + paragraphCount.numberValue + ' paragraph elements' );
+console.log(`This document contains ${paragraphCount.numberValue} paragraph elements.`);
 ```
 
 Although JavaScript allows us to convert the number to a string for display, the XPath interface will not automatically convert the numerical result if the `stringValue` property is requested, so the following code will **not** work:
 
 ```js
-var paragraphCount = document.evaluate('count(//p)', document, null, XPathResult.ANY_TYPE, null );
+const paragraphCount = document.evaluate('count(//p)', document, null, XPathResult.ANY_TYPE, null);
 
-alert( 'This document contains ' + paragraphCount.stringValue + ' paragraph elements' );
+console.log(`This document contains ${paragraphCount.stringValue} paragraph elements.');
 ```
 
 Instead, it will return an exception with the code `NS_DOM_TYPE_ERROR`.
@@ -126,18 +126,18 @@ Once we have iterated over all of the individual matched nodes, `iterateNext()` 
 Note however, that if the document is mutated (the document tree is modified) between iterations that will invalidate the iteration and the `invalidIteratorState` property of `XPathResult` is set to `true`, and a `NS_ERROR_DOM_INVALID_STATE_ERR` exception is thrown.
 
 ```js
-var iterator = document.evaluate('//phoneNumber', documentNode, null, XPathResult.UNORDERED_NODE_ITERATOR_TYPE, null );
+const iterator = document.evaluate('//phoneNumber', documentNode, null, XPathResult.UNORDERED_NODE_ITERATOR_TYPE, null);
 
 try {
-  var thisNode = iterator.iterateNext();
+  let thisNode = iterator.iterateNext();
 
   while (thisNode) {
-    alert( thisNode.textContent );
+    console.log(thisNode.textContent);
     thisNode = iterator.iterateNext();
   }
 }
-catch (e) {
-  alert( 'Error: Document tree modified during iteration ' + e );
+catch(e) {
+  console.error(`Error: Document tree modified during iteration ${e}`);
 }
 ```
 
@@ -153,11 +153,11 @@ The `XPathResult` object returned is a static node-set of matched nodes, which a
 Snapshots do not change with document mutations, so unlike the iterators, the snapshot does not become invalid, but it may not correspond to the current document, for example, the nodes may have been moved, it might contain nodes that no longer exist, or new nodes could have been added.
 
 ```js
-var nodesSnapshot = document.evaluate('//phoneNumber', documentNode, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null );
+const nodesSnapshot = document.evaluate('//phoneNumber', documentNode, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
 
-for ( var i=0; i < nodesSnapshot.snapshotLength; i++ )
+for (let i=0; i < nodesSnapshot.snapshotLength; i++)
 {
-  alert( nodesSnapshot.snapshotItem(i).textContent );
+  console.log(nodesSnapshot.snapshotItem(i).textContent);
 }
 ```
 
@@ -173,9 +173,9 @@ The `XPathResult` object returned is only the first found node that matched the 
 Note that, for the unordered subtype the single node returned might not be the first in document order, but for the ordered subtype you are guaranteed to get the first matched node in the document order.
 
 ```js
-var firstPhoneNumber = document.evaluate('//phoneNumber', documentNode, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null );
+const firstPhoneNumber = document.evaluate('//phoneNumber', documentNode, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
 
-alert( 'The first phone number found is ' + firstPhoneNumber.singleNodeValue.textContent );
+console.log(`The first phone number found is ${firstPhoneNumber.singleNodeValue.textContent}`);
 ```
 
 #### The ANY_TYPE Constant
@@ -184,7 +184,7 @@ When the result type in the `resultType` parameter is specified as `ANY_TYPE`, t
 
 It could be any of the simple types (`NUMBER_TYPE, STRING_TYPE, BOOLEAN_TYPE`), **but**, if the returned result type is a node-set then it will **only** be an `UNORDERED_NODE_ITERATOR_TYPE`.
 
-To determine that type after evaluation, we use the `resultType` property of the `XPathResult` object. The [constant](#xpathresult_defined_constants) values of this property are defined in the appendix. None Yet =====Any_Type Example ===== \<pre> \</pre>
+To determine that type after evaluation, we use the `resultType` property of the `XPathResult` object. The [constant](#xpathresult_defined_constants) values of this property are defined in the appendix. None Yet ==== Any_Type Example ===== \<pre> \</pre>
 
 ## Examples
 
@@ -195,7 +195,7 @@ The following code is intended to be placed in any JavaScript fragment within or
 To extract all the `<h2>` heading elements in an HTML document using XPath, the `xpathExpression` is '`//h2`'. Where, `//` is the Recursive Descent Operator that matches elements with the nodeName `h2` anywhere in the document tree. The full code for this is: link to introductory xpath doc
 
 ```js
-var headings = document.evaluate('//h2', document, null, XPathResult.ANY_TYPE, null );
+var headings = document.evaluate('//h2', document, null, XPathResult.ANY_TYPE, null);
 ```
 
 Notice that, since HTML does not have namespaces, we have passed `null` for the `namespaceResolver` parameter.
@@ -205,12 +205,12 @@ Since we wish to search over the entire document for the headings, we have used 
 The result of this expression is an `XPathResult` object. If we wish to know the type of result returned, we may evaluate the `resultType` property of the returned object. In this case, that will evaluate to `4`, an `UNORDERED_NODE_ITERATOR_TYPE`. This is the default return type when the result of the XPath expression is a node set. It provides access to a single node at a time and may not return nodes in a particular order. To access the returned nodes, we use the `iterateNext()` method of the returned object:
 
 ```js
-var thisHeading = headings.iterateNext();
+let thisHeading = headings.iterateNext();
 
-var alertText = 'Level 2 headings in this document are:\n'
+let alertText = 'Level 2 headings in this document are:\n'
 
 while (thisHeading) {
-  alertText += thisHeading.textContent + '\n';
+  alertText += `${thisHeading.textContent}\n`;
   thisHeading = headings.iterateNext();
 }
 ```
@@ -242,24 +242,16 @@ To make the contents of the XML document available within the extension, we crea
 JavaScript used in the extensions xul/js documents.
 
 ```js
-var req = new XMLHttpRequest();
+const req = new XMLHttpRequest();
 
 req.open("GET", "chrome://yourextension/content/peopleDB.xml", false);
 req.send(null);
 
-var xmlDoc = req.responseXML;
+const xmlDoc = req.responseXML;
 
-var nsResolver = xmlDoc.createNSResolver( xmlDoc.ownerDocument === null ? xmlDoc.documentElement : xmlDoc.ownerDocument.documentElement);
+const nsResolver = xmlDoc.createNSResolver( xmlDoc.ownerDocument === null ? xmlDoc.documentElement : xmlDoc.ownerDocument.documentElement);
 
-var personIterator = xmlDoc.evaluate('//person', xmlDoc, nsResolver, XPathResult.ANY_TYPE, null );
-```
-
-### Note
-
-When the XPathResult object is not defined, the constants can be retrieved in privileged code using `Components.interfaces.nsIDOMXPathResult.ANY_TYPE` (`CI.nsIDOMXPathResult`). Similarly, an XPathEvaluator can be created using:
-
-```js
-Components.classes["@mozilla.org/dom/xpath-evaluator;1"].createInstance(Components.interfaces.nsIDOMXPathEvaluator)
+const personIterator = xmlDoc.evaluate('//person', xmlDoc, nsResolver, XPathResult.ANY_TYPE, null);
 ```
 
 ## Appendix
@@ -278,7 +270,7 @@ In order to associate the '`mathml:`' prefix with the namespace URI '`http://www
 
 ```js
 function nsResolver(prefix) {
-  var ns = {
+  const ns = {
     'xhtml': 'http://www.w3.org/1999/xhtml',
     'mathml': 'http://www.w3.org/1998/Math/MathML'
   };
@@ -289,7 +281,7 @@ function nsResolver(prefix) {
 Our call to `document.evaluate` would then looks like:
 
 ```js
-document.evaluate( '//xhtml:td/mathml:math', document, nsResolver, XPathResult.ANY_TYPE, null );
+document.evaluate('//xhtml:td/mathml:math', document, nsResolver, XPathResult.ANY_TYPE, null);
 ```
 
 ### Implementing a default namespace for XML documents
@@ -337,9 +329,9 @@ This could inadvertently grab some elements if one of its attributes existed tha
 In order to accurately grab elements with the XLink `@href` attribute (without also being confined to predefined prefixes in a namespace resolver), one could obtain them as follows:
 
 ```js
-var xpathEls = 'someElements[@*[local-name() = "href" and namespace-uri() = "http://www.w3.org/1999/xlink"]]'; // Grabs elements with any single attribute that has both the local name 'href' and the XLink namespace
-var thislevel = xml.evaluate(xpathEls, xml, null, XPathResult.ANY_TYPE, null);
-var thisitemEl = thislevel.iterateNext();
+const xpathEls = 'someElements[@*[local-name() = "href" and namespace-uri() = "http://www.w3.org/1999/xlink"]]'; // Grabs elements with any single attribute that has both the local name 'href' and the XLink namespace
+const thislevel = xml.evaluate(xpathEls, xml, null, XPathResult.ANY_TYPE, null);
+let thisitemEl = thislevel.iterateNext();
 ```
 
 #### XPathResult Defined Constants

--- a/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.md
+++ b/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.md
@@ -184,7 +184,7 @@ When the result type in the `resultType` parameter is specified as `ANY_TYPE`, t
 
 It could be any of the simple types (`NUMBER_TYPE, STRING_TYPE, BOOLEAN_TYPE`), **but**, if the returned result type is a node-set then it will **only** be an `UNORDERED_NODE_ITERATOR_TYPE`.
 
-To determine that type after evaluation, we use the `resultType` property of the `XPathResult` object. The [constant](#xpathresult_defined_constants) values of this property are defined in the appendix. None Yet ==== Any_Type Example ===== \<pre> \</pre>
+To determine that type after evaluation, we use the `resultType` property of the `XPathResult` object. The [constant](#xpathresult_defined_constants) values of this property are defined in the appendix. None Yet =====Any_Type Example===== \<pre> \</pre>
 
 ## Examples
 

--- a/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.md
+++ b/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.md
@@ -48,14 +48,14 @@ Returns `xpathResult`, which is an `XPathResult` object of the type [specified](
 We create a namespace resolver using the `createNSResolver` method of the [document](/en-US/docs/Web/API/Document) object.
 
 ```js
-var nsResolver = document.createNSResolver( contextNode.ownerDocument == null ? contextNode.documentElement : contextNode.ownerDocument.documentElement );
+var nsResolver = document.createNSResolver( contextNode.ownerDocument === null ? contextNode.documentElement : contextNode.ownerDocument.documentElement );
 ```
 
 Or alternatively by using the `createNSResolver` method of a `XPathEvaluator` object.
 
 ```js
 var xpEvaluator = new XPathEvaluator();
-var nsResolver = xpEvaluator.createNSResolver( contextNode.ownerDocument == null ? contextNode.documentElement : contextNode.ownerDocument.documentElement );
+var nsResolver = xpEvaluator.createNSResolver( contextNode.ownerDocument === null ? contextNode.documentElement : contextNode.ownerDocument.documentElement );
 ```
 
 And then pass `document.evaluate`, the `nsResolver` variable as the `namespaceResolver` parameter.
@@ -184,7 +184,7 @@ When the result type in the `resultType` parameter is specified as `ANY_TYPE`, t
 
 It could be any of the simple types (`NUMBER_TYPE, STRING_TYPE, BOOLEAN_TYPE`), **but**, if the returned result type is a node-set then it will **only** be an `UNORDERED_NODE_ITERATOR_TYPE`.
 
-To determine that type after evaluation, we use the `resultType` property of the `XPathResult` object. The [constant](#xpathresult_defined_constants) values of this property are defined in the appendix. None Yet =====Any_Type Example===== \<pre> \</pre>
+To determine that type after evaluation, we use the `resultType` property of the `XPathResult` object. The [constant](#xpathresult_defined_constants) values of this property are defined in the appendix. None Yet =====Any_Type Example ===== \<pre> \</pre>
 
 ## Examples
 
@@ -249,7 +249,7 @@ req.send(null);
 
 var xmlDoc = req.responseXML;
 
-var nsResolver = xmlDoc.createNSResolver( xmlDoc.ownerDocument == null ? xmlDoc.documentElement : xmlDoc.ownerDocument.documentElement);
+var nsResolver = xmlDoc.createNSResolver( xmlDoc.ownerDocument === null ? xmlDoc.documentElement : xmlDoc.ownerDocument.documentElement);
 
 var personIterator = xmlDoc.evaluate('//person', xmlDoc, nsResolver, XPathResult.ANY_TYPE, null );
 ```

--- a/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.md
+++ b/files/en-us/web/xpath/introduction_to_using_xpath_in_javascript/index.md
@@ -21,7 +21,7 @@ The main interface to using XPath is the [evaluate](/en-US/docs/Web/API/Document
 This method evaluates [XPath](/en-US/docs/Web/XPath) expressions against an [XML](/en-US/docs/Glossary/XML) based document (including HTML documents), and returns a [`XPathResult`](/en-US/docs/Web/API/XPathResult) object, which can be a single node or a set of nodes. The existing documentation for this method is located at [document.evaluate](/en-US/docs/Web/API/Document/evaluate), but it is rather sparse for our needs at the moment; a more comprehensive examination will be given below.
 
 ```js
-const xpathResult = document.evaluate( xpathExpression, contextNode, namespaceResolver, resultType, result );
+const xpathResult = document.evaluate(xpathExpression, contextNode, namespaceResolver, resultType, result);
 ```
 
 ### Parameters

--- a/files/en-us/web/xpath/snippets/index.md
+++ b/files/en-us/web/xpath/snippets/index.md
@@ -80,7 +80,7 @@ You can now "query" the document with XPath expressions. Although walking the DO
 // display the last names of all people in the doc
 const results = evaluateXPath(people, "//person/@last-name");
 for (let i in results)
-  alert("Person #" + i + " has the last name " + results[i].value);
+  console.log("Person #" + i + " has the last name " + results[i].value);
 
 // get the 2nd person node
 results = evaluateXPath(people, "/people/person[2]");
@@ -141,11 +141,11 @@ function getXPathForElement(el, xml) {
       tempitem2 = tempitem2.previousSibling;
     }
 
-    xpath = "*[name()='"+el.nodeName+"' and namespace-uri()='"+(el.namespaceURI ===null?'':el.namespaceURI)+"']["+pos+']'+'/'+xpath;
+    xpath = `*[name()='${el.nodeName}' and namespace-uri()='${el.namespaceURI === null ? '' : el.namespaceURI)}'][${pos}]/${xpath}`;
 
     el = el.parentNode;
   }
-  xpath = '/*'+"[name()='"+xml.documentElement.nodeName+"' and namespace-uri()='"+(el.namespaceURI ===null?'':el.namespaceURI)+"']"+'/'+xpath;
+  xpath = `/*[name()='${xml.documentElement.nodeName}' and namespace-uri()='${el.namespaceURI === null ? '' : el.namespaceURI}']/${xpath}`;
   xpath = xpath.replace(/\/$/, '');
   return xpath;
 }

--- a/files/en-us/web/xpath/snippets/index.md
+++ b/files/en-us/web/xpath/snippets/index.md
@@ -112,7 +112,7 @@ function docEvaluateArray (expr, doc, context, resolver) {
   resolver = resolver || null;
   context = context || doc;
 
-  result = doc.evaluate(expr, context, resolver, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
+  const result = doc.evaluate(expr, context, resolver, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
   for (let i = 0; i < result.snapshotLength; i++) {
     a.push(result.snapshotItem(i));
   }

--- a/files/en-us/web/xpath/snippets/index.md
+++ b/files/en-us/web/xpath/snippets/index.md
@@ -23,7 +23,7 @@ The following custom utility function can be used to evaluate XPath expressions 
 // initial work.
 function evaluateXPath(aNode, aExpr) {
   var xpe = new XPathEvaluator();
-  var nsResolver = xpe.createNSResolver(aNode.ownerDocument == null ?
+  var nsResolver = xpe.createNSResolver(aNode.ownerDocument === null ?
     aNode.documentElement : aNode.ownerDocument.documentElement);
   var result = xpe.evaluate(aExpr, aNode, nsResolver, 0, null);
   var found = [];
@@ -140,11 +140,11 @@ function getXPathForElement(el, xml) {
       tempitem2 = tempitem2.previousSibling;
     }
 
-    xpath = "*[name()='"+el.nodeName+"' and namespace-uri()='"+(el.namespaceURI===null?'':el.namespaceURI)+"']["+pos+']'+'/'+xpath;
+    xpath = "*[name()='"+el.nodeName+"' and namespace-uri()='"+(el.namespaceURI ===null?'':el.namespaceURI)+"']["+pos+']'+'/'+xpath;
 
     el = el.parentNode;
   }
-  xpath = '/*'+"[name()='"+xml.documentElement.nodeName+"' and namespace-uri()='"+(el.namespaceURI===null?'':el.namespaceURI)+"']"+'/'+xpath;
+  xpath = '/*'+"[name()='"+xml.documentElement.nodeName+"' and namespace-uri()='"+(el.namespaceURI ===null?'':el.namespaceURI)+"']"+'/'+xpath;
   xpath = xpath.replace(/\/$/, '');
   return xpath;
 }

--- a/files/en-us/web/xpath/snippets/index.md
+++ b/files/en-us/web/xpath/snippets/index.md
@@ -22,12 +22,11 @@ The following custom utility function can be used to evaluate XPath expressions 
 // thanks wanderingstan at morethanwarm dot mail dot com for the
 // initial work.
 function evaluateXPath(aNode, aExpr) {
-  var xpe = new XPathEvaluator();
-  var nsResolver = xpe.createNSResolver(aNode.ownerDocument === null ?
-    aNode.documentElement : aNode.ownerDocument.documentElement);
-  var result = xpe.evaluate(aExpr, aNode, nsResolver, 0, null);
-  var found = [];
-  var res;
+  const xpe = new XPathEvaluator();
+  const nsResolver = xpe.createNSResolver(aNode.ownerDocument === null ? aNode.documentElement : aNode.ownerDocument.documentElement);
+  const result = xpe.evaluate(aExpr, aNode, nsResolver, 0, null);
+  const found = [];
+  let res;
   while (res = result.iterateNext())
     found.push(res);
   return found;
@@ -38,13 +37,13 @@ This function uses the **`new XPathEvaluator()`** constructor, which is supporte
 
 ```js
   // XPathEvaluator is implemented on objects that implement Document
-  var xpe = aNode.ownerDocument || aNode;
+  const xpe = aNode.ownerDocument || aNode;
 ```
 
 In that case the creation of the [XPathNSResolver](/en-US/docs/Web/API/Document/createNSResolver) can be simplified as:
 
 ```js
-  var nsResolver = xpe.createNSResolver(xpe.documentElement);
+  const nsResolver = xpe.createNSResolver(xpe.documentElement);
 ```
 
 Note however that `createNSResolver` should only be used if you are sure the namespace prefixes in the XPath expression match those in the document you want to query (and that no default namespace is being used (though see [document.createNSResolver](/en-US/docs/Web/API/Document/createNSResolver) for a workaround)). Otherwise, you have to provide your own implementation of XPathNSResolver.
@@ -79,8 +78,8 @@ You can now "query" the document with XPath expressions. Although walking the DO
 
 ```js
 // display the last names of all people in the doc
-var results = evaluateXPath(people, "//person/@last-name");
-for (var i in results)
+const results = evaluateXPath(people, "//person/@last-name");
+for (let i in results)
   alert("Person #" + i + " has the last name " + results[i].value);
 
 // get the 2nd person node
@@ -91,7 +90,7 @@ results = evaluateXPath(people, "//person[address/@city='denver']");
 
 // get all the addresses that have "south" in the street name
 results = evaluateXPath(people,  "//address[contains(@street, 'south')]");
-alert(results.length);
+console.log(results.length);
 ```
 
 ### docEvaluateArray
@@ -102,20 +101,22 @@ The following is a simple utility function to get (ordered) XPath results into a
 
 ```js
 // Example usage:
-// var els = docEvaluateArray('//a');
-// alert(els[0].nodeName); // gives 'A' in HTML document with at least one link
+// const els = docEvaluateArray('//a');
+// console.log(els[0].nodeName); // gives 'A' in HTML document with at least one link
 
 function docEvaluateArray (expr, doc, context, resolver) {
-    var i, result, a = [];
-    doc = doc || (context ? context.ownerDocument : document);
-    resolver = resolver || null;
-    context = context || doc;
+  let i;
+  let result;
+  const a = [];
+  doc = doc || (context ? context.ownerDocument : document);
+  resolver = resolver || null;
+  context = context || doc;
 
-    result = doc.evaluate(expr, context, resolver, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
-    for(i = 0; i < result.snapshotLength; i++) {
-        a[i] = result.snapshotItem(i);
-    }
-    return a;
+  result = doc.evaluate(expr, context, resolver, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
+  for (let i = 0; i < result.snapshotLength; i++) {
+    a.push(result.snapshotItem(i));
+  }
+  return a;
 }
 ```
 
@@ -127,13 +128,13 @@ The following function allows one to pass an element and an XML document to find
 
 ```js
 function getXPathForElement(el, xml) {
-  var xpath = '';
-  var pos, tempitem2;
+  let xpath = '';
+  let pos, tempitem2;
 
-  while(el !== xml.documentElement) {
+  while (el !== xml.documentElement) {
     pos = 0;
     tempitem2 = el;
-    while(tempitem2) {
+    while (tempitem2) {
       if (tempitem2.nodeType === 1 && tempitem2.nodeName === el.nodeName) { // If it is ELEMENT_NODE of the same name
         pos += 1;
       }

--- a/files/en-us/web/xpath/snippets/index.md
+++ b/files/en-us/web/xpath/snippets/index.md
@@ -79,7 +79,7 @@ You can now "query" the document with XPath expressions. Although walking the DO
 ```js
 // display the last names of all people in the doc
 const results = evaluateXPath(people, "//person/@last-name");
-for (let i in results)
+for (const i in results)
   console.log("Person #" + i + " has the last name " + results[i].value);
 
 // get the 2nd person node

--- a/files/en-us/web/xpath/snippets/index.md
+++ b/files/en-us/web/xpath/snippets/index.md
@@ -106,7 +106,6 @@ The following is a simple utility function to get (ordered) XPath results into a
 
 function docEvaluateArray (expr, doc, context, resolver) {
   let i;
-  let result;
   const a = [];
   doc = doc || (context ? context.ownerDocument : document);
   resolver = resolver || null;

--- a/files/en-us/web/xslt/xslt_js_interface_in_gecko/advanced_example/index.md
+++ b/files/en-us/web/xslt/xslt_js_interface_in_gecko/advanced_example/index.md
@@ -66,7 +66,7 @@ function sort() {
   // set the sorting parameter in the XSL file
   var sortVal = xsltProcessor.getParameter(null, "myOrder");
 
-  if (sortVal == "" || sortVal == "descending")
+  if (sortVal === "" || sortVal === "descending")
     xsltProcessor.setParameter(null, "myOrder", "ascending");
   else
     xsltProcessor.setParameter(null, "myOrder", "descending");

--- a/files/en-us/web/xslt/xslt_js_interface_in_gecko/setting_parameters/index.md
+++ b/files/en-us/web/xslt/xslt_js_interface_in_gecko/setting_parameters/index.md
@@ -23,7 +23,7 @@ XSLT provides the `xsl:param` element, which is a child of the `xsl:stylesheet` 
 
 var sortVal = xsltProcessor.getParameter(null, "myOrder");
 
-if (sortVal == "" || sortVal == "descending")
+if (sortVal === "" || sortVal === "descending")
   xsltProcessor.setParameter(null, "myOrder", "ascending");
 else
   xsltProcessor.setParameter(null, "myOrder", "descending");


### PR DESCRIPTION
As part of our Modernizing JS project, we want to use `===` instead of `==` whenever possible.

This PR deals with cases where we compare with a _string_ or a _null_.

(There are also some cleaning, especially areoung XPath pages).