### PR TITLE
SVGStyleElement.disabled + HTMLStyleElement.disabled

### DIFF
--- a/files/en-us/web/api/htmlstyleelement/disabled/index.md
+++ b/files/en-us/web/api/htmlstyleelement/disabled/index.md
@@ -1,0 +1,139 @@
+---
+title: HTMLStyleElement.disabled
+slug: Web/API/HTMLStyleElement/disabled
+page-type: web-api-instance-property
+tags:
+  - API
+  - HTML DOM
+  - HTMLStyleElement
+  - Property
+  - Reference
+browser-compat: api.HTMLStyleElement.disabled
+---
+{{APIRef("HTML DOM")}}
+
+The **`HTMLStyleElement.disabled`** property can be used to get and set whether the stylesheet is disabled (`true`) or not (`false`).
+
+Note that there is no corresponding `disabled` attribute on the [HTML `<style>` element](/en-US/docs/Web/HTML/Element/style).
+
+## Value
+
+Returns `true` if the stylesheet is disabled, or there is no associated stylesheet; otherwise `false`.
+The value is `false` by default (if there is an associated stylesheet).
+
+The property can be used to enable or disable an associated stylesheet.
+Setting the property `true` when there is no associated stylesheet has no effect.
+
+## Examples
+
+### Disabling an inline style
+
+This example demonstrates programmatically setting the disabled property on a style that was defined in the HTML using the [HTML `<style>` element](/en-US/docs/Web/HTML/Element/style).
+Note that you can also access any/all stylesheets in the document using [`Document.styleSheets`](/en-US/docs/Web/API/Document/styleSheets).
+
+#### HTML
+
+The HTML contains a [HTML `<style>` element](/en-US/docs/Web/HTML/Element/style) element that makes paragraph elements blue, a paragraph element, and a button that will be used to enabled and disable the style.
+
+```html
+<button>Enable</button>
+<style id="InlineStyle">
+  p { color: blue; }
+</style>
+<p>Text is black when style is disabled; blue when enabled.<p>
+```
+
+#### JavaScript
+
+The code below gets the `style` element using its id, and then sets it as disabled.
+As the style already exists, as it is defined in the SVG, this should succeed.
+
+```js
+const style = document.getElementById("InlineStyle")
+style.disabled = true;  
+```
+
+We then add an event handler for the button that toggles the `disabled` value and button text.
+
+```js
+const button = document.querySelector('button');
+
+button.addEventListener('click', () => {
+   style.disabled = !style.disabled;
+   const buttonText = style.disabled ? 'Enable' : 'Disable';
+   button.innerText = buttonText;
+   });
+```
+
+#### Result
+
+The result is shown below.
+Press the button to toggle the `disabled` property value on the style used for the paragraph text.
+
+{{EmbedLiveSample("Disabling a style defined in the SVG")}}
+
+### Disabling a programmatically defined style
+
+This example is very similar to the one above, except that the style is defined programmatically.
+
+#### HTML
+
+The HTML is similar to the previous case, but the definition does not include any default styling.
+
+```html
+<button>Enable</button>
+<p>Text is black when style is disabled; blue when enabled.<p>
+```
+
+#### JavaScript
+
+First we create the new style element on the HTML.
+This is done by first creating a style element using [`Document.createElement()`](/en-US/docs/Web/API/Document/createElement), creating and appending a text node with the style definition, and then appending the style element to the document body.
+
+```js
+// Create the `style` element
+const style = document.createElement('style')
+const node = document.createTextNode('p { color: blue; }');
+style.appendChild(node);
+document.body.appendChild(style);
+```
+
+We can then disable the style as shown below.
+Note that this is the earliest point at which setting the property to `true` will succeed.
+Before this point the document did not have an associated style, and so the value defaults to `false`.
+
+```js
+//Disable the style
+style.disabled=true; 
+```
+
+Last of all we add an event handler for the button that toggles the disabled state and button text (this is the same as in the previous example).
+
+```js
+const button = document.querySelector('button');
+
+button.addEventListener('click', () => {
+   style.disabled = !style.disabled;
+   const buttonText = style.disabled ? 'Enable' : 'Disable';
+   button.innerText = buttonText;
+   });
+```
+
+#### Result
+
+The result is shown below.
+Press the button to toggle the `disabled` state on the style used for the text.
+
+{{EmbedLiveSample("Disabling a programmatically defined style")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("SVGStyleElement.disabled")}}

--- a/files/en-us/web/api/htmlstyleelement/disabled/index.md
+++ b/files/en-us/web/api/htmlstyleelement/disabled/index.md
@@ -22,7 +22,7 @@ Returns `true` if the stylesheet is disabled, or there is no associated styleshe
 The value is `false` by default (if there is an associated stylesheet).
 
 The property can be used to enable or disable an associated stylesheet.
-Setting the property `true` when there is no associated stylesheet has no effect.
+Setting the property to `true` when there is no associated stylesheet has no effect.
 
 ## Examples
 

--- a/files/en-us/web/api/htmlstyleelement/disabled/index.md
+++ b/files/en-us/web/api/htmlstyleelement/disabled/index.md
@@ -33,7 +33,7 @@ Note that you can also access any/all stylesheets in the document using [`Docume
 
 #### HTML
 
-The HTML contains a [HTML `<style>` element](/en-US/docs/Web/HTML/Element/style) element that makes paragraph elements blue, a paragraph element, and a button that will be used to enabled and disable the style.
+The HTML contains an [HTML `<style>` element](/en-US/docs/Web/HTML/Element/style) element that makes paragraph elements blue, a paragraph element, and a button that will be used to enabled and disable the style.
 
 ```html
 <button>Enable</button>

--- a/files/en-us/web/api/htmlstyleelement/index.md
+++ b/files/en-us/web/api/htmlstyleelement/index.md
@@ -27,7 +27,7 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
 - {{domxref("HTMLStyleElement.type")}} {{deprecated_inline}}
   - : A string reflecting the HTML attribute representing the type of style being applied by this statement.
 - {{domxref("HTMLStyleElement.disabled")}}
-  - : A boolean value reflecting the HTML attribute representing whether or not the stylesheet is disabled (true) or not (false).
+  - : A boolean value indicating whether or not the associated stylesheet is disabled.
 - {{domxref("HTMLStyleElement.sheet")}} {{readonlyInline}}
   - : Returns the {{domxref("CSSStyleSheet")}} object associated with the given element, or `null` if there is none
 - {{domxref("HTMLStyleElement.scoped")}} {{non-standard_inline}} {{deprecated_inline}}

--- a/files/en-us/web/api/svgstyleelement/disabled/index.md
+++ b/files/en-us/web/api/svgstyleelement/disabled/index.md
@@ -1,0 +1,74 @@
+---
+title: SVGStyleElement.disabled
+slug: Web/API/SVGStyleElement/disabled
+page-type: web-api-instance-property
+tags:
+  - API
+  - Property
+  - Reference
+  - SVG
+  - SVG DOM
+  - Experimental
+browser-compat: api.SVGStyleElement.disabled
+---
+{{APIRef("SVG")}} {{SeeCompatTable}}
+
+The **`SVGStyleElement.disabled`** property can be used to get and set whether the stylesheet is disabled (`true`) or not (`false`).
+
+## Value
+
+Returns `true` if the stylesheet is disabled, or there is no associated stylesheet; otherwise `false`.
+
+The property can be used to enable or disable an associated stylesheet.
+Setting the property `true` when there is no associated stylesheet has no effect.
+
+## Examples
+
+### SVG
+
+```html
+<button>Disable</button>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <circle cx="50" cy="50" r="25" />
+</svg>
+
+```
+
+
+### JavaScript
+
+
+```js
+const svg = document.getElementsByTagName("svg")[0];
+const style = document.createElementNS('http://www.w3.org/2000/svg', 'style');
+const node = document.createTextNode('circle { fill: red; }');
+
+svg.appendChild(style);
+style.disabled=true;  //Won't work!
+style.appendChild(node);
+```
+
+
+
+
+```js
+const button = document.querySelector('button');
+
+button.addEventListener('click', () => {
+   style.disabled = !style.disabled;
+   const buttonText = style.disabled ? 'Enable' : 'Disable';
+   button.innerText = buttonText;
+   });
+```
+
+### Result
+
+{{EmbedLiveSample("Examples")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/svgstyleelement/disabled/index.md
+++ b/files/en-us/web/api/svgstyleelement/disabled/index.md
@@ -14,7 +14,7 @@ browser-compat: api.SVGStyleElement.disabled
 
 The **`SVGStyleElement.disabled`** property can be used to get and set whether the stylesheet is disabled (`true`) or not (`false`).
 
-Note that similar to the {{domxref("HTMLStyleElement.disabled")}} property (which it mirrors) there is no equivalent `disabled` property on the [SVG `<style>` element](/en-US/docs/Web/SVG/Element/style).
+Note that there is no corresponding `disabled` property on the [SVG `<style>` element](/en-US/docs/Web/SVG/Element/style).
 
 ## Value
 
@@ -74,7 +74,7 @@ button.addEventListener('click', () => {
 #### Result
 
 The result is shown below.
-Press the button to toggle the enabled state on the style used for the circle.
+Press the button to toggle the `disabled` property on the style used for the circle.
 
 {{EmbedLiveSample("Disabling a style defined in the SVG")}}
 
@@ -119,7 +119,7 @@ Before this point the SVG did not have a style associated, and so the value defa
 
 ```js
 //Disable the style
-style.disabled=true;  // Works
+style.disabled=true;
 ```
 
 Last of all we add an event handler for the button that toggles the disabled state and button text (this is the same as in the previous example).
@@ -148,3 +148,7 @@ Press the button to toggle the `disabled` state on the style used for the circle
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("HTMLStyleElement.disabled")}}

--- a/files/en-us/web/api/svgstyleelement/disabled/index.md
+++ b/files/en-us/web/api/svgstyleelement/disabled/index.md
@@ -14,7 +14,7 @@ browser-compat: api.SVGStyleElement.disabled
 
 The **`SVGStyleElement.disabled`** property can be used to get and set whether the stylesheet is disabled (`true`) or not (`false`).
 
-Note that there is no corresponding `disabled` property on the [SVG `<style>` element](/en-US/docs/Web/SVG/Element/style).
+Note that there is no corresponding `disabled` attribute on the [SVG `<style>` element](/en-US/docs/Web/SVG/Element/style).
 
 ## Value
 

--- a/files/en-us/web/api/svgstyleelement/disabled/index.md
+++ b/files/en-us/web/api/svgstyleelement/disabled/index.md
@@ -8,10 +8,9 @@ tags:
   - Reference
   - SVG
   - SVG DOM
-  - Experimental
 browser-compat: api.SVGStyleElement.disabled
 ---
-{{APIRef("SVG")}} {{SeeCompatTable}}
+{{APIRef("SVG")}}
 
 The **`SVGStyleElement.disabled`** property can be used to get and set whether the stylesheet is disabled (`true`) or not (`false`).
 
@@ -20,7 +19,7 @@ Note that similar to the {{domxref("HTMLStyleElement.disabled")}} property (whic
 ## Value
 
 Returns `true` if the stylesheet is disabled, or there is no associated stylesheet; otherwise `false`.
-The value is `false` by default.
+The value is `false` by default (if there is an associated stylesheet).
 
 The property can be used to enable or disable an associated stylesheet.
 Setting the property `true` when there is no associated stylesheet has no effect.

--- a/files/en-us/web/api/svgstyleelement/disabled/index.md
+++ b/files/en-us/web/api/svgstyleelement/disabled/index.md
@@ -50,7 +50,7 @@ The HTML contains an SVG definition for a [`<circle>`](/en-US/docs/Web/SVG/Eleme
 
 #### JavaScript
 
-The code below gets the `style` element (a `SVGStyleElement`) using its id, and then sets it as disabled.
+The code below gets the `style` element (an `SVGStyleElement`) using its id, and then sets it as disabled.
 As the style already exists, as it is defined in the SVG, this should succeed.
 
 ```js

--- a/files/en-us/web/api/svgstyleelement/disabled/index.md
+++ b/files/en-us/web/api/svgstyleelement/disabled/index.md
@@ -15,41 +15,52 @@ browser-compat: api.SVGStyleElement.disabled
 
 The **`SVGStyleElement.disabled`** property can be used to get and set whether the stylesheet is disabled (`true`) or not (`false`).
 
+Note that similar to the {{domxref("HTMLStyleElement.disabled")}} property (which it mirrors) there is no equivalent `disabled` property on the [SVG `<style>` element](/en-US/docs/Web/SVG/Element/style).
+
 ## Value
 
 Returns `true` if the stylesheet is disabled, or there is no associated stylesheet; otherwise `false`.
+The value is `false` by default.
 
 The property can be used to enable or disable an associated stylesheet.
 Setting the property `true` when there is no associated stylesheet has no effect.
 
 ## Examples
 
-### SVG
+### Disabling a style defined in the SVG
+
+This example demonstrates programmatically setting the disabled property on a style that was defined in the HTML SVG definition.
+
+#### HTML
+
+The HTML contains an SVG definition for a [`<circle>`](/en-US/docs/Web/SVG/Element/circle) with a [`<style>`](/en-US/docs/Web/SVG/Element/style) element, along with a button that will be used to disable the style.
 
 ```html
-<button>Disable</button>
+<button>Enable</button>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <circle cx="50" cy="50" r="25" />
+  <style id="circle_style_id">
+    circle {
+      fill: gold;
+      stroke: green;
+      stroke-width: 3px;
+    }
+  </style>
+  <circle cx="50" cy="50" r="25" />
 </svg>
-
 ```
 
+#### JavaScript
 
-### JavaScript
-
+The code below gets the `style` element (a `SVGStyleElement`) using its id, and then sets it as disabled.
+As the style already exists, as it is defined in the SVG, this should succeed.
 
 ```js
 const svg = document.getElementsByTagName("svg")[0];
-const style = document.createElementNS('http://www.w3.org/2000/svg', 'style');
-const node = document.createTextNode('circle { fill: red; }');
-
-svg.appendChild(style);
-style.disabled=true;  //Won't work!
-style.appendChild(node);
+const style = svg.getElementById("circle_style_id")
+style.disabled = true;  
 ```
 
-
-
+We then add an event handler for the button that toggles the disabled state and button text.
 
 ```js
 const button = document.querySelector('button');
@@ -61,9 +72,75 @@ button.addEventListener('click', () => {
    });
 ```
 
-### Result
+#### Result
 
-{{EmbedLiveSample("Examples")}}
+The result is shown below.
+Press the button to toggle the enabled state on the style used for the circle.
+
+{{EmbedLiveSample("Disabling a style defined in the SVG")}}
+
+### Disabling a programmatically defined style
+
+This example is very similar to the one above, except that the style is defined programmatically.
+
+Note that you can have multiple styles applied both in SVG source and programmatically.
+This example is primarily provided to demonstrate how to create the style externally, and show at what point the style can be disabled.
+
+#### HTML
+
+The HTML is similar to the previous case, but the SVG definition does not include any default styling.
+
+```html
+<button>Enable</button>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <circle cx="50" cy="50" r="25" />
+</svg>
+```
+
+#### JavaScript
+
+First we create the new SVG style node.
+This is done by first creating a style element in the SVG namespace using [`Document.createElementNS()`](/en-US/docs/Web/API/Document/createElementNS), creating and appending a text node with the style definition, and then appending the node to the SVG defined above.
+
+> **Note:** You must use [`Document.createElementNS()`](/en-US/docs/Web/API/Document/createElementNS) and not [`Document.createElement()`](/en-US/docs/Web/API/Document/createElement) to create the style, or by default you'll create the equivalent HTML style element.
+
+```js
+const svg = document.getElementsByTagName("svg")[0];
+
+// Create the `style` element in the SVG namespace
+const style = document.createElementNS('http://www.w3.org/2000/svg', 'style');
+const node = document.createTextNode('circle { fill: red; }');
+svg.appendChild(style);
+style.appendChild(node);
+```
+
+Then we disable the style.
+Note that this is the earliest point at which setting the property to `true` will succeed.
+Before this point the SVG did not have a style associated, and so the value defaults to `false`.
+
+```js
+//Disable the style
+style.disabled=true;  // Works
+```
+
+Last of all we add an event handler for the button that toggles the disabled state and button text (this is the same as in the previous example).
+
+```js
+const button = document.querySelector('button');
+
+button.addEventListener('click', () => {
+   style.disabled = !style.disabled;
+   const buttonText = style.disabled ? 'Enable' : 'Disable';
+   button.innerText = buttonText;
+   });
+```
+
+#### Result
+
+The result is shown below.
+Press the button to toggle the `disabled` state on the style used for the circle.
+
+{{EmbedLiveSample("Disabling a programmatically defined style")}}
 
 ## Specifications
 

--- a/files/en-us/web/api/svgstyleelement/disabled/index.md
+++ b/files/en-us/web/api/svgstyleelement/disabled/index.md
@@ -22,7 +22,7 @@ Returns `true` if the stylesheet is disabled, or there is no associated styleshe
 The value is `false` by default (if there is an associated stylesheet).
 
 The property can be used to enable or disable an associated stylesheet.
-Setting the property `true` when there is no associated stylesheet has no effect.
+Setting the property to `true` when there is no associated stylesheet has no effect.
 
 ## Examples
 

--- a/files/en-us/web/api/svgstyleelement/index.md
+++ b/files/en-us/web/api/svgstyleelement/index.md
@@ -12,8 +12,6 @@ browser-compat: api.SVGStyleElement
 ---
 {{APIRef("SVG")}}
 
-## SVG style interface
-
 The **`SVGStyleElement`** interface corresponds to the SVG {{SVGElement("style")}} element.
 
 {{InheritanceDiagram}}
@@ -39,6 +37,12 @@ _This interface also inherits properties from its parent interface, {{domxref("S
   - : A string corresponding to the {{SVGAttr("title")}} attribute of the given element.
 
     SVG 1.1 defined that a {{domxref("DOMException")}} is raised with code `NO_MODIFICATION_ALLOWED_ERR` on an attempt to change the value of a read-only attribute. This restriction was removed in SVG 2.
+
+- {{domxref("SVGStyleElement.sheet")}} {{readonlyInline}}
+  - : Returns the {{domxref("CSSStyleSheet")}} object associated with the given element, or `null` if there is none.
+  
+- {{domxref("SVGStyleElement.disabled")}}
+  - : A boolean value reflecting the HTML attribute representing whether or not the stylesheet is disabled (true) or not (false).
 
 ## Methods
 

--- a/files/en-us/web/api/svgstyleelement/index.md
+++ b/files/en-us/web/api/svgstyleelement/index.md
@@ -42,7 +42,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
   - : Returns the {{domxref("CSSStyleSheet")}} object associated with the given element, or `null` if there is none.
   
 - {{domxref("SVGStyleElement.disabled")}}
-  - : A boolean value reflecting the HTML attribute representing whether or not the stylesheet is disabled (true) or not (false).
+  - : A boolean value indicating whether or not the associated stylesheet is disabled.
 
 ## Methods
 


### PR DESCRIPTION
FF104 adds support for [`SVGStyleElement.disabled`](https://developer.mozilla.org/en-US/docs/Web/API/SVGStyleElement) (in https://bugzilla.mozilla.org/show_bug.cgi?id=1712623). 

This adds supporting docs. I'm going to do other properties in separate PR

