### PR TITLE
null is a primitive not an object

### DIFF
--- a/files/en-us/glossary/null/index.md
+++ b/files/en-us/glossary/null/index.md
@@ -7,21 +7,13 @@ tags:
 ---
 In computer science, a **`null`** value represents a reference that points, generally intentionally, to a nonexistent or invalid {{glossary("object")}} or address. The meaning of a null reference varies among language implementations.
 
-In {{Glossary("JavaScript")}}, `null` is marked as one of the {{Glossary("Primitive", "primitive values")}}, because its behavior is seemingly primitive.
-
-But in certain cases, `null` is not as "primitive" as it first seems! Every Object is derived from `null` value, and therefore `typeof` operator returns `object` for it:
+In {{Glossary("JavaScript")}}, `null` is marked as one of the {{Glossary("Primitive", "primitive values")}}, because its behavior is seemingly primitive. However, when using the [`typeof`](/en-US/docs/Web/JavaScript/Reference/Operators/typeof) operator, it returns `"object"`.
 
 ```js
-typeof null === 'object' // true
+console.log(typeof null); // "object"
 ```
 
-As stated above, `null` is primitive, because its behavior is seemingly primitive.
-So, 
-
-```js
-console.log(typeof null); // object
-```
-returning "object" is a bug it the language which cannot be fixed because it will break too many scripts.
+This is considered [a bug](/en-US/docs/Web/JavaScript/Reference/Operators/typeof#typeof_null), but one which cannot be fixed because it will break too many scripts.
 
 ## See also
 

--- a/files/en-us/glossary/null/index.md
+++ b/files/en-us/glossary/null/index.md
@@ -15,6 +15,14 @@ But in certain cases, `null` is not as "primitive" as it first seems! Every Obje
 typeof null === 'object' // true
 ```
 
+As stated above, `null` is primitive, because its behavior is seemingly primitive.
+So, 
+
+```js
+console.log(typeof null); // object
+```
+returning "object" is a bug it the language which cannot be fixed because it will break too many scripts.
+
 ## See also
 
 - [JavaScript data types](/en-US/docs/Web/JavaScript/Data_structures)


### PR DESCRIPTION
As stated above,

In {{Glossary("JavaScript")}}, `null` is marked as one of the {{Glossary("Primitive", "primitive values")}}, because its behavior is seemingly primitive.

So typeof null returning "object" is a bug it the language which cannot be fixed because it will break too many scripts.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
