### PR TITLE
Remove `InterWiki` macro calls, part 5

### DIFF
--- a/files/en-us/glossary/nat/index.md
+++ b/files/en-us/glossary/nat/index.md
@@ -13,4 +13,4 @@ tags:
 ## See also
 
 - [WebRTC protocols](/en-US/docs/Web/API/WebRTC_API/Protocols)
-- {{interwiki("wikipedia", "NAT")}} on Wikipedia
+- [NAT](https://en.wikipedia.org/wiki/NAT) on Wikipedia

--- a/files/en-us/glossary/native/index.md
+++ b/files/en-us/glossary/native/index.md
@@ -13,4 +13,4 @@ On the other hand, a Web App that runs inside a browser is not native — it is 
 
 ## See also
 
-- {{Interwiki("wikipedia", "Native (computing)")}} on Wikipedia
+- [Native (computing)](https://en.wikipedia.org/wiki/Native_(computing)) on Wikipedia

--- a/files/en-us/glossary/netscape_navigator/index.md
+++ b/files/en-us/glossary/netscape_navigator/index.md
@@ -14,4 +14,4 @@ Netscape helped make the {{glossary("World Wide Web","Web")}} graphical rather t
 
 ## See also
 
-- {{Interwiki("wikipedia", "Netscape Navigator")}} on Wikipedia
+- [Netscape Navigator](https://en.wikipedia.org/wiki/Netscape_Navigator) on Wikipedia

--- a/files/en-us/glossary/nntp/index.md
+++ b/files/en-us/glossary/nntp/index.md
@@ -9,5 +9,5 @@ tags:
 
 ## See also
 
-- {{Interwiki("wikipedia", "Network_News_Transfer_Protocol", "NNTP")}} at Wikipedia
+- [NNTP](https://en.wikipedia.org/wiki/Network_News_Transfer_Protocol) at Wikipedia
 - From the IETF: [RFC 3977 about NNTP](https://datatracker.ietf.org/doc/html/rfc3977) (2006)

--- a/files/en-us/glossary/node.js/index.md
+++ b/files/en-us/glossary/node.js/index.md
@@ -15,7 +15,7 @@ Node.js is a cross-platform {{Glossary("JavaScript")}} runtime environment that 
 
 ## See also
 
-- {{Interwiki("Wikipedia", "Node.js")}} on Wikipedia
+- [Node.js](https://en.wikipedia.org/wiki/Node.js) on Wikipedia
 - [Node.js website](https://nodejs.org/)
 - [API reference documentation](https://nodejs.org/api/)
 - [Guides](https://nodejs.org/en/docs/guides/)

--- a/files/en-us/glossary/node/networking/index.md
+++ b/files/en-us/glossary/node/networking/index.md
@@ -9,4 +9,4 @@ In networking, a **node** is a connection point in the network. In physical netw
 
 ## See also
 
-- {{Interwiki("wikipedia", "Node (networking)", "Node")}} on Wikipedia
+- [Node](https://en.wikipedia.org/wiki/Node_(networking)) on Wikipedia

--- a/files/en-us/glossary/null/index.md
+++ b/files/en-us/glossary/null/index.md
@@ -19,7 +19,7 @@ typeof null === 'object' // true
 
 - [JavaScript data types](/en-US/docs/Web/JavaScript/Data_structures)
 - The JavaScript global object: [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null)
-- {{Interwiki("wikipedia", "Null pointer")}} on Wikipedia
+- [Null pointer](https://en.wikipedia.org/wiki/Null_pointer) on Wikipedia
 - **[Glossary](/en-US/docs/Glossary)**
 
   - {{Glossary("JavaScript")}}

--- a/files/en-us/glossary/number/index.md
+++ b/files/en-us/glossary/number/index.md
@@ -10,7 +10,7 @@ In {{Glossary("JavaScript")}}, **Number** is a numeric data type in the [double-
 
 ## See also
 
-- {{Interwiki("wikipedia", "Data type#Numeric_types", "Numeric types")}} on Wikipedia
+- [Numeric types](https://en.wikipedia.org/wiki/Data_type#Numeric_types) on Wikipedia
 - The JavaScript type: [`Number`](/en-US/docs/Web/JavaScript/Data_structures#number_type)
 - The JavaScript global object {{jsxref("Number")}}
 - [Glossary:](/en-US/docs/Glossary)

--- a/files/en-us/glossary/object_reference/index.md
+++ b/files/en-us/glossary/object_reference/index.md
@@ -11,4 +11,4 @@ The concept of object references becomes clear when assigning the same object to
 
 ## See also
 
-- {{Interwiki("wikipedia", "Reference (computer science)")}} on Wikipedia
+- [Reference (computer science)](https://en.wikipedia.org/wiki/Reference_(computer_science)) on Wikipedia

--- a/files/en-us/glossary/oop/index.md
+++ b/files/en-us/glossary/oop/index.md
@@ -12,6 +12,6 @@ tags:
 
 ## See also
 
-- {{Interwiki("wikipedia", "Object-oriented programming")}} on Wikipedia
+- [Object-oriented programming](https://en.wikipedia.org/wiki/Object-oriented_programming) on Wikipedia
 - [Introduction to object-oriented JavaScript](/en-US/docs/Learn/JavaScript/Objects)
 - [Inheritance and the prototype chain](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Inheritance_and_the_prototype_chain)

--- a/files/en-us/glossary/opengl/index.md
+++ b/files/en-us/glossary/opengl/index.md
@@ -10,5 +10,5 @@ tags:
 
 ## See also
 
-- {{Interwiki("wikipedia", "OpenGL")}} on Wikipedia
+- [OpenGL](https://en.wikipedia.org/wiki/OpenGL) on Wikipedia
 - [OpenGL](https://www.opengl.org/)

--- a/files/en-us/glossary/openssl/index.md
+++ b/files/en-us/glossary/openssl/index.md
@@ -9,5 +9,5 @@ OpenSSL is an open-source implementation of {{glossary("SSL")}} and {{glossary("
 
 ## See also
 
-- {{Interwiki("wikipedia", "OpenSSL")}} on Wikipedia
+- [OpenSSL](https://en.wikipedia.org/wiki/OpenSSL) on Wikipedia
 - [Official website](https://www.openssl.org/)

--- a/files/en-us/glossary/opera_browser/index.md
+++ b/files/en-us/glossary/opera_browser/index.md
@@ -12,5 +12,5 @@ tags:
 
 ## See also
 
-- {{Interwiki("wikipedia", "Opera Browser")}} on Wikipedia
+- [Opera Browser](https://en.wikipedia.org/wiki/Opera_Browser) on Wikipedia
 - [Opera browser web site](https://www.opera.com/)

--- a/files/en-us/glossary/operand/index.md
+++ b/files/en-us/glossary/operand/index.md
@@ -9,4 +9,4 @@ An **operand** is the part of an instruction representing the data manipulated b
 
 ## See also
 
-- {{Interwiki("wikipedia", "Operand")}} on Wikipedia
+- [Operand](https://en.wikipedia.org/wiki/Operand) on Wikipedia

--- a/files/en-us/glossary/operator/index.md
+++ b/files/en-us/glossary/operator/index.md
@@ -9,5 +9,5 @@ Reserved **syntax** consisting of punctuation or alphanumeric characters that ca
 
 ## See also
 
-- {{Interwiki("wikipedia", "Operator (computer programming)")}} on Wikipedia
+- [Operator (computer programming)](https://en.wikipedia.org/wiki/Operator_(computer_programming)) on Wikipedia
 - [JavaScript operators](/en-US/docs/Web/JavaScript/Reference/Operators)

--- a/files/en-us/glossary/ota/index.md
+++ b/files/en-us/glossary/ota/index.md
@@ -13,4 +13,4 @@ _Over The Air_ (**OTA**) refers to automatic updating of software on connected d
 
 ## See also
 
-- {{Interwiki("wikipedia", "Over-the-air programming")}} on Wikipedia
+- [Over-the-air programming](https://en.wikipedia.org/wiki/Over-the-air_programming) on Wikipedia

--- a/files/en-us/glossary/pdf/index.md
+++ b/files/en-us/glossary/pdf/index.md
@@ -11,4 +11,4 @@ tags:
 
 ## See also
 
-- {{Interwiki("wikipedia", "Portable Document Format", "PDF")}} on Wikipedia
+- [PDF](https://en.wikipedia.org/wiki/Portable_Document_Format) on Wikipedia

--- a/files/en-us/glossary/php/index.md
+++ b/files/en-us/glossary/php/index.md
@@ -52,8 +52,8 @@ PHP (a recursive initialism for PHP: Hypertext Preprocessor) is an open-source s
 ## See also
 
 - [Official website](https://www.php.net/)
-- {{Interwiki("wikipedia", "PHP")}} on Wikipedia
-- [PHP](https://en.wikibooks.org/wiki/PHP_Programming) on Wikibooks
+- [PHP](https://en.wikipedia.org/wiki/PHP) on Wikipedia
+- [PHP programming](https://en.wikibooks.org/wiki/PHP_Programming) on Wikibooks
 - [MDN Web Docs Glossary](/en-US/docs/Glossary)
 
   - {{Glossary("Java")}}

--- a/files/en-us/glossary/pop/index.md
+++ b/files/en-us/glossary/pop/index.md
@@ -12,7 +12,7 @@ Clients usually retrieve all messages and then delete them from the server, but 
 
 ## See also
 
-- {{Interwiki("wikipedia", "Post Office Protocol", "POP")}} on Wikipedia
+- [POP](https://en.wikipedia.org/wiki/Post_Office_Protocol) on Wikipedia
 - [RFC 1734](https://datatracker.ietf.org/doc/html/rfc1734) (Specification of POP3 authentication mechanism)
 - [RFC 1939](https://datatracker.ietf.org/doc/html/rfc1939) (Specification of POP3)
 - [RFC 2449](https://datatracker.ietf.org/doc/html/rfc2449) (Specification of POP3 extension mechanism)

--- a/files/en-us/glossary/primitive/index.md
+++ b/files/en-us/glossary/primitive/index.md
@@ -25,7 +25,7 @@ Primitives have no methods but still behave as if they do. When properties are a
 ## See also
 
 - [JavaScript data types](/en-US/docs/Web/JavaScript/Data_structures)
-- {{Interwiki("wikipedia", "Primitive data type")}} (Wikipedia)
+- [Primitive data type](https://en.wikipedia.org/wiki/Primitive_data_type) (Wikipedia)
 - [Glossary](/en-US/docs/Glossary)
 
   - {{Glossary("JavaScript")}}

--- a/files/en-us/glossary/privileged/index.md
+++ b/files/en-us/glossary/privileged/index.md
@@ -9,5 +9,5 @@ Users are said to be **privileged** when they are granted additional rights to a
 
 ## See also
 
-- {{Interwiki("wikipedia", "Privilege (computing)")}} on Wikipedia
+- [Privilege (computing)](https://en.wikipedia.org/wiki/Privilege_(computing)) on Wikipedia
 - [Information Security Tutorial](/en-US/docs/Web/Security/Information_Security_Basics)

--- a/files/en-us/glossary/progressive_enhancement/index.md
+++ b/files/en-us/glossary/progressive_enhancement/index.md
@@ -18,7 +18,7 @@ Progressive enhancement is a useful technique that allows web developers to focu
 
 ## See also
 
-- {{Interwiki("wikipedia", "Progressive enhancement")}} at Wikipedia
+- [Progressive enhancement](https://en.wikipedia.org/wiki/Progressive_enhancement) at Wikipedia
 - [What is Progressive Enhancement, and why it matters](https://www.freecodecamp.org/news/what-is-progressive-enhancement-and-why-it-matters-e80c7aaf834a/) at freeCodeCamp
 - [Progressive Enhancement reading list 2021](https://www.quirksmode.org/blog/archives/2021/02/progressive_enh_1.html) at QuirksMode
 - [Understanding Progressive Enhancement](https://alistapart.com/article/understandingprogressiveenhancement/) by Aaron Gustafson; a 2008 _A List Apart_ article which first "placed progressive enhancement at the forefront of web developer thinking"

--- a/files/en-us/glossary/promise/index.md
+++ b/files/en-us/glossary/promise/index.md
@@ -13,6 +13,6 @@ When the called function finishes its work {{Glossary("asynchronous", "asynchron
 
 ## See also
 
-- {{interwiki("wikipedia", "Futures and promises")}}
+- [Futures and promises](https://en.wikipedia.org/wiki/Futures_and_promises)
 - {{jsxref("Promise")}} in the [JavaScript Reference](/en-US/docs/Web/JavaScript/Reference).
 - [Using promises](/en-US/docs/Web/JavaScript/Guide/Using_promises)

--- a/files/en-us/glossary/property/javascript/index.md
+++ b/files/en-us/glossary/property/javascript/index.md
@@ -18,5 +18,5 @@ A property has a name (a {{glossary("string")}}, or {{glossary("symbol")}}) and 
 
 ## See also
 
-- {{InterWiki('wikipedia','Property (programming)')}} on Wikipedia
+- [Property (programming)](https://en.wikipedia.org/wiki/Property_(programming)) on Wikipedia
 - [Introduction to object-oriented JavaScript](/en-US/docs/Learn/JavaScript/Objects)

--- a/files/en-us/glossary/protocol/index.md
+++ b/files/en-us/glossary/protocol/index.md
@@ -10,7 +10,7 @@ A **protocol** is a system of rules that define how data is exchanged within or 
 
 ## See also
 
-- {{Interwiki("wikipedia", "Communications protocol")}} on Wikipedia
+- [Communications protocol](https://en.wikipedia.org/wiki/Communications_protocol) on Wikipedia
 - [RFC Official Internet Protocol Standards](https://www.rfc-editor.org/standards)
 - [HTTP overview](/en-US/docs/Web/HTTP/Overview)
 - Glossary:

--- a/files/en-us/glossary/prototype-based_programming/index.md
+++ b/files/en-us/glossary/prototype-based_programming/index.md
@@ -11,4 +11,4 @@ In simple words: this type of style allows the creation of an {{Glossary('Object
 
 ## See also
 
-- {{Interwiki("wikipedia", "Prototype-based programming", "Prototype-based programming")}} on Wikipedia
+- [Prototype-based programming](https://en.wikipedia.org/wiki/Prototype-based_programming) on Wikipedia

--- a/files/en-us/glossary/prototype/index.md
+++ b/files/en-us/glossary/prototype/index.md
@@ -12,4 +12,4 @@ See [Inheritance and the prototype chain](/en-US/docs/Web/JavaScript/Inheritance
 
 ## See also
 
-- {{Interwiki("wikipedia", "Software Prototyping")}} on Wikipedia
+- [Software Prototyping](https://en.wikipedia.org/wiki/Software_Prototyping) on Wikipedia

--- a/files/en-us/glossary/pseudocode/index.md
+++ b/files/en-us/glossary/pseudocode/index.md
@@ -10,4 +10,4 @@ Pseudocode refers to code-like syntax that is generally used to indicate to huma
 
 ## See also
 
-- {{interwiki("wikipedia", "Pseudocode", "Pseudocode")}} on Wikipedia.
+- [Pseudocode](https://en.wikipedia.org/wiki/Pseudocode) on Wikipedia.

--- a/files/en-us/glossary/python/index.md
+++ b/files/en-us/glossary/python/index.md
@@ -16,7 +16,7 @@ Python is developed under an OSI-approved open source license, making it freely 
 
 ## See also
 
-- {{interwiki('wikipedia','Python (programming language)','Python')}} on Wikipedia
+- [Python](https://en.wikipedia.org/wiki/Python_(programming_language)) on Wikipedia
 - [Official Python docs tutorials](https://docs.python.org/3/tutorial/index.html)
 - [Tutorials Point Python tutorial](https://www.tutorialspoint.com/python/index.htm)
 - [AlphaCodingSkills Python Tutorial](https://www.alphacodingskills.com/python/python-tutorial.php)

--- a/files/en-us/glossary/quaternion/index.md
+++ b/files/en-us/glossary/quaternion/index.md
@@ -15,6 +15,6 @@ While mathematical quaternions are more involved than this, the **unit quaternio
 
 ## See also
 
-- {{interwiki("wikipedia", "Quaternions and spatial rotation")}} on Wikipedia
-- {{interwiki("wikipedia", "Quaternion")}} on Wikipedia
+- [Quaternions and spatial rotation](https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation) on Wikipedia
+- [Quaternion](https://en.wikipedia.org/wiki/Quaternion) on Wikipedia
 - {{domxref("XRRigidTransform.orientation")}} in the WebXR Device API reference

--- a/files/en-us/glossary/rdf/index.md
+++ b/files/en-us/glossary/rdf/index.md
@@ -12,4 +12,4 @@ tags:
 
 ## See also
 
-- {{Interwiki("wikipedia", "Resource Description Framework")}} on Wikipedia
+- [Resource Description Framework](https://en.wikipedia.org/wiki/Resource_Description_Framework) on Wikipedia

--- a/files/en-us/glossary/recursion/index.md
+++ b/files/en-us/glossary/recursion/index.md
@@ -78,5 +78,5 @@ console.log(reduce((a, b) => a + b, 0, [1, 2, 3, 4, 5, 6, 7, 8, 9]));
 
 ## See also
 
-- {{Interwiki("wikipedia", "Recursion (computer science)")}} on Wikipedia
+- [Recursion (computer science)](https://en.wikipedia.org/wiki/Recursion_(computer_science)) on Wikipedia
 - [More details about recursion in JavaScript](/en-US/docs/Web/JavaScript/Guide/Functions#recursion)

--- a/files/en-us/glossary/reference/index.md
+++ b/files/en-us/glossary/reference/index.md
@@ -12,4 +12,4 @@ In computing, a reference is a value that indirectly accesses data to retrieve a
 
 ## See also
 
-- {{Interwiki("wikipedia", "Reference (computer science)")}} on Wikipedia
+- [Reference (computer science)](https://en.wikipedia.org/wiki/Reference_(computer_science)) on Wikipedia

--- a/files/en-us/glossary/regular_expression/index.md
+++ b/files/en-us/glossary/regular_expression/index.md
@@ -12,7 +12,7 @@ Regular expressions are implemented in various languages, but the best-known imp
 
 ## See also
 
-- {{Interwiki("wikipedia", "Regular expressions")}} on Wikipedia
+- [Regular expressions](https://en.wikipedia.org/wiki/Regular_expressions) on Wikipedia
 - [Interactive tutorial](https://regexone.com/)
 - [Visualized Regular Expression](https://regexper.com/)
 - [Writing regular expressions in JavaScript](/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)

--- a/files/en-us/glossary/rendering_engine/index.md
+++ b/files/en-us/glossary/rendering_engine/index.md
@@ -11,5 +11,5 @@ A **rendering engine** is software that draws text and images on the screen. The
 
 ## See also
 
-- {{Interwiki("wikipedia", "Web browser engine")}} on Wikipedia
+- [Web browser engine](https://en.wikipedia.org/wiki/Web_browser_engine) on Wikipedia
 - [Venkatraman.R - Behind Browsers (Part 1, Basics)](https://medium.com/@ramsunvtech/behind-browser-basics-part-1-b733e9f3c0e6)

--- a/files/en-us/glossary/rest/index.md
+++ b/files/en-us/glossary/rest/index.md
@@ -19,5 +19,5 @@ HTTP APIs in general are sometimes colloquially referred to as RESTful APIs, RES
 
 - [restapitutorial.com](https://www.restapitutorial.com/)
 - [restcookbook.com](https://restcookbook.com/)
-- {{Interwiki("wikipedia", "Representational_state_transfer", "REST")}} on Wikipedia
+- [REST](https://en.wikipedia.org/wiki/Representational_state_transfer) on Wikipedia
 - [REST Architecture](https://www.service-architecture.com/articles/web-services/representational-state-transfer-rest.html)

--- a/files/en-us/glossary/ril/index.md
+++ b/files/en-us/glossary/ril/index.md
@@ -14,4 +14,4 @@ RIL (Radio Interface Layer) is a mobile operating system component which communi
 
 ## See also
 
-- {{Interwiki("wikipedia", "Radio Interface Layer")}} on Wikipedia
+- [Radio Interface Layer](https://en.wikipedia.org/wiki/Radio_Interface_Layer) on Wikipedia

--- a/files/en-us/glossary/rng/index.md
+++ b/files/en-us/glossary/rng/index.md
@@ -18,6 +18,6 @@ Most PRNGs are not cryptographically secure.
 
 ## See also
 
-- {{Interwiki("wikipedia", "Pseudorandom number generator")}} on Wikipedia
+- [Pseudorandom number generator](https://en.wikipedia.org/wiki/Pseudorandom_number_generator) on Wikipedia
 - {{jsxref("Math.random()")}}, a built-in JavaScript PRNG function. Note that this is not a cryptographically secure PRNG.
 - {{domxref("Crypto.getRandomValues()")}}: this is intended to provide cryptographically secure numbers.

--- a/files/en-us/glossary/robots.txt/index.md
+++ b/files/en-us/glossary/robots.txt/index.md
@@ -11,7 +11,7 @@ For example, the site admin can forbid crawlers to visit a certain folder (and a
 
 ## See also
 
-- {{Interwiki("wikipedia", "Robots.txt")}} on Wikipedia
+- [Robots.txt](https://en.wikipedia.org/wiki/Robots.txt) on Wikipedia
 - <https://developers.google.com/search/reference/robots_txt>
 - Standard specification draft: [https://datatracker.ietf.org/doc/html/draft-rep-wg-topic](https://datatracker.ietf.org/doc/html/draft-rep-wg-topic-00)
 - <https://www.robotstxt.org/>

--- a/files/en-us/glossary/routers/index.md
+++ b/files/en-us/glossary/routers/index.md
@@ -14,7 +14,7 @@ There are three definitions for **routers** on the web:
 
 For network layer context:
 
-- {{Interwiki("wikipedia", "Router (computing)")}} on Wikipedia
+- [Router (computing)](https://en.wikipedia.org/wiki/Router_(computing)) on Wikipedia
 
 For SPA in application layer context, most of the popular SPA frameworks have their routing libraries:
 

--- a/files/en-us/glossary/rss/index.md
+++ b/files/en-us/glossary/rss/index.md
@@ -12,5 +12,5 @@ tags:
 
 ## See also
 
-- {{Interwiki("wikipedia", "RSS")}} on Wikipedia
+- [RSS](https://en.wikipedia.org/wiki/RSS) on Wikipedia
 - [Latest specification](https://www.rssboard.org/rss-specification)

--- a/files/en-us/glossary/rtcp/index.md
+++ b/files/en-us/glossary/rtcp/index.md
@@ -18,5 +18,5 @@ RTCP periodically transmits control packets to all of an RTP session's participa
 ## See also
 
 - [Introduction to the Real-time Transport Protocol](/en-US/docs/Web/API/WebRTC_API/Intro_to_RTP)
-- {{interwiki("wikipedia", "RTP Control Protocol")}}
+- [RTP Control Protocol](https://en.wikipedia.org/wiki/RTP_Control_Protocol)
 - {{RFC(3550, "RFC 3550 Section 6", 6)}}

--- a/files/en-us/glossary/rtf/index.md
+++ b/files/en-us/glossary/rtf/index.md
@@ -14,5 +14,5 @@ Three programmers in the Microsoft Word team created RTF in the 1980s, and Micro
 
 ## See also
 
-- {{Interwiki("wikipedia", "Rich Text Format")}} on Wikipedia
+- [Rich Text Format](https://en.wikipedia.org/wiki/Rich_Text_Format) on Wikipedia
 - [specification v1.9.1 from Microsoft](https://interoperability.blob.core.windows.net/files/Archive_References/%5bMSFT-RTF%5d.pdf)

--- a/files/en-us/glossary/rtp/index.md
+++ b/files/en-us/glossary/rtp/index.md
@@ -16,5 +16,5 @@ RTP is rarely used alone; instead, it is used in conjunction with other protocol
 ## See also
 
 - [Introduction to the Real-time Transport Protocol](/en-US/docs/Web/API/WebRTC_API/Intro_to_RTP)
-- {{Interwiki("wikipedia", "Real-time_Transport_Protocol","RTP")}} on Wikipedia
+- [RTP](https://en.wikipedia.org/wiki/Real-time_Transport_Protocol) on Wikipedia
 - {{RFC(3550)}} (one of the documents that specify precisely how the protocol works)

--- a/files/en-us/glossary/rtsp/index.md
+++ b/files/en-us/glossary/rtsp/index.md
@@ -11,7 +11,7 @@ Real-time streaming protocol (RTSP) is a network protocol that controls how the 
 
 ## See also
 
-- {{Interwiki("wikipedia", "Real_Time_Streaming_Protocol","RTSP")}} on Wikipedia
+- [RTSP](https://en.wikipedia.org/wiki/Real_Time_Streaming_Protocol) on Wikipedia
 - [RFC 7826](https://datatracker.ietf.org/doc/html/rfc7826) (one of the documents that specifies precisely how the protocol works)
 - [Glossary](/en-US/docs/Glossary)
 

--- a/files/en-us/glossary/scm/index.md
+++ b/files/en-us/glossary/scm/index.md
@@ -12,4 +12,4 @@ Some SCM systems include CVS, SVN, GIT.
 
 ## See also
 
-- {{Interwiki("wikipedia", "Revision control")}} on Wikipedia
+- [Revision control](https://en.wikipedia.org/wiki/Revision_control) on Wikipedia

--- a/files/en-us/glossary/scope/index.md
+++ b/files/en-us/glossary/scope/index.md
@@ -64,4 +64,4 @@ console.log(x); // ReferenceError: x is not defined
 
 ## See also
 
-- {{Interwiki("wikipedia", "Scope (computer science)")}} on Wikipedia
+- [Scope (computer science)](https://en.wikipedia.org/wiki/Scope_(computer_science)) on Wikipedia

--- a/files/en-us/glossary/sctp/index.md
+++ b/files/en-us/glossary/sctp/index.md
@@ -12,4 +12,4 @@ tags:
 ## See also
 
 - {{RFC(4960, "Stream Control Transmission Protocol")}}
-- {{Interwiki("wikipedia", "Stream Control Transmission Protocol")}} on Wikipedia
+- [Stream Control Transmission Protocol](https://en.wikipedia.org/wiki/Stream_Control_Transmission_Protocol) on Wikipedia

--- a/files/en-us/glossary/sdp/index.md
+++ b/files/en-us/glossary/sdp/index.md
@@ -32,4 +32,4 @@ SDP is never used alone, but by protocols like {{Glossary("RTP")}} and {{Glossar
 ## See also
 
 - [WebRTC protocols](/en-US/docs/Web/API/WebRTC_API/Protocols)
-- {{Interwiki("wikipedia", "Session Description Protocol")}} on Wikipedia
+- [Session Description Protocol](https://en.wikipedia.org/wiki/Session_Description_Protocol) on Wikipedia

--- a/files/en-us/glossary/second-level_domain/index.md
+++ b/files/en-us/glossary/second-level_domain/index.md
@@ -15,7 +15,7 @@ As another example, in `developer.mozilla.org`, the `developer` subdomain is use
 
 ## See also
 
-- {{Interwiki("wikipedia", "Second-level domain", "SLD")}} (Wikipedia)
+- [SLD](https://en.wikipedia.org/wiki/Second-level_domain) (Wikipedia)
 - [Glossary](/en-US/docs/Glossary)
 
   - {{Glossary("DNS")}}


### PR DESCRIPTION
Adding to #18974

We are phasing out the `Interwiki` macro: https://github.com/mdn/content/pull/18723#pullrequestreview-1048593401

The PR converts `{{interwiki(...)}}` macro calls to markdown style links `[...](https://…)`.