### PR TITLE
Fixed anchors in <input> page links

### DIFF
--- a/files/en-us/web/api/htmlinputelement/index.md
+++ b/files/en-us/web/api/htmlinputelement/index.md
@@ -55,7 +55,7 @@ Some properties only apply to input element types that support the corresponding
   - : `string`: **Returns / Sets** the element's [`step`](/en-US/docs/Web/HTML/Element/input#step) attribute, which works with [`min`](/en-US/docs/Web/HTML/Element/input#min) and [`max`](/en-US/docs/Web/HTML/Element/input#max) to limit the increments at which a numeric or date-time value can be set. It can be the string `any` or a positive floating point number. If this is not set to `any`, the control accepts only values at multiples of the step value greater than the minimum.
 
 - {{domxref("HTMLInputElement.type", "type")}}
-  - : `string`: **Returns / Sets** the element's [`type`](/en-US/docs/Web/HTML/Element/input#type) attribute, indicating the type of control to display. See the [`type`](/en-US/docs/Web/HTML/Element/input#type) attribute of {{ HTMLElement("input") }} for possible values.
+  - : `string`: **Returns / Sets** the element's [`type`](/en-US/docs/Web/HTML/Element/input#type) attribute, indicating the type of control to display. For possible values, see the documentation for the [`type`](/en-US/docs/Web/HTML/Element/input#type) attribute.
 
 - {{domxref("HTMLInputElement.useMap", "useMap")}} {{deprecated_inline}}
   - : `string`: **Represents** a client-side image map.

--- a/files/en-us/web/api/htmlinputelement/index.md
+++ b/files/en-us/web/api/htmlinputelement/index.md
@@ -43,19 +43,19 @@ Some properties only apply to input element types that support the corresponding
   - : {{domxref("NodeList")}} array: **Returns** a list of {{ HTMLElement("label") }} elements that are labels for this element.
 
 - {{domxref("HTMLInputElement.list", "list")}} {{readonlyInline}}
-  - : {{domxref("HTMLElement")}}: **Returns** the element pointed by the {{ htmlattrxref("list", "input") }} attribute. The property may be `null` if no HTML element found in the same tree.
+  - : {{domxref("HTMLElement")}}: **Returns** the element pointed by the [`list`](/en-US/docs/Web/HTML/Element/input#list) attribute. The property may be `null` if no HTML element found in the same tree.
 
 - {{domxref("HTMLInputElement.multiple", "multiple")}}
-  - : `boolean`: **Returns / Sets** the element's {{ htmlattrxref("multiple", "input") }} attribute, indicating whether more than one value is possible (e.g., multiple files).
+  - : `boolean`: **Returns / Sets** the element's [`multiple`](/en-US/docs/Web/HTML/Element/input#multiple) attribute, indicating whether more than one value is possible (e.g., multiple files).
 
 - {{domxref("HTMLInputElement.name", "name")}}
-  - : `string`: **Returns / Sets** the element's {{ htmlattrxref("name", "input") }} attribute, containing a name that identifies the element when submitting the form.
+  - : `string`: **Returns / Sets** the element's [`name`](/en-US/docs/Web/HTML/Element/input#name) attribute, containing a name that identifies the element when submitting the form.
 
 - {{domxref("HTMLInputElement.step", "step")}}
-  - : `string`: **Returns / Sets** the element's {{ htmlattrxref("step", "input") }} attribute, which works with {{htmlattrxref("min","input")}} and {{htmlattrxref("max","input")}} to limit the increments at which a numeric or date-time value can be set. It can be the string `any` or a positive floating point number. If this is not set to `any`, the control accepts only values at multiples of the step value greater than the minimum.
+  - : `string`: **Returns / Sets** the element's [`step`](/en-US/docs/Web/HTML/Element/input#step) attribute, which works with [`min`](/en-US/docs/Web/HTML/Element/input#min) and [`max`](/en-US/docs/Web/HTML/Element/input#max) to limit the increments at which a numeric or date-time value can be set. It can be the string `any` or a positive floating point number. If this is not set to `any`, the control accepts only values at multiples of the step value greater than the minimum.
 
 - {{domxref("HTMLInputElement.type", "type")}}
-  - : `string`: **Returns / Sets** the element's {{ htmlattrxref("type", "input") }} attribute, indicating the type of control to display. See {{ htmlattrxref("type", "input") }} attribute of {{ HTMLElement("input") }} for possible values.
+  - : `string`: **Returns / Sets** the element's [`type`](/en-US/docs/Web/HTML/Element/input#type) attribute, indicating the type of control to display. See [`type`](/en-US/docs/Web/HTML/Element/input#type) attribute of {{ HTMLElement("input") }} for possible values.
 
 - {{domxref("HTMLInputElement.useMap", "useMap")}} {{deprecated_inline}}
   - : `string`: **Represents** a client-side image map.
@@ -75,33 +75,33 @@ Some properties only apply to input element types that support the corresponding
   - : {{domxref("HTMLFormElement")}}: **Returns** a reference to the parent {{HtmlElement("form")}} element.
 
 - {{domxref("HTMLInputElement.formAction", "formAction")}}
-  - : `string`: **Returns / Sets** the element's {{ htmlattrxref("formaction", "input") }} attribute, containing the URI of a program that processes information submitted by the element. This overrides the {{ htmlattrxref("action", "form") }} attribute of the parent form.
+  - : `string`: **Returns / Sets** the element's [`formaction`](/en-US/docs/Web/HTML/Element/input#formaction) attribute, containing the URI of a program that processes information submitted by the element. This overrides the {{ htmlattrxref("action", "form") }} attribute of the parent form.
 
 - {{domxref("HTMLInputElement.formEnctype", "formEnctype")}}
-  - : `string`: **Returns / Sets** the element's {{ htmlattrxref("formenctype", "input") }} attribute, containing the type of content that is used to submit the form to the server. This overrides the {{ htmlattrxref("enctype", "form") }} attribute of the parent form.
+  - : `string`: **Returns / Sets** the element's [`formenctype`](/en-US/docs/Web/HTML/Element/input#formenctype) attribute, containing the type of content that is used to submit the form to the server. This overrides the {{ htmlattrxref("enctype", "form") }} attribute of the parent form.
 
 - {{domxref("HTMLInputElement.formMethod", "formMethod")}}
-  - : `string`: **Returns / Sets** the element's {{ htmlattrxref("formmethod", "input") }} attribute, containing the HTTP method that the browser uses to submit the form. This overrides the {{ htmlattrxref("method", "form") }} attribute of the parent form.
+  - : `string`: **Returns / Sets** the element's [`formmethod`](/en-US/docs/Web/HTML/Element/input#formmethod) attribute, containing the HTTP method that the browser uses to submit the form. This overrides the {{ htmlattrxref("method", "form") }} attribute of the parent form.
 
 - {{domxref("HTMLInputElement.formNoValidate", "formNoValidate")}}
-  - : `boolean`: **Returns / Sets** the element's {{ htmlattrxref("formnovalidate", "input") }} attribute, indicating that the form is not to be validated when it is submitted. This overrides the {{ htmlattrxref("novalidate", "form") }} attribute of the parent form.
+  - : `boolean`: **Returns / Sets** the element's [`formnovalidate`](/en-US/docs/Web/HTML/Element/input#formnovalidate) attribute, indicating that the form is not to be validated when it is submitted. This overrides the {{ htmlattrxref("novalidate", "form") }} attribute of the parent form.
 
 - {{domxref("HTMLInputElement.formTarget", "formTarget")}}
-  - : `string`: **Returns / Sets** the element's {{ htmlattrxref("formtarget", "input") }} attribute, containing a name or keyword indicating where to display the response that is received after submitting the form. This overrides the {{ htmlattrxref("target", "form") }} attribute of the parent form.
+  - : `string`: **Returns / Sets** the element's [`formtarget`](/en-US/docs/Web/HTML/Element/input#formtarget) attribute, containing a name or keyword indicating where to display the response that is received after submitting the form. This overrides the {{ htmlattrxref("target", "form") }} attribute of the parent form.
 
 ### Properties that apply to any type of input element that is not hidden
 
 - {{domxref("HTMLInputElement.autofocus", "autofocus")}}
-  - : `boolean`: **Returns / Sets** the element's {{ htmlattrxref("autofocus", "input") }} attribute, which specifies that a form control should have input focus when the page loads, unless the user overrides it, for example by typing in a different control. Only one form element in a document can have the {{htmlattrxref("autofocus","input")}} attribute.
+  - : `boolean`: **Returns / Sets** the element's [`autofocus`](/en-US/docs/Web/HTML/Element/input#autofocus) attribute, which specifies that a form control should have input focus when the page loads, unless the user overrides it, for example by typing in a different control. Only one form element in a document can have the [`autofocus`](/en-US/docs/Web/HTML/Element/input#autofocus) attribute.
 
 - {{domxref("HTMLInputElement.disabled", "disabled")}}
-  - : `boolean`: **Returns / Sets** the element's {{ htmlattrxref("disabled", "input") }} attribute, indicating that the control is not available for interaction. The input values will not be submitted with the form. See also {{ htmlattrxref("readOnly", "input") }}.
+  - : `boolean`: **Returns / Sets** the element's [`disabled`](/en-US/docs/Web/HTML/Element/input#disabled) attribute, indicating that the control is not available for interaction. The input values will not be submitted with the form. See also [`readonly`](/en-US/docs/Web/HTML/Element/input#readonly).
 
 - {{domxref("HTMLInputElement.required", "required")}}
-  - : `boolean`: **Returns / Sets** the element's {{ htmlattrxref("required", "input") }} attribute, indicating that the user must fill in a value before submitting a form.
+  - : `boolean`: **Returns / Sets** the element's [`required`](/en-US/docs/Web/HTML/Element/input#required) attribute, indicating that the user must fill in a value before submitting a form.
 
 - {{domxref("HTMLInputElement.validationMessage", "validationMessage")}} {{readonlyInline}}
-  - : `string`: **Returns** a localized message that describes the validation constraints that the control does not satisfy (if any). This is the empty string if the control is not a candidate for constraint validation ({{htmlattrxref("willValidate","input")}} is `false`), or it satisfies its constraints. This value can be set by the {{domxref("HTMLInputElement.setCustomValidity()", "setCustomValidity()")}} method.
+  - : `string`: **Returns** a localized message that describes the validation constraints that the control does not satisfy (if any). This is the empty string if the control is not a candidate for constraint validation ([`willValidate`](/en-US/docs/Web/API/HTMLObjectElement/willValidate) is `false`), or it satisfies its constraints. This value can be set by the {{domxref("HTMLInputElement.setCustomValidity()", "setCustomValidity()")}} method.
 
 - {{domxref("HTMLInputElement.validity", "validity")}} {{readonlyInline}}
   - : {{domxref("ValidityState")}}: **Returns** the element's current validity state.
@@ -123,21 +123,21 @@ Some properties only apply to input element types that support the corresponding
 ### Properties that apply only to elements of type image
 
 - {{domxref("HTMLInputElement.alt", "alt")}}
-  - : `string`: **Returns / Sets** the element's {{ htmlattrxref("alt", "input") }} attribute, containing alternative text to use.
+  - : `string`: **Returns / Sets** the element's [`alt`](/en-US/docs/Web/HTML/Element/input#alt) attribute, containing alternative text to use.
 
 - {{domxref("HTMLInputElement.height", "height")}}
-  - : `string`: **Returns / Sets** the element's {{ htmlattrxref("height", "input") }} attribute, which defines the height of the image displayed for the button.
+  - : `string`: **Returns / Sets** the element's [`height`](/en-US/docs/Web/HTML/Element/input#height) attribute, which defines the height of the image displayed for the button.
 
 - {{domxref("HTMLInputElement.src", "src")}}
-  - : `string`: **Returns / Sets** the element's {{ htmlattrxref("src", "input") }} attribute, which specifies a URI for the location of an image to display on the graphical submit button.
+  - : `string`: **Returns / Sets** the element's [`src`](/en-US/docs/Web/HTML/Element/input#src) attribute, which specifies a URI for the location of an image to display on the graphical submit button.
 
 - {{domxref("HTMLInputElement.width", "width")}}
-  - : `string`: **Returns / Sets** the element's {{ htmlattrxref("width", "input") }} attribute, which defines the width of the image displayed for the button.
+  - : `string`: **Returns / Sets** the element's [`width`](/en-US/docs/Web/HTML/Element/input#width) attribute, which defines the width of the image displayed for the button.
 
 ### Properties that apply only to elements of type file
 
 - {{domxref("HTMLInputElement.accept", "accept")}}
-  - : `string`: **Returns / Sets** the element's {{ htmlattrxref("accept", "input") }} attribute, containing comma-separated list of file types that can be selected.
+  - : `string`: **Returns / Sets** the element's [`accept`](/en-US/docs/Web/HTML/Element/input#accept) attribute, containing comma-separated list of file types that can be selected.
 
 - {{domxref("HTMLInputElement.allowdirs", "allowdirs")}} {{non-standard_inline}}
   - : `boolean`: Part of the non-standard Directory Upload API. Indicates whether or not to allow directories and files both to be selected in the file list. Implemented only in Firefox and is hidden behind a preference.
@@ -146,7 +146,7 @@ Some properties only apply to input element types that support the corresponding
   - : {{domxref("FileList")}}: **Returns / Sets** a list of {{domxref("File")}} objects representing the files selected for upload.
 
 - {{domxref("HTMLInputElement.webkitdirectory", "webkitdirectory")}} {{Non-standard_inline}}
-  - : `boolean`: **Returns** the {{htmlattrxref("webkitdirectory", "input")}} attribute. If `true`, the file system picker interface only accepts directories instead of files.
+  - : `boolean`: **Returns** the [`webkitdirectory`](/en-US/docs/Web/HTML/Element/input#webkitdirectory) attribute. If `true`, the file system picker interface only accepts directories instead of files.
 
 - {{domxref("HTMLInputElement.webkitEntries", "webkitEntries")}} {{Non-standard_inline}}
   - : {{domxref("FileSystemEntry")}} array: **Describes** the currently selected files or directories.
@@ -154,28 +154,28 @@ Some properties only apply to input element types that support the corresponding
 ### Properties that apply only to visible elements containing text or numbers
 
 - {{domxref("HTMLInputElement.autocomplete", "autocomplete")}}
-  - : `string`: **Returns / Sets** the element's {{htmlattrxref("autocomplete", "input")}} attribute, indicating whether the value of the control can be automatically completed by the browser.
+  - : `string`: **Returns / Sets** the element's [`autocomplete`](/en-US/docs/Web/HTML/Element/input#autocomplete) attribute, indicating whether the value of the control can be automatically completed by the browser.
 
 - {{domxref("HTMLInputElement.max", "max")}}
-  - : `string`: **Returns / Sets** the element's {{ htmlattrxref("max", "input") }} attribute, containing the maximum (numeric or date-time) value for this item, which must not be less than its minimum ({{htmlattrxref("min","input")}} attribute) value.
+  - : `string`: **Returns / Sets** the element's [`max`](/en-US/docs/Web/HTML/Element/input#max) attribute, containing the maximum (numeric or date-time) value for this item, which must not be less than its minimum ([`min`](/en-US/docs/Web/HTML/Element/input#min) attribute) value.
 
 - {{domxref("HTMLInputElement.maxLength", "maxLength")}}
-  - : `unsigned long`: **Returns / Sets** the element's {{ htmlattrxref("maxlength", "input") }} attribute, containing the maximum number of characters (in Unicode code points) that the value can have.
+  - : `unsigned long`: **Returns / Sets** the element's [`maxlength`](/en-US/docs/Web/HTML/Element/input#maxlength) attribute, containing the maximum number of characters (in Unicode code points) that the value can have.
 
 - {{domxref("HTMLInputElement.min", "min")}}
-  - : `string`: **Returns / Sets** the element's {{ htmlattrxref("min", "input") }} attribute, containing the minimum (numeric or date-time) value for this item, which must not be greater than its maximum ({{htmlattrxref("max","input")}} attribute) value.
+  - : `string`: **Returns / Sets** the element's [`min`](/en-US/docs/Web/HTML/Element/input#min) attribute, containing the minimum (numeric or date-time) value for this item, which must not be greater than its maximum ([`max`](/en-US/docs/Web/HTML/Element/input#max) attribute) value.
 
 - {{domxref("HTMLInputElement.minLength", "minLength")}}
-  - : `unsigned long`: **Returns / Sets** the element's {{ htmlattrxref("minlength", "input") }} attribute, containing the minimum number of characters (in Unicode code points) that the value can have.
+  - : `unsigned long`: **Returns / Sets** the element's [`minlength`](/en-US/docs/Web/HTML/Element/input#minlength) attribute, containing the minimum number of characters (in Unicode code points) that the value can have.
 
 - {{domxref("HTMLInputElement.pattern", "pattern")}}
-  - : `string`: **Returns / Sets** the element's {{ htmlattrxref("pattern", "input") }} attribute, containing a regular expression that the control's value is checked against. Use the {{htmlattrxref("title","input")}} attribute to describe the pattern to help the user. This attribute only applies when the value of the {{htmlattrxref("type","input")}} attribute is `text`, `search`, `tel`, `url` or `email`.
+  - : `string`: **Returns / Sets** the element's [`pattern`](/en-US/docs/Web/HTML/Element/input#pattern) attribute, containing a regular expression that the control's value is checked against. Use the [`title`](/en-US/docs/Web/HTML/Element/input#title) attribute to describe the pattern to help the user. This attribute only applies when the value of the [`type`](/en-US/docs/Web/HTML/Element/input#type) attribute is `text`, `search`, `tel`, `url` or `email`.
 
 - {{domxref("HTMLInputElement.placeholder", "placeholder")}}
-  - : `string`: **Returns / Sets** the element's {{ htmlattrxref("placeholder", "input") }} attribute, containing a hint to the user of what can be entered in the control. The placeholder text must not contain carriage returns or line-feeds. This attribute only applies when the value of the {{htmlattrxref("type","input")}} attribute is `text`, `search`, `tel`, `url` or `email`.
+  - : `string`: **Returns / Sets** the element's [`placeholder`](/en-US/docs/Web/HTML/Element/input#placeholder) attribute, containing a hint to the user of what can be entered in the control. The placeholder text must not contain carriage returns or line-feeds. This attribute only applies when the value of the [`type`](/en-US/docs/Web/HTML/Element/input#type) attribute is `text`, `search`, `tel`, `url` or `email`.
 
 - {{domxref("HTMLInputElement.readOnly", "readOnly")}}
-  - : `boolean`: **Returns / Sets** the element's {{ htmlattrxref("readonly", "input") }} attribute, indicating that the user cannot modify the value of the control. This is ignored if the {{htmlattrxref("type","input")}} is `hidden`, `range`, `color`, `checkbox`, `radio`, `file`, or a button type.
+  - : `boolean`: **Returns / Sets** the element's [`readonly`](/en-US/docs/Web/HTML/Element/input#readonly) attribute, indicating that the user cannot modify the value of the control. This is ignored if the [`type`](/en-US/docs/Web/HTML/Element/input#type) is `hidden`, `range`, `color`, `checkbox`, `radio`, `file`, or a button type.
 
 - {{domxref("HTMLInputElement.selectionEnd", "selectionEnd")}}
   - : `unsigned long`: **Returns / Sets** the end index of the selected text. When there's no selection, this returns the offset of the character immediately following the current text input cursor position.
@@ -187,7 +187,7 @@ Some properties only apply to input element types that support the corresponding
   - : `string`: **Returns / Sets** the direction in which selection occurred. Possible values are: `forward` (the selection was performed in the start-to-end direction of the current locale), `backward` (the opposite direction) or `none` (the direction is unknown).
 
 - {{domxref("HTMLInputElement.size", "size")}}
-  - : `unsigned long`: **Returns / Sets** the element's {{ htmlattrxref("size", "input") }} attribute, containing visual size of the control. This value is in pixels unless the value of {{htmlattrxref("type","input")}} is `text` or `password`, in which case, it is an integer number of characters. Applies only when {{htmlattrxref("type","input")}} is set to `text`, `search`, `tel`, `url`, `email`, or `password`.
+  - : `unsigned long`: **Returns / Sets** the element's [`size`](/en-US/docs/Web/HTML/Element/input#size) attribute, containing visual size of the control. This value is in pixels unless the value of [`type`](/en-US/docs/Web/HTML/Element/input#type) is `text` or `password`, in which case, it is an integer number of characters. Applies only when [`type`](/en-US/docs/Web/HTML/Element/input#type) is set to `text`, `search`, `tel`, `url`, `email`, or `password`.
 
 ## Methods
 
@@ -222,18 +222,18 @@ Some properties only apply to input element types that support the corresponding
   - :  Runs the `checkValidity()` method, and if it returns false (for an invalid input or no pattern attribute provided), then it reports to the user that the input is invalid in the same manner as if you submitted a form.
 
 - {{domxref("HTMLInputElement.stepDown()", "stepDown()")}}
-  - : Decrements the {{htmlattrxref("value","input")}} by ({{htmlattrxref("step","input")}} \* n), where n defaults to 1 if not specified. Throws an `InvalidStateError` exception:
-    - if the method is not applicable to for the current {{htmlattrxref("type","input")}} value,
-    - if the element has no {{htmlattrxref("step","input")}} value,
-    - if the {{htmlattrxref("value","input")}} cannot be converted to a number,
-    - if the resulting value is above the {{htmlattrxref("max","input")}} or below the {{htmlattrxref("min","input")}}.
+  - : Decrements the [`value`](/en-US/docs/Web/HTML/Element/input#value) by ([`step`](/en-US/docs/Web/HTML/Element/input#step) \* n), where n defaults to 1 if not specified. Throws an `InvalidStateError` exception:
+    - if the method is not applicable to for the current [`type`](/en-US/docs/Web/HTML/Element/input#type) value,
+    - if the element has no [`step`](/en-US/docs/Web/HTML/Element/input#step) value,
+    - if the [`value`](/en-US/docs/Web/HTML/Element/input#value) cannot be converted to a number,
+    - if the resulting value is above the [`max`](/en-US/docs/Web/HTML/Element/input#max) or below the [`min`](/en-US/docs/Web/HTML/Element/input#min).
 
 - {{domxref("HTMLInputElement.stepUp()", "stepUp()")}}
-  - : Increments the {{htmlattrxref("value","input")}} by ({{htmlattrxref("step","input")}} \* n), where n defaults to 1 if not specified. Throws an `InvalidStateError` exception:
-    - if the method is not applicable to for the current {{htmlattrxref("type","input")}} value.,
-    - if the element has no {{htmlattrxref("step","input")}} value,
-    - if the {{htmlattrxref("value","input")}} cannot be converted to a number,
-    - if the resulting value is above the {{htmlattrxref("max","input")}} or below the {{htmlattrxref("min","input")}}.
+  - : Increments the [`value`](/en-US/docs/Web/HTML/Element/input#value) by ([`step`](/en-US/docs/Web/HTML/Element/input#step) \* n), where n defaults to 1 if not specified. Throws an `InvalidStateError` exception:
+    - if the method is not applicable to for the current [`type`](/en-US/docs/Web/HTML/Element/input#type) value.,
+    - if the element has no [`step`](/en-US/docs/Web/HTML/Element/input#step) value,
+    - if the [`value`](/en-US/docs/Web/HTML/Element/input#value) cannot be converted to a number,
+    - if the resulting value is above the [`max`](/en-US/docs/Web/HTML/Element/input#max) or below the [`min`](/en-US/docs/Web/HTML/Element/input#min).
 
 ## Events
 

--- a/files/en-us/web/api/htmlinputelement/index.md
+++ b/files/en-us/web/api/htmlinputelement/index.md
@@ -146,7 +146,7 @@ Some properties only apply to input element types that support the corresponding
   - : {{domxref("FileList")}}: **Returns / Sets** a list of {{domxref("File")}} objects representing the files selected for upload.
 
 - {{domxref("HTMLInputElement.webkitdirectory", "webkitdirectory")}} {{Non-standard_inline}}
-  - : `boolean`: **Returns** the [`webkitdirectory`](/en-US/docs/Web/HTML/Element/input#webkitdirectory) attribute. If `true`, the file system picker interface only accepts directories instead of files.
+  - : `boolean`: **Returns** the [`webkitdirectory`](/en-US/docs/Web/HTML/Element/input#webkitdirectory) attribute. If `true`, the file-system-picker interface only accepts directories instead of files.
 
 - {{domxref("HTMLInputElement.webkitEntries", "webkitEntries")}} {{Non-standard_inline}}
   - : {{domxref("FileSystemEntry")}} array: **Describes** the currently selected files or directories.

--- a/files/en-us/web/api/htmlinputelement/index.md
+++ b/files/en-us/web/api/htmlinputelement/index.md
@@ -43,7 +43,7 @@ Some properties only apply to input element types that support the corresponding
   - : {{domxref("NodeList")}} array: **Returns** a list of {{ HTMLElement("label") }} elements that are labels for this element.
 
 - {{domxref("HTMLInputElement.list", "list")}} {{readonlyInline}}
-  - : {{domxref("HTMLElement")}}: **Returns** the element pointed by the [`list`](/en-US/docs/Web/HTML/Element/input#list) attribute. The property may be `null` if no HTML element found in the same tree.
+  - : {{domxref("HTMLElement")}}: **Returns** the element pointed to by the [`list`](/en-US/docs/Web/HTML/Element/input#list) attribute. The property may be `null` if no HTML element is found in the same tree.
 
 - {{domxref("HTMLInputElement.multiple", "multiple")}}
   - : `boolean`: **Returns / Sets** the element's [`multiple`](/en-US/docs/Web/HTML/Element/input#multiple) attribute, indicating whether more than one value is possible (e.g., multiple files).

--- a/files/en-us/web/api/htmlinputelement/index.md
+++ b/files/en-us/web/api/htmlinputelement/index.md
@@ -55,7 +55,7 @@ Some properties only apply to input element types that support the corresponding
   - : `string`: **Returns / Sets** the element's [`step`](/en-US/docs/Web/HTML/Element/input#step) attribute, which works with [`min`](/en-US/docs/Web/HTML/Element/input#min) and [`max`](/en-US/docs/Web/HTML/Element/input#max) to limit the increments at which a numeric or date-time value can be set. It can be the string `any` or a positive floating point number. If this is not set to `any`, the control accepts only values at multiples of the step value greater than the minimum.
 
 - {{domxref("HTMLInputElement.type", "type")}}
-  - : `string`: **Returns / Sets** the element's [`type`](/en-US/docs/Web/HTML/Element/input#type) attribute, indicating the type of control to display. See [`type`](/en-US/docs/Web/HTML/Element/input#type) attribute of {{ HTMLElement("input") }} for possible values.
+  - : `string`: **Returns / Sets** the element's [`type`](/en-US/docs/Web/HTML/Element/input#type) attribute, indicating the type of control to display. See the [`type`](/en-US/docs/Web/HTML/Element/input#type) attribute of {{ HTMLElement("input") }} for possible values.
 
 - {{domxref("HTMLInputElement.useMap", "useMap")}} {{deprecated_inline}}
   - : `string`: **Represents** a client-side image map.

--- a/files/en-us/web/api/htmlinputelement/index.md
+++ b/files/en-us/web/api/htmlinputelement/index.md
@@ -75,7 +75,7 @@ Some properties only apply to input element types that support the corresponding
   - : {{domxref("HTMLFormElement")}}: **Returns** a reference to the parent {{HtmlElement("form")}} element.
 
 - {{domxref("HTMLInputElement.formAction", "formAction")}}
-  - : `string`: **Returns / Sets** the element's [`formaction`](/en-US/docs/Web/HTML/Element/input#formaction) attribute, containing the URI of a program that processes information submitted by the element. This overrides the {{ htmlattrxref("action", "form") }} attribute of the parent form.
+  - : `string`: **Returns / Sets** the element's [`formaction`](/en-US/docs/Web/HTML/Element/input#formaction) attribute, containing the URL of a program that processes information submitted by the element. This overrides the {{ htmlattrxref("action", "form") }} attribute of the parent form.
 
 - {{domxref("HTMLInputElement.formEnctype", "formEnctype")}}
   - : `string`: **Returns / Sets** the element's [`formenctype`](/en-US/docs/Web/HTML/Element/input#formenctype) attribute, containing the type of content that is used to submit the form to the server. This overrides the {{ htmlattrxref("enctype", "form") }} attribute of the parent form.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
I replaced all the anchors for the `<input>` page links.

#### Motivation
All of the links to the `<input>` page used `htmlattrxref`, so their anchors were all broken. 

#### Related issues
#15725, #16660 and #18361 were similar issues.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
