### PR TITLE
Remove `InterWiki` macro calls, part 2

### DIFF
--- a/files/en-us/glossary/api/index.md
+++ b/files/en-us/glossary/api/index.md
@@ -19,5 +19,5 @@ For example:
 
 ## See also
 
-- {{Interwiki("wikipedia", "API", "API")}} on Wikipedia
+- [API](https://en.wikipedia.org/wiki/API) on Wikipedia
 - [Web API reference](/en-US/docs/Web/API)

--- a/files/en-us/glossary/arpanet/index.md
+++ b/files/en-us/glossary/arpanet/index.md
@@ -9,4 +9,4 @@ The **ARPANET** (Advanced Research Projects Agency NETwork) was an early compute
 
 ## See also
 
-- {{Interwiki("wikipedia", "ARPANET")}} on Wikipedia
+- [ARPANET](https://en.wikipedia.org/wiki/ARPANET) on Wikipedia

--- a/files/en-us/glossary/ascii/index.md
+++ b/files/en-us/glossary/ascii/index.md
@@ -9,4 +9,4 @@ tags:
 
 ## See also
 
-{{Interwiki("wikipedia", "ASCII")}} on Wikipedia
+[ASCII](https://en.wikipedia.org/wiki/ASCII) on Wikipedia

--- a/files/en-us/glossary/bandwidth/index.md
+++ b/files/en-us/glossary/bandwidth/index.md
@@ -9,4 +9,4 @@ Bandwidth is the measure of how much information can pass through a data connect
 
 ## See also
 
-- {{Interwiki("wikipedia", "Bandwidth")}} on Wikipedia
+- [Bandwidth](https://en.wikipedia.org/wiki/Bandwidth) on Wikipedia

--- a/files/en-us/glossary/bidi/index.md
+++ b/files/en-us/glossary/bidi/index.md
@@ -9,4 +9,4 @@ tags:
 
 ## See also
 
-- {{Interwiki("wikipedia", "Bi-directional text")}} on Wikipedia
+- [Bi-directional text](https://en.wikipedia.org/wiki/Bi-directional_text) on Wikipedia

--- a/files/en-us/glossary/bigint/index.md
+++ b/files/en-us/glossary/bigint/index.md
@@ -12,6 +12,6 @@ In {{Glossary("JavaScript")}}, **BigInt** is a numeric data type that can repres
 
 ## See also
 
-- {{Interwiki("wikipedia", "Data type#Numeric_types", "Numeric types")}} on Wikipedia
+- [Numeric types](https://en.wikipedia.org/wiki/Data_type#Numeric_types) on Wikipedia
 - The JavaScript type: [`BigInt`](/en-US/docs/Web/JavaScript/Data_structures#bigint_type)
 - The JavaScript global object {{jsxref("BigInt")}}

--- a/files/en-us/glossary/boolean/index.md
+++ b/files/en-us/glossary/boolean/index.md
@@ -37,10 +37,10 @@ for (var i=0; i < 4; i++) {
 }
 ```
 
-The Boolean value is named after English mathematician {{interwiki("wikipedia", "George Boole")}}, who pioneered the field of mathematical logic.
+The Boolean value is named after English mathematician [George Boole](https://en.wikipedia.org/wiki/George_Boole), who pioneered the field of mathematical logic.
 
 ## See also
 
-- {{Interwiki("wikipedia", "Boolean data type", "Boolean")}} on Wikipedia
+- [Boolean](https://en.wikipedia.org/wiki/Boolean_data_type) on Wikipedia
 - The JavaScript global object: {{jsxref("Boolean")}}
 - [JavaScript data types and data structures](/en-US/docs/Web/JavaScript/Data_structures)

--- a/files/en-us/glossary/bootstrap/index.md
+++ b/files/en-us/glossary/bootstrap/index.md
@@ -14,6 +14,6 @@ Initially, Bootstrap was called Twitter Blueprint and was developed by a team wo
 
 ## See also
 
-- {{interwiki("wikipedia", "Bootstrap (front-end framework)", "Bootstrap")}} on Wikipedia
+- [Bootstrap](https://en.wikipedia.org/wiki/Bootstrap_(front-end_framework)) on Wikipedia
 - [Download Bootstrap](https://getbootstrap.com/)
 - [Get started with the latest version](https://www.w3schools.com/bootstrap4/bootstrap_get_started.asp)

--- a/files/en-us/glossary/brotli_compression/index.md
+++ b/files/en-us/glossary/brotli_compression/index.md
@@ -18,5 +18,5 @@ Brotli is compatible with most modern browsers, but you may want to consider a f
 
 - [brotli.org](https://brotli.org/)
 - [Brotli GitHub repository](https://github.com/google/brotli)
-- {{interwiki("wikipedia", "Brotli")}} on Wikipedia
+- [Brotli](https://en.wikipedia.org/wiki/Brotli) on Wikipedia
 - [Brotli on Caniuse](https://caniuse.com/#feat=brotli)

--- a/files/en-us/glossary/browser/index.md
+++ b/files/en-us/glossary/browser/index.md
@@ -9,7 +9,7 @@ A **Web browser** or **browser** is a program that retrieves and displays pages 
 
 ## See also
 
-- {{Interwiki("wikipedia", "Web browser")}} on Wikipedia
+- [Web browser](https://en.wikipedia.org/wiki/Web_browser) on Wikipedia
 - {{Glossary("user agent")}} (Glossary)
 - {{HTTPHeader("User-agent")}} (HTTP Header)
 - Download a browser

--- a/files/en-us/glossary/cache/index.md
+++ b/files/en-us/glossary/cache/index.md
@@ -9,4 +9,4 @@ A **cache** (web cache or HTTP cache) is a component that stores HTTP responses 
 
 ## See also
 
-- {{interwiki("wikipedia", "Web cache")}} on Wikipedia
+- [Web cache](https://en.wikipedia.org/wiki/Web_cache) on Wikipedia

--- a/files/en-us/glossary/caldav/index.md
+++ b/files/en-us/glossary/caldav/index.md
@@ -10,6 +10,6 @@ CalDAV (Calendaring extensions to {{Glossary("WebDAV")}}) is a {{glossary("proto
 
 ## See also
 
-- {{Interwiki("wikipedia", "CalDAV")}} on Wikipedia
+- [CalDAV](https://en.wikipedia.org/wiki/CalDAV) on Wikipedia
 - [RFC 4791: Calendaring extensions to WebDAV (CalDAV)](https://datatracker.ietf.org/doc/html/rfc4791)
 - [RFC 6638: Scheduling Extensions to CalDAV](https://datatracker.ietf.org/doc/html/rfc6638)

--- a/files/en-us/glossary/call_stack/index.md
+++ b/files/en-us/glossary/call_stack/index.md
@@ -65,7 +65,7 @@ In summary, then, we start with an empty Call Stack. Whenever we invoke a functi
 
 ## See also
 
-- {{Interwiki("wikipedia", "Call stack")}} on Wikipedia
+- [Call stack](https://en.wikipedia.org/wiki/Call_stack) on Wikipedia
 - [Glossary](/en-US/docs/Glossary)
 
   - {{Glossary("Call stack")}}

--- a/files/en-us/glossary/callback_function/index.md
+++ b/files/en-us/glossary/callback_function/index.md
@@ -30,4 +30,4 @@ Note, however, that callbacks are often used to continue code execution after an
 
 ## See also
 
-- {{interwiki("wikipedia", "Callback_(computer_programming)", "Callback")}} on Wikipedia
+- [Callback](https://en.wikipedia.org/wiki/Callback_(computer_programming)) on Wikipedia

--- a/files/en-us/glossary/canvas/index.md
+++ b/files/en-us/glossary/canvas/index.md
@@ -14,7 +14,7 @@ It is a low level, procedural model that updates a [bitmap](https://en.wikipedia
 
 ## See also
 
-- {{Interwiki("wikipedia", "Canvas element", "Canvas")}} on Wikipedia
+- [Canvas](https://en.wikipedia.org/wiki/Canvas_element) on Wikipedia
 - [The Canvas tutorial on MDN](/en-US/docs/Web/API/Canvas_API/Tutorial)
 - The HTML {{HTMLElement("canvas")}} element on MDN
 - [The Canvas general documentation on MDN](/en-US/docs/Web/API/Canvas_API)

--- a/files/en-us/glossary/card_sorting/index.md
+++ b/files/en-us/glossary/card_sorting/index.md
@@ -10,4 +10,4 @@ Card sorting is a simple technique used in {{glossary("Information architecture"
 
 ## See also
 
-- {{interwiki("wikipedia", "Card_sorting", "Card sorting")}} on Wikipedia
+- [Card sorting](https://en.wikipedia.org/wiki/Card_sorting) on Wikipedia

--- a/files/en-us/glossary/carddav/index.md
+++ b/files/en-us/glossary/carddav/index.md
@@ -10,5 +10,5 @@ tags:
 
 ## See also
 
-- {{Interwiki("wikipedia", "CardDAV")}} on Wikipedia
+- [CardDAV](https://en.wikipedia.org/wiki/CardDAV) on Wikipedia
 - [RFC 6352: vCard Extensions to Web Distributed Authoring and Versioning (WebDAV)](https://datatracker.ietf.org/doc/html/rfc6352)

--- a/files/en-us/glossary/caret/index.md
+++ b/files/en-us/glossary/caret/index.md
@@ -20,7 +20,7 @@ On the web, a caret is used to represent the insertion point in {{HTMLElement("i
 
 ## See also
 
-- {{interwiki("wikipedia", "Caret navigation")}} on Wikipedia
+- [Caret navigation](https://en.wikipedia.org/wiki/Caret_navigation) on Wikipedia
 
 ### CSS related to the caret
 

--- a/files/en-us/glossary/certified/index.md
+++ b/files/en-us/glossary/certified/index.md
@@ -15,4 +15,4 @@ For details on certification in {{glossary("Cryptography")}}, please refer to {{
 
 ## See also
 
-- {{Interwiki("wikipedia", "Professional_certification_(computer_technology)#Information_systems_security", "Certification")}} on Wikipedia
+- [Certification](https://en.wikipedia.org/wiki/Professional_certification_(computer_technology)#Information_systems_security) on Wikipedia

--- a/files/en-us/glossary/character/index.md
+++ b/files/en-us/glossary/character/index.md
@@ -10,8 +10,8 @@ A _character_ is either a symbol (letters, numbers, punctuation) or non-printing
 
 ## See also
 
-- {{interwiki("wikipedia", "Character (computing)")}} on Wikipedia
-- {{interwiki("wikipedia", "Character encoding")}} on Wikipedia
-- {{interwiki("wikipedia", "ASCII")}} on Wikipedia
-- {{interwiki("wikipedia", "UTF-8")}} on Wikipedia
-- {{interwiki("wikipedia", "Unicode")}} on Wikipedia
+- [Character (computing)](https://en.wikipedia.org/wiki/Character_(computing)) on Wikipedia
+- [Character encoding](https://en.wikipedia.org/wiki/Character_encoding) on Wikipedia
+- [ASCII](https://en.wikipedia.org/wiki/ASCII) on Wikipedia
+- [UTF-8](https://en.wikipedia.org/wiki/UTF-8) on Wikipedia
+- [Unicode](https://en.wikipedia.org/wiki/Unicode) on Wikipedia

--- a/files/en-us/glossary/character_encoding/index.md
+++ b/files/en-us/glossary/character_encoding/index.md
@@ -18,4 +18,4 @@ This ensures that you can use characters from just about any human language in y
 ## See also
 
 - [Character encoding on W3C](https://www.w3.org/International/articles/definitions-characters/)
-- {{Interwiki("wikipedia", "Character encoding")}} on Wikipedia
+- [Character encoding](https://en.wikipedia.org/wiki/Character_encoding) on Wikipedia

--- a/files/en-us/glossary/character_set/index.md
+++ b/files/en-us/glossary/character_set/index.md
@@ -10,12 +10,12 @@ A **character set** is an encoding system to let computers know how to recognize
 
 In earlier times, countries developed their own character sets due to their different languages used, such as Kanji JIS codes (e.g. Shift-JIS, EUC-JP, etc.) for Japanese, Big5 for traditional Chinese, and KOI8-R for Russian. However, {{Glossary("Unicode")}} gradually became most acceptable character set for its universal language support.
 
-If a character set is used incorrectly (For example, Unicode for an article encoded in Big5), you may see nothing but broken characters, which are called {{Interwiki("wikipedia", "Mojibake")}}.
+If a character set is used incorrectly (For example, Unicode for an article encoded in Big5), you may see nothing but broken characters, which are called [Mojibake](https://en.wikipedia.org/wiki/Mojibake).
 
 ## See also
 
-- {{Interwiki("wikipedia", "Character encoding")}} (Wikipedia)
-- {{Interwiki("wikipedia", "Mojibake")}} (Wikipedia)
+- [Character encoding](https://en.wikipedia.org/wiki/Character_encoding) (Wikipedia)
+- [Mojibake](https://en.wikipedia.org/wiki/Mojibake) (Wikipedia)
 - [Glossary](/en-US/docs/Glossary)
 
   - {{Glossary("Character")}}

--- a/files/en-us/glossary/cia/index.md
+++ b/files/en-us/glossary/cia/index.md
@@ -9,4 +9,4 @@ CIA (Confidentiality, Integrity, Availability) (also called the CIA triad or AIC
 
 ## See also
 
-- {{Interwiki("wikipedia", "Information_security#Key_concepts", "CIA")}} on Wikipedia
+- [CIA](https://en.wikipedia.org/wiki/Information_security#Key_concepts) on Wikipedia

--- a/files/en-us/glossary/cipher/index.md
+++ b/files/en-us/glossary/cipher/index.md
@@ -22,7 +22,7 @@ They also are classified according to how their {{glossary("key", "keys")}} are 
 
 ## See also
 
-- {{Interwiki("wikipedia", "Cipher")}} on Wikipedia
+- [Cipher](https://en.wikipedia.org/wiki/Cipher) on Wikipedia
 - [Encryption and Decryption](/en-US/docs/Archive/Security/Encryption_and_Decryption)
 - [MDN Web Docs Glossary](/en-US/docs/Glossary)
 

--- a/files/en-us/glossary/ciphertext/index.md
+++ b/files/en-us/glossary/ciphertext/index.md
@@ -11,4 +11,4 @@ In {{glossary("cryptography")}}, a ciphertext is a scrambled message that convey
 
 ## See also
 
-- {{Interwiki("wikipedia", "Ciphertext")}} on Wikipedia
+- [Ciphertext](https://en.wikipedia.org/wiki/Ciphertext) on Wikipedia

--- a/files/en-us/glossary/closure/index.md
+++ b/files/en-us/glossary/closure/index.md
@@ -9,5 +9,5 @@ The binding which defines the **{{glossary("scope")}}** of execution. In {{gloss
 
 ## See also
 
-- {{Interwiki("wikipedia", "Closure_%28computer_programming%29", "Closure")}} on Wikipedia
+- [Closure](https://en.wikipedia.org/wiki/Closure_%28computer_programming%29) on Wikipedia
 - [Closure](/en-US/docs/Web/JavaScript/Closures) on MDN

--- a/files/en-us/glossary/cms/index.md
+++ b/files/en-us/glossary/cms/index.md
@@ -11,4 +11,4 @@ A CMS (Content Management System) is software that allows users to publish, orga
 
 ## See also
 
-- {{Interwiki("wikipedia", "Content management system")}} on Wikipedia
+- [Content management system](https://en.wikipedia.org/wiki/Content_management_system) on Wikipedia

--- a/files/en-us/glossary/codec/index.md
+++ b/files/en-us/glossary/codec/index.md
@@ -9,7 +9,7 @@ A *codec* (a blend word derived from "**co**der-**dec**oder") is a program, algo
 
 ## See also
 
-- {{Interwiki("wikipedia", "Codec")}} on Wikipedia
+- [Codec](https://en.wikipedia.org/wiki/Codec) on Wikipedia
 - [Web video codec guide](/en-US/docs/Web/Media/Formats/Video_codecs)
 - [Web audio codec guide](/en-US/docs/Web/Media/Formats/Audio_codecs)
 - [Guide to media types and formats on the web](/en-US/docs/Web/Media/Formats)

--- a/files/en-us/glossary/compile/index.md
+++ b/files/en-us/glossary/compile/index.md
@@ -21,4 +21,4 @@ Compilers may also translate among higher-level languages — for example, from 
 
 - [Compiling from C/C++ to WebAssembly](/en-US/docs/WebAssembly/C_to_wasm)
 - [Compiling from Rust to WebAssembly](/en-US/docs/WebAssembly/Rust_to_wasm)
-- Wikipedia: {{Interwiki("wikipedia", "Compiler")}}
+- Wikipedia: [Compiler](https://en.wikipedia.org/wiki/Compiler)

--- a/files/en-us/glossary/compile_time/index.md
+++ b/files/en-us/glossary/compile_time/index.md
@@ -10,4 +10,4 @@ The _compile time_ is the time from when the program is first loaded until the p
 
 ## See also
 
-- {{Interwiki("wikipedia", "Compile time")}} on Wikipedia
+- [Compile time](https://en.wikipedia.org/wiki/Compile_time) on Wikipedia

--- a/files/en-us/glossary/computer_programming/index.md
+++ b/files/en-us/glossary/computer_programming/index.md
@@ -13,5 +13,5 @@ Using an appropriate language, you can program/create all sorts of software. For
 
 ## See also
 
-- {{Interwiki("wikipedia", "Computer programming")}} on Wikipedia
+- [Computer programming](https://en.wikipedia.org/wiki/Computer_programming) on Wikipedia
 - [List of Programming Languages: Wikipedia](https://en.wikipedia.org/wiki/List_of_programming_languages)

--- a/files/en-us/glossary/conditional/index.md
+++ b/files/en-us/glossary/conditional/index.md
@@ -12,7 +12,7 @@ An instruction or a set of instructions is executed if a specific condition is f
 
 ## See also
 
-- {{interwiki("wikipedia", "Exception_handling#Condition_systems", "Condition")}} on Wikipedia
+- [Condition](https://en.wikipedia.org/wiki/Exception_handling#Condition_systems) on Wikipedia
 - [Control flow](/en-US/docs/Glossary/Control_flow) on MDN
 - [Making decisions in your code — conditionals](/en-US/docs/Learn/JavaScript/Building_blocks/conditionals)
 - [Control flow and error handling in JavaScript](/en-US/docs/Web/JavaScript/Guide/Control_flow_and_error_handling) on MDN

--- a/files/en-us/glossary/constant/index.md
+++ b/files/en-us/glossary/constant/index.md
@@ -12,4 +12,4 @@ Like variables, some constants are bound to identifiers. For example, the identi
 
 ## See also
 
-- {{Interwiki("wikipedia", "Constant_(computer_programming)", "Constant")}} on Wikipedia
+- [Constant](https://en.wikipedia.org/wiki/Constant_(computer_programming)) on Wikipedia

--- a/files/en-us/glossary/constructor/index.md
+++ b/files/en-us/glossary/constructor/index.md
@@ -33,6 +33,6 @@ var defaultReference = new Default();
 
 ## See also
 
-- {{Interwiki("wikipedia", "Constructor_%28object-oriented_programming%29", "Constructor")}} on Wikipedia
+- [Constructor](https://en.wikipedia.org/wiki/Constructor_%28object-oriented_programming%29) on Wikipedia
 - [The constructor in object oriented programming for JavaScript](/en-US/docs/Learn/JavaScript/Objects#the_constructor) on MDN
 - [New operator in JavaScript](/en-US/docs/Web/JavaScript/Reference/Operators/new) on MDN

--- a/files/en-us/glossary/control_flow/index.md
+++ b/files/en-us/glossary/control_flow/index.md
@@ -28,6 +28,6 @@ Control flow means that when you read a script, you must not only read from star
 
 ## See also
 
-- {{Interwiki("wikipedia", "Control flow")}} on Wikipedia
+- [Control flow](https://en.wikipedia.org/wiki/Control_flow) on Wikipedia
 - [JavaScript Reference - Control flow](/en-US/docs/Web/JavaScript/Reference#control_flow) on MDN
 - [Statements (Control flow)](/en-US/docs/Web/JavaScript/Guide/Control_flow_and_error_handling) on MDN

--- a/files/en-us/glossary/copyleft/index.md
+++ b/files/en-us/glossary/copyleft/index.md
@@ -11,4 +11,4 @@ Copyleft is a term, usually referring to a license, used to indicate that such l
 
 ## See also
 
-- {{Interwiki("wikipedia", "Copyleft")}} on Wikipedia
+- [Copyleft](https://en.wikipedia.org/wiki/Copyleft) on Wikipedia

--- a/files/en-us/glossary/cors/index.md
+++ b/files/en-us/glossary/cors/index.md
@@ -13,7 +13,7 @@ The [same-origin security policy](/en-US/docs/Web/Security/Same-origin_policy) f
 ## See also
 
 - [Cross-Origin Resource Sharing (CORS)](/en-US/docs/Web/HTTP/CORS) on MDN
-- {{Interwiki("wikipedia", "Cross-origin resource sharing")}} on Wikipedia
+- [Cross-origin resource sharing](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) on Wikipedia
 - [Fetch specification](https://fetch.spec.whatwg.org)
 
 ### CORS headers

--- a/files/en-us/glossary/crawler/index.md
+++ b/files/en-us/glossary/crawler/index.md
@@ -11,5 +11,5 @@ A web crawler is a program, often called a bot or robot, which systematically br
 
 ## See also
 
-- {{Interwiki("wikipedia", "Web crawler")}} on Wikipedia
+- [Web crawler](https://en.wikipedia.org/wiki/Web_crawler) on Wikipedia
 - {{Glossary("Search engine")}} (Glossary)

--- a/files/en-us/glossary/crlf/index.md
+++ b/files/en-us/glossary/crlf/index.md
@@ -19,5 +19,5 @@ A CR immediately followed by a LF (CRLF, `\r\n`, or `0x0D0A`) moves the cursor d
 
 ## See also
 
-- {{interwiki("wikipedia", "Newline#In_programming_languages", "Newline")}} on Wikipedia
-- {{interwiki("wikipedia", "Carriage_return#Computers", "Carriage return")}} on Wikipedia
+- [Newline](https://en.wikipedia.org/wiki/Newline#In_programming_languages) on Wikipedia
+- [Carriage return](https://en.wikipedia.org/wiki/Carriage_return#Computers) on Wikipedia

--- a/files/en-us/glossary/cross-site_scripting/index.md
+++ b/files/en-us/glossary/cross-site_scripting/index.md
@@ -16,7 +16,7 @@ These attacks succeed if the Web app does not employ enough validation or encodi
 ## See also
 
 - [Cross-site scripting (XSS)](/en-US/docs/Web/Security/Types_of_attacks#cross-site_scripting_xss)
-- {{Interwiki("wikipedia", "Cross-site scripting")}} on Wikipedia
+- [Cross-site scripting](https://en.wikipedia.org/wiki/Cross-site_scripting) on Wikipedia
 - [Cross-site scripting on OWASP](https://owasp.org/www-community/attacks/xss/)
 - [Another article about Cross-site scripting](https://www.acunetix.com/blog/articles/dom-xss-explained/)
 - [XSS Attack – Exploit & Protection](https://secure.wphackedhelp.com/blog/wordpress-xss-attack/)

--- a/files/en-us/glossary/crud/index.md
+++ b/files/en-us/glossary/crud/index.md
@@ -9,4 +9,4 @@ tags:
 
 ## See also
 
-- {{Interwiki("wikipedia", "CRUD")}} on Wikipedia
+- [CRUD](https://en.wikipedia.org/wiki/CRUD) on Wikipedia

--- a/files/en-us/glossary/cryptanalysis/index.md
+++ b/files/en-us/glossary/cryptanalysis/index.md
@@ -11,4 +11,4 @@ tags:
 
 ## See also
 
-- {{Interwiki("wikipedia", "Cryptanalysis")}} on Wikipedia
+- [Cryptanalysis](https://en.wikipedia.org/wiki/Cryptanalysis) on Wikipedia

--- a/files/en-us/glossary/cryptographic_hash_function/index.md
+++ b/files/en-us/glossary/cryptographic_hash_function/index.md
@@ -19,7 +19,7 @@ Cryptographic hash functions such as MD5 and SHA-1 are considered broken, as att
 
 ## See also
 
-- {{interwiki("wikipedia", "Cryptographic hash function", "Cryptographic hash function")}} on Wikipedia
+- [Cryptographic hash function](https://en.wikipedia.org/wiki/Cryptographic_hash_function) on Wikipedia
 - [MDN Web Docs Glossary](/en-US/docs/Glossary)
 
   - {{Glossary("Symmetric-key cryptography")}}

--- a/files/en-us/glossary/cryptography/index.md
+++ b/files/en-us/glossary/cryptography/index.md
@@ -13,7 +13,7 @@ More than just **data confidentiality**, cryptography also tackles **identificat
 
 ## See also
 
-- {{Interwiki("wikipedia", "Cryptography")}} on Wikipedia
+- [Cryptography](https://en.wikipedia.org/wiki/Cryptography) on Wikipedia
 - [Information security tutorial](/en-US/docs/Web/Security/Information_Security_Basics)
 - [Encrypting and Decrypting](/en-US/docs/Archive/Security/Encryption_and_Decryption)
 - [MDN Web Docs Glossary](/en-US/docs/Glossary)

--- a/files/en-us/glossary/csrf/index.md
+++ b/files/en-us/glossary/csrf/index.md
@@ -19,5 +19,5 @@ There are many ways to prevent CSRF, such as implementing {{glossary("REST", "RE
 
 ## See also
 
-- {{Interwiki("wikipedia", "Cross-site request forgery")}} on Wikipedia
+- [Cross-site request forgery](https://en.wikipedia.org/wiki/Cross-site_request_forgery) on Wikipedia
 - [Prevention measures](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html)

--- a/files/en-us/glossary/css/index.md
+++ b/files/en-us/glossary/css/index.md
@@ -32,6 +32,6 @@ p {
 ## See also
 
 - [Learn CSS](/en-US/docs/Learn/CSS)
-- {{interwiki("wikipedia", "CSS")}} on Wikipedia
+- [CSS](https://en.wikipedia.org/wiki/CSS) on Wikipedia
 - [The CSS documentation on MDN](/en-US/docs/Web/CSS)
 - [The CSS Working Group current work](https://www.w3.org/Style/CSS/current-work)

--- a/files/en-us/glossary/data_structure/index.md
+++ b/files/en-us/glossary/data_structure/index.md
@@ -10,4 +10,4 @@ tags:
 
 ## See also
 
-- {{interwiki("wikipedia", "Data_structure", "Data structure")}} on Wikipedia
+- [Data structure](https://en.wikipedia.org/wiki/Data_structure) on Wikipedia

--- a/files/en-us/glossary/database/index.md
+++ b/files/en-us/glossary/database/index.md
@@ -16,7 +16,7 @@ Browsers also have their own database system called {{glossary("IndexedDB")}}.
 
 ## See also
 
-- {{Interwiki("wikipedia", "Database")}} on Wikipedia
+- [Database](https://en.wikipedia.org/wiki/Database) on Wikipedia
 - Glossary
 
   - {{Glossary("IndexedDB")}}

--- a/files/en-us/glossary/developer_tools/index.md
+++ b/files/en-us/glossary/developer_tools/index.md
@@ -12,7 +12,7 @@ Current browsers provide integrated developer tools, which allow to inspect a we
 
 ## See also
 
-- {{interwiki("wikipedia", "Web development tools", "Web development tools")}} on Wikipedia
+- [Web development tools](https://en.wikipedia.org/wiki/Web_development_tools) on Wikipedia
 - [Firefox Developer Tools](https://firefox-source-docs.mozilla.org/devtools-user/index.html) on MDN
 - [Firebug](https://getfirebug.com/) (former developer tool for Firefox)
 - [Chrome DevTools](https://developer.chrome.com/docs/devtools/) on chrome.com

--- a/files/en-us/glossary/digest/index.md
+++ b/files/en-us/glossary/digest/index.md
@@ -22,4 +22,4 @@ It is critical to choose the proper hash function for your use case to avoid col
 ## See also
 
 - See {{glossary("Cryptographic hash function")}}
-- {{interwiki("wikipedia", "Cryptographic_hash_function", "Hash function")}} on Wikipedia
+- [Hash function](https://en.wikipedia.org/wiki/Cryptographic_hash_function) on Wikipedia


### PR DESCRIPTION
Adding to #18974

We are phasing out the `Interwiki` macro: https://github.com/mdn/content/pull/18723#pullrequestreview-1048593401

The PR converts `{{interwiki(...)}}` macro calls to markdown style links `[...](https://…)`.