### PR TITLE
fixed incorrect use of corresponding variable type

### DIFF
--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_typescript/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_typescript/index.md
@@ -337,7 +337,7 @@ Let's start with our `Alert.svelte` component.
     export let ms = 3000
 
       let visible: boolean
-      let timeout: number
+      let timeout: null | ReturnType<typeof setTimeout>
 
       const onMessageChange = (message: string, ms: number) => {
         clearTimeout(timeout)


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Changed timeout variable type, because the previous type presented the error: "Type 'Timeout' is not assignable to type 'number'".
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
To allow readers to know what type should be provided for the timeout variable to satisfy TypeScript's requirements.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
