### PR TITLE
What does not work

### DIFF
--- a/files/en-us/web/css/using_css_custom_properties/index.md
+++ b/files/en-us/web/css/using_css_custom_properties/index.md
@@ -314,3 +314,4 @@ element.style.setProperty("--my-var", jsVar + 4);
 
 - [Custom property syntax](/en-US/docs/Web/CSS/--*)
 - [`var()`](/en-US/docs/Web/CSS/var)
+- [The big gotcha with Custom Properties](https://css-tricks.com/the-big-gotcha-with-custom-properties/) (CSS Tricks)


### PR DESCRIPTION
Docs are great in reference form. Clear and concise. In practical terms, nothing ever works as simply as reference docs might imply with their 'perfect world' context.

Adding links to content elsewhere that add real world experience context to articles will help people get a fuller perspective of how to actually use the reference in real life.

#### Summary
Add a link to a relevant third-party article.

#### Motivation
Help developers get a fuller perspective of how CSS Custom Properties work in reality.
