### PR TITLE
Drop Yaffle's EventSource polyfill

### DIFF
--- a/files/en-us/web/api/server-sent_events/index.md
+++ b/files/en-us/web/api/server-sent_events/index.md
@@ -41,7 +41,6 @@ To learn how to use server-sent events, see our article [Using server-sent event
 - [Mercure: a real-time communication protocol (publish-subscribe) built on top of SSE](https://mercure.rocks)
 - [EventSource polyfill for Node.js](https://github.com/EventSource/eventsource)
 - Remy Sharp's [EventSource polyfill](https://github.com/remy/polyfills/blob/master/EventSource.js)
-- Yaffle's [EventSource polyfill](https://github.com/Yaffle/EventSource)
 - Rick Waldron's [jquery plugin](https://github.com/rwaldron/jquery.eventsource)
 - intercooler.js [declarative SSE support](https://intercoolerjs.org/docs.html#sse)
 


### PR DESCRIPTION
In March, this package was updated and now, on each page loading from Russian time zones, [it shows an `alert` and opens a new page with propaganda against the Russian government](https://github.com/Yaffle/EventSource/blob/de137927e13d8afac153d2485152ccec48948a7a/src/eventsource.js#L1032). I don't want to comment on this slogan, nobody is right in this war. The affected version still is not removed from the NPM or marked as malware. If you accidentally miss it and your (quite popular) website will show this message, with new Russian laws, you can get up to 15 years of prison. I don't think that someone will be happy because of such a surprise from a polyfill that he found on MDN.