### PR TITLE
Fix the “CSP errors and warnings” page

### DIFF
--- a/files/en-us/web/http/csp/errors/index.md
+++ b/files/en-us/web/http/csp/errors/index.md
@@ -13,43 +13,41 @@ tags:
 ---
 {{HTTPSidebar}}
 
-This page will be a parent for reference articles about CSP errors and warnings, and will provide an overview of them, and generic troubleshooting advice, if possible.
-
-## The errors
+When you see any of the following messages logged in the browser devtools console, it indicates that a problem related to [CSP](/en-US/docs/Web/HTTP/CSP) has occurred.
 
 - [The page's settings blocked the loading of a resource: %1$S](/en-US/docs/Web/HTTP/CSP/Errors/CSPViolation)
-- [The page's settings blocked the loading of a resource at %2$S ("%1$S").](/en-US/docs/Web/HTTP/CSP/Errors/CSPViolationWithURI)
-- [A violation occurred for a report-only CSP policy ("%1$S"). The behavior was allowed, and a CSP report was sent.](/en-US/docs/Web/HTTP/CSP/Errors/CSPROViolation)
-- [The page's settings observed the loading of a resource at %2$S ("%1$S"). A CSP report is being sent.](/en-US/docs/Web/HTTP/CSP/Errors/CSPROViolationWithURI)
-- [Tried to send report to invalid URI: "%1$S"](/en-US/docs/Web/HTTP/CSP/Errors/triedToSendReport)
-- [couldn't parse report URI: %1$S](/en-US/docs/Web/HTTP/CSP/Errors/couldNotParseReportURI)
-- [Couldn't process unknown directive '%1$S'](/en-US/docs/Web/HTTP/CSP/Errors/couldNotProcessUnknownDirective)
-- [Ignoring unknown option %1$S](/en-US/docs/Web/HTTP/CSP/Errors/ignoringUnknownOption)
-- [Ignoring duplicate source %1$S](/en-US/docs/Web/HTTP/CSP/Errors/ignoringDuplicateSrc)
-- [Ignoring source '%1$S' (Not supported when delivered via meta element).](/en-US/docs/Web/HTTP/CSP/Errors/ignoringSrcFromMetaCSP)
-- [Ignoring "%1$S" within script-src or style-src: nonce-source or hash-source specified](/en-US/docs/Web/HTTP/CSP/Errors/ignoringSrcWithinScriptStyleSrc)
-- [Ignoring "%1$S" within script-src: 'strict-dynamic' specified](/en-US/docs/Web/HTTP/CSP/Errors/ignoringSrcForStrictDynamic)
-- [Ignoring source "%1$S" (Only supported within script-src).](/en-US/docs/Web/HTTP/CSP/Errors/ignoringStrictDynamic)
-- [Keyword 'strict-dynamic' within "%1$S" with no valid nonce or hash might block all scripts from loading](/en-US/docs/Web/HTTP/CSP/Errors/strictDynamicButNoHashOrNonce)
-- [The report URI (%1$S) should be an HTTP or HTTPS URI.](/en-US/docs/Web/HTTP/CSP/Errors/reportURInotHttpsOrHttp2)
-- [This site (%1$S) has a Report-Only policy without a report URI. CSP will not block and cannot report violations of this policy.](/en-US/docs/Web/HTTP/CSP/Errors/reportURInotInReportOnlyHeader)
-- [Failed to parse unrecognized source %1$S](/en-US/docs/Web/HTTP/CSP/Errors/failedToParseUnrecognizedSource)
-- [An attempt to execute inline scripts has been blocked](/en-US/docs/Web/HTTP/CSP/Errors/inlineScriptBlocked)
-- [An attempt to apply inline style sheets has been blocked](/en-US/docs/Web/HTTP/CSP/Errors/inlineStyleBlocked)
-- [An attempt to call JavaScript from a string (by calling a function like eval) has been blocked](/en-US/docs/Web/HTTP/CSP/Errors/scriptFromStringBlocked)
-- [Upgrading insecure request '%1$S' to use '%2$S'](/en-US/docs/Web/HTTP/CSP/Errors/upgradeInsecureRequest)
-- [Ignoring srcs for directive '%1$S'](/en-US/docs/Web/HTTP/CSP/Errors/ignoreSrcForDirective)
-- [Interpreting %1$S as a hostname, not a keyword. If you intended this to be a keyword, use '%2$S' (wrapped in single quotes).](/en-US/docs/Web/HTTP/CSP/Errors/hostNameMightBeKeyword)
-- [Not supporting directive '%1$S'. Directive and values will be ignored.](/en-US/docs/Web/HTTP/CSP/Errors/notSupportingDirective)
-- [Blocking insecure request '%1$S'.](/en-US/docs/Web/HTTP/CSP/Errors/blockAllMixedContent)
-- [Ignoring '%1$S' since it does not contain any parameters.](/en-US/docs/Web/HTTP/CSP/Errors/ignoringDirectiveWithNoValues)
-- [Ignoring sandbox directive when delivered in a report-only policy '%1$S'](/en-US/docs/Web/HTTP/CSP/Errors/ignoringReportOnlyDirective)
-- [Referrer Directive '%1$S' has been deprecated. Please use the Referrer-Policy header instead.](/en-US/docs/Web/HTTP/CSP/Errors/deprecatedReferrerDirective)
-- [Ignoring '%1$S' because of '%2$S' directive.](/en-US/docs/Web/HTTP/CSP/Errors/IgnoringSrcBecauseOfDirective)
-- [Couldn't parse invalid source %1$S](/en-US/docs/Web/HTTP/CSP/Errors/couldntParseInvalidSource)
-- [Couldn't parse invalid host %1$S](/en-US/docs/Web/HTTP/CSP/Errors/couldntParseInvalidHost)
-- [Couldn't parse scheme in %1$S](/en-US/docs/Web/HTTP/CSP/Errors/couldntParseScheme)
-- [Couldn't parse port in %1$S](/en-US/docs/Web/HTTP/CSP/Errors/couldntParsePort)
-- [Duplicate %1$S directives detected. All but the first instance will be ignored.](/en-US/docs/Web/HTTP/CSP/Errors/duplicateDirective)
-- [Directive '%1$S' has been deprecated. Please use directive 'worker-src' to control workers, or directive 'frame-src' to control frames respectively.](/en-US/docs/Web/HTTP/CSP/Errors/deprecatedChildSrcDirective)
-- [Couldn't parse invalid sandbox flag '%1$S'](/en-US/docs/Web/HTTP/CSP/Errors/couldntParseInvalidSandboxFlag)
+- The page's settings blocked the loading of a resource at %2$S ("%1$S").
+- A violation occurred for a report-only CSP policy ("%1$S"). The behavior was allowed, and a CSP report was sent.
+- The page's settings observed the loading of a resource at %2$S ("%1$S"). A CSP report is being sent.
+- Tried to send report to invalid URI: "%1$S"
+- Couldn't parse report URI: %1$S
+- Couldn't process unknown directive '%1$S'
+- Ignoring unknown option %1$S
+- Ignoring duplicate source %1$S
+- Ignoring source '%1$S' (Not supported when delivered via meta element).
+- Ignoring "%1$S" within script-src or style-src: nonce-source or hash-source specified
+- Ignoring "%1$S" within script-src: 'strict-dynamic' specified
+- Ignoring source "%1$S" (Only supported within script-src).
+- Keyword 'strict-dynamic' within "%1$S" with no valid nonce or hash might block all scripts from loading
+- The report URI (%1$S) should be an HTTP or HTTPS URI.
+- This site (%1$S) has a Report-Only policy without a report URI. CSP will not block and cannot report violations of this policy.
+- Failed to parse unrecognized source %1$S
+- An attempt to execute inline scripts has been blocked
+- An attempt to apply inline style sheets has been blocked
+- An attempt to call JavaScript from a string (by calling a function like eval) has been blocked
+- Upgrading insecure request '%1$S' to use '%2$S'
+- Ignoring srcs for directive '%1$S'
+- Interpreting %1$S as a hostname, not a keyword. If you intended this to be a keyword, use '%2$S' (wrapped in single quotes).
+- Not supporting directive '%1$S'. Directive and values will be ignored.
+- Blocking insecure request '%1$S'.(/en-US/docs/Web/HTTP/CSP/Errors/blockAllMixedContent)
+- Ignoring '%1$S' since it does not contain any parameters.
+- Ignoring sandbox directive when delivered in a report-only policy '%1$S'
+- Referrer Directive '%1$S' has been deprecated. Please use the Referrer-Policy header instead.
+- Ignoring '%1$S' because of '%2$S' directive.
+- Couldn't parse invalid source %1$S
+- Couldn't parse invalid host %1$S
+- Couldn't parse scheme in %1$S
+- Couldn't parse port in %1$S
+- Duplicate %1$S directives detected. All but the first instance will be ignored.
+- Directive '%1$S' has been deprecated. Please use directive 'worker-src' to control workers, or directive 'frame-src' to control frames respectively.
+- Couldn't parse invalid sandbox flag '%1$S'


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/17459

Of the 39 error messages listed on the “CSP errors and warnings” page — with links to pages for each of them — we only have exactly one of them actually documented. The other 38 are broken “page-not-created” links to non-existent pages.

So this change un-links all the messages that we don’t have documented yet (and which it seems we don’t have any active plans to document).

This entire page is arguably broken by design and I’d be happy with any other kind of change we might want to make to un-break it (for example, just deleting the entire page, or re-directing it) — as long as whatever change we make resolves issue #17459 rather than causing it to continue to be kept open indefinitely.