### PR TITLE
Add type information for `WebAssembly.Memory.prototype.buffer`

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/webassembly/memory/buffer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/memory/buffer/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.WebAssembly.Memory.buffer
 ---
 {{JSRef}}
 
-The **`buffer`** prototype property of the {{jsxref("WebAssembly.Memory")}} object returns the buffer contained in the memory.  Depending on whether or not the memory was constructed with `shared: true`, the buffer is either an {{jsxref("ArrayBuffer")}} or a {{jsxref("SharedArrayBuffer")}}, 
+The **`buffer`** prototype property of the {{jsxref("WebAssembly.Memory")}} object returns the buffer contained in the memory. Depending on whether or not the memory was constructed with `shared: true`, the buffer is either an {{jsxref("ArrayBuffer")}} or a {{jsxref("SharedArrayBuffer")}}, 
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/memory/buffer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/memory/buffer/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.WebAssembly.Memory.buffer
 ---
 {{JSRef}}
 
-The **`buffer`** prototype property of the {{jsxref("WebAssembly.Memory")}} object returns the buffer contained in the memory. Depending on whether or not the memory was constructed with `shared: true`, the buffer is either an {{jsxref("ArrayBuffer")}} or a {{jsxref("SharedArrayBuffer")}}, 
+The **`buffer`** prototype property of the {{jsxref("WebAssembly.Memory")}} object returns the buffer contained in the memory. Depending on whether or not the memory was constructed with `shared: true`, the buffer is either an {{jsxref("ArrayBuffer")}} or a {{jsxref("SharedArrayBuffer")}}.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/webassembly/memory/buffer/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/webassembly/memory/buffer/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.WebAssembly.Memory.buffer
 ---
 {{JSRef}}
 
-The **`buffer`** prototype property of the {{jsxref("WebAssembly.Memory")}} object returns the buffer contained in the memory.
+The **`buffer`** prototype property of the {{jsxref("WebAssembly.Memory")}} object returns the buffer contained in the memory.  Depending on whether or not the memory was constructed with `shared: true`, the buffer is either an {{jsxref("ArrayBuffer")}} or a {{jsxref("SharedArrayBuffer")}}, 
 
 ## Examples
 


### PR DESCRIPTION
Link to the types `WebAssembly.Memory.prototype.buffer` could have and describe the circumstances under which it would have one or the other of these types.