### PR TITLE
Fix OpenGraph entries

### DIFF
--- a/files/en-us/web/progressive_web_apps/app_structure/index.md
+++ b/files/en-us/web/progressive_web_apps/app_structure/index.md
@@ -80,7 +80,7 @@ From the HTML point of view, the app shell is everything outside the content sec
   <meta name="author" content="end3r">
   <meta name="theme-color" content="#B12A34">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta property="og:image" content="icons/icon-512.png">
+  <meta property="og:image" content="https://js13kgames.com/img/js13kgames-banner.png">
   <link rel="icon" href="favicon.ico">
   <link rel="stylesheet" href="style.css">
   <link rel="manifest" href="js13kpwa.webmanifest">
@@ -89,18 +89,18 @@ From the HTML point of view, the app shell is everything outside the content sec
 </head>
 <body>
 <header>
-  <p><a class="logo" href="http://js13kgames.com"><img src="img/js13kgames.png" alt="js13kGames"></a></p>
+  <p><a class="logo" href="https://js13kgames.com"><img src="img/js13kgames.png" alt="js13kGames"></a></p>
 </header>
 <main>
   <h1>js13kGames A-Frame entries</h1>
-  <p class="description">List of games submitted to the <a href="http://js13kgames.com/aframe">A-Frame category</a> in the <a href="http://2017.js13kgames.com">js13kGames 2017</a> competition. You can <a href="https://github.com/mdn/pwa-examples/blob/master/js13kpwa">fork js13kPWA on GitHub</a> to check its source code.</p>
+  <p class="description">List of games submitted to the <a href="https://js13kgames.com/aframe">A-Frame category</a> in the <a href="https://2017.js13kgames.com">js13kGames 2017</a> competition. You can <a href="https://github.com/mdn/pwa-examples/blob/master/js13kpwa">fork js13kPWA on GitHub</a> to check its source code.</p>
   <button id="notifications">Request dummy notifications</button>
   <section id="content">
     // Content inserted in here
   </section>
 </main>
 <footer>
-  <p>© js13kGames 2012-2018, created and maintained by <a href="http://end3r.com">Andrzej Mazur</a> from <a href="http://enclavegames.com">Enclave Games</a>.</p>
+  <p>© js13kGames 2012-2018, created and maintained by <a href="https://end3r.com">Andrzej Mazur</a> from <a href="https://enclavegames.com">Enclave Games</a>.</p>
 </footer>
 </body>
 </html>


### PR DESCRIPTION
#### Summary
1) Fixed 'og:image' path, which was using relative path, which isn't allowed in the open graph protocol:
2) Updated URL's from HTTP to HTTPS

#### Motivation
I searched about what to add to the header for pwa and saw the 'og:image' meta tag which was missing in my HTML file. So I added it and found out that relative paths don't work. To prevent someone making eventually the same mistake, here a little (and my first) fix.

#### Supporting details
https://indieweb.org/The-Open-Graph-protocol#Disallows_relative_URLs

#### Metadata
- [ ] Fixes a typo, bug, or other error