### PR TITLE
Range.cloneRange(): Update return value to Range

### DIFF
--- a/files/en-us/web/api/range/clonerange/index.md
+++ b/files/en-us/web/api/range/clonerange/index.md
@@ -30,7 +30,7 @@ None.
 
 ### Return value
 
-None ({{jsxref("undefined")}}).
+A {{domxref("Range")}} object.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
I changed the return value to `Range` because the [WhatWG DOM Standard](https://dom.spec.whatwg.org/#dom-range-clonerange) states browsers should return a `Range` rather than `undefined`.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I made this change because it tells readers about the correct return value.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
* https://dom.spec.whatwg.org/#dom-range-clonerange

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
N/A

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
