### PR TITLE
Add missing semicolons to class fields documents

### DIFF
--- a/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
@@ -147,7 +147,7 @@ class SubClass extends BaseClassWithPrivateStaticField { };
 let error = null;
 
 try {
-  SubClass.basePublicStaticMethod()
+  SubClass.basePublicStaticMethod();
 } catch(e) { error = e};
 
 console.log(error instanceof TypeError);

--- a/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/private_class_fields/index.md
@@ -148,7 +148,9 @@ let error = null;
 
 try {
   SubClass.basePublicStaticMethod();
-} catch(e) { error = e};
+} catch (e) {
+  error = e;
+}
 
 console.log(error instanceof TypeError);
 // true

--- a/files/en-us/web/javascript/reference/classes/public_class_fields/index.md
+++ b/files/en-us/web/javascript/reference/classes/public_class_fields/index.md
@@ -17,16 +17,16 @@ inheritance.
 
 ```js
 class ClassWithInstanceField {
-  instanceField = 'instance field'
+  instanceField = 'instance field';
 }
 
 class ClassWithStaticField {
-  static staticField = 'static field'
+  static staticField = 'static field';
 }
 
 class ClassWithPublicInstanceMethod {
   publicMethod() {
-    return 'hello world'
+    return 'hello world';
   }
 }
 ```
@@ -46,10 +46,10 @@ accessed again from the class constructor.
 
 ```js
 class ClassWithStaticField {
-  static staticField = 'static field'
+  static staticField = 'static field';
 }
 
-console.log(ClassWithStaticField.staticField)
+console.log(ClassWithStaticField.staticField);
 // expected output: "static field"
 ```
 
@@ -57,11 +57,11 @@ Fields without initializers are initialized to `undefined`.
 
 ```js
 class ClassWithStaticField {
-  static staticField
+  static staticField;
 }
 
-console.assert(Object.hasOwn(ClassWithStaticField, 'staticField'))
-console.log(ClassWithStaticField.staticField)
+console.assert(Object.hasOwn(ClassWithStaticField, 'staticField'));
+console.log(ClassWithStaticField.staticField);
 // expected output: "undefined"
 ```
 
@@ -70,17 +70,17 @@ prototype chain.
 
 ```js
 class ClassWithStaticField {
-  static baseStaticField = 'base field'
+  static baseStaticField = 'base field';
 }
 
 class SubClassWithStaticField extends ClassWithStaticField {
-  static subStaticField = 'sub class field'
+  static subStaticField = 'sub class field';
 }
 
-console.log(SubClassWithStaticField.subStaticField)
+console.log(SubClassWithStaticField.subStaticField);
 // expected output: "sub class field"
 
-console.log(SubClassWithStaticField.baseStaticField)
+console.log(SubClassWithStaticField.baseStaticField);
 // expected output: "base field"
 ```
 
@@ -90,20 +90,20 @@ also reference it by name, and use `super` to get the superclass constructor
 
 ```js
 class ClassWithStaticField {
-  static baseStaticField = 'base static field'
-  static anotherBaseStaticField = this.baseStaticField
+  static baseStaticField = 'base static field';
+  static anotherBaseStaticField = this.baseStaticField;
 
-  static baseStaticMethod() { return 'base static method output' }
+  static baseStaticMethod() { return 'base static method output'; }
 }
 
 class SubClassWithStaticField extends ClassWithStaticField {
-  static subStaticField = super.baseStaticMethod()
+  static subStaticField = super.baseStaticMethod();
 }
 
-console.log(ClassWithStaticField.anotherBaseStaticField)
+console.log(ClassWithStaticField.anotherBaseStaticField);
 // expected output: "base static field"
 
-console.log(SubClassWithStaticField.subStaticField)
+console.log(SubClassWithStaticField.subStaticField);
 // expected output: "base static method output"
 ```
 
@@ -119,11 +119,11 @@ constructor body runs), or just after `super()` returns in a subclass.
 
 ```js
 class ClassWithInstanceField {
-  instanceField = 'instance field'
+  instanceField = 'instance field';
 }
 
-const instance = new ClassWithInstanceField()
-console.log(instance.instanceField)
+const instance = new ClassWithInstanceField();
+console.log(instance.instanceField);
 // expected output: "instance field"
 ```
 
@@ -131,26 +131,26 @@ Fields without initializers are initialized to `undefined`.
 
 ```js
 class ClassWithInstanceField {
-  instanceField
+  instanceField;
 }
 
-const instance = new ClassWithInstanceField()
-console.assert(Object.hasOwn(instance, 'instanceField'))
-console.log(instance.instanceField)
+const instance = new ClassWithInstanceField();
+console.assert(Object.hasOwn(instance, 'instanceField'));
+console.log(instance.instanceField);
 // expected output: "undefined"
 ```
 
 Like properties, field names may be computed.
 
 ```js
-const PREFIX = 'prefix'
+const PREFIX = 'prefix';
 
 class ClassWithComputedFieldName {
-  [`${PREFIX}Field`] = 'prefixed field'
+  [`${PREFIX}Field`] = 'prefixed field';
 }
 
-const instance = new ClassWithComputedFieldName()
-console.log(instance.prefixField)
+const instance = new ClassWithComputedFieldName();
+console.log(instance.prefixField);
 // expected output: "prefixed field"
 ```
 
@@ -160,22 +160,22 @@ the superclass prototype using `super`.
 
 ```js
 class ClassWithInstanceField {
-  baseInstanceField = 'base field'
-  anotherBaseInstanceField = this.baseInstanceField
-  baseInstanceMethod() { return 'base method output' }
+  baseInstanceField = 'base field';
+  anotherBaseInstanceField = this.baseInstanceField;
+  baseInstanceMethod() { return 'base method output'; }
 }
 
 class SubClassWithInstanceField extends ClassWithInstanceField {
-  subInstanceField = super.baseInstanceMethod()
+  subInstanceField = super.baseInstanceMethod();
 }
 
-const base = new ClassWithInstanceField()
-const sub = new SubClassWithInstanceField()
+const base = new ClassWithInstanceField();
+const sub = new SubClassWithInstanceField();
 
-console.log(base.anotherBaseInstanceField)
+console.log(base.anotherBaseInstanceField);
 // expected output: "base field"
 
-console.log(sub.subInstanceField)
+console.log(sub.subInstanceField);
 // expected output: "base method output"
 ```
 
@@ -275,12 +275,12 @@ As the name implies, public instance methods are methods available on class inst
 ```js
 class ClassWithPublicInstanceMethod {
   publicMethod() {
-    return 'hello world'
+    return 'hello world';
   }
 }
 
-const instance = new ClassWithPublicInstanceMethod()
-console.log(instance.publicMethod())
+const instance = new ClassWithPublicInstanceMethod();
+console.log(instance.publicMethod());
 // expected output: "hello world"
 ```
 
@@ -304,20 +304,20 @@ call methods from the superclass.
 
 ```js
 class BaseClass {
-  msg = 'hello world'
+  msg = 'hello world';
   basePublicMethod() {
-    return this.msg
+    return this.msg;
   }
 }
 
 class SubClass extends BaseClass {
   subPublicMethod() {
-    return super.basePublicMethod()
+    return super.basePublicMethod();
   }
 }
 
-const instance = new SubClass()
-console.log(instance.subPublicMethod())
+const instance = new SubClass();
+console.log(instance.subPublicMethod());
 // expected output: "hello world"
 ```
 
@@ -327,21 +327,21 @@ public instance getter or setter.
 
 ```js
 class ClassWithGetSet {
-  #msg = 'hello world'
+  #msg = 'hello world';
   get msg() {
-    return this.#msg
+    return this.#msg;
   }
   set msg(x) {
-    this.#msg = `hello ${x}`
+    this.#msg = `hello ${x}`;
  }
 }
 
-const instance = new ClassWithGetSet()
-console.log(instance.msg)
+const instance = new ClassWithGetSet();
+console.log(instance.msg);
 // expected output: "hello world"
 
-instance.msg = 'cake'
-console.log(instance.msg)
+instance.msg = 'cake';
+console.log(instance.msg);
 // expected output: "hello cake"
 ```
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

Add missing semicolons to class public fields document's code examples.

#### Motivation

[While the semicolon can be omitted](https://tc39.es/ecma262/#sec-rules-of-automatic-semicolon-insertion), the trailing semi-colon is part of syntax for class field definition,
and the document's code example must follow the standard syntax, to avoid confusion and unexpected behavior due to the case that semicolon is not inserted and parsed as different syntax.

Especially, given the field definition syntax allows computed property name, the first character can be `[`, and if the trailing semicolon is omitted from the previous field definition, the `[` becomes part of the initializer, and it becomes either syntax error or unexpected behavior.

Example:

```js
class C {
 ["foo"] = 10
 ["bar"] = 10
}
```

The above is parsed in the same way as the following.
`["bar"] = 10` is not class field, but it's part of initializer `10["bar"] = 10` for `["foo"]` field.

```js
class C {
 ["foo"] = 10["bar"] = 10
}
```

If we have semicolon, such issue doesn't happen.

```js
class C {
 ["foo"] = 10;
 ["bar"] = 10;
}
```

#### Supporting details

this is part of the spec.

https://tc39.es/ecma262/#prod-ClassElement
```
ClassElement[Yield, Await] :
  MethodDefinition[?Yield, ?Await]
  static MethodDefinition[?Yield, ?Await]
  FieldDefinition[?Yield, ?Await] ;
  static FieldDefinition[?Yield, ?Await] ;
  ClassStaticBlock
  ;
```


#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
