### PR TITLE
Remove deki URLs

### DIFF
--- a/files/en-us/web/css/_colon_checked/index.md
+++ b/files/en-us/web/css/_colon_checked/index.md
@@ -157,12 +157,6 @@ This example utilizes the `:checked` pseudo-class to let the user toggle content
 
 {{EmbedLiveSample("Toggling_elements_with_a_hidden_checkbox", "auto", 220)}}
 
-### Image gallery
-
-You can use the `:checked` pseudo-class to build an image gallery with full-size images that show only when the user clicks on a thumbnail. See [this demo](/@api/deki/files/6268/=css-checked-gallery.zip "css-checked-gallery.zip") for a possible cue.
-
-> **Note:** For an analogous effect, but based on the [`:hover`](/en-US/docs/Web/CSS/:hover) pseudo-class and without hidden radioboxes, see [this demo](/@api/deki/files/6247/=css-gallery.zip "css-gallery.zip"), taken from the [:hover](/en-US/docs/Web/CSS/:hover) reference page.
-
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
Those demos are gone and the `:hover` page doesn't have any such demo.