### PR TITLE
promise cloneinto clarification

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/sharing_objects_with_page_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/sharing_objects_with_page_scripts/index.md
@@ -194,20 +194,6 @@ Now page scripts see a new property on the window, `messenger`, which has a func
 window.messenger.notify("Message from the page script!");
 ```
 
-In the special case of a Promise, which is not supported by [structured clone algorithm](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm), the desired result can be achieved using `window.Promise` instead of `Promise`, and then cloning the resolution value with `cloneInto` like this:
-
-```js
-let promise = new window.Promise(resolve => {
-  // if just a primitive, then cloneInto is not needed:
-  // resolve("string is a primitive");
-
-  // if not a primitive, such as an object, then the value must be cloned
-  let result = { exampleKey: "exampleValue" };
-  resolve(cloneInto(result, window));
-});
-// now promise can be passed to the web page.
-```
-
 ### Constructors from the page context
 
 On the xrayed window object pristine constructors for some built-in JavaScript objects such as `Object`, `Function` or `Proxy` and various DOM classes are available. `XMLHttpRequest` does not behave in this way, see the [XHR and fetch](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts#xhr_and_fetch) section for details. They will create instances belonging to the page global's object hierarchy and then return an xray wrapper.
@@ -274,4 +260,20 @@ window.eval(`
 `);
 
 document.dispatchEvent(ev); // true, undefined, "unwrapped", "propC"
+```
+
+### Promise cloning
+
+A Promise cannot be cloned directly using `cloneInto`, as Promise is not supported by the [structured clone algorithm](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm). However, the desired result can be achieved using `window.Promise` instead of `Promise`, and then cloning the resolution value like this:
+
+```js
+let promise = new window.Promise(resolve => {
+  // if just a primitive, then cloneInto is not needed:
+  // resolve("string is a primitive");
+
+  // if not a primitive, such as an object, then the value must be cloned
+  let result = { exampleKey: "exampleValue" };
+  resolve(cloneInto(result, window));
+});
+// now the promise can be passed to the web page
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/sharing_objects_with_page_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/sharing_objects_with_page_scripts/index.md
@@ -188,13 +188,13 @@ window.wrappedJSObject.messenger = cloneInto(
   {cloneFunctions: true});
 ```
 
-Now page scripts sees a new property on the window, `messenger`, which has a function `notify()`:
+Now page scripts see a new property on the window, `messenger`, which has a function `notify()`:
 
 ```js
 window.messenger.notify("Message from the page script!");
 ```
 
-In the special case of a Promise, which is not supported by [structured clone algorithm](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm), the desired result can be achieved by using `window.Promise` instead of `Promise`, and then cloning the resolution value with `cloneInto` like this:
+In the special case of a Promise, which is not supported by [structured clone algorithm](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm), the desired result can be achieved using `window.Promise` instead of `Promise`, and then cloning the resolution value with `cloneInto` like this:
 
 ```js
 let promise = new window.Promise(resolve => {

--- a/files/en-us/mozilla/add-ons/webextensions/sharing_objects_with_page_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/sharing_objects_with_page_scripts/index.md
@@ -36,7 +36,7 @@ In Firefox, part of the isolation between content scripts and page scripts is im
 
 The purpose of this feature is to make it harder for the less-privileged script to confuse the more-privileged script by redefining the native properties of objects.
 
-So for example, when a content script accesses the page's [window](/en-US/docs/Web/API/Window), it won't see any properties the page script added to the window, and if the page script has redefined any existing properties of the window, the content script will see the original version.
+So, for example, when a content script accesses the page's [window](/en-US/docs/Web/API/Window), it won't see any properties the page script added to the window, and if the page script has redefined any existing properties of the window, the content script will see the original version.
 
 ## Accessing page script objects from content scripts
 
@@ -188,10 +188,24 @@ window.wrappedJSObject.messenger = cloneInto(
   {cloneFunctions: true});
 ```
 
-Now page scripts will see a new property on the window, `messenger`, which has a function `notify()`:
+Now page scripts sees a new property on the window, `messenger`, which has a function `notify()`:
 
 ```js
 window.messenger.notify("Message from the page script!");
+```
+
+In the special case of a Promise, which is not supported by [structured clone algorithm](/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm), the desired result can be achieved by using `window.Promise` instead of `Promise`, and then cloning the resolution value with `cloneInto` like this:
+
+```js
+let promise = new window.Promise(resolve => {
+  // if just a primitive, then cloneInto is not needed:
+  // resolve("string is a primitive");
+
+  // if not a primitive, such as an object, then the value must be cloned
+  let result = { exampleKey: "exampleValue" };
+  resolve(cloneInto(result, window));
+});
+// now promise can be passed to the web page.
 ```
 
 ### Constructors from the page context


### PR DESCRIPTION
#### Summary
Add the documentation suggested by @Rob--W in [cloneInto example code fails: Error: Encountered unsupported value type writing stack-scoped structured clone
#15059](https://github.com/mdn/content/issues/15059#issuecomment-1198017259) to offer an option for cloning promises.

#### Related issues
Fixes [#15059](https://github.com/mdn/content/issues/15059)

#### Metadata

This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error