### PR TITLE
change the returned value of Object(null) or Object(undefined) to mat…

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/index.md
@@ -20,7 +20,7 @@ Changes to the `Object` prototype object are seen by **all** objects through pro
 The `Object` constructor creates an object wrapper for the given value.
 
 - If the value is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or {{jsxref("undefined")}}, it will create and return an empty object.
-- If the value is an object already, it will return the value.
+- If the value is an object already, it will return `new Object(value, Object.prototype)`.
 - Otherwise, it will return an object of a Type that corresponds to the given value.
 
 When called in a non-constructor context, `Object` behaves identically to `new Object()`.


### PR DESCRIPTION
…ch specs

According to specification : 
' If NewTarget is neither undefined nor the active function, then
a. Return ? OrdinaryCreateFromConstructor(NewTarget, "%Object.prototype%"). '
check the below link :
https://tc39.es/ecma262/multipage/fundamental-objects.html#sec-object-objects

that means it returns a new object of the same value and adds to it Object.prototype  = `new Object(value, Object.prototype)`

for ex :
Object(null) // returns {}

//an object without prototypal inheritance or without [[prototype]] property that points to Object.prototype 

new Object(Object(null))     // returns  {[[prototype]]:Object.prototype}

//so it will not return the exact value as hinted but a new one from the value with prototypal inheritance

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
