### PR TITLE
Added: alt attribute to few images

### DIFF
--- a/files/en-us/glossary/main_axis/index.md
+++ b/files/en-us/glossary/main_axis/index.md
@@ -20,7 +20,7 @@ Should you choose `row` or `row-reverse` then your main axis will run along the 
 
 Choose `column` or `column-reverse` and your main axis will run top to bottom of the page in the block direction.
 
-![This image shows three HTML elements arranged one below the other as their flex-direction is set to column so that the main-axis of the container element of the arranged items runs vertically i.e. from top to bottom](basics2.png)
+![Three flex items taking up the full width of the container, displayed one below the other in code order.  Flex-direction is set to column. The main axis is vertical i.e. from top to bottom](basics2.png)
 
 On the main axis you can control the sizing of flex items by adding any available space to the items themselves, by way of `flex` properties on the items. Or, you can control the space between and around items by using the `justify-content` property.
 

--- a/files/en-us/glossary/main_axis/index.md
+++ b/files/en-us/glossary/main_axis/index.md
@@ -20,7 +20,7 @@ Should you choose `row` or `row-reverse` then your main axis will run along the 
 
 Choose `column` or `column-reverse` and your main axis will run top to bottom of the page in the block direction.
 
-![](basics2.png)
+![This image shows three HTML elements arranged one below the other as their flex-direction is set to column so that the main-axis of the container element of the arranged items runs vertically i.e. from top to bottom](basics2.png)
 
 On the main axis you can control the sizing of flex items by adding any available space to the items themselves, by way of `flex` properties on the items. Or, you can control the space between and around items by using the `justify-content` property.
 

--- a/files/en-us/glossary/session_hijacking/index.md
+++ b/files/en-us/glossary/session_hijacking/index.md
@@ -10,7 +10,7 @@ tags:
 
 Most authentication occurs only at the start of a {{glossary("TCP")}} session. In TCP session hijacking, an attacker gains access by taking over a TCP session between two machines in mid session.
 
-![The attacker sniff accesses a legitimate session id from a user interacting with a web server, then uses that session identifier to spoof the session between the regular user and the server to exploit the user's session and access the server directly.](session_hijacking_3.jpg)
+![The attacker sniffs and accesses a legitimate session id from a user interacting with a web server, then uses that session identifier to spoof the session between the regular user and the server to exploit the user's session and access the server directly.](session_hijacking_3.jpg)
 
 ### Session hijacking occurs because
 

--- a/files/en-us/glossary/session_hijacking/index.md
+++ b/files/en-us/glossary/session_hijacking/index.md
@@ -10,7 +10,7 @@ tags:
 
 Most authentication occurs only at the start of a {{glossary("TCP")}} session. In TCP session hijacking, an attacker gains access by taking over a TCP session between two machines in mid session.
 
-![](session_hijacking_3.jpg)
+![This image shows how an attacker is trying to bypass the session between a regular user and the server to exploit the user's session](session_hijacking_3.jpg)
 
 ### Session hijacking occurs because
 

--- a/files/en-us/glossary/session_hijacking/index.md
+++ b/files/en-us/glossary/session_hijacking/index.md
@@ -10,7 +10,7 @@ tags:
 
 Most authentication occurs only at the start of a {{glossary("TCP")}} session. In TCP session hijacking, an attacker gains access by taking over a TCP session between two machines in mid session.
 
-![This image shows how an attacker is trying to bypass the session between a regular user and the server to exploit the user's session](session_hijacking_3.jpg)
+![The attacker sniff accesses a legitimate session id from a user interacting with a web server, then uses that session identifier to spoof the session between the regular user and the server to exploit the user's session and access the server directly.](session_hijacking_3.jpg)
 
 ### Session hijacking occurs because
 

--- a/files/en-us/glossary/sql_injection/index.md
+++ b/files/en-us/glossary/sql_injection/index.md
@@ -12,11 +12,11 @@ SQL injection takes advantage of Web apps that fail to validate user input. Hack
 
 SQL injection can gain unauthorized access to a database or to retrieve information directly from the database. Many data breaches are due to SQL injection.
 
-[![This image is a pie chart which represents that SQL injection is responsible for 50% of vulnerabilities followed by Cross Site Scripting which is responsible for 42% of vulnerabilities](sql_inj_xss.gif)](https://cdn.acunetix.com/wp_content/uploads/2010/09/sql_inj_xss.gif)
+[![Pie chart of most common vulnerabilities: SQL Injection is responsible for 50% of vulnerabilities, Cross Site Scripting is responsible for 42% of vulnerabilities, Source Code Disclosure is responsible for 7% of vulnerabilities.](sql_inj_xss.gif)](https://cdn.acunetix.com/wp_content/uploads/2010/09/sql_inj_xss.gif)
 
 ## How It Works
 
-![This image is a screenshot of the login page of an application with username field and password field](updates_loginscreen.png)
+![Screenshot of the login form with username and password fields](updates_loginscreen.png)
 
 After entering username and password, behind the GUI the SQL queries work as follows:
 

--- a/files/en-us/glossary/sql_injection/index.md
+++ b/files/en-us/glossary/sql_injection/index.md
@@ -12,11 +12,11 @@ SQL injection takes advantage of Web apps that fail to validate user input. Hack
 
 SQL injection can gain unauthorized access to a database or to retrieve information directly from the database. Many data breaches are due to SQL injection.
 
-[![](sql_inj_xss.gif)](https://cdn.acunetix.com/wp_content/uploads/2010/09/sql_inj_xss.gif)
+[![This image is a pie chart which represents that SQL injection is responsible for 50% of vulnerabilities followed by Cross Site Scripting which is responsible for 42% of vulnerabilities](sql_inj_xss.gif)](https://cdn.acunetix.com/wp_content/uploads/2010/09/sql_inj_xss.gif)
 
 ## How It Works
 
-![](updates_loginscreen.png)
+![This image is a screenshot of the login page of an application with username field and password field](updates_loginscreen.png)
 
 After entering username and password, behind the GUI the SQL queries work as follows:
 

--- a/files/en-us/glossary/state_machine/index.md
+++ b/files/en-us/glossary/state_machine/index.md
@@ -26,13 +26,13 @@ There are two types of basic state machines:
 
 _Figure 1: Deterministic Finite State Machine_
 
-![This is the image of a Deterministic Finite State Machine where the machine transitions from state 1 to state 2 for input X and it transitions from state 1 to state 3 for input Y](statemachine1.png)
+![The machine transitions from state 1 to state 2 for input X and from state 1 to state 3 for input Y](statemachine1.png)
 
 In _Figure 1_, the state begins in State 1; the state changes to State 2 given input 'X', or to State 3 given input 'Y'.
 
 _Figure 2: Non-Deterministic Finite State Machine_
 
-![This is the image of a Non-Deterministic Finite State Machine where the machine remains in state 1 for input X and it transitions from state 1 to state 2 for the same input X](statemachine2.png)
+![The machine may remain in state 1, transitioning to itself, or may transition from state 1 to state 2 for input X](statemachine2.png)
 
 In _Figure 2_, given input 'X', the state can persist or change to State 2.
 

--- a/files/en-us/glossary/state_machine/index.md
+++ b/files/en-us/glossary/state_machine/index.md
@@ -26,13 +26,13 @@ There are two types of basic state machines:
 
 _Figure 1: Deterministic Finite State Machine_
 
-![](statemachine1.png)
+![This is the image of a Deterministic Finite State Machine where the machine transitions from state 1 to state 2 for input X and it transitions from state 1 to state 3 for input Y](statemachine1.png)
 
 In _Figure 1_, the state begins in State 1; the state changes to State 2 given input 'X', or to State 3 given input 'Y'.
 
 _Figure 2: Non-Deterministic Finite State Machine_
 
-![](statemachine2.png)
+![This is the image of a Non-Deterministic Finite State Machine where the machine remains in state 1 for input X and it transitions from state 1 to state 2 for the same input X](statemachine2.png)
 
 In _Figure 2_, given input 'X', the state can persist or change to State 2.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
* I have added `alt` attributes to a handful of items in the content

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
* Adding the `alt` attribute to the image displays the value of `alt` attribute when the respective `image fails to load` rather than leaving the space blank.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
@estelle has collected the list of images from the documentation that do not have the `alt` attribute. [link to the spreadsheet](https://docs.google.com/spreadsheets/d/1cDHee6mwDMlY6zANEmg8MjR8tL-wrCS86uawpWZ4XbA/edit#gid=0)
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
N/A
#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]
N/A
This PR…
-->
- [ ] Adds a new document
- [X] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
