### PR TITLE
Update extension_pages api in docs

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/content_security_policy/index.md
@@ -118,7 +118,7 @@ Require that all types of content should be packaged with the extension:
 
 ```json
 "content_security_policy": {
-  "extension_page": "default-src 'self'"
+  "extension_pages": "default-src 'self'"
 } 
 ```
 
@@ -134,7 +134,7 @@ Allow remote scripts from "https://example.com":
 
 ```json
 "content_security_policy": {
-  "extension_page": "script-src 'self' https://example.com; object-src 'self'"
+  "extension_pages": "script-src 'self' https://example.com; object-src 'self'"
 } 
 ```
 
@@ -150,7 +150,7 @@ Allow remote scripts from any subdomain of "jquery.com":
 
 ```json
 "content_security_policy": {
-  "extension_page": "script-src 'self' https://*.jquery.com; object-src 'self'"
+  "extension_pages": "script-src 'self' https://*.jquery.com; object-src 'self'"
 } 
 ```
 
@@ -166,7 +166,7 @@ Allow [`eval()` and friends](/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_S
 
 ```json
 "content_security_policy": {
-  "extension_page": "script-src 'self' 'unsafe-eval'; object-src 'self';"
+  "extension_pages": "script-src 'self' 'unsafe-eval'; object-src 'self';"
 } 
 ```
 
@@ -182,7 +182,7 @@ Allow the inline script: `"<script>alert('Hello, world.');</script>"`:
 
 ```json
 "content_security_policy": {
-  "extension_page": "script-src 'self' 'sha256-qznLcsROx4GACP2dm0UCKCzCG+HiZ1guq6ZZDob/Tng='; object-src 'self'"
+  "extension_pages": "script-src 'self' 'sha256-qznLcsROx4GACP2dm0UCKCzCG+HiZ1guq6ZZDob/Tng='; object-src 'self'"
 } 
 ```
 
@@ -198,7 +198,7 @@ Keep the rest of the policy, but also require that images should be packaged wit
 
 ```json
 "content_security_policy": {
-  "extension_page": "script-src 'self'; object-src 'self'; img-src 'self'"
+  "extension_pages": "script-src 'self'; object-src 'self'; img-src 'self'"
 } 
 ```
 
@@ -216,7 +216,7 @@ For backward compatibility, Manifest V2 extensions can use WebAssembly without t
 
 ```json
 "content_security_policy": {
-  "extension_page": "script-src 'self' 'wasm-unsafe-eval'"
+  "extension_pages": "script-src 'self' 'wasm-unsafe-eval'"
 }
 ```
 


### PR DESCRIPTION
The docs refer to extension_page in the examples. This should be changed to extension_pages