### PR TITLE
Fix return value for performance.now

### DIFF
--- a/files/en-us/web/api/performance/now/index.md
+++ b/files/en-us/web/api/performance/now/index.md
@@ -48,7 +48,7 @@ None.
 
 ### Return value
 
-None ({{jsxref("undefined")}}).
+Returns a {{domxref("DOMHighResTimeStamp")}} measured in milliseconds.
 
 ## Examples
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Fixes return value for `performance.now()`, currents says none which is incorrect: 
![image](https://user-images.githubusercontent.com/19228318/182483636-4f0001a2-7939-4cd3-91cf-e2f0d6ef6691.png)

<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
Fixes incorrect information for the return value of it.
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
