### PR TITLE
Updated hyperlink to the Date strings section

### DIFF
--- a/files/en-us/web/html/element/input/date/index.md
+++ b/files/en-us/web/html/element/input/date/index.md
@@ -74,7 +74,7 @@ The input UI generally varies from browser to browser; see [Browser compatibilit
 
 ## Value
 
-A string representing the date entered in the input. The date is formatted according to ISO8601, described in {{SectionOnPage("/en-US/docs/Web/HTML/Date_and_time_formats", "Format of a valid date string")}}.
+A string representing the date entered in the input. The date is formatted according to ISO8601, described in {{SectionOnPage("/en-US/docs/Web/HTML/Date_and_time_formats", "Date strings")}}.
 
 You can set a default value for the input with a date inside the {{htmlattrxref("value", "input")}} attribute, like so:
 

--- a/files/en-us/web/html/element/input/date/index.md
+++ b/files/en-us/web/html/element/input/date/index.md
@@ -74,7 +74,7 @@ The input UI generally varies from browser to browser; see [Browser compatibilit
 
 ## Value
 
-A string representing the date entered in the input. The date is formatted according to ISO8601, described in {{SectionOnPage("/en-US/docs/Web/HTML/Date_and_time_formats", "Date strings")}}.
+A string representing the date entered in the input. The date is formatted according to ISO8601, described in [Date strings format](/en-US/docs/Web/HTML/Date_and_time_formats#date_strings).
 
 You can set a default value for the input with a date inside the {{htmlattrxref("value", "input")}} attribute, like so:
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/18986

#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
- The link will now direct to the `Date strings` section of the `Date and time formats used in HTML` page

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
- Attempting to fix a hyperlink that does not direct properly

#### Metadata
This PR…
-->
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
