### PR TITLE
Improve Object() constructor description

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/index.md
@@ -17,7 +17,7 @@ Nearly all objects in JavaScript are instances of {{jsxref("Object")}}; a typica
 
 Changes to the `Object` prototype object are seen by **all** objects through prototype chaining, unless the properties and methods subject to those changes are overridden further along the prototype chain. This provides a very powerful although potentially dangerous mechanism to override or extend object behavior.
 
-The `Object` constructor creates an object wrapper for the given value.
+The `Object` constructor performs the following steps when called.
 
 - If the value is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or {{jsxref("undefined")}}, it will create and return an empty object.
 - If the value is an object already, it will return the value.

--- a/files/en-us/web/javascript/reference/global_objects/object/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/index.md
@@ -17,7 +17,7 @@ Nearly all objects in JavaScript are instances of {{jsxref("Object")}}; a typica
 
 Changes to the `Object` prototype object are seen by **all** objects through prototype chaining, unless the properties and methods subject to those changes are overridden further along the prototype chain. This provides a very powerful although potentially dangerous mechanism to override or extend object behavior.
 
-The `Object` constructor performs the following steps when called.
+The `Object` constructor's behavior depends on the input's type.
 
 - If the value is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or {{jsxref("undefined")}}, it will create and return an empty object.
 - If the value is an object already, it will return the value.

--- a/files/en-us/web/javascript/reference/global_objects/object/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/index.md
@@ -34,7 +34,7 @@ There isn't any method in an Object itself to delete its own properties (such as
 ## Constructor
 
 - {{jsxref("Object/Object", "Object()")}}
-  - : Creates a new `Object` object. It is a wrapper for the given value.
+  - : Turns the input into an object.
 
 ## Static methods
 

--- a/files/en-us/web/javascript/reference/global_objects/object/object/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/object/index.md
@@ -10,8 +10,8 @@ browser-compat: javascript.builtins.Object.Object
 ---
 {{JSRef}}
 
-The **`Object` constructor** creates an object wrapper for the
-given value.
+The `Object` constructor performs the following steps when called.
+
 
 - If the value is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or {{jsxref("undefined")}}, it will create and
   return an empty object.

--- a/files/en-us/web/javascript/reference/global_objects/object/object/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/object/index.md
@@ -10,8 +10,7 @@ browser-compat: javascript.builtins.Object.Object
 ---
 {{JSRef}}
 
-The `Object` constructor performs the following steps when called.
-
+The **`Object` constructor** turns the input into an object. Its behavior depends on the input's type.
 
 - If the value is [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) or {{jsxref("undefined")}}, it will create and
   return an empty object.


### PR DESCRIPTION
As the Object constructor does not always make a wrapper for the value, I think it will be more accurate to make it "The `Object` constructor performs the following steps when called.".

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
