### PR TITLE
Remove `Interwiki` macro calls, part 1

### DIFF
--- a/files/en-us/glossary/abstraction/index.md
+++ b/files/en-us/glossary/abstraction/index.md
@@ -42,4 +42,4 @@ obj.display();
 
 ## See also
 
-- {{interwiki("wikipedia", "Abstraction (computer science)", "Abstraction")}} on Wikipedia
+- [Abstraction](https://en.wikipedia.org/wiki/Abstraction_(computer_science)) on Wikipedia

--- a/files/en-us/glossary/accessibility/index.md
+++ b/files/en-us/glossary/accessibility/index.md
@@ -10,7 +10,7 @@ _Web Accessibility_ (**A11Y**) refers to best practices for keeping a website us
 ## See also
 
 - [Accessibility resources at MDN](/en-US/docs/Web/Accessibility)
-- {{Interwiki("wikipedia", "Web accessibility")}} on Wikipedia
+- [Web accessibility](https://en.wikipedia.org/wiki/Web_accessibility) on Wikipedia
 - [Learn accessibility on MDN](/en-US/docs/Learn/Accessibility)
 - [Web Accessibility In Mind](https://webaim.org/)
 - [The ARIA documentation on MDN](/en-US/docs/Web/Accessibility/ARIA)

--- a/files/en-us/glossary/ajax/index.md
+++ b/files/en-us/glossary/ajax/index.md
@@ -16,7 +16,7 @@ With interactive websites and modern web standards, Ajax is gradually being repl
 
 ## See also
 
-- {{interwiki("wikipedia", "AJAX")}} on Wikipedia
+- [AJAX](https://en.wikipedia.org/wiki/AJAX) on Wikipedia
 - [Ajax](/en-US/docs/Web/Guide/AJAX)
 - [Ajax - Getting started](/en-US/docs/Web/Guide/AJAX/Getting_Started)
 - [Glossary](/en-US/docs/Glossary):

--- a/files/en-us/glossary/algorithm/index.md
+++ b/files/en-us/glossary/algorithm/index.md
@@ -20,6 +20,6 @@ There are also Machine Learning algorithms such as Linear Regression, Logistic R
 
 ## See also
 
-- {{Interwiki("wikipedia", "Algorithm", "Algorithm")}} on Wikipedia
+- [Algorithm](https://en.wikipedia.org/wiki/Algorithm) on Wikipedia
 - [Explanations of sorting algorithms](https://www.toptal.com/developers/sorting-algorithms)
 - [Explanations of algorithmic complexity](https://www.bigocheatsheet.com/)

--- a/files/en-us/glossary/alpha/index.md
+++ b/files/en-us/glossary/alpha/index.md
@@ -27,7 +27,7 @@ As you can see, the color without an alpha channel completely blocks the backgro
 
 ## See also
 
-- {{interwiki("wikipedia", "Alpha compositing")}} on Wikipedia
-- {{interwiki("wikipedia", "RGBA color model")}} on Wikipedia
-- {{interwiki("wikipedia", "Channel (digital image)")}} on Wikipedia
+- [Alpha compositing](https://en.wikipedia.org/wiki/Alpha_compositing) on Wikipedia
+- [RGBA color model](https://en.wikipedia.org/wiki/RGBA_color_model) on Wikipedia
+- [Channel (digital image)](https://en.wikipedia.org/wiki/Channel_(digital_image)) on Wikipedia
 - [CSS color](/en-US/docs/Web/CSS/CSS_Colors)

--- a/files/en-us/glossary/apple_safari/index.md
+++ b/files/en-us/glossary/apple_safari/index.md
@@ -10,7 +10,7 @@ tags:
 
 ## See also
 
-- {{Interwiki("wikipedia", "Safari (web browser)", "Safari")}} on Wikipedia
+- [Safari](https://en.wikipedia.org/wiki/Safari_(web_browser)) on Wikipedia
 - [Safari on apple.com](https://www.apple.com/safari/)
 - [The WebKit project](https://webkit.org/)
 - [WebKit nightly build](https://webkit.org/build-archives/)

--- a/files/en-us/glossary/argument/index.md
+++ b/files/en-us/glossary/argument/index.md
@@ -10,5 +10,5 @@ An **argument** is a {{glossary("value")}} ({{Glossary("primitive")}} or {{Gloss
 
 ## See also
 
-- {{Interwiki("wikipedia", "Parameter_(computer_programming)", "Difference between Parameter and Argument")}} on Wikipedia
+- [Difference between Parameter and Argument](https://en.wikipedia.org/wiki/Parameter_(computer_programming)) on Wikipedia
 - The {{jsxref("Functions/arguments","arguments")}} object in {{glossary("JavaScript")}}

--- a/files/en-us/glossary/arpa/index.md
+++ b/files/en-us/glossary/arpa/index.md
@@ -10,4 +10,4 @@ tags:
 ## See also
 
 - [Official website](https://www.iana.org/domains/arpa)
-- {{Interwiki("wikipedia", ".arpa")}} on Wikipedia
+- [.arpa](https://en.wikipedia.org/wiki/.arpa) on Wikipedia

--- a/files/en-us/glossary/array/index.md
+++ b/files/en-us/glossary/array/index.md
@@ -22,5 +22,5 @@ let catNamesArray = ["Jacqueline", "Sophia", "Autumn"];
 
 ## See also
 
-- {{Interwiki("wikipedia", "Array data structure", "Array")}} on Wikipedia
+- [Array](https://en.wikipedia.org/wiki/Array_data_structure) on Wikipedia
 - JavaScript {{jsxref("Array")}} on MDN

--- a/files/en-us/mdn/structures/macros/other/index.md
+++ b/files/en-us/mdn/structures/macros/other/index.md
@@ -11,9 +11,8 @@ In contrast to the macros listed in [Commonly-used macros](/en-US/docs/MDN/Struc
 
 ## Special contexts
 
-These macros are used only with particular contexts, such as a specific API reference.
+This macro is used only with particular contexts, such as a specific API reference.
 
-- [`Interwiki`](https://github.com/mdn/yari/blob/main/kumascript/macros/Interwiki.ejs) makes it easy to create interwiki links. Currently it supports linking to Wikipedia and Wikimo. The first parameter is the name of the wiki ("wikipedia" or "wikimo"), and the second is the path of the article. For example, `\{\{interwiki("wikipedia", "Firefox")\}\}` shows up as {{ interwiki("wikipedia", "Firefox") }}. This template auto-detects the page language and directs to the same language on Wikipedia, for example.
 - [`RFC`](https://github.com/mdn/yari/blob/main/kumascript/macros/RFC.ejs) creates a link to the specified RFC, given its number. The syntax is: `\{\{RFC(number)\}\}`. For example, `\{\{RFC(2616)\}\}` becomes {{ RFC(2616) }}.
 
 ### Landing page components

--- a/files/en-us/web/api/textdecoder/encoding/index.md
+++ b/files/en-us/web/api/textdecoder/encoding/index.md
@@ -21,50 +21,50 @@ It can be one of the following values:
 
 - The recommended encoding for the Web: `'utf-8'`.
 - The legacy single-byte encodings:
-  `{{interwiki('wikipedia', 'Code_page_866', "'ibm866'")}}`,
-  `{{interwiki('wikipedia', 'ISO/IEC_8859-2', "'iso-8859-2'")}}`,
-  `{{interwiki('wikipedia', 'ISO/IEC_8859-3', "'iso-8859-3'")}}`,
-  `{{interwiki('wikipedia', 'ISO/IEC_8859-4', "'iso-8859-4'")}}`,
-  `{{interwiki('wikipedia', 'ISO/IEC_8859-5', "'iso-8859-5'")}}`,
-  `{{interwiki('wikipedia', 'ISO/IEC_8859-6', "'iso-8859-6'")}}`,
-  `{{interwiki('wikipedia', 'ISO/IEC_8859-7', "'iso-8859-7'")}}`,
-  `{{interwiki('wikipedia', 'ISO/IEC_8859-8', "'iso-8859-8'")}}'`,
-  `{{interwiki('wikipedia', 'ISO-8859-8-I', "'iso-8859-8i'")}}`,
-  `{{interwiki('wikipedia', 'ISO/IEC_8859-10', "'iso-8859-10'")}}`,
-  `{{interwiki('wikipedia', 'ISO/IEC_8859-13', "'iso-8859-13'")}}`,
-  `{{interwiki('wikipedia', 'ISO/IEC_8859-14', "'iso-8859-14'")}}`,
-  `{{interwiki('wikipedia', 'ISO/IEC_8859-15', "'iso-8859-15'")}}`,
-  `{{interwiki('wikipedia', 'ISO/IEC_8859-16', "'iso-8859-16'")}}`,
-  `{{interwiki('wikipedia', 'KOI8-R', "'koi8-r'")}}`,
-  `{{interwiki('wikipedia', 'KOI8-U', "'koi8-u'")}}`,
-  `{{interwiki('wikipedia', 'Mac OS Roman', "'macintosh'")}}`,
-  `{{interwiki('wikipedia', 'Windows-874', "'windows-874'")}}`,
-  `{{interwiki('wikipedia', 'Windows-1250', "'windows-1250'")}}`,
-  `{{interwiki('wikipedia', 'Windows-1251', "'windows-1251'")}}`,
-  `{{interwiki('wikipedia', 'Windows-1252', "'windows-1252'")}}`,
-  `{{interwiki('wikipedia', 'Windows-1253', "'windows-1253'")}}`,
-  `{{interwiki('wikipedia', 'Windows-1254', "'windows-1254'")}}`,
-  `{{interwiki('wikipedia', 'Windows-1255', "'windows-1255'")}}`,
-  `{{interwiki('wikipedia', 'Windows-1256', "'windows-1256'")}}`,
-  `{{interwiki('wikipedia', 'Windows-1257', "'windows-1257'")}}`,
-  `{{interwiki('wikipedia', 'Windows-1258', "'windows-1258'")}}`, or
-  `{{interwiki('wikipedia', 'Macintosh Cyrillic encoding', "'x-mac-cyrillic'")}}`.
+  `['ibm866'](https://en.wikipedia.org/wiki/Code_page_866)`,
+  `['iso-8859-2'](https://en.wikipedia.org/wiki/ISO/IEC_8859-2)`,
+  `['iso-8859-3'](https://en.wikipedia.org/wiki/ISO/IEC_8859-3)`,
+  `['iso-8859-4'](https://en.wikipedia.org/wiki/ISO/IEC_8859-4)`,
+  `['iso-8859-5'](https://en.wikipedia.org/wiki/ISO/IEC_8859-5)`,
+  `['iso-8859-6'](https://en.wikipedia.org/wiki/ISO/IEC_8859-6)`,
+  `['iso-8859-7'](https://en.wikipedia.org/wiki/ISO/IEC_8859-7)`,
+  `['iso-8859-8'](https://en.wikipedia.org/wiki/ISO/IEC_8859-8)'`,
+  `['iso-8859-8i'](https://en.wikipedia.org/wiki/ISO-8859-8-I)`,
+  `['iso-8859-10'](https://en.wikipedia.org/wiki/ISO/IEC_8859-10)`,
+  `['iso-8859-13'](https://en.wikipedia.org/wiki/ISO/IEC_8859-13)`,
+  `['iso-8859-14'](https://en.wikipedia.org/wiki/ISO/IEC_8859-14)`,
+  `['iso-8859-15'](https://en.wikipedia.org/wiki/ISO/IEC_8859-15)`,
+  `['iso-8859-16'](https://en.wikipedia.org/wiki/ISO/IEC_8859-16)`,
+  `['koi8-r'](https://en.wikipedia.org/wiki/KOI8-R)`,
+  `['koi8-u'](https://en.wikipedia.org/wiki/KOI8-U)`,
+  `['macintosh'](https://en.wikipedia.org/wiki/Mac_OS_Roman)`,
+  `['windows-874'](https://en.wikipedia.org/wiki/Windows-874)`,
+  `['windows-1250'](https://en.wikipedia.org/wiki/Windows-1250)`,
+  `['windows-1251'](https://en.wikipedia.org/wiki/Windows-1251)`,
+  `['windows-1252'](https://en.wikipedia.org/wiki/Windows-1252)`,
+  `['windows-1253'](https://en.wikipedia.org/wiki/Windows-1253)`,
+  `['windows-1254'](https://en.wikipedia.org/wiki/Windows-1254)`,
+  `['windows-1255'](https://en.wikipedia.org/wiki/Windows-1255)`,
+  `['windows-1256'](https://en.wikipedia.org/wiki/Windows-1256)`,
+  `['windows-1257'](https://en.wikipedia.org/wiki/Windows-1257)`,
+  `['windows-1258'](https://en.wikipedia.org/wiki/Windows-1258)`, or
+  `['x-mac-cyrillic'](https://en.wikipedia.org/wiki/Macintosh_Cyrillic_encoding)`.
 - The legacy multi-byte Chinese (simplified) encodings:
-  `{{interwiki('wikipedia', 'GBK', "'gbk'")}}`,
-  `{{interwiki('wikipedia', 'GB_18030', "'gb18030'")}}`, and
-  `{{interwiki('wikipedia', 'HZ_(character_encoding)', "'hz-gb-2312'")}}`.
+  `['gbk'](https://en.wikipedia.org/wiki/GBK)`,
+  `['gb18030'](https://en.wikipedia.org/wiki/GB_18030)`, and
+  `['hz-gb-2312'](https://en.wikipedia.org/wiki/HZ_(character_encoding))`.
 - The legacy multi-byte Chinese (traditional) encoding:
-  `{{interwiki('wikipedia', 'Big5', "'big5'")}}`.
+  `['big5'](https://en.wikipedia.org/wiki/Big5)`.
 - The legacy multi-byte Japanese encodings:
-  `{{interwiki('wikipedia', 'Extended_Unix_Code#EUC-JP', "'euc-jp'")}}`,
-  `{{interwiki('wikipedia', 'ISO/IEC_2022#ISO-2022-JP', "'iso-2022-jp'")}}`,
-  and `{{interwiki('wikipedia', 'Shift JIS', "'shift-jis'")}}`.
+  `['euc-jp'](https://en.wikipedia.org/wiki/Extended_Unix_Code#EUC-JP)`,
+  `['iso-2022-jp'](https://en.wikipedia.org/wiki/ISO/IEC_2022#ISO-2022-JP)`,
+  and `['shift-jis'](https://en.wikipedia.org/wiki/Shift_JIS)`.
 - The legacy multi-byte Korean encodings:
-  `{{interwiki('wikipedia', 'Extended_Unix_Code#EUC-KR', "'euc-kr'")}}`, and
-  `{{interwiki('wikipedia', 'ISO/IEC_2022#ISO-2022-KR', "'iso-2022-kr'")}}`.
+  `['euc-kr'](https://en.wikipedia.org/wiki/Extended_Unix_Code#EUC-KR)`, and
+  `['iso-2022-kr'](https://en.wikipedia.org/wiki/ISO/IEC_2022#ISO-2022-KR)`.
 - The legacy miscellaneous encodings:
-  `{{interwiki('wikipedia', 'UTF-16#Byte_order_encoding_schemes', "'utf-16be'")}}`,
-  `{{interwiki('wikipedia', 'UTF-16#Byte_order_encoding_schemes', "'utf-16le'")}}`,
+  `['utf-16be'](https://en.wikipedia.org/wiki/UTF-16#Byte_order_encoding_schemes)`,
+  `['utf-16le'](https://en.wikipedia.org/wiki/UTF-16#Byte_order_encoding_schemes)`,
   and `'x-user-defined'`.
 - A special encoding, `'replacement'`, which only emits an error and an
   `EOF` code point. It is used to prevent attacks that mismatch encodings

--- a/files/en-us/web/api/textdecoder/encoding/index.md
+++ b/files/en-us/web/api/textdecoder/encoding/index.md
@@ -21,50 +21,50 @@ It can be one of the following values:
 
 - The recommended encoding for the Web: `'utf-8'`.
 - The legacy single-byte encodings:
-  `['ibm866'](https://en.wikipedia.org/wiki/Code_page_866)`,
-  `['iso-8859-2'](https://en.wikipedia.org/wiki/ISO/IEC_8859-2)`,
-  `['iso-8859-3'](https://en.wikipedia.org/wiki/ISO/IEC_8859-3)`,
-  `['iso-8859-4'](https://en.wikipedia.org/wiki/ISO/IEC_8859-4)`,
-  `['iso-8859-5'](https://en.wikipedia.org/wiki/ISO/IEC_8859-5)`,
-  `['iso-8859-6'](https://en.wikipedia.org/wiki/ISO/IEC_8859-6)`,
-  `['iso-8859-7'](https://en.wikipedia.org/wiki/ISO/IEC_8859-7)`,
-  `['iso-8859-8'](https://en.wikipedia.org/wiki/ISO/IEC_8859-8)'`,
-  `['iso-8859-8i'](https://en.wikipedia.org/wiki/ISO-8859-8-I)`,
-  `['iso-8859-10'](https://en.wikipedia.org/wiki/ISO/IEC_8859-10)`,
-  `['iso-8859-13'](https://en.wikipedia.org/wiki/ISO/IEC_8859-13)`,
-  `['iso-8859-14'](https://en.wikipedia.org/wiki/ISO/IEC_8859-14)`,
-  `['iso-8859-15'](https://en.wikipedia.org/wiki/ISO/IEC_8859-15)`,
-  `['iso-8859-16'](https://en.wikipedia.org/wiki/ISO/IEC_8859-16)`,
-  `['koi8-r'](https://en.wikipedia.org/wiki/KOI8-R)`,
-  `['koi8-u'](https://en.wikipedia.org/wiki/KOI8-U)`,
-  `['macintosh'](https://en.wikipedia.org/wiki/Mac_OS_Roman)`,
-  `['windows-874'](https://en.wikipedia.org/wiki/Windows-874)`,
-  `['windows-1250'](https://en.wikipedia.org/wiki/Windows-1250)`,
-  `['windows-1251'](https://en.wikipedia.org/wiki/Windows-1251)`,
-  `['windows-1252'](https://en.wikipedia.org/wiki/Windows-1252)`,
-  `['windows-1253'](https://en.wikipedia.org/wiki/Windows-1253)`,
-  `['windows-1254'](https://en.wikipedia.org/wiki/Windows-1254)`,
-  `['windows-1255'](https://en.wikipedia.org/wiki/Windows-1255)`,
-  `['windows-1256'](https://en.wikipedia.org/wiki/Windows-1256)`,
-  `['windows-1257'](https://en.wikipedia.org/wiki/Windows-1257)`,
-  `['windows-1258'](https://en.wikipedia.org/wiki/Windows-1258)`, or
-  `['x-mac-cyrillic'](https://en.wikipedia.org/wiki/Macintosh_Cyrillic_encoding)`.
+  ['ibm866'](https://en.wikipedia.org/wiki/Code_page_866),
+  ['iso-8859-2'](https://en.wikipedia.org/wiki/ISO/IEC_8859-2),
+  ['iso-8859-3'](https://en.wikipedia.org/wiki/ISO/IEC_8859-3),
+  ['iso-8859-4'](https://en.wikipedia.org/wiki/ISO/IEC_8859-4),
+  ['iso-8859-5'](https://en.wikipedia.org/wiki/ISO/IEC_8859-5),
+  ['iso-8859-6'](https://en.wikipedia.org/wiki/ISO/IEC_8859-6),
+  ['iso-8859-7'](https://en.wikipedia.org/wiki/ISO/IEC_8859-7),
+  ['iso-8859-8'](https://en.wikipedia.org/wiki/ISO/IEC_8859-8)'`,
+  ['iso-8859-8i'](https://en.wikipedia.org/wiki/ISO-8859-8-I),
+  ['iso-8859-10'](https://en.wikipedia.org/wiki/ISO/IEC_8859-10),
+  ['iso-8859-13'](https://en.wikipedia.org/wiki/ISO/IEC_8859-13),
+  ['iso-8859-14'](https://en.wikipedia.org/wiki/ISO/IEC_8859-14),
+  ['iso-8859-15'](https://en.wikipedia.org/wiki/ISO/IEC_8859-15),
+  ['iso-8859-16'](https://en.wikipedia.org/wiki/ISO/IEC_8859-16),
+  ['koi8-r'](https://en.wikipedia.org/wiki/KOI8-R),
+  ['koi8-u'](https://en.wikipedia.org/wiki/KOI8-U),
+  ['macintosh'](https://en.wikipedia.org/wiki/Mac_OS_Roman),
+  ['windows-874'](https://en.wikipedia.org/wiki/Windows-874),
+  ['windows-1250'](https://en.wikipedia.org/wiki/Windows-1250),
+  ['windows-1251'](https://en.wikipedia.org/wiki/Windows-1251),
+  ['windows-1252'](https://en.wikipedia.org/wiki/Windows-1252),
+  ['windows-1253'](https://en.wikipedia.org/wiki/Windows-1253),
+  ['windows-1254'](https://en.wikipedia.org/wiki/Windows-1254),
+  ['windows-1255'](https://en.wikipedia.org/wiki/Windows-1255),
+  ['windows-1256'](https://en.wikipedia.org/wiki/Windows-1256),
+  ['windows-1257'](https://en.wikipedia.org/wiki/Windows-1257),
+  ['windows-1258'](https://en.wikipedia.org/wiki/Windows-1258), or
+  ['x-mac-cyrillic'](https://en.wikipedia.org/wiki/Macintosh_Cyrillic_encoding).
 - The legacy multi-byte Chinese (simplified) encodings:
-  `['gbk'](https://en.wikipedia.org/wiki/GBK)`,
-  `['gb18030'](https://en.wikipedia.org/wiki/GB_18030)`, and
-  `['hz-gb-2312'](https://en.wikipedia.org/wiki/HZ_(character_encoding))`.
+  ['gbk'](https://en.wikipedia.org/wiki/GBK),
+  ['gb18030'](https://en.wikipedia.org/wiki/GB_18030), and
+  ['hz-gb-2312'](https://en.wikipedia.org/wiki/HZ_(character_encoding)).
 - The legacy multi-byte Chinese (traditional) encoding:
-  `['big5'](https://en.wikipedia.org/wiki/Big5)`.
+  ['big5'](https://en.wikipedia.org/wiki/Big5).
 - The legacy multi-byte Japanese encodings:
-  `['euc-jp'](https://en.wikipedia.org/wiki/Extended_Unix_Code#EUC-JP)`,
-  `['iso-2022-jp'](https://en.wikipedia.org/wiki/ISO/IEC_2022#ISO-2022-JP)`,
-  and `['shift-jis'](https://en.wikipedia.org/wiki/Shift_JIS)`.
+  ['euc-jp'](https://en.wikipedia.org/wiki/Extended_Unix_Code#EUC-JP),
+  ['iso-2022-jp'](https://en.wikipedia.org/wiki/ISO/IEC_2022#ISO-2022-JP),
+  and ['shift-jis'](https://en.wikipedia.org/wiki/Shift_JIS).
 - The legacy multi-byte Korean encodings:
-  `['euc-kr'](https://en.wikipedia.org/wiki/Extended_Unix_Code#EUC-KR)`, and
-  `['iso-2022-kr'](https://en.wikipedia.org/wiki/ISO/IEC_2022#ISO-2022-KR)`.
+  ['euc-kr'](https://en.wikipedia.org/wiki/Extended_Unix_Code#EUC-KR), and
+  ['iso-2022-kr'](https://en.wikipedia.org/wiki/ISO/IEC_2022#ISO-2022-KR).
 - The legacy miscellaneous encodings:
-  `['utf-16be'](https://en.wikipedia.org/wiki/UTF-16#Byte_order_encoding_schemes)`,
-  `['utf-16le'](https://en.wikipedia.org/wiki/UTF-16#Byte_order_encoding_schemes)`,
+  ['utf-16be'](https://en.wikipedia.org/wiki/UTF-16#Byte_order_encoding_schemes),
+  ['utf-16le'](https://en.wikipedia.org/wiki/UTF-16#Byte_order_encoding_schemes),
   and `'x-user-defined'`.
 - A special encoding, `'replacement'`, which only emits an error and an
   `EOF` code point. It is used to prevent attacks that mismatch encodings


### PR DESCRIPTION
We are phasing out the `Interwiki` macro: https://github.com/mdn/content/pull/18723#pullrequestreview-1048593401

The PR converts `{{interwiki(...)}}` macro calls to markdown style links `[...](https://…)`.