### PR TITLE
MINOR: remove text/css in style

### DIFF
--- a/files/en-us/learn/css/building_blocks/styling_tables/index.md
+++ b/files/en-us/learn/css/building_blocks/styling_tables/index.md
@@ -97,7 +97,7 @@ Let's work through styling our table example together.
 3. Link the CSS to the HTML by placing the following line of HTML inside your {{htmlelement("head")}}:
 
     ```html
-    <link href="style.css" rel="stylesheet" type="text/css">
+    <link href="style.css" rel="stylesheet">
     ```
 
 ### Spacing and layout

--- a/files/en-us/learn/css/howto/css_faq/index.md
+++ b/files/en-us/learn/css/howto/css_faq/index.md
@@ -100,7 +100,7 @@ CSS does not exactly allow one style to be defined in terms of another. However,
 HTML elements can be assigned multiple classes by listing the classes in the `class` attribute, with a blank space to separate them.
 
 ```html
-<style type="text/css">
+<style>
 .news { background: black; color: white; }
 .today { font-weight: bold; }
 </style>

--- a/files/en-us/learn/html/introduction_to_html/document_and_website_structure/index.md
+++ b/files/en-us/learn/html/introduction_to_html/document_and_website_structure/index.md
@@ -89,7 +89,7 @@ Our example seen above is represented by the following code (you can also [find 
 ```html
 <!DOCTYPE html>
 <html lang="en-us">
-<head>
+  <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
 

--- a/files/en-us/learn/html/introduction_to_html/document_and_website_structure/index.md
+++ b/files/en-us/learn/html/introduction_to_html/document_and_website_structure/index.md
@@ -88,18 +88,14 @@ Our example seen above is represented by the following code (you can also [find 
 
 ```html
 <!DOCTYPE html>
-<html>
-  <head>
+<html lang="en-us">
+<head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
 
     <title>My page title</title>
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300|Sonsie+One" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300|Sonsie+One" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
-
-    <!-- the below three lines are a fix to get HTML5 semantic elements working in old versions of Internet Explorer-->
-    <!--[if lt IE 9]>
-      <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.js"></script>
-    <![endif]-->
   </head>
 
   <body>

--- a/files/en-us/learn/javascript/client-side_web_apis/third_party_apis/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/third_party_apis/index.md
@@ -68,7 +68,7 @@ Third party APIs, on the other hand, are located on third party servers. To acce
 
 ```html
 <script src="https://api.mqcdn.com/sdk/mapquest-js/v1.3.2/mapquest.js" defer></script>
-<link type="text/css" rel="stylesheet" href="https://api.mqcdn.com/sdk/mapquest-js/v1.3.2/mapquest.css"/>
+<link rel="stylesheet" href="https://api.mqcdn.com/sdk/mapquest-js/v1.3.2/mapquest.css"/>
 ```
 
 You can then start using the objects available in that library. For example:

--- a/files/en-us/learn/performance/web_performance_basics/index.md
+++ b/files/en-us/learn/performance/web_performance_basics/index.md
@@ -39,7 +39,7 @@ To load CSS asynchronously one can set the media type to print and then change t
 The downside with this approach is the flash of unstyled text (FOUT.) The simplest way to address this is by inlining CSS that is required for any content that is rendered above the fold, or what you see in the browser viewport before scrolling. These styles will improve perceived performance as the CSS does not require a file request.
 
 ```html
-<style type="text/css">
+<style>
 // Insert your CSS here
 </style>
 ```

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/feature_detection/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/feature_detection/index.md
@@ -237,7 +237,7 @@ if (window.matchMedia("(max-width: 480px)").matches) {
 As an example, our [Snapshot](https://github.com/chrisdavidmills/snapshot) demo makes use of it to selectively apply the Brick JavaScript library and use it to handle the UI layout, but only for the small screen layout (480px wide or less). We first use the `media` attribute to only apply the Brick CSS to the page if the page width is 480px or less:
 
 ```css
-<link href="dist/brick.css" type="text/css" rel="stylesheet" media="all and (max-width: 480px)">
+<link href="dist/brick.css" rel="stylesheet" media="all and (max-width: 480px)">
 ```
 
 We then use `matchMedia()` in the JavaScript several times, to only run Brick navigation functions if we are on the small screen layout (in wider screen layouts, everything can be seen at once, so we don't need to navigate between different views).

--- a/files/en-us/web/accessibility/seizure_disorders/index.md
+++ b/files/en-us/web/accessibility/seizure_disorders/index.md
@@ -426,16 +426,16 @@ Use the {{HTMLElement('link')}} element, alongside with and together with the at
 ```html
 <head>
   <title>Home Page</title>
-  <link href="main.css" rel="stylesheet" type="text/css" title="Default Style">
-  <link href="alternate1.css" rel="alternate stylesheet" type="text/css" title="Alternate One">
-  <link href="alternate2.css" rel="alternate stylesheet" type="text/css" title="Alternate Two">
+  <link href="main.css" rel="stylesheet" title="Default Style">
+  <link href="alternate1.css" rel="alternate stylesheet" title="Alternate One">
+  <link href="alternate2.css" rel="alternate stylesheet" title="Alternate Two">
 </head>
 ```
 
 **{{CSSxref('@import')}}** is also a way to incorporate style sheets, but it is not quite as well supported as the {{HTMLElement('link')}} element.
 
 ```html
-<style type="text/css">
+<style>
   @import url(alternate1.css);
   @import url(alternate2.css);
 </style>

--- a/files/en-us/web/api/css_object_model/using_dynamic_styling_information/index.md
+++ b/files/en-us/web/api/css_object_model/using_dynamic_styling_information/index.md
@@ -60,8 +60,11 @@ Also, when you set this property on an element, you override any styles that hav
 To change a particular element's style, you can adapt the following example for the element(s) you want to style.
 
 ```html
-<html>
+<!DOCTYPE html>
+<html lang="en-us">
 <head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
 <title>simple style example</title>
 
 <script>
@@ -76,7 +79,7 @@ function resetStyle(elemId) {
 }
 </script>
 
-<style type="text/css">
+<style>
 #p1 {
   border: solid blue 2px;
 }
@@ -111,10 +114,12 @@ More important than the two properties noted here is the use of the `style` obje
 
 ```html
 <!DOCTYPE html>
-<html>
- <head>
-  <title>style Property Example</title>
-  <link rel="StyleSheet" href="example.css" type="text/css">
+<html lang="en-us">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>Style Property Example</title>
+  <link rel="StyleSheet" href="example.css">
   <script>
     function setStyle() {
       document.getElementById('d').style.color = 'orange';

--- a/files/en-us/web/api/css_object_model/using_dynamic_styling_information/index.md
+++ b/files/en-us/web/api/css_object_model/using_dynamic_styling_information/index.md
@@ -25,21 +25,21 @@ In this example the background of the page is set to red using CSS. The JavaScri
 
 ```html
 <html>
-<head>
-<title>Modifying a stylesheet rule with CSSOM</title>
-<style>
-body {
- background-color: red;
-}
-</style>
-<script>
-var stylesheet = document.styleSheets[0];
-stylesheet.cssRules[0].style.backgroundColor="aqua";
-</script>
-</head>
-<body>
-The stylesheet declaration for the body's background color is modified via JavaScript.
-</body>
+  <head>
+    <title>Modifying a stylesheet rule with CSSOM</title>
+    <style>
+      body {
+        background-color: red;
+      }
+    </style>
+    <script>
+      var stylesheet = document.styleSheets[0];
+      stylesheet.cssRules[0].style.backgroundColor="aqua";
+    </script>
+  </head>
+  <body>
+    The stylesheet declaration for the body's background color is modified via JavaScript.
+  </body>
 </html>
 ```
 
@@ -62,41 +62,37 @@ To change a particular element's style, you can adapt the following example for 
 ```html
 <!DOCTYPE html>
 <html lang="en-us">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width">
-<title>simple style example</title>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>simple style example</title>
 
-<script>
+    <script>
+      function alterStyle(elem) {
+        elem.style.background = 'green';
+      }
 
-function alterStyle(elem) {
-  elem.style.background = 'green';
-}
+      function resetStyle(elemId) {
+        elem = document.getElementById(elemId);
+        elem.style.background = 'white';
+      }
+    </script>
+    <style>
+      #p1 {
+        border: solid blue 2px;
+      }
+    </style>
+  </head>
 
-function resetStyle(elemId) {
-  elem = document.getElementById(elemId);
-  elem.style.background = 'white';
-}
-</script>
+  <body>
+    <!-- passes a reference to the element's object as parameter 'this'. -->
+    <p id="p1" onclick="alterStyle(this);">
+     Click here to change background color.
+    </p>
 
-<style>
-#p1 {
-  border: solid blue 2px;
-}
-</style>
-</head>
-
-<body>
-
-<!-- passes a reference to the element's object as parameter 'this'. -->
-<p id="p1" onclick="alterStyle(this);">
- Click here to change background color.
-</p>
-
-<!-- passes the 'p1' id of another element's style to modify. -->
-<button onclick="resetStyle('p1');">Reset background color</button>
-
-</body>
+    <!-- passes the 'p1' id of another element's style to modify. -->
+    <button onclick="resetStyle('p1');">Reset background color</button>
+  </body>
 </html>
 ```
 
@@ -115,19 +111,19 @@ More important than the two properties noted here is the use of the `style` obje
 ```html
 <!DOCTYPE html>
 <html lang="en-us">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width">
-  <title>Style Property Example</title>
-  <link rel="StyleSheet" href="example.css">
-  <script>
-    function setStyle() {
-      document.getElementById('d').style.color = 'orange';
-    }
-    function resetStyle() {
-      document.getElementById('d').style.color = 'black';
-    }
-  </script>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>Style Property Example</title>
+    <link rel="StyleSheet" href="example.css">
+    <script>
+      function setStyle() {
+        document.getElementById('d').style.color = 'orange';
+      }
+      function resetStyle() {
+        document.getElementById('d').style.color = 'black';
+      }
+    </script>
  </head>
 
  <body>

--- a/files/en-us/web/api/document/createprocessinginstruction/index.md
+++ b/files/en-us/web/api/document/createprocessinginstruction/index.md
@@ -46,7 +46,7 @@ None ({{jsxref("undefined")}}).
 
 ```js
 const doc = new DOMParser().parseFromString('<foo />', 'application/xml');
-const pi = doc.createProcessingInstruction('xml-stylesheet', 'href="mycss.css" type="text/css"');
+const pi = doc.createProcessingInstruction('xml-stylesheet', 'href="mycss.css"');
 
 doc.insertBefore(pi, doc.firstChild);
 

--- a/files/en-us/web/api/document/mozsetimageelement/index.md
+++ b/files/en-us/web/api/document/mozsetimageelement/index.md
@@ -44,7 +44,7 @@ block is clicked by the user.
 [View this example live](https://media.prod.mdn.mozit.cloud/samples/domref/mozSetImageElement.html).
 
 ```html
-<style type="text/css">
+<style>
   #mybox {
     background-image: -moz-element(#canvasbg);
     text-align: center;

--- a/files/en-us/web/api/element/setcapture/index.md
+++ b/files/en-us/web/api/element/setcapture/index.md
@@ -44,10 +44,13 @@ In this example, the current mouse coordinates are drawn while you mouse around 
 clicking and holding down on an element.
 
 ```html
-<html>
+<!DOCTYPE html>
+<html lang="en-us">
 <head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
   <title>Mouse Capture Example</title>
-  <style type="text/css">
+  <style>
     #myButton {
       border: solid black 1px;
       color: black;

--- a/files/en-us/web/api/htmlstyleelement/media/index.md
+++ b/files/en-us/web/api/htmlstyleelement/media/index.md
@@ -23,12 +23,15 @@ A string describing a single medium or a comma-separated list.
 ## Examples
 
 ```html
-<!doctype html>
-<html>
+<!DOCTYPE html>
+<html lang="en-us">
 <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>Test page</title>
 
-<link id="LinkedStyle" rel="stylesheet" href="document.css" type="text/css" media="screen" />
-<style id="InlineStyle" rel="stylesheet" type="text/css" media="screen, print">
+<link id="LinkedStyle" rel="stylesheet" href="document.css" media="screen" />
+<style id="InlineStyle" rel="stylesheet" media="screen, print">
 p { color: blue; }
 </style>
 </head>

--- a/files/en-us/web/api/mouseevent/layerx/index.md
+++ b/files/en-us/web/api/mouseevent/layerx/index.md
@@ -45,7 +45,7 @@ function showCoords(evt){
 }
 </script>
 
-<style type="text/css">
+<style>
 
  #d1 {
   border: solid blue 1px;

--- a/files/en-us/web/api/mouseevent/layery/index.md
+++ b/files/en-us/web/api/mouseevent/layery/index.md
@@ -45,7 +45,7 @@ function showCoords(evt){
 }
 </script>
 
-<style type="text/css">
+<style>
 
  #d1 {
   border: solid blue 1px;

--- a/files/en-us/web/api/stylesheet/href/index.md
+++ b/files/en-us/web/api/stylesheet/href/index.md
@@ -23,9 +23,13 @@ A string containing the stylesheet's URI.
 On a local machine:
 
 ```html
-<html>
+<!DOCTYPE html>
+<html lang="en-us">
 <head>
-  <link rel="StyleSheet" href="example.css" type="text/css" />
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>href example</title>
+  <link rel="styleSheet" href="example.css" />
   <script>
   function sref() {
     alert(document.styleSheets[0].href);

--- a/files/en-us/web/api/stylesheet/media/index.md
+++ b/files/en-us/web/api/stylesheet/media/index.md
@@ -20,11 +20,15 @@ A read-only array-like `MediaList` object.
 ## Examples
 
 ```html
-<!doctype html>
-<html>
+<!DOCTYPE html>
+<html lang="en-us">
 <head>
-<link rel="stylesheet" href="document.css" type="text/css" media="screen" />
-<style rel="stylesheet" type="text/css" media="screen, print">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+<title>Test page</title>
+
+<link rel="stylesheet" href="document.css" media="screen" />
+<style rel="stylesheet" media="screen, print">
 body { background-color: snow; }
 </style>
 </head>

--- a/files/en-us/web/css/@font-face/index.md
+++ b/files/en-us/web/css/@font-face/index.md
@@ -119,10 +119,13 @@ The `@font-face` at-rule may be used not only at the top level of a CSS, but als
 This example specifies a downloadable font to use, applying it to the entire body of the document:
 
 ```html
-<html>
+<!DOCTYPE html>
+<html lang="en-us">
 <head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
   <title>Web Font Sample</title>
-  <style type="text/css" media="screen, print">
+  <style media="screen, print">
     @font-face {
       font-family: "Bitstream Vera Serif Bold";
       src: url("https://mdn.github.io/css-examples/web-fonts/VeraSeBd.ttf");

--- a/files/en-us/web/css/_doublecolon_part/index.md
+++ b/files/en-us/web/css/_doublecolon_part/index.md
@@ -33,7 +33,7 @@ custom-element::part(foo) {
 
 ```html
 <template id="tabbed-custom-element">
-<style type="text/css">
+<style>
 *, ::before, ::after {
   box-sizing: border-box;
   padding: 1rem;

--- a/files/en-us/web/css/alternative_style_sheets/index.md
+++ b/files/en-us/web/css/alternative_style_sheets/index.md
@@ -21,11 +21,11 @@ Firefox lets the user select the stylesheet using the _View > Page Style_ submen
 The alternate stylesheets are commonly specified using a {{HTMLElement("link")}} element with `rel="alternate stylesheet"` and `title="…"` attributes. For example:
 
 ```html
-<link href="reset.css" rel="stylesheet" type="text/css">
+<link href="reset.css" rel="stylesheet">
 
-<link href="default.css" rel="stylesheet" type="text/css" title="Default Style">
-<link href="fancy.css" rel="alternate stylesheet" type="text/css" title="Fancy">
-<link href="basic.css" rel="alternate stylesheet" type="text/css" title="Basic">
+<link href="default.css" rel="stylesheet" title="Default Style">
+<link href="fancy.css" rel="alternate stylesheet" title="Fancy">
+<link href="basic.css" rel="alternate stylesheet" title="Basic">
 ```
 
 In this example, the styles "Default Style", "Fancy", and "Basic" will be listed in the _Page Style_ submenu, with "Default Style" pre-selected. When the user selects a different style, the page will immediately be re-rendered using that style sheet.

--- a/files/en-us/web/css/css_positioning/understanding_z_index/stacking_context_example_2/index.md
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/stacking_context_example_2/index.md
@@ -35,10 +35,13 @@ To better understand the situation, this is the stacking context hierarchy:
 ## Example source code
 
 ```html
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html>
-<head><style type="text/css">
+<!DOCTYPE html>
+<html lang="en-us">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
+    <title>Stacking context demo</title>
+<style>
 
 div { font: 12px Arial; }
 

--- a/files/en-us/web/css/css_positioning/understanding_z_index/stacking_context_example_3/index.md
+++ b/files/en-us/web/css/css_positioning/understanding_z_index/stacking_context_example_3/index.md
@@ -57,7 +57,7 @@ This problem can be avoided by removing overlapping between different level menu
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html>
-<head><style type="text/css">
+<head><style>
 
 div { font: 12px Arial; }
 

--- a/files/en-us/web/guide/html/editable_content/index.md
+++ b/files/en-us/web/guide/html/editable_content/index.md
@@ -136,7 +136,7 @@ function printDoc() {
   oPrintWin.document.close();
 }
 </script>
-<style type="text/css">
+<style>
 .intLink { cursor: pointer; }
 img.intLink { border: 0; }
 #toolBar1 select { font-size:10px; }

--- a/files/en-us/web/http/headers/content-security-policy/style-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/style-src/index.md
@@ -66,7 +66,7 @@ Content-Security-Policy: style-src https://example.com/
 the following stylesheets are blocked and won't load:
 
 ```html
-<link href="https://not-example.com/styles/main.css" rel="stylesheet" type="text/css" />
+<link href="https://not-example.com/styles/main.css" rel="stylesheet" />
 
 <style>
 #inline-style { background: red; }

--- a/files/en-us/web/progressive_web_apps/responsive/responsive_design_building_blocks/index.md
+++ b/files/en-us/web/progressive_web_apps/responsive/responsive_design_building_blocks/index.md
@@ -254,7 +254,7 @@ Last, we have used `flex: 1;` to make the buttons always take up the same propor
 What's more relevant to this article is that we didn't want the Brick CSS and JavaScript files being applied to the markup unless we were looking at the mobile app view. To achieve this, we applied the Brick CSS to the page using a separate {{HTMLElement("link")}} element with a `media` attribute:
 
 ```html
-<link href="dist/brick.css" type="text/css" rel="stylesheet" media="all and (max-width: 480px)">
+<link href="dist/brick.css" rel="stylesheet" media="all and (max-width: 480px)">
 ```
 
 This says that the whole stylesheet will not be linked to the HTML unless the viewport width is 480px or less. Moving on to the JavaScript, {{HTMLElement("script")}} elements don't accept `media` attributes, so I had to do this a different way. Fortunately there is a JavaScript construct called {{domxref("window.matchMedia()")}}, which can conditionally run JavaScript constructs depending on whether a media query returns `true` or not. We opened up the `brick.js` file and wrapped the whole lot in the following:


### PR DESCRIPTION
There is only one type of style language. type is only needed on link and style if a styling language other than CSS is used. 
A few minor additional tweaks.


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
