### PR TITLE
Reformat DirectoryEntrySync & DirectoryReaderSync pages

### DIFF
--- a/files/en-us/web/api/directoryentrysync/index.md
+++ b/files/en-us/web/api/directoryentrysync/index.md
@@ -38,39 +38,10 @@ const dirEntry = fs.root.getDirectory('project_dir', {create: true});
 
 ## Method overview
 
-<table class="no-markdown">
-  <tbody>
-    <tr>
-      <td>
-        <code>DirectoryReaderSync <a href="#createreader">createReader</a> ();</code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>
-          <a href="/en-US/docs/Web/API/FileEntrySync">FileEntrySync</a>
-          <a href="#getfile">getFile</a> (in DOMString <em>path</em>, in
-          optional Flags <em>options</em>);
-        </code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>
-          DirectoryEntrySync <a href="#getdirectory">getDirectory</a> (in
-          DOMString path, in optional Flags <em>options</em>);
-        </code>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <code>
-          void <a href="#removerecursively">removeRecursively</a> ();
-        </code>
-      </td>
-    </tr>
-  </tbody>
-</table>
+- <a href="#createreader">createReader()</a>
+- <a href="#getfile">getFile()</a>
+- <a href="#getdirectory">getDirectory()</a>
+- <a href="#removerecursively">removeRecursively()</a>
 
 ## Methods
 
@@ -78,8 +49,10 @@ const dirEntry = fs.root.getDirectory('project_dir', {create: true});
 
 Creates a new `DirectoryReaderSync` to read entries from this directory.
 
+#### Syntax
+
 ```
-DirectoryReaderSync createReader ();
+createReader()
 ```
 
 ##### Returns
@@ -104,18 +77,19 @@ This method can raise a {{domxref("DOMException")}} with the following codes:
 
 Depending on how you've set the `options` parameter, the method either creates a file or looks up an existing file.
 
+#### Syntax
+
 ```
-void getFile (
-  in DOMString path, in optional Flags options
-);
+getFile(path)
+getFile(path, options)
 ```
 
 ##### Parameter
 
-- path
+- `path`
   - : Either an absolute path or a relative path from the directory to the file to be looked up or created. You cannot create a file whose immediate parent does not exist. Create the parent directory first.
-- options
-  - : An object literal describing the behavior of the method. If the file does not exist, it is created.
+- `options`
+  - : (optional) An object literal describing the behavior of the method. If the file does not exist, it is created.
 
 <table class="no-markdown">
   <thead>
@@ -183,18 +157,19 @@ This method can raise a {{domxref("DOMException")}} with the following codes:
 
 Creates or looks up a directory. The method is similar to `getFile()` with DirectoryEntrySync being passed.
 
+#### Syntax
+
 ```
-void getDirectory (
-  in DOMString path, in optional Flags options
-);
+getDirectory(path)
+getDirectory(path, options)
 ```
 
 ##### Parameter
 
-- path
+- `path`
   - : Either an absolute path or a relative path from the directory to the file to be looked up or created. You cannot create a file whose immediate parent does not exist. Create the parent directory first.
-- options
-  - : An object literal describing the behavior of the method if the file does not exist.
+- `options`
+  - : (optional) An object literal describing the behavior of the method if the file does not exist.
 
 <table class="no-markdown">
   <thead>
@@ -266,8 +241,10 @@ Deletes a directory and all of its contents. You cannot delete the root director
 
 If you delete a directory that contains a file that cannot be removed or if an error occurs while the deletion is in progress, some of the contents might not be deleted. Catch these cases with error callbacks and retry the deletion.
 
+#### Syntax
+
 ```
-void removeRecursively ();
+removeRecursively()
 ```
 
 ##### Parameter
@@ -322,7 +299,7 @@ This method can raise a {{domxref("DOMException")}} with the following codes:
 ## Specifications
 
 This feature is not part of any current specification. It is no longer on track to become a standard.
-Use the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries API) instead.
+Use the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API) instead.
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/directoryreadersync/index.md
+++ b/files/en-us/web/api/directoryreadersync/index.md
@@ -16,38 +16,40 @@ The `DirectoryReaderSync` interface lets you read the entries in a directory.
 
 ## Basic concepts
 
-Before you call the only method in this interface, [`readEntries()`](#readentries), create the [`DirectoryEntrySync`](/en-US/docs/Web/API/DirectoryEntrySync) object. But DirectoryEntrySync (as well as [FileEntrySync](/en-US/docs/Web/API/FileEntrySync)) is not a data type that you can pass between a calling app and Web Worker thread. It's not a big deal, because you don't really need to have the main app and the worker thread see the same JavaScript object; you just need them to access the same files. You can do that by passing a list of  `filesystem:` URLs—which are just strings—instead of a list of entries. You can also use the `filesystem:` URL to look up the entry with `resolveLocalFileSystemURL()`). That gets you back to a DirectoryEntrySync (as well as FileEntrySync) object.
+Before you call the only method in this interface, [`readEntries()`](#readentries), create the [`DirectoryEntrySync`](/en-US/docs/Web/API/DirectoryEntrySync) object. But DirectoryEntrySync (as well as [`FileEntrySync`](/en-US/docs/Web/API/FileEntrySync)) is not a data type that you can pass between a calling app and Web Worker thread. It's not a big deal, because you don't really need to have the main app and the worker thread see the same JavaScript object; you just need them to access the same files. You can do that by passing a list of `filesystem:` URLs—which are just strings—instead of a list of entries. You can also use the `filesystem:` URL to look up the entry with `resolveLocalFileSystemURL()`. That gets you back to a DirectoryEntrySync (as well as FileEntrySync) object.
 
 #### Example
 
-In the following code snippet from [HTML5Rocks](https://web.dev/read-files/), we create Web Workers and pass data from it to the main app.
+In the following code snippet from [HTML5Rocks (web.dev)](https://web.dev/filesystem-sync/), we create Web Workers and pass data from it to the main app.
 
 ```js
 // Taking care of the browser-specific prefixes.
-  window.resolveLocalFileSystemURL = window.resolveLocalFileSystemURL ||
-                                     window.webkitResolveLocalFileSystemURL;
+window.resolveLocalFileSystemURL =
+  window.resolveLocalFileSystemURL || window.webkitResolveLocalFileSystemURL;
 
 // Create web workers
-  const worker = new Worker('worker.js');
-  worker.onmessage = function(e) {
-    const urls = e.data.entries;
-    urls.forEach(function(url, i) {
-      window.resolveLocalFileSystemURL(url, function(fileEntry) {
-        // Print out file's name.
-        console.log(fileEntry.name);
-      });
+const worker = new Worker("worker.js");
+worker.onmessage = (e) => {
+  const urls = e.data.entries;
+  urls.forEach((url) => {
+    window.resolveLocalFileSystemURL(url, (fileEntry) => {
+      // Print out file's name.
+      console.log(fileEntry.name);
     });
-  };
+  });
+};
 
-  worker.postMessage({'cmd': 'list'});
+worker.postMessage({cmd: "list"});
 ```
 
-The following is Worker.js code that gets the contents of the directory.
+The following is `worker.js` code that gets the contents of the directory.
 
 ```js
+// worker.js
+
 // Taking care of the browser-specific prefixes.
-self.requestFileSystemSync = self.webkitRequestFileSystemSync ||
-                             self.requestFileSystemSync;
+self.requestFileSystemSync =
+  self.webkitRequestFileSystemSync || self.requestFileSystemSync;
 
 // Global for holding the list of entry file system URLs.
 const paths = [];
@@ -55,7 +57,7 @@ const paths = [];
 function getAllEntries(dirReader) {
   const entries = dirReader.readEntries();
 
-  for (let i = 0, entry; entry = entries[i]; ++i) {
+  for (const entry of entries) {
     // Stash this entry's filesystem in URL
     paths.push(entry.toURL());
 
@@ -71,16 +73,16 @@ function onError(e) {
   postMessage(`ERROR: ${e.toString()}`);
 }
 
-self.onmessage = function(e) {
-  const data = e.data;
+self.onmessage = (e) => {
+  const cmd = e.data.cmd;
 
   // Ignore everything else except our 'list' command.
-  if (!data.cmd || data.cmd != 'list') {
+  if (!cmd || cmd !== "list") {
     return;
   }
 
   try {
-    const fs = requestFileSystemSync(TEMPORARY, 1024*1024 /*1MB*/);
+    const fs = requestFileSystemSync(TEMPORARY, 1024 * 1024 /*1MB*/);
 
     getAllEntries(fs.root.createReader());
 
@@ -93,29 +95,23 @@ self.onmessage = function(e) {
 
 ## Method overview
 
-<table class="standard-table">
-  <tbody>
-    <tr>
-      <td>
-        <code>
-          EntrySync <a href="#createreader" title="#readEntries">readEntries</a> ();
-        </code>
-      </td>
-    </tr>
-  </tbody>
-</table>
+- <a href="#createreader()" title="#readEntries">readEntries()</a>
 
 ## Method
 
 ### readEntries()
 
-Returns a lost of entries from a specific directory. Call this method until an empty array is returned.
+Returns a list of entries from a specific directory. Call this method until an empty array is returned.
+
+#### Syntax
 
 ```
-EntrySync readEntries ();
+readEntries()
 ```
 
-##### Returns
+##### Return value
+
+Array containing [`FileEntrySync`](/en-US/docs/Web/API/FileEntrySync) and [`DirectoryEntrySync`](/en-US/docs/Web/API/DirectoryEntrySync)
 
 ##### Parameter
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

- "modernised" code blocks
- Add syntax blocks
- Fix one internal link
- Fix link to Html5Rocks (now web.dev), was pointing to wrong article

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

There were already some modernization done for these pages. Biggest motivation was to change this code `for (let i = 0, entry; entry = entries[i]; ++i) {` to something better, as I don't think that is something that should be used as example.  This code is coming from the linked page https://web.dev/filesystem-sync/#example:-fetching-all-entries so I'm not sure should that code have been touched in the first place.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

Google's specification for these

- https://chromium.googlesource.com/chromium/blink/+/refs/heads/main/Source/modules/filesystem/DirectoryReaderSync.idl
- https://chromium.googlesource.com/chromium/blink/+/refs/heads/main/Source/modules/filesystem/DirectoryEntrySync.idl

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
