### PR TITLE
Update BCD info, part 7

### DIFF
--- a/files/en-us/web/api/document/exitpointerlock/index.md
+++ b/files/en-us/web/api/document/exitpointerlock/index.md
@@ -4,13 +4,12 @@ slug: Web/API/Document/exitPointerLock
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Method
   - Reference
   - mouse lock
 browser-compat: api.Document.exitPointerLock
 ---
-{{APIRef("DOM")}} {{SeeCompatTable}}
+{{APIRef("DOM")}}
 
 The **`exitPointerLock()`** method asynchronously releases a
 pointer lock previously requested through {{domxref("Element.requestPointerLock")}}.

--- a/files/en-us/web/api/document/origin/index.md
+++ b/files/en-us/web/api/document/origin/index.md
@@ -6,7 +6,6 @@ tags:
   - API
   - DOM
   - Document
-  - Experimental
   - Interface
   - Property
   - Read-only

--- a/files/en-us/web/api/document/timeline/index.md
+++ b/files/en-us/web/api/document/timeline/index.md
@@ -8,7 +8,6 @@ tags:
   - AnimationTimeline
   - Document
   - DocumentTimeline
-  - Experimental
   - Property
   - Reference
   - Web Animations

--- a/files/en-us/web/api/document/timeline/index.md
+++ b/files/en-us/web/api/document/timeline/index.md
@@ -16,7 +16,7 @@ tags:
   - web animations api
 browser-compat: api.Document.timeline
 ---
-{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}
+{{ APIRef("Web Animations") }}
 
 The `timeline` readonly property of the {{domxref("Document")}} interface represents the default timeline of the current document. This timeline is a special instance of {{domxref("DocumentTimeline")}} that is automatically created on page load.
 

--- a/files/en-us/web/api/dommatrix/dommatrix/index.md
+++ b/files/en-us/web/api/dommatrix/dommatrix/index.md
@@ -5,7 +5,6 @@ page-type: web-api-constructor
 tags:
   - API
   - Constructor
-  - Experimental
   - Geometry
   - Geometry Interfaces
   - Reference

--- a/files/en-us/web/api/domquad/index.md
+++ b/files/en-us/web/api/domquad/index.md
@@ -7,11 +7,10 @@ tags:
   - DOM
   - DOM Reference
   - DOMQuad
-  - Experimental
   - Geometry
 browser-compat: api.DOMQuad
 ---
-{{SeeCompatTable}}{{APIRef("Geometry Interfaces")}}
+{{APIRef("Geometry Interfaces")}}
 
 A `DOMQuad` is a collection of four `DOMPoint`s defining the corners of an arbitrary quadrilateral. Returning `DOMQuad`s lets `getBoxQuads()` return accurate information even when arbitrary 2D or 3D transforms are present. It has a handy `bounds` attribute returning a `DOMRectReadOnly` for those cases where you just want an axis-aligned bounding rectangle.
 

--- a/files/en-us/web/api/element/animationcancel_event/index.md
+++ b/files/en-us/web/api/element/animationcancel_event/index.md
@@ -13,7 +13,7 @@ tags:
 browser-compat: api.Element.animationcancel_event
 page-type: web-api-event
 ---
-{{APIRef}}{{SeeCompatTable}}
+{{APIRef}}
 
 The **`animationcancel`** event is fired when a [CSS Animation](/en-US/docs/Web/CSS/CSS_Animations) unexpectedly aborts. In other words, any time it stops running without sending an {{domxref("Element/animationend_event", "animationend")}} event. This might happen when the {{cssxref("animation-name")}} is changed such that the animation is removed, or when the animating node is hidden using CSS. Therefore, either directly or because any of its containing nodes are hidden.
 

--- a/files/en-us/web/api/element/getanimations/index.md
+++ b/files/en-us/web/api/element/getanimations/index.md
@@ -18,7 +18,7 @@ tags:
   - web animations api
 browser-compat: api.Element.getAnimations
 ---
-{{ SeeCompatTable() }}{{APIRef("Web Animations")}}
+{{APIRef("Web Animations")}}
 
 The `getAnimations()` method of the {{domxref("Element")}} interface
 (specified on the `Animatable` mixin) returns an array of all

--- a/files/en-us/web/api/element/getanimations/index.md
+++ b/files/en-us/web/api/element/getanimations/index.md
@@ -9,7 +9,6 @@ tags:
   - CSS Animations
   - CSS Transitions
   - Element
-  - Experimental
   - Method
   - Reference
   - Transitions

--- a/files/en-us/web/api/element/requestpointerlock/index.md
+++ b/files/en-us/web/api/element/requestpointerlock/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - DOM
-  - Experimental
   - Method
   - NeedsExample
   - PointerEvent
@@ -13,7 +12,7 @@ tags:
   - mouse lock
 browser-compat: api.Element.requestPointerLock
 ---
-{{ APIRef("DOM") }}{{ SeeCompatTable }}
+{{ APIRef("DOM") }}
 
 The **`Element.requestPointerLock()`** method lets you
 asynchronously ask for the pointer to be locked on the given element.

--- a/files/en-us/web/api/element/transitioncancel_event/index.md
+++ b/files/en-us/web/api/element/transitioncancel_event/index.md
@@ -12,7 +12,7 @@ tags:
 browser-compat: api.Element.transitioncancel_event
 page-type: web-api-event
 ---
-{{APIRef}}{{SeeCompatTable}}
+{{APIRef}}
 
 The **`transitioncancel`** event is fired when a [CSS transition](/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions) is canceled.
 

--- a/files/en-us/web/api/element/transitionrun_event/index.md
+++ b/files/en-us/web/api/element/transitionrun_event/index.md
@@ -13,7 +13,7 @@ tags:
 browser-compat: api.Element.transitionrun_event
 page-type: web-api-event
 ---
-{{APIRef}}{{SeeCompatTable}}
+{{APIRef}}
 
 The **`transitionrun`** event is fired when a [CSS transition](/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions) is first created, i.e. before any {{cssxref("transition-delay")}} has begun.
 

--- a/files/en-us/web/api/element/transitionstart_event/index.md
+++ b/files/en-us/web/api/element/transitionstart_event/index.md
@@ -12,7 +12,7 @@ tags:
 browser-compat: api.Element.transitionstart_event
 page-type: web-api-event
 ---
-{{APIRef}}{{SeeCompatTable}}
+{{APIRef}}
 
 The **`transitionstart`** event is fired when a [CSS transition](/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions) has actually started, i.e., after any {{cssxref("transition-delay")}} has ended.
 

--- a/files/en-us/web/api/extendablecookiechangeevent/changed/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/changed/index.md
@@ -8,10 +8,9 @@ tags:
   - Reference
   - changed
   - ExtendableCookieChangeEvent
-  - Experimental
 browser-compat: api.ExtendableCookieChangeEvent.changed
 ---
-{{securecontext_header}}{{APIRef("Cookie Store API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("Cookie Store API")}}
 
 The **`changed`** read-only property of the {{domxref("ExtendableCookieChangeEvent")}} interface returns any cookies that have been changed by the given `ExtendableCookieChangeEvent` instance.
 

--- a/files/en-us/web/api/extendablecookiechangeevent/deleted/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/deleted/index.md
@@ -8,10 +8,9 @@ tags:
   - Reference
   - deleted
   - ExtendableCookieChangeEvent
-  - Experimental
 browser-compat: api.ExtendableCookieChangeEvent.deleted
 ---
-{{securecontext_header}}{{APIRef("Cookie Store API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("Cookie Store API")}}
 
 The **`deleted`** read-only property of the {{domxref("ExtendableCookieChangeEvent")}} interface returns any cookies that have been deleted by the given `ExtendableCookieChangeEvent` instance.
 

--- a/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/extendablecookiechangeevent/index.md
@@ -7,10 +7,9 @@ tags:
   - Constructor
   - Reference
   - ExtendableCookieChangeEvent
-  - Experimental
 browser-compat: api.ExtendableCookieChangeEvent.ExtendableCookieChangeEvent
 ---
-{{securecontext_header}}{{APIRef("Cookie Store API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("Cookie Store API")}}
 
 The **`ExtendableCookieChangeEvent()`** constructor creates a new {{domxref("ExtendableCookieChangeEvent")}} object
 which is the event type passed to {{domxref("ServiceWorkerRegistration/cookiechange_event", "ServiceWorkerRegistration.oncookiechange()")}}.

--- a/files/en-us/web/api/extendablecookiechangeevent/index.md
+++ b/files/en-us/web/api/extendablecookiechangeevent/index.md
@@ -7,10 +7,9 @@ tags:
   - Interface
   - Reference
   - ExtendableCookieChangeEvent
-  - Experimental
 browser-compat: api.ExtendableCookieChangeEvent
 ---
-{{securecontext_header}}{{APIRef("Cookie Store API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("Cookie Store API")}}
 
 The **`ExtendableCookieChangeEvent`** interface of the['Cookie Store API'](/en-US/docs/Web/API/Cookie_Store_API) is the event type passed to {{domxref("ServiceWorkerRegistration.oncookiechange()")}} when any cookie changes occur. A cookie change event consists of a cookie and a type (either "changed" or "deleted".)
 

--- a/files/en-us/web/api/extendableevent/extendableevent/index.md
+++ b/files/en-us/web/api/extendableevent/extendableevent/index.md
@@ -5,7 +5,6 @@ page-type: web-api-constructor
 tags:
   - API
   - Constructor
-  - Experimental
   - ExtendableEvent
   - Reference
   - Service Workers

--- a/files/en-us/web/api/extendableevent/index.md
+++ b/files/en-us/web/api/extendableevent/index.md
@@ -4,7 +4,6 @@ slug: Web/API/ExtendableEvent
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - ExtendableEvent
   - Interface
   - Offline

--- a/files/en-us/web/api/extendablemessageevent/data/index.md
+++ b/files/en-us/web/api/extendablemessageevent/data/index.md
@@ -4,7 +4,6 @@ slug: Web/API/ExtendableMessageEvent/data
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - ExtendableMessageEvent
   - Property
   - Reference

--- a/files/en-us/web/api/extendablemessageevent/extendablemessageevent/index.md
+++ b/files/en-us/web/api/extendablemessageevent/extendablemessageevent/index.md
@@ -5,7 +5,6 @@ page-type: web-api-constructor
 tags:
   - API
   - Constructor
-  - Experimental
   - ExtendableMessageEvent
   - Reference
   - Service Workers

--- a/files/en-us/web/api/extendablemessageevent/index.md
+++ b/files/en-us/web/api/extendablemessageevent/index.md
@@ -4,7 +4,6 @@ slug: Web/API/ExtendableMessageEvent
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - ExtendableMessageEvent
   - Interface
   - Reference

--- a/files/en-us/web/api/extendablemessageevent/lasteventid/index.md
+++ b/files/en-us/web/api/extendablemessageevent/lasteventid/index.md
@@ -4,7 +4,6 @@ slug: Web/API/ExtendableMessageEvent/lastEventId
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - ExtendableMessageEvent
   - Property
   - Reference

--- a/files/en-us/web/api/extendablemessageevent/origin/index.md
+++ b/files/en-us/web/api/extendablemessageevent/origin/index.md
@@ -4,7 +4,6 @@ slug: Web/API/ExtendableMessageEvent/origin
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - ExtendableMessageEvent
   - Property
   - Reference

--- a/files/en-us/web/api/extendablemessageevent/ports/index.md
+++ b/files/en-us/web/api/extendablemessageevent/ports/index.md
@@ -4,7 +4,6 @@ slug: Web/API/ExtendableMessageEvent/ports
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - ExtendableMessageEvent
   - Property
   - Reference

--- a/files/en-us/web/api/extendablemessageevent/source/index.md
+++ b/files/en-us/web/api/extendablemessageevent/source/index.md
@@ -4,7 +4,6 @@ slug: Web/API/ExtendableMessageEvent/source
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - ExtendableMessageEvent
   - Property
   - Reference

--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -4,7 +4,6 @@ slug: Web/API/fetch
 page-type: web-api-global-function
 tags:
   - API
-  - Experimental
   - Fetch
   - Fetch API
   - GlobalFetch

--- a/files/en-us/web/api/fetch_api/using_fetch/index.md
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.md
@@ -5,7 +5,6 @@ page-type: guide
 tags:
   - API
   - BODY
-  - Experimental
   - Fetch
   - Guide
   - HTTP

--- a/files/en-us/web/api/fetchevent/clientid/index.md
+++ b/files/en-us/web/api/fetchevent/clientid/index.md
@@ -4,7 +4,6 @@ slug: Web/API/FetchEvent/clientId
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - FetchEvent
   - Property
   - Reference

--- a/files/en-us/web/api/fetchevent/request/index.md
+++ b/files/en-us/web/api/fetchevent/request/index.md
@@ -4,7 +4,6 @@ slug: Web/API/FetchEvent/request
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - FetchEvent
   - Offline
   - Property

--- a/files/en-us/web/api/fetchevent/respondwith/index.md
+++ b/files/en-us/web/api/fetchevent/respondwith/index.md
@@ -4,7 +4,6 @@ slug: Web/API/FetchEvent/respondWith
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - FetchEvent
   - Method
   - Offline

--- a/files/en-us/web/api/focusevent/relatedtarget/index.md
+++ b/files/en-us/web/api/focusevent/relatedtarget/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - Event
-  - Experimental
   - FocusEvent
   - Property
   - Reference

--- a/files/en-us/web/api/formdataevent/index.md
+++ b/files/en-us/web/api/formdataevent/index.md
@@ -4,7 +4,6 @@ slug: Web/API/FormDataEvent
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - FormDataEvent
   - Forms
   - Landing

--- a/files/en-us/web/api/gamepad_api/index.md
+++ b/files/en-us/web/api/gamepad_api/index.md
@@ -4,7 +4,6 @@ slug: Web/API/Gamepad_API
 page-type: web-api-overview
 tags:
   - API
-  - Experimental
   - Gamepad API
   - Games
   - Overview

--- a/files/en-us/web/api/gamepadhapticactuator/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/index.md
@@ -4,7 +4,6 @@ slug: Web/API/GamepadHapticActuator
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - Gamepad
   - GamepadHapticActuator
   - Interface
@@ -14,7 +13,7 @@ tags:
   - WebVR
 browser-compat: api.GamepadHapticActuator
 ---
-{{APIRef("Gamepad API")}}{{SeeCompatTable}}{{securecontext_header}}
+{{APIRef("Gamepad API")}}{{securecontext_header}}
 
 The **`GamepadHapticActuator`** interface of the [Gamepad API](/en-US/docs/Web/API/Gamepad_API) represents hardware in the controller designed to provide haptic feedback to the user (if available), most commonly vibration hardware.
 
@@ -30,7 +29,7 @@ This interface is accessible through the {{domxref("Gamepad.hapticActuators")}} 
 - {{domxref("GamepadHapticActuator.pulse()")}} {{readonlyInline}}
   - : Makes the hardware pulse at a certain intensity for a specified duration.
 
-- {{domxref("GamepadHapticActuator.playEffect()")}} {{readonlyInline}}
+- {{domxref("GamepadHapticActuator.playEffect()")}} {{readonlyInline}} {{Experimental_Inline}} {{Non-standard_Inline}}
   - : Makes the hardware play a specific vibration pattern.
 
 ## Examples

--- a/files/en-us/web/api/gamepadhapticactuator/pulse/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/pulse/index.md
@@ -4,7 +4,6 @@ slug: Web/API/GamepadHapticActuator/pulse
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Gamepad
   - Gamepad API
   - GamepadHapticActuator
@@ -13,7 +12,7 @@ tags:
   - pulse
 browser-compat: api.GamepadHapticActuator.pulse
 ---
-{{APIRef("Gamepad")}}{{SeeCompatTable}}
+{{APIRef("Gamepad")}}
 
 The **`pulse()`** method of the {{domxref("GamepadHapticActuator")}} interface makes the hardware pulse at a certain intensity for a specified duration.
 

--- a/files/en-us/web/api/gamepadhapticactuator/type/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/type/index.md
@@ -4,7 +4,6 @@ slug: Web/API/GamepadHapticActuator/type
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Gamepad
   - Gamepad API
   - GamepadHapticActuator
@@ -13,7 +12,7 @@ tags:
   - Type
 browser-compat: api.GamepadHapticActuator.type
 ---
-{{APIRef("Gamepad")}}{{SeeCompatTable}}
+{{APIRef("Gamepad")}}
 
 The **`type`** read-only property of the {{domxref("GamepadHapticActuator")}} interface returns an enum representing the type of the haptic hardware.
 

--- a/files/en-us/web/api/headers/index.md
+++ b/files/en-us/web/api/headers/index.md
@@ -4,7 +4,6 @@ slug: Web/API/Headers
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - Fetch
   - Fetch API
   - Headers

--- a/files/en-us/web/api/htmlcanvaselement/capturestream/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/capturestream/index.md
@@ -4,7 +4,6 @@ slug: Web/API/HTMLCanvasElement/captureStream
 page-type: web-api-instance-method
 tags:
   - Canvas
-  - Experimental
   - Frame Capture
   - HTMLCanvasElement
   - Interface

--- a/files/en-us/web/api/htmldialogelement/close/index.md
+++ b/files/en-us/web/api/htmldialogelement/close/index.md
@@ -13,8 +13,6 @@ browser-compat: api.HTMLDialogElement.close
 ---
 {{ APIRef("HTML DOM") }}
 
-{{ SeeCompatTable() }}
-
 The **`close()`** method of the {{domxref("HTMLDialogElement")}}
 interface closes the dialog. An optional string may be passed as an
 argument, updating the `returnValue` of the dialog.

--- a/files/en-us/web/api/htmldialogelement/close/index.md
+++ b/files/en-us/web/api/htmldialogelement/close/index.md
@@ -4,7 +4,6 @@ slug: Web/API/HTMLDialogElement/close
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - HTML DOM
   - HTMLDialogElement
   - Method

--- a/files/en-us/web/api/htmldialogelement/close_event/index.md
+++ b/files/en-us/web/api/htmldialogelement/close_event/index.md
@@ -5,7 +5,6 @@ page-type: web-api-event
 tags:
   - API
   - Event
-  - Experimental
   - HTML DOM
   - HTMLDialogElement
   - Reference

--- a/files/en-us/web/api/htmldialogelement/open/index.md
+++ b/files/en-us/web/api/htmldialogelement/open/index.md
@@ -13,8 +13,6 @@ browser-compat: api.HTMLDialogElement.open
 ---
 {{ APIRef("HTML DOM") }}
 
-{{ SeeCompatTable() }}
-
 The **`open`** property of the
 {{domxref("HTMLDialogElement")}} interface is a boolean value reflecting the
 {{htmlattrxref("open", "dialog")}} HTML attribute, indicating whether the dialog is

--- a/files/en-us/web/api/htmldialogelement/open/index.md
+++ b/files/en-us/web/api/htmldialogelement/open/index.md
@@ -4,7 +4,6 @@ slug: Web/API/HTMLDialogElement/open
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - HTML DOM
   - HTMLDialogElement
   - Property

--- a/files/en-us/web/api/htmldialogelement/returnvalue/index.md
+++ b/files/en-us/web/api/htmldialogelement/returnvalue/index.md
@@ -13,8 +13,6 @@ browser-compat: api.HTMLDialogElement.returnValue
 ---
 {{ APIRef("HTML DOM") }}
 
-{{ SeeCompatTable() }}
-
 The **`returnValue`** property of the
 {{domxref("HTMLDialogElement")}} interface gets or sets the return value for the
 `<dialog>`, usually to indicate which button the user pressed to

--- a/files/en-us/web/api/htmldialogelement/returnvalue/index.md
+++ b/files/en-us/web/api/htmldialogelement/returnvalue/index.md
@@ -4,7 +4,6 @@ slug: Web/API/HTMLDialogElement/returnValue
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - HTML DOM
   - HTMLDialogElement
   - Property

--- a/files/en-us/web/api/htmldialogelement/show/index.md
+++ b/files/en-us/web/api/htmldialogelement/show/index.md
@@ -11,7 +11,7 @@ tags:
   - show
 browser-compat: api.HTMLDialogElement.show
 ---
-{{ APIRef("HTML DOM") }} {{ SeeCompatTable() }}
+{{ APIRef("HTML DOM") }}
 
 The **`show()`** method of the {{domxref("HTMLDialogElement")}}
 interface displays the dialog modelessly, i.e. still allowing interaction with content

--- a/files/en-us/web/api/htmldialogelement/show/index.md
+++ b/files/en-us/web/api/htmldialogelement/show/index.md
@@ -4,7 +4,6 @@ slug: Web/API/HTMLDialogElement/show
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - HTML DOM
   - HTMLDialogElement
   - Method

--- a/files/en-us/web/api/htmldialogelement/showmodal/index.md
+++ b/files/en-us/web/api/htmldialogelement/showmodal/index.md
@@ -11,7 +11,7 @@ tags:
   - showModal
 browser-compat: api.HTMLDialogElement.showModal
 ---
-{{ APIRef("HTML DOM") }} {{ SeeCompatTable() }}
+{{ APIRef("HTML DOM") }}
 
 The **`showModal()`** method of the
 {{domxref("HTMLDialogElement")}} interface displays the dialog as a modal, over the top

--- a/files/en-us/web/api/htmldialogelement/showmodal/index.md
+++ b/files/en-us/web/api/htmldialogelement/showmodal/index.md
@@ -4,7 +4,6 @@ slug: Web/API/HTMLDialogElement/showModal
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - HTML DOM
   - HTMLDialogElement
   - Method

--- a/files/en-us/web/api/htmlelement/nonce/index.md
+++ b/files/en-us/web/api/htmlelement/nonce/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - Content Security Policy
-  - Experimental
   - HTML DOM
   - HTMLElement
   - Property

--- a/files/en-us/web/api/htmlimageelement/referrerpolicy/index.md
+++ b/files/en-us/web/api/htmlimageelement/referrerpolicy/index.md
@@ -4,7 +4,6 @@ slug: Web/API/HTMLImageElement/referrerPolicy
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - HTMLImageElement
   - Property
   - Referrer Policy

--- a/files/en-us/web/api/htmllinkelement/referrerpolicy/index.md
+++ b/files/en-us/web/api/htmllinkelement/referrerpolicy/index.md
@@ -4,13 +4,12 @@ slug: Web/API/HTMLLinkElement/referrerPolicy
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - HTMLLinkElement
   - Property
   - Reference
 browser-compat: api.HTMLLinkElement.referrerPolicy
 ---
-{{APIRef}}{{SeeCompatTable}}
+{{APIRef}}
 
 The
 **`HTMLLinkElement.referrerPolicy`**

--- a/files/en-us/web/api/htmlmediaelement/controlslist/index.md
+++ b/files/en-us/web/api/htmlmediaelement/controlslist/index.md
@@ -11,7 +11,7 @@ tags:
   - Reference
 browser-compat: api.HTMLMediaElement.controlsList
 ---
-{{SeeCompatTable}}{{APIRef("HTML DOM")}}
+{{APIRef("HTML DOM")}}
 
 The **`controlsList`** property of the
 {{domxref("HTMLMediaElement")}} interface returns a DOMTokenList that helps the user

--- a/files/en-us/web/api/htmlmediaelement/fastseek/index.md
+++ b/files/en-us/web/api/htmlmediaelement/fastseek/index.md
@@ -12,7 +12,7 @@ tags:
   - fastSeek
 browser-compat: api.HTMLMediaElement.fastSeek
 ---
-{{APIRef("HTML DOM")}} {{SeeCompatTable}}
+{{APIRef("HTML DOM")}}
 
 The **`HTMLMediaElement.fastSeek()`** method quickly seeks the
 media to the new time with precision tradeoff.

--- a/files/en-us/web/api/htmlmediaelement/setmediakeys/index.md
+++ b/files/en-us/web/api/htmlmediaelement/setmediakeys/index.md
@@ -6,7 +6,6 @@ tags:
   - API
   - Audio
   - EncryptedMediaExtensions
-  - Experimental
   - HTMLMediaElement
   - Media
   - Method
@@ -14,7 +13,7 @@ tags:
   - Video
 browser-compat: api.HTMLMediaElement.setMediaKeys
 ---
-{{APIRef("HTML DOM")}}{{SeeCompatTable}}
+{{APIRef("HTML DOM")}}
 
 The **`setMediaKeys()`** property of the
 {{domxref("HTMLMediaElement")}} interface returns a {{jsxref("Promise")}} that resolves

--- a/files/en-us/web/api/htmlmediaelement/setsinkid/index.md
+++ b/files/en-us/web/api/htmlmediaelement/setsinkid/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Audio
-  - Experimental
   - HTMLMediaElement
   - Media
   - Method
@@ -13,7 +12,7 @@ tags:
   - setSinkId
 browser-compat: api.HTMLMediaElement.setSinkId
 ---
-{{APIRef("HTML DOM")}} {{SeeCompatTable}}
+{{APIRef("HTML DOM")}}
 
 The **`HTMLMediaElement.setSinkId()`** method sets the ID of
 the audio device to use for output and returns a [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise).


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.

It focuses on files that have only left behind 'experimental' tags and headers.