### PR TITLE
“Canvas tutorial”: Drop sentence that doesn’t match current content

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/index.md
@@ -15,7 +15,7 @@ tags:
 
 This tutorial describes how to use the [**`<canvas>`**](/en-US/docs/Web/HTML/Element/canvas) element to draw 2D graphics, starting with the basics. The examples provided should give you some clear ideas about what you can do with canvas, and will provide code snippets that may get you started in building your own content.
 
-`<canvas>` is an [HTML](/en-US/docs/Web/HTML) element which can be used to draw graphics via scripting (usually [JavaScript](/en-US/docs/Glossary/JavaScript)). This can, for instance, be used to draw graphs, combine photos, or create simple animations. The images on this page show examples of [**`<canvas>`**](/en-US/docs/Web/HTML/Element/canvas) implementations which will be created in this tutorial.
+`<canvas>` is an [HTML](/en-US/docs/Web/HTML) element which can be used to draw graphics via scripting (usually [JavaScript](/en-US/docs/Glossary/JavaScript)). This can, for instance, be used to draw graphs, combine photos, or create simple animations.
 
 First introduced in WebKit by Apple for the macOS Dashboard, `<canvas>` has since been implemented in browsers. Today, all major browsers support it.
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/18934