### PR TITLE
fix: Remove nested HTML in snippet

### DIFF
--- a/files/en-us/web/api/media_streams_api/taking_still_photos/index.md
+++ b/files/en-us/web/api/media_streams_api/taking_still_photos/index.md
@@ -44,10 +44,10 @@ We also have an {{HTMLElement("img")}} element into which we will draw the image
 
 ```html
 <canvas id="canvas">
-  <div class="output">
-    <img id="photo" alt="The screen capture will appear in this box.">
-  </div>
 </canvas>
+<div class="output">
+  <img id="photo" alt="The screen capture will appear in this box.">
+</div>
 ```
 
 That's all of the relevant HTML. The rest is just some page layout fluff and a bit of text offering a link back to this page.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The introductory HTML snippet for the canvas and image elements didn't match the full HTML example at the bottom of the page. Using the introductory HTML snippet also hid the output from the takePicture function (since canvas is set to display none).

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
When I was coding along with the tutorial, I tried using the introductory snippet. I noticed I had no output. I'd like to make the snippet accurate so that users can either use the code from the  introductory HTML snippet, or the full HTML example at the bottom of the page.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
[The HTML Markup](https://developer.mozilla.org/en-US/docs/Web/API/Media_Streams_API/Taking_still_photos#the_html_markup): The section where the incorrect HTML snippet is introduced.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
