### PR TITLE
`sin()` - New CSS functional notation

### DIFF
--- a/files/en-us/web/css/sin/index.md
+++ b/files/en-us/web/css/sin/index.md
@@ -1,0 +1,72 @@
+---
+title: sin()
+slug: Web/CSS/sin
+tags:
+  - CSS
+  - CSS Function
+  - Sin-Related
+  - Function
+  - Layout
+  - Reference
+  - Web
+  - sin
+browser-compat: css.types.sin
+spec-urls: https://drafts.csswg.org/css-values/#trig-funcs
+---
+{{CSSRef}}
+
+The **`sin()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) is a trigonometric function that returns the sine of a number, which is a value between `-1` and `1`. The function contain a single calculation which must resolve to either a `<number>` or an `<angle>` by interpreting the result of the argument as radians. That is, `sin(45deg)`, `sin(0.125turn)`, and `sin(3.14159 / 4)` all represent the same value, approximately `.707`.
+
+## Syntax
+
+```css
+width: calc( sin(-45deg) * 1px );
+```
+
+The `sin()` function takes only one expression as its argument.
+
+### Formal syntax
+
+{{CSSSyntax}}
+
+## Examples
+
+### Boxes Size
+
+For example, when creating a 100x100 box based on external parameter, in this case `sin(90deg)`. Thus `sin(90deg)` will return `1` making the box `100px` width and `100px` height.
+
+```css
+div {
+  background-color: red;
+  width: calc( sin(90deg) * 100px );
+  height: calc( sin(90deg) * 100px );
+}
+```
+
+### Controling Animation Duration
+
+Another usecase is to control the {{cssxref("animation-duration")}}. Redusing duration based on the sine value. In this case the animation duration will be `1s`.
+
+```css
+div {
+  animation-name: MyAnimation;
+  animation-duration: calc( sin(0.25turn) * 1s );
+}
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{CSSxRef("cos")}}
+- {{CSSxRef("tan")}}
+- {{CSSxRef("asin")}}
+- {{CSSxRef("acos")}}
+- {{CSSxRef("atan")}}
+- {{CSSxRef("atan2")}}

--- a/files/en-us/web/css/sin/index.md
+++ b/files/en-us/web/css/sin/index.md
@@ -15,7 +15,7 @@ spec-urls: https://drafts.csswg.org/css-values/#trig-funcs
 ---
 {{CSSRef}}
 
-The **`sin()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) is a trigonometric function that returns the sine of a number, which is a value between `-1` and `1`. The function contain a single calculation which must resolve to either a `<number>` or an `<angle>` by interpreting the result of the argument as radians. That is, `sin(45deg)`, `sin(0.125turn)`, and `sin(3.14159 / 4)` all represent the same value, approximately `.707`.
+The **`sin()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) is a trigonometric function that returns the sine of a number, which is a value between `-1` and `1`. The function contains a single calculation that must resolve to either a `<number>` or an `<angle>` by interpreting the result of the argument as radians. That is, `sin(45deg)`, `sin(0.125turn)`, and `sin(3.14159 / 4)` all represent the same value, approximately `.707`.
 
 ## Syntax
 
@@ -33,7 +33,7 @@ The `sin()` function takes only one expression as its argument.
 
 ### Boxes Size
 
-For example, when creating a 100x100 box based on external parameter, in this case `sin(90deg)`. Thus `sin(90deg)` will return `1` making the box `100px` width and `100px` height.
+For example, when creating a 100x100 box based on external parameters, in this case `sin(90deg)`. Thus `sin(90deg)` will return `1` making the box `100px` width and `100px` height.
 
 ```css
 div {
@@ -45,11 +45,11 @@ div {
 
 ### Controling Animation Duration
 
-Another usecase is to control the {{cssxref("animation-duration")}}. Redusing duration based on the sine value. In this case the animation duration will be `1s`.
+Another use-case is to control the {{cssxref("animation-duration")}}. Reducing duration based on the sine value. In this case, the animation duration will be `1s`.
 
 ```css
 div {
-  animation-name: MyAnimation;
+  animation-name: myAnimation;
   animation-duration: calc( sin(0.25turn) * 1s );
 }
 ```


### PR DESCRIPTION
#### Summary
Document the CSS `sin()` functional notation.

#### Motivation
[Safari/webkit already supports](https://webkit.org/blog/12445/new-webkit-features-in-safari-15-4/) this CSS function. [Chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=1190444) will follow soon.

#### Supporting details
https://drafts.csswg.org/css-values/#trig-funcs

#### Related issues


#### Metadata
- [x] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
