### PR TITLE
Corrected local server address

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_getting_started/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_getting_started/index.md
@@ -283,7 +283,7 @@ We are applying a style to our [`<h1>`](/en-US/docs/Web/HTML/Element/Heading_Ele
 
 In Svelte, CSS inside a component's `<style>` block will be scoped only to that component. This works by adding a class to selected elements, which is based on a hash of the component styles.
 
-You can see this in action by opening `localhost:5042` in a new browser tab, right/<kbd>Ctrl</kbd>-clicking on the _HELLO WORLD!_ label, and choosing _Inspect_:
+You can see this in action by opening `localhost:8080` in a new browser tab, right/<kbd>Ctrl</kbd>-clicking on the _HELLO WORLD!_ label, and choosing _Inspect_:
 
 ![Svelte starter app with devtools open, showing classes for scoped styles](02-svelte-component-scoped-styles.png)
 
@@ -300,7 +300,7 @@ At this point you can try updating your `App.svelte` component — for example c
 <h1>Hello {name} from MDN!</h1>
 ```
 
-Just save your changes and the app running at `localhost:5042` will be automatically updated.
+Just save your changes and the app running at `localhost:8080` will be automatically updated.
 
 ### A first look at Svelte reactivity
 


### PR DESCRIPTION
Changed where the Svelte tutorial application will be served at to the correct address.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Changed where Svelte tutorial application will be served when a user tries the commands on this page.
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
To help clarify to users what will happen so that they do not think that they made a mistake when their version of the application isn't served at localhost:5042.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
