### PR TITLE
Update index.md

### DIFF
--- a/files/en-us/web/css/var/index.md
+++ b/files/en-us/web/css/var/index.md
@@ -26,7 +26,6 @@ The `var()` function cannot be used in property names, selectors or anything els
 
 The first argument to the function is the name of the custom property to be substituted. An optional second argument to the function serves as a fallback value. If the custom property referenced by the first argument is invalid, the function uses the second value.
 
-{{csssyntax}}
 
 > **Note:** The syntax of the fallback, like that of custom properties, allows commas. For example, `var(--foo, red, blue)` defines a fallback of `red, blue`; that is, anything between the first comma and the end of the function is considered a fallback value.
 


### PR DESCRIPTION
removes redundant csssyntax tag that fails to load at https://developer.mozilla.org/en-US/docs/Web/CSS/var
- [x] Fixes a typo, bug, or other error


