### PR TITLE
Fixed anchors in <input> and attribute page links

### DIFF
--- a/files/en-us/web/html/element/input/submit/index.md
+++ b/files/en-us/web/html/element/input/submit/index.md
@@ -35,8 +35,8 @@ browser-compat: html.elements.input.type_submit
     <tr>
       <td><strong>Supported common attributes</strong></td>
       <td>
-        [`type`](/en-US/docs/Web/HTML/Element/input#type) and
-        [`value`](/en-US/docs/Web/HTML/Element/input#value)
+        <a href="/en-US/docs/Web/HTML/Element/input#type"><code>type</code></a> and
+        <a href="/en-US/docs/Web/HTML/Element/input#value"><code>value</code></a>
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/input/submit/index.md
+++ b/files/en-us/web/html/element/input/submit/index.md
@@ -35,8 +35,8 @@ browser-compat: html.elements.input.type_submit
     <tr>
       <td><strong>Supported common attributes</strong></td>
       <td>
-        {{htmlattrxref("type", "input")}} and
-        {{htmlattrxref("value", "input")}}
+        [`type`](/en-US/docs/Web/HTML/Element/input#type) and
+        [`value`](/en-US/docs/Web/HTML/Element/input#value)
       </td>
     </tr>
     <tr>
@@ -56,7 +56,7 @@ browser-compat: html.elements.input.type_submit
 
 ## Value
 
-An `<input type="submit">` element's {{htmlattrxref("value", "input")}} attribute contains a string which is displayed as the button's label. Buttons do not have a true value otherwise.
+An `<input type="submit">` element's [`value`](/en-US/docs/Web/HTML/Element/input#value) attribute contains a string which is displayed as the button's label. Buttons do not have a true value otherwise.
 
 ### Setting the value attribute
 
@@ -93,7 +93,7 @@ A string that identifies the encoding method to use when submitting the form dat
 - `application/x-www-form-urlencoded`
   - : This, the default value, sends the form data as a string after URL encoding the text using an algorithm such as {{jsxref("encodeURI", "encodeURI()")}}.
 - `multipart/form-data`
-  - : Uses the {{domxref("FormData")}} API to manage the data, allowing for files to be submitted to the server. You _must_ use this encoding type if your form includes any {{HTMLElement("input")}} elements of {{htmlattrxref("type", "input")}} `file` ([`<input type="file">`](/en-US/docs/Web/HTML/Element/input/file)).
+  - : Uses the {{domxref("FormData")}} API to manage the data, allowing for files to be submitted to the server. You _must_ use this encoding type if your form includes any {{HTMLElement("input")}} elements of [`type`](/en-US/docs/Web/HTML/Element/input#type) `file` ([`<input type="file">`](/en-US/docs/Web/HTML/Element/input/file)).
 - `text/plain`
   - : Plain text; mostly useful only for debugging, so you can easily see the data that's to be submitted.
 
@@ -169,9 +169,9 @@ Upon submitting, the data name/value pair gets sent to the server. In this insta
 
 ### Adding a submit keyboard shortcut
 
-Keyboard shortcuts, also known as access keys and keyboard equivalents, let the user trigger a button using a key or combination of keys on the keyboard. To add a keyboard shortcut to a submit button — just as you would with any {{HTMLElement("input")}} for which it makes sense — you use the {{htmlattrxref("accesskey")}} global attribute.
+Keyboard shortcuts, also known as access keys and keyboard equivalents, let the user trigger a button using a key or combination of keys on the keyboard. To add a keyboard shortcut to a submit button — just as you would with any {{HTMLElement("input")}} for which it makes sense — you use the [`accesskey`](/en-US/docs/Web/HTML/Global_attributes/accesskey) global attribute.
 
-In this example, <kbd>s</kbd> is specified as the access key (you'll need to press <kbd>s</kbd> plus the particular modifier keys for your browser/OS combination. In order to avoid conflicts with the user agent's own keyboard shortcuts, different modifier keys are used for access keys than for other shortcuts on the host computer. See {{htmlattrxref("accesskey")}} for further details.
+In this example, <kbd>s</kbd> is specified as the access key (you'll need to press <kbd>s</kbd> plus the particular modifier keys for your browser/OS combination. In order to avoid conflicts with the user agent's own keyboard shortcuts, different modifier keys are used for access keys than for other shortcuts on the host computer. See [`accesskey`](/en-US/docs/Web/HTML/Global_attributes/accesskey) for further details.
 
 Here's the previous example with the <kbd>s</kbd> access key added:
 
@@ -192,11 +192,11 @@ For example, in Firefox for Mac, pressing <kbd>Control</kbd>-<kbd>Option</kbd>-<
 
 {{EmbedLiveSample("Adding_a_submit_keyboard_shortcut", 650, 100)}}
 
-The problem with the above example is that the user will not know what the access key is! This is especially true since the modifiers are typically non-standard to avoid conflicts. When building a site, be sure to provide this information in a way that doesn't interfere with the site design (for example by providing an easily accessible link that points to information on what the site access keys are). Adding a tooltip to the button (using the {{htmlattrxref("title")}} attribute) can also help, although it's not a complete solution for accessibility purposes.
+The problem with the above example is that the user will not know what the access key is! This is especially true since the modifiers are typically non-standard to avoid conflicts. When building a site, be sure to provide this information in a way that doesn't interfere with the site design (for example by providing an easily accessible link that points to information on what the site access keys are). Adding a tooltip to the button (using the [`title`](/en-US/docs/Web/HTML/Global_attributes/title) attribute) can also help, although it's not a complete solution for accessibility purposes.
 
 ### Disabling and enabling a submit button
 
-To disable a submit button, specify the {{htmlattrxref("disabled")}} global attribute on it, like so:
+To disable a submit button, specify the [`disabled `](/en-US/docs/Web/HTML/Attributes/disabled) attribute on it, like so:
 
 ```html
 <input type="submit" value="Send" disabled>


### PR DESCRIPTION
#### Summary
I replaced all the anchors for the `<input>` and attribute page links.

#### Motivation
All of the links to the `<input>` page and attribute pages used `htmlattrxref`, so their anchors were all broken. 

#### Related issues
#15725, #16660, #18361 and #18923 were similar issues.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
