### PR TITLE
Correct return value

### DIFF
--- a/files/en-us/web/api/navigator/getgamepads/index.md
+++ b/files/en-us/web/api/navigator/getgamepads/index.md
@@ -34,7 +34,7 @@ None.
 
 ### Return value
 
-None ({{jsxref("undefined")}}).
+An {{jsxref("Array")}} of {{domxref("Gamepad")}} objects, eventually empty.
 
 ## Examples
 


### PR DESCRIPTION
The return value is not none, but an Array. In the spec `sequence<GamePad?> getGamePads()`.