### PR TITLE
Batch replace en_US links by en-US in mdn section

### DIFF
--- a/files/en-us/mdn/community/contributing/getting_started/index.md
+++ b/files/en-us/mdn/community/contributing/getting_started/index.md
@@ -37,7 +37,7 @@ To contribute, you will need a GitHub account. If you do not already have one, g
 
 ### Additional reading and learning material
 
-- [Basic etiquette for open source projects](/en_US/docs/MDN/Community/Open_source_etiquette): If you've never contributed to an open source project before, we encourage you to read this document.
+- [Basic etiquette for open source projects](/en-US/docs/MDN/Community/Open_source_etiquette): If you've never contributed to an open source project before, we encourage you to read this document.
 - [Learn web development](https://developer.mozilla.org/docs/Learn): If you are new to HTML, CSS, JavaScript, we have some great content to help you get started.
 - [Deep dive into collaborating with pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests)
 

--- a/files/en-us/mdn/community/issues/index.md
+++ b/files/en-us/mdn/community/issues/index.md
@@ -9,7 +9,7 @@ tags:
 ---
 {{MDNSidebar}}
 
-[Issues](https://docs.github.com/en/github/managing-your-work-on-github/about-issues) are used to track all bugs and work that has a clear actionable outcome. If you have found a bug with either our content or the platform, please search current open issues against the [relevant repository](/en_US/docs/MDN/Community/Contributing/Our_repositories/) to ensure someone has not already reported the issue. If the issue is new, please file an issue using the relevant template available in the repository.
+[Issues](https://docs.github.com/en/github/managing-your-work-on-github/about-issues) are used to track all bugs and work that has a clear actionable outcome. If you have found a bug with either our content or the platform, please search current open issues against the [relevant repository](/en-US/docs/MDN/Community/Contributing/Our_repositories/) to ensure someone has not already reported the issue. If the issue is new, please file an issue using the relevant template available in the repository.
 
 > **Note:** If an issue has a triage label, we haven't reviewed it yet, and you shouldn't begin work on it.
 
@@ -80,7 +80,7 @@ Most issues need some investigation before work can start, if you need to ask qu
 
 If you take on an issue we expect work to happen in a timely manner. If you can no longer take on the task, leave a comment and unassign yourself.
 
-Fork and branch the repository, do your work and open a [pull request](/en_US/docs/MDN/Community/Pull_requests).
+Fork and branch the repository, do your work and open a [pull request](/en-US/docs/MDN/Community/Pull_requests).
 
 _(more stuff)_
 

--- a/files/en-us/mdn/community/issues/issue_triage/index.md
+++ b/files/en-us/mdn/community/issues/issue_triage/index.md
@@ -14,7 +14,7 @@ This document looks at the process for triaging content bugs and getting them re
 
 Anyone can report a content bug by writing an issue at <https://github.com/mdn/content/issues/new> using the "Content bug" issue template, or by using the "Report a problem with this content on GitHub" link at the bottom of each MDN page.
 
-Once reported, content bugs are listed at <https://github.com/mdn/content/issues>, and are designed to be done by individuals with minimal process requirements. Anyone is welcome to work on a content bug, using the process outlined at [Fixing MDN content bugs](/en_US/docs/MDN/Community/Issues).
+Once reported, content bugs are listed at <https://github.com/mdn/content/issues>, and are designed to be done by individuals with minimal process requirements. Anyone is welcome to work on a content bug, using the process outlined at [Fixing MDN content bugs](/en-US/docs/MDN/Community/Issues).
 
 ## Overall triage process
 

--- a/files/en-us/mdn/community/open_source_etiquette/index.md
+++ b/files/en-us/mdn/community/open_source_etiquette/index.md
@@ -65,7 +65,7 @@ If you receive anything that makes you feel uncomfortable, you should always rep
 
 Think about what you want to do on the project. For example, we have a large list of issues filed at on the [contributors task board](https://github.com/orgs/mdn/projects/25/views/1), broken up by various task types.
 
-You could also contribute by opening [pull requests](/en_US/docs/MDN/Community/Pull_requests) to fix problems that you come across while reading MDN articles.
+You could also contribute by opening [pull requests](/en-US/docs/MDN/Community/Pull_requests) to fix problems that you come across while reading MDN articles.
 
 A lot of the work on MDN revolves around writing documentation and code examples, but there are other ways to contribute too:
 

--- a/files/en-us/mdn/community/pull_requests/index.md
+++ b/files/en-us/mdn/community/pull_requests/index.md
@@ -52,8 +52,8 @@ perfectly in accordance with all of these points immediately. It is more
 important to make sure the content is readable, useful, correct, and not
 inappropriate, than it is to follow every guideline to the letter.
 
-1. Familiarize yourself with the [MDN Code example guidelines](/en_US/docs/MDN/Writing_guidelines/Writing_style_guide/Code_example_guidelines) and make sure that code examples follow the guidelines. You'll get used to them eventually, and we are intending to automatically lint against our guidelines at some point in the future.
-1. Familiarize yourself with the [MDN Writing style guide](/en_US/docs/MDN/Writing_guidelines/Writing_style_guide), and use it to inform your reviews of new text content.
+1. Familiarize yourself with the [MDN Code example guidelines](/en-US/docs/MDN/Writing_guidelines/Writing_style_guide/Code_example_guidelines) and make sure that code examples follow the guidelines. You'll get used to them eventually, and we are intending to automatically lint against our guidelines at some point in the future.
+1. Familiarize yourself with the [MDN Writing style guide](/en-US/docs/MDN/Writing_guidelines/Writing_style_guide), and use it to inform your reviews of new text content.
 1. Familiarize yourself with the MDN [pull request guidelines](https://github.com/mdn/content/blob/main/README.md#pull-request-etiquette).
    The key points here are
    - You have the right to request more information to help your review if the submitter has not explained why they are making this change.

--- a/files/en-us/mdn/writing_guidelines/attrib_copyright_license/index.md
+++ b/files/en-us/mdn/writing_guidelines/attrib_copyright_license/index.md
@@ -20,7 +20,7 @@ This section covers the types of content we provide and the copyrights and licen
 
 Your reuse of the content here is published under the same license as the original content—CC-BY-SA v2.5 or any later version. When reusing the content on MDN Web Docs, you need to ensure that attribution is given to the original content as well as to "Mozilla Contributors". Include a hyperlink (online) or URL (in print) to the specific page of the content being sourced. For example, to provide attribution for _this_ article, you can write:
 
-> [Attributions and copyright licensing](/en_US/docs/MDN/Writing_guidelines/Attrib_copyright_license) by [Mozilla Contributors](/en-US/docs/MDN/About/contributors.txt) is licensed under [CC-BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/). <!--need to revisit the contributors.txt link-->
+> [Attributions and copyright licensing](/en-US/docs/MDN/Writing_guidelines/Attrib_copyright_license) by [Mozilla Contributors](/en-US/docs/MDN/About/contributors.txt) is licensed under [CC-BY-SA 2.5](https://creativecommons.org/licenses/by-sa/2.5/). <!--need to revisit the contributors.txt link-->
 
 In the above example, "Mozilla Contributors" links to the history of the cited page. See [Best practices for attribution](https://wiki.creativecommons.org/wiki/Marking/Users) for further explanation.
 

--- a/files/en-us/mdn/writing_guidelines/howto/creating_moving_deleting/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/creating_moving_deleting/index.md
@@ -8,7 +8,7 @@ page-type: mdn-writing-guide
 ---
 {{MDNSidebar}}
 
-This article describes how to create, move, delete, or edit a page. In all these instances, it's a good idea to check our guidelines for [What we write](/en_US/docs/MDN/Writing_guidelines/What_we_write) to confirm if any of these actions should be taken and discuss it with the [MDN Web Docs team](https://github.com/mdn/mdn-community/discussions) before proceeding.
+This article describes how to create, move, delete, or edit a page. In all these instances, it's a good idea to check our guidelines for [What we write](/en-US/docs/MDN/Writing_guidelines/What_we_write) to confirm if any of these actions should be taken and discuss it with the [MDN Web Docs team](https://github.com/mdn/mdn-community/discussions) before proceeding.
 
 ## Creating pages
 
@@ -16,7 +16,7 @@ All pages on MDN Web Docs are authored in markdown format. The content is writte
 
 > **Note:** The name of the directory differs slightly from the slug of the page. Most notably, the slug follows sentence casing.
 
-There are a lot of different [page types](/en_US/docs/MDN/Writing_guidelines/Page_structures/Page_types) with certain structures and supporting page templates for them, which you can copy to get you started.
+There are a lot of different [page types](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types) with certain structures and supporting page templates for them, which you can copy to get you started.
 
 A document's `index.md` file must start with front matter that defines the `title`, `slug`, `page-type`, and `tags`. All of this front matter information can be found in the aforementioned page templates. Alternatively, you might find it helpful to refer to the front matter within a similar document's `index.md`.
 

--- a/files/en-us/mdn/writing_guidelines/howto/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/index.md
@@ -9,7 +9,7 @@ tags:
 
 {{MDNSidebar}}
 
-This section of MDN Web Docs writing guidelines contains all the step-by-step information for accomplishing specific tasks when contributing to MDN Web Docs: how we use markdown, how we add an entry to the glossary, how we move or delete pages, and more. To find out more about _how to contribute_ (which happens through GitHub), see our [contribution guidelines](/en_US/docs/MDN/Community/Contributing).
+This section of MDN Web Docs writing guidelines contains all the step-by-step information for accomplishing specific tasks when contributing to MDN Web Docs: how we use markdown, how we add an entry to the glossary, how we move or delete pages, and more. To find out more about _how to contribute_ (which happens through GitHub), see our [contribution guidelines](/en-US/docs/MDN/Community/Contributing).
 
 > **Note:** All the way through this section, we assume that you've read the contribution guidelines, are familiar with the `mdn/content` repository, and know how to use git and GitHub.
 

--- a/files/en-us/mdn/writing_guidelines/index.md
+++ b/files/en-us/mdn/writing_guidelines/index.md
@@ -8,31 +8,31 @@ tags:
 ---
 {{MDNSidebar}}
 
-MDN Web Docs is an open-source project. The sections outlined below describe our guidelines for *what* we document and *how* we do it on MDN Web Docs. To learn about _how to contribute_, see our [contribution guidelines](/en_US/docs/MDN/Community).
+MDN Web Docs is an open-source project. The sections outlined below describe our guidelines for *what* we document and *how* we do it on MDN Web Docs. To learn about _how to contribute_, see our [contribution guidelines](/en-US/docs/MDN/Community).
 
-- [What we write](/en_US/docs/MDN/Writing_guidelines/What_we_write)
+- [What we write](/en-US/docs/MDN/Writing_guidelines/What_we_write)
 
   - : This section covers what we include on MDN Web Docs and want we don't, as well as a number of other policies, such as when we write about new technologies, the content suggestion process, and whether we accept external links. This is a good place to start if you're considering writing or updating content for us. This section also includes:
-    - [Inclusion criteria](/en_US/docs/MDN/Writing_guidelines/What_we_write/Criteria_for_inclusion)
+    - [Inclusion criteria](/en-US/docs/MDN/Writing_guidelines/What_we_write/Criteria_for_inclusion)
       - : It provides an in-depth criteria for content to be included on MDN Web Docs, the application process for getting new documentation added on MDN Web Docs, and the expectations and guidelines for a party applying.
 
-- [How to write for MDN Web Docs](/en_US/docs/MDN/Writing_guidelines/Howto)
+- [How to write for MDN Web Docs](/en-US/docs/MDN/Writing_guidelines/Howto)
 
   - : This section covers all the information for creating and editing pages, including certain processes and techniques we adhere to. This section provides information about getting started, a general overview into how pages are structured, and where to find how-tos on specific tasks. This section includes topics such as:
 
-    - [Using markdown](/en_US/docs/MDN/Writing_guidelines/Howto/Markdown_in_MDN)
+    - [Using markdown](/en-US/docs/MDN/Writing_guidelines/Howto/Markdown_in_MDN)
 
       - : The markdown format we use derives from [GitHub flavored markdown (GFM)](https://github.github.com/gfm/). This section is a guide to the markdown we use on MDN Web Docs, including formats for specific in-page components, such as notes and definition lists.
 
-    - [Adding images and media](/en_US/docs/MDN/Writing_guidelines/Howto/Images_media)
+    - [Adding images and media](/en-US/docs/MDN/Writing_guidelines/Howto/Images_media)
 
       - : This section describes the requirements for including media in pages, such as images.
 
-    - [Adding an entry to the glossary](/en_US/docs/MDN/Writing_guidelines/Howto/Write_a_new_entry_in_the_glossary)
+    - [Adding an entry to the glossary](/en-US/docs/MDN/Writing_guidelines/Howto/Write_a_new_entry_in_the_glossary)
 
       - : This section explains how to add and link to entries in the MDN Web Docs glossary. It also provides guidelines about glossary entry layout and content.
 
-    - [How to research a technology](/en_US/docs/MDN/Writing_guidelines/Howto/Research_technology)
+    - [How to research a technology](/en-US/docs/MDN/Writing_guidelines/Howto/Research_technology)
 
       - : This section provides some handy tips for researching a technology you are documenting.
 
@@ -40,29 +40,29 @@ MDN Web Docs is an open-source project. The sections outlined below describe our
 
       - : This section explains how to move or delete a page.
 
-- [Our writing style guide](/en_US/docs/MDN/Writing_guidelines/Writing_style_guide)
+- [Our writing style guide](/en-US/docs/MDN/Writing_guidelines/Writing_style_guide)
 
   - : The writing style guide covers the language and style we use to write on MDN Web Docs. It also covers how to format code examples.
 
-- [Page types on MDN Web Docs](/en_US/docs/MDN/Writing_guidelines/Page_structures/Page_types)
+- [Page types on MDN Web Docs](/en-US/docs/MDN/Writing_guidelines/Page_structures/Page_types)
 
   - : Each page on MDN Web Docs has a specific page type, whether that's a CSS reference page or a JavaScript guide page. This section lists the different page types and provides templates for each type. It's a good idea to browse these to understand which page type you are writing.
 
-- [Page structures on MDN Web Docs](/en_US/docs/MDN/Writing_guidelines/Page_structures)
+- [Page structures on MDN Web Docs](/en-US/docs/MDN/Writing_guidelines/Page_structures)
 
   - : This section covers the various page structures that we use to provide consistent presentation of information on MDN Web Docs. This includes:
 
-    - [Code examples](/en_US/docs/MDN/Writing_guidelines/Page_structures/Code_examples)
+    - [Code examples](/en-US/docs/MDN/Writing_guidelines/Page_structures/Code_examples)
 
       - : There are a lot of different ways to include code examples on pages. This section outlines them and provides syntax guidelines for the different languages.
 
-    - [Macros](/en_US/docs/MDN/Writing_guidelines/Page_structures/Macros)
+    - [Macros](/en-US/docs/MDN/Writing_guidelines/Page_structures/Macros)
 
       - : Macros are shortcuts that are used in pages to generate content, such as sidebars. This section lists the macros we use and what they do.
 
-- [How to label a technology](/en_US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete)
+- [How to label a technology](/en-US/docs/MDN/Writing_guidelines/Experimental_deprecated_obsolete)
 
   - : This section covers our definitions for the terms obsolete, deprecated, and experimental and provides guidelines on when we remove content from MDN Web Docs.
 
-- [Attributions and copyright licensing information](/en_US/docs/MDN/Writing_guidelines/Attrib_copyright_license)
+- [Attributions and copyright licensing information](/en-US/docs/MDN/Writing_guidelines/Attrib_copyright_license)
   - : This section describes what copyright license content is and how to attribute correctly.

--- a/files/en-us/mdn/writing_guidelines/what_we_write/criteria_for_inclusion/index.md
+++ b/files/en-us/mdn/writing_guidelines/what_we_write/criteria_for_inclusion/index.md
@@ -11,7 +11,7 @@ tags:
 
 This article describes, in detail, criteria for content to be included on MDN Web Docs, the application process for including new documentation, and expectations and guidelines for a party applying.
 
-This is aimed at larger projects. To suggest a new page or article, please refer to the [Suggesting content](/en_US/docs/MDN/Writing_guidelines/What_we_write#suggesting_content) section on the "What we write" page.
+This is aimed at larger projects. To suggest a new page or article, please refer to the [Suggesting content](/en-US/docs/MDN/Writing_guidelines/What_we_write#suggesting_content) section on the "What we write" page.
 
 ## Web standards technologies
 

--- a/files/en-us/mdn/writing_guidelines/what_we_write/index.md
+++ b/files/en-us/mdn/writing_guidelines/what_we_write/index.md
@@ -34,7 +34,7 @@ If you'd like to suggest content for MDN Web Docs, please make sure you read thi
 
 For new reference pages or guides, please open a discussion on [our community repository](https://github.com/mdn/mdn-community/discussions/categories/content-suggestions) outlining what content you are suggesting and why (please be as explicit as possible).
 
-For suggesting larger projects that involve new sections of content, please refer to the [Criteria for inclusion](/en_US/docs/MDN/Writing_guidelines/What_we_write/Criteria_for_inclusion) page, which also outlines the application process.
+For suggesting larger projects that involve new sections of content, please refer to the [Criteria for inclusion](/en-US/docs/MDN/Writing_guidelines/What_we_write/Criteria_for_inclusion) page, which also outlines the application process.
 
 ## Topics that belong on MDN Web Docs
 
@@ -63,7 +63,7 @@ We also document some broader topics, such as [SVG](/en-US/docs/Web/SVG), [XML](
 
 All content on MDN Web Docs must be relevant to the technology section in which it appears. Contributors are expected to follow these [MDN writing guidelines](/en-US/docs/MDN/Writing_guidelines) for writing style, code samples, and other topics.
 
-For more details about the criteria for whether or not a technology can be documented on MDN Web Docs, see the [Criteria for inclusion](/en_US/docs/MDN/Writing_guidelines/What_we_write/Criteria_for_inclusion) page.
+For more details about the criteria for whether or not a technology can be documented on MDN Web Docs, see the [Criteria for inclusion](/en-US/docs/MDN/Writing_guidelines/What_we_write/Criteria_for_inclusion) page.
 
 ### When we document a new technology
 


### PR DESCRIPTION
#### Summary
Some links were using the `en_US` form (whereas the content normally uses the IETF tag `en-US`) which was causing an error on a local environment.
Note: in production, the link was working as intended.

#### Motivation
Consistency

#### Supporting details
https://github.com/mdn/content/search?l=Markdown&q=en-US&type=code

https://github.com/mdn/content/search?l=Markdown&q=en_US&type=code

#### Related issues
None a priori

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
