### PR TITLE
Make bad example bad again

### DIFF
--- a/files/en-us/learn/css/first_steps/how_css_is_structured/index.md
+++ b/files/en-us/learn/css/first_steps/how_css_is_structured/index.md
@@ -547,7 +547,7 @@ padding-left: 10px;
 
 But these declarations are invalid:
 
-```css
+```css example-bad
 margin: 0auto;
 padding- left: 10px;
 ```

--- a/files/en-us/learn/css/first_steps/how_css_is_structured/index.md
+++ b/files/en-us/learn/css/first_steps/how_css_is_structured/index.md
@@ -549,7 +549,7 @@ But these declarations are invalid:
 
 ```css
 margin: 0auto;
-padding-left: 10px;
+padding- left: 10px;
 ```
 
 Do you see the spacing errors? First, `0auto` is not recognized as a valid value for the `margin` property. The entry `0auto` is meant to be two separate values: `0` and `auto`. Second, the browser does not recognize `padding-` as a valid property. The correct property name (`padding-left`) is separated by an errant space.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Simple typo fix: Added the mentioned 'errant space' to the padding-left property. This property is supposed to be invalid, but was previously identical to the valid property listed in the example above it.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
If both examples demonstrate valid syntax, it is confusing to readers. They will see two identical properties, being told that one is correct and the other incorrect.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
