### PR TITLE
Change jQuery version

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/manifest.json/background/index.md
@@ -71,7 +71,7 @@ The `background` key is an object that must have one of these properties:
             location with the <code>&#x3C;script></code> tag (e.g.
             <code
               >&#x3C;script src =
-              "https://code.jquery.com/jquery-1.7.1.min.js"></code
+              "https://code.jquery.com/jquery-3.6.0.min.js"></code
             >), you will also have to change the
             <code
               ><a


### PR DESCRIPTION
#### Summary
jQuery 1 & 2 are no longer accepted by AMO. It would avoid confusion by using jQuery v3+ for the example.


This PR…
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error


