### PR TITLE
Remove mention of GestureEvent constructor

### DIFF
--- a/files/en-us/web/api/gestureevent/index.md
+++ b/files/en-us/web/api/gestureevent/index.md
@@ -18,11 +18,6 @@ The **`GestureEvent`** is a proprietary interface specific to WebKit which gives
 
 `GestureEvent` derives from {{domxref("UIEvent")}}, which in turn derives from {{domxref("Event")}}.
 
-## Constructor
-
-- {{domxref("GestureEvent.GestureEvent", "GestureEvent()")}}
-  - : Creates a `GestureEvent` object.
-
 ## Properties
 
 _This interface also inherits properties of its parents, {{domxref("UIEvent")}} and {{domxref("Event")}}._


### PR DESCRIPTION
This PR removes mention of the `GestureEvent` constructor from MDN.  Related BCD PR: https://github.com/mdn/browser-compat-data/pull/17215
