### PR TITLE
update a broken link

### DIFF
--- a/files/en-us/web/demos/index.md
+++ b/files/en-us/web/demos/index.md
@@ -21,7 +21,7 @@ If you know of a good demonstration or application of open web technology, pleas
 
 ### Canvas
 
-- [Blob Sallad: an interactive blob using JavaScript and canvas](https://www.blobsallad.se/) ([code demos)](https://blobsallad.se/article/)
+- [Blob Sallad: an interactive blob using JavaScript and canvas](https://www.blobsallad.se/) ([code demos)](https://web.archive.org/web/20190807191003/https://blobsallad.se/article/)
 - [miniPaint: Image editor](https://viliusle.github.io/miniPaint/) ([source code](https://github.com/viliusle/miniPaint))
 - [Zen Photon Garden](https://zenphoton.com) ([source code](https://github.com/scanlime/zenphoton))
 - [Multi touch in canvas demo](https://maximumroulette.com/) ([source code](https://github.com/zlatnaspirala/multi-touch-canvas-handler))


### PR DESCRIPTION
They've disallowed directory listing, but the examples are accessible.
Giving the link to the directory from web.archive.