### PR TITLE
Fix PopUp Info Custom Elements

### DIFF
--- a/files/en-us/web/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/web_components/using_custom_elements/index.md
@@ -77,7 +77,7 @@ class PopUpInfo extends HTMLElement {
 
 The preceding code snippet contains the [`constructor()`](/en-US/docs/Web/JavaScript/Reference/Classes/constructor) definition for the class, which always starts by calling [`super()`](/en-US/docs/Web/JavaScript/Reference/Operators/super) so that the correct prototype chain is established.
 
-Inside the constructor, we define all the functionality the element will have when an instance of it is instantiated. In this case we attach a shadow root to the custom element, use some DOM manipulation to create the element's internal shadow DOM structure — which is then attached to the shadow root — and finally attach some CSS to the shadow root to style it.
+Inside the method connectedCallback, we define all the functionality the element will have when the element is connected to the DOM. In this case we attach a shadow root to the custom element, use some DOM manipulation to create the element's internal shadow DOM structure — which is then attached to the shadow root — and finally attach some CSS to the shadow root to style it. We cannot use constructor() because it is impossible to get the element's attributes before it is connected to the DOM.
 
 ```js
 // Create a shadow root

--- a/files/en-us/web/web_components/using_custom_elements/index.md
+++ b/files/en-us/web/web_components/using_custom_elements/index.md
@@ -77,7 +77,7 @@ class PopUpInfo extends HTMLElement {
 
 The preceding code snippet contains the [`constructor()`](/en-US/docs/Web/JavaScript/Reference/Classes/constructor) definition for the class, which always starts by calling [`super()`](/en-US/docs/Web/JavaScript/Reference/Operators/super) so that the correct prototype chain is established.
 
-Inside the method connectedCallback, we define all the functionality the element will have when the element is connected to the DOM. In this case we attach a shadow root to the custom element, use some DOM manipulation to create the element's internal shadow DOM structure — which is then attached to the shadow root — and finally attach some CSS to the shadow root to style it. We cannot use constructor() because it is impossible to get the element's attributes before it is connected to the DOM.
+Inside the method connectedCallback, we define all the functionality the element will have when the element is connected to the DOM. In this case we attach a shadow root to the custom element, use some DOM manipulation to create the element's internal shadow DOM structure — which is then attached to the shadow root — and finally attach some CSS to the shadow root to style it. We don't use `constructor()` because an element's attributes are unavailable until connected to the DOM.
 
 ```js
 // Create a shadow root


### PR DESCRIPTION
#### Summary
I fixed a bug in the PopUp Info Custom Elements.

#### Motivation
I decided to made this change because the documentation had an error on this point.
It is very important to do not have any errors in the documentation when you trying to understand how it works.
I was in this situation and I needed to search elsewhere on the web to find the solution.

#### Supporting details
With this bug, we cannot use `this.getAttributes()`.
So this code is not working.

We must use this method after the element's connection to the DOM.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error