### PR TITLE
MINOR: CSS missing ALT attributes

### DIFF
--- a/files/en-us/web/css/_doublecolon_-moz-range-progress/index.md
+++ b/files/en-us/web/css/_doublecolon_-moz-range-progress/index.md
@@ -45,7 +45,7 @@ input[type=range]::-moz-range-progress {
 
 A progress bar using this style might look something like this:
 
-![](screen_shot_2015-12-04_at_20.14.48.png)
+![The progress bar is a thick green square to the left of the thumb and a thin grey line to the right. The thumb is a circle with a diameter the height of the green area.](screen_shot_2015-12-04_at_20.14.48.png)
 
 ## Specifications
 

--- a/files/en-us/web/css/_doublecolon_-webkit-progress-bar/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-progress-bar/index.md
@@ -49,7 +49,7 @@ progress {
 
 If you're not using a WebKit or Blink browser, the code above results in a progress bar that looks like this:
 
-![The progress bar is a horizontal bar about the height of a letter. The left 20% is green. The right 80% is organge.](progress-bar.png)
+![The progress bar is a horizontal bar about the height of a letter. The left 20% is green. The right 80% is orange.](progress-bar.png)
 
 ## Specifications
 

--- a/files/en-us/web/css/_doublecolon_-webkit-progress-bar/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-progress-bar/index.md
@@ -49,7 +49,7 @@ progress {
 
 If you're not using a WebKit or Blink browser, the code above results in a progress bar that looks like this:
 
-![](progress-bar.png)
+![The progress bar is a horizontal bar about the height of a letter. The left 20% is green. The right 80% is organge.](progress-bar.png)
 
 ## Specifications
 

--- a/files/en-us/web/css/_doublecolon_-webkit-progress-inner-element/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-progress-inner-element/index.md
@@ -55,7 +55,7 @@ progress {
 
 If you're not using a Blink or WebKit browser, the above code results in a progress bar looking like this:
 
-![Progressbar is long green and grey box with a black border. The left 20% of the box is green. The right 80% is grey.](-webkit-progress-inner-element_example.png)
+![Progressbar is a long green and grey box with a black border. The left 20% of the box is green. The right 80% is grey.](-webkit-progress-inner-element_example.png)
 
 ## Specifications
 

--- a/files/en-us/web/css/_doublecolon_-webkit-progress-inner-element/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-progress-inner-element/index.md
@@ -55,7 +55,7 @@ progress {
 
 If you're not using a Blink or WebKit browser, the above code results in a progress bar looking like this:
 
-![](-webkit-progress-inner-element_example.png)
+![Progressbar is long green and grey box with a black border. The left 20% of the box is green. The right 80% is grey.](-webkit-progress-inner-element_example.png)
 
 ## Specifications
 

--- a/files/en-us/web/css/_doublecolon_-webkit-progress-value/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-progress-value/index.md
@@ -51,7 +51,7 @@ progress {
 
 A progress bar using the style above would look like this:
 
-![](progress-value.png)
+![A long orange and grey box. The left 20% is organge. The right 80% is grey.](progress-value.png)
 
 ## Specifications
 

--- a/files/en-us/web/css/_doublecolon_-webkit-progress-value/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-progress-value/index.md
@@ -51,7 +51,7 @@ progress {
 
 A progress bar using the style above would look like this:
 
-![A long orange and grey box. The left 20% is organge. The right 80% is grey.](progress-value.png)
+![A long orange and grey box. The left 20% is orange. The right 80% is grey.](progress-value.png)
 
 ## Specifications
 

--- a/files/en-us/web/css/_doublecolon_backdrop/index.md
+++ b/files/en-us/web/css/_doublecolon_backdrop/index.md
@@ -52,7 +52,7 @@ video::backdrop {
 
 The resulting screen looks like this:
 
-![An almost full screen video player with purple above and below the player as it doesn't completely fill the screen.](bbb-backdrop.png)
+![An almost full-screen video player with purple above and below the player as the video player doesn't completely fill the screen.](bbb-backdrop.png)
 
 [See this example in action](https://mdn.github.io/css-examples/backdrop/index.html), after changing the color of the background cause the video to go fullscreen to see the change to the backdrop color.
 

--- a/files/en-us/web/css/_doublecolon_backdrop/index.md
+++ b/files/en-us/web/css/_doublecolon_backdrop/index.md
@@ -52,7 +52,7 @@ video::backdrop {
 
 The resulting screen looks like this:
 
-![](bbb-backdrop.png)
+![An almost full screen video player with purple above and below the player as it doesn't completely fill the screen.](bbb-backdrop.png)
 
 [See this example in action](https://mdn.github.io/css-examples/backdrop/index.html), after changing the color of the background cause the video to go fullscreen to see the change to the backdrop color.
 

--- a/files/en-us/web/css/border-image-width/index.md
+++ b/files/en-us/web/css/border-image-width/index.md
@@ -79,7 +79,7 @@ The `border-image-width` property may be specified using one, two, three, or fou
 
 This example creates a border image using the following ".png" file, which is 90 by 90 pixels:
 
-![](border.png)
+![Square image containing eight circles. The circles in each corner are light purple. The four side circles are blue. The area in the middle, where a ninth circle could fit, is blank.](border.png)
 
 Thus, each circle in the source image is 30 by 30 pixels.
 

--- a/files/en-us/web/css/css_box_alignment/box_alignment_in_grid_layout/index.md
+++ b/files/en-us/web/css/css_box_alignment/box_alignment_in_grid_layout/index.md
@@ -33,7 +33,7 @@ The block axis crosses the inline axis in the direction that blocks are displaye
 
 To align things on the block axis you use the properties that start with `align-`, {{cssxref("align-content")}}, {{cssxref("align-items")}} and {{cssxref("align-self")}}.
 
-![The block axes are vertical](block_axis.png)
+![The block axes are vertical.](block_axis.png)
 
 ## Self alignment
 

--- a/files/en-us/web/css/css_box_alignment/box_alignment_in_grid_layout/index.md
+++ b/files/en-us/web/css/css_box_alignment/box_alignment_in_grid_layout/index.md
@@ -25,7 +25,7 @@ As a two-dimensional layout method, when working with grid layout we always have
 
 The inline axis is the axis that corresponds to the direction that words in a sentence would run in the writing mode used. Therefore, in a horizontal language such as English or Arabic the inline direction runs horizontally. Should you be in a vertical writing mode the inline axis will run vertically.
 
-![](inline_axis.png)
+![Inline axes are horizontal.](inline_axis.png)
 
 To align things on the inline axis you use the properties that start with `justify-`, {{cssxref("justify-content")}}, {{cssxref("justify-items")}} and {{cssxref("justify-self")}}.
 
@@ -33,7 +33,7 @@ The block axis crosses the inline axis in the direction that blocks are displaye
 
 To align things on the block axis you use the properties that start with `align-`, {{cssxref("align-content")}}, {{cssxref("align-items")}} and {{cssxref("align-self")}}.
 
-![](block_axis.png)
+![The block axes are vertical](block_axis.png)
 
 ## Self alignment
 

--- a/files/en-us/web/css/css_box_alignment/index.md
+++ b/files/en-us/web/css/css_box_alignment/index.md
@@ -51,7 +51,7 @@ Alignment is linked to writing modes in that when we align an item we do not con
 
 When using the box alignment properties you will align content on one of two axes — the inline (or main) axis, and the block (or cross) axis. The inline axis is the axis along which words in a sentence flow in the writing mode being used — for English, for example, the inline axis is horizontal. The block axis is the axis along which blocks, such as paragraph elements, are laid out and it runs across the Inline axis.
 
-![Inline axis is the left / right direction. Block axis is top / bottom.](two-axes.png)
+![Inline axis is the left / right, or horizontal, direction. Block axis is vertical, or top / bottom.](two-axes.png)
 
 When aligning items on the inline axis you will use the properties which begin with `justify-`:
 
@@ -77,7 +77,7 @@ The **alignment container** is the box the subject is being aligned inside. This
 
 The below image shows an alignment container with two alignment subjects inside.
 
-![A box containing two rectangles that are the same width but have different heights. The two rectangles are top aligned, meaning they both have their top lines about 10px inside the top of the box in which they are contained.](align-container-subjects.png)
+![A box containing two rectangles of the same width but different heights. The two rectangles are top aligned, meaning they both have their top lines about 10px inside the top of the box in which they are contained.](align-container-subjects.png)
 
 ### Fallback alignment
 
@@ -140,7 +140,7 @@ For example, in Flex Layout items are aligned with `flex-start` initially. Worki
 
 If you set `justify-content: space-between` on the flex container, the available space is now shared out and placed between the items.
 
-![Three rectangles of different widths are inside a box. The first rectangle is aligned to the left side of the containing box. The third rectangle is aligned right, and the middle rectangle is equally spaced between the first and last.](justify-content-space-between.png)
+![Three rectangles of different widths are inside a box. The first rectangle is aligned to the left side of the containing box, the third rectangle is aligned right, and the middle rectangle is equally spaced between the first and last.](justify-content-space-between.png)
 
 There needs to be space available in the dimension you wish to align the items in, in order for these keywords to take effect. With no space, there is nothing to distribute.
 

--- a/files/en-us/web/css/css_box_alignment/index.md
+++ b/files/en-us/web/css/css_box_alignment/index.md
@@ -51,7 +51,7 @@ Alignment is linked to writing modes in that when we align an item we do not con
 
 When using the box alignment properties you will align content on one of two axes — the inline (or main) axis, and the block (or cross) axis. The inline axis is the axis along which words in a sentence flow in the writing mode being used — for English, for example, the inline axis is horizontal. The block axis is the axis along which blocks, such as paragraph elements, are laid out and it runs across the Inline axis.
 
-![](two-axes.png)
+![Inline axis is the left / right direction. Block axis is top / bottom.](two-axes.png)
 
 When aligning items on the inline axis you will use the properties which begin with `justify-`:
 
@@ -77,7 +77,7 @@ The **alignment container** is the box the subject is being aligned inside. This
 
 The below image shows an alignment container with two alignment subjects inside.
 
-![](align-container-subjects.png)
+![A box containing two rectangles that are the same width but have different heights. The two rectangles are top aligned, meaning they both have their top lines about 10px inside the top of the box in which they are contained.](align-container-subjects.png)
 
 ### Fallback alignment
 
@@ -111,7 +111,7 @@ For example, when working in CSS Grid Layout, if you are working in English and 
 
 Both of these examples have `justify-content: start`, however the location of start changes according to the writing mode.
 
-![](writing-mode-start.png)
+![There are two boxes, each with 3 children of differing heights but similar widths. The first box has three children with the letters A, B, and C. These three boxes are all aligned to the left. The second box has three children with arabic letters in them. Those three boxes are all aligned to the right.](writing-mode-start.png)
 
 ### Baseline alignment
 
@@ -136,11 +136,11 @@ The **distributed alignment keywords** are used with the `align-content` and `ju
 
 For example, in Flex Layout items are aligned with `flex-start` initially. Working in a horizontal top to bottom writing mode such as English, with `flex-direction` as `row` the items start on the far left and any available space after displaying the items is placed after the items.
 
-![](justify-content-start.png)
+![Three rectangles of different widths are inside a box. They are all aligned to the left side of the containing box, with about 10px between them, and 10px between the left side of the first rectangle and the parent container.](justify-content-start.png)
 
 If you set `justify-content: space-between` on the flex container, the available space is now shared out and placed between the items.
 
-![](justify-content-space-between.png)
+![Three rectangles of different widths are inside a box. The first rectangle is aligned to the left side of the containing box. The third rectangle is aligned right, and the middle rectangle is equally spaced between the first and last.](justify-content-space-between.png)
 
 There needs to be space available in the dimension you wish to align the items in, in order for these keywords to take effect. With no space, there is nothing to distribute.
 

--- a/files/en-us/web/css/css_columns/handling_overflow_in_multicol/index.md
+++ b/files/en-us/web/css/css_columns/handling_overflow_in_multicol/index.md
@@ -19,7 +19,7 @@ In this situation, the content should visibly overflow into the next column, rat
 
 {{EmbedGHLiveSample("css-examples/multicol/overflow/image.html", '100%', 800)}}
 
-![](image-overflow-multicol.png)
+![There are two columns of text. In the left column there is a photo that is wider than the column. The image expands into that second column, appearing behind the text of the right column. The flow of text in the right column isn't effected by the protruding photo, but the appearance is.](image-overflow-multicol.png)
 
 If you want an image to size down to fit the column box, the standard responsive images solution of setting `max-width: 100%` will achieve that for you.
 

--- a/files/en-us/web/css/css_flow_layout/block_and_inline_layout_in_normal_flow/index.md
+++ b/files/en-us/web/css/css_flow_layout/block_and_inline_layout_in_normal_flow/index.md
@@ -32,11 +32,11 @@ Note that the CSS 2.1 specification describes documents as being in a horizontal
 
 Block elements in a horizontal writing mode such as English, layout vertically, one below the other.
 
-![](mdn-horizontal.png)
+![Inline direction is horizontal. Block direction is vertical.](mdn-horizontal.png)
 
 In a vertical writing mode then would lay out horizontally.
 
-![](mdn-vertical.png)
+![Inline direction is vertical. Block direction is horizontal.](mdn-vertical.png)
 
 In this guide, we will be working in English and therefore a horizontal writing mode. However, everything described should work in the same way if your document is in a vertical writing mode.
 
@@ -64,7 +64,7 @@ You can read more about margin collapsing in our article [Mastering Margin Colla
 
 > **Note:** If you are not sure whether margins are collapsing, check the Box Model values in your browser DevTools. This will give you the actual size of the margin which can help you to identify what is happening.
 >
-> ![](box-model.png)
+> ![Screen shot box model panel in browser dev tools which shows the four values for margin, border, and padding along with height and width in a graphic at top and lists box-sizing, display, float, line-height, position, and z-index below the graphic.](box-model.png)
 
 ## Elements participating in an inline formatting context
 

--- a/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
@@ -93,7 +93,7 @@ If we want to start making this more grid-like we need to add column tracks.
 
 We define rows and columns on our grid with the {{cssxref("grid-template-rows")}} and {{cssxref("grid-template-columns")}} properties. These define grid tracks. A _grid track_ is the space between any two lines on the grid. In the below image you can see a track highlighted – this is the first row track in our grid.
 
-![](1_grid_track.png)
+![A box with 3 grid items. Above the three items is a solid light green area which is the track.](1_grid_track.png)
 
 ### Basic example
 

--- a/files/en-us/web/css/css_grid_layout/box_alignment_in_css_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/box_alignment_in_css_grid_layout/index.md
@@ -21,7 +21,7 @@ This guide presents demonstrations of how box alignment in grid layout works. Yo
 
 When working with grid layout you have two axes available to align things against – the _block axis_ and the _inline axis_. The block axis is the axis upon which blocks are laid out in block layout. If you have two paragraphs on your page they display one below the other, so it is this direction we describe as the block axis.
 
-![Block axes are vertical](block_axis.png)
+![Block axes are vertical.](block_axis.png)
 
 The _inline axis_ runs across the block axis, it is the direction in which text in regular inline flow runs.
 

--- a/files/en-us/web/css/css_grid_layout/box_alignment_in_css_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/box_alignment_in_css_grid_layout/index.md
@@ -21,11 +21,11 @@ This guide presents demonstrations of how box alignment in grid layout works. Yo
 
 When working with grid layout you have two axes available to align things against – the _block axis_ and the _inline axis_. The block axis is the axis upon which blocks are laid out in block layout. If you have two paragraphs on your page they display one below the other, so it is this direction we describe as the block axis.
 
-![](block_axis.png)
+![Block axes are vertical](block_axis.png)
 
 The _inline axis_ runs across the block axis, it is the direction in which text in regular inline flow runs.
 
-![](7_inline_axis.png)
+![Inline / row axis are horizontal.](7_inline_axis.png)
 
 We are able to align the content inside grid areas, and the grid tracks themselves on these two axes.
 

--- a/files/en-us/web/css/css_images/using_css_gradients/index.md
+++ b/files/en-us/web/css/css_images/using_css_gradients/index.md
@@ -116,7 +116,7 @@ div {
 
 When using an angle, `0deg` creates a vertical gradient running bottom to top, `90deg` creates a horizontal gradient running left to right, and so on in a clockwise direction. Negative angles run in the counterclockwise direction.
 
-![](linear_red_angles.png)
+![Four boxes listing angle and showing associated gradient. 0deg starts and top and goes to bottom. 90deg starts at right and goes left. 180deg starts and bottom and goes to the top. -90deg starts at left and goes right.](linear_red_angles.png)
 
 ## Declaring colors & creating effects
 

--- a/files/en-us/web/css/css_shapes/basic_shapes/index.md
+++ b/files/en-us/web/css/css_shapes/basic_shapes/index.md
@@ -28,7 +28,7 @@ Understanding the reference box used by CSS Shapes is important when using Basic
 
 The Firefox Shapes Inspector helpfully shows the reference box in use when you inspect a shape. In the screenshot below I have created a circle, using `shape-outside: circle(50%)`. The floated element has 20 pixels of padding, border and margin applied, and the Shapes Inspector highlights these reference boxes. When using a Basic Shape the reference box used by default is the margin-box. You can see in the screenshot that the shape is being defined with reference to that part of the Box Model.
 
-![](shapes-reference-box.png)
+![An imaged clipped into a circle floated left, with a paragraph of text. The left edge of the text is circular abutting the clipped shape on the outside of the margin with the margin following the shape clipping.](shapes-reference-box.png)
 
 You can add the various Box Values after your Basic Shape definition. Therefore the default behavior is as if you have defined.
 

--- a/files/en-us/web/css/easing-function/index.md
+++ b/files/en-us/web/css/easing-function/index.md
@@ -23,11 +23,11 @@ The easing functions in the cubic-bezier subset of easing functions are often ca
 
 Depending on the specific function used, the calculated output can sometimes grow to be greater than `1.0` or smaller than `0.0` during the course of an animation. This causes the value to go farther than the final state, and then return. In animations, for some properties, such as {{cssxref("left")}} or {{cssxref("right")}}, this creates a kind of "bouncing" effect.
 
-![](tf_with_output_gt_than_1.png)
+![Graph of the easing function showing the output ratio going above 1, to 1.5, at the transition durations midpoint.](tf_with_output_gt_than_1.png)
 
 However, certain properties will restrict the output if it goes outside an allowable range. For example, a color component greater than `255` or smaller than `0` will be clipped to the closest allowed value (`255` and `0`, respectively). Some `cubic-bezier()` curves exhibit this property.
 
-![](tf_with_output_gt_than_1_clipped.png)
+![Graph of the easing function showing the output ratio reaching 1, and then staying at 1 for the rest of the time.](tf_with_output_gt_than_1_clipped.png)
 
 ### Easing functions
 

--- a/files/en-us/web/css/gradient/radial-gradient/index.md
+++ b/files/en-us/web/css/gradient/radial-gradient/index.md
@@ -67,7 +67,7 @@ Because `<gradient>`s belong to the `<image>` data type, they can only be used w
 
 ### Composition of a radial gradient
 
-![Graph explaining radial gradients: the virtual radiant ray is horizontal starting from the mid point. The elliptal gradient, and therefore the ending shape, has the same aspect ratio as the box upon which it is declared.](radial_gradient.png)
+![Graph explaining radial gradients: the virtual radiant ray is horizontal starting from the midpoint. The elliptical gradient, and therefore the ending shape, has the same aspect ratio as the box upon which it is declared.](radial_gradient.png)
 
 A radial gradient is defined by a _center point_, an _ending shape_, and two or more _color-stop points_.
 

--- a/files/en-us/web/css/gradient/radial-gradient/index.md
+++ b/files/en-us/web/css/gradient/radial-gradient/index.md
@@ -67,7 +67,9 @@ Because `<gradient>`s belong to the `<image>` data type, they can only be used w
 
 ### Composition of a radial gradient
 
-![](radial_gradient.png)A radial gradient is defined by a _center point_, an _ending shape_, and two or more _color-stop points_.
+![Graph explaining radial gradients: the virtual radiant ray is horizontal starting from the mid point. The elliptal gradient, and therefore the ending shape, has the same aspect ratio as the box upon which it is declared.](radial_gradient.png)
+
+A radial gradient is defined by a _center point_, an _ending shape_, and two or more _color-stop points_.
 
 To create a smooth gradient, the `radial-gradient()` function draws a series of concentric shapes radiating out from the center to the _ending shape_ (and potentially beyond). The ending shape may be either a circle or an ellipse.
 

--- a/files/en-us/web/css/mask-border/index.md
+++ b/files/en-us/web/css/mask-border/index.md
@@ -76,7 +76,7 @@ mask-border: unset;
 
 In this example, we will mask an element's border with a diamond pattern. The source for the mask is a ".png" file of 90 by 90 pixels, with three diamonds going vertically and horizontally:
 
-![The image used for mask: a transparent square with three rows of three diamonds in very light, almost white, shade of grey. The middle part between the diamonds is also solid grey. The parts between the outside of the diamonds and the edge of the image are transparent.](mask-border-diamonds.png)
+![The image used for the mask examples on this page. The mask is a transparent square with three rows of three diamonds each. The diamonds are a very light, almost white, shade of grey. The middle part between the diamonds is also solid grey. The parts between the outside of the diamonds and the edge of the image are transparent.](mask-border-diamonds.png)
 
 To match the size of a single diamond, we will use a value of 90 divided by 3, or `30`, for slicing the image into corner and edge regions. A repeat value of `round` will make the mask slices fit evenly, i.e., without clipping or gaps.
 

--- a/files/en-us/web/css/mask-border/index.md
+++ b/files/en-us/web/css/mask-border/index.md
@@ -76,7 +76,7 @@ mask-border: unset;
 
 In this example, we will mask an element's border with a diamond pattern. The source for the mask is a ".png" file of 90 by 90 pixels, with three diamonds going vertically and horizontally:
 
-![](mask-border-diamonds.png)
+![The image used for mask: a transparent square with three rows of three diamonds in very light, almost white, shade of grey. The middle part between the diamonds is also solid grey. The parts between the outside of the diamonds and the edge of the image are transparent.](mask-border-diamonds.png)
 
 To match the size of a single diamond, we will use a value of 90 divided by 3, or `30`, for slicing the image into corner and edge regions. A repeat value of `round` will make the mask slices fit evenly, i.e., without clipping or gaps.
 

--- a/files/en-us/web/css/position_value/index.md
+++ b/files/en-us/web/css/position_value/index.md
@@ -18,7 +18,9 @@ The **`<position>`** (or **`<bg-position>`**) [CSS](/en-US/docs/Web/CSS) [data t
 
 ## Syntax
 
-![Grid showing placement of various values. 0 0 is the top left corner. The four values right, right center, center left 100%, and top 50% left 100%, are all equivalent, being on the right edge in the middle vertically. The two values top 75px left 100px and left 100px top 75px are the same. bottom left 25% is the same as top 100% left 25%.](position_type.png)The `<position>` data type is specified with one or two keywords, with optional offsets.
+![Grid showing placement of various values. 0 0 is the top left corner. The four values, right, right center, center left 100%, and top 50% left 100%, are all equivalent, being on the right edge in the middle vertically. The two values, top 75px left 100px and left 100px top 75px, are the same. Bottom left 25% is the same as top 100% left 25%.](position_type.png)
+
+The `<position>` data type is specified with one or two keywords, with optional offsets.
 
 The keyword values are `center`, `top`, `right`, `bottom`, and `left`. Each keyword represents either an edge of the element's box or the center line between two edges. Depending on the context, `center` represents either the center between the left and right edges, or the center between the top and bottom edges.
 

--- a/files/en-us/web/css/position_value/index.md
+++ b/files/en-us/web/css/position_value/index.md
@@ -18,7 +18,7 @@ The **`<position>`** (or **`<bg-position>`**) [CSS](/en-US/docs/Web/CSS) [data t
 
 ## Syntax
 
-![](position_type.png)The `<position>` data type is specified with one or two keywords, with optional offsets.
+![Grid showing placement of various values. 0 0 is the top left corner. The four values right, right center, center left 100%, and top 50% left 100%, are all equivalent, being on the right edge in the middle vertically. The two values top 75px left 100px and left 100px top 75px are the same. bottom left 25% is the same as top 100% left 25%.](position_type.png)The `<position>` data type is specified with one or two keywords, with optional offsets.
 
 The keyword values are `center`, `top`, `right`, `bottom`, and `left`. Each keyword represents either an edge of the element's box or the center line between two edges. Depending on the context, `center` represents either the center between the left and right edges, or the center between the top and bottom edges.
 

--- a/files/en-us/web/css/ratio/index.md
+++ b/files/en-us/web/css/ratio/index.md
@@ -18,7 +18,7 @@ The **`<ratio>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/CSS
 
 In Media Queries Level 3, the `<ratio>` data type consisted of a strictly positive {{cssxref("&lt;integer&gt;")}} followed by a forward slash ('/', Unicode `U+002F SOLIDUS`) and a second strictly positive {{cssxref("&lt;integer&gt;")}}. Spaces before and after the slash are optional. The first number represents the width, while the second represents the height.
 
-In Media Queries Level 4, the \<ratio> date type is updated to consist of a strictly positive {{cssxref("&lt;number&gt;")}} followed by a forward slash ('/', Unicode `U+002F SOLIDUS`) and a second strictly positive {{cssxref("&lt;number&gt;")}}. In addition a single {{cssxref("&lt;number&gt;")}} as a value is allowable.
+In Media Queries Level 4, the `<ratio>` date type is updated to consist of a strictly positive {{cssxref("&lt;number&gt;")}} followed by a forward slash ('/', Unicode `U+002F SOLIDUS`) and a second strictly positive {{cssxref("&lt;number&gt;")}}. In addition a single {{cssxref("&lt;number&gt;")}} as a value is allowable.
 
 ## Examples
 
@@ -32,10 +32,10 @@ In Media Queries Level 4, the \<ratio> date type is updated to consist of a stri
 
 |                                     | Ratio               | Usage                                           |
 | ----------------------------------- | ------------------- | ----------------------------------------------- |
-| ![](ratio4_3.png)                   | `4/3`               | Traditional TV format in the twentieth century. |
-| ![](ratio16_9.png)                  | `16/9`              | Modern "widescreen" TV format.                  |
-| ![Ratio1_1.85.png](ratio1_1.85.png) | `185/100` = `91/50` | The most common movie format since the 1960s.   |
-| ![Ratio1_2.39.png](ratio1_2.39.png) | `239/100`           | "Widescreen," anamorphic movie format.          |
+| ![A rectangle that is three units tall and four units wide](ratio4_3.png)                   | `4/3`               | Traditional TV format in the twentieth century. |
+| ![A rectangle that is nine units tall and sixteen units wide](ratio16_9.png)                  | `16/9`              | Modern "widescreen" TV format.                  |
+| ![A rectangle that is 1 unit tall and 1.85 units wide](ratio1_1.85.png) | `185/100` = `91/50` | The most common movie format since the 1960s.   |
+| ![A rectangle that is 1 unit tall and 2.39 units wide](ratio1_2.39.png) | `239/100`           | "Widescreen," anamorphic movie format.          |
 
 ## Specifications
 

--- a/files/en-us/web/css/ratio/index.md
+++ b/files/en-us/web/css/ratio/index.md
@@ -32,10 +32,10 @@ In Media Queries Level 4, the `<ratio>` date type is updated to consist of a str
 
 |                                     | Ratio               | Usage                                           |
 | ----------------------------------- | ------------------- | ----------------------------------------------- |
-| ![A rectangle that is three units tall and four units wide](ratio4_3.png)                   | `4/3`               | Traditional TV format in the twentieth century. |
-| ![A rectangle that is nine units tall and sixteen units wide](ratio16_9.png)                  | `16/9`              | Modern "widescreen" TV format.                  |
-| ![A rectangle that is 1 unit tall and 1.85 units wide](ratio1_1.85.png) | `185/100` = `91/50` | The most common movie format since the 1960s.   |
-| ![A rectangle that is 1 unit tall and 2.39 units wide](ratio1_2.39.png) | `239/100`           | "Widescreen," anamorphic movie format.          |
+| ![A rectangle that is three units tall and four units wide](ratio4_3.png)    | `4/3`               | Traditional TV format in the twentieth century. |
+| ![A rectangle that is nine units tall and sixteen units wide](ratio16_9.png) | `16/9`              | Modern "widescreen" TV format.                  |
+| ![A rectangle that is 1 unit tall and 1.85 units wide](ratio1_1.85.png)      | `185/100` = `91/50` | The most common movie format since the 1960s.   |
+| ![A rectangle that is 1 unit tall and 2.39 units wide](ratio1_2.39.png)      | `239/100`           | "Widescreen," anamorphic movie format.          |
 
 ## Specifications
 

--- a/files/en-us/web/css/shape/index.md
+++ b/files/en-us/web/css/shape/index.md
@@ -30,7 +30,7 @@ rect(top, right, bottom, left)
 
 #### Values
 
-![](rect.png)
+![A graph showing top, right, bottom, and left, as described below. These define the rectangle's shape. The upper left corner is defined by the top left value. The bottom right corner is defined by the bottom and right values.](rect.png)
 
 - _top_
   - : Is a {{cssxref("length")}} representing the offset for the top of the rectangle relative to the top border of the element's box.

--- a/files/en-us/web/css/shape/index.md
+++ b/files/en-us/web/css/shape/index.md
@@ -30,7 +30,7 @@ rect(top, right, bottom, left)
 
 #### Values
 
-![A graph showing top, right, bottom, and left, as described below. These define the rectangle's shape. The upper left corner is defined by the top left value. The bottom right corner is defined by the bottom and right values.](rect.png)
+![A graph showing top, right, bottom, and left, as described below. These define the rectangle's shape. The upper left corner is defined by the top and left values. The bottom right corner is defined by the bottom and right values.](rect.png)
 
 - _top_
   - : Is a {{cssxref("length")}} representing the offset for the top of the rectangle relative to the top border of the element's box.


### PR DESCRIPTION
Every image in markdown should have a non-empty alt attribute. 

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
