### PR TITLE
Change titles for column-gap and row-gap pages

### DIFF
--- a/files/en-us/web/css/column-gap/index.md
+++ b/files/en-us/web/css/column-gap/index.md
@@ -1,5 +1,5 @@
 ---
-title: column-gap (grid-column-gap)
+title: column-gap
 slug: Web/CSS/column-gap
 tags:
   - CSS
@@ -19,6 +19,8 @@ The **`column-gap`** [CSS](/en-US/docs/Web/CSS) property sets the size of the ga
 {{EmbedInteractiveExample("pages/css/column-gap.html")}}
 
 Initially a part of [Multi-column Layout](/en-US/docs/Web/CSS/CSS_Columns), the definition of `column-gap` has been broadened to include multiple layout methods. Now specified in [Box Alignment](/en-US/docs/Web/CSS/CSS_Box_Alignment), it may be used in Multi-column, Flexible Box, and Grid layouts.
+
+Note that `grid-column-gap` is an alias for this property.
 
 ## Syntax
 

--- a/files/en-us/web/css/row-gap/index.md
+++ b/files/en-us/web/css/row-gap/index.md
@@ -1,5 +1,5 @@
 ---
-title: row-gap (grid-row-gap)
+title: row-gap
 slug: Web/CSS/row-gap
 tags:
   - CSS
@@ -36,6 +36,8 @@ row-gap: revert;
 row-gap: revert-layer;
 row-gap: unset;
 ```
+
+Note that `grid-row-gap` is an alias for this property.
 
 ### Values
 


### PR DESCRIPTION
Change the titles of two pages:

* https://developer.mozilla.org/en-US/docs/Web/CSS/column-gap
* https://developer.mozilla.org/en-US/docs/Web/CSS/row-gap

...as discussed in https://github.com/mdn/yari/pull/6618#issuecomment-1209720021. We could instead pass an explicit argument to CSSSyntax for these pages, but this seems like a reasonable change anyway.