### PR TITLE
Update BCD info, part 1

### DIFF
--- a/files/en-us/web/api/accelerometer/index.md
+++ b/files/en-us/web/api/accelerometer/index.md
@@ -12,6 +12,7 @@ tags:
   - Sensor
   - Sensor APIs
   - Sensors
+  - Experimental
 browser-compat: api.Accelerometer
 ---
 {{APIRef("Sensor API")}}{{SeeCompatTable}}
@@ -26,18 +27,18 @@ If a feature policy blocks the use of a feature, it is because your code is inco
 
 ## Constructor
 
-- {{domxref("Accelerometer.Accelerometer()", "Accelerometer()")}}
+- {{domxref("Accelerometer.Accelerometer()", "Accelerometer()")}} {{Experimental_Inline}}
   - : Creates a new `Accelerometer` object.
 
 ## Properties
 
 _In addition to the properties listed below, `Accelerometer` inherits properties from its parent interfaces, {{domxref("Sensor")}} and {{domxref("EventTarget")}}._
 
-- {{domxref('Accelerometer.x')}} {{readonlyinline}}
+- {{domxref('Accelerometer.x')}} {{readonlyinline}} {{Experimental_Inline}}
   - : Returns a double containing the acceleration of the device along the device's x axis.
-- {{domxref('Accelerometer.y')}} {{readonlyinline}}
+- {{domxref('Accelerometer.y')}} {{readonlyinline}} {{Experimental_Inline}}
   - : Returns a double containing the acceleration of the device along the device's y axis.
-- {{domxref('Accelerometer.z')}} {{readonlyinline}}
+- {{domxref('Accelerometer.z')}} {{readonlyinline}} {{Experimental_Inline}}
   - : Returns a double containing the acceleration of the device along the device's z axis.
 
 ## Methods

--- a/files/en-us/web/api/audiocontext/index.md
+++ b/files/en-us/web/api/audiocontext/index.md
@@ -29,9 +29,9 @@ An audio context controls both the creation of the nodes it contains and the exe
 
 _Also inherits properties from its parent interface, {{domxref("BaseAudioContext")}}._
 
-- {{domxref("AudioContext.baseLatency")}} {{readonlyinline}} {{experimental_inline}}
+- {{domxref("AudioContext.baseLatency")}} {{readonlyinline}}
   - : Returns the number of seconds of processing latency incurred by the {{domxref("AudioContext")}} passing the audio from the {{domxref("AudioDestinationNode")}} to the audio subsystem.
-- {{domxref("AudioContext.outputLatency")}} {{readonlyinline}} {{experimental_inline}}
+- {{domxref("AudioContext.outputLatency")}} {{readonlyinline}}
   - : Returns an estimation of the output latency of the current audio context.
 
 ## Methods

--- a/files/en-us/web/api/audiodata/allocationsize/index.md
+++ b/files/en-us/web/api/audiodata/allocationsize/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.AudioData.allocationSize
 ---
-{{DefaultAPISidebar("WebCodecs API")}}{{SeeCompatTable}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`allocationSize()`** method of the {{domxref("AudioData")}} interface returns the size in bytes required to hold the current sample as filtered by options passed into the method.
 

--- a/files/en-us/web/api/audiodata/allocationsize/index.md
+++ b/files/en-us/web/api/audiodata/allocationsize/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - allocationSize
   - AudioData
+  - Experimental
 browser-compat: api.AudioData.allocationSize
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{DefaultAPISidebar("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`allocationSize()`** method of the {{domxref("AudioData")}} interface returns the size in bytes required to hold the current sample as filtered by options passed into the method.
 

--- a/files/en-us/web/api/backgroundfetchevent/index.md
+++ b/files/en-us/web/api/backgroundfetchevent/index.md
@@ -7,9 +7,10 @@ tags:
   - Interface
   - Reference
   - BackgroundFetchEvent
+  - Experimental
 browser-compat: api.BackgroundFetchEvent
 ---
-{{DefaultAPISidebar("Background Fetch API")}}
+{{DefaultAPISidebar("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`BackgroundFetchEvent`** interface of the {{domxref('Background Fetch API','','',' ')}} is the event type for background fetch events dispatched on the {{domxref("ServiceWorkerGlobalScope", "service worker global scope")}}.
 
@@ -19,14 +20,14 @@ It is the event type passed to `onbackgroundfetchabort` and `onbackgroundfetchcl
 
 ## Constructor
 
-- {{domxref("BackgroundFetchEvent.BackgroundFetchEvent()", "BackgroundFetchEvent()")}}
+- {{domxref("BackgroundFetchEvent.BackgroundFetchEvent()", "BackgroundFetchEvent()")}} {{Experimental_Inline}}
   - : Creates a new `BackgroundFetchEvent` object. This constructor is not typically used, as the browser creates these objects itself and provides them to background fetch event callbacks.
 
 ## Properties
 
 _Inherits properties from its ancestor, {{domxref("Event")}}_.
 
-- {{domxref("BackgroundFetchEvent.registration")}} {{ReadOnlyInline}}
+- {{domxref("BackgroundFetchEvent.registration")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the {{domxref("BackgroundFetchRegistration")}} that the event was initialized to.
 
 ### Event handlers

--- a/files/en-us/web/api/backgroundfetchevent/index.md
+++ b/files/en-us/web/api/backgroundfetchevent/index.md
@@ -10,7 +10,7 @@ tags:
   - Experimental
 browser-compat: api.BackgroundFetchEvent
 ---
-{{DefaultAPISidebar("Background Fetch API")}}{{SeeCompatTable}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`BackgroundFetchEvent`** interface of the {{domxref('Background Fetch API','','',' ')}} is the event type for background fetch events dispatched on the {{domxref("ServiceWorkerGlobalScope", "service worker global scope")}}.
 

--- a/files/en-us/web/api/backgroundfetchrecord/index.md
+++ b/files/en-us/web/api/backgroundfetchrecord/index.md
@@ -10,7 +10,7 @@ tags:
   - Experimental
 browser-compat: api.BackgroundFetchRecord
 ---
-{{DefaultAPISidebar("Background Fetch API")}}{{SeeCompatTable}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`BackgroundFetchRecord`** interface of the {{domxref('Background Fetch API','','',' ')}} represents an individual request and response.
 

--- a/files/en-us/web/api/backgroundfetchrecord/index.md
+++ b/files/en-us/web/api/backgroundfetchrecord/index.md
@@ -7,9 +7,10 @@ tags:
   - Interface
   - Reference
   - BackgroundFetchRecord
+  - Experimental
 browser-compat: api.BackgroundFetchRecord
 ---
-{{DefaultAPISidebar("Background Fetch API")}}
+{{DefaultAPISidebar("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`BackgroundFetchRecord`** interface of the {{domxref('Background Fetch API','','',' ')}} represents an individual request and response.
 
@@ -19,9 +20,9 @@ There will be one `BackgroundFetchRecord` for each resource requested by `fetch(
 
 ## Properties
 
-- {{domxref("BackgroundFetchRecord.request","request")}} {{ReadOnlyInline}}
+- {{domxref("BackgroundFetchRecord.request","request")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a {{domxref("Request")}}.
-- {{domxref("BackgroundFetchRecord.responseReady","responseReady")}} {{ReadOnlyInline}}
+- {{domxref("BackgroundFetchRecord.responseReady","responseReady")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a promise that resolves with a {{domxref("Response")}}.
 
 ## Examples

--- a/files/en-us/web/api/canvasrenderingcontext2d/drawwindow/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/drawwindow/index.md
@@ -12,7 +12,7 @@ tags:
   - Deprecated
 browser-compat: api.CanvasRenderingContext2D.drawWindow
 ---
-{{APIRef}} {{deprecated_header}}
+{{APIRef}} {{deprecated_header}}{{Non-standard_header}}
 
 The deprecated, non-standard and internal only
 **`CanvasRenderingContext2D.drawWindow()`**

--- a/files/en-us/web/api/canvasrenderingcontext2d/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/index.md
@@ -295,28 +295,28 @@ Most of these APIs are [deprecated and were removed shortly after Chrome 36](htt
 
 ### WebKit only
 
-- {{non-standard_inline}} {{deprecated_inline}} `CanvasRenderingContext2D.webkitBackingStorePixelRatio`
+- `CanvasRenderingContext2D.webkitBackingStorePixelRatio` {{non-standard_inline}} {{deprecated_inline}} 
   - : The backing store size in relation to the canvas element. See [High DPI Canvas](https://www.html5rocks.com/en/tutorials/canvas/hidpi/).
-- {{non-standard_inline}} {{deprecated_inline}} `CanvasRenderingContext2D.webkitGetImageDataHD`
+- `CanvasRenderingContext2D.webkitGetImageDataHD` {{non-standard_inline}} {{deprecated_inline}}
   - : Intended for HD backing stores, but removed from canvas specifications.
-- {{non-standard_inline}} {{deprecated_inline}} `CanvasRenderingContext2D.webkitPutImageDataHD`
+- `CanvasRenderingContext2D.webkitPutImageDataHD` {{non-standard_inline}} {{deprecated_inline}}
   - : Intended for HD backing stores, but removed from canvas specifications.
 
 ### Gecko only
 
 #### Prefixed APIs
 
-- {{non-standard_inline}} `CanvasRenderingContext2D.mozImageSmoothingEnabled`
+- `CanvasRenderingContext2D.mozImageSmoothingEnabled` {{non-standard_inline}}
   - : See {{domxref("CanvasRenderingContext2D.imageSmoothingEnabled")}}.
-- {{non-standard_inline}} {{deprecated_inline}} `CanvasRenderingContext2D.mozTextStyle`
+- `CanvasRenderingContext2D.mozTextStyle` {{non-standard_inline}} {{deprecated_inline}}
   - : Introduced in Gecko 1.9, deprecated in favor of the {{domxref("CanvasRenderingContext2D.font")}} property.
-- {{non-standard_inline}} {{deprecated_inline}} `CanvasRenderingContext2D.mozDrawText()`
+- `CanvasRenderingContext2D.mozDrawText()` {{non-standard_inline}} {{deprecated_inline}}
   - : This method was introduced in Gecko 1.9 and is removed starting with Gecko 7.0. Use {{domxref("CanvasRenderingContext2D.strokeText()")}} or {{domxref("CanvasRenderingContext2D.fillText()")}} instead.
-- {{non-standard_inline}} {{deprecated_inline}} `CanvasRenderingContext2D.mozMeasureText()`
+- `CanvasRenderingContext2D.mozMeasureText()` {{non-standard_inline}} {{deprecated_inline}}
   - : This method was introduced in Gecko 1.9 and is unimplemented starting with Gecko 7.0. Use {{domxref("CanvasRenderingContext2D.measureText()")}} instead.
-- {{non-standard_inline}} {{deprecated_inline}} `CanvasRenderingContext2D.mozPathText()`
+- `CanvasRenderingContext2D.mozPathText()` {{non-standard_inline}} {{deprecated_inline}}
   - : This method was introduced in Gecko 1.9 and is removed starting with Gecko 7.0.
-- {{non-standard_inline}} {{deprecated_inline}} `CanvasRenderingContext2D.mozTextAlongPath()`
+- `CanvasRenderingContext2D.mozTextAlongPath()` {{non-standard_inline}} {{deprecated_inline}}
   - : This method was introduced in Gecko 1.9 and is removed starting with Gecko 7.0.
 
 #### Internal APIs (chrome-context only)
@@ -328,7 +328,7 @@ Most of these APIs are [deprecated and were removed shortly after Chrome 36](htt
 
 ### Internet Explorer
 
-- {{non-standard_inline}} `CanvasRenderingContext2D.msFillRule`
+- `CanvasRenderingContext2D.msFillRule` {{non-standard_inline}}
   - : The [fill rule](https://cairographics.org/manual/cairo-cairo-t.html#cairo-fill-rule-t) to use. This must be one of `evenodd` or `nonzero` (default).
 
 ## Specifications

--- a/files/en-us/web/api/canvasrenderingcontext2d/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/index.md
@@ -177,7 +177,7 @@ The following methods can be used to manipulate paths of objects.
   - : Strokes the current sub-paths with the current stroke style.
 - {{domxref("CanvasRenderingContext2D.drawFocusIfNeeded()")}}
   - : If a given element is focused, this method draws a focus ring around the current path.
-- {{domxref("CanvasRenderingContext2D.scrollPathIntoView()")}}
+- {{domxref("CanvasRenderingContext2D.scrollPathIntoView()")}} {{Experimental_Inline}}
   - : Scrolls the current path or a given path into the view.
 - {{domxref("CanvasRenderingContext2D.clip()")}}
   - : Creates a clipping path from the current sub-paths. Everything drawn after `clip()` is called appears inside the clipping path only. For an example, see [Clipping paths](/en-US/docs/Web/API/Canvas_API/Tutorial/Compositing) in the Canvas tutorial.
@@ -202,7 +202,7 @@ Objects in the `CanvasRenderingContext2D` rendering context have a current trans
   - : Multiplies the current transformation matrix with the matrix described by its arguments.
 - {{domxref("CanvasRenderingContext2D.setTransform()")}}
   - : Resets the current transform to the identity matrix, and then invokes the `transform()` method with the same arguments.
-- {{domxref("CanvasRenderingContext2D.resetTransform()")}} {{experimental_inline}}
+- {{domxref("CanvasRenderingContext2D.resetTransform()")}}
   - : Resets the current transform by the identity matrix.
 
 ### Compositing
@@ -230,9 +230,9 @@ See also the {{domxref("ImageData")}} object.
 
 ### Image smoothing
 
-- {{domxref("CanvasRenderingContext2D.imageSmoothingEnabled")}} {{experimental_inline}}
+- {{domxref("CanvasRenderingContext2D.imageSmoothingEnabled")}}
   - : Image smoothing mode; if disabled, images will not be smoothed if scaled.
-- {{domxref("CanvasRenderingContext2D.imageSmoothingQuality")}} {{experimental_inline}}
+- {{domxref("CanvasRenderingContext2D.imageSmoothingQuality")}}
   - : Allows you to set the quality of image smoothing.
 
 ### The canvas state
@@ -250,7 +250,7 @@ The `CanvasRenderingContext2D` rendering context contains a variety of drawing s
 
 ### Filters
 
-- {{domxref("CanvasRenderingContext2D.filter")}} {{experimental_inline}}
+- {{domxref("CanvasRenderingContext2D.filter")}}
   - : Applies a CSS or SVG filter to the canvas, e.g., to change its brightness or blurriness.
 
 ## Non-standard APIs
@@ -259,38 +259,38 @@ The `CanvasRenderingContext2D` rendering context contains a variety of drawing s
 
 Most of these APIs are [deprecated and were removed shortly after Chrome 36](https://bugs.chromium.org/p/chromium/issues/detail?id=363198).
 
-- {{non-standard_inline}} {{deprecated_inline}} `CanvasRenderingContext2D.clearShadow()`
+- `CanvasRenderingContext2D.clearShadow()` {{non-standard_inline}} {{deprecated_inline}}
   - : Removes all shadow settings like {{domxref("CanvasRenderingContext2D.shadowColor")}} and {{domxref("CanvasRenderingContext2D.shadowBlur")}}.
-- {{non-standard_inline}} {{deprecated_inline}} `CanvasRenderingContext2D.drawImageFromRect()`
+- `CanvasRenderingContext2D.drawImageFromRect()` {{non-standard_inline}} {{deprecated_inline}}
   - : This is redundant with an equivalent overload of `drawImage`.
-- {{non-standard_inline}} {{deprecated_inline}} `CanvasRenderingContext2D.setAlpha()`
+- `CanvasRenderingContext2D.setAlpha()` {{non-standard_inline}} {{deprecated_inline}}
   - : Use {{domxref("CanvasRenderingContext2D.globalAlpha")}} instead.
-- {{non-standard_inline}} {{deprecated_inline}} `CanvasRenderingContext2D.setCompositeOperation()`
+- `CanvasRenderingContext2D.setCompositeOperation()` {{non-standard_inline}} {{deprecated_inline}}
   - : Use {{domxref("CanvasRenderingContext2D.globalCompositeOperation")}} instead.
-- {{non-standard_inline}} {{deprecated_inline}} `CanvasRenderingContext2D.setLineWidth()`
+- `CanvasRenderingContext2D.setLineWidth()` {{non-standard_inline}} {{deprecated_inline}}
   - : Use {{domxref("CanvasRenderingContext2D.lineWidth")}} instead.
-- {{non-standard_inline}} {{deprecated_inline}} `CanvasRenderingContext2D.setLineJoin()`
+- `CanvasRenderingContext2D.setLineJoin()` {{non-standard_inline}} {{deprecated_inline}}
   - : Use {{domxref("CanvasRenderingContext2D.lineJoin")}} instead.
-- {{non-standard_inline}} {{deprecated_inline}} `CanvasRenderingContext2D.setLineCap()`
+- `CanvasRenderingContext2D.setLineCap()` {{non-standard_inline}} {{deprecated_inline}}
   - : Use {{domxref("CanvasRenderingContext2D.lineCap")}} instead.
-- {{non-standard_inline}} {{deprecated_inline}} `CanvasRenderingContext2D.setMiterLimit()`
+- `CanvasRenderingContext2D.setMiterLimit()`  {{non-standard_inline}} {{deprecated_inline}}
   - : Use {{domxref("CanvasRenderingContext2D.miterLimit")}} instead.
-- {{non-standard_inline}} {{deprecated_inline}} `CanvasRenderingContext2D.setStrokeColor()`
+- `CanvasRenderingContext2D.setStrokeColor()`  {{non-standard_inline}} {{deprecated_inline}}
   - : Use {{domxref("CanvasRenderingContext2D.strokeStyle")}} instead.
-- {{non-standard_inline}} {{deprecated_inline}} `CanvasRenderingContext2D.setFillColor()`
+- `CanvasRenderingContext2D.setFillColor()` {{non-standard_inline}} {{deprecated_inline}}
   - : Use {{domxref("CanvasRenderingContext2D.fillStyle")}} instead.
-- {{non-standard_inline}} {{deprecated_inline}} `CanvasRenderingContext2D.setShadow()`
+- `CanvasRenderingContext2D.setShadow()`  {{non-standard_inline}} {{deprecated_inline}}
   - : Use {{domxref("CanvasRenderingContext2D.shadowColor")}} and {{domxref("CanvasRenderingContext2D.shadowBlur")}} instead.
-- {{non-standard_inline}} {{deprecated_inline}} `CanvasRenderingContext2D.webkitLineDash`
+- `CanvasRenderingContext2D.webkitLineDash` {{non-standard_inline}} {{deprecated_inline}}
   - : Use {{domxref("CanvasRenderingContext2D.getLineDash()")}} and {{domxref("CanvasRenderingContext2D.setLineDash()")}} instead.
-- {{non-standard_inline}} {{deprecated_inline}} `CanvasRenderingContext2D.webkitLineDashOffset`
+- `CanvasRenderingContext2D.webkitLineDashOffset` {{non-standard_inline}} {{deprecated_inline}}
   - : Use {{domxref("CanvasRenderingContext2D.lineDashOffset")}} instead.
-- {{non-standard_inline}} {{deprecated_inline}} `CanvasRenderingContext2D.webkitImageSmoothingEnabled`
+- `CanvasRenderingContext2D.webkitImageSmoothingEnabled` {{non-standard_inline}} {{deprecated_inline}}
   - : Use {{domxref("CanvasRenderingContext2D.imageSmoothingEnabled")}} instead.
 
 ### Blink only
 
-- {{non-standard_inline}} `CanvasRenderingContext2D.isContextLost()`
+- `CanvasRenderingContext2D.isContextLost()` {{non-standard_inline}}
   - : Inspired by the same `WebGLRenderingContext` method it returns `true` if the Canvas context has been lost, or `false` if not.
 
 ### WebKit only
@@ -321,7 +321,7 @@ Most of these APIs are [deprecated and were removed shortly after Chrome 36](htt
 
 #### Internal APIs (chrome-context only)
 
-- {{non-standard_inline}} {{domxref("CanvasRenderingContext2D.drawWindow()")}}
+- {{domxref("CanvasRenderingContext2D.drawWindow()")}} {{Deprecated_Inline}} {{non-standard_inline}}
   - : Renders a region of a window into the `canvas`. The contents of the window's viewport are rendered, ignoring viewport clipping and scrolling.
 - {{non-standard_inline}} `CanvasRenderingContext2D.demote()`
   - : This causes a context that is currently using a hardware-accelerated backend to fallback to a software one. All state should be preserved.

--- a/files/en-us/web/api/domimplementation/hasfeature/index.md
+++ b/files/en-us/web/api/domimplementation/hasfeature/index.md
@@ -11,9 +11,7 @@ tags:
   - Reference
 browser-compat: api.DOMImplementation.hasFeature
 ---
-{{ApiRef("DOM")}}
-
-{{Deprecated_Header}}
+{{ApiRef("DOM")}}{{Deprecated_Header}}
 
 The
 **`DOMImplementation.hasFeature()`** method returns a

--- a/files/en-us/web/api/domimplementation/index.md
+++ b/files/en-us/web/api/domimplementation/index.md
@@ -27,7 +27,7 @@ _No inherited method._
   - : Creates and returns a {{domxref("DocumentType")}}.
 - {{domxref("DOMImplementation.createHTMLDocument()")}}
   - : Creates and returns an HTML {{domxref("Document")}}.
-- {{domxref("DOMImplementation.hasFeature()")}}
+- {{domxref("DOMImplementation.hasFeature()")}} {{Deprecated_Inline}}
   - : Returns a boolean value indicating if a given feature is supported or not. This function is unreliable and kept for compatibility purpose alone: except for SVG-related queries, it always returns `true`. Old browsers are very inconsistent in their behavior.
 
 ## Specifications

--- a/files/en-us/web/api/element/domactivate_event/index.md
+++ b/files/en-us/web/api/element/domactivate_event/index.md
@@ -16,7 +16,7 @@ tags:
   - onactivate
 browser-compat: api.Element.DOMActivate_event
 ---
-{{APIRef}}
+{{APIRef}}{{Deprecated_Header}}
 
 {{Deprecated_Header}}
 

--- a/files/en-us/web/api/element/domactivate_event/index.md
+++ b/files/en-us/web/api/element/domactivate_event/index.md
@@ -18,8 +18,6 @@ browser-compat: api.Element.DOMActivate_event
 ---
 {{APIRef}}{{Deprecated_Header}}
 
-{{Deprecated_Header}}
-
 The **`DOMActivate`** event is fired at an element when it becomes active, such as when it is clicked on using the mouse or a keypress is used to navigate to it.
 
 ## Syntax


### PR DESCRIPTION
Similar to #19134.

The PR updates BCD info of some WebAPI docs.

Note: It's easy to review the changes. Open the preview URLs hosted by the PR companion, in new tab, and look at the  BCD tables at the bottom of the pages.