### PR TITLE
fix: add a missing word in getBytesInUse

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getbytesinuse/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/getbytesinuse/index.md
@@ -37,7 +37,7 @@ let gettingSpace = browser.storage.<storageType>.getBytesInUse(
 ### Parameters
 
 - `keys`
-  - : A key (string) or keys (an array of strings) to identify the item(s) whose storage space you want to retrieve. If an array is passed in, 0 will be returned. If you pass `null` or `undefined` here, the function will return the space used by the entire storage area.
+  - : A key (string) or keys (an array of strings) to identify the item(s) whose storage space you want to retrieve. If an empty array is passed in, 0 will be returned. If you pass `null` or `undefined` here, the function will return the space used by the entire storage area.
 
 ### Return value
 


### PR DESCRIPTION
#### Summary
`getBytesInUse` function was missing a word in a description of its parameters, wrongly implying that passing any array would return a 0 value while in reality only passing an **empty** array return a 0 value, not any array

#### Motivation
 
Avoids confusing the readers on how to use this API

#### Supporting details
[Chrome API description](https://developer.chrome.com/docs/extensions/reference/storage/#property-session) correctly states that 
> An empty list will return 0.

#### Related issues
None

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
