### PR TITLE
Update BCD info, part 2

### DIFF
--- a/files/en-us/web/api/accelerometer/accelerometer/index.md
+++ b/files/en-us/web/api/accelerometer/accelerometer/index.md
@@ -12,6 +12,7 @@ tags:
   - Sensor
   - Sensor APIs
   - Sensors
+  - Experimental
 browser-compat: api.Accelerometer.Accelerometer
 ---
 {{APIRef("Sensor API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/accelerometer/x/index.md
+++ b/files/en-us/web/api/accelerometer/x/index.md
@@ -13,6 +13,7 @@ tags:
   - Sensor APIs
   - Sensors
   - x
+  - Experimental
 browser-compat: api.Accelerometer.x
 ---
 {{APIRef("Sensor API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/accelerometer/y/index.md
+++ b/files/en-us/web/api/accelerometer/y/index.md
@@ -12,6 +12,7 @@ tags:
   - Sensor
   - Sensor APIs
   - Sensors
+  - Experimental
   - 'y'
 browser-compat: api.Accelerometer.y
 ---

--- a/files/en-us/web/api/accelerometer/z/index.md
+++ b/files/en-us/web/api/accelerometer/z/index.md
@@ -13,6 +13,7 @@ tags:
   - Sensor APIs
   - Sensors
   - z
+  - Experimental
 browser-compat: api.Accelerometer.z
 ---
 {{APIRef("Sensor API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/audiodata/audiodata/index.md
+++ b/files/en-us/web/api/audiodata/audiodata/index.md
@@ -7,9 +7,10 @@ tags:
   - Constructor
   - Reference
   - AudioData
+  - Experimental
 browser-compat: api.AudioData.AudioData
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`AudioData()`** constructor creates a new {{domxref("AudioData")}} object which represents an individual audio sample.
 

--- a/files/en-us/web/api/audiodata/clone/index.md
+++ b/files/en-us/web/api/audiodata/clone/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - clone
   - AudioData
+  - Experimental
 browser-compat: api.AudioData.clone
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`clone()`** method of the {{domxref("AudioData")}} interface creates a new `AudioData` object with reference to the same media resource as the original.
 

--- a/files/en-us/web/api/audiodata/close/index.md
+++ b/files/en-us/web/api/audiodata/close/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - close
   - AudioData
+  - Experimental
 browser-compat: api.AudioData.close
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`close()`** method of the {{domxref("AudioData")}} interface clears all states and releases the reference to the media resource.
 

--- a/files/en-us/web/api/audiodata/copyto/index.md
+++ b/files/en-us/web/api/audiodata/copyto/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - copyTo
   - AudioData
+  - Experimental
 browser-compat: api.AudioData.copyTo
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`copyTo()`** method of the {{domxref("AudioData")}} interface copies a plane of an `AudioData` object to a destination buffer.
 

--- a/files/en-us/web/api/audiodata/duration/index.md
+++ b/files/en-us/web/api/audiodata/duration/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - duration
   - AudioData
+  - Experimental
 browser-compat: api.AudioData.duration
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`duration`** read-only property of the {{domxref("AudioData")}} interface returns the duration in microseconds of this `AudioData` object.
 

--- a/files/en-us/web/api/audiodata/format/index.md
+++ b/files/en-us/web/api/audiodata/format/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - format
   - AudioData
+  - Experimental
 browser-compat: api.AudioData.format
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`format`** read-only property of the {{domxref("AudioData")}} interface returns the sample format of the `AudioData` object.
 

--- a/files/en-us/web/api/audiodata/index.md
+++ b/files/en-us/web/api/audiodata/index.md
@@ -7,9 +7,10 @@ tags:
   - Interface
   - Reference
   - AudioData
+  - Experimental
 browser-compat: api.AudioData
 ---
-{{APIRef("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`AudioData`** interface of the [WebCodecs API](/en-US/docs/Web/API/WebCodecs_API) represents an audio sample.
 
@@ -33,33 +34,33 @@ In planar format, the number of planes is equal to {{domxref("AudioData.numberOf
 
 ## Constructor
 
-- {{domxref("AudioData.AudioData", "AudioData()")}}
+- {{domxref("AudioData.AudioData", "AudioData()")}} {{Experimental_Inline}}
   - : Creates a new `AudioData` object.
 
 ## Properties
 
-- {{domxref("AudioData.format")}} {{ReadOnlyInline}}
+- {{domxref("AudioData.format")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the sample format of the audio.
-- {{domxref("AudioData.sampleRate")}} {{ReadOnlyInline}}
+- {{domxref("AudioData.sampleRate")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the sample rate of the audio in Hz.
-- {{domxref("AudioData.numberOfFrames")}} {{ReadOnlyInline}}
+- {{domxref("AudioData.numberOfFrames")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the number of frames.
-- {{domxref("AudioData.numberOfChannels")}} {{ReadOnlyInline}}
+- {{domxref("AudioData.numberOfChannels")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the number of audio channels.
-- {{domxref("AudioData.duration")}} {{ReadOnlyInline}}
+- {{domxref("AudioData.duration")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the duration of the audio in microseconds.
-- {{domxref("AudioData.timestamp")}} {{ReadOnlyInline}}
+- {{domxref("AudioData.timestamp")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the timestamp of the audio in microseconds.
 
 ## Methods
 
-- {{domxref("AudioData.allocationSize()")}}
+- {{domxref("AudioData.allocationSize()")}} {{Experimental_Inline}}
   - : Returns the number of bytes required to hold the sample as filtered by options passed into the method.
-- {{domxref("AudioData.copyTo()")}}
+- {{domxref("AudioData.copyTo()")}} {{Experimental_Inline}}
   - : Copies the samples from the specified plane of the `AudioData` object to the destination.
-- {{domxref("AudioData.clone()")}}
+- {{domxref("AudioData.clone()")}} {{Experimental_Inline}}
   - : Creates a new `AudioData` object with reference to the same media resource as the original.
-- {{domxref("AudioData.close()")}}
+- {{domxref("AudioData.close()")}} {{Experimental_Inline}}
   - : Clears all states and releases the reference to the media resource.
 
 ## Specifications

--- a/files/en-us/web/api/audiodata/numberofchannels/index.md
+++ b/files/en-us/web/api/audiodata/numberofchannels/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - numberOfChannels
   - AudioData
+  - Experimental
 browser-compat: api.AudioData.numberOfChannels
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`numberOfChannels`** read-only property of the {{domxref("AudioData")}} interface returns the number of channels in the `AudioData` object.
 

--- a/files/en-us/web/api/audiodata/numberofframes/index.md
+++ b/files/en-us/web/api/audiodata/numberofframes/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - numberOfFrames
   - AudioData
+  - Experimental
 browser-compat: api.AudioData.numberOfFrames
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`numberOfFrames`** read-only property of the {{domxref("AudioData")}} interface returns the number of frames in the `AudioData` object.
 

--- a/files/en-us/web/api/audiodata/samplerate/index.md
+++ b/files/en-us/web/api/audiodata/samplerate/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - sampleRate
   - AudioData
+  - Experimental
 browser-compat: api.AudioData.sampleRate
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`sampleRate`** read-only property of the {{domxref("AudioData")}} interface returns the sample rate in Hz.
 

--- a/files/en-us/web/api/audiodata/timestamp/index.md
+++ b/files/en-us/web/api/audiodata/timestamp/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - timestamp
   - AudioData
+  - Experimental
 browser-compat: api.AudioData.timestamp
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`duration`** read-only property of the {{domxref("AudioData")}} interface returns the timestamp of this `AudioData` object.
 

--- a/files/en-us/web/api/audiodecoder/audiodecoder/index.md
+++ b/files/en-us/web/api/audiodecoder/audiodecoder/index.md
@@ -7,9 +7,10 @@ tags:
   - Constructor
   - Reference
   - AudioDecoder
+  - Experimental
 browser-compat: api.AudioDecoder.AudioDecoder
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`AudioDecoder()`** constructor creates a new {{domxref("AudioDecoder")}} object with the provided `init.output` callback assigned as the output callback, the provided `init.error` callback as the error callback, and the {{domxref("AudioDecoder.state")}} set to `"unconfigured"`.
 

--- a/files/en-us/web/api/audiodecoder/close/index.md
+++ b/files/en-us/web/api/audiodecoder/close/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - close
   - AudioDecoder
+  - Experimental
 browser-compat: api.AudioDecoder.close
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`close()`** method of the {{domxref("AudioDecoder")}} interface ends all pending work and releases system resources.
 

--- a/files/en-us/web/api/audiodecoder/configure/index.md
+++ b/files/en-us/web/api/audiodecoder/configure/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - configure
   - AudioDecoder
+  - Experimental
 browser-compat: api.AudioDecoder.configure
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`configure()`** method of the {{domxref("AudioDecoder")}} interface enqueues a control message to configure the audio decoder for decoding chunks.
 

--- a/files/en-us/web/api/audiodecoder/decode/index.md
+++ b/files/en-us/web/api/audiodecoder/decode/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - decode
   - AudioDecoder
+  - Experimental
 browser-compat: api.AudioDecoder.decode
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`decode()`** method of the {{domxref("AudioDecoder")}} interface enqueues a control message to decode a given chunk of audio.
 

--- a/files/en-us/web/api/audiodecoder/decodequeuesize/index.md
+++ b/files/en-us/web/api/audiodecoder/decodequeuesize/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - decodeQueueSize
   - AudioDecoder
+  - Experimental
 browser-compat: api.AudioDecoder.decodeQueueSize
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`decodeQueueSize`** read-only property of the {{domxref("AudioDecoder")}} interface returns the number of pending decode requests in the queue.
 

--- a/files/en-us/web/api/audiodecoder/flush/index.md
+++ b/files/en-us/web/api/audiodecoder/flush/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - flush
   - AudioDecoder
+  - Experimental
 browser-compat: api.AudioDecoder.flush
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`flush()`** method of the {{domxref("AudioDecoder")}} interface returns a Promise that resolves once all pending messages in the queue have been completed.
 

--- a/files/en-us/web/api/audiodecoder/index.md
+++ b/files/en-us/web/api/audiodecoder/index.md
@@ -7,35 +7,36 @@ tags:
   - Interface
   - Reference
   - AudioDecoder
+  - Experimental
 browser-compat: api.AudioDecoder
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`AudioDecoder`** interface of the {{domxref('WebCodecs API','','',' ')}} decodes chunks of audio.
 
 ## Constructor
 
-- {{domxref("AudioDecoder.AudioDecoder", "AudioDecoder()")}}
+- {{domxref("AudioDecoder.AudioDecoder", "AudioDecoder()")}} {{Experimental_Inline}}
   - : Creates a new `AudioDecoder` object.
 
 ## Properties
 
-- {{domxref("AudioDecoder.decodeQueueSize")}} {{ReadOnlyInline}}
+- {{domxref("AudioDecoder.decodeQueueSize")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : An integer representing the number of decode queue requests.
-- {{domxref("AudioDecoder.state")}} {{ReadOnlyInline}}
+- {{domxref("AudioDecoder.state")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Represents the state of the underlying codec and whether it is configured for decoding.
 
 ## Methods
 
-- {{domxref("AudioDecoder.configure()")}}
+- {{domxref("AudioDecoder.configure()")}} {{Experimental_Inline}}
   - : Enqueues a control message to configure the audio decoder for decoding chunks.
 - {{domxref("AudioDecoder.decode()")}}
   - : Enqueues a control message to decode a given chunk of audio.
-- {{domxref("AudioDecoder.flush()")}}
+- {{domxref("AudioDecoder.flush()")}} {{Experimental_Inline}}
   - : Returns a promise that resolves once all pending messages in the queue have been completed.
-- {{domxref("AudioDecoder.reset()")}}
+- {{domxref("AudioDecoder.reset()")}} {{Experimental_Inline}}
   - : Resets all states including configuration, control messages in the control message queue, and all pending callbacks.
-- {{domxref("AudioDecoder.close()")}}
+- {{domxref("AudioDecoder.close()")}} {{Experimental_Inline}}
   - : Ends all pending work and releases system resources.
 
 ## Specifications

--- a/files/en-us/web/api/audiodecoder/reset/index.md
+++ b/files/en-us/web/api/audiodecoder/reset/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - reset
   - AudioDecoder
+  - Experimental
 browser-compat: api.AudioDecoder.reset
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`reset()`** method of the {{domxref("AudioDecoder")}} interface resets all states including configuration, control messages in the control message queue, and all pending callbacks.
 

--- a/files/en-us/web/api/audiodecoder/state/index.md
+++ b/files/en-us/web/api/audiodecoder/state/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - state
   - AudioDecoder
+  - Experimental
 browser-compat: api.AudioDecoder.state
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`state`** read-only property of the {{domxref("AudioDecoder")}} interface returns the current state of the underlying codec.
 

--- a/files/en-us/web/api/audioencoder/audioencoder/index.md
+++ b/files/en-us/web/api/audioencoder/audioencoder/index.md
@@ -7,9 +7,10 @@ tags:
   - Constructor
   - Reference
   - AudioEncoder
+  - Experimental
 browser-compat: api.AudioEncoder.AudioEncoder
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`AudioEncoder()`** constructor creates a new {{domxref("AudioEncoder")}} object with the provided `init.output` callback assigned as the output callback, the provided `init.error` callback as the error callback, and the {{domxref("AudioEncoder.state")}} set to `"unconfigured"`.
 

--- a/files/en-us/web/api/audioencoder/close/index.md
+++ b/files/en-us/web/api/audioencoder/close/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - close
   - AudioEncoder
+  - Experimental
 browser-compat: api.AudioEncoder.close
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`close()`** method of the {{domxref("AudioEncoder")}} interface ends all pending work and releases system resources.
 

--- a/files/en-us/web/api/audioencoder/configure/index.md
+++ b/files/en-us/web/api/audioencoder/configure/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - configure
   - AudioEncoder
+  - Experimental
 browser-compat: api.AudioEncoder.configure
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`configure()`** method of the {{domxref("AudioEncoder")}} interface enqueues a control message to configure the audio encoder for encoding chunks.
 

--- a/files/en-us/web/api/audioencoder/encode/index.md
+++ b/files/en-us/web/api/audioencoder/encode/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - encode
   - AudioEncoder
+  - Experimental
 browser-compat: api.AudioEncoder.encode
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`encode()`** method of the {{domxref("AudioEncoder")}} interface enqueues a control message to encode a given {{domxref("AudioData")}} object.
 

--- a/files/en-us/web/api/audioencoder/encodequeuesize/index.md
+++ b/files/en-us/web/api/audioencoder/encodequeuesize/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - encodeQueueSize
   - AudioEncoder
+  - Experimental
 browser-compat: api.AudioEncoder.encodeQueueSize
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`encodeQueueSize`** read-only property of the {{domxref("AudioEncoder")}} interface returns the number of pending encode requests in the queue.
 

--- a/files/en-us/web/api/audioencoder/flush/index.md
+++ b/files/en-us/web/api/audioencoder/flush/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - flush
   - AudioEncoder
+  - Experimental
 browser-compat: api.AudioEncoder.flush
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`flush()`** method of the {{domxref("AudioEncoder")}} interface returns a Promise that resolves once all pending messages in the queue have been completed.
 


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.

Note: It's easy to review the changes. Open the preview URLs hosted by the PR companion, in new tab, and look at the BCD tables at the bottom of the pages.