### PR TITLE
SVGStyleElement docs

### DIFF
--- a/files/en-us/web/api/svgstyleelement/disabled/index.md
+++ b/files/en-us/web/api/svgstyleelement/disabled/index.md
@@ -66,8 +66,7 @@ const button = document.querySelector('button');
 
 button.addEventListener('click', () => {
    style.disabled = !style.disabled;
-   const buttonText = style.disabled ? 'Enable' : 'Disable';
-   button.innerText = buttonText;
+   button.textContent = style.disabled ? 'Enable' : 'Disable';
    });
 ```
 
@@ -129,8 +128,7 @@ const button = document.querySelector('button');
 
 button.addEventListener('click', () => {
    style.disabled = !style.disabled;
-   const buttonText = style.disabled ? 'Enable' : 'Disable';
-   button.innerText = buttonText;
+   button.textContent = style.disabled ? 'Enable' : 'Disable';
    });
 ```
 

--- a/files/en-us/web/api/svgstyleelement/disabled/index.md
+++ b/files/en-us/web/api/svgstyleelement/disabled/index.md
@@ -54,7 +54,7 @@ The code below gets the `style` element (an `SVGStyleElement`) using its id, and
 The style already exists because it is defined in the SVG, so this should succeed.
 
 ```js
-const svg = document.getElementsByTagName("svg")[0];
+const svg = document.querySelector("svg");
 const style = svg.getElementById("circle_style_id")
 style.disabled = true;  
 ```
@@ -103,7 +103,7 @@ This is done by first creating a style element in the SVG namespace using [`Docu
 > **Note:** You must use [`Document.createElementNS()`](/en-US/docs/Web/API/Document/createElementNS) and not [`Document.createElement()`](/en-US/docs/Web/API/Document/createElement) to create the style, or by default you'll create the equivalent HTML style element.
 
 ```js
-const svg = document.getElementsByTagName("svg")[0];
+const svg = document.querySelector("svg");
 
 // Create the `style` element in the SVG namespace
 const style = document.createElementNS('http://www.w3.org/2000/svg', 'style');

--- a/files/en-us/web/api/svgstyleelement/disabled/index.md
+++ b/files/en-us/web/api/svgstyleelement/disabled/index.md
@@ -51,7 +51,7 @@ The HTML contains an SVG definition for a [`<circle>`](/en-US/docs/Web/SVG/Eleme
 #### JavaScript
 
 The code below gets the `style` element (an `SVGStyleElement`) using its id, and then sets it as disabled.
-As the style already exists, as it is defined in the SVG, this should succeed.
+The style already exists because it is defined in the SVG, so this should succeed.
 
 ```js
 const svg = document.getElementsByTagName("svg")[0];

--- a/files/en-us/web/api/svgstyleelement/index.md
+++ b/files/en-us/web/api/svgstyleelement/index.md
@@ -20,7 +20,7 @@ The **`SVGStyleElement`** interface corresponds to the SVG {{SVGElement("style")
 
 _This interface also inherits properties from its parent interface, {{domxref("SVGElement")}}._
 
-- {{domxref("SVGStyleElement.type")}}
+- {{domxref("SVGStyleElement.type")}} {{deprecated_inline}}
 
   - : A string corresponding to the {{SVGAttr("type")}} attribute of the given element.
 
@@ -30,9 +30,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 
 - {{domxref("SVGStyleElement.title")}}
 
-  - : A string corresponding to the {{SVGAttr("title")}} attribute of the given element.
-
-    SVG 1.1 defined that a {{domxref("DOMException")}} is raised with code `NO_MODIFICATION_ALLOWED_ERR` on an attempt to change the value of a read-only attribute. This restriction was removed in SVG 2.
+  - : A string corresponding to the [`title` attribute](/en-US/docs/Web/SVG/Element/style#title) of the given element.
 
 - {{domxref("SVGStyleElement.sheet")}} {{readonlyInline}}
   - : Returns the {{domxref("CSSStyleSheet")}} object associated with the given element, or `null` if there is none.

--- a/files/en-us/web/api/svgstyleelement/index.md
+++ b/files/en-us/web/api/svgstyleelement/index.md
@@ -49,3 +49,7 @@ _This interface doesn't implement any specific methods, but inherits methods fro
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("HTMLStyleElement")}}

--- a/files/en-us/web/api/svgstyleelement/index.md
+++ b/files/en-us/web/api/svgstyleelement/index.md
@@ -30,7 +30,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 
 - {{domxref("SVGStyleElement.title")}}
 
-  - : A string corresponding to the [`title` attribute](/en-US/docs/Web/SVG/Element/style#title) of the given element.
+  - : A string corresponding to the [`title`](/en-US/docs/Web/SVG/Element/style#title) attribute of the given element.
 
 - {{domxref("SVGStyleElement.sheet")}} {{readonlyInline}}
   - : Returns the {{domxref("CSSStyleSheet")}} object associated with the given element, or `null` if there is none.
@@ -46,9 +46,9 @@ _This interface doesn't implement any specific methods, but inherits methods fro
 
 ### Dynamically adding an SVG style element
 
-To dynamically create an SVG style element (`SVGStyleElement`) you need to use [`Document.createElementNS()`](/en-US/docs/Web/API/Document/createElementNS), specifying a `style` element in the SVG namespace.
+To dynamically create an SVG style element ([`SVGStyleElement`](/en-US/docs/Web/API/SVGStyleElement)), you need to use [`Document.createElementNS()`](/en-US/docs/Web/API/Document/createElementNS), specifying a `style` element in the SVG namespace.
 
-> **Note:** [`Document.createElement()`](/en-US/docs/Web/API/Document/createElement) can't be used to create SVG style elements (it returns an `HTMLStyleElement`).
+> **Note:** [`Document.createElement()`](/en-US/docs/Web/API/Document/createElement) can't be used to create SVG style elements (it returns an [`HTMLStyleElement`](/en-US/docs/Web/API/HTMLStyleElement)).
 
 Given the following SVG element:
 
@@ -62,7 +62,7 @@ You can create an SVG style element as shown:
 
 ```js
 // Get the the SVG element object by tag name
-const svg = document.getElementsByTagName("svg")[0];
+const svg = document.querySelector("svg");
 
 // Create the `style` element in the SVG namespace
 const style = document.createElementNS('http://www.w3.org/2000/svg', 'style');
@@ -94,14 +94,14 @@ For example, consider the HTML below that defines an SVG file with a style eleme
 To fetch the first `style` element in the first `svg` element, you might use {{Document.getElementsByTagName()}} as shown below.
 
 ```js
-const svg = document.getElementsByTagName("svg")[0];
-const style = svg.getElementsByTagName("style")[0];
+const svg = document.querySelector("svg");
+const style = svg.querySelector("style");
 ```
 
 Alternatively, you can could use {{Document.getElementById()}}, specifying the tag id:
 
 ```js
-const svg = document.getElementsByTagName("svg")[0];
+const svg = document.querySelector("svg");
 const style = svg.getElementById("circle_style_id")
 
 // or just get the element from document by id
@@ -114,7 +114,7 @@ This example demonstrates how to get and set the properties of a style element, 
 
 #### HTML
 
-The HTML contains an SVG definition for a [`<circle>`](/en-US/docs/Web/SVG/Element/circle) with a [`<style>`](/en-US/docs/Web/SVG/Element/style) element, along with an [HTML `<button>`](/en-US/docs/Web/HTML/Element/button) element that will be used to enable and disable the style, and an [HTML `<textarea>`](/en-US/docs/Web/HTML/Element/button) element for logging the property values.
+The HTML contains an SVG definition for a [`<circle>`](/en-US/docs/Web/SVG/Element/circle) with a [`<style>`](/en-US/docs/Web/SVG/Element/style) element, along with an HTML [`<button>`](/en-US/docs/Web/HTML/Element/button) element that will be used to enable and disable the style, and an HTML [`<textarea>`](/en-US/docs/Web/HTML/Element/button) element for logging the property values.
 
 ```html
 <button>Disable</button>
@@ -139,7 +139,7 @@ We have not set `type` as it is deprecated, or `disabled` because there is no su
 The code below gets the `style` element (an `SVGStyleElement`) using its id.
 
 ```js
-const svg = document.getElementsByTagName("svg")[0];
+const svg = document.querySelector("svg");
 const style = svg.getElementById("circle_style_id");
 ```
 
@@ -152,8 +152,7 @@ const log = document.getElementById("log")
 
 function setLogText() {
   //Log current values of properties
-  log.value = '';
-  log.value += `style.media: ${style.media} (frame width: ${window.innerWidth})\n`; // 'all' by default
+  log.value = `style.media: ${style.media} (frame width: ${window.innerWidth})\n`; // 'all' by default
   log.value += `style.title: ${style.title}\n`; // no default value
   log.value += `style.disabled: ${style.disabled}\n`;  // 'false' by default
   log.value += `style.type: ${style.type}\n`;  // deprecated (do not use)

--- a/files/en-us/web/api/svgstyleelement/index.md
+++ b/files/en-us/web/api/svgstyleelement/index.md
@@ -178,8 +178,7 @@ const button = document.querySelector('button');
 
 button.addEventListener('click', () => {
    style.disabled = !style.disabled;
-   const buttonText = style.disabled ? 'Enable' : 'Disable';
-   button.innerText = buttonText;
+   button.textContent = style.disabled ? 'Enable' : 'Disable';
 
    // Log after button presses
    setLogText();

--- a/files/en-us/web/api/svgstyleelement/index.md
+++ b/files/en-us/web/api/svgstyleelement/index.md
@@ -76,7 +76,7 @@ svg.appendChild(style);
 ### Accessing an existing SVG style
 
 You can access an SVG style element that was defined in HTML (or an SVG file) using the normal HTML methods for getting tags, ids, and so on.
-These include: {{Document.getElementsByTagName()}}, {{Document.getElementById()}}, {{Document.querySelector()}}, {{Document.querySelectorAll()}}, and so on.
+These include: {{domxref("Document.getElementsByTagName()")}}, {{domxref("Document.getElementById()")}}, {{domxref("Document.querySelector()")}}, {{domxref("Document.querySelectorAll()")}}, and so on.
 
 For example, consider the HTML below that defines an SVG file with a style element.
 

--- a/files/en-us/web/api/svgstyleelement/index.md
+++ b/files/en-us/web/api/svgstyleelement/index.md
@@ -28,8 +28,6 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 
   - : A string corresponding to the {{SVGAttr("media")}} attribute of the given element.
 
-    SVG 1.1 defined that a {{domxref("DOMException")}} is raised with code `NO_MODIFICATION_ALLOWED_ERR` on an attempt to change the value of a read-only attribute. This restriction was removed in SVG 2.
-
 - {{domxref("SVGStyleElement.title")}}
 
   - : A string corresponding to the {{SVGAttr("title")}} attribute of the given element.

--- a/files/en-us/web/api/svgstyleelement/index.md
+++ b/files/en-us/web/api/svgstyleelement/index.md
@@ -42,6 +42,158 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 
 _This interface doesn't implement any specific methods, but inherits methods from its parent interface, {{domxref("SVGElement")}}._
 
+## Examples
+
+### Dynamically adding an SVG style element
+
+To dynamically create an SVG style element (`SVGStyleElement`) you need to use [`Document.createElementNS()`](/en-US/docs/Web/API/Document/createElementNS), specifying a `style` element in the SVG namespace.
+
+> **Note:** [`Document.createElement()`](/en-US/docs/Web/API/Document/createElement) can't be used to create SVG style elements (it returns an `HTMLStyleElement`).
+
+Given the following SVG element:
+
+```html
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <circle cx="50" cy="50" r="25" />
+</svg>
+```
+
+You can create an SVG style element as shown:
+
+```js
+// Get the the SVG element object by tag name
+const svg = document.getElementsByTagName("svg")[0];
+
+// Create the `style` element in the SVG namespace
+const style = document.createElementNS('http://www.w3.org/2000/svg', 'style');
+const node = document.createTextNode('circle { fill: red; }');
+style.appendChild(node);
+
+// Append the style element to the SVG element
+svg.appendChild(style);
+```
+
+### Accessing an existing SVG style
+
+You can access an SVG style element that was defined in HTML (or an SVG file) using the normal HTML methods for getting tags, ids, and so on.
+For example, consider the HTML below that defines an SVG file with a style element.
+
+```html
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style id="circle_style_id">
+    circle {
+      fill: gold;
+      stroke: green;
+      stroke-width: 3px;
+    }
+  </style>
+  <circle cx="50" cy="50" r="25" />
+</svg>
+```
+
+To fetch the first `style` element in the first `svg` element, you might use {{Document.getElementsByTagName()}} as shown below.
+
+```js
+const svg = document.getElementsByTagName("svg")[0];
+const style = svg.getElementsByTagName("style")[0];
+```
+
+Alternatively, you can could use {{Document.getElementById()}}, specifying the tag id:
+
+```js
+const svg = document.getElementsByTagName("svg")[0];
+const style = svg.getElementById("circle_style_id")
+
+// or just get the element from document by id
+const style = document.getElementById("circle_style_id")
+```
+
+## Getting and setting properties
+
+This example demonstrates how to get and set the properties of a style element, which in this case was specified in an SVG definition.
+
+#### HTML
+
+The HTML contains an SVG definition for a [`<circle>`](/en-US/docs/Web/SVG/Element/circle) with a [`<style>`](/en-US/docs/Web/SVG/Element/style) element, along with an [HTML `<button>`](/en-US/docs/Web/HTML/Element/button) element that will be used to enable and disable the style, and an [HTML `<textarea>`](/en-US/docs/Web/HTML/Element/button) element for logging the property values.
+
+```html
+<button>Disable</button>
+<textarea id="log" rows="6" cols="90"></textarea>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style id="circle_style_id" media="all and (min-width: 600px)">
+    circle {
+      fill: gold;
+      stroke: green;
+      stroke-width: 3px;
+    }
+  </style>
+  <circle cx="60" cy="60" r="50" />
+</svg>
+```
+
+Note that above we have set the `media` attribute on the `style` tag.
+We have not set `type` as it is deprecated, or `disabled` because there is no such attribute (only the property on the element).
+
+#### JavaScript
+
+The code below gets the `style` element (an `SVGStyleElement`) using its id.
+
+```js
+const svg = document.getElementsByTagName("svg")[0];
+const style = svg.getElementById("circle_style_id");
+```
+
+We then add a function to log the style properties.
+This is called after initialization, whenever the frame resizes, and if the button is pressed.
+
+```js
+// Get logging text area
+const log = document.getElementById("log")
+
+function setLogText() {
+  //Log current values of properties
+  log.value = '';
+  log.value += `style.media: ${style.media} (frame width: ${window.innerWidth})\n`; // 'all' by default
+  log.value += `style.title: ${style.title}\n`; // no default value
+  log.value += `style.disabled: ${style.disabled}\n`;  // 'false' by default
+  log.value += `style.type: ${style.type}\n`;  // deprecated (do not use)
+  log.value += `style.sheet.rules[0].cssText: ${style.sheet.rules[0].cssText}\n`;
+}
+
+// Log initial property values
+setLogText();
+
+// Log when the frame resizes
+addEventListener('resize', () => {
+    setLogText();
+});
+```
+
+Last of all we set an event handler for the button.
+When the button is clicked the {{domxref("SVGStyleElement.disabled","disabled")}} property is toggled.
+This also updates the log and the button text.
+
+```js
+const button = document.querySelector('button');
+
+button.addEventListener('click', () => {
+   style.disabled = !style.disabled;
+   const buttonText = style.disabled ? 'Enable' : 'Disable';
+   button.innerText = buttonText;
+
+   // Log after button presses
+   setLogText();
+   });
+```
+
+#### Result
+
+The result is shown below.
+Toggle the button to enable and disable the SVG style element.
+If the SVG style is not disabled, you can also resize the window width to see the effect of the `media` property on the style when the frame holding the live example is 600px wide.
+
+{{EmbedLiveSample("Getting and setting properties","200","250")}}
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/svgstyleelement/index.md
+++ b/files/en-us/web/api/svgstyleelement/index.md
@@ -76,6 +76,8 @@ svg.appendChild(style);
 ### Accessing an existing SVG style
 
 You can access an SVG style element that was defined in HTML (or an SVG file) using the normal HTML methods for getting tags, ids, and so on.
+These include: {{Document.getElementsByTagName()}}, {{Document.getElementById()}}, {{Document.querySelector()}}, {{Document.querySelectorAll()}}, and so on.
+
 For example, consider the HTML below that defines an SVG file with a style element.
 
 ```html
@@ -91,7 +93,7 @@ For example, consider the HTML below that defines an SVG file with a style eleme
 </svg>
 ```
 
-To fetch the first `style` element in the first `svg` element, you might use {{Document.getElementsByTagName()}} as shown below.
+To fetch the first `style` element in the first `svg` element, you might use {{Document.querySelector()}} as shown below.
 
 ```js
 const svg = document.querySelector("svg");
@@ -102,10 +104,13 @@ Alternatively, you can could use {{Document.getElementById()}}, specifying the t
 
 ```js
 const svg = document.querySelector("svg");
-const style = svg.getElementById("circle_style_id")
+const style = svg.getElementById("circle_style_id");
+```
 
-// or just get the element from document by id
-const style = document.getElementById("circle_style_id")
+Or just get the element from document by id (in this case using `document.querySelector()`):
+
+```js
+const style = document.querySelector("#circle_style_id");
 ```
 
 ## Getting and setting properties

--- a/files/en-us/web/api/svgstyleelement/media/index.md
+++ b/files/en-us/web/api/svgstyleelement/media/index.md
@@ -90,7 +90,7 @@ The button text shows the value of the media attribute originally applied to the
 Shrink the width of the frame to the media query width shown in the button to watch the style being applied.
 Press the button to toggle the value of the `media` property on the style (which will be reflected on the button).
 
-{{EmbedLiveSample("Disabling a style defined in the SVG")}}
+{{EmbedLiveSample("Examples")}}
 
 > **Note:** The `media` property may be set to any string, but will be ignored if the string is not a valid media query.
 

--- a/files/en-us/web/api/svgstyleelement/media/index.md
+++ b/files/en-us/web/api/svgstyleelement/media/index.md
@@ -41,11 +41,6 @@ We also define a `button` that will be used to display the current style and cha
 ```html
 <button></button>
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-  <style id="circle_style_id" media="all and (min-width: 600px)">
-    circle {
-      fill: gold;
-    }
-  </style>
   <circle cx="60" cy="60" r="50" />
 </svg>
 ```
@@ -56,7 +51,11 @@ The code below gets the `style` element (an `SVGStyleElement`) using its id.
 
 ```js
 const svg = document.getElementsByTagName("svg")[0];
-const style = svg.getElementById("circle_style_id")
+// Create the `style` element in the SVG namespace
+const style = document.createElementNS('http://www.w3.org/2000/svg', 'style');
+const node = document.createTextNode('circle { fill: red; }');
+svg.appendChild(style);
+style.appendChild(node);
 ```
 
 We then add a function to set the button text to show the current value of the style's `media` property along with the current window width.

--- a/files/en-us/web/api/svgstyleelement/media/index.md
+++ b/files/en-us/web/api/svgstyleelement/media/index.md
@@ -12,16 +12,16 @@ browser-compat: api.SVGStyleElement.media
 ---
 {{APIRef("SVG")}}
 
-The **`SVGStyleElement.media`** property is a media query string corresponding to the [`media` attribute](/en-US/docs/Web/SVG/Element/style#media) of the given SVG style element.
+The **`SVGStyleElement.media`** property is a media query string corresponding to the [`media`](/en-US/docs/Web/SVG/Element/style#media) attribute of the given SVG style element.
 
 The query must be matched for the style to apply.
 
 ## Value
 
 A string defining a valid media query list with one or more comma separated values.
-For example `"screen, print"`, or `all` (the default).
+For example `"screen, print"`, or `"all"` (the default).
 
-The value is initialized with the string specified in the corresponding style's [`media` attribute](/en-US/docs/Web/SVG/Element/style#media).
+The value is initialized with the string specified in the corresponding style's [`media`](/en-US/docs/Web/SVG/Element/style#media) attribute.
 
 ## Examples
 
@@ -29,8 +29,7 @@ This example demonstrates programmatically getting and setting the media propert
 
 #### HTML
 
-The HTML contains an SVG definition for a [`<circle>`](/en-US/docs/Web/SVG/Element/circle) with a [`<style>`](/en-US/docs/Web/SVG/Element/style) element that is conditional
-on the media query "all and (min-width: 600px)".
+The HTML contains an SVG definition for a [`<circle>`](/en-US/docs/Web/SVG/Element/circle) with a [`<style>`](/en-US/docs/Web/SVG/Element/style) element that is conditional on the media query `"all and (min-width: 600px)"`.
 We also define a `button` that will be used to display the current style and change the style.
 
 ```html
@@ -45,7 +44,7 @@ We also define a `button` that will be used to display the current style and cha
 The code below gets the `style` element (an `SVGStyleElement`) using its id.
 
 ```js
-const svg = document.getElementsByTagName("svg")[0];
+const svg = document.querySelector("svg");
 // Create the `style` element in the SVG namespace
 const style = document.createElementNS('http://www.w3.org/2000/svg', 'style');
 const node = document.createTextNode('circle { fill: red; }');

--- a/files/en-us/web/api/svgstyleelement/media/index.md
+++ b/files/en-us/web/api/svgstyleelement/media/index.md
@@ -1,0 +1,107 @@
+---
+title: SVGStyleElement.media
+slug: Web/API/SVGStyleElement/media
+page-type: web-api-instance-property
+tags:
+  - API
+  - Property
+  - Reference
+  - SVG
+  - SVG DOM
+browser-compat: api.SVGStyleElement.media
+---
+{{APIRef("SVG")}}
+
+The **`SVGStyleElement.media`** property is a media query string corresponding to the [`media` attribute](/en-US/docs/Web/SVG/Element/style#media) of the given SVG style element.
+
+The query must be matched for the style to apply.
+
+## Value
+
+A string defining a valid media query list with one or more comma separated values.
+For example `"screen, print"`, or `all` (the default).
+
+The value is initialized with the string specified in the corresponding style's [`media` attribute](/en-US/docs/Web/SVG/Element/style#media).
+
+## Exceptions
+
+SVG 1.1 defined that a {{domxref("DOMException")}} is raised with code `NO_MODIFICATION_ALLOWED_ERR` on an attempt to change the value of a read-only attribute.
+This restriction was removed in SVG 2.
+
+## Examples
+
+This example demonstrates programmatically getting and setting the media property on a style that was defined in an SVG definition.
+
+#### HTML
+
+The HTML contains an SVG definition for a [`<circle>`](/en-US/docs/Web/SVG/Element/circle) with a [`<style>`](/en-US/docs/Web/SVG/Element/style) element that is conditional
+on the media query "all and (min-width: 600px)".
+We also define a `button` that will be used to display the current style and change the style.
+
+```html
+<button></button>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style id="circle_style_id" media="all and (min-width: 600px)">
+    circle {
+      fill: gold;
+    }
+  </style>
+  <circle cx="60" cy="60" r="50" />
+</svg>
+```
+
+#### JavaScript
+
+The code below gets the `style` element (an `SVGStyleElement`) using its id.
+
+```js
+const svg = document.getElementsByTagName("svg")[0];
+const style = svg.getElementById("circle_style_id")
+```
+
+We then add a function to set the button text to show the current value of the style's `media` property along with the current window width.
+This function is called to set the initial button text, and also when the window is resized or the button is pressed.
+The button event handler also sets the value of the style's `media` property.
+
+```js
+const button = document.querySelector('button');
+
+function setButtonText() {
+  button.innerText = `Media: ${style.media} (Width: ${window.innerWidth})`;
+}
+setButtonText();
+
+
+addEventListener('resize', () => {
+    setButtonText();
+});
+
+
+button.addEventListener('click', () => {
+   style.media = "all and (min-width: 700px)";
+   setButtonText();
+   });
+```
+
+#### Result
+
+The result is shown below.
+The button text shows the value of the media attribute originally applied to the SVG style along with the width of the current frame (since the code is run in a frame).
+Shrink the width of the frame to the media query width shown in the button to watch the style being applied.
+Press the button to toggle the value of the `media` property on the style (which will be reflected on the button).
+
+{{EmbedLiveSample("Disabling a style defined in the SVG")}}
+
+> **Note:** The `media` property may be set to any string, but will be ignored if the string is not a valid media query.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLStyleElement.media")}}

--- a/files/en-us/web/api/svgstyleelement/media/index.md
+++ b/files/en-us/web/api/svgstyleelement/media/index.md
@@ -61,7 +61,7 @@ The button event handler also sets the value of the style's `media` property.
 const button = document.querySelector('button');
 
 function setButtonText() {
-  button.innerText = `Media: ${style.media} (Width: ${window.innerWidth})`;
+  button.textContent = `Media: ${style.media} (Width: ${window.innerWidth})`;
 }
 setButtonText();
 

--- a/files/en-us/web/api/svgstyleelement/media/index.md
+++ b/files/en-us/web/api/svgstyleelement/media/index.md
@@ -23,11 +23,6 @@ For example `"screen, print"`, or `all` (the default).
 
 The value is initialized with the string specified in the corresponding style's [`media` attribute](/en-US/docs/Web/SVG/Element/style#media).
 
-## Exceptions
-
-SVG 1.1 defined that a {{domxref("DOMException")}} is raised with code `NO_MODIFICATION_ALLOWED_ERR` on an attempt to change the value of a read-only attribute.
-This restriction was removed in SVG 2.
-
 ## Examples
 
 This example demonstrates programmatically getting and setting the media property on a style that was defined in an SVG definition.

--- a/files/en-us/web/api/svgstyleelement/sheet/index.md
+++ b/files/en-us/web/api/svgstyleelement/sheet/index.md
@@ -46,18 +46,19 @@ svg.appendChild(style);
 style.appendChild(node);
 ```
 
-We then get the sheet associated with this new element using `style.sheet` and log it to the text area.
+The code below then logs the sheet and CSS rule associated with this new element, using `style.sheet`. 
+To make 
 
 ```js
 // Log the sheet associated with this new element.
 const log = document.getElementById("log")
-log.value = `Style sheet object: ${style.sheet} with rules[0].cssText:\n ${style.sheet.rules[0].cssText}`;
+log.value = `${style.sheet} with rules[0].cssText:\n ${style.sheet.rules[0].cssText}`;
 ```
 
 #### Result
 
 The result is shown below.
-The CSS rule displayed below is the one that is applied to this SVG circle.
+On success, the log shows the `CSSStyleSheet` object applied to the SVG circle.
 
 {{EmbedLiveSample("Examples")}}
 

--- a/files/en-us/web/api/svgstyleelement/sheet/index.md
+++ b/files/en-us/web/api/svgstyleelement/sheet/index.md
@@ -1,0 +1,74 @@
+---
+title: SVGStyleElement.sheet
+slug: Web/API/SVGStyleElement/sheet
+page-type: web-api-instance-property
+tags:
+  - API
+  - Property
+  - Reference
+  - SVG
+  - SVG DOM
+browser-compat: api.SVGStyleElement.sheet
+---
+{{APIRef("SVG")}}
+
+The **`SVGStyleElement.sheet`** read-only property returns the {{domxref("CSSStyleSheet")}} corresponding to the given SVG style element, or `null` if there is none.
+
+## Value
+
+A {{domxref("CSSStyleSheet")}}, or `null` if the element has no associated style sheet.
+
+## Examples
+
+This example demonstrates how to get the CSS sheet associated with an element.
+
+#### HTML
+
+The HTML contains an SVG definition for a [`<circle>`](/en-US/docs/Web/SVG/Element/circle).
+
+```html
+<textarea id="log" rows="3" cols="50"></textarea>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <circle cx="50" cy="50" r="25" />
+</svg>
+```
+
+#### JavaScript
+
+The code below creates a `style` element (an `SVGStyleElement`) and adds it to the SVG.
+
+```js
+const svg = document.getElementsByTagName("svg")[0];
+// Create the `style` element in the SVG namespace
+const style = document.createElementNS('http://www.w3.org/2000/svg', 'style');
+const node = document.createTextNode('circle { fill: red; }');
+svg.appendChild(style);
+style.appendChild(node);
+```
+
+We then get the sheet associated with this new element using `style.sheet` and log it to the text area.
+
+```js
+// Log the sheet associated with this new element.
+const log = document.getElementById("log")
+log.value = `Style sheet object: ${style.sheet} with rules[0].cssText:\n ${style.sheet.rules[0].cssText}`;
+```
+
+#### Result
+
+The result is shown below.
+The CSS rule displayed below is the one that is applied to this SVG circle.
+
+{{EmbedLiveSample("Examples")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("HTMLStyleElement.sheet")}}

--- a/files/en-us/web/api/svgstyleelement/sheet/index.md
+++ b/files/en-us/web/api/svgstyleelement/sheet/index.md
@@ -38,7 +38,7 @@ The HTML contains an SVG definition for a [`<circle>`](/en-US/docs/Web/SVG/Eleme
 The code below creates a `style` element (an `SVGStyleElement`) and adds it to the SVG.
 
 ```js
-const svg = document.getElementsByTagName("svg")[0];
+const svg = document.querySelector("svg");
 // Create the `style` element in the SVG namespace
 const style = document.createElementNS('http://www.w3.org/2000/svg', 'style');
 const node = document.createTextNode('circle { fill: red; }');

--- a/files/en-us/web/api/svgstyleelement/title/index.md
+++ b/files/en-us/web/api/svgstyleelement/title/index.md
@@ -1,0 +1,78 @@
+---
+title: SVGStyleElement.title
+slug: Web/API/SVGStyleElement/title
+page-type: web-api-instance-property
+tags:
+  - API
+  - Property
+  - Reference
+  - SVG
+  - SVG DOM
+browser-compat: api.SVGStyleElement.title
+---
+{{APIRef("SVG")}}
+
+The **`SVGStyleElement.title`** property is is a string corresponding to the [`title` attribute](/en-US/docs/Web/SVG/Element/style#title) of the given SVG style element.
+It may be used to select between [alternate style sheets](/en-US/docs/Web/CSS/Alternative_style_sheets).
+
+## Value
+
+A string with any value.
+
+The value is initialized with the string specified in the corresponding style's [`title` attribute](/en-US/docs/Web/SVG/Element/style#title).
+
+## Examples
+
+This example demonstrates programmatically getting and setting the `title` property on a style that was defined in an SVG definition.
+
+#### HTML
+
+The HTML contains an SVG definition for a [`<circle>`](/en-US/docs/Web/SVG/Element/circle) with a [`<style>`](/en-US/docs/Web/SVG/Element/style) element that has a `title`.
+We also define a text area for logging the current title.
+
+```html
+<textarea id="log" rows="3" cols="50"></textarea>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <style title="gold fill style">
+    circle {
+      fill: gold;
+    }
+  </style>
+  <circle cx="50" cy="40" r="25" />
+</svg>
+```
+
+#### JavaScript
+
+The code below gets the `style` element (an `SVGStyleElement`) using its tag name, logs the title, then changes and logs the title again.
+
+```js
+const log = document.getElementById("log")
+
+const svg = document.getElementsByTagName("svg")[0];
+const style = svg.getElementsByTagName("style")[0];
+log.value = `Initial title: ${style.title}\n`;
+style.title = "Altered Title";
+log.value += `New title: ${style.title}`;
+```
+
+#### Result
+
+The text in the log below shows that the title initially reflects the matching attribute on the `<style>` element, but can then be changed to another value.
+
+{{EmbedLiveSample("Examples")}}
+
+Note that alternate styles are not applied by default; they must be selected as the preferred stylesheet by the user.
+To apply the alternate stylesheets on FireFox:
+
+1. Open the Menu Bar (Press `F10` or tap the `Alt` key)
+2. Open **View > Page Style** submenu
+3. Select the stylesheets based on their names.
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}

--- a/files/en-us/web/api/svgstyleelement/title/index.md
+++ b/files/en-us/web/api/svgstyleelement/title/index.md
@@ -12,14 +12,14 @@ browser-compat: api.SVGStyleElement.title
 ---
 {{APIRef("SVG")}}
 
-The **`SVGStyleElement.title`** property is is a string corresponding to the [`title` attribute](/en-US/docs/Web/SVG/Element/style#title) of the given SVG style element.
+The **`SVGStyleElement.title`** property is is a string corresponding to the [`title`](/en-US/docs/Web/SVG/Element/style#title) attribute of the given SVG style element.
 It may be used to select between [alternate style sheets](/en-US/docs/Web/CSS/Alternative_style_sheets).
 
 ## Value
 
 A string with any value.
 
-The value is initialized with the string specified in the corresponding style's [`title` attribute](/en-US/docs/Web/SVG/Element/style#title).
+The value is initialized with the string specified in the corresponding style's [`title`](/en-US/docs/Web/SVG/Element/style#title) attribute.
 
 ## Examples
 
@@ -49,8 +49,8 @@ The code below gets the `style` element (an `SVGStyleElement`) using its tag nam
 ```js
 const log = document.getElementById("log")
 
-const svg = document.getElementsByTagName("svg")[0];
-const style = svg.getElementsByTagName("style")[0];
+const svg = document.querySelector("svg");
+const style = svg.querySelector("style");
 log.value = `Initial title: ${style.title}\n`;
 style.title = "Altered Title";
 log.value += `New title: ${style.title}`;

--- a/files/en-us/web/api/svgstyleelement/type/index.md
+++ b/files/en-us/web/api/svgstyleelement/type/index.md
@@ -14,7 +14,7 @@ browser-compat: api.SVGStyleElement.type
 {{APIRef("SVG")}} {{Deprecated_Header}}
 
 The **`SVGStyleElement.type`** property returns the type of the current style.
-The value mirrors the [SVG `<style>` element's `type` attribute](/en-US/docs/Web/SVG/Element/style#type).
+The value reflects the associated [SVG `<style>` element's `type` attribute](/en-US/docs/Web/SVG/Element/style#type).
 
 Authors should not use this property or rely on the value.
 

--- a/files/en-us/web/api/svgstyleelement/type/index.md
+++ b/files/en-us/web/api/svgstyleelement/type/index.md
@@ -14,7 +14,7 @@ browser-compat: api.SVGStyleElement.type
 {{APIRef("SVG")}} {{Deprecated_Header}}
 
 The **`SVGStyleElement.type`** property returns the type of the current style.
-The value reflects the associated [SVG `<style>` element's `type` attribute](/en-US/docs/Web/SVG/Element/style#type).
+The value reflects the associated SVG `<style>` element's [`type`](/en-US/docs/Web/SVG/Element/style#type) attribute.
 
 Authors should not use this property or rely on the value.
 

--- a/files/en-us/web/svg/element/style/index.md
+++ b/files/en-us/web/svg/element/style/index.md
@@ -42,10 +42,10 @@ html,body,svg { height:100% }
     *Value type*: [**\<string>**](/en-US/docs/Web/SVG/Content_type#string); *Default value*: `text/css`; *Animatable*: **no**
 - {{SVGAttr("media")}}
   - : This attribute defines to which {{cssxref('@media', 'media')}} the style applies.
-    *Value type*: [**\<string>**](/en-US/docs/Web/SVG/Content_type#string); *Default value*: `all`; *Animatable*: **no**
+    *Value type*: [**`<string>`**](/en-US/docs/Web/SVG/Content_type#string); *Default value*: `all`; *Animatable*: **no**
 - {{SVGAttr("title")}}
   - : This attribute the title of the style sheet which can be used to switch between [alternate style sheets](/en-US/docs/Web/CSS/Alternative_style_sheets).
-    *Value type*: [**\<string>**](/en-US/docs/Web/SVG/Content_type#string); *Default value*: *none*; *Animatable*: **no**
+    *Value type*: [**`<string>`**](/en-US/docs/Web/SVG/Content_type#string); *Default value*: *none*; *Animatable*: **no**
 
 ### Global attributes
 

--- a/files/en-us/web/svg/element/style/index.md
+++ b/files/en-us/web/svg/element/style/index.md
@@ -44,7 +44,7 @@ html,body,svg { height:100% }
   - : This attribute defines to which {{cssxref('@media', 'media')}} the style applies.
     *Value type*: [**\<string>**](/en-US/docs/Web/SVG/Content_type#string); *Default value*: `all`; *Animatable*: **no**
 - {{SVGAttr("title")}}
-  - : This attribute the title of the style sheet which can be used to switch between alternate style sheets.
+  - : This attribute the title of the style sheet which can be used to switch between [alternate style sheets](/en-US/docs/Web/CSS/Alternative_style_sheets).
     *Value type*: [**\<string>**](/en-US/docs/Web/SVG/Content_type#string); *Default value*: *none*; *Animatable*: **no**
 
 ### Global attributes


### PR DESCRIPTION
This adds missing docs for `SVGStyleElement` including examples and the docs for `SVGStyleElement.media`,  `SVGStyleElement.sheet` and  `SVGStyleElement.title` properties. It is part of the tidy I am doing for https://github.com/mdn/content/issues/18775

Note that most of the properties are not readonly. FF allows them to be written, and if valid values are uses, respects them. Chrome, at least in some case allows you to set the values, but does NOT respect them even if valid - at least for `media`. 
While the fact that are not read-only means that the intent is that they are set, in some cases there are APIs I have run into where they allow values to be set but it is not meaningful to do so. So I am querying that. Upshot, might do a post process of this if https://github.com/w3c/svgwg/issues/891 confirms the intent (i.e. that chrome is off spec).

When this goes in I will need to update BCD to provide links to the new docs.