### PR TITLE
Contradicting statements

### DIFF
--- a/files/en-us/learn/javascript/asynchronous/promises/index.md
+++ b/files/en-us/learn/javascript/asynchronous/promises/index.md
@@ -174,9 +174,7 @@ First, a promise can be in one of three states:
 
  Note that what "succeeded" or "failed" means here is up to the API in question: for example, `fetch()` considers a request successful if the server returned an error like [404 Not Found](/en-US/docs/Web/HTTP/Status/404), but not if a network error prevented the request being sent.
 
-Sometimes, we use the term **settled** to cover both **fulfilled** and **rejected**.
-
-A promise is **resolved** if it is settled, or if it has been "locked in" to follow the state of another promise.
+A promise is **fulfilled** if the asynchronous function does not throw an error, or if it has been "locked in" to follow the state of another promise.
 
 The article [Let's talk about how to talk about promises](https://thenewtoys.dev/blog/2021/02/08/lets-talk-about-how-to-talk-about-promises/) gives a great explanation of the details of this terminology.
 


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
If **settled** can be used to refer to both resolved and rejected, then what is the use of having a handler for rejection? I feel that this line is contradicting with previous explanations of a promise being resolved and rejected.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
* I had been learning about JS promises from the MDN docs. 
* I felt that this line is contradicting with the previous explanations of resolve and rejected in the same lesson. Hence, I wanted to propose this change so that it would be helpful to everyone.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
