### PR TITLE
Remove unnecessary () after typeof

### DIFF
--- a/files/en-us/web/accessibility/aria/web_applications_and_aria_faq/index.html
+++ b/files/en-us/web/accessibility/aria/web_applications_and_aria_faq/index.html
@@ -206,7 +206,7 @@ function updateProgress(percentComplete) {
 <pre class="brush: js">var progressBar = document.getElementById("progress-bar");
 
 // Check to see if the browser supports the HTML5 &lt;progress&gt; element.
-var supportsHTML5Progress = (typeof (HTMLProgressElement) !== "undefined");
+var supportsHTML5Progress = (typeof HTMLProgressElement) !== "undefined";
 
 function setupProgress() {
   if (!supportsHTML5Progress) {

--- a/files/en-us/web/accessibility/aria/web_applications_and_aria_faq/index.html
+++ b/files/en-us/web/accessibility/aria/web_applications_and_aria_faq/index.html
@@ -206,7 +206,7 @@ function updateProgress(percentComplete) {
 <pre class="brush: js">var progressBar = document.getElementById("progress-bar");
 
 // Check to see if the browser supports the HTML5 &lt;progress&gt; element.
-var supportsHTML5Progress = (typeof HTMLProgressElement) !== "undefined";
+var supportsHTML5Progress = typeof HTMLProgressElement !== "undefined";
 
 function setupProgress() {
   if (!supportsHTML5Progress) {

--- a/files/en-us/web/javascript/guide/expressions_and_operators/index.md
+++ b/files/en-us/web/javascript/guide/expressions_and_operators/index.md
@@ -908,7 +908,6 @@ The [`typeof` operator](/en-US/docs/Web/JavaScript/Reference/Operators/typeof) i
 
 ```js
 typeof operand
-typeof operand
 ```
 
 The `typeof` operator returns a string indicating the type of the unevaluated operand.

--- a/files/en-us/web/javascript/guide/expressions_and_operators/index.md
+++ b/files/en-us/web/javascript/guide/expressions_and_operators/index.md
@@ -908,7 +908,7 @@ The [`typeof` operator](/en-US/docs/Web/JavaScript/Reference/Operators/typeof) i
 
 ```js
 typeof operand
-typeof (operand)
+typeof operand
 ```
 
 The `typeof` operator returns a string indicating the type of the unevaluated operand.


### PR DESCRIPTION
In some cases (where there is no expression before the equality operator), there is no need to put parentheses right after typeof.

This removes the 2 occurrences.