### PR TITLE
Ff104 HTMLElement.focus() - add focusVisible option

### DIFF
--- a/files/en-us/mozilla/firefox/releases/104/index.md
+++ b/files/en-us/mozilla/firefox/releases/104/index.md
@@ -31,7 +31,7 @@ This article provides information about the changes in Firefox 104 that will aff
 
 - Serialization of [native Error types](h/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#error_types) additionally includes the [`stack`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack) property when used with [`window.postMessage()`](/en-US/docs/Web/API/Window/postMessage) and [`structuredClone()`](/en-US/docs/Web/API/structuredClone) (on error types that include `stack`).
   The `stack` is not yet serialized when errors are sent using other APIs, such as [`Worker.postMessage()`](/en-US/docs/Web/API/Worker/postMessage)
-  (See {{bug(1774866)}} for more details.)
+  (See {{bug(1765083)}} for more details.)
 
 #### Removals
 
@@ -46,6 +46,10 @@ This article provides information about the changes in Firefox 104 that will aff
 ### APIs
 
 #### DOM
+
+- [`HTMLElement.focus()`](/en-US/docs/Web/API/HTMLElement/focus) now supports the parameter [`option.focusVisible`](/en-US/docs/Web/API/HTMLElement/focus#focusvisible), which can be used force a browser to display visual indication after the element is focused.
+  Note that browsers may automatically provide visual indication on focused elements if the implementation determines that it will improve accessibility.
+  (See {{bug(1774866)}} for more details.)
 
 #### Media, WebRTC, and Web Audio
 

--- a/files/en-us/mozilla/firefox/releases/104/index.md
+++ b/files/en-us/mozilla/firefox/releases/104/index.md
@@ -31,7 +31,7 @@ This article provides information about the changes in Firefox 104 that will aff
 
 - Serialization of [native Error types](h/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#error_types) additionally includes the [`stack`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack) property when used with [`window.postMessage()`](/en-US/docs/Web/API/Window/postMessage) and [`structuredClone()`](/en-US/docs/Web/API/structuredClone) (on error types that include `stack`).
   The `stack` is not yet serialized when errors are sent using other APIs, such as [`Worker.postMessage()`](/en-US/docs/Web/API/Worker/postMessage)
-  (See {{bug(1765083)}} for more details.)
+  (See {{bug(1774866)}} for more details.)
 
 #### Removals
 
@@ -49,7 +49,7 @@ This article provides information about the changes in Firefox 104 that will aff
 
 - [`HTMLElement.focus()`](/en-US/docs/Web/API/HTMLElement/focus) now supports the parameter [`option.focusVisible`](/en-US/docs/Web/API/HTMLElement/focus#focusvisible), which can be used force a browser to display visual indication after the element is focused.
   Note that browsers may automatically provide visual indication on focused elements if the implementation determines that it will improve accessibility.
-  (See {{bug(1774866)}} for more details.)
+  (See {{bug(1765083)}} for more details.)
 
 #### Media, WebRTC, and Web Audio
 

--- a/files/en-us/web/api/htmlelement/focus/index.md
+++ b/files/en-us/web/api/htmlelement/focus/index.md
@@ -20,7 +20,7 @@ The **`HTMLElement.focus()`** method sets focus on the specified element, if it 
 The focused element is the element that will receive keyboard and similar events by default.
 
 By default the browser will scroll the element into view after focusing it, and it may also provide visible indication of the focused element (typically by displaying a "focus ring" around the element).
-Parameter options are provided disable the default scrolling and force visible indication on elements.
+Parameter options are provided to disable the default scrolling and force visible indication on elements.
 
 ## Syntax
 

--- a/files/en-us/web/api/htmlelement/focus/index.md
+++ b/files/en-us/web/api/htmlelement/focus/index.md
@@ -64,7 +64,7 @@ This example uses a button to set the focus on a text field.
 #### JavaScript
 
 The code below adds an event handler to set the focus on the text field when the button is pressed.
-Note that most browsers will automatically add visible indication (a "focus ring") for the focused element, so the code does not set the option parameter with `focusVisible` set true.
+Note that most browsers will automatically add visible indication (a "focus ring") for a focused text field, so the code does not set `focusVisible` to `true`.
 
 ```js
 document.getElementById("focusButton").addEventListener("click", () => {

--- a/files/en-us/web/api/htmlelement/focus/index.md
+++ b/files/en-us/web/api/htmlelement/focus/index.md
@@ -16,9 +16,11 @@ browser-compat: api.HTMLElement.focus
 ---
 {{ APIRef("HTML DOM") }}
 
-The **`HTMLElement.focus()`** method
-sets focus on the specified element, if it can be focused. The focused element is
-the element which will receive keyboard and similar events by default.
+The **`HTMLElement.focus()`** method sets focus on the specified element, if it can be focused.
+The focused element is the element that will receive keyboard and similar events by default.
+
+By default the browser will scroll the element into view after focusing it, and it may also provide visible indication of the focused element (typically by displaying a "focus ring" around the element).
+Parameter options are provided disable the default scrolling and force visible indication on elements.
 
 ## Syntax
 
@@ -31,16 +33,16 @@ focus(options)
 
 - `options` {{optional_inline}}
 
-  - : An optional object providing options to control aspects of the focusing process.
-    This object may contain the following property:
+  - : An optional object for controlling aspects of the focusing process.
+    This object may contain the following properties:
 
     - `preventScroll` {{optional_inline}}
-      - : A Boolean value indicating whether or not the browser should scroll the
-        document to bring the newly-focused element into view. A value of
-        `false` for `preventScroll` (the default) means that
-        the browser will scroll the element into view after focusing it. If
-        `preventScroll` is set to `true`, no scrolling will
-        occur.
+      - : A boolean value indicating whether or not the browser should scroll the document to bring the newly-focused element into view.
+        A value of `false` for `preventScroll` (the default) means that the browser will scroll the element into view after focusing it.
+        If `preventScroll` is set to `true`, no scrolling will occur.
+    - `focusVisible` {{optional_inline}} {{experimental_inline}}
+      - : A boolean value that should be set to `true` to force visible indication that the element is focused.
+        If the property is not `true` or not specified, a browser may still provide visible indication if it determines that this would improve accessibility for users.
 
 ### Return value
 
@@ -50,7 +52,19 @@ None ({{jsxref("undefined")}}).
 
 ### Focus on a text field
 
+This example uses a button to set the focus on a text field.
+
+#### HTML
+
+```html
+<input id="myTextField" value="Text field.">
+<button id="focusButton">Click to set focus on the text field</button>
+```
+
 #### JavaScript
+
+The code below adds an event handler to set the focus on the text field when the button is pressed.
+Note that most browsers will automatically add visible indication (a "focus ring") for the focused element, so the code does not set the option parameter with `focusVisible` set true.
 
 ```js
 document.getElementById("focusButton").addEventListener("click", () => {
@@ -58,65 +72,90 @@ document.getElementById("focusButton").addEventListener("click", () => {
 });
 ```
 
-#### HTML
-
-```html
-<input id="myTextField" value="Text field.">
-<button id="focusButton">Click me to focus on the text field!</button>
-```
-
 #### Result
+
+Select the button to set focus on the text field.
 
 {{ EmbedLiveSample('Focus_on_a_text_field') }}
 
 ### Focus on a button
 
+This example demonstrates how you can set the focus on a button element.
+
+#### HTML
+
+First we define three buttons.
+Both the middle and right button will set focus on the left-most button.
+The right right-most button will also specify `focusVisible`.
+
+```html
+<button id="myButton">Button</button>
+<button id="focusButton">Click to set focus on "Button"</button>
+<button id="focusButtonVisibleIndication">Click to set focus and focusVisible on "Button"</button>
+```
+
 #### JavaScript
+
+The code below sets up handlers for click events on the middle and right buttons.
 
 ```js
 document.getElementById("focusButton").addEventListener("click", () => {
   document.getElementById("myButton").focus();
 });
-```
 
-#### HTML
-
-```html
-<button id="myButton">Click Me!</button>
-<button id="focusButton">Click me to focus on the button!</button>
+document.getElementById("focusButtonVisibleIndication").addEventListener("click", () => {
+  document.getElementById("myButton").focus({focusVisible: true});
+});
 ```
 
 #### Result
+
+Select either the middle button or right-most button to set focus on the left-most button.
+
+Browsers do not usually show visible focus indication on button elements when focus is set programmatically, so the effect of selecting the middle button may not be obvious.
+However provided the `focusVisible` option is supported on your browser, you should see focus changing on the left-most button when the right-most button is selected.
 
 {{ EmbedLiveSample('Focus_on_a_button') }}
 
-### Focus with focusOption
+### Focus with and without scrolling
 
-#### JavaScript
-
-```js
-focusScrollMethod = function getFocus() {
-  document.getElementById("myButton").focus({preventScroll:false});
-}
-focusNoScrollMethod = function getFocusWithoutScrolling() {
-  document.getElementById("myButton").focus({preventScroll:true});
-}
-```
+This example shows the effect of setting focus with the option [`preventScroll`](#preventscroll) set `true` and `false` (the default).
 
 #### HTML
 
-```html
-<button type="button" onclick="focusScrollMethod()">Click me to focus on the button!</button>
-<button type="button" onclick="focusNoScrollMethod()">Click me to focus on the button without scrolling!</button>
+The HTML defines two buttons that will be used to set the focus of a third button that is off-screen
 
-<div id="container" style="height: 1000px; width: 1000px;">
-<button type="button" id="myButton" style="margin-top: 500px;">Click Me!</button>
+```html
+<button id="focus_scroll">Click to set focus on off-screen button</button>
+<button id="focus_no_scroll">Click to set focus on offscreen button without scrolling</button>
+
+<div id="container">
+<button id="myButton" style="margin-top: 500px;">Button</button>
 </div>
+```
+
+#### JavaScript
+
+This code sets a click event handler on the first and second buttons to set the focus on the last button.
+Note that the first handler doesn't specify the `preventScroll` option so scrolling to the focused element will be enabled.
+
+```js
+document.getElementById("focus_scroll").addEventListener("click", () => {
+  document.getElementById("myButton").focus();  // default: {preventScroll:false}
+});
+
+
+document.getElementById("focus_no_scroll").addEventListener("click", () => {
+  document.getElementById("myButton").focus({preventScroll:true});
+});
 ```
 
 #### Result
 
-{{ EmbedLiveSample('Focus_with_focusOption') }}
+Select the first button to set focus and scroll to the off-screen button.
+Selecting the second button set's the focus, but scrolling is disabled.
+
+{{ EmbedLiveSample('Focus with and without scrolling') }}
 
 ## Specifications
 
@@ -124,13 +163,9 @@ focusNoScrollMethod = function getFocusWithoutScrolling() {
 
 ## Notes
 
-- If you call `HTMLElement.focus()` from a mousedown event handler, you
-  must call `event.preventDefault()` to keep the focus from leaving the
-  `HTMLElement`
-- Behavior of the focus in relation to different HTML features like
-  [`tabindex`](/en-US/docs/Web/HTML/Global_attributes/tabindex) or {{Glossary("shadow tree","shadow dom", 1)}},
-  which previously remained under-specified, were recently updated (as October
-  of 2019). Checkout [WHATWG blog](https://blog.whatwg.org/focusing-on-focus) for more info.
+- If you call `HTMLElement.focus()` from a mousedown event handler, you must call `event.preventDefault()` to keep the focus from leaving the `HTMLElement`
+- Behavior of the focus in relation to different HTML features like [`tabindex`](/en-US/docs/Web/HTML/Global_attributes/tabindex) or {{Glossary("shadow tree","shadow dom", 1)}}, which previously remained under-specified, were updated in October 2019).
+  See the [WHATWG blog](https://blog.whatwg.org/focusing-on-focus) for more information.
 
 ## Browser compatibility
 

--- a/files/en-us/web/api/htmlelement/focus/index.md
+++ b/files/en-us/web/api/htmlelement/focus/index.md
@@ -42,7 +42,7 @@ focus(options)
         If `preventScroll` is set to `true`, no scrolling will occur.
     - `focusVisible` {{optional_inline}} {{experimental_inline}}
       - : A boolean value that should be set to `true` to force visible indication that the element is focused.
-        If the property is not `true` or not specified, a browser may still provide visible indication if it determines that this would improve accessibility for users.
+        By default, or if the property is not `true`, a browser may still provide visible indication if it determines that this would improve accessibility for users.
 
 ### Return value
 


### PR DESCRIPTION
FF104 adds support for [`HTMLElement.focus()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#parameters) param `focusVisible` in https://bugzilla.mozilla.org/show_bug.cgi?id=1765083. This allows you to force a focus ring to be displayed on an element even if the browser does not otherwise consider it necessary - for example for a button.

This adds docs for the new feature and a release note

Related docs work can be tracked in https://github.com/mdn/content/issues/19302