### PR TITLE
Update BCD info, part 3

### DIFF
--- a/files/en-us/web/api/audioencoder/index.md
+++ b/files/en-us/web/api/audioencoder/index.md
@@ -29,7 +29,7 @@ The **`AudioEncoder`** interface of the [WebCodecs API](/en-US/docs/Web/API/WebC
 
 - {{domxref("AudioEncoder.configure()")}} {{Experimental_Inline}}
   - : Enqueues a control message to configure the audio encoder for encoding chunks.
-- {{domxref("AudioEncoder.encode()")}}
+- {{domxref("AudioEncoder.encode()")}} {{Experimental_Inline}}
   - : Enqueues a control message to encode a given {{domxref("AudioData")}} objects.
 - {{domxref("AudioEncoder.flush()")}} {{Experimental_Inline}}
   - : Returns a promise that resolves once all pending messages in the queue have been completed.

--- a/files/en-us/web/api/audioencoder/index.md
+++ b/files/en-us/web/api/audioencoder/index.md
@@ -7,34 +7,35 @@ tags:
   - Interface
   - Reference
   - AudioEncoder
+  - Experimental
 browser-compat: api.AudioEncoder
 ---
-{{APIRef("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 The **`AudioEncoder`** interface of the [WebCodecs API](/en-US/docs/Web/API/WebCodecs_API) encodes {{domxref("AudioData")}} objects.
 
 ## Constructor
 
-- {{domxref("AudioEncoder.AudioEncoder", "AudioEncoder()")}}
+- {{domxref("AudioEncoder.AudioEncoder", "AudioEncoder()")}} {{Experimental_Inline}}
   - : Creates a new `AudioEncoder` object.
 
 ## Properties
 
-- {{domxref("AudioEncoder.encodeQueueSize")}} {{ReadOnlyInline}}
+- {{domxref("AudioEncoder.encodeQueueSize")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : An integer representing the number of encode queue requests.
-- {{domxref("AudioEncoder.state")}} {{ReadOnlyInline}}
+- {{domxref("AudioEncoder.state")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Represents the state of the underlying codec and whether it is configured for encoding.
 
 ## Methods
 
-- {{domxref("AudioEncoder.configure()")}}
+- {{domxref("AudioEncoder.configure()")}} {{Experimental_Inline}}
   - : Enqueues a control message to configure the audio encoder for encoding chunks.
 - {{domxref("AudioEncoder.encode()")}}
   - : Enqueues a control message to encode a given {{domxref("AudioData")}} objects.
-- {{domxref("AudioEncoder.flush()")}}
+- {{domxref("AudioEncoder.flush()")}} {{Experimental_Inline}}
   - : Returns a promise that resolves once all pending messages in the queue have been completed.
-- {{domxref("AudioEncoder.reset()")}}
+- {{domxref("AudioEncoder.reset()")}} {{Experimental_Inline}}
   - : Resets all states including configuration, control messages in the control message queue, and all pending callbacks.
-- {{domxref("AudioEncoder.close()")}}
+- {{domxref("AudioEncoder.close()")}} {{Experimental_Inline}}
   - : Ends all pending work and releases system resources.
 
 ## Specifications

--- a/files/en-us/web/api/audioencoder/reset/index.md
+++ b/files/en-us/web/api/audioencoder/reset/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - reset
   - AudioEncoder
+   - Experimental
 browser-compat: api.AudioEncoder.reset
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`reset()`** method of the {{domxref("AudioEncoder")}} interface resets all states including configuration, control messages in the control message queue, and all pending callbacks.
 

--- a/files/en-us/web/api/audioencoder/state/index.md
+++ b/files/en-us/web/api/audioencoder/state/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - state
   - AudioEncoder
+  - Experimental
 browser-compat: api.AudioEncoder.state
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`state`** read-only property of the {{domxref("AudioEncoder")}} interface returns the current state of the underlying codec.
 

--- a/files/en-us/web/api/audiolistener/setorientation/index.md
+++ b/files/en-us/web/api/audiolistener/setorientation/index.md
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Audio API
   - setOrientation
+  - Deprecated
 browser-compat: api.AudioListener.setOrientation
 ---
 {{ APIRef("Web Audio API") }}{{deprecated_header}}

--- a/files/en-us/web/api/audioprocessingevent/index.md
+++ b/files/en-us/web/api/audioprocessingevent/index.md
@@ -21,22 +21,22 @@ The [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) `AudioProcessingEvent` re
 
 ## Constructor
 
-- `AudioProcessingEvent()`
+- `AudioProcessingEvent()` {{Deprecated_Inline}}
   - : Creates a new `AudioProcessingEvent` object.
 
 ## Properties
 
 _Also implements the properties inherited from its parent, {{domxref("Event")}}_.
 
-- `playbackTime` {{ReadOnlyInline}}
+- `playbackTime` {{ReadOnlyInline}} {{Deprecated_Inline}}
   - : A double representing the time when the audio will be played,
     as defined by the time of {{domxref("BaseAudioContext/currentTime", "AudioContext.currentTime")}}.
-- `inputBuffer` {{ReadOnlyInline}}
+- `inputBuffer` {{ReadOnlyInline}} {{Deprecated_Inline}}
   - : An {{domxref("AudioBuffer")}} that is the buffer containing the input audio data to be processed.
     The number of channels is defined as a parameter `numberOfInputChannels`,
     of the factory method {{domxref("BaseAudioContext/createScriptProcessor", "AudioContext.createScriptProcessor()")}}.
     Note that the returned <code>AudioBuffer</code> is only valid in the scope of the event handler.
-- `outputBuffer` {{ReadOnlyInline}}
+- `outputBuffer` {{ReadOnlyInline}} {{Deprecated_Inline}}
   - : An {{domxref("AudioBuffer")}} that is the buffer where the output audio data should be written.
     The number of channels is defined as a parameter, <code>numberOfOutputChannels</code>,
     of the factory method {{domxref("BaseAudioContext/createScriptProcessor", "AudioContext.createScriptProcessor()")}}.

--- a/files/en-us/web/api/background_synchronization_api/index.md
+++ b/files/en-us/web/api/background_synchronization_api/index.md
@@ -37,7 +37,7 @@ As this API relies on service workers, functionality provided by this API is onl
 
 - {{domxref('SyncManager')}} {{Experimental_Inline}}
   - : Registers tasks to be run in a service worker at a later time with network connectivity. These tasks are referred to as _background sync requests_.
-- {{domxref('SyncEvent')}} 
+- {{domxref('SyncEvent')}}
   - : Represents a synchronization event, sent to the {{domxref('ServiceWorkerGlobalScope', 'global scope')}} of a {{domxref('ServiceWorker')}}. It provides a way to run tasks in the service worker with network connectivity.
 
 ## Service Worker Additions

--- a/files/en-us/web/api/background_synchronization_api/index.md
+++ b/files/en-us/web/api/background_synchronization_api/index.md
@@ -12,9 +12,10 @@ tags:
   - Service Workers
   - Sync
   - Web Background Synchronization API
+  - Experimental
 browser-compat: api.SyncManager
 ---
-{{securecontext_header}}
+{{securecontext_header}}{{SeeCompatTable}}
 
 {{DefaultAPISidebar("Background Sync")}}
 

--- a/files/en-us/web/api/background_synchronization_api/index.md
+++ b/files/en-us/web/api/background_synchronization_api/index.md
@@ -35,9 +35,9 @@ As this API relies on service workers, functionality provided by this API is onl
 
 ## Background Synchronization Interfaces
 
-- {{domxref('SyncManager')}}
+- {{domxref('SyncManager')}} {{Experimental_Inline}}
   - : Registers tasks to be run in a service worker at a later time with network connectivity. These tasks are referred to as _background sync requests_.
-- {{domxref('SyncEvent')}}
+- {{domxref('SyncEvent')}} 
   - : Represents a synchronization event, sent to the {{domxref('ServiceWorkerGlobalScope', 'global scope')}} of a {{domxref('ServiceWorker')}}. It provides a way to run tasks in the service worker with network connectivity.
 
 ## Service Worker Additions

--- a/files/en-us/web/api/backgroundfetchevent/backgroundfetchevent/index.md
+++ b/files/en-us/web/api/backgroundfetchevent/backgroundfetchevent/index.md
@@ -7,9 +7,10 @@ tags:
   - Constructor
   - Reference
   - BackgroundFetchEvent
+  - Experimental
 browser-compat: api.BackgroundFetchEvent.BackgroundFetchEvent
 ---
-{{APIRef("Background Fetch API")}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`BackgroundFetchEvent()`** constructor creates a new {{domxref("BackgroundFetchEvent")}} object. This constructor is not typically used as the browser creates these objects itself and provides them to background fetch event callbacks.
 

--- a/files/en-us/web/api/backgroundfetchevent/registration/index.md
+++ b/files/en-us/web/api/backgroundfetchevent/registration/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - registration
   - BackgroundFetchEvent
+  - Experimental
 browser-compat: api.BackgroundFetchEvent.registration
 ---
-{{DefaultAPISidebar("Background Fetch API")}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`registration`** read-only property of the {{domxref("BackgroundFetchEvent")}} interface returns a {{domxref("BackgroundFetchRegistration")}} object.
 

--- a/files/en-us/web/api/backgroundfetchmanager/fetch/index.md
+++ b/files/en-us/web/api/backgroundfetchmanager/fetch/index.md
@@ -13,7 +13,7 @@ tags:
   - Fetch
 browser-compat: api.BackgroundFetchManager.fetch
 ---
-{{DefaultAPISidebar("Background Fetch API")}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`fetch()`** method of the {{domxref("BackgroundFetchManager")}} interface returns a {{jsxref("Promise")}} that resolves with a {{domxref("BackgroundFetchRegistration")}} object for a supplied array of URLs and {{domxref("Request")}} objects.
 

--- a/files/en-us/web/api/backgroundfetchmanager/get/index.md
+++ b/files/en-us/web/api/backgroundfetchmanager/get/index.md
@@ -13,7 +13,7 @@ tags:
   - Fetch
 browser-compat: api.BackgroundFetchManager.get
 ---
-{{DefaultAPISidebar("Background Fetch API")}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`get()`** method of the {{domxref("BackgroundFetchManager")}} interface returns a {{jsxref("Promise")}} that resolves with the {{domxref("BackgroundFetchRegistration")}} associated with the provided `id` or {{jsxref("undefined")}} if the `id` is not found.
 

--- a/files/en-us/web/api/backgroundfetchmanager/getids/index.md
+++ b/files/en-us/web/api/backgroundfetchmanager/getids/index.md
@@ -13,7 +13,7 @@ tags:
   - Fetch
 browser-compat: api.BackgroundFetchManager.getIds
 ---
-{{DefaultAPISidebar("Background Fetch API")}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`getIds()`** method of the {{domxref("BackgroundFetchManager")}} interface returns the IDs of all registered background fetches.
 

--- a/files/en-us/web/api/backgroundfetchmanager/index.md
+++ b/files/en-us/web/api/backgroundfetchmanager/index.md
@@ -12,7 +12,7 @@ tags:
   - Fetch
 browser-compat: api.BackgroundFetchManager
 ---
-{{DefaultAPISidebar("Background Fetch API")}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`BackgroundFetchManager`** interface of the {{domxref('Background Fetch API','','',' ')}} is a map where the keys are background fetch IDs and the values are {{domxref("BackgroundFetchRegistration")}} objects.
 
@@ -22,9 +22,9 @@ None.
 
 ## Methods
 
-- {{domxref('BackgroundFetchManager.fetch','fetch()' )}}
+- {{domxref('BackgroundFetchManager.fetch','fetch()' )}} {{Experimental_Inline}}
   - : Returns a {{jsxref("Promise")}} that resolves with a {{domxref("BackgroundFetchRegistration")}} object for a supplied array of URLs and {{domxref("Request")}} objects.
-- {{domxref('BackgroundFetchManager.get','get()')}}
+- {{domxref('BackgroundFetchManager.get','get()')}} {{Experimental_Inline}}
   - : Returns a {{jsxref("Promise")}} that resolves with the {{domxref("BackgroundFetchRegistration")}} associated with the provided `id` or {{jsxref("undefined")}} if the `id` is not found.
 - {{domxref('BackgroundFetchManager.getIDs','getIDs()')}}
   - : Returns the IDs of all registered background fetches.

--- a/files/en-us/web/api/backgroundfetchmanager/index.md
+++ b/files/en-us/web/api/backgroundfetchmanager/index.md
@@ -26,7 +26,7 @@ None.
   - : Returns a {{jsxref("Promise")}} that resolves with a {{domxref("BackgroundFetchRegistration")}} object for a supplied array of URLs and {{domxref("Request")}} objects.
 - {{domxref('BackgroundFetchManager.get','get()')}} {{Experimental_Inline}}
   - : Returns a {{jsxref("Promise")}} that resolves with the {{domxref("BackgroundFetchRegistration")}} associated with the provided `id` or {{jsxref("undefined")}} if the `id` is not found.
-- {{domxref('BackgroundFetchManager.getIDs','getIDs()')}}
+- {{domxref('BackgroundFetchManager.getIDs','getIDs()')}} {{Experimental_Inline}}
   - : Returns the IDs of all registered background fetches.
 
 ## Examples

--- a/files/en-us/web/api/backgroundfetchrecord/request/index.md
+++ b/files/en-us/web/api/backgroundfetchrecord/request/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - request
   - BackgroundFetchRecord
+  - Experimental
 browser-compat: api.BackgroundFetchRecord.request
 ---
-{{DefaultAPISidebar("Background Fetch API")}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`request`** read-only property of the {{domxref("BackgroundFetchRecord")}} interface returns the details of the resource to be fetched.
 

--- a/files/en-us/web/api/backgroundfetchrecord/responseready/index.md
+++ b/files/en-us/web/api/backgroundfetchrecord/responseready/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - responseReady
   - BackgroundFetchRecord
+  - Experimental
 browser-compat: api.BackgroundFetchRecord.responseReady
 ---
-{{DefaultAPISidebar("Background Fetch API")}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`responseReady`** read-only property of the {{domxref("BackgroundFetchRecord")}} interface returns a {{jsxref("Promise")}} that resolves with a {{domxref("Response")}}.
 

--- a/files/en-us/web/api/backgroundfetchregistration/abort/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/abort/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - abort
   - BackgroundFetchRegistration
+  - Experimental
 browser-compat: api.BackgroundFetchRegistration.abort
 ---
-{{APIRef("Background Fetch API")}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`abort()`** method of the {{domxref("BackgroundFetchRegistration")}} interface aborts an active background fetch.
 

--- a/files/en-us/web/api/backgroundfetchregistration/downloaded/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/downloaded/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - downloaded
   - BackgroundFetchRegistration
+  - Experimental
 browser-compat: api.BackgroundFetchRegistration.downloaded
 ---
-{{APIRef("Background Fetch API")}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`downloaded`** read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns the size in bytes that has been downloaded, initially `0`.
 

--- a/files/en-us/web/api/backgroundfetchregistration/downloadtotal/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/downloadtotal/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - downloadTotal
   - BackgroundFetchRegistration
+  - Experimental
 browser-compat: api.BackgroundFetchRegistration.downloadTotal
 ---
-{{APIRef("Background Fetch API")}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`downloadTotal`** read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns the total size in bytes of this download. This is set when the background fetch was registered, or `0` if not set.
 

--- a/files/en-us/web/api/backgroundfetchregistration/failurereason/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/failurereason/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - failureReason
   - BackgroundFetchRegistration
+  - Experimental
 browser-compat: api.BackgroundFetchRegistration.failureReason
 ---
-{{APIRef("Background Fetch API")}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`failureReason`** read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns a string with a value that indicates a reason for a background fetch failure.
 

--- a/files/en-us/web/api/backgroundfetchregistration/id/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/id/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - id
   - BackgroundFetchRegistration
+  - Experimental
 browser-compat: api.BackgroundFetchRegistration.id
 ---
-{{APIRef("Background Fetch API")}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`id`** read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns a copy of the background fetch's `ID`.
 

--- a/files/en-us/web/api/backgroundfetchregistration/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/index.md
@@ -67,7 +67,7 @@ The following properties are available synchronously, as convenience properties 
 
 Listen to these events using [`addEventListener()`](/en-US/docs/Web/API/EventTarget/addEventListener) or by assigning an event listener to the `oneventname` property of this interface.
 
-- [`progress`](/en-US/docs/Web/API/BackgroundFetchRegistration/progress_event)
+- [`progress`](/en-US/docs/Web/API/BackgroundFetchRegistration/progress_event)  {{Experimental_Inline}}
 
   - : Fired when there is a change to any of the following properties:
     {{domxref("BackgroundFetchRegistration.uploaded", "uploaded")}},

--- a/files/en-us/web/api/backgroundfetchregistration/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/index.md
@@ -7,9 +7,10 @@ tags:
   - Interface
   - Reference
   - BackgroundFetchRegistration
+  - Experimental
 browser-compat: api.BackgroundFetchRegistration
 ---
-{{APIRef("Background Fetch API")}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`BackgroundFetchRegistration`** interface of the {{domxref('Background Fetch API','','',' ')}} represents an individual background fetch.
 
@@ -21,19 +22,19 @@ A `BackgroundFetchRegistration` instance is returned by the {{domxref("Backgroun
 
 The following properties are available synchronously, as convenience properties copied from those in the `BackgroundFetchRegistration` instance.
 
-- {{domxref("BackgroundFetchRegistration.id")}} {{ReadOnlyInline}}
+- {{domxref("BackgroundFetchRegistration.id")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A string containing the background fetch's ID.
-- {{domxref("BackgroundFetchRegistration.uploadTotal")}} {{ReadOnlyInline}}
+- {{domxref("BackgroundFetchRegistration.uploadTotal")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A {{jsxref("number")}} containing the total number of bytes to be uploaded.
-- {{domxref("BackgroundFetchRegistration.uploaded")}} {{ReadOnlyInline}}
+- {{domxref("BackgroundFetchRegistration.uploaded")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A {{jsxref("number")}} containing the size in bytes successfully sent, initially `0`.
-- {{domxref("BackgroundFetchRegistration.downloadTotal")}} {{ReadOnlyInline}}
+- {{domxref("BackgroundFetchRegistration.downloadTotal")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A {{jsxref("number")}} containing the total size in bytes of this download. This is the value set when the background fetch was registered, or `0`.
-- {{domxref("BackgroundFetchRegistration.downloaded")}} {{ReadOnlyInline}}
+- {{domxref("BackgroundFetchRegistration.downloaded")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A {{jsxref("number")}} containing the size in bytes that has been downloaded, initially `0`.
-- {{domxref("BackgroundFetchRegistration.result")}} {{ReadOnlyInline}}
+- {{domxref("BackgroundFetchRegistration.result")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns an empty string initially, on completion either the string `"success"` or `"failure"`.
-- {{domxref("BackgroundFetchRegistration.failureReason")}} {{ReadOnlyInline}}
+- {{domxref("BackgroundFetchRegistration.failureReason")}} {{ReadOnlyInline}} {{Experimental_Inline}}
 
   - : One of the following strings:
 
@@ -50,16 +51,16 @@ The following properties are available synchronously, as convenience properties 
     - `"download-total-exceeded"`
       - : The provided `downloadTotal` was exceeded. This value was set when the background fetch was registered.
 
-- {{domxref("BackgroundFetchRegistration.recordsAvailable")}} {{ReadOnlyInline}}
+- {{domxref("BackgroundFetchRegistration.recordsAvailable")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : A {{jsxref("boolean")}} indicating whether the `recordsAvailable` flag is set.
 
 ## Methods
 
-- {{domxref("BackgroundFetchRegistration.abort","BackgroundFetchRegistration.abort()")}}
+- {{domxref("BackgroundFetchRegistration.abort","BackgroundFetchRegistration.abort()")}} {{Experimental_Inline}}
   - : Aborts the background fetch. Returns a {{jsxref("Promise")}} that resolves with `true` if the fetch was successfully aborted.
-- {{domxref("BackgroundFetchRegistration.match","BackgroundFetchRegistration.match()")}}
+- {{domxref("BackgroundFetchRegistration.match","BackgroundFetchRegistration.match()")}} {{Experimental_Inline}}
   - : Returns a single {{domxref("BackgroundFetchRecord")}} object which is the first match for the arguments.
-- {{domxref("BackgroundFetchRegistration.matchAll","BackgroundFetchRegistration.matchAll()")}}
+- {{domxref("BackgroundFetchRegistration.matchAll","BackgroundFetchRegistration.matchAll()")}} {{Experimental_Inline}}
   - : Returns a {{jsxref("Promise")}} that resolves with an array of {{domxref("BackgroundFetchRecord")}} objects containing requests and responses.
 
 ## Events

--- a/files/en-us/web/api/backgroundfetchregistration/match/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/match/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - match
   - BackgroundFetchRegistration
+  - Experimental
 browser-compat: api.BackgroundFetchRegistration.match
 ---
-{{APIRef("Background Fetch API")}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`match()`** method of the {{domxref("BackgroundFetchRegistration")}} interface returns the first matching {{domxref("BackgroundFetchRecord")}}.
 

--- a/files/en-us/web/api/backgroundfetchregistration/matchall/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/matchall/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - matchAll
   - BackgroundFetchRegistration
+  - Experimental
 browser-compat: api.BackgroundFetchRegistration.matchAll
 ---
-{{APIRef("Background Fetch API")}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`matchAll()`** method of the {{domxref("BackgroundFetchRegistration")}} interface returns an array of matching {{domxref("BackgroundFetchRecord")}} objects.
 

--- a/files/en-us/web/api/backgroundfetchregistration/progress_event/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/progress_event/index.md
@@ -7,9 +7,10 @@ tags:
   - API
   - Reference
   - Event
+  - Experimental
 browser-compat: api.BackgroundFetchRegistration.progress_event
 ---
-{{APIRef("Background Fetch API")}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`progress`** event of the {{domxref("BackgroundFetchRegistration")}} interface thrown when the associated background fetch progresses.
 

--- a/files/en-us/web/api/backgroundfetchregistration/recordsavailable/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/recordsavailable/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - recordsAvailable
   - BackgroundFetchRegistration
+  - Experimental
 browser-compat: api.BackgroundFetchRegistration.recordsAvailable
 ---
-{{APIRef("Background Fetch API")}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`recordsAvailable`** read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns `true` if there are requests and responses to be accessed. If this returns false then {{domxref("BackgroundFetchRegistration.match()","match()")}} and {{domxref("BackgroundFetchRegistration.matchAll()","matchAll()")}} can't be used.
 

--- a/files/en-us/web/api/backgroundfetchregistration/result/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/result/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - result
   - BackgroundFetchRegistration
+  - Experimental
 browser-compat: api.BackgroundFetchRegistration.result
 ---
-{{APIRef("Background Fetch API")}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`result`** read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns a string indicating whether the background fetch was successful or failed.
 

--- a/files/en-us/web/api/backgroundfetchregistration/uploaded/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/uploaded/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - uploaded
   - BackgroundFetchRegistration
+  - Experimental
 browser-compat: api.BackgroundFetchRegistration.uploaded
 ---
-{{APIRef("Background Fetch API")}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`uploaded`** read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns the size in bytes successfully sent, initially `0`.
 

--- a/files/en-us/web/api/backgroundfetchregistration/uploadtotal/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/uploadtotal/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - uploadTotal
   - BackgroundFetchRegistration
+  - Experimental
 browser-compat: api.BackgroundFetchRegistration.uploadTotal
 ---
-{{APIRef("Background Fetch API")}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`uploadTotal`** read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns the total number of bytes to be sent to the server.
 

--- a/files/en-us/web/api/backgroundfetchupdateuievent/backgroundfetchupdateuievent/index.md
+++ b/files/en-us/web/api/backgroundfetchupdateuievent/backgroundfetchupdateuievent/index.md
@@ -7,9 +7,10 @@ tags:
   - Constructor
   - Reference
   - BackgroundFetchUpdateUIEvent
+  - Experimental
 browser-compat: api.BackgroundFetchUpdateUIEvent.BackgroundFetchUpdateUIEvent
 ---
-{{APIRef("Background Fetch API")}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`BackgroundFetchUpdateUIEvent()`** constructor creates a new {{domxref("BackgroundFetchUpdateUIEvent")}} object. This constructor is not typically used as the browser creates these objects itself and provides them to background fetch event callbacks.
 

--- a/files/en-us/web/api/backgroundfetchupdateuievent/index.md
+++ b/files/en-us/web/api/backgroundfetchupdateuievent/index.md
@@ -7,9 +7,10 @@ tags:
   - Interface
   - Reference
   - BackgroundFetchUpdateUIEvent
+  - Experimental
 browser-compat: api.BackgroundFetchUpdateUIEvent
 ---
-{{DefaultAPISidebar("Background Fetch API")}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`BackgroundFetchUpdateUIEvent`** interface of the {{domxref('Background Fetch API','','',' ')}} is an event type for the {{domxref("ServiceWorkerGlobalScope.backgroundfetchsuccess_event", "backgroundfetchsuccess")}} and {{domxref("ServiceWorkerGlobalScope.backgroundfetchfail_event", "backgroundfetchfail")}} events, and provides a method for updating the title and icon of the app to inform a user of the success or failure of a background fetch.
 
@@ -17,7 +18,7 @@ The **`BackgroundFetchUpdateUIEvent`** interface of the {{domxref('Background Fe
 
 ## Constructor
 
-- {{domxref("BackgroundFetchUpdateUIEvent.BackgroundFetchUpdateUIEvent()", "BackgroundFetchUpdateUIEvent()")}}
+- {{domxref("BackgroundFetchUpdateUIEvent.BackgroundFetchUpdateUIEvent()", "BackgroundFetchUpdateUIEvent()")}} {{Experimental_Inline}}
   - : Creates a new `BackgroundFetchUIEvent` object. This constructor is not typically used, as the browser creates these objects itself for the {{domxref("ServiceWorkerGlobalScope.backgroundfetchsuccess_event", "backgroundfetchsuccess")}} and {{domxref("ServiceWorkerGlobalScope.backgroundfetchfail_event", "backgroundfetchfail")}} events.
 
 ## Properties
@@ -26,7 +27,7 @@ _This interface doesn't implement any specific properties, but inherits properti
 
 ## Methods
 
-- {{domxref("BackgroundFetchUpdateUIEvent.updateUI()")}}
+- {{domxref("BackgroundFetchUpdateUIEvent.updateUI()")}} {{Experimental_Inline}}
   - : Updates the title and icon in the user interface to show the status of a background fetch. Resolves with a {{jsxref("Promise")}}.
 
 ## Examples

--- a/files/en-us/web/api/backgroundfetchupdateuievent/updateui/index.md
+++ b/files/en-us/web/api/backgroundfetchupdateuievent/updateui/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - updateUI
   - BackgroundFetchUpdateUIEvent
+  - Experimental
 browser-compat: api.BackgroundFetchUpdateUIEvent.updateUI
 ---
-{{DefaultAPISidebar("Background Fetch API")}}
+{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
 
 The **`updateUI()`** method of the {{domxref("BackgroundFetchUpdateUIEvent")}} interface updates the title and icon in the user interface to show the status of a background fetch.
 

--- a/files/en-us/web/api/badging_api/index.md
+++ b/files/en-us/web/api/badging_api/index.md
@@ -7,9 +7,10 @@ tags:
   - Overview
   - Reference
   - Badging API
+  - Experimental
 browser-compat: api.Navigator.setAppBadge
 ---
-{{DefaultAPISidebar("Badging API")}}
+{{DefaultAPISidebar("Badging API")}}{{SeeCompatTable}}
 
 The **Badging API** gives web developers a method of setting a badge on a document or application, to act as a notification that state has changed without displaying a more distracting notification. A common use case for this would be an application with a messaging feature displaying a badge on the app icon to show that new messages have arrived.
 

--- a/files/en-us/web/api/barcode_detection_api/index.md
+++ b/files/en-us/web/api/barcode_detection_api/index.md
@@ -234,7 +234,7 @@ You can check for formats supported by the user agent via the {{domxref('Barcode
 
 ## Interfaces
 
-- {{domxref("BarcodeDetector")}}
+- {{domxref("BarcodeDetector")}} {{Experimental_Inline}}
   - : The **`BarcodeDetector`** interface of the Barcode Detection API allows detection of linear and two dimensional barcodes in images.
 
 ## Examples

--- a/files/en-us/web/api/barcodedetector/index.md
+++ b/files/en-us/web/api/barcodedetector/index.md
@@ -11,18 +11,18 @@ tags:
   - Experimental
 browser-compat: api.BarcodeDetector
 ---
-{{securecontext_header}}{{DefaultAPISidebar("Barcode Detector API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("Barcode Detector API")}}{{SeeCompatTable}}
 
 The **`BarcodeDetector`** interface of the {{domxref('Barcode Detection API')}} allows detection of linear and two dimensional barcodes in images.
 
 ## Constructors
 
-- {{domxref('BarcodeDetector.BarcodeDetector', 'BarcodeDetector.BarcodeDetector()')}}
+- {{domxref('BarcodeDetector.BarcodeDetector', 'BarcodeDetector.BarcodeDetector()')}} {{Experimental_Inline}}
   - : Creates and returns a `BarcodeDetector` object, with optional `barcodeDetectorOptions`
 
 ## Methods
 
-- {{domxref('BarcodeDetector.detect', 'detect()')}}
+- {{domxref('BarcodeDetector.detect', 'detect()')}} {{Experimental_Inline}}
 
   - : Returns a {{jsxref('Promise')}} which fulfills with an array of `detectedBarcode` objects with the following properties:
 
@@ -31,7 +31,7 @@ The **`BarcodeDetector`** interface of the {{domxref('Barcode Detection API')}} 
     - `format`: The detected barcode format. (For a full list of formats see the \[landing page])
     - `rawValue`: A string decoded from the barcode data.
 
-- {{domxref('BarcodeDetector.getSupportedFormats', 'getSupportedFormats()')}}
+- {{domxref('BarcodeDetector.getSupportedFormats', 'getSupportedFormats()')}} {{Experimental_Inline}}
   - : Returns a {{jsxref('Promise')}} which fulfills with an {{jsxref('Array')}} of supported [barcode format types](/en-US/docs/Web/API/Barcode_Detection_API#supported_barcode_formats).
 
 ## Examples

--- a/files/en-us/web/api/baseaudiocontext/createscriptprocessor/index.md
+++ b/files/en-us/web/api/baseaudiocontext/createscriptprocessor/index.md
@@ -10,6 +10,7 @@ tags:
   - Reference
   - Web Audio API
   - createScriptProcessor
+  - Deprecated
 browser-compat: api.BaseAudioContext.createScriptProcessor
 ---
 {{APIRef("Web Audio API")}}{{deprecated_header}}

--- a/files/en-us/web/api/baseaudiocontext/index.md
+++ b/files/en-us/web/api/baseaudiocontext/index.md
@@ -23,7 +23,7 @@ A `BaseAudioContext` can be a target of events, therefore it implements the {{do
 
 ## Properties
 
-- {{domxref("BaseAudioContext.audioWorklet")}} {{experimental_inline}} {{readonlyInline}} {{securecontext_inline}}
+- {{domxref("BaseAudioContext.audioWorklet")}} {{readonlyInline}} {{securecontext_inline}}
   - : Returns the {{domxref("AudioWorklet")}} object, which can be used to create and manage {{domxref("AudioNode")}}s in which JavaScript code implementing the {{domxref("AudioWorkletProcessor")}} interface are run in the background to process audio data.
 - {{domxref("BaseAudioContext.currentTime")}} {{readonlyInline}}
   - : Returns a double representing an ever-increasing hardware time in seconds used for scheduling. It starts at `0`.

--- a/files/en-us/web/api/beforeinstallpromptevent/index.md
+++ b/files/en-us/web/api/beforeinstallpromptevent/index.md
@@ -9,8 +9,11 @@ tags:
   - Experimental
   - Interface
   - Reference
+  - Non-standard
 browser-compat: api.BeforeInstallPromptEvent
 ---
+{{SeeCompatTable}}{{Non-standard_header}}
+
 The **`BeforeInstallPromptEvent`** is the interface of the {{domxref("Window.beforeinstallprompt_event", "beforeinstallprompt")}} event fired at the {{domxref("Window")}} object before a user is prompted to "install" a website to a home screen on mobile.
 
 This interface inherits from the {{domxref("Event")}} interface.
@@ -19,21 +22,21 @@ This interface inherits from the {{domxref("Event")}} interface.
 
 ## Constructor
 
-- {{domxref("BeforeInstallPromptEvent.BeforeInstallPromptEvent","BeforeInstallPromptEvent()")}}
+- {{domxref("BeforeInstallPromptEvent.BeforeInstallPromptEvent","BeforeInstallPromptEvent()")}}{{Non-standard_Inline}} {{Experimental_Inline}}
   - : Creates a new `BeforeInstallPromptEvent` object.
 
 ## Properties
 
 _Inherits properties from its parent, {{domxref("Event")}}._
 
-- {{domxref("BeforeInstallPromptEvent.platforms")}} {{readonlyinline}}
+- {{domxref("BeforeInstallPromptEvent.platforms")}} {{readonlyinline}}{{Non-standard_Inline}} {{Experimental_Inline}}
   - : Returns an array of string items containing the platforms on which the event was dispatched. This is provided for user agents that want to present a choice of versions to the user such as, for example, "web" or "play" which would allow the user to choose between a web version or an Android version.
-- {{domxref("BeforeInstallPromptEvent.userChoice")}} {{readonlyinline}}
+- {{domxref("BeforeInstallPromptEvent.userChoice")}} {{readonlyinline}}{{Non-standard_Inline}} {{Experimental_Inline}}
   - : Returns a {{jsxref("Promise")}} that resolves to a string containing either "accepted" or "dismissed".
 
 ## Methods
 
-- {{domxref("BeforeInstallPromptEvent.prompt()")}}
+- {{domxref("BeforeInstallPromptEvent.prompt()")}} {{Experimental_Inline}}
   - : Allows a developer to show the install prompt at a time of their own choosing. This method returns a {{jsxref("Promise")}}.
 
 ## Example

--- a/files/en-us/web/api/beforeinstallpromptevent/prompt/index.md
+++ b/files/en-us/web/api/beforeinstallpromptevent/prompt/index.md
@@ -11,6 +11,8 @@ tags:
   - prompt
 browser-compat: api.BeforeInstallPromptEvent.prompt
 ---
+{{SeeCompatTable}}
+
 The **`prompt()`** method of the
 {{domxref("BeforeInstallPromptEvent")}} interface allows a developer to show the
 install prompt at a time of their own choosing.

--- a/files/en-us/web/api/blobbuilder/index.md
+++ b/files/en-us/web/api/blobbuilder/index.md
@@ -9,9 +9,10 @@ tags:
   - File API
   - Deprecated
   - Reference
+  - Non-standard
 browser-compat: api.BlobBuilder
 ---
-{{APIRef("File API")}}{{ deprecated_header}}
+{{APIRef("File API")}}{{ deprecated_header}}{{Non-standard_header}}
 
 > **Note:** The `BlobBuilder` interface has been
 > deprecated in favor of the newly introduced {{domxref('Blob')}} constructor.

--- a/files/en-us/web/api/bluetooth/availabilitychanged_event/index.md
+++ b/files/en-us/web/api/bluetooth/availabilitychanged_event/index.md
@@ -8,6 +8,7 @@ tags:
   - Web Bluetooth API
   - Event
   - Reference
+  - Experimental
 browser-compat: api.Bluetooth.availabilitychanged_event
 ---
 {{APIRef("Bluetooth API")}}{{securecontext_header}}{{SeeCompatTable}}

--- a/files/en-us/web/api/bluetooth/getavailability/index.md
+++ b/files/en-us/web/api/bluetooth/getavailability/index.md
@@ -7,6 +7,7 @@ tags:
   - Bluetooth
   - Reference
   - Web Bluetooth API
+  - Experimental
 browser-compat: api.Bluetooth.getAvailability
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef("Bluetooth API")}}

--- a/files/en-us/web/api/bluetooth/getdevices/index.md
+++ b/files/en-us/web/api/bluetooth/getdevices/index.md
@@ -7,6 +7,7 @@ tags:
   - Bluetooth
   - Reference
   - Web Bluetooth API
+  - Experimental
 browser-compat: api.Bluetooth.getDevices
 ---
 {{securecontext_header}}{{SeeCompatTable}}{{APIRef("Bluetooth API")}}

--- a/files/en-us/web/api/bluetooth/index.md
+++ b/files/en-us/web/api/bluetooth/index.md
@@ -23,7 +23,7 @@ options.
 
 _Inherits properties from its parent {{domxref("EventTarget")}}._
 
-- {{domxref("Bluetooth.referringDevice")}} {{readonlyinline}}
+- {{domxref("Bluetooth.referringDevice")}} {{readonlyinline}} {{Experimental_Inline}}
   - : Returns a reference to the device, if any, from which the user opened the current
     page. For example, an Eddystone beacon might advertise a URL, which the user agent
     allows the user to open. A BluetoothDevice representing the beacon would be available
@@ -31,22 +31,22 @@ _Inherits properties from its parent {{domxref("EventTarget")}}._
 
 ## Methods
 
-- {{domxref("Bluetooth.getAvailability","Bluetooth.getAvailability()")}}
+- {{domxref("Bluetooth.getAvailability","Bluetooth.getAvailability()")}} {{Experimental_Inline}}
   - : Returns a {{jsxref("Promise")}} that resolved to a boolean value indicating
     whether the user-agent has the ability to support Bluetooth. Some user-agents let the
     user configure an option that affects what is returned by this value. If this option
     is set, that is the value returned by this method.
-- {{domxref("Bluetooth.getDevices","Bluetooth.getDevices()")}}
+- {{domxref("Bluetooth.getDevices","Bluetooth.getDevices()")}} {{Experimental_Inline}}
   - : Returns a {{jsxref("Promise")}} that resolved to an array of
     {{domxref("BluetoothDevice")}}s which the origin already obtained permission for via a
     call to {{domxref("Bluetooth.requestDevice","Bluetooth.requestDevice()")}}.
-- {{domxref("Bluetooth.requestDevice","Bluetooth.requestDevice()")}}
+- {{domxref("Bluetooth.requestDevice","Bluetooth.requestDevice()")}} {{Experimental_Inline}}
   - : Returns a {{jsxref("Promise")}} to a {{domxref("BluetoothDevice")}} object with the
     specified options.
 
 ## Events
 
-- {{domxref("Bluetooth.availabilitychanged_event", "availabilitychanged")}}
+- {{domxref("Bluetooth.availabilitychanged_event", "availabilitychanged")}} {{Experimental_Inline}}
   - : An event that fires when Bluetooth capabilities have changed in availability.
 
 ## Specifications

--- a/files/en-us/web/api/bluetooth/referringdevice/index.md
+++ b/files/en-us/web/api/bluetooth/referringdevice/index.md
@@ -8,6 +8,7 @@ tags:
   - Reference
   - Web Bluetooth API
   - Property
+  - Experimental
 browser-compat: api.Bluetooth.referringDevice
 ---
 {{APIRef("Bluetooth API")}}{{securecontext_header}}{{SeeCompatTable}}

--- a/files/en-us/web/api/bluetooth/requestdevice/index.md
+++ b/files/en-us/web/api/bluetooth/requestdevice/index.md
@@ -9,6 +9,7 @@ tags:
   - Reference
   - Web Bluetooth API
   - requestDevice
+  - Experimental
 browser-compat: api.Bluetooth.requestDevice
 ---
 {{APIRef("Bluetooth API")}} {{securecontext_header}}{{SeeCompatTable}}

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/authenticatedsignedwrites/index.md
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/authenticatedsignedwrites/index.md
@@ -14,7 +14,7 @@ tags:
   - authenticatedSignedWrites
 browser-compat: api.BluetoothCharacteristicProperties.authenticatedSignedWrites
 ---
-{{securecontext_header}}{{APIRef("Bluetooth API")}}
+{{securecontext_header}}{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`authenticatedSignedWrites`** read-only
 property of the {{domxref("BluetoothCharacteristicProperties")}} interface returns a

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/broadcast/index.md
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/broadcast/index.md
@@ -14,7 +14,7 @@ tags:
   - broadcast
 browser-compat: api.BluetoothCharacteristicProperties.broadcast
 ---
-{{securecontext_header}}{{APIRef("Bluetooth API")}}
+{{securecontext_header}}{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`broadcast`** read-only property of the
 {{domxref("BluetoothCharacteristicProperties")}} interface returns a

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/indicate/index.md
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/indicate/index.md
@@ -14,7 +14,7 @@ tags:
   - indicate
 browser-compat: api.BluetoothCharacteristicProperties.indicate
 ---
-{{securecontext_header}}{{APIRef("Bluetooth API")}}
+{{securecontext_header}}{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`indicate`** read-only property of the
 {{domxref("BluetoothCharacteristicProperties")}} interface returns a

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/notify/index.md
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/notify/index.md
@@ -14,7 +14,7 @@ tags:
   - notify
 browser-compat: api.BluetoothCharacteristicProperties.notify
 ---
-{{securecontext_header}}{{APIRef("")}}
+{{securecontext_header}}{{APIRef("")}}{{SeeCompatTable}}
 
 The **`notify`** read-only property of the
 {{domxref("BluetoothCharacteristicProperties")}} interface returns a

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/read/index.md
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/read/index.md
@@ -14,7 +14,7 @@ tags:
   - read
 browser-compat: api.BluetoothCharacteristicProperties.read
 ---
-{{securecontext_header}}{{APIRef("Bluetooth API")}}
+{{securecontext_header}}{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`read`** read-only property of the
 {{domxref("BluetoothCharacteristicProperties")}} interface returns a

--- a/files/en-us/web/api/bluetoothcharacteristicproperties/reliablewrite/index.md
+++ b/files/en-us/web/api/bluetoothcharacteristicproperties/reliablewrite/index.md
@@ -15,7 +15,7 @@ tags:
   - reliableWrite
 browser-compat: api.BluetoothCharacteristicProperties.reliableWrite
 ---
-{{securecontext_header}}{{APIRef("Bluetooth API")}}
+{{securecontext_header}}{{APIRef("Bluetooth API")}}{{SeeCompatTable}}
 
 The **`reliableWrite`** read-only property of
 the {{domxref("BluetoothCharacteristicProperties")}} interface returns a


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.

Note: It's easy to review the changes. Open the preview URLs hosted by the PR companion, in new tabs, and look at the BCD tables at the bottom of the pages.