### PR TITLE
“Animating textures in WebGL”: Drop “autoplay”; add “playsInline”

### DIFF
--- a/files/en-us/web/api/webgl_api/tutorial/animating_textures_in_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/animating_textures_in_webgl/index.md
@@ -28,7 +28,7 @@ function setupVideo(url) {
   let playing = false;
   let timeupdate = false;
 
-  video.autoplay = true;
+  video.playsInline = true;
   video.muted = true;
   video.loop = true;
 


### PR DESCRIPTION
Relates to https://github.com/mdn/content/issues/13775. See also https://github.com/mdn/dom-examples/pull/142.

Tested in Safari mobile on iOS 15.5, tested in Firefox mobile and Chrome mobile on Android, and tested in Safari, Chrome, and Firefox on desktop macOS — and found that the demo works as expected in all browsers without the `autoplay` attribute needing to be specified, and works in Safari mobile on iOS 15.5 as long as `playsInline` is specified.

See https://stackoverflow.com/a/73244068/441757 for live running code.