### PR TITLE
Add `captureStream()` to list of SecurityErrors on a tainted canvas

### DIFF
--- a/files/en-us/web/html/cors_enabled_image/index.md
+++ b/files/en-us/web/html/cors_enabled_image/index.md
@@ -30,8 +30,7 @@ If the foreign content comes from an image obtained from either as {{domxref("HT
 Calling any of the following on a tainted canvas will result in an error:
 
 - Calling {{domxref("CanvasRenderingContext2D.getImageData", "getImageData()")}} on the canvas's context
-- Calling {{domxref("HTMLCanvasElement.toBlob", "toBlob()")}} on the {{HTMLElement("canvas")}} element itself
-- Calling {{domxref("HTMLCanvasElement.toDataURL", "toDataURL()")}} on the canvas
+- Calling {{domxref("HTMLCanvasElement.toBlob", "toBlob()")}}, {{domxref("HTMLCanvasElement.toDataURL", "toDataURL()")}} or {{domxref("HTMLCanvasElement.captureStream", "captureStream()")}} on the {{HTMLElement("canvas")}} element itself
 
 Attempting any of these when the canvas is tainted will cause a `SecurityError` to be thrown. This protects users from having private data exposed by using images to pull information from remote web sites without permission.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
1. Added `HTMLCanvasElement.captureStream()` to the *"Calling any of the following on a tainted canvas will result in an error"* list.
2. Chained methods based on relation to canvas context or canvas element.

#### Motivation
1. Another method that throws a `SecurityError` when invoked on a tainted canvas.
2. Combining list items by target (context, element) makes it a bit more structured now that there are more related methods being added.

#### Supporting details
> Content from a canvas that is not [origin-clean](https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-origin-clean) MUST NOT be captured. This method throws a [SecurityError](https://webidl.spec.whatwg.org/#securityerror) exception if the canvas is not [origin-clean](https://www.w3.org/TR/mediacapture-fromelement/#dfn-origin-clean).

[From the `captureStream()` spec](https://www.w3.org/TR/mediacapture-fromelement/#dom-htmlcanvaselement-capturestream)

#### Related issues
N/A

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
