### PR TITLE
Add `SecurityError` Exception for `captureStream()`

### DIFF
--- a/files/en-us/web/api/htmlcanvaselement/capturestream/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/capturestream/index.md
@@ -47,6 +47,10 @@ A reference to a {{domxref("MediaStream")}} object, which has a single
 - `NotSupportedError` {{domxref("DOMException")}}
   - : Thrown if the value of `frameRate` is negative.
 
+- `SecurityError` {{domxref("DOMException")}}
+  - : The canvas's bitmap is not origin clean;
+    at least some of its contents have or may have been loaded from a site other than the one from which the document itself was loaded.
+
 ## Example
 
 ```js


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
`HTMLCanvasElement.captureStream()` will throw a `SecurityError` when invoked on a tainted canvas.

#### Motivation
Listing another exception that `captureStream()` can throw.

#### Supporting details
> Content from a canvas that is not [origin-clean](https://html.spec.whatwg.org/multipage/canvas.html#concept-canvas-origin-clean) MUST NOT be captured. This method throws a [SecurityError](https://webidl.spec.whatwg.org/#securityerror) exception if the canvas is not [origin-clean](https://www.w3.org/TR/mediacapture-fromelement/#dfn-origin-clean).

[From the `captureStream()` spec](https://www.w3.org/TR/mediacapture-fromelement/#dom-htmlcanvaselement-capturestream)

#### Related issues
Follow-up on https://github.com/mdn/content/pull/19121#issuecomment-1204760312

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
