### PR TITLE
Update BCD info, part 5

### DIFF
--- a/files/en-us/web/api/csstransformcomponent/is2d/index.md
+++ b/files/en-us/web/api/csstransformcomponent/is2d/index.md
@@ -13,7 +13,7 @@ tags:
   - is2D
 browser-compat: api.CSSTransformComponent.is2D
 ---
-{{APIRef("CSS Typed OM")}}
+{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}
 
 The **`is2D`** read-only property of the {{domxref("CSSTransformComponent")}} interface indicates where the transform is 2D or 3D.
 

--- a/files/en-us/web/api/csstransformcomponent/tomatrix/index.md
+++ b/files/en-us/web/api/csstransformcomponent/tomatrix/index.md
@@ -13,7 +13,7 @@ tags:
   - toMatrix
 browser-compat: api.CSSTransformComponent.toMatrix
 ---
-{{APIRef("CSS Typed OM")}}
+{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}
 
 The **`toMatrix()`** method of the
 {{domxref("CSSTransformComponent")}} interface returns a {{domxref('DOMMatrix')}}

--- a/files/en-us/web/api/csstransformcomponent/tostring/index.md
+++ b/files/en-us/web/api/csstransformcomponent/tostring/index.md
@@ -13,7 +13,7 @@ tags:
   - Reference
 browser-compat: api.CSSTransformComponent.toString
 ---
-{{APIRef("CSS Typed OM")}}
+{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}
 
 The **`toString()`** method of the {{domxref("CSSTransformComponent")}} interface is a {{Glossary("stringifier")}} returning a [CSS Transforms](/en-US/docs/Web/CSS/CSS_Transforms) function.
 

--- a/files/en-us/web/api/cssvariablereferencevalue/cssvariablereferencevalue/index.md
+++ b/files/en-us/web/api/cssvariablereferencevalue/cssvariablereferencevalue/index.md
@@ -10,6 +10,7 @@ tags:
   - Houdini
   - NeedsExample
   - Reference
+  - Experimental
 browser-compat: api.CSSVariableReferenceValue.CSSVariableReferenceValue
 ---
 {{APIRef("CSSOM")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/cssvariablereferencevalue/fallback/index.md
+++ b/files/en-us/web/api/cssvariablereferencevalue/fallback/index.md
@@ -11,6 +11,7 @@ tags:
   - Property
   - Reference
   - fallback
+  - Experimental
 browser-compat: api.CSSVariableReferenceValue.fallback
 ---
 {{APIRef("CSSOM")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/cssvariablereferencevalue/variable/index.md
+++ b/files/en-us/web/api/cssvariablereferencevalue/variable/index.md
@@ -11,6 +11,7 @@ tags:
   - Property
   - Reference
   - variable
+  - Experimental
 browser-compat: api.CSSVariableReferenceValue.variable
 ---
 {{APIRef("CSSOM")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/customstateset/add/index.md
+++ b/files/en-us/web/api/customstateset/add/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - add
   - CustomStateSet
+  - Experimental
 browser-compat: api.CustomStateSet.add
 ---
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}{{SeeCompatTable}}
 
 The **`add`** method of the {{domxref("CustomStateSet")}} interface adds an item to the `CustomStateSet`, after checking that the value is in the correct format.
 

--- a/files/en-us/web/api/customstateset/clear/index.md
+++ b/files/en-us/web/api/customstateset/clear/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - clear
   - CustomStateSet
+  - Experimental
 browser-compat: api.CustomStateSet.clear
 ---
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}{{SeeCompatTable}}
 
 The **`clear()`** method of the {{domxref("CustomStateSet")}} interface removes all elements from the `CustomStateSet` object.
 

--- a/files/en-us/web/api/customstateset/delete/index.md
+++ b/files/en-us/web/api/customstateset/delete/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - delete
   - CustomStateSet
+  - Experimental
 browser-compat: api.CustomStateSet.delete
 ---
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}{{SeeCompatTable}}
 
 The **`delete()`** method of the {{domxref("CustomStateSet")}} interface deletes a single value from the `CustomStateSet`.
 

--- a/files/en-us/web/api/customstateset/entries/index.md
+++ b/files/en-us/web/api/customstateset/entries/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - entries
   - CustomStateSet
+  - Experimental
 browser-compat: api.CustomStateSet.entries
 ---
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}{{SeeCompatTable}}
 
 The **`entries`** method of the {{domxref("CustomStateSet")}} interface returns a new {{jsxref("Iterator")}} object, containing an array of `[value,value]` for each element in the `CustomStateSet`.
 

--- a/files/en-us/web/api/customstateset/foreach/index.md
+++ b/files/en-us/web/api/customstateset/foreach/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - forEach
   - CustomStateSet
+  - Experimental
 browser-compat: api.CustomStateSet.forEach
 ---
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}{{SeeCompatTable}}
 
 The **`forEach()`** method of the {{domxref("CustomStateSet")}} interface executes a provided function for each value in the `CustomStateSet` object.
 

--- a/files/en-us/web/api/customstateset/has/index.md
+++ b/files/en-us/web/api/customstateset/has/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - has
   - CustomStateSet
+  - Experimental
 browser-compat: api.CustomStateSet.has
 ---
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}{{SeeCompatTable}}
 
 The **`has()`** method of the {{domxref("CustomStateSet")}} interface returns a {{jsxref("Boolean")}} asserting whether an element is present with the given value.
 

--- a/files/en-us/web/api/customstateset/keys/index.md
+++ b/files/en-us/web/api/customstateset/keys/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - keys
   - CustomStateSet
+  - Experimental
 browser-compat: api.CustomStateSet.keys
 ---
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}{{SeeCompatTable}}
 
 The **`keys()`** method of the {{domxref("CustomStateSet")}} interface is an alias for {{domxref("CustomStateSet.values")}}.
 

--- a/files/en-us/web/api/customstateset/size/index.md
+++ b/files/en-us/web/api/customstateset/size/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - size
   - CustomStateSet
+  - Experimental
 browser-compat: api.CustomStateSet.size
 ---
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}{{SeeCompatTable}}
 
 The **`size`** property of the {{domxref("CustomStateSet")}} interface returns the number of values in the `CustomStateSet`.
 

--- a/files/en-us/web/api/customstateset/values/index.md
+++ b/files/en-us/web/api/customstateset/values/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - values
   - CustomStateSet
+  - Experimental
 browser-compat: api.CustomStateSet.values
 ---
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}{{SeeCompatTable}}
 
 The **`values()`** method of the {{domxref("CustomStateSet")}} interface returns a new iterator object that yields the values for each element in the `CustomStateSet` object in insertion order.
 

--- a/files/en-us/web/api/datatransfer/addelement/index.md
+++ b/files/en-us/web/api/datatransfer/addelement/index.md
@@ -8,11 +8,10 @@ tags:
   - Non-standard
   - Reference
   - drag and drop
+  - Experimental
 browser-compat: api.DataTransfer.addElement
 ---
-{{APIRef("HTML Drag and Drop API")}}
-
-{{Non-standard_header()}}
+{{APIRef("HTML Drag and Drop API")}}{{SeeCompatTable}}{{Non-standard_header}}
 
 The **`DataTransfer.addElement()`** method sets the drag source
 to the given element. This element will be the element to which {{domxref("HTMLElement/drag_event", "drag")}} and

--- a/files/en-us/web/api/datatransfer/mozcleardataat/index.md
+++ b/files/en-us/web/api/datatransfer/mozcleardataat/index.md
@@ -11,9 +11,7 @@ tags:
   - Deprecated
 browser-compat: api.DataTransfer.mozClearDataAt
 ---
-{{APIRef("HTML Drag and Drop API")}}
-
-{{ Non-standard_header() }}{{deprecated_header}}
+{{APIRef("HTML Drag and Drop API")}}{{Deprecated_Header}}{{Non-standard_header}}
 
 The **`DataTransfer.mozClearDataAt()`** method removes the data
 associated with the given format for an item at the specified index. The index must be

--- a/files/en-us/web/api/datatransfer/mozcursor/index.md
+++ b/files/en-us/web/api/datatransfer/mozcursor/index.md
@@ -8,11 +8,10 @@ tags:
   - Property
   - Reference
   - drag and drop
+  - Experimental
 browser-compat: api.DataTransfer.mozCursor
 ---
-{{APIRef("HTML Drag and Drop API")}}
-
-{{ Non-standard_header() }}
+{{APIRef("HTML Drag and Drop API")}}{{SeeCompatTable}}{{Non-standard_header}}
 
 The **`DataTransfer.mozCursor`** property returns or sets the
 drag cursor's state. This is primarily used to control the cursor during tab drags.

--- a/files/en-us/web/api/datatransfer/mozgetdataat/index.md
+++ b/files/en-us/web/api/datatransfer/mozgetdataat/index.md
@@ -11,9 +11,7 @@ tags:
   - Deprecated
 browser-compat: api.DataTransfer.mozGetDataAt
 ---
-{{APIRef("HTML Drag and Drop API")}}
-
-{{ Non-standard_header() }}{{deprecated_header}}
+{{APIRef("HTML Drag and Drop API")}}{{Deprecated_Header}}{{Non-standard_header}}
 
 The **`DataTransfer.mozGetDataAt()`** method is used to
 retrieve an item in the drag event's {{domxref("DataTransfer","data transfer")}} object,

--- a/files/en-us/web/api/datatransfer/mozitemcount/index.md
+++ b/files/en-us/web/api/datatransfer/mozitemcount/index.md
@@ -11,9 +11,7 @@ tags:
   - Deprecated
 browser-compat: api.DataTransfer.mozItemCount
 ---
-{{APIRef("HTML Drag and Drop API")}}
-
-{{ Non-standard_header() }}{{deprecated_header}}
+{{APIRef("HTML Drag and Drop API")}}{{Deprecated_Header}}{{Non-standard_header}}
 
 The **`DataTransfer.mozItemCount`** property returns the number
 of items being dragged. This can be used, for example, to get the number of files being

--- a/files/en-us/web/api/datatransfer/mozsetdataat/index.md
+++ b/files/en-us/web/api/datatransfer/mozsetdataat/index.md
@@ -11,9 +11,7 @@ tags:
   - Deprecated
 browser-compat: api.DataTransfer.mozSetDataAt
 ---
-{{APIRef("HTML Drag and Drop API")}}
-
-{{deprecated_header}}{{Non-standard_header()}}
+{{APIRef("HTML Drag and Drop API")}}{{Deprecated_Header}}{{Non-standard_header}}
 
 The **`DataTransfer.mozSetDataAt()`** method is used to add
 data to a specific index in the drag event's {{domxref("DataTransfer","data transfer")}}

--- a/files/en-us/web/api/datatransfer/mozsourcenode/index.md
+++ b/files/en-us/web/api/datatransfer/mozsourcenode/index.md
@@ -8,11 +8,10 @@ tags:
   - Property
   - Reference
   - drag and drop
+  - Experimental
 browser-compat: api.DataTransfer.mozSourceNode
 ---
-{{APIRef("HTML Drag and Drop API")}}
-
-{{ Non-standard_header() }}
+{{APIRef("HTML Drag and Drop API")}}{{SeeCompatTable}}{{Non-standard_header}}
 
 The **`DataTransfer.mozSourceNode`** property is used to
 determine the {{domxref("Node")}} over which the mouse cursor was located when the drag

--- a/files/en-us/web/api/datatransfer/moztypesat/index.md
+++ b/files/en-us/web/api/datatransfer/moztypesat/index.md
@@ -11,9 +11,7 @@ tags:
   - Deprecated
 browser-compat: api.DataTransfer.mozTypesAt
 ---
-{{APIRef("HTML Drag and Drop API")}}
-
-{{deprecated_header}}{{Non-standard_header()}}
+{{APIRef("HTML Drag and Drop API")}}{{Deprecated_Header}}{{Non-standard_header}}
 
 The **`DataTransfer.mozTypesAt()`** method returns a list of
 the format types that are stored for an item at the specified index. If the index is not

--- a/files/en-us/web/api/datatransfer/mozusercancelled/index.md
+++ b/files/en-us/web/api/datatransfer/mozusercancelled/index.md
@@ -8,11 +8,10 @@ tags:
   - Property
   - Reference
   - drag and drop
+  - Experimental
 browser-compat: api.DataTransfer.mozUserCancelled
 ---
-{{APIRef("HTML Drag and Drop API")}}
-
-{{ Non-standard_header() }}
+{{APIRef("HTML Drag and Drop API")}}{{SeeCompatTable}}{{Non-standard_header}}
 
 The **`DataTransfer.mozUserCancelled`** property is used in the
 {{domxref("HTMLElement/dragend_event", "dragend")}} event handler to determine if the user canceled the drag or not. If

--- a/files/en-us/web/api/datatransferitem/getasfilesystemhandle/index.md
+++ b/files/en-us/web/api/datatransferitem/getasfilesystemhandle/index.md
@@ -8,9 +8,10 @@ tags:
   - File
   - File System Access API
   - Method
+  - Experimental
 browser-compat: api.DataTransferItem.getAsFileSystemHandle
 ---
-{{securecontext_header}}{{DefaultAPISidebar("HTML Drag and Drop API")}}
+{{securecontext_header}}{{APIRef("HTML Drag and Drop API")}}{{SeeCompatTable}}
 
 The **`getAsFileSystemHandle()`** method of the
 {{domxref("DataTransferItem")}} interface returns a {{domxref('FileSystemFileHandle')}}

--- a/files/en-us/web/api/document/createtouch/index.md
+++ b/files/en-us/web/api/document/createtouch/index.md
@@ -11,9 +11,10 @@ tags:
   - Reference
   - createTouch
   - touch
+  - Non-standard
 browser-compat: api.Document.createTouch
 ---
-{{APIRef("DOM")}}{{Deprecated_Header}}
+{{APIRef("DOM")}}{{Deprecated_Header}}{{Non-standard_header}}
 
 The **`Document.createTouch()`** method creates and returns a new {{DOMxRef("Touch")}} object.
 

--- a/files/en-us/web/api/document/createtouchlist/index.md
+++ b/files/en-us/web/api/document/createtouchlist/index.md
@@ -11,9 +11,10 @@ tags:
   - Mobile
   - createTouchList
   - touch
+  - Non-standard
 browser-compat: api.Document.createTouchList
 ---
-{{APIRef("DOM")}}{{Deprecated_Header}}
+{{APIRef("DOM")}}{{Deprecated_Header}}{{Non-standard_header}}
 
 The **`Document.createTouchList()`** method creates and returns a new {{DOMxRef("TouchList")}} object.
 

--- a/files/en-us/web/api/document/enablestylesheetsforset/index.md
+++ b/files/en-us/web/api/document/enablestylesheetsforset/index.md
@@ -11,9 +11,10 @@ tags:
   - NeedsSpecTable
   - Reference
   - Deprecated
+  - Non-standard
 browser-compat: api.Document.enableStyleSheetsForSet
 ---
-{{APIRef("DOM")}}{{deprecated_header}}
+{{APIRef("DOM")}}{{deprecated_header}}{{Non-standard_header}}
 
 Enables the style sheets matching the specified name in the current style sheet set,
 and disables all other style sheets (except those without a title, which are always

--- a/files/en-us/web/api/document/featurepolicy/index.md
+++ b/files/en-us/web/api/document/featurepolicy/index.md
@@ -9,9 +9,10 @@ tags:
   - Feature-Policy
   - Reference
   - Property
+  - Experimental
 browser-compat: api.Document.featurePolicy
 ---
-{{APIRef("Feature Policy")}}
+{{APIRef("Feature Policy")}}{{SeeCompatTable}}
 
 The **`featurePolicy`** read-only property of the {{domxref("Document")}} interface returns the {{domxref("FeaturePolicy")}} interface which provides a simple API for inspecting the feature policies applied to a specific document.
 

--- a/files/en-us/web/api/document/height/index.md
+++ b/files/en-us/web/api/document/height/index.md
@@ -11,9 +11,10 @@ tags:
   - Property
   - Reference
   - Deprecated
+  - Non-standard
 browser-compat: api.Document.height
 ---
-{{APIRef("DOM")}} {{deprecated_header}}
+{{APIRef("DOM")}} {{deprecated_header}}{{Non-standard_header}}
 
 > **Note:** Starting in {{Gecko("6.0")}}, `document.height` is
 > no longer supported. Instead, use `document.body.clientHeight`. See

--- a/files/en-us/web/api/document/laststylesheetset/index.md
+++ b/files/en-us/web/api/document/laststylesheetset/index.md
@@ -12,9 +12,10 @@ tags:
   - Stylesheets
   - lastStyleSheetSet
   - Deprecated
+  - Non-standard
 browser-compat: api.Document.lastStyleSheetSet
 ---
-{{APIRef("DOM")}}{{deprecated_header}}
+{{APIRef("DOM")}}{{deprecated_header}}{{Non-standard_header}}
 
 The **`Document.lastStyleSheetSet`** property returns the last enabled style sheet set. This property's
 value changes whenever the {{domxref("document.selectedStyleSheetSet")}} property is

--- a/files/en-us/web/api/document/origin/index.md
+++ b/files/en-us/web/api/document/origin/index.md
@@ -11,9 +11,10 @@ tags:
   - Property
   - Read-only
   - Deprecated
+  - Non-standard
 browser-compat: api.Document.origin
 ---
-{{APIRef("DOM")}}{{deprecated_header}}
+{{APIRef("DOM")}}{{deprecated_header}}{{Non-standard_header}}
 
 > **Note:** Use `self.origin` instead.
 

--- a/files/en-us/web/api/document/preferredstylesheetset/index.md
+++ b/files/en-us/web/api/document/preferredstylesheetset/index.md
@@ -11,9 +11,10 @@ tags:
   - Reference
   - Stylesheets
   - Deprecated
+  - Non-standard
 browser-compat: api.Document.preferredStyleSheetSet
 ---
-{{APIRef("DOM")}}{{deprecated_header}}
+{{APIRef("DOM")}}{{deprecated_header}}{{Non-standard_header}}
 
 The **`preferredStyleSheetSet`** property returns the preferred style sheet set as set by the page
 author.

--- a/files/en-us/web/api/document/querycommandenabled/index.md
+++ b/files/en-us/web/api/document/querycommandenabled/index.md
@@ -8,9 +8,10 @@ tags:
   - Method
   - Reference
   - Deprecated
+  - Non-standard
 browser-compat: api.Document.queryCommandEnabled
 ---
-{{ApiRef("DOM")}}{{deprecated_header}}
+{{ApiRef("DOM")}}{{deprecated_header}}{{Non-standard_header}}
 
 The **`Document.queryCommandEnabled()`** method reports whether
 or not the specified editor command is enabled by the browser.

--- a/files/en-us/web/api/document/querycommandstate/index.md
+++ b/files/en-us/web/api/document/querycommandstate/index.md
@@ -7,9 +7,10 @@ tags:
   - DOM
   - Reference
   - Deprecated
+  - Non-standard
 browser-compat: api.Document.queryCommandState
 ---
-{{ApiRef("DOM")}}{{deprecated_header}}
+{{ApiRef("DOM")}}{{deprecated_header}}{{Non-standard_header}}
 
 The **`queryCommandState()`** method will tell you if the current selection has a certain {{domxref("Document.execCommand()")}} command applied.
 

--- a/files/en-us/web/api/document/querycommandsupported/index.md
+++ b/files/en-us/web/api/document/querycommandsupported/index.md
@@ -10,9 +10,10 @@ tags:
   - Reference
   - editor
   - Deprecated
+  - Non-standard
 browser-compat: api.Document.queryCommandSupported
 ---
-{{ApiRef("DOM")}}{{deprecated_header}}
+{{ApiRef("DOM")}}{{deprecated_header}}{{Non-standard_header}}
 
 The **`Document.queryCommandSupported()`** method reports
 whether or not the specified editor command is supported by the browser.

--- a/files/en-us/web/api/document/registerelement/index.md
+++ b/files/en-us/web/api/document/registerelement/index.md
@@ -9,9 +9,10 @@ tags:
   - Method
   - Reference
   - Web Components
+  - Non-standard
 browser-compat: api.Document.registerElement
 ---
-{{APIRef("DOM")}}{{Deprecated_header}}
+{{APIRef("DOM")}}{{Deprecated_header}}{{Non-standard_header}}
 
 > **Warning:** `document.registerElement()` is deprecated in
 > favor of {{DOMxRef("CustomElementRegistry.define()","customElements.define()")}}.

--- a/files/en-us/web/api/document/releasecapture/index.md
+++ b/files/en-us/web/api/document/releasecapture/index.md
@@ -7,9 +7,10 @@ tags:
   - DOM
   - Method
   - Reference
+  - Non-standard
 browser-compat: api.Document.releaseCapture
 ---
-{{ApiRef("DOM")}}
+{{ApiRef("DOM")}}{{Non-standard_header}}
 
 The **`releaseCapture()`** method releases mouse capture if
 it's currently enabled on an element within this document.

--- a/files/en-us/web/api/document/selectedstylesheetset/index.md
+++ b/files/en-us/web/api/document/selectedstylesheetset/index.md
@@ -10,9 +10,10 @@ tags:
   - Reference
   - Stylesheets
   - Deprecated
+  - Non-standard
 browser-compat: api.Document.selectedStyleSheetSet
 ---
-{{APIRef("DOM")}}{{deprecated_header}}
+{{APIRef("DOM")}}{{deprecated_header}}{{Non-standard_header}}
 
 The **`selectedStyleSheetSet`** property indicates the name of the style sheet set that's currently in use.
 

--- a/files/en-us/web/api/document/stylesheetsets/index.md
+++ b/files/en-us/web/api/document/stylesheetsets/index.md
@@ -10,9 +10,10 @@ tags:
   - Reference
   - Stylesheets
   - Deprecated
+  - Non-standard
 browser-compat: api.Document.styleSheetSets
 ---
-{{APIRef("DOM")}}{{deprecated_header}}
+{{APIRef("DOM")}}{{deprecated_header}}{{Non-standard_header}}
 
 The **`styleSheetSets`** read-only property returns a live list of all of the currently-available style sheet sets.
 

--- a/files/en-us/web/api/document/width/index.md
+++ b/files/en-us/web/api/document/width/index.md
@@ -11,9 +11,10 @@ tags:
   - Property
   - Reference
   - Deprecated
+  - Non-standard
 browser-compat: api.Document.width
 ---
-{{APIRef("DOM")}} {{deprecated_header}}
+{{APIRef("DOM")}} {{deprecated_header}}{{Non-standard_header}}
 
 > **Note:** Starting in {{Gecko("6.0")}}, `document.width` is
 > no longer supported. Instead, use `document.body.clientWidth`. See

--- a/files/en-us/web/api/domexception/code/index.md
+++ b/files/en-us/web/api/domexception/code/index.md
@@ -9,6 +9,7 @@ tags:
   - Property
   - Reference
   - deprecated
+  - Deprecated
 browser-compat: api.DOMException.code
 ---
 {{ APIRef("DOM") }} {{deprecated_header}}

--- a/files/en-us/web/api/element/dommousescroll_event/index.md
+++ b/files/en-us/web/api/element/dommousescroll_event/index.md
@@ -18,10 +18,6 @@ browser-compat: api.Element.DOMMouseScroll_event
 ---
 {{APIRef}}{{Deprecated_Header}}{{Non-standard_header}}
 
-{{Deprecated_Header}}
-
-{{ Non-standard_header() }}
-
 The DOM `DOMMouseScroll` event is fired asynchronously when mouse wheel or similar device is operated and the accumulated scroll amount is over 1 line or 1 page since last event. It's represented by the {{ domxref("MouseScrollEvent") }} interface. This event was only implemented by Firefox. You should instead use the standard {{domxref("Element.wheel_event", "wheel")}} event.
 
 If you want to prevent the default action of mouse wheel events, it's not enough to handle only this event on Gecko because If scroll amount by a native mouse wheel event is less than 1 line (or less than 1 page when the system setting is by page scroll), other mouse wheel events may be fired without this event.

--- a/files/en-us/web/api/element/dommousescroll_event/index.md
+++ b/files/en-us/web/api/element/dommousescroll_event/index.md
@@ -16,7 +16,7 @@ tags:
   - scrolling
 browser-compat: api.Element.DOMMouseScroll_event
 ---
-{{APIRef}}
+{{APIRef}}{{Deprecated_Header}}{{Non-standard_header}}
 
 {{Deprecated_Header}}
 

--- a/files/en-us/web/api/element/securitypolicyviolation_event/index.md
+++ b/files/en-us/web/api/element/securitypolicyviolation_event/index.md
@@ -7,9 +7,10 @@ tags:
   - API
   - Event
   - Reference
+  - Deprecated
 browser-compat: api.Element.securitypolicyviolation_event
 ---
-{{APIRef}}
+{{APIRef}}{{Deprecated_Header}}
 
 The **`securitypolicyviolation`** event is fired when a [Content Security Policy](/en-US/docs/Web/HTTP/CSP) is violated.
 

--- a/files/en-us/web/api/element/sethtml/index.md
+++ b/files/en-us/web/api/element/sethtml/index.md
@@ -10,7 +10,7 @@ tags:
   - Experimental
 browser-compat: api.Element.setHTML
 ---
-{{SeeCompatTable}}{{DefaultAPISidebar("HTML Sanitizer API")}}
+{{APIRef("HTML Sanitizer API")}}{{SeeCompatTable}}
 
 The **`setHTML()`** method of the {{domxref("Element")}} interface is used to parse and sanitize a string of HTML and then insert it into the DOM as a subtree of the element.
 It should be used instead of {{domxref("Element.innerHTML")}} for inserting untrusted strings of HTML into an element.

--- a/files/en-us/web/api/element/show_event/index.md
+++ b/files/en-us/web/api/element/show_event/index.md
@@ -8,9 +8,10 @@ tags:
   - Event
   - Reference
   - show
+  - Non-standard
 browser-compat: api.Element.show_event
 ---
-{{APIRef}}{{deprecated_header}}
+{{APIRef}}{{deprecated_header}}{{Non-standard_header}}
 
 The **`show`** event is fired when a {{domxref("Element/contextmenu_event", "contextmenu")}} event was fired on/bubbled to an element that has a [`contextmenu` attribute](/en-US/docs/Web/HTML/Global_attributes/contextmenu).
 

--- a/files/en-us/web/api/element/webkitmouseforcedown_event/index.md
+++ b/files/en-us/web/api/element/webkitmouseforcedown_event/index.md
@@ -19,9 +19,10 @@ tags:
   - mouse
   - touch
   - webkitmouseforcedown
+  - Non-standard
 browser-compat: api.Element.webkitmouseforcedown_event
 ---
-{{APIRef}}{{Non-standard_header()}}
+{{APIRef}}{{Non-standard_header}}
 
 After a {{domxref("Element.mousedown_event", "mousedown")}} event has been fired at the element, if and when sufficient pressure has been applied to the mouse or trackpad button to qualify as a "force click," Safari begins sending **`webkitmouseforcedown`** events to the element.
 

--- a/files/en-us/web/api/element_timing_api/index.md
+++ b/files/en-us/web/api/element_timing_api/index.md
@@ -8,9 +8,10 @@ tags:
   - Performance
   - Overview
   - Reference
+  - Experimental
 browser-compat: api.PerformanceElementTiming
 ---
-{{DefaultAPISidebar("Element Timing")}}
+{{DefaultAPISidebar("Element Timing")}}{{SeeCompatTable}}
 
 The **Element Timing API** provides features for monitoring the loading performance of large image elements and text nodes as they appear on screen.
 

--- a/files/en-us/web/api/elementinternals/ariarelevant/index.md
+++ b/files/en-us/web/api/elementinternals/ariarelevant/index.md
@@ -10,9 +10,10 @@ tags:
   - AriaAttributes
   - AriaMixin
   - ElementInternals
+  - Non-standard
 browser-compat: api.ElementInternals.ariaRelevant
 ---
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}{{Non-standard_header}}
 
 The **`ariaRelevant`** property of the {{domxref("ElementInternals")}} interface reflects the value of the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant) attribute, which indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. This is used to describe what changes in an `aria-live` region are relevant and should be announced.
 

--- a/files/en-us/web/api/elementinternals/states/index.md
+++ b/files/en-us/web/api/elementinternals/states/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - states
   - ElementInternals
+  - Experimental
 browser-compat: api.ElementInternals.states
 ---
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}{{SeeCompatTable}}
 
 The **`states`** read-only property of the {{domxref("ElementInternals")}} interface returns a {{domxref("CustomStateSet")}} representing the possible states of the custom element.
 


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.

Note: It's easy to review the changes. Open the preview URLs hosted by the PR companion, in new tabs, and look at the BCD tables at the bottom of the pages.