### PR TITLE
Remove improper uses of var in a11y

### DIFF
--- a/files/en-us/web/accessibility/an_overview_of_accessible_web_applications_and_widgets/index.md
+++ b/files/en-us/web/accessibility/an_overview_of_accessible_web_applications_and_widgets/index.md
@@ -132,7 +132,7 @@ The JavaScript to update the **`aria-hidden`** property has the form shown in Ex
 _Example 2c. JavaScript to update the aria-hidden attribute_
 
 ```js
-var showTip = function(el) {
+function showTip(el) {
   el.setAttribute('aria-hidden', 'false');
 }
 ```

--- a/files/en-us/web/accessibility/aria/aria_live_regions/index.md
+++ b/files/en-us/web/accessibility/aria/aria_live_regions/index.md
@@ -176,7 +176,7 @@ As an illustration of `aria-atomic`, consider a site with a simple clock, showin
 ```js
 /* basic JavaScript to update the clock */
 function updateClock() {
-  var now = new Date();
+  const now = new Date();
   document.getElementById('clock-hours').innerHTML = now.getHours();
   document.getElementById('clock-mins').innerHTML = ("0"+now.getMinutes()).substr(-2);
 }
@@ -217,7 +217,7 @@ Another example of `aria-atomic` - an update/notification made as a result of a 
 
 ```js
 function change(event) {
-  var yearOut = document.getElementById("year-output");
+  const yearOut = document.getElementById("year-output");
 
   switch (event.target.id) {
     case "year":

--- a/files/en-us/web/accessibility/aria/index.md
+++ b/files/en-us/web/accessibility/aria/index.md
@@ -32,7 +32,7 @@ Along with placing them directly in the markup, ARIA attributes can be added to 
 
 ```js
 // Find the progress bar <div> in the DOM.
-var progressBar = document.getElementById("percent-loaded");
+const progressBar = document.getElementById("percent-loaded");
 
 // Set its ARIA roles and states,
 // so that assistive technologies know what kind of widget it is.

--- a/files/en-us/web/accessibility/aria/roles/alert_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/alert_role/index.md
@@ -56,7 +56,7 @@ const btn = document.querySelector('button');
 btn.addEventListener('click', triggerAlert);
 
 function triggerAlert() {
-  var alertEl = document.querySelector('.alert');
+  const alertEl = document.querySelector('.alert');
   alertEl.setAttribute("role", "alert");
 }
 ```

--- a/files/en-us/web/accessibility/aria/roles/button_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/button_role/index.md
@@ -230,13 +230,16 @@ function handleBtnKeyDown(event) {
 }
 
 function toggleButton(element) {
-  var audio = document.getElementById('audio');
+  const audio = document.getElementById('audio');
+
   // Check to see if the button is pressed
-  var pressed = (element.getAttribute("aria-pressed") === "true");
+  const pressed = element.getAttribute("aria-pressed") === "true";
+  
   // Change aria-pressed to the opposite state
   element.setAttribute("aria-pressed", !pressed);
-  // toggle the play state of the audio file
-  if(pressed) {
+  
+  // Toggle the play state of the audio file
+  if (pressed) {
      audio.pause();
   } else {
      audio.play();


### PR DESCRIPTION
This PR removes all the remaining improper uses of var in web/accessibility \o/.