### PR TITLE
FF104 Release note: SVGStyleElement.disabled

### DIFF
--- a/files/en-us/mozilla/firefox/releases/104/index.md
+++ b/files/en-us/mozilla/firefox/releases/104/index.md
@@ -49,6 +49,12 @@ This article provides information about the changes in Firefox 104 that will aff
 
 #### Media, WebRTC, and Web Audio
 
+#### SVG
+
+- The [`SVGStyleElement.disabled`](/en-US/docs/Web/API/SVGStyleElement/disabled) property can now be used to disable or enable an SVG style element, or to check its disabled state.
+  This mirrors the behavior of [`HTMLStyleElement.disabled`](/en-US/docs/Web/API/HTMLStyleElement/disabled).
+  (See {{bug(1712623)}} for more details.)
+
 #### Removals
 
 ### WebAssembly


### PR DESCRIPTION
FF104 added support for the `SVGStyleElement.disabled` property in https://bugzilla.mozilla.org/show_bug.cgi?id=1712623

This adds a release note.

Other docs work may be tracked in #18775