### PR TITLE
scroll-timeline at-rule removed from spec; drop Specifications section

### DIFF
--- a/files/en-us/web/css/@scroll-timeline/index.md
+++ b/files/en-us/web/css/@scroll-timeline/index.md
@@ -166,10 +166,6 @@ We create an `@scroll-timeline` called `squareTimeline`, setting the `source` as
 
 {{EmbedLiveSample("Simple_example")}}
 
-## Specifications
-
-{{Specifications}}
-
 ## Browser compatibility
 
 {{Compat}}


### PR DESCRIPTION
https://github.com/w3c/csswg-drafts/commit/fc6766d dropped the scroll-timeline at-rule from the “Scroll-linked Animations” spec

Related BCD change: https://github.com/mdn/browser-compat-data/pull/17212