### PR TITLE
Minor: lang attribute on HTML element

### DIFF
--- a/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_babylon.js/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_babylon.js/index.md
@@ -28,7 +28,7 @@ Here's the HTML structure we will use:
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-GB">
 <head>
     <meta charset="utf-8">
     <title>MDN Games: Babylon.js demo</title>

--- a/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_playcanvas/engine/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_playcanvas/engine/index.md
@@ -40,7 +40,7 @@ Here's the HTML structure we will use.
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-GB">
 <head>
     <meta charset="utf-8">
     <title>MDN Games: PlayCanvas demo</title>

--- a/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_three.js/index.md
+++ b/files/en-us/games/techniques/3d_on_the_web/building_up_a_basic_demo_with_three.js/index.md
@@ -35,7 +35,7 @@ Here's the HTML structure we will use:
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-GB">
 <head>
   <meta charset="utf-8">
   <title>MDN Games: Three.js demo</title>

--- a/files/en-us/games/tutorials/html5_gamedev_phaser_device_orientation/index.md
+++ b/files/en-us/games/tutorials/html5_gamedev_phaser_device_orientation/index.md
@@ -41,7 +41,7 @@ We will be rendering our game on Canvas, but we won't do it manually — this wi
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-GB">
 <head>
     <meta charset="utf-8" />
     <title>Cyber Orb demo</title>

--- a/files/en-us/learn/css/first_steps/how_css_is_structured/index.md
+++ b/files/en-us/learn/css/first_steps/how_css_is_structured/index.md
@@ -59,7 +59,7 @@ You reference an external CSS stylesheet from an HTML `<link>` element:
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-GB">
   <head>
     <meta charset="utf-8">
     <title>My CSS experiment</title>
@@ -107,7 +107,7 @@ The HTML for an internal stylesheet might look like this:
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-GB">
   <head>
     <meta charset="utf-8">
     <title>My CSS experiment</title>
@@ -140,7 +140,7 @@ Inline styles are CSS declarations that affect a single HTML element, contained 
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-GB">
   <head>
     <meta charset="utf-8">
     <title>My CSS experiment</title>

--- a/files/en-us/learn/html/introduction_to_html/getting_started/index.md
+++ b/files/en-us/learn/html/introduction_to_html/getting_started/index.md
@@ -496,7 +496,7 @@ Individual HTML elements aren't very useful on their own. Next, let's examine ho
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>My test page</title>

--- a/files/en-us/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
+++ b/files/en-us/learn/html/introduction_to_html/the_head_metadata_in_html/index.md
@@ -43,7 +43,7 @@ Let's revisit the simple [HTML document we covered in the previous article](/en-
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>My test page</title>

--- a/files/en-us/learn/html/tables/advanced/index.md
+++ b/files/en-us/learn/html/tables/advanced/index.md
@@ -116,7 +116,7 @@ Your finished table should look something like the following:
 
 ```html hidden
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>My spending record</title>

--- a/files/en-us/learn/javascript/client-side_web_apis/manipulating_documents/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/manipulating_documents/index.md
@@ -60,7 +60,7 @@ We have created a simple example page at [dom-example.html](https://github.com/m
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>Simple DOM example</title>

--- a/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.md
@@ -72,7 +72,7 @@ Consider a web page like this:
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
   </head>

--- a/files/en-us/mozilla/add-ons/webextensions/extending_the_developer_tools/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/extending_the_developer_tools/index.md
@@ -41,9 +41,10 @@ Note that the devtools page does not get access to any other WebExtension APIs, 
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
+    <title>DevTools Extension</title>
   </head>
   <body>
     <script src="devtools.js"></script>

--- a/files/en-us/web/api/audiocontext/createmediastreamdestination/index.md
+++ b/files/en-us/web/api/audiocontext/createmediastreamdestination/index.md
@@ -43,8 +43,9 @@ From here, you can play and save the opus file.
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-us">
   <head>
+    <meta charset="UTF-8">
     <title>createMediaStreamDestination() demo</title>
   </head>
   <body>

--- a/files/en-us/web/api/canvas_api/manipulating_video_using_canvas/index.md
+++ b/files/en-us/web/api/canvas_api/manipulating_video_using_canvas/index.md
@@ -24,8 +24,10 @@ The HTML document used to render this content is shown below.
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-us">
   <head>
+    <meta charset="UTF-8">
+    <title>Video test page</title>
     <style>
       body {
         background: black;

--- a/files/en-us/web/api/canvas_api/tutorial/basic_usage/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/basic_usage/index.md
@@ -89,7 +89,7 @@ Here is a minimalistic template, which we'll be using as a starting point for la
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
   <head>
     <meta charset="utf-8"/>
     <title>Canvas tutorial</title>
@@ -123,9 +123,10 @@ To begin, let's take a look at a simple example that draws two intersecting rect
 
 ```html
 <!DOCTYPE html>
-<html>
- <head>
-  <meta charset="utf-8"/>
+<html lang="en-us">
+  <head>
+    <meta charset="UTF-8"/>
+    <title>Canvas experiment</title>
   <script type="application/javascript">
     function draw() {
       const canvas = document.getElementById('canvas');

--- a/files/en-us/web/api/document/createelement/index.md
+++ b/files/en-us/web/api/document/createelement/index.md
@@ -48,8 +48,9 @@ This creates a new `<div>` and inserts it before the element with the ID "`div1`
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-us">
 <head>
+  <meta charset="UTF-8">
   <title>||Working with elements||</title>
 </head>
 <body>

--- a/files/en-us/web/api/document/getelementbyid/index.md
+++ b/files/en-us/web/api/document/getelementbyid/index.md
@@ -74,8 +74,8 @@ Unlike some other element-lookup methods such as {{domxref("Document.querySelect
 ### Example
 
 ```html
-<!doctype html>
-<html>
+<!DOCTYPE html>
+<html lang="en-US">
 <head>
     <meta charset="UTF-8">
     <title>Document</title>

--- a/files/en-us/web/api/document/title/index.md
+++ b/files/en-us/web/api/document/title/index.md
@@ -35,8 +35,9 @@ document).
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-us">
 <head>
+  <meta charset="UTF-8">
   <title>Hello World!</title>
 </head>
 <body>

--- a/files/en-us/web/api/document_object_model/whitespace/index.md
+++ b/files/en-us/web/api/document_object_model/whitespace/index.md
@@ -46,8 +46,9 @@ Take the following document, for example:
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-us">
 <head>
+  <meta charset="UTF-8">
   <title>My Document</title>
 </head>
 <body>

--- a/files/en-us/web/api/domimplementation/createhtmldocument/index.md
+++ b/files/en-us/web/api/domimplementation/createhtmldocument/index.md
@@ -89,9 +89,10 @@ replaces the contents of the frame with the new document's contents.
 The returned document is pre-constructed with the following HTML:
 
 ```html
-<!doctype html>
-<html>
+<!DOCTYPE html>
+<html lang="en-us">
 <head>
+<meta charset="UTF-8">
 <title>title</title>
 </head>
 <body>

--- a/files/en-us/web/api/element/getattributens/index.md
+++ b/files/en-us/web/api/element/getattributens/index.md
@@ -62,12 +62,16 @@ custom namespace.
 </svg>
 ```
 
-In an HTML5 document the attribute has to be accessed with `test:foo` since
+In an HTML document the attribute has to be accessed with `test:foo` since
 namespaces are not supported.
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-us">
+<head>
+  <meta charset="UTF-8">
+  <title>getAttributeNS() test page</title>
+</head>
 <body>
 
 <svg xmlns="http://www.w3.org/2000/svg"

--- a/files/en-us/web/api/element/scrollwidth/index.md
+++ b/files/en-us/web/api/element/scrollwidth/index.md
@@ -37,8 +37,9 @@ A number.
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-us">
   <head>
+    <meta charset="UTF-8">
     <title>Example</title>
     <style>
       div {

--- a/files/en-us/web/api/event/comparison_of_event_targets/index.md
+++ b/files/en-us/web/api/event/comparison_of_event_targets/index.md
@@ -144,7 +144,7 @@ There are five targets to consider:
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
+++ b/files/en-us/web/api/file_api/using_files_from_web_applications/index.md
@@ -73,7 +73,7 @@ The following example shows a possible use of the `size` property:
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <head>
   <meta charset="UTF-8">
   <title>File(s) size</title>
@@ -438,10 +438,10 @@ if (isset($_FILES['myFile'])) {
     exit;
 }
 ?><!DOCTYPE html>
-<html>
+<html lang="en-us">
 <head>
-    <title>dnd binary upload</title>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta charset="UTF-8">
+  <title>dnd binary upload</title>
     <script type="application/javascript">
         function sendFile(file) {
             const uri = "/index.php";

--- a/files/en-us/web/api/history_api/example/index.md
+++ b/files/en-us/web/api/history_api/example/index.md
@@ -19,8 +19,8 @@ This is an example of an AJAX website composed only of three pages (_first_page.
         ob_start();
     } else {
 ?>
-<!doctype html>
-<html>
+<!DOCTYPE html>
+<html lang="en-US">
 <head>
 <?php
         include "include/header.php";
@@ -67,8 +67,8 @@ This is an example of an AJAX website composed only of three pages (_first_page.
         ob_start();
     } else {
 ?>
-<!doctype html>
-<html>
+<!DOCTYPE html>
+<html lang="en-US">
 <head>
 <?php
         include "include/header.php";
@@ -114,8 +114,8 @@ This is an example of an AJAX website composed only of three pages (_first_page.
         echo json_encode(array("page" => $page_title, "content" => $page_content));
     } else {
 ?>
-<!doctype html>
-<html>
+<!DOCTYPE html>
+<html lang="en-US">
 <head>
 <?php
         include "include/header.php";

--- a/files/en-us/web/api/htmlelement/style/index.md
+++ b/files/en-us/web/api/htmlelement/style/index.md
@@ -43,8 +43,8 @@ The `style` property is not useful for completely learning about the styles appl
 The following code snippet demonstrates the difference between the values obtained using the element's `style` property and that obtained using the `getComputedStyle()` method:
 
 ```html
-<!DOCTYPE HTML>
-<html>
+<!DOCTYPE html>
+<html lang="en-US">
   <body style="font-weight:bold;">
     <div style="color:red" id="myElement">..</div>
   </body>

--- a/files/en-us/web/api/htmlformelement/index.md
+++ b/files/en-us/web/api/htmlformelement/index.md
@@ -177,8 +177,8 @@ Extract information from a `<form>` element and set some of its attributes:
 Submit a `<form>` into a new window:
 
 ```html
-<!doctype html>
-<html>
+<!DOCTYPE html>
+<html lang="en-US">
 <head>
 <meta charset="utf-8">
 <title>Example new-window form submission</title>

--- a/files/en-us/web/api/htmltitleelement/index.md
+++ b/files/en-us/web/api/htmltitleelement/index.md
@@ -23,8 +23,8 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}._
   - : A string representing the text of the document's title, and only the text part. For example, consider this:
 
 ```html
-<!doctype html>
-<html>
+<!DOCTYPE html>
+<html lang="en-US">
   <head>
     <title>Hello world! <span class="highlight">Isn't this wonderful</span> really?</title>
   </head>

--- a/files/en-us/web/api/pagetransitionevent/index.md
+++ b/files/en-us/web/api/pagetransitionevent/index.md
@@ -28,7 +28,7 @@ _This interface also inherits properties from its parent, {{domxref("Event")}}._
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
 <body>
 </body>
 </html>

--- a/files/en-us/web/api/web_workers_api/using_web_workers/index.md
+++ b/files/en-us/web/api/web_workers_api/using_web_workers/index.md
@@ -686,7 +686,7 @@ The worker sets the property `onmessage` to a function which will receive messag
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
   <head>
     <meta charset="UTF-8"  />
     <title>Fibonacci number generator</title>

--- a/files/en-us/web/api/window/location/index.md
+++ b/files/en-us/web/api/window/location/index.md
@@ -97,8 +97,8 @@ taken by the server, the current document is reloaded with the modified search s
 ### Example #6: Using bookmarks without changing the `hash` property:
 
 ```html
-<!doctype html>
-<html>
+<!DOCTYPE html>
+<html lang="en-US">
   <head>
   <meta charset="UTF-8"/>
   <title>MDN Example</title>

--- a/files/en-us/web/api/window/scrollbars/index.md
+++ b/files/en-us/web/api/window/scrollbars/index.md
@@ -26,9 +26,10 @@ The following complete HTML example shows how the `visible` property of the
 scrollbars object is used.
 
 ```html
-<!doctype html>
-<html>
+<!DOCTYPE html>
+<html lang="en-us">
 <head>
+  <meta charset="UTF-8">
   <title>Various DOM Tests</title>
   <script>
     let visibleScrollbars = window.scrollbars.visible;

--- a/files/en-us/web/api/window/unload_event/index.md
+++ b/files/en-us/web/api/window/unload_event/index.md
@@ -72,9 +72,10 @@ See the [Page Lifecycle API](https://developer.chrome.com/blog/page-lifecycle-ap
 
 ```html
 <!DOCTYPE html>
-<html>
-  <head>
-    <title>Parent Frame</title>
+<html lang="en-us">
+   <head>
+     <meta charset="UTF-8">
+     <title>Parent Frame</title>
     <script>
       window.addEventListener('beforeunload', (event) => {
         console.log('I am the 1st one.');
@@ -94,9 +95,10 @@ Below, the content of `child-frame.html`:
 
 ```html
 <!DOCTYPE html>
-<html>
-  <head>
-    <title>Child Frame</title>
+<html lang="en-us">
+   <head>
+     <meta charset="UTF-8">
+     <title>Child Frame</title>
     <script>
       window.addEventListener('beforeunload', (event) => {
         console.log('I am the 2nd one.');

--- a/files/en-us/web/css/box-align/index.md
+++ b/files/en-us/web/css/box-align/index.md
@@ -74,8 +74,9 @@ If the alignment is set using the element's `align` attribute, then the style is
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-us">
 <head>
+<meta charset="UTF-8">
 <title>CSS box-align example</title>
 <style>
 div.example {

--- a/files/en-us/web/css/box-flex/index.md
+++ b/files/en-us/web/css/box-flex/index.md
@@ -72,8 +72,9 @@ A trick to make all content elements in a containing box the same size, is to gi
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-us">
   <head>
+    <meta charset="UTF-8">
     <title>-moz-box-flex example</title>
     <style>
       div.example {

--- a/files/en-us/web/guide/ajax/getting_started/index.md
+++ b/files/en-us/web/guide/ajax/getting_started/index.md
@@ -307,7 +307,7 @@ This is repeated every 5 seconds, using a `setInterval()` call. The idea would b
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>XHR log time</title>

--- a/files/en-us/web/html/element/head/index.md
+++ b/files/en-us/web/html/element/head/index.md
@@ -85,9 +85,11 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 ## Example
 
 ```html
-<!doctype html>
-<html>
+<!DOCTYPE html>
+<html lang="en-us">
   <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width">
     <title>Document title</title>
   </head>
 </html>

--- a/files/en-us/web/html/element/style/index.md
+++ b/files/en-us/web/html/element/style/index.md
@@ -47,9 +47,11 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 In the following example, we apply a very simple stylesheet to a document:
 
 ```html
-<!doctype html>
-<html>
+<!DOCTYPE html>
+<html lang="en-us">
 <head>
+  <meta charset="UTF-8">
+  <title>Test page</title>
   <style>
     p {
       color: red;
@@ -69,9 +71,11 @@ In the following example, we apply a very simple stylesheet to a document:
 In this example we've included two `<style>` elements — notice how the conflicting declarations in the later `<style>` element override those in the earlier one, if they have equal [specificity](/en-US/docs/Web/CSS/Specificity).
 
 ```html
-<!doctype html>
-<html>
+<!DOCTYPE html>
+<html lang="en-us">
 <head>
+  <meta charset="UTF-8">
+  <title>Test page</title>
   <style>
     p {
       color: white;
@@ -100,9 +104,11 @@ In this example we've included two `<style>` elements — notice how the conflic
 In this example we build on the previous one, including a `media` attribute on the second `<style>` element so it is only applied when the viewport is less than 500px in width.
 
 ```html
-<!doctype html>
-<html>
+<!DOCTYPE html>
+<html lang="en-us">
 <head>
+  <meta charset="UTF-8">
+  <title>Test page</title>
   <style>
     p {
       color: white;

--- a/files/en-us/web/http/csp/index.md
+++ b/files/en-us/web/http/csp/index.md
@@ -197,8 +197,9 @@ The HTML of `signup.html` looks like this:
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-us">
   <head>
+    <meta charset="UTF-8">
     <title>Sign Up</title>
     <link rel="stylesheet" href="css/style.css">
   </head>

--- a/files/en-us/web/http/headers/content-security-policy-report-only/index.md
+++ b/files/en-us/web/http/headers/content-security-policy-report-only/index.md
@@ -96,8 +96,9 @@ The HTML of `signup.html` looks like this:
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-us">
   <head>
+    <meta charset="UTF-8">
     <title>Sign Up</title>
     <link rel="stylesheet" href="css/style.css">
   </head>

--- a/files/en-us/web/http/range_requests/index.md
+++ b/files/en-us/web/http/range_requests/index.md
@@ -88,8 +88,8 @@ Content-Length: 282
 Content-Type: text/html
 Content-Range: bytes 0-50/1270
 
-<!doctype html>
-<html>
+<!DOCTYPE html>
+<html lang="en-US">
 <head>
     <title>Example Do
 --3d6b6a416f9b5

--- a/files/en-us/web/javascript/guide/modules/index.md
+++ b/files/en-us/web/javascript/guide/modules/index.md
@@ -185,10 +185,10 @@ Module-defined variables are scoped to the module unless explicitly attached to 
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-us">
 <head>
+  <meta charset="UTF-8">
   <title></title>
-  <meta charset="utf-8">
   <link rel="stylesheet" href="">
 </head>
 <body>

--- a/files/en-us/web/javascript/reference/errors/property_access_denied/index.md
+++ b/files/en-us/web/javascript/reference/errors/property_access_denied/index.md
@@ -36,7 +36,7 @@ violated the [same-origin policy](/en-US/docs/Web/Security/Same-origin_policy).
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
   <head>
     <iframe id="myframe" src="http://www1.w3c-test.org/common/blank.html"></iframe>
     <script>

--- a/files/en-us/web/javascript/reference/global_objects/string/raw/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/raw/index.md
@@ -85,7 +85,7 @@ Many tools give special treatment to literals tagged by a particular name.
 ```js
 // Some formatters will format this literal's content as HTML
 const doc = html`<!DOCTYPE html>
-<html>
+<html lang="en-US">
   <head>
     <title>Hello</title>
   </head>

--- a/files/en-us/web/javascript/reference/template_literals/index.md
+++ b/files/en-us/web/javascript/reference/template_literals/index.md
@@ -262,7 +262,7 @@ This is useful for many tools which give special treatment to literals tagged by
 const html = (strings, ...values) => String.raw({ raw: strings }, ...values);
 // Some formatters will format this literal's content as HTML
 const doc = html`<!DOCTYPE html>
-<html>
+<html lang="en-US">
   <head>
     <title>Hello</title>
   </head>

--- a/files/en-us/web/mathml/authoring/index.md
+++ b/files/en-us/web/mathml/authoring/index.md
@@ -18,9 +18,10 @@ Each MathML equation is represented by a root [`math`](/en-US/docs/Web/MathML/El
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-us">
 <head>
- <title>MathML in HTML5</title>
+  <meta charset="UTF-8">
+  <title>MathML in HTML5</title>
 </head>
 <body>
 
@@ -110,8 +111,9 @@ A [custom element](/en-US/docs/Web/Web_Components/Using_custom_elements) can be 
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-us">
   <head>
+    <meta charset="UTF-8">
     <title>MathML in HTML5</title>
     <script src="https://fred-wang.github.io/TeXZilla/TeXZilla-min.js"></script>
     <script src="https://fred-wang.github.io/TeXZilla/examples/customElement.js"></script>
@@ -140,6 +142,7 @@ For authors not familiar with LaTeX, alternative input methods are available suc
 <head>
 <meta charset="utf-8"> 
 <meta name="viewport" content="width=device-width">
+<title>ASCII MathML</title>
 ...
 <!-- ASCIIMathML.js -->
 <script src="/path/to/ASCIIMathML.js"></script>
@@ -171,8 +174,9 @@ Instead of generating MathML expression at page load, you can instead rely on co
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-us">
   <head>
+    <meta charset="UTF-8">
     <title>MathML in HTML5</title>
   </head>
   <body>
@@ -201,8 +205,9 @@ After running that command, a file `output.html` containing the following HTML o
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-us">
   <head>
+    <meta charset="UTF-8">
     <title>MathML in HTML5</title>
   </head>
   <body>

--- a/files/en-us/web/performance/how_browsers_work/index.md
+++ b/files/en-us/web/performance/how_browsers_work/index.md
@@ -67,8 +67,8 @@ After the 8 round trips, the browser is finally able to make the request.
 Once we have an established connection to a web server, the browser sends an initial [HTTP `GET` request](/en-US/docs/Web/HTTP/Methods) on behalf of the user, which for websites is most often an HTML file. Once the server receives the request, it will reply with relevant response headers and the contents of the HTML.
 
 ```html
-<!doctype HTML>
-<html>
+<!DOCTYPE html>
+<html lang="en-US">
  <head>
   <meta charset="UTF-8"/>
   <title>My simple page</title>

--- a/files/en-us/web/web_components/using_shadow_dom/index.md
+++ b/files/en-us/web/web_components/using_shadow_dom/index.md
@@ -18,7 +18,7 @@ This article assumes you are already familiar with the concept of the [DOM (Docu
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>Simple DOM example</title>

--- a/files/en-us/webassembly/rust_to_wasm/index.md
+++ b/files/en-us/webassembly/rust_to_wasm/index.md
@@ -210,7 +210,7 @@ Let's start by creating a file named `index.html` in the root of the project, an
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>hello-wasm example</title>
@@ -319,7 +319,7 @@ Finally, we need to modify the HTML file; open the `index.html` file and replace
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <title>hello-wasm example</title>


### PR DESCRIPTION
All code examples which include a doctype followed by HTML now include the lang attribute. 
a few were EN-GB so people see it doesn't always have to be en-us

also added meta charset if it was missing.
and a needed viewport 

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [X] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
