### PR TITLE
Recommend against Object.create for building inheritance

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/create/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/create/index.md
@@ -177,12 +177,17 @@ console.log('Is rect an instance of Shape?', rect instanceof Shape); // true
 rect.move(1, 1); // Outputs, 'Shape moved.'
 ```
 
-This example of prototypal inheritance uses `Object.create()`. 
+This example of inheritance uses `Object.create()`. 
 However it is not considered a good idea to use the above pattern for inheritance. 
-It is because `Rectangle.prototype = Object.create(Shape.prototype);` causes prototypal re-assignment because of which `[[prototype]]` of `Rectangle` loses link to its `constructor`. 
+It is because `Rectangle.prototype = Object.create(Shape.prototype);` changes the `prototype` of `Rectangle`.
+The `Rectangle.prototype` is used when creating new instances. 
 
 Instead it is advised to use `setPrototypeOf()` to [mutate prototype](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain#building_longer_inheritance_chains). Like so:
 `Object.setPrototypeOf(Rectangle.prototype, Shape.prototype);` 
+
+A point to note here is that the `Rectangle.[[Prototype]]` which is also `Rectangle.__proto__` remains unchanged in both cases. 
+
+The [two reasons](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain#constructors) why re-assigning a `Constructor.prototype` is a bad idea. 
 
 
 ### Using propertiesObject argument with Object.create()

--- a/files/en-us/web/javascript/reference/global_objects/object/create/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/create/index.md
@@ -162,23 +162,12 @@ function Rectangle() {
 }
 
 // subclass extends superclass
-Object.setPrototypeOf(
-  Rectangle.prototype,
-  Shape.prototype,
-);
-// In class terms, the above is equivalent to using `extends`
-// It is advisable to use `setPrototypeOf` as the correct way to set a prototype
-<!-- Using Object.setPrototype is a more advisable way of extending a subclass -->
-<!-- For reference, see link: [building longer inheritance chains](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain#building_longer_inheritance_chains) -->
+Rectangle.prototype = Object.create(Shape.prototype);
 
-
-// Before `setPrototypeOf`, subclass was extended as follows
-// Rectangle.prototype = Object.create(Shape.prototype);
-// This re-assigns `Rectangle.prototype` to a new object
-// with `Shape.prototype` as its `[[Prototype]]`
-// Because of the re-assignment, we need to do:
-// Rectangle.prototype.constructor = Rectangle;
-// By using `setPrototypeOf` instead, no such re-assignment for Rectangle.prototype.constructor is required
+//If you don't set Rectangle.prototype.constructor to Rectangle,
+//it will take the prototype.constructor of Shape (parent).
+//To avoid that, we set the prototype.constructor to Rectangle (child).
+Rectangle.prototype.constructor = Rectangle;
 
 const rect = new Rectangle();
 
@@ -187,6 +176,14 @@ console.log("Constructor of Rectangle", Rectangle.prototype.constructor); // fun
 console.log('Is rect an instance of Shape?', rect instanceof Shape); // true
 rect.move(1, 1); // Outputs, 'Shape moved.'
 ```
+
+This example of prototypal inheritance uses `Object.create()`. 
+However it is not considered a good idea to use the above pattern for inheritance. 
+It is because `Rectangle.prototype = Object.create(Shape.prototype);` causes prototypal re-assignment because of which `[[prototype]]` of `Rectangle` loses link to its `constructor`. 
+
+Instead it is advised to use `setPrototypeOf()` to [mutate prototype](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain#building_longer_inheritance_chains). Like so:
+`Object.setPrototypeOf(Rectangle.prototype, Shape.prototype);` 
+
 
 ### Using propertiesObject argument with Object.create()
 

--- a/files/en-us/web/javascript/reference/global_objects/object/create/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/create/index.md
@@ -162,16 +162,28 @@ function Rectangle() {
 }
 
 // subclass extends superclass
-Rectangle.prototype = Object.create(Shape.prototype);
+Object.setPrototypeOf(
+  Rectangle.prototype,
+  Shape.prototype,
+);
+// In class terms, the above is equivalent to using `extends`
+// It is advisable to use `setPrototypeOf` as the correct way to set a prototype
+<!-- Using Object.setPrototype is a more advisable way of extending a subclass -->
+<!-- For reference, see link: [building longer inheritance chains](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain#building_longer_inheritance_chains) -->
 
-//If you don't set Rectangle.prototype.constructor to Rectangle,
-//it will take the prototype.constructor of Shape (parent).
-//To avoid that, we set the prototype.constructor to Rectangle (child).
-Rectangle.prototype.constructor = Rectangle;
+
+// Before `setPrototypeOf`, subclass was extended as follows
+// Rectangle.prototype = Object.create(Shape.prototype);
+// This re-assigns `Rectangle.prototype` to a new object
+// with `Shape.prototype` as its `[[Prototype]]`
+// Because of the re-assignment, we need to do:
+// Rectangle.prototype.constructor = Rectangle;
+// By using `setPrototypeOf` instead, no such re-assignment for Rectangle.prototype.constructor is required
 
 const rect = new Rectangle();
 
 console.log('Is rect an instance of Rectangle?', rect instanceof Rectangle); // true
+console.log("Constructor of Rectangle", Rectangle.prototype.constructor); // function Rectangle()
 console.log('Is rect an instance of Shape?', rect instanceof Shape); // true
 rect.move(1, 1); // Outputs, 'Shape moved.'
 ```
@@ -270,3 +282,4 @@ o2 = Object.create({p: 42}) */
 - {{jsxref("Object.prototype.isPrototypeOf()")}}
 - {{jsxref("Reflect.construct()")}}
 - John Resig's post on [getPrototypeOf()](https://johnresig.com/blog/objectgetprototypeof/)
+- [Building longer inheritance chains](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain#building_longer_inheritance_chains)


### PR DESCRIPTION
Update classical inheritance example. Use setPrototypeOf property. Which is a more advisable property to use rather than re-assignment of prototype.


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
It is frowned upon to re-assign an object prototype like it is done in the classical inheritance example. 
Instead `Object.setPrototypeOf` should be used.
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Seeing a lot of conflicting information can be confusing for beginners. So it is good to mention different ways of doing something along with specifying the best practice for the same. 

#### Supporting details
[Supporting link](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain#building_longer_inheritance_chains)
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
NA
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
