### PR TITLE
match patterns: fix example URL that is broken into two code elements

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/match_patterns/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/match_patterns/index.md
@@ -242,7 +242,7 @@ The special value `<all_urls>` matches all URLs under any of the supported schem
         <p><code>https://mozilla.org/a</code><br />(unmatched path)</p>
         <p><code>https://mozilla.org/</code><br />(unmatched path)</p>
         <p>
-          <code>https://mozilla.org/path/</code><code>?foo=1</code
+          <code>https://mozilla.org/path/?foo=1</code
           ><br />(unmatched path due to URL query string)
         </p>
       </td>


### PR DESCRIPTION
#### Summary

This fixes the example URL rendered like "https://mozilla.org/path/ ?foo=1" in https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Match_patterns#examples

#### Motivation

It is broken as an URL.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
