### PR TITLE
Fixes {{jsxref("null")}} that leads to a flaw

### DIFF
--- a/files/en-us/glossary/null/index.md
+++ b/files/en-us/glossary/null/index.md
@@ -18,7 +18,7 @@ typeof null === 'object' // true
 ## See also
 
 - [JavaScript data types](/en-US/docs/Web/JavaScript/Data_structures)
-- The JavaScript global object: {{jsxref("null")}}
+- The JavaScript global object: [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)
 - {{Interwiki("wikipedia", "Null pointer")}} on Wikipedia
 - **[Glossary](/en-US/docs/Glossary)**
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/extension/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/extension/index.md
@@ -32,7 +32,7 @@ Utilities related to your extension. Get URLs to resources packages with your ex
 ## Functions
 
 - {{WebExtAPIRef("extension.getBackgroundPage()")}}
-  - : Returns the [`Window`](/en-US/docs/Web/API/Window) object for the background page running inside the current extension. Returns {{jsxref("null")}} if the extension has no background page.
+  - : Returns the [`Window`](/en-US/docs/Web/API/Window) object for the background page running inside the current extension. Returns [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if the extension has no background page.
 - {{WebExtAPIRef("extension.getExtensionTabs()")}} {{deprecated_inline}}
   - : Returns an array of the JavaScript [Window](/en-US/docs/Web/API/Window) objects for each of the tabs running inside the current extension.
 - {{WebExtAPIRef("extension.getURL()")}} {{deprecated_inline}}

--- a/files/en-us/web/api/angle_instanced_arrays/drawarraysinstancedangle/index.md
+++ b/files/en-us/web/api/angle_instanced_arrays/drawarraysinstancedangle/index.md
@@ -52,7 +52,7 @@ None ({{jsxref("undefined")}}).
 
 - If `mode` is not one of the accepted values, a `gl.INVALID_ENUM` error is thrown.
 - If `first`, `count` or `primcount` are negative, a `gl.INVALID_VALUE` error is thrown.
-- if `gl.CURRENT_PROGRAM` is {{jsxref("null")}}, a `gl.INVALID_OPERATION` error is thrown.
+- if `gl.CURRENT_PROGRAM` is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), a `gl.INVALID_OPERATION` error is thrown.
 
 ## Examples
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/canvas/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/canvas/index.md
@@ -15,7 +15,7 @@ browser-compat: api.CanvasRenderingContext2D.canvas
 The **`CanvasRenderingContext2D.canvas`** property, part of the
 [Canvas API](/en-US/docs/Web/API/Canvas_API), is a read-only reference to the
 {{domxref("HTMLCanvasElement")}} object that is associated with a given context. It
-might be {{jsxref("null")}} if there is no associated {{HTMLElement("canvas")}} element.
+might be [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if there is no associated {{HTMLElement("canvas")}} element.
 
 ## Value
 

--- a/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/createpattern/index.md
@@ -55,7 +55,7 @@ createPattern(image, repetition)
     - `"no-repeat"` (neither direction)
 
     If `repetition` is specified as an empty string (`""`) or
-    {{jsxref("null")}} (but not {{jsxref("undefined")}}), a value of `"repeat"`
+    [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) (but not {{jsxref("undefined")}}), a value of `"repeat"`
     will be used.
 
 ### Return value

--- a/files/en-us/web/api/canvasrenderingcontext2d/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/index.md
@@ -244,7 +244,7 @@ The `CanvasRenderingContext2D` rendering context contains a variety of drawing s
 - {{domxref("CanvasRenderingContext2D.restore()")}}
   - : Restores the drawing style state to the last element on the 'state stack' saved by `save()`.
 - {{domxref("CanvasRenderingContext2D.canvas")}}
-  - : A read-only back-reference to the {{domxref("HTMLCanvasElement")}}. Might be {{jsxref("null")}} if it is not associated with a {{HTMLElement("canvas")}} element.
+  - : A read-only back-reference to the {{domxref("HTMLCanvasElement")}}. Might be [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if it is not associated with a {{HTMLElement("canvas")}} element.
 - {{domxref("CanvasRenderingContext2D.getContextAttributes()")}}
   - : Returns an object containing the actual context attributes. Context attributes can be requested with {{domxref("HTMLCanvasElement.getContext()")}}.
 

--- a/files/en-us/web/api/element/setattribute/index.md
+++ b/files/en-us/web/api/element/setattribute/index.md
@@ -45,7 +45,7 @@ or the attribute's name, with no leading or trailing whitespace. See the [exampl
 
 Since the specified `value` gets converted into a string, specifying
 `null` doesn't necessarily do what you expect. Instead of removing the
-attribute or setting its value to be {{jsxref("null")}}, it instead sets the attribute's
+attribute or setting its value to be [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), it instead sets the attribute's
 value to the string `"null"`. If you wish to remove an attribute, call
 {{domxref("Element.removeAttribute", "removeAttribute()")}}.
 

--- a/files/en-us/web/api/federatedcredential/protocol/index.md
+++ b/files/en-us/web/api/federatedcredential/protocol/index.md
@@ -18,7 +18,7 @@ browser-compat: api.FederatedCredential.protocol
 The **`protocol`** property of the
 {{domxref("FederatedCredential")}} interface returns a read-only
 string containing a credential's federated identity protocol. If this
-property is {{jsxref("null")}}, the protocol may be inferred from the
+property is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), the protocol may be inferred from the
 {{domxref("FederatedCredential.provider")}} property.
 
 ## Value

--- a/files/en-us/web/api/formdata/get/index.md
+++ b/files/en-us/web/api/formdata/get/index.md
@@ -32,7 +32,7 @@ get(name)
 
 ### Return value
 
-A value whose key matches the specified `name`. Otherwise, {{jsxref("null")}}.
+A value whose key matches the specified `name`. Otherwise, [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
 
 ## Examples
 

--- a/files/en-us/web/api/history/state/index.md
+++ b/files/en-us/web/api/history/state/index.md
@@ -19,7 +19,7 @@ a way to look at the state without having to wait for a {{domxref("Window/popsta
 
 ## Value
 
-The state at the top of the history stack. The value is {{jsxref("null")}} until the
+The state at the top of the history stack. The value is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) until the
 {{domxref("History.pushState","pushState()")}} or
 {{domxref("History.replaceState","replaceState()")}} method is used.
 

--- a/files/en-us/web/api/htmlcanvaselement/getcontext/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/getcontext/index.md
@@ -14,7 +14,7 @@ browser-compat: api.HTMLCanvasElement.getContext
 
 The
 **`HTMLCanvasElement.getContext()`** method returns a drawing
-context on the canvas, or {{jsxref("null")}} if the context identifier is not
+context on the canvas, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if the context identifier is not
 supported, or the canvas has already been set to a different context mode.
 
 Later calls to this method on the same canvas element, with the same

--- a/files/en-us/web/api/htmlcollection/nameditem/index.md
+++ b/files/en-us/web/api/htmlcollection/nameditem/index.md
@@ -29,7 +29,7 @@ const item = collection.namedItem(key);
 
 ### Return value
 
-- `item` is the first {{domxref("Element")}} in the {{domxref("HTMLCollection")}} matching the _key_, or {{jsxref("null")}}, if there are none.
+- `item` is the first {{domxref("Element")}} in the {{domxref("HTMLCollection")}} matching the _key_, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), if there are none.
 
 ## Example
 

--- a/files/en-us/web/api/htmlformcontrolscollection/nameditem/index.md
+++ b/files/en-us/web/api/htmlformcontrolscollection/nameditem/index.md
@@ -36,7 +36,7 @@ namedItem(str)
 ### Return value
 
 - `item` is a {{domxref("RadioNodeList")}} , {{domxref("Element")}}, or
-  {{jsxref("null")}}.
+  [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
 
 ## Examples
 

--- a/files/en-us/web/api/node/textcontent/index.md
+++ b/files/en-us/web/api/node/textcontent/index.md
@@ -17,10 +17,10 @@ interface represents the text content of the node and its descendants.
 
 ## Value
 
-A string, or {{jsxref("null")}}. Its value depends on the situation:
+A string, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null). Its value depends on the situation:
 
 - If the node is a {{domxref("document")}} or a {{glossary("doctype")}},
-  `textContent` returns {{jsxref("null")}}.
+  `textContent` returns [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
 
   > **Note:** To get _all_ of the text and [CDATA data](/en-US/docs/Web/API/CDATASection) for the whole
   > document, use `document.documentElement.textContent`.

--- a/files/en-us/web/api/offscreencanvas/getcontext/index.md
+++ b/files/en-us/web/api/offscreencanvas/getcontext/index.md
@@ -14,7 +14,7 @@ browser-compat: api.OffscreenCanvas.getContext
 {{APIRef("Canvas API")}} {{SeeCompatTable}}
 
 The **`OffscreenCanvas.getContext()`** method returns a drawing
-context for an offscreen canvas, or {{jsxref("null")}} if the context identifier is not
+context for an offscreen canvas, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if the context identifier is not
 supported.
 
 > **Note:** This API is currently implemented for [WebGL1](/en-US/docs/Web/API/WebGLRenderingContext) and [WebGL2](/en-US/docs/Web/API/WebGL2RenderingContext) contexts only. See

--- a/files/en-us/web/api/request/body/index.md
+++ b/files/en-us/web/api/request/body/index.md
@@ -21,7 +21,7 @@ and `null` is return in these cases.
 
 ## Value
 
-A {{domxref("ReadableStream")}} or {{jsxref("null")}}.
+A {{domxref("ReadableStream")}} or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
 
 ## Examples
 

--- a/files/en-us/web/api/storageevent/index.md
+++ b/files/en-us/web/api/storageevent/index.md
@@ -29,7 +29,7 @@ _In addition to the properties listed below, this interface inherits the propert
 
 - {{domxref("StorageEvent.key", "key")}} {{ReadOnlyInline}}
   - : Returns a string that represents the key changed.
-    The `key` attribute is {{jsxref("null")}}
+    The `key` attribute is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)
     when the change is caused by the storage `clear()` method.
 - {{domxref("StorageEvent.newValue", "newValue")}} {{ReadOnlyInline}}
   - : Returns a string with the new value of the `key`.

--- a/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockparameter/index.md
@@ -59,7 +59,7 @@ getActiveUniformBlockParameter(program, uniformBlockIndex, pname)
 ### Return value
 
 Depends on which information is requested using the `pname` parameter. If an
-error occurs, {{jsxref("null")}} is returned.
+error occurs, [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) is returned.
 
 ## Examples
 

--- a/files/en-us/web/api/webgl2renderingcontext/getbuffersubdata/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getbuffersubdata/index.md
@@ -77,7 +77,7 @@ An `INVALID_VALUE` error is generated if:
 
 - `offset` + `returnedData.byteLength` would extend beyond the
   end of the buffer
-- `returnedData` is {{jsxref("null")}}
+- `returnedData` is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)
 - `offset` is less than zero.
 
 An `INVALID_OPERATION` error is generated if:

--- a/files/en-us/web/api/webgl2renderingcontext/getquery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getquery/index.md
@@ -13,7 +13,7 @@ browser-compat: api.WebGL2RenderingContext.getQuery
 {{APIRef("WebGL")}}
 
 The **`WebGL2RenderingContext.getQuery()`** method of the [WebGL 2 API](/en-US/docs/Web/API/WebGL_API) returns the currently active
-{{domxref("WebGLQuery")}} for the `target`, or {{jsxref("null")}}.
+{{domxref("WebGLQuery")}} for the `target`, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
 
 ## Syntax
 

--- a/files/en-us/web/api/webgl2renderingcontext/teximage3d/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/teximage3d/index.md
@@ -108,7 +108,7 @@ texImage3D(target, level, internalformat, width, height, depth, border, format, 
     - `gl.UNSIGNED_INT_5_9_9_9_REV`
     - `gl.UNSIGNED_INT_24_8`
     - `gl.FLOAT_32_UNSIGNED_INT_24_8_REV` (pixels must be
-      {{jsxref("null")}})
+      [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null))
 
 - `source`
   - : One of the following objects can be used as a pixel source for the texture:

--- a/files/en-us/web/api/webgl2renderingcontext/texsubimage3d/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/texsubimage3d/index.md
@@ -109,7 +109,7 @@ texSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, fo
     - `gl.UNSIGNED_INT_5_9_9_9_REV`
     - `gl.UNSIGNED_INT_24_8`
     - `gl.FLOAT_32_UNSIGNED_INT_24_8_REV` (pixels must be
-      {{jsxref("null")}})
+      [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null))
 
 - `pixels`
 

--- a/files/en-us/web/api/webgl_api/by_example/boilerplate_1/index.md
+++ b/files/en-us/web/api/webgl_api/by_example/boilerplate_1/index.md
@@ -19,7 +19,7 @@ By now you are quite used to seeing the same pieces of {{Glossary("HTML")}}, {{G
 
 Specifically, the HTML has a {{HTMLElement("p")}} element that contains some descriptive text about the page and may also hold error messages; a {{HTMLElement("canvas")}} element; and optionally a {{HTMLElement("button")}}. The CSS contains rules for `body`, `canvas`, and `button`. Any additional non-trivial CSS and HTML will be displayed on the pages of specific examples.
 
-In following examples, we will use a JavaScript helper function, `getRenderingContext()`, to initialize the {{domxref("WebGLRenderingContext","WebGL rendering context", "", 1)}}. By now, you should be able to understand what the function does. Basically, it gets the WebGL rendering context from the canvas element, initializes the drawing buffer, clears it black, and returns the initialized context. In case of error, it displays an error message and returns {{jsxref("null")}}.
+In following examples, we will use a JavaScript helper function, `getRenderingContext()`, to initialize the {{domxref("WebGLRenderingContext","WebGL rendering context", "", 1)}}. By now, you should be able to understand what the function does. Basically, it gets the WebGL rendering context from the canvas element, initializes the drawing buffer, clears it black, and returns the initialized context. In case of error, it displays an error message and returns [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
 
 Finally, all JavaScript code will run within an immediate function, which is a common JavaScript technique (see {{Glossary("Function")}}). The function declaration and invocation will also be hidden.
 

--- a/files/en-us/web/api/webglrenderingcontext/canvas/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/canvas/index.md
@@ -13,7 +13,7 @@ browser-compat: api.WebGLRenderingContext.canvas
 
 The **`WebGLRenderingContext.canvas`** property is a read-only
 reference to the {{domxref("HTMLCanvasElement")}} or {{domxref("OffscreenCanvas")}}
-object that is associated with the context. It might be {{jsxref("null")}} if it is not
+object that is associated with the context. It might be [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if it is not
 associated with a {{HTMLElement("canvas")}} element or an {{domxref("OffscreenCanvas")}}
 object.
 
@@ -26,7 +26,7 @@ gl.canvas;
 ### Return value
 
 Either a {{domxref("HTMLCanvasElement")}} or {{domxref("OffscreenCanvas")}} object or
-{{jsxref("null")}}.
+[`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/drawarrays/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/drawarrays/index.md
@@ -51,7 +51,7 @@ None ({{jsxref("undefined")}}).
   `gl.INVALID_ENUM` error is thrown.
 - If `first` or `count` are negative, a
   `gl.INVALID_VALUE` error is thrown.
-- if `gl.CURRENT_PROGRAM` is {{jsxref("null")}}, a
+- if `gl.CURRENT_PROGRAM` is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), a
   `gl.INVALID_OPERATION` error is thrown.
 
 ## Examples

--- a/files/en-us/web/api/webglrenderingcontext/getcontextattributes/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getcontextattributes/index.md
@@ -14,7 +14,7 @@ browser-compat: api.WebGLRenderingContext.getContextAttributes
 
 The **`WebGLRenderingContext.getContextAttributes()`** method
 returns a `WebGLContextAttributes` object that contains the actual context
-parameters. Might return {{jsxref("null")}}, if the context is lost.
+parameters. Might return [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), if the context is lost.
 
 ## Syntax
 
@@ -29,7 +29,7 @@ None.
 ### Return value
 
 A `WebGLContextAttributes` object that contains the actual context
-parameters, or {{jsxref("null")}} if the context is lost.
+parameters, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if the context is lost.
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/getextension/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getextension/index.md
@@ -28,7 +28,7 @@ getExtension(name)
 
 ### Return value
 
-A WebGL extension object, or {{jsxref("null")}} if name does not match
+A WebGL extension object, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if name does not match
 (case-insensitive) to one of the strings in
 {{domxref("WebGLRenderingContext.getSupportedExtensions")}}.
 

--- a/files/en-us/web/api/webglrenderingcontext/gettexparameter/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/gettexparameter/index.md
@@ -175,7 +175,7 @@ getTexParameter(target, pname)
 ### Return value
 
 Returns the requested texture information (as specified with `pname`). If an
-error occurs, {{jsxref("null")}} is returned.
+error occurs, [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) is returned.
 
 ## Examples
 

--- a/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.md
@@ -79,7 +79,7 @@ getUniformLocation(program, name)
 ### Return value
 
 A {{domxref("WebGLUniformLocation")}} value indicating the location of the named
-variable, if it exists. If the specified variable doesn't exist, {{jsxref("null")}} is
+variable, if it exists. If the specified variable doesn't exist, [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) is
 returned instead.
 
 The `WebGLUniformLocation` is an opaque value used to uniquely identify the

--- a/files/en-us/web/api/webglrenderingcontext/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/index.md
@@ -42,7 +42,7 @@ See the [WebGL constants](/en-US/docs/Web/API/WebGL_API/Constants) page.
 The following properties and methods provide general information and functionality to deal with the WebGL context:
 
 - {{domxref("WebGLRenderingContext.canvas")}}
-  - : A read-only back-reference to the {{domxref("HTMLCanvasElement")}}. Might be {{jsxref("null")}} if it is not associated with a {{HTMLElement("canvas")}} element.
+  - : A read-only back-reference to the {{domxref("HTMLCanvasElement")}}. Might be [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if it is not associated with a {{HTMLElement("canvas")}} element.
 - {{domxref("WebGLRenderingContext.commit()")}} {{experimental_inline}}
   - : Pushes frames back to the original {{domxref("HTMLCanvasElement")}}, if the context is not directly fixed to a specific canvas.
 - {{domxref("WebGLRenderingContext.drawingBufferWidth")}}
@@ -50,7 +50,7 @@ The following properties and methods provide general information and functionali
 - {{domxref("WebGLRenderingContext.drawingBufferHeight")}}
   - : The read-only height of the current drawing buffer. Should match the height of the canvas element associated with this context.
 - {{domxref("WebGLRenderingContext.getContextAttributes()")}}
-  - : Returns a `WebGLContextAttributes` object that contains the actual context parameters. Might return {{jsxref("null")}}, if the context is lost.
+  - : Returns a `WebGLContextAttributes` object that contains the actual context parameters. Might return [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), if the context is lost.
 - {{domxref("WebGLRenderingContext.isContextLost()")}}
   - : Returns `true` if the context is lost, otherwise returns `false`.
 - {{domxref("WebGLRenderingContext.makeXRCompatible()")}}

--- a/files/en-us/web/api/webglrenderingcontext/teximage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/teximage2d/index.md
@@ -804,7 +804,7 @@ texImage2D(target, level, internalformat, width, height, border, format, type, s
     - `gl.UNSIGNED_INT_5_9_9_9_REV`
     - `gl.UNSIGNED_INT_24_8`
     - `gl.FLOAT_32_UNSIGNED_INT_24_8_REV` (pixels must be
-        {{jsxref("null")}})
+        [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null))
 
 - `pixels`
 

--- a/files/en-us/web/api/webglrenderingcontext/texsubimage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/texsubimage2d/index.md
@@ -125,7 +125,7 @@ texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixe
     - `gl.UNSIGNED_INT_5_9_9_9_REV`
     - `gl.UNSIGNED_INT_24_8`
     - `gl.FLOAT_32_UNSIGNED_INT_24_8_REV` (pixels must be
-        {{jsxref("null")}})
+        [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null))
 
 - `pixels`
 

--- a/files/en-us/web/api/window/frameelement/index.md
+++ b/files/en-us/web/api/window/frameelement/index.md
@@ -24,7 +24,7 @@ in which the window is embedded.
 
 The element which the window is embedded into. If the window isn't embedded into
 another document, or if the document into which it's embedded has a different
-{{glossary("origin")}}, the value is {{jsxref("null")}} instead.
+{{glossary("origin")}}, the value is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) instead.
 
 ## Examples
 

--- a/files/en-us/web/api/window/opener/index.md
+++ b/files/en-us/web/api/window/opener/index.md
@@ -27,7 +27,7 @@ In other words, if window `A` opens window `B`,
 A {{domxref("Window")}}-like object referring to the window that opened the current
 window (using {{domxref("window.open()")}}, or by a link with {{htmlattrxref("target",
   "a")}} attribute set). If this window was not opened by being linked to or created by
-another, returns {{jsxref("null")}}.
+another, returns [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
 
 If the opener is not on the same origin as the current page, functionality of the
 opener object is limited. For example, variables and functions on the window object are
@@ -37,7 +37,7 @@ phishing attacks possible, where a trusted page that is opened in the original w
 replaced by a phishing page by the newly opened page.
 
 In the following cases, the browser does not populate `window.opener`, but
-leaves it {{jsxref("null")}}:
+leaves it [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null):
 
 - The opener can be omitted by specifying
   `{{htmlattrxref("rel", "a")}}=noopener` on a link, or passing

--- a/files/en-us/web/api/window/storage_event/index.md
+++ b/files/en-us/web/api/window/storage_event/index.md
@@ -36,7 +36,7 @@ A {{domxref("StorageEvent")}}. Inherits from {{domxref("Event")}}.
 
 - {{domxref("StorageEvent.key", "key")}} {{ReadOnlyInline}}
   - : Returns a string that represents the key changed.
-    The `key` attribute is {{jsxref("null")}}
+    The `key` attribute is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)
     when the change is caused by the storage `clear()` method.
 - {{domxref("StorageEvent.newValue", "newValue")}} {{ReadOnlyInline}}
   - : Returns a string with the new value of the `key`.

--- a/files/en-us/web/api/xrcompositionlayer/chromaticaberrationcorrection/index.md
+++ b/files/en-us/web/api/xrcompositionlayer/chromaticaberrationcorrection/index.md
@@ -22,7 +22,7 @@ Chromatic aberration ("color fringing") is an imperfection wherein a lens fails 
 ## Value
 
 A boolean. `true` enables chromatic aberration correction for the layer; `false` disables it.
-If the device doesn't support this feature, `chromaticAberrationCorrection` is {{jsxref("null")}} and setting it will not do anything.
+If the device doesn't support this feature, `chromaticAberrationCorrection` is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) and setting it will not do anything.
 
 If `chromaticAberrationCorrection` was changed, it will take effect in the next frame.
 

--- a/files/en-us/web/api/xrcompositionlayer/index.md
+++ b/files/en-us/web/api/xrcompositionlayer/index.md
@@ -37,7 +37,7 @@ Several layer types inherit from `XRCompositionLayer`:
 - {{domxref("XRCompositionLayer.blendTextureSourceAlpha")}}
   - : A boolean enabling the layer's texture alpha channel.
 - {{domxref("XRCompositionLayer.chromaticAberrationCorrection")}}
-  - : A boolean enabling optical chromatic aberration correction for the layer if the device supports it, {{jsxref("null")}} otherwise.
+  - : A boolean enabling optical chromatic aberration correction for the layer if the device supports it, [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) otherwise.
 - {{domxref("XRCompositionLayer.layout")}} {{ReadOnlyInline}}
   - : The layout type of the layer.
 - {{domxref("XRCompositionLayer.mipLevels")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/xrframe/getlightestimate/index.md
+++ b/files/en-us/web/api/xrframe/getlightestimate/index.md
@@ -28,7 +28,7 @@ getLightEstimate(lightProbe)
 
 ### Return value
 
-An {{domxref("XRLightEstimate")}} object or {{jsxref("null")}} if the device cannot estimate lighting for this frame.
+An {{domxref("XRLightEstimate")}} object or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if the device cannot estimate lighting for this frame.
 
 ## Examples
 

--- a/files/en-us/web/api/xrhittestsource/cancel/index.md
+++ b/files/en-us/web/api/xrhittestsource/cancel/index.md
@@ -34,7 +34,7 @@ None ({{jsxref("undefined")}}).
 
 ### Unsubscribe from hit test
 
-The `cancel()` method unsubscribes from a hit test source. Since the {{domxref("XRHitTestSource")}} object will no longer be usable, you can clean up and set it to {{jsxref("null")}}.
+The `cancel()` method unsubscribes from a hit test source. Since the {{domxref("XRHitTestSource")}} object will no longer be usable, you can clean up and set it to [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
 
 ```js
 hitTestSource.cancel();

--- a/files/en-us/web/api/xrhittestsource/index.md
+++ b/files/en-us/web/api/xrhittestsource/index.md
@@ -57,7 +57,7 @@ function onXRFrame(time, xrFrame) {
 
 ### Unsubscribe from hit test
 
-To unsubscribe from a hit test source, call {{domxref("XRHitTestSource.cancel()")}}. Since the object will no longer be usable, you can clean up and set the `XRHitTestSource` object to {{jsxref("null")}}.
+To unsubscribe from a hit test source, call {{domxref("XRHitTestSource.cancel()")}}. Since the object will no longer be usable, you can clean up and set the `XRHitTestSource` object to [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
 
 ```js
 hitTestSource.cancel();

--- a/files/en-us/web/api/xrinputsource/hand/index.md
+++ b/files/en-us/web/api/xrinputsource/hand/index.md
@@ -25,7 +25,7 @@ The read-only **`hand`** property of the {{domxref("XRInputSource")}} interface 
 
 ## Value
 
-An {{domxref("XRHand")}} object or {{jsxref("null")}} if the {{domxref("XRSession")}} has not been [requested](/en-US/docs/Web/API/XRSystem/requestSession) with the `hand-tracking` feature descriptor.
+An {{domxref("XRHand")}} object or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if the {{domxref("XRSession")}} has not been [requested](/en-US/docs/Web/API/XRSystem/requestSession) with the `hand-tracking` feature descriptor.
 
 ## Examples
 

--- a/files/en-us/web/api/xrpose/angularvelocity/index.md
+++ b/files/en-us/web/api/xrpose/angularvelocity/index.md
@@ -21,7 +21,7 @@ the angular velocity in radians per second relative to the base
 ## Value
 
 A {{DOMxRef("DOMPointReadOnly")}} describing the angular velocity in radians
-per second relative to the base {{DOMxRef("XRSpace")}}. Returns {{jsxref("null")}}
+per second relative to the base {{DOMxRef("XRSpace")}}. Returns [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)
 if the user agent can't populate this value.
 
 ## Specifications

--- a/files/en-us/web/api/xrpose/linearvelocity/index.md
+++ b/files/en-us/web/api/xrpose/linearvelocity/index.md
@@ -21,7 +21,7 @@ the linear velocity in meters per second relative to the base
 ## Value
 
 A {{DOMxRef("DOMPointReadOnly")}} describing the linear velocity in meters
-per second relative to the base {{DOMxRef("XRSpace")}}. Returns {{jsxref("null")}}
+per second relative to the base {{DOMxRef("XRSpace")}}. Returns [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)
 if the user agent can't populate this value.
 
 ## Specifications

--- a/files/en-us/web/api/xrprojectionlayer/fixedfoveation/index.md
+++ b/files/en-us/web/api/xrprojectionlayer/fixedfoveation/index.md
@@ -35,7 +35,7 @@ Note that some user agents might implement certain levels of foveation, so you m
 - `2/3`: medium foveation
 - `1.0`: maximum foveation
 
-Some devices don't support foveated rendering. In that case `fixedFoveation` is {{jsxref("null")}} and setting it will not do anything.
+Some devices don't support foveated rendering. In that case `fixedFoveation` is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) and setting it will not do anything.
 
 ## Examples
 

--- a/files/en-us/web/api/xrprojectionlayer/index.md
+++ b/files/en-us/web/api/xrprojectionlayer/index.md
@@ -36,7 +36,7 @@ _Inherits properties from its parent, {{domxref("XRCompositionLayer")}}._
 - {{domxref("XRCompositionLayer.blendTextureSourceAlpha")}}
   - : A boolean enabling the layer's texture alpha channel.
 - {{domxref("XRCompositionLayer.chromaticAberrationCorrection")}}
-  - : A boolean enabling optical chromatic aberration correction for the layer if the device supports it, {{jsxref("null")}} otherwise.
+  - : A boolean enabling optical chromatic aberration correction for the layer if the device supports it, [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) otherwise.
 - {{domxref("XRProjectionLayer.fixedFoveation")}}
   - : A number indicating the amount of foveation used by the XR compositor for the layer. Fixed Foveated Rendering (FFR) renders the edges of the eye textures at a lower resolution than the center and reduces the GPU load.
 - {{domxref("XRProjectionLayer.ignoreDepthValues")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/xrsession/domoverlaystate/index.md
+++ b/files/en-us/web/api/xrsession/domoverlaystate/index.md
@@ -22,7 +22,7 @@ The *read-only* **`domOverlayState`** property of an `immersive-ar`
 
 ## Value
 
-Returns {{jsxref("null")}} if the DOM overlay feature is not supported or not enabled or an object containing information about the DOM overlay state with the following properties:
+Returns [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if the DOM overlay feature is not supported or not enabled or an object containing information about the DOM overlay state with the following properties:
 
 - `type`
 

--- a/files/en-us/web/api/xrtransientinputhittestsource/cancel/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestsource/cancel/index.md
@@ -34,7 +34,7 @@ None ({{jsxref("undefined")}}).
 
 ### Unsubscribe from hit test
 
-The `cancel()` method unsubscribes from a transient input hit test source. Since the {{domxref("XRTransientInputHitTestSource")}} object will no longer be usable, you can clean up and set it to {{jsxref("null")}}.
+The `cancel()` method unsubscribes from a transient input hit test source. Since the {{domxref("XRTransientInputHitTestSource")}} object will no longer be usable, you can clean up and set it to [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
 
 ```js
 transientHitTestSource.cancel();

--- a/files/en-us/web/api/xrtransientinputhittestsource/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestsource/index.md
@@ -57,7 +57,7 @@ function onXRFrame(time, xrFrame) {
 
 ### Unsubscribe from a transient input hit test
 
-To unsubscribe from a transient input hit test source, use the {{domxref("XRTransientInputHitTestSource.cancel()")}} method. Since the object will no longer be usable, you can clean up and set the `XRTransientInputHitTestSource` object to {{jsxref("null")}}.
+To unsubscribe from a transient input hit test source, use the {{domxref("XRTransientInputHitTestSource.cancel()")}} method. Since the object will no longer be usable, you can clean up and set the `XRTransientInputHitTestSource` object to [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
 
 ```js
 transientHitTestSource.cancel();

--- a/files/en-us/web/api/xrview/index.md
+++ b/files/en-us/web/api/xrview/index.md
@@ -33,7 +33,7 @@ The [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API)'s **`XRView`** inte
 - {{domxref("XRView.projectionMatrix", "projectionMatrix")}} {{ReadOnlyInline}}
   - : The projection matrix that will transform the scene to appear correctly given the point-of-view indicated by `eye`. This matrix should be used directly in order to avoid presentation distortions that may lead to potentially serious user discomfort.
 - {{domxref("XRView.recommendedViewportScale", "recommendedViewportScale")}} {{ReadOnlyInline}}
-  - : The recommended viewport scale value that you can use for `requestViewportScale()` if the user agent has such a recommendation; {{jsxref("null")}} otherwise.
+  - : The recommended viewport scale value that you can use for `requestViewportScale()` if the user agent has such a recommendation; [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) otherwise.
 - {{domxref("XRView.transform", "transform")}} {{ReadOnlyInline}}
   - : An {{domxref("XRRigidTransform")}} which describes the current position and orientation of the viewpoint in relation to the {{domxref("XRReferenceSpace")}} specified when {{domxref("XRFrame.getViewerPose", "getViewerPose()")}} was called on the {{domxref("XRFrame")}} being rendered.
 

--- a/files/en-us/web/api/xrview/recommendedviewportscale/index.md
+++ b/files/en-us/web/api/xrview/recommendedviewportscale/index.md
@@ -14,11 +14,11 @@ browser-compat: api.XRView.recommendedViewportScale
 ---
 {{APIRef("WebXR Device API")}}
 
-The read-only **`recommendedViewportScale`** property of the {{domxref("XRView")}} interface is the recommended viewport scale value that you can use for {{domxref("XRView.requestViewportScale()")}} if the user agent has such a recommendation; {{jsxref("null")}} otherwise.
+The read-only **`recommendedViewportScale`** property of the {{domxref("XRView")}} interface is the recommended viewport scale value that you can use for {{domxref("XRView.requestViewportScale()")}} if the user agent has such a recommendation; [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) otherwise.
 
 ## Value
 
-A number greater than 0.0 and less than or equal to 1.0; or {{jsxref("null")}} if the user agent does not provide a recommended scale.
+A number greater than 0.0 and less than or equal to 1.0; or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if the user agent does not provide a recommended scale.
 
 ## Examples
 

--- a/files/en-us/web/api/xrwebgllayer/fixedfoveation/index.md
+++ b/files/en-us/web/api/xrwebgllayer/fixedfoveation/index.md
@@ -36,7 +36,7 @@ Note that some user agents might implement certain levels of foveation, so you m
 - `2/3`: medium foveation
 - `1.0`: maximum foveation
 
-Some devices don't support foveated rendering. In that case `fixedFoveation` is {{jsxref("null")}} and setting it will not do anything.
+Some devices don't support foveated rendering. In that case `fixedFoveation` is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) and setting it will not do anything.
 
 ## Examples
 

--- a/files/en-us/web/api/xrwebglsubimage/imageindex/index.md
+++ b/files/en-us/web/api/xrwebglsubimage/imageindex/index.md
@@ -15,11 +15,11 @@ browser-compat: api.XRWebGLSubImage.imageIndex
 ---
 {{APIRef("WebXR Device API")}}
 
-The read-only **`imageIndex`** property of the {{domxref("XRWebGLSubImage")}} interface is a number representing the offset into the texture array if the layer was requested with `texture-array`; {{jsxref("null")}} otherwise.
+The read-only **`imageIndex`** property of the {{domxref("XRWebGLSubImage")}} interface is a number representing the offset into the texture array if the layer was requested with `texture-array`; [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) otherwise.
 
 ## Value
 
-A number or {{jsxref("null")}} if the layer wasn't requested with `texture-array`.
+A number or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if the layer wasn't requested with `texture-array`.
 
 ### Using `imageIndex`
 

--- a/files/en-us/web/api/xrwebglsubimage/index.md
+++ b/files/en-us/web/api/xrwebglsubimage/index.md
@@ -27,7 +27,7 @@ _Inherits properties from its parent, {{domxref("XRSubImage")}}._
 - {{domxref("XRWebGLSubImage.depthStencilTexture")}} {{ReadOnlyInline}}
   - : A depth/stencil {{domxref("WebGLTexture")}} object for the {{domxref("XRCompositionLayer")}} to render.
 - {{domxref("XRWebGLSubImage.imageIndex")}} {{ReadOnlyInline}}
-  - : A number representing the offset into the texture array if the layer was requested with `texture-array`; {{jsxref("null")}} otherwise.
+  - : A number representing the offset into the texture array if the layer was requested with `texture-array`; [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) otherwise.
 - {{domxref("XRWebGLSubImage.textureWidth")}} {{ReadOnlyInline}}
   - : A number representing the width in pixels of the GL attachment.
 - {{domxref("XRWebGLSubImage.textureHeight")}} {{ReadOnlyInline}}

--- a/files/en-us/web/javascript/a_re-introduction_to_javascript/index.md
+++ b/files/en-us/web/javascript/a_re-introduction_to_javascript/index.md
@@ -188,7 +188,7 @@ There's our first brush with JavaScript objects! Did we mention that you can use
 
 ## Other types
 
-JavaScript distinguishes between {{jsxref("null")}}, which is a value that indicates a deliberate non-value (and is only accessible through the `null` keyword), and {{jsxref("undefined")}}, which is a value of type `undefined` that indicates an uninitialized variable — that is, a value hasn't even been assigned yet. We'll talk about variables later, but in JavaScript it is possible to declare a variable without assigning a value to it. If you do this, the variable's type is `undefined`. `undefined` is actually a constant.
+JavaScript distinguishes between [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), which is a value that indicates a deliberate non-value (and is only accessible through the `null` keyword), and {{jsxref("undefined")}}, which is a value of type `undefined` that indicates an uninitialized variable — that is, a value hasn't even been assigned yet. We'll talk about variables later, but in JavaScript it is possible to declare a variable without assigning a value to it. If you do this, the variable's type is `undefined`. `undefined` is actually a constant.
 
 JavaScript has a boolean type, with possible values `true` and `false` (both of which are keywords.) Any value can be converted to a boolean according to the following rules:
 

--- a/files/en-us/web/javascript/data_structures/index.md
+++ b/files/en-us/web/javascript/data_structures/index.md
@@ -46,7 +46,7 @@ Boolean represents a logical entity and can have two values: `true` and `false`.
 
 ### Null type
 
-The Null type has exactly one value: `null`. See {{jsxref("null")}} and [Null](/en-US/docs/Glossary/Null) for more details.
+The Null type has exactly one value: `null`. See [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) and [Null](/en-US/docs/Glossary/Null) for more details.
 
 ### Undefined type
 

--- a/files/en-us/web/javascript/guide/grammar_and_types/index.md
+++ b/files/en-us/web/javascript/guide/grammar_and_types/index.md
@@ -134,7 +134,7 @@ let a;
 a + 2;  // Evaluates to NaN
 ```
 
-When you evaluate a {{jsxref("null")}} variable, the null value behaves as `0` in numeric contexts and as `false` in boolean contexts. For example:
+When you evaluate a [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) variable, the null value behaves as `0` in numeric contexts and as `false` in boolean contexts. For example:
 
 ```js
 const n = null;

--- a/files/en-us/web/javascript/guide/working_with_objects/index.md
+++ b/files/en-us/web/javascript/guide/working_with_objects/index.md
@@ -47,7 +47,7 @@ const myCar = {
 };
 ```
 
-Unassigned properties of an object are {{jsxref("undefined")}} (and not {{jsxref("null")}}).
+Unassigned properties of an object are {{jsxref("undefined")}} (and not [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)).
 
 ```js
 myCar.color; // undefined

--- a/files/en-us/web/javascript/reference/classes/extends/index.md
+++ b/files/en-us/web/javascript/reference/classes/extends/index.md
@@ -45,7 +45,7 @@ class ModernClass {
 class AnotherChildClass extends ModernClass {}
 ```
 
-The `.prototype` of the `ParentClass` must be an {{jsxref("Object")}} or {{jsxref("null")}}.
+The `.prototype` of the `ParentClass` must be an {{jsxref("Object")}} or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
 
 ```js
 function ParentClass() {}

--- a/files/en-us/web/javascript/reference/errors/cant_convert_x_to_bigint/index.md
+++ b/files/en-us/web/javascript/reference/errors/cant_convert_x_to_bigint/index.md
@@ -9,7 +9,7 @@ tags:
 ---
 {{jsSidebar("Errors")}}
 
-The JavaScript exception "x can't be converted to BigInt" occurs when attempting to convert a {{jsxref("Symbol")}}, {{jsxref("null")}}, or {{jsxref("undefined")}} value to a {{jsxref("BigInt")}}, or if an operation expecting a BigInt parameter receives a number.
+The JavaScript exception "x can't be converted to BigInt" occurs when attempting to convert a {{jsxref("Symbol")}}, [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), or {{jsxref("undefined")}} value to a {{jsxref("BigInt")}}, or if an operation expecting a BigInt parameter receives a number.
 
 ## Message
 

--- a/files/en-us/web/javascript/reference/errors/delete_in_strict_mode/index.md
+++ b/files/en-us/web/javascript/reference/errors/delete_in_strict_mode/index.md
@@ -54,7 +54,7 @@ delete x;
 // is deprecated
 ```
 
-To free the contents of a variable, you can set it to {{jsxref("null")}}:
+To free the contents of a variable, you can set it to [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null):
 
 ```js example-good
 'use strict';

--- a/files/en-us/web/javascript/reference/errors/in_operator_no_object/index.md
+++ b/files/en-us/web/javascript/reference/errors/in_operator_no_object/index.md
@@ -53,7 +53,7 @@ Instead you will need to use {{jsxref("String.prototype.indexOf()")}}, for examp
 
 ### The operand can't be null or undefined
 
-Make sure the object you are inspecting isn't actually {{jsxref("null")}} or
+Make sure the object you are inspecting isn't actually [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or
 {{jsxref("undefined")}}.
 
 ```js example-bad

--- a/files/en-us/web/javascript/reference/errors/more_arguments_needed/index.md
+++ b/files/en-us/web/javascript/reference/errors/more_arguments_needed/index.md
@@ -45,7 +45,7 @@ const obj2 = Object.setPrototypeOf({});
 // TypeError: Object.setPrototypeOf requires at least 2 arguments, but only 1 were passed
 ```
 
-You can fix this by setting {{jsxref("null")}} as the prototype, for example:
+You can fix this by setting [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) as the prototype, for example:
 
 ```js example-good
 const obj = Object.create(null);

--- a/files/en-us/web/javascript/reference/errors/no_non-null_object/index.md
+++ b/files/en-us/web/javascript/reference/errors/no_non-null_object/index.md
@@ -10,7 +10,7 @@ tags:
 {{JSSidebar("Errors")}}
 
 The JavaScript exception "is not a non-null object" occurs when an object is expected
-somewhere and wasn't provided. {{jsxref("null")}} is not an object and won't work.
+somewhere and wasn't provided. [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) is not an object and won't work.
 
 ## Message
 
@@ -30,7 +30,7 @@ TypeError: Attempted to add a non-object value to a WeakSet (Safari)
 
 ## What went wrong?
 
-An object is expected somewhere and wasn't provided. {{jsxref("null")}} is not an
+An object is expected somewhere and wasn't provided. [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) is not an
 object and won't work. You must provide a proper object in the given situation.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/errors/no_properties/index.md
+++ b/files/en-us/web/javascript/reference/errors/no_properties/index.md
@@ -10,7 +10,7 @@ tags:
 {{jsSidebar("Errors")}}
 
 The JavaScript exception "null (or undefined) has no properties" occurs when you
-attempt to access properties of {{jsxref("null")}} and {{jsxref("undefined")}}. They
+attempt to access properties of [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) and {{jsxref("undefined")}}. They
 don't have any.
 
 ## Message
@@ -28,7 +28,7 @@ TypeError: undefined is not an object (evaluating 'undefined.x') (Safari)
 
 ## What went wrong?
 
-Both {{jsxref("null")}} and {{jsxref("undefined")}}, have no properties you could
+Both [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) and {{jsxref("undefined")}}, have no properties you could
 access.
 
 ## Examples
@@ -45,5 +45,5 @@ undefined.bar;
 
 ## See also
 
-- {{jsxref("null")}}
+- [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)
 - {{jsxref("undefined")}}

--- a/files/en-us/web/javascript/reference/errors/unexpected_type/index.md
+++ b/files/en-us/web/javascript/reference/errors/unexpected_type/index.md
@@ -10,7 +10,7 @@ tags:
 {{jsSidebar("Errors")}}
 
 The JavaScript exception "_x_ is (not) _y_" occurs when there was an
-unexpected type. Oftentimes, unexpected {{jsxref("undefined")}} or {{jsxref("null")}}
+unexpected type. Oftentimes, unexpected {{jsxref("undefined")}} or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)
 values.
 
 ## Message
@@ -32,7 +32,7 @@ TypeError: Symbol.keyFor requires that the first argument be a symbol (Safari)
 ## What went wrong?
 
 There was an unexpected type. This occurs oftentimes with {{jsxref("undefined")}} or
-{{jsxref("null")}} values.
+[`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) values.
 
 Also, certain methods, such as {{jsxref("Object.create()")}} or
 {{jsxref("Symbol.keyFor()")}}, require a specific type, that must be provided.
@@ -78,4 +78,4 @@ if (foo) {
 ## See also
 
 - {{jsxref("undefined")}}
-- {{jsxref("null")}}
+- [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)

--- a/files/en-us/web/javascript/reference/global_objects/boolean/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/boolean/index.md
@@ -14,11 +14,11 @@ The **`Boolean`** object is an object wrapper for a boolean value.
 
 ## Description
 
-The value passed as the first parameter is converted to a boolean value, if necessary. If the value is omitted or is `0`, `-0`, {{jsxref("null")}}, `false`, {{jsxref("NaN")}}, {{jsxref("undefined")}}, or the empty string (`""`), the object has an initial value of `false`. All other values, including any object, an empty array (`[]`), or the string "`false`", create an object with an initial value of `true`.
+The value passed as the first parameter is converted to a boolean value, if necessary. If the value is omitted or is `0`, `-0`, [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), `false`, {{jsxref("NaN")}}, {{jsxref("undefined")}}, or the empty string (`""`), the object has an initial value of `false`. All other values, including any object, an empty array (`[]`), or the string "`false`", create an object with an initial value of `true`.
 
 Do not confuse the {{Glossary("Primitive", "primitive")}} `Boolean` values `true` and `false` with the `true` and `false` values of the `Boolean` object.
 
-**Any** object of which the value is not {{jsxref("undefined")}} or {{jsxref("null")}}, including a `Boolean` object whose value is `false`, evaluates to `true` when passed to a conditional statement. For example, the condition in the following {{jsxref("Statements/if...else", "if")}} statement evaluates to `true`:
+**Any** object of which the value is not {{jsxref("undefined")}} or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), including a `Boolean` object whose value is `false`, evaluates to `true` when passed to a conditional statement. For example, the condition in the following {{jsxref("Statements/if...else", "if")}} statement evaluates to `true`:
 
 ```js
 const x = new Boolean(false);

--- a/files/en-us/web/javascript/reference/global_objects/json/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/json/index.md
@@ -21,7 +21,7 @@ it has no interesting functionality of its own.
 ### JavaScript and JSON differences
 
 JSON is a syntax for serializing objects, arrays, numbers, strings, booleans, and
-{{jsxref("null")}}. It is based upon JavaScript syntax but is distinct from it: some
+[`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null). It is based upon JavaScript syntax but is distinct from it: some
 JavaScript is _not_ JSON.
 
 - **Objects and Arrays**
@@ -124,7 +124,7 @@ whitespace characters.
     <var>replacer</var>[, <var>space</var>]])")}}
   - : Return a JSON string corresponding to the specified value, optionally including only
     certain properties or replacing property values in a user-defined manner. By default,
-    all instances of {{jsxref("undefined")}} are replaced with {{jsxref("null")}}, and
+    all instances of {{jsxref("undefined")}} are replaced with [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), and
     other unsupported native data types are censored. The `replacer`
     option allows for specifying other behavior.
 

--- a/files/en-us/web/javascript/reference/global_objects/math/abs/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/abs/index.md
@@ -43,7 +43,7 @@ created (`Math` is not a constructor).
 
 Passing an empty object, an array with more than one member, a non-numeric string or
 {{jsxref("undefined")}}/empty variable returns {{jsxref("NaN")}}. Passing
-{{jsxref("null")}}, an empty string or an empty array returns 0.
+[`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), an empty string or an empty array returns 0.
 
 ```js
 Math.abs('-1');     // 1

--- a/files/en-us/web/javascript/reference/global_objects/math/ceil/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/math/ceil/index.md
@@ -12,7 +12,7 @@ browser-compat: javascript.builtins.Math.ceil
 
 The **`Math.ceil()`** function always rounds a number up to the next largest integer.
 
-> **Note:** `Math.ceil({{jsxref("null")}})` returns integer 0 and does not give a {{jsxref("NaN")}} error.
+> **Note:** `Math.ceil([`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null))` returns integer 0 and does not give a {{jsxref("NaN")}} error.
 
 {{EmbedInteractiveExample("pages/js/math-ceil.html")}}
 

--- a/files/en-us/web/javascript/reference/global_objects/object/assign/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/assign/index.md
@@ -63,7 +63,7 @@ In case of an error, for example if a property is non-writable, a
 changed if any properties are added before the error is raised.
 
 > **Note:** `Object.assign()` does not throw on
-> {{jsxref("null")}} or {{jsxref("undefined")}} sources.
+> [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or {{jsxref("undefined")}} sources.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/object/create/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/create/index.md
@@ -44,7 +44,7 @@ A new object with the specified prototype object and properties.
 
 The `proto` parameter has to be either
 
-- {{jsxref("null")}} or
+- [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or
 - an {{jsxref("Object")}} excluding [primitive wrapper objects](/en-US/docs/Glossary/Primitive#primitive_wrapper_objects_in_javascript).
 
 If `proto` is neither of these a {{jsxref("TypeError")}} is thrown.

--- a/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md
@@ -101,7 +101,7 @@ descriptor has both \[`value` or `writable`] and \[`get` or `set`] keys, an exce
 Bear in mind that these attributes are not necessarily the descriptor's own properties.
 Inherited properties will be considered as well. In order to ensure these defaults are
 preserved, you might freeze the {{jsxref("Object")}} upfront, specify all
-options explicitly, or point to {{jsxref("null")}} with {{jsxref("Object.create",
+options explicitly, or point to [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) with {{jsxref("Object.create",
   "Object.create(null)")}}.
 
 ```js

--- a/files/en-us/web/javascript/reference/global_objects/object/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/index.md
@@ -19,7 +19,7 @@ Changes to the `Object` prototype object are seen by **all** objects through pro
 
 The `Object` constructor creates an object wrapper for the given value.
 
-- If the value is {{jsxref("null")}} or {{jsxref("undefined")}}, it will create and return an empty object.
+- If the value is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or {{jsxref("undefined")}}, it will create and return an empty object.
 - If the value is an object already, it will return the value.
 - Otherwise, it will return an object of a Type that corresponds to the given value.
 

--- a/files/en-us/web/javascript/reference/global_objects/object/is/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/is/index.md
@@ -40,7 +40,7 @@ A {{jsxref("Boolean")}} indicating whether or not the two arguments are the same
 `Object.is()` determines whether two values are [the same value](/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness). Two values are the same if one of the following holds:
 
 - both {{jsxref("undefined")}}
-- both {{jsxref("null")}}
+- both [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)
 - both `true` or both `false`
 - both strings of the same length with the same characters in the same order
 - both the same object (meaning both values reference the same object in memory)

--- a/files/en-us/web/javascript/reference/global_objects/object/object/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/object/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Object.Object
 The **`Object` constructor** creates an object wrapper for the
 given value.
 
-- If the value is {{jsxref("null")}} or {{jsxref("undefined")}}, it will create and
+- If the value is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or {{jsxref("undefined")}}, it will create and
   return an empty object.
 - Otherwise, it will return an object of a Type that corresponds to the given value.
 - If the value is an object already, it will return the value.

--- a/files/en-us/web/javascript/reference/global_objects/object/tostring/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/tostring/index.md
@@ -63,7 +63,7 @@ Object.prototype.toString.call(arr) // "[object Array]"
 
 The [`arguments`](/en-US/docs/Web/JavaScript/Reference/Functions/arguments) object returns `"[object Arguments]"`. Everything else, including user-defined classes, unless with a custom `Symbol.toStringTag`, will return `"[object Object]"`.
 
-`Object.prototype.toString()` invoked on {{jsxref("null")}} and {{jsxref("undefined")}} returns `[object Null]` and `[object Undefined]`, respectively.
+`Object.prototype.toString()` invoked on [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) and {{jsxref("undefined")}} returns `[object Null]` and `[object Undefined]`, respectively.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/reflect/getprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/getprototypeof/index.md
@@ -32,7 +32,7 @@ Reflect.getPrototypeOf(target)
 ### Return value
 
 The prototype of the given object. If there are no inherited properties,
-{{jsxref("null")}} is returned.
+[`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) is returned.
 
 ### Exceptions
 

--- a/files/en-us/web/javascript/reference/global_objects/reflect/setprototypeof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/reflect/setprototypeof/index.md
@@ -16,7 +16,7 @@ The static
 **`Reflect.setPrototypeOf()`** method is the same method as
 {{jsxref("Object.setPrototypeOf()")}}, except for its return type. It sets the
 prototype (i.e., the internal `[[Prototype]]` property) of a specified
-object to another object or to {{jsxref("null")}}, and returns `true` if
+object to another object or to [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), and returns `true` if
 the operation was successful, or `false` otherwise.
 
 {{EmbedInteractiveExample("pages/js/reflect-setprototypeof.html")}}
@@ -32,7 +32,7 @@ Reflect.setPrototypeOf(target, prototype)
 - `target`
   - : The target object of which to set the prototype.
 - `prototype`
-  - : The object's new prototype (an object or {{jsxref("null")}}).
+  - : The object's new prototype (an object or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)).
 
 ### Return value
 
@@ -42,7 +42,7 @@ A {{jsxref("Boolean")}} indicating whether or not the prototype was successfully
 
 A {{jsxref("TypeError")}}, if `target` is not an
 {{jsxref("Object")}} or if `prototype` is neither an object nor
-{{jsxref("null")}}.
+[`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@match/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@match/index.md
@@ -32,7 +32,7 @@ regexp[Symbol.match](str)
 ### Return value
 
 An {{jsxref("Array")}} containing the entire match result and any parentheses-captured
-matched results, or {{jsxref("null")}} if there were no matches.
+matched results, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if there were no matches.
 
 ## Description
 

--- a/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/exec/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.RegExp.exec
 
 The **`exec()`** method executes a
 search for a match in a specified string. Returns a result array, or
-{{jsxref("null")}}.
+[`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
 
 JavaScript {{jsxref("RegExp")}} objects are **stateful** when they have
 the {{jsxref("RegExp.global", "global")}} or {{jsxref("RegExp.sticky", "sticky")}} flags
@@ -55,7 +55,7 @@ set, `indices`; see below) and updates the
 The returned array has the matched text as the first item, and then one item for each
 parenthetical capture group of the matched text.
 
-If the match fails, the `exec()` method returns {{jsxref("null")}}, and sets
+If the match fails, the `exec()` method returns [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null), and sets
 {{jsxref("RegExp.lastIndex", "lastIndex")}} to `0`.
 
 ## Description

--- a/files/en-us/web/javascript/reference/global_objects/string/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/index.md
@@ -413,7 +413,7 @@ You must be careful which level of characters you are iterating on. For example,
 
 It's possible to use `String` as a more reliable
 {{jsxref("String.prototype.toString()", "toString()")}} alternative, as it works when
-used on {{jsxref("null")}} and {{jsxref("undefined")}}. For example:
+used on [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) and {{jsxref("undefined")}}. For example:
 
 ```js
 const nullVar = null;

--- a/files/en-us/web/javascript/reference/global_objects/string/match/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/match/index.md
@@ -37,7 +37,7 @@ match(regexp)
 
 ### Return value
 
-An {{jsxref("Array")}} whose contents depend on the presence or absence of the global (`g`) flag, or {{jsxref("null")}} if no matches are found. If the regular expression does not include the `g` flag, `str.match()` will return the same result as {{jsxref("RegExp.prototype.exec()", "RegExp.exec()")}}.
+An {{jsxref("Array")}} whose contents depend on the presence or absence of the global (`g`) flag, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if no matches are found. If the regular expression does not include the `g` flag, `str.match()` will return the same result as {{jsxref("RegExp.prototype.exec()", "RegExp.exec()")}}.
 
 - If the `g` flag is used, all results matching the complete regular
   expression will be returned, but capturing groups will not.

--- a/files/en-us/web/javascript/reference/global_objects/string/touppercase/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/touppercase/index.md
@@ -29,7 +29,7 @@ A new string representing the calling string converted to upper case.
 ### Exceptions
 
 - {{jsxref("TypeError")}}
-  - : When called on {{jsxref("null")}} or {{jsxref("undefined")}}, for example,
+  - : When called on [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or {{jsxref("undefined")}}, for example,
     `String.prototype.toUpperCase.call(undefined)`.
 
 ## Description

--- a/files/en-us/web/javascript/reference/global_objects/undefined/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/undefined/index.md
@@ -153,4 +153,4 @@ if (y === void 0) {
 ## See also
 
 - JavaScript's {{Glossary("Primitive", "primitive types")}}
-- {{jsxref("null")}}
+- [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/table/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/table/index.md
@@ -38,7 +38,7 @@ The **`WebAssembly.Table()`** object is a JavaScript wrapper object — an array
 
 ### Creating a new WebAssembly Table instance
 
-The following example (see table2.html [source code](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/table2.html) and [live version](https://mdn.github.io/webassembly-examples/js-api-examples/table2.html)) creates a new WebAssembly Table instance with an initial size of 2 elements. We then print out the table length and contents of the two indexes (retrieved via {{jsxref("WebAssembly/Table/get", "Table.prototype.get()")}} to show that the length is two and both elements are {{jsxref("null")}}.
+The following example (see table2.html [source code](https://github.com/mdn/webassembly-examples/blob/master/js-api-examples/table2.html) and [live version](https://mdn.github.io/webassembly-examples/js-api-examples/table2.html)) creates a new WebAssembly Table instance with an initial size of 2 elements. We then print out the table length and contents of the two indexes (retrieved via {{jsxref("WebAssembly/Table/get", "Table.prototype.get()")}} to show that the length is two and both elements are [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null).
 
 ```js
 const tbl = new WebAssembly.Table({ initial: 2, element: "anyfunc" });

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/table/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/table/set/index.md
@@ -54,7 +54,7 @@ creates a new WebAssembly Table instance with an initial size of 2
 references. We then print out the table length and contents of the two indexes
 (retrieved via {{jsxref("WebAssembly/Table/get","Table.prototype.get()")}}) to show that
 the length is two, and the indexes currently contain no function references (they
-currently return {{jsxref("null")}}).
+currently return [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)).
 
 ```js
 const tbl = new WebAssembly.Table({ initial: 2, element: "anyfunc" });

--- a/files/en-us/web/javascript/reference/lexical_grammar/index.md
+++ b/files/en-us/web/javascript/reference/lexical_grammar/index.md
@@ -282,7 +282,7 @@ A few identifiers have a special meaning in some contexts without being reserved
 
 ### Null literal
 
-See also {{jsxref("null")}} for more information.
+See also [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) for more information.
 
 ```js
 null

--- a/files/en-us/web/javascript/reference/operators/logical_or/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_or/index.md
@@ -106,7 +106,7 @@ o10 = false || varObject // f || object returns varObject
 
 > **Note:** If you use this operator to provide a default value to some
 > variable, be aware that any _falsy_ value will not be used. If you only need to
-> filter out {{jsxref("null")}} or {{jsxref("undefined")}}, consider using
+> filter out [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or {{jsxref("undefined")}}, consider using
 > [the nullish coalescing operator](/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator).
 
 ### Conversion rules for booleans

--- a/files/en-us/web/javascript/reference/operators/logical_or_assignment/index.md
+++ b/files/en-us/web/javascript/reference/operators/logical_or_assignment/index.md
@@ -70,7 +70,7 @@ rendering work, or loss of focus, etc.
 
 Note: Pay attention to the value returned by the API you're checking against. If an
 empty string is returned (a {{Glossary("falsy")}} value), `||=` must be used,
-otherwise you want to use the `??=` operator (for {{jsxref("null")}} or
+otherwise you want to use the `??=` operator (for [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or
 {{jsxref("undefined")}} return values).
 
 ## Specifications

--- a/files/en-us/web/javascript/reference/operators/nullish_coalescing_operator/index.md
+++ b/files/en-us/web/javascript/reference/operators/nullish_coalescing_operator/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.operators.nullish_coalescing
 
 The **nullish coalescing operator (`??`)** is a logical
 operator that returns its right-hand side operand when its left-hand side operand is
-{{jsxref("null")}} or {{jsxref("undefined")}}, and otherwise returns its left-hand side
+[`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or {{jsxref("undefined")}}, and otherwise returns its left-hand side
 operand.
 
 This can be seen as a special case of the [logical OR (`||`) operator](/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR),


### PR DESCRIPTION
I don't know why. (I never liked `{{jsxref("null")}}`)