### PR TITLE
Remove mention of "left-hand side expression" from operators guide

### DIFF
--- a/files/en-us/web/javascript/guide/expressions_and_operators/index.md
+++ b/files/en-us/web/javascript/guide/expressions_and_operators/index.md
@@ -17,7 +17,7 @@ At a high level, an _expression_ is a valid unit of code that resolves to a valu
 
 The expression `x = 7` is an example of the first type. This expression uses the `=` _operator_ to assign the value seven to the variable `x`. The expression itself evaluates to `7`.
 
-The expression `3 + 4` is an example of the second type. This expression uses the `+` operator to add `3` and `4` together, and produces a value `7`. However, if it's not eventually part of a bigger construct (for example, a [variable declaration](/en-US/docs/Web/JavaScript/Guide/Grammar_and_Types#declarations)), its result will be immediately discarded — this is usually a programmer mistake, because the evaluation doesn't produce any effects.
+The expression `3 + 4` is an example of the second type. This expression uses the `+` operator to add `3` and `4` together and produces a value, `7`. However, if it's not eventually part of a bigger construct (for example, a [variable declaration](/en-US/docs/Web/JavaScript/Guide/Grammar_and_Types#declarations) like `const z = 3 + 4`), its result will be immediately discarded — this is usually a programmer mistake because the evaluation doesn't produce any effects.
 
 As the examples above also illustrate, all complex expressions are joined by _operators_, such as `=` and `+`. In this section, we will introduce the following operators:
 

--- a/files/en-us/web/javascript/guide/expressions_and_operators/index.md
+++ b/files/en-us/web/javascript/guide/expressions_and_operators/index.md
@@ -42,7 +42,7 @@ const x = 1 + 2 * 3;
 const y = 2 * 3 + 1;
 ```
 
-Despite `*` and `+` coming in different orders, both expressions would result in `7`, because `*` has higher precedence than `+`, so the `*`-joined expression will always be evaluated first. You can override operator precedence by using parentheses (which create a [grouped expression](#grouping_operator) — the basic expression). To see a complete table of operator precedence as well as various caveats, see the [Operator Precedence Reference](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence#table) page. 
+Despite `*` and `+` coming in different orders, both expressions would result in `7` because `*` has precedence over `+`, so the `*`-joined expression will always be evaluated first. You can override operator precedence by using parentheses (which creates a [grouped expression](#grouping_operator) — the basic expression). To see a complete table of operator precedence as well as various caveats, see the [Operator Precedence Reference](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence#table) page. 
 
 JavaScript has both _binary_ and _unary_ operators, and one special ternary operator, the conditional operator.
 A binary operator requires two operands, one before the operator and one after the operator:

--- a/files/en-us/web/javascript/guide/expressions_and_operators/index.md
+++ b/files/en-us/web/javascript/guide/expressions_and_operators/index.md
@@ -13,7 +13,7 @@ tags:
 
 This chapter describes JavaScript's expressions and operators, including assignment, comparison, arithmetic, bitwise, logical, string, ternary and more.
 
-An _expression_, at a high level, is any valid unit of code that resolves to a value. Every syntactically valid expression resolves to some value — but conceptually, there are two types of expressions: those that have side effects (such as assigning values), and those that purely _evaluate_.
+At a high level, an _expression_ is a valid unit of code that resolves to a value. There are two types of expressions: those that have side effects (such as assigning values) and those that purely _evaluate_.
 
 The expression `x = 7` is an example of the first type. This expression uses the `=` _operator_ to assign the value seven to the variable `x`. The expression itself evaluates to `7`.
 

--- a/files/en-us/web/javascript/guide/expressions_and_operators/index.md
+++ b/files/en-us/web/javascript/guide/expressions_and_operators/index.md
@@ -51,7 +51,7 @@ A binary operator requires two operands, one before the operator and one after t
 operand1 operator operand2
 ```
 
-For example, `3+4` or `x*y`. This form is called an _infix_ binary operator, because the operator is placed between two operands. All binary operators in JavaScript are infix.
+For example, `3 + 4` or `x * y`. This form is called an _infix_ binary operator, because the operator is placed between two operands. All binary operators in JavaScript are infix.
 
 A unary operator requires a single operand, either before or after the operator:
 

--- a/files/en-us/web/javascript/guide/expressions_and_operators/index.md
+++ b/files/en-us/web/javascript/guide/expressions_and_operators/index.md
@@ -13,48 +13,56 @@ tags:
 
 This chapter describes JavaScript's expressions and operators, including assignment, comparison, arithmetic, bitwise, logical, string, ternary and more.
 
-A complete and detailed list of operators and expressions is also available in the [reference](/en-US/docs/Web/JavaScript/Reference/Operators).
+An _expression_, at a high level, is any valid unit of code that resolves to a value. Every syntactically valid expression resolves to some value — but conceptually, there are two types of expressions: those that have side effects (such as assigning values), and those that purely _evaluate_.
 
-## Operators
+The expression `x = 7` is an example of the first type. This expression uses the `=` _operator_ to assign the value seven to the variable `x`. The expression itself evaluates to `7`.
 
-JavaScript has the following types of operators.
-This section describes the operators and contains information about operator precedence.
+The expression `3 + 4` is an example of the second type. This expression uses the `+` operator to add `3` and `4` together, and produces a value `7`. However, if it's not eventually part of a bigger construct (for example, a [variable declaration](/en-US/docs/Web/JavaScript/Guide/Grammar_and_Types#declarations)), its result will be immediately discarded — this is usually a programmer mistake, because the evaluation doesn't produce any effects.
+
+As the examples above also illustrate, all complex expressions are joined by _operators_, such as `=` and `+`. In this section, we will introduce the following operators:
 
 - [Assignment operators](#assignment_operators)
 - [Comparison operators](#comparison_operators)
 - [Arithmetic operators](#arithmetic_operators)
 - [Bitwise operators](#bitwise_operators)
 - [Logical operators](#logical_operators)
+- [BigInt operators](#bigint_operators)
 - [String operators](#string_operators)
 - [Conditional (ternary) operator](#conditional_ternary_operator)
 - [Comma operator](#comma_operator)
 - [Unary operators](#unary_operators)
 - [Relational operators](#relational_operators)
 
+These operators join operands either formed by higher-precedence operators or one of the [basic expressions](#basic_expressions). A complete and detailed list of operators and expressions is also available in the [reference](/en-US/docs/Web/JavaScript/Reference/Operators).
+
+The _precedence_ of operators determines the order they are applied when evaluating an expression. Fo example:
+
+```js
+const x = 1 + 2 * 3;
+const y = 2 * 3 + 1;
+```
+
+Despite `*` and `+` coming in different orders, both expressions would result in `7`, because `*` has higher precedence than `+`, so the `*`-joined expression will always be evaluated first. You can override operator precedence by using parentheses (which create a [grouped expression](#grouping_operator) — the basic expression). To see a complete table of operator precedence as well as various caveats, see the [Operator Precedence Reference](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence#table) page. 
+
 JavaScript has both _binary_ and _unary_ operators, and one special ternary operator, the conditional operator.
 A binary operator requires two operands, one before the operator and one after the operator:
 
-```js
+```
 operand1 operator operand2
 ```
 
-For example, `3+4` or `x*y`.
+For example, `3+4` or `x*y`. This form is called an _infix_ binary operator, because the operator is placed between two operands. All binary operators in JavaScript are infix.
 
 A unary operator requires a single operand, either before or after the operator:
 
-```js
-operator operand
 ```
-
-or
-
-```js
+operator operand
 operand operator
 ```
 
-For example, `x++` or `++x`.
+For example, `x++` or `++x`. The `operator operand` form is called a _postfix_ unary operator, and the `operand operator` form is called a _prefix_ unary operator. `++` and `--` are the only postfix operators in JavaScript — all other operators, like `!`, `typeof`, etc. are prefix.
 
-### Assignment operators
+## Assignment operators
 
 An assignment operator assigns a value to its left operand based on the value of its right operand.
 The simple assignment operator is equal (`=`), which assigns the value of its right operand to its left operand.
@@ -81,7 +89,7 @@ There are also compound assignment operators that are shorthand for the operatio
 | [Logical OR assignment](/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR_assignment)                     | `x \|\|= f()`      | `x \|\| (x = f())` |
 | [Logical nullish assignment](/en-US/docs/Web/JavaScript/Reference/Operators/Logical_nullish_assignment)           | `x ??= f()`        | `x ?? (x = f())`   |
 
-#### Assigning to properties
+### Assigning to properties
 
 If an expression evaluates to an [object](/en-US/docs/Web/JavaScript/Guide/Working_with_Objects), then the left-hand side of an assignment expression may make assignments to properties of that expression.
 For example:
@@ -113,7 +121,7 @@ console.log(val); // Prints 0.
 
 It is an error to assign values to unmodifiable properties or to properties of an expression without properties (`null` or `undefined`).
 
-#### Destructuring
+### Destructuring
 
 For more complex assignments, the [destructuring assignment](/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment) syntax is a JavaScript expression that makes it possible to extract data from arrays or objects using a syntax that mirrors the construction of array and
 object literals.
@@ -130,7 +138,7 @@ const three = foo[2];
 const [one, two, three] = foo;
 ```
 
-#### Evaluation and nesting
+### Evaluation and nesting
 
 In general, assignments are used within a variable declaration (i.e., with [`const`][], [`let`][], or [`var`][]) or as standalone statements).
 
@@ -215,7 +223,7 @@ y = [ f(), x = g() ]
 x[f()] = g()
 ```
 
-##### Evaluation example 1
+#### Evaluation example 1
 
 `y = x = f()` is equivalent to `y = (x = f())`,
 because the assignment operator `=` is [right-associative][].
@@ -238,7 +246,7 @@ However, it evaluates from left to right:
    `x` and `y` are assigned to `2`,
    and the console has printed "F!".
 
-##### Evaluation example 2
+#### Evaluation example 2
 
 `y = [ f(), x = g() ]` also evaluates from left to right:
 
@@ -269,7 +277,7 @@ However, it evaluates from left to right:
    `y` is now assigned to `[ 2, 3 ]`,
    and the console has printed "F!" then "G!".
 
-##### Evaluation example 3
+#### Evaluation example 3
 
 `x[f()] = g()` also evaluates from left to right.
 (This example assumes that `x` is already assigned to some object.
@@ -294,7 +302,7 @@ For more information about objects, read [Working with Objects](/en-US/docs/Web/
    `x[2]` is now assigned to `3`,
    and the console has printed "F!" then "G!".
 
-#### Avoid assignment chains
+### Avoid assignment chains
 
 Chaining assignments or nesting assignments in other expressions can
 result in surprising behavior. For this reason,
@@ -313,7 +321,7 @@ This statement seemingly declares the variables `x`, `y`, and `z`.
 However, it only actually declares the variable `z`.
 `y` and `x` are either invalid references to nonexistent variables (in [strict mode](/en-US/docs/Web/JavaScript/Reference/Strict_mode)) or, worse, would implicitly create [global variables](/en-US/docs/Glossary/Global_variable) for `x` and `y` in [sloppy mode](/en-US/docs/Glossary/Sloppy_mode).
 
-### Comparison operators
+## Comparison operators
 
 A comparison operator compares its operands and returns a logical value based on whether the comparison is true.
 The operands can be numerical, string, logical, or [object](/en-US/docs/Web/JavaScript/Guide/Working_with_Objects) values.
@@ -436,7 +444,7 @@ const var2 = 4;
 > **Note:** `=>` is not a comparison operator but rather is the notation
 > for [Arrow functions](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions).
 
-### Arithmetic operators
+## Arithmetic operators
 
 An arithmetic operator takes numerical values (either literals or variables) as their operands and returns a single numerical value.
 The standard arithmetic operators are addition (`+`), subtraction (`-`), multiplication (`*`), and division (`/`).
@@ -533,7 +541,7 @@ In addition to the standard arithmetic operations (`+`, `-`, `*`, `/`), JavaScri
   </tbody>
 </table>
 
-### Bitwise operators
+## Bitwise operators
 
 A bitwise operator treats their operands as a set of 32 bits (zeros and ones), rather
 than as decimal, hexadecimal, or octal numbers. For example, the decimal number nine has
@@ -552,7 +560,7 @@ The following table summarizes JavaScript's bitwise operators.
 | [Sign-propagating right shift](/en-US/docs/Web/JavaScript/Reference/Operators/Right_shift)   | `a >> b`  | Shifts `a` in binary representation `b` bits to the right, discarding bits shifted off.                                                                                 |
 | [Zero-fill right shift](/en-US/docs/Web/JavaScript/Reference/Operators/Unsigned_right_shift) | `a >>> b` | Shifts `a` in binary representation `b` bits to the right, discarding bits shifted off, and shifting in zeros from the left.                                            |
 
-#### Bitwise logical operators
+### Bitwise logical operators
 
 Conceptually, the bitwise logical operators work as follows:
 
@@ -584,7 +592,7 @@ the most significant (left-most) bit set to 1 represent negative numbers
 (two's-complement representation). `~x` evaluates to the same value that
 `-x - 1` evaluates to.
 
-#### Bitwise shift operators
+### Bitwise shift operators
 
 The bitwise shift operators take two operands: the first is a quantity to be shifted, and the second specifies the number of bit positions by which the first operand is to be
 shifted.
@@ -654,7 +662,7 @@ The shift operators are listed in the following table.
   </tbody>
 </table>
 
-### Logical operators
+## Logical operators
 
 Logical operators are typically used with Boolean (logical) values; when they are, they return a Boolean value.
 However, the `&&` and `||` operators actually return the value of one of the specified operands, so if these
@@ -746,7 +754,7 @@ const n2 = !false; // !f returns true
 const n3 = !'Cat'; // !t returns false
 ```
 
-#### Short-circuit evaluation
+### Short-circuit evaluation
 
 As logical expressions are evaluated left to right, they are tested for possible
 "short-circuit" evaluation using the following rules:
@@ -763,7 +771,7 @@ or [`undefined`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined "
 It is one of JavaScript's primitive types.").
 It is thus the better alternative to provide defaults, when values like `''` or `0` are valid values for the first expression, too.
 
-### BigInt operators
+## BigInt operators
 
 Most operators that can be used between numbers can be used between [`BigInt`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) values as well.
 
@@ -802,7 +810,7 @@ const a = 1n > 2; // false
 const b = 3 > 2n; // true
 ```
 
-### String operators
+## String operators
 
 In addition to the comparison operators, which can be used on string values, the concatenation operator (+) concatenates two string values together, returning another string that is the union of the two operand strings.
 
@@ -821,7 +829,7 @@ let mystring = 'alpha';
 mystring += 'bet'; // evaluates to "alphabet" and assigns this value to mystring.
 ```
 
-### Conditional (ternary) operator
+## Conditional (ternary) operator
 
 The [conditional operator](/en-US/docs/Web/JavaScript/Reference/Operators/Conditional_Operator)
 is the only JavaScript operator that takes three operands.
@@ -845,7 +853,7 @@ This statement assigns the value "adult" to the variable `status` if
 `age` is eighteen or more. Otherwise, it assigns the value "minor" to
 `status`.
 
-### Comma operator
+## Comma operator
 
 The [comma operator](/en-US/docs/Web/JavaScript/Reference/Operators/Comma_Operator) (`,`)
 evaluates both of its operands and returns the value of the last operand.
@@ -866,11 +874,11 @@ for (let i = 0, j = 9; i <= j; i++, j--) {
 }
 ```
 
-### Unary operators
+## Unary operators
 
 A unary operation is an operation with only one operand.
 
-#### delete
+### delete
 
 The [`delete`](/en-US/docs/Web/JavaScript/Reference/Operators/delete) operator deletes an object's property.
 The syntax is:
@@ -894,7 +902,7 @@ const myObj = {h: 4};
 delete myObj.h; // returns true (can delete user-defined properties)
 ```
 
-##### Deleting array elements
+#### Deleting array elements
 
 Since arrays are just objects, it's technically possible to `delete` elements from them.
 This is however regarded as a bad practice, try to avoid it.
@@ -902,7 +910,7 @@ When you delete an array property, the array length is not affected and other el
 To achieve that behavior, it is much better to just overwrite the element with the value `undefined`.
 To actually manipulate the array, use the various array methods such as [`splice`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice).
 
-#### `typeof`
+### typeof
 
 The [`typeof` operator](/en-US/docs/Web/JavaScript/Reference/Operators/typeof) is used in either of the following ways:
 
@@ -979,7 +987,7 @@ typeof Option;   // returns "function"
 typeof String;   // returns "function"
 ```
 
-#### `void`
+### void
 
 The [`void` operator](/en-US/docs/Web/JavaScript/Reference/Operators/void) is used in either of the following ways:
 
@@ -991,11 +999,11 @@ void expression
 The `void` operator specifies an expression to be evaluated without returning a value. `expression` is a JavaScript expression to evaluate.
 The parentheses surrounding the expression are optional, but it is good style to use them.
 
-### Relational operators
+## Relational operators
 
 A relational operator compares its operands and returns a Boolean value based on whether the comparison is true.
 
-#### in
+### in
 
 The [`in` operator](/en-US/docs/Web/JavaScript/Reference/Operators/in) returns `true` if the specified property is in the specified object.
 The syntax is:
@@ -1029,7 +1037,7 @@ const mycar = { make: 'Honda', model: 'Accord', year: 1998 };
 'model' in mycar; // returns true
 ```
 
-#### instanceof
+### instanceof
 
 The [`instanceof` operator](/en-US/docs/Web/JavaScript/Reference/Operators/instanceof) returns `true`
 if the specified object is of the specified object type. The syntax is:
@@ -1052,65 +1060,11 @@ if (theDay instanceof Date) {
 }
 ```
 
-### Operator precedence
+## Basic expressions
 
-The _precedence_ of operators determines the order they are applied when evaluating an expression.
-You can override operator precedence by using parentheses.
+All operators eventually operate on one or more basic expressions. These basic expressions include [identifiers](/en-US/docs/Web/JavaScript/Guide/Grammar_and_Types#declarations) and [literals](/en-US/docs/Web/JavaScript/Guide/Grammar_and_Types#literals), but there are a few other kinds as well. They are briefly introduced below, and their semantics are described in detail in their respective reference sections.
 
-The following table describes the precedence of operators, from highest to lowest.
-
-| Operator type          | Individual operators                                                                      |
-| ---------------------- | ----------------------------------------------------------------------------------------- |
-| member                 | `.` `[]`                                                                                  |
-| call / create instance | `()` `new`                                                                                |
-| negation/increment     | `!` `~` `-` `+` `++` `--` `typeof` `void` `delete`                                        |
-| exponentiate           | `**`                                                                                      |
-| multiply/divide        | `*` `/` `%`                                                                               |
-| addition/subtraction   | `+` `-`                                                                                   |
-| bitwise shift          | `<<` `>>` `>>>`                                                                           |
-| relational             | `<` `<=` `>` `>=` `in` `instanceof`                                                       |
-| equality               | `==` `!=` `===` `!==`                                                                     |
-| bitwise-and            | `&`                                                                                       |
-| bitwise-xor            | `^`                                                                                       |
-| bitwise-or             | `\|`                                                                                      |
-| logical-and            | `&&`                                                                                      |
-| logical-or             | `\|\|`                                                                                    |
-| conditional            | `?:`                                                                                      |
-| assignment             | `=` `+=` `-=` `**=` `*=` `/=` `%=` `<<=` `>>=` `>>>=` `&=` `^=` `\|=` `&&=` `\|\|=` `??=` |
-| comma                  | `,`                                                                                       |
-
-A more detailed version of this table, complete with links to additional details about
-each operator, may be found in the
-[JavaScript Reference](/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence#table).
-
-## Expressions
-
-An _expression_ is any valid unit of code that resolves to a value.
-
-Every syntactically valid expression resolves to some value but conceptually, there are two types of expressions: with side effects (for example: those that assign value to a
-variable) and those that in some sense evaluate and therefore resolve to a value.
-
-The expression `x = 7` is an example of the first type.
-This expression uses the = _operator_ to assign the value seven to the variable `x`.
-The expression itself evaluates to seven.
-
-The code `3 + 4` is an example of the second expression type.
-This expression uses the + operator to add three and four together without assigning the result, seven, to a variable.
-
-JavaScript has the following expression categories:
-
-- Arithmetic: evaluates to a number, for example 3.14159. (Generally uses [arithmetic operators](#arithmetic_operators).)
-- String: evaluates to a character string, for example, "Fred" or "234".
-  (Generally uses [string operators](#string_operators).)
-- Logical: evaluates to true or false. (Often involves [logical operators](#logical_operators).)
-- Primary expressions: Basic keywords and general expressions in JavaScript.
-- Left-hand-side expressions: Left values are the destination of an assignment.
-
-### Primary expressions
-
-Basic keywords and general expressions in JavaScript.
-
-#### this
+### this
 
 Use the [`this` keyword](/en-US/docs/Web/JavaScript/Reference/Operators/this) to refer to the current object.
 In general, `this` refers to the calling object in a method.
@@ -1125,8 +1079,9 @@ Suppose a function called `validate` validates an object's `value` property, giv
 
 ```js
 function validate(obj, lowval, hival) {
-  if ((obj.value < lowval) || (obj.value > hival))
+  if ((obj.value < lowval) || (obj.value > hival)) {
     console.log('Invalid Value!');
+  }
 }
 ```
 
@@ -1137,7 +1092,7 @@ You could call `validate` in each form element's `onChange` event handler, using
 <input type="text" name="age" size=3 onChange="validate(this, 18, 99);">
 ```
 
-#### Grouping operator
+### Grouping operator
 
 The grouping operator `( )` controls the precedence of evaluation in
 expressions. For example, you can override multiplication and division first, then
@@ -1161,22 +1116,17 @@ a + (b * c)   // 7
 a * c + b * c // 9
 ```
 
-### Left-hand-side expressions
+### new
 
-Left values are the destination of an assignment.
-
-#### new
-
-You can use the [`new` operator](/en-US/docs/Web/JavaScript/Reference/Operators/new) to create an instance of a user-defined object type or of one of the
-built-in object types. Use `new` as follows:
+You can use the [`new` operator](/en-US/docs/Web/JavaScript/Reference/Operators/new) to create an instance of a user-defined object type or of one of the built-in object types. Use `new` as follows:
 
 ```js
 const objectName = new objectType([param1, param2, ..., paramN]);
 ```
 
-#### super
+### super
 
-The [super keyword](/en-US/docs/Web/JavaScript/Reference/Operators/super) is used to call functions on an object's parent.
+The [`super` keyword](/en-US/docs/Web/JavaScript/Reference/Operators/super) is used to call functions on an object's parent.
 It is useful with [classes](/en-US/docs/Web/JavaScript/Reference/Classes) to call the parent constructor, for example.
 
 ```js
@@ -1184,5 +1134,4 @@ super([arguments]); // calls the parent constructor.
 super.functionOnParent([arguments]);
 ```
 
-{{PreviousNext("Web/JavaScript/Guide/Functions",
-  "Web/JavaScript/Guide/Numbers_and_dates")}}
+{{PreviousNext("Web/JavaScript/Guide/Functions", "Web/JavaScript/Guide/Numbers_and_dates")}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation

The concepts of "primary expression" and "left-hand side expression" have different semantics in spec versus in colloquial language. We are better off removing the mentions to them and focusing the page on "operator" usage.

Fix https://github.com/mdn/content/issues/6586

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
