### PR TITLE
Drops the commmon "MDN Web Docs" in page titles

### DIFF
--- a/files/en-us/mdn/community/contributing/index.md
+++ b/files/en-us/mdn/community/contributing/index.md
@@ -9,7 +9,7 @@ tags:
 ---
 {{MDNSidebar}}
 
-- [Getting started](/en-US/docs/MDN/Community/Contributing/Getting_Started)
+- [Getting started](/en-US/docs/MDN/Community/Contributing/Getting_started)
 - [Our repositories](/en-US/docs/MDN/Community/Contributing/Our_repositories)
 - [Translated content](/en-US/docs/MDN/Community/Contributing/Translated_content)
 - [Security vulnerability response](/en-US/docs/MDN/Community/Contributing/Security_vulnerability_response)

--- a/files/en-us/mdn/community/contributing/index.md
+++ b/files/en-us/mdn/community/contributing/index.md
@@ -9,7 +9,7 @@ tags:
 ---
 {{MDNSidebar}}
 
-- [Getting started](/en-US/docs/MDN/Community/Contributing/Getting-Started)
+- [Getting started](/en-US/docs/MDN/Community/Contributing/Getting_Started)
 - [Our repositories](/en-US/docs/MDN/Community/Contributing/Our_repositories)
 - [Translated content](/en-US/docs/MDN/Community/Contributing/Translated_content)
 - [Security vulnerability response](/en-US/docs/MDN/Community/Contributing/Security_vulnerability_response)

--- a/files/en-us/mdn/community/discussions/index.md
+++ b/files/en-us/mdn/community/discussions/index.md
@@ -1,5 +1,5 @@
 ---
-title: MDN Web Docs Community Discussions
+title: Community Discussions
 slug: MDN/Community/Discussions
 page-type: mdn-community-guide
 tags:
@@ -11,7 +11,7 @@ tags:
 
 On MDN Web Docs, we encourage our community to start and/or engage in discussions around topics related to the overall project. Discussions are categorized by different topic areas. We ask that you keep each discussion focused on the topic at hand instead of covering multiple topics in one discussion.
 
-_NOTE:_ mdn-community/discussions is not the place to report problems. For any problems you encounter on MDN Web Docs, it is best to raise issues against the [relevant project](https://github.com/mdn/). If you're ever in doubt about whether to open an issue or a discussion, consider the following guidelines:
+_NOTE:_ `mdn-community/discussions` is not the place to report problems. For any problems you encounter on MDN Web Docs, it is best to raise issues against the [relevant project](https://github.com/mdn/). If you're ever in doubt about whether to open an issue or a discussion, consider the following guidelines:
 
 - Issues are for reporting a bug or a work item with clearly defined and actionable tasks and outcomes.
 - Discussions are the right place if the issue needs a discussion to agree upon a course of action or define an actionable piece of work.

--- a/files/en-us/mdn/community/index.md
+++ b/files/en-us/mdn/community/index.md
@@ -1,5 +1,5 @@
 ---
-title: MDN Web Docs Community Guidelines
+title: Community Guidelines
 slug: MDN/Community
 page-type: mdn-community-guide
 tags:
@@ -23,7 +23,7 @@ tags:
 - [Help fix known platform issues](https://github.com/mdn/yari/issues)
 - [Help us keep browser compatibility data up to date.](https://github.com/mdn/browser-compat-data)
 
-## Quick Links
+## Quick links
 
 - [Our repositories overview](contributing/our-repositories/)
 - [Users and teams](users-teams/)

--- a/files/en-us/mdn/community/issues/content_suggestions_feature_proposals/index.md
+++ b/files/en-us/mdn/community/issues/content_suggestions_feature_proposals/index.md
@@ -1,5 +1,5 @@
 ---
-title: Proposing new content or features for MDN Web Docs
+title: Proposing new content or features
 slug: MDN/Community/Issues/Content_suggestions_feature_proposals
 page-type: mdn-community-guide
 tags:

--- a/files/en-us/mdn/community/issues/index.md
+++ b/files/en-us/mdn/community/issues/index.md
@@ -1,5 +1,5 @@
 ---
-title: Using GitHub Issues on MDN Web Docs
+title: Issue guidelines
 slug: MDN/Community/Issues
 page-type: mdn-community-guide
 tags:
@@ -11,7 +11,7 @@ tags:
 
 [Issues](https://docs.github.com/en/github/managing-your-work-on-github/about-issues) are used to track all bugs and work that has a clear actionable outcome. If you have found a bug with either our content or the platform, please search current open issues against the [relevant repository](/en_US/docs/MDN/Community/Contributing/Our_repositories/) to ensure someone has not already reported the issue. If the issue is new, please file an issue using the relevant template available in the repository.
 
-> NOTE: If an issue has a triage label, we haven't reviewed it yet, and you shouldn't begin work on it.
+> **Note:** If an issue has a triage label, we haven't reviewed it yet, and you shouldn't begin work on it.
 
 If the issue you are filing is not to report a bug, please ensure that it lists actionable tasks or a clear outcome. For example:
 

--- a/files/en-us/mdn/community/learn_forum/index.md
+++ b/files/en-us/mdn/community/learn_forum/index.md
@@ -1,5 +1,5 @@
 ---
-title: MDN Web Docs Learn Forum
+title: Learn forum
 slug: MDN/Community/Learn_forum
 page-type: mdn-community-guide
 tags:
@@ -11,20 +11,20 @@ tags:
 
 Our [Learn web development](/en-US/docs/Learn) pages get over a million views per month, and have [active forums](https://discourse.mozilla.org/c/mdn/learn/250) where people go to ask for general help, or request that their assessments be marked. We'd love some help with answering posts, and growing our learning community.
 
-## What do we need help with?
+## What we need help with
 
 In the [MDN learning forum](https://discourse.mozilla.org/c/mdn/learn/250), there are two main types of post that we'd like you to help out with answering:
 
 1. General questions about web development.
 2. Specific questions asking for help or assessment with the skill tests and assessments that appear on the Learn web development section on MDN.
 
-## How can you benefit?
+## How you can benefit
 
 - Helping people with their code problems is a great way to learn more about web technologies — as you research a solution and write an answer to someone's question, you will gain a deeper understanding of the subject, and improve your skills.
 - As you get more involved in the MDN community, you'll get to know Mozilla staff and other community members, giving you a valuable network of contacts for getting help with your own issues and increasing your visibility.
 - Helping to answer coding questions is largely its own reward, but it will also demonstrate your expertise in web technologies and possibly even help you with your course, or job opportunities.
 
-## What skills do you need?
+## What skills you need
 
 - You should be knowledgeable in web technologies such as HTML, CSS, and JavaScript. Ideally you should also be good at explaining technical topics, and enjoy helping beginners learn to code.
 - The language of the forum is English — you should have a reasonable proficiency with the English language, but it really doesn't need to be perfect. We have people from all over the world visiting our forums, and we want everyone who visits us to feel as comfortable and included as possible.
@@ -34,7 +34,7 @@ In the [MDN learning forum](https://discourse.mozilla.org/c/mdn/learn/250), ther
 1. Sign up for [Mozilla Discourse](https://discourse.mozilla.org/), if you haven't already.
 2. Have a look at [Learn web development](/en-US/docs/Learn) section and gain a basic level of familiarity with what's there, if you haven't already (see the [Structure of the MDN Learning Area](#structure_of_the_mdn_learning_area) section below for help).
 
-### Once you are set up
+After you are set up:
 
 1. Have a look at the [learning forum](https://discourse.mozilla.org/c/mdn/learn/250) and see if there are any posts that have no replies — this is the best place to start.
 

--- a/files/en-us/mdn/community/mdn_content/index.md
+++ b/files/en-us/mdn/community/mdn_content/index.md
@@ -10,11 +10,11 @@ tags:
 ---
 {{MDNSidebar}}
 
-Problems with MDN docs are reported as [content repo issues](https://github.com/mdn/content/issues). This article helps you find the _best_ issues to work on, based on your expertise and how much time you have available, and outlines the main steps to fixing them.
+Problems with MDN Web Docs are reported as [content repo issues](https://github.com/mdn/content/issues). This article helps you find the _best_ issues to work on, based on your expertise and how much time you have available, and outlines the main steps to fixing them.
 
 > **Note:** We get a lot of content bugs — any help you can give in fixing them is very much appreciated!
 
-## What do we need help with?
+## What we need help with
 
 To help you choose what content issues to work on, we've sorted them using GitHub labels.
 
@@ -28,13 +28,13 @@ The labels below help you find tasks based on how much time you have available.
 
 If you'd prefer to browse your tasks and choose by technology category instead, you can also find content type labels on [issues in the content repository](https://github.com/mdn/content/issues).
 
-## How can you benefit?
+## How you can benefit
 
 - Fixing MDN content bugs is a great way to learn more about web technologies — as you research a problem and create the required content, you will gain a deeper understanding of the subject, and improve your skills.
 - As you get more involved in the MDN community, you'll get to know Mozilla staff and other community members, giving you a valuable network of contacts for getting help with your own issues and increasing your visibility.
 - Helping to fix problems is largely its own reward, but it will also serve as a record of your open source contributions, demonstrating your expertise in web technologies and possibly even helping you with your course, or job opportunities.
 
-## What skills do you need?
+## What skills you need
 
 - You need to be knowledgeable in the topic areas that you choose to help with (e.g. JavaScript, CSS).
 - Most of the examples and pages that you will help with are written in English, so you should have a reasonable understanding of the English language. But don't worry if your English is not perfect! Our team is more than happy to help clean up any writing.
@@ -44,7 +44,7 @@ If you'd prefer to browse your tasks and choose by technology category instead, 
 1. First of all, sign up for a [GitHub account](https://github.com/join), if you don't already have one — you'll need this to communicate on the GitHub issues.
 2. Next, choose one or more topic areas you'd like to help with. Use the list above to get more information to help you make your selection. If you are not sure what a good choice would be, ask for help in the [MDN Web Docs chat room](https://chat.mozilla.org/#/room/#mdn:mozilla.org) on [Matrix](https://wiki.mozilla.org/Matrix).
 
-### Once you are set up
+After you are set up, you can:
 
 1. Choose an issue to work on that interests you, and ask us to assign it to you with a comment on the issue.
 2. If you need any help when you are working on it, feel free to contact us in the [MDN Web Docs chat room](https://chat.mozilla.org/#/room/#mdn:mozilla.org) on [Matrix](https://wiki.mozilla.org/Matrix).

--- a/files/en-us/mdn/community/open_source_etiquette/index.md
+++ b/files/en-us/mdn/community/open_source_etiquette/index.md
@@ -1,5 +1,5 @@
 ---
-title: Open Source Etiquette
+title: Open source etiquette
 slug: MDN/Community/Open_source_etiquette
 page-type: mdn-community-guide
 tags:

--- a/files/en-us/mdn/community/pull_requests/index.md
+++ b/files/en-us/mdn/community/pull_requests/index.md
@@ -1,5 +1,5 @@
 ---
-title: MDN Web Docs Pull Request Guidelines
+title: Pull request guidelines
 slug: MDN/Community/Pull_requests
 page-type: mdn-community-guide
 tags:
@@ -130,4 +130,4 @@ Don’t:
 
 ## Pull requests we accept
 
-## `idle` pull requests
+## Idle pull requests

--- a/files/en-us/mdn/community/users_teams/index.md
+++ b/files/en-us/mdn/community/users_teams/index.md
@@ -1,5 +1,5 @@
 ---
-title: MDN Web Docs Users and Teams
+title: Users and teams
 slug: MDN/Community/Users_teams
 page-type: mdn-community-guide
 tags:

--- a/files/en-us/mdn/index.md
+++ b/files/en-us/mdn/index.md
@@ -1,5 +1,5 @@
 ---
-title: The MDN project
+title: The MDN Web Docs project
 slug: MDN
 tags:
   - Landing

--- a/files/en-us/mdn/writing_guidelines/attrib_copyright_license/index.md
+++ b/files/en-us/mdn/writing_guidelines/attrib_copyright_license/index.md
@@ -1,5 +1,5 @@
 ---
-title: Attributions and copyright licensing
+title: Attribution and copyright licensing
 slug: MDN/Writing_guidelines/Attrib_copyright_license
 page-type: mdn-writing-guide
 tags:

--- a/files/en-us/mdn/writing_guidelines/howto/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/index.md
@@ -1,5 +1,5 @@
 ---
-title: MDN Web Docs how-to guides
+title: How-to guides
 slug: MDN/Writing_guidelines/Howto
 page-type: mdn-writing-guide
 tags:

--- a/files/en-us/mdn/writing_guidelines/index.md
+++ b/files/en-us/mdn/writing_guidelines/index.md
@@ -1,5 +1,5 @@
 ---
-title: MDN Web Docs writing guidelines
+title: Writing guidelines
 slug: MDN/Writing_guidelines
 page-type: mdn-writing-guide
 tags:

--- a/files/en-us/mdn/writing_guidelines/page_structures/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/index.md
@@ -1,5 +1,5 @@
 ---
-title: Document structures
+title: Page structures
 slug: MDN/Writing_guidelines/Page_structures
 tags:
   - Landing

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/index.md
@@ -1,5 +1,5 @@
 ---
-title: MDN Web Docs writing style guide
+title: Writing style guide
 slug: MDN/Writing_guidelines/Writing_style_guide
 page-type: mdn-writing-guide
 tags:


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Since we're calling the parent project "MDN Web Docs", dropping this repeated phrase in page titles. This will also help keep the breadcrumb short, minus the common phrase

There are a few other changes in titles to keep sentence casing.