### PR TITLE
Fix improper var in mdn/ and mozilla/

### DIFF
--- a/files/en-us/glossary/undefined/index.md
+++ b/files/en-us/glossary/undefined/index.md
@@ -12,9 +12,9 @@ tags:
 ## Example
 
 ```js
-var x; //create a variable but assign it no value
+let x; //create a variable but assign it no value
 
-console.log("x's value is ", x) //logs "x's value is undefined"
+console.log(`x's value is ${x}`) //logs "x's value is undefined"
 ```
 
 ## See also

--- a/files/en-us/mdn/tools/kumascript/index.md
+++ b/files/en-us/mdn/tools/kumascript/index.md
@@ -105,7 +105,7 @@ KumaScript templates are processed by an [embedded JavaScript template engine](h
 - Nothing inside a `<% %>` block can ever contribute to the output stream. But, you can transition from JS mode to output mode using `<% %>`—for example:
 
   ```js
-  <% for (var i = 0; i < $0; i++) { %>
+  <% for (let i = 0; i < $0; i++) { %>
     Hello #<%= i %>
   <% } %>
   ```
@@ -262,7 +262,7 @@ Assuming this template were saved in the macros directory as `MathLib.ejs`, you 
 
 ```js
 <%
-var math_lib = require("MathLib");
+const math_lib = require("MathLib");
 %>
 The result of 2 + 2 = <%= math_lib.add(2, 2) %>
 ```
@@ -377,7 +377,7 @@ Templates can be localized using the `mdn.localString()` method, which takes an 
 
 ```js
 <%
-var text = mdn.localString({
+const text = mdn.localString({
   "en-US": "Hello world!",
   "es": "¡Hola mundo!",
   // ...
@@ -389,7 +389,7 @@ Each locale may also take an object containing a mapping of keys to strings, for
 
 ```js
 <%
-var text = mdn.localStringMap({
+const text = mdn.localStringMap({
   'en-US': {
     'Complete_beginners_start_here': 'Complete beginners start here!',
     'Getting_started_with_the_web': 'Getting started with the web',
@@ -411,13 +411,13 @@ The `mdn.localString()` function will automatically load strings for the appropr
 
 ```js
 <%
-var s_title = mdn.localString({
+const s_title = mdn.localString({
   "en-US": "Firefox for Developers",
   "de": "Firefox für Entwickler",
   "es": "Firefox para desarrolladores"
 });
 
-var body = mdn.localString({
+const body = mdn.localString({
   "en-US": {
     "hello": "Hello!",
     "goodbye": "Goodbye!",

--- a/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/write_an_api_reference/information_contained_in_a_webidl_file/index.md
@@ -440,7 +440,7 @@ The iterator will iterate over values of type _valueType_. The generated methods
 - `keys()`, which returns an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the keys, that are its indexes (that are `unsigned long`). In the case of value iterators, `keys()` and `entries()` are identical.
 - `forEach()`, which returns an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the keys that calls a given callback function one for each entry in the list.
 
-Such an iterator allows to use the syntax `for (var p in object)` as a shorthand of `for (var p in object.entries())`. We add a sentence about it in the interface description.
+Such an iterator allows to use the syntax `for (const p in object)` as a shorthand of `for (const p in object.entries())`. We add a sentence about it in the interface description.
 
 > **Note:** the value pairs to iterate over can be defined in two different ways:
 >
@@ -460,7 +460,7 @@ The iterator will iterate over values of type _valueType_, with keys of type _ke
 - `keys()` that returns an [`iterator`](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) on the keys. E.g. {{domxref('FormData.keys()')}}
 - Once {{bug(1216751)}} lands, `forEach()`.
 
-Such an iterator allows to use the syntax `for (var p in object)` as a shorthand of `for (var p in object.entries())`. We add a sentence about it in the interface description. E.g. {{domxref('FormData')}}.
+Such an iterator allows to use the syntax `for (const p in object)` as a shorthand of `for (const p in object.entries())`. We add a sentence about it in the interface description. E.g. {{domxref('FormData')}}.
 
 > **Note:** the value pairs to iterate over are _not_ defined in the webidl file, but in the prose accompanying it. Such a prose is in the spec and usually starts with: _"The [value pairs to iterate over](https://heycam.github.io/webidl/#dfn-value-pairs-to-iterate-over)…"_
 >
@@ -487,7 +487,7 @@ In cases where the set-like declaration is not prefixed by read-only, the follow
 - `clear()` that empties the set-like structure. E.g. the `.clear()` method of {{domxref('FontFaceSet')}}.
 - `delete()` that removes an entry. E.g. the `.delete()` method of {{domxref('FontFaceSet')}}.
 
-Such an set interface also allows to use the syntax `for (var p in object)` as a shorthand of `for (var p in object.entries())`.
+Such an set interface also allows to use the syntax `for (const p in object)` as a shorthand of `for (const p in object.entries())`.
 
 ## Special Behaviors
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/syntax_sections/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/syntax_sections/index.md
@@ -41,7 +41,7 @@ A few rules to follow in terms of markup within the syntax block:
   //responseStr = element.querySelector(selector);
 
   new IntersectionObserver(callback, options)
-  // var observer = new IntersectionObserver(callback, options);
+  // const observer = new IntersectionObserver(callback, options);
   ```
 
 ### Constructors and methods

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getframeid/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getframeid/index.md
@@ -19,7 +19,7 @@ Returns the frame ID of any window global or frame element when called from a co
 ## Syntax
 
 ```js
-const gettingInfo = browser.runtime.getFrameId()
+getFrameId()
 ```
 
 ### Parameters

--- a/files/en-us/mozilla/add-ons/webextensions/api/runtime/getframeid/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/runtime/getframeid/index.md
@@ -19,7 +19,7 @@ Returns the frame ID of any window global or frame element when called from a co
 ## Syntax
 
 ```js
-var gettingInfo = browser.runtime.getFrameId()
+const gettingInfo = browser.runtime.getFrameId()
 ```
 
 ### Parameters


### PR DESCRIPTION
Both mdn/ and mozilla/ are done with this PR

Note that I haven't fixed the ones in mdn/firefox as most are about old stuff like XUL at a specific point in the past (in the first decade of the century)