### PR TITLE
markdownlint: 2 spaces per tab

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -7,6 +7,9 @@
   "MD007": {
     "indent": 2
   },
+  "MD010": {
+    "spaces_per_tab": 2
+  },
   "MD013": false,
   "MD014": false,
   "MD023": false,


### PR DESCRIPTION
Resolves https://github.com/mdn/content/pull/19041#pullrequestreview-1058118126