### PR TITLE
Update DOMMatrix example to correct input order

### DIFF
--- a/files/en-us/web/api/dommatrix/dommatrix/index.md
+++ b/files/en-us/web/api/dommatrix/dommatrix/index.md
@@ -47,8 +47,8 @@ const translateX = 12;
 const translateY = 8;
 const angle = Math.PI / 2;
 const matrix = new DOMMatrix([
-  Math.sin(angle) * scaleX,
   Math.cos(angle) * scaleX,
+  Math.sin(angle) * scaleX,
   -Math.sin(angle) * scaleY,
   Math.cos(angle) * scaleY,
   translateX,


### PR DESCRIPTION
The order of inputs would have produced skewed the results. The DOMMatrix goes top-left to bottom-right. When the rotation angle is zero, the inputs should give the identity matrix, that being 1, 0, 0, 1, but the first two inputs were out of order. I have tested my changes in code for validity.
