### PR TITLE
Remove browser compatibility notes for Window.requestAnimationFrame

### DIFF
--- a/files/en-us/web/api/window/requestanimationframe/index.md
+++ b/files/en-us/web/api/window/requestanimationframe/index.md
@@ -112,11 +112,6 @@ function step(timestamp) {
 window.requestAnimationFrame(step);
 ```
 
-## Notes
-
-Edge versions below 17 and Internet Explorer do not reliably fire
-`requestAnimationFrame` before the paint cycle.
-
 ## Specifications
 
 {{Specifications}}


### PR DESCRIPTION
This PR removes the browser compatibility notes from the MDN page, as they are being moved to BCD in https://github.com/mdn/browser-compat-data/pull/17303.