### PR TITLE
Remove documentation for maction@tooltip

### DIFF
--- a/files/en-us/web/mathml/element/maction/index.md
+++ b/files/en-us/web/mathml/element/maction/index.md
@@ -20,13 +20,12 @@ This element's attributes include the [global MathML attributes](/en-US/docs/Web
 
 - `actiontype`
 
-  - : The action which specifies what happens for this element. Possible values are:
+  - : The action which specifies what happens for this element. Special behavior
+    for the following values were implemented by some browsers:
 
     - `statusline`: If there is a click on the _expression_ or the reader moves the pointer over it, the _message_ is sent to the browser's status line. The syntax is: `<maction actiontype="statusline"> expression message </maction>.`
     - `toggle`: When there is a click on the subexpression, the rendering alternates the display of selected subexpressions. Therefore each click increments the `selection` value.
       The syntax is: `<maction actiontype="toggle" selection="positive-integer" > expression1 expression2 expressionN </maction>`.
-    - `tooltip`: When the pointer moves over the _expression_, a tooltip box with a _message_ is displayed near the expression.
-      The syntax is: `<maction actiontype="tooltip"> expression message </maction>.`
 
 - `selection`
   - : The child element currently visible, only taken into account for `actiontype="toggle"` or non-standard `actiontype` values. The default value is `1`, which is the first child element.
@@ -48,12 +47,12 @@ The following example uses the "toggle" `actiontype`:
   <mfrac>
     <mrow>
       <mn>3</mn>
-      <mo>&sdot;</mo>
+      <mo>×</mo>
       <mn>2</mn>
     </mrow>
     <mrow>
       <mn>4</mn>
-      <mo>&sdot;</mo>
+      <mo>×</mo>
       <mn>2</mn>
     </mrow>
   </mfrac>


### PR DESCRIPTION
#### Summary

Remove documentation for maction@tooltip
Also use multiplication symbol for the example.

#### Motivation

This was not implemented in any browser and is not part of
MathML Core or MathML 4. 

#### Supporting details

https://w3c.github.io/mathml-core/#dfn-maction
https://w3c.github.io/mathml/#presm_enliven

#### Related issues

https://github.com/mdn/browser-compat-data/pull/17064

Note: `browser-compat-data` tests complain when one adds a subfeature is not in a standard track and that has never been  implemented in browsers. So tooltip is not added there.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
