### PR TITLE
Fix anchor of a link on `SharedWorker()`

### DIFF
--- a/files/en-us/web/api/sharedworker/sharedworker/index.md
+++ b/files/en-us/web/api/sharedworker/sharedworker/index.md
@@ -66,7 +66,7 @@ new SharedWorker(aURL, options)
 - `NetworkError`  {{domxref("DOMException")}}
   - : Thrown if the MIME type of the worker script is incorrect.
     It should _always_ be `text/javascript`
-    (for historical reasons [other JavaScript MIME types](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#javascript_types) may be accepted).
+    (for historical reasons [other JavaScript MIME types](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#textjavascript) may be accepted).
 - `SyntaxError`  {{domxref("DOMException")}}
   - : Thrown if _aURL_ cannot be parsed.
 

--- a/files/en-us/web/api/sharedworker/sharedworker/index.md
+++ b/files/en-us/web/api/sharedworker/sharedworker/index.md
@@ -61,12 +61,9 @@ new SharedWorker(aURL, options)
 ### Exceptions
 
 - `SecurityError` {{domxref("DOMException")}}
-  - : Thrown if the document is not allowed to start workers,
-    for example if the URL has an invalid syntax or if the same-origin policy is violated.
+  - : Thrown if the document is not allowed to start workers, for example if the URL has an invalid syntax or if the same-origin policy is violated.
 - `NetworkError`  {{domxref("DOMException")}}
-  - : Thrown if the MIME type of the worker script is incorrect.
-    It should _always_ be `text/javascript`
-    (for historical reasons [other JavaScript MIME types](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#textjavascript) may be accepted).
+  - : Thrown if the MIME type of the worker script is incorrect. It should _always_ be `text/javascript` (for historical reasons [other JavaScript MIME types](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#textjavascript) may be accepted).
 - `SyntaxError`  {{domxref("DOMException")}}
   - : Thrown if _aURL_ cannot be parsed.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary/Motivation

The [`#javascript_types` anchor](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#javascript_types) does not "exist" on the [MIME types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) page, so this PR changes the anchor of the link to [`#textjavascript`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types#textjavascript).

(I also removed some newlines that were in the middle of sentences.)

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
