### PR TITLE
Page for the new :modal pseudo-class

### DIFF
--- a/files/en-us/web/css/_colon_modal/index.md
+++ b/files/en-us/web/css/_colon_modal/index.md
@@ -103,7 +103,7 @@ favDialog.addEventListener('close', () => {
 
 ### Result
 
-{{EmbedLiveSample("Advanced_example", "100%", 300)}}
+{{EmbedLiveSample("Styling_a_modal_dialog", "100%", 300)}}
 
 ## Specifications
 

--- a/files/en-us/web/css/_colon_modal/index.md
+++ b/files/en-us/web/css/_colon_modal/index.md
@@ -60,10 +60,9 @@ This example styles a modal dialog that opens when the "Update details" button i
 
 ```css
 :modal {
-  position: absolute;
-  top: 10%;
-  left: 10%;
+  border: 5px solid red;
   background-color: yellow;
+  box-shadow: 3px 3px 10px rgba(0 0 0 / 0.5);
 }
 ```
 

--- a/files/en-us/web/css/_colon_modal/index.md
+++ b/files/en-us/web/css/_colon_modal/index.md
@@ -1,0 +1,120 @@
+---
+title: ':modal'
+slug: Web/CSS/:modal
+tags:
+  - CSS
+  - Modal
+  - Pseudo-class
+  - Reference
+  - Selector
+browser-compat: css.selectors.modal
+---
+{{CSSRef}}
+
+The **`:modal`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) matches an element that is in a state in which it excludes all interaction with elements outside it until the interaction has been dismissed. Multiple elements can be selected by the `:modal` pseudo-class at the same time, but only one of them will be active and able to receive input.
+
+## Syntax
+
+```
+:modal
+```
+
+## Usage notes
+
+Examples of elements that will prevent user interaction with the rest of the page and will be selected by the `:modal` pseudo-class include:
+
+- The [`dialog`](/en-US/docs/Web/HTML/Element/dialog) element opened with the `showModal()` API.
+- The element selected by the [`:fullscreen`](/en-US/docs/Web/CSS/:fullscreen) pseudo-class when opened with the `requestFullscreen()` API.
+
+## Examples
+
+### Styling a modal dialog
+
+This example styles a modal dialog that opens when the "Update details" button is activated. This example has been built on top of the dialog element [example](/en-US/docs/Web/HTML/Element/dialog#advanced_example).
+
+```html hidden
+<!-- Simple modal dialog containing a form -->
+<dialog id="favDialog">
+  <form method="dialog">
+    <p><label>Favorite animal:
+      <select>
+        <option value="default">Choose…</option>
+        <option>Brine shrimp</option>
+        <option>Red panda</option>
+        <option>Spider monkey</option>
+      </select>
+    </label></p>
+    <div>
+      <button value="cancel">Cancel</button>
+      <button id="confirmBtn" value="default">Confirm</button>
+    </div>
+  </form>
+</dialog>
+<p>
+  <button id="updateDetails">Update details</button>
+</p>
+<output></output>
+```
+
+#### CSS
+
+```css
+:modal {
+  position: absolute;
+  top: 10%;
+  left: 10%;
+  background-color: yellow;
+}
+```
+
+```js hidden
+const updateButton = document.getElementById('updateDetails');
+const favDialog = document.getElementById('favDialog');
+const outputBox = document.querySelector('output');
+const selectEl = favDialog.querySelector('select');
+const confirmBtn = favDialog.querySelector('#confirmBtn');
+
+// If a browser doesn't support the dialog, then hide the
+// dialog contents by default.
+if (typeof favDialog.showModal !== 'function') {
+  favDialog.hidden = true;
+  /* a fallback script to allow this dialog/form to function
+     for legacy browsers that do not support <dialog>
+     could be provided here.
+  */
+}
+// "Update details" button opens the <dialog> modally
+updateButton.addEventListener('click', () => {
+  if (typeof favDialog.showModal === "function") {
+    favDialog.showModal();
+  } else {
+    outputBox.value = "Sorry, the <dialog> API is not supported by this browser.";
+  }
+});
+// "Favorite animal" input sets the value of the submit button
+selectEl.addEventListener('change', (e) => {
+  confirmBtn.value = selectEl.value;
+});
+// "Confirm" button of form triggers "close" on dialog because of [method="dialog"]
+favDialog.addEventListener('close', () => {
+  outputBox.value = favDialog.returnValue + " button clicked - " + (new Date()).toString();
+});
+```
+
+### Result
+
+{{EmbedLiveSample("Advanced_example", "100%", 300)}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [`dialog`](/en-US/docs/Web/HTML/Element/dialog) element
+- Other element display state pseudo-classes: {{CSSxRef(":fullscreen")}} and {{CSSxRef(":picture-in-picture")}}
+- Complete list of [pseudo-classes](/en-US/docs/Web/CSS/Pseudo-classes)

--- a/files/en-us/web/css/pseudo-classes/index.md
+++ b/files/en-us/web/css/pseudo-classes/index.md
@@ -54,23 +54,23 @@ These pseudo-classes relate to form elements, and enable selecting elements base
 - {{CSSxRef(":read-write")}}
   - : Represents any element that is user-editable.
 - {{CSSxRef(":placeholder-shown")}}
-  - : Matches an input element that is displaying placeholder text, for example from the HTML5 `placeholder` attribute.
+  - : Matches an input element that is displaying placeholder text. For example, it will match the `placeholder` attribute in the {{htmlelement("input")}} and {{htmlelement("textarea")}} elements.
 - {{CSSxRef(":default")}}
   - : Matches one or more UI elements that are the default among a set of elements.
 - {{CSSxRef(":checked")}}
-  - : Matches when elements such as checkboxes and radiobuttons are toggled on.
+  - : Matches when elements such as checkboxes and radio buttons are toggled on.
 - {{CSSxRef(":indeterminate")}}
-  - : Matches when UI elements are in an indeterminate state.
+  - : Matches UI elements when they are in an indeterminate state.
 - {{CSSxRef(":blank")}}
   - : Matches a user-input element which is empty, containing an empty string or other null input.
 - {{CSSxRef(":valid")}}
-  - : Matches an element with valid contents. For example an input element with type 'email' which contains a validly formed email address.
+  - : Matches an element with valid contents. For example, an input element with the type 'email' that contains a validly formed email address or an empty value if the control is not required.
 - {{CSSxRef(":invalid")}}
-  - : Matches an element with invalid contents. For example an input element with type 'email' with a name entered.
+  - : Matches an element with invalid contents. For example, an input element with type 'email' with a name entered.
 - {{CSSxRef(":in-range")}}
-  - : Applies to elements with range limitations, for example a slider control, when the selected value is in the allowed range.
+  - : Applies to elements with range limitations. For example, a slider control when the selected value is in the allowed range.
 - {{CSSxRef(":out-of-range")}}
-  - : Applies to elements with range limitations, for example a slider control, when the selected value is outside the allowed range.
+  - : Applies to elements with range limitations. For example, a slider control when the selected value is outside the allowed range.
 - {{CSSxRef(":required")}}
   - : Matches when a form element is required.
 - {{CSSxRef(":optional")}}
@@ -82,9 +82,9 @@ These pseudo-classes relate to form elements, and enable selecting elements base
 
 These pseudo-classes reflect the document language, and enable the selection of elements based on language or script direction.
 
-- {{CSSxRef(":dir")}}
+- {{CSSxRef(":dir()")}}
   - : The directionality pseudo-class selects an element based on its directionality as determined by the document language.
-- {{CSSxRef(":lang")}}
+- {{CSSxRef(":lang()")}}
   - : Select an element based on its content language.
 
 ## Location pseudo-classes
@@ -98,7 +98,7 @@ These pseudo-classes relate to links, and to targeted elements within the curren
 - {{CSSxRef(":visited")}}
   - : Matches links that have been visited.
 - {{CSSxRef(":local-link")}}
-  - : Matches links whose absolute URL is the same as the target URL, for example anchor links to the same page.
+  - : Matches links whose absolute URL is the same as the target URL. For example, anchor links to the same page.
 - {{CSSxRef(":target")}}
   - : Matches the element which is the target of the document URL.
 - {{CSSxRef(":target-within")}}
@@ -143,7 +143,7 @@ These pseudo-classes relate to the location of an element within the document tr
 - {{CSSxRef(":last-child")}}
   - : Matches an element that is the last of its siblings.
 - {{CSSxRef(":only-child")}}
-  - : Matches an element that has no siblings. For example a list item with no other list items in that list.
+  - : Matches an element that has no siblings. For example, a list item with no other list items in that list.
 - {{CSSxRef(":nth-of-type")}}
   - : Uses A*n*+B notation to select elements from a list of sibling elements that match a certain type from a list of sibling elements.
 - {{CSSxRef(":nth-last-of-type")}}
@@ -160,9 +160,9 @@ These pseudo-classes relate to the location of an element within the document tr
 These pseudo-classes require some interaction by the user in order for them to apply, such as holding a mouse pointer over an element.
 
 - {{CSSxRef(":hover")}}
-  - : Matches when a user designates an item with a pointing device, for example holding the mouse pointer over it.
+  - : Matches when a user designates an item with a pointing device, such as holding the mouse pointer over the item.
 - {{CSSxRef(":active")}}
-  - : Matches when an item is being activated by the user, for example clicked on.
+  - : Matches when an item is being activated by the user. For example, when the item is clicked on.
 - {{CSSxRef(":focus")}}
   - : Matches when an element has focus.
 - {{CSSxRef(":focus-visible")}}

--- a/files/en-us/web/css/pseudo-classes/index.md
+++ b/files/en-us/web/css/pseudo-classes/index.md
@@ -28,70 +28,18 @@ Pseudo-classes let you apply a style to an element not only in relation to the c
 
 > **Note:** In contrast to pseudo-classes, [pseudo-elements](/en-US/docs/Web/CSS/Pseudo-elements) can be used to style a _specific part_ of an element.
 
-## Linguistic pseudo-classes
+## Element display state pseudo-classes
 
-These pseudo-classes reflect the document language, and enable the selection of elements based on language or script direction.
+These pseudo-classes enable the selection of elements based on their display states.
 
-- {{CSSxRef(":dir")}}
-  - : The directionality pseudo-class selects an element based on its directionality as determined by the document language.
-- {{CSSxRef(":lang")}}
-  - : Select an element based on its content language.
+- {{CSSxRef(":fullscreen")}}
+  - : Matches an element that is currently in fullscreen mode.
+- {{CSSxRef(":modal")}}
+  - : Matches an element that is in a state in which it excludes all interaction with elements outside it until the interaction has been dismissed.
+- {{CSSxRef(":picture-in-picture")}}
+  - : Matches an element that is currently in picture-in-picture mode.
 
-## Location pseudo-classes
-
-These pseudo-classes relate to links, and to targeted elements within the current document.
-
-- {{CSSxRef(":any-link")}}
-  - : Matches an element if the element would match either {{CSSxRef(":link")}} or {{CSSxRef(":visited")}}.
-- {{CSSxRef(":link")}}
-  - : Matches links that have not yet been visited.
-- {{CSSxRef(":visited")}}
-  - : Matches links that have been visited.
-- {{CSSxRef(":local-link")}}
-  - : Matches links whose absolute URL is the same as the target URL, for example anchor links to the same page.
-- {{CSSxRef(":target")}}
-  - : Matches the element which is the target of the document URL.
-- {{CSSxRef(":target-within")}}
-  - : Matches elements which are the target of the document URL, but also elements which have a descendant which is the target of the document URL.
-- {{CSSxRef(":scope")}}
-  - : Represents elements that are a reference point for selectors to match against.
-
-## User action pseudo-classes
-
-These pseudo-classes require some interaction by the user in order for them to apply, such as holding a mouse pointer over an element.
-
-- {{CSSxRef(":hover")}}
-  - : Matches when a user designates an item with a pointing device, for example holding the mouse pointer over it.
-- {{CSSxRef(":active")}}
-  - : Matches when an item is being activated by the user, for example clicked on.
-- {{CSSxRef(":focus")}}
-  - : Matches when an element has focus.
-- {{CSSxRef(":focus-visible")}}
-  - : Matches when an element has focus and the user agent identifies that the element should be visibly focused.
-- {{CSSxRef(":focus-within")}}
-  - : Matches an element to which {{CSSxRef(":focus")}} applies, plus any element that has a descendant to which {{CSSxRef(":focus")}} applies.
-
-## Time-dimensional pseudo-classes
-
-These pseudo-classes apply when viewing something which has timing, such as a [WebVTT](/en-US/docs/Web/API/WebVTT_API) caption track.
-
-- {{CSSxRef(":current")}}
-  - : Represents the element or ancestor of the element that is being displayed.
-- {{CSSxRef(":past")}}
-  - : Represents an element that occurs entirely before the {{CSSxRef(":current")}} element.
-- {{CSSxRef(":future")}}
-  - : Represents an element that occurs entirely after the {{CSSxRef(":current")}} element.
-
-## Resource state pseudo-classes
-
-These pseudo-classes apply to media that is capable of being in a state where it would be described as playing, such as a video.
-
-- {{CSSxRef(":playing")}}
-  - : Represents a media element that is capable of playing when that element is playing.
-- {{CSSxRef(":paused")}}
-  - : Represents a media element that is capable of playing when that element is paused.
-
-## The input pseudo-classes
+## Input pseudo-classes
 
 These pseudo-classes relate to form elements, and enable selecting elements based on HTML attributes and the state that the field is in before and after interaction.
 
@@ -130,6 +78,54 @@ These pseudo-classes relate to form elements, and enable selecting elements base
 - {{CSSxRef(":user-invalid")}}
   - : Represents an element with incorrect input, but only when the user has interacted with it.
 
+## Linguistic pseudo-classes
+
+These pseudo-classes reflect the document language, and enable the selection of elements based on language or script direction.
+
+- {{CSSxRef(":dir")}}
+  - : The directionality pseudo-class selects an element based on its directionality as determined by the document language.
+- {{CSSxRef(":lang")}}
+  - : Select an element based on its content language.
+
+## Location pseudo-classes
+
+These pseudo-classes relate to links, and to targeted elements within the current document.
+
+- {{CSSxRef(":any-link")}}
+  - : Matches an element if the element would match either {{CSSxRef(":link")}} or {{CSSxRef(":visited")}}.
+- {{CSSxRef(":link")}}
+  - : Matches links that have not yet been visited.
+- {{CSSxRef(":visited")}}
+  - : Matches links that have been visited.
+- {{CSSxRef(":local-link")}}
+  - : Matches links whose absolute URL is the same as the target URL, for example anchor links to the same page.
+- {{CSSxRef(":target")}}
+  - : Matches the element which is the target of the document URL.
+- {{CSSxRef(":target-within")}}
+  - : Matches elements which are the target of the document URL, but also elements which have a descendant which is the target of the document URL.
+- {{CSSxRef(":scope")}}
+  - : Represents elements that are a reference point for selectors to match against.
+
+## Resource state pseudo-classes
+
+These pseudo-classes apply to media that is capable of being in a state where it would be described as playing, such as a video.
+
+- {{CSSxRef(":playing")}}
+  - : Represents a media element that is capable of playing when that element is playing.
+- {{CSSxRef(":paused")}}
+  - : Represents a media element that is capable of playing when that element is paused.
+
+## Time-dimensional pseudo-classes
+
+These pseudo-classes apply when viewing something which has timing, such as a [WebVTT](/en-US/docs/Web/API/WebVTT_API) caption track.
+
+- {{CSSxRef(":current")}}
+  - : Represents the element or ancestor of the element that is being displayed.
+- {{CSSxRef(":past")}}
+  - : Represents an element that occurs entirely before the {{CSSxRef(":current")}} element.
+- {{CSSxRef(":future")}}
+  - : Represents an element that occurs entirely after the {{CSSxRef(":current")}} element.
+
 ## Tree-structural pseudo-classes
 
 These pseudo-classes relate to the location of an element within the document tree.
@@ -158,6 +154,21 @@ These pseudo-classes relate to the location of an element within the document tr
   - : Matches an element that is the last of its siblings, and also matches a certain type selector.
 - {{CSSxRef(":only-of-type")}}
   - : Matches an element that has no siblings of the chosen type selector.
+
+## User action pseudo-classes
+
+These pseudo-classes require some interaction by the user in order for them to apply, such as holding a mouse pointer over an element.
+
+- {{CSSxRef(":hover")}}
+  - : Matches when a user designates an item with a pointing device, for example holding the mouse pointer over it.
+- {{CSSxRef(":active")}}
+  - : Matches when an item is being activated by the user, for example clicked on.
+- {{CSSxRef(":focus")}}
+  - : Matches when an element has focus.
+- {{CSSxRef(":focus-visible")}}
+  - : Matches when an element has focus and the user agent identifies that the element should be visibly focused.
+- {{CSSxRef(":focus-within")}}
+  - : Matches an element to which {{CSSxRef(":focus")}} applies, plus any element that has a descendant to which {{CSSxRef(":focus")}} applies.
 
 ## Syntax
 
@@ -234,6 +245,10 @@ L
 - {{CSSxRef(":left")}}
 - {{CSSxRef(":link")}}
 - {{CSSxRef(":local-link")}} {{Experimental_Inline}}
+
+M
+
+- {{CSSxRef(":modal")}}
 
 N
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
- Added a new page for the `:modal `pseudo class
- Updated the existing Pseudo classes page to:
   - Arrange the categories alphabetically
   - Add a category for "Element display state pseudo classes" (https://www.w3.org/TR/selectors-4/#display-state-pseudos)
   - Add `:modal` to the alphabetical index

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The new pseudo class has been implemented (made available) in FF103.

[https://github.com/mdn/content/issues/17470#issuecomment-1192654305:
On chrome it's shipping in 106: https://chromestatus.com/feature/5192833009975296
On safari it's available since 15.6: https://developer.apple.com/documentation/safari-release-notes/safari-15_6-release-notes]

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Bug tracker: https://bugzilla.mozilla.org/show_bug.cgi?id=1768535
Spec: https://www.w3.org/TR/selectors-4/#modal-state

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Doc issue tracker: https://github.com/mdn/content/issues/17470

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [X] Adds a new document
- [X] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
