### PR TITLE
CSS Math Functions - Group items and add headings

### DIFF
--- a/files/en-us/web/css/css_functions/index.md
+++ b/files/en-us/web/css/css_functions/index.md
@@ -82,12 +82,12 @@ These functions are used when the {{cssxref("&lt;transform-function&gt;")}} CSS 
 
 The math functions allow CSS numeric values to be written as mathematical expressions.
 
-### Basic Arithmetic
+### Basic arithmetic
 
 - {{cssxref("calc", "calc()")}}
   - : A math function that allows basic arithmetic to be performed on numerical CSS values.
 
-### Comparison Functions
+### Comparison functions
 
 - {{cssxref("min", "min()")}}
   - : A comparison function that represents the smallest of a list of values.
@@ -96,7 +96,7 @@ The math functions allow CSS numeric values to be written as mathematical expres
 - {{cssxref("clamp", "clamp()")}}
   - : A comparison function that takes a minimum, central, and maximum value and represents its central calculation.
 
-### Stepped Value Functions
+### Stepped value functions
 
 - {{cssxref("round", "round()")}} {{Experimental_Inline}}
   - : Contains an optional rounding strategy, and two calculations A and B, and returns the value of A, rounded according to the rounding strategy, to the nearest integer multiple of B either above or below A.
@@ -105,7 +105,7 @@ The math functions allow CSS numeric values to be written as mathematical expres
 - {{cssxref("rem", "rem()")}} {{Experimental_Inline}}
   - : A modulus function that contains two calculations A and B, and returns the difference between A and the nearest integer multiple of B either above or below A.
 
-### Trigonometric Functions
+### Trigonometric functions
 
 - {{cssxref("sin", "sin()")}} {{Experimental_Inline}}
   - : Contains a single calculation which must resolve to either a {{cssxref("&lt;number&gt;")}} or an {{cssxref("&lt;angle&gt;")}}.
@@ -122,7 +122,7 @@ The math functions allow CSS numeric values to be written as mathematical expres
 - {{cssxref("atan2", "atan2()")}} {{Experimental_Inline}}
   - : Contains two comma-separated calculations, A and B. A and B can resolve to any {{cssxref("&lt;number&gt;")}}, {{cssxref("&lt;dimension&gt;")}}, or {{cssxref("&lt;percentage&gt;")}}, but must have the same type, or else the function is invalid.
 
-### Exponential Functions
+### Exponential functions
 
 - {{cssxref("pow", "pow()")}} {{Experimental_Inline}}
   - : Contains two comma-separated calculations A and B, both of which must resolve as a {{cssxref("&lt;number&gt;")}}, and returns the result of raising A to the power of B, returning the value as a {{cssxref("&lt;number&gt;")}}.
@@ -135,7 +135,7 @@ The math functions allow CSS numeric values to be written as mathematical expres
 - {{cssxref("exp", "exp()")}} {{Experimental_Inline}}
   - : Contains one calculation which must resolve to a {{cssxref("&lt;number&gt;")}}, and returns the same value as pow(e, A) as a {{cssxref("&lt;number&gt;")}}.
 
-### Sign-Related Functions
+### Sign-related functions
 
 - {{cssxref("abs", "abs()")}} {{Experimental_Inline}}
   - : Takes a calculation and returns the absolute value.

--- a/files/en-us/web/css/css_functions/index.md
+++ b/files/en-us/web/css/css_functions/index.md
@@ -82,49 +82,65 @@ These functions are used when the {{cssxref("&lt;transform-function&gt;")}} CSS 
 
 The math functions allow CSS numeric values to be written as mathematical expressions.
 
+### Basic Arithmetic
+
 - {{cssxref("calc", "calc()")}}
   - : A math function that allows basic arithmetic to be performed on numerical CSS values.
-- {{cssxref("clamp", "clamp()")}}
-  - : A comparison function that takes a minimum, central, and maximum value and represents its central calculation.
-- {{cssxref("max", "max()")}}
-  - : A comparison function that represents the largest of a list of values.
+
+### Comparison Functions
+
 - {{cssxref("min", "min()")}}
   - : A comparison function that represents the smallest of a list of values.
-- {{cssxref("abs", "abs()")}} {{Experimental_Inline}}
-  - : Takes a calculation and returns the absolute value.
-- {{cssxref("acos", "acos()")}} {{Experimental_Inline}}
-  - : An inverse trigonometric function the angle returned must be normalized to the range \[0deg, 180deg].
+- {{cssxref("max", "max()")}}
+  - : A comparison function that represents the largest of a list of values.
+- {{cssxref("clamp", "clamp()")}}
+  - : A comparison function that takes a minimum, central, and maximum value and represents its central calculation.
+
+### Stepped Value Functions
+
+- {{cssxref("round", "round()")}} {{Experimental_Inline}}
+  - : Contains an optional rounding strategy, and two calculations A and B, and returns the value of A, rounded according to the rounding strategy, to the nearest integer multiple of B either above or below A.
+- {{cssxref("mod", "mod()")}} {{Experimental_Inline}}
+  - : A modulus function that contains two calculations A and B, and returns the difference between A and the nearest integer multiple of B either above or below A.
+- {{cssxref("rem", "rem()")}} {{Experimental_Inline}}
+  - : A modulus function that contains two calculations A and B, and returns the difference between A and the nearest integer multiple of B either above or below A.
+
+### Trigonometric Functions
+
+- {{cssxref("sin", "sin()")}} {{Experimental_Inline}}
+  - : Contains a single calculation which must resolve to either a {{cssxref("&lt;number&gt;")}} or an {{cssxref("&lt;angle&gt;")}}.
+- {{cssxref("cos", "cos()")}} {{Experimental_Inline}}
+  - : Contains a single calculation which must resolve to either a {{cssxref("&lt;number&gt;")}} or an {{cssxref("&lt;angle&gt;")}}.
+- {{cssxref("tan", "tan()")}} {{Experimental_Inline}}
+  - : Contains a single calculation which must resolve to either a {{cssxref("&lt;number&gt;")}} or an {{cssxref("&lt;angle&gt;")}}.
 - {{cssxref("asin", "asin()")}} {{Experimental_Inline}}
   - : An inverse trigonometric function the angle returned must be normalized to the range \[-90deg, 90deg].
+- {{cssxref("acos", "acos()")}} {{Experimental_Inline}}
+  - : An inverse trigonometric function the angle returned must be normalized to the range \[0deg, 180deg].
 - {{cssxref("atan", "atan()")}} {{Experimental_Inline}}
   - : An inverse trigonometric function the angle returned must be normalized to the range \[-90deg, 90deg].
 - {{cssxref("atan2", "atan2()")}} {{Experimental_Inline}}
   - : Contains two comma-separated calculations, A and B. A and B can resolve to any {{cssxref("&lt;number&gt;")}}, {{cssxref("&lt;dimension&gt;")}}, or {{cssxref("&lt;percentage&gt;")}}, but must have the same type, or else the function is invalid.
-- {{cssxref("cos", "cos()")}} {{Experimental_Inline}}
-  - : Contains a single calculation which must resolve to either a {{cssxref("&lt;number&gt;")}} or an {{cssxref("&lt;angle&gt;")}}.
-- {{cssxref("exp", "exp()")}} {{Experimental_Inline}}
-  - : Contains one calculation which must resolve to a {{cssxref("&lt;number&gt;")}}, and returns the same value as pow(e, A) as a {{cssxref("&lt;number&gt;")}}.
+
+### Exponential Functions
+
+- {{cssxref("pow", "pow()")}} {{Experimental_Inline}}
+  - : Contains two comma-separated calculations A and B, both of which must resolve as a {{cssxref("&lt;number&gt;")}}, and returns the result of raising A to the power of B, returning the value as a {{cssxref("&lt;number&gt;")}}.
+- {{cssxref("sqrt", "sqrt()")}} {{Experimental_Inline}}
+  - : Contains a single calculation which must resolve to a {{cssxref("&lt;number&gt;")}}, and returns the square root of the value as a {{cssxref("&lt;number&gt;")}}.
 - {{cssxref("hypot", "hypot()")}} {{Experimental_Inline}}
   - : Contains one or more comma-separated calculations, and returns the length of an N-dimensional vector with components equal to each of the calculations.
 - {{cssxref("log", "log()")}} {{Experimental_Inline}}
   - : Contains one or two calculations (representing the value to be logarithmed, and the base of the logarithm, defaulting to e), which must both resolve as a {{cssxref("&lt;number&gt;")}}, and returns the logarithm base B of the value A, as a {{cssxref("&lt;number&gt;")}}.
-- {{cssxref("mod", "mod()")}} {{Experimental_Inline}}
-  - : A modulus function that contains two calculations A and B, and returns the difference between A and the nearest integer multiple of B either above or below A.
-- {{cssxref("pow", "pow()")}} {{Experimental_Inline}}
-  - : Contains two comma-separated calculations A and B, both of which must resolve as a {{cssxref("&lt;number&gt;")}}, and returns the result of raising A to the power of B, returning the value as a {{cssxref("&lt;number&gt;")}}.
-- {{cssxref("rem", "rem()")}} {{Experimental_Inline}}
-  - : A modulus function that contains two calculations A and B, and returns the difference between A and the nearest integer multiple of B either above or below A.
-- {{cssxref("round", "round()")}} {{Experimental_Inline}}
-  - : Contains an optional rounding strategy, and two calculations A and B, and returns the value of A, rounded according to the rounding strategy, to the nearest integer multiple of B either above or below A.
+- {{cssxref("exp", "exp()")}} {{Experimental_Inline}}
+  - : Contains one calculation which must resolve to a {{cssxref("&lt;number&gt;")}}, and returns the same value as pow(e, A) as a {{cssxref("&lt;number&gt;")}}.
+
+### Sign-Related Functions
+
+- {{cssxref("abs", "abs()")}} {{Experimental_Inline}}
+  - : Takes a calculation and returns the absolute value.
 - {{cssxref("sign_function", "sign()")}} {{Experimental_Inline}}
-  - : Takes a calculation and returns -1 if the numeric value is negative,
-    \+1 if the numeric value is positive, 0⁺ if the numeric value is 0⁺, and 0⁻ if the numeric value is 0⁻.
-- {{cssxref("sin", "sin()")}} {{Experimental_Inline}}
-  - : Contains a single calculation which must resolve to either a {{cssxref("&lt;number&gt;")}} or an {{cssxref("&lt;angle&gt;")}}.
-- {{cssxref("sqrt", "sqrt()")}} {{Experimental_Inline}}
-  - : Contains a single calculation which must resolve to a {{cssxref("&lt;number&gt;")}}, and returns the square root of the value as a {{cssxref("&lt;number&gt;")}}.
-- {{cssxref("tan", "tan()")}} {{Experimental_Inline}}
-  - : Contains a single calculation which must resolve to either a {{cssxref("&lt;number&gt;")}} or an {{cssxref("&lt;angle&gt;")}}.
+  - : Takes a calculation and returns -1 if the numeric value is negative, \+1 if the numeric value is positive, 0⁺ if the numeric value is 0⁺, and 0⁻ if the numeric value is 0⁻.
 
 ## Filter functions
 


### PR DESCRIPTION
#### Summary
The [current list of CSS math functions](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Functions#math_functions) is a long list of functions that make no sense. This PR groups similar functions and adds sub-headings, based on [the spec](https://www.w3.org/TR/css-values-4/#math) headings.

#### Motivation
Simplify the navigation and group similar functions by topic.

#### Supporting details
Spec: https://www.w3.org/TR/css-values-4/#math

10. Mathematical Expressions
10.1. Basic Arithmetic: `calc()`
10.2. Comparison Functions: `min()`, `max()`, and `clamp()`
10.3. Stepped Value Functions: `round()`, `mod()`, and `rem()`
10.4. Trigonometric Functions: `sin()`, `cos()`, `tan()`, `asin()`, `acos()`, `atan()`, and `atan2()`
10.5. Exponential Functions: `pow()`, `sqrt()`, `hypot()`, `log()`, `exp()`
10.6. Sign-Related Functions: `abs()`, `sign()`
10.7. Numeric Constants: `e`, `pi`

#### Metadata
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
