### PR TITLE
Add fourth example of pseudoclassical inheritance

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/setprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/setprototypeof/index.md
@@ -183,7 +183,7 @@ class SuperHero extends Human {}
 const superMan = new SuperHero();
 ```
 
-However if we want to implement subclasses, without using `class`, we can do the following:
+However, if we want to implement subclasses without using `class`, we can do the following:
 
 ```js
 function Human(name, level) {
@@ -213,14 +213,13 @@ const superMan = new SuperHero('Clark Kent', 1);
 
 console.log(superMan.fly());
 console.log(superMan.speak())
-
 ```
 
-The similarity between classical inheritance (with classes) and pseudoclassical inheritance (with function prototypes) as done above is mentioned in [Inheritance chains](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain#building_longer_inheritance_chains).
+The similarity between classical inheritance (with classes) and pseudoclassical inheritance (with constructors' `prototype` property) as done above is mentioned in [Inheritance chains](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain#building_longer_inheritance_chains).
 
-In the `class` example `SuperHero` can inherit from `Human` without using `extends`. It is done by using `setPrototypeOf`. 
+In the example below, which also uses classes, `SuperHero` is made to inherit from `Human` without using `extends` by using `setPrototypeOf` instead. 
 
-**Though it is not advisable to use `setPrototypeOf` instead of `extends`.**
+> **Warning:** It is not advisable to use `setPrototypeOf` instead of `extends` due to performance and readability reasons.
 
 ```js
 class Human {}
@@ -229,14 +228,13 @@ class SuperHero {}
 // Set the instance properties
 Object.setPrototypeOf(SuperHero.prototype, Human.prototype);
 
-// Hook up the static properties (since we cannot `call` Human inside SuperHero with `this` context as can be done with functions)
+// Hook up the static properties
 Object.setPrototypeOf(SuperHero, Human);
 
 const superMan = new SuperHero();
 ```
 
 Subclassing without extends is mentioned in [ES-6 subclassing](https://hacks.mozilla.org/2015/08/es6-in-depth-subclassing/).
-
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/object/setprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/setprototypeof/index.md
@@ -172,6 +172,72 @@ console.log(george.identity); // 'George'
 george(); // 'Hello guys!!'
 ```
 
+#### Fourth example: Pseudoclassical inheritance using Object.setPrototypeOf
+
+Inheritance in JS using classes.
+
+```js
+class Human {}
+class SuperHero extends Human {}
+
+const superMan = new SuperHero();
+```
+
+However if we want to implement subclasses, without using `class`, we can do the following:
+
+```js
+function Human(name, level) {
+  this.name = name;
+  this.level = level;
+}
+
+function SuperHero(name, level) {
+  Human.call(this, name, level);
+}
+
+Object.setPrototypeOf(SuperHero.prototype, Human.prototype);
+
+// Set the `[[Prototype]]` of `SuperHero.prototype`
+// to `Human.prototype`
+// To set the prototypal inheritance chain
+
+Human.prototype.speak = function () {
+  return `${this.name} says hello.`;
+}
+
+SuperHero.prototype.fly = function () {
+  return `${this.name} is flying.`;
+}
+
+const superMan = new SuperHero('Clark Kent', 1);
+
+console.log(superMan.fly());
+console.log(superMan.speak())
+
+```
+
+The similarity between classical inheritance (with classes) and pseudoclassical inheritance (with function prototypes) as done above is mentioned in [Inheritance chains](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain#building_longer_inheritance_chains).
+
+In the `class` example `SuperHero` can inherit from `Human` without using `extends`. It is done by using `setPrototypeOf`. 
+
+**Though it is not advisable to use `setPrototypeOf` instead of `extends`.**
+
+```js
+class Human {}
+class SuperHero {}
+
+// Set the instance properties
+Object.setPrototypeOf(SuperHero.prototype, Human.prototype);
+
+// Hook up the static properties (since we cannot `call` Human inside SuperHero with `this` context as can be done with functions)
+Object.setPrototypeOf(SuperHero, Human);
+
+const superMan = new SuperHero();
+```
+
+Subclassing without extends is mentioned in [ES-6 subclassing](https://hacks.mozilla.org/2015/08/es6-in-depth-subclassing/).
+
+
 ## Examples
 
 ### Using Object.setPrototypeOf
@@ -195,3 +261,5 @@ const dict = Object.setPrototypeOf({}, null);
 - {{jsxref("Object.prototype.isPrototypeOf()")}}
 - {{jsxref("Object.getPrototypeOf()")}}
 - {{jsxref("Object.prototype.__proto__")}}
+- [Inheritance chain](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain#building_longer_inheritance_chains)
+- [ES-6 subclassing](https://hacks.mozilla.org/2015/08/es6-in-depth-subclassing/)


### PR DESCRIPTION
Example of pseudo-classical subclasses using Object.setPrototypeOf.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Add another example for potential use case of Object.setPrototypeOf. 
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
So that we have different examples for one property in one file.
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Motivation to add example was inspired by:
- [ES-6 subclasses](https://hacks.mozilla.org/2015/08/es6-in-depth-subclassing/)
- [Inheritance chain](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain#building_longer_inheritance_chains)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
