### PR TITLE
Set playsInline on video in “Animating textures in WebGL”

### DIFF
--- a/files/en-us/web/api/webgl_api/tutorial/animating_textures_in_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/animating_textures_in_webgl/index.md
@@ -31,6 +31,7 @@ function setupVideo(url) {
   video.autoplay = true;
   video.muted = true;
   video.loop = true;
+  video.playsInline = true;
 
   // Waiting for these 2 events ensures
   // there is data in the video


### PR DESCRIPTION
Fixes https://github.com/mdn/content/issues/13775

This is an attempt at making the live sample work in iOS Safari.