### PR TITLE
Deprecated convention about custom HTTP headers

### DIFF
--- a/files/en-us/web/http/headers/access-control-expose-headers/index.md
+++ b/files/en-us/web/http/headers/access-control-expose-headers/index.md
@@ -49,10 +49,10 @@ The {{Glossary("CORS-safelisted response header", "CORS-safelisted response head
 Access-Control-Expose-Headers: Content-Encoding
 ```
 
-To additionally expose a custom header, like `X-Kuma-Revision`, you can specify multiple headers separated by a comma:
+To additionally expose a custom header, like `Kuma-Revision`, you can specify multiple headers separated by a comma:
 
 ```
-Access-Control-Expose-Headers: Content-Encoding, X-Kuma-Revision
+Access-Control-Expose-Headers: Content-Encoding, Kuma-Revision
 ```
 
 For requests without credentials, a server can also respond with a wildcard value:


### PR DESCRIPTION
From [this](https://www.rfc-editor.org/rfc/rfc6648) RFC, custom HTTP headers should not start anymore with "X-".

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
