### PR TITLE
no more vars in Web/API (7)

### DIFF
--- a/files/en-us/web/api/webglrenderingcontext/drawingbufferheight/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/drawingbufferheight/index.md
@@ -34,8 +34,8 @@ Given this {{HTMLElement("canvas")}} element:
 You can get the height of the drawing buffer with the following lines:
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
 gl.drawingBufferHeight; // 150
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/drawingbufferwidth/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/drawingbufferwidth/index.md
@@ -34,8 +34,8 @@ Given this {{HTMLElement("canvas")}} element:
 You can get the width of the drawing buffer with the following lines:
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
 gl.drawingBufferWidth; // 300
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/getattachedshaders/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getattachedshaders/index.md
@@ -35,7 +35,7 @@ given `WebGLProgram`.
 ## Examples
 
 ```js
-var program = gl.createProgram();
+const program = gl.createProgram();
 
 // Attach pre-existing shaders
 gl.attachShader(program, vertexShader);

--- a/files/en-us/web/api/webglrenderingcontext/getcontextattributes/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getcontextattributes/index.md
@@ -42,8 +42,8 @@ Given this {{HTMLElement("canvas")}} element
 and given this WebGL context
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
 gl.getContextAttributes();
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/getextension/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getextension/index.md
@@ -38,7 +38,7 @@ Once a WebGL extension is enabled, you are able to use the methods, properties o
 constants that this extension object provides.
 
 ```js
-var canvas = document.getElementById('canvas');
+const canvas = document.getElementById('canvas');
 gl = canvas.getContext('webgl');
 
 gl.getExtension('WEBGL_lose_context').loseContext();

--- a/files/en-us/web/api/webglrenderingcontext/getprograminfolog/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getprograminfolog/index.md
@@ -39,7 +39,7 @@ string of length 0.
 ### Checking program errors
 
 ```js
-var program = gl.createProgram();
+const program = gl.createProgram();
 
 // Attach pre-existing shaders
 gl.attachShader(program, vertexShader);

--- a/files/en-us/web/api/webglrenderingcontext/getshaderinfolog/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getshaderinfolog/index.md
@@ -44,7 +44,7 @@ gl.shaderSource(shader, shaderCode);
 /* compile shader source code. */
 gl.compileShader(shader);
 
-var message = gl.getShaderInfoLog(shader);
+const message = gl.getShaderInfoLog(shader);
 
 if (message.length > 0) {
   /* message may be an error or a warning */

--- a/files/en-us/web/api/webglrenderingcontext/getshaderprecisionformat/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getshaderprecisionformat/index.md
@@ -49,8 +49,8 @@ The following code gets the precision format of a `gl.VERTEX_SHADER` with a
 `gl.MEDIUM_FLOAT` precision type.
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
 
 gl.getShaderPrecisionFormat(gl.VERTEX_SHADER, gl.MEDIUM_FLOAT);
 // WebGLShaderPrecisionFormat { rangeMin: 127, rangeMax: 127, precision: 23 }

--- a/files/en-us/web/api/webglrenderingcontext/getshadersource/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getshadersource/index.md
@@ -34,10 +34,10 @@ A string containing the source code of the shader.
 ## Examples
 
 ```js
-var shader = gl.createShader(gl.VERTEX_SHADER);
+const shader = gl.createShader(gl.VERTEX_SHADER);
 gl.shaderSource(shader, originalSource);
 
-var source = gl.getShaderSource(shader);
+const source = gl.getShaderSource(shader);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webglrenderingcontext/getsupportedextensions/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getsupportedextensions/index.md
@@ -33,10 +33,10 @@ An {{jsxref("Array")}} of strings with all the supported WebGL extensions.
 ## Examples
 
 ```js
-var canvas = document.getElementById('canvas');
+const canvas = document.getElementById('canvas');
 gl = canvas.getContext('webgl');
 
-var extensions = gl.getSupportedExtensions();
+const extensions = gl.getSupportedExtensions();
 // Array [ 'ANGLE_instanced_arrays', 'EXT_blend_minmax', … ]
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/getuniform/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getuniform/index.md
@@ -177,7 +177,7 @@ The returned type depends on the uniform type:
 ## Examples
 
 ```js
-var loc = gl.getUniformLocation(program, 'u_foobar');
+const loc = gl.getUniformLocation(program, 'u_foobar');
 gl.getUniform(program, loc);
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/isbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/isbuffer/index.md
@@ -35,9 +35,9 @@ A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether or not the buff
 ### Creating a buffer
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var buffer = gl.createBuffer();
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const buffer = gl.createBuffer();
 
 gl.isBuffer(buffer);
 ```

--- a/files/en-us/web/api/webglrenderingcontext/isframebuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/isframebuffer/index.md
@@ -36,9 +36,9 @@ A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether or not the fram
 ### Checking a frame buffer
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var framebuffer = gl.createFramebuffer();
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const framebuffer = gl.createFramebuffer();
 
 gl.isFramebuffer(framebuffer);
 ```

--- a/files/en-us/web/api/webglrenderingcontext/isprogram/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/isprogram/index.md
@@ -35,9 +35,9 @@ A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether or not the prog
 ### Checking a program
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var program = gl.createProgram();
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const program = gl.createProgram();
 
 // …
 

--- a/files/en-us/web/api/webglrenderingcontext/isrenderbuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/isrenderbuffer/index.md
@@ -36,9 +36,9 @@ A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether or not the rend
 ### Checking a renderbuffer
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var renderbuffer = gl.createRenderbuffer();
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const renderbuffer = gl.createRenderbuffer();
 
 gl.isRenderbuffer(renderbuffer);
 ```

--- a/files/en-us/web/api/webglrenderingcontext/isshader/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/isshader/index.md
@@ -35,9 +35,9 @@ A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether or not the shad
 ### Checking a shader
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var shader = gl.createShader(gl.VERTEX_SHADER);
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const shader = gl.createShader(gl.VERTEX_SHADER);
 
 // …
 

--- a/files/en-us/web/api/webglrenderingcontext/istexture/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/istexture/index.md
@@ -35,9 +35,9 @@ A {{domxref("WebGL_API/Types", "GLboolean")}} indicating whether or not the text
 ### Checking a texture
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var texture = gl.createTexture();
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const texture = gl.createTexture();
 
 gl.isTexture(texture);
 ```

--- a/files/en-us/web/api/webglrenderingcontext/pixelstorei/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/pixelstorei/index.md
@@ -195,7 +195,7 @@ textures with the {{domxref("WebGLRenderingContext.texImage2D()")}} and
 {{domxref("WebGLRenderingContext.texSubImage2D()")}} methods.
 
 ```js
-var tex = gl.createTexture();
+const tex = gl.createTexture();
 gl.bindTexture(gl.TEXTURE_2D, tex);
 gl.pixelStorei(gl.PACK_ALIGNMENT, 4);
 ```

--- a/files/en-us/web/api/webglrenderingcontext/readpixels/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/readpixels/index.md
@@ -119,9 +119,9 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var pixels = new Uint8Array(gl.drawingBufferWidth * gl.drawingBufferHeight * 4);
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const pixels = new Uint8Array(gl.drawingBufferWidth * gl.drawingBufferHeight * 4);
 gl.readPixels(0, 0, gl.drawingBufferWidth, gl.drawingBufferHeight, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
 console.log(pixels); // Uint8Array
 ```

--- a/files/en-us/web/api/webglrenderingcontext/shadersource/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/shadersource/index.md
@@ -35,10 +35,10 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var shader = gl.createShader(gl.VERTEX_SHADER);
+const shader = gl.createShader(gl.VERTEX_SHADER);
 gl.shaderSource(shader, originalSource);
 
-var source = gl.getShaderSource(shader);
+const source = gl.getShaderSource(shader);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webglrenderingcontext/useprogram/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/useprogram/index.md
@@ -33,7 +33,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var program = gl.createProgram();
+const program = gl.createProgram();
 
 // Attach pre-existing shaders
 gl.attachShader(program, vertexShader);

--- a/files/en-us/web/api/webglsampler/index.md
+++ b/files/en-us/web/api/webglsampler/index.md
@@ -31,7 +31,7 @@ When working with `WebGLSampler` objects, the following methods of the {{domxref
 in this example, `gl` must be a {{domxref("WebGL2RenderingContext")}}. `WebGLSampler` objects are not available in WebGL 1.
 
 ```js
-var sampler = gl.createSampler();
+const sampler = gl.createSampler();
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webglshaderprecisionformat/index.md
+++ b/files/en-us/web/api/webglshaderprecisionformat/index.md
@@ -26,8 +26,8 @@ The **WebGLShaderPrecisionFormat** interface is part of the [WebGL API](/en-US/d
 A `WebGLShaderPrecisionFormat` object is returned by the {{domxref("WebGLRenderingContext.getShaderPrecisionFormat()")}} method.
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
 gl.getShaderPrecisionFormat(gl.VERTEX_SHADER, gl.MEDIUM_FLOAT);
 // WebGLShaderPrecisionFormat { rangeMin: 127, rangeMax: 127, precision: 23 }
 ```

--- a/files/en-us/web/api/webglshaderprecisionformat/precision/index.md
+++ b/files/en-us/web/api/webglshaderprecisionformat/precision/index.md
@@ -18,8 +18,8 @@ For integer formats this value is always 0.
 ## Examples
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
 
 gl.getShaderPrecisionFormat(gl.VERTEX_SHADER, gl.MEDIUM_FLOAT).precision; // 23
 gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.LOW_INT).precision; // 0

--- a/files/en-us/web/api/webglshaderprecisionformat/rangemax/index.md
+++ b/files/en-us/web/api/webglshaderprecisionformat/rangemax/index.md
@@ -16,8 +16,8 @@ The read-only **`WebGLShaderPrecisionFormat.rangeMax`** property returns the bas
 ## Examples
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
 
 gl.getShaderPrecisionFormat(gl.VERTEX_SHADER, gl.MEDIUM_FLOAT).rangeMax; // 127
 gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.LOW_INT).rangeMax; // 24

--- a/files/en-us/web/api/webglshaderprecisionformat/rangemin/index.md
+++ b/files/en-us/web/api/webglshaderprecisionformat/rangemin/index.md
@@ -16,8 +16,8 @@ The read-only **`WebGLShaderPrecisionFormat.rangeMin`** property returns the bas
 ## Examples
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
 
 gl.getShaderPrecisionFormat(gl.VERTEX_SHADER, gl.MEDIUM_FLOAT).rangeMin; // 127
 gl.getShaderPrecisionFormat(gl.FRAGMENT_SHADER, gl.LOW_INT).rangeMin; // 24

--- a/files/en-us/web/api/webglsync/index.md
+++ b/files/en-us/web/api/webglsync/index.md
@@ -32,7 +32,7 @@ When working with `WebGLSync` objects, the following methods of the {{domxref("W
 in this example, `gl` must be a {{domxref("WebGL2RenderingContext")}}. `WebGLSync` objects are not available in WebGL 1.
 
 ```js
-var sync = gl.fenceSync(gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
+const sync = gl.fenceSync(gl.SYNC_GPU_COMMANDS_COMPLETE, 0);
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webgltexture/index.md
+++ b/files/en-us/web/api/webgltexture/index.md
@@ -49,9 +49,9 @@ The WebXR _opaque texture_ is identical to the standard `WebGLTexture` with the 
 ### Creating a texture
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
-var texture = gl.createTexture();
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
+const texture = gl.createTexture();
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webgltransformfeedback/index.md
+++ b/files/en-us/web/api/webgltransformfeedback/index.md
@@ -36,7 +36,7 @@ When working with `WebGLTransformFeedback` objects, the following methods of the
 in this example, `gl` must be a {{domxref("WebGL2RenderingContext")}}. `WebGLTransformFeedback` objects are not available in WebGL 1.
 
 ```js
-var transformFeedback = gl.createTransformFeedback();
+const transformFeedback = gl.createTransformFeedback();
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webgluniformlocation/index.md
+++ b/files/en-us/web/api/webgluniformlocation/index.md
@@ -24,10 +24,10 @@ The `WebGLUniformLocation` object does not define any methods or properties of i
 ### Getting an uniform location
 
 ```js
-var canvas = document.getElementById('canvas');
-var gl = canvas.getContext('webgl');
+const canvas = document.getElementById('canvas');
+const gl = canvas.getContext('webgl');
 
-var location = gl.getUniformLocation(WebGLProgram, 'uniformName');
+const location = gl.getUniformLocation(WebGLProgram, 'uniformName');
 ```
 
 ## Specifications

--- a/files/en-us/web/api/webglvertexarrayobject/index.md
+++ b/files/en-us/web/api/webglvertexarrayobject/index.md
@@ -27,7 +27,7 @@ When working with `WebGLVertexArrayObject` objects, the following methods are us
 ## Examples
 
 ```js
-var vao = gl.createVertexArray();
+const vao = gl.createVertexArray();
 gl.bindVertexArray(vao);
 
 // …

--- a/files/en-us/web/api/websockets_api/writing_websocket_servers/index.md
+++ b/files/en-us/web/api/websockets_api/writing_websocket_servers/index.md
@@ -133,11 +133,11 @@ To read the payload data, you must know when to stop reading. That's why the pay
 If the MASK bit was set (and it should be, for client-to-server messages), read the next 4 octets (32 bits); this is the masking key. Once the payload length and masking key is decoded, you can read that number of bytes from the socket. Let's call the data **ENCODED**, and the key **MASK**. To get **DECODED**, loop through the octets (bytes a.k.a. characters for text data) of **ENCODED** and XOR the octet with the (i modulo 4)th octet of MASK. In pseudo-code (that happens to be valid JavaScript):
 
 ```js
-var MASK = [1, 2, 3, 4]                   // 4-byte mask
-var ENCODED = [105, 103, 111, 104, 110]   // encoded string "hello"
+const MASK = [1, 2, 3, 4]                   // 4-byte mask
+const ENCODED = [105, 103, 111, 104, 110]   // encoded string "hello"
 
-var DECODED = []                          // byte array of decoded payload
-for (var i = 0; i < ENCODED.length; i++) {
+const DECODED = []                          // byte array of decoded payload
+for (let i = 0; i < ENCODED.length; i++) {
   DECODED[i] = ENCODED[i] ^ MASK[i % 4]
 }
 ```

--- a/files/en-us/web/api/wheelevent/deltamode/index.md
+++ b/files/en-us/web/api/wheelevent/deltamode/index.md
@@ -30,7 +30,7 @@ An `unsigned long`.
 ## Examples
 
 ```js
-var syntheticEvent = new WheelEvent("syntheticWheel", {"deltaX": 4, "deltaMode": 0});
+const syntheticEvent = new WheelEvent("syntheticWheel", {"deltaX": 4, "deltaMode": 0});
 
 console.log(syntheticEvent.deltaMode);
 ```

--- a/files/en-us/web/api/wheelevent/deltamode/index.md
+++ b/files/en-us/web/api/wheelevent/deltamode/index.md
@@ -30,7 +30,7 @@ An `unsigned long`.
 ## Examples
 
 ```js
-const syntheticEvent = new WheelEvent("syntheticWheel", {"deltaX": 4, "deltaMode": 0});
+const syntheticEvent = new WheelEvent("syntheticWheel", { "deltaX": 4, "deltaMode": 0 });
 
 console.log(syntheticEvent.deltaMode);
 ```

--- a/files/en-us/web/api/wheelevent/deltax/index.md
+++ b/files/en-us/web/api/wheelevent/deltax/index.md
@@ -24,7 +24,7 @@ A number.
 ## Examples
 
 ```js
-const syntheticEvent = new WheelEvent("syntheticWheel", {"deltaX": 4, "deltaMode": 0});
+const syntheticEvent = new WheelEvent("syntheticWheel", { "deltaX": 4, "deltaMode": 0 });
 
 console.log(syntheticEvent.deltaX);
 ```

--- a/files/en-us/web/api/wheelevent/deltax/index.md
+++ b/files/en-us/web/api/wheelevent/deltax/index.md
@@ -24,7 +24,7 @@ A number.
 ## Examples
 
 ```js
-var syntheticEvent = new WheelEvent("syntheticWheel", {"deltaX": 4, "deltaMode": 0});
+const syntheticEvent = new WheelEvent("syntheticWheel", {"deltaX": 4, "deltaMode": 0});
 
 console.log(syntheticEvent.deltaX);
 ```

--- a/files/en-us/web/api/wheelevent/deltay/index.md
+++ b/files/en-us/web/api/wheelevent/deltay/index.md
@@ -24,7 +24,7 @@ A number.
 ## Examples
 
 ```js
-var syntheticEvent = new WheelEvent("syntheticWheel", {"deltaY": 4, "deltaMode": 0});
+const syntheticEvent = new WheelEvent("syntheticWheel", {"deltaY": 4, "deltaMode": 0});
 
 console.log(syntheticEvent.deltaY);
 ```

--- a/files/en-us/web/api/wheelevent/deltay/index.md
+++ b/files/en-us/web/api/wheelevent/deltay/index.md
@@ -24,7 +24,7 @@ A number.
 ## Examples
 
 ```js
-const syntheticEvent = new WheelEvent("syntheticWheel", {"deltaY": 4, "deltaMode": 0});
+const syntheticEvent = new WheelEvent("syntheticWheel", { "deltaY": 4, "deltaMode": 0 });
 
 console.log(syntheticEvent.deltaY);
 ```

--- a/files/en-us/web/api/wheelevent/deltaz/index.md
+++ b/files/en-us/web/api/wheelevent/deltaz/index.md
@@ -25,7 +25,7 @@ A number.
 ## Examples
 
 ```js
-var syntheticEvent = new WheelEvent("syntheticWheel", {"deltaZ": 4, "deltaMode": 0});
+const syntheticEvent = new WheelEvent("syntheticWheel", {"deltaZ": 4, "deltaMode": 0});
 
 console.log(syntheticEvent.deltaZ);
 ```

--- a/files/en-us/web/api/wheelevent/deltaz/index.md
+++ b/files/en-us/web/api/wheelevent/deltaz/index.md
@@ -25,7 +25,7 @@ A number.
 ## Examples
 
 ```js
-const syntheticEvent = new WheelEvent("syntheticWheel", {"deltaZ": 4, "deltaMode": 0});
+const syntheticEvent = new WheelEvent("syntheticWheel", { "deltaZ": 4, "deltaMode": 0 });
 
 console.log(syntheticEvent.deltaZ);
 ```

--- a/files/en-us/web/api/window/content/index.md
+++ b/files/en-us/web/api/window/content/index.md
@@ -16,7 +16,7 @@ In unprivileged content (webpages), `content` is normally equivalent to [top](/e
 ### Syntax
 
 ```js
-var windowObject = window.content;
+const windowObject = window.content;
 ```
 
 ### Example

--- a/files/en-us/web/api/window/deviceorientation_event/index.md
+++ b/files/en-us/web/api/window/deviceorientation_event/index.md
@@ -64,7 +64,7 @@ if (window.DeviceOrientationEvent) {
     }, true);
 }
 
-var handleOrientationEvent = function(frontToBack, leftToRight, rotateDegrees) {
+const handleOrientationEvent = function(frontToBack, leftToRight, rotateDegrees) {
     // do something amazing
 };
 ```

--- a/files/en-us/web/api/window/devicepixelratio/index.md
+++ b/files/en-us/web/api/window/devicepixelratio/index.md
@@ -61,16 +61,16 @@ should be added to allow for a sharper image.
 #### JavaScript
 
 ```js
-var canvas = document.getElementById('canvas');
-var ctx = canvas.getContext('2d');
+const canvas = document.getElementById('canvas');
+const ctx = canvas.getContext('2d');
 
 // Set display size (css pixels).
-var size = 200;
+const size = 200;
 canvas.style.width = `${size}px`;
 canvas.style.height = `${size}px`;
 
 // Set actual size in memory (scaled to account for extra pixel density).
-var scale = window.devicePixelRatio; // Change to 1 on retina screens to see blurry canvas.
+const scale = window.devicePixelRatio; // Change to 1 on retina screens to see blurry canvas.
 canvas.width = Math.floor(size * scale);
 canvas.height = Math.floor(size * scale);
 
@@ -84,10 +84,10 @@ ctx.font = '18px Arial';
 ctx.textAlign = 'center';
 ctx.textBaseline = 'middle';
 
-var x = size / 2;
-var y = size / 2;
+const x = size / 2;
+const y = size / 2;
 
-var textString = "I love MDN";
+const textString = "I love MDN";
 ctx.fillText(textString, x, y);
 ```
 

--- a/files/en-us/web/api/window/innerheight/index.md
+++ b/files/en-us/web/api/window/innerheight/index.md
@@ -49,16 +49,16 @@ or any object that behaves like a window, such as a tab or frame.
 ### Assuming a frameset
 
 ```js
-var intFrameHeight = window.innerHeight; // or
+console.log(window.innerHeight); // or
 
-var intFrameHeight = self.innerHeight;
-// will return the height of the frame viewport within the frameset
+console.log(self.innerHeight);
+// will log the height of the frame viewport within the frameset
 
-var intFramesetHeight = parent.innerHeight;
-// will return the height of the viewport of the closest frameset
+console.log(parent.innerHeight);
+// will log the height of the viewport of the closest frameset
 
-var intOuterFramesetHeight = top.innerHeight;
-// will return the height of the viewport of the outermost frameset
+console.log(top.innerHeight);
+// will log the height of the viewport of the outermost frameset
 ```
 
 To change the size of a window, see {{domxref("window.resizeBy()")}} and

--- a/files/en-us/web/api/window/innerwidth/index.md
+++ b/files/en-us/web/api/window/innerwidth/index.md
@@ -46,17 +46,17 @@ like a window, such as a frame or tab.
 ## Examples
 
 ```js
-// This will return the width of the viewport
-var intFrameWidth = window.innerWidth;
+// This will log the width of the viewport
+console.log(window.innerWidth);
 
-// This will return the width of the frame viewport within a frameset
-var intFrameWidth = self.innerWidth;
+// This will log the width of the frame viewport within a frameset
+console.log(self.innerWidth);
 
-// This will return the width of the viewport of the closest frameset
-var intFramesetWidth = parent.innerWidth;
+// This will log the width of the viewport of the closest frameset
+console.log(parent.innerWidth);
 
-// This will return the width of the viewport of the outermost frameset
-var intOuterFramesetWidth = top.innerWidth;
+// This will log the width of the viewport of the outermost frameset
+console.log(top.innerWidth);
 ```
 
 ## Demo

--- a/files/en-us/web/api/window/location/index.md
+++ b/files/en-us/web/api/window/location/index.md
@@ -72,7 +72,7 @@ function reloadPageWithHash() {
 ```js
 function showLoc() {
   const logLines = ["Property (Typeof): Value", `location (${typeof location}): ${location}`];
-  for (let prop in location) {
+  for (const prop in location) {
     logLines.push(`${prop} (${typeof location[prop]}): ${location[prop] || "n/a"}`);
   }
   alert(logLines.join("\n"));

--- a/files/en-us/web/api/window/navigator/index.md
+++ b/files/en-us/web/api/window/navigator/index.md
@@ -27,7 +27,7 @@ The {{domxref("navigator")}} object.
 
 ```js
 let sBrowser;
-let sUsrAg = navigator.userAgent;
+const sUsrAg = navigator.userAgent;
 
 // The order matters here, and this may report false positives for unlisted browsers.
 

--- a/files/en-us/web/api/window/navigator/index.md
+++ b/files/en-us/web/api/window/navigator/index.md
@@ -26,7 +26,8 @@ The {{domxref("navigator")}} object.
 ### Example #1: Browser detect and return a string
 
 ```js
-var sBrowser, sUsrAg = navigator.userAgent;
+let sBrowser;
+let sUsrAg = navigator.userAgent;
 
 // The order matters here, and this may report false positives for unlisted browsers.
 

--- a/files/en-us/web/api/window/opendialog/index.md
+++ b/files/en-us/web/api/window/opendialog/index.md
@@ -57,7 +57,7 @@ The opened window.
 ## Examples
 
 ```js
-var win = openDialog("http://example.tld/zzz.xul", "dlg", "", "pizza", 6.98);
+const win = openDialog("http://example.tld/zzz.xul", "dlg", "", "pizza", 6.98);
 ```
 
 ## Notes
@@ -100,8 +100,8 @@ window.
 To access these extra parameters from within dialog code, use the following scheme:
 
 ```js
-var food  = window.arguments[0];
-var price = window.arguments[1];
+const food  = window.arguments[0];
+const price = window.arguments[1];
 ```
 
 Note that you can access this property from within anywhere in the dialog code.
@@ -120,7 +120,7 @@ properties on it, containing the values you want to return or preserve past the
 `window.close()` operation.
 
 ```js
-var retVals = { address: null, delivery: null };
+const retVals = { address: null, delivery: null };
 openDialog("http://example.tld/zzz.xul", "dlg", "modal", "pizza", 6.98,
     retVals);
 ```
@@ -132,7 +132,7 @@ described below, you can now access them via the `retVals` array after the
 Inside the dialog code, you can set the properties as follows:
 
 ```js
-var retVals = window.arguments[2];
+const retVals = window.arguments[2];
 retVals.address  = enteredAddress;
 retVals.delivery = "immediate";
 ```

--- a/files/en-us/web/api/window/pageyoffset/index.md
+++ b/files/en-us/web/api/window/pageyoffset/index.md
@@ -45,7 +45,7 @@ additional details on this value and its use.
 ## Examples
 
 ```js hidden
-var contentHTML = `
+const contentHTML = `
     <h2 id="introduction">Introduction</h2>
   <p>Lorem ipsum dolor sit amet, consectetur adipiscing
 elit. Aenean volutpat vitae felis non dictum. Ut auctor
@@ -116,11 +116,11 @@ which we'll output the value of `pageYOffset` when we've finished the scroll.
 ### JavaScript
 
 ```js
-var frame = document.getElementById("frame");
-var frameDoc = frame.contentDocument;
-var info = document.getElementById("info");
+const frame = document.getElementById("frame");
+const frameDoc = frame.contentDocument;
+const info = document.getElementById("info");
 
-var target = frameDoc.getElementById("overview");
+const target = frameDoc.getElementById("overview");
 frameDoc.scrollingElement.scrollTop = target.offsetTop;
 
 info.innerText = `Y offset after scrolling: ${frame.contentWindow.pageYOffset} pixels`;

--- a/files/en-us/web/api/window/postmessage/index.md
+++ b/files/en-us/web/api/window/postmessage/index.md
@@ -157,7 +157,7 @@ example).
  * In window A's scripts, with A being on http://example.com:8080:
  */
 
-var popup = window.open(/* popup details */);
+const popup = window.open(/* popup details */);
 
 // When the popup has fully loaded, if not blocked by a popup blocker:
 

--- a/files/en-us/web/api/window/scrollx/index.md
+++ b/files/en-us/web/api/window/scrollx/index.md
@@ -55,21 +55,6 @@ The `pageXOffset` property is an alias for the `scrollX` property:
 window.pageXOffset == window.scrollX; // always true
 ```
 
-For cross-browser compatibility, use `window.pageXOffset` instead of
-`window.scrollX`. _Additionally_, older versions of Internet Explorer
-(< 9) do not support either property and must be worked around by checking other
-non-standard properties. A fully compatible example:
-
-```js
-const x = (window.pageXOffset !== undefined)
-  ? window.pageXOffset
-  : (document.documentElement || document.body.parentNode || document.body).scrollLeft;
-
-const y = (window.pageYOffset !== undefined)
-  ? window.pageYOffset
-  : (document.documentElement || document.body.parentNode || document.body).scrollTop;
-```
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/window/scrollx/index.md
+++ b/files/en-us/web/api/window/scrollx/index.md
@@ -61,11 +61,11 @@ For cross-browser compatibility, use `window.pageXOffset` instead of
 non-standard properties. A fully compatible example:
 
 ```js
-var x = (window.pageXOffset !== undefined)
+const x = (window.pageXOffset !== undefined)
   ? window.pageXOffset
   : (document.documentElement || document.body.parentNode || document.body).scrollLeft;
 
-var y = (window.pageYOffset !== undefined)
+const y = (window.pageYOffset !== undefined)
   ? window.pageYOffset
   : (document.documentElement || document.body.parentNode || document.body).scrollTop;
 ```

--- a/files/en-us/web/api/window/scrolly/index.md
+++ b/files/en-us/web/api/window/scrolly/index.md
@@ -63,19 +63,6 @@ property:
 window.pageYOffset === window.scrollY; // always true
 ```
 
-For cross-browser compatibility, use `window.pageYOffset` instead of
-`window.scrollY`. **Additionally**, older versions of Internet
-Explorer (< 9) do not support either property and must be worked around by checking
-other non-standard properties. A fully compatible example:
-
-```js
-const supportPageOffset = window.pageXOffset !== undefined;
-const isCSS1Compat = ((document.compatMode || "") === "CSS1Compat");
-
-const x = supportPageOffset ? window.pageXOffset : isCSS1Compat ? document.documentElement.scrollLeft : document.body.scrollLeft;
-const y = supportPageOffset ? window.pageYOffset : isCSS1Compat ? document.documentElement.scrollTop : document.body.scrollTop;
-```
-
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/window/scrolly/index.md
+++ b/files/en-us/web/api/window/scrolly/index.md
@@ -69,11 +69,11 @@ Explorer (< 9) do not support either property and must be worked around by check
 other non-standard properties. A fully compatible example:
 
 ```js
-var supportPageOffset = window.pageXOffset !== undefined;
-var isCSS1Compat = ((document.compatMode || "") === "CSS1Compat");
+const supportPageOffset = window.pageXOffset !== undefined;
+const isCSS1Compat = ((document.compatMode || "") === "CSS1Compat");
 
-var x = supportPageOffset ? window.pageXOffset : isCSS1Compat ? document.documentElement.scrollLeft : document.body.scrollLeft;
-var y = supportPageOffset ? window.pageYOffset : isCSS1Compat ? document.documentElement.scrollTop : document.body.scrollTop;
+const x = supportPageOffset ? window.pageXOffset : isCSS1Compat ? document.documentElement.scrollLeft : document.body.scrollLeft;
+const y = supportPageOffset ? window.pageYOffset : isCSS1Compat ? document.documentElement.scrollTop : document.body.scrollTop;
 ```
 
 ## Specifications

--- a/files/en-us/web/api/window/self/index.md
+++ b/files/en-us/web/api/window/self/index.md
@@ -32,10 +32,10 @@ if (window.parent.frames[0] !== window.self) {
 Furthermore, when executing in the active document of a browsing context, `window` is a reference to the current global object and thus all of the following are equivalent:
 
 ```js
-var w1 = window;
-var w2 = self;
-var w3 = window.window;
-var w4 = window.self;
+const w1 = window;
+const w2 = self;
+const w3 = window.window;
+const w4 = window.self;
 // w1, w2, w3, w4 all strictly equal, but only w2 will function in workers
 ```
 

--- a/files/en-us/web/api/window/showdirectorypicker/index.md
+++ b/files/en-us/web/api/window/showdirectorypicker/index.md
@@ -21,7 +21,7 @@ select a directory.
 ## Syntax
 
 ```js
-var FileSystemDirectoryHandle = window.showDirectoryPicker();
+const FileSystemDirectoryHandle = window.showDirectoryPicker();
 ```
 
 ### Parameters

--- a/files/en-us/web/api/worker/error_event/index.md
+++ b/files/en-us/web/api/worker/error_event/index.md
@@ -36,7 +36,7 @@ A generic {{domxref("Event")}}.
 The following code snippet creates a {{domxref("Worker")}} object using the {{domxref("Worker.Worker", "Worker()")}} constructor and sets up an `onerror` handler on the resulting object:
 
 ```js
-var myWorker = new Worker('worker.js');
+const myWorker = new Worker('worker.js');
 
 myWorker.onerror = function(event) {
   console.log('There is an error with your worker!');

--- a/files/en-us/web/api/worker/index.md
+++ b/files/en-us/web/api/worker/index.md
@@ -61,9 +61,9 @@ _Inherits methods from its parent, {{domxref("EventTarget")}}._
 The following code snippet creates a {{domxref("Worker")}} object using the {{domxref("Worker.Worker", "Worker()")}} constructor, then uses the worker object:
 
 ```js
-var myWorker = new Worker('/worker.js');
-var first = document.querySelector('input#number1');
-var second = document.querySelector('input#number2');
+const myWorker = new Worker('/worker.js');
+const first = document.querySelector('input#number1');
+const second = document.querySelector('input#number2');
 
 first.onchange = function() {
   myWorker.postMessage([first.value, second.value]);

--- a/files/en-us/web/api/worker/terminate/index.md
+++ b/files/en-us/web/api/worker/terminate/index.md
@@ -34,7 +34,7 @@ None ({{jsxref("undefined")}}).
 The following code snippet shows creation of a {{domxref("Worker")}} object using the {{domxref("Worker.Worker", "Worker()")}} constructor, which is then immediately terminated.
 
 ```js
-var myWorker = new Worker('worker.js');
+const myWorker = new Worker('worker.js');
 
 myWorker.terminate();
 ```

--- a/files/en-us/web/api/worker/worker/index.md
+++ b/files/en-us/web/api/worker/worker/index.md
@@ -53,7 +53,7 @@ new Worker(aURL, options)
 The following code snippet shows creation of a {{domxref("Worker")}} object using the `Worker()` constructor and subsequent usage of the object:
 
 ```js
-var myWorker = new Worker('worker.js');
+const myWorker = new Worker('worker.js');
 
 first.onchange = function() {
   myWorker.postMessage([first.value,second.value]);

--- a/files/en-us/web/api/workerlocation/hash/index.md
+++ b/files/en-us/web/api/workerlocation/hash/index.md
@@ -22,7 +22,7 @@ A string.
 
 ```js
 // In a Web worker, on the page https://developer.mozilla.org/en-US/docs/Web/API/WorkerLocation/hash#examples
-var result = location.hash; // Returns '#examples'
+const result = location.hash; // Returns '#examples'
 ```
 
 ## Specifications

--- a/files/en-us/web/api/workerlocation/host/index.md
+++ b/files/en-us/web/api/workerlocation/host/index.md
@@ -22,7 +22,7 @@ A string.
 
 ```js
 // In a Web worker, on the page http://localhost:8080/
-var result = location.host; // Returns 'localhost:8080'
+const result = location.host; // Returns 'localhost:8080'
 ```
 
 ## Specifications

--- a/files/en-us/web/api/workerlocation/hostname/index.md
+++ b/files/en-us/web/api/workerlocation/hostname/index.md
@@ -22,7 +22,7 @@ A string.
 
 ```js
 // In a Web worker, on the page http://localhost:8080/
-var result = location.hostname; // Returns 'localhost'
+const result = location.hostname; // Returns 'localhost'
 ```
 
 ## Specifications

--- a/files/en-us/web/api/workerlocation/href/index.md
+++ b/files/en-us/web/api/workerlocation/href/index.md
@@ -22,7 +22,7 @@ A string.
 
 ```js
 // In a Web worker, on the page https://developer.mozilla.org/en-US/docs/Web
-var result = location.href; // Returns 'https://developer.mozilla.org/en-US/docs/Web'
+const result = location.href; // Returns 'https://developer.mozilla.org/en-US/docs/Web'
 ```
 
 ## Specifications

--- a/files/en-us/web/api/workerlocation/origin/index.md
+++ b/files/en-us/web/api/workerlocation/origin/index.md
@@ -22,7 +22,7 @@ A string.
 
 ```js
 // On this page, returns the origin
-var result = self.location.origin; // Returns:'https://developer.mozilla.org:443'
+const result = self.location.origin; // Returns:'https://developer.mozilla.org:443'
 ```
 
 ## Specifications

--- a/files/en-us/web/api/workerlocation/pathname/index.md
+++ b/files/en-us/web/api/workerlocation/pathname/index.md
@@ -22,7 +22,7 @@ A string.
 
 ```js
 // In a Web worker, on the page https://developer.mozilla.org/en-US/docs/Web
-var result = location.pathname; // Returns '/en-US/docs/Web'
+const result = location.pathname; // Returns '/en-US/docs/Web'
 ```
 
 ## Specifications

--- a/files/en-us/web/api/workerlocation/port/index.md
+++ b/files/en-us/web/api/workerlocation/port/index.md
@@ -22,7 +22,7 @@ A string.
 
 ```js
 // In a Web worker, on the page http://localhost:8080/
-var result = location.port; // Returns '8080'
+const result = location.port; // Returns '8080'
 ```
 
 ## Specifications

--- a/files/en-us/web/api/workerlocation/protocol/index.md
+++ b/files/en-us/web/api/workerlocation/protocol/index.md
@@ -22,7 +22,7 @@ A string.
 
 ```js
 // In a Web worker, on the page https://developer.mozilla.org/en-US/docs/Web
-var result = location.protocol; // Returns 'https:'
+const result = location.protocol; // Returns 'https:'
 ```
 
 ## Specifications

--- a/files/en-us/web/api/workerlocation/search/index.md
+++ b/files/en-us/web/api/workerlocation/search/index.md
@@ -22,7 +22,7 @@ A string.
 
 ```js
 // In a Web worker, on the page https://developer.mozilla.org/en-US/docs/Web?t=67
-var result = location.search; // Returns:'?t=67'
+const result = location.search; // Returns:'?t=67'
 ```
 
 ## Specifications

--- a/files/en-us/web/api/workerlocation/tostring/index.md
+++ b/files/en-us/web/api/workerlocation/tostring/index.md
@@ -32,7 +32,7 @@ None ({{jsxref("undefined")}}).
 
 ```js
 // In a Web worker, on the page https://developer.mozilla.org/en-US/docs/Web
-var result = location.toString(); // Returns 'https://developer.mozilla.org/en-US/docs/Web'
+const result = location.toString(); // Returns 'https://developer.mozilla.org/en-US/docs/Web'
 ```
 
 ## Browser compatibility

--- a/files/en-us/web/api/xmldocument/async/index.md
+++ b/files/en-us/web/api/xmldocument/async/index.md
@@ -31,7 +31,7 @@ function loadXMLData(e) {
   alert(new XMLSerializer().serializeToString(e.target)); // Gives querydata.xml contents as string
 }
 
-var xmlDoc = document.implementation.createDocument("", "test", null);
+const xmlDoc = document.implementation.createDocument("", "test", null);
 
 xmlDoc.async = false;
 xmlDoc.onload = loadXMLData;

--- a/files/en-us/web/api/xmldocument/load/index.md
+++ b/files/en-us/web/api/xmldocument/load/index.md
@@ -33,7 +33,7 @@ None ({{jsxref("undefined")}}).
 ## Examples
 
 ```js
-var xmlDoc = document.implementation.createDocument("", "test", null);
+const xmlDoc = document.implementation.createDocument("", "test", null);
 
 function documentLoaded (e) {
   alert(new XMLSerializer().serializeToString(e.target)); // Gives querydata.xml contents as string

--- a/files/en-us/web/api/xmlhttprequest/abort/index.md
+++ b/files/en-us/web/api/xmlhttprequest/abort/index.md
@@ -47,9 +47,9 @@ This example begins loading content from the MDN home page, then due to some con
 aborts the transfer by calling `abort()`.
 
 ```js
-const xhr = new XMLHttpRequest(),
-    method = "GET",
-    url = "https://developer.mozilla.org/";
+const xhr = new XMLHttpRequest();
+const method = "GET";
+const url = "https://developer.mozilla.org/";
 xhr.open(method, url, true);
 
 xhr.send();

--- a/files/en-us/web/api/xmlhttprequest/abort/index.md
+++ b/files/en-us/web/api/xmlhttprequest/abort/index.md
@@ -47,7 +47,7 @@ This example begins loading content from the MDN home page, then due to some con
 aborts the transfer by calling `abort()`.
 
 ```js
-var xhr = new XMLHttpRequest(),
+const xhr = new XMLHttpRequest(),
     method = "GET",
     url = "https://developer.mozilla.org/";
 xhr.open(method, url, true);

--- a/files/en-us/web/api/xmlhttprequest/readystate/index.md
+++ b/files/en-us/web/api/xmlhttprequest/readystate/index.md
@@ -37,7 +37,7 @@ The **XMLHttpRequest.readyState** property returns the state an XMLHttpRequest c
 ## Example
 
 ```js
-var xhr = new XMLHttpRequest();
+const xhr = new XMLHttpRequest();
 console.log('UNSENT', xhr.readyState); // readyState will be 0
 
 xhr.open('GET', '/api', true);

--- a/files/en-us/web/api/xmlhttprequest/responsetext/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responsetext/index.md
@@ -45,7 +45,7 @@ You know the entire content has been received when the value of
 ## Examples
 
 ```js
-var xhr = new XMLHttpRequest();
+const xhr = new XMLHttpRequest();
 xhr.open('GET', '/server', true);
 
 // If specified, responseType must be empty string or "text"

--- a/files/en-us/web/api/xmlhttprequest/responseurl/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responseurl/index.md
@@ -21,7 +21,7 @@ The read-only **`XMLHttpRequest.responseURL`** property returns the serialized U
 ```js
 const xhr = new XMLHttpRequest();
 xhr.open('GET', 'http://example.com/test', true);
-xhr.onload = function () {
+xhr.onload = () => {
   console.log(xhr.responseURL); // http://example.com/test
 };
 xhr.send(null);

--- a/files/en-us/web/api/xmlhttprequest/responseurl/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responseurl/index.md
@@ -19,7 +19,7 @@ The read-only **`XMLHttpRequest.responseURL`** property returns the serialized U
 ## Example
 
 ```js
-var xhr = new XMLHttpRequest();
+const xhr = new XMLHttpRequest();
 xhr.open('GET', 'http://example.com/test', true);
 xhr.onload = function () {
   console.log(xhr.responseURL); // http://example.com/test

--- a/files/en-us/web/api/xmlhttprequest/responsexml/index.md
+++ b/files/en-us/web/api/xmlhttprequest/responsexml/index.md
@@ -56,7 +56,7 @@ data is not XML/HTML.
 ## Examples
 
 ```js
-var xhr = new XMLHttpRequest;
+const xhr = new XMLHttpRequest;
 xhr.open('GET', '/server');
 
 // If specified, responseType must be empty string or "document"

--- a/files/en-us/web/api/xmlhttprequest/send/index.md
+++ b/files/en-us/web/api/xmlhttprequest/send/index.md
@@ -72,7 +72,7 @@ None ({{jsxref("undefined")}}).
 ## Example: GET
 
 ```js
-var xhr = new XMLHttpRequest();
+const xhr = new XMLHttpRequest();
 xhr.open('GET', '/server', true);
 
 xhr.onload = function () {
@@ -89,7 +89,7 @@ xhr.send(null);
 ## Example: POST
 
 ```js
-var xhr = new XMLHttpRequest();
+const xhr = new XMLHttpRequest();
 xhr.open("POST", '/server', true);
 
 //Send the proper header information along with the request

--- a/files/en-us/web/api/xmlhttprequest/status/index.md
+++ b/files/en-us/web/api/xmlhttprequest/status/index.md
@@ -26,7 +26,7 @@ A number.
 ## Examples
 
 ```js
-var xhr = new XMLHttpRequest();
+const xhr = new XMLHttpRequest();
 console.log('UNSENT: ', xhr.status);
 
 xhr.open('GET', '/server');

--- a/files/en-us/web/api/xmlhttprequest/statustext/index.md
+++ b/files/en-us/web/api/xmlhttprequest/statustext/index.md
@@ -27,7 +27,7 @@ A string.
 ## Examples
 
 ```js
-var xhr = new XMLHttpRequest();
+const xhr = new XMLHttpRequest();
 console.log('0 UNSENT', xhr.statusText);
 
 xhr.open('GET', '/server', true);

--- a/files/en-us/web/api/xmlhttprequest/timeout/index.md
+++ b/files/en-us/web/api/xmlhttprequest/timeout/index.md
@@ -26,7 +26,7 @@ In Internet Explorer, the timeout property may be set only after calling the [op
 ## Example
 
 ```js
-var xhr = new XMLHttpRequest();
+const xhr = new XMLHttpRequest();
 xhr.open('GET', '/server', true);
 
 xhr.timeout = 2000; // time in milliseconds

--- a/files/en-us/web/api/xmlhttprequest/using_xmlhttprequest_in_ie6/index.md
+++ b/files/en-us/web/api/xmlhttprequest/using_xmlhttprequest_in_ie6/index.md
@@ -11,18 +11,19 @@ tags:
 In all modern browsers, you can create a new XMLHttpRequest object using the following code:
 
 ```js
-var request = new XMLHttpRequest()
+const request = new XMLHttpRequest()
 ```
 
 However, if you need to also support Internet Explorer 6 and older, you need to extend your code like this:
 
 ```js
+let request;
 if (window.XMLHttpRequest) {
     //Firefox, Opera, IE7, and other browsers will use the native object
-    var request = new XMLHttpRequest();
+    request = new XMLHttpRequest();
 } else {
     //IE 5 and 6 will use the ActiveX control
-    var request = new ActiveXObject("Microsoft.XMLHTTP");
+    request = new ActiveXObject("Microsoft.XMLHTTP");
 }
 ```
 

--- a/files/en-us/web/api/xmlhttprequest/withcredentials/index.md
+++ b/files/en-us/web/api/xmlhttprequest/withcredentials/index.md
@@ -31,7 +31,7 @@ A boolean.
 ## Examples
 
 ```js
-var xhr = new XMLHttpRequest();
+const xhr = new XMLHttpRequest();
 xhr.open('GET', 'http://example.com/', true);
 xhr.withCredentials = true;
 xhr.send(null);

--- a/files/en-us/web/api/xpathevaluator/createexpression/index.md
+++ b/files/en-us/web/api/xpathevaluator/createexpression/index.md
@@ -65,10 +65,10 @@ The following example shows the use of the `evaluate()` method.
 ### JavaScript
 
 ```js
-var xpath = "//div";
-var evaluator = new XPathEvaluator();
-var expression = evaluator.createExpression(xpath);
-var result = expression.evaluate(document, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE);
+const xpath = "//div";
+const evaluator = new XPathEvaluator();
+const expression = evaluator.createExpression(xpath);
+const result = expression.evaluate(document, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE);
 document.querySelector("output").textContent = result.snapshotLength;
 ```
 

--- a/files/en-us/web/api/xpathevaluator/evaluate/index.md
+++ b/files/en-us/web/api/xpathevaluator/evaluate/index.md
@@ -95,8 +95,8 @@ The following example shows the use of the `evaluate()` method.
 ### JavaScript
 
 ```js
-var evaluator = new XPathEvaluator();
-var result = evaluator.evaluate("//div", document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE);
+const evaluator = new XPathEvaluator();
+const result = evaluator.evaluate("//div", document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE);
 document.querySelector("output").textContent = result.snapshotLength;
 ```
 

--- a/files/en-us/web/api/xpathevaluator/index.md
+++ b/files/en-us/web/api/xpathevaluator/index.md
@@ -43,10 +43,10 @@ The following example shows the use of the `XPathEvaluator` interface.
 ### JavaScript
 
 ```js
-var xpath = "//div";
-var evaluator = new XPathEvaluator();
-var expression = evaluator.createExpression(xpath);
-var result = expression.evaluate(document, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE);
+const xpath = "//div";
+const evaluator = new XPathEvaluator();
+const expression = evaluator.createExpression(xpath);
+const result = expression.evaluate(document, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE);
 document.querySelector("output").textContent = result.snapshotLength;
 ```
 

--- a/files/en-us/web/api/xpathexpression/evaluate/index.md
+++ b/files/en-us/web/api/xpathexpression/evaluate/index.md
@@ -87,10 +87,10 @@ The following example shows the use of the `evaluate()` method.
 ### JavaScript
 
 ```js
-var xpath = "//div";
-var evaluator = new XPathEvaluator();
-var expression = evaluator.createExpression("//div");
-var result = expression.evaluate(document, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE);
+const xpath = "//div";
+const evaluator = new XPathEvaluator();
+const expression = evaluator.createExpression("//div");
+const result = expression.evaluate(document, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE);
 document.querySelector("output").textContent = result.snapshotLength;
 ```
 

--- a/files/en-us/web/api/xpathexpression/index.md
+++ b/files/en-us/web/api/xpathexpression/index.md
@@ -41,10 +41,10 @@ The following example shows the use of the `XPathExpression` interface.
 ### JavaScript
 
 ```js
-var xpath = "//div";
-var evaluator = new XPathEvaluator();
-var expression = evaluator.createExpression(xpath);
-var result = expression.evaluate(document, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE);
+const xpath = "//div";
+const evaluator = new XPathEvaluator();
+const expression = evaluator.createExpression(xpath);
+const result = expression.evaluate(document, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE);
 document.querySelector("output").textContent = result.snapshotLength;
 ```
 

--- a/files/en-us/web/api/xpathresult/booleanvalue/index.md
+++ b/files/en-us/web/api/xpathresult/booleanvalue/index.md
@@ -45,8 +45,8 @@ The following example shows the use of the `booleanValue` property.
 ### JavaScript
 
 ```js
-var xpath = "//div/text() = 'XPath example'";
-var result = document.evaluate(xpath, document, null, XPathResult.BOOLEAN_TYPE, null);
+const xpath = "//div/text() = 'XPath example'";
+const result = document.evaluate(xpath, document, null, XPathResult.BOOLEAN_TYPE, null);
 document.querySelector("output").textContent = result.booleanValue;
 ```
 

--- a/files/en-us/web/api/xpathresult/invaliditeratorstate/index.md
+++ b/files/en-us/web/api/xpathresult/invaliditeratorstate/index.md
@@ -39,8 +39,8 @@ The following example shows the use of the `invalidIteratorState` property.
 ### JavaScript
 
 ```js
-var xpath = "//div";
-var result = document.evaluate(xpath, document, null, XPathResult.ANY_TYPE, null);
+const xpath = "//div";
+const result = document.evaluate(xpath, document, null, XPathResult.ANY_TYPE, null);
 // Invalidates the iterator state
 document.querySelector("div").remove();
 document.querySelector("output").textContent = result.invalidIteratorState ? "invalid" : "valid";

--- a/files/en-us/web/api/xpathresult/iteratenext/index.md
+++ b/files/en-us/web/api/xpathresult/iteratenext/index.md
@@ -58,11 +58,11 @@ The following example shows the use of the `iterateNext()` method.
 ### JavaScript
 
 ```js
-var xpath = "//div";
-var result = document.evaluate(xpath, document, null, XPathResult.ANY_TYPE, null);
-var node = null;
-var tagNames = [];
-while(node = result.iterateNext()) {
+const xpath = "//div";
+const result = document.evaluate(xpath, document, null, XPathResult.ANY_TYPE, null);
+let node = null;
+const tagNames = [];
+while (node = result.iterateNext()) {
   tagNames.push(node.localName);
 }
 document.querySelector("output").textContent = tagNames.join(", ");

--- a/files/en-us/web/api/xpathresult/numbervalue/index.md
+++ b/files/en-us/web/api/xpathresult/numbervalue/index.md
@@ -45,8 +45,8 @@ The following example shows the use of the `numberValue` property.
 ### JavaScript
 
 ```js
-var xpath = "count(//div)";
-var result = document.evaluate(xpath, document, null, XPathResult.NUMBER_TYPE, null);
+const xpath = "count(//div)";
+const result = document.evaluate(xpath, document, null, XPathResult.NUMBER_TYPE, null);
 document.querySelector("output").textContent = result.numberValue;
 ```
 

--- a/files/en-us/web/api/xpathresult/resulttype/index.md
+++ b/files/en-us/web/api/xpathresult/resulttype/index.md
@@ -134,8 +134,8 @@ The following example shows the use of the `resultType` property.
 ### JavaScript
 
 ```js
-var xpath = "//div";
-var result = document.evaluate(xpath, document, null, XPathResult.ANY_TYPE, null);
+const xpath = "//div";
+const result = document.evaluate(xpath, document, null, XPathResult.ANY_TYPE, null);
 document.querySelector("output").textContent =
   result.resultType >= XPathResult.UNORDERED_NODE_ITERATOR_TYPE &&
   result.resultType <= XPathResult.FIRST_ORDERED_NODE_TYPE;

--- a/files/en-us/web/api/xpathresult/singlenodevalue/index.md
+++ b/files/en-us/web/api/xpathresult/singlenodevalue/index.md
@@ -46,8 +46,8 @@ The following example shows the use of the `singleNodeValue` property.
 ### JavaScript
 
 ```js
-var xpath = "//*[text()='XPath example']";
-var result = document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
+const xpath = "//*[text()='XPath example']";
+const result = document.evaluate(xpath, document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null);
 document.querySelector("output").textContent = result.singleNodeValue.localName;
 ```
 

--- a/files/en-us/web/api/xpathresult/snapshotlength/index.md
+++ b/files/en-us/web/api/xpathresult/snapshotlength/index.md
@@ -45,8 +45,8 @@ The following example shows the use of the `snapshotLength` property.
 ### JavaScript
 
 ```js
-var xpath = "//div";
-var result = document.evaluate(xpath, document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
+const xpath = "//div";
+const result = document.evaluate(xpath, document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null);
 document.querySelector("output").textContent = result.snapshotLength;
 ```
 

--- a/files/en-us/web/api/xpathresult/stringvalue/index.md
+++ b/files/en-us/web/api/xpathresult/stringvalue/index.md
@@ -45,8 +45,8 @@ The following example shows the use of the `stringValue` property.
 ### JavaScript
 
 ```js
-var xpath = "//div/text()";
-var result = document.evaluate(xpath, document, null, XPathResult.STRING_TYPE, null);
+const xpath = "//div/text()";
+const result = document.evaluate(xpath, document, null, XPathResult.STRING_TYPE, null);
 document.querySelector("output").textContent = result.stringValue;
 ```
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Replaces `var` in Web/API with `const` where applicable and `let` otherwise.
Mostly automated via my ESLint setup, using the rules `no-var` and `prefer-const`

#### Motivation

* See #16662
* See https://github.com/mdn/content/discussions/10389
* See https://github.com/orgs/mdn/discussions/143

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
