### PR TITLE
Add an API removal in dev changelog of Firefox 103

### DIFF
--- a/files/en-us/mozilla/firefox/releases/103/index.md
+++ b/files/en-us/mozilla/firefox/releases/103/index.md
@@ -87,6 +87,8 @@ This article provides information about the changes in Firefox 103 that will aff
 
 #### Removals
 
+- Removed the ServiceWorker API in Webextensions (`'serviceWorker' in navigator` now returns false when run inside an extension). ({{bug(1593931)}})
+
 ### Other
 
 ## Older versions


### PR DESCRIPTION
#### Summary
The ServiceWorker API has been removed inside a Webextension, which should be mentioned in the dev changelog of Firefox 103.

#### Motivation
With Firefox<103, the API was available, but registering a ServiceWorker was failing on a security issue.
Since Firefox 103, the API is not available at all.

It's a significant change, that broke our kiwix extension (see https://github.com/kiwix/kiwix-js/issues/877).
So I think it's worth mentioning it here.

#### Supporting details
The API availability can be tested with `'serviceWorker' in navigator`

#### Related issues
https://bugzilla.mozilla.org/show_bug.cgi?id=1593931 is the bugzilla issue that triggered the API removal

#### Metadata
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error