### PR TITLE
Update BCD info, part 8

### DIFF
--- a/files/en-us/web/api/credential/index.md
+++ b/files/en-us/web/api/credential/index.md
@@ -5,14 +5,13 @@ page-type: web-api-interface
 tags:
   - API
   - Credential Management API
-  - Experimental
   - Interface
   - NeedsExample
   - Reference
   - credential management
 browser-compat: api.Credential
 ---
-{{SeeCompatTable}}{{APIRef("Credential Management API")}}{{securecontext_header}}
+{{APIRef("Credential Management API")}}{{securecontext_header}}
 
 The **`Credential`** interface of the [Credential Management API](/en-US/docs/Web/API/Credential_Management_API) provides information about an entity (usually a user) as a prerequisite to a trust decision.
 

--- a/files/en-us/web/api/credential/type/index.md
+++ b/files/en-us/web/api/credential/type/index.md
@@ -11,7 +11,7 @@ tags:
   - credential management
 browser-compat: api.Credential.type
 ---
-{{SeeCompatTable}}{{APIRef("Credential Management API")}}
+{{APIRef("Credential Management API")}}
 
 The **`type`** property of the
 {{domxref("Credential")}} interface returns a string containing the

--- a/files/en-us/web/api/credentialscontainer/create/index.md
+++ b/files/en-us/web/api/credentialscontainer/create/index.md
@@ -11,7 +11,7 @@ tags:
   - credential management
 browser-compat: api.CredentialsContainer.create
 ---
-{{APIRef("Credential Management API")}}{{SeeCompatTable}}
+{{APIRef("Credential Management API")}}
 
 The **`create()`** method of the
 {{domxref("CredentialsContainer")}} interface returns a {{jsxref("Promise")}} that

--- a/files/en-us/web/api/credentialscontainer/get/index.md
+++ b/files/en-us/web/api/credentialscontainer/get/index.md
@@ -12,7 +12,7 @@ tags:
   - credential management
 browser-compat: api.CredentialsContainer.get
 ---
-{{APIRef("Credential Management API")}}{{SeeCompatTable}}
+{{APIRef("Credential Management API")}}
 
 The **`get()`** method of the
 {{domxref("CredentialsContainer")}} interface returns a {{jsxref("Promise")}} to a

--- a/files/en-us/web/api/credentialscontainer/index.md
+++ b/files/en-us/web/api/credentialscontainer/index.md
@@ -6,14 +6,13 @@ tags:
   - API
   - Credential Management API
   - CredentialsContainer
-  - Experimental
   - Interface
   - NeedsExample
   - Reference
   - credential management
 browser-compat: api.CredentialsContainer
 ---
-{{SeeCompatTable}}{{APIRef("Credential Management API")}}{{securecontext_header}}
+{{APIRef("Credential Management API")}}{{securecontext_header}}
 
 The **`CredentialsContainer`** interface of the [Credential Management API](/en-US/docs/Web/API/Credential_Management_API) exposes methods to request credentials and notify the user agent when events such as successful sign in or sign out happen. This interface is accessible from {{domxref('Navigator.credentials')}}.
 

--- a/files/en-us/web/api/credentialscontainer/preventsilentaccess/index.md
+++ b/files/en-us/web/api/credentialscontainer/preventsilentaccess/index.md
@@ -12,7 +12,7 @@ tags:
   - credential management
 browser-compat: api.CredentialsContainer.preventSilentAccess
 ---
-{{APIRef("Credential Management API")}}{{SeeCompatTable}}
+{{APIRef("Credential Management API")}}
 
 The **`preventSilentAccess()`** method
 of the {{domxref("CredentialsContainer")}} interface sets a flag that specifies

--- a/files/en-us/web/api/credentialscontainer/store/index.md
+++ b/files/en-us/web/api/credentialscontainer/store/index.md
@@ -12,7 +12,7 @@ tags:
   - credential management
 browser-compat: api.CredentialsContainer.store
 ---
-{{APIRef("Credential Management API")}}{{SeeCompatTable}}
+{{APIRef("Credential Management API")}}
 
 The **`store()`** method of the
 {{domxref("CredentialsContainer")}} stores a set of credentials for the user inside a

--- a/files/en-us/web/api/crossoriginisolated/index.md
+++ b/files/en-us/web/api/crossoriginisolated/index.md
@@ -4,13 +4,12 @@ slug: Web/API/crossOriginIsolated
 page-type: web-api-global-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - crossOriginIsolated
 browser-compat: api.crossOriginIsolated
 ---
-{{APIRef()}}{{SeeCompatTable}}
+{{APIRef()}}
 
 The global **`crossOriginIsolated`** read-only property returns a boolean value that
 indicates whether a {{JSxRef("SharedArrayBuffer")}} can be sent via a

--- a/files/en-us/web/api/css/escape/index.md
+++ b/files/en-us/web/api/css/escape/index.md
@@ -12,7 +12,7 @@ tags:
   - escape()
 browser-compat: api.CSS.escape
 ---
-{{APIRef("CSSOM")}}{{SeeCompatTable}}
+{{APIRef("CSSOM")}}
 
 The **`CSS.escape()`** static method returns a
 string containing the escaped string passed as parameter, mostly for

--- a/files/en-us/web/api/css_counter_styles/index.md
+++ b/files/en-us/web/api/css_counter_styles/index.md
@@ -8,7 +8,7 @@ tags:
   - Overview
 browser-compat: api.CSSCounterStyleRule
 ---
-{{DefaultAPISidebar("CSS Counter Styles")}}{{SeeCompatTable}}
+{{DefaultAPISidebar("CSS Counter Styles")}}
 
 The CSS Counter Styles module allows to define custom counter styles, which can be used for CSS list-marker and generated-content counters.
 

--- a/files/en-us/web/api/cssanimation/animationname/index.md
+++ b/files/en-us/web/api/cssanimation/animationname/index.md
@@ -10,7 +10,7 @@ tags:
   - Reference
 browser-compat: api.CSSAnimation.animationName
 ---
-{{APIRef("Web Animations API")}}{{SeeCompatTable}}
+{{APIRef("Web Animations API")}}
 
 The **`animationName`** property of the
 {{domxref("CSSAnimation")}} interface returns the {{CSSXref("animation-name")}}. This

--- a/files/en-us/web/api/cssanimation/index.md
+++ b/files/en-us/web/api/cssanimation/index.md
@@ -10,7 +10,7 @@ tags:
   - Reference
 browser-compat: api.CSSAnimation
 ---
-{{APIRef("Web Animations API")}}{{SeeCompatTable}}
+{{APIRef("Web Animations API")}}
 
 The **`CSSAnimation`** interface of the {{domxref('Web Animations API','','',' ')}} represents an {{domxref("Animation")}} object.
 

--- a/files/en-us/web/api/csspositionvalue/csspositionvalue/index.md
+++ b/files/en-us/web/api/csspositionvalue/csspositionvalue/index.md
@@ -7,7 +7,6 @@ tags:
   - CSS Typed Object Model API
   - CSSPositionValue
   - Constructor
-  - Experimental
   - Houdini
   - Reference
   - Deprecated

--- a/files/en-us/web/api/csspositionvalue/index.md
+++ b/files/en-us/web/api/csspositionvalue/index.md
@@ -6,7 +6,6 @@ tags:
   - API
   - CSS Typed Object Model API
   - CSSPositionValue
-  - Experimental
   - Houdini
   - Interface
   - Reference

--- a/files/en-us/web/api/csspositionvalue/x/index.md
+++ b/files/en-us/web/api/csspositionvalue/x/index.md
@@ -6,7 +6,6 @@ tags:
   - API
   - CSS Typed Object Model API
   - CSSPositionValue
-  - Experimental
   - Houdini
   - Property
   - Reference

--- a/files/en-us/web/api/csspositionvalue/y/index.md
+++ b/files/en-us/web/api/csspositionvalue/y/index.md
@@ -6,7 +6,6 @@ tags:
   - API
   - CSS Typed Object Model API
   - CSSPositionValue
-  - Experimental
   - Houdini
   - Property
   - Reference

--- a/files/en-us/web/api/csspropertyrule/index.md
+++ b/files/en-us/web/api/csspropertyrule/index.md
@@ -7,7 +7,6 @@ tags:
   - CSS
   - CSS Properties and Values API
   - CSSPropertyRule
-  - Experimental
   - Houdini
   - Interface
   - Reference

--- a/files/en-us/web/api/csspropertyrule/inherits/index.md
+++ b/files/en-us/web/api/csspropertyrule/inherits/index.md
@@ -7,7 +7,6 @@ tags:
   - CSS
   - CSS Properties and Values API
   - CSSPropertyRule
-  - Experimental
   - Houdini
   - Property
   - Reference

--- a/files/en-us/web/api/csspropertyrule/initialvalue/index.md
+++ b/files/en-us/web/api/csspropertyrule/initialvalue/index.md
@@ -7,14 +7,13 @@ tags:
   - CSS
   - CSS Properties and Values API
   - CSSPropertyRule
-  - Experimental
   - Houdini
   - Property
   - Reference
   - Read-only
 browser-compat: api.CSSPropertyRule.initialValue
 ---
-{{APIRef("CSS Properties and Values API")}}{{SeeCompatTable}}
+{{APIRef("CSS Properties and Values API")}}
 
 The read-only **`initialValue`** nullable property of the {{domxref("CSSPropertyRule")}} interface returns the initial value of the custom property registration represented by the {{cssxref("@property")}} rule, controlling the property's initial value.
 

--- a/files/en-us/web/api/csspropertyrule/name/index.md
+++ b/files/en-us/web/api/csspropertyrule/name/index.md
@@ -7,7 +7,6 @@ tags:
   - CSS
   - CSS Properties and Values API
   - CSSPropertyRule
-  - Experimental
   - Houdini
   - Property
   - Reference

--- a/files/en-us/web/api/csspropertyrule/syntax/index.md
+++ b/files/en-us/web/api/csspropertyrule/syntax/index.md
@@ -7,7 +7,6 @@ tags:
   - CSS
   - CSS Properties and Values API
   - CSSPropertyRule
-  - Experimental
   - Houdini
   - Property
   - Reference

--- a/files/en-us/web/api/cssstylerule/stylemap/index.md
+++ b/files/en-us/web/api/cssstylerule/stylemap/index.md
@@ -8,11 +8,10 @@ tags:
   - CSSStyleRule
   - Reference
   - Houdini
-  - Experimental
   - Property
 browser-compat: api.CSSStyleRule.styleMap
 ---
-{{APIRef("CSSOM")}}{{SeeCompatTable}}
+{{APIRef("CSSOM")}}
 
 The **`styleMap`** read-only property of the
 {{domxref("CSSStyleRule")}} interface returns a {{domxref('StylePropertyMap')}} object

--- a/files/en-us/web/api/csstransition/index.md
+++ b/files/en-us/web/api/csstransition/index.md
@@ -10,7 +10,7 @@ tags:
   - Reference
 browser-compat: api.CSSTransition
 ---
-{{APIRef("Web Animations API")}}{{SeeCompatTable}}
+{{APIRef("Web Animations API")}}
 
 The **`CSSTransition`** interface of the {{domxref('Web Animations API','','',' ')}} represents an {{domxref("Animation")}} object used for a [CSS Transition](/en-US/docs/Web/CSS/CSS_Transitions).
 

--- a/files/en-us/web/api/csstransition/transitionproperty/index.md
+++ b/files/en-us/web/api/csstransition/transitionproperty/index.md
@@ -10,7 +10,7 @@ tags:
   - Reference
 browser-compat: api.CSSTransition.transitionProperty
 ---
-{{APIRef("Web Animations API")}}{{SeeCompatTable}}
+{{APIRef("Web Animations API")}}
 
 The **`transitionProperty`** property of the
 {{domxref("CSSTransition")}} interface returns the **expanded transition property

--- a/files/en-us/web/api/customelementregistry/get/index.md
+++ b/files/en-us/web/api/customelementregistry/get/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - CustomElementRegistry
-  - Experimental
   - Method
   - Reference
   - Web Components

--- a/files/en-us/web/api/document/caretpositionfrompoint/index.md
+++ b/files/en-us/web/api/document/caretpositionfrompoint/index.md
@@ -9,7 +9,7 @@ tags:
   - Reference
 browser-compat: api.Document.caretPositionFromPoint
 ---
-{{APIRef("CSSOM View")}} {{SeeCompatTable}}
+{{APIRef("CSSOM View")}}
 
 The **`caretPositionFromPoint()`**
 property of the {{domxref("Document")}} interface returns a

--- a/files/en-us/web/api/htmlmenuelement/index.md
+++ b/files/en-us/web/api/htmlmenuelement/index.md
@@ -4,14 +4,13 @@ slug: Web/API/HTMLMenuElement
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - Draft
   - HTMLMenuElement
   - Interface
   - Reference
 browser-compat: api.HTMLMenuElement
 ---
-{{APIRef("HTML DOM")}}{{SeeCompatTable}}
+{{APIRef("HTML DOM")}}
 
 The **`HTMLMenuElement`** interface provides special properties (beyond those defined on the regular {{DOMxRef("HTMLElement")}} interface it also has available to it by inheritance) for manipulating {{HTMLElement("menu")}} elements.
 
@@ -28,11 +27,11 @@ _Inherits properties from its parent, {{domxref("HTMLElement")}}, and its ancest
 
 - `compact` {{deprecated_inline}}
   - : A Boolean value determining if the menu displays in a compact way.
-- `type` {{deprecated_inline}}
+- `type` {{deprecated_inline}} {{Non-standard_Inline}}
   - : Returns `context` if the menu is a context menu.
     This use of the {{HTMLElement("menu")}} element has never been implemented widely
     and is now deprecated.
-- `label` {{deprecated_inline}}
+- `label` {{deprecated_inline}} {{Non-standard_Inline}}
   - : A string associating the menu with a name,
     displayed when the menu is used as a context menu.
     This use of the {{HTMLElement("menu")}} element has never been implemented widely

--- a/files/en-us/web/api/htmloptionscollection/index.md
+++ b/files/en-us/web/api/htmloptionscollection/index.md
@@ -12,7 +12,9 @@ tags:
   - Reference
 browser-compat: api.HTMLOptionsCollection
 ---
-{{ APIRef("HTML DOM") }}The **`HTMLOptionsCollection`** interface represents a collection of [`<option>`](/en-US/docs/Web/HTML/Element/option) HTML elements (in document order) and offers methods and properties for selecting from the list as well as optionally altering its items. This object is returned only by the `options` property of [select](/en-US/docs/Web/API/HTMLSelectElement).
+{{ APIRef("HTML DOM") }}
+
+The **`HTMLOptionsCollection`** interface represents a collection of [`<option>`](/en-US/docs/Web/HTML/Element/option) HTML elements (in document order) and offers methods and properties for selecting from the list as well as optionally altering its items. This object is returned only by the `options` property of [select](/en-US/docs/Web/API/HTMLSelectElement).
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/htmlpictureelement/index.md
+++ b/files/en-us/web/api/htmlpictureelement/index.md
@@ -4,13 +4,12 @@ slug: Web/API/HTMLPictureElement
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - HTML DOM
   - Interface
   - Reference
 browser-compat: api.HTMLPictureElement
 ---
-{{APIRef("HTML DOM")}}{{SeeCompatTable}}
+{{APIRef("HTML DOM")}}
 
 The **`HTMLPictureElement`** interface represents a {{HTMLElement("picture")}} HTML element. It doesn't implement specific properties or methods.
 

--- a/files/en-us/web/api/htmlscriptelement/supports/index.md
+++ b/files/en-us/web/api/htmlscriptelement/supports/index.md
@@ -8,11 +8,10 @@ tags:
   - Method
   - Reference
   - supports
-  - Experimental
   - Feature detection
 browser-compat: api.HTMLScriptElement.supports
 ---
-{{APIRef}}{{SeeCompatTable}}
+{{APIRef}}
 
 The **`supports()`** static method of the {{domxref("HTMLScriptElement")}} interface provides a simple and consistent method to feature-detect what types of scripts are supported by the user agent.
 


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.
It focuses on files that have only left behind 'experimental' tags and headers.