### PR TITLE
Clarify that URLs in the HTTP Link header must be encoded

### DIFF
--- a/files/en-us/web/http/headers/link/index.md
+++ b/files/en-us/web/http/headers/link/index.md
@@ -23,7 +23,7 @@ Link: <uri-reference>; param1=value1; param2="value2"
 ```
 
 - `<uri-reference>`
-  - : The URI reference, must be enclosed between `<` and `>` and encoded.
+  - : The URI reference, must be enclosed between `<` and `>` and [percent encoded](/en-US/docs/Glossary/percent-encoding).
 
 ### Parameters
 

--- a/files/en-us/web/http/headers/link/index.md
+++ b/files/en-us/web/http/headers/link/index.md
@@ -23,7 +23,7 @@ Link: <uri-reference>; param1=value1; param2="value2"
 ```
 
 - `<uri-reference>`
-  - : The URI reference, must be enclosed between `<` and `>`.
+  - : The URI reference, must be enclosed between `<` and `>` and encoded.
 
 ### Parameters
 
@@ -39,6 +39,18 @@ Link: <https://example.com>; rel="preconnect"
 
 ```http example-bad
 Link: https://bad.example; rel="preconnect"
+```
+
+### Encoding URLs
+
+The URI (absolute or relative) must encode char codes greater than 255:
+
+```http example-good
+Link: <https://example.com/%E8%8B%97%E6%9D%A1>; rel="preconnect"
+```
+
+```http example-bad
+Link: <https://example.com/苗条>; rel="preconnect"
 ```
 
 ### Specifying multiple links


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Clarify that URLs in the HTTP Link header must be encoded

#### Motivation
HTTP headers cannot hold characters that are frequently contained in URLs. Clarify the handling of these URLs - especially since the URLs do not need to be encoded when embedded within the page in a `link` element

#### Supporting details
https://github.com/nodejs/undici/issues/1590#issuecomment-1204546225

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
