### PR TITLE
Update: remove note. add alt.

### DIFF
--- a/files/en-us/web/web_components/using_shadow_dom/index.md
+++ b/files/en-us/web/web_components/using_shadow_dom/index.md
@@ -12,8 +12,6 @@ tags:
 
 An important aspect of web components is encapsulation — being able to keep the markup structure, style, and behavior hidden and separate from other code on the page so that different parts do not clash, and the code can be kept nice and clean. The Shadow DOM API is a key part of this, providing a way to attach a hidden separated DOM to an element. This article covers the basics of using the Shadow DOM.
 
-> **Note:** Shadow DOM is supported by default in Firefox (63 and onwards), Chrome, Opera, and Safari. The new Chromium-based Edge (79 and onwards) supports it too; the old Edge didn't.
-
 ## High-level view
 
 This article assumes you are already familiar with the concept of the [DOM (Document Object Model)](/en-US/docs/Web/API/Document_Object_Model/Introduction) — a tree-like structure of connected nodes that represents the different elements and strings of text appearing in a markup document (usually an HTML document in the case of web documents). As an example, consider the following HTML fragment:
@@ -36,7 +34,7 @@ This article assumes you are already familiar with the concept of the [DOM (Docu
 
 This fragment produces the following DOM structure:
 
-![](dom-screenshot.png)
+![DOM Tree with elements and text nodes, content of non empty text nodes, inluding element's attribute names and contents ](dom-screenshot.png)
 
 _Shadow_ DOM allows hidden DOM trees to be attached to elements in the regular DOM tree — this shadow DOM tree starts with a shadow root, underneath which you can attach any element, in the same way as the normal DOM.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Added alt attribute for an image that was missing it.
Removed note that shadow DOM is supported in FF63+ but not in Edge as it's supported in most modern browsers for a long time and doesn't need to hilite this anymore.
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
