### PR TITLE
Make the live sample in the “Blob” article work

### DIFF
--- a/files/en-us/web/api/blob/index.md
+++ b/files/en-us/web/api/blob/index.md
@@ -74,28 +74,44 @@ The following code creates a JavaScript [typed array](/en-US/docs/Web/JavaScript
 The main piece of this code for example purposes is the `typedArrayToURL()` function, which creates a `Blob` from the given typed array and returns an object URL for it. Having converted the data into an object URL, it can be used in a number of ways, including as the value of the {{HTMLElement("img")}} element's {{htmlattrxref("src", "img")}} attribute (assuming the data contains an image, of course).
 
 ```js
-function typedArrayToURL(typedArray, mimeType) {
-  return URL.createObjectURL(new Blob([typedArray.buffer], {type: mimeType}))
+function showViewLiveResultButton() {
+  if (window.self !== window.top) {
+    // Ensure that if our document is in a frame, we get the user
+    // to first open it in its own tab or window. Otherwise, this
+    // example won’t work.
+    const p = document.querySelector("p");
+    p.textContent = "";
+    const button = document.createElement("button");
+    button.textContent = "View live result of the example code above";
+    p.append(button);
+    button.addEventListener('click', () => window.open(location.href));
+    return true;
+  }
+  return false;
 }
 
-const bytes = new Uint8Array(59);
+if (!showViewLiveResultButton()) {
+  function typedArrayToURL(typedArray, mimeType) {
+    return URL.createObjectURL(new Blob([typedArray.buffer],
+        {type: mimeType}))
+  }
+  const bytes = new Uint8Array(59);
 
-for (let i = 0; i < 59; i++) {
-  bytes[i] = 32 + i;
+  for (let i = 0; i < 59; i++) {
+    bytes[i] = 32 + i;
+  }
+
+  const url = typedArrayToURL(bytes, 'text/plain');
+
+  const link = document.createElement('a');
+  link.href = url;
+  link.innerText = 'Open the array URL';
+
+  document.body.appendChild(link);
 }
-
-const url = typedArrayToURL(bytes, 'text/plain');
-
-const link = document.createElement('a');
-link.href = url;
-link.innerText = 'Open the array URL';
-
-document.body.appendChild(link);
 ```
 
 #### Result
-
-Click the link in the example to see the browser decode the object URL.
 
 {{EmbedLiveSample("Creating_a_URL_representing_the_contents_of_a_typed_array", 600, 200)}}
 


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/11610. The CSP policy that MDN articles are served with prevents embedding a “blob:” live sample in any of them. So to make it possible for users to see the Blob article live example as expected, we need to do the same kind of trick/hack we did in https://github.com/mdn/content/pull/12796 and in https://github.com/mdn/content/pull/12625.