### PR TITLE
dialog: Update accessibility notes

### DIFF
--- a/files/en-us/web/html/element/dialog/index.md
+++ b/files/en-us/web/html/element/dialog/index.md
@@ -87,11 +87,13 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 To ensure accessibility for users of Safari versions below 15.4, consider using a polyfill such as [a11y-dialog](https://a11y-dialog.netlify.app/) as earlier implementations of <dialog> had [usability issues with some forms of assistive technology](https://www.scottohara.me/blog/2019/03/05/open-dialog.html).
 
-When implementing a dialog, it is important to consider the most appropriate place to set user focus, including the to [autofocus](/en-US/docs/Web/HTML/Global_attributes/autofocus) attribute if appropriate.
+When implementing a dialog, it is important to consider the most appropriate place to set user focus, including using the [autofocus](/en-US/docs/Web/HTML/Global_attributes/autofocus) attribute if appropriate.
 
-Ensure the “Escape” key closes the dialog. If multiple dialogs are open, Escape should only close the last shown dialog.
+Ensure the <kbd>Escape</kbd> key closes the dialog. If multiple dialogs are open, escape should only close the last shown dialog.
 
-The <dialog> element is equivalent to [role="dialog"](/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role) with the modal dialog behaving similar to setting [aria-modal="true"](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal). Ensure your implementation of dialog doesn't break expected default behaviors and follows proper labeling recommendations.
+The `<dialog>` element is equivalent to [role="dialog"](/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role) with modal dialogs behaving similar to having [aria-modal="true"](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal) set. 
+
+Ensure your dialog implementation doesn't break expected default behaviors and follows proper labeling recommendations.
 
 ## Usage notes
 

--- a/files/en-us/web/html/element/dialog/index.md
+++ b/files/en-us/web/html/element/dialog/index.md
@@ -86,6 +86,8 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 ## Accessibility considerations
 
 The `dialog` element still has [usability issues with some forms of assistive technology](https://www.scottohara.me/blog/2019/03/05/open-dialog.html). Because of this, it is advised to use an interim solution such as [a11y-dialog](https://a11y-dialog.netlify.app/) as support continues to improve.
+  
+As of March 2022, this is not the case anymore and both Webkit 15.4 and Firefox 98 support the `<dialog>` element.
 
 ## Usage notes
 

--- a/files/en-us/web/html/element/dialog/index.md
+++ b/files/en-us/web/html/element/dialog/index.md
@@ -85,9 +85,13 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 ## Accessibility considerations
 
-The `dialog` element still has [usability issues with some forms of assistive technology](https://www.scottohara.me/blog/2019/03/05/open-dialog.html). Because of this, it is advised to use an interim solution such as [a11y-dialog](https://a11y-dialog.netlify.app/) as support continues to improve.
-  
-As of March 2022, this is not the case anymore and both Webkit 15.4 and Firefox 98 support the `<dialog>` element.
+To ensure accessibility for users of Safari versions below 15.4, consider using a polyfill such as [a11y-dialog](https://a11y-dialog.netlify.app/) as earlier implementations of <dialog> had [usability issues with some forms of assistive technology](https://www.scottohara.me/blog/2019/03/05/open-dialog.html).
+
+When implementing a dialog, it is important to consider the most appropriate place to set user focus, including the to [autofocus](/en-US/docs/Web/HTML/Global_attributes/autofocus) attribute if appropriate.
+
+Ensure the “Escape” key closes the dialog. If multiple dialogs are open, Escape should only close the last shown dialog.
+
+The <dialog> element is equivalent to [role="dialog"](/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role) with the modal dialog behaving similar to setting [aria-modal="true"](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal). Ensure your implementation of dialog doesn't break expected default behaviors and follows proper labeling recommendations.
 
 ## Usage notes
 

--- a/files/en-us/web/html/element/dialog/index.md
+++ b/files/en-us/web/html/element/dialog/index.md
@@ -85,13 +85,13 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 ## Accessibility considerations
 
-To ensure accessibility for users of Safari versions below 15.4, consider using a polyfill such as [a11y-dialog](https://a11y-dialog.netlify.app/) as earlier implementations of `<dialog>` had [usability issues with some forms of assistive technology](https://www.scottohara.me/blog/2019/03/05/open-dialog.html).
+To ensure accessibility for users of Safari versions below 15.4, consider using a polyfill such as [a11y-dialog](https://a11y-dialog.netlify.app/) as earlier implementations of the `<dialog>` element had [usability issues with some forms of assistive technology](https://www.scottohara.me/blog/2019/03/05/open-dialog.html).
 
-When implementing a dialog, it is important to consider the most appropriate place to set user focus, including using the [autofocus](/en-US/docs/Web/HTML/Global_attributes/autofocus) attribute if appropriate.
+When implementing a dialog, it is important to consider the most appropriate place to set user focus. Explicitly indicating the initial focus placement by use of the [autofocus](/en-US/docs/Web/HTML/Global_attributes/autofocus) attribute will help ensure initial focus is set to the element deemed the best initial focus placement for any particular dialog.  When in doubt, as it may not always be known where initial focus could be set within a dialog, particularly for instances where a dialog's content is dynamically rendered when invoked, then if necessary authors may decide focusing the `<dialog>` element itself would provide the best initial focus placement.
 
-Ensure the <kbd>Escape</kbd> key closes the dialog. If multiple dialogs are open, escape should only close the last shown dialog.
+Ensure a mechanism is provided to allow users to close a dialog. The most robust way to ensure all users can close a dialog is to include an explicit button to do so. For instance, a confirmation, cancel or close button as appropriate. Additionally, for those using a device with a keyboard, the <kbd>Escape</kbd> key is commonly expected to close modal dialogs as well. By default, a `<dialog>` invoked by the `showModal()` method will allow for its dismissal by the <kbd>Escape</kbd>.  A non-modal dialog does not dismiss via the <kbd>Escape</kbd> key by default, and depending on what the non-modal dialog represents, it may not be desired for this behavior. If multiple modal dialogs are open, <kbd>Escape</kbd> should only close the last shown dialog.
 
-The `<dialog>` element is equivalent to [role="dialog"](/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role) with modal dialogs behaving similar to having [aria-modal="true"](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal) set. 
+The `<dialog>` element is exposed by browsers similarly to custom dialogs using the ARIA [role="dialog"](/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role) attribute. `<dialog>` elements invoked by the `showModal()` method will have an implicit [aria-modal="true"](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-modal), where as `<dialog>` elements invoked by the `show()` method, or rendered by use of the `open` attribute or changing the default `display` of a `<dialog>` will be exposed as `[aria-modal="false"]`.  It is recommended to use the appropriate `showModal()` or `show()` method to render dialogs.
 
 Ensure your dialog implementation doesn't break expected default behaviors and follows proper labeling recommendations.
 

--- a/files/en-us/web/html/element/dialog/index.md
+++ b/files/en-us/web/html/element/dialog/index.md
@@ -85,7 +85,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 ## Accessibility considerations
 
-To ensure accessibility for users of Safari versions below 15.4, consider using a polyfill such as [a11y-dialog](https://a11y-dialog.netlify.app/) as earlier implementations of <dialog> had [usability issues with some forms of assistive technology](https://www.scottohara.me/blog/2019/03/05/open-dialog.html).
+To ensure accessibility for users of Safari versions below 15.4, consider using a polyfill such as [a11y-dialog](https://a11y-dialog.netlify.app/) as earlier implementations of `<dialog>` had [usability issues with some forms of assistive technology](https://www.scottohara.me/blog/2019/03/05/open-dialog.html).
 
 When implementing a dialog, it is important to consider the most appropriate place to set user focus, including using the [autofocus](/en-US/docs/Web/HTML/Global_attributes/autofocus) attribute if appropriate.
 


### PR DESCRIPTION
#### Summary

Update the accessibility section to mention that the dialog element is no longer not recommended, following an update of
See the updates at https://www.scottohara.me/blog/2019/03/05/open-dialog.html

#### Motivation
So that people who don't click on the linked article think that the element is still not supported correctly.

#### Supporting details
- https://www.scottohara.me/blog/2019/03/05/open-dialog.html
- https://webkit.org/blog/12445/new-webkit-features-in-safari-15-4/
- https://www.mozilla.org/en-US/firefox/98.0/releasenotes/?utm_source=firefox-browser&utm_medium=firefox-desktop&utm_campaign=about-dialog


#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
