### PR TITLE
Support for persistAcrossSessions

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/registeredcontentscript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/registeredcontentscript/index.md
@@ -33,7 +33,7 @@ Values of this type are objects. They contain these properties:
 - `matches` {{optional_inline}}
   - : `array` of `string`. Array of the pages this content script is injected into. Must be specified for {{WebExtAPIRef("scripting.registerContentScripts()")}}.
 - `persistAcrossSessions` {{optional_inline}}
-  - : `boolean`. Specifies if this content script persists into future sessions; that is, it is a persistent content script. Defaults to `true`.
+  - : `boolean`. Specifies if this content script persists across browser restarts and updates and extension restarts. Defaults to `true`.
 - `runAt` {{optional_inline}}
   - : {{WebExtAPIRef("extensionTypes.RunAt")}}. Specifies when JavaScript files are injected into the web page. The default value is `document_idle`. In Firefox, `runAt` also affects the point where the CSS is inserted. In Chrome, `runAt` does not affect the CSS insertion point.
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/scripting/registeredcontentscript/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/scripting/registeredcontentscript/index.md
@@ -33,7 +33,7 @@ Values of this type are objects. They contain these properties:
 - `matches` {{optional_inline}}
   - : `array` of `string`. Array of the pages this content script is injected into. Must be specified for {{WebExtAPIRef("scripting.registerContentScripts()")}}.
 - `persistAcrossSessions` {{optional_inline}}
-  - : `boolean`. Specifies if this content script persists into future sessions. Defaults to `true`. Firefox does not support registering persistent scripts, see ({{bug("1751436")}}), so this flag must be set to `false` to register non-persistent scripts.
+  - : `boolean`. Specifies if this content script persists into future sessions; that is, it is a persistent content script. Defaults to `true`.
 - `runAt` {{optional_inline}}
   - : {{WebExtAPIRef("extensionTypes.RunAt")}}. Specifies when JavaScript files are injected into the web page. The default value is `document_idle`. In Firefox, `runAt` also affects the point where the CSS is inserted. In Chrome, `runAt` does not affect the CSS insertion point.
 

--- a/files/en-us/mozilla/firefox/releases/105/index.md
+++ b/files/en-us/mozilla/firefox/releases/105/index.md
@@ -53,6 +53,8 @@ This article provides information about the changes in Firefox 105 that will aff
 
 ## Changes for add-on developers
 
+- Support for defining persistent scripts using {{WebExtAPIRef("scripting")}} has been added. A script is identified as persistent using the `persistAcrossSessions` property in {{WebExtAPIRef("scripting.RegisteredContentScript")}} ({{bug("1751436")}}).
+
 #### Removals
 
 ### Other


### PR DESCRIPTION
#### Summary
Support for  identifying a content script as persistent in the `scripting` API is added in Firefox 105. This change removes the note that `persistAcrossSessions` did not support the "true" setting and adds a release note.

#### Related issues
Addresses the documentation needs of [Bug 1751436](https://bugzilla.mozilla.org/show_bug.cgi?id=1751436) Add support for `persistAcrossSessions` in `scripting.RegisteredContentScript`

#### Metadata

This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
