### PR TITLE
Fix example click event name

### DIFF
--- a/files/en-us/web/api/element/click_event/index.md
+++ b/files/en-us/web/api/element/click_event/index.md
@@ -30,9 +30,9 @@ If the button is pressed on one element and the pointer is moved outside the ele
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('auxclick', (event) => {});
+addEventListener('click', (event) => {});
 
-onauxclick = (event) => { };
+onclick = (event) => { };
 ```
 
 ## Event type


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
It seems the code example got copied from https://github.com/mdn/content/blob/main/files/en-us/web/api/element/auxclick_event/index.md and so features `auxclick` instead of `click`.
There are no other problematic hits for `auxclick`.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

This is a bit confusing for newcomers and even to those more experienced that just copy and paste examples.

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
