### PR TITLE
Indicate that CORS' origin header must include protocol

### DIFF
--- a/files/en-us/web/http/cors/errors/corsalloworiginnotmatchingorigin/index.md
+++ b/files/en-us/web/http/cors/errors/corsalloworiginnotmatchingorigin/index.md
@@ -37,6 +37,8 @@ configuration is typically found in a `.conf` file (`httpd.conf`
 and `apache.conf` are common names for these), or in an
 `.htaccess` file.
 
+> **Warning:** You must include the HTTPS or HTTP protocol in the origin.
+
 ```
 Header set Access-Control-Allow-Origin 'origin'
 ```

--- a/files/en-us/web/http/cors/errors/corsalloworiginnotmatchingorigin/index.md
+++ b/files/en-us/web/http/cors/errors/corsalloworiginnotmatchingorigin/index.md
@@ -37,7 +37,7 @@ configuration is typically found in a `.conf` file (`httpd.conf`
 and `apache.conf` are common names for these), or in an
 `.htaccess` file.
 
-> **Warning:** You must include the HTTPS or HTTP protocol in the origin.
+> **Warning:** You must include the HTTPS or HTTP protocol as part of the origin.
 
 ```
 Header set Access-Control-Allow-Origin 'origin'


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
This PR proposes a new warning on the [CORS header 'Access-Control-Allow-Origin' does not match 'xyz'](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSAllowOriginNotMatchingOrigin) page to warn developers that they must include the `HTTPS` or `HTTP` protocol as part of their `Access-Control-Allow-Origin` header.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
This change may help others save time by noticing that they must include the `HTTPS` or `HTTP` protocol when writing a `CORS` header.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
As this [accepted response](https://stackoverflow.com/questions/35303654/cors-header-access-control-allow-origin-does-not-match-but-it-does/50513329#50513329) states, the `Access-Control-Allow-Origin` header should include the protocol.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Fixes #19032

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
Thank you!