### PR TITLE
Clarify how to format a datetime-local value

### DIFF
--- a/files/en-us/web/html/element/input/datetime-local/index.md
+++ b/files/en-us/web/html/element/input/datetime-local/index.md
@@ -100,7 +100,7 @@ const dateControl = document.querySelector('input[type="datetime-local"]');
 dateControl.value = '2017-06-01T08:30';
 ```
 
-There are several methods provided by JavaScript's {{jsxref("Date")}} that can be used to convert numeric date information into a properly-formatted string, or you can do it manually. For example, the {{jsxref("Date.toISOString()")}} method can be used for this purpose.
+There are several methods provided by JavaScript's {{jsxref("Date")}} that can be used to convert numeric date information into a properly-formatted string. For example, the {{jsxref("Date.toISOString()")}} method returns the date/time in UTC with the suffix "`Z`" denoting that timezone; removing the "`Z`" would provide a value in the format expected by a `datetime-local` input.
 
 ## Additional attributes
 


### PR DESCRIPTION


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
The existing language suggests that one can take a `Date` object, call `toISOString()` on it, and use the resulting string as the value for a datetime-local input. This doesn't work, because `toISOString()` includes a "`Z`" at the end to indicate the timezone, while datetime-local expects the value to have no time-zone offset information.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString describes the behavior of toISOString returning a value ending in Z.
https://html.spec.whatwg.org/dev/input.html#local-date-and-time-state-(type=datetime-local) defines how datetime-local works and specifies that the value (if not empty) must be a valid local date and time string, which doesn't include timezone information (https://html.spec.whatwg.org/dev/common-microsyntaxes.html#valid-local-date-and-time-string defines "valid local date and time string").

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
