### PR TITLE
Fixes titles for consistency and sentence casing

### DIFF
--- a/files/en-us/web/css/css_animations/index.md
+++ b/files/en-us/web/css/css_animations/index.md
@@ -15,7 +15,7 @@ browser-compat: css.properties.animation
 
 ## Reference
 
-### CSS Properties
+### Properties
 
 - {{cssxref("animation")}}
 - {{cssxref("animation-delay")}}
@@ -28,7 +28,7 @@ browser-compat: css.properties.animation
 - {{cssxref("animation-timeline")}}
 - {{cssxref("animation-timing-function")}}
 
-### CSS At-rules
+### At-rules
 
 - {{cssxref("@keyframes")}}
 - {{cssxref("@scroll-timeline")}}

--- a/files/en-us/web/css/css_backgrounds_and_borders/index.md
+++ b/files/en-us/web/css/css_backgrounds_and_borders/index.md
@@ -17,7 +17,7 @@ These styles can also decorate borders with lines or images, and make them squar
 
 ## Reference
 
-### CSS Properties
+### Properties
 
 - {{cssxref("background")}}
 - {{cssxref("background-attachment")}}

--- a/files/en-us/web/css/css_box_model/index.md
+++ b/files/en-us/web/css/css_box_model/index.md
@@ -38,7 +38,7 @@ The Box Model specification defines a set of keywords that refer to the edges of
 
 > **Note:** This specification defines the physical padding and margin properties. Flow-relative properties, which relate to text direction, are defined in [Logical Properties and Values](/en-US/docs/Web/CSS/CSS_Logical_Properties).
 
-### Properties for controlling the margins of a box
+### Properties for controlling the margin of a box
 
 Margins surround the border edge of a box, and provide spacing between boxes.
 
@@ -49,7 +49,7 @@ Margins surround the border edge of a box, and provide spacing between boxes.
 - {{CSSxRef("margin-top")}}
 - {{CSSxRef("margin-trim")}} {{Experimental_Inline}}
 
-### Properties for controlling the paddings of a box
+### Properties for controlling the padding for a box
 
 Padding is inserted between the content edge and border edge of a box.
 

--- a/files/en-us/web/css/css_box_model/index.md
+++ b/files/en-us/web/css/css_box_model/index.md
@@ -13,7 +13,7 @@ spec-urls: https://drafts.csswg.org/css-box/
 
 **CSS Box Model** is a module of CSS that defines the rectangular boxes—including their padding and margin—that are generated for elements and laid out according to the [visual formatting model](/en-US/docs/Web/CSS/Visual_formatting_model).
 
-## The Box Model
+## Box model overview
 
 A box in CSS consists of a content area, which is where any text, images, or other HTML elements are displayed. This is optionally surrounded by padding, a border, and a margin, on one or more sides. The box model describes how these elements work together to create a box as displayed by CSS. To learn more about it read [Introduction to the CSS Box Model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model).
 
@@ -36,11 +36,9 @@ The Box Model specification defines a set of keywords that refer to the edges of
 
 ## Reference
 
-### Properties
-
 > **Note:** This specification defines the physical padding and margin properties. Flow-relative properties, which relate to text direction, are defined in [Logical Properties and Values](/en-US/docs/Web/CSS/CSS_Logical_Properties).
 
-#### Properties controlling the margins of a box
+### Properties for controlling the margins of a box
 
 Margins surround the border edge of a box, and provide spacing between boxes.
 
@@ -51,7 +49,7 @@ Margins surround the border edge of a box, and provide spacing between boxes.
 - {{CSSxRef("margin-top")}}
 - {{CSSxRef("margin-trim")}} {{Experimental_Inline}}
 
-#### Properties controlling the paddings of a box
+### Properties for controlling the paddings of a box
 
 Padding is inserted between the content edge and border edge of a box.
 
@@ -61,7 +59,7 @@ Padding is inserted between the content edge and border edge of a box.
 - {{CSSxRef("padding-right")}}
 - {{CSSxRef("padding-top")}}
 
-#### Other properties
+### Other properties
 
 There are other properties that relate to the box model, that are defined elsewhere.
 

--- a/files/en-us/web/css/css_columns/basic_concepts_of_multicol/index.md
+++ b/files/en-us/web/css/css_columns/basic_concepts_of_multicol/index.md
@@ -1,5 +1,5 @@
 ---
-title: Basic concepts of multicol
+title: Basic concepts of multi-column layout
 slug: Web/CSS/CSS_Columns/Basic_Concepts_of_Multicol
 tags:
   - CSS
@@ -28,21 +28,21 @@ The properties defined by the specification are:
 - {{cssxref("column-fill")}}
 - {{cssxref("column-gap")}}
 
-By adding `column-count` or `column-width` to an element, that element becomes a _multi-column container_, or _multicol container_ for short. The columns are anonymous boxes and described as column boxes in the specification.
+By adding `column-count` or `column-width` to an element, the element becomes a _multi-column container_ or _multicol container_ for short. The columns are anonymous boxes and described as column boxes in the specification.
 
 ## Defining columns
 
-To create a multicol container you must use at least one of the `column-*` properties, these being `column-count` and `column-width`.
+To create a multicol container, you must use at least one of the `column-*` properties, these being `column-count` and `column-width`.
 
 ### Specifying the number of columns
 
 The `column-count` property specifies the number of columns that you would like the content to be displayed as. The browser will then assign the correct amount of space to each column box to create the requested number of columns.
 
-In the below example we use the `column-count` property to create three columns on the `.container` element. The content, including the children of `.container` is then split between the three columns.
+In the below example, we use the `column-count` property to create three columns on the `.container` element. The content, including the children of `.container`, is then split between the three columns.
 
 {{EmbedGHLiveSample("css-examples/multicol/basics/column-count.html", '100%', 550)}}
 
-In the above example the content is wrapped in paragraph `p` tags with default styling. Therefore, there is a margin above each paragraph. You can see how this margin causes the first line of text to be pushed down. This is because a multicol container creates a new Block Formatting Context (BFC) which means margins on child elements do not collapse with any margin on the container.
+In the above example, the content is wrapped in paragraph `p` tags with default styling. Therefore, there is a margin above each paragraph. You can see how this margin causes the first line of text to be pushed down. This is because a multicol container creates a new Block Formatting Context (BFC) which means margins on child elements do not collapse with any margin on the container.
 
 ### Specifying the width of columns
 
@@ -50,7 +50,7 @@ The `column-width` property is used to set the optimal width for every column bo
 
 The column box will only shrink to be smaller than the declared column width in the case of a single column with less available width than the value of `column-width`.
 
-In the below example we use the `column-width` property with a value of 200px. We get as many 200 pixel columns as will fit the container, with the extra space shared equally.
+In the below example, we use the `column-width` property with a value of 200px. We get as many 200 pixel columns as will fit the container, with the extra space shared equally.
 
 {{EmbedGHLiveSample("css-examples/multicol/basics/column-width.html", '100%', 550)}}
 
@@ -64,7 +64,7 @@ In this next example, we use `column-width` of 200px and `column-count` of 2. Ev
 
 {{EmbedGHLiveSample("css-examples/multicol/basics/column-count-width.html", '100%', 550)}}
 
-### Shorthand for columns property
+### Shorthand for column properties
 
 You can use the `columns` shorthand to set `column-count` and `column-width`. If you set a length unit, this will be used for `column-width`, set an integer and it will be used for `column-count`. You can set both, separating the two values with a space.
 
@@ -94,4 +94,4 @@ This CSS would give the same result as example 3, with both `column-count` and `
 
 ## Next steps
 
-In this guide, we've learned the basic use of multiple-column layout. In the next guide, we will look at how much we can [style the columns themselves](/en-US/docs/Web/CSS/CSS_Columns/Styling_Columns).
+In this guide, we've learned the basic use of multi-column layout. In the next guide, we will look at how much we can [style the columns themselves](/en-US/docs/Web/CSS/CSS_Columns/Styling_Columns).

--- a/files/en-us/web/css/css_columns/basic_concepts_of_multicol/index.md
+++ b/files/en-us/web/css/css_columns/basic_concepts_of_multicol/index.md
@@ -1,5 +1,5 @@
 ---
-title: Basic Concepts of Multicol
+title: Basic concepts of multicol
 slug: Web/CSS/CSS_Columns/Basic_Concepts_of_Multicol
 tags:
   - CSS
@@ -9,11 +9,11 @@ tags:
 ---
 {{CSSRef}}
 
-Multiple-column Layout, usually referred to as multicol, is a specification for laying out content into a set of column boxes much like columns in a newspaper. This guide explains how the specification works with some common use case examples.
+Multiple-column layout, usually referred to as multicol, is a specification for laying out content into a set of column boxes much like columns in a newspaper. This guide explains how the specification works with some common use case examples.
 
-## Key Concepts and Terminology
+## Key concepts and terminology
 
-Multicol is unlike any of the other layout methods we have in CSS in that it fragments the content, including all descendent elements, into columns. This happens in the same way that content is fragmented into pages when we work with [CSS Paged Media](/en-US/docs/Web/CSS/CSS_Pages), for example by creating a print stylesheet.
+Multicol is unlike any of the other layout methods we have in CSS; it fragments the content, including all descendent elements, into columns. This happens in the same way that content is fragmented into pages when we work with [CSS Paged Media](/en-US/docs/Web/CSS/CSS_Pages) by creating a print stylesheet.
 
 The properties defined by the specification are:
 
@@ -28,13 +28,13 @@ The properties defined by the specification are:
 - {{cssxref("column-fill")}}
 - {{cssxref("column-gap")}}
 
-By adding `column-count` or `column-width` to an element, that element becomes a _multi-column container_, or _multicol container_ for short. The columns are anonymous boxes and described as column boxes in the specification.
+By adding `column-count` or `column-width` to an element, that element becomes a _multi-column container_, or a _multicol container_, for short. The columns are anonymous boxes and described as column boxes in the specification.
 
 ## Defining columns
 
 To create a multicol container you must use at least one of the `column-*` properties, these being `column-count` and `column-width`.
 
-### The `column-count` property
+### Specifying the number of columns
 
 The `column-count` property specifies the number of columns that you would like the content to be displayed as. The browser will then assign the correct amount of space to each column box to create the requested number of columns.
 
@@ -44,7 +44,7 @@ In the below example we use the `column-count` property to create three columns 
 
 In the above example the content is wrapped in paragraph `p` tags with default styling. Therefore, there is a margin above each paragraph. You can see how this margin causes the first line of text to be pushed down. This is because a multicol container creates a new Block Formatting Context (BFC) which means margins on child elements do not collapse with any margin on the container.
 
-### The `column-width` property
+### Specifying the width of columns
 
 The `column-width` property is used to set the optimal width for every column box. If you declare a column-width, the browser will work out how many columns of that width will fit into the multicol container and distribute any extra space equally between the columns. Therefore, the column width should be seen as a minimum width, as column boxes are likely to be wider due to the additional space.
 
@@ -54,17 +54,17 @@ In the below example we use the `column-width` property with a value of 200px. W
 
 {{EmbedGHLiveSample("css-examples/multicol/basics/column-width.html", '100%', 550)}}
 
-### Using `column-count` and `column-width` together
+### Specifying both number and width of columns
 
-If you specify both properties on a multicol container then `column-count` will act as a maximum number of columns. Therefore the behavior as described for column-width will happen, until the number of columns in column-count is reached. After this point no more columns will be drawn, and the extra space is distributed evenly between the existing columns, even if there is enough room for more columns of the specified `column-width` size.
+If you specify both the properties on a multicol container, then `column-count` will act as a maximum number of columns. Therefore, the behavior as described for `column-width` will happen, until the number of columns in `column-count` is reached. After this point, no more columns will be drawn, and the extra space is distributed evenly between the existing columns, even if there is enough room for more columns of the specified `column-width` size.
 
-When using both properties together you may get fewer columns than specified in the value for `column-count`.
+When using both properties together, you may get fewer columns than specified in the value for `column-count`.
 
-In this next example we use `column-width` of 200px and `column-count` of 2. Even if there is space for more than two columns, we get two. If there is not enough space for two columns of 200px, however, we get one.
+In this next example, we use `column-width` of 200px and `column-count` of 2. Even if there is space for more than two columns, we get two. If there is not enough space for two columns of 200px, however, we get one.
 
 {{EmbedGHLiveSample("css-examples/multicol/basics/column-count-width.html", '100%', 550)}}
 
-### The `columns` shorthand
+### Property shorthand
 
 You can use the `columns` shorthand to set `column-count` and `column-width`. If you set a length unit, this will be used for `column-width`, set an integer and it will be used for `column-count`. You can set both, separating the two values with a space.
 
@@ -92,6 +92,6 @@ This CSS would give the same result as example 3, with both `column-count` and `
 }
 ```
 
-## Next Steps
+## Next steps
 
-In this guide we've learned the basic use of Multiple-column Layout. In the next guide, we will look at how much we can [style the columns themselves](/en-US/docs/Web/CSS/CSS_Columns/Styling_Columns).
+In this guide, we've learned the basic use of Multiple-Column Layout. In the next guide, we will look at how much we can [style the columns themselves](/en-US/docs/Web/CSS/CSS_Columns/Styling_Columns).

--- a/files/en-us/web/css/css_columns/basic_concepts_of_multicol/index.md
+++ b/files/en-us/web/css/css_columns/basic_concepts_of_multicol/index.md
@@ -28,7 +28,7 @@ The properties defined by the specification are:
 - {{cssxref("column-fill")}}
 - {{cssxref("column-gap")}}
 
-By adding `column-count` or `column-width` to an element, that element becomes a _multi-column container_, or a _multicol container_, for short. The columns are anonymous boxes and described as column boxes in the specification.
+By adding `column-count` or `column-width` to an element, that element becomes a _multi-column container_, or _multicol container_ for short. The columns are anonymous boxes and described as column boxes in the specification.
 
 ## Defining columns
 
@@ -64,7 +64,7 @@ In this next example, we use `column-width` of 200px and `column-count` of 2. Ev
 
 {{EmbedGHLiveSample("css-examples/multicol/basics/column-count-width.html", '100%', 550)}}
 
-### Property shorthand
+### Shorthand for columns property
 
 You can use the `columns` shorthand to set `column-count` and `column-width`. If you set a length unit, this will be used for `column-width`, set an integer and it will be used for `column-count`. You can set both, separating the two values with a space.
 
@@ -94,4 +94,4 @@ This CSS would give the same result as example 3, with both `column-count` and `
 
 ## Next steps
 
-In this guide, we've learned the basic use of Multiple-Column Layout. In the next guide, we will look at how much we can [style the columns themselves](/en-US/docs/Web/CSS/CSS_Columns/Styling_Columns).
+In this guide, we've learned the basic use of multiple-column layout. In the next guide, we will look at how much we can [style the columns themselves](/en-US/docs/Web/CSS/CSS_Columns/Styling_Columns).

--- a/files/en-us/web/css/css_columns/handling_content_breaks_in_multicol/index.md
+++ b/files/en-us/web/css/css_columns/handling_content_breaks_in_multicol/index.md
@@ -1,5 +1,5 @@
 ---
-title: Handling content breaks in multicol
+title: Handling content breaks in multi-column layout
 slug: Web/CSS/CSS_Columns/Handling_content_breaks_in_multicol
 tags:
   - CSS
@@ -9,11 +9,11 @@ tags:
 ---
 {{CSSRef}}
 
-Content is broken between column boxes in multiple-column layout in the same way that it is broken between pages in paged media. In both contexts we control where and how things break by using properties of the CSS Fragmentation specification. In this guide we see how Fragmentation works in multicol.
+Content is broken between column boxes in multi-column layout in the same way that it is broken between pages in paged media. In both contexts, we control where and how things break by using properties of the CSS Fragmentation specification. In this guide, we see how fragmentation works in a _multi-column container_ or _multicol container_ for short.
 
 ## Fragmentation basics
 
-The [CSS Fragmentation specification](https://www.w3.org/TR/css-break-3/) details how content breaks between the fragmentation containers, or _fragmentainers_. In multicol, the fragmentainer is the column box.
+The [CSS Fragmentation specification](https://www.w3.org/TR/css-break-3/) details how content breaks between the fragmentation containers or _fragmentainers_. In multicol, the fragmentainer is the column box.
 
 A column box can contain other markup and there are many places where a break would not be ideal. For example, we would generally prefer that the figcaption of an image not be separated into a new column away from the image it refers to and ending a column with a heading looks strange. The fragmentation properties give us ways to exercise some control over this.
 

--- a/files/en-us/web/css/css_columns/handling_overflow_in_multicol/index.md
+++ b/files/en-us/web/css/css_columns/handling_overflow_in_multicol/index.md
@@ -1,5 +1,5 @@
 ---
-title: Handling Overflow in Multicol
+title: Handling overflow in multicol
 slug: Web/CSS/CSS_Columns/Handling_Overflow_in_Multicol
 tags:
   - CSS
@@ -9,7 +9,7 @@ tags:
 ---
 {{CSSRef}}
 
-In this guide we look at how multicol deals with overflow, both inside the column boxes and in situations where there is more content than will fit into the container.
+In this guide, we look at how multicol deals with overflow, both inside the column boxes and in situations where there is more content than will fit into the container.
 
 ## Overflow inside column boxes
 
@@ -27,22 +27,24 @@ If you want an image to size down to fit the column box, the standard responsive
 
 ## More columns than will fit
 
-How overflowing columns are handled depends on whether you are in a fragmented media context, such as print, or a continuous media context, such as a web page.
+How overflowing columns are handled depends on if the media context is fragmented, such as print, or continuous, such as a web page.
 
-In fragmented media, once a fragment (for example a page) is filled with columns, the columns will move to a new page and fill that up with columns. In continuous media, columns will overflow in the inline direction. On the web this means that you will get a horizontal scrollbar.
+In fragmented media, after a fragment (for example, a page) is filled with columns, the columns will move to a new page and fill that up with columns. In continuous media, columns will overflow in the inline direction. On the web this means that you will get a horizontal scrollbar.
 
 The example below shows this overflow behavior. My multicol container has a height and there is more text than space to create columns, therefore we get columns created outside of the container.
 
 {{EmbedGHLiveSample("css-examples/multicol/overflow/overflow-inline.html", '100%', 800)}}
 
-In a future version of the specification it would be useful to be able to have overflow columns in continuous media display in the block direction, therefore allowing the reader to scroll down to view the next set of columns.
+In a future version of the specification, it would be useful to be able to have overflow columns in continuous media display in the block direction, therefore allowing the reader to scroll down to view the next set of columns.
 
 ## Using vertical media queries
 
 One issue with multicol on the web is that, if your columns are taller than the viewport, the reader will need to scroll up and down to read, which is not good user experience. One way to avoid this is to only apply the column properties if you know you have enough height.
 
-In the example below we have used a `min-height` query to check the height before applying the column properties.
+In the example below, we have used a `min-height` query to check the height before applying the column properties.
 
 {{EmbedGHLiveSample("css-examples/multicol/overflow/min-height.html", '100%', 800)}}
 
-In the final guide in this series we will see [how Multicol works with the Fragmentation spec](/en-US/docs/Web/CSS/CSS_Columns/Handling_content_breaks_in_multicol) to give us control over how content breaks between columns.
+## Next steps
+
+In the final guide in this series, we will see [how multicol works with the Fragmentation spec](/en-US/docs/Web/CSS/CSS_Columns/Handling_content_breaks_in_multicol) to give us control over how content breaks between columns.

--- a/files/en-us/web/css/css_columns/handling_overflow_in_multicol/index.md
+++ b/files/en-us/web/css/css_columns/handling_overflow_in_multicol/index.md
@@ -27,7 +27,7 @@ If you want an image to size down to fit the column box, the standard responsive
 
 ## More columns than will fit
 
-How overflowing columns are handled depends on if the media context is fragmented, such as print, or continuous, such as a web page.
+How overflowing columns are handled depends on whether the media context is fragmented, such as print, or is continuous, such as a web page.
 
 In fragmented media, after a fragment (for example, a page) is filled with columns, the columns will move to a new page and fill that up with columns. In continuous media, columns will overflow in the inline direction. On the web this means that you will get a horizontal scrollbar.
 

--- a/files/en-us/web/css/css_columns/handling_overflow_in_multicol/index.md
+++ b/files/en-us/web/css/css_columns/handling_overflow_in_multicol/index.md
@@ -1,5 +1,5 @@
 ---
-title: Handling overflow in multicol
+title: Handling overflow in multi-column layout
 slug: Web/CSS/CSS_Columns/Handling_Overflow_in_Multicol
 tags:
   - CSS
@@ -9,7 +9,7 @@ tags:
 ---
 {{CSSRef}}
 
-In this guide, we look at how multicol deals with overflow, both inside the column boxes and in situations where there is more content than will fit into the container.
+In this guide, we look at how to deal with overflow in a multi-column (_multicol_) layout, both inside the column boxes and in situations where there is more content than will fit into the container.
 
 ## Overflow inside column boxes
 
@@ -31,7 +31,7 @@ How overflowing columns are handled depends on whether the media context is frag
 
 In fragmented media, after a fragment (for example, a page) is filled with columns, the columns will move to a new page and fill that up with columns. In continuous media, columns will overflow in the inline direction. On the web this means that you will get a horizontal scrollbar.
 
-The example below shows this overflow behavior. My multicol container has a height and there is more text than space to create columns, therefore we get columns created outside of the container.
+The example below shows this overflow behavior. The multicol container has a height and there is more text than space to create columns; therefore, we get columns created outside of the container.
 
 {{EmbedGHLiveSample("css-examples/multicol/overflow/overflow-inline.html", '100%', 800)}}
 

--- a/files/en-us/web/css/css_columns/index.md
+++ b/files/en-us/web/css/css_columns/index.md
@@ -26,7 +26,7 @@ Multiple-column layout is closely related to [Paged Media](/en-US/docs/Web/CSS/C
 
 ## Reference
 
-### Properties for multiple-column layout
+### Properties for multi-column layout
 
 - {{cssxref("column-count")}}
 - {{cssxref("column-fill")}}
@@ -49,15 +49,15 @@ Multiple-column layout is closely related to [Paged Media](/en-US/docs/Web/CSS/C
 
 ## Guides
 
-- [Basic concepts of multicol](/en-US/docs/Web/CSS/CSS_Columns/Basic_Concepts_of_Multicol)
+- [Basic concepts of multi-column layout](/en-US/docs/Web/CSS/CSS_Columns/Basic_Concepts_of_Multicol)
   - : An overview of the Multiple-column Layout specification
 - [Styling columns](/en-US/docs/Web/CSS/CSS_Columns/Styling_Columns)
   - : How to use column rules and manage the spacing between columns.
 - [Spanning and balancing](/en-US/docs/Web/CSS/CSS_Columns/Spanning_Columns)
   - : How to make elements span across all columns and controlling the way columns are filled.
-- [Handling overflow in multicol](/en-US/docs/Web/CSS/CSS_Columns/Handling_Overflow_in_Multicol)
+- [Handling overflow in multi-column layout](/en-US/docs/Web/CSS/CSS_Columns/Handling_Overflow_in_Multicol)
   - : What happens when an item overflows the column it is in and what happens when there is too much columned content to fit a container.
-- [Handling content breaks in multicol](/en-US/docs/Web/CSS/CSS_Columns/Handling_content_breaks_in_multicol)
+- [Handling content breaks in multi-column layout](/en-US/docs/Web/CSS/CSS_Columns/Handling_content_breaks_in_multicol)
   - : Introduction to the Fragmentation specification and how to control where column content breaks.
 
 ## Specifications

--- a/files/en-us/web/css/css_columns/index.md
+++ b/files/en-us/web/css/css_columns/index.md
@@ -1,5 +1,5 @@
 ---
-title: CSS Multi-column Layout
+title: CSS Multi-Column Layout
 slug: Web/CSS/CSS_Columns
 tags:
   - CSS
@@ -12,21 +12,21 @@ spec-urls: https://drafts.csswg.org/css-multicol/
 ---
 {{CSSRef("CSS3 Multicol")}}
 
-**CSS Multi-column Layout** is a module of CSS that adds support for multi-column layouts. Support is included for establishing the number of columns in a layout, as well as how content should flow from column to column, gap sizes between columns, and column dividing lines (known as column rules) along with their appearance.
+**CSS Multi-Column Layout** is a module of CSS that adds support for multi-column layouts. Support is included for establishing the number of columns in a layout, as well as how content should flow from column to column, gap sizes between columns, and column dividing lines (known as column rules) along with their appearance.
 
 ## Basic example
 
-In the following example the {{cssxref("column-count")}} property has been applied to the element with a class of container. As the value of `column-count` is `3`, the content is arranged into 3 columns of equal size.
+In the following example, the {{cssxref("column-count")}} property has been applied to the element with a class of container. As the value of `column-count` is `3`, the content is arranged into 3 columns of equal sizes.
 
 {{EmbedGHLiveSample("css-examples/multicol/basics/column-count.html", '100%', 550)}}
 
-## Relationship to Fragmentation
+## Relationship to fragmentation
 
-Multiple-column Layout is closely related to [Paged Media](/en-US/docs/Web/CSS/CSS_Pages), in that each column box becomes a fragment, much like a printed page becomes a fragment of an overall document. Therefore the properties now defined in the [CSS Fragmentation](/en-US/docs/Web/CSS/CSS_Fragmentation) specification are required in order to control how content breaks between columns.
+Multiple-column layout is closely related to [Paged Media](/en-US/docs/Web/CSS/CSS_Pages), in that each column box becomes a fragment, much like a printed page becomes a fragment of an overall document. Therefore, the properties now defined in the [CSS Fragmentation](/en-US/docs/Web/CSS/CSS_Fragmentation) specification are required to control how content breaks between columns.
 
 ## Reference
 
-### Multiple-column Layout Properties
+### Properties for multiple-column layout
 
 - {{cssxref("column-count")}}
 - {{cssxref("column-fill")}}
@@ -39,7 +39,7 @@ Multiple-column Layout is closely related to [Paged Media](/en-US/docs/Web/CSS/C
 - {{cssxref("column-width")}}
 - {{cssxref("columns")}}
 
-### Related CSS Fragmentation Properties
+### Properties related to CSS fragmentation
 
 - {{cssxref("break-after")}}
 - {{cssxref("break-before")}}
@@ -49,15 +49,15 @@ Multiple-column Layout is closely related to [Paged Media](/en-US/docs/Web/CSS/C
 
 ## Guides
 
-- [Basic Concepts of Multicol](/en-US/docs/Web/CSS/CSS_Columns/Basic_Concepts_of_Multicol)
-  - : An overview of the Multiple-column Layout specification
-- [Styling Columns](/en-US/docs/Web/CSS/CSS_Columns/Styling_Columns)
+- [Basic concepts of multicol](/en-US/docs/Web/CSS/CSS_Columns/Basic_Concepts_of_Multicol)
+  - : An overview of the Multiple-Column Layout specification
+- [Styling columns](/en-US/docs/Web/CSS/CSS_Columns/Styling_Columns)
   - : How to use column rules and manage the spacing between columns.
-- [Spanning and Balancing](/en-US/docs/Web/CSS/CSS_Columns/Spanning_Columns)
+- [Spanning and balancing](/en-US/docs/Web/CSS/CSS_Columns/Spanning_Columns)
   - : How to make elements span across all columns and controlling the way columns are filled.
-- [Handling Overflow in Multicol](/en-US/docs/Web/CSS/CSS_Columns/Handling_Overflow_in_Multicol)
+- [Handling overflow in multicol](/en-US/docs/Web/CSS/CSS_Columns/Handling_Overflow_in_Multicol)
   - : What happens when an item overflows the column it is in and what happens when there is too much columned content to fit a container.
-- [Content Breaks in Multicol](/en-US/docs/Web/CSS/CSS_Columns/Handling_content_breaks_in_multicol)
+- [Handling content breaks in multicol](/en-US/docs/Web/CSS/CSS_Columns/Handling_content_breaks_in_multicol)
   - : Introduction to the Fragmentation specification and how to control where column content breaks.
 
 ## Specifications

--- a/files/en-us/web/css/css_columns/index.md
+++ b/files/en-us/web/css/css_columns/index.md
@@ -1,5 +1,5 @@
 ---
-title: CSS Multi-Column Layout
+title: CSS Multi-column Layout
 slug: Web/CSS/CSS_Columns
 tags:
   - CSS
@@ -12,11 +12,11 @@ spec-urls: https://drafts.csswg.org/css-multicol/
 ---
 {{CSSRef("CSS3 Multicol")}}
 
-**CSS Multi-Column Layout** is a module of CSS that adds support for multi-column layouts. Support is included for establishing the number of columns in a layout, as well as how content should flow from column to column, gap sizes between columns, and column dividing lines (known as column rules) along with their appearance.
+**CSS Multi-column Layout** is a module of CSS that adds support for multi-column layouts. Support is included for establishing the number of columns in a layout, as well as how content should flow from column to column, gap sizes between columns, and column dividing lines (known as column rules) along with their appearance.
 
 ## Basic example
 
-In the following example, the {{cssxref("column-count")}} property has been applied to the element with a class of container. As the value of `column-count` is `3`, the content is arranged into 3 columns of equal sizes.
+In the following example, the {{cssxref("column-count")}} property has been applied to the `<div>` element with the class `container`. As the value of `column-count` is `3`, the content is arranged into three columns of the same size.
 
 {{EmbedGHLiveSample("css-examples/multicol/basics/column-count.html", '100%', 550)}}
 
@@ -50,7 +50,7 @@ Multiple-column layout is closely related to [Paged Media](/en-US/docs/Web/CSS/C
 ## Guides
 
 - [Basic concepts of multicol](/en-US/docs/Web/CSS/CSS_Columns/Basic_Concepts_of_Multicol)
-  - : An overview of the Multiple-Column Layout specification
+  - : An overview of the Multiple-column Layout specification
 - [Styling columns](/en-US/docs/Web/CSS/CSS_Columns/Styling_Columns)
   - : How to use column rules and manage the spacing between columns.
 - [Spanning and balancing](/en-US/docs/Web/CSS/CSS_Columns/Spanning_Columns)

--- a/files/en-us/web/css/css_columns/spanning_columns/index.md
+++ b/files/en-us/web/css/css_columns/spanning_columns/index.md
@@ -1,5 +1,5 @@
 ---
-title: Spanning and Balancing Columns
+title: Spanning and balancing columns
 slug: Web/CSS/CSS_Columns/Spanning_Columns
 tags:
   - CSS
@@ -9,11 +9,11 @@ tags:
 ---
 {{CSSRef}}
 
-In this guide we look at how to make elements span across columns inside the multicol container and how to control how the columns are filled.
+In this guide, we look at how to make elements span across columns inside the multicol container and how to control how the columns are filled.
 
 > **Note:** The spanning and balancing functionality covered in this guide is not as well supported across browsers as the functionality covered in the previous two sections in this guide.
 
-## Spanning the Columns
+## Spanning the columns
 
 To cause an item to span across columns use the property {{cssxref("column-span")}} with a value of `all`. This will cause the element to span all of the columns.
 
@@ -31,7 +31,7 @@ When a spanner is introduced, it breaks the flow of columns and columns restart 
 
 ### Limitations of column-span
 
-In the current level 1 specification there are only two allowable values for `column-span`. The value `none` is the initial value and means the item does not span, remaining within a column. The value `all` means the item spans all of the columns. You cannot cause an item to span two out of three columns for example.
+In the current level 1 specification, there are only two allowable values for `column-span`. The value `none` is the initial value and means the item does not span, remaining within a column. The value `all` means the item spans all of the columns. You cannot cause an item to span two out of three columns for example.
 
 ### Things to watch out for
 
@@ -41,7 +41,7 @@ If the spanning element is inside another element which has margins, padding and
 
 Additionally, if a spanning element appears later in the content it can cause unexpected or unwanted behavior when there is not enough content to create columns after the spanner. Use spanning carefully and test at various breakpoints to make sure you get the intended effect.
 
-## Column Filling and Balancing
+## Filling and balancing the columns
 
 A balanced set of columns is where all columns have approximately the same amount of content. Filling and balancing comes into play when the amount of content does not match the amount of space provided, such as when a height is declared on the container.
 
@@ -59,4 +59,6 @@ The other value for `column-fill` is `auto`. In this case, rather than filling a
 
 Note that column balancing is not supported by all browsers. Check that you are getting the sort of effect that you expect in the browsers you support.
 
-In the next guide you will learn [how multicol handles overflow](/en-US/docs/Web/CSS/CSS_Columns/Handling_Overflow_in_Multicol), both within columns and where there are more columns than will fit the container.
+## Next steps
+
+In the next guide, you will learn [how multicol handles overflow](/en-US/docs/Web/CSS/CSS_Columns/Handling_Overflow_in_Multicol), both within columns and where there are more columns than will fit the container.

--- a/files/en-us/web/css/css_columns/spanning_columns/index.md
+++ b/files/en-us/web/css/css_columns/spanning_columns/index.md
@@ -9,7 +9,7 @@ tags:
 ---
 {{CSSRef}}
 
-In this guide, we look at how to make elements span across columns inside the multicol container and how to control how the columns are filled.
+In this guide, we look at how to make elements span across columns inside the multi-column (_multicol_) container and how to control how the columns are filled.
 
 > **Note:** The spanning and balancing functionality covered in this guide is not as well supported across browsers as the functionality covered in the previous two sections in this guide.
 

--- a/files/en-us/web/css/css_columns/spanning_columns/index.md
+++ b/files/en-us/web/css/css_columns/spanning_columns/index.md
@@ -31,7 +31,7 @@ When a spanner is introduced, it breaks the flow of columns and columns restart 
 
 ### Limitations of column-span
 
-In the current level 1 specification, there are only two allowable values for `column-span`. The value `none` is the initial value and means the item does not span, remaining within a column. The value `all` means the item spans all of the columns. You cannot cause an item to span two out of three columns for example.
+In the current level 1 specification, there are only two allowable values for `column-span`. The value `none` is the initial value and means that the item does not span and remains within a column. The value `all` means that the item spans all of the columns. This means that, for example, you cannot cause an item to span two out of three columns.
 
 ### Things to watch out for
 
@@ -41,7 +41,7 @@ If the spanning element is inside another element which has margins, padding and
 
 Additionally, if a spanning element appears later in the content it can cause unexpected or unwanted behavior when there is not enough content to create columns after the spanner. Use spanning carefully and test at various breakpoints to make sure you get the intended effect.
 
-## Filling and balancing the columns
+## Filling and balancing columns
 
 A balanced set of columns is where all columns have approximately the same amount of content. Filling and balancing comes into play when the amount of content does not match the amount of space provided, such as when a height is declared on the container.
 

--- a/files/en-us/web/css/css_columns/styling_columns/index.md
+++ b/files/en-us/web/css/css_columns/styling_columns/index.md
@@ -33,7 +33,7 @@ The specification defines `column-rule-width`, `column-rule-style` and `column-r
 
 These properties are applied to the element which is the multicol container and therefore all columns will have the same rule. Rules are only drawn between columns and not on the outer edges. Rules should also only be drawn between columns which have content.
 
-In this next example, a 5px-dotted rule with a color of rebeccapurple has been created using the longhand values.
+In this next example, a 5px-dotted rule with a color of `rebeccapurple` has been created using the longhand values.
 
 {{EmbedGHLiveSample("css-examples/multicol/styling/column-rule.html", '100%', 550)}}
 

--- a/files/en-us/web/css/css_columns/styling_columns/index.md
+++ b/files/en-us/web/css/css_columns/styling_columns/index.md
@@ -1,5 +1,5 @@
 ---
-title: Styling Columns
+title: Styling columns
 slug: Web/CSS/CSS_Columns/Styling_Columns
 tags:
   - CSS
@@ -11,13 +11,13 @@ tags:
 
 As column boxes created inside multicol containers are anonymous boxes, there is little we can do to style them. However, we do have a few things that we can do. This guide explains how to change the gap and style rules between columns.
 
-## Can I Style the Column Boxes?
+## Styling column boxes
 
-Sadly, not at present. The anonymous boxes that make up your columns can't be targeted in any way, meaning it isn't possible to change a box's background color or have one column larger than the others. Perhaps in future versions of the specification it might be. For now, however, we are able to change the spacing and add lines between columns.
+Sadly, column boxes cannot be styled at present. The anonymous boxes that make up your columns can't be targeted in any way, meaning it isn't possible to change a box's background color or have one column larger than the others. Perhaps in future versions of the specification it might be. For now, however, we are able to change the spacing and add lines between columns.
 
-## The `column-gap` property
+## Column gaps
 
-The gap between our columns is controlled by the `column-gap` property. This property was originally defined in the Multi-column Layout specification. However, it is now defined in [Box Alignment](/en-US/docs/Web/CSS/CSS_Box_Alignment) in order to unify gaps between boxes in other specifications such as [CSS Grid Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout).
+The gap between columns is controlled using the `column-gap` property. This property was originally defined in the Multi-column Layout specification. However, it is now defined in [Box Alignment](/en-US/docs/Web/CSS/CSS_Box_Alignment) in order to unify gaps between boxes in other specifications such as [CSS Grid Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout).
 
 The initial value of `column-gap` in multicol is `1em`. This means your columns will not run into each other. In other layout methods the initial value for `column-gap` is 0. If you use the keyword value "normal" the gap will be set to 1em.
 
@@ -33,16 +33,16 @@ The specification defines `column-rule-width`, `column-rule-style` and `column-r
 
 These properties are applied to the element which is the multicol container and therefore all columns will have the same rule. Rules are only drawn between columns and not on the outer edges. Rules should also only be drawn between columns which have content.
 
-In this next example I have created a 5px dotted rule with a color of rebeccapurple, using the longhand values.
+In this next example, a 5px-dotted rule with a color of rebeccapurple has been created using the longhand values.
 
 {{EmbedGHLiveSample("css-examples/multicol/styling/column-rule.html", '100%', 550)}}
 
 Note that the rule itself does not take up any space: a wide rule will not push the columns apart to make space for the rule. Instead, the rule overlays the gap.
 
-In this next example we have a very wide rule of 40px and a 10px gap. The rule displays under the content of the columns. In order to make space on both sides of the rule, the gap would need to be increased to be larger than 40px.
+The example below uses a very wide rule of 40px and a 10px gap. The rule displays under the content of the columns. To make space on both sides of the rule, the gap would need to be increased to be larger than 40px.
 
 {{EmbedGHLiveSample("css-examples/multicol/styling/column-rule-wide.html", '100%', 550)}}
 
 ## Summary
 
-This details all the current ways in which column boxes can be styled. In the next guide we will take a look at making elements inside a container [span across all columns](/en-US/docs/Web/CSS/CSS_Columns/Spanning_Columns).
+This article details all the current ways in which column boxes can be styled. In the next guide, we will take a look at making elements inside a container [span across all columns](/en-US/docs/Web/CSS/CSS_Columns/Spanning_Columns).

--- a/files/en-us/web/css/css_columns/styling_columns/index.md
+++ b/files/en-us/web/css/css_columns/styling_columns/index.md
@@ -9,7 +9,7 @@ tags:
 ---
 {{CSSRef}}
 
-As column boxes created inside multicol containers are anonymous boxes, there is little we can do to style them. However, we do have a few things that we can do. This guide explains how to change the gap and style rules between columns.
+As column boxes created inside multi-column (_multicol_) containers are anonymous boxes, there is little we can do to style them. However, we do have a few things that we can do. This guide explains how to change the gap and style rules between columns.
 
 ## Styling column boxes
 
@@ -19,7 +19,7 @@ Sadly, column boxes cannot be styled at present. The anonymous boxes that make u
 
 The gap between columns is controlled using the `column-gap` property. This property was originally defined in the Multi-column Layout specification. However, it is now defined in [Box Alignment](/en-US/docs/Web/CSS/CSS_Box_Alignment) in order to unify gaps between boxes in other specifications such as [CSS Grid Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout).
 
-The initial value of `column-gap` in multicol is `1em`. This means your columns will not run into each other. In other layout methods the initial value for `column-gap` is 0. If you use the keyword value "normal" the gap will be set to 1em.
+The initial value of `column-gap` in multicol is `1em`. This means your columns will not run into each other. In other layout methods, the initial value for `column-gap` is 0. If you use the keyword value "normal", the gap will be set to 1em.
 
 You can change the gap by using any length unit as the value of `column-gap`. In the example below, the `column-gap` is set to 40px.
 
@@ -43,6 +43,6 @@ The example below uses a very wide rule of 40px and a 10px gap. The rule display
 
 {{EmbedGHLiveSample("css-examples/multicol/styling/column-rule-wide.html", '100%', 550)}}
 
-## Summary
+## Next steps
 
 This article details all the current ways in which column boxes can be styled. In the next guide, we will take a look at making elements inside a container [span across all columns](/en-US/docs/Web/CSS/CSS_Columns/Spanning_Columns).

--- a/files/en-us/web/css/css_columns/using_multi-column_layouts/index.md
+++ b/files/en-us/web/css/css_columns/using_multi-column_layouts/index.md
@@ -59,7 +59,7 @@ The `column-count` property sets the number of columns to a particular number. E
 
 ### Result
 
-Will display the content in two columns (if you're using a multi-column compliant browser):
+The content will be displayed in two columns (if you're using a multi-column compliant browser):
 
 {{EmbedLiveSample("Example_1", "100%")}}
 

--- a/files/en-us/web/css/css_columns/using_multi-column_layouts/index.md
+++ b/files/en-us/web/css/css_columns/using_multi-column_layouts/index.md
@@ -11,7 +11,7 @@ tags:
 ---
 {{CSSRef}}
 
-The **CSS Multi-Column Layout Module** extends the _block layout mode_ to allow the easy definition of multiple columns of text. People have trouble reading text if lines are too long; if it takes too long for the eyes to move from the end of the one line to the beginning of the next, they lose track of which line they were on. Therefore, to make maximum use of a large screen, authors should have limited-width columns of text placed side by side, just as newspapers do.
+The **CSS Multi-column Layout Module** extends the _block layout mode_ to allow the easy definition of multiple columns of text. People have trouble reading text if lines are too long; if it takes too long for the eyes to move from the end of the one line to the beginning of the next, they lose track of which line they were on. Therefore, to make maximum use of a large screen, authors should have limited-width columns of text placed side by side, just as newspapers do.
 
 Unfortunately this is impossible to do with CSS and HTML without forcing column breaks at fixed positions, or severely restricting the markup allowed in the text, or using heroic scripting. This limitation is solved by adding new CSS properties to extend the traditional block layout mode.
 

--- a/files/en-us/web/css/css_columns/using_multi-column_layouts/index.md
+++ b/files/en-us/web/css/css_columns/using_multi-column_layouts/index.md
@@ -11,7 +11,7 @@ tags:
 ---
 {{CSSRef}}
 
-The **CSS Multi-column Layout Module** extends the _block layout mode_ to allow the easy definition of multiple columns of text. People have trouble reading text if lines are too long; if it takes too long for the eyes to move from the end of the one line to the beginning of the next, they lose track of which line they were on. Therefore, to make maximum use of a large screen, authors should have limited-width columns of text placed side by side, just as newspapers do.
+The **CSS Multi-Column Layout Module** extends the _block layout mode_ to allow the easy definition of multiple columns of text. People have trouble reading text if lines are too long; if it takes too long for the eyes to move from the end of the one line to the beginning of the next, they lose track of which line they were on. Therefore, to make maximum use of a large screen, authors should have limited-width columns of text placed side by side, just as newspapers do.
 
 Unfortunately this is impossible to do with CSS and HTML without forcing column breaks at fixed positions, or severely restricting the markup allowed in the text, or using heroic scripting. This limitation is solved by adding new CSS properties to extend the traditional block layout mode.
 

--- a/files/en-us/web/css/css_display/index.md
+++ b/files/en-us/web/css/css_display/index.md
@@ -40,7 +40,7 @@ browser-compat: css.properties.display
 - [Introduction to formatting contexts](/en-US/docs/Web/CSS/CSS_Flow_Layout/Intro_to_formatting_contexts)
 - [In flow and out of flow](/en-US/docs/Web/CSS/CSS_Flow_Layout/In_Flow_and_Out_of_Flow)
 
-### Flex
+### Flexbox
 
 - [Basic concepts of flexbox](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox)
 - [Aligning items in a flex container](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container)

--- a/files/en-us/web/css/css_display/index.md
+++ b/files/en-us/web/css/css_display/index.md
@@ -40,7 +40,7 @@ browser-compat: css.properties.display
 - [Introduction to formatting contexts](/en-US/docs/Web/CSS/CSS_Flow_Layout/Intro_to_formatting_contexts)
 - [In flow and out of flow](/en-US/docs/Web/CSS/CSS_Flow_Layout/In_Flow_and_Out_of_Flow)
 
-### Flexbox
+### Flexible box layout
 
 - [Basic concepts of flexbox](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox)
 - [Aligning items in a flex container](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container)
@@ -51,7 +51,7 @@ browser-compat: css.properties.display
 - [Backwards compatibility of flexbox](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Backwards_Compatibility_of_Flexbox)
 - [Typical use cases of flexbox](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Typical_Use_Cases_of_Flexbox)
 
-### Grid
+### Grid layout
 
 - [Basic concepts of grid layout](/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout)
 - [Relationship of grid layout to other layout methods](/en-US/docs/Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout)

--- a/files/en-us/web/css/css_display/index.md
+++ b/files/en-us/web/css/css_display/index.md
@@ -15,11 +15,11 @@ browser-compat: css.properties.display
 
 ## Reference
 
-### CSS properties
+### Properties
 
 - {{CSSxRef("display")}}
 
-### CSS data types
+### Data types
 
 - {{CSSxRef("&lt;display-outside&gt;")}}
 - {{CSSxRef("&lt;display-inside&gt;")}}
@@ -32,37 +32,37 @@ browser-compat: css.properties.display
 
 - [Adapting to the two-value syntax of display](/en-US/docs/Web/CSS/display/two-value_syntax_of_display)
 
-### CSS Flow Layout (`display: block`, `display: inline`)
+### Flow layout (display: block, display: inline)
 
-- [Block and Inline Layout in Normal Flow](/en-US/docs/Web/CSS/CSS_Flow_Layout/Block_and_Inline_Layout_in_Normal_Flow)
-- [Flow Layout and Overflow](/en-US/docs/Web/CSS/CSS_Flow_Layout/Flow_Layout_and_Overflow)
-- [Flow Layout and Writing Modes](/en-US/docs/Web/CSS/CSS_Flow_Layout/Flow_Layout_and_Writing_Modes)
-- [Formatting Contexts Explained](/en-US/docs/Web/CSS/CSS_Flow_Layout/Intro_to_formatting_contexts)
-- [In Flow and Out of Flow](/en-US/docs/Web/CSS/CSS_Flow_Layout/In_Flow_and_Out_of_Flow)
+- [Block and inline layout in normal flow](/en-US/docs/Web/CSS/CSS_Flow_Layout/Block_and_Inline_Layout_in_Normal_Flow)
+- [Flow layout and overflow](/en-US/docs/Web/CSS/CSS_Flow_Layout/Flow_Layout_and_Overflow)
+- [Flow layout and writing modes](/en-US/docs/Web/CSS/CSS_Flow_Layout/Flow_Layout_and_Writing_Modes)
+- [Introduction to formatting contexts](/en-US/docs/Web/CSS/CSS_Flow_Layout/Intro_to_formatting_contexts)
+- [In flow and out of flow](/en-US/docs/Web/CSS/CSS_Flow_Layout/In_Flow_and_Out_of_Flow)
 
-### `display: flex`
+### Flex
 
 - [Basic concepts of flexbox](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox)
-- [Aligning Items in a Flex Container](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container)
-- [Controlling Ratios of Flex Items Along the Main Axis](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Controlling_Ratios_of_Flex_Items_Along_the_Main_Ax)
-- [Mastering Wrapping of Flex Items](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Mastering_Wrapping_of_Flex_Items)
-- [Ordering Flex Items](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Ordering_Flex_Items)
+- [Aligning items in a flex container](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container)
+- [Controlling ratios of flex items along the main axis](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Controlling_Ratios_of_Flex_Items_Along_the_Main_Ax)
+- [Mastering wrapping of flex items](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Mastering_Wrapping_of_Flex_Items)
+- [Ordering flex items](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Ordering_Flex_Items)
 - [Relationship of flexbox to other layout methods](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Relationship_of_Flexbox_to_Other_Layout_Methods)
-- [Backwards Compatibility of Flexbox](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Backwards_Compatibility_of_Flexbox)
-- [Typical use cases of Flexbox](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Typical_Use_Cases_of_Flexbox)
+- [Backwards compatibility of flexbox](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Backwards_Compatibility_of_Flexbox)
+- [Typical use cases of flexbox](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Typical_Use_Cases_of_Flexbox)
 
-### `display: grid`
+### Grid
 
-- [Basic Concepts of Grid Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout)
-- [Relationship to other layout methods](/en-US/docs/Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout)
+- [Basic concepts of grid layout](/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout)
+- [Relationship of grid layout to other layout methods](/en-US/docs/Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout)
 - [Line-based placement](/en-US/docs/Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid)
 - [Grid template areas](/en-US/docs/Web/CSS/CSS_Grid_Layout/Grid_Template_Areas)
 - [Layout using named grid lines](/en-US/docs/Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines)
 - [Auto-placement in grid layout](/en-US/docs/Web/CSS/CSS_Grid_Layout/Auto-placement_in_CSS_Grid_Layout)
 - [Box alignment in grid layout](/en-US/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout)
 - [Grids, logical values and writing modes](/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Logical_Values_and_Writing_Modes)
-- [CSS Grid Layout and Accessibility](/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Layout_and_Accessibility)
-- [CSS Grid Layout and Progressive Enhancement](/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_and_Progressive_Enhancement)
+- [CSS Grid Layout and accessibility](/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Layout_and_Accessibility)
+- [CSS Grid Layout and progressive enhancement](/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_and_Progressive_Enhancement)
 - [Realizing common layouts using grids](/en-US/docs/Web/CSS/CSS_Grid_Layout/Realizing_common_layouts_using_CSS_Grid_Layout)
 
 ## Specifications

--- a/files/en-us/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/aligning_items_in_a_flex_container/index.md
@@ -1,5 +1,5 @@
 ---
-title: Aligning Items in a Flex Container
+title: Aligning items in a flex container
 slug: Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container
 tags:
   - Align

--- a/files/en-us/web/css/css_flexible_box_layout/backwards_compatibility_of_flexbox/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/backwards_compatibility_of_flexbox/index.md
@@ -1,5 +1,5 @@
 ---
-title: Backwards Compatibility of Flexbox
+title: Backwards compatibility of flexbox
 slug: Web/CSS/CSS_Flexible_Box_Layout/Backwards_Compatibility_of_Flexbox
 tags:
   - '@supports'

--- a/files/en-us/web/css/css_flexible_box_layout/controlling_ratios_of_flex_items_along_the_main_ax/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/controlling_ratios_of_flex_items_along_the_main_ax/index.md
@@ -1,5 +1,5 @@
 ---
-title: Controlling Ratios of Flex Items Along the Main Axis
+title: Controlling ratios of flex items along the main axis
 slug: >-
   Web/CSS/CSS_Flexible_Box_Layout/Controlling_Ratios_of_Flex_Items_Along_the_Main_Ax
 tags:

--- a/files/en-us/web/css/css_flexible_box_layout/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/index.md
@@ -14,7 +14,7 @@ spec-urls: https://drafts.csswg.org/css-flexbox/
 
 **CSS Flexible Box Layout** is a module of [CSS](/en-US/docs/Web/CSS) that defines a CSS box model optimized for user interface design, and the layout of items in one dimension. In the flex layout model, the children of a flex container can be laid out in any direction, and can "flex" their sizes, either growing to fill unused space or shrinking to avoid overflowing the parent. Both horizontal and vertical alignment of the children can be easily manipulated.
 
-## Basic Example
+## Basic example
 
 In the following example a container has been set to `display: flex`, which means that the three child items become flex items. The value of `justify-content` has been set to `space-between` in order to space the items out evenly on the main axis. An equal amount of space is placed between each item with the left and right items being flush with the edges of the flex container. You can also see that the items are stretching on the cross axis, due to the default value of `align-items` being `stretch`. The items stretch to the height of the flex container, making them each appear as tall as the tallest item.
 
@@ -22,7 +22,7 @@ In the following example a container has been set to `display: flex`, which mean
 
 ## Reference
 
-### CSS Properties
+### Properties
 
 - {{cssxref("flex")}}
 - {{cssxref("flex-basis")}}
@@ -33,7 +33,7 @@ In the following example a container has been set to `display: flex`, which mean
 - {{cssxref("flex-wrap")}}
 - {{cssxref("order")}}
 
-### Alignment Properties
+### Properties for alignment
 
 The properties `align-content`, `align-self`, `align-items` and `justify-content` initially appeared in the Flexbox specification, but are now defined in Box Alignment. The Flexbox spec now refers to the Box Alignment specification for up to date definitions. Also additional alignment properties are now defined in Box Alignment.
 
@@ -47,32 +47,23 @@ The properties `align-content`, `align-self`, `align-items` and `justify-content
 - {{cssxref("column-gap")}}
 - {{cssxref("gap")}}
 
-### Glossary entries
-
-- {{Glossary("Flexbox", "", 1)}}
-- {{Glossary("Flex Container", "", 1)}}
-- {{Glossary("Flex Item", "", 1)}}
-- {{Glossary("Main Axis", "", 1)}}
-- {{Glossary("Cross Axis", "", 1)}}
-- {{Glossary("Flex", "", 1)}}
-
 ## Guides
 
-- [Basic Concepts of Flexbox](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox)
+- [Basic concepts of flexbox](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox)
   - : An overview of the features of Flexbox
-- [Relationship of Flexbox to other layout methods](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Relationship_of_Flexbox_to_Other_Layout_Methods)
+- [Relationship of flexbox to other layout methods](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Relationship_of_Flexbox_to_Other_Layout_Methods)
   - : How Flexbox relates to other layout methods, and other CSS specifications
 - [Aligning items in a flex container](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Aligning_Items_in_a_Flex_Container)
   - : How the Box Alignment properties work with Flexbox.
 - [Ordering flex items](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Ordering_Flex_Items)
   - : Explaining the different ways to change the order and direction of items, and covering the potential issues in doing so.
-- [Controlling Ratios of flex items along the main axis](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Controlling_Ratios_of_Flex_Items_Along_the_Main_Ax)
+- [Controlling ratios of flex items along the main axis](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Controlling_Ratios_of_Flex_Items_Along_the_Main_Ax)
   - : Explaining the flex-grow, flex-shrink and flex-basis properties.
 - [Mastering wrapping of flex items](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Mastering_Wrapping_of_Flex_Items)
   - : How to create flex containers with multiple lines and control the display of the items in those lines.
-- [Typical use cases of Flexbox](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Typical_Use_Cases_of_Flexbox)
+- [Typical use cases of flexbox](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Typical_Use_Cases_of_Flexbox)
   - : Common design patterns that are typical Flexbox use cases.
-- [Backwards compatibility of Flexbox](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Backwards_Compatibility_of_Flexbox)
+- [Backwards compatibility of flexbox](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Backwards_Compatibility_of_Flexbox)
   - : Browser status of Flexbox, interoperability issues and supporting older browsers and versions of the spec
 
 ## Specifications
@@ -81,5 +72,11 @@ The properties `align-content`, `align-self`, `align-items` and `justify-content
 
 ## See also
 
-- [Flexbugs](https://github.com/philipwalton/flexbugs)
-  - : a community-curated list of Flexbox browser bugs and workarounds
+- Glossary terms:
+  - {{Glossary("Flexbox", "", 1)}}
+  - {{Glossary("Flex Container", "", 1)}}
+  - {{Glossary("Flex Item", "", 1)}}
+  - {{Glossary("Main Axis", "", 1)}}
+  - {{Glossary("Cross Axis", "", 1)}}
+  - {{Glossary("Flex", "", 1)}}
+- [Flexbugs](https://github.com/philipwalton/flexbugs): a community-curated list of Flexbox browser bugs and workarounds

--- a/files/en-us/web/css/css_flexible_box_layout/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/index.md
@@ -79,4 +79,3 @@ The properties `align-content`, `align-self`, `align-items` and `justify-content
   - {{Glossary("Main Axis", "", 1)}}
   - {{Glossary("Cross Axis", "", 1)}}
   - {{Glossary("Flex", "", 1)}}
-- [Flexbugs](https://github.com/philipwalton/flexbugs): a community-curated list of Flexbox browser bugs and workarounds

--- a/files/en-us/web/css/css_flexible_box_layout/mastering_wrapping_of_flex_items/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/mastering_wrapping_of_flex_items/index.md
@@ -1,5 +1,5 @@
 ---
-title: Mastering Wrapping of Flex Items
+title: Mastering wrapping of flex items
 slug: Web/CSS/CSS_Flexible_Box_Layout/Mastering_Wrapping_of_Flex_Items
 tags:
   - CSS

--- a/files/en-us/web/css/css_flexible_box_layout/ordering_flex_items/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/ordering_flex_items/index.md
@@ -1,5 +1,5 @@
 ---
-title: Ordering Flex Items
+title: Ordering flex items
 slug: Web/CSS/CSS_Flexible_Box_Layout/Ordering_Flex_Items
 tags:
   - Accessibility

--- a/files/en-us/web/css/css_flexible_box_layout/typical_use_cases_of_flexbox/index.md
+++ b/files/en-us/web/css/css_flexible_box_layout/typical_use_cases_of_flexbox/index.md
@@ -1,5 +1,5 @@
 ---
-title: Typical use cases of Flexbox
+title: Typical use cases of flexbox
 slug: Web/CSS/CSS_Flexible_Box_Layout/Typical_Use_Cases_of_Flexbox
 tags:
   - CSS
@@ -11,7 +11,7 @@ tags:
 ---
 {{CSSRef}}
 
-In this guide we will take a look at some of the common use cases for flexbox — those places where it makes more sense than another layout method.
+In this guide, we will take a look at some of the common use cases for flexbox — those places where it makes more sense than another layout method.
 
 ## Why choose flexbox?
 

--- a/files/en-us/web/css/css_flow_layout/flow_layout_and_overflow/index.md
+++ b/files/en-us/web/css/css_flow_layout/flow_layout_and_overflow/index.md
@@ -1,5 +1,5 @@
 ---
-title: Flow Layout and Overflow
+title: Flow layout and overflow
 slug: Web/CSS/CSS_Flow_Layout/Flow_Layout_and_Overflow
 tags:
   - CSS

--- a/files/en-us/web/css/css_flow_layout/flow_layout_and_writing_modes/index.md
+++ b/files/en-us/web/css/css_flow_layout/flow_layout_and_writing_modes/index.md
@@ -1,5 +1,5 @@
 ---
-title: Flow Layout and Writing Modes
+title: Flow layout and writing modes
 slug: Web/CSS/CSS_Flow_Layout/Flow_Layout_and_Writing_Modes
 tags:
   - CSS
@@ -12,7 +12,7 @@ The CSS 2.1 specification, which details how normal flow behaves, assumes a hori
 
 This is not a comprehensive guide to the use of writing modes in CSS, the aim here is to document the areas where flow layout interacts with writing modes in possibly unanticipated ways. The [external resources](#external_resources) and [see also](#see_also) sections of this document link to more writing modes resources.
 
-## The Writing Modes Specification
+## Writing Modes specification
 
 The CSS Writing Modes Level 3 Specification defines the impact a change the document writing mode has on flow layout. In the writing modes introduction, [the specification says](https://drafts.csswg.org/css-writing-modes-3/#text-flow),
 
@@ -26,7 +26,7 @@ While certain languages will use a particular writing mode or text direction, we
 
 {{EmbedGHLiveSample("css-examples/flow/writing-modes/creative-use.html", '100%', 720)}}
 
-## The `writing-mode` property and block flow
+## Block flow direction
 
 The {{cssxref("writing-mode")}} property accepts the values `horizontal-tb`, `vertical-rl` and `vertical-lr`. These values control the direction that blocks flow on the page. The initial value is `horizontal-tb,` which is a top to bottom block flow direction with a horizontal inline direction. Left to right languages, such as English, and Right to left languages. such as Arabic, are all `horizontal-tb`.
 
@@ -42,7 +42,7 @@ The final example demonstrates the third possible value for `writing-mode` — `
 
 {{EmbedGHLiveSample("css-examples/flow/writing-modes/vertical-lr.html", '100%', 720)}}
 
-## Boxes with a different writing mode to their parent
+## Different writing mode from parent
 
 When a nested box is assigned a different writing mode to its parent, then an inline level box will display as if it has `display: inline-block`.
 
@@ -58,7 +58,7 @@ Replaced elements such as images will not change their orientation based on the 
 
 {{EmbedGHLiveSample("css-examples/flow/writing-modes/replaced.html", '100%', 720)}}
 
-## Logical Properties and Values
+## Logical properties and values
 
 Once you are working in writing modes other than `horizontal-tb` many of the properties and values that are mapped to the physical dimensions of the screen seem strange. For example, if you give a box a width of 100px, in `horizontal-tb` that would control the size in the inline direction. In `vertical-lr` it controls the size in the block direction because it does not rotate with the text.
 
@@ -77,9 +77,6 @@ In most cases, flow layout works as you would expect it to when changing the wri
 ## See also
 
 - [Writing Modes](/en-US/docs/Web/CSS/CSS_Writing_Modes)
-
-## External Resources
-
 - _[CSS Writing Modes](https://24ways.org/2016/css-writing-modes/)_, Jen Simmons on 24 Ways
 
 {{QuickLinksWithSubpages("/en-US/docs/Web/CSS/CSS_Flow_Layout/")}}

--- a/files/en-us/web/css/css_flow_layout/flow_layout_and_writing_modes/index.md
+++ b/files/en-us/web/css/css_flow_layout/flow_layout_and_writing_modes/index.md
@@ -12,7 +12,7 @@ The CSS 2.1 specification, which details how normal flow behaves, assumes a hori
 
 This is not a comprehensive guide to the use of writing modes in CSS, the aim here is to document the areas where flow layout interacts with writing modes in possibly unanticipated ways. The [external resources](#external_resources) and [see also](#see_also) sections of this document link to more writing modes resources.
 
-## Writing Modes specification
+## Writing modes specification
 
 The CSS Writing Modes Level 3 Specification defines the impact a change the document writing mode has on flow layout. In the writing modes introduction, [the specification says](https://drafts.csswg.org/css-writing-modes-3/#text-flow),
 
@@ -42,7 +42,7 @@ The final example demonstrates the third possible value for `writing-mode` — `
 
 {{EmbedGHLiveSample("css-examples/flow/writing-modes/vertical-lr.html", '100%', 720)}}
 
-## Different writing mode from parent
+## Nested writing modes
 
 When a nested box is assigned a different writing mode to its parent, then an inline level box will display as if it has `display: inline-block`.
 

--- a/files/en-us/web/css/css_flow_layout/in_flow_and_out_of_flow/index.md
+++ b/files/en-us/web/css/css_flow_layout/in_flow_and_out_of_flow/index.md
@@ -32,7 +32,7 @@ Out of flow items create a new Block Formatting Context (BFC) and therefore ever
 
 ### Floated items
 
-In this example, there is a `div` and then two paragraphs. Background color has been added to the paragraphs, and the `div` is floated left. The `div` is now out of flow.
+In this example, there is a `div` and then two paragraphs. A background color has been added to the paragraphs, and the `div` is floated left. The `div` is now out of flow.
 
 As a float it is first laid out according to where it would be in normal flow, then taken out of flow and moved to the left as far as possible.
 

--- a/files/en-us/web/css/css_flow_layout/in_flow_and_out_of_flow/index.md
+++ b/files/en-us/web/css/css_flow_layout/in_flow_and_out_of_flow/index.md
@@ -1,5 +1,5 @@
 ---
-title: In Flow and Out of Flow
+title: In flow and out of flow
 slug: Web/CSS/CSS_Flow_Layout/In_Flow_and_Out_of_Flow
 tags:
   - CSS
@@ -12,9 +12,9 @@ tags:
 ---
 {{CSSRef}}
 
-In the [previous guide](/en-US/docs/Web/CSS/CSS_Flow_Layout/Block_and_Inline_Layout_in_Normal_Flow) I explained block and inline layout in normal flow. All elements that are in flow, will be laid out using this method.
+The [previous guide](/en-US/docs/Web/CSS/CSS_Flow_Layout/Block_and_Inline_Layout_in_Normal_Flow) explained block and inline layout in normal flow. All elements that are in flow will be laid out using this method.
 
-In the following example I have a heading, paragraph, a list and a final paragraph which contains a `strong` element. The heading and paragraphs are block level, the `strong` element inline. The list is displayed using flexbox to arrange the items into a row, however it too is participating in block and inline layout - the container has an outside `display` type of `block`.
+The following example contains a heading, paragraph, a list and a final paragraph which contains a `strong` element. The heading and paragraphs are block level, the `strong` element inline. The list is displayed using flexbox to arrange the items into a row, however it too is participating in block and inline layout - the container has an outside `display` type of `block`.
 
 {{EmbedGHLiveSample("css-examples/flow/in-flow/in-flow.html", '100%', 800)}}
 
@@ -30,9 +30,9 @@ All elements are in-flow apart from:
 
 Out of flow items create a new Block Formatting Context (BFC) and therefore everything inside them can be seen as a mini layout, separate from the rest of the page. The root element therefore is out of flow, as the container for everything in our document, and establishes the Block Formatting Context for the document.
 
-### Floated Items
+### Floated items
 
-In this example I have a `div`, and then two paragraphs. I've added a background color to the paragraphs, and then floated the `div` left. The `div` is now out of flow.
+In this example, there is a `div` and then two paragraphs. Background color has been added to the paragraphs, and the `div` is floated left. The `div` is now out of flow.
 
 As a float it is first laid out according to where it would be in normal flow, then taken out of flow and moved to the left as far as possible.
 
@@ -40,7 +40,7 @@ As a float it is first laid out according to where it would be in normal flow, t
 
 You can see the background color of the following paragraph running underneath, it is only the line boxes of that paragraph that have been shortened to cause the effect of wrapping content around the float. The box of our paragraph is still displaying according to the rules of normal flow. This is why, to make space around a floated item, you must add a margin to the item, in order to push the line boxes away from it. You cannot apply anything to the following in-flow content to achieve that.
 
-### Absolute Positioning
+### Absolute positioning
 
 Giving an item `position: absolute` or `position: fixed` removes it from flow, and any space that it would have taken up is removed. In the next example I have three paragraph elements, the second element has `position` `absolute`, with offset values of `top: 30px` and `right: 30px`. It has been removed from document flow.
 
@@ -50,18 +50,18 @@ Using `position: fixed` also removes the item from flow, however the offsets are
 
 When taking an item out of flow with positioning, you will need to manage the possibility of content overlapping. Out of flow essentially means that the other elements on your page no longer know that element exists so will not respond to it.
 
-### Relative Positioning and Flow
+### Relative positioning and flow
 
-If you give an item relative positioning with `position: relative` it remains in flow, however you are then able to use the offset values to push it around. The space that it would have been placed in normal flow is reserved however, as you can see in the example below.
+If you give an item relative positioning with `position: relative`, it remains in flow. However, you are then able to use the offset values to push it around. The space that it would have been placed in normal flow is reserved however, as you can see in the example below.
 
 {{EmbedGHLiveSample("css-examples/flow/in-flow/relative.html", '100%', 800)}}
 
-When you do anything to remove, or shift an item from where it would be placed in normal flow, you can expect to need to do some managing of the content and the content around it to prevent overlaps. Whether that involves clearing floats, or ensuring that an element with `position: absolute` does not sit on top of some other content. For this reason methods which remove elements from being in-flow should be used with understanding of the effect that they have.
+When you do anything to remove or shift an item from where it would be placed in normal flow, you can expect to need to do some managing of the content and the content around it to prevent overlaps. Whether that involves clearing floats, or ensuring that an element with `position: absolute` does not sit on top of some other content. For this reason methods which remove elements from being in-flow should be used with understanding of the effect that they have.
 
 ## Summary
 
-In this guide we have covered the ways to take an element out of flow in order to achieve some very specific types of positioning. In the next guide we will look at a related issue, that of creating a [Block Formatting Context](/en-US/docs/Web/Guide/CSS/Block_formatting_context), in [Formatting Contexts Explained](/en-US/docs/Web/CSS/CSS_Flow_Layout/Intro_to_formatting_contexts).
+In this guide, we have covered the ways to take an element out of flow in order to achieve some very specific types of positioning. In the next guide we will look at a related issue, that of creating a [Block Formatting Context](/en-US/docs/Web/Guide/CSS/Block_formatting_context), in [Formatting Contexts Explained](/en-US/docs/Web/CSS/CSS_Flow_Layout/Intro_to_formatting_contexts).
 
 ## See also
 
-- Learn Layout: _[Positioning](/en-US/docs/Learn/CSS/CSS_layout/Positioning)_
+- [Positioning](/en-US/docs/Learn/CSS/CSS_layout/Positioning) in the CSS Layout learn area

--- a/files/en-us/web/css/css_fragmentation/index.md
+++ b/files/en-us/web/css/css_fragmentation/index.md
@@ -19,6 +19,8 @@ Fragmentation occurs when an inline box wraps onto multiple lines. It also occur
 
 ## Reference
 
+### Properties
+
 - {{cssxref("box-decoration-break")}}
 - {{cssxref("break-after")}}
 - {{cssxref("break-before")}}

--- a/files/en-us/web/css/css_generated_content/index.md
+++ b/files/en-us/web/css/css_generated_content/index.md
@@ -29,8 +29,4 @@ See the [how to guide for generated content](/en-US/docs/Learn/CSS/Howto/Generat
 ## See also
 
 - [Using CSS generated content](/en-US/docs/Learn/CSS/Howto/Generated_content)
-- {{cssxref("content")}}
-- {{cssxref("quotes")}}
-- {{cssxref("::before")}}
-- {{cssxref("::after")}}
-- {{cssxref("::marker")}}
+- Pseudo-elements: {{cssxref("::before")}}, {{cssxref("::after")}}, {{cssxref("::marker")}}

--- a/files/en-us/web/css/css_grid_layout/auto-placement_in_css_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/auto-placement_in_css_grid_layout/index.md
@@ -1,5 +1,5 @@
 ---
-title: Auto-placement in CSS Grid Layout
+title: Auto-placement in grid layout
 slug: Web/CSS/CSS_Grid_Layout/Auto-placement_in_CSS_Grid_Layout
 tags:
   - CSS

--- a/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
@@ -759,4 +759,4 @@ We can control the order in which items stack up by using the `z-index` property
 
 ## Next steps
 
-In this article, we took a very quick look through the Grid Layout specification. Have a play with the code examples, and then move onto [the next part of this guide](/en-US/docs/Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout), where we will really start to dig into the detail of CSS Grid Layout.
+In this article, we took a very quick look at the possibilities of grid layouts. Explore and play with the code examples, and then move on to [the next part of this guide](/en-US/docs/Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout), where we will really start to dig into the details of CSS Grid Layout.

--- a/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/basic_concepts_of_grid_layout/index.md
@@ -1,5 +1,5 @@
 ---
-title: Basic Concepts of grid layout
+title: Basic concepts of grid layout
 slug: Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout
 tags:
   - CSS
@@ -37,7 +37,7 @@ More than one item can be placed into a grid cell or area and they can partially
 
 Grid is a powerful specification that, when combined with other parts of CSS such as [flexbox](/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout), can help you create layouts that were previously impossible to build in CSS. It all starts by creating a grid in your **grid container**.
 
-## The Grid container
+## Grid container
 
 We create a _grid container_ by declaring `display: grid` or `display: inline-grid` on an element. As soon as we do this, all _direct children_ of that element become _grid items_.
 
@@ -299,7 +299,7 @@ Repeat notation takes the track listing, and uses it to create a repeating patte
 }
 ```
 
-### The implicit and explicit grid
+### Implicit and explicit grids
 
 When creating our example grid we specifically defined our column tracks with the {{cssxref("grid-template-columns")}} property, but the grid also created rows on its own. These rows are part of the implicit grid. Whereas the explicit grid consists of any rows and columns defined with {{cssxref("grid-template-columns")}} or {{cssxref("grid-template-rows")}}.
 
@@ -307,7 +307,7 @@ If you place something outside of the defined grid—or due to the amount of con
 
 You can also define a set size for tracks created in the implicit grid with the {{cssxref("grid-auto-rows")}} and {{cssxref("grid-auto-columns")}} properties.
 
-In the below example we use `grid-auto-rows` to ensure that tracks created in the implicit grid are 200 pixels tall.
+In the below example, we use `grid-auto-rows` to ensure that tracks created in the implicit grid are 200 pixels tall.
 
 ```html
 <div class="wrapper">
@@ -639,7 +639,7 @@ In the current specification, we would edit the above nested grid example to cha
 }
 ```
 
-## Layering items with `z-index`
+## Layering items with z-index
 
 Grid items can occupy the same cell, and in this case we can use the {{cssxref("z-index")}} property to control the order in which overlapping items stack.
 
@@ -757,6 +757,6 @@ We can control the order in which items stack up by using the `z-index` property
 
 {{ EmbedLiveSample('Controlling_the_order', '230', '460') }}
 
-## Next Steps
+## Next steps
 
-In this article we have had a very quick look through the Grid Layout Specification. Have a play with the code examples, and then move onto [the next part of this guide where we will really start to dig into the detail of CSS Grid Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout).
+In this article, we took a very quick look through the Grid Layout specification. Have a play with the code examples, and then move onto [the next part of this guide](/en-US/docs/Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout), where we will really start to dig into the detail of CSS Grid Layout.

--- a/files/en-us/web/css/css_grid_layout/box_alignment_in_css_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/box_alignment_in_css_grid_layout/index.md
@@ -1,5 +1,5 @@
 ---
-title: Box alignment in CSS Grid Layout
+title: Box alignment in grid layout
 slug: Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout
 tags:
   - Alignment in Grids

--- a/files/en-us/web/css/css_grid_layout/css_grid_and_progressive_enhancement/index.md
+++ b/files/en-us/web/css/css_grid_layout/css_grid_and_progressive_enhancement/index.md
@@ -1,5 +1,5 @@
 ---
-title: CSS Grid Layout and Progressive Enhancement
+title: CSS Grid Layout and progressive enhancement
 slug: Web/CSS/CSS_Grid_Layout/CSS_Grid_and_Progressive_Enhancement
 tags:
   - CSS

--- a/files/en-us/web/css/css_grid_layout/css_grid_layout_and_accessibility/index.md
+++ b/files/en-us/web/css/css_grid_layout/css_grid_layout_and_accessibility/index.md
@@ -1,5 +1,5 @@
 ---
-title: CSS Grid Layout and accessibility
+title: Grid layout and accessibility
 slug: Web/CSS/CSS_Grid_Layout/CSS_Grid_Layout_and_Accessibility
 tags:
   - Accessibility

--- a/files/en-us/web/css/css_grid_layout/css_grid_layout_and_accessibility/index.md
+++ b/files/en-us/web/css/css_grid_layout/css_grid_layout_and_accessibility/index.md
@@ -1,5 +1,5 @@
 ---
-title: CSS Grid Layout and Accessibility
+title: CSS Grid Layout and accessibility
 slug: Web/CSS/CSS_Grid_Layout/CSS_Grid_Layout_and_Accessibility
 tags:
   - Accessibility

--- a/files/en-us/web/css/css_grid_layout/css_grid_logical_values_and_writing_modes/index.md
+++ b/files/en-us/web/css/css_grid_layout/css_grid_logical_values_and_writing_modes/index.md
@@ -1,5 +1,5 @@
 ---
-title: CSS grids, logical values, and writing modes
+title: Grids, logical values, and writing modes
 slug: Web/CSS/CSS_Grid_Layout/CSS_Grid_Logical_Values_and_Writing_Modes
 tags:
   - CSS

--- a/files/en-us/web/css/css_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/index.md
@@ -126,18 +126,18 @@ The example below shows a three-column track grid with new rows created at a min
 
 ## Guides
 
-- [Basic concepts of Grid Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout)
-- [Relationship of grid Layout to other layout methods](/en-US/docs/Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout)
-- [Layout using line-based placement](/en-US/docs/Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid)
+- [Basic concepts of grid layout](/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout)
+- [Relationship of grid layout to other layout methods](/en-US/docs/Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout)
 - [Grid template areas](/en-US/docs/Web/CSS/CSS_Grid_Layout/Grid_Template_Areas)
-- [Layout using named grid lines](/en-US/docs/Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines)
-- [Auto-placement in CSS Grid Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout/Auto-placement_in_CSS_Grid_Layout)
-- [Box alignment in CSS Grid Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout)
-- [CSS grids, logical values, and writing modes](/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Logical_Values_and_Writing_Modes)
-- [CSS Grid Layout and accessibility](/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Layout_and_Accessibility)
-- [Realizing common layouts using CSS Grid Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout/Realizing_common_layouts_using_CSS_Grid_Layout)
+- [Grid layout using line-based placement](/en-US/docs/Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid)
+- [Grid layout using named grid lines](/en-US/docs/Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines)
+- [Auto-placement in grid layout](/en-US/docs/Web/CSS/CSS_Grid_Layout/Auto-placement_in_CSS_Grid_Layout)
+- [Box alignment in grid layout](/en-US/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout)
+- [Grids, logical values, and writing modes](/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Logical_Values_and_Writing_Modes)
+- [Grid layout and accessibility](/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Layout_and_Accessibility)
+- [Realizing common layouts using grids](/en-US/docs/Web/CSS/CSS_Grid_Layout/Realizing_common_layouts_using_CSS_Grid_Layout)
 - [Subgrid](/en-US/docs/Web/CSS/CSS_Grid_Layout/Subgrid)
-- [Masonry Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout/Masonry_Layout) {{Experimental_Inline}}
+- [Masonry layout](/en-US/docs/Web/CSS/CSS_Grid_Layout/Masonry_Layout) {{Experimental_Inline}}
 
 ## Specifications
 

--- a/files/en-us/web/css/css_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/index.md
@@ -89,7 +89,7 @@ The example below shows a three-column track grid with new rows created at a min
 
 ## Reference
 
-### CSS properties
+### Properties
 
 - {{CSSxRef("display")}}
 - {{CSSxRef("grid-template-columns")}}
@@ -114,51 +114,49 @@ The example below shows a three-column track grid with new rows created at a min
 - {{CSSxRef("align-tracks")}} {{Experimental_Inline}}
 - {{CSSxRef("justify-tracks")}} {{Experimental_Inline}}
 
-### CSS functions
+### Functions
 
 - {{CSSxRef("repeat", "repeat()")}}
 - {{CSSxRef("minmax", "minmax()")}}
 - {{CSSxRef("fit-content_function", "fit-content()")}}
 
-### CSS data types
+### Data types
 
 - {{CSSxRef("&lt;flex&gt;")}}
-
-### Glossary entries
-
-- [Grid](/en-US/docs/Glossary/Grid)
-- [Grid lines](/en-US/docs/Glossary/Grid_Lines)
-- [Grid tracks](/en-US/docs/Glossary/Grid_Tracks)
-- [Grid cell](/en-US/docs/Glossary/Grid_Cell)
-- [Grid area](/en-US/docs/Glossary/Grid_Areas)
-- [Gutters](/en-US/docs/Glossary/Gutters)
-- [Grid axis](/en-US/docs/Glossary/Grid_Axis)
-- [Grid row](/en-US/docs/Glossary/Grid_Rows)
-- [Grid column](/en-US/docs/Glossary/Grid_Column)
 
 ## Guides
 
 - [Basic concepts of Grid Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout)
-- [Relationship of Grid Layout to other layout methods](/en-US/docs/Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout)
+- [Relationship of grid Layout to other layout methods](/en-US/docs/Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout)
 - [Layout using line-based placement](/en-US/docs/Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid)
 - [Grid template areas](/en-US/docs/Web/CSS/CSS_Grid_Layout/Grid_Template_Areas)
 - [Layout using named grid lines](/en-US/docs/Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines)
 - [Auto-placement in CSS Grid Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout/Auto-placement_in_CSS_Grid_Layout)
 - [Box alignment in CSS Grid Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout/Box_Alignment_in_CSS_Grid_Layout)
-- [CSS Grid, Logical Values and Writing Modes](/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Logical_Values_and_Writing_Modes)
+- [CSS grids, logical values, and writing modes](/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Logical_Values_and_Writing_Modes)
 - [CSS Grid Layout and accessibility](/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Layout_and_Accessibility)
 - [Realizing common layouts using CSS Grid Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout/Realizing_common_layouts_using_CSS_Grid_Layout)
 - [Subgrid](/en-US/docs/Web/CSS/CSS_Grid_Layout/Subgrid)
 - [Masonry Layout](/en-US/docs/Web/CSS/CSS_Grid_Layout/Masonry_Layout) {{Experimental_Inline}}
 
-## External resources
+## Specifications
 
+{{Specifications}}
+
+## See also
+
+- Glossary terms:
+  - [Grid](/en-US/docs/Glossary/Grid)
+  - [Grid lines](/en-US/docs/Glossary/Grid_Lines)
+  - [Grid tracks](/en-US/docs/Glossary/Grid_Tracks)
+  - [Grid cell](/en-US/docs/Glossary/Grid_Cell)
+  - [Grid area](/en-US/docs/Glossary/Grid_Areas)
+  - [Gutters](/en-US/docs/Glossary/Gutters)
+  - [Grid axis](/en-US/docs/Glossary/Grid_Axis)
+  - [Grid row](/en-US/docs/Glossary/Grid_Rows)
+  - [Grid column](/en-US/docs/Glossary/Grid_Column)
 - [Grid by Example](https://gridbyexample.com/) - A collection of usage examples and video tutorials
 - [CSS Grid Reference - Codrops](https://tympanus.net/codrops/css_reference/grid/)
 - [CSS Grid Inspector - Firefox DevTools](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/examine_grid_layouts/index.html)
 - [CSS Grid Playground](https://mozilladevelopers.github.io/playground/css-grid/)
 - [CSS Grid Garden](https://cssgridgarden.com) - A game for learning CSS grid
-
-## Specifications
-
-{{Specifications}}

--- a/files/en-us/web/css/css_grid_layout/layout_using_named_grid_lines/index.md
+++ b/files/en-us/web/css/css_grid_layout/layout_using_named_grid_lines/index.md
@@ -1,5 +1,5 @@
 ---
-title: Layout using named grid lines
+title: Grid layout using named grid lines
 slug: Web/CSS/CSS_Grid_Layout/Layout_using_Named_Grid_Lines
 tags:
   - CSS

--- a/files/en-us/web/css/css_grid_layout/line-based_placement_with_css_grid/index.md
+++ b/files/en-us/web/css/css_grid_layout/line-based_placement_with_css_grid/index.md
@@ -1,5 +1,5 @@
 ---
-title: Line-based placement with CSS Grid
+title: Grid layout using line-based placement
 slug: Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid
 tags:
   - CSS

--- a/files/en-us/web/css/css_grid_layout/masonry_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/masonry_layout/index.md
@@ -1,5 +1,5 @@
 ---
-title: Masonry Layout
+title: Masonry layout
 slug: Web/CSS/CSS_Grid_Layout/Masonry_Layout
 tags:
   - CSS

--- a/files/en-us/web/css/css_grid_layout/realizing_common_layouts_using_css_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/realizing_common_layouts_using_css_grid_layout/index.md
@@ -1,5 +1,5 @@
 ---
-title: Realizing common layouts using CSS Grid Layout
+title: Realizing common layouts using grids
 slug: Web/CSS/CSS_Grid_Layout/Realizing_common_layouts_using_CSS_Grid_Layout
 tags:
   - CSS

--- a/files/en-us/web/css/css_grid_layout/relationship_of_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/relationship_of_grid_layout/index.md
@@ -446,7 +446,7 @@ I have given `.box3` position relative and then positioned the sub-item with the
 
 {{ EmbedLiveSample('With_a_grid_area_as_the_parent', '500', '460') }}
 
-## Grid and `display: contents`
+## Grid and display: contents
 
 A final interaction with another layout specification that is worth noting is the interaction between CSS Grid Layout and `display: contents`. The `contents` value of the display property is a new value that is described in the [Display specification](https://drafts.csswg.org/css-display/#box-generation) as follows:
 
@@ -510,7 +510,7 @@ In the following markup, I have a grid and the first item on the grid is set to 
 
 {{ EmbedLiveSample('Grid_layout_with_nested_child_elements', '400', '440') }}
 
-### Using `display: contents`
+### Using display: contents
 
 If I now add `display:` `contents` to the rules for `box1`, the box for that item vanishes and the sub-items now become grid items and lay themselves out using the auto-placement rules.
 
@@ -573,5 +573,5 @@ As you can see from this guide, CSS Grid Layout is just one part of your toolkit
 
 ## See also
 
-- [Flexbox Guides](/en-US/docs/Learn/CSS/CSS_layout/Flexbox)
-- [Multiple-column Layout Guides](/en-US/docs/Web/CSS/CSS_Columns)
+- [Flexbox guides](/en-US/docs/Learn/CSS/CSS_layout/Flexbox)
+- [Multiple-column layout guides](/en-US/docs/Web/CSS/CSS_Columns)

--- a/files/en-us/web/css/css_logical_properties/index.md
+++ b/files/en-us/web/css/css_logical_properties/index.md
@@ -36,7 +36,7 @@ Logical properties and values use the abstract terms _block_ and _inline_ to des
 - {{CSSxRef("min-block-size")}}
 - {{CSSxRef("min-inline-size")}}
 
-### Properties for margins, borders and padding
+### Properties for margins, borders, and padding
 
 - {{CSSxRef("border-block")}}
 - {{CSSxRef("border-block-color")}}
@@ -116,9 +116,9 @@ Logical properties and values use the abstract terms _block_ and _inline_ to des
 ## Guides
 
 - [Basic concepts of logical properties and values](/en-US/docs/Web/CSS/CSS_Logical_Properties/Basic_concepts)
-- [Logical Properties for sizing](/en-US/docs/Web/CSS/CSS_Logical_Properties/Sizing)
-- [Logical Properties for margins, borders and padding](/en-US/docs/Web/CSS/CSS_Logical_Properties/Margins_borders_padding)
-- [Logical Properties for floating and positioning](/en-US/docs/Web/CSS/CSS_Logical_Properties/Floating_and_positioning)
+- [Logical properties for sizing](/en-US/docs/Web/CSS/CSS_Logical_Properties/Sizing)
+- [Logical properties for margins, borders, and padding](/en-US/docs/Web/CSS/CSS_Logical_Properties/Margins_borders_padding)
+- [Logical properties for floating and positioning](/en-US/docs/Web/CSS/CSS_Logical_Properties/Floating_and_positioning)
 
 ## Specifications
 

--- a/files/en-us/web/css/css_logical_properties/margins_borders_padding/index.md
+++ b/files/en-us/web/css/css_logical_properties/margins_borders_padding/index.md
@@ -1,5 +1,5 @@
 ---
-title: Logical properties for margins, borders and padding
+title: Logical properties for margins, borders, and padding
 slug: Web/CSS/CSS_Logical_Properties/Margins_borders_padding
 tags:
   - CSS

--- a/files/en-us/web/css/css_miscellaneous/index.md
+++ b/files/en-us/web/css/css_miscellaneous/index.md
@@ -18,10 +18,6 @@ These pages contain CSS properties that are supported by browsers but either are
 - {{cssxref("all")}}
 - {{cssxref("text-rendering")}}
 
-## Guides
-
-_None._
-
 ## Specifications
 
 _These properties are mostly unrelated to each other. Consult their individual pages for specifications._

--- a/files/en-us/web/css/css_pages/index.md
+++ b/files/en-us/web/css/css_pages/index.md
@@ -17,7 +17,7 @@ spec-urls:
 
 ## Reference
 
-### CSS properties
+### Properties
 
 - {{cssxref("page-break-after")}}
 - {{cssxref("page-break-before")}}

--- a/files/en-us/web/css/css_positioning/index.md
+++ b/files/en-us/web/css/css_positioning/index.md
@@ -15,7 +15,7 @@ spec-urls: https://drafts.csswg.org/css-position/
 
 ## Reference
 
-### CSS properties
+### Properties
 
 - {{cssxref("top")}}
 - {{cssxref("right")}}

--- a/files/en-us/web/css/css_scroll_snap/index.md
+++ b/files/en-us/web/css/css_scroll_snap/index.md
@@ -15,7 +15,7 @@ spec-urls: https://drafts.csswg.org/css-scroll-snap/
 
 ## Reference
 
-### CSS Properties on Containers
+### Properties on containers
 
 - {{cssxref("scroll-snap-type")}}
 - {{cssxref("scroll-padding")}}
@@ -30,7 +30,7 @@ spec-urls: https://drafts.csswg.org/css-scroll-snap/
 - {{cssxref("scroll-padding-block-start")}}
 - {{cssxref("scroll-padding-block-end")}}
 
-### CSS Properties on Children
+### Properties on children
 
 - {{cssxref("scroll-snap-align")}}
 - {{cssxref("scroll-margin")}}

--- a/files/en-us/web/css/css_scroll_snap_points/index.md
+++ b/files/en-us/web/css/css_scroll_snap_points/index.md
@@ -17,7 +17,7 @@ spec-urls: https://drafts.csswg.org/css-scroll-snap/
 
 ## Reference
 
-### CSS properties
+### Properties
 
 - {{cssxref("scroll-snap-coordinate")}}
 - {{cssxref("scroll-snap-destination")}}

--- a/files/en-us/web/css/css_scrollbars/index.md
+++ b/files/en-us/web/css/css_scrollbars/index.md
@@ -14,9 +14,9 @@ browser-compat:
 
 **CSS Scrollbars** standardizes the obsolete scrollbar color properties introduced in 2000 by Windows IE 5.5.
 
-## Basic Example
+## Basic example
 
-In this example we have chosen to use a thin scrollbar, with a green track and purple thumb.
+In this example, we have chosen to use a thin scrollbar with a green track and purple thumb.
 
 ```css
 .scroller {
@@ -46,7 +46,7 @@ Dandelion cucumber earthnut pea peanut soko zucchini.
 
 ## Reference
 
-### CSS Properties
+### Properties
 
 - {{CSSxRef("scrollbar-width")}}
 - {{CSSxRef("scrollbar-color")}}

--- a/files/en-us/web/css/css_selectors/index.md
+++ b/files/en-us/web/css/css_selectors/index.md
@@ -76,7 +76,7 @@ spec-urls: https://drafts.csswg.org/selectors/
     **Syntax:** `A || B`
     **Example:** `col || td` will match all {{HTMLElement("td")}} elements that belong to the scope of the {{HTMLElement("col")}}.
 
-## Pseudo
+## Pseudo selectors
 
 - [Pseudo classes](/en-US/docs/Web/CSS/Pseudo-classes)
   - : The `:` pseudo allow the selection of elements based on state information that is not contained in the document tree.

--- a/files/en-us/web/css/css_selectors/index.md
+++ b/files/en-us/web/css/css_selectors/index.md
@@ -76,7 +76,7 @@ spec-urls: https://drafts.csswg.org/selectors/
     **Syntax:** `A || B`
     **Example:** `col || td` will match all {{HTMLElement("td")}} elements that belong to the scope of the {{HTMLElement("col")}}.
 
-## Pseudo selectors
+## Pseudo-classes and pseudo-elements
 
 - [Pseudo classes](/en-US/docs/Web/CSS/Pseudo-classes)
   - : The `:` pseudo allow the selection of elements based on state information that is not contained in the document tree.

--- a/files/en-us/web/css/css_shapes/basic_shapes/index.md
+++ b/files/en-us/web/css/css_shapes/basic_shapes/index.md
@@ -1,5 +1,5 @@
 ---
-title: Basic Shapes
+title: Basic shapes
 slug: Web/CSS/CSS_Shapes/Basic_Shapes
 tags:
   - CSS
@@ -11,26 +11,26 @@ tags:
 
 CSS Shapes can be defined using the {{cssxref("&lt;basic-shape&gt;")}} type, and in this guide I'll explain how each of the different values accepted by this type work. They range from simple circles to complex polygons.
 
-Before looking at the shapes, it is worth understanding two pieces of information that go together to make these shapes possible:
+Before looking at shapes, it is worth understanding two pieces of information that go together to make these shapes possible:
 
 - The `<basic-shape>` type
 - The reference box
 
 ## The \<basic-shape> type
 
-The `<basic-shape>` type is used as the value for all of our Basic Shapes. This type uses Functional Notation: the type of shape is followed by brackets, inside of which are additional values used to describe the shape.
+The `<basic-shape>` type is used as the value for all of our basic shapes. This type uses Functional Notation: the type of shape is followed by brackets, inside of which are additional values used to describe the shape.
 
 The arguments which are accepted vary depending on the shape that you are creating. We will cover these in the examples below.
 
 ## The reference box
 
-Understanding the reference box used by CSS Shapes is important when using Basic Shapes, as it defines each shape's coordinate system. You have already met the reference box in [the guide on creating shapes from Box Values](/en-US/docs/Web/CSS/CSS_Shapes/From_box_values), which directly uses the reference box to create the shape.
+Understanding the reference box used by CSS Shapes is important when using basic shapes, as it defines each shape's coordinate system. You have already met the reference box in [the guide on creating shapes from Box Values](/en-US/docs/Web/CSS/CSS_Shapes/From_box_values), which directly uses the reference box to create the shape.
 
-The Firefox Shapes Inspector helpfully shows the reference box in use when you inspect a shape. In the screenshot below I have created a circle, using `shape-outside: circle(50%)`. The floated element has 20 pixels of padding, border and margin applied, and the Shapes Inspector highlights these reference boxes. When using a Basic Shape the reference box used by default is the margin-box. You can see in the screenshot that the shape is being defined with reference to that part of the Box Model.
+The Firefox Shapes Inspector helpfully shows the reference box in use when you inspect a shape. In the screenshot below I have created a circle, using `shape-outside: circle(50%)`. The floated element has 20 pixels of padding, border and margin applied, and the Shapes Inspector highlights these reference boxes. When using a basic shape, the reference box used by default is the margin-box. You can see in the screenshot that the shape is being defined with reference to that part of the Box Model.
 
 ![An imaged clipped into a circle floated left, with a paragraph of text. The left edge of the text is circular abutting the clipped shape on the outside of the margin with the margin following the shape clipping.](shapes-reference-box.png)
 
-You can add the various Box Values after your Basic Shape definition. Therefore the default behavior is as if you have defined.
+You can add the various box values after your basic shape definition. Therefore the default behavior is as if you have defined.
 
 ```css
 .shape {
@@ -48,7 +48,7 @@ You can therefore change this in order that your shape uses the different parts 
 
 What is worth noting is that the `margin-box` will clip the shape, therefore shapes created in reference to other shapes which extend past the margin box will have the shape clipped to the margin box. We will see this in the following examples of basic shapes.
 
-For an excellent description of references boxes as they apply to CSS Shapes see [Understanding Reference Boxes for CSS Shapes](http://razvancaliman.com/writing/css-shapes-reference-boxes/).
+For an excellent description of references boxes as they apply to CSS Shapes, see [Understanding Reference Boxes for CSS Shapes](http://razvancaliman.com/writing/css-shapes-reference-boxes/).
 
 ## inset()
 

--- a/files/en-us/web/css/css_shapes/from_box_values/index.md
+++ b/files/en-us/web/css/css_shapes/from_box_values/index.md
@@ -66,12 +66,12 @@ The `content-box` value defines the shape enclosed by the outside content edge. 
 
 {{EmbedGHLiveSample("css-examples/shapes/box/content-box.html", '100%', 800)}}
 
-## When to use the box values
+## When to use box values
 
-Using box values is a simple way to create shapes, however this is by nature only going to work with very simple shapes that can be defined using the well-supported `border-radius` property. The examples shown above show one such use case. You can create a circular shape using border-radius and then curve text around it.
+Using box values is a simple way to create shapes; however, this is by nature only going to work with very simple shapes that can be defined using the well-supported `border-radius` property. The examples shown above show one such use case. You can create a circular shape using border-radius and then curve text around it.
 
 You can create some interesting effects however with just this simple technique. In my final example of this section, I have floated two elements left and right, giving each a border-radius of 100% in the direction closest to the text.
 
 {{EmbedGHLiveSample("css-examples/shapes/box/bottom-margin-box.html", '100%', 800)}}
 
-For more complex shapes you will need to use one of the [basic shapes](/en-US/docs/Web/CSS/CSS_Shapes/Basic_Shapes) as a value, or define your Shape from an image as covered in other guides in this section.
+For more complex shapes, you will need to use one of the [basic shapes](/en-US/docs/Web/CSS/CSS_Shapes/Basic_Shapes) as a value, or define your shape from an image as covered in other guides in this section.

--- a/files/en-us/web/css/css_shapes/index.md
+++ b/files/en-us/web/css/css_shapes/index.md
@@ -36,11 +36,10 @@ The example below shows an image that has been floated left, and the `shape-outs
 
 ## Guides
 
-- [Overview of CSS Shapes](/en-US/docs/Web/CSS/CSS_Shapes/Overview_of_CSS_Shapes)
-- [Shapes from Box Values](/en-US/docs/Web/CSS/CSS_Shapes/From_box_values)
-- [Basic Shapes](/en-US/docs/Web/CSS/CSS_Shapes/Basic_Shapes)
-- [Shapes from Images](/en-US/docs/Web/CSS/CSS_Shapes/Shapes_From_Images)
-- [Edit Shape Paths in CSS — Firefox Developer Tools](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/edit_css_shapes/index.html)
+- [Overview of shapes](/en-US/docs/Web/CSS/CSS_Shapes/Overview_of_CSS_Shapes)
+- [Shapes from box values](/en-US/docs/Web/CSS/CSS_Shapes/From_box_values)
+- [Basic shapes](/en-US/docs/Web/CSS/CSS_Shapes/Basic_Shapes)
+- [Shapes from images](/en-US/docs/Web/CSS/CSS_Shapes/Shapes_From_Images)
 
 ## Specifications
 
@@ -48,10 +47,11 @@ The example below shows an image that has been floated left, and the `shape-outs
 
 ## See also
 
-- [A list of CSS Shapes resources](https://codepen.io/KristopherVanSant/post/css-shapes-resources)
+- [CSS Shapes resources](https://codepen.io/KristopherVanSant/post/css-shapes-resources)
 - [CSS Shapes 101](https://alistapart.com/article/css-shapes-101/)
 - [Creating non-rectangular layouts with CSS Shapes](https://www.sarasoueidan.com/blog/css-shapes/)
-- [How To Use CSS Shapes in Your Web Design](https://webdesign.tutsplus.com/tutorials/how-to-use-css-shapes-in-your-web-design--cms-27498)
+- [How to use CSS Shapes in your web design](https://webdesign.tutsplus.com/tutorials/how-to-use-css-shapes-in-your-web-design--cms-27498)
 - [How to get started with CSS Shapes](https://www.webdesignerdepot.com/2015/03/how-to-get-started-with-css-shapes/)
 - [What I learned in one weekend with CSS Shapes](https://medium.com/@MHarreither/what-i-learned-in-one-weekend-with-css-shapes-66ae9be69cc5)
-- [CSS vs. SVG: Shapes and Arbitrarily-Shaped UI Components](https://blog.adobe.com/en/2015/09/01/css-vs-svg-shapes-and-arbitrarily-shaped-ui-components)
+- [CSS vs. SVG: Shapes and arbitrarily-shaped UI components](https://blog.adobe.com/en/2015/09/01/css-vs-svg-shapes-and-arbitrarily-shaped-ui-components)
+- [Edit shape paths in CSS — Firefox Developer Tools](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/edit_css_shapes/index.html)

--- a/files/en-us/web/css/css_shapes/index.md
+++ b/files/en-us/web/css/css_shapes/index.md
@@ -42,16 +42,16 @@ The example below shows an image that has been floated left, and the `shape-outs
 - [Shapes from Images](/en-US/docs/Web/CSS/CSS_Shapes/Shapes_From_Images)
 - [Edit Shape Paths in CSS — Firefox Developer Tools](https://firefox-source-docs.mozilla.org/devtools-user/page_inspector/how_to/edit_css_shapes/index.html)
 
-## External Resources
+## Specifications
+
+{{Specifications}}
+
+## See also
 
 - [A list of CSS Shapes resources](https://codepen.io/KristopherVanSant/post/css-shapes-resources)
 - [CSS Shapes 101](https://alistapart.com/article/css-shapes-101/)
 - [Creating non-rectangular layouts with CSS Shapes](https://www.sarasoueidan.com/blog/css-shapes/)
-- [How To Use CSS Shapes In Your Web Design](https://webdesign.tutsplus.com/tutorials/how-to-use-css-shapes-in-your-web-design--cms-27498)
-- [How To Get Started With CSS Shapes](https://www.webdesignerdepot.com/2015/03/how-to-get-started-with-css-shapes/)
-- [What I Learned In One Weekend With CSS Shapes](https://medium.com/@MHarreither/what-i-learned-in-one-weekend-with-css-shapes-66ae9be69cc5)
+- [How To Use CSS Shapes in Your Web Design](https://webdesign.tutsplus.com/tutorials/how-to-use-css-shapes-in-your-web-design--cms-27498)
+- [How to get started with CSS Shapes](https://www.webdesignerdepot.com/2015/03/how-to-get-started-with-css-shapes/)
+- [What I learned in one weekend with CSS Shapes](https://medium.com/@MHarreither/what-i-learned-in-one-weekend-with-css-shapes-66ae9be69cc5)
 - [CSS vs. SVG: Shapes and Arbitrarily-Shaped UI Components](https://blog.adobe.com/en/2015/09/01/css-vs-svg-shapes-and-arbitrarily-shaped-ui-components)
-
-## Specifications
-
-{{Specifications}}

--- a/files/en-us/web/css/css_shapes/overview_of_css_shapes/index.md
+++ b/files/en-us/web/css/css_shapes/overview_of_css_shapes/index.md
@@ -1,5 +1,5 @@
 ---
-title: Overview of CSS Shapes
+title: Overview of shapes
 slug: Web/CSS/CSS_Shapes/Overview_of_CSS_Shapes
 tags:
   - CSS
@@ -34,9 +34,9 @@ In the following example I have an image floated left. I have then applied the `
 
 As in this level of the specification an element has to be floated in order to apply `<basic-shape>` to it; this has the side-effect of creating a simple fallback for many cases. If you do not have Shapes support in the browser, the user will see content flowing around the sides of a rectangular box as before. If they do have Shapes support then the visual display is enhanced.
 
-### Basic Shapes
+### Basic shapes
 
-The value `circle(50%)` is an example of a Basic Shape. The specification defines four `<basic-shape>` values, which are:
+The value `circle(50%)` is an example of a basic shape. The specification defines four `<basic-shape>` values, which are:
 
 - `inset()`
 - `circle()`
@@ -49,20 +49,20 @@ We have already seen how `circle()` creates a circular shape. An `ellipse()` is 
 
 In our [Guide to Basic Shapes](/en-US/docs/Web/CSS/CSS_Shapes/Basic_Shapes) we explore each of the possible Basic Shapes and how to create them.
 
-### Shapes from the Box Value
+### Shapes from the box value
 
-Shapes can also be created around the Box Value, therefore you could create your shape on the:
+Shapes can also be created around the box value. Therefor, you could create your shape on:
 
 - `border-box`
 - `padding-box`
 - `content-box`
 - `margin-box`
 
-In the example below you can change the value `border-box` to any of the other allowed values to see how the shape moves closer or further away from the box.
+In the example below, you can change the value `border-box` to any of the other allowed values to see how the shape moves closer or further away from the box.
 
 {{EmbedGHLiveSample("css-examples/shapes/overview/box.html", '100%', 810)}}
 
-To explore the box values in more detail see our guide covering [Shapes From Box Values](/en-US/docs/Web/CSS/CSS_Shapes/From_box_values).
+To explore the box values in more detail, see our guide covering [Shapes from box values](/en-US/docs/Web/CSS/CSS_Shapes/From_box_values).
 
 ### Shapes from images
 
@@ -94,7 +94,7 @@ In the example below we have added a `shape-margin` to a basic shape. Change the
 
 ## Using Generated Content as the floated item
 
-In the examples above we have used images or a visible element to define the shape, meaning that you can see the shape on the page. Instead, you might want to cause some text to flow along a non-rectangular invisible line. You can do this with Shapes, however you will still need a floated item, which you can then make invisible. That could be a redundant element inserted into the document, an empty {{htmlelement("div")}} or {{htmlelement("span")}} perhaps, but our preference is to use generated content. This means we can keep things used for styling inside the CSS.
+In the examples above, we have used images or a visible element to define the shape, meaning that you can see the shape on the page. Instead, you might want to cause some text to flow along a non-rectangular invisible line. You can do this with Shapes, however you will still need a floated item, which you can then make invisible. That could be a redundant element inserted into the document, an empty {{htmlelement("div")}} or {{htmlelement("span")}} perhaps, but our preference is to use generated content. This means we can keep things used for styling inside the CSS.
 
 In this next example, we use generated content to insert an element with height and width of 150px. We can then use Basic Shapes, Box Values or even the Alpha Channel of an image to create a shape for the text to wrap around.
 

--- a/files/en-us/web/css/css_shapes/shapes_from_images/index.md
+++ b/files/en-us/web/css/css_shapes/shapes_from_images/index.md
@@ -1,5 +1,5 @@
 ---
-title: Shapes From Images
+title: Shapes from images
 slug: Web/CSS/CSS_Shapes/Shapes_From_Images
 tags:
   - CSS
@@ -10,15 +10,15 @@ tags:
 
 In this guide, we will take a look at how we can create a shape from an image file with an alpha channel or even from a CSS Gradient. This is a very flexible way to create shapes. Rather than drawing a path with a complex polygon in CSS, you can create the shape in a graphics program and then use the path created by the pixels less opaque than a threshold value.
 
-## A simple shape from an image
+## Creating shapes from images
 
-To use an image for the shape the image needs to have an Alpha Channel, an area that is not fully opaque. The {{cssxref("shape-image-threshold")}} property is used to set a threshold for this opacity. Pixels that are more opaque than this value will be used to calculate the area of the shape.
+To use an image for creating a shape, the image needs to have an Alpha Channel, an area that is not fully opaque. The {{cssxref("shape-image-threshold")}} property is used to set a threshold for this opacity. Pixels that are more opaque than this value will be used to calculate the area of the shape.
 
-As a simple example, I have an image of a star with a solid red area and an area that is fully transparent. I use the path to the image file as the value of the {{cssxref("shape-outside")}} property. The content now wraps around the star shape.
+In the example below, there is an image of a star with a solid red area and an area that is fully transparent. The path to the image file is used as the value for the {{cssxref("shape-outside")}} property. The content now wraps around the star shape.
 
 {{EmbedGHLiveSample("css-examples/shapes/image/simple-example.html", '100%', 800)}}
 
-I can use {{cssxref("shape-margin")}} to move the text away from the shape, giving a margin around the created shape and the text.
+You can use {{cssxref("shape-margin")}} to move the text away from the shape, giving a margin around the created shape and the text.
 
 {{EmbedGHLiveSample("css-examples/shapes/image/margin.html", '100%', 800)}}
 
@@ -48,16 +48,16 @@ You do need something to float, but that could be some generated content as in t
 
 ## Creating shapes using a gradient
 
-As a [CSS gradient](/en-US/docs/Web/CSS/CSS_Images/Using_CSS_gradients) is treated as an image, you can use a gradient to generate your shape, by having transparent or semi-transparent areas as part of the gradient.
+Because a [CSS gradient](/en-US/docs/Web/CSS/CSS_Images/Using_CSS_gradients) is treated as an image, you can use a gradient to generate a shape by having transparent or semi-transparent areas as part of the gradient.
 
-In this next example, I have used generated content and floated this content, giving it a background image of a linear gradient. I am using that same value as the value of {{cssxref("shape-outside")}}. The linear gradient goes from purple to transparent, so by changing the value of {{cssxref("shape-image-threshold")}} I can decide how transparent the pixels need to be that create my shape. You can play with that value in the example below to see how the diagonal line will move across the shape depending on that value.
+The next example uses generated content. The content has been floated, giving it a background image of a linear gradient. I am using that same value as the value of {{cssxref("shape-outside")}}. The linear gradient goes from purple to transparent. By changing the value of {{cssxref("shape-image-threshold")}}, you can decide how transparent the pixels need to be that create the shape. You can play with that value in the example below to see how the diagonal line will move across the shape depending on that value.
 
 You could also try removing the background image completely, thus using the gradient purely to create the shape and not displaying it on the page at all.
 
 {{EmbedGHLiveSample("css-examples/shapes/image/gradient.html", '100%', 800)}}
 
-In this next example, I am using a radial gradient with an ellipse, once again using a transparent part of the gradient to create the shape.
+The next example uses a radial gradient with an ellipse, once again using a transparent part of the gradient to create the shape.
 
 {{EmbedGHLiveSample("css-examples/shapes/image/radial-gradient.html", '100%', 800)}}
 
-You can experiment directly in these live examples, to see how changing the gradient will change the path of your shape.
+You can experiment directly in these live examples to see how changing the gradient will change the path of your shape.

--- a/files/en-us/web/css/css_text_decoration/index.md
+++ b/files/en-us/web/css/css_text_decoration/index.md
@@ -31,10 +31,6 @@ spec-urls: https://drafts.csswg.org/css-text-decor/
 - {{cssxref("text-underline-offset")}}
 - {{cssxref("text-underline-position")}}
 
-## Guides
-
-_None._
-
 ## Examples
 
 ```css

--- a/files/en-us/web/css/css_variables/index.md
+++ b/files/en-us/web/css/css_variables/index.md
@@ -13,7 +13,9 @@ spec-urls: https://drafts.csswg.org/css-variables/
 
 **CSS Custom Properties for Cascading Variables** is a [CSS](/en-US/docs/Web/CSS) module that allows for the creation of custom properties that can be used over and over.
 
-## CSS properties
+## Reference
+
+### Properties
 
 - {{cssxref("--*")}}
 

--- a/files/en-us/web/css/media_queries/index.md
+++ b/files/en-us/web/css/media_queries/index.md
@@ -47,7 +47,7 @@ You can learn more about programmatically using media queries in [Testing media 
   - : Introduces media queries, their syntax, and the operators and media features which are used to construct media query expressions.
 - [Testing media queries programmatically](/en-US/docs/Web/CSS/Media_Queries/Testing_media_queries)
   - : Describes how to use media queries in your JavaScript code to determine the state of a device, and to set up listeners that notify your code when the results of media queries change (such as when the user rotates the screen or resizes the browser).
-- [Using Media Queries for Accessibility](/en-US/docs/Web/CSS/Media_Queries/Using_Media_Queries_for_Accessibility)
+- [Using media queries for accessibility](/en-US/docs/Web/CSS/Media_Queries/Using_Media_Queries_for_Accessibility)
   - : Learn how Media Queries can help users understand your website better.
 
 ## Specifications

--- a/files/en-us/web/css/media_queries/using_media_queries_for_accessibility/index.md
+++ b/files/en-us/web/css/media_queries/using_media_queries_for_accessibility/index.md
@@ -1,5 +1,5 @@
 ---
-title: Using Media Queries for Accessibility
+title: Using media queries for accessibility
 slug: Web/CSS/Media_Queries/Using_Media_Queries_for_Accessibility
 tags:
   - '@media'

--- a/files/en-us/web/css/pseudo-elements/index.md
+++ b/files/en-us/web/css/pseudo-elements/index.md
@@ -36,7 +36,7 @@ You can use only one pseudo-element in a selector. It must appear after the simp
 
 > **Note:** As a rule, double colons (`::`) should be used instead of a single colon (`:`). This distinguishes pseudo-classes from pseudo-elements. However, since this distinction was not present in older versions of the W3C spec, most browsers support both syntaxes for the original pseudo-elements.
 
-## Index
+## Alphabetical index
 
 Pseudo-elements defined by a set of CSS specifications include the following:
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### How to access

You get the 'Modules' drop-down in the 'Reference' section in the CSS sidebar.

#### Current status
<!-- ✍️ In a sentence or two, describe your changes -->

The 'Modules' pages include more or less the following sections and subsections based on whether or not they are applicable for the page (examples: [CSS Images](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Images) and [CSS Display](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Display)):

```
- Reference
  - Properties
  - At-rules
  - Functions
  - Data types
- Guides
- Specifications
- Browser compatibility
- See also
```

The subsections under 'Reference' also match the categories in the CSS sidebar (screenshot below).

![Screenshot 2022-08-10 at 12 06 34 AM](https://user-images.githubusercontent.com/23019147/183771867-58e62ebf-bb32-4923-91b6-2a13b9e24854.png)
====
 
- On some pages, the section title "Properties" is "CSS Properties". 
- On some pages, the section title "Alt-rules" is "CSS Alt-rules".  


#### What this PR fixes
- Updates the section titles to ensure consistency: "Properties", "Alt-rules", "Data types"
- Updates casing of page and section titles to follow sentence casing
- Moves glossary entries and external resources to "See also" section
- Rewrites some sentences to remove the occurrence of the first person "I"

#### Question
Should the "Types" drop-down in the sidebar be called "Data types"?



#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
