### PR TITLE
Fix: flatDeep function in Array.flat reference.

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/flat/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/flat/index.md
@@ -59,8 +59,8 @@ const arr = [1, 2, [3, 4, [5, 6]]];
 
 // to enable deep level flatten use recursion with reduce and concat
 function flatDeep(arr, d = 1) {
-  if (!Array.isArray(val)) {
-    return val;
+  if (!Array.isArray(arr)) {
+    return arr;
   }
   return d > 0
     ? arr.reduce((acc, val) => acc.concat(flatDeep(val, d - 1)), [])


### PR DESCRIPTION

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
using undefined variable "val" instead of "arr" in flatDeep function in [Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)
[Array.prototype.flat()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat)

#### Supporting details
[https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat](url)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
- [ ] Solution: Just replaced "arr" with "val"
