### PR TITLE
Swap erroneous tag

### DIFF
--- a/files/en-us/web/api/htmlcollection/nameditem/index.md
+++ b/files/en-us/web/api/htmlcollection/nameditem/index.md
@@ -6,7 +6,7 @@ tags:
   - API
   - Element Lists
   - HTMLCollection
-  - Interface
+  - Method
   - Reference
 browser-compat: api.HTMLCollection.namedItem
 ---


### PR DESCRIPTION
The tag `Method` is needed to populate the sidebar correctly