### PR TITLE
no more vars in Web/API (6)

### DIFF
--- a/files/en-us/web/api/videotrack/index.md
+++ b/files/en-us/web/api/videotrack/index.md
@@ -39,8 +39,8 @@ The most common use for accessing a `VideoTrack` object is to toggle its {{domxr
 To get a `VideoTrack` for a given media element, use the element's {{domxref("HTMLMediaElement.videoTracks", "videoTracks")}} property, which returns a {{domxref("VideoTrackList")}} object from which you can get the individual tracks contained in the media:
 
 ```js
-var el = document.querySelector("video");
-var tracks = el.videoTracks;
+const el = document.querySelector("video");
+const tracks = el.videoTracks;
 ```
 
 You can then access the media's individual tracks using either array syntax or functions such as {{jsxref("Array.forEach", "forEach()")}}.
@@ -48,15 +48,15 @@ You can then access the media's individual tracks using either array syntax or f
 This first example gets the first video track on the media:
 
 ```js
-var firstTrack = tracks[0];
+const firstTrack = tracks[0];
 ```
 
 The next example scans through all of the media's video tracks, activating the first video track that is in the user's preferred language (taken from a variable `userLanguage`).
 
 ```js
-for (var i = 0; i < tracks.length; i++) {
-  if (tracks[i].language === userLanguage) {
-    tracks[i].selected = true;
+for (const track of tracks) {
+  if (track.language === userLanguage) {
+    track.selected = true;
     break;
   }
 };

--- a/files/en-us/web/api/videotracklist/index.md
+++ b/files/en-us/web/api/videotracklist/index.md
@@ -62,7 +62,7 @@ In addition to being able to obtain direct access to the video tracks present on
 To get a media element's {{domxref("VideoTrackList")}}, use its {{domxref("HTMLMediaElement.videoTracks", "videoTracks")}} property.
 
 ```js
-var videoTracks = document.querySelector("video").videoTracks;
+const videoTracks = document.querySelector("video").videoTracks;
 ```
 
 ### Monitoring track count changes

--- a/files/en-us/web/api/videotracklist/length/index.md
+++ b/files/en-us/web/api/videotracklist/length/index.md
@@ -39,8 +39,8 @@ element found in the {{Glossary("DOM")}} by {{domxref("Document.querySelector",
   "querySelector()")}}.
 
 ```js
-var videoElem = document.querySelector("video");
-var numVideoTracks = 0;
+const videoElem = document.querySelector("video");
+let numVideoTracks = 0;
 
 if (videoElem.videoTracks) {
   numVideoTracks = videoElem.videoTracks.length;

--- a/files/en-us/web/api/vrdisplay/depthfar/index.md
+++ b/files/en-us/web/api/vrdisplay/depthfar/index.md
@@ -30,7 +30,7 @@ It initial value is `10000.0`.
 ## Examples
 
 ```js
-var vrDisplay;
+let vrDisplay;
 
 navigator.getVRDisplays().then(function(displays) {
   vrDisplay = displays[0];

--- a/files/en-us/web/api/vrdisplay/depthnear/index.md
+++ b/files/en-us/web/api/vrdisplay/depthnear/index.md
@@ -29,7 +29,7 @@ A double, representing the z-depth in meters; its initial value is `0.01`.
 ## Examples
 
 ```js
-var vrDisplay;
+let vrDisplay;
 
 navigator.getVRDisplays().then(function(displays) {
   vrDisplay = displays[0];

--- a/files/en-us/web/api/vrdisplayevent/vrdisplayevent/index.md
+++ b/files/en-us/web/api/vrdisplayevent/vrdisplayevent/index.md
@@ -45,7 +45,7 @@ A new {{domxref("VRDisplayEvent")}} object.
 ## Examples
 
 ```js
-var myEventObject = new VRDisplayEvent('custom', {
+const myEventObject = new VRDisplayEvent('custom', {
   display: vrDisplay,
   reason: 'Custom reason'
 });

--- a/files/en-us/web/api/vrframedata/timestamp/index.md
+++ b/files/en-us/web/api/vrframedata/timestamp/index.md
@@ -31,8 +31,8 @@ A {{domxref("DOMHighResTimeStamp")}} object.
 ## Examples
 
 ```js
-var frameData = new VRFrameData();
-var vrDisplay;
+const frameData = new VRFrameData();
+let vrDisplay;
 
 navigator.getVRDisplays().then(function(displays) {
   vrDisplay = displays[0];

--- a/files/en-us/web/api/vttregion/index.md
+++ b/files/en-us/web/api/vttregion/index.md
@@ -39,11 +39,11 @@ The `VTTRegion` interface—part of the API for handling WebVTT (text tracks on 
 ## Examples
 
 ```js
-var region = new VTTRegion();
+const region = new VTTRegion();
 region.width = 50;  // Use 50% of the video width
 region.lines = 4;  // Use 4 lines of height.
 region.viewportAnchorX = 25;  // Have the region start at 25% from the left.
-var cue = new VTTCue(2, 3, 'Cool text to be displayed');
+const cue = new VTTCue(2, 3, 'Cool text to be displayed');
 cue.region = region;  // This cue will be drawn only within this region.
 ```
 

--- a/files/en-us/web/api/wakelocksentinel/released/index.md
+++ b/files/en-us/web/api/wakelocksentinel/released/index.md
@@ -18,7 +18,7 @@ a {{domxref("WakeLockSentinel")}} has been released yet.
 ## Syntax
 
 ```js
-var released = sentinel.released;
+const released = sentinel.released;
 ```
 
 ### Value

--- a/files/en-us/web/api/webgl2renderingcontext/beginquery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/beginquery/index.md
@@ -48,7 +48,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var query = gl.createQuery();
+const query = gl.createQuery();
 gl.beginQuery(gl.ANY_SAMPLES_PASSED, query);
 
 // …

--- a/files/en-us/web/api/webgl2renderingcontext/begintransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/begintransformfeedback/index.md
@@ -41,7 +41,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var transformFeedback = gl.createTransformFeedback();
+const transformFeedback = gl.createTransformFeedback();
 gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, transformFeedback);
 gl.beginTransformFeedback(gl.TRIANGLES);
 gl.drawArrays(gl.TRIANGLES, 0, 3);

--- a/files/en-us/web/api/webgl2renderingcontext/bindsampler/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/bindsampler/index.md
@@ -36,7 +36,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var sampler = gl.createSampler();
+const sampler = gl.createSampler();
 gl.bindSampler(0, sampler);
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/bindtransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/bindtransformfeedback/index.md
@@ -37,7 +37,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var transformFeedback = gl.createTransformFeedback();
+const transformFeedback = gl.createTransformFeedback();
 gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, transformFeedback);
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/bindvertexarray/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/bindvertexarray/index.md
@@ -34,7 +34,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var vao = gl.createVertexArray();
+const vao = gl.createVertexArray();
 gl.bindVertexArray(vao);
 
 // …

--- a/files/en-us/web/api/webgl2renderingcontext/clientwaitsync/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/clientwaitsync/index.md
@@ -49,8 +49,8 @@ A {{domxref("WebGL_API/Types", "GLenum")}} indicating the sync object's status.
 ## Examples
 
 ```js
-var sync = gl.fenceSync(gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
-var status = gl.clientWaitSync(sync, 0, 0);
+const sync = gl.fenceSync(gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
+const status = gl.clientWaitSync(sync, 0, 0);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webgl2renderingcontext/copybuffersubdata/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/copybuffersubdata/index.md
@@ -56,11 +56,11 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var srcBuffer = gl.createBuffer();
-var dstBuffer = gl.createBuffer();
+const srcBuffer = gl.createBuffer();
+const dstBuffer = gl.createBuffer();
 
-var data = new Float32Array(vertices);
-var length = vertices.length * 4;
+const data = new Float32Array(vertices);
+const length = vertices.length * 4;
 
 gl.bindBuffer(gl.ARRAY_BUFFER, srcBuffer);
 gl.bufferData(gl.ARRAY_BUFFER, data, gl.STATIC_DRAW);

--- a/files/en-us/web/api/webgl2renderingcontext/createquery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/createquery/index.md
@@ -36,7 +36,7 @@ A {{domxref("WebGLQuery")}} object.
 `WebGLQuery` objects are not available in WebGL 1.
 
 ```js
-var query = gl.createQuery();
+const query = gl.createQuery();
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webgl2renderingcontext/createsampler/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/createsampler/index.md
@@ -36,7 +36,7 @@ A {{domxref("WebGLSampler")}} object.
 `WebGLSampler` objects are not available in WebGL 1.
 
 ```js
-var sampler = gl.createSampler();
+const sampler = gl.createSampler();
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webgl2renderingcontext/createtransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/createtransformfeedback/index.md
@@ -36,7 +36,7 @@ A {{domxref("WebGLTransformFeedback")}} object.
 `WebGLTransformFeedback` objects are not available in WebGL 1.
 
 ```js
-var transformFeedback = gl.createTransformFeedback();
+const transformFeedback = gl.createTransformFeedback();
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webgl2renderingcontext/createvertexarray/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/createvertexarray/index.md
@@ -36,7 +36,7 @@ points to vertex array data.
 ## Examples
 
 ```js
-var vao = gl.createVertexArray();
+const vao = gl.createVertexArray();
 gl.bindVertexArray(vao);
 
 // …

--- a/files/en-us/web/api/webgl2renderingcontext/deletequery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/deletequery/index.md
@@ -36,7 +36,7 @@ None ({{jsxref("undefined")}}).
 `WebGLQuery` objects are not available in WebGL 1.
 
 ```js
-var query = gl.createQuery();
+const query = gl.createQuery();
 
 // …
 

--- a/files/en-us/web/api/webgl2renderingcontext/deletesampler/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/deletesampler/index.md
@@ -37,7 +37,7 @@ None ({{jsxref("undefined")}}).
 `WebGLSampler` objects are not available in WebGL 1.
 
 ```js
-var sampler = gl.createSampler();
+const sampler = gl.createSampler();
 
 // …
 

--- a/files/en-us/web/api/webgl2renderingcontext/deletesync/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/deletesync/index.md
@@ -36,7 +36,7 @@ None ({{jsxref("undefined")}}).
 objects are not available in WebGL 1.
 
 ```js
-var sync = gl.fenceSync(gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
+const sync = gl.fenceSync(gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
 
 // …
 

--- a/files/en-us/web/api/webgl2renderingcontext/deletetransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/deletetransformfeedback/index.md
@@ -37,7 +37,7 @@ None ({{jsxref("undefined")}}).
 `WebGLTransformFeedback` objects are not available in WebGL 1.
 
 ```js
-var transformFeedback = gl.createTransformFeedback();
+const transformFeedback = gl.createTransformFeedback();
 
 // …
 

--- a/files/en-us/web/api/webgl2renderingcontext/deletevertexarray/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/deletevertexarray/index.md
@@ -34,7 +34,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var vao = gl.createVertexArray();
+const vao = gl.createVertexArray();
 gl.bindVertexArray(vao);
 
 // …

--- a/files/en-us/web/api/webgl2renderingcontext/endquery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/endquery/index.md
@@ -45,7 +45,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var query = gl.createQuery();
+const query = gl.createQuery();
 gl.beginQuery(gl.ANY_SAMPLES_PASSED, query);
 
 // …

--- a/files/en-us/web/api/webgl2renderingcontext/endtransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/endtransformfeedback/index.md
@@ -33,7 +33,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var transformFeedback = gl.createTransformFeedback();
+const transformFeedback = gl.createTransformFeedback();
 gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, transformFeedback);
 gl.beginTransformFeedback(gl.TRIANGLES);
 gl.drawArrays(gl.TRIANGLES, 0, 3);

--- a/files/en-us/web/api/webgl2renderingcontext/fencesync/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/fencesync/index.md
@@ -40,7 +40,7 @@ A {{domxref("WebGLSync")}} object.
 objects are not available in WebGL 1.
 
 ```js
-var sync = gl.fenceSync(gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
+const sync = gl.fenceSync(gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockname/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockname/index.md
@@ -37,7 +37,7 @@ A string indicating the active uniform block name.
 ## Examples
 
 ```js
-var blockName = gl.getActiveUniformBlockName(program, 0);
+const blockName = gl.getActiveUniformBlockName(program, 0);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockparameter/index.md
@@ -64,7 +64,7 @@ error occurs, [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) is r
 ## Examples
 
 ```js
-var blockSize = gl.getActiveUniformBlockParameter(program,
+const blockSize = gl.getActiveUniformBlockParameter(program,
                       blockIndex, gl.UNIFORM_BLOCK_DATA_SIZE);
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getactiveuniformblockparameter/index.md
@@ -64,8 +64,11 @@ error occurs, [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) is r
 ## Examples
 
 ```js
-const blockSize = gl.getActiveUniformBlockParameter(program,
-                      blockIndex, gl.UNIFORM_BLOCK_DATA_SIZE);
+const blockSize = gl.getActiveUniformBlockParameter(
+  program,
+  blockIndex,
+  gl.UNIFORM_BLOCK_DATA_SIZE
+);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webgl2renderingcontext/getactiveuniforms/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getactiveuniforms/index.md
@@ -64,8 +64,8 @@ Depends on which information is requested using the `pname` parameter.
 ## Examples
 
 ```js
-var uniformIndices = gl.getUniformIndices(program, ['UBORed', 'UBOGreen', 'UBOBlue']);
-var uniformOffsets = gl.getActiveUniforms(program, uniformIndices, gl.UNIFORM_OFFSET);
+const uniformIndices = gl.getUniformIndices(program, ['UBORed', 'UBOGreen', 'UBOBlue']);
+const uniformOffsets = gl.getActiveUniforms(program, uniformIndices, gl.UNIFORM_OFFSET);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webgl2renderingcontext/getbuffersubdata/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getbuffersubdata/index.md
@@ -89,11 +89,11 @@ An `INVALID_OPERATION` error is generated if:
 ## Examples
 
 ```js
-var buffer = gl.createBuffer();
+const buffer = gl.createBuffer();
 gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
 gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(vertices), gl.STATIC_DRAW);
 
-var arrBuffer = new ArrayBuffer(vertices.length * Float32Array.BYTES_PER_ELEMENT);
+const arrBuffer = new ArrayBuffer(vertices.length * Float32Array.BYTES_PER_ELEMENT);
 gl.getBufferSubData(gl.ARRAY_BUFFER, 0, new Float32Array(arrBuffer));
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/getindexedparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getindexedparameter/index.md
@@ -50,7 +50,7 @@ Depends on the requested information (as specified with `target`).
 ## Examples
 
 ```js
-var binding = gl.getIndexedParameter(gl.TRANSFORM_FEEDBACK_BUFFER_BINDING, 0);
+const binding = gl.getIndexedParameter(gl.TRANSFORM_FEEDBACK_BUFFER_BINDING, 0);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webgl2renderingcontext/getinternalformatparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getinternalformatparameter/index.md
@@ -53,7 +53,7 @@ Depends on the requested information (as specified with `pname`). It is an
 ## Examples
 
 ```js
-var samples = gl.getInternalformatParameter(gl.RENDERBUFFER,
+const samples = gl.getInternalformatParameter(gl.RENDERBUFFER,
                                             gl.RGBA8, gl.SAMPLES);
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/getinternalformatparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getinternalformatparameter/index.md
@@ -53,8 +53,11 @@ Depends on the requested information (as specified with `pname`). It is an
 ## Examples
 
 ```js
-const samples = gl.getInternalformatParameter(gl.RENDERBUFFER,
-                                            gl.RGBA8, gl.SAMPLES);
+const samples = gl.getInternalformatParameter(
+  gl.RENDERBUFFER,
+  gl.RGBA8,
+  gl.SAMPLES
+);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webgl2renderingcontext/getquery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getquery/index.md
@@ -49,7 +49,7 @@ A {{domxref("WebGLQuery")}} object.
 ## Examples
 
 ```js
-var currentQuery = gl.getQuery(gl.ANY_SAMPLES_PASSED, gl.CURRENT_QUERY);
+const currentQuery = gl.getQuery(gl.ANY_SAMPLES_PASSED, gl.CURRENT_QUERY);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webgl2renderingcontext/getqueryparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getqueryparameter/index.md
@@ -45,10 +45,10 @@ Depends on the `pname` parameter, either a {{domxref("WebGL_API/Types", "GLuint"
 ## Examples
 
 ```js
-var query = gl.createQuery();
+const query = gl.createQuery();
 gl.beginQuery(gl.ANY_SAMPLES_PASSED, query);
 
-var result = gl.getQueryParameter(query, gl.QUERY_RESULT);
+const result = gl.getQueryParameter(query, gl.QUERY_RESULT);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webgl2renderingcontext/getsamplerparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getsamplerparameter/index.md
@@ -57,7 +57,7 @@ Depends on the `pname` parameter, either a {{domxref("WebGL_API/Types", "GLenum"
 ## Examples
 
 ```js
-var sampler = gl.createSampler();
+const sampler = gl.createSampler();
 gl.getSamplerParameter(sampler, gl.TEXTURE_COMPARE_FUNC);
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/getsyncparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getsyncparameter/index.md
@@ -52,7 +52,7 @@ Depends on the `pname` parameter, either a {{domxref("WebGL_API/Types", "GLenum"
 ## Examples
 
 ```js
-var sync = gl.fenceSync(gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
+const sync = gl.fenceSync(gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
 gl.getSyncParameter(sync, gl.SYNC_STATUS);
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/getuniformblockindex/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getuniformblockindex/index.md
@@ -43,7 +43,7 @@ A {{domxref("WebGL_API/Types", "GLuint")}} indicating the uniform block index.
 // } instanceName;
 
 // use the block name, not the instance name:
-var blockIndex = gl.getUniformBlockIndex(program, 'UBOData');
+const blockIndex = gl.getUniformBlockIndex(program, 'UBOData');
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webgl2renderingcontext/getuniformindices/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/getuniformindices/index.md
@@ -37,7 +37,7 @@ An {{jsxref("Array")}} of {{domxref("WebGL_API/Types", "GLuint")}} containing th
 ## Examples
 
 ```js
-var uniformIndices = gl.getUniformIndices(program, ['UBORed', 'UBOGreen', 'UBOBlue']);
+const uniformIndices = gl.getUniformIndices(program, ['UBORed', 'UBOGreen', 'UBOBlue']);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webgl2renderingcontext/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/index.md
@@ -16,8 +16,8 @@ The **WebGL2RenderingContext** interface provides the OpenGL ES 3.0 rendering co
 To get an object of this interface, call {{domxref("HTMLCanvasElement.getContext()", "getContext()")}} on a `<canvas>` element, supplying "webgl2" as the argument:
 
 ```js
-var canvas = document.getElementById('myCanvas');
-var gl = canvas.getContext('webgl2');
+const canvas = document.getElementById('myCanvas');
+const gl = canvas.getContext('webgl2');
 ```
 
 > **Note:** WebGL 2 is an extension to WebGL 1. The `WebGL2RenderingContext` interface implements all members of the {{domxref("WebGLRenderingContext")}} interface. Some methods of the WebGL 1 context can accept additional values when used in a WebGL 2 context. You will find this info noted on the WebGL 1 reference pages.

--- a/files/en-us/web/api/webgl2renderingcontext/isquery/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/isquery/index.md
@@ -37,7 +37,7 @@ A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether the given objec
 `WebGLQuery` objects are not available in WebGL 1.
 
 ```js
-var query = gl.createQuery();
+const query = gl.createQuery();
 
 // …
 

--- a/files/en-us/web/api/webgl2renderingcontext/issampler/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/issampler/index.md
@@ -37,7 +37,7 @@ A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether the given objec
 `WebGLSampler` objects are not available in WebGL 1.
 
 ```js
-var sampler = gl.createSampler();
+const sampler = gl.createSampler();
 
 // …
 

--- a/files/en-us/web/api/webgl2renderingcontext/issync/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/issync/index.md
@@ -37,7 +37,7 @@ A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether the given objec
 objects are not available in WebGL 1.
 
 ```js
-var sync = gl.fenceSync(gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
+const sync = gl.fenceSync(gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
 
 // …
 

--- a/files/en-us/web/api/webgl2renderingcontext/istransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/istransformfeedback/index.md
@@ -39,7 +39,7 @@ A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether the given objec
 `WebGLTransformFeedback` objects are not available in WebGL 1.
 
 ```js
-var transformFeedback = gl.createTransformFeedback();
+const transformFeedback = gl.createTransformFeedback();
 
 // …
 

--- a/files/en-us/web/api/webgl2renderingcontext/isvertexarray/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/isvertexarray/index.md
@@ -36,7 +36,7 @@ A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether the given objec
 ## Examples
 
 ```js
-var vao = gl.createVertexArray();
+const vao = gl.createVertexArray();
 gl.bindVertexArray(vao);
 
 // …

--- a/files/en-us/web/api/webgl2renderingcontext/pausetransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/pausetransformfeedback/index.md
@@ -33,7 +33,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var transformFeedback = gl.createTransformFeedback();
+const transformFeedback = gl.createTransformFeedback();
 gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, transformFeedback);
 gl.beginTransformFeedback(gl.TRIANGLES);
 gl.pauseTransformFeedback();

--- a/files/en-us/web/api/webgl2renderingcontext/resumetransformfeedback/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/resumetransformfeedback/index.md
@@ -33,7 +33,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var transformFeedback = gl.createTransformFeedback();
+const transformFeedback = gl.createTransformFeedback();
 gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, transformFeedback);
 gl.beginTransformFeedback(gl.TRIANGLES);
 gl.pauseTransformFeedback();

--- a/files/en-us/web/api/webgl2renderingcontext/samplerparameter/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/samplerparameter/index.md
@@ -70,7 +70,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var sampler = gl.createSampler();
+const sampler = gl.createSampler();
 gl.samplerParameteri(sampler, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/transformfeedbackvaryings/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/transformfeedbackvaryings/index.md
@@ -45,8 +45,11 @@ const transformFeedback = gl.createTransformFeedback();
 gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, transformFeedback);
 const transformFeedbackOutputs = ['gl_Position', 'anotherOutput'];
 
-gl.transformFeedbackVaryings(shaderProg, transformFeedbackOutputs,
-                             gl.INTERLEAVED_ATTRIBS);
+gl.transformFeedbackVaryings(
+  shaderProg,
+  transformFeedbackOutputs,
+  gl.INTERLEAVED_ATTRIBS
+);
 gl.linkProgram(shaderProg);
 ```
 

--- a/files/en-us/web/api/webgl2renderingcontext/transformfeedbackvaryings/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/transformfeedbackvaryings/index.md
@@ -41,9 +41,9 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var transformFeedback = gl.createTransformFeedback();
+const transformFeedback = gl.createTransformFeedback();
 gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, transformFeedback);
-var transformFeedbackOutputs = ['gl_Position', 'anotherOutput'];
+const transformFeedbackOutputs = ['gl_Position', 'anotherOutput'];
 
 gl.transformFeedbackVaryings(shaderProg, transformFeedbackOutputs,
                              gl.INTERLEAVED_ATTRIBS);

--- a/files/en-us/web/api/webgl2renderingcontext/waitsync/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/waitsync/index.md
@@ -42,7 +42,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var sync = gl.fenceSync(gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
+const sync = gl.fenceSync(gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
 gl.waitSync(sync, 0, gl.TIMEOUT_IGNORED);
 ```
 

--- a/files/en-us/web/api/webgl_api/constants/index.md
+++ b/files/en-us/web/api/webgl_api/constants/index.md
@@ -18,8 +18,8 @@ The [WebGL API](/en-US/docs/Web/API/WebGL_API) provides several constants that a
 Standard WebGL constants are installed on the {{domxref("WebGLRenderingContext")}} and {{domxref("WebGL2RenderingContext")}} objects, so that you use them as `gl.CONSTANT_NAME`:
 
 ```js
-var canvas = document.getElementById('myCanvas');
-var gl = canvas.getContext('webgl');
+const canvas = document.getElementById('myCanvas');
+const gl = canvas.getContext('webgl');
 
 gl.getParameter(gl.LINE_WIDTH);
 ```
@@ -27,8 +27,8 @@ gl.getParameter(gl.LINE_WIDTH);
 Some constants are also provided by [WebGL extensions](/en-US/docs/Web/API/WebGL_API/Using_Extensions). A [list](#constants_defined_in_webgl_extensions) is provided below.
 
 ```js
-var debugInfo = gl.getExtension('WEBGL_debug_renderer_info');
-var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);
+const debugInfo = gl.getExtension('WEBGL_debug_renderer_info');
+const vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);
 ```
 
 The [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial) has more information, examples, and resources on how to get started with WebGL.

--- a/files/en-us/web/api/webgl_api/tutorial/animating_objects_with_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/animating_objects_with_webgl/index.md
@@ -15,7 +15,7 @@ tags:
 In this example, we'll actually rotate our camera. By doing so, it will look as if we are rotating the square. The first thing we'll need is a variable in which to track the current rotation of the camera:
 
 ```js
-var squareRotation = 0.0;
+let squareRotation = 0.0;
 ```
 
 Now we need to update the `drawScene()` function to apply the current rotation to the camera when drawing it. After translating the camera to the initial drawing position for the square, we apply the rotation like this:

--- a/files/en-us/web/api/webgl_api/using_extensions/index.md
+++ b/files/en-us/web/api/webgl_api/using_extensions/index.md
@@ -19,7 +19,7 @@ Extensions may be supported by browser vendors before being officially ratified 
 If you wish to work with the bleeding edge of extensions, and want to keep working on upon ratification (assuming, of course, that the extension doesn't change in incompatible ways), that you query the canonical extension name as well as the vendor extension name. For instance:
 
 ```js
-var ext = (
+const ext = (
   gl.getExtension('OES_vertex_array_object') ||
   gl.getExtension('MOZ_OES_vertex_array_object') ||
   gl.getExtension('WEBKIT_OES_vertex_array_object')
@@ -48,7 +48,7 @@ WebGL extensions are prefixed with "ANGLE", "OES", "EXT" or "WEBGL". These prefi
 The WebGL context supports querying what extensions are available.
 
 ```js
-var available_extensions = gl.getSupportedExtensions();
+const available_extensions = gl.getSupportedExtensions();
 ```
 
 The {{domxref("WebGLRenderingContext.getSupportedExtensions()")}} method returns an array of strings, one for each supported extension.
@@ -101,7 +101,7 @@ The current extensions are:
 Before an extension can be used it has to be enabled using {{domxref("WebGLRenderingContext.getExtension()")}}. For example:
 
 ```js
-var float_texture_ext = gl.getExtension('OES_texture_float');
+const float_texture_ext = gl.getExtension('OES_texture_float');
 ```
 
 The return value is `null` if the extension is not supported, or an extension object otherwise.

--- a/files/en-us/web/api/webgl_color_buffer_float/index.md
+++ b/files/en-us/web/api/webgl_color_buffer_float/index.md
@@ -39,7 +39,7 @@ This extension extends {{domxref("WebGLRenderingContext.renderbufferStorage()")}
 ## Examples
 
 ```js
-var ext = gl.getExtension('WEBGL_color_buffer_float');
+const ext = gl.getExtension('WEBGL_color_buffer_float');
 
 gl.renderbufferStorage(gl.RENDERBUFFER, ext.RGBA32F_EXT, 256, 256);
 ```

--- a/files/en-us/web/api/webgl_compressed_texture_astc/getsupportedprofiles/index.md
+++ b/files/en-us/web/api/webgl_compressed_texture_astc/getsupportedprofiles/index.md
@@ -43,7 +43,7 @@ tonal range of real-world scenes (100,000:1).
 ## Examples
 
 ```js
-var ext = gl.getExtension('WEBGL_compressed_texture_astc');
+const ext = gl.getExtension('WEBGL_compressed_texture_astc');
 ext.getSupportedProfiles(); // ["ldr"]
 ```
 

--- a/files/en-us/web/api/webgl_compressed_texture_astc/index.md
+++ b/files/en-us/web/api/webgl_compressed_texture_astc/index.md
@@ -232,9 +232,9 @@ The compressed texture formats are exposed by 28 constants and can be used in tw
 ## Examples
 
 ```js
-var ext = gl.getExtension('WEBGL_compressed_texture_astc');
+const ext = gl.getExtension('WEBGL_compressed_texture_astc');
 
-var texture = gl.createTexture();
+const texture = gl.createTexture();
 gl.bindTexture(gl.TEXTURE_2D, texture);
 
 gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGBA_ASTC_12x12_KHR, 512, 512, 0, textureData);

--- a/files/en-us/web/api/webgl_compressed_texture_etc/index.md
+++ b/files/en-us/web/api/webgl_compressed_texture_etc/index.md
@@ -47,9 +47,9 @@ The compressed texture formats are exposed by 10 constants and can be used in tw
 ## Examples
 
 ```js
-var ext = gl.getExtension('WEBGL_compressed_texture_etc');
+const ext = gl.getExtension('WEBGL_compressed_texture_etc');
 
-var texture = gl.createTexture();
+const texture = gl.createTexture();
 gl.bindTexture(gl.TEXTURE_2D, texture);
 
 gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGBA8_ETC2_EAC, 512, 512, 0, textureData);

--- a/files/en-us/web/api/webgl_compressed_texture_etc1/index.md
+++ b/files/en-us/web/api/webgl_compressed_texture_etc1/index.md
@@ -29,9 +29,9 @@ The compressed texture format is exposed by a constant and can be used with the 
 ## Examples
 
 ```js
-var ext = gl.getExtension('WEBGL_compressed_texture_etc1');
+const ext = gl.getExtension('WEBGL_compressed_texture_etc1');
 
-var texture = gl.createTexture();
+const texture = gl.createTexture();
 gl.bindTexture(gl.TEXTURE_2D, texture);
 
 gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGB_ETC1_WEBGL, 512, 512, 0, textureData);

--- a/files/en-us/web/api/webgl_compressed_texture_pvrtc/index.md
+++ b/files/en-us/web/api/webgl_compressed_texture_pvrtc/index.md
@@ -40,9 +40,9 @@ The compressed texture formats are exposed by four constants and can be used in 
 ## Examples
 
 ```js
-var ext = gl.getExtension('WEBGL_compressed_texture_pvrtc');
+const ext = gl.getExtension('WEBGL_compressed_texture_pvrtc');
 
-var texture = gl.createTexture();
+const texture = gl.createTexture();
 gl.bindTexture(gl.TEXTURE_2D, texture);
 
 gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGB_PVRTC_4BPPV1_IMG, 512, 512, 0, textureData);

--- a/files/en-us/web/api/webgl_compressed_texture_s3tc/index.md
+++ b/files/en-us/web/api/webgl_compressed_texture_s3tc/index.md
@@ -35,13 +35,13 @@ The compressed texture formats are exposed by four constants and can be used in 
 ## Examples
 
 ```js
-var ext = (
+const ext = (
   gl.getExtension('WEBGL_compressed_texture_s3tc') ||
   gl.getExtension('MOZ_WEBGL_compressed_texture_s3tc') ||
   gl.getExtension('WEBKIT_WEBGL_compressed_texture_s3tc')
 );
 
-var texture = gl.createTexture();
+const texture = gl.createTexture();
 gl.bindTexture(gl.TEXTURE_2D, texture);
 
 gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGBA_S3TC_DXT5_EXT, 512, 512, 0, textureData);

--- a/files/en-us/web/api/webgl_compressed_texture_s3tc_srgb/index.md
+++ b/files/en-us/web/api/webgl_compressed_texture_s3tc_srgb/index.md
@@ -35,9 +35,9 @@ The compressed texture formats are exposed by four constants and can be used in 
 ## Examples
 
 ```js
-var ext = gl.getExtension('WEBGL_compressed_texture_s3tc_srgb');
+const ext = gl.getExtension('WEBGL_compressed_texture_s3tc_srgb');
 
-var texture = gl.createTexture();
+const texture = gl.createTexture();
 gl.bindTexture(gl.TEXTURE_2D, texture);
 
 gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_SRGB_S3TC_DXT1_EXT, 512, 512, 0, textureData);

--- a/files/en-us/web/api/webgl_debug_renderer_info/index.md
+++ b/files/en-us/web/api/webgl_debug_renderer_info/index.md
@@ -33,12 +33,12 @@ WebGL extensions are available using the {{domxref("WebGLRenderingContext.getExt
 With the help of this extension, privileged contexts are able to retrieve debugging information about the user's graphic driver:
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
 
-var debugInfo = gl.getExtension('WEBGL_debug_renderer_info');
-var vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);
-var renderer = gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL);
+const debugInfo = gl.getExtension('WEBGL_debug_renderer_info');
+const vendor = gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL);
+const renderer = gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL);
 
 console.log(vendor);
 console.log(renderer);

--- a/files/en-us/web/api/webgl_debug_shaders/gettranslatedshadersource/index.md
+++ b/files/en-us/web/api/webgl_debug_shaders/gettranslatedshadersource/index.md
@@ -39,14 +39,14 @@ returned, if:
 ## Examples
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
 
-var shader = gl.createShader(gl.FRAGMENT_SHADER);
+const shader = gl.createShader(gl.FRAGMENT_SHADER);
 gl.shaderSource(shader, 'void main() { gl_FragColor = vec4(gl_FragCoord.x, 0.0, 0.0, 1.0); }');
 gl.compileShader(shader);
 
-var src = gl.getExtension('WEBGL_debug_shaders').getTranslatedShaderSource(shader);
+const src = gl.getExtension('WEBGL_debug_shaders').getTranslatedShaderSource(shader);
 console.log(src);
 // "void main(){
 // (gl_FragColor = vec4(gl_FragCoord.x, 0.0, 0.0, 1.0));

--- a/files/en-us/web/api/webgl_depth_texture/index.md
+++ b/files/en-us/web/api/webgl_depth_texture/index.md
@@ -41,7 +41,7 @@ This extension extends {{domxref("WebGLRenderingContext.framebufferTexture2D()")
 ## Examples
 
 ```js
-var ext = gl.getExtension('WEBGL_depth_texture');
+const ext = gl.getExtension('WEBGL_depth_texture');
 
 gl.texImage2D(gl.TEXTURE_2D, 0, gl.DEPTH_COMPONENT, 512, 512, 0, gl.DEPTH_COMPONENT, gl.UNSIGNED_SHORT, null);
 ```

--- a/files/en-us/web/api/webgl_draw_buffers/index.md
+++ b/files/en-us/web/api/webgl_draw_buffers/index.md
@@ -42,13 +42,13 @@ This extension exposes one new method.
 Enabling the extension:
 
 ```js
-var ext = gl.getExtension('WEBGL_draw_buffers');
+const ext = gl.getExtension('WEBGL_draw_buffers');
 ```
 
 Binding multiple textures (to a `tx[]` array) to different framebuffer color attachments:
 
 ```js
-var fb = gl.createFramebuffer();
+const fb = gl.createFramebuffer();
 gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
 gl.framebufferTexture2D(gl.FRAMEBUFFER, ext.COLOR_ATTACHMENT0_WEBGL, gl.TEXTURE_2D, tx[0], 0);
 gl.framebufferTexture2D(gl.FRAMEBUFFER, ext.COLOR_ATTACHMENT1_WEBGL, gl.TEXTURE_2D, tx[1], 0);

--- a/files/en-us/web/api/webgl_lose_context/losecontext/index.md
+++ b/files/en-us/web/api/webgl_lose_context/losecontext/index.md
@@ -40,8 +40,8 @@ With this method, you can simulate the
 event:
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
 
 canvas.addEventListener('webglcontextlost', function(e) {
   console.log(e);

--- a/files/en-us/web/api/webgl_lose_context/restorecontext/index.md
+++ b/files/en-us/web/api/webgl_lose_context/restorecontext/index.md
@@ -43,8 +43,8 @@ With this method, you can simulate the
 event:
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
 
 canvas.addEventListener('webglcontextrestored', function(e) {
   console.log(e);

--- a/files/en-us/web/api/webglactiveinfo/name/index.md
+++ b/files/en-us/web/api/webglactiveinfo/name/index.md
@@ -16,10 +16,10 @@ The read-only **`WebGLActiveInfo.name`** property represents the name of the req
 ## Examples
 
 ```js
-var activeAttrib = gl.getActiveAttrib(program, index);
+const activeAttrib = gl.getActiveAttrib(program, index);
 activeAttrib.name;
 
-var activeUniform = gl.getActiveUniform(program, index);
+const activeUniform = gl.getActiveUniform(program, index);
 activeUniform.name;
 ```
 

--- a/files/en-us/web/api/webglactiveinfo/size/index.md
+++ b/files/en-us/web/api/webglactiveinfo/size/index.md
@@ -16,10 +16,10 @@ The read-only **`WebGLActiveInfo.size`** property is a {{jsxref("Number")}} repr
 ## Examples
 
 ```js
-var activeAttrib = gl.getActiveAttrib(program, index);
+const activeAttrib = gl.getActiveAttrib(program, index);
 activeAttrib.size;
 
-var activeUniform = gl.getActiveUniform(program, index);
+const activeUniform = gl.getActiveUniform(program, index);
 activeUniform.size;
 ```
 

--- a/files/en-us/web/api/webglactiveinfo/type/index.md
+++ b/files/en-us/web/api/webglactiveinfo/type/index.md
@@ -16,10 +16,10 @@ The read-only **`WebGLActiveInfo.type`** property represents the type of the req
 ## Examples
 
 ```js
-var activeAttrib = gl.getActiveAttrib(program, index);
+const activeAttrib = gl.getActiveAttrib(program, index);
 activeAttrib.type;
 
-var activeUniform = gl.getActiveUniform(program, index);
+const activeUniform = gl.getActiveUniform(program, index);
 activeUniform.type;
 ```
 

--- a/files/en-us/web/api/webglbuffer/index.md
+++ b/files/en-us/web/api/webglbuffer/index.md
@@ -28,9 +28,9 @@ The `WebGLBuffer` object does not define any methods or properties of its own an
 ### Creating a buffer
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var buffer = gl.createBuffer();
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const buffer = gl.createBuffer();
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webglcontextevent/index.md
+++ b/files/en-us/web/api/webglcontextevent/index.md
@@ -32,8 +32,8 @@ _This interface doesn't define any own methods, but inherits methods from its pa
 With the help of the {{domxref("WEBGL_lose_context")}} extension, you can simulate the {{domxref("HTMLCanvasElement/webglcontextlost_event", "webglcontextlost")}} and {{domxref("HTMLCanvasElement/webglcontextrestored_event", "webglcontextrestored")}} events:
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
 
 canvas.addEventListener('webglcontextlost', function(e) {
   console.log(e);

--- a/files/en-us/web/api/webglcontextevent/statusmessage/index.md
+++ b/files/en-us/web/api/webglcontextevent/statusmessage/index.md
@@ -20,8 +20,8 @@ The read-only **`WebGLContextEvent.statusMessage`** property contains additional
 The `statusMessage` property can contain a platform dependent string with details of an event. This can occur, for example, if the {{domxref("HTMLCanvasElement/webglcontextcreationerror_event", "webglcontextcreationerror")}} event is fired.
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
 
 canvas.addEventListener('webglcontextcreationerror', function(e) {
   console.log(`WebGL context creation failed: ${e.statusMessage || 'Unknown error'}`);

--- a/files/en-us/web/api/webglframebuffer/index.md
+++ b/files/en-us/web/api/webglframebuffer/index.md
@@ -28,9 +28,9 @@ The `WebGLFramebuffer` object does not define any methods or properties of its o
 ### Creating a frame buffer
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var buffer = gl.createFramebuffer();
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const buffer = gl.createFramebuffer();
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webglprogram/index.md
+++ b/files/en-us/web/api/webglprogram/index.md
@@ -33,7 +33,7 @@ gl.attachShader(program, fragmentShader);
 gl.linkProgram(program);
 
 if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
-  var info = gl.getProgramInfoLog(program);
+  const info = gl.getProgramInfoLog(program);
   throw `Could not compile WebGL program. \n\n${info}`;
 }
 ```

--- a/files/en-us/web/api/webglquery/index.md
+++ b/files/en-us/web/api/webglquery/index.md
@@ -35,7 +35,7 @@ When working with `WebGLQuery` objects, the following methods of the {{domxref("
 in this example, `gl` must be a {{domxref("WebGL2RenderingContext")}}. `WebGLQuery` objects are not available in WebGL 1.
 
 ```js
-var query = gl.createQuery();
+const query = gl.createQuery();
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webglrenderbuffer/index.md
+++ b/files/en-us/web/api/webglrenderbuffer/index.md
@@ -28,9 +28,9 @@ The `WebGLRenderbuffer` object does not define any methods or properties of its 
 ### Creating a render buffer
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var buffer = gl.createRenderbuffer();
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const buffer = gl.createRenderbuffer();
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webglrenderingcontext/bindbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/bindbuffer/index.md
@@ -70,9 +70,9 @@ and the current binding will remain untouched.
 ### Binding a buffer to a target
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var buffer = gl.createBuffer();
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const buffer = gl.createBuffer();
 
 gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
 ```

--- a/files/en-us/web/api/webglrenderingcontext/bindframebuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/bindframebuffer/index.md
@@ -59,9 +59,9 @@ A `gl.INVALID_ENUM` error is thrown if `target` is not
 ### Binding a frame buffer
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var framebuffer = gl.createFramebuffer();
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const framebuffer = gl.createFramebuffer();
 
 gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffer);
 ```

--- a/files/en-us/web/api/webglrenderingcontext/bindrenderbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/bindrenderbuffer/index.md
@@ -50,9 +50,9 @@ A `gl.INVALID_ENUM` error is thrown if `target` is not
 ### Binding a renderbuffer
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var renderbuffer = gl.createRenderbuffer();
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const renderbuffer = gl.createRenderbuffer();
 
 gl.bindRenderbuffer(gl.RENDERBUFFER, renderbuffer);
 ```

--- a/files/en-us/web/api/webglrenderingcontext/bindtexture/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/bindtexture/index.md
@@ -54,9 +54,9 @@ A `gl.INVALID_ENUM` error is thrown if `target` is not
 ### Binding a texture
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var texture = gl.createTexture();
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const texture = gl.createTexture();
 
 gl.bindTexture(gl.TEXTURE_2D, texture);
 ```

--- a/files/en-us/web/api/webglrenderingcontext/bufferdata/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/bufferdata/index.md
@@ -134,9 +134,9 @@ None ({{jsxref("undefined")}}).
 ### Using bufferData
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var buffer = gl.createBuffer();
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const buffer = gl.createBuffer();
 gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
 gl.bufferData(gl.ARRAY_BUFFER, 1024, gl.STATIC_DRAW);
 ```
@@ -156,8 +156,8 @@ gl.getBufferParameter(gl.ARRAY_BUFFER, gl.BUFFER_USAGE);
 To calculate size parameter for a typed array.
 
 ```js
-var dataArray = new Float32Array([1, 2, 3, 4]);
-var sizeInBytes = dataArray.length * dataArray.BYTES_PER_ELEMENT;
+const dataArray = new Float32Array([1, 2, 3, 4]);
+const sizeInBytes = dataArray.length * dataArray.BYTES_PER_ELEMENT;
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webglrenderingcontext/buffersubdata/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/buffersubdata/index.md
@@ -90,9 +90,9 @@ None ({{jsxref("undefined")}}).
 ### Using `bufferSubData`
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var buffer = gl.createBuffer();
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const buffer = gl.createBuffer();
 gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
 gl.bufferData(gl.ARRAY_BUFFER, 1024, gl.STATIC_DRAW);
 gl.bufferSubData(gl.ARRAY_BUFFER, 512, data);

--- a/files/en-us/web/api/webglrenderingcontext/canvas/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/canvas/index.md
@@ -42,8 +42,8 @@ You can get back a reference to it from the `WebGLRenderingContext` using
 the `canvas` property:
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
 gl.canvas; // HTMLCanvasElement
 ```
 
@@ -52,8 +52,8 @@ gl.canvas; // HTMLCanvasElement
 Example using the experimental {{domxref("OffscreenCanvas")}} object.
 
 ```js
-var offscreen = new OffscreenCanvas(256, 256);
-var gl = offscreen.getContext('webgl');
+const offscreen = new OffscreenCanvas(256, 256);
+const gl = offscreen.getContext('webgl');
 gl.canvas; // OffscreenCanvas
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/checkframebufferstatus/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/checkframebufferstatus/index.md
@@ -73,9 +73,9 @@ A {{domxref("WebGL_API/Types", "GLenum")}} indicating the completeness status of
 ## Examples
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var framebuffer = gl.createFramebuffer();
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const framebuffer = gl.createFramebuffer();
 
 // …
 

--- a/files/en-us/web/api/webglrenderingcontext/commit/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/commit/index.md
@@ -35,9 +35,9 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var htmlCanvas = document.createElement('canvas');
-var offscreen = htmlCanvas.transferControlToOffscreen();
-var gl = offscreen.getContext('webgl');
+const htmlCanvas = document.createElement('canvas');
+const offscreen = htmlCanvas.transferControlToOffscreen();
+const gl = offscreen.getContext('webgl');
 
 // Perform some drawing using the gl context
 

--- a/files/en-us/web/api/webglrenderingcontext/compileshader/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/compileshader/index.md
@@ -33,7 +33,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var shader = gl.createShader(gl.VERTEX_SHADER);
+const shader = gl.createShader(gl.VERTEX_SHADER);
 gl.shaderSource(shader, shaderSource);
 gl.compileShader(shader);
 ```

--- a/files/en-us/web/api/webglrenderingcontext/compressedteximage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/compressedteximage2d/index.md
@@ -177,13 +177,13 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var ext = (
+const ext = (
   gl.getExtension('WEBGL_compressed_texture_s3tc') ||
   gl.getExtension('MOZ_WEBGL_compressed_texture_s3tc') ||
   gl.getExtension('WEBKIT_WEBGL_compressed_texture_s3tc')
 );
 
-var texture = gl.createTexture();
+const texture = gl.createTexture();
 gl.bindTexture(gl.TEXTURE_2D, texture);
 gl.compressedTexImage2D(gl.TEXTURE_2D, 0, ext.COMPRESSED_RGBA_S3TC_DXT5_EXT, 512, 512, 0, textureData);
 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);

--- a/files/en-us/web/api/webglrenderingcontext/compressedtexsubimage2d/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/compressedtexsubimage2d/index.md
@@ -156,7 +156,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var ext = (
+const ext = (
   gl.getExtension('WEBGL_compressed_texture_s3tc') ||
   gl.getExtension('MOZ_WEBGL_compressed_texture_s3tc') ||
   gl.getExtension('WEBKIT_WEBGL_compressed_texture_s3tc')

--- a/files/en-us/web/api/webglrenderingcontext/createbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/createbuffer/index.md
@@ -34,9 +34,9 @@ A {{domxref("WebGLBuffer")}} storing data such as vertices or colors.
 ### Creating a buffer
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var buffer = gl.createBuffer();
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const buffer = gl.createBuffer();
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webglrenderingcontext/createframebuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/createframebuffer/index.md
@@ -35,9 +35,9 @@ A {{domxref("WebGLFramebuffer")}} object.
 ### Creating a frame buffer
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var framebuffer = gl.createFramebuffer();
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const framebuffer = gl.createFramebuffer();
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webglrenderingcontext/createrenderbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/createrenderbuffer/index.md
@@ -36,9 +36,9 @@ source or target of an rendering operation.
 ### Creating a render buffer
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var renderBuffer = gl.createRenderbuffer();
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const renderBuffer = gl.createRenderbuffer();
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webglrenderingcontext/createtexture/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/createtexture/index.md
@@ -38,9 +38,9 @@ See also the [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial) on [Using 
 ### Creating a texture
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var texture = gl.createTexture();
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const texture = gl.createTexture();
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webglrenderingcontext/deletebuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/deletebuffer/index.md
@@ -36,9 +36,9 @@ None ({{jsxref("undefined")}}).
 ### Deleting a buffer
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var buffer = gl.createBuffer();
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const buffer = gl.createBuffer();
 
 // …
 

--- a/files/en-us/web/api/webglrenderingcontext/deleteframebuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/deleteframebuffer/index.md
@@ -37,9 +37,9 @@ None ({{jsxref("undefined")}}).
 ### Deleting a frame buffer
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var framebuffer = gl.createFramebuffer();
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const framebuffer = gl.createFramebuffer();
 
 // …
 

--- a/files/en-us/web/api/webglrenderingcontext/deleteprogram/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/deleteprogram/index.md
@@ -37,9 +37,9 @@ None ({{jsxref("undefined")}}).
 ### Deleting a program
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var program = gl.createProgram();
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const program = gl.createProgram();
 
 // …
 

--- a/files/en-us/web/api/webglrenderingcontext/deleterenderbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/deleterenderbuffer/index.md
@@ -37,9 +37,9 @@ None ({{jsxref("undefined")}}).
 ### Deleting a renderbuffer
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var renderbuffer = gl.createRenderbuffer();
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const renderbuffer = gl.createRenderbuffer();
 
 // …
 

--- a/files/en-us/web/api/webglrenderingcontext/deletetexture/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/deletetexture/index.md
@@ -38,9 +38,9 @@ None ({{jsxref("undefined")}}).
 ### Deleting a texture
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var texture = gl.createTexture();
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const texture = gl.createTexture();
 
 // …
 

--- a/files/en-us/web/api/webglrenderingcontext/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/index.md
@@ -25,8 +25,8 @@ The **`WebGLRenderingContext`** interface provides an interface to the OpenGL ES
 To get an access to a WebGL context for 2D and/or 3D graphics rendering, call {{domxref("HTMLCanvasElement.getContext()", "getContext()")}} on a `<canvas>` element, supplying "webgl" as the argument:
 
 ```js
-var canvas = document.getElementById('myCanvas');
-var gl = canvas.getContext('webgl');
+const canvas = document.getElementById('myCanvas');
+const gl = canvas.getContext('webgl');
 ```
 
 Once you have the WebGL rendering context for a canvas, you can render within it. The [WebGL tutorial](/en-US/docs/Web/API/WebGL_API/Tutorial) has more information, examples, and resources on how to get started with WebGL.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Replaces `var` in Web/API with `const` where applicable and `let` otherwise.
Mostly automated via my ESLint setup, using the rules `no-var` and `prefer-const`

#### Motivation

* See #16662
* See https://github.com/mdn/content/discussions/10389
* See https://github.com/orgs/mdn/discussions/143

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
