### PR TITLE
Bug in JavaScript code

### DIFF
--- a/files/en-us/learn/forms/form_validation/index.md
+++ b/files/en-us/learn/forms/form_validation/index.md
@@ -754,7 +754,7 @@ The big changes are in the JavaScript code, which needs to do much more heavy li
 ```js
 const form  = document.querySelector('form');
 const email = document.getElementById('mail');
-const error = email.nextElementSibling();
+const error = email.nextElementSibling;
 
 // As per the HTML Specification
 const emailRegExp = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;


### PR DESCRIPTION
This pull request fixes an error in the example JavaScript code for the lesson https://developer.mozilla.org/en-US/docs/Learn/Forms/Form_validation#validating_forms_without_a_built-in_api.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The line:
`const error = email.nextElementSibling();`
was changed to:
`const error = email.nextElementSibling;`

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The JavaScript code for the section "An example that doesn't use the constraint validation API" has an uncaught TypeError on line 3: nextElementSibling is a property and not a function. Currently the demo shown on the page is non-functional because of this bug, but removing the parentheses will fix it.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://developer.mozilla.org/en-US/docs/Web/API/Element/nextElementSibling

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
