### PR TITLE
Added: alt attribute to few images

### DIFF
--- a/files/en-us/learn/accessibility/accessibility_troubleshooting/index.md
+++ b/files/en-us/learn/accessibility/accessibility_troubleshooting/index.md
@@ -43,7 +43,7 @@ Alternatively, you could use a site like [JSBin](https://jsbin.com/) or [Glitch]
 
 The finished assessment site should look like so:
 
-![](assessment-site-finished.png)
+![Screenshot of the finished assessment site](assessment-site-finished.png)
 
 You will see some differences/issues with the display of the starting state of the assessment — this is mainly due to the differences in the markup, which in turn cause some styling issues as the CSS is not applied properly. Don't worry — you'll be fixing these problems in the upcoming sections!
 

--- a/files/en-us/learn/accessibility/accessibility_troubleshooting/index.md
+++ b/files/en-us/learn/accessibility/accessibility_troubleshooting/index.md
@@ -43,7 +43,7 @@ Alternatively, you could use a site like [JSBin](https://jsbin.com/) or [Glitch]
 
 The finished assessment site should look like so:
 
-![Screenshot of the finished assessment site](assessment-site-finished.png)
+![Screenshot of the finished assessment site with good color contrast. The search input has placeholder text and a sumbit button that reads go, but no visible label.](assessment-site-finished.png)
 
 You will see some differences/issues with the display of the starting state of the assessment — this is mainly due to the differences in the markup, which in turn cause some styling issues as the CSS is not applied properly. Don't worry — you'll be fixing these problems in the upcoming sections!
 

--- a/files/en-us/learn/accessibility/css_and_javascript/index.md
+++ b/files/en-us/learn/accessibility/css_and_javascript/index.md
@@ -158,9 +158,9 @@ a:active {
 
 The standard link conventions are underlined and a different color (default: blue) in their standard state, another color variation when the link has previously been visited (default: purple), and yet another color when the link is activated (default: red). In addition, the mouse pointer changes to a pointer icon when links are moused over, and the link receives a highlight when focused (e.g. via tabbing) or activated. The following image shows the highlight in both Firefox (a dotted outline) and Chrome (a blue outline):
 
-![](focus-highlight-firefox.png)
+![Screenshot of a list of links in Firefox browser. The list contains 4 items. The second list item is highlighted using a blue dotted outline when it is focussed via tabbing.](focus-highlight-firefox.png)
 
-![](focus-highlight-chrome.png)
+![Screenshot of a list of links in Chrome browser. The list contains 4 items. The third list item is highlighted using a blue outline when it is focussed via tabbing.](focus-highlight-chrome.png)
 
 You can be creative with link styles, as long as you keep giving users feedback when they interact with the links. Something should definitely happen when states change, and you shouldn't get rid of the pointer cursor or the outline — both are very important accessibility aids for those using keyboard controls.
 
@@ -203,9 +203,9 @@ Another tip is to not rely on color alone for signposts/information, as this wil
 
 There are many instances where a visual design will require that not all content is shown at once. For example, in our [Tabbed info box example](https://mdn.github.io/learning-area/css/css-layout/practical-positioning-examples/info-box.html) (see [source code](https://github.com/mdn/learning-area/blob/main/css/css-layout/practical-positioning-examples/info-box.html)) we have three panels of information, but we are [positioning](/en-US/docs/Learn/CSS/CSS_layout/Positioning) them on top of one another and providing tabs that can be clicked to show each one (it is also keyboard accessible — you can alternatively use Tab and Enter/Return to select them).
 
-![](tabbed-info-box.png)
+![Screenshot containing three tabs namely Tab 1, Tab 2 & Tab 3. Tab 1 is selected and only it's content is displayed. Only the content of the selected tab is visible and the content of other tabs is hidden. If a tab is selected then it's text-color changes from  black to white and the background-color changes from orangered to saddlebrown.](tabbed-info-box.png)
 
-Screen reader users don't care about any of this — they are happy with the content as long as the source order makes sense, and they can get to it all. Absolute positioning (as used in this example) is generally seen as one of the best mechanisms of hiding content for visual effect, because it doesn't stop screen readers from getting to it.
+Screen reader users don't care about any of this — they are happy with the content as long as the source order makes sense, and they can get to it all. Absolute positioning (as used in this example) is generally seen as one of the best mech#a83602anisms of hiding content for visual effect, because it doesn't stop screen readers from getting to it.
 
 On the other hand, you shouldn't use {{cssxref("visibility")}}`:hidden` or {{cssxref("display")}}`:none`, because they do hide content from screen readers. Unless of course, there is a good reason why you want this content to be hidden from screen readers.
 

--- a/files/en-us/learn/accessibility/css_and_javascript/index.md
+++ b/files/en-us/learn/accessibility/css_and_javascript/index.md
@@ -203,9 +203,9 @@ Another tip is to not rely on color alone for signposts/information, as this wil
 
 There are many instances where a visual design will require that not all content is shown at once. For example, in our [Tabbed info box example](https://mdn.github.io/learning-area/css/css-layout/practical-positioning-examples/info-box.html) (see [source code](https://github.com/mdn/learning-area/blob/main/css/css-layout/practical-positioning-examples/info-box.html)) we have three panels of information, but we are [positioning](/en-US/docs/Learn/CSS/CSS_layout/Positioning) them on top of one another and providing tabs that can be clicked to show each one (it is also keyboard accessible — you can alternatively use Tab and Enter/Return to select them).
 
-![Screenshot containing three tabs namely Tab 1, Tab 2 & Tab 3. Tab 1 is selected and only it's content is displayed. Only the content of the selected tab is visible and the content of other tabs is hidden. If a tab is selected then it's text-color changes from  black to white and the background-color changes from orangered to saddlebrown.](tabbed-info-box.png)
+![Three tab interface with Tab 1 selected and only its contents are displayed. The contents of other tabs are hidden. If a tab is selected, then it's text-color changes from black to white and the background-color changes from orange-red to saddle brown.](tabbed-info-box.png)
 
-Screen reader users don't care about any of this — they are happy with the content as long as the source order makes sense, and they can get to it all. Absolute positioning (as used in this example) is generally seen as one of the best mech#a83602anisms of hiding content for visual effect, because it doesn't stop screen readers from getting to it.
+Screen reader users don't care about any of this — they are happy with the content as long as the source order makes sense, and they can get to it all. Absolute positioning (as used in this example) is generally seen as one of the best mechanisms of hiding content for visual effect because it doesn't stop screen readers from getting to it.
 
 On the other hand, you shouldn't use {{cssxref("visibility")}}`:hidden` or {{cssxref("display")}}`:none`, because they do hide content from screen readers. Unless of course, there is a good reason why you want this content to be hidden from screen readers.
 

--- a/files/en-us/learn/accessibility/html/index.md
+++ b/files/en-us/learn/accessibility/html/index.md
@@ -371,7 +371,7 @@ UI control text labels are very useful to all users, but getting them right is p
 
 You should make sure that your button and link text labels are understandable and distinctive. Don't just use "Click here" for your labels, as screen reader users sometimes get up a list of buttons and form controls. The following screenshot shows our controls being listed by VoiceOver on Mac.
 
-![](voiceover-formcontrols.png)
+![List of form input labels being listed by VoiceOver software on Mac. This list contains meaningless labels given to various form controls like button, textfield and link](voiceover-formcontrols.png)
 
 Make sure your labels make sense out of context, read on their own, as well as in the context of the paragraph they are in. For example, the following shows an example of good link text:
 
@@ -406,7 +406,7 @@ The following is a much better example:
 
 With code like this, the label will be clearly associated with the input; the description will be more like "Fill in your name: edit text."
 
-![](voiceover-good-form-label.png)
+![A good form label called "Fill in your name" is given to a text input form control. ](voiceover-good-form-label.png)
 
 As an added bonus, in most browsers associating a label with a form input means that you can click the label to select or activate the form element. This gives the input a bigger hit area, making it easier to select.
 

--- a/files/en-us/learn/accessibility/html/index.md
+++ b/files/en-us/learn/accessibility/html/index.md
@@ -371,7 +371,7 @@ UI control text labels are very useful to all users, but getting them right is p
 
 You should make sure that your button and link text labels are understandable and distinctive. Don't just use "Click here" for your labels, as screen reader users sometimes get up a list of buttons and form controls. The following screenshot shows our controls being listed by VoiceOver on Mac.
 
-![List of form input labels being listed by VoiceOver software on Mac. This list contains meaningless labels given to various form controls like button, textfield and link](voiceover-formcontrols.png)
+![List of form input labels being listed by VoiceOver software on Mac. This list contains meaningless labels like 'happy menu button` given to various form controls like button, textfield and link](voiceover-formcontrols.png)
 
 Make sure your labels make sense out of context, read on their own, as well as in the context of the paragraph they are in. For example, the following shows an example of good link text:
 
@@ -406,7 +406,7 @@ The following is a much better example:
 
 With code like this, the label will be clearly associated with the input; the description will be more like "Fill in your name: edit text."
 
-![A good form label called "Fill in your name" is given to a text input form control. ](voiceover-good-form-label.png)
+![A good form label that reads 'Fill in your name' is given to a text input form control. ](voiceover-good-form-label.png)
 
 As an added bonus, in most browsers associating a label with a form input means that you can click the label to select or activate the form element. This gives the input a bigger hit area, making it easier to select.
 

--- a/files/en-us/learn/accessibility/wai-aria_basics/index.md
+++ b/files/en-us/learn/accessibility/wai-aria_basics/index.md
@@ -156,7 +156,7 @@ If you try testing the example with a screenreader in a modern browser, you'll a
 
 If you go to VoiceOver's landmarks menu (accessed using VoiceOver key + U and then using the cursor keys to cycle through the menu choices), you'll see that most of the elements are nicely listed so they can be accessed quickly.
 
-![](landmarks-list.png)
+![four landmarks namely banner, navigation, main, complementary are listed by Mac's VoiceOver menu for quick accessibility](landmarks-list.png)
 
 However, we could do better here. The search form is a really important landmark that people will want to find, but it is not listed in the landmarks menu or treated like a notable landmark, beyond the actual input being called out as a search input (`<input type="search">`). In addition, some older browsers (most notably IE8) don't recognize the semantics of the HTML5 elements.
 

--- a/files/en-us/learn/accessibility/wai-aria_basics/index.md
+++ b/files/en-us/learn/accessibility/wai-aria_basics/index.md
@@ -156,7 +156,7 @@ If you try testing the example with a screenreader in a modern browser, you'll a
 
 If you go to VoiceOver's landmarks menu (accessed using VoiceOver key + U and then using the cursor keys to cycle through the menu choices), you'll see that most of the elements are nicely listed so they can be accessed quickly.
 
-![four landmarks namely banner, navigation, main, complementary are listed by Mac's VoiceOver menu for quick accessibility](landmarks-list.png)
+![Mac's VoiceOver menu for quick accessibility. Landmarks header and landmarks list including banner, navigation, main, and complementary.](landmarks-list.png)
 
 However, we could do better here. The search form is a really important landmark that people will want to find, but it is not listed in the landmarks menu or treated like a notable landmark, beyond the actual input being called out as a search input (`<input type="search">`). In addition, some older browsers (most notably IE8) don't recognize the semantics of the HTML5 elements.
 

--- a/files/en-us/learn/common_questions/upload_files_to_a_web_server/index.md
+++ b/files/en-us/learn/common_questions/upload_files_to_a_web_server/index.md
@@ -58,7 +58,7 @@ There are several SFTP clients out there. Our demo covers [FileZilla](https://fi
 
 Open the FileZilla application; you should see something like this:
 
-![](filezilla-ui.png)
+![Screenshot of the user interface of Filezilla application](filezilla-ui.png)
 
 ### Logging in
 
@@ -96,7 +96,7 @@ To connect your SFTP client to the distant server, follow these steps:
 
 Your window should look something like this:
 
-![](site-manager.png)
+![Screenshot of a fictious website with url "http://demozilla.examplehostingprovider.net/" whose content is empty](site-manager.png)
 
 Now press _Connect_ to connect to the SFTP server.
 
@@ -106,7 +106,7 @@ Note: Make sure your hosting provider offers SFTP (Secure FTP) connection to you
 
 Once connected, your screen should look something like this (we've connected to an example of our own to give you an idea):
 
-![](connected.png)
+![Screenshot of the SFTP client displaying the website contents once it has been connected to the SFTP server provided by the corresponding website's hosting provider](connected.png)
 
 Let's examine what you're seeing:
 

--- a/files/en-us/learn/common_questions/upload_files_to_a_web_server/index.md
+++ b/files/en-us/learn/common_questions/upload_files_to_a_web_server/index.md
@@ -58,7 +58,7 @@ There are several SFTP clients out there. Our demo covers [FileZilla](https://fi
 
 Open the FileZilla application; you should see something like this:
 
-![Screenshot of the user interface of Filezilla application](filezilla-ui.png)
+![Screenshot of the user interface of Filezilla FTP application. Host input has focus.](filezilla-ui.png)
 
 ### Logging in
 
@@ -96,7 +96,7 @@ To connect your SFTP client to the distant server, follow these steps:
 
 Your window should look something like this:
 
-![Screenshot of a fictious website with url "http://demozilla.examplehostingprovider.net/" whose content is empty](site-manager.png)
+![Screenshot of default landing page of a fictitious website when the file directory is empty](site-manager.png)
 
 Now press _Connect_ to connect to the SFTP server.
 
@@ -106,7 +106,7 @@ Note: Make sure your hosting provider offers SFTP (Secure FTP) connection to you
 
 Once connected, your screen should look something like this (we've connected to an example of our own to give you an idea):
 
-![Screenshot of the SFTP client displaying the website contents once it has been connected to the SFTP server provided by the corresponding website's hosting provider](connected.png)
+![SFTP client displaying website contents once it has been connected to the SFTP server. Local files are on the left. Remote files are on the right.](connected.png)
 
 Let's examine what you're seeing:
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
* I have added alt attributes to a handful of items in the content
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
* Adding the alt attribute to the image displays the value of `alt` attribute when the respective `image fails to load` rather than leaving the space blank.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
@estelle  has collected the list of images from the documentation that do not have the alt attribute. [link to the spreadsheet](https://docs.google.com/spreadsheets/d/1cDHee6mwDMlY6zANEmg8MjR8tL-wrCS86uawpWZ4XbA/edit#gid=0)
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
