### PR TITLE
stylesheet.replace promise resolves with the same object and no new one

### DIFF
--- a/files/en-us/web/api/cssstylesheet/replace/index.md
+++ b/files/en-us/web/api/cssstylesheet/replace/index.md
@@ -12,7 +12,7 @@ browser-compat: api.CSSStyleSheet.replace
 ---
 {{APIRef("CSSOM")}}
 
-The **`replace()`** method of the {{domxref("CSSStyleSheet")}} interface asynchronously replaces the content of the stylesheet with the content passed into it. The method returns a promise that resolves with a `CSSStyleSheet` object.
+The **`replace()`** method of the {{domxref("CSSStyleSheet")}} interface asynchronously replaces the content of the stylesheet with the content passed into it. The method returns a promise that resolves with the `CSSStyleSheet` object.
 
 The `replace()` and {{domxref("CSSStyleSheet.replaceSync()")}} methods can only be used on a stylesheet created with the {{domxref("CSSStyleSheet.CSSStyleSheet()","CSSStyleSheet()")}} constructor.
 
@@ -31,7 +31,7 @@ replace(text)
 
 ### Return value
 
-A {{jsxref("Promise")}} that resolves with a {{domxref("CSSStyleSheet")}}.
+A {{jsxref("Promise")}} that resolves with the {{domxref("CSSStyleSheet")}}.
 
 ### Exceptions
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Made clear that the api does not return a new object

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
I had code which called replace a few hundred times and was surprised that the promises did not get different stylesheets.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://drafts.csswg.org/cssom/#dom-cssstylesheet-replace

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
