### PR TITLE
Event (Web API) mark deprecated Event interfaces

### DIFF
--- a/files/en-us/web/api/event/index.md
+++ b/files/en-us/web/api/event/index.md
@@ -28,7 +28,7 @@ Below is a list of interfaces which are based on the main `Event` interface, wit
 Note that all event interfaces have names which end in "Event".
 
 - {{domxref("AnimationEvent")}}
-- {{domxref("AudioProcessingEvent")}}
+- {{domxref("AudioProcessingEvent")}} {{Deprecated_Inline}}
 - {{domxref("BeforeUnloadEvent")}}
 - {{domxref("BlobEvent")}}
 - {{domxref("ClipboardEvent")}}
@@ -37,7 +37,7 @@ Note that all event interfaces have names which end in "Event".
 - {{domxref("CustomEvent")}}
 - {{domxref("DeviceMotionEvent")}}
 - {{domxref("DeviceOrientationEvent")}}
-- {{domxref("DeviceProximityEvent")}}
+- {{domxref("DeviceProximityEvent")}} {{Deprecated_Inline}}
 - {{domxref("DragEvent")}}
 - {{domxref("ErrorEvent")}}
 - {{domxref("FetchEvent")}}
@@ -49,10 +49,10 @@ Note that all event interfaces have names which end in "Event".
 - {{domxref("IDBVersionChangeEvent")}}
 - {{domxref("InputEvent")}}
 - {{domxref("KeyboardEvent")}}
-- {{domxref("MediaStreamEvent")}}
+- {{domxref("MediaStreamEvent")}} {{Deprecated_Inline}}
 - {{domxref("MessageEvent")}}
 - {{domxref("MouseEvent")}}
-- {{domxref("MutationEvent")}}
+- {{domxref("MutationEvent")}} {{Deprecated_Inline}}
 - {{domxref("OfflineAudioCompletionEvent")}}
 - {{domxref("PageTransitionEvent")}}
 - {{domxref("PaymentRequestUpdateEvent")}}
@@ -63,13 +63,13 @@ Note that all event interfaces have names which end in "Event".
 - {{domxref("RTCPeerConnectionIceEvent")}}
 - {{domxref("StorageEvent")}}
 - {{domxref("SubmitEvent")}}
-- {{domxref("SVGEvent")}}
+- {{domxref("SVGEvent")}} {{Deprecated_Inline}}
 - {{domxref("TimeEvent")}}
 - {{domxref("TouchEvent")}}
 - {{domxref("TrackEvent")}}
 - {{domxref("TransitionEvent")}}
 - {{domxref("UIEvent")}}
-- {{domxref("UserProximityEvent")}}
+- {{domxref("UserProximityEvent")}} {{Deprecated_Inline}}
 - {{domxref("WebGLContextEvent")}}
 - {{domxref("WheelEvent")}}
 


### PR DESCRIPTION
```
Mark with {{Deprecated_Inline}} the 6 deprecated interfaces:

- AudioProcessingEvent
- DeviceProximityEvent
- MediaStreamEvent
- MutationEvent
- SVGEvent
- UserProximityEvent
```

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Mark with {{Deprecated_Inline}} the 6 deprecated Event interfaces

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
While reading this, I clicked in one of the deprecated interfaces, and i was like, ey the index could mark those that are deprecated (before clicking) the same way it's done in other docs

This PR…
-->

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
- [X] Improves slightly a document 

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
