### PR TITLE
Update contradictory code snippet for srcset's pixel density, width

### DIFF
--- a/files/en-us/web/html/element/picture/index.md
+++ b/files/en-us/web/html/element/picture/index.md
@@ -127,7 +127,7 @@ It is composed of a comma-separated list of image descriptors. Each image descri
 
 ```html
 <picture>
-  <source srcset="logo-768.png 768w, logo-768-1.5x.png 1.5x">
+  <source srcset="logo-768.png, logo-768-1.5x.png 1.5x">
   <source srcset="logo-480.png, logo-480-2x.png 2x">
   <img src="logo-320.png" alt="logo">
 </picture>


### PR DESCRIPTION
#### Summary
The pixel density or the width should be shown. Not both.

#### Motivation
This was causing confusion among my co-workers and leading to misunderstandings. The docs should commit to using the best practices for the srcset.

#### Supporting details

From [mdn](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture#the_srcset_attribute)

> It is composed of a comma-separated list of image descriptors. Each image descriptor is composed of a URL of the image, and either:
> 
> a width descriptor, followed by a w (such as 300w); OR
> a pixel density descriptor, followed by an x (such as 2x) to serve a high-res image for high-DPI screens.
> 

html spec https://html.spec.whatwg.org/multipage/images.html#srcset-attribute
> There must not be an [image candidate string](https://html.spec.whatwg.org/multipage/images.html#image-candidate-string) for an element that has the same [width descriptor value](https://html.spec.whatwg.org/multipage/images.html#width-descriptor-value) as another [image candidate string](https://html.spec.whatwg.org/multipage/images.html#image-candidate-string)'s [width descriptor value](https://html.spec.whatwg.org/multipage/images.html#width-descriptor-value) for the same element.
> 
> There must not be an [image candidate string](https://html.spec.whatwg.org/multipage/images.html#image-candidate-string) for an element that has the same [pixel density descriptor value](https://html.spec.whatwg.org/multipage/images.html#pixel-density-descriptor-value) as another [image candidate string](https://html.spec.whatwg.org/multipage/images.html#image-candidate-string)'s [pixel density descriptor value](https://html.spec.whatwg.org/multipage/images.html#pixel-density-descriptor-value) for the same element. For the purpose of this requirement, an [image candidate string](https://html.spec.whatwg.org/multipage/images.html#image-candidate-string) with no descriptors is equivalent to an [image candidate string](https://html.spec.whatwg.org/multipage/images.html#image-candidate-string) with a 1x descriptor.
> 
> If an [image candidate string](https://html.spec.whatwg.org/multipage/images.html#image-candidate-string) for an element has the [width descriptor](https://html.spec.whatwg.org/multipage/images.html#width-descriptor) specified, all other [image candidate strings](https://html.spec.whatwg.org/multipage/images.html#image-candidate-string) for that element must also have the [width descriptor](https://html.spec.whatwg.org/multipage/images.html#width-descriptor) specified.
> 
> The specified width in an [image candidate string](https://html.spec.whatwg.org/multipage/images.html#image-candidate-string)'s [width descriptor](https://html.spec.whatwg.org/multipage/images.html#width-descriptor) must match the [intrinsic width](https://drafts.csswg.org/css-images/#intrinsic-width) in the resource given by the [image candidate string](https://html.spec.whatwg.org/multipage/images.html#image-candidate-string)'s URL, if it has an [intrinsic width](https://drafts.csswg.org/css-images/#intrinsic-width).

#### Related issues

Closes https://github.com/mdn/content/issues/18853

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->

