### PR TITLE
update a broken link

### DIFF
--- a/files/en-us/web/api/cssrule/type/index.md
+++ b/files/en-us/web/api/cssrule/type/index.md
@@ -54,7 +54,7 @@ An integer which will be one of the type constants listed in the table below.
       <td><code>CSSRule.IMPORT_RULE</code></td>
       <td><code>3</code></td>
       <td>{{domxref("CSSImportRule")}}</td>
-      <td></td>
+      <td>An {{cssxref("@import")}} rule.</td>
     </tr>
     <tr>
       <td><code>CSSRule.MEDIA_RULE</code></td>

--- a/files/en-us/web/api/cssrule/type/index.md
+++ b/files/en-us/web/api/cssrule/type/index.md
@@ -30,147 +30,37 @@ for (const rule of rules) {
 
 ## Value
 
-An integer which will be one of the type constants listed in the table below.
 
-<table class="no-markdown">
-  <tbody>
-    <tr>
-      <th>Type</th>
-      <th>Value</th>
-      <th>Rule-specific interface</th>
-      <th>Comments and examples</th>
-    </tr>
-    <tr>
-      <td><code>CSSRule.STYLE_RULE</code></td>
-      <td><code>1</code></td>
-      <td>{{domxref("CSSStyleRule")}}</td>
-      <td>
-        The most common kind of rule:<br /><code
-          >selector { prop1: val1; prop2: val2; }</code
-        >
-      </td>
-    </tr>
-    <tr>
-      <td><code>CSSRule.IMPORT_RULE</code></td>
-      <td><code>3</code></td>
-      <td>{{domxref("CSSImportRule")}}</td>
-      <td>An {{cssxref("@import")}} rule.</td>
-    </tr>
-    <tr>
-      <td><code>CSSRule.MEDIA_RULE</code></td>
-      <td><code>4</code></td>
-      <td>{{domxref("CSSMediaRule")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><code>CSSRule.FONT_FACE_RULE</code></td>
-      <td><code>5</code></td>
-      <td>{{domxref("CSSFontFaceRule")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><code>CSSRule.PAGE_RULE</code></td>
-      <td><code>6</code></td>
-      <td>{{domxref("CSSPageRule")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><code>CSSRule.KEYFRAMES_RULE</code></td>
-      <td><code>7</code></td>
-      <td>
-        {{domxref("CSSKeyframesRule")}}
-        {{experimental_inline}}
-      </td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><code>CSSRule.KEYFRAME_RULE</code></td>
-      <td><code>8</code></td>
-      <td>
-        {{domxref("CSSKeyframeRule")}}
-        {{experimental_inline}}
-      </td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><em>Reserved for future use</em></td>
-      <td><code>9</code></td>
-      <td></td>
-      <td>Should be used to define color profiles in the future</td>
-    </tr>
-    <tr>
-      <td><code>CSSRule.NAMESPACE_RULE</code></td>
-      <td><code>10</code></td>
-      <td>
-        {{domxref("CSSNamespaceRule")}}
-        {{experimental_inline}}
-      </td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><code>CSSRule.COUNTER_STYLE_RULE</code></td>
-      <td><code>11</code></td>
-      <td>
-        {{domxref("CSSCounterStyleRule")}}
-        {{experimental_inline}}
-      </td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><code>CSSRule.SUPPORTS_RULE</code></td>
-      <td><code>12</code></td>
-      <td>{{domxref("CSSSupportsRule")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><code>CSSRule.DOCUMENT_RULE</code></td>
-      <td><code>13</code></td>
-      <td>
-        {{domxref("CSSDocumentRule")}}
-        {{experimental_inline}}
-      </td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><code>CSSRule.FONT_FEATURE_VALUES_RULE</code></td>
-      <td><code>14</code></td>
-      <td>{{domxref("CSSFontFeatureValuesRule")}}</td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><code>CSSRule.VIEWPORT_RULE</code></td>
-      <td><code>15</code></td>
-      <td>
-        {{domxref("CSSViewportRule")}}
-        {{experimental_inline}}
-      </td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><code>CSSRule.REGION_STYLE_RULE</code></td>
-      <td><code>16</code></td>
-      <td>
-        {{domxref("CSSRegionStyleRule")}}
-        {{experimental_inline}}
-      </td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><code>CSSRule.UNKNOWN_RULE</code></td>
-      <td><code>0</code></td>
-      <td>
-        {{domxref("CSSUnknownRule")}} {{deprecated_inline}}
-      </td>
-      <td></td>
-    </tr>
-    <tr>
-      <td><code>CSSRule.CHARSET_RULE</code></td>
-      <td><code>2</code></td>
-      <td><code>CSSCharsetRule</code> {{deprecated_inline}}</td>
-      <td>(Removed in most browsers.)</td>
-    </tr>
-  </tbody>
-</table>
+- `CSSRule.STYLE_RULE` (`1`)
+  - : The rule is a {{domxref("CSSStyleRule")}}, the most common kind of rule: `selector { prop1: val1; prop2: val2; }`.
+- `CSSRule.IMPORT_RULE` (`3`)
+  - : The rule is a {{domxref("CSSImportRule")}} and represents an {{cssxref("@import")}} rule.
+- `CSSRule.MEDIA_RULE` (`4`)
+  - : The rule is a {{domxref("CSSMediaRule")}}.
+- `CSSRule.FONT_FACE_RULE` (`5`)
+  - : The rule is a {{domxref("CSSFontFaceRule")}}
+- `CSSRule.PAGE_RULE` (`6`)
+  - : The rule is a {{domxref("CSSPageRule")}}.
+- `CSSRule.KEYFRAMES_RULE` (`7`)
+  - : The rule is a {{domxref("CSSKeyframesRule")}}.
+- `CSSRule.KEYFRAME_RULE` (`8`)
+  - : The rule is a {{domxref("CSSKeyframeRule")}}.
+- `CSSRule.NAMESPACE_RULE` (`10`)
+  - : The rule is a {{domxref("CSSNamespaceRule")}}.
+- `CSSRule.COUNTER_STYLE_RULE` (`11`)
+  - : The rule is a {{domxref("CSSCounterStyleRule")}}.
+- `CSSRule.SUPPORTS_RULE` (`12`)
+  - : The rule is a {{domxref("CSSSupportsRule")}}.
+- `CSSRule.DOCUMENT_RULE` (`13`)
+  - : The rule is a {{domxref("CSSDocumentRule")}}.
+- `CSSRule.FONT_FEATURE_VALUES_RULE` (`14`)
+  - : The rule is a {{domxref("CSSFontFeatureValuesRule")}}.
+- `CSSRule.VIEWPORT_RULE` (`15`)
+  - : The rule is a {{domxref("CSSViewportRule")}}.
+- `CSSRule.REGION_STYLE_RULE` (`16`)
+  - : The rule is a {{domxref("CSSRegionStyleRule")}}.
+  
+Both `CSSRule.UNKNOWN_RULE` (`0`) and `CSSRule.CHARSET_RULE` (`2`) are deprecated and cannot be obtained any more
 
 ## Examples
 

--- a/files/en-us/web/api/cssrule/type/index.md
+++ b/files/en-us/web/api/cssrule/type/index.md
@@ -58,8 +58,8 @@ An integer which will be one of the type constants listed in the table below.
         An {{cssxref("@import")}} rule. (Until the documentation is
         completed, see the interface definition in the Mozilla source code:
         <a
-          href="http://mxr.mozilla.org/mozilla-central/source/dom/interfaces/css/nsIDOMCSSImportRule.idl#9"
-          >nsIDOMCSSImportRule</a
+          href="https://searchfox.org/mozilla-central/source/dom/webidl/CSSImportRule.webidl"
+          >CSSImportRule</a
         >.)
       </td>
     </tr>

--- a/files/en-us/web/api/cssrule/type/index.md
+++ b/files/en-us/web/api/cssrule/type/index.md
@@ -54,14 +54,7 @@ An integer which will be one of the type constants listed in the table below.
       <td><code>CSSRule.IMPORT_RULE</code></td>
       <td><code>3</code></td>
       <td>{{domxref("CSSImportRule")}}</td>
-      <td>
-        An {{cssxref("@import")}} rule. (Until the documentation is
-        completed, see the interface definition in the Mozilla source code:
-        <a
-          href="https://searchfox.org/mozilla-central/source/dom/webidl/CSSImportRule.webidl"
-          >CSSImportRule</a
-        >.)
-      </td>
+      <td></td>
     </tr>
     <tr>
       <td><code>CSSRule.MEDIA_RULE</code></td>


### PR DESCRIPTION
It's `CSSImportRule.webidl` now.

We could also use chromium link [nsIDOMCSSImportRule.idl](https://chromium.googlesource.com/chromium/deps/xulrunner-sdk/+/ca6bc7c1f70a630f808c4e07ecb4ac224686a69f/win/idl/nsIDOMCSSImportRule.idl) (it has the exact same file name)