### PR TITLE
[Canvas - Drawing text] Add accessibility concerns (low vision)

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/drawing_text/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/drawing_text/index.md
@@ -154,9 +154,9 @@ function draw() {
 
 ## Accessibility concerns
 
-Text written on canvas can cause legibility issues with users relying on screen magnification. The pixels within a canvas element do not scale and can become blurry with magnification. This is because they are not a vector but letter-shaped collection of pixels. When zooming in on it, the pixels become bigger. 
+The `<canvas>` element is just a bitmap and does not provide information about any drawn objects. Text written on canvas can cause legibility issues with users relying on screen magnification. The pixels within a canvas element do not scale and can become blurry with magnification. This is because they are not a vector but letter-shaped collection of pixels. When zooming in on it, the pixels become bigger. 
 
-An alternive is to use HTML elements or SVG instead of canvas. 
+Canvas content is not exposed to accessibility tools like semantic HTML is. In general, you should avoid using canvas in an accessible website or app. An alternative is to use HTML elements or SVG instead of canvas. 
 
 ## Gecko-specific notes
 

--- a/files/en-us/web/api/canvas_api/tutorial/drawing_text/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/drawing_text/index.md
@@ -152,6 +152,12 @@ function draw() {
 }
 ```
 
+## Accessibility concerns
+
+Text written on canvas can cause legibility issues with users relying on screen magnification. The pixels within a canvas element do not scale and can become blurry with magnification. This is because they are not a vector but letter-shaped collection of pixels. When zooming in on it, the pixels become bigger. 
+
+An alternive is to use HTML elements or SVG instead of canvas. 
+
 ## Gecko-specific notes
 
 In Gecko (the rendering engine of Firefox, Firefox OS and other Mozilla based applications), some [prefixed APIs](/en-US/docs/Web/API/CanvasRenderingContext2D#prefixed_apis) were implemented in earlier versions to draw text on a canvas. These are now deprecated and removed, and are no longer guaranteed to work.


### PR DESCRIPTION

#### Summary
Add section about accessibility concerns for people with low vision relying on screen magnification.

#### Motivation
This helps developers make canvas more accessible for people using screen magnification.

#### Supporting details

That article explains the accessibility limits of reading text on canvas. They mention that zooming text is an issue:

> Allows a screen magnifier user to locate and zoom text rendered on canvas.

Source: https://www.w3.org/wiki/Reading_text_in_canvas


#### Metadata

This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
