### PR TITLE
Update propertyName variable to use let instead of const

### DIFF
--- a/files/en-us/web/javascript/guide/working_with_objects/index.md
+++ b/files/en-us/web/javascript/guide/working_with_objects/index.md
@@ -113,7 +113,7 @@ console.log(myObj.myString); //[Log] This key is in variable str
 This allows accessing any property as determined at runtime:
 
 ```js
-const propertyName = 'make';
+let propertyName = 'make';
 myCar[propertyName] = 'Ford';
 
 // access different properties by changing the contents of the variable


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The propertyName variable in the concerned code snippet is defined using const instead of let which would yield a TypeError as the variable is getting reassigned.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
