### PR TITLE
Put demo in livesample

### DIFF
--- a/files/en-us/web/accessibility/aria/forms/multipart_labels/index.md
+++ b/files/en-us/web/accessibility/aria/forms/multipart_labels/index.md
@@ -24,24 +24,27 @@ You have a form where you ask your user a question, but the answer is mentioned 
 
 If you're using a screen reader, have you noticed that, when you go to this setting in Firefox, it tells you "Delete history after 21 days"?, followed by the announcement that you're in a textbox, and that it contains the number 21. Isn't that cool? You do not need to navigate around to find out the unit. "Days" could easily be "months" or "years", and in many ordinary dialogs, there is no way to find this out other than navigating around with screen reviewing commands.
 
-The solution is in an ARIA attribute called **aria-labelledby**. Its parameter is a string that consists of the IDs of the HTML elements you want to concatenate into a single accessible name.
+The solution is in an ARIA attribute called `aria-labelledby`. Its parameter is a string that consists of the IDs of the HTML elements you want to concatenate into a single accessible name.
 
-Both **aria-labelledby** and **aria-describedby** are specified on the form element that is to be labelled, for example an \<input> In both cases, the label for/label control bindings that may also exist are overridden by **aria-labelledby**. If on an HTML page you provide **aria-labelledby**, you should also provide a label for construct to also support older browsers that do not have ARIA support yet. With Firefox 3, your visually impaired users will automatically get better accessibility from the new attribute, but the users of older browsers are not left in the dark this way.
+Both `aria-labelledby` and `aria-describedby` are specified on the form element that is to be labelled, for example an `<input>` In both cases, the label for/label control bindings that may also exist are overridden by `aria-labelledby`. If on an HTML page you provide `aria-labelledby`, you should also provide a label for construct to also support older browsers that do not have ARIA support yet. With Firefox 3, your visually impaired users will automatically get better accessibility from the new attribute, but the users of older browsers are not left in the dark this way.
 
-Example:
+### Example
 
-<input>
+{{ EmbedLiveSample("Example") }}
 
-Shut down computer after
-
-<input>
-
-minutes
+```css hidden
+body {
+  margin: 1rem;
+}
+```
 
 ```html
 <input aria-labelledby="labelShutdown shutdownTime shutdownUnit" type="checkbox" />
+
 <span id="labelShutdown">Shut down computer after</span>
+
 <input aria-labelledby="labelShutdown shutdownTime shutdownUnit" id="shutdownTime" type="text" value="10" />
+
 <span id="shutdownUnit"> minutes</span>
 ```
 
@@ -53,4 +56,4 @@ JAWS 8.0 has its own logic to find labels, causing it to always override the acc
 
 ## Can this be done without ARIA?
 
-Community member Ben Millard has pointed out in a blog post that [controls can be embedded in labels as shown in the above example using HTML 4](https://projectcerbera.com/blog/2008/03#day24), by embedding the input into the label. Thanks for that info, Ben! It is very useful and shows that some techniques that have been available for years escape even the gurus sometimes. This technique works in Firefox; however, it doesn't currently work in many other browsers, including IE. For labels with embedded form controls, using **aria-labelledby** is still the best approach.
+Community member Ben Millard has pointed out in a blog post that [controls can be embedded in labels as shown in the above example using HTML 4](https://projectcerbera.com/blog/2008/03#day24), by embedding the input into the label. Thanks for that info, Ben! It is very useful and shows that some techniques that have been available for years escape even the gurus sometimes. This technique works in Firefox; however, it doesn't currently work in many other browsers, including IE. For labels with embedded form controls, using `aria-labelledby` is still the best approach.


### PR DESCRIPTION
Markdown linter complains about bare html, e.g. `<input/>`.
