### PR TITLE
Fix generator `getPage` example

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/generator/next/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/generator/next/index.md
@@ -73,7 +73,7 @@ In this example, `getPage` takes a list and "paginates" it into chunks of size `
 ```js
 function* getPage(list, pageSize = 1) {
   for (let index = 0; index < list.length; index += pageSize) {
-    yield list.slice(index, pageSize);
+    yield list.slice(index, index + pageSize);
   }
 }
 


### PR DESCRIPTION
#### Summary

There's an error in the `getPage` example in the use of `slice`. I independently made the same mistake today and was pointed at this page.

#### Motivation

Having examples match their supposed output is For Great Good. :smile_cat: 

#### Supporting details

Here's a fun detail: the `slice` API gets people all the time.

#### Related issues

N/A

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
