### PR TITLE
Avoid classical for when looping through all items of an Array-like object

### DIFF
--- a/files/en-us/web/api/user_timing_api/using_the_user_timing_api/index.md
+++ b/files/en-us/web/api/user_timing_api/using_the_user_timing_api/index.md
@@ -38,8 +38,9 @@ function create_marks(ev) {
     do_work(50000);
     performance.mark("mark-2");
     const marks = ["mark-1", "mark-2", "mark-2"];
-    for (let i=0; i < marks.length; i++)
-      log(`... Created mark = ${marks[i]}`, 0);
+    marks.forEach((mark) => {
+      log(`... Created mark = ${mark}`, 0);
+    });
   }
 }
 ```
@@ -59,31 +60,31 @@ function display_marks(ev) {
   // Display each mark using getEntries()
   let entries = performance.getEntries();
   let j=0;
-  for (let i = 0; i < entries.length; i++) {
-    if (entries[i].entryType === "mark") {
+  entries.forEach((entry, i) => {
+    if (entry.entryType === "mark") {
       if (j === 0) { log("= getEntries()", 0); j++ }
-      log(`... [${i}] = ${entries[i].name}`, 0);
-    }
-  }
+      log(`... [${i}] = ${entry.name}`, 0);
+    };
+  });
 
   // Display each mark using getEntriesByType()
   entries = performance.getEntriesByType("mark");
-  for (let i = 0; i < entries.length; i++) {
+  entries.forEach((entry, i) => {
     if (i === 0) log("= getEntriesByType('mark')", 0);
-    log(`... [${i}] = ${entries[i].name}`, 0);
-  }
+    log(`... [${i}] = ${entry.name}`, 0);
+  });
 
   // Display each mark using getEntriesName(); must look for each mark separately
   entries = performance.getEntriesByName("mark-1","mark");
-  for (let i = 0; i < entries.length; i++) {
+  entries.forEach((entry, i) => {
     if (i === 0) log("= getEntriesByName('mark-1', 'mark')", 0);
-    log(`... ${entries[i].name}`, 0);
-  }
+    log(`... ${entry.name}`, 0);
+  });
   entries = performance.getEntriesByName("mark-2","mark");
-  for (let i = 0; i < entries.length; i++) {
+  entries.forEach((entry, i) => {
     if (i === 0) log("= getEntriesByName('mark-2', 'mark')", 0);
-    log(`... ${entries[i].name}`, 0);
-  }
+    log(`... ${entry.name}`, 0);
+  });
 }
 ```
 
@@ -141,12 +142,13 @@ function create_measures(ev) {
 
   // Log the marks and measures
   const marks = ["mark-A", "mark-B", "mark-C", "mark-D"];
-  for (let i = 0; i < marks.length; i++)
-    log(`... Created mark = ${marks[i]}`, 1);
+  marks.forEach((mark) => {
+    log(`... Created mark = ${mark}`, 1);
+  });
   const measures = ["measures-1", "measures-2"];
-  for (let i = 0; i < measures.length; i++)
-    log(`... Created measure = ${measures[i]}`, 1);
-
+  measures.forEach((measure) => {
+    log(`... Created measure = ${measure}`, 1);
+  });
 }
 ```
 
@@ -165,31 +167,31 @@ function display_measures(ev) {
   // Display each measure using getEntries()
   let entries = performance.getEntries();
   let j=0;
-  for (let i = 0; i < entries.length; i++) {
-    if (entries[i].entryType === "measure") {
+  entries.forEach((entry, i) => {
+    if (entry.entryType === "measure") {
       if (j === 0) { log("= getEntries()", 1); j++ }
-      log(`... [${i}] = ${entries[i].name}`, 1);
+      log(`... [${i}] = ${entry.name}`, 1);
     }
-  }
+  });
 
   // Display each measure using getEntriesByType
   entries = performance.getEntriesByType("measure");
-  for (let i = 0; i < entries.length; i++) {
+  entries.forEach((entry, i) => {
     if (i === 0) log("= getEntriesByType('measure')", 1);
-    log(`... [${i}] = ${entries[i].name}`, 1);
-  }
+    log(`... [${i}] = ${entriy.name}`, 1);
+  });
 
   // Display each measure using getEntriesName() - have to look for each measure separately
   entries = performance.getEntriesByName("measure-1","measure");
-  for (let i = 0; i < entries.length; i++) {
+  entries.forEach((entry, i) => {
     if (i === 0) log("= getEntriesByName('measure-1', 'measure')", 1);
-    log(`... ${entries[i].name}`, 1);
-  }
+    log(`... ${entry.name}`, 1);
+  });
   entries = performance.getEntriesByName("measure-2","measure");
-  for (let i = 0; i < entries.length; i++) {
+  entries.forEach((entry, i) => {
     if (i === 0) log("= getEntriesByName('measure-2', 'measure')", 1);
-    log(`... ${entries[i].name}`, 1);
-  }
+    log(`... ${entry.name}`, 1);
+  });
 }
 ```
 

--- a/files/en-us/web/api/vrdisplaycapabilities/index.md
+++ b/files/en-us/web/api/vrdisplaycapabilities/index.md
@@ -39,7 +39,7 @@ This interface is accessible through the {{domxref("VRDisplay.capabilities")}} p
 ```js
 function reportDisplays() {
   navigator.getVRDisplays().then((displays) => {
-    displays.foreach((display, i) => {
+    displays.forEach((display, i) => {
       const cap = display.capabilities;
       // cap is a VRDisplayCapabilities object
       const listItem = document.createElement('li');

--- a/files/en-us/web/api/vrdisplaycapabilities/index.md
+++ b/files/en-us/web/api/vrdisplaycapabilities/index.md
@@ -39,20 +39,20 @@ This interface is accessible through the {{domxref("VRDisplay.capabilities")}} p
 ```js
 function reportDisplays() {
   navigator.getVRDisplays().then((displays) => {
-    for (let i = 0; i < displays.length; i++) {
-      const cap = displays[i].capabilities;
+    displays.foreach((display, i) => {
+      const cap = display.capabilities;
       // cap is a VRDisplayCapabilities object
       const listItem = document.createElement('li');
       listItem.innerHTML = `<strong>Display ${i + 1}</strong><br>` +
-        `VR Display ID: ${displays[i].displayId}<br>` +
-        `VR Display Name: ${displays[i].displayName}<br>` +
+        `VR Display ID: ${display.displayId}<br>` +
+        `VR Display Name: ${display.displayName}<br>` +
         `Display can present content: ${cap.canPresent}<br>` +
         `Display is separate from the computer's main display: ${cap.hasExternalDisplay}<br>` +
         `Display can return position info: ${cap.hasPosition}<br>` +
         `Display can return orientation info: ${cap.hasOrientation}<br>` +
         `Display max layers: ${cap.maxLayers}`;
       list.appendChild(listItem);
-    }
+    });
   });
 }
 ```

--- a/files/en-us/web/api/web_audio_api/using_audioworklet/index.md
+++ b/files/en-us/web/api/web_audio_api/using_audioworklet/index.md
@@ -151,7 +151,7 @@ process(inputList, outputList, parameters) {
     let channelCount = Math.min(input.length, output.length);
 
     for (let channelNum = 0; channelNum < channelCount; channelNum++) {
-      for (let i = 0; i < input[channelNum].lengt; i++) {
+      for (let i = 0; i < input[channelNum].length; i++) {
         let sample = output[channelNum][i] + input[channelNum][i];
 
         if (sample > 1.0) {

--- a/files/en-us/web/api/web_audio_api/using_audioworklet/index.md
+++ b/files/en-us/web/api/web_audio_api/using_audioworklet/index.md
@@ -68,9 +68,9 @@ class MyAudioProcessor extends AudioWorkletProcessor {
   }
 
   process(inputList, outputList, parameters) {
-    /* using the inputs (or not, as needed), write the output
-       into each of the outputs */
-
+    // Use the inputs (or not, as needed),
+    // write the output into each of the outputs
+    // …
     return true;
   }
 };
@@ -130,8 +130,7 @@ process(inputList, outputList, parameters) {
       for (let i = 0; i < sampleCount; i++) {
         let sample = input[channelNum][i];
 
-        /* Manipulate the sample */
-
+        // Manipulate the sample
         output[channelNum][i] = sample;
       }
     }
@@ -209,7 +208,7 @@ async function createMyAudioProcessor() {
       audioContext = new AudioContext();
       await audioContext.resume();
       await audioContext.audioWorklet.addModule("module-url/module.js");
-    } catch (e) {
+    } catch(e) {
       return null;
     }
   }

--- a/files/en-us/web/api/web_audio_api/using_audioworklet/index.md
+++ b/files/en-us/web/api/web_audio_api/using_audioworklet/index.md
@@ -120,13 +120,11 @@ process(inputList, outputList, parameters) {
   const sourceLimit = Math.min(inputList.length, outputList.length);
 
   for (let inputNum = 0; inputNum < sourceLimit; inputNum++) {
-    let input = inputList[inputNum];
-    let output = outputList[inputNum];
-    let channelCount = Math.min(input.length, output.length);
+    const input = inputList[inputNum];
+    const output = outputList[inputNum];
+    const channelCount = Math.min(input.length, output.length);
 
     for (let channelNum = 0; channelNum < channelCount; channelNum++) {
-      let sampleCount = input[channelNum].length;
-
       input[channelNum].forEach((sample, i) => {
         // Manipulate the sample
         output[channelNum][i] = sample;

--- a/files/en-us/web/api/web_audio_api/using_audioworklet/index.md
+++ b/files/en-us/web/api/web_audio_api/using_audioworklet/index.md
@@ -127,12 +127,10 @@ process(inputList, outputList, parameters) {
     for (let channelNum = 0; channelNum < channelCount; channelNum++) {
       let sampleCount = input[channelNum].length;
 
-      for (let i = 0; i < sampleCount; i++) {
-        let sample = input[channelNum][i];
-
+      input[channelNum].forEach((sample, i) => {
         // Manipulate the sample
         output[channelNum][i] = sample;
-      }
+      });
     }
   };
 

--- a/files/en-us/web/api/web_audio_api/using_audioworklet/index.md
+++ b/files/en-us/web/api/web_audio_api/using_audioworklet/index.md
@@ -68,7 +68,7 @@ class MyAudioProcessor extends AudioWorkletProcessor {
   }
 
   process(inputList, outputList, parameters) {
-    // Use the inputs (or not, as needed),
+    // Using the inputs (or not, as needed),
     // write the output into each of the outputs
     // …
     return true;

--- a/files/en-us/web/api/web_audio_api/using_audioworklet/index.md
+++ b/files/en-us/web/api/web_audio_api/using_audioworklet/index.md
@@ -153,9 +153,7 @@ process(inputList, outputList, parameters) {
     let channelCount = Math.min(input.length, output.length);
 
     for (let channelNum = 0; channelNum < channelCount; channelNum++) {
-      let sampleCount = input[channelNum].length;
-
-      for (let i = 0; i < sampleCount; i++) {
+      for (let i = 0; i < input[channelNum].lengt; i++) {
         let sample = output[channelNum][i] + input[channelNum][i];
 
         if (sample > 1.0) {

--- a/files/en-us/web/api/web_audio_api/using_audioworklet/index.md
+++ b/files/en-us/web/api/web_audio_api/using_audioworklet/index.md
@@ -208,7 +208,7 @@ async function createMyAudioProcessor() {
       audioContext = new AudioContext();
       await audioContext.resume();
       await audioContext.audioWorklet.addModule("module-url/module.js");
-    } catch(e) {
+    } catch (e) {
       return null;
     }
   }

--- a/files/en-us/web/api/web_audio_api/using_iir_filters/index.md
+++ b/files/en-us/web/api/web_audio_api/using_iir_filters/index.md
@@ -194,19 +194,19 @@ canvasCtx.fillText('20k', width - spacing, height - spacing + fontSize);
 // Loop over our magnitude response data and plot our filter
 canvasCtx.beginPath();
 
-for (let i = 0; i < magResponseOutput.length; i++) {
+magResponseOutput.forEach((magResponseData, i) => {
   if (i === 0) {
     canvasCtx.moveTo(
       spacing,
-      height - magResponseOutput[i] * 100 - spacing,
+      height - magResponseData * 100 - spacing,
     );
   } else {
     canvasCtx.lineTo(
       width / totalArrayItems * i,
-      height - magResponseOutput[i] * 100 - spacing,
+      height - magResponseData * 100 - spacing,
     );
   }
-}
+});
 
 canvasCtx.stroke();
 ```

--- a/files/en-us/web/api/web_midi_api/index.md
+++ b/files/en-us/web/api/web_midi_api/index.md
@@ -88,8 +88,8 @@ This example prints incoming MIDI messages on a single port to the console.
 ```js
 function onMIDIMessage(event) {
   let str = `MIDI message received at timestamp ${event.timeStamp}[${event.data.length} bytes]: `;
-  for (let i=0; i<event.data.length; i++) {
-    str += `0x${event.data[i].toString(16)} `;
+  for (const character of event.data) {
+    str += `0x${character.toString(16)} `;
   }
   console.log(str);
 }

--- a/files/en-us/web/api/web_speech_api/using_the_web_speech_api/index.md
+++ b/files/en-us/web/api/web_speech_api/using_the_web_speech_api/index.md
@@ -258,7 +258,7 @@ function populateVoiceList() {
     const option = document.createElement('option');
     option.textContent = `${voice.name} (${voice.lang})`;
 
-    if (voices[i].default) {
+    if (voice.default) {
       option.textContent += ' — DEFAULT';
     }
 

--- a/files/en-us/web/api/web_workers_api/using_web_workers/index.md
+++ b/files/en-us/web/api/web_workers_api/using_web_workers/index.md
@@ -571,11 +571,8 @@ Modern browsers contain an additional way to pass certain types of objects to or
 For example, when transferring an {{jsxref("ArrayBuffer")}} from your main app to a worker script, the original {{jsxref("ArrayBuffer")}} is cleared and no longer usable. Its content is (quite literally) transferred to the worker context.
 
 ```js
-// Create a 32MB "file" and fill it.
-const uInt8Array = new Uint8Array(1024 * 1024 * 32); // 32MB
-for (let i = 0; i < uInt8Array.length; ++i) {
-  uInt8Array[i] = i;
-}
+// Create a 32MB "file" and fill it with consecutive values from 0 to 255 – 32MB = 1024 * 1024 * 32
+const uInt8Array = Uint8Array.from({ length: 1024 * 1024 * 32 }, (v, i) => i);
 worker.postMessage(uInt8Array.buffer, [uInt8Array.buffer]);
 ```
 

--- a/files/en-us/web/api/webgl_api/tutorial/creating_3d_objects_using_webgl/index.md
+++ b/files/en-us/web/api/webgl_api/tutorial/creating_3d_objects_using_webgl/index.md
@@ -101,9 +101,7 @@ We also need to build an array of colors for each of the 24 vertices. This code 
 
   const colors = [];
 
-  for (let j = 0; j < faceColors.length; ++j) {
-    const c = faceColors[j];
-
+  for (const c of faceColors) 
     // Repeat each color four times for the four vertices of the face
     colors.push(c, c, c, c);
   }

--- a/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.md
@@ -226,16 +226,16 @@ const vertices = await response.json();
 const buffer = new ArrayBuffer(20 * vertices.length);
 // Fill array buffer
 const dv = new DataView(buffer);
-for (let i = 0; i < vertices.length; i++) {
-  dv.setFloat32(20 * i, vertices[i].position[0], true);
-  dv.setFloat32(20 * i + 4, vertices[i].position[1], true);
-  dv.setFloat32(20 * i + 8, vertices[i].position[2], true);
-  dv.setInt8(20 * i + 12, vertices[i].normal[0] * 0x7F);
-  dv.setInt8(20 * i + 13, vertices[i].normal[1] * 0x7F);
-  dv.setInt8(20 * i + 14, vertices[i].normal[2] * 0x7F);
+vertices.forEach((vertice, i) => {
+  dv.setFloat32(20 * i, vertice.position[0], true);
+  dv.setFloat32(20 * i + 4, vertice.position[1], true);
+  dv.setFloat32(20 * i + 8, vertice.position[2], true);
+  dv.setInt8(20 * i + 12, vertice.normal[0] * 0x7F);
+  dv.setInt8(20 * i + 13, vertice.normal[1] * 0x7F);
+  dv.setInt8(20 * i + 14, vertice.normal[2] * 0x7F);
   dv.setInt8(20 * i + 15, 0);
-  dv.setUint16(20 * i + 16, vertices[i].texCoord[0] * 0xFFFF, true);
-  dv.setUint16(20 * i + 18, vertices[i].texCoord[1] * 0xFFFF, true);
+  dv.setUint16(20 * i + 16, vertice.texCoord[0] * 0xFFFF, true);
+  dv.setUint16(20 * i + 18, vertice.texCoord[1] * 0xFFFF, true);
 }
 ```
 

--- a/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.md
@@ -218,13 +218,13 @@ First, we dynamically create the array buffer from JSON data using a
 data to be in little-endian.
 
 ```js
-//load geometry with fetch() and Response.json()
+// Load geometry with fetch() and Response.json()
 const response = await fetch('assets/geometry.json');
 const vertices = await response.json();
 
-//Create array buffer
+// Create array buffer
 const buffer = new ArrayBuffer(20 * vertices.length);
-//Fill array buffer
+// Fill array buffer
 const dv = new DataView(buffer);
 for (let i = 0; i < vertices.length; i++) {
   dv.setFloat32(20 * i, vertices[i].position[0], true);

--- a/files/en-us/web/api/webrtc_api/signaling_and_video_calling/index.md
+++ b/files/en-us/web/api/webrtc_api/signaling_and_video_calling/index.md
@@ -46,12 +46,7 @@ First up is the addition of the function `sendToOneUser()`. As the name suggests
 function sendToOneUser(target, msgString) {
   const isUnique = true;
 
-  for (const connection of connectionArray) {
-    if (connection.username === target) {
-      connection.send(msgString);
-      break;
-    }
-  }
+  connectionArray.find((conn) => conn.username === target).send(msgString);
 }
 ```
 

--- a/files/en-us/web/api/webrtc_api/signaling_and_video_calling/index.md
+++ b/files/en-us/web/api/webrtc_api/signaling_and_video_calling/index.md
@@ -44,8 +44,6 @@ First up is the addition of the function `sendToOneUser()`. As the name suggests
 
 ```js
 function sendToOneUser(target, msgString) {
-  const isUnique = true;
-
   connectionArray.find((conn) => conn.username === target).send(msgString);
 }
 ```

--- a/files/en-us/web/api/webrtc_api/signaling_and_video_calling/index.md
+++ b/files/en-us/web/api/webrtc_api/signaling_and_video_calling/index.md
@@ -45,11 +45,10 @@ First up is the addition of the function `sendToOneUser()`. As the name suggests
 ```js
 function sendToOneUser(target, msgString) {
   const isUnique = true;
-  let i;
 
-  for (i=0; i < connectionArray.length; i++) {
-    if (connectionArray[i].username === target) {
-      connectionArray[i].send(msgString);
+  for (const connection of connectionArray) {
+    if (connection.username === target) {
+      connection.send(msgString);
       break;
     }
   }
@@ -67,8 +66,8 @@ if (sendToClients) {
   if (msg.target && msg.target.length !== 0) {
     sendToOneUser(msg.target, msgString);
   } else {
-    for (i=0; i < connectionArray.length; i++) {
-      connectionArray[i].send(msgString);
+    for (const connection of connectionArray) {
+      connection.send(msgString);
     }
   }
 }

--- a/files/en-us/web/api/websockets_api/writing_websocket_servers/index.md
+++ b/files/en-us/web/api/websockets_api/writing_websocket_servers/index.md
@@ -128,18 +128,16 @@ To read the payload data, you must know when to stop reading. That's why the pay
 2. Read the next 16 bits and interpret those as an unsigned integer. You're **done**.
 3. Read the next 64 bits and interpret those as an unsigned integer. (The most significant bit _must_ be 0.) You're **done**.
 
-### Reading and Unmasking the Data
+### Reading and unmasking the Data
 
-If the MASK bit was set (and it should be, for client-to-server messages), read the next 4 octets (32 bits); this is the masking key. Once the payload length and masking key is decoded, you can read that number of bytes from the socket. Let's call the data **ENCODED**, and the key **MASK**. To get **DECODED**, loop through the octets (bytes a.k.a. characters for text data) of **ENCODED** and XOR the octet with the (i modulo 4)th octet of MASK. In pseudo-code (that happens to be valid JavaScript):
+If the MASK bit was set (and it should be, for client-to-server messages), read the next 4 octets (32 bits); this is the masking key. Once the payload length and masking key is decoded, you can read that number of bytes from the socket. Let's call the data `encoded`, and the key `mask`. To get `decoded`, loop through the octets (bytes a.k.a. characters for text data) of `encoded` and XOR the octet with the (i modulo 4)th octet of MASK. In pseudo-code (that happens to be valid JavaScript):
 
 ```js
-const MASK = [1, 2, 3, 4]                   // 4-byte mask
-const ENCODED = [105, 103, 111, 104, 110]   // encoded string "hello"
+const mask = [1, 2, 3, 4]; // 4-byte mask
+const encoded = [105, 103, 111, 104, 110]; // encoded string "hello"
 
-const DECODED = []                          // byte array of decoded payload
-for (let i = 0; i < ENCODED.length; i++) {
-  DECODED[i] = ENCODED[i] ^ MASK[i % 4]
-}
+// Create the byte Array of decoded payload
+const decoded = encoded.from((elt, i) => elt ^ mask[i % 4]); // Perform an XOR on the mask
 ```
 
 Now you can figure out what **DECODED** means depending on your application.

--- a/files/en-us/web/api/websockets_api/writing_websocket_servers/index.md
+++ b/files/en-us/web/api/websockets_api/writing_websocket_servers/index.md
@@ -137,7 +137,7 @@ const MASK = [1, 2, 3, 4]; // 4-byte mask
 const ENCODED = [105, 103, 111, 104, 110]; // encoded string "hello"
 
 // Create the byte Array of decoded payload
-const DECODED = Uint8Array.from(ENCODED(elt, i) => elt ^ mask[i % 4]); // Perform an XOR on the mask
+const DECODED = Uint8Array.from(ENCODED, (elt, i) => elt ^ mask[i % 4]); // Perform an XOR on the mask
 ```
 
 Now you can figure out what **DECODED** means depending on your application.

--- a/files/en-us/web/api/websockets_api/writing_websocket_servers/index.md
+++ b/files/en-us/web/api/websockets_api/writing_websocket_servers/index.md
@@ -130,7 +130,7 @@ To read the payload data, you must know when to stop reading. That's why the pay
 
 ### Reading and unmasking the data
 
-If the MASK bit was set (and it should be, for client-to-server messages), read the next 4 octets (32 bits); this is the masking key. Once the payload length and masking key is decoded, you can read that number of bytes from the socket. Let's call the data `ENCODED`, and the key `MASK`. To get `DECODED`, loop through the octets (bytes a.k.a. characters for text data) of `encoded` and XOR the octet with the (i modulo 4)th octet of `MASK`. In pseudo-code (that happens to be valid JavaScript):
+If the MASK bit was set (and it should be, for client-to-server messages), read the next 4 octets (32 bits); this is the masking key. Once the payload length and masking key is decoded, you can read that number of bytes from the socket. Let's call the data `ENCODED`, and the key `MASK`. To get `DECODED`, loop through the octets (bytes a.k.a. characters for text data) of `ENCODED` and XOR the octet with the (i modulo 4)th octet of `MASK`. In pseudo-code (that happens to be valid JavaScript):
 
 ```js
 const MASK = [1, 2, 3, 4]; // 4-byte mask

--- a/files/en-us/web/api/websockets_api/writing_websocket_servers/index.md
+++ b/files/en-us/web/api/websockets_api/writing_websocket_servers/index.md
@@ -128,7 +128,7 @@ To read the payload data, you must know when to stop reading. That's why the pay
 2. Read the next 16 bits and interpret those as an unsigned integer. You're **done**.
 3. Read the next 64 bits and interpret those as an unsigned integer. (The most significant bit _must_ be 0.) You're **done**.
 
-### Reading and unmasking the Data
+### Reading and unmasking the data
 
 If the MASK bit was set (and it should be, for client-to-server messages), read the next 4 octets (32 bits); this is the masking key. Once the payload length and masking key is decoded, you can read that number of bytes from the socket. Let's call the data `ENCODED`, and the key `MASK`. To get `DECODED`, loop through the octets (bytes a.k.a. characters for text data) of `encoded` and XOR the octet with the (i modulo 4)th octet of `MASK`. In pseudo-code (that happens to be valid JavaScript):
 

--- a/files/en-us/web/api/websockets_api/writing_websocket_servers/index.md
+++ b/files/en-us/web/api/websockets_api/writing_websocket_servers/index.md
@@ -130,14 +130,14 @@ To read the payload data, you must know when to stop reading. That's why the pay
 
 ### Reading and unmasking the Data
 
-If the MASK bit was set (and it should be, for client-to-server messages), read the next 4 octets (32 bits); this is the masking key. Once the payload length and masking key is decoded, you can read that number of bytes from the socket. Let's call the data `encoded`, and the key `mask`. To get `decoded`, loop through the octets (bytes a.k.a. characters for text data) of `encoded` and XOR the octet with the (i modulo 4)th octet of MASK. In pseudo-code (that happens to be valid JavaScript):
+If the MASK bit was set (and it should be, for client-to-server messages), read the next 4 octets (32 bits); this is the masking key. Once the payload length and masking key is decoded, you can read that number of bytes from the socket. Let's call the data `ENCODED`, and the key `MASK`. To get `DECODED`, loop through the octets (bytes a.k.a. characters for text data) of `encoded` and XOR the octet with the (i modulo 4)th octet of `MASK`. In pseudo-code (that happens to be valid JavaScript):
 
 ```js
-const mask = [1, 2, 3, 4]; // 4-byte mask
-const encoded = [105, 103, 111, 104, 110]; // encoded string "hello"
+const MASK = [1, 2, 3, 4]; // 4-byte mask
+const ENCODED = [105, 103, 111, 104, 110]; // encoded string "hello"
 
 // Create the byte Array of decoded payload
-const decoded = encoded.from((elt, i) => elt ^ mask[i % 4]); // Perform an XOR on the mask
+const DECODED = Uint8Array.from(ENCODED(elt, i) => elt ^ mask[i % 4]); // Perform an XOR on the mask
 ```
 
 Now you can figure out what **DECODED** means depending on your application.

--- a/files/en-us/web/api/webvr_api/using_vr_controllers_with_webvr/index.md
+++ b/files/en-us/web/api/webvr_api/using_vr_controllers_with_webvr/index.md
@@ -70,7 +70,7 @@ function reportDisplays() {
       const cap = display.capabilities;
       // cap is a VRDisplayCapabilities object
       const listItem = document.createElement('li');
-      listItem.innerHTML = `<strong>Display ${i+1}</strong><br>` +
+      listItem.innerHTML = `<strong>Display ${i + 1}</strong><br>` +
         `VR Display ID: ${display.displayId}<br>` +
         `VR Display Name: ${display.displayName}<br>` +
         `Display can present content: ${cap.canPresent}<br>` +

--- a/files/en-us/web/api/webvr_api/using_vr_controllers_with_webvr/index.md
+++ b/files/en-us/web/api/webvr_api/using_vr_controllers_with_webvr/index.md
@@ -66,20 +66,20 @@ Here we first use a tracking variable, `initialRun`, to note that this is the fi
 function reportDisplays() {
   navigator.getVRDisplays().then((displays) => {
     console.log(`${displays.length} displays`);
-    for (let i = 0; i < displays.length; i++) {
-      const cap = displays[i].capabilities;
+    displays.forEach((display, i) => {
+      const cap = display.capabilities;
       // cap is a VRDisplayCapabilities object
       const listItem = document.createElement('li');
       listItem.innerHTML = `<strong>Display ${i+1}</strong><br>` +
-        `VR Display ID: ${displays[i].displayId}<br>` +
-        `VR Display Name: ${displays[i].displayName}<br>` +
+        `VR Display ID: ${display.displayId}<br>` +
+        `VR Display Name: ${display.displayName}<br>` +
         `Display can present content: ${cap.canPresent}<br>` +
         `Display is separate from the computer's main display: ${cap.hasExternalDisplay}<br>` +
         `Display can return position info: ${cap.hasPosition}<br>` +
         `Display can return orientation info: ${cap.hasOrientation}<br>` +
         `Display max layers: ${cap.maxLayers}`;
       list.appendChild(listItem);
-    }
+    });
 
     setTimeout(reportGamepads, 1000);
     // For VR, controllers will only be active after their corresponding headset is active
@@ -99,8 +99,7 @@ The `reportGamepads()` function looks like this:
 function reportGamepads() {
     const gamepads = navigator.getGamepads();
     console.log(`${gamepads.length} controllers`);
-    for (let i = 0; i < gamepads.length; ++i) {
-        const gp = gamepads[i];
+    for (const gp of gamepads) {
         const listItem = document.createElement('li');
         listItem.classList = 'gamepad';
         listItem.innerHTML = `<strong>Gamepad ${gp.index}</strong> (${gp.id})<br>` +

--- a/files/en-us/web/api/webxr_device_api/inputs/index.md
+++ b/files/en-us/web/api/webxr_device_api/inputs/index.md
@@ -207,12 +207,12 @@ The most direct way to decide which controller is primary is to have a user-defi
 ```js
 let primaryInputSource = xrSession.inputSources[0];
 
-for (let i=0; i < xrSession.inputSources.length; i++) {
-  if (xrSession.inputSources[i].handedness === user.handedness) {
-    primaryInputSource = inputSources[i];
+xrSession.inputSources.forEach((inputSource) => {
+  if (inputSource.handedness === user.handedness) {
+    primaryInputSource = inputSource;
     break;
   }
-}
+});
 ```
 
 This snippet of code starts by assuming that the first input source is the primary, but then looks for one whose {{domxref("XRInputSource.handedness", "handedness")}} matches the one specified in the `user` object. If it matches, that input source is selected as the primary.

--- a/files/en-us/web/api/webxr_device_api/inputs/index.md
+++ b/files/en-us/web/api/webxr_device_api/inputs/index.md
@@ -205,14 +205,9 @@ There are a few ways you can decide upon a primary controller. We'll look at thr
 The most direct way to decide which controller is primary is to have a user-definable "Handedness" preference that the user sets to indicate which of their hands is dominant. You would then look at each input source and find one matching this, if available, falling back to another controller if no controller is in that hand.
 
 ```js
-let primaryInputSource = xrSession.inputSources[0];
-
-xrSession.inputSources.forEach((inputSource) => {
-  if (inputSource.handedness === user.handedness) {
-    primaryInputSource = inputSource;
-    break;
-  }
-});
+const primaryInputSource =
+  xrSession.inputSources.find((src) => src.handedness === user.handedness) ??
+  xrSession.inputSources[0];
 ```
 
 This snippet of code starts by assuming that the first input source is the primary, but then looks for one whose {{domxref("XRInputSource.handedness", "handedness")}} matches the one specified in the `user` object. If it matches, that input source is selected as the primary.

--- a/files/en-us/web/api/window/speechsynthesis/index.md
+++ b/files/en-us/web/api/window/speechsynthesis/index.md
@@ -59,11 +59,7 @@ inputForm.onsubmit = (event) => {
 
   const utterThis = new SpeechSynthesisUtterance(inputTxt.value);
   const selectedOption = voiceSelect.selectedOptions[0].getAttribute('data-name');
-  for (const voice of voices) {
-    if (voice.name === selectedOption) {
-      utterThis.voice = voice;
-    }
-  }
+  utterThis.voice = voices.find((v) => v.name === selectedOption);
   synth.speak(utterThis);
   inputTxt.blur();
 }

--- a/files/en-us/web/api/window/speechsynthesis/index.md
+++ b/files/en-us/web/api/window/speechsynthesis/index.md
@@ -35,16 +35,16 @@ const voiceSelect = document.querySelector('select');
 function populateVoiceList() {
   voices = synth.getVoices();
 
-  for (let i = 0; i < voices.length ; i++) {
+  for (const voice of voices) {
     const option = document.createElement('option');
-    option.textContent = `${voices[i].name} (${voices[i].lang})`;
+    option.textContent = `${voice.name} (${voice.lang})`;
 
-    if (voices[i].default) {
+    if (voice.default) {
       option.textContent += ' — DEFAULT';
     }
 
-    option.setAttribute('data-lang', voices[i].lang);
-    option.setAttribute('data-name', voices[i].name);
+    option.setAttribute('data-lang', voice.lang);
+    option.setAttribute('data-name', voice.name);
     voiceSelect.appendChild(option);
   }
 }
@@ -59,9 +59,9 @@ inputForm.onsubmit = (event) => {
 
   const utterThis = new SpeechSynthesisUtterance(inputTxt.value);
   const selectedOption = voiceSelect.selectedOptions[0].getAttribute('data-name');
-  for (let i = 0; i < voices.length ; i++) {
-    if (voices[i].name === selectedOption) {
-      utterThis.voice = voices[i];
+  for (const voice of voices) {
+    if (voice.name === selectedOption) {
+      utterThis.voice = voice;
     }
   }
   synth.speak(utterThis);

--- a/files/en-us/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.md
+++ b/files/en-us/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.md
@@ -21,7 +21,7 @@ req.onload = (event) => {
   const arrayBuffer = req.response; // Note: not req.responseText
   if (arrayBuffer) {
     const byteArray = new Uint8Array(arrayBuffer);
-    for (let i = 0; i < byteArray.byteLength; i++) {
+    byteArray.forEach((element, index)) => {
       // do something with each byte in the array
     }
   }
@@ -100,9 +100,9 @@ const array = new ArrayBuffer(512);
 const longInt8View = new Uint8Array(array);
 
 // generate some data
-for (let i=0; i< longInt8View.length; i++) {
-  longInt8View[i] = i % 256;
-}
+longInt8View.forEach((element, i) =>  {
+  element = i % 256;
+});
 
 const xhr = new XMLHttpRequest;
 xhr.open("POST", url, false);

--- a/files/en-us/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.md
+++ b/files/en-us/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.md
@@ -98,9 +98,7 @@ You can send JavaScript typed arrays as binary data as well.
 ```js
 const array = new ArrayBuffer(512);
 // Create a new array with fake data (Consecutive numbers (0 - 255), looping back to 0) 
-const longInt8View = Uint8Array.from(array, (element, i) =>  {
-  element = i % 256;
-});
+const longInt8View = Uint8Array.from(array, (v, i) => i % 256);
 
 const xhr = new XMLHttpRequest;
 xhr.open("POST", url, false);

--- a/files/en-us/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.md
+++ b/files/en-us/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.md
@@ -97,10 +97,8 @@ You can send JavaScript typed arrays as binary data as well.
 
 ```js
 const array = new ArrayBuffer(512);
-const longInt8View = new Uint8Array(array);
-
-// generate some data
-longInt8View.forEach((element, i) =>  {
+// Create a new array with fake data (Consecutive numbers (0 - 255), looping back to 0) 
+const longInt8View = Uint8Array.from(array, (element, i) =>  {
   element = i % 256;
 });
 


### PR DESCRIPTION
Classical `for` loops are error-prone (setting the right condition, not mixing indices…) and difficult to read when used to loop on all elements of an Array-like structure.

This PR changes some occurrences to use the modern `for…of`, or `.forEach()` in some occurrences.

Note that:
- I use `for…of` if I don't need the index
- I use `.forEach()` when I do, or on an object where `for…of` may not work.
- There were a couple of cases where the loop copied an Array into a new one; I used `Array.from()` instead.