### PR TITLE
Fixed link to checkValidity page

### DIFF
--- a/files/en-us/web/api/htmlinputelement/invalid_event/index.md
+++ b/files/en-us/web/api/htmlinputelement/invalid_event/index.md
@@ -16,7 +16,7 @@ browser-compat: api.HTMLInputElement.invalid_event
 
 The **`invalid`** event fires when a submittable element has been checked for validity and doesn't satisfy its constraints.
 
-This event can be useful for displaying a summary of the problems with a form on submission. When a form is submitted, `invalid` events are fired at each form control that is invalid. The validity of submittable elements is checked before submitting their owner {{HtmlElement("form")}}, or after the [`checkValidity()`](/en-US/docs/Learn/Forms#constraint_validation_api) method of the element or its owner `<form>` is called.
+This event can be useful for displaying a summary of the problems with a form on submission. When a form is submitted, `invalid` events are fired at each form control that is invalid. The validity of submittable elements is checked before submitting their owner {{HtmlElement("form")}}, or after the [`checkValidity()`](/en-US/docs/Web/API/HTMLInputElement/checkValidity) method of the element or its owner `<form>` is called.
 
 It is not checked on {{domxref("Element/blur_event", "blur")}}.
 


### PR DESCRIPTION
#### Summary
I fixed the link to `checkValidity` to `HTMLInputElement.checkValidity()`.

#### Motivation
The link to `checkValidity` linked to a broken anchor on the `Learn/Forms` page. 

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
