### PR TITLE
Update broken links

### DIFF
--- a/files/en-us/mozilla/firefox/releases/16/index.md
+++ b/files/en-us/mozilla/firefox/releases/16/index.md
@@ -51,7 +51,7 @@ Firefox 16 shipped on October 9, 2012. This article lists key changes that are u
 ### JavaScript
 
 - [`Number`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number) objects now offer `isFinite()`, `toInteger()`, and `isInteger()` methods. ([bug 761480](https://bugzilla.mozilla.org/show_bug.cgi?id=761480), [bug 761495](https://bugzilla.mozilla.org/show_bug.cgi?id=761495))
-- The Harmony [spread operator](http://wiki.ecmascript.org/doku.php?id=harmony:spread) is now supported in [`Array`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) initializers ([bug 574130](https://bugzilla.mozilla.org/show_bug.cgi?id=574130)). Note it is not yet supported in calls ([bug 762363](https://bugzilla.mozilla.org/show_bug.cgi?id=762363)).
+- The Harmony [spread operator](https://web.archive.org/web/20161222114355/http://wiki.ecmascript.org/doku.php?id=harmony:spread) is now supported in [`Array`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array) initializers ([bug 574130](https://bugzilla.mozilla.org/show_bug.cgi?id=574130)). Note it is not yet supported in calls ([bug 762363](https://bugzilla.mozilla.org/show_bug.cgi?id=762363)).
 - The experimental {{jsxref("TypedArray.prototype.move()")}} method has been added (available in Aurora and Nightly channels only) ({{bug(730873)}}).
 
 ### WebGL

--- a/files/en-us/mozilla/firefox/releases/26/index.md
+++ b/files/en-us/mozilla/firefox/releases/26/index.md
@@ -29,7 +29,7 @@ Firefox 26 was released on December 10, 2013. This article lists key changes tha
 
 [EcmaScript 2015](/en-US/docs/Web/JavaScript/ECMAScript_6_support_in_Mozilla) implementation continues!
 
-- The ECMAScript 2015 compliant syntax for [Generators (yield)](http://wiki.ecmascript.org/doku.php?id=harmony:generators) has been implemented ({{bug("666399")}}).
+- The ECMAScript 2015 compliant syntax for [Generators (yield)](https://web.archive.org/web/20170126155949/http://wiki.ecmascript.org/doku.php?id=harmony:generators) has been implemented ({{bug("666399")}}).
 - Generator/Iterator results are now boxed like `{ value: foo, done: bool }` ({{bug(907744)}}).
 - New mathematical methods have been implemented on [`Math`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math): [`Math.fround()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/fround) ({{bug("900125")}}).
 - The [reserved words](/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#keywords) cannot be used for function names:such a usage now throws a [`SyntaxError`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError) ({{bug("907958")}}).

--- a/files/en-us/mozilla/firefox/releases/37/index.md
+++ b/files/en-us/mozilla/firefox/releases/37/index.md
@@ -52,7 +52,7 @@ Highlights:
 
 - ES2015 Proxy {{jsxref("Global_Objects/Proxy/handler/enumerate", "enumerate")}} trap is implemented ({{bug(783829)}}).
 - The `configurable` attribute of the {{jsxref("Function.length")}} property is now `true` per the ES2015 specification ({{bug(911142)}}).
-- The development of [ParallelJS (PJS)](http://wiki.ecmascript.org/doku.php?id=strawman:data_parallelism) has been discontinued due to the limited future prospects, little attention and code complexity. The experimental implementation that had been enabled only on the Nightly channel, including the `Array.prototype.mapPar`, `filterPar` and `reducePar` methods, has been completely removed.
+- The development of [ParallelJS (PJS)](https://web.archive.org/web/20161113115816/http://wiki.ecmascript.org/doku.php?id=strawman:data_parallelism) has been discontinued due to the limited future prospects, little attention and code complexity. The experimental implementation that had been enabled only on the Nightly channel, including the `Array.prototype.mapPar`, `filterPar` and `reducePar` methods, has been completely removed.
 
 ### Interfaces/APIs/DOM
 

--- a/files/en-us/web/javascript/reference/functions/default_parameters/index.md
+++ b/files/en-us/web/javascript/reference/functions/default_parameters/index.md
@@ -269,4 +269,4 @@ preFilledObject({ z: 2 });  // 2
 
 ## See also
 
-- [Original proposal at ecmascript.org](http://wiki.ecmascript.org/doku.php?id=harmony:parameter_default_values)
+- [Original proposal at ecmascript.org](https://web.archive.org/web/20161222115423/http://wiki.ecmascript.org/doku.php?id=harmony:parameter_default_values)


### PR DESCRIPTION
`wiki.ecmascript.org` is non responsive since 2017.