### PR TITLE
no more vars in Web/API (5)

### DIFF
--- a/files/en-us/web/api/document/origin/index.md
+++ b/files/en-us/web/api/document/origin/index.md
@@ -28,14 +28,14 @@ A string containing the document's origin.
 ## Examples
 
 ```js
-var origin = document.origin;
-// On this page, returns:'https://developer.mozilla.org'
+console.log(document.origin);
+// On this page, logs: 'https://developer.mozilla.org'
 
-var origin = document.origin;
-// On "about:blank", returns:'null'
+console.log(document.origin);
+// On "about:blank", logs: 'null'
 
-var origin = document.origin;
-// On "data:text/html,<p>foo</p>", returns:'null'
+console.log(document.origin);
+// On "data:text/html,<p>foo</p>", logs: 'null'
 ```
 
 ## Browser compatibility

--- a/files/en-us/web/api/domimplementation/createdocument/index.md
+++ b/files/en-us/web/api/domimplementation/createdocument/index.md
@@ -41,8 +41,8 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var doc = document.implementation.createDocument ('http://www.w3.org/1999/xhtml', 'html', null);
-var body = document.createElementNS('http://www.w3.org/1999/xhtml', 'body');
+const doc = document.implementation.createDocument('http://www.w3.org/1999/xhtml', 'html', null);
+const body = document.createElementNS('http://www.w3.org/1999/xhtml', 'body');
 body.setAttribute('id', 'abc');
 doc.documentElement.appendChild(body);
 alert(doc.getElementById('abc')); // [object HTMLBodyElement]

--- a/files/en-us/web/api/hmdvrdevice/index.md
+++ b/files/en-us/web/api/hmdvrdevice/index.md
@@ -42,16 +42,16 @@ The following example, taken from the WebVR spec, finds the first available `HMD
 
 ```js
 navigator.getVRDevices().then(function(devices) {
-  for (var i = 0; i < devices.length; ++i) {
-    if (devices[i] instanceof HMDVRDevice) {
-      gHMD = devices[i];
+  for (const device of devices) {
+    if (device instanceof HMDVRDevice) {
+      gHMD = device;
       break;
     }
   }
 
   if (gHMD) {
-    for (var i = 0; i < devices.length; ++i) {
-      if (devices[i] instanceof PositionSensorVRDevice && devices[i].hardwareUnitId === gHMD.hardwareUnitId) {
+    for (const device of devices) {
+      if (device instanceof PositionSensorVRDevice && device.hardwareUnitId === gHMD.hardwareUnitId) {
         gPositionSensor = devices[i];
         break;
       }

--- a/files/en-us/web/api/screen/unlockorientation/index.md
+++ b/files/en-us/web/api/screen/unlockorientation/index.md
@@ -40,7 +40,7 @@ Returns `true` if the orientation was successfully unlocked or
 ## Examples
 
 ```js
-var unlockOrientation = screen.unlockOrientation || screen.mozUnlockOrientation || screen.msUnlockOrientation || (screen.orientation && screen.orientation.unlock);
+const unlockOrientation = screen.unlockOrientation || screen.mozUnlockOrientation || screen.msUnlockOrientation || (screen.orientation && screen.orientation.unlock);
 
 if (unlockOrientation()) {
   // orientation was unlocked

--- a/files/en-us/web/api/screen_capture_api/using_screen_capture/index.md
+++ b/files/en-us/web/api/screen_capture_api/using_screen_capture/index.md
@@ -176,7 +176,7 @@ const stopElem = document.getElementById("stop");
 
 // Options for getDisplayMedia()
 
-var displayMediaOptions = {
+const displayMediaOptions = {
   video: {
     cursor: "always"
   },

--- a/files/en-us/web/api/selection/collapse/index.md
+++ b/files/en-us/web/api/selection/collapse/index.md
@@ -42,7 +42,7 @@ None ({{jsxref("undefined")}}).
 
 ```js
 /* Place the caret at the beginning of an HTML document's body. */
-var body = document.getElementsByTagName("body")[0];
+const body = document.getElementsByTagName("body")[0];
 window.getSelection().collapse(body,0);
 ```
 

--- a/files/en-us/web/api/selection/collapse/index.md
+++ b/files/en-us/web/api/selection/collapse/index.md
@@ -42,7 +42,7 @@ None ({{jsxref("undefined")}}).
 
 ```js
 /* Place the caret at the beginning of an HTML document's body. */
-const body = document.getElementsByTagName("body")[0];
+const body = document.querySelector("body");
 window.getSelection().collapse(body,0);
 ```
 

--- a/files/en-us/web/api/selection/index.md
+++ b/files/en-us/web/api/selection/index.md
@@ -72,7 +72,7 @@ A user may make a selection from left to right (in document order) or right to l
 Calling the {{DOMxRef("Selection.toString()")}} method returns the text contained within the selection, e.g.:
 
 ```js
-var selObj = window.getSelection();
+const selObj = window.getSelection();
 window.alert(selObj);
 ```
 
@@ -83,8 +83,8 @@ Note that using a selection object as the argument to `window.alert` will call t
 A selection object represents the {{DOMxRef("Range")}}s that the user has selected. Typically, it holds only one range, accessed as follows:
 
 ```js
-var selObj = window.getSelection();
-var range  = selObj.getRangeAt(0);
+const selObj = window.getSelection();
+const range  = selObj.getRangeAt(0);
 ```
 
 - `selObj` is a Selection object

--- a/files/en-us/web/api/selection/removerange/index.md
+++ b/files/en-us/web/api/selection/removerange/index.md
@@ -35,9 +35,9 @@ None ({{jsxref("undefined")}}).
 ```js
 /* Programmatically, more than one range can be selected.
  * This will remove all ranges except the first. */
-s = window.getSelection();
-if(s.rangeCount > 1) {
- for(var i = 1; i < s.rangeCount; i++) {
+const s = window.getSelection();
+if (s.rangeCount > 1) {
+ for (let i = 1; i < s.rangeCount; i++) {
   s.removeRange(s.getRangeAt(i));
  }
 }

--- a/files/en-us/web/api/selection/setbaseandextent/index.md
+++ b/files/en-us/web/api/selection/setbaseandextent/index.md
@@ -110,7 +110,7 @@ button.onclick = function() {
     selection.setBaseAndExtent(one, aOffset.value, two, fOffset.value);
     const text = selection.toString();
     output.textContent = text;
-  } catch(e) {
+  } catch (e) {
     output.textContent = e.message;
   }
 }

--- a/files/en-us/web/api/selection/setbaseandextent/index.md
+++ b/files/en-us/web/api/selection/setbaseandextent/index.md
@@ -92,23 +92,23 @@ selection into the output paragraph at the very bottom of the HTML.
 The JavaScript looks like so:
 
 ```js
-var one = document.querySelector('.one');
-var two = document.querySelector('.two');
+const one = document.querySelector('.one');
+const two = document.querySelector('.two');
 
-var aOffset = document.getElementById('aOffset');
-var fOffset = document.getElementById('fOffset');
+const aOffset = document.getElementById('aOffset');
+const fOffset = document.getElementById('fOffset');
 
-var button = document.querySelector('button');
+const button = document.querySelector('button');
 
-var output = document.querySelector('.output');
+const output = document.querySelector('.output');
 
-var selection;
+let selection;
 
 button.onclick = function() {
   try {
     selection = document.getSelection();
     selection.setBaseAndExtent(one, aOffset.value, two, fOffset.value);
-    var text = selection.toString();
+    const text = selection.toString();
     output.textContent = text;
   } catch(e) {
     output.textContent = e.message;

--- a/files/en-us/web/api/selection/type/index.md
+++ b/files/en-us/web/api/selection/type/index.md
@@ -37,7 +37,7 @@ In this example, the event handler will fire each time a new selection is made.
 text, or a range has been selected.
 
 ```js
-var selection;
+let selection;
 
 document.onselectionchange = function() {
   console.log('New selection made');

--- a/files/en-us/web/api/serviceworker/state/index.md
+++ b/files/en-us/web/api/serviceworker/state/index.md
@@ -43,7 +43,7 @@ This code snippet is from the [service worker registration-events sample](https:
 and returns its value.
 
 ```js
-var serviceWorker;
+let serviceWorker;
 if (registration.installing) {
   serviceWorker = registration.installing;
   document.querySelector('#kind').textContent = 'installing';

--- a/files/en-us/web/api/serviceworker/statechange_event/index.md
+++ b/files/en-us/web/api/serviceworker/statechange_event/index.md
@@ -35,7 +35,7 @@ This code snippet is from the [service worker registration-events sample](https:
 and returns its value.
 
 ```js
-var serviceWorker;
+let serviceWorker;
 if (registration.installing) {
   serviceWorker = registration.installing;
   document.querySelector('#kind').textContent = 'installing';

--- a/files/en-us/web/api/serviceworkerregistration/getnotifications/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/getnotifications/index.md
@@ -52,7 +52,7 @@ A {{jsxref("Promise")}} that resolves to a list of {{domxref("Notification")}} o
 ```js
 navigator.serviceWorker.register('sw.js');
 
-var options = { tag : 'user_alerts' };
+const options = { tag : 'user_alerts' };
 
 navigator.serviceWorker.ready.then(function(registration) {
   registration.getNotifications(options).then(function(notifications) {

--- a/files/en-us/web/api/setinterval/index.md
+++ b/files/en-us/web/api/setinterval/index.md
@@ -81,7 +81,7 @@ avoid confusion when maintaining your code.
 The following example demonstrates `setInterval()`'s basic syntax.
 
 ```js
-var intervalID = setInterval(myCallback, 500, 'Parameter 1', 'Parameter 2');
+const intervalID = setInterval(myCallback, 500, 'Parameter 1', 'Parameter 2');
 
 function myCallback(a, b)
 {

--- a/files/en-us/web/api/sharedworker/error_event/index.md
+++ b/files/en-us/web/api/sharedworker/error_event/index.md
@@ -36,7 +36,7 @@ A generic {{domxref("Event")}}.
 The following code snippet creates a {{domxref("SharedWorker")}} object using the {{domxref("SharedWorker.SharedWorker", "SharedWorker()")}} constructor and sets up an `onerror` handler on the resulting object:
 
 ```js
-var mySharedWorker = new SharedWorker('shared-worker.js');
+const mySharedWorker = new SharedWorker('shared-worker.js');
 
 mySharedWorker.onerror = function(event) {
   console.log('There is an error with your worker!');

--- a/files/en-us/web/api/sharedworker/port/index.md
+++ b/files/en-us/web/api/sharedworker/port/index.md
@@ -30,7 +30,7 @@ using the `SharedWorker.port` property — the port is started using its
 `start()` method:
 
 ```js
-var myWorker = new SharedWorker('worker.js');
+const myWorker = new SharedWorker('worker.js');
 myWorker.port.start();
 ```
 

--- a/files/en-us/web/api/sharedworker/sharedworker/index.md
+++ b/files/en-us/web/api/sharedworker/sharedworker/index.md
@@ -76,7 +76,7 @@ The following code snippet shows creation of a {{domxref("SharedWorker")}} objec
 the `SharedWorker()` constructor and subsequent usage of the object:
 
 ```js
-var myWorker = new SharedWorker('worker.js');
+const myWorker = new SharedWorker('worker.js');
 
 myWorker.port.start();
 

--- a/files/en-us/web/api/sharedworkerglobalscope/name/index.md
+++ b/files/en-us/web/api/sharedworkerglobalscope/name/index.md
@@ -28,7 +28,7 @@ A string.
 If a shared worker is created using a constructor with a `name` option:
 
 ```js
-var myWorker = new SharedWorker("worker.js", { name : "mySharedWorker" });
+const myWorker = new SharedWorker("worker.js", { name : "mySharedWorker" });
 ```
 
 the {{domxref("SharedWorkerGlobalScope")}} will now have a name of "mySharedWorker",

--- a/files/en-us/web/api/speechgrammar/index.md
+++ b/files/en-us/web/api/speechgrammar/index.md
@@ -34,9 +34,9 @@ Grammar is defined using [JSpeech Grammar Format](https://www.w3.org/TR/jsgf/) (
 ## Examples
 
 ```js
-var grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
-var recognition = new SpeechRecognition();
-var speechRecognitionList = new SpeechGrammarList();
+const grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
+const recognition = new SpeechRecognition();
+const speechRecognitionList = new SpeechGrammarList();
 speechRecognitionList.addFromString(grammar, 1);
 recognition.grammars = speechRecognitionList;
 

--- a/files/en-us/web/api/speechgrammar/speechgrammar/index.md
+++ b/files/en-us/web/api/speechgrammar/speechgrammar/index.md
@@ -32,13 +32,13 @@ None.
 ## Examples
 
 ```js
-var grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
-var recognition = new SpeechRecognition();
-var speechRecognitionList = new SpeechGrammarList();
+const grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
+const recognition = new SpeechRecognition();
+const speechRecognitionList = new SpeechGrammarList();
 speechRecognitionList.addFromString(grammar, 1);
 recognition.grammars = speechRecognitionList;
 
-var newGrammar = new SpeechGrammar();
+const newGrammar = new SpeechGrammar();
 newGrammar.src = '#JSGF V1.0; grammar names; public <name> = chris | kirsty | mike;'
 speechRecognitionList[1] = newGrammar; // should add the new SpeechGrammar object to the list
 ```

--- a/files/en-us/web/api/speechgrammar/src/index.md
+++ b/files/en-us/web/api/speechgrammar/src/index.md
@@ -27,9 +27,9 @@ A string representing the grammar.
 ## Examples
 
 ```js
-var grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
-var recognition = new SpeechRecognition();
-var speechRecognitionList = new SpeechGrammarList();
+const grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
+const recognition = new SpeechRecognition();
+const speechRecognitionList = new SpeechGrammarList();
 speechRecognitionList.addFromString(grammar, 1);
 recognition.grammars = speechRecognitionList;
 

--- a/files/en-us/web/api/speechgrammar/weight/index.md
+++ b/files/en-us/web/api/speechgrammar/weight/index.md
@@ -27,9 +27,9 @@ A float representing the weight of the grammar, in the range 0.0–1.0.
 ## Examples
 
 ```js
-var grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
-var recognition = new SpeechRecognition();
-var speechRecognitionList = new SpeechGrammarList();
+const grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
+const recognition = new SpeechRecognition();
+const speechRecognitionList = new SpeechGrammarList();
 speechRecognitionList.addFromString(grammar, 1);
 recognition.grammars = speechRecognitionList;
 

--- a/files/en-us/web/api/speechgrammarlist/addfromstring/index.md
+++ b/files/en-us/web/api/speechgrammarlist/addfromstring/index.md
@@ -46,9 +46,9 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
-var recognition = new SpeechRecognition();
-var speechRecognitionList = new SpeechGrammarList();
+const grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
+const recognition = new SpeechRecognition();
+const speechRecognitionList = new SpeechGrammarList();
 speechRecognitionList.addFromString(grammar, 1);
 recognition.grammars = speechRecognitionList;
 ```

--- a/files/en-us/web/api/speechgrammarlist/addfromuri/index.md
+++ b/files/en-us/web/api/speechgrammarlist/addfromuri/index.md
@@ -49,9 +49,9 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
-var recognition = new SpeechRecognition();
-var speechRecognitionList = new SpeechGrammarList();
+const grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
+const recognition = new SpeechRecognition();
+const speechRecognitionList = new SpeechGrammarList();
 speechRecognitionList.addFromString(grammar, 1);
 recognition.grammars = speechRecognitionList;
 

--- a/files/en-us/web/api/speechgrammarlist/index.md
+++ b/files/en-us/web/api/speechgrammarlist/index.md
@@ -43,9 +43,9 @@ Grammar is defined using [JSpeech Grammar Format](https://www.w3.org/TR/jsgf/) (
 In our simple [Speech color changer](https://github.com/mdn/dom-examples/tree/master/web-speech-api/speech-color-changer) example, we create a new `SpeechRecognition` object instance using the {{domxref("SpeechRecognition.SpeechRecognition", "SpeechRecognition()")}} constructor, create a new {{domxref("SpeechGrammarList")}}, add our grammar string to it using the {{domxref("SpeechGrammarList.addFromString")}} method, and set it to be the grammar that will be recognized by the `SpeechRecognition` instance using the {{domxref("SpeechRecognition.grammars")}} property.
 
 ```js
-var grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
-var recognition = new SpeechRecognition();
-var speechRecognitionList = new SpeechGrammarList();
+const grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
+const recognition = new SpeechRecognition();
+const speechRecognitionList = new SpeechGrammarList();
 speechRecognitionList.addFromString(grammar, 1);
 recognition.grammars = speechRecognitionList;
 ```

--- a/files/en-us/web/api/speechgrammarlist/length/index.md
+++ b/files/en-us/web/api/speechgrammarlist/length/index.md
@@ -28,9 +28,9 @@ A number indicating the number of {{domxref("SpeechGrammar")}} objects contained
 ## Examples
 
 ```js
-var grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
-var recognition = new SpeechRecognition();
-var speechRecognitionList = new SpeechGrammarList();
+const grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
+const recognition = new SpeechRecognition();
+const speechRecognitionList = new SpeechGrammarList();
 speechRecognitionList.addFromString(grammar, 1);
 recognition.grammars = speechRecognitionList;
 

--- a/files/en-us/web/api/speechgrammarlist/speechgrammarlist/index.md
+++ b/files/en-us/web/api/speechgrammarlist/speechgrammarlist/index.md
@@ -39,9 +39,9 @@ method, and set it to be the grammar that will be recognized by the
 {{domxref("SpeechRecognition.grammars")}} property.
 
 ```js
-var grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
-var recognition = new SpeechRecognition();
-var speechRecognitionList = new SpeechGrammarList();
+const grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
+const recognition = new SpeechRecognition();
+const speechRecognitionList = new SpeechGrammarList();
 speechRecognitionList.addFromString(grammar, 1);
 recognition.grammars = speechRecognitionList;
 ```

--- a/files/en-us/web/api/speechrecognition/abort/index.md
+++ b/files/en-us/web/api/speechrecognition/abort/index.md
@@ -36,14 +36,14 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
-var recognition = new SpeechRecognition();
-var speechRecognitionList = new SpeechGrammarList();
+const grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
+const recognition = new SpeechRecognition();
+const speechRecognitionList = new SpeechGrammarList();
 speechRecognitionList.addFromString(grammar, 1);
 recognition.grammars = speechRecognitionList;
 
-var diagnostic = document.querySelector('.output');
-var bg = document.querySelector('html');
+const diagnostic = document.querySelector('.output');
+const bg = document.querySelector('html');
 
 document.body.onclick = function() {
   recognition.start();

--- a/files/en-us/web/api/speechrecognition/audioend_event/index.md
+++ b/files/en-us/web/api/speechrecognition/audioend_event/index.md
@@ -31,7 +31,7 @@ A generic {{DOMxRef("Event")}} with no added properties.
 You can use the `audioend` event in an [`addEventListener`](/en-US/docs/Web/API/EventTarget/addEventListener) method:
 
 ```js
-var recognition = new webkitSpeechRecognition() || new SpeechRecognition();
+const recognition = new webkitSpeechRecognition() || new SpeechRecognition();
 
 recognition.addEventListener('audioend', function() {
   console.log('Audio capturing ended');

--- a/files/en-us/web/api/speechrecognition/audiostart_event/index.md
+++ b/files/en-us/web/api/speechrecognition/audiostart_event/index.md
@@ -34,7 +34,7 @@ A generic {{DOMxRef("Event")}} with no added properties.
 You can use the `audiostart` event in an [`addEventListener`](/en-US/docs/Web/API/EventTarget/addEventListener) method:
 
 ```js
-var recognition = new webkitSpeechRecognition() || new SpeechRecognition();
+const recognition = new webkitSpeechRecognition() || new SpeechRecognition();
 
 recognition.addEventListener('audiostart', function() {
   console.log('Audio capturing started');

--- a/files/en-us/web/api/speechrecognition/continuous/index.md
+++ b/files/en-us/web/api/speechrecognition/continuous/index.md
@@ -32,9 +32,9 @@ continuous (single result each time.)
 This code is excerpted from our [Speech color changer](https://github.com/mdn/dom-examples/blob/master/web-speech-api/speech-color-changer/script.js) example.
 
 ```js
-var grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
-var recognition = new SpeechRecognition();
-var speechRecognitionList = new SpeechGrammarList();
+const grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
+const recognition = new SpeechRecognition();
+const speechRecognitionList = new SpeechGrammarList();
 speechRecognitionList.addFromString(grammar, 1);
 recognition.grammars = speechRecognitionList;
 recognition.continuous = false;

--- a/files/en-us/web/api/speechrecognition/end_event/index.md
+++ b/files/en-us/web/api/speechrecognition/end_event/index.md
@@ -31,7 +31,7 @@ A generic {{DOMxRef("Event")}} with no added properties.
 You can use the `end` event in an [`addEventListener`](/en-US/docs/Web/API/EventTarget/addEventListener) method:
 
 ```js
-var recognition = new webkitSpeechRecognition() || new SpeechRecognition();
+const recognition = new webkitSpeechRecognition() || new SpeechRecognition();
 
 recognition.addEventListener('end', function() {
   console.log('Speech recognition service disconnected');

--- a/files/en-us/web/api/speechrecognition/error_event/index.md
+++ b/files/en-us/web/api/speechrecognition/error_event/index.md
@@ -42,7 +42,7 @@ _In addition to the properties listed below, properties from the parent interfac
 You can use the `error` event in an [`addEventListener`](/en-US/docs/Web/API/EventTarget/addEventListener) method:
 
 ```js
-var recognition = new webkitSpeechRecognition() || new SpeechRecognition();
+const recognition = new webkitSpeechRecognition() || new SpeechRecognition();
 
 recognition.addEventListener('error', function(event) {
   console.log(`Speech recognition error detected: ${event.error}`);

--- a/files/en-us/web/api/speechrecognition/grammars/index.md
+++ b/files/en-us/web/api/speechrecognition/grammars/index.md
@@ -31,9 +31,9 @@ This code is excerpted from our
 [Speech color changer](https://github.com/mdn/dom-examples/blob/master/web-speech-api/speech-color-changer/script.js) example.
 
 ```js
-var grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
-var recognition = new SpeechRecognition();
-var speechRecognitionList = new SpeechGrammarList();
+const grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
+const recognition = new SpeechRecognition();
+const speechRecognitionList = new SpeechGrammarList();
 speechRecognitionList.addFromString(grammar, 1);
 recognition.grammars = speechRecognitionList;
 //recognition.continuous = false;

--- a/files/en-us/web/api/speechrecognition/interimresults/index.md
+++ b/files/en-us/web/api/speechrecognition/interimresults/index.md
@@ -33,9 +33,9 @@ results are returned, and `false` means they aren't.
 This code is excerpted from our [Speech color changer](https://github.com/mdn/dom-examples/blob/master/web-speech-api/speech-color-changer/script.js) example.
 
 ```js
-var grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
-var recognition = new SpeechRecognition();
-var speechRecognitionList = new SpeechGrammarList();
+const grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
+const recognition = new SpeechRecognition();
+const speechRecognitionList = new SpeechGrammarList();
 speechRecognitionList.addFromString(grammar, 1);
 recognition.grammars = speechRecognitionList;
 //recognition.continuous = false;

--- a/files/en-us/web/api/speechrecognition/lang/index.md
+++ b/files/en-us/web/api/speechrecognition/lang/index.md
@@ -28,9 +28,9 @@ A string representing the BCP 47 language tag for the current `SpeechRecognition
 This code is excerpted from our [Speech color changer](https://github.com/mdn/dom-examples/blob/master/web-speech-api/speech-color-changer/script.js) example.
 
 ```js
-var grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
-var recognition = new SpeechRecognition();
-var speechRecognitionList = new SpeechGrammarList();
+const grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
+const recognition = new SpeechRecognition();
+const speechRecognitionList = new SpeechGrammarList();
 speechRecognitionList.addFromString(grammar, 1);
 recognition.grammars = speechRecognitionList;
 //recognition.continuous = false;

--- a/files/en-us/web/api/speechrecognition/maxalternatives/index.md
+++ b/files/en-us/web/api/speechrecognition/maxalternatives/index.md
@@ -31,9 +31,9 @@ A number representing the maximum returned alternatives for each result.
 This code is excerpted from our [Speech color changer](https://github.com/mdn/dom-examples/blob/master/web-speech-api/speech-color-changer/script.js) example.
 
 ```js
-var grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
-var recognition = new SpeechRecognition();
-var speechRecognitionList = new SpeechGrammarList();
+const grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
+const recognition = new SpeechRecognition();
+const speechRecognitionList = new SpeechGrammarList();
 speechRecognitionList.addFromString(grammar, 1);
 recognition.grammars = speechRecognitionList;
 //recognition.continuous = false;

--- a/files/en-us/web/api/speechrecognition/nomatch_event/index.md
+++ b/files/en-us/web/api/speechrecognition/nomatch_event/index.md
@@ -48,7 +48,7 @@ _In addition to the properties listed below, properties from the parent interfac
 You can use the `nomatch` event in an [`addEventListener`](/en-US/docs/Web/API/EventTarget/addEventListener) method:
 
 ```js
-var recognition = new webkitSpeechRecognition() || new SpeechRecognition();
+const recognition = new webkitSpeechRecognition() || new SpeechRecognition();
 
 recognition.addEventListener('nomatch', function() {
   console.log('Speech not recognized');

--- a/files/en-us/web/api/speechrecognition/soundend_event/index.md
+++ b/files/en-us/web/api/speechrecognition/soundend_event/index.md
@@ -31,7 +31,7 @@ A generic {{DOMxRef("Event")}} with no added properties.
 You can use the `soundend` event in an [`addEventListener`](/en-US/docs/Web/API/EventTarget/addEventListener) method:
 
 ```js
-var recognition = new webkitSpeechRecognition() || new SpeechRecognition();
+const recognition = new webkitSpeechRecognition() || new SpeechRecognition();
 
 recognition.addEventListener('soundend', function(event) {
   console.log('Sound has stopped being received');

--- a/files/en-us/web/api/speechrecognition/soundstart_event/index.md
+++ b/files/en-us/web/api/speechrecognition/soundstart_event/index.md
@@ -31,7 +31,7 @@ A generic {{DOMxRef("Event")}} with no added properties.
 You can use the `soundstart` event in an [`addEventListener`](/en-US/docs/Web/API/EventTarget/addEventListener) method:
 
 ```js
-var recognition = new webkitSpeechRecognition() || new SpeechRecognition();
+const recognition = new webkitSpeechRecognition() || new SpeechRecognition();
 
 recognition.addEventListener('soundstart', function() {
   console.log('Some sound is being received');

--- a/files/en-us/web/api/speechrecognition/speechend_event/index.md
+++ b/files/en-us/web/api/speechrecognition/speechend_event/index.md
@@ -31,7 +31,7 @@ A generic {{DOMxRef("Event")}} with no added properties.
 You can use the `speechend` event in an [`addEventListener`](/en-US/docs/Web/API/EventTarget/addEventListener) method:
 
 ```js
-var recognition = new webkitSpeechRecognition() || new SpeechRecognition();
+const recognition = new webkitSpeechRecognition() || new SpeechRecognition();
 
 recognition.addEventListener('speechend', function() {
   console.log('Speech has stopped being detected');

--- a/files/en-us/web/api/speechrecognition/speechrecognition/index.md
+++ b/files/en-us/web/api/speechrecognition/speechrecognition/index.md
@@ -32,9 +32,9 @@ None.
 This code is excerpted from our [Speech color changer](https://github.com/mdn/dom-examples/blob/master/web-speech-api/speech-color-changer/script.js) example.
 
 ```js
-var grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
-var recognition = new SpeechRecognition();
-var speechRecognitionList = new SpeechGrammarList();
+const grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
+const recognition = new SpeechRecognition();
+const speechRecognitionList = new SpeechGrammarList();
 speechRecognitionList.addFromString(grammar, 1);
 recognition.grammars = speechRecognitionList;
 //recognition.continuous = false;

--- a/files/en-us/web/api/speechrecognition/speechstart_event/index.md
+++ b/files/en-us/web/api/speechrecognition/speechstart_event/index.md
@@ -31,7 +31,7 @@ A generic {{DOMxRef("Event")}} with no added properties.
 You can use the `speechstart` event in an [`addEventListener`](/en-US/docs/Web/API/EventTarget/addEventListener) method:
 
 ```js
-var recognition = new webkitSpeechRecognition() || new SpeechRecognition();
+const recognition = new webkitSpeechRecognition() || new SpeechRecognition();
 
 recognition.addEventListener('speechstart', function() {
   console.log('Speech has been detected');

--- a/files/en-us/web/api/speechrecognition/start/index.md
+++ b/files/en-us/web/api/speechrecognition/start/index.md
@@ -36,14 +36,14 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
-var recognition = new SpeechRecognition();
-var speechRecognitionList = new SpeechGrammarList();
+const grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
+const recognition = new SpeechRecognition();
+const speechRecognitionList = new SpeechGrammarList();
 speechRecognitionList.addFromString(grammar, 1);
 recognition.grammars = speechRecognitionList;
 
-var diagnostic = document.querySelector('.output');
-var bg = document.querySelector('html');
+const diagnostic = document.querySelector('.output');
+const bg = document.querySelector('html');
 
 document.body.onclick = function() {
   recognition.start();

--- a/files/en-us/web/api/speechrecognition/start_event/index.md
+++ b/files/en-us/web/api/speechrecognition/start_event/index.md
@@ -31,7 +31,7 @@ A generic {{DOMxRef("Event")}} with no added properties.
 You can use the `start` event in an [`addEventListener`](/en-US/docs/Web/API/EventTarget/addEventListener) method:
 
 ```js
-var recognition = new webkitSpeechRecognition() || new SpeechRecognition();
+const recognition = new webkitSpeechRecognition() || new SpeechRecognition();
 
 recognition.addEventListener('start', function() {
   console.log('Speech recognition service has started');

--- a/files/en-us/web/api/speechrecognition/stop/index.md
+++ b/files/en-us/web/api/speechrecognition/stop/index.md
@@ -36,14 +36,14 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
-var recognition = new SpeechRecognition();
-var speechRecognitionList = new SpeechGrammarList();
+const grammar = '#JSGF V1.0; grammar colors; public <color> = aqua | azure | beige | bisque | black | blue | brown | chocolate | coral | crimson | cyan | fuchsia | ghostwhite | gold | goldenrod | gray | green | indigo | ivory | khaki | lavender | lime | linen | magenta | maroon | moccasin | navy | olive | orange | orchid | peru | pink | plum | purple | red | salmon | sienna | silver | snow | tan | teal | thistle | tomato | turquoise | violet | white | yellow ;'
+const recognition = new SpeechRecognition();
+const speechRecognitionList = new SpeechGrammarList();
 speechRecognitionList.addFromString(grammar, 1);
 recognition.grammars = speechRecognitionList;
 
-var diagnostic = document.querySelector('.output');
-var bg = document.querySelector('html');
+const diagnostic = document.querySelector('.output');
+const bg = document.querySelector('html');
 
 document.body.onclick = function() {
   recognition.start();

--- a/files/en-us/web/api/speechrecognitionerrorevent/error/index.md
+++ b/files/en-us/web/api/speechrecognitionerrorevent/error/index.md
@@ -49,7 +49,7 @@ A string naming the type of error. The possible error types are:
 ## Examples
 
 ```js
-var recognition = new SpeechRecognition();
+const recognition = new SpeechRecognition();
 
 recognition.onerror = function(event) {
   console.log(`Speech recognition error detected: ${event.error}`);

--- a/files/en-us/web/api/speechrecognitionerrorevent/index.md
+++ b/files/en-us/web/api/speechrecognitionerrorevent/index.md
@@ -22,7 +22,7 @@ _`SpeechRecognitionErrorEvent` also inherits properties from its parent interfac
 ## Examples
 
 ```js
-var recognition = new SpeechRecognition();
+const recognition = new SpeechRecognition();
 
 recognition.onerror = function(event) {
   console.log(`Speech recognition error detected: ${event.error}`);

--- a/files/en-us/web/api/speechrecognitionerrorevent/message/index.md
+++ b/files/en-us/web/api/speechrecognitionerrorevent/message/index.md
@@ -29,7 +29,7 @@ the implementors to decide upon.
 ## Examples
 
 ```js
-var recognition = new SpeechRecognition();
+const recognition = new SpeechRecognition();
 
 recognition.onerror = function(event) {
   console.log(`Speech recognition error detected: ${event.error}`);

--- a/files/en-us/web/api/speechrecognitionresultlist/index.md
+++ b/files/en-us/web/api/speechrecognitionresultlist/index.md
@@ -42,7 +42,7 @@ recognition.onresult = function(event) {
   // These also have getters so they can be accessed like arrays.
   // The second [0] returns the SpeechRecognitionAlternative at position 0.
   // We then return the transcript property of the SpeechRecognitionAlternative object
-  var color = event.results[0][0].transcript;
+  const color = event.results[0][0].transcript;
   diagnostic.textContent = `Result received: ${color}.`;
   bg.style.backgroundColor = color;
 }

--- a/files/en-us/web/api/speechrecognitionresultlist/item/index.md
+++ b/files/en-us/web/api/speechrecognitionresultlist/item/index.md
@@ -53,7 +53,7 @@ recognition.onresult = function(event) {
   // These also have getters so they can be accessed like arrays.
   // The second [0] returns the SpeechRecognitionAlternative at position 0.
   // We then return the transcript property of the SpeechRecognitionAlternative object
-  var color = event.results[0][0].transcript;
+  const color = event.results[0][0].transcript;
   diagnostic.textContent = `Result received: ${color}.`;
   bg.style.backgroundColor = color;
 }

--- a/files/en-us/web/api/speechrecognitionresultlist/length/index.md
+++ b/files/en-us/web/api/speechrecognitionresultlist/length/index.md
@@ -41,7 +41,7 @@ recognition.onresult = function(event) {
   // These also have getters so they can be accessed like arrays.
   // The second [0] returns the SpeechRecognitionAlternative at position 0.
   // We then return the transcript property of the SpeechRecognitionAlternative object
-  var color = event.results[0][0].transcript;
+  const color = event.results[0][0].transcript;
   diagnostic.textContent = `Result received: ${color}.`;
   bg.style.backgroundColor = color;
 

--- a/files/en-us/web/api/speechsynthesis/cancel/index.md
+++ b/files/en-us/web/api/speechsynthesis/cancel/index.md
@@ -37,10 +37,10 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var synth = window.speechSynthesis;
+const synth = window.speechSynthesis;
 
-var utterance1 = new SpeechSynthesisUtterance('How about we say this now? This is quite a long sentence to say.');
-var utterance2 = new SpeechSynthesisUtterance('We should say another sentence too, just to be on the safe side.');
+const utterance1 = new SpeechSynthesisUtterance('How about we say this now? This is quite a long sentence to say.');
+const utterance2 = new SpeechSynthesisUtterance('We should say another sentence too, just to be on the safe side.');
 
 synth.speak(utterance1);
 synth.speak(utterance2);

--- a/files/en-us/web/api/speechsynthesis/pause/index.md
+++ b/files/en-us/web/api/speechsynthesis/pause/index.md
@@ -35,10 +35,10 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var synth = window.speechSynthesis;
+const synth = window.speechSynthesis;
 
-var utterance1 = new SpeechSynthesisUtterance('How about we say this now? This is quite a long sentence to say.');
-var utterance2 = new SpeechSynthesisUtterance('We should say another sentence too, just to be on the safe side.');
+const utterance1 = new SpeechSynthesisUtterance('How about we say this now? This is quite a long sentence to say.');
+const utterance2 = new SpeechSynthesisUtterance('We should say another sentence too, just to be on the safe side.');
 
 synth.speak(utterance1);
 synth.speak(utterance2);

--- a/files/en-us/web/api/speechsynthesis/paused/index.md
+++ b/files/en-us/web/api/speechsynthesis/paused/index.md
@@ -32,11 +32,11 @@ A boolean value.
 ## Examples
 
 ```js
-var synth = window.speechSynthesis;
+const synth = window.speechSynthesis;
 
 synth.pause();
 
-var amIPaused = synth.paused; // will return true
+const amIPaused = synth.paused; // will return true
 ```
 
 ## Specifications

--- a/files/en-us/web/api/speechsynthesis/pending/index.md
+++ b/files/en-us/web/api/speechsynthesis/pending/index.md
@@ -26,15 +26,15 @@ A boolean value.
 ## Examples
 
 ```js
-var synth = window.speechSynthesis;
+const synth = window.speechSynthesis;
 
-var utterance1 = new SpeechSynthesisUtterance('How about we say this now? This is quite a long sentence to say.');
-var utterance2 = new SpeechSynthesisUtterance('We should say another sentence too, just to be on the safe side.');
+const utterance1 = new SpeechSynthesisUtterance('How about we say this now? This is quite a long sentence to say.');
+const utterance2 = new SpeechSynthesisUtterance('We should say another sentence too, just to be on the safe side.');
 
 synth.speak(utterance1);
 synth.speak(utterance2);
 
-var amIPending = synth.pending; // will return true if utterance 1 is still being spoken and utterance 2 is in the queue
+const amIPending = synth.pending; // will return true if utterance 1 is still being spoken and utterance 2 is in the queue
 ```
 
 ## Specifications

--- a/files/en-us/web/api/speechsynthesis/speaking/index.md
+++ b/files/en-us/web/api/speechsynthesis/speaking/index.md
@@ -28,15 +28,15 @@ A boolean value.
 ## Examples
 
 ```js
-var synth = window.speechSynthesis;
+const synth = window.speechSynthesis;
 
-var utterance1 = new SpeechSynthesisUtterance('How about we say this now? This is quite a long sentence to say.');
-var utterance2 = new SpeechSynthesisUtterance('We should say another sentence too, just to be on the safe side.');
+const utterance1 = new SpeechSynthesisUtterance('How about we say this now? This is quite a long sentence to say.');
+const utterance2 = new SpeechSynthesisUtterance('We should say another sentence too, just to be on the safe side.');
 
 synth.speak(utterance1);
 synth.speak(utterance2);
 
-var amISpeaking = synth.speaking; // will return true if utterance 1 or utterance 2 are currently being spoken
+const amISpeaking = synth.speaking; // will return true if utterance 1 or utterance 2 are currently being spoken
 ```
 
 ## Specifications

--- a/files/en-us/web/api/storage/key/index.md
+++ b/files/en-us/web/api/storage/key/index.md
@@ -39,7 +39,7 @@ The following function iterates over the local storage keys:
 
 ```js
 function forEachKey(callback) {
-  for (var i = 0; i < localStorage.length; i++) {
+  for (let i = 0; i < localStorage.length; i++) {
     callback(localStorage.key(i));
   }
 }
@@ -49,7 +49,7 @@ The following function iterates over the local storage keys and gets the value s
 each key:
 
 ```js
-for (var i = 0; i < localStorage.length; i++) {
+for (let i = 0; i < localStorage.length; i++) {
   console.log(localStorage.getItem(localStorage.key(i)));
 }
 ```

--- a/files/en-us/web/api/structuredclone/index.md
+++ b/files/en-us/web/api/structuredclone/index.md
@@ -74,8 +74,8 @@ The following code shows how to clone an array and transfer its underlying resou
 On return, the original `uInt8Array.buffer` will be cleared.
 
 ```js
-var uInt8Array = new Uint8Array(1024 * 1024 * 16); // 16MB
-for (var i = 0; i < uInt8Array.length; ++i) {
+const uInt8Array = new Uint8Array(1024 * 1024 * 16); // 16MB
+for (let i = 0; i < uInt8Array.length; ++i) {
   uInt8Array[i] = i;
 }
 

--- a/files/en-us/web/api/svgaelement/index.md
+++ b/files/en-us/web/api/svgaelement/index.md
@@ -49,7 +49,7 @@ _This interface has no methods but inherits methods from its parent, {{domxref("
 In the example below, the {{SVGAttr("target")}} attribute of the {{SVGElement("a")}} element is set to `_blank` and when the link is clicked, it logs to notify whether the condition is met or not.
 
 ```js
-var linkRef = document.querySelector("a");
+const linkRef = document.querySelector("a");
 linkRef.target = "_self";
 
 linkRef.onclick = function(){

--- a/files/en-us/web/api/svgaelement/target/index.md
+++ b/files/en-us/web/api/svgaelement/target/index.md
@@ -30,7 +30,7 @@ The code is taken from the ["SVGAElement example code"](/en-US/docs/Web/API/SVGA
 
 ```js
 // ...
-var linkRef = document.querySelector('a');
+const linkRef = document.querySelector('a');
 linkRef.target ='_blank';
 // ...
 ```

--- a/files/en-us/web/api/svganimatedstring/animval/index.md
+++ b/files/en-us/web/api/svganimatedstring/animval/index.md
@@ -13,7 +13,7 @@ AnimVal attribute or animVal property contains the same value as the {{domxref("
 ## Syntax
 
 ```js
-var currentValue = object.animVal
+const currentValue = object.animVal
 ```
 
 ## Specifications

--- a/files/en-us/web/api/svggraphicselement/getbbox/index.md
+++ b/files/en-us/web/api/svggraphicselement/getbbox/index.md
@@ -79,17 +79,17 @@ elements.
 ### JavaScript
 
 ```js
-var rectBBox = document.querySelector('#rect_1');
-var rectBoundingClientRect = document.querySelector('#rect_2');
-var groupElement = document.querySelector('#group_text_1');
+const rectBBox = document.querySelector('#rect_1');
+const rectBoundingClientRect = document.querySelector('#rect_2');
+const groupElement = document.querySelector('#group_text_1');
 
-var bboxGroup = groupElement.getBBox();
+const bboxGroup = groupElement.getBBox();
 rectBBox.setAttribute('x', bboxGroup.x);
 rectBBox.setAttribute('y', bboxGroup.y);
 rectBBox.setAttribute('width', bboxGroup.width);
 rectBBox.setAttribute('height', bboxGroup.height);
 
-var boundingClientRectGroup = groupElement.getBoundingClientRect();
+const boundingClientRectGroup = groupElement.getBoundingClientRect();
 rectBoundingClientRect.setAttribute('x', boundingClientRectGroup.x);
 rectBoundingClientRect.setAttribute('y', boundingClientRectGroup.y);
 rectBoundingClientRect.setAttribute('width', boundingClientRectGroup.width);

--- a/files/en-us/web/api/svgimageelement/decoding/index.md
+++ b/files/en-us/web/api/svgimageelement/decoding/index.md
@@ -33,7 +33,7 @@ A string representing the decoding hint. Possible values are:
 ## Examples
 
 ```js
-var img = new Image();
+const img = new Image();
 img.decoding = 'sync';
 img.src = 'img/logo.svg';
 ```

--- a/files/en-us/web/api/textdecoder/textdecoder/index.md
+++ b/files/en-us/web/api/textdecoder/textdecoder/index.md
@@ -45,7 +45,7 @@ new TextDecoder(utfLabel, options)
 ```js
 const textDecoder1 = new TextDecoder("iso-8859-2");
 const textDecoder2 = new TextDecoder();
-const textDecoder3 = new TextDecoder("csiso2022kr", {fatal: true}); // Allows TypeError exception to be thrown.
+const textDecoder3 = new TextDecoder("csiso2022kr", { fatal: true }); // Allows TypeError exception to be thrown.
 const textDecoder4 = new TextDecoder("iso-2022-cn"); // Throw a RangeError exception.
 ```
 

--- a/files/en-us/web/api/textdecoder/textdecoder/index.md
+++ b/files/en-us/web/api/textdecoder/textdecoder/index.md
@@ -43,10 +43,10 @@ new TextDecoder(utfLabel, options)
 ## Examples
 
 ```js
-var textDecoder1 = new TextDecoder("iso-8859-2");
-var textDecoder2 = new TextDecoder();
-var textDecoder3 = new TextDecoder("csiso2022kr", {fatal: true}); // Allows TypeError exception to be thrown.
-var textDecoder4 = new TextDecoder("iso-2022-cn"); // Throw a RangeError exception.
+const textDecoder1 = new TextDecoder("iso-8859-2");
+const textDecoder2 = new TextDecoder();
+const textDecoder3 = new TextDecoder("csiso2022kr", {fatal: true}); // Allows TypeError exception to be thrown.
+const textDecoder4 = new TextDecoder("iso-2022-cn"); // Throw a RangeError exception.
 ```
 
 ## Specifications

--- a/files/en-us/web/api/texttracklist/index.md
+++ b/files/en-us/web/api/texttracklist/index.md
@@ -66,7 +66,7 @@ In addition to being able to obtain direct access to the text tracks present on 
 To get a media element's `TextTrackList`, use its {{domxref("HTMLMediaElement.textTracks", "textTracks")}} property.
 
 ```js
-var textTracks = document.querySelector("video").textTracks;
+const textTracks = document.querySelector("video").textTracks;
 ```
 
 ### Monitoring track count changes

--- a/files/en-us/web/api/texttracklist/length/index.md
+++ b/files/en-us/web/api/texttracklist/length/index.md
@@ -37,8 +37,8 @@ This snippet gets the number of text tracks in the first media element found in 
 {{Glossary("DOM")}} by {{domxref("Document.querySelector", "querySelector()")}}.
 
 ```js
-var mediaElem = document.querySelector("video, audio");
-var numTextTracks = 0;
+const mediaElem = document.querySelector("video, audio");
+let numTextTracks = 0;
 
 if (mediaElem.textTracks) {
   numTextTracks = mediaElem.textTracks.length;

--- a/files/en-us/web/api/timeranges/end/index.md
+++ b/files/en-us/web/api/timeranges/end/index.md
@@ -40,11 +40,11 @@ A number.
 Given a video element with the ID `"myVideo"`:
 
 ```js
-var v = document.getElementById("myVideo");
+const v = document.getElementById("myVideo");
 
-var buf = v.buffered;
+const buf = v.buffered;
 
-var numRanges = buf.length;
+const numRanges = buf.length;
 
 if (buf.length === 1) {
   // only one range

--- a/files/en-us/web/api/timeranges/length/index.md
+++ b/files/en-us/web/api/timeranges/length/index.md
@@ -26,11 +26,11 @@ A number.
 Given a video element with the ID "myVideo":
 
 ```js
-var v = document.GetElementById("myVideo");
+const v = document.GetElementById("myVideo");
 
-var buf = v.buffered;
+const buf = v.buffered;
 
-var numRanges = buf.length;
+const numRanges = buf.length;
 
 if (buf.length === 1) {
   // Only one range

--- a/files/en-us/web/api/timeranges/length/index.md
+++ b/files/en-us/web/api/timeranges/length/index.md
@@ -26,7 +26,7 @@ A number.
 Given a video element with the ID "myVideo":
 
 ```js
-const v = document.GetElementById("myVideo");
+const v = document.getElementById("myVideo");
 
 const buf = v.buffered;
 

--- a/files/en-us/web/api/timeranges/start/index.md
+++ b/files/en-us/web/api/timeranges/start/index.md
@@ -41,11 +41,11 @@ A number.
 Given a video element with the ID "myVideo":
 
 ```js
-var v = document.getElementById("myVideo");
+const v = document.getElementById("myVideo");
 
-var buf = v.buffered;
+const buf = v.buffered;
 
-var numRanges = buf.length;
+const numRanges = buf.length;
 
 if (buf.length === 1) {
   // only one range

--- a/files/en-us/web/api/touch/force/index.md
+++ b/files/en-us/web/api/touch/force/index.md
@@ -39,7 +39,7 @@ point but the code could invoke different processing depending on the value.
 someElement.addEventListener('touchstart', function(e) {
    // Iterate through the list of touch points and log each touch
    // point's force.
-   for (var i=0; i < e.targetTouches.length; i++) {
+   for (let i = 0; i < e.targetTouches.length; i++) {
      // Add code to "switch" based on the force value. For example
      // minimum pressure vs. maximum pressure could result in
      // different handling of the user's input.

--- a/files/en-us/web/api/touch/identifier/index.md
+++ b/files/en-us/web/api/touch/identifier/index.md
@@ -29,7 +29,7 @@ A `long` that represents the unique ID of the {{ domxref("Touch") }} object.
 someElement.addEventListener('touchmove', function(e) {
 // Iterate through the list of touch points that changed
 // since the last event and print each touch point's identifier.
-  for (var i=0; i < e.changedTouches.length; i++) {
+  for (let i = 0; i < e.changedTouches.length; i++) {
     console.log(`changedTouches[${i}].identifier = ${e.changedTouches[i].identifier}`);
   }
 }, false);

--- a/files/en-us/web/api/touch/target/index.md
+++ b/files/en-us/web/api/touch/target/index.md
@@ -27,12 +27,12 @@ In following simple code snippet, we assume the user initiates one or more touch
 
 ```js
 // Register a touchmove listener for the 'source' element
-var src = document.getElementById("source");
+const src = document.getElementById("source");
 
 src.addEventListener('touchstart', function(e) {
   // Iterate through the touch points that were activated
   // for this element.
-  for (var i=0; i < e.targetTouches.length; i++) {
+  for (let i = 0; i < e.targetTouches.length; i++) {
     console.log(`touchpoint[${i}].target = ${e.targetTouches[i].target}`);
   }
 }, false);

--- a/files/en-us/web/api/touch_events/multi-touch_interaction/index.md
+++ b/files/en-us/web/api/touch_events/multi-touch_interaction/index.md
@@ -251,7 +251,7 @@ function log(name, ev, printTargetIds) {
 
   if (printTargetIds) {
     s = "";
-    for (var i=0; i < ev.targetTouches.length; i++) {
+    for (let i = 0; i < ev.targetTouches.length; i++) {
       s += `... id = ${ev.targetTouches[i].identifier}<br>`;
     }
     o.innerHTML += s;

--- a/files/en-us/web/api/touch_events/using_touch_events/index.md
+++ b/files/en-us/web/api/touch_events/using_touch_events/index.md
@@ -82,7 +82,7 @@ Access the attributes of a touch point.
 someElement.addEventListener('touchstart', function(ev) {
   // Iterate through the touch points that were activated
   // for this element and process each event 'target'
-  for (var i=0; i < ev.targetTouches.length; i++) {
+  for (let i = 0; i < ev.targetTouches.length; i++) {
     process_target(ev.targetTouches[i].target);
   }
 }, false);

--- a/files/en-us/web/api/touchevent/changedtouches/index.md
+++ b/files/en-us/web/api/touchevent/changedtouches/index.md
@@ -36,7 +36,7 @@ In following code snippet, the {{event("touchmove")}} event handler iterates thr
 someElement.addEventListener('touchmove', function(e) {
    // Iterate through the list of touch points that changed
    // since the last event and print each touch point's identifier.
-   for (var i=0; i < e.changedTouches.length; i++) {
+   for (let i = 0; i < e.changedTouches.length; i++) {
      console.log(`changedTouches[${i}].identifier = ${e.changedTouches[i].identifier}`);
    }
 }, false);

--- a/files/en-us/web/api/treewalker/currentnode/index.md
+++ b/files/en-us/web/api/treewalker/currentnode/index.md
@@ -21,7 +21,7 @@ A {{domxref("Node")}}.
 ## Examples
 
 ```js
-var treeWalker = document.createTreeWalker(
+const treeWalker = document.createTreeWalker(
     document.body,
     NodeFilter.SHOW_ELEMENT,
     { acceptNode(node) { return NodeFilter.FILTER_ACCEPT; } },

--- a/files/en-us/web/api/treewalker/filter/index.md
+++ b/files/en-us/web/api/treewalker/filter/index.md
@@ -26,7 +26,7 @@ A {{domxref("NodeFilter")}} object.
 ## Examples
 
 ```js
-var treeWalker = document.createTreeWalker(
+const treeWalker = document.createTreeWalker(
     document.body,
     NodeFilter.SHOW_ELEMENT,
     { acceptNode(node) { return NodeFilter.FILTER_ACCEPT; } },

--- a/files/en-us/web/api/treewalker/firstchild/index.md
+++ b/files/en-us/web/api/treewalker/firstchild/index.md
@@ -34,13 +34,13 @@ A {{domxref("Node")}} object or `null`.
 ## Examples
 
 ```js
-var treeWalker = document.createTreeWalker(
+const treeWalker = document.createTreeWalker(
     document.body,
     NodeFilter.SHOW_ELEMENT,
     { acceptNode(node) { return NodeFilter.FILTER_ACCEPT; } },
     false
 );
-var node = treeWalker.firstChild(); // returns the first child of the root element, or null if none
+const node = treeWalker.firstChild(); // returns the first child of the root element, or null if none
 ```
 
 ## Specifications

--- a/files/en-us/web/api/treewalker/lastchild/index.md
+++ b/files/en-us/web/api/treewalker/lastchild/index.md
@@ -34,12 +34,12 @@ A {{domxref("Node")}} object or `null`.
 ## Examples
 
 ```js
-var treeWalker = document.createTreeWalker(
+const treeWalker = document.createTreeWalker(
     document.body,
     NodeFilter.SHOW_ELEMENT,
     { acceptNode(node) { return NodeFilter.FILTER_ACCEPT; } }
 );
-var node = treeWalker.lastChild(); // returns the last visible child of the root element
+const node = treeWalker.lastChild(); // returns the last visible child of the root element
 ```
 
 ## Specifications

--- a/files/en-us/web/api/treewalker/nextnode/index.md
+++ b/files/en-us/web/api/treewalker/nextnode/index.md
@@ -34,13 +34,13 @@ A {{domxref("Node")}} object or `null`.
 ## Examples
 
 ```js
-var treeWalker = document.createTreeWalker(
+const treeWalker = document.createTreeWalker(
     document.body,
     NodeFilter.SHOW_ELEMENT,
     { acceptNode(node) { return NodeFilter.FILTER_ACCEPT; } },
     false
 );
-var node = treeWalker.nextNode(); // returns the first child of root, as it is the next node in document order
+const node = treeWalker.nextNode(); // returns the first child of root, as it is the next node in document order
 ```
 
 ## Specifications

--- a/files/en-us/web/api/treewalker/nextsibling/index.md
+++ b/files/en-us/web/api/treewalker/nextsibling/index.md
@@ -33,14 +33,14 @@ A {{domxref("Node")}} object or `null`.
 ## Examples
 
 ```js
-var treeWalker = document.createTreeWalker(
+const treeWalker = document.createTreeWalker(
     document.body,
     NodeFilter.SHOW_ELEMENT,
     { acceptNode(node) { return NodeFilter.FILTER_ACCEPT; } },
     false
 );
 treeWalker.firstChild();
-var node = treeWalker.nextSibling(); // returns null if the first child of the root element has no sibling
+const node = treeWalker.nextSibling(); // returns null if the first child of the root element has no sibling
 ```
 
 ## Specifications

--- a/files/en-us/web/api/treewalker/parentnode/index.md
+++ b/files/en-us/web/api/treewalker/parentnode/index.md
@@ -35,13 +35,13 @@ A {{domxref("Node")}} object or `null`.
 ## Examples
 
 ```js
-var treeWalker = document.createTreeWalker(
+const treeWalker = document.createTreeWalker(
     document.body,
     NodeFilter.SHOW_ELEMENT,
     { acceptNode(node) { return NodeFilter.FILTER_ACCEPT; } },
     false
 );
-var node = treeWalker.parentNode(); // returns null as there is no parent
+const node = treeWalker.parentNode(); // returns null as there is no parent
 ```
 
 ## Specifications

--- a/files/en-us/web/api/treewalker/previousnode/index.md
+++ b/files/en-us/web/api/treewalker/previousnode/index.md
@@ -35,13 +35,13 @@ A {{domxref("Node")}} object or `null`.
 ## Examples
 
 ```js
-var treeWalker = document.createTreeWalker(
+const treeWalker = document.createTreeWalker(
     document.body,
     NodeFilter.SHOW_ELEMENT,
     { acceptNode(node) { return NodeFilter.FILTER_ACCEPT; } },
     false
 );
-var node = treeWalker.previousNode(); // returns null as there is no parent
+const node = treeWalker.previousNode(); // returns null as there is no parent
 ```
 
 ## Specifications

--- a/files/en-us/web/api/treewalker/previoussibling/index.md
+++ b/files/en-us/web/api/treewalker/previoussibling/index.md
@@ -35,13 +35,13 @@ A {{domxref("Node")}} object or `null`.
 ## Examples
 
 ```js
-var treeWalker = document.createTreeWalker(
+const treeWalker = document.createTreeWalker(
     document.body,
     NodeFilter.SHOW_ELEMENT,
     { acceptNode(node) { return NodeFilter.FILTER_ACCEPT; } },
     false
 );
-var node = treeWalker.previousSibling(); // returns null as there is no previous sibling
+const node = treeWalker.previousSibling(); // returns null as there is no previous sibling
 ```
 
 ## Specifications

--- a/files/en-us/web/api/treewalker/root/index.md
+++ b/files/en-us/web/api/treewalker/root/index.md
@@ -21,7 +21,7 @@ A {{domxref("Node")}} object.
 ## Examples
 
 ```js
-var treeWalker = document.createTreeWalker(
+const treeWalker = document.createTreeWalker(
     document.body,
     NodeFilter.SHOW_ELEMENT,
     { acceptNode(node) { return NodeFilter.FILTER_ACCEPT; } },

--- a/files/en-us/web/api/uievent/inituievent/index.md
+++ b/files/en-us/web/api/uievent/inituievent/index.md
@@ -57,7 +57,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var e = document.createEvent("UIEvent");
+const e = document.createEvent("UIEvent");
 // creates a click event that bubbles, can be cancelled,
 // and with its view and detail property initialized to window and 1,
 // respectively

--- a/files/en-us/web/api/urlsearchparams/entries/index.md
+++ b/files/en-us/web/api/urlsearchparams/entries/index.md
@@ -41,8 +41,8 @@ Returns an {{jsxref("Iteration_protocols","iterator")}}.
 const searchParams = new URLSearchParams("key1=value1&key2=value2");
 
 // Display the key/value pairs
-for(const pair of searchParams.entries()) {
-   console.log(`${pair[0]}, ${pair[1]}`);
+for(const [key, value] of searchParams.entries()) {
+   console.log(`${key}, ${value}`);
 }
 ```
 

--- a/files/en-us/web/api/urlsearchparams/entries/index.md
+++ b/files/en-us/web/api/urlsearchparams/entries/index.md
@@ -38,10 +38,10 @@ Returns an {{jsxref("Iteration_protocols","iterator")}}.
 
 ```js
 // Create a test URLSearchParams object
-var searchParams = new URLSearchParams("key1=value1&key2=value2");
+const searchParams = new URLSearchParams("key1=value1&key2=value2");
 
 // Display the key/value pairs
-for(var pair of searchParams.entries()) {
+for(const pair of searchParams.entries()) {
    console.log(`${pair[0]}, ${pair[1]}`);
 }
 ```

--- a/files/en-us/web/api/urlsearchparams/foreach/index.md
+++ b/files/en-us/web/api/urlsearchparams/foreach/index.md
@@ -49,7 +49,7 @@ None ({{jsxref("undefined")}}).
 
 ```js
 // Create a test URLSearchParams object
-var searchParams = new URLSearchParams("key1=value1&key2=value2");
+const searchParams = new URLSearchParams("key1=value1&key2=value2");
 
 // Log the values
 searchParams.forEach(function(value, key) {

--- a/files/en-us/web/api/urlsearchparams/foreach/index.md
+++ b/files/en-us/web/api/urlsearchparams/foreach/index.md
@@ -52,7 +52,7 @@ None ({{jsxref("undefined")}}).
 const searchParams = new URLSearchParams("key1=value1&key2=value2");
 
 // Log the values
-searchParams.forEach(function(value, key) {
+searchParams.forEach((value, key) => {
   console.log(value, key);
 });
 ```

--- a/files/en-us/web/api/urlsearchparams/keys/index.md
+++ b/files/en-us/web/api/urlsearchparams/keys/index.md
@@ -37,10 +37,10 @@ Returns an {{jsxref("Iteration_protocols","iterator")}}.
 
 ```js
 // Create a test URLSearchParams object
-var searchParams = new URLSearchParams("key1=value1&key2=value2");
+const searchParams = new URLSearchParams("key1=value1&key2=value2");
 
 // Display the keys
-for(var key of searchParams.keys()) {
+for(const key of searchParams.keys()) {
   console.log(key);
 }
 ```

--- a/files/en-us/web/api/urlsearchparams/sort/index.md
+++ b/files/en-us/web/api/urlsearchparams/sort/index.md
@@ -38,7 +38,7 @@ None ({{jsxref("undefined")}}).
 
 ```js
 // Create a test URLSearchParams object
-var searchParams = new URLSearchParams("c=4&a=2&b=3&a=1");
+const searchParams = new URLSearchParams("c=4&a=2&b=3&a=1");
 
 // Sort the key/value pairs
 searchParams.sort();

--- a/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
+++ b/files/en-us/web/api/urlsearchparams/urlsearchparams/index.md
@@ -43,18 +43,18 @@ various inputs.
 
 ```js
 // Retrieve params via url.search, passed into ctor
-var url = new URL('https://example.com?foo=1&bar=2');
-var params = new URLSearchParams(url.search);
+const url = new URL('https://example.com?foo=1&bar=2');
+const params = new URLSearchParams(url.search);
 
 // Pass in a string literal
-var params2 = new URLSearchParams("foo=1&bar=2");
-var params2a = new URLSearchParams("?foo=1&bar=2");
+const params2 = new URLSearchParams("foo=1&bar=2");
+const params2a = new URLSearchParams("?foo=1&bar=2");
 
 // Pass in a sequence of pairs
-var params3 = new URLSearchParams([["foo", "1"], ["bar", "2"]]);
+const params3 = new URLSearchParams([["foo", "1"], ["bar", "2"]]);
 
 // Pass in a record
-var params4 = new URLSearchParams({"foo": "1", "bar": "2"});
+const params4 = new URLSearchParams({"foo": "1", "bar": "2"});
 ```
 
 This example shows how to build a new URL with an object of search parameters from an existing URL that has search parameters.

--- a/files/en-us/web/api/urlsearchparams/values/index.md
+++ b/files/en-us/web/api/urlsearchparams/values/index.md
@@ -39,9 +39,9 @@ Returns an {{jsxref("Iteration_protocols","iterator")}}.
 The following example passes a URL search string to the `URLSearchParams` constructor, then uses the iterator returned by `values()` to print the values to the console.
 
 ```js
-var searchParams = new URLSearchParams("key1=value1&key2=value2");
+const searchParams = new URLSearchParams("key1=value1&key2=value2");
 
-for(var value of searchParams.values()) {
+for(const value of searchParams.values()) {
   console.log(value);
 }
 ```
@@ -56,7 +56,7 @@ value2
 This example does much the same as above, but first casts the iterator into an array.
 
 ```js
-var searchParams = new URLSearchParams("key1=value1&key2=value2");
+const searchParams = new URLSearchParams("key1=value1&key2=value2");
 
 console.log(Array.from(searchParams.values()));
 ```

--- a/files/en-us/web/api/validitystate/badinput/index.md
+++ b/files/en-us/web/api/validitystate/badinput/index.md
@@ -26,7 +26,7 @@ A boolean.
 ```
 
 ```js
-var input = document.getElementById("age");
+const input = document.getElementById("age");
 if (input.validity.badInput) {
   console.log("Bad input detected…");
 } else {

--- a/files/en-us/web/api/vibration_api/index.md
+++ b/files/en-us/web/api/vibration_api/index.md
@@ -49,7 +49,7 @@ Calling {{DOMxRef("Navigator.vibrate()")}} with a value of `0`, an empty array, 
 Some basic `setInterval` and `clearInterval` action will allow you to create persistent vibration:
 
 ```js
-var vibrateInterval;
+let vibrateInterval;
 
 // Starts vibration at passed in level
 function startVibrate(duration) {

--- a/files/en-us/web/api/videoplaybackquality/corruptedvideoframes/index.md
+++ b/files/en-us/web/api/videoplaybackquality/corruptedvideoframes/index.md
@@ -45,8 +45,8 @@ value is greater than 5%, calls a function called `downgradeVideo()` that
 would be implemented to switch to a different video that might tax the network less.
 
 ```js
-var videoElem = document.getElementById("my_vid");
-var quality = videoElem.getVideoPlaybackQuality();
+const videoElem = document.getElementById("my_vid");
+const quality = videoElem.getVideoPlaybackQuality();
 
 if (quality.corruptedVideoFrames/quality.totalVideoFrames > 0.05) {
   downgradeVideo(videoElem);

--- a/files/en-us/web/api/videoplaybackquality/creationtime/index.md
+++ b/files/en-us/web/api/videoplaybackquality/creationtime/index.md
@@ -39,8 +39,8 @@ function called `lostFramesThresholdExceeded()` is called to, perhaps,
 update a quality indicator to show an increase in frame loss.
 
 ```js
-var videoElem = document.getElementById("my_vid");
-var quality = videoElem.getVideoPlaybackQuality();
+const videoElem = document.getElementById("my_vid");
+const quality = videoElem.getVideoPlaybackQuality();
 
 if ((quality.corruptedVideoFrames + quality.droppedVideoFrames)/quality.totalVideoFrames > 0.1) {
   lostFramesThresholdExceeded();

--- a/files/en-us/web/api/videoplaybackquality/droppedvideoframes/index.md
+++ b/files/en-us/web/api/videoplaybackquality/droppedvideoframes/index.md
@@ -44,11 +44,11 @@ then determines what percentage of frames have been dropped. That value is then
 presented in an element for the user's reference.
 
 ```js
-var videoElem = document.getElementById("my_vid");
-var percentElem = document.getElementById("percent");
-var quality = videoElem.getVideoPlaybackQuality();
+const videoElem = document.getElementById("my_vid");
+const percentElem = document.getElementById("percent");
+const quality = videoElem.getVideoPlaybackQuality();
 
-var dropPercent = (quality.droppedVideoFrames/quality.totalVideoFrames)*100;
+const dropPercent = (quality.droppedVideoFrames/quality.totalVideoFrames)*100;
 percentElem.innerText = Math.trunc(dropPercent).toString(10);
 ```
 

--- a/files/en-us/web/api/videoplaybackquality/totalframedelay/index.md
+++ b/files/en-us/web/api/videoplaybackquality/totalframedelay/index.md
@@ -29,8 +29,8 @@ A number.
 ## Examples
 
 ```js
-var videoElt = document.getElementById('my_vid');
-var quality = videoElt.getVideoPlaybackQuality();
+const videoElt = document.getElementById('my_vid');
+const quality = videoElt.getVideoPlaybackQuality();
 
 alert(quality.totalFrameDelay);
 ```

--- a/files/en-us/web/api/videoplaybackquality/totalvideoframes/index.md
+++ b/files/en-us/web/api/videoplaybackquality/totalvideoframes/index.md
@@ -44,8 +44,8 @@ dropped. If that exceeds 10% (0.1), a function called
 indicator to show an increase in frame loss.
 
 ```js
-var videoElem = document.getElementById("my_vid");
-var quality = videoElem.getVideoPlaybackQuality();
+const videoElem = document.getElementById("my_vid");
+const quality = videoElem.getVideoPlaybackQuality();
 
 if ((quality.corruptedVideoFrames + quality.droppedVideoFrames)/quality.totalVideoFrames > 0.1) {
   lostFramesThresholdExceeded();


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Replaces `var` in Web/API with `const` where applicable and `let` otherwise.
Mostly automated via my ESLint setup, using the rules `no-var` and `prefer-const`

#### Motivation

* See #16662
* See https://github.com/mdn/content/discussions/10389
* See https://github.com/orgs/mdn/discussions/143

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
