### PR TITLE
Fix a typo

### DIFF
--- a/files/en-us/web/api/backgroundfetchmanager/index.md
+++ b/files/en-us/web/api/backgroundfetchmanager/index.md
@@ -26,7 +26,7 @@ None.
   - : Returns a {{jsxref("Promise")}} that resolves with a {{domxref("BackgroundFetchRegistration")}} object for a supplied array of URLs and {{domxref("Request")}} objects.
 - {{domxref('BackgroundFetchManager.get','get()')}}
   - : Returns a {{jsxref("Promise")}} that resolves with the {{domxref("BackgroundFetchRegistration")}} associated with the provided `id` or {{jsxref("undefined")}} if the `id` is not found.
-- {{domxref('BackgroundFetchManager.getIDs','getIDs()')}}
+- {{domxref('BackgroundFetchManager.getIds','getIds()')}}
   - : Returns the IDs of all registered background fetches.
 
 ## Examples


### PR DESCRIPTION
The 'd' in `getIDs` is not capital, see the compat table or the method page.