### PR TITLE
Fixing the ColorWithAlpha derived class in the Extends and Inheritance section.

### DIFF
--- a/files/en-us/web/javascript/guide/using_classes/index.md
+++ b/files/en-us/web/javascript/guide/using_classes/index.md
@@ -585,13 +585,13 @@ class ColorWithAlpha extends Color {
     this.#alpha = a;
   }
   get alpha() {
-    return this.#values[3];
+    return this.#alpha;
   }
   set alpha(value) {
     if (value < 0 || value > 1) {
       throw new RangeError("Alpha value must be between 0 and 1");
     }
-    this.#values[3] = value;
+    this.#alpha = value;
   }
 }
 ```


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The ColorWithAlpha derived class is currently trying to access the #values private property from its parent class Color which would throw a syntax error.
The code block has been updated to now use the correct #alpha field in the get alpha() and set alpha() accessor properties.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
