### PR TITLE
SVGStyleElement/HTMLStyleElement .type deprecated

### DIFF
--- a/files/en-us/web/api/htmlstyleelement/type/index.md
+++ b/files/en-us/web/api/htmlstyleelement/type/index.md
@@ -15,27 +15,23 @@ browser-compat: api.HTMLStyleElement.type
 ---
 {{APIRef("HTML DOM")}} {{Deprecated_Header}}
 
-The **`HTMLStyleElement.type`** read-only property returns the
-type of the current style.
+The **`HTMLStyleElement.type`** property returns the type of the current style.
+The value mirrors the [HTML `<style>` element's `type` attribute](/en-US/docs/Web/HTML/Element/style#attr-type).
 
-For Gecko, the type is most often given as "text/css." From the W3C spec on CSS: "The
-expectation is that binding-specific casting methods can be used to cast down from an
-instance of the CSSRule interface to the specific derived interface implied by the
-type."
+Authors should not use this property or rely on the value.
 
 ## Value
 
-A string.
+The permitted values are an empty string or a case-insensitive match for "text/css".
 
-## Examples
+## Specifications
 
-```js
-if (newStyle.type !== "text/css"){
-   // not supported!
-   warnCSS();
-}
-```
+{{Specifications}}
 
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("SVGStyleElement.type")}}

--- a/files/en-us/web/api/svgstyleelement/index.md
+++ b/files/en-us/web/api/svgstyleelement/index.md
@@ -26,8 +26,6 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 
   - : A string corresponding to the {{SVGAttr("type")}} attribute of the given element.
 
-    SVG 1.1 defined that a {{domxref("DOMException")}} is raised with code `NO_MODIFICATION_ALLOWED_ERR` on an attempt to change the value of a read-only attribute. This restriction was removed in SVG 2.
-
 - {{domxref("SVGStyleElement.media")}}
 
   - : A string corresponding to the {{SVGAttr("media")}} attribute of the given element.

--- a/files/en-us/web/api/svgstyleelement/type/index.md
+++ b/files/en-us/web/api/svgstyleelement/type/index.md
@@ -1,0 +1,41 @@
+---
+title: SVGStyleElement.type
+slug: Web/API/SVGStyleElement/type
+page-type: web-api-instance-property
+tags:
+  - API
+  - Property
+  - Reference
+  - SVG
+  - SVG DOM
+  - Deprecated
+browser-compat: api.SVGStyleElement.type
+---
+{{APIRef("SVG")}} {{Deprecated_Header}}
+
+The **`SVGStyleElement.type`** property returns the type of the current style.
+The value mirrors the [SVG `<style>` element's `type` attribute](/en-US/docs/Web/SVG/Element/style#type).
+
+Authors should not use this property or rely on the value.
+
+## Value
+
+The permitted values are an empty string or a case-insensitive match for "text/css".
+
+## Exceptions
+
+SVG 1.1 defined that a {{domxref("DOMException")}} is raised with code `NO_MODIFICATION_ALLOWED_ERR` on an attempt to change the value of a read-only attribute.
+This restriction was removed in SVG 2.
+
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLStyleElement.type")}}


### PR DESCRIPTION
`SVGStyleElement.type` has the same behavior as [HTMLStyleElement.type](https://developer.mozilla.org/en-US/docs/Web/API/HTMLStyleElement/type) from HTML5. Both mirror their corresponding style element attribute, and that is marked as obsolete: https://html.spec.whatwg.org/multipage/obsolete.html#attr-style-type

This adds docs for both and matches them up.

It is part of the tidy I am doing for #18775