### PR TITLE
Fix undesired syntax highlighting on example

### DIFF
--- a/files/en-us/web/api/console/index.md
+++ b/files/en-us/web/api/console/index.md
@@ -144,7 +144,7 @@ for (let i=0; i<5; i++) {
 
 The output looks like this:
 
-```bash
+```
 [13:14:13.481] Hello, Bob. You've called me 1 times.
 [13:14:13.483] Hello, Bob. You've called me 2 times.
 [13:14:13.485] Hello, Bob. You've called me 3 times.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
The current webpage shows strange syntax highlighting that causes it to alternate colors after every quote like so:
![image](https://user-images.githubusercontent.com/35144594/181612184-32dc70de-84e3-42e2-8d85-6f5f2990605c.png)
This change removes the `bash` from the code markdown type to eliminate that undesired highlighting artifact. 

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
It looked weird and bugged me, so I took the 30 seconds to change it. If everyone does this with small errors we can gradually help improve this great open source resource as a community. 


#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
