### PR TITLE
refactor: typo in `font-stretch` alt attribute values

### DIFF
--- a/files/en-us/web/css/font-stretch/index.md
+++ b/files/en-us/web/css/font-stretch/index.md
@@ -102,27 +102,27 @@ The table below demonstrates the effect of supplying various different percentag
   <tbody>
     <tr>
       <th scope="row">Helvetica Neue</th>
-      <td><img alt="Example use of font-strech property on the letter e in Helvetica Neue set at 50%" src="screenshot_2018-06-06_example_page.png" /></td>
-      <td><img alt="Example use of font-strech property on the letter e in Helvetica Neue set at 62.5%" src="screenshot_2018-06-06_example_page.png" /></td>
-      <td><img alt="Example use of font-strech property on the letter e in Helvetica Neue set at 75%" src="screenshot_2018-06-06_example_page.png" /></td>
-      <td><img alt="Example use of font-strech property on the letter e in Helvetica Neue set at 87.5%" src="screenshot_2018-06-06_example_page.png" /></td>
-      <td><img alt="Example use of font-strech property on the letter e in Helvetica Neue set at 100%" src="screenshot_2018-06-06_example_page1.png" /></td>
-      <td><img alt="Example use of font-strech property on the letter e in Helvetica Neue set at 112.5%" src="screenshot_2018-06-06_example_page1.png" /></td>
-      <td><img alt="Example use of font-strech property on the letter e in Helvetica Neue set at 125%" src="screenshot_2018-06-06_example_page1.png" /></td>
-      <td><img alt="Example use of font-strech property on the letter e in Helvetica Neue set at 150%" src="screenshot_2018-06-06_example_page1.png" /></td>
-      <td><img alt="Example use of font-strech property on the letter e in Helvetica Neue set at 200%" src="screenshot_2018-06-06_example_page1.png" /></td>
+      <td><img alt="Example use of font-stretch property on the letter e in Helvetica Neue set at 50%" src="screenshot_2018-06-06_example_page.png" /></td>
+      <td><img alt="Example use of font-stretch property on the letter e in Helvetica Neue set at 62.5%" src="screenshot_2018-06-06_example_page.png" /></td>
+      <td><img alt="Example use of font-stretch property on the letter e in Helvetica Neue set at 75%" src="screenshot_2018-06-06_example_page.png" /></td>
+      <td><img alt="Example use of font-stretch property on the letter e in Helvetica Neue set at 87.5%" src="screenshot_2018-06-06_example_page.png" /></td>
+      <td><img alt="Example use of font-stretch property on the letter e in Helvetica Neue set at 100%" src="screenshot_2018-06-06_example_page1.png" /></td>
+      <td><img alt="Example use of font-stretch property on the letter e in Helvetica Neue set at 112.5%" src="screenshot_2018-06-06_example_page1.png" /></td>
+      <td><img alt="Example use of font-stretch property on the letter e in Helvetica Neue set at 125%" src="screenshot_2018-06-06_example_page1.png" /></td>
+      <td><img alt="Example use of font-stretch property on the letter e in Helvetica Neue set at 150%" src="screenshot_2018-06-06_example_page1.png" /></td>
+      <td><img alt="Example use of font-stretch property on the letter e in Helvetica Neue set at 200%" src="screenshot_2018-06-06_example_page1.png" /></td>
     </tr>
     <tr>
       <th scope="row">League Mono Variable</th>
-      <td><img alt="Example use of font-strech property on the letter e in League Mono Variable set at 50%" src="screenshot_2018-06-06_example_page.png" /></td>
-      <td><img alt="Example use of font-strech property on the letter e in League Mono Variable set at 62.5%" src="screenshot_2018-06-06_example_page1.png" /></td>
-      <td><img alt="Example use of font-strech property on the letter e in League Mono Variable set at 75%" src="screenshot_2018-06-06_example_page2.png" /></td>
-      <td><img alt="Example use of font-strech property on the letter e in League Mono Variable set at 87.5%" src="screenshot_2018-06-06_example_page3.png" /></td>
-      <td><img alt="Example use of font-strech property on the letter e in League Mono Variable set at 100%" src="l-100.png" /></td>
-      <td><img alt="Example use of font-strech property on the letter e in League Mono Variable set at 112.5%" src="l-112.5.png" /></td>
-      <td><img alt="Example use of font-strech property on the letter e in League Mono Variable set at 125%" src="l-125.png" /></td>
-      <td><img alt="Example use of font-strech property on the letter e in League Mono Variable set at 150%" src="l-150.png" /></td>
-      <td><img alt="Example use of font-strech property on the letter e in League Mono Variable set at 200%" src="l-200.png" /></td>
+      <td><img alt="Example use of font-stretch property on the letter e in League Mono Variable set at 50%" src="screenshot_2018-06-06_example_page.png" /></td>
+      <td><img alt="Example use of font-stretch property on the letter e in League Mono Variable set at 62.5%" src="screenshot_2018-06-06_example_page1.png" /></td>
+      <td><img alt="Example use of font-stretch property on the letter e in League Mono Variable set at 75%" src="screenshot_2018-06-06_example_page2.png" /></td>
+      <td><img alt="Example use of font-stretch property on the letter e in League Mono Variable set at 87.5%" src="screenshot_2018-06-06_example_page3.png" /></td>
+      <td><img alt="Example use of font-stretch property on the letter e in League Mono Variable set at 100%" src="l-100.png" /></td>
+      <td><img alt="Example use of font-stretch property on the letter e in League Mono Variable set at 112.5%" src="l-112.5.png" /></td>
+      <td><img alt="Example use of font-stretch property on the letter e in League Mono Variable set at 125%" src="l-125.png" /></td>
+      <td><img alt="Example use of font-stretch property on the letter e in League Mono Variable set at 150%" src="l-150.png" /></td>
+      <td><img alt="Example use of font-stretch property on the letter e in League Mono Variable set at 200%" src="l-200.png" /></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
A little typo in `front-stretch` alt attributes values.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
In order to correct this typo error.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
N/A

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
https://github.com/mdn/content/pull/19205

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
