### PR TITLE
add PerformanceLongTaskTiming subtypes

### DIFF
--- a/files/en-us/web/api/performanceentry/index.md
+++ b/files/en-us/web/api/performanceentry/index.md
@@ -22,6 +22,7 @@ The **`PerformanceEntry`** object encapsulates a single performance metric that 
 - {{domxref("PerformanceNavigationTiming")}}
 - {{domxref("PerformanceResourceTiming")}}
 - {{domxref("PerformancePaintTiming")}}
+- {{domxref("PerformanceLongTaskTiming")}}
 
 {{AvailableInWorkers}}
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
add PerformanceLongTaskTiming subtypes

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I found  PerformanceLongTaskTiming in Performance entry type names, and it's subtype in it self api doc. But it is not in PerformanceEntry doc.
Of course if there is some wrong with my commit,  your reply is welcome!

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
PerformanceEntry doc:
https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry

entryType doc:
https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry/entryType

PerformanceLongTaskTiming doc:
https://developer.mozilla.org/en-US/docs/Web/API/PerformanceLongTaskTiming

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
