### PR TITLE
FF104 Error stacks are serialized for window.postMessage and structuredClone()

### DIFF
--- a/files/en-us/mozilla/firefox/releases/104/index.md
+++ b/files/en-us/mozilla/firefox/releases/104/index.md
@@ -29,6 +29,10 @@ This article provides information about the changes in Firefox 104 that will aff
   These are used to find the value and index (respectively) of the last element in an {{jsxref("Array")}} or {{jsxref("TypedArray")}} that matches a supplied test function.
   (See {{bug(1775026)}} for more details.)
 
+- Serialization of [native Error types](h/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#error_types) additionally includes the [`stack`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack) property when used with [`window.postMessage()`](/en-US/docs/Web/API/Window/postMessage) and [`structuredClone()`](/en-US/docs/Web/API/structuredClone) (on error types that include `stack`).
+  The `stack` is not yet serialized when errors are sent using other APIs, such as [`Worker.postMessage()`](/en-US/docs/Web/API/Worker/postMessage)
+  (See {{bug(1774866)}} for more details.)
+
 #### Removals
 
 ### HTTP


### PR DESCRIPTION
This adds release note for addition of `Error.stack` to serialized properties of errors in FF104 (but only in some methods) done in https://bugzilla.mozilla.org/show_bug.cgi?id=1774866#c19 

Other docs work can be tracked in #18998