### PR TITLE
Fix typo in showPicker() docs

### DIFF
--- a/files/en-us/web/api/htmlinputelement/showpicker/index.md
+++ b/files/en-us/web/api/htmlinputelement/showpicker/index.md
@@ -83,7 +83,7 @@ The code simply gets the previous element of the selected button and calls `show
 
 ```js
 document.querySelectorAll("button").forEach((button) => {
-  button.addEventListener("click", () => {
+  button.addEventListener("click", (event) => {
     const input = event.srcElement.previousElementSibling;
     try {
       input.showPicker();


### PR DESCRIPTION
Added the event parameter needed for the event handler function.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The example for addEventListener used the event parameter but did not have the parameter in the containing event handler. 

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I read this documentation for the first time and was briefly confused, I believe this fix to be the accurate version that will ease confusion for others.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
[MDN addEventListener documentation](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#the_event_listener_callback)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
