### PR TITLE
[`<img>`] Fix code block continuing until end of page

### DIFF
--- a/files/en-us/web/html/element/img/index.md
+++ b/files/en-us/web/html/element/img/index.md
@@ -329,7 +329,7 @@ Due to a [VoiceOver bug](https://bugs.webkit.org/show_bug.cgi?id=216364), VoiceO
 
 ```html
  <img src="mdn.svg" alt="MDN logo" role="img">
-``
+```
 
 ### The title attribute
 


### PR DESCRIPTION
#### Summary
The third commit in PR #19098 removed a backtick, which resulted in the code block continuing until the end of the page.

#### Metadata

This PR…

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error