### PR TITLE
Avoid classical for when looping through all items of an Array-like object (part #2)

### DIFF
--- a/files/en-us/web/api/performance/getentries/index.md
+++ b/files/en-us/web/api/performance/getentries/index.md
@@ -42,7 +42,7 @@ None.
 ## Examples
 
 ```js
-function use_PerformanceEntry_methods() {
+function usePerformanceEntryMethods() {
   console.log("PerformanceEntry tests…");
 
   if (performance.mark === undefined) {
@@ -61,28 +61,41 @@ function use_PerformanceEntry_methods() {
   performance.mark("End");
 
   // Use getEntries() to iterate through the each entry
-  let perf = performance.getEntries();
-  perf.forEach((entry, i) => {
-    log(`Entry[${i}]`);
-    checkPerformanceEntry(entry);
-  });
+  performance.getEntries()
+    .forEach((entry, i) => {
+      log(`Entry[${i}]`);
+      checkPerformanceEntry(entry);
+    });
 
   // Use getEntriesByType() to get all "mark" entries
-  perf = performance.getEntriesByType("mark");
-  perf.forEach((entry, i) => {
-    log(`Mark only entry[${i}]:`);
-    log(`  name      = ${entry.name}`);
-    log(`  startTime = ${entry.startTime}`);
-    log(`  duration  = ${entry.duration}`);
-  });
+  performance.getEntriesByType("mark")
+    .forEach((entry, i) => {
+      log(`Mark only entry[${i}]:`);
+      checkPerformanceEntry(entry);
+    });
 
   // Use getEntriesByName() to get all "mark" entries named "Begin"
-  perf = performance.getEntriesByName("Begin", "mark");
-  perf.forEach((entry, i) => {
-    log(`Mark and Begin entry[${i}]:`);
-    log(`  name      = ${perf.name}`);
-    log(`  startTime = ${perf.startTime}`);
-    log(`  duration  = ${perf.duration}`);
+  performance.getEntriesByName("Begin", "mark")
+    .forEach((entry, i) => {
+      log(`Mark and Begin entry[${i}]:`);
+      checkPerformanceEntry(entry);
+    });
+}
+
+function checkPerformanceEntry(obj) {
+  const properties = ["name", "entryType", "startTime", "duration"];
+  const methods = ["toJSON"];
+
+  // Check each property
+  properties.forEach((property) => {
+    const supported = property in obj;
+    console.log(`…${property} = ${supported ? obj[property] : "Not supported"}`);
+  });
+
+  // Check each method
+  methods.forEach((method) => {
+    const supported = typeof obj[method] === "function";
+    console.log(`…${method} = ${supported ? obj[method] : "Not supported"}`);
   });
 }
 ```

--- a/files/en-us/web/api/performance/getentries/index.md
+++ b/files/en-us/web/api/performance/getentries/index.md
@@ -63,21 +63,21 @@ function usePerformanceEntryMethods() {
   // Use getEntries() to iterate through the each entry
   performance.getEntries()
     .forEach((entry, i) => {
-      log(`Entry[${i}]`);
+      console.log(`Entry[${i}]`);
       checkPerformanceEntry(entry);
     });
 
   // Use getEntriesByType() to get all "mark" entries
   performance.getEntriesByType("mark")
     .forEach((entry, i) => {
-      log(`Mark only entry[${i}]:`);
+      console.log(`Mark only entry[${i}]:`);
       checkPerformanceEntry(entry);
     });
 
   // Use getEntriesByName() to get all "mark" entries named "Begin"
   performance.getEntriesByName("Begin", "mark")
     .forEach((entry, i) => {
-      log(`Mark and Begin entry[${i}]:`);
+      console.log(`Mark and Begin entry[${i}]:`);
       checkPerformanceEntry(entry);
     });
 }

--- a/files/en-us/web/api/performance/getentries/index.md
+++ b/files/en-us/web/api/performance/getentries/index.md
@@ -95,7 +95,7 @@ function checkPerformanceEntry(obj) {
   // Check each method
   methods.forEach((method) => {
     const supported = typeof obj[method] === "function";
-    console.log(`…${method} = ${supported ? obj[method] : "Not supported"}`);
+    console.log(`…${method} = ${supported ? JSON.stringify(obj[method]()) : "Not supported"}`);
   });
 }
 ```

--- a/files/en-us/web/api/performance/getentries/index.md
+++ b/files/en-us/web/api/performance/getentries/index.md
@@ -61,29 +61,29 @@ function use_PerformanceEntry_methods() {
   performance.mark("End");
 
   // Use getEntries() to iterate through the each entry
-  let p = performance.getEntries();
-  for (let i = 0; i < p.length; i++) {
-    console.log(`Entry[${i}]`);
-    check_PerformanceEntry(p[i]);
-  }
+  let perf = performance.getEntries();
+  perf.forEach((entry, i) => {
+    log(`Entry[${i}]`);
+    checkPerformanceEntry(entry);
+  });
 
   // Use getEntriesByType() to get all "mark" entries
-  p = performance.getEntriesByType("mark");
-  for (let i=0; i < p.length; i++) {
-    console.log(`Mark only entry[${i}]:`);
-    console.log(`  name      = ${p[i].name}`);
-    console.log(`  startTime = ${p[i].startTime}`);
-    console.log(`  duration  = ${p[i].duration}`);
-  }
+  perf = performance.getEntriesByType("mark");
+  perf.forEach((entry, i) => {
+    log(`Mark only entry[${i}]:`);
+    log(`  name      = ${entry.name}`);
+    log(`  startTime = ${entry.startTime}`);
+    log(`  duration  = ${entry.duration}`);
+  });
 
   // Use getEntriesByName() to get all "mark" entries named "Begin"
-  p = performance.getEntriesByName("Begin", "mark");
-  for (let i=0; i < p.length; i++) {
-    console.log(`Mark and Begin entry[${i}]:`);
-    console.log(`  name      = ${p[i].name}`);
-    console.log(`  startTime = ${p[i].startTime}`);
-    console.log(`  duration  = ${p[i].duration}`);
-  }
+  perf = performance.getEntriesByName("Begin", "mark");
+  perf.forEach((entry, i) => {
+    log(`Mark and Begin entry[${i}]:`);
+    log(`  name      = ${perf.name}`);
+    log(`  startTime = ${perf.startTime}`);
+    log(`  duration  = ${perf.duration}`);
+  });
 }
 ```
 

--- a/files/en-us/web/api/performance/getentriesbyname/index.md
+++ b/files/en-us/web/api/performance/getentriesbyname/index.md
@@ -67,28 +67,28 @@ function usePerformanceEntryMethods() {
   // Use getEntries() to iterate through the each entry
   performance.getEntries()
     .forEach((entry, i) => {
-      log(`Entry[${i}]`);
+      console.log(`Entry[${i}]`);
       checkPerformanceEntry(entry);
     });
     
   // Use getEntries(name, entryType) to get specific entries
   performance.getEntries({ name: "Begin", entryType: "mark" })
     .forEach((entry, i) => {
-      log(`Begin[${i}]`);
+      console.log(`Begin[${i}]`);
       checkPerformanceEntry(entry);
     });
 
   // Use getEntriesByType() to get all "mark" entries
   performance.getEntriesByType("mark")
     .forEach((entry, i) => {
-      log(`Mark only entry[${i}]:`);
+      console.log(`Mark only entry[${i}]:`);
       checkPerformanceEntry(entry);
     });
 
   // Use getEntriesByName() to get all "mark" entries named "Begin"
   performance.getEntriesByName("Begin", "mark")
     .forEach((entry, i) => {
-      log(`Mark and Begin entry[${i}]:`);
+      lconsole.og(`Mark and Begin entry[${i}]:`);
       checkPerformanceEntry(entry);
     });
 }

--- a/files/en-us/web/api/performance/getentriesbyname/index.md
+++ b/files/en-us/web/api/performance/getentriesbyname/index.md
@@ -88,7 +88,7 @@ function usePerformanceEntryMethods() {
   // Use getEntriesByName() to get all "mark" entries named "Begin"
   performance.getEntriesByName("Begin", "mark")
     .forEach((entry, i) => {
-      lconsole.og(`Mark and Begin entry[${i}]:`);
+      console.log(`Mark and Begin entry[${i}]:`);
       checkPerformanceEntry(entry);
     });
 }

--- a/files/en-us/web/api/performance/getentriesbyname/index.md
+++ b/files/en-us/web/api/performance/getentriesbyname/index.md
@@ -65,36 +65,36 @@ function use_PerformanceEntry_methods() {
   performance.mark("End");
 
   // Use getEntries() to iterate through the each entry
-  let p = performance.getEntries();
-  for (let i=0; i < p.length; i++) {
+  let perf = performance.getEntries();
+  perf.forEach((entry, i) => {
     log(`Entry[${i}]`);
-    check_PerformanceEntry(p[i]);
-  }
+    checkPerformanceEntry(entry);
+  });
 
   // Use getEntries(name, entryType) to get specific entries
-  p = performance.getEntries({name : "Begin", entryType: "mark"});
-  for (let i=0; i < p.length; i++) {
+  perf = performance.getEntries({ name : "Begin", entryType: "mark" });
+  perf.forEach((entry, i) => {
     log(`Begin[${i}]`);
-    check_PerformanceEntry(p[i]);
-  }
+    checkPerformanceEntry(entry);
+  });
 
   // Use getEntriesByType() to get all "mark" entries
-  p = performance.getEntriesByType("mark");
-  for (let i=0; i < p.length; i++) {
+  perf = performance.getEntriesByType("mark");
+  perf.forEach((entry, i) => {
     log(`Mark only entry[${i}]:`);
-    log(`  name      = ${p[i].name}`);
-    log(`  startTime = ${p[i].startTime}`);
-    log(`  duration  = ${p[i].duration}`);
-  }
+    log(`  name      = ${entry.name}`);
+    log(`  startTime = ${entry.startTime}`);
+    log(`  duration  = ${entry.duration}`);
+  });
 
   // Use getEntriesByName() to get all "mark" entries named "Begin"
-  p = performance.getEntriesByName("Begin", "mark");
-  for (let i=0; i < p.length; i++) {
+  perf = performance.getEntriesByName("Begin", "mark");
+  perf.forEach((entry, i) => {
     log(`Mark and Begin entry[${i}]:`);
-    log(`  name      = ${p[i].name}`);
-    log(`  startTime = ${p[i].startTime}`);
-    log(`  duration  = ${p[i].duration}`);
-  }
+    log(`  name      = ${perf.name}`);
+    log(`  startTime = ${perf.startTime}`);
+    log(`  duration  = ${perf.duration}`);
+  });
 }
 ```
 

--- a/files/en-us/web/api/performance/getentriesbyname/index.md
+++ b/files/en-us/web/api/performance/getentriesbyname/index.md
@@ -46,11 +46,11 @@ A list of {{domxref("PerformanceEntry")}} objects that have the specified
 ## Examples
 
 ```js
-function use_PerformanceEntry_methods() {
+function usePerformanceEntryMethods() {
   console.log("PerformanceEntry tests…");
 
   if (performance.mark === undefined) {
-    console.error("The property performance.mark is not supported.");
+    console.error("The property performance.mark is not supported");
     return;
   }
 
@@ -65,35 +65,41 @@ function use_PerformanceEntry_methods() {
   performance.mark("End");
 
   // Use getEntries() to iterate through the each entry
-  let perf = performance.getEntries();
-  perf.forEach((entry, i) => {
-    log(`Entry[${i}]`);
-    checkPerformanceEntry(entry);
-  });
-
-  // Use getEntries(name, entryType) to get specific entries
-  perf = performance.getEntries({ name : "Begin", entryType: "mark" });
-  perf.forEach((entry, i) => {
-    log(`Begin[${i}]`);
-    checkPerformanceEntry(entry);
-  });
+  performance.getEntries()
+    .forEach((entry, i) => {
+      log(`Entry[${i}]`);
+      checkPerformanceEntry(entry);
+    });
 
   // Use getEntriesByType() to get all "mark" entries
-  perf = performance.getEntriesByType("mark");
-  perf.forEach((entry, i) => {
-    log(`Mark only entry[${i}]:`);
-    log(`  name      = ${entry.name}`);
-    log(`  startTime = ${entry.startTime}`);
-    log(`  duration  = ${entry.duration}`);
-  });
+  performance.getEntriesByType("mark")
+    .forEach((entry, i) => {
+      log(`Mark only entry[${i}]:`);
+      checkPerformanceEntry(entry);
+    });
 
   // Use getEntriesByName() to get all "mark" entries named "Begin"
-  perf = performance.getEntriesByName("Begin", "mark");
-  perf.forEach((entry, i) => {
-    log(`Mark and Begin entry[${i}]:`);
-    log(`  name      = ${perf.name}`);
-    log(`  startTime = ${perf.startTime}`);
-    log(`  duration  = ${perf.duration}`);
+  performance.getEntriesByName("Begin", "mark")
+    .forEach((entry, i) => {
+      log(`Mark and Begin entry[${i}]:`);
+      checkPerformanceEntry(entry);
+    });
+}
+
+function checkPerformanceEntry(obj) {
+  const properties = ["name", "entryType", "startTime", "duration"];
+  const methods = ["toJSON"];
+
+  // Check each property
+  properties.forEach((property) => {
+    const supported = property in obj;
+    console.log(`…${property} = ${supported ? obj[property] : "Not supported"}`);
+  });
+
+  // Check each method
+  methods.forEach((method) => {
+    const supported = typeof obj[method] === "function";
+    console.log(`…${method} = ${supported ? obj[method] : "Not supported"}`);
   });
 }
 ```

--- a/files/en-us/web/api/performance/getentriesbyname/index.md
+++ b/files/en-us/web/api/performance/getentriesbyname/index.md
@@ -70,6 +70,13 @@ function usePerformanceEntryMethods() {
       log(`Entry[${i}]`);
       checkPerformanceEntry(entry);
     });
+    
+  // Use getEntries(name, entryType) to get specific entries
+  performance.getEntries({name : "Begin", entryType: "mark"})
+    .forEach((entry, i) => {
+      log(`Begin[${i}]`);
+      checkPerformanceEntry(entry);
+  }
 
   // Use getEntriesByType() to get all "mark" entries
   performance.getEntriesByType("mark")

--- a/files/en-us/web/api/performance/getentriesbyname/index.md
+++ b/files/en-us/web/api/performance/getentriesbyname/index.md
@@ -72,11 +72,11 @@ function usePerformanceEntryMethods() {
     });
     
   // Use getEntries(name, entryType) to get specific entries
-  performance.getEntries({name : "Begin", entryType: "mark"})
+  performance.getEntries({ name: "Begin", entryType: "mark" })
     .forEach((entry, i) => {
       log(`Begin[${i}]`);
       checkPerformanceEntry(entry);
-  }
+    });
 
   // Use getEntriesByType() to get all "mark" entries
   performance.getEntriesByType("mark")

--- a/files/en-us/web/api/performance/getentriesbytype/index.md
+++ b/files/en-us/web/api/performance/getentriesbytype/index.md
@@ -45,50 +45,56 @@ function usePerformanceEntryMethods() {
   console.log("PerformanceEntry tests…");
 
   if (performance.mark === undefined) {
-    console.error("The property performance.mark is not supported.");
+    console.error("The property performance.mark is not supported");
     return;
   }
 
   // Create some performance entries via the mark() method
   performance.mark("Begin");
-  doWork(50000);
+  do_work(50000);
   performance.mark("End");
   performance.mark("Begin");
-  doWork(100000);
+  do_work(100000);
   performance.mark("End");
-  doWork(200000);
+  do_work(200000);
   performance.mark("End");
 
   // Use getEntries() to iterate through the each entry
-  let perf = performance.getEntries();
-  perf.forEach((entry, i) => {
-    log(`Entry[${i}]`);
-    checkPerformanceEntry(entry);
-  });
-
-  // Use getEntries(name, entryType) to get specific entries
-  perf = performance.getEntries({ name : "Begin", entryType: "mark" });
-  perf.forEach((entry, i) => {
-    log(`Begin[${i}]`);
-    checkPerformanceEntry(entry);
-  });
+  performance.getEntries()
+    .forEach((entry, i) => {
+      log(`Entry[${i}]`);
+      checkPerformanceEntry(entry);
+    });
 
   // Use getEntriesByType() to get all "mark" entries
-  perf = performance.getEntriesByType("mark");
-  perf.forEach((entry, i) => {
-    log(`Mark only entry[${i}]:`);
-    log(`  name      = ${entry.name}`);
-    log(`  startTime = ${entry.startTime}`);
-    log(`  duration  = ${entry.duration}`);
-  });
+  performance.getEntriesByType("mark")
+    .forEach((entry, i) => {
+      log(`Mark only entry[${i}]:`);
+      checkPerformanceEntry(entry);
+    });
 
   // Use getEntriesByName() to get all "mark" entries named "Begin"
-  perf = performance.getEntriesByName("Begin", "mark");
-  perf.forEach((entry, i) => {
-    log(`Mark and Begin entry[${i}]:`);
-    log(`  name      = ${perf.name}`);
-    log(`  startTime = ${perf.startTime}`);
-    log(`  duration  = ${perf.duration}`);
+  performance.getEntriesByName("Begin", "mark")
+    .forEach((entry, i) => {
+      log(`Mark and Begin entry[${i}]:`);
+      checkPerformanceEntry(entry);
+    });
+}
+
+function checkPerformanceEntry(obj) {
+  const properties = ["name", "entryType", "startTime", "duration"];
+  const methods = ["toJSON"];
+
+  // Check each property
+  properties.forEach((property) => {
+    const supported = property in obj;
+    console.log(`…${property} = ${supported ? obj[property] : "Not supported"}`);
+  });
+
+  // Check each method
+  methods.forEach((method) => {
+    const supported = typeof obj[method] === "function";
+    console.log(`…${method} = ${supported ? obj[method] : "Not supported"}`);
   });
 }
 ```

--- a/files/en-us/web/api/performance/getentriesbytype/index.md
+++ b/files/en-us/web/api/performance/getentriesbytype/index.md
@@ -60,36 +60,36 @@ function usePerformanceEntryMethods() {
   performance.mark("End");
 
   // Use getEntries() to iterate through the each entry
-  let p = performance.getEntries();
-  for (let i=0; i < p.length; i++) {
+  let perf = performance.getEntries();
+  perf.forEach((entry, i) => {
     log(`Entry[${i}]`);
-    checkPerformanceEntry(p[i]);
-  }
+    checkPerformanceEntry(entry);
+  });
 
   // Use getEntries(name, entryType) to get specific entries
-  p = performance.getEntries({name : "Begin", entryType: "mark"});
-  for (let i=0; i < p.length; i++) {
+  perf = performance.getEntries({ name : "Begin", entryType: "mark" });
+  perf.forEach((entry, i) => {
     log(`Begin[${i}]`);
-    checkPerformanceEntry(p[i]);
-  }
+    checkPerformanceEntry(entry);
+  });
 
   // Use getEntriesByType() to get all "mark" entries
-  p = performance.getEntriesByType("mark");
-  for (let i=0; i < p.length; i++) {
+  perf = performance.getEntriesByType("mark");
+  perf.forEach((entry, i) => {
     log(`Mark only entry[${i}]:`);
-    log(`  name      = ${p[i].name}`);
-    log(`  startTime = ${p[i].startTime}`);
-    log(`  duration  = ${p[i].duration}`);
-  }
+    log(`  name      = ${entry.name}`);
+    log(`  startTime = ${entry.startTime}`);
+    log(`  duration  = ${entry.duration}`);
+  });
 
   // Use getEntriesByName() to get all "mark" entries named "Begin"
-  p = performance.getEntriesByName("Begin", "mark");
-  for (let i=0; i < p.length; i++) {
+  perf = performance.getEntriesByName("Begin", "mark");
+  perf.forEach((entry, i) => {
     log(`Mark and Begin entry[${i}]:`);
-    log(`  name      = ${p[i].name}`);
-    log(`  startTime = ${p[i].startTime}`);
-    log(`  duration  = ${p[i].duration}`);
-  }
+    log(`  name      = ${perf.name}`);
+    log(`  startTime = ${perf.startTime}`);
+    log(`  duration  = ${perf.duration}`);
+  });
 }
 ```
 

--- a/files/en-us/web/api/performance/getentriesbytype/index.md
+++ b/files/en-us/web/api/performance/getentriesbytype/index.md
@@ -56,7 +56,7 @@ function usePerformanceEntryMethods() {
   performance.mark("Begin");
   doWork(100000);
   performance.mark("End");
-  do_work(200000);
+  doWork(200000);
   performance.mark("End");
 
   // Use getEntries() to iterate through the each entry

--- a/files/en-us/web/api/performance/getentriesbytype/index.md
+++ b/files/en-us/web/api/performance/getentriesbytype/index.md
@@ -65,6 +65,13 @@ function usePerformanceEntryMethods() {
       log(`Entry[${i}]`);
       checkPerformanceEntry(entry);
     });
+    
+  // Use getEntries(name, entryType) to get specific entries
+  performance.getEntries({name : "Begin", entryType: "mark"})
+    .forEach((entry, i) => {
+      log(`Begin[${i}]`);
+      checkPerformanceEntry(entry);
+  }
 
   // Use getEntriesByType() to get all "mark" entries
   performance.getEntriesByType("mark")

--- a/files/en-us/web/api/performance/getentriesbytype/index.md
+++ b/files/en-us/web/api/performance/getentriesbytype/index.md
@@ -51,7 +51,7 @@ function usePerformanceEntryMethods() {
 
   // Create some performance entries via the mark() method
   performance.mark("Begin");
-  do_work(50000);
+  doWork(50000);
   performance.mark("End");
   performance.mark("Begin");
   do_work(100000);

--- a/files/en-us/web/api/performance/getentriesbytype/index.md
+++ b/files/en-us/web/api/performance/getentriesbytype/index.md
@@ -54,7 +54,7 @@ function usePerformanceEntryMethods() {
   doWork(50000);
   performance.mark("End");
   performance.mark("Begin");
-  do_work(100000);
+  doWork(100000);
   performance.mark("End");
   do_work(200000);
   performance.mark("End");

--- a/files/en-us/web/api/performance/getentriesbytype/index.md
+++ b/files/en-us/web/api/performance/getentriesbytype/index.md
@@ -69,7 +69,7 @@ function usePerformanceEntryMethods() {
   // Use getEntries(name, entryType) to get specific entries
   performance.getEntries({ name: "Begin", entryType: "mark" })
     .forEach((entry, i) => {
-      lconsole.og(`Begin[${i}]`);
+      console.log(`Begin[${i}]`);
       checkPerformanceEntry(entry);
     });
 
@@ -101,7 +101,7 @@ function checkPerformanceEntry(obj) {
   // Check each method
   methods.forEach((method) => {
     const supported = typeof obj[method] === "function";
-    console.log(`…${method} = ${supported ? obj[method] : "Not supported"}`);
+    console.log(`…${method} = ${supported ? JSON.stringify(obj[method]()) : "Not supported"}`);
   });
 }
 ```

--- a/files/en-us/web/api/performance/getentriesbytype/index.md
+++ b/files/en-us/web/api/performance/getentriesbytype/index.md
@@ -67,11 +67,11 @@ function usePerformanceEntryMethods() {
     });
     
   // Use getEntries(name, entryType) to get specific entries
-  performance.getEntries({name : "Begin", entryType: "mark"})
+  performance.getEntries({ name: "Begin", entryType: "mark" })
     .forEach((entry, i) => {
       log(`Begin[${i}]`);
       checkPerformanceEntry(entry);
-  }
+    });
 
   // Use getEntriesByType() to get all "mark" entries
   performance.getEntriesByType("mark")

--- a/files/en-us/web/api/performance/getentriesbytype/index.md
+++ b/files/en-us/web/api/performance/getentriesbytype/index.md
@@ -62,28 +62,28 @@ function usePerformanceEntryMethods() {
   // Use getEntries() to iterate through the each entry
   performance.getEntries()
     .forEach((entry, i) => {
-      log(`Entry[${i}]`);
+      console.log(`Entry[${i}]`);
       checkPerformanceEntry(entry);
     });
     
   // Use getEntries(name, entryType) to get specific entries
   performance.getEntries({ name: "Begin", entryType: "mark" })
     .forEach((entry, i) => {
-      log(`Begin[${i}]`);
+      lconsole.og(`Begin[${i}]`);
       checkPerformanceEntry(entry);
     });
 
   // Use getEntriesByType() to get all "mark" entries
   performance.getEntriesByType("mark")
     .forEach((entry, i) => {
-      log(`Mark only entry[${i}]:`);
+      console.log(`Mark only entry[${i}]:`);
       checkPerformanceEntry(entry);
     });
 
   // Use getEntriesByName() to get all "mark" entries named "Begin"
   performance.getEntriesByName("Begin", "mark")
     .forEach((entry, i) => {
-      log(`Mark and Begin entry[${i}]:`);
+      console.log(`Mark and Begin entry[${i}]:`);
       checkPerformanceEntry(entry);
     });
 }

--- a/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
+++ b/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
@@ -162,7 +162,7 @@ function PerformanceObservers() {
   observeAll.observe({entryTypes: ['frame', 'mark', 'measure', 'navigation', 'resource', 'server']});
 
   // Create observer for just the "mark" event type
-  const observe_mark = new PerformanceObserver((list, obs) => {
+  const observeMark = new PerformanceObserver((list, obs) => {
     const perfEntries = list.getEntries();
     
     // Should only have 'mark' entries

--- a/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
+++ b/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
@@ -19,18 +19,21 @@ function log(s) {
   const o = document.getElementsByTagName("output")[0];
   o.innerHTML += `${s} <br>`;
 }
-function do_work (n) {
+
+function doWork (n) {
   for (let i=0 ; i < n; i++) {
      const m = Math.random(); // This is an example of work taking some time
   }
 }
-function print_perf_entry(pe) {
+
+function printPerfEntry(pe) {
   log(`name: ${pe.name}`);
   log(`entryType: ${pe.entryType}`);
   log(`startTime: ${pe.startTime}`);
   log(`duration: ${pe.duration}`);
 }
-function print_PerformanceEntries() {
+
+function printPerformanceEntries() {
   if (performance.mark === undefined) {
     console.error("The property performance.mark is not supported.");
     return;
@@ -38,38 +41,38 @@ function print_PerformanceEntries() {
 
   // Create some performance entries via the mark() and measure() methods
   performance.mark("Begin");
-  do_work(50000);
+  doWork(50000);
   performance.mark("End");
-  do_work(50000);
+  doWork(50000);
   performance.measure("Measure1", "Begin", "End");
 
   // Use getEntries() to iterate all entries
-  let p = performance.getEntries();
-  p.forEach((entry, i) => {
-    log(`All Entry[${i}]`);
-    print_perf_entry(entry);
-  });
+  performance.getEntries()
+    .forEach((entry, i) => {
+      log(`All Entry[${i}]`);
+      printPerfEntry(entry);
+    });
 
   // Use getEntries(name, entryType) to get specific entries
-  p = performance.getEntries({name : "Measure1", entryType: "measure"});
-  p.forEach((entry, i) => {
-    log(`Begin and Measure [${i}]`);
-    print_perf_entry(entry);
-  });
+  performance.getEntries({name : "Measure1", entryType: "measure"})
+    .forEach((entry, i) => {
+      log(`Begin and Measure [${i}]`);
+      printPerfEntry(entry);
+    });
 
   // Use getEntriesByType() to get all "mark" entries
-  p = performance.getEntriesByType("mark");
-  p.forEach((entry, i) => {
-    log(`Mark only [${i}]`);
-    print_perf_entry(entry);
-  });
+  performance.getEntriesByType("mark")
+    .forEach((entry, i) => {
+      log(`Mark only [${i}]`);
+      printPerfEntry(entry);
+    });
 
   // Use getEntriesByName() to get all "mark" entries named "Begin"
-  p = performance.getEntriesByName("Begin", "mark");
-  p.forEach((entry, i) => {
-    log(`Begin and Mark [${i}]`);
-    print_perf_entry(entry);
-  });
+  performance.getEntriesByName("Begin", "mark")
+    .forEach((entry, i) => {
+      log(`Begin and Mark [${i}]`);
+      printPerfEntry(entry);
+    });
 }
 ```
 
@@ -78,31 +81,31 @@ function print_PerformanceEntries() {
 The {{domxref("PerformanceEntry")}} interface encapsulates a single _performance entry_ i.e. a single performance metric. This interface has four properties and a JSON _serializer_ ({{domxref("Performance.toJSON","toJSON()")}}. The following example shows the use of these properties.
 
 ```js
-function print_PerformanceEntry(ev) {
+function printPerformanceEntry(ev) {
   const properties = ["name", "entryType", "startTime", "duration"];
 
   // Create a few performance entries
   performance.mark("Start");
-  do_work(50000);
+  doWork(50000);
   performance.mark("Stop");
   performance.measure("measure-1");
 
-  const perf = performance.getEntries();
-  perf.forEach((perfEntry, i) => {
-    log(`PerfEntry[${i}]`);
-    properties.forEach((prop) => {
-      // Check each property in window.performance
-      const supported = prop in perfEntry;
-      console.log(`… ${prop} = ${suppported ? perfEntry[prop] : "Not supported"}`);
+  performance.getEntries()
+    .forEach((perfEntry, i) => {
+      log(`PerfEntry[${i}]`);
+      properties.forEach((prop) => {
+        // Check each property in window.performance
+        const supported = prop in perfEntry;
+        console.log(`… ${prop} = ${suppported ? perfEntry[prop] : "Not supported"}`);
+      });
     });
-  });
 }
 ```
 
 This interface also includes a {{domxref("PerformanceEntry.toJSON","toJSON()")}} method that returns the serialization of the {{domxref("PerformanceEntry")}} object. The following examples show the use of this method.
 
 ```js
-function PerfEntry_toJSON() {
+function perfEntryToJSON() {
 
   // Create a few performance entries
   performance.mark("mark-1");
@@ -139,22 +142,23 @@ function PerformanceObservers() {
     // Print all entries
     let perfEntries = list.getEntries();
     perfEntries.forEach((entry) =>  {
-      print_perf_entry(entry);
+      printPerfEntry(entry);
     });
 
     // Print entries named "Begin" with type "mark"
     perfEntries = list.getEntriesByName("Begin", "mark");
     perfEntries.forEach((entry) =>  {
-      print_perf_entry(entry);
+      printPerfEntry(entry);
     });
 
     // Print entries with type "mark"
     perfEntries = list.getEntriesByType("mark");
     perfEntries.forEach((entry) =>  {
-      print_perf_entry(entry);
+      printPerfEntry(entry);
     });
   });
-  // subscribe to all performance event types
+  
+  // Subscribe to all performance event types
   observe_all.observe({entryTypes: ['frame', 'mark', 'measure', 'navigation', 'resource', 'server']});
 
   // Create observer for just the "mark" event type
@@ -163,13 +167,15 @@ function PerformanceObservers() {
     
     // Should only have 'mark' entries
     perfEntries.forEach((entry) =>  {
-      print_perf_entry(entry);
+      printPerfEntry(entry);
     });
   });
-  // subscribe to only the 'mark' event
+  
+  // Subscribe to only the 'mark' event
   observe_mark.observe({entryTypes: ['mark']});
 }
-function print_perf_entry(pe) {
+
+function printPerfEntry(pe) {
   log(`name: ${pe.name}`);
   log(`entryType: ${pe.entryType}`);
   log(`startTime: ${pe.startTime}`);

--- a/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
+++ b/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
@@ -96,7 +96,7 @@ function printPerformanceEntry(ev) {
       properties.forEach((prop) => {
         // Check each property in window.performance
         const supported = prop in perfEntry;
-        console.log(`… ${prop} = ${suppported ? perfEntry[prop] : "Not supported"}`);
+        log(`… ${prop} = ${suppported ? perfEntry[prop] : "Not supported"}`);
       });
     });
 }
@@ -106,7 +106,6 @@ This interface also includes a {{domxref("PerformanceEntry.toJSON","toJSON()")}}
 
 ```js
 function perfEntryToJSON() {
-
   // Create a few performance entries
   performance.mark("mark-1");
   performance.mark("mark-2");
@@ -140,20 +139,17 @@ function PerformanceObservers() {
   // Create observer for all performance event types
   const observeAll = new PerformanceObserver((list, obs) => {
     // Print all entries
-    let perfEntries = list.getEntries();
-    perfEntries.forEach((entry) =>  {
+    list.getEntries().forEach((entry) =>  {
       printPerfEntry(entry);
     });
 
     // Print entries named "Begin" with type "mark"
-    perfEntries = list.getEntriesByName("Begin", "mark");
-    perfEntries.forEach((entry) =>  {
+    list.getEntriesByName("Begin", "mark").forEach((entry) =>  {
       printPerfEntry(entry);
     });
 
     // Print entries with type "mark"
-    perfEntries = list.getEntriesByType("mark");
-    perfEntries.forEach((entry) =>  {
+    list.getEntriesByType("mark").forEach((entry) =>  {
       printPerfEntry(entry);
     });
   });

--- a/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
+++ b/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
@@ -159,7 +159,7 @@ function PerformanceObservers() {
   });
   
   // Subscribe to all performance event types
-  observe_all.observe({entryTypes: ['frame', 'mark', 'measure', 'navigation', 'resource', 'server']});
+  observeAll.observe({entryTypes: ['frame', 'mark', 'measure', 'navigation', 'resource', 'server']});
 
   // Create observer for just the "mark" event type
   const observe_mark = new PerformanceObserver((list, obs) => {

--- a/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
+++ b/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
@@ -172,7 +172,7 @@ function PerformanceObservers() {
   });
   
   // Subscribe to only the 'mark' event
-  observe_mark.observe({entryTypes: ['mark']});
+  observeMark.observe({entryTypes: ['mark']});
 }
 
 function printPerfEntry(pe) {

--- a/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
+++ b/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
@@ -20,8 +20,8 @@ function log(s) {
   o.innerHTML += `${s} <br>`;
 }
 
-function doWork (n) {
-  for (let i=0 ; i < n; i++) {
+function doWork(n) {
+  for (let i = 0; i < n; i++) {
      const m = Math.random(); // This is an example of work taking some time
   }
 }
@@ -159,7 +159,9 @@ function PerformanceObservers() {
   });
   
   // Subscribe to all performance event types
-  observeAll.observe({entryTypes: ['frame', 'mark', 'measure', 'navigation', 'resource', 'server']});
+  observeAll.observe({
+    entryTypes: ['frame', 'mark', 'measure', 'navigation', 'resource', 'server'],
+  });
 
   // Create observer for just the "mark" event type
   const observeMark = new PerformanceObserver((list, obs) => {
@@ -172,7 +174,7 @@ function PerformanceObservers() {
   });
   
   // Subscribe to only the 'mark' event
-  observeMark.observe({entryTypes: ['mark']});
+  observeMark.observe({ entryTypes: ['mark'] });
 }
 
 function printPerfEntry(pe) {

--- a/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
+++ b/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
@@ -139,7 +139,7 @@ function PerformanceObservers() {
   // Create observer for all performance event types
   const observeAll = new PerformanceObserver((list, obs) => {
     // Print all entries
-    list.getEntries().forEach((entry) =>  {
+    list.getEntries().forEach((entry) => {
       printPerfEntry(entry);
     });
 

--- a/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
+++ b/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
@@ -87,20 +87,15 @@ function print_PerformanceEntry(ev) {
   performance.mark("Stop");
   performance.measure("measure-1");
 
-  const p = performance.getEntries();
-  for (let i=0; i < p.length; i++) {
+  const perf = performance.getEntries();
+  perf.forEach((perfEntry, i) => {
     log(`PerfEntry[${i}]`);
-    for (let j=0; j < properties.length; j++) {
-      // check each property in window.performance
-      const supported = properties[j] in p[i];
-      if (supported) {
-        const pe = p[i];
-        console.log(`… ${properties[j]} = ${pe[properties[j]]}`);
-      } else {
-        console.log(`… ${properties[j]} = Not supported`);
-      }
-    }
-  }
+    properties.forEach((prop) => {
+      // Check each property in window.performance
+      const supported = prop in perfEntry;
+      console.log(`… ${prop} = ${suppported ? perfEntry[prop] : "Not supported"}`);
+    });
+  });
 }
 ```
 
@@ -143,21 +138,21 @@ function PerformanceObservers() {
   const observe_all = new PerformanceObserver((list, obs) => {
     // Print all entries
     let perfEntries = list.getEntries();
-    for (let i=0; i < perfEntries.length; i++) {
-      print_perf_entry(perfEntries[i]);
-    }
+    perfEntries.forEach((entry) =>  {
+      print_perf_entry(entry);
+    });
 
     // Print entries named "Begin" with type "mark"
     perfEntries = list.getEntriesByName("Begin", "mark");
-    for (let i=0; i < perfEntries.length; i++) {
-      print_perf_entry(perfEntries[i]);
-    }
+    perfEntries.forEach((entry) =>  {
+      print_perf_entry(entry);
+    });
 
     // Print entries with type "mark"
     perfEntries = list.getEntriesByType("mark");
-    for (let i=0; i < perfEntries.length; i++) {
-      print_perf_entry(perfEntries[i]);
-    }
+    perfEntries.forEach((entry) =>  {
+      print_perf_entry(entry);
+    });
   });
   // subscribe to all performance event types
   observe_all.observe({entryTypes: ['frame', 'mark', 'measure', 'navigation', 'resource', 'server']});
@@ -165,10 +160,11 @@ function PerformanceObservers() {
   // Create observer for just the "mark" event type
   const observe_mark = new PerformanceObserver((list, obs) => {
     const perfEntries = list.getEntries();
+    
     // Should only have 'mark' entries
-    for (let i=0; i < perfEntries.length; i++) {
-      print_perf_entry(perfEntries[i]);
-    }
+    perfEntries.forEach((entry) =>  {
+      print_perf_entry(entry);
+    });
   });
   // subscribe to only the 'mark' event
   observe_mark.observe({entryTypes: ['mark']});

--- a/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
+++ b/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
@@ -54,7 +54,7 @@ function printPerformanceEntries() {
     });
 
   // Use getEntries(name, entryType) to get specific entries
-  performance.getEntries({name : "Measure1", entryType: "measure"})
+  performance.getEntries({ name: "Measure1", entryType: "measure" })
     .forEach((entry, i) => {
       log(`Begin and Measure [${i}]`);
       printPerfEntry(entry);

--- a/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
+++ b/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
@@ -144,12 +144,12 @@ function PerformanceObservers() {
     });
 
     // Print entries named "Begin" with type "mark"
-    list.getEntriesByName("Begin", "mark").forEach((entry) =>  {
+    list.getEntriesByName("Begin", "mark").forEach((entry) => {
       printPerfEntry(entry);
     });
 
     // Print entries with type "mark"
-    list.getEntriesByType("mark").forEach((entry) =>  {
+    list.getEntriesByType("mark").forEach((entry) => {
       printPerfEntry(entry);
     });
   });

--- a/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
+++ b/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
@@ -160,11 +160,9 @@ function PerformanceObservers() {
   });
 
   // Create observer for just the "mark" event type
-  const observeMark = new PerformanceObserver((list, obs) => {
-    const perfEntries = list.getEntries();
-    
+  const observeMark = new PerformanceObserver((list, obs) => { 
     // Should only have 'mark' entries
-    perfEntries.forEach((entry) =>  {
+    list.getEntries().forEach((entry) =>  {
       printPerfEntry(entry);
     });
   });

--- a/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
+++ b/files/en-us/web/api/performance_timeline/using_performance_timeline/index.md
@@ -138,7 +138,7 @@ The following example shows how to register two observers: the first one registe
 ```js
 function PerformanceObservers() {
   // Create observer for all performance event types
-  const observe_all = new PerformanceObserver((list, obs) => {
+  const observeAll = new PerformanceObserver((list, obs) => {
     // Print all entries
     let perfEntries = list.getEntries();
     perfEntries.forEach((entry) =>  {

--- a/files/en-us/web/api/performanceentry/duration/index.md
+++ b/files/en-us/web/api/performanceentry/duration/index.md
@@ -57,7 +57,7 @@ the difference between the {{domxref("PerformanceResourceTiming.responseEnd")}} 
 The following example shows the use of the `duration` property.
 
 ```js
-function run_PerformanceEntry() {
+function runPerformanceEntry() {
   console.log("PerformanceEntry support…");
 
   if (performance.mark === undefined) {
@@ -71,14 +71,14 @@ function run_PerformanceEntry() {
   performance.mark("End");
 
   // Use getEntries() to iterate through the each entry
-  const perf = performance.getEntries();
-  perf.forEach((entry, i) => {
-    log(`Entry[${i}]`);
-    check_PerformanceEntry(entry);
-  });
+  performance.getEntries()
+    .forEach((entry, i) => {
+      log(`Entry[${i}]`);
+      checkPerformanceEntry(entry);
+    });
 }
 
-function check_PerformanceEntry(obj) {
+function checkPerformanceEntry(obj) {
   const properties = ["name", "entryType", "startTime", "duration"];
   const methods = ["toJSON"];
 

--- a/files/en-us/web/api/performanceentry/duration/index.md
+++ b/files/en-us/web/api/performanceentry/duration/index.md
@@ -83,15 +83,15 @@ function check_PerformanceEntry(obj) {
   const methods = ["toJSON"];
 
   // Check each property
-  properties.forEach((prop) => {
-    const supported = prop in obj;
-    console.log(`…${prop} = ${supported ? obj[prop] : "Not supported"}`);
+  properties.forEach((property) => {
+    const supported = property in obj;
+    console.log(`…${property} = ${supported ? obj[property] : "Not supported"}`);
   });
 
   // Check each method
   methods.forEach((meth) => {
     const supported = typeof obj[meth] === "function";
-    console.log(`…${meth} = ${supported ? obj[meth] : "Not supported"}`);
+    console.log(`…${method} = ${supported ? obj[method] : "Not supported"}`);
   });
 }
 ```

--- a/files/en-us/web/api/performanceentry/duration/index.md
+++ b/files/en-us/web/api/performanceentry/duration/index.md
@@ -73,7 +73,7 @@ function runPerformanceEntry() {
   // Use getEntries() to iterate through the each entry
   performance.getEntries()
     .forEach((entry, i) => {
-      log(`Entry[${i}]`);
+      console.log(`Entry[${i}]`);
       checkPerformanceEntry(entry);
     });
 }

--- a/files/en-us/web/api/performanceentry/duration/index.md
+++ b/files/en-us/web/api/performanceentry/duration/index.md
@@ -91,7 +91,7 @@ function checkPerformanceEntry(obj) {
   // Check each method
   methods.forEach((method) => {
     const supported = typeof obj[method] === "function";
-    console.log(`…${method} = ${supported ? obj[method] : "Not supported"}`);
+    console.log(`…${method} = ${supported ? JSON.stringify(obj[method]()) : "Not supported"}`);
   });
 }
 ```

--- a/files/en-us/web/api/performanceentry/duration/index.md
+++ b/files/en-us/web/api/performanceentry/duration/index.md
@@ -71,35 +71,28 @@ function run_PerformanceEntry() {
   performance.mark("End");
 
   // Use getEntries() to iterate through the each entry
-  const p = performance.getEntries();
-  for (let i=0; i < p.length; i++) {
+  const perf = performance.getEntries();
+  perf.forEach((entry, i) => {
     log(`Entry[${i}]`);
-    check_PerformanceEntry(p[i]);
-  }
+    check_PerformanceEntry(entry);
+  });
 }
+
 function check_PerformanceEntry(obj) {
   const properties = ["name", "entryType", "startTime", "duration"];
   const methods = ["toJSON"];
 
-  for (let i = 0; i < properties.length; i++) {
-    // check each property
-    const supported = properties[i] in obj;
-    if (supported) {
-      console.log(`…${properties[i]} = ${obj[properties[i]]}`);
-    } else {
-      console.log(`…${properties[i]} = Not supported`);
-    }
-  }
-  for (let i = 0; i < methods.length; i++) {
-    // check each method
-    const supported = typeof obj[methods[i]] === "function";
-    if (supported) {
-      const js = obj[methods[i]]();
-      console.log(`…${methods[i]}() = ${JSON.stringify(js)}`);
-    } else {
-      console.log(`…${methods[i]} = Not supported`);
-    }
-  }
+  // Check each property
+  properties.forEach((prop) => {
+    const supported = prop in obj;
+    console.log(`…${prop} = ${supported ? obj[prop] : "Not supported"}`);
+  });
+
+  // Check each method
+  methods.forEach((meth) => {
+    const supported = typeof obj[meth] === "function";
+    console.log(`…${meth} = ${supported ? obj[meth] : "Not supported"}`);
+  });
 }
 ```
 

--- a/files/en-us/web/api/performanceentry/duration/index.md
+++ b/files/en-us/web/api/performanceentry/duration/index.md
@@ -89,8 +89,8 @@ function checkPerformanceEntry(obj) {
   });
 
   // Check each method
-  methods.forEach((meth) => {
-    const supported = typeof obj[meth] === "function";
+  methods.forEach((method) => {
+    const supported = typeof obj[method] === "function";
     console.log(`…${method} = ${supported ? obj[method] : "Not supported"}`);
   });
 }

--- a/files/en-us/web/api/performanceentry/entrytype/index.md
+++ b/files/en-us/web/api/performanceentry/entrytype/index.md
@@ -101,7 +101,7 @@ table below.
 The following example shows the use of the `entryType` property.
 
 ```js
-function run_PerformanceEntry() {
+function runPerformanceEntry() {
   // Check for feature support before continuing
   if (performance.mark === undefined) {
     console.log("performance.mark not supported");
@@ -112,10 +112,10 @@ function run_PerformanceEntry() {
   performance.mark("begin");
 
   // Check the entryType of all the "begin" entries
-  const entriesNamedBegin = performance.getEntriesByName("begin");
-  entriesNamedBegin.forEach((entry) => {
-    console.log(`Entry is type: ${entry.entryType}`);
-  });
+  entriesNamedBegin = performance.getEntriesByName("begin")
+    .forEach((entry) => {
+      console.log(`Entry is type: ${entry.entryType}`);
+    });
 
 }
 ```

--- a/files/en-us/web/api/performanceentry/entrytype/index.md
+++ b/files/en-us/web/api/performanceentry/entrytype/index.md
@@ -112,7 +112,7 @@ function runPerformanceEntry() {
   performance.mark("begin");
 
   // Check the entryType of all the "begin" entries
-  entriesNamedBegin = performance.getEntriesByName("begin")
+  performance.getEntriesByName("begin")
     .forEach((entry) => {
       console.log(`Entry is type: ${entry.entryType}`);
     });

--- a/files/en-us/web/api/performanceentry/entrytype/index.md
+++ b/files/en-us/web/api/performanceentry/entrytype/index.md
@@ -102,8 +102,7 @@ The following example shows the use of the `entryType` property.
 
 ```js
 function run_PerformanceEntry() {
-
-  // check for feature support before continuing
+  // Check for feature support before continuing
   if (performance.mark === undefined) {
     console.log("performance.mark not supported");
     return;
@@ -114,10 +113,9 @@ function run_PerformanceEntry() {
 
   // Check the entryType of all the "begin" entries
   const entriesNamedBegin = performance.getEntriesByName("begin");
-  for (let i=0; i < entriesNamedBegin.length; i++) {
-      const typeOfEntry = entriesNamedBegin[i].entryType;
-      console.log(`Entry is type: ${typeOfEntry}`);
-  }
+  entriesNamedBegin.forEach((entry) => {
+    console.log(`Entry is type: ${entry.entryType}`);
+  });
 
 }
 ```

--- a/files/en-us/web/api/performanceentry/name/index.md
+++ b/files/en-us/web/api/performanceentry/name/index.md
@@ -101,7 +101,7 @@ function runPerformanceEntry() {
   // Use getEntries() to iterate through the each entry
   performance.getEntries()
     .forEach((entry, i) => {
-      log(`Entry[${i}]`);
+      console.log(`Entry[${i}]`);
       checkPerformanceEntry(entry);
     });
 }

--- a/files/en-us/web/api/performanceentry/name/index.md
+++ b/files/en-us/web/api/performanceentry/name/index.md
@@ -99,35 +99,28 @@ function run_PerformanceEntry() {
   performance.mark("End");
 
   // Use getEntries() to iterate through the each entry
-  const p = performance.getEntries();
-  for (let i=0; i < p.length; i++) {
+  const perf = performance.getEntries();
+  perf.forEach((entry, i) => {
     log(`Entry[${i}]`);
-    check_PerformanceEntry(p[i]);
-  }
+    check_PerformanceEntry(entry);
+  });
 }
+
 function check_PerformanceEntry(obj) {
   const properties = ["name", "entryType", "startTime", "duration"];
   const methods = ["toJSON"];
 
-  for (let i = 0; i < properties.length; i++) {
-    // check each property
-    const supported = properties[i] in obj;
-    if (supported) {
-      console.log(`…${properties[i]} = ${obj[properties[i]]}`);
-    } else {
-      console.log(`…${properties[i]} = Not supported`);
-    }
-  }
-  for (let i = 0; i < methods.length; i++) {
-    // check each method
-    const supported = typeof obj[methods[i]] === "function";
-    if (supported) {
-      const js = obj[methods[i]]();
-      console.log(`…${methods[i]}() = ${JSON.stringify(js)}`);
-    } else {
-      console.log(`…${methods[i]} = Not supported`);
-    }
-  }
+  // Check each property
+  properties.forEach((prop) => {
+    const supported = prop in obj;
+    console.log(`…${prop} = ${supported ? obj[prop] : "Not supported"}`);
+  });
+
+  // Check each method
+  methods.forEach((meth) => {
+    const supported = typeof obj[meth] === "function";
+    console.log(`…${meth} = ${supported ? obj[meth] : "Not supported"}`);
+  });
 }
 ```
 

--- a/files/en-us/web/api/performanceentry/name/index.md
+++ b/files/en-us/web/api/performanceentry/name/index.md
@@ -119,7 +119,7 @@ function checkPerformanceEntry(obj) {
   // Check each method
   methods.forEach((method) => {
     const supported = typeof obj[method] === "function";
-    console.log(`…${method} = ${supported ? obj[method] : "Not supported"}`);
+    console.log(`…${method} = ${supported ? JSON.stringify(obj[method]()) : "Not supported"}`);
   });
 }
 ```

--- a/files/en-us/web/api/performanceentry/name/index.md
+++ b/files/en-us/web/api/performanceentry/name/index.md
@@ -85,7 +85,7 @@ the value of {{domxref("PerformanceEntry.entryType")}}, as shown by the table be
 The following example shows the use of the `name` property.
 
 ```js
-function run_PerformanceEntry() {
+function runPerformanceEntry() {
   console.log("PerformanceEntry support…");
 
   if (performance.mark === undefined) {
@@ -99,27 +99,27 @@ function run_PerformanceEntry() {
   performance.mark("End");
 
   // Use getEntries() to iterate through the each entry
-  const perf = performance.getEntries();
-  perf.forEach((entry, i) => {
-    log(`Entry[${i}]`);
-    check_PerformanceEntry(entry);
-  });
+  performance.getEntries()
+    .forEach((entry, i) => {
+      log(`Entry[${i}]`);
+      checkPerformanceEntry(entry);
+    });
 }
 
-function check_PerformanceEntry(obj) {
+function checkPerformanceEntry(obj) {
   const properties = ["name", "entryType", "startTime", "duration"];
   const methods = ["toJSON"];
 
   // Check each property
-  properties.forEach((prop) => {
-    const supported = prop in obj;
-    console.log(`…${prop} = ${supported ? obj[prop] : "Not supported"}`);
+  properties.forEach((property) => {
+    const supported = property in obj;
+    console.log(`…${property} = ${supported ? obj[property] : "Not supported"}`);
   });
 
   // Check each method
-  methods.forEach((meth) => {
-    const supported = typeof obj[meth] === "function";
-    console.log(`…${meth} = ${supported ? obj[meth] : "Not supported"}`);
+  methods.forEach((method) => {
+    const supported = typeof obj[method] === "function";
+    console.log(`…${method} = ${supported ? obj[method] : "Not supported"}`);
   });
 }
 ```

--- a/files/en-us/web/api/performanceentry/starttime/index.md
+++ b/files/en-us/web/api/performanceentry/starttime/index.md
@@ -52,7 +52,7 @@ the {{domxref("PerformanceResourceTiming.fetchStart")}}
 The following example shows the use of the `startTime` property.
 
 ```js
-function run_PerformanceEntry() {
+function runPerformanceEntry() {
   console.log("PerformanceEntry support…");
 
   if (performance.mark === undefined) {
@@ -66,27 +66,27 @@ function run_PerformanceEntry() {
   performance.mark("End");
 
   // Use getEntries() to iterate through the each entry
-  const perf = performance.getEntries();
-  perf.forEach((entry, i) => {
-    log(`Entry[${i}]`);
-    check_PerformanceEntry(entry);
-  });
+  performance.getEntries()
+    .forEach((entry, i) => {
+      log(`Entry[${i}]`);
+      checkPerformanceEntry(entry);
+    });
 }
 
-function check_PerformanceEntry(obj) {
+function checkPerformanceEntry(obj) {
   const properties = ["name", "entryType", "startTime", "duration"];
   const methods = ["toJSON"];
 
   // Check each property
-  properties.forEach((prop) => {
-    const supported = prop in obj;
-    console.log(`…${prop} = ${supported ? obj[prop] : "Not supported"}`);
+  properties.forEach((property) => {
+    const supported = property in obj;
+    console.log(`…${property} = ${supported ? obj[property] : "Not supported"}`);
   });
 
   // Check each method
-  methods.forEach((meth) => {
-    const supported = typeof obj[meth] === "function";
-    console.log(`…${meth} = ${supported ? obj[meth] : "Not supported"}`);
+  methods.forEach((method) => {
+    const supported = typeof obj[method] === "function";
+    console.log(`…${method} = ${supported ? obj[method] : "Not supported"}`);
   });
 }
 ```

--- a/files/en-us/web/api/performanceentry/starttime/index.md
+++ b/files/en-us/web/api/performanceentry/starttime/index.md
@@ -68,7 +68,7 @@ function runPerformanceEntry() {
   // Use getEntries() to iterate through the each entry
   performance.getEntries()
     .forEach((entry, i) => {
-      log(`Entry[${i}]`);
+      console.log(`Entry[${i}]`);
       checkPerformanceEntry(entry);
     });
 }

--- a/files/en-us/web/api/performanceentry/starttime/index.md
+++ b/files/en-us/web/api/performanceentry/starttime/index.md
@@ -66,35 +66,28 @@ function run_PerformanceEntry() {
   performance.mark("End");
 
   // Use getEntries() to iterate through the each entry
-  const p = performance.getEntries();
-  for (let i=0; i < p.length; i++) {
+  const perf = performance.getEntries();
+  perf.forEach((entry, i) => {
     log(`Entry[${i}]`);
-    check_PerformanceEntry(p[i]);
-  }
+    check_PerformanceEntry(entry);
+  });
 }
+
 function check_PerformanceEntry(obj) {
   const properties = ["name", "entryType", "startTime", "duration"];
   const methods = ["toJSON"];
 
-  for (let i = 0; i < properties.length; i++) {
-    // check each property
-    const supported = properties[i] in obj;
-    if (supported) {
-      console.log(`…${properties[i]} = ${obj[properties[i]]}`);
-    } else {
-      console.log(`…${properties[i]} = Not supported`);
-    }
-  }
-  for (let i = 0; i < methods.length; i++) {
-    // check each method
-    const supported = typeof obj[methods[i]] === "function";
-    if (supported) {
-      const js = obj[methods[i]]();
-      console.log(`…${methods[i]}() = ${JSON.stringify(js)}`);
-    } else {
-      console.log(`…${methods[i]} = Not supported`);
-    }
-  }
+  // Check each property
+  properties.forEach((prop) => {
+    const supported = prop in obj;
+    console.log(`…${prop} = ${supported ? obj[prop] : "Not supported"}`);
+  });
+
+  // Check each method
+  methods.forEach((meth) => {
+    const supported = typeof obj[meth] === "function";
+    console.log(`…${meth} = ${supported ? obj[meth] : "Not supported"}`);
+  });
 }
 ```
 

--- a/files/en-us/web/api/performanceentry/starttime/index.md
+++ b/files/en-us/web/api/performanceentry/starttime/index.md
@@ -86,7 +86,7 @@ function checkPerformanceEntry(obj) {
   // Check each method
   methods.forEach((method) => {
     const supported = typeof obj[method] === "function";
-    console.log(`…${method} = ${supported ? obj[method] : "Not supported"}`);
+    console.log(`…${method} = ${supported ? JSON.stringify(obj[method]()) : "Not supported"}`);
   });
 }
 ```

--- a/files/en-us/web/api/performanceentry/tojson/index.md
+++ b/files/en-us/web/api/performanceentry/tojson/index.md
@@ -51,7 +51,7 @@ function runPerformanceEntry() {
   // Use getEntries() to iterate through the each entry
   performance.getEntries()
     .forEach((entry, i) => {
-      log(`Entry[${i}]`);
+      console.log(`Entry[${i}]`);
       checkPerformanceEntry(entry);
     });
 }

--- a/files/en-us/web/api/performanceentry/tojson/index.md
+++ b/files/en-us/web/api/performanceentry/tojson/index.md
@@ -35,7 +35,7 @@ A JSON object that is the serialization of the {{domxref("PerformanceEntry")}} o
 The following example shows the use of the `toJSON()` method.
 
 ```js
-function run_PerformanceEntry() {
+function runPerformanceEntry() {
   console.log("PerformanceEntry support…");
 
   if (performance.mark === undefined) {
@@ -45,31 +45,31 @@ function run_PerformanceEntry() {
 
   // Create some performance entries via the mark() method
   performance.mark("Begin");
-  do_work(50000);
+  doWork(50000);
   performance.mark("End");
 
   // Use getEntries() to iterate through the each entry
-  const perf = performance.getEntries();
-  perf.forEach((entry, i) => {
-    log(`Entry[${i}]`);
-    check_PerformanceEntry(entry);
-  });
+  performance.getEntries()
+    .forEach((entry, i) => {
+      log(`Entry[${i}]`);
+      checkPerformanceEntry(entry);
+    });
 }
 
-function check_PerformanceEntry(obj) {
+function checkPerformanceEntry(obj) {
   const properties = ["name", "entryType", "startTime", "duration"];
   const methods = ["toJSON"];
 
   // Check each property
-  properties.forEach((prop) => {
-    const supported = prop in obj;
-    console.log(`…${prop} = ${supported ? obj[prop] : "Not supported"}`);
+  properties.forEach((property) => {
+    const supported = property in obj;
+    console.log(`…${property} = ${supported ? obj[property] : "Not supported"}`);
   });
 
   // Check each method
-  methods.forEach((meth) => {
-    const supported = typeof obj[meth] === "function";
-    console.log(`…${meth} = ${supported ? obj[meth] : "Not supported"}`);
+  methods.forEach((method) => {
+    const supported = typeof obj[method] === "function";
+    console.log(`…${method} = ${supported ? obj[method] : "Not supported"}`);
   });
 }
 ```

--- a/files/en-us/web/api/performanceentry/tojson/index.md
+++ b/files/en-us/web/api/performanceentry/tojson/index.md
@@ -49,35 +49,28 @@ function run_PerformanceEntry() {
   performance.mark("End");
 
   // Use getEntries() to iterate through the each entry
-  const p = performance.getEntries();
-  for (let i=0; i < p.length; i++) {
+  const perf = performance.getEntries();
+  perf.forEach((entry, i) => {
     log(`Entry[${i}]`);
-    check_PerformanceEntry(p[i]);
-  }
+    check_PerformanceEntry(entry);
+  });
 }
+
 function check_PerformanceEntry(obj) {
   const properties = ["name", "entryType", "startTime", "duration"];
   const methods = ["toJSON"];
 
-  for (let i=0; i < properties.length; i++) {
-    // check each property
-    const supported = properties[i] in obj;
-    if (supported) {
-      console.log(`…${properties[i]} = ${obj[properties[i]]}`);
-    } else {
-      console.log(`…${properties[i]} = Not supported`);
-    }
-  }
-  for (let i=0; i < methods.length; i++) {
-    // check each method
-    const supported = typeof obj[methods[i]] === "function";
-    if (supported) {
-      const js = obj[methods[i]]();
-      console.log(`…${methods[i]}() = ${JSON.stringify(js)}`);
-    } else {
-      console.log(`…${methods[i]} = Not supported`);
-    }
-  }
+  // Check each property
+  properties.forEach((prop) => {
+    const supported = prop in obj;
+    console.log(`…${prop} = ${supported ? obj[prop] : "Not supported"}`);
+  });
+
+  // Check each method
+  methods.forEach((meth) => {
+    const supported = typeof obj[meth] === "function";
+    console.log(`…${meth} = ${supported ? obj[meth] : "Not supported"}`);
+  });
 }
 ```
 

--- a/files/en-us/web/api/performanceentry/tojson/index.md
+++ b/files/en-us/web/api/performanceentry/tojson/index.md
@@ -69,7 +69,7 @@ function checkPerformanceEntry(obj) {
   // Check each method
   methods.forEach((method) => {
     const supported = typeof obj[method] === "function";
-    console.log(`…${method} = ${supported ? obj[method] : "Not supported"}`);
+    console.log(`…${method} = ${supported ? JSON.stringify(obj[method]()) : "Not supported"}`);
   });
 }
 ```

--- a/files/en-us/web/api/performancenavigationtiming/domcomplete/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/domcomplete/index.md
@@ -27,7 +27,7 @@ current document to _[complete](https://html.spec.whatwg.org/multipage/syntax.ht
 The following example illustrates this property's usage.
 
 ```js
-function print_nav_timing_data() {
+function printNavTimingData() {
   // Use getEntriesByType() to just get the "navigation" events
   const perfEntries = performance.getEntriesByType("navigation");
   perfEntries.forEach((p, i) => {

--- a/files/en-us/web/api/performancenavigationtiming/domcomplete/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/domcomplete/index.md
@@ -30,23 +30,22 @@ The following example illustrates this property's usage.
 function print_nav_timing_data() {
   // Use getEntriesByType() to just get the "navigation" events
   const perfEntries = performance.getEntriesByType("navigation");
-
-  for (let i=0; i < perfEntries.length; i++) {
+  perfEntries.forEach((p, i) => {
     console.log(`= Navigation entry[${i}]`);
-    const p = perfEntries[i];
+    
     // DOM Properties
     console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
     console.log(`DOM complete = ${p.domComplete}`);
     console.log(`DOM interactive = ${p.interactive}`);
 
-    // document load and unload time
+    // Document load and unload time
     console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
     console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
 
-    // other properties
+    // Other properties
     console.log(`type = ${p.type}`);
     console.log(`redirectCount = ${p.redirectCount}`);
-  }
+  });
 }
 ```
 

--- a/files/en-us/web/api/performancenavigationtiming/domcomplete/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/domcomplete/index.md
@@ -29,23 +29,23 @@ The following example illustrates this property's usage.
 ```js
 function printNavTimingData() {
   // Use getEntriesByType() to just get the "navigation" events
-  const perfEntries = performance.getEntriesByType("navigation");
-  perfEntries.forEach((p, i) => {
-    console.log(`= Navigation entry[${i}]`);
-    
-    // DOM Properties
-    console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
-    console.log(`DOM complete = ${p.domComplete}`);
-    console.log(`DOM interactive = ${p.interactive}`);
+  performance.getEntriesByType("navigation")
+    .forEach((p, i) => {
+      console.log(`= Navigation entry[${i}]`);
 
-    // Document load and unload time
-    console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
-    console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
+      // DOM Properties
+      console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
+      console.log(`DOM complete = ${p.domComplete}`);
+      console.log(`DOM interactive = ${p.domInteractive}`);
 
-    // Other properties
-    console.log(`type = ${p.type}`);
-    console.log(`redirectCount = ${p.redirectCount}`);
-  });
+      // Document load and unload time
+      console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
+      console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
+
+      // Other properties
+      console.log(`type = ${p.type}`);
+      console.log(`redirectCount = ${p.redirectCount}`);
+    });
 }
 ```
 

--- a/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventend/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventend/index.md
@@ -30,23 +30,22 @@ The following example illustrates this property's usage.
 function print_nav_timing_data() {
   // Use getEntriesByType() to just get the "navigation" events
   const perfEntries = performance.getEntriesByType("navigation");
-
-  for (let i=0; i < perfEntries.length; i++) {
+  perfEntries.forEach((p, i) => {
     console.log(`= Navigation entry[${i}]`);
-    const p = perfEntries[i];
-    // dom Properties
+    
+    // DOM Properties
     console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
     console.log(`DOM complete = ${p.domComplete}`);
-    console.log(`DOM interactive = ${p.domInteractive}`);
+    console.log(`DOM interactive = ${p.interactive}`);
 
-    // document load and unload time
+    // Document load and unload time
     console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
     console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
 
-    // other properties
+    // Other properties
     console.log(`type = ${p.type}`);
     console.log(`redirectCount = ${p.redirectCount}`);
-  }
+  });
 }
 ```
 

--- a/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventend/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventend/index.md
@@ -36,7 +36,7 @@ function printNavTimingData() {
     // DOM Properties
     console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
     console.log(`DOM complete = ${p.domComplete}`);
-    console.log(`DOM interactive = ${p.interactive}`);
+    console.log(`DOM interactive = ${p.domInteractive}`);
 
     // Document load and unload time
     console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);

--- a/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventend/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventend/index.md
@@ -27,7 +27,7 @@ event completes.
 The following example illustrates this property's usage.
 
 ```js
-function print_nav_timing_data() {
+function printNavTimingData() {
   // Use getEntriesByType() to just get the "navigation" events
   const perfEntries = performance.getEntriesByType("navigation");
   perfEntries.forEach((p, i) => {

--- a/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventend/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventend/index.md
@@ -29,23 +29,23 @@ The following example illustrates this property's usage.
 ```js
 function printNavTimingData() {
   // Use getEntriesByType() to just get the "navigation" events
-  const perfEntries = performance.getEntriesByType("navigation");
-  perfEntries.forEach((p, i) => {
-    console.log(`= Navigation entry[${i}]`);
-    
-    // DOM Properties
-    console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
-    console.log(`DOM complete = ${p.domComplete}`);
-    console.log(`DOM interactive = ${p.domInteractive}`);
+  performance.getEntriesByType("navigation")
+    .forEach((p, i) => {
+      console.log(`= Navigation entry[${i}]`);
 
-    // Document load and unload time
-    console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
-    console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
+      // DOM Properties
+      console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
+      console.log(`DOM complete = ${p.domComplete}`);
+      console.log(`DOM interactive = ${p.domInteractive}`);
 
-    // Other properties
-    console.log(`type = ${p.type}`);
-    console.log(`redirectCount = ${p.redirectCount}`);
-  });
+      // Document load and unload time
+      console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
+      console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
+
+      // Other properties
+      console.log(`type = ${p.type}`);
+      console.log(`redirectCount = ${p.redirectCount}`);
+    });
 }
 ```
 

--- a/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventstart/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventstart/index.md
@@ -30,23 +30,22 @@ The following example illustrates this property's usage.
 function print_nav_timing_data() {
   // Use getEntriesByType() to just get the "navigation" events
   const perfEntries = performance.getEntriesByType("navigation");
-
-  for (let i=0; i < perfEntries.length; i++) {
+  perfEntries.forEach((p, i) => {
     console.log(`= Navigation entry[${i}]`);
-    const p = perfEntries[i];
-    // dom Properties
+    
+    // DOM Properties
     console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
     console.log(`DOM complete = ${p.domComplete}`);
     console.log(`DOM interactive = ${p.interactive}`);
 
-    // document load and unload time
+    // Document load and unload time
     console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
     console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
 
-    // other properties
+    // Other properties
     console.log(`type = ${p.type}`);
     console.log(`redirectCount = ${p.redirectCount}`);
-  }
+  });
 }
 ```
 

--- a/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventstart/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventstart/index.md
@@ -27,25 +27,25 @@ event at the current document.
 The following example illustrates this property's usage.
 
 ```js
-function print_nav_timing_data() {
+function printNavTimingData() {
   // Use getEntriesByType() to just get the "navigation" events
-  const perfEntries = performance.getEntriesByType("navigation");
-  perfEntries.forEach((p, i) => {
-    console.log(`= Navigation entry[${i}]`);
-    
-    // DOM Properties
-    console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
-    console.log(`DOM complete = ${p.domComplete}`);
-    console.log(`DOM interactive = ${p.interactive}`);
+  performance.getEntriesByType("navigation")
+    .forEach((p, i) => {
+      console.log(`= Navigation entry[${i}]`);
 
-    // Document load and unload time
-    console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
-    console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
+      // DOM Properties
+      console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
+      console.log(`DOM complete = ${p.domComplete}`);
+      console.log(`DOM interactive = ${p.domInteractive}`);
 
-    // Other properties
-    console.log(`type = ${p.type}`);
-    console.log(`redirectCount = ${p.redirectCount}`);
-  });
+      // Document load and unload time
+      console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
+      console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
+
+      // Other properties
+      console.log(`type = ${p.type}`);
+      console.log(`redirectCount = ${p.redirectCount}`);
+    });
 }
 ```
 

--- a/files/en-us/web/api/performancenavigationtiming/dominteractive/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/dominteractive/index.md
@@ -27,25 +27,25 @@ current document to [interactive](https://html.spec.whatwg.org/multipage/syntax.
 The following example illustrates this property's usage.
 
 ```js
-function print_nav_timing_data() {
+function printNavTimingData() {
   // Use getEntriesByType() to just get the "navigation" events
-  const perfEntries = performance.getEntriesByType("navigation");
-  perfEntries.forEach((p, i) => {
-    console.log(`= Navigation entry[${i}]`);
-    
-    // DOM Properties
-    console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
-    console.log(`DOM complete = ${p.domComplete}`);
-    console.log(`DOM interactive = ${p.interactive}`);
+  performance.getEntriesByType("navigation")
+    .forEach((p, i) => {
+      console.log(`= Navigation entry[${i}]`);
 
-    // Document load and unload time
-    console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
-    console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
+      // DOM Properties
+      console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
+      console.log(`DOM complete = ${p.domComplete}`);
+      console.log(`DOM interactive = ${p.domInteractive}`);
 
-    // Other properties
-    console.log(`type = ${p.type}`);
-    console.log(`redirectCount = ${p.redirectCount}`);
-  });
+      // Document load and unload time
+      console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
+      console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
+
+      // Other properties
+      console.log(`type = ${p.type}`);
+      console.log(`redirectCount = ${p.redirectCount}`);
+    });
 }
 ```
 

--- a/files/en-us/web/api/performancenavigationtiming/dominteractive/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/dominteractive/index.md
@@ -30,23 +30,22 @@ The following example illustrates this property's usage.
 function print_nav_timing_data() {
   // Use getEntriesByType() to just get the "navigation" events
   const perfEntries = performance.getEntriesByType("navigation");
-
-  for (let i=0; i < perfEntries.length; i++) {
+  perfEntries.forEach((p, i) => {
     console.log(`= Navigation entry[${i}]`);
-    const p = perfEntries[i];
-    // dom Properties
+    
+    // DOM Properties
     console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
     console.log(`DOM complete = ${p.domComplete}`);
-    console.log(`DOM interactive = ${p.domInteractive}`);
+    console.log(`DOM interactive = ${p.interactive}`);
 
-    // document load and unload time
+    // Document load and unload time
     console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
     console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
 
-    // other properties
+    // Other properties
     console.log(`type = ${p.type}`);
     console.log(`redirectCount = ${p.redirectCount}`);
-  }
+  });
 }
 ```
 

--- a/files/en-us/web/api/performancenavigationtiming/loadeventend/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/loadeventend/index.md
@@ -25,25 +25,25 @@ event of the current document is completed.
 The following example illustrates this property's usage.
 
 ```js
-function print_nav_timing_data() {
+function printNavTimingData() {
   // Use getEntriesByType() to just get the "navigation" events
-  const perfEntries = performance.getEntriesByType("navigation");
-  perfEntries.forEach((p, i) => {
-    console.log(`= Navigation entry[${i}]`);
-    
-    // DOM Properties
-    console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
-    console.log(`DOM complete = ${p.domComplete}`);
-    console.log(`DOM interactive = ${p.interactive}`);
+  performance.getEntriesByType("navigation")
+    .forEach((p, i) => {
+      console.log(`= Navigation entry[${i}]`);
 
-    // Document load and unload time
-    console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
-    console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
+      // DOM Properties
+      console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
+      console.log(`DOM complete = ${p.domComplete}`);
+      console.log(`DOM interactive = ${p.domInteractive}`);
 
-    // Other properties
-    console.log(`type = ${p.type}`);
-    console.log(`redirectCount = ${p.redirectCount}`);
-  });
+      // Document load and unload time
+      console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
+      console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
+
+      // Other properties
+      console.log(`type = ${p.type}`);
+      console.log(`redirectCount = ${p.redirectCount}`);
+    });
 }
 ```
 

--- a/files/en-us/web/api/performancenavigationtiming/loadeventend/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/loadeventend/index.md
@@ -28,23 +28,22 @@ The following example illustrates this property's usage.
 function print_nav_timing_data() {
   // Use getEntriesByType() to just get the "navigation" events
   const perfEntries = performance.getEntriesByType("navigation");
-
-  for (let i=0; i < perfEntries.length; i++) {
+  perfEntries.forEach((p, i) => {
     console.log(`= Navigation entry[${i}]`);
-    const p = perfEntries[i];
-    // dom Properties
+    
+    // DOM Properties
     console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
     console.log(`DOM complete = ${p.domComplete}`);
-    console.log(`DOM interactive = ${p.domInteractive}`);
+    console.log(`DOM interactive = ${p.interactive}`);
 
-    // document load and unload time
+    // Document load and unload time
     console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
     console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
 
-    // other properties
+    // Other properties
     console.log(`type = ${p.type}`);
     console.log(`redirectCount = ${p.redirectCount}`);
-  }
+  });
 }
 ```
 

--- a/files/en-us/web/api/performancenavigationtiming/loadeventstart/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/loadeventstart/index.md
@@ -28,23 +28,22 @@ The following example illustrates this property's usage.
 function print_nav_timing_data() {
   // Use getEntriesByType() to just get the "navigation" events
   const perfEntries = performance.getEntriesByType("navigation");
-
-  for (let i=0; i < perfEntries.length; i++) {
+  perfEntries.forEach((p, i) => {
     console.log(`= Navigation entry[${i}]`);
-    const p = perfEntries[i];
-    // dom Properties
+    
+    // DOM Properties
     console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
     console.log(`DOM complete = ${p.domComplete}`);
     console.log(`DOM interactive = ${p.interactive}`);
 
-    // document load and unload time
+    // Document load and unload time
     console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
     console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
 
-    // other properties
+    // Other properties
     console.log(`type = ${p.type}`);
     console.log(`redirectCount = ${p.redirectCount}`);
-  }
+  });
 }
 ```
 

--- a/files/en-us/web/api/performancenavigationtiming/loadeventstart/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/loadeventstart/index.md
@@ -25,25 +25,25 @@ time immediately before the load event of the current document is fired.
 The following example illustrates this property's usage.
 
 ```js
-function print_nav_timing_data() {
+function printNavTimingData() {
   // Use getEntriesByType() to just get the "navigation" events
-  const perfEntries = performance.getEntriesByType("navigation");
-  perfEntries.forEach((p, i) => {
-    console.log(`= Navigation entry[${i}]`);
-    
-    // DOM Properties
-    console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
-    console.log(`DOM complete = ${p.domComplete}`);
-    console.log(`DOM interactive = ${p.interactive}`);
+  performance.getEntriesByType("navigation")
+    .forEach((p, i) => {
+      console.log(`= Navigation entry[${i}]`);
 
-    // Document load and unload time
-    console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
-    console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
+      // DOM Properties
+      console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
+      console.log(`DOM complete = ${p.domComplete}`);
+      console.log(`DOM interactive = ${p.domInteractive}`);
 
-    // Other properties
-    console.log(`type = ${p.type}`);
-    console.log(`redirectCount = ${p.redirectCount}`);
-  });
+      // Document load and unload time
+      console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
+      console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
+
+      // Other properties
+      console.log(`type = ${p.type}`);
+      console.log(`redirectCount = ${p.redirectCount}`);
+    });
 }
 ```
 

--- a/files/en-us/web/api/performancenavigationtiming/redirectcount/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/redirectcount/index.md
@@ -27,25 +27,25 @@ under the current browsing context.
 The following example illustrates this property's usage.
 
 ```js
-function print_nav_timing_data() {
+function printNavTimingData() {
   // Use getEntriesByType() to just get the "navigation" events
-  const perfEntries = performance.getEntriesByType("navigation");
-  perfEntries.forEach((p, i) => {
-    console.log(`= Navigation entry[${i}]`);
-    
-    // DOM Properties
-    console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
-    console.log(`DOM complete = ${p.domComplete}`);
-    console.log(`DOM interactive = ${p.interactive}`);
+  performance.getEntriesByType("navigation")
+    perfEntries.forEach((p, i) => {
+      console.log(`= Navigation entry[${i}]`);
 
-    // Document load and unload time
-    console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
-    console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
+      // DOM Properties
+      console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
+      console.log(`DOM complete = ${p.domComplete}`);
+      console.log(`DOM interactive = ${p.domInteractive}`);
 
-    // Other properties
-    console.log(`type = ${p.type}`);
-    console.log(`redirectCount = ${p.redirectCount}`);
-  });
+      // Document load and unload time
+      console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
+      console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
+
+      // Other properties
+      console.log(`type = ${p.type}`);
+      console.log(`redirectCount = ${p.redirectCount}`);
+    });
 }
 ```
 

--- a/files/en-us/web/api/performancenavigationtiming/redirectcount/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/redirectcount/index.md
@@ -30,23 +30,22 @@ The following example illustrates this property's usage.
 function print_nav_timing_data() {
   // Use getEntriesByType() to just get the "navigation" events
   const perfEntries = performance.getEntriesByType("navigation");
-
-  for (let i=0; i < perfEntries.length; i++) {
+  perfEntries.forEach((p, i) => {
     console.log(`= Navigation entry[${i}]`);
-    const p = perfEntries[i];
-    // dom Properties
+    
+    // DOM Properties
     console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
     console.log(`DOM complete = ${p.domComplete}`);
     console.log(`DOM interactive = ${p.interactive}`);
 
-    // document load and unload time
+    // Document load and unload time
     console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
     console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
 
-    // other properties
+    // Other properties
     console.log(`type = ${p.type}`);
     console.log(`redirectCount = ${p.redirectCount}`);
-  }
+  });
 }
 ```
 

--- a/files/en-us/web/api/performancenavigationtiming/redirectcount/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/redirectcount/index.md
@@ -30,7 +30,7 @@ The following example illustrates this property's usage.
 function printNavTimingData() {
   // Use getEntriesByType() to just get the "navigation" events
   performance.getEntriesByType("navigation")
-    perfEntries.forEach((p, i) => {
+    .forEach((p, i) => {
       console.log(`= Navigation entry[${i}]`);
 
       // DOM Properties

--- a/files/en-us/web/api/performancenavigationtiming/type/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/type/index.md
@@ -37,23 +37,22 @@ The following example illustrates this property's usage.
 function print_nav_timing_data() {
   // Use getEntriesByType() to just get the "navigation" events
   const perfEntries = performance.getEntriesByType("navigation");
-
-  for (let i=0; i < perfEntries.length; i++) {
+  perfEntries.forEach((p, i) => {
     console.log(`= Navigation entry[${i}]`);
-    const p = perfEntries[i];
-    // dom Properties
+    
+    // DOM Properties
     console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
     console.log(`DOM complete = ${p.domComplete}`);
     console.log(`DOM interactive = ${p.interactive}`);
 
-    // document load and unload time
+    // Document load and unload time
     console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
     console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
 
-    // other properties
+    // Other properties
     console.log(`type = ${p.type}`);
     console.log(`redirectCount = ${p.redirectCount}`);
-  }
+  });
 }
 ```
 

--- a/files/en-us/web/api/performancenavigationtiming/type/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/type/index.md
@@ -34,25 +34,25 @@ A string containing one of the following values:
 The following example illustrates this property's usage.
 
 ```js
-function print_nav_timing_data() {
+function printNavTimingData() {
   // Use getEntriesByType() to just get the "navigation" events
-  const perfEntries = performance.getEntriesByType("navigation");
-  perfEntries.forEach((p, i) => {
-    console.log(`= Navigation entry[${i}]`);
-    
-    // DOM Properties
-    console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
-    console.log(`DOM complete = ${p.domComplete}`);
-    console.log(`DOM interactive = ${p.interactive}`);
+  performance.getEntriesByType("navigation")
+    .forEach((p, i) => {
+      console.log(`= Navigation entry[${i}]`);
 
-    // Document load and unload time
-    console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
-    console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
+      // DOM Properties
+      console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
+      console.log(`DOM complete = ${p.domComplete}`);
+      console.log(`DOM interactive = ${p.domInteractive}`);
 
-    // Other properties
-    console.log(`type = ${p.type}`);
-    console.log(`redirectCount = ${p.redirectCount}`);
-  });
+      // Document load and unload time
+      console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
+      console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
+
+      // Other properties
+      console.log(`type = ${p.type}`);
+      console.log(`redirectCount = ${p.redirectCount}`);
+    });
 }
 ```
 

--- a/files/en-us/web/api/performancenavigationtiming/unloadeventend/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/unloadeventend/index.md
@@ -30,23 +30,22 @@ The following example illustrates this property's usage.
 function print_nav_timing_data() {
   // Use getEntriesByType() to just get the "navigation" events
   const perfEntries = performance.getEntriesByType("navigation");
-
-  for (let i=0; i < perfEntries.length; i++) {
+  perfEntries.forEach((p, i) => {
     console.log(`= Navigation entry[${i}]`);
-    const p = perfEntries[i];
-    // dom Properties
+    
+    // DOM Properties
     console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
     console.log(`DOM complete = ${p.domComplete}`);
     console.log(`DOM interactive = ${p.interactive}`);
 
-    // document load and unload time
+    // Document load and unload time
     console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
     console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
 
-    // other properties
+    // Other properties
     console.log(`type = ${p.type}`);
     console.log(`redirectCount = ${p.redirectCount}`);
-  }
+  });
 }
 ```
 

--- a/files/en-us/web/api/performancenavigationtiming/unloadeventend/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/unloadeventend/index.md
@@ -27,25 +27,25 @@ document.
 The following example illustrates this property's usage.
 
 ```js
-function print_nav_timing_data() {
+function printNavTimingData() {
   // Use getEntriesByType() to just get the "navigation" events
-  const perfEntries = performance.getEntriesByType("navigation");
-  perfEntries.forEach((p, i) => {
-    console.log(`= Navigation entry[${i}]`);
-    
-    // DOM Properties
-    console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
-    console.log(`DOM complete = ${p.domComplete}`);
-    console.log(`DOM interactive = ${p.interactive}`);
+  performance.getEntriesByType("navigation")
+    .forEach((p, i) => {
+      console.log(`= Navigation entry[${i}]`);
 
-    // Document load and unload time
-    console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
-    console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
+      // DOM Properties
+      console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
+      console.log(`DOM complete = ${p.domComplete}`);
+      console.log(`DOM interactive = ${p.domInteractive}`);
 
-    // Other properties
-    console.log(`type = ${p.type}`);
-    console.log(`redirectCount = ${p.redirectCount}`);
-  });
+      // Document load and unload time
+      console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
+      console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
+
+      // Other properties
+      console.log(`type = ${p.type}`);
+      console.log(`redirectCount = ${p.redirectCount}`);
+    });
 }
 ```
 

--- a/files/en-us/web/api/performancenavigationtiming/unloadeventstart/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/unloadeventstart/index.md
@@ -30,23 +30,22 @@ The following example illustrates this property's usage.
 function print_nav_timing_data() {
   // Use getEntriesByType() to just get the "navigation" events
   const perfEntries = performance.getEntriesByType("navigation");
-
-  for (let i = 0; i < perfEntries.length; i++) {
+  perfEntries.forEach((p, i) => {
     console.log(`= Navigation entry[${i}]`);
-    const p = perfEntries[i];
-    // dom Properties
+    
+    // DOM Properties
     console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
     console.log(`DOM complete = ${p.domComplete}`);
     console.log(`DOM interactive = ${p.interactive}`);
 
-    // document load and unload time
+    // Document load and unload time
     console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
     console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
 
-    // other properties
+    // Other properties
     console.log(`type = ${p.type}`);
     console.log(`redirectCount = ${p.redirectCount}`);
-  }
+  });
 }
 ```
 

--- a/files/en-us/web/api/performancenavigationtiming/unloadeventstart/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/unloadeventstart/index.md
@@ -27,25 +27,25 @@ document.
 The following example illustrates this property's usage.
 
 ```js
-function print_nav_timing_data() {
+function printNavTimingData() {
   // Use getEntriesByType() to just get the "navigation" events
-  const perfEntries = performance.getEntriesByType("navigation");
-  perfEntries.forEach((p, i) => {
-    console.log(`= Navigation entry[${i}]`);
-    
-    // DOM Properties
-    console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
-    console.log(`DOM complete = ${p.domComplete}`);
-    console.log(`DOM interactive = ${p.interactive}`);
+  performance.getEntriesByType("navigation")
+    .forEach((p, i) => {
+      console.log(`= Navigation entry[${i}]`);
 
-    // Document load and unload time
-    console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
-    console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
+      // DOM Properties
+      console.log(`DOM content loaded = ${p.domContentLoadedEventEnd - p.domContentLoadedEventStart}`);
+      console.log(`DOM complete = ${p.domComplete}`);
+      console.log(`DOM interactive = ${p.domInteractive}`);
 
-    // Other properties
-    console.log(`type = ${p.type}`);
-    console.log(`redirectCount = ${p.redirectCount}`);
-  });
+      // Document load and unload time
+      console.log(`document load = ${p.loadEventEnd - p.loadEventStart}`);
+      console.log(`document unload = ${p.unloadEventEnd - p.unloadEventStart}`);
+
+      // Other properties
+      console.log(`type = ${p.type}`);
+      console.log(`redirectCount = ${p.redirectCount}`);
+    });
 }
 ```
 

--- a/files/en-us/web/api/performanceobserver/disconnect/index.md
+++ b/files/en-us/web/api/performanceobserver/disconnect/index.md
@@ -39,20 +39,20 @@ None ({{jsxref("undefined")}}).
 ```js
 const observer = new PerformanceObserver((list, obj) => {
   list.getEntries()
-    .forEach((entries) => {
+    .forEach((entry) => {
       // Process "mark" and "frame" events
     });
 });
-observer.observe({entryTypes: ["mark", "frame"]});
+observer.observe({ entryTypes: ["mark", "frame"] });
 
-function perf_observer(list, observer) {
+function perfObserver(list, observer) {
   // Process the "measure" event
   // …
   // Disable additional performance events
   observer.disconnect();
 }
-const observer2 = new PerformanceObserver(perf_observer);
-observer2.observe({entryTypes: ["measure"]});
+const observer2 = new PerformanceObserver(perfObserver);
+observer2.observe({ entryTypes: ["measure"] });
 ```
 
 ## Specifications

--- a/files/en-us/web/api/performanceobserver/disconnect/index.md
+++ b/files/en-us/web/api/performanceobserver/disconnect/index.md
@@ -38,10 +38,10 @@ None ({{jsxref("undefined")}}).
 
 ```js
 const observer = new PerformanceObserver((list, obj) => {
-  const entries = list.getEntries();
-  entries.forEach((entries) => {
-    // Process "mark" and "frame" events
-  });
+  list.getEntries()
+    .forEach((entries) => {
+      // Process "mark" and "frame" events
+    });
 });
 observer.observe({entryTypes: ["mark", "frame"]});
 

--- a/files/en-us/web/api/performanceobserver/disconnect/index.md
+++ b/files/en-us/web/api/performanceobserver/disconnect/index.md
@@ -39,9 +39,9 @@ None ({{jsxref("undefined")}}).
 ```js
 const observer = new PerformanceObserver((list, obj) => {
   const entries = list.getEntries();
-  for (let i=0; i < entries.length; i++) {
+  entries.forEach((entries) => {
     // Process "mark" and "frame" events
-  }
+  });
 });
 observer.observe({entryTypes: ["mark", "frame"]});
 

--- a/files/en-us/web/api/performanceobserver/observe/index.md
+++ b/files/en-us/web/api/performanceobserver/observe/index.md
@@ -70,9 +70,9 @@ for `"mark"` and `"frame"` events, and the other watches for
 ```js
 const observer = new PerformanceObserver((list, obj) => {
   const entries = list.getEntries();
-  for (let i=0; i < entries.length; i++) {
+  entries.forEach((entries) => {
     // Process "mark" and "frame" events
-  }
+  });
 });
 observer.observe({entryTypes: ["mark", "frame"]});
 

--- a/files/en-us/web/api/performanceobserver/observe/index.md
+++ b/files/en-us/web/api/performanceobserver/observe/index.md
@@ -69,10 +69,10 @@ for `"mark"` and `"frame"` events, and the other watches for
 
 ```js
 const observer = new PerformanceObserver((list, obj) => {
-  const entries = list.getEntries();
-  entries.forEach((entries) => {
-    // Process "mark" and "frame" events
-  });
+  list.getEntries()
+    .forEach((entries) => {
+      // Process "mark" and "frame" events
+    });
 });
 observer.observe({entryTypes: ["mark", "frame"]});
 

--- a/files/en-us/web/api/performanceobserver/observe/index.md
+++ b/files/en-us/web/api/performanceobserver/observe/index.md
@@ -70,17 +70,17 @@ for `"mark"` and `"frame"` events, and the other watches for
 ```js
 const observer = new PerformanceObserver((list, obj) => {
   list.getEntries()
-    .forEach((entries) => {
+    .forEach((entry) => {
       // Process "mark" and "frame" events
     });
 });
-observer.observe({entryTypes: ["mark", "frame"]});
+observer.observe({ entryTypes: ["mark", "frame"] });
 
-function perf_observer(list, observer) {
+function perfObserver(list, observer) {
   // Process the "measure" event
 }
-const observer2 = new PerformanceObserver(perf_observer);
-observer2.observe({entryTypes: ["measure"]});
+const observer2 = new PerformanceObserver(perfObserver);
+observer2.observe({ entryTypes: ["measure"] });
 ```
 
 ## Specifications

--- a/files/en-us/web/api/performanceobserver/performanceobserver/index.md
+++ b/files/en-us/web/api/performanceobserver/performanceobserver/index.md
@@ -44,9 +44,9 @@ A new {{domxref("PerformanceObserver")}} object which will call the specified
 ```js
 const observer = new PerformanceObserver((list, obj) => {
   const entries = list.getEntries();
-  for (let i=0; i < entries.length; i++) {
+  entries.forEach((entries) => {
     // Process "mark" and "frame" events
-  }
+  });
 });
 observer.observe({entryTypes: ["mark", "frame"]});
 

--- a/files/en-us/web/api/performanceobserver/performanceobserver/index.md
+++ b/files/en-us/web/api/performanceobserver/performanceobserver/index.md
@@ -44,17 +44,17 @@ A new {{domxref("PerformanceObserver")}} object which will call the specified
 ```js
 const observer = new PerformanceObserver((list, obj) => {
   list.getEntries()
-    .forEach((entries) => {
+    .forEach((entry) => {
       // Process "mark" and "frame" events
     });
 });
-observer.observe({entryTypes: ["mark", "frame"]});
+observer.observe({ entryTypes: ["mark", "frame"] });
 
-function perf_observer(list, observer) {
+function perfObserver(list, observer) {
   // Process the "measure" event
 }
-const observer2 = new PerformanceObserver(perf_observer);
-observer2.observe({entryTypes: ["measure"]});
+const observer2 = new PerformanceObserver(perfObserver);
+observer2.observe({ entryTypes: ["measure"] });
 ```
 
 ## Specifications

--- a/files/en-us/web/api/performanceobserver/performanceobserver/index.md
+++ b/files/en-us/web/api/performanceobserver/performanceobserver/index.md
@@ -43,10 +43,10 @@ A new {{domxref("PerformanceObserver")}} object which will call the specified
 
 ```js
 const observer = new PerformanceObserver((list, obj) => {
-  const entries = list.getEntries();
-  entries.forEach((entries) => {
-    // Process "mark" and "frame" events
-  });
+  list.getEntries()
+    .forEach((entries) => {
+      // Process "mark" and "frame" events
+    });
 });
 observer.observe({entryTypes: ["mark", "frame"]});
 

--- a/files/en-us/web/api/performanceobserver/takerecords/index.md
+++ b/files/en-us/web/api/performanceobserver/takerecords/index.md
@@ -38,9 +38,9 @@ A list of {{domxref("PerformanceEntry")}} objects.
 ```js
 const observer = new PerformanceObserver((list, obj) => {
   const entries = list.getEntries();
-  for (let i=0; i < entries.length; i++) {
+  entries.forEach((entries) => {
     // Process "mark" and "frame" events
-  }
+  });
 });
 observer.observe({entryTypes: ["mark", "frame"]});
 const records = observer.takeRecords();

--- a/files/en-us/web/api/performanceobserver/takerecords/index.md
+++ b/files/en-us/web/api/performanceobserver/takerecords/index.md
@@ -37,12 +37,12 @@ A list of {{domxref("PerformanceEntry")}} objects.
 
 ```js
 const observer = new PerformanceObserver((list, obj) => {
-  const entries = list.getEntries();
-  entries.forEach((entries) => {
-    // Process "mark" and "frame" events
-  });
+  list.getEntries();
+    .forEach((entry) => {
+      // Process "mark" and "frame" events
+    });
 });
-observer.observe({entryTypes: ["mark", "frame"]});
+observer.observe({ entryTypes: ["mark", "frame"] });
 const records = observer.takeRecords();
 console.log(records[0].name);
 console.log(records[0].startTime);

--- a/files/en-us/web/api/performanceobserver/takerecords/index.md
+++ b/files/en-us/web/api/performanceobserver/takerecords/index.md
@@ -37,7 +37,7 @@ A list of {{domxref("PerformanceEntry")}} objects.
 
 ```js
 const observer = new PerformanceObserver((list, obj) => {
-  list.getEntries();
+  list.getEntries()
     .forEach((entry) => {
       // Process "mark" and "frame" events
     });

--- a/files/en-us/web/api/performanceresourcetiming/connectend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/connectend/index.md
@@ -49,9 +49,8 @@ function printStartAndEndProperties(perfEntry) {
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
   for (const property of properties) {
-    // Check each property
-    const value = perfEntry[property];
-    console.log(`… ${property} = ${property in PerfEntry ? value : "NOT supported"}`);
+    // Log the property
+    console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);
   }
 }
 ```

--- a/files/en-us/web/api/performanceresourcetiming/connectend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/connectend/index.md
@@ -31,14 +31,14 @@ properties of all "`resource`"
 {{domxref("PerformanceEntry.entryType","type")}} events are logged.
 
 ```js
-function print_PerformanceEntries() {
+function printPerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
-  const p = performance.getEntriesByType("resource");
-  p.forEach((entry) => {
-    print_start_and_end_properties(entry);
-  });
+  performance.getEntriesByType("resource")
+    .forEach((entry) => {
+      printStartAndEndProperties(entry);
+    });
 }
-function print_start_and_end_properties(perfEntry) {
+function printStartAndEndProperties(perfEntry) {
   // Print timestamps of the *start and *end properties
   properties = ["connectStart", "connectEnd",
                 "domainLookupStart", "domainLookupEnd",

--- a/files/en-us/web/api/performanceresourcetiming/connectend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/connectend/index.md
@@ -34,9 +34,9 @@ properties of all "`resource`"
 function print_PerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
   const p = performance.getEntriesByType("resource");
-  for (let i=0; i < p.length; i++) {
-    print_start_and_end_properties(p[i]);
-  }
+  p.forEach((entry) => {
+    print_start_and_end_properties(entry);
+  });
 }
 function print_start_and_end_properties(perfEntry) {
   // Print timestamps of the *start and *end properties
@@ -47,15 +47,10 @@ function print_start_and_end_properties(perfEntry) {
                 "requestStart",
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
-
-  for (let i=0; i < properties.length; i++) {
-    // check each property
-    const value = perfEntry[properties[i]];
-    if (properties[i] in perfEntry) {
-      console.log(`… ${properties[i]} = ${value}`);
-    } else {
-      console.log(`… ${properties[i]} = NOT supported`);
-    }
+  for (const property of properties) {
+    // Check each property
+    const value = perfEntry[property];
+    console.log(`… ${property} = ${property in PerfEntry ? value : "NOT supported"}`);
   }
 }
 ```

--- a/files/en-us/web/api/performanceresourcetiming/connectend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/connectend/index.md
@@ -38,6 +38,7 @@ function printPerformanceEntries() {
       printStartAndEndProperties(entry);
     });
 }
+
 function printStartAndEndProperties(perfEntry) {
   // Print timestamps of the *start and *end properties
   properties = ["connectStart", "connectEnd",

--- a/files/en-us/web/api/performanceresourcetiming/connectstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/connectstart/index.md
@@ -46,6 +46,7 @@ function printStartAndEndProperties(perfEntry) {
                 "requestStart",
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
+
   for (const property of properties) {
     // Log the property
     console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);

--- a/files/en-us/web/api/performanceresourcetiming/connectstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/connectstart/index.md
@@ -29,15 +29,16 @@ properties of all "`resource`"
 {{domxref("PerformanceEntry.entryType","type")}} events are logged.
 
 ```js
-function print_PerformanceEntries() {
+function printPerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
-  const p = performance.getEntriesByType("resource");
-  p.forEach((entry) => {
-    print_start_and_end_properties(entry);
-  });
+  performance.getEntriesByType("resource")
+    .forEach((entry) => {
+      printStartAndEndProperties(entry);
+    });
 }
-function print_start_and_end_properties(perfEntry) {
-  // Print timestamps of the PerformanceEntry *start and *end properties
+
+function printStartAndEndProperties(perfEntry) {
+  // Print timestamps of the *start and *end properties
   properties = ["connectStart", "connectEnd",
                 "domainLookupStart", "domainLookupEnd",
                 "fetchStart",
@@ -45,8 +46,7 @@ function print_start_and_end_properties(perfEntry) {
                 "requestStart",
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
-
-   for (const property of properties) {
+  for (const property of properties) {
     // Check each property
     const value = perfEntry[property];
     console.log(`… ${property} = ${property in PerfEntry ? value : "NOT supported"}`);

--- a/files/en-us/web/api/performanceresourcetiming/connectstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/connectstart/index.md
@@ -32,9 +32,9 @@ properties of all "`resource`"
 function print_PerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
   const p = performance.getEntriesByType("resource");
-  for (let i=0; i < p.length; i++) {
-    print_start_and_end_properties(p[i]);
-  }
+  p.forEach((entry) => {
+    print_start_and_end_properties(entry);
+  });
 }
 function print_start_and_end_properties(perfEntry) {
   // Print timestamps of the PerformanceEntry *start and *end properties
@@ -46,14 +46,10 @@ function print_start_and_end_properties(perfEntry) {
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
 
-  for (let i=0; i < properties.length; i++) {
-    // check each property
-    const value = perfEntry[properties[i]];
-    if (properties[i] in perfEntry) {
-      console.log(`… ${properties[i]} = ${value}`);
-    } else {
-      console.log(`… ${properties[i]} = NOT supported`);
-    }
+   for (const property of properties) {
+    // Check each property
+    const value = perfEntry[property];
+    console.log(`… ${property} = ${property in PerfEntry ? value : "NOT supported"}`);
   }
 }
 ```

--- a/files/en-us/web/api/performanceresourcetiming/connectstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/connectstart/index.md
@@ -47,9 +47,8 @@ function printStartAndEndProperties(perfEntry) {
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
   for (const property of properties) {
-    // Check each property
-    const value = perfEntry[property];
-    console.log(`… ${property} = ${property in PerfEntry ? value : "NOT supported"}`);
+    // Log the property
+    console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);
   }
 }
 ```

--- a/files/en-us/web/api/performanceresourcetiming/decodedbodysize/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/decodedbodysize/index.md
@@ -30,32 +30,18 @@ The following example, the value of the size properties of all "`resource`"
 {{domxref("PerformanceEntry.entryType","type")}} events are logged.
 
 ```js
-function log_sizes(perfEntry){
+function log_sizes(entry){
   // Check for support of the *size properties and print their values
   // if supported.
-  if ("decodedBodySize" in perfEntry) {
-    console.log(`decodedBodySize = ${perfEntry.decodedBodySize}`);
-  } else {
-    console.log("decodedBodySize = NOT supported");
-  }
-
-  if ("encodedBodySize" in perfEntry) {
-    console.log(`encodedBodySize = ${perfEntry.encodedBodySize}`);
-  } else {
-    console.log("encodedBodySize = NOT supported");
-  }
-
-  if ("transferSize" in perfEntry) {
-    console.log(`transferSize = ${perfEntry.transferSize}`);
-  } else {
-    console.log("transferSize = NOT supported");
-  }
+  console.log(`decodedBodySize = ${"decodedBodySize" in entry ? entry.decodedBodySize : "NOT supported"}`);
+  console.log(`encodedBodySize = ${"encodedBodySize" in entry ? entry.encodedBodySize : "NOT supported"}`);
+  console.log(`transferSize = ${"transferSize" in entry ? entry.transferSize : "NOT supported"}`);
 }
 function check_PerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
-  const p = performance.getEntriesByType("resource");
-  for (let i=0; i < p.length; i++) {
-    log_sizes(p[i]);
+  const entries = performance.getEntriesByType("resource");
+  for (const entry of entries) {
+    log_sizes(entry);
   }
 }
 ```

--- a/files/en-us/web/api/performanceresourcetiming/decodedbodysize/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/decodedbodysize/index.md
@@ -39,8 +39,7 @@ function logSizes(entry){
 }
 function checkPerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
-  const entries = performance.getEntriesByType("resource");
-  for (const entry of entries) {
+  for (const entry of performance.getEntriesByType("resource")) {
     logSizes(entry);
   }
 }

--- a/files/en-us/web/api/performanceresourcetiming/decodedbodysize/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/decodedbodysize/index.md
@@ -30,18 +30,18 @@ The following example, the value of the size properties of all "`resource`"
 {{domxref("PerformanceEntry.entryType","type")}} events are logged.
 
 ```js
-function log_sizes(entry){
+function logSizes(entry){
   // Check for support of the *size properties and print their values
   // if supported.
   console.log(`decodedBodySize = ${"decodedBodySize" in entry ? entry.decodedBodySize : "NOT supported"}`);
   console.log(`encodedBodySize = ${"encodedBodySize" in entry ? entry.encodedBodySize : "NOT supported"}`);
   console.log(`transferSize = ${"transferSize" in entry ? entry.transferSize : "NOT supported"}`);
 }
-function check_PerformanceEntries() {
+function checkPerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
   const entries = performance.getEntriesByType("resource");
   for (const entry of entries) {
-    log_sizes(entry);
+    logSizes(entry);
   }
 }
 ```

--- a/files/en-us/web/api/performanceresourcetiming/decodedbodysize/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/decodedbodysize/index.md
@@ -33,9 +33,9 @@ The following example, the value of the size properties of all "`resource`"
 function logSizes(entry){
   // Check for support of the *size properties and print their values
   // if supported.
-  console.log(`decodedBodySize = ${"decodedBodySize" in entry ? entry.decodedBodySize : "NOT supported"}`);
-  console.log(`encodedBodySize = ${"encodedBodySize" in entry ? entry.encodedBodySize : "NOT supported"}`);
-  console.log(`transferSize = ${"transferSize" in entry ? entry.transferSize : "NOT supported"}`);
+  console.log(`decodedBodySize = ${perfEntry.decodedBodySize ?? "NOT supported"}`);
+  console.log(`encodedBodySize = ${perfEntry.encodedBodySize ?? "NOT supported"}`);
+  console.log(`transferSize = ${perfEntry.transferSize ?? "NOT supported"}`);
 }
 function checkPerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events

--- a/files/en-us/web/api/performanceresourcetiming/decodedbodysize/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/decodedbodysize/index.md
@@ -30,7 +30,7 @@ The following example, the value of the size properties of all "`resource`"
 {{domxref("PerformanceEntry.entryType","type")}} events are logged.
 
 ```js
-function logSizes(entry){
+function logSizes(entry) {
   // Check for support of the *size properties and print their values
   // if supported.
   console.log(`decodedBodySize = ${perfEntry.decodedBodySize ?? "NOT supported"}`);

--- a/files/en-us/web/api/performanceresourcetiming/domainlookupend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/domainlookupend/index.md
@@ -34,14 +34,15 @@ properties of all "`resource`"
 {{domxref("PerformanceEntry.entryType","type")}} events are logged.
 
 ```js
-function print_PerformanceEntries() {
+function printPerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
-  const entries = performance.getEntriesByType("resource");
-  p.forEach((entry) => {
-    print_start_and_end_properties(entry);
-  });
+  performance.getEntriesByType("resource")
+    .forEach((entry) => {
+      printStartAndEndProperties(entry);
+    });
 }
-function print_start_and_end_properties(perfEntry) {
+
+function printStartAndEndProperties(perfEntry) {
   // Print timestamps of the *start and *end properties
   properties = ["connectStart", "connectEnd",
                 "domainLookupStart", "domainLookupEnd",

--- a/files/en-us/web/api/performanceresourcetiming/domainlookupend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/domainlookupend/index.md
@@ -51,10 +51,10 @@ function printStartAndEndProperties(perfEntry) {
                 "requestStart",
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
+                
   for (const property of properties) {
-    // Check each property
-    const value = perfEntry[property];
-    console.log(`… ${property} = ${property in PerfEntry ? value : "NOT supported"}`);
+    // Log the property
+    console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);
   }
 }
 ```

--- a/files/en-us/web/api/performanceresourcetiming/domainlookupend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/domainlookupend/index.md
@@ -37,9 +37,9 @@ properties of all "`resource`"
 function print_PerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
   const entries = performance.getEntriesByType("resource");
-  for (const entry of entries) {
+  p.forEach((entry) => {
     print_start_and_end_properties(entry);
-  }
+  });
 }
 function print_start_and_end_properties(perfEntry) {
   // Print timestamps of the *start and *end properties
@@ -50,16 +50,10 @@ function print_start_and_end_properties(perfEntry) {
                 "requestStart",
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
-
   for (const property of properties) {
-    // check each property
-    const supported = property in perfEntry;
+    // Check each property
     const value = perfEntry[property];
-    if (supported) {
-      console.log(`… ${property} = ${value}`);
-    } else {
-      console.log(`… ${property} = NOT supported`);
-    }
+    console.log(`… ${property} = ${property in PerfEntry ? value : "NOT supported"}`);
   }
 }
 ```

--- a/files/en-us/web/api/performanceresourcetiming/domainlookupstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/domainlookupstart/index.md
@@ -46,10 +46,10 @@ function printStartAndEndProperties(perfEntry) {
                 "requestStart",
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
+                
   for (const property of properties) {
-    // Check each property
-    const value = perfEntry[property];
-    console.log(`… ${property} = ${property in PerfEntry ? value : "NOT supported"}`);
+    // Log the property
+    console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);
   }
 }
 ```

--- a/files/en-us/web/api/performanceresourcetiming/domainlookupstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/domainlookupstart/index.md
@@ -32,9 +32,9 @@ properties of all "`resource`"
 function print_PerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
   const entries = performance.getEntriesByType("resource");
-  for (const entry of entries) {
+  p.forEach((entry) => {
     print_start_and_end_properties(entry);
-  }
+  });
 }
 function print_start_and_end_properties(perfEntry) {
   // Print timestamps of the PerformanceEntry *start and *end properties
@@ -44,17 +44,11 @@ function print_start_and_end_properties(perfEntry) {
                 "redirectStart", "redirectEnd",
                 "requestStart",
                 "responseStart", "responseEnd",
-                "secureConnectionStart"];
-
+                "secureConnectionStart"]; 
   for (const property of properties) {
-    // check each property
-    const supported = property in perfEntry;
+    // Check each property
     const value = perfEntry[property];
-    if (supported) {
-      console.log(`… ${property} = ${value}`);
-    } else {
-      console.log(`… ${property} = NOT supported`);
-    }
+    console.log(`… ${property} = ${property in PerfEntry ? value : "NOT supported"}`);
   }
 }
 ```

--- a/files/en-us/web/api/performanceresourcetiming/domainlookupstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/domainlookupstart/index.md
@@ -29,22 +29,23 @@ properties of all "`resource`"
 {{domxref("PerformanceEntry.entryType","type")}} events are logged.
 
 ```js
-function print_PerformanceEntries() {
+function printPerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
-  const entries = performance.getEntriesByType("resource");
-  p.forEach((entry) => {
-    print_start_and_end_properties(entry);
-  });
+  performance.getEntriesByType("resource")
+    .forEach((entry) => {
+      printStartAndEndProperties(entry);
+    });
 }
-function print_start_and_end_properties(perfEntry) {
-  // Print timestamps of the PerformanceEntry *start and *end properties
+
+function printStartAndEndProperties(perfEntry) {
+  // Print timestamps of the *start and *end properties
   properties = ["connectStart", "connectEnd",
                 "domainLookupStart", "domainLookupEnd",
                 "fetchStart",
                 "redirectStart", "redirectEnd",
                 "requestStart",
                 "responseStart", "responseEnd",
-                "secureConnectionStart"]; 
+                "secureConnectionStart"];
   for (const property of properties) {
     // Check each property
     const value = perfEntry[property];

--- a/files/en-us/web/api/performanceresourcetiming/domainlookupstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/domainlookupstart/index.md
@@ -46,7 +46,7 @@ function printStartAndEndProperties(perfEntry) {
                 "requestStart",
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
-  
+
   for (const property of properties) {
     // Log the property
     console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);

--- a/files/en-us/web/api/performanceresourcetiming/domainlookupstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/domainlookupstart/index.md
@@ -46,7 +46,7 @@ function printStartAndEndProperties(perfEntry) {
                 "requestStart",
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
-                
+  
   for (const property of properties) {
     // Log the property
     console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);

--- a/files/en-us/web/api/performanceresourcetiming/encodedbodysize/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/encodedbodysize/index.md
@@ -31,18 +31,19 @@ The following example, the value of the size properties of all "`resource`"
 {{domxref("PerformanceEntry.entryType","type")}} events are logged.
 
 ```js
-function log_sizes(entry){
+function logSizes(entry){
   // Check for support of the PerformanceEntry.*size properties and print their values
   // if supported.
   console.log(`decodedBodySize = ${"decodedBodySize" in entry ? entry.decodedBodySize : "NOT supported"}`);
   console.log(`encodedBodySize = ${"encodedBodySize" in entry ? entry.encodedBodySize : "NOT supported"}`);
   console.log(`transferSize = ${"transferSize" in entry ? entry.transferSize : "NOT supported"}`);
 }
-function check_PerformanceEntries() {
+
+function checkPerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
   const entries = performance.getEntriesByType("resource");
   for (const entry of entries) {
-    log_sizes(entry);
+    logSizes(entry);
   }
 }
 ```

--- a/files/en-us/web/api/performanceresourcetiming/encodedbodysize/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/encodedbodysize/index.md
@@ -31,26 +31,12 @@ The following example, the value of the size properties of all "`resource`"
 {{domxref("PerformanceEntry.entryType","type")}} events are logged.
 
 ```js
-function log_sizes(perfEntry){
+function log_sizes(entry){
   // Check for support of the PerformanceEntry.*size properties and print their values
   // if supported.
-  if ("decodedBodySize" in perfEntry) {
-    console.log(`decodedBodySize = ${perfEntry.decodedBodySize}`);
-  } else {
-    console.log("decodedBodySize = NOT supported");
-  }
-
-  if ("encodedBodySize" in perfEntry) {
-    console.log(`encodedBodySize = ${perfEntry.encodedBodySize}`);
-  } else {
-    console.log("encodedBodySize = NOT supported");
-  }
-
-  if ("transferSize" in perfEntry) {
-    console.log(`transferSize = ${perfEntry.transferSize}`);
-  } else {
-    console.log("transferSize = NOT supported");
-  }
+  console.log(`decodedBodySize = ${"decodedBodySize" in entry ? entry.decodedBodySize : "NOT supported"}`);
+  console.log(`encodedBodySize = ${"encodedBodySize" in entry ? entry.encodedBodySize : "NOT supported"}`);
+  console.log(`transferSize = ${"transferSize" in entry ? entry.transferSize : "NOT supported"}`);
 }
 function check_PerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events

--- a/files/en-us/web/api/performanceresourcetiming/encodedbodysize/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/encodedbodysize/index.md
@@ -31,7 +31,7 @@ The following example, the value of the size properties of all "`resource`"
 {{domxref("PerformanceEntry.entryType","type")}} events are logged.
 
 ```js
-function logSizes(entry){
+function logSizes(entry) {
   // Check for support of the PerformanceEntry.*size properties and print their values
   // if supported.
   console.log(`decodedBodySize = ${perfEntry.decodedBodySize ?? "NOT supported"}`);

--- a/files/en-us/web/api/performanceresourcetiming/encodedbodysize/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/encodedbodysize/index.md
@@ -34,9 +34,9 @@ The following example, the value of the size properties of all "`resource`"
 function logSizes(entry){
   // Check for support of the PerformanceEntry.*size properties and print their values
   // if supported.
-  console.log(`decodedBodySize = ${"decodedBodySize" in entry ? entry.decodedBodySize : "NOT supported"}`);
-  console.log(`encodedBodySize = ${"encodedBodySize" in entry ? entry.encodedBodySize : "NOT supported"}`);
-  console.log(`transferSize = ${"transferSize" in entry ? entry.transferSize : "NOT supported"}`);
+  console.log(`decodedBodySize = ${perfEntry.decodedBodySize ?? "NOT supported"}`);
+  console.log(`encodedBodySize = ${perfEntry.encodedBodySize ?? "NOT supported"}`);
+  console.log(`transferSize = ${perfEntry.transferSize ?? "NOT supported"}`);
 }
 
 function checkPerformanceEntries() {

--- a/files/en-us/web/api/performanceresourcetiming/fetchstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/fetchstart/index.md
@@ -32,15 +32,16 @@ properties of all "`resource`"
 {{domxref("PerformanceEntry.entryType","type")}} events are logged.
 
 ```js
-function print_PerformanceEntries() {
+function printPerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
-  const p = performance.getEntriesByType("resource");
- p.forEach((entry) => {
-    print_start_and_end_properties(entry);
-  });
+  performance.getEntriesByType("resource")
+    .forEach((entry) => {
+      printStartAndEndProperties(entry);
+    });
 }
-function print_start_and_end_properties(perfEntry) {
-  // Print timestamps of the PerformanceEntry *start and *end properties
+
+function printStartAndEndProperties(perfEntry) {
+  // Print timestamps of the *start and *end properties
   properties = ["connectStart", "connectEnd",
                 "domainLookupStart", "domainLookupEnd",
                 "fetchStart",

--- a/files/en-us/web/api/performanceresourcetiming/fetchstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/fetchstart/index.md
@@ -49,10 +49,10 @@ function printStartAndEndProperties(perfEntry) {
                 "requestStart",
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
-  for (const property of properties) {
-    // Check each property
-    const value = perfEntry[property];
-    console.log(`… ${property} = ${property in PerfEntry ? value : "NOT supported"}`);
+
+for (const property of properties) {
+    // Log the property
+    console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);
   }
 }
 ```

--- a/files/en-us/web/api/performanceresourcetiming/fetchstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/fetchstart/index.md
@@ -35,9 +35,9 @@ properties of all "`resource`"
 function print_PerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
   const p = performance.getEntriesByType("resource");
-  for (let i=0; i < p.length; i++) {
-    print_start_and_end_properties(p[i]);
-  }
+ p.forEach((entry) => {
+    print_start_and_end_properties(entry);
+  });
 }
 function print_start_and_end_properties(perfEntry) {
   // Print timestamps of the PerformanceEntry *start and *end properties
@@ -48,15 +48,10 @@ function print_start_and_end_properties(perfEntry) {
                 "requestStart",
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
-
-  for (let i=0; i < properties.length; i++) {
-    // check each property
-    if (properties[i] in perfEntry) {
-      const value = perfEntry[properties[i]];
-      console.log(`… ${properties[i]} = ${value}`);
-    } else {
-      console.log(`… ${properties[i]} = NOT supported`);
-    }
+  for (const property of properties) {
+    // Check each property
+    const value = perfEntry[property];
+    console.log(`… ${property} = ${property in PerfEntry ? value : "NOT supported"}`);
   }
 }
 ```

--- a/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
@@ -36,14 +36,15 @@ initiated the performance event, as specified above.
 ## Examples
 
 ```js
-function print_PerformanceEntries() {
+function printPerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
-  const p = performance.getEntriesByType("resource");
-  p.forEach((entry) => {
-    print_start_and_end_properties(entry);
-  });
+  performance.getEntriesByType("resource")
+    .forEach((entry) => {
+      printInitiatorType(entry);
+    });
 }
-function print_initiatorType(perfEntry) {
+
+function printInitiatorType(perfEntry) {
   // Print this performance entry object's initiatorType value
   const value = "initiatorType" in perfEntry;
   console.log(`… initiatorType = ${value ? perfEntry.initiatorType : "NOT supported"}`);

--- a/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
@@ -39,18 +39,14 @@ initiated the performance event, as specified above.
 function print_PerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
   const p = performance.getEntriesByType("resource");
-  for (let i = 0; i < p.length; i++) {
-    print_initiatorType(p[i]);
-  }
+  p.forEach((entry) => {
+    print_start_and_end_properties(entry);
+  });
 }
 function print_initiatorType(perfEntry) {
   // Print this performance entry object's initiatorType value
   const value = "initiatorType" in perfEntry;
-  if (value) {
-    console.log(`… initiatorType = ${perfEntry.initiatorType}`);
-  } else {
-    console.log("… initiatorType = NOT supported");
-  }
+  console.log(`… initiatorType = ${value ? perfEntry.initiatorType : "NOT supported"}`);
 }
 ```
 

--- a/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/initiatortype/index.md
@@ -46,8 +46,7 @@ function printPerformanceEntries() {
 
 function printInitiatorType(perfEntry) {
   // Print this performance entry object's initiatorType value
-  const value = "initiatorType" in perfEntry;
-  console.log(`… initiatorType = ${value ? perfEntry.initiatorType : "NOT supported"}`);
+  console.log(`… initiatorType = ${perfEntry.initiatorType ?? "NOT supported"}`);
 }
 ```
 

--- a/files/en-us/web/api/performanceresourcetiming/nexthopprotocol/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/nexthopprotocol/index.md
@@ -32,14 +32,15 @@ fetch the resource, as identified by the [ALPN Protocol ID (RFC7301)](https://da
 The following example uses the `nextHopProtocol` property.
 
 ```js
-function print_PerformanceEntries() {
+function printPerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
-  const p = performance.getEntriesByType("resource");
-  p.forEach((entry) => {
-    print_start_and_end_properties(entry);
-  });
+  performance.getEntriesByType("resource")
+    .forEach((entry) => {
+      printNextHopProtocol(entry);
+    });
 }
-function print_nextHopProtocol(perfEntry) {
+
+function printNextHopProtocol(perfEntry) {
   const value = "nextHopProtocol" in perfEntry;
   console.log(`nextHopProtocol = ${value ? perfEntry.nextHopProtocol: "NOT supported"}`);
 }

--- a/files/en-us/web/api/performanceresourcetiming/nexthopprotocol/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/nexthopprotocol/index.md
@@ -41,8 +41,7 @@ function printPerformanceEntries() {
 }
 
 function printNextHopProtocol(perfEntry) {
-  const value = "nextHopProtocol" in perfEntry;
-  console.log(`nextHopProtocol = ${value ? perfEntry.nextHopProtocol: "NOT supported"}`);
+  console.log(`nextHopProtocol = ${perfEntry.nextHopProtocol ?? "NOT supported"}`);
 }
 ```
 

--- a/files/en-us/web/api/performanceresourcetiming/nexthopprotocol/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/nexthopprotocol/index.md
@@ -35,17 +35,13 @@ The following example uses the `nextHopProtocol` property.
 function print_PerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
   const p = performance.getEntriesByType("resource");
-  for (let i = 0; i < p.length; i++) {
-    print_nextHopProtocol(p[i]);
-  }
+  p.forEach((entry) => {
+    print_start_and_end_properties(entry);
+  });
 }
 function print_nextHopProtocol(perfEntry) {
   const value = "nextHopProtocol" in perfEntry;
-  if (value) {
-    console.log(`nextHopProtocol = ${perfEntry.nextHopProtocol}`);
-  } else {
-    console.log("nextHopProtocol = NOT supported");
-  }
+  console.log(`nextHopProtocol = ${value ? perfEntry.nextHopProtocol: "NOT supported"}`);
 }
 ```
 

--- a/files/en-us/web/api/performanceresourcetiming/redirectend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/redirectend/index.md
@@ -52,10 +52,10 @@ function printStartAndEndProperties(perfEntry) {
                 "requestStart",
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
-  for (const property of properties) {
-    // Check each property
-    const value = perfEntry[property];
-    console.log(`… ${property} = ${property in PerfEntry ? value : "NOT supported"}`);
+
+for (const property of properties) {
+    // Log the property
+    console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);
   }
 }
 ```

--- a/files/en-us/web/api/performanceresourcetiming/redirectend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/redirectend/index.md
@@ -35,15 +35,16 @@ properties of all "`resource`"
 {{domxref("PerformanceEntry.entryType","type")}} events are logged.
 
 ```js
-function print_PerformanceEntries() {
+function printPerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
-  const p = performance.getEntriesByType("resource");
-  p.forEach((entry) => {
-    print_start_and_end_properties(entry);
-  });
+  performance.getEntriesByType("resource")
+    .forEach((entry) => {
+      printStartAndEndProperties(entry);
+    });
 }
-function print_start_and_end_properties(perfEntry) {
-  // Print timestamps of the PerformanceEntry *start and *end properties
+
+function printStartAndEndProperties(perfEntry) {
+  // Print timestamps of the *start and *end properties
   properties = ["connectStart", "connectEnd",
                 "domainLookupStart", "domainLookupEnd",
                 "fetchStart",

--- a/files/en-us/web/api/performanceresourcetiming/redirectend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/redirectend/index.md
@@ -38,9 +38,9 @@ properties of all "`resource`"
 function print_PerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
   const p = performance.getEntriesByType("resource");
-  for (let i=0; i < p.length; i++) {
-    print_start_and_end_properties(p[i]);
-  }
+  p.forEach((entry) => {
+    print_start_and_end_properties(entry);
+  });
 }
 function print_start_and_end_properties(perfEntry) {
   // Print timestamps of the PerformanceEntry *start and *end properties
@@ -51,15 +51,10 @@ function print_start_and_end_properties(perfEntry) {
                 "requestStart",
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
-
-  for (let i=0; i < properties.length; i++) {
-    // check each property
-    if (properties[i] in perfEntry) {
-      const value = perfEntry[properties[i]];
-      console.log(`… ${properties[i]} = ${value}`);
-    } else {
-      console.log(`… ${properties[i]} = NOT supported`);
-    }
+  for (const property of properties) {
+    // Check each property
+    const value = perfEntry[property];
+    console.log(`… ${property} = ${property in PerfEntry ? value : "NOT supported"}`);
   }
 }
 ```

--- a/files/en-us/web/api/performanceresourcetiming/redirectend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/redirectend/index.md
@@ -53,7 +53,7 @@ function printStartAndEndProperties(perfEntry) {
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
 
-for (const property of properties) {
+  for (const property of properties) {
     // Log the property
     console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);
   }

--- a/files/en-us/web/api/performanceresourcetiming/redirectstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/redirectstart/index.md
@@ -51,10 +51,10 @@ function printStartAndEndProperties(perfEntry) {
                 "requestStart",
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
+
   for (const property of properties) {
-    // Check each property
-    const value = perfEntry[property];
-    console.log(`… ${property} = ${property in PerfEntry ? value : "NOT supported"}`);
+    // Log the property
+    console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);
   }
 }
 ```

--- a/files/en-us/web/api/performanceresourcetiming/redirectstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/redirectstart/index.md
@@ -37,9 +37,9 @@ properties of all "`resource`"
 function print_PerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
   const p = performance.getEntriesByType("resource");
-  for (let i=0; i < p.length; i++) {
-    print_start_and_end_properties(p[i]);
-  }
+  p.forEach((entry) => {
+    print_start_and_end_properties(entry);
+  });
 }
 function print_start_and_end_properties(perfEntry) {
   // Print timestamps of the PerformanceEntry *start and *end properties
@@ -50,15 +50,10 @@ function print_start_and_end_properties(perfEntry) {
                 "requestStart",
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
-
-  for (let i=0; i < properties.length; i++) {
-    // check each property
-    const value = perfEntry[properties[i]];
-    if (properties[i] in perfEntry) {
-      console.log(`… ${properties[i]} = ${value}`);
-    } else {
-      console.log(`… ${properties[i]} = NOT supported`);
-    }
+  for (const property of properties) {
+    // Check each property
+    const value = perfEntry[property];
+    console.log(`… ${property} = ${property in PerfEntry ? value : "NOT supported"}`);
   }
 }
 ```

--- a/files/en-us/web/api/performanceresourcetiming/redirectstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/redirectstart/index.md
@@ -34,15 +34,16 @@ properties of all "`resource`"
 {{domxref("PerformanceEntry.entryType","type")}} events are logged.
 
 ```js
-function print_PerformanceEntries() {
+function printPerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
-  const p = performance.getEntriesByType("resource");
-  p.forEach((entry) => {
-    print_start_and_end_properties(entry);
-  });
+  performance.getEntriesByType("resource")
+    .forEach((entry) => {
+      printStartAndEndProperties(entry);
+    });
 }
-function print_start_and_end_properties(perfEntry) {
-  // Print timestamps of the PerformanceEntry *start and *end properties
+
+function printStartAndEndProperties(perfEntry) {
+  // Print timestamps of the *start and *end properties
   properties = ["connectStart", "connectEnd",
                 "domainLookupStart", "domainLookupEnd",
                 "fetchStart",

--- a/files/en-us/web/api/performanceresourcetiming/requeststart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/requeststart/index.md
@@ -36,9 +36,9 @@ properties of all "`resource`"
 function print_PerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
   const p = performance.getEntriesByType("resource");
-  for (let i=0; i < p.length; i++) {
-    print_start_and_end_properties(p[i]);
-  }
+  p.forEach((entry) => {
+    print_start_and_end_properties(entry);
+  });
 }
 function print_start_and_end_properties(perfEntry) {
   // Print timestamps of the PerformanceEntry *start and *end properties
@@ -49,15 +49,10 @@ function print_start_and_end_properties(perfEntry) {
                 "requestStart",
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
-
-  for (let i=0; i < properties.length; i++) {
-    // check each property
-    const value = perfEntry[properties[i]];
-    if (properties[i] in perfEntry) {
-      console.log(`… ${properties[i]} = ${value}`);
-    } else {
-      console.log(`… ${properties[i]} = NOT supported`);
-    }
+  for (const property of properties) {
+    // Check each property
+    const value = perfEntry[property];
+    console.log(`… ${property} = ${property in PerfEntry ? value : "NOT supported"}`);
   }
 }
 ```

--- a/files/en-us/web/api/performanceresourcetiming/requeststart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/requeststart/index.md
@@ -50,10 +50,10 @@ function printStartAndEndProperties(perfEntry) {
                 "requestStart",
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
+
   for (const property of properties) {
-    // Check each property
-    const value = perfEntry[property];
-    console.log(`… ${property} = ${property in PerfEntry ? value : "NOT supported"}`);
+    // Log the property
+    console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);
   }
 }
 ```

--- a/files/en-us/web/api/performanceresourcetiming/requeststart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/requeststart/index.md
@@ -33,15 +33,16 @@ properties of all "`resource`"
 {{domxref("PerformanceEntry.entryType","type")}} events are logged.
 
 ```js
-function print_PerformanceEntries() {
+function printPerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
-  const p = performance.getEntriesByType("resource");
-  p.forEach((entry) => {
-    print_start_and_end_properties(entry);
-  });
+  performance.getEntriesByType("resource")
+    .forEach((entry) => {
+      printStartAndEndProperties(entry);
+    });
 }
-function print_start_and_end_properties(perfEntry) {
-  // Print timestamps of the PerformanceEntry *start and *end properties
+
+function printStartAndEndProperties(perfEntry) {
+  // Print timestamps of the *start and *end properties
   properties = ["connectStart", "connectEnd",
                 "domainLookupStart", "domainLookupEnd",
                 "fetchStart",

--- a/files/en-us/web/api/performanceresourcetiming/responseend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/responseend/index.md
@@ -31,15 +31,16 @@ properties of all "`resource`"
 {{domxref("PerformanceEntry.entryType","type")}} events are logged.
 
 ```js
-function print_PerformanceEntries() {
+function printPerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
-  const p = performance.getEntriesByType("resource");
-  p.forEach((entry) => {
-    print_start_and_end_properties(entry);
-  });
+  performance.getEntriesByType("resource")
+    .forEach((entry) => {
+      printStartAndEndProperties(entry);
+    });
 }
-function print_start_and_end_properties(perfEntry) {
-  // Print timestamps of the PerformanceEntry *start and *end properties
+
+function printStartAndEndProperties(perfEntry) {
+  // Print timestamps of the *start and *end properties
   properties = ["connectStart", "connectEnd",
                 "domainLookupStart", "domainLookupEnd",
                 "fetchStart",
@@ -47,7 +48,7 @@ function print_start_and_end_properties(perfEntry) {
                 "requestStart",
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
-   for (const property of properties) {
+  for (const property of properties) {
     // Check each property
     const value = perfEntry[property];
     console.log(`… ${property} = ${property in PerfEntry ? value : "NOT supported"}`);

--- a/files/en-us/web/api/performanceresourcetiming/responseend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/responseend/index.md
@@ -48,10 +48,10 @@ function printStartAndEndProperties(perfEntry) {
                 "requestStart",
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
-  for (const property of properties) {
-    // Check each property
-    const value = perfEntry[property];
-    console.log(`… ${property} = ${property in PerfEntry ? value : "NOT supported"}`);
+ 
+ for (const property of properties) {
+    // Log the property
+    console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);
   }
 }
 ```

--- a/files/en-us/web/api/performanceresourcetiming/responseend/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/responseend/index.md
@@ -34,9 +34,9 @@ properties of all "`resource`"
 function print_PerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
   const p = performance.getEntriesByType("resource");
-  for (let i=0; i < p.length; i++) {
-    print_start_and_end_properties(p[i]);
-  }
+  p.forEach((entry) => {
+    print_start_and_end_properties(entry);
+  });
 }
 function print_start_and_end_properties(perfEntry) {
   // Print timestamps of the PerformanceEntry *start and *end properties
@@ -47,15 +47,10 @@ function print_start_and_end_properties(perfEntry) {
                 "requestStart",
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
-
-  for (let i=0; i < properties.length; i++) {
-    // check each property
-    const value = perfEntry[properties[i]];
-    if (properties[i] in perfEntry) {
-      console.log(`… ${properties[i]} = ${value}`);
-    } else {
-      console.log(`… ${properties[i]} = NOT supported`);
-    }
+   for (const property of properties) {
+    // Check each property
+    const value = perfEntry[property];
+    console.log(`… ${property} = ${property in PerfEntry ? value : "NOT supported"}`);
   }
 }
 ```

--- a/files/en-us/web/api/performanceresourcetiming/responsestart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/responsestart/index.md
@@ -46,10 +46,10 @@ function printStartAndEndProperties(perfEntry) {
                 "requestStart",
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
+
   for (const property of properties) {
-    // Check each property
-    const value = perfEntry[property];
-    console.log(`… ${property} = ${property in PerfEntry ? value : "NOT supported"}`);
+    // Log the property
+    console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);
   }
 }
 ```

--- a/files/en-us/web/api/performanceresourcetiming/responsestart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/responsestart/index.md
@@ -32,9 +32,9 @@ properties of all "`resource`"
 function print_PerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
   const p = performance.getEntriesByType("resource");
-  for (let i=0; i < p.length; i++) {
-    print_start_and_end_properties(p[i]);
-  }
+  p.forEach((entry) => {
+    print_start_and_end_properties(entry);
+  });
 }
 function print_start_and_end_properties(perfEntry) {
   // Print timestamps of the PerformanceEntry *start and *end properties
@@ -45,15 +45,10 @@ function print_start_and_end_properties(perfEntry) {
                 "requestStart",
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
-
-  for (let i=0; i < properties.length; i++) {
-    // check each property
-    const value = perfEntry[properties[i]];
-    if (properties[i] in perfEntry) {
-      console.log(`… ${properties[i]} = ${value}`);
-    } else {
-      console.log(`… ${properties[i]} = NOT supported`);
-    }
+  for (const property of properties) {
+    // Check each property
+    const value = perfEntry[property];
+    console.log(`… ${property} = ${property in PerfEntry ? value : "NOT supported"}`);
   }
 }
 ```

--- a/files/en-us/web/api/performanceresourcetiming/responsestart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/responsestart/index.md
@@ -29,15 +29,16 @@ properties of all "`resource`"
 {{domxref("PerformanceEntry.entryType","type")}} events are logged.
 
 ```js
-function print_PerformanceEntries() {
+function printPerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
-  const p = performance.getEntriesByType("resource");
-  p.forEach((entry) => {
-    print_start_and_end_properties(entry);
-  });
+  performance.getEntriesByType("resource")
+    .forEach((entry) => {
+      printStartAndEndProperties(entry);
+    });
 }
-function print_start_and_end_properties(perfEntry) {
-  // Print timestamps of the PerformanceEntry *start and *end properties
+
+function printStartAndEndProperties(perfEntry) {
+  // Print timestamps of the *start and *end properties
   properties = ["connectStart", "connectEnd",
                 "domainLookupStart", "domainLookupEnd",
                 "fetchStart",

--- a/files/en-us/web/api/performanceresourcetiming/secureconnectionstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/secureconnectionstart/index.md
@@ -32,15 +32,16 @@ properties of all "`resource`"
 {{domxref("PerformanceEntry.entryType","type")}} events are logged.
 
 ```js
-function print_PerformanceEntries() {
+function printPerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
-  const p = performance.getEntriesByType("resource");
-  p.forEach((entry) => {
-    print_start_and_end_properties(entry);
-  });
+  performance.getEntriesByType("resource")
+    .forEach((entry) => {
+      printStartAndEndProperties(entry);
+    });
 }
-function print_start_and_end_properties(perfEntry) {
-  // Print timestamps of the PerformanceEntry *start and *end properties
+
+function printStartAndEndProperties(perfEntry) {
+  // Print timestamps of the *start and *end properties
   properties = ["connectStart", "connectEnd",
                 "domainLookupStart", "domainLookupEnd",
                 "fetchStart",

--- a/files/en-us/web/api/performanceresourcetiming/secureconnectionstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/secureconnectionstart/index.md
@@ -49,10 +49,10 @@ function printStartAndEndProperties(perfEntry) {
                 "requestStart",
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
+
   for (const property of properties) {
-    // Check each property
-    const value = perfEntry[property];
-    console.log(`… ${property} = ${property in PerfEntry ? value : "NOT supported"}`);
+    // Log the property
+    console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);
   }
 }
 ```

--- a/files/en-us/web/api/performanceresourcetiming/secureconnectionstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/secureconnectionstart/index.md
@@ -35,9 +35,9 @@ properties of all "`resource`"
 function print_PerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
   const p = performance.getEntriesByType("resource");
-  for (let i=0; i < p.length; i++) {
-    print_start_and_end_properties(p[i]);
-  }
+  p.forEach((entry) => {
+    print_start_and_end_properties(entry);
+  });
 }
 function print_start_and_end_properties(perfEntry) {
   // Print timestamps of the PerformanceEntry *start and *end properties
@@ -48,15 +48,10 @@ function print_start_and_end_properties(perfEntry) {
                 "requestStart",
                 "responseStart", "responseEnd",
                 "secureConnectionStart"];
-
-  for (let i=0; i < properties.length; i++) {
-    // check each property
-    const value = perfEntry[properties[i]];
-    if (properties[i] in perfEntry) {
-      console.log(`… ${properties[i]} = ${value}`);
-    } else {
-      console.log(`… ${properties[i]} = NOT supported`);
-    }
+  for (const property of properties) {
+    // Check each property
+    const value = perfEntry[property];
+    console.log(`… ${property} = ${property in PerfEntry ? value : "NOT supported"}`);
   }
 }
 ```

--- a/files/en-us/web/api/performanceresourcetiming/transfersize/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/transfersize/index.md
@@ -55,9 +55,9 @@ function log_sizes(perfEntry){
 function check_PerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
   const p = performance.getEntriesByType("resource");
-  for (let i=0; i < p.length; i++) {
-    log_sizes(p[i]);
-  }
+  p.forEach((entry) => {
+    log_sizes(entry[i]);
+  });
 }
 ```
 

--- a/files/en-us/web/api/performanceresourcetiming/transfersize/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/transfersize/index.md
@@ -31,7 +31,7 @@ The following example, the value of size properties of all "`resource`"
 {{domxref("PerformanceEntry.entryType","type")}} events are logged.
 
 ```js
-function logSizes(perfEntry){
+function logSizes(perfEntry) {
   // Check for support of the PerformanceEntry.*size properties and print their values
   // if supported.
   console.log(`decodedBodySize = ${"decodedBodySize" in perfEntry ? perfEntry.decodedBodySize : "NOT supported"}`);

--- a/files/en-us/web/api/performanceresourcetiming/transfersize/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/transfersize/index.md
@@ -31,33 +31,20 @@ The following example, the value of size properties of all "`resource`"
 {{domxref("PerformanceEntry.entryType","type")}} events are logged.
 
 ```js
-function log_sizes(perfEntry){
+function logSizes(perfEntry){
   // Check for support of the PerformanceEntry.*size properties and print their values
   // if supported.
-  if ("decodedBodySize" in perfEntry) {
-    console.log(`decodedBodySize = ${perfEntry.decodedBodySize}`);
-  } else {
-    console.log("decodedBodySize = NOT supported");
-  }
-
-  if ("encodedBodySize" in perfEntry) {
-    console.log(`encodedBodySize = ${perfEntry.encodedBodySize}`);
-  } else {
-    console.log("encodedBodySize = NOT supported");
-  }
-
-  if ("transferSize" in perfEntry) {
-    console.log(`transferSize = ${perfEntry.transferSize}`);
-  } else {
-    console.log("transferSize = NOT supported");
-  }
+  console.log(`decodedBodySize = ${"decodedBodySize" in perfEntry ? perfEntry.decodedBodySize : "NOT supported"}`);
+  console.log(`encodedBodySize = ${"encodedBodySize" in perfEntry ? perfEntry.encodedBodySize : "NOT supported"}`);
+  console.log(`transferSize = ${"transferSize" in perfEntry ? perfEntry.transferSize : "NOT supported"}`);
 }
-function check_PerformanceEntries() {
+
+function checkPerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
-  const p = performance.getEntriesByType("resource");
-  p.forEach((entry) => {
-    log_sizes(entry[i]);
-  });
+  performance.getEntriesByType("resource")
+    .forEach((entry) => {
+      logSizes(entry[i]);
+    });
 }
 ```
 

--- a/files/en-us/web/api/performanceresourcetiming/transfersize/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/transfersize/index.md
@@ -34,9 +34,9 @@ The following example, the value of size properties of all "`resource`"
 function logSizes(perfEntry) {
   // Check for support of the PerformanceEntry.*size properties and print their values
   // if supported.
-  console.log(`decodedBodySize = ${"decodedBodySize" in perfEntry ? perfEntry.decodedBodySize : "NOT supported"}`);
-  console.log(`encodedBodySize = ${"encodedBodySize" in perfEntry ? perfEntry.encodedBodySize : "NOT supported"}`);
-  console.log(`transferSize = ${"transferSize" in perfEntry ? perfEntry.transferSize : "NOT supported"}`);
+  console.log(`decodedBodySize = ${perfEntry.decodedBodySize ?? "NOT supported"}`);
+  console.log(`encodedBodySize = ${perfEntry.encodedBodySize ?? "NOT supported"}`);
+  console.log(`transferSize = ${perfEntry.transferSize ?? "NOT supported"}`);
 }
 
 function checkPerformanceEntries() {

--- a/files/en-us/web/api/performanceresourcetiming/workerstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/workerstart/index.md
@@ -49,7 +49,8 @@ function printStartAndEndProperties(perfEntry) {
                 "redirectStart", "redirectEnd",
                 "requestStart",
                 "responseStart", "responseEnd",
-                "secureConnectionStart"];
+                "secureConnectionStart",
+                "workerStart"];
   for (const property of properties) {
     // Check each property
     const value = perfEntry[property];

--- a/files/en-us/web/api/performanceresourcetiming/workerstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/workerstart/index.md
@@ -36,9 +36,9 @@ properties of all "`resource`"
 function print_PerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
   const p = performance.getEntriesByType("resource");
-  for (let i=0; i < p.length; i++) {
-    print_start_and_end_properties(p[i]);
-  }
+  p.forEach((entry) => {
+    print_start_and_end_properties(entry);
+  });
 }
 function print_start_and_end_properties(perfEntry) {
   // Print timestamps of the PerformanceEntry *start and *end properties

--- a/files/en-us/web/api/performanceresourcetiming/workerstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/workerstart/index.md
@@ -33,32 +33,27 @@ properties of all "`resource`"
 {{domxref("PerformanceEntry.entryType","type")}} events are logged.
 
 ```js
-function print_PerformanceEntries() {
+function printPerformanceEntries() {
   // Use getEntriesByType() to just get the "resource" events
-  const p = performance.getEntriesByType("resource");
-  p.forEach((entry) => {
-    print_start_and_end_properties(entry);
-  });
+  performance.getEntriesByType("resource")
+    .forEach((entry) => {
+      printStartAndEndProperties(entry);
+    });
 }
-function print_start_and_end_properties(perfEntry) {
-  // Print timestamps of the PerformanceEntry *start and *end properties
+
+function printStartAndEndProperties(perfEntry) {
+  // Print timestamps of the *start and *end properties
   properties = ["connectStart", "connectEnd",
                 "domainLookupStart", "domainLookupEnd",
                 "fetchStart",
                 "redirectStart", "redirectEnd",
                 "requestStart",
                 "responseStart", "responseEnd",
-                "secureConnectionStart",
-                "workerStart"];
-
-  for (let i=0; i < properties.length; i++) {
-    // check each property
-    const value = perfEntry[properties[i]];
-    if (properties[i] in perfEntry) {
-      console.log(`… ${properties[i]} = ${value}`);
-    } else {
-      console.log(`… ${properties[i]} = NOT supported`);
-    }
+                "secureConnectionStart"];
+  for (const property of properties) {
+    // Check each property
+    const value = perfEntry[property];
+    console.log(`… ${property} = ${property in PerfEntry ? value : "NOT supported"}`);
   }
 }
 ```

--- a/files/en-us/web/api/performanceresourcetiming/workerstart/index.md
+++ b/files/en-us/web/api/performanceresourcetiming/workerstart/index.md
@@ -51,10 +51,10 @@ function printStartAndEndProperties(perfEntry) {
                 "responseStart", "responseEnd",
                 "secureConnectionStart",
                 "workerStart"];
+
   for (const property of properties) {
-    // Check each property
-    const value = perfEntry[property];
-    console.log(`… ${property} = ${property in PerfEntry ? value : "NOT supported"}`);
+    // Log the property
+    console.log(`… ${property} = ${perfEntry[property] ?? "NOT supported"}`);
   }
 }
 ```

--- a/files/en-us/web/api/pointer_events/multi-touch_interaction/index.md
+++ b/files/en-us/web/api/pointer_events/multi-touch_interaction/index.md
@@ -63,18 +63,18 @@ const evCache3 = [];
 Event handlers are registered for the following pointer events: {{domxref("HTMLElement/pointerdown_event", "pointerdown")}}, {{domxref("HTMLElement/pointermove_event", "pointermove")}} and {{domxref("HTMLElement/pointerup_event", "pointerup")}}. The handler for {{domxref("HTMLElement/pointerup_event", "pointerup")}} is used for the {{domxref("HTMLElement/pointercancel_event", "pointercancel")}}, {{domxref("HTMLElement/pointerout_event", "pointerout")}} and {{domxref("HTMLElement/pointerleave_event", "pointerleave")}} events, since these four events have the same semantics in this application.
 
 ```js
-function set_handlers(name) {
+function setHandlers(name) {
  // Install event handlers for the given element
  const el = document.getElementById(name);
- el.onpointerdown = pointerdown_handler;
- el.onpointermove = pointermove_handler;
+ el.onpointerdown = pointerdownHandler;
+ el.onpointermove = pointermoveHandler;
 
  // Use same handler for pointer{up,cancel,out,leave} events since
  // the semantics for these events - in this app - are the same.
- el.onpointerup = pointerup_handler;
+ el.onpointerup = pointerupHandler;
  el.onpointercancel = pointerup_handler;
- el.onpointerout = pointerup_handler;
- el.onpointerleave = pointerup_handler;
+ el.onpointerout = pointerupHandler;
+ el.onpointerleave = pointerupHandler;
 }
 
 function init() {
@@ -91,13 +91,13 @@ The {{domxref("HTMLElement/pointerdown_event", "pointerdown")}} event is fired w
 In this application, when a pointer is placed down on an element, the background color of the element changes, depending on the number of active touch points the element has. See the [`update_background`](#update_background_color) function for more details about the color changes.
 
 ```js
-function pointerdown_handler(ev) {
+function pointerdownHandler(ev) {
  // The pointerdown event signals the start of a touch interaction.
  // Save this event for later processing (this could be part of a
  // multi-touch interaction) and update the background color
- push_event(ev);
+ pushEvent(ev);
  if (logEvents) log(`pointerDown: name = ${ev.target.id}`, ev);
- update_background(ev);
+ updateBackground(ev);
 }
 ```
 
@@ -108,14 +108,14 @@ The {{domxref("HTMLElement/pointermove_event", "pointermove")}} handler is calle
 In this application, a pointer move is represented by the target's border being set to `dashed` to provide a clear visual indication that the element has received this event.
 
 ```js
-function pointermove_handler(ev) {
+function pointermoveHandler(ev) {
  // Note: if the user makes more than one "simultaneous" touch, most browsers
  // fire at least one pointermove event and some will fire several pointermoves.
  //
  // This function sets the target element's border to "dashed" to visually
  // indicate the target received a move event.
  if (logEvents) log("pointerMove", ev);
- update_background(ev);
+ updateBackground(ev);
  ev.target.style.border = "dashed";
 }
 ```
@@ -127,12 +127,12 @@ The {{domxref("HTMLElement/pointerup_event", "pointerup")}} event is fired when 
 In this application, this handler is also used for {{domxref("HTMLElement/pointercancel_event", "pointercancel")}}, {{domxref("HTMLElement/pointerleave_event", "pointerleave")}} and {{domxref("HTMLElement/pointerout_event", "pointerout")}} events.
 
 ```js
-function pointerup_handler(ev) {
+function pointerupHandler(ev) {
   if (logEvents) log(ev.type, ev);
   // Remove this touch point from the cache and reset the target's
   // background and border
-  remove_event(ev);
-  update_background(ev);
+  removeEvent(ev);
+  updateBackground(ev);
   ev.target.style.border = "1px solid black";
 }
 ```
@@ -166,31 +166,27 @@ These functions support the application but aren't directly involved with the ev
 These functions manage the global event caches `evCache1`, `evCache2` and `evCache3`.
 
 ```js
-function get_cache(ev) {
- // Return the cache for this event's target element
- switch(ev.target.id) {
-   case "target1": return evCache1;
-   case "target2": return evCache2;
-   case "target3": return evCache3;
-   default: log("Error with cache handling",ev);
- }
+function getCache(ev) {
+  // Return the cache for this event's target element
+  switch(ev.target.id) {
+    case "target1": return evCache1;
+    case "target2": return evCache2;
+    case "target3": return evCache3;
+    default: log("Error with cache handling",ev);
+  }
 }
 
-function push_event(ev) {
- // Save this event in the target's cache
- const cache = get_cache(ev);
- cache.push(ev);
+function pushEvent(ev) {
+  // Save this event in the target's cache
+  const evCache = getCache(ev);
+  evCache.push(ev);
 }
 
-function remove_event(ev) {
- // Remove this event from the target's cache
- const cache = get_cache(ev);
- for (const i in cache) {
-   if (cache[i].pointerId === ev.pointerId) {
-     cache.splice(i, 1);
-     break;
-   }
- }
+function removeEvent(ev) {
+  // Remove this event from the target's cache
+  const evCache = getCache(ev);
+  const index = evCache.findIndex((cachedEv) => cachedEv.pointerId === ev.pointerId);
+  evCache.splice(index, 1);
 }
 ```
 
@@ -199,15 +195,15 @@ function remove_event(ev) {
 The background color of the touch areas will change as follows: no active touches is `white`; one active touch is `yellow`; two simultaneous touches is `ping` and three or more simultaneous touches is `lightblue`.
 
 ```js
-function update_background(ev) {
- // Change background color based on the number of simultaneous touches/pointers
- // currently down:
- //   white - target element has no touch points i.e. no pointers down
- //   yellow - one pointer down
- //   pink - two pointers down
- //   lightblue - three or more pointers down
- const evCache = get_cache(ev);
- switch (evCache.length) {
+function updateBackground(ev) {
+  // Change background color based on the number of simultaneous touches/pointers
+  // currently down:
+  //   white - target element has no touch points i.e. no pointers down
+  //   yellow - one pointer down
+  //   pink - two pointers down
+  //   lightblue - three or more pointers down
+  const evCache = getCache(ev);
+  switch (evCache.length) {
    case 0:
      // Target element has no touch points
      ev.target.style.background = "white";
@@ -223,7 +219,7 @@ function update_background(ev) {
    default:
      // Three or more simultaneous touches
      ev.target.style.background = "lightblue";
- }
+  }
 }
 ```
 

--- a/files/en-us/web/api/pointer_events/multi-touch_interaction/index.md
+++ b/files/en-us/web/api/pointer_events/multi-touch_interaction/index.md
@@ -64,23 +64,23 @@ Event handlers are registered for the following pointer events: {{domxref("HTMLE
 
 ```js
 function setHandlers(name) {
- // Install event handlers for the given element
- const el = document.getElementById(name);
- el.onpointerdown = pointerdownHandler;
- el.onpointermove = pointermoveHandler;
+  // Install event handlers for the given element
+  const el = document.getElementById(name);
+  el.onpointerdown = pointerdownHandler;
+  el.onpointermove = pointermoveHandler;
 
- // Use same handler for pointer{up,cancel,out,leave} events since
- // the semantics for these events - in this app - are the same.
- el.onpointerup = pointerupHandler;
- el.onpointercancel = pointerup_handler;
- el.onpointerout = pointerupHandler;
- el.onpointerleave = pointerupHandler;
+  // Use same handler for pointer{up,cancel,out,leave} events since
+  // the semantics for these events - in this app - are the same.
+  el.onpointerup = pointerupHandler;
+  el.onpointercancel = pointerupHandler;
+  el.onpointerout = pointerupHandler;
+  el.onpointerleave = pointerupHandler;
 }
 
 function init() {
- set_handlers("target1");
- set_handlers("target2");
- set_handlers("target3");
+  setHandlers("target1");
+  setHandlers("target2");
+  setHandlers("target3");
 }
 ```
 
@@ -92,12 +92,14 @@ In this application, when a pointer is placed down on an element, the background
 
 ```js
 function pointerdownHandler(ev) {
- // The pointerdown event signals the start of a touch interaction.
- // Save this event for later processing (this could be part of a
- // multi-touch interaction) and update the background color
- pushEvent(ev);
- if (logEvents) log(`pointerDown: name = ${ev.target.id}`, ev);
- updateBackground(ev);
+  // The pointerdown event signals the start of a touch interaction.
+  // Save this event for later processing (this could be part of a
+  // multi-touch interaction) and update the background color
+  pushEvent(ev);
+  if (logEvents) {
+    log(`pointerDown: name = ${ev.target.id}`, ev);
+  }
+  updateBackground(ev);
 }
 ```
 
@@ -109,14 +111,16 @@ In this application, a pointer move is represented by the target's border being 
 
 ```js
 function pointermoveHandler(ev) {
- // Note: if the user makes more than one "simultaneous" touch, most browsers
- // fire at least one pointermove event and some will fire several pointermoves.
- //
- // This function sets the target element's border to "dashed" to visually
- // indicate the target received a move event.
- if (logEvents) log("pointerMove", ev);
- updateBackground(ev);
- ev.target.style.border = "dashed";
+  // Note: if the user makes more than one "simultaneous" touch, most browsers
+  // fire at least one pointermove event and some will fire several pointermoves.
+  //
+  // This function sets the target element's border to "dashed" to visually
+  // indicate the target received a move event.
+  if (logEvents) {
+    log("pointerMove", ev);
+  }
+  updateBackground(ev);
+  ev.target.style.border = "dashed";
 }
 ```
 
@@ -128,7 +132,9 @@ In this application, this handler is also used for {{domxref("HTMLElement/pointe
 
 ```js
 function pointerupHandler(ev) {
-  if (logEvents) log(ev.type, ev);
+  if (logEvents) {
+    log(ev.type, ev);
+  }
   // Remove this touch point from the cache and reset the target's
   // background and border
   removeEvent(ev);
@@ -168,11 +174,11 @@ These functions manage the global event caches `evCache1`, `evCache2` and `evCac
 ```js
 function getCache(ev) {
   // Return the cache for this event's target element
-  switch(ev.target.id) {
+  switch (ev.target.id) {
     case "target1": return evCache1;
     case "target2": return evCache2;
     case "target3": return evCache3;
-    default: log("Error with cache handling",ev);
+    default: log("Error with cache handling", ev);
   }
 }
 
@@ -204,21 +210,21 @@ function updateBackground(ev) {
   //   lightblue - three or more pointers down
   const evCache = getCache(ev);
   switch (evCache.length) {
-   case 0:
-     // Target element has no touch points
-     ev.target.style.background = "white";
-     break;
-   case 1:
-     // Single touch point
-     ev.target.style.background = "yellow";
-     break;
-   case 2:
-     // Two simultaneous touch points
-     ev.target.style.background = "pink";
-     break;
-   default:
-     // Three or more simultaneous touches
-     ev.target.style.background = "lightblue";
+    case 0:
+      // Target element has no touch points
+      ev.target.style.background = "white";
+      break;
+    case 1:
+      // Single touch point
+      ev.target.style.background = "yellow";
+      break;
+    case 2:
+      // Two simultaneous touch points
+      ev.target.style.background = "pink";
+      break;
+    default:
+      // Three or more simultaneous touches
+      ev.target.style.background = "lightblue";
   }
 }
 ```
@@ -245,7 +251,7 @@ function log(name, ev) {
 }
 
 function clearLog(event) {
- const o = document.getElementsByTagName('output')[0];
- o.innerHTML = "";
+  const o = document.getElementsByTagName('output')[0];
+  o.innerHTML = "";
 }
 ```

--- a/files/en-us/web/api/pointer_events/multi-touch_interaction/index.md
+++ b/files/en-us/web/api/pointer_events/multi-touch_interaction/index.md
@@ -185,7 +185,7 @@ function push_event(ev) {
 function remove_event(ev) {
  // Remove this event from the target's cache
  const cache = get_cache(ev);
- for (let i = 0; i < cache.length; i++) {
+ for (const i in cache) {
    if (cache[i].pointerId === ev.pointerId) {
      cache.splice(i, 1);
      break;

--- a/files/en-us/web/api/pointer_events/pinch_zoom_gestures/index.md
+++ b/files/en-us/web/api/pointer_events/pinch_zoom_gestures/index.md
@@ -99,7 +99,7 @@ function pointermove_handler(ev) {
  ev.target.style.border = "dashed";
 
  // Find this event in the cache and update its record with this event
- for (let i = 0; i < evCache.length; i++) {
+ for (const i in evCache) {
    if (ev.pointerId === evCache[i].pointerId) {
      evCache[i] = ev;
      break;
@@ -182,7 +182,7 @@ This function helps manage the global event caches `evCache`.
 ```js
 function remove_event(ev) {
  // Remove this event from the target's cache
- for (let i = 0; i < evCache.length; i++) {
+ for (const i in evCache) {
    if (evCache[i].pointerId === ev.pointerId) {
      evCache.splice(i, 1);
      break;

--- a/files/en-us/web/api/pointer_events/pinch_zoom_gestures/index.md
+++ b/files/en-us/web/api/pointer_events/pinch_zoom_gestures/index.md
@@ -178,12 +178,8 @@ This function helps manage the global event caches `evCache`.
 ```js
 function remove_event(ev) {
  // Remove this event from the target's cache
- for (const i in evCache) {
-   if (evCache[i].pointerId === ev.pointerId) {
-     evCache.splice(i, 1);
-     break;
-   }
- }
+ const index = evCache.findIndex((cachedEv) => cachedEv.pointerId === ev.pointerId);
+ evCache.splice(index, 1);
 }
 ```
 

--- a/files/en-us/web/api/pointer_events/pinch_zoom_gestures/index.md
+++ b/files/en-us/web/api/pointer_events/pinch_zoom_gestures/index.md
@@ -99,12 +99,8 @@ function pointermove_handler(ev) {
  ev.target.style.border = "dashed";
 
  // Find this event in the cache and update its record with this event
- evCache.forEach((event, i, evCache) => {
-   if (ev.pointerId === evCache[i].pointerId) {
-     evCache[i] = ev;
-     break;
-   }
- }
+ const index = evCache.findIndex((cachedEv) => cachedEv.pointerId === ev.pointerId);
+ evCache[index] = ev;
 
  // If two pointers are down, check for pinch gestures
  if (evCache.length === 2) {

--- a/files/en-us/web/api/pointer_events/pinch_zoom_gestures/index.md
+++ b/files/en-us/web/api/pointer_events/pinch_zoom_gestures/index.md
@@ -99,7 +99,7 @@ function pointermove_handler(ev) {
  ev.target.style.border = "dashed";
 
  // Find this event in the cache and update its record with this event
- for (const i in evCache) {
+ evCache.forEach((event, i, evCache) => {
    if (ev.pointerId === evCache[i].pointerId) {
      evCache[i] = ev;
      break;

--- a/files/en-us/web/api/pointer_events/pinch_zoom_gestures/index.md
+++ b/files/en-us/web/api/pointer_events/pinch_zoom_gestures/index.md
@@ -52,17 +52,17 @@ Event handlers are registered for the following pointer events: {{domxref("HTMLE
 
 ```js
 function init() {
- // Install event handlers for the pointer target
- const el = document.getElementById("target");
- el.onpointerdown = pointerdownHandler;
- el.onpointermove = pointermoveHandler;
+  // Install event handlers for the pointer target
+  const el = document.getElementById("target");
+  el.onpointerdown = pointerdownHandler;
+  el.onpointermove = pointermoveHandler;
 
- // Use same handler for pointer{up,cancel,out,leave} events since
- // the semantics for these events - in this app - are the same.
- el.onpointerup = pointerupHandler;
- el.onpointercancel = pointerupHandler;
- el.onpointerout = pointerupHandler;
- el.onpointerleave = pointerupHandler;
+  // Use same handler for pointer{up,cancel,out,leave} events since
+  // the semantics for these events - in this app - are the same.
+  el.onpointerup = pointerupHandler;
+  el.onpointercancel = pointerupHandler;
+  el.onpointerout = pointerupHandler;
+  el.onpointerleave = pointerupHandler;
 }
 ```
 
@@ -72,10 +72,10 @@ The {{domxref("HTMLElement/pointerdown_event", "pointerdown")}} event is fired w
 
 ```js
 function pointerdownHandler(ev) {
- // The pointerdown event signals the start of a touch interaction.
- // This event is cached to support 2-finger gestures
- evCache.push(ev);
- log("pointerDown", ev);
+  // The pointerdown event signals the start of a touch interaction.
+  // This event is cached to support 2-finger gestures
+  evCache.push(ev);
+  log("pointerDown", ev);
 }
 ```
 
@@ -87,42 +87,42 @@ When this event is processed, the target's border is set to `dashed` to provide 
 
 ```js
 function pointermoveHandler(ev) {
- // This function implements a 2-pointer horizontal pinch/zoom gesture.
- //
- // If the distance between the two pointers has increased (zoom in),
- // the target element's background is changed to "pink" and if the
- // distance is decreasing (zoom out), the color is changed to "lightblue".
- //
- // This function sets the target element's border to "dashed" to visually
- // indicate the pointer's target received a move event.
- log("pointerMove", ev);
- ev.target.style.border = "dashed";
+  // This function implements a 2-pointer horizontal pinch/zoom gesture.
+  //
+  // If the distance between the two pointers has increased (zoom in),
+  // the target element's background is changed to "pink" and if the
+  // distance is decreasing (zoom out), the color is changed to "lightblue".
+  //
+  // This function sets the target element's border to "dashed" to visually
+  // indicate the pointer's target received a move event.
+  log("pointerMove", ev);
+  ev.target.style.border = "dashed";
 
- // Find this event in the cache and update its record with this event
- const index = evCache.findIndex((cachedEv) => cachedEv.pointerId === ev.pointerId);
- evCache[index] = ev;
+  // Find this event in the cache and update its record with this event
+  const index = evCache.findIndex((cachedEv) => cachedEv.pointerId === ev.pointerId);
+  evCache[index] = ev;
 
- // If two pointers are down, check for pinch gestures
- if (evCache.length === 2) {
-   // Calculate the distance between the two pointers
-   const curDiff = Math.abs(evCache[0].clientX - evCache[1].clientX);
+  // If two pointers are down, check for pinch gestures
+  if (evCache.length === 2) {
+    // Calculate the distance between the two pointers
+    const curDiff = Math.abs(evCache[0].clientX - evCache[1].clientX);
 
-   if (prevDiff > 0) {
-     if (curDiff > prevDiff) {
-       // The distance between the two pointers has increased
-       log("Pinch moving OUT -> Zoom in", ev);
-       ev.target.style.background = "pink";
-     }
-     if (curDiff < prevDiff) {
-       // The distance between the two pointers has decreased
-       log("Pinch moving IN -> Zoom out",ev);
-       ev.target.style.background = "lightblue";
-     }
-   }
+    if (prevDiff > 0) {
+      if (curDiff > prevDiff) {
+         // The distance between the two pointers has increased
+         log("Pinch moving OUT -> Zoom in", ev);
+         ev.target.style.background = "pink";
+      }
+      if (curDiff < prevDiff) {
+        // The distance between the two pointers has decreased
+        log("Pinch moving IN -> Zoom out",ev);
+        ev.target.style.background = "lightblue";
+      }
+    }
 
-   // Cache the distance for the next move event
-   prevDiff = curDiff;
- }
+    // Cache the distance for the next move event
+    prevDiff = curDiff;
+  }
 }
 ```
 
@@ -177,9 +177,9 @@ This function helps manage the global event caches `evCache`.
 
 ```js
 function removeEvent(ev) {
- // Remove this event from the target's cache
- const index = evCache.findIndex((cachedEv) => cachedEv.pointerId === ev.pointerId);
- evCache.splice(index, 1);
+  // Remove this event from the target's cache
+  const index = evCache.findIndex((cachedEv) => cachedEv.pointerId === ev.pointerId);
+  evCache.splice(index, 1);
 }
 ```
 
@@ -207,8 +207,8 @@ function log(prefix, ev) {
 }
 
 function clearLog(event) {
- const o = document.getElementsByTagName('output')[0];
- o.innerHTML = "";
+  const o = document.getElementsByTagName('output')[0];
+  o.innerHTML = "";
 }
 ```
 

--- a/files/en-us/web/api/pointer_events/pinch_zoom_gestures/index.md
+++ b/files/en-us/web/api/pointer_events/pinch_zoom_gestures/index.md
@@ -54,15 +54,15 @@ Event handlers are registered for the following pointer events: {{domxref("HTMLE
 function init() {
  // Install event handlers for the pointer target
  const el = document.getElementById("target");
- el.onpointerdown = pointerdown_handler;
- el.onpointermove = pointermove_handler;
+ el.onpointerdown = pointerdownHandler;
+ el.onpointermove = pointermoveHandler;
 
  // Use same handler for pointer{up,cancel,out,leave} events since
  // the semantics for these events - in this app - are the same.
- el.onpointerup = pointerup_handler;
- el.onpointercancel = pointerup_handler;
- el.onpointerout = pointerup_handler;
- el.onpointerleave = pointerup_handler;
+ el.onpointerup = pointerupHandler;
+ el.onpointercancel = pointerupHandler;
+ el.onpointerout = pointerupHandler;
+ el.onpointerleave = pointerupHandler;
 }
 ```
 
@@ -71,7 +71,7 @@ function init() {
 The {{domxref("HTMLElement/pointerdown_event", "pointerdown")}} event is fired when a pointer (mouse, pen/stylus or touch point on a touchscreen) makes contact with the _contact surface_. In this application, the event's state must be cached in case this down event is part of a two-pointer pinch/zoom gesture.
 
 ```js
-function pointerdown_handler(ev) {
+function pointerdownHandler(ev) {
  // The pointerdown event signals the start of a touch interaction.
  // This event is cached to support 2-finger gestures
  evCache.push(ev);
@@ -86,7 +86,7 @@ The {{domxref("HTMLElement/pointermove_event", "pointermove")}} event handler de
 When this event is processed, the target's border is set to `dashed` to provide a clear visual indication the element has received a move event.
 
 ```js
-function pointermove_handler(ev) {
+function pointermoveHandler(ev) {
  // This function implements a 2-pointer horizontal pinch/zoom gesture.
  //
  // If the distance between the two pointers has increased (zoom in),
@@ -133,7 +133,7 @@ The {{domxref("HTMLElement/pointerup_event", "pointerup")}} event is fired when 
 In this application, this handler is also used for {{domxref("HTMLElement/pointercancel_event", "pointercancel")}}, {{domxref("HTMLElement/pointerleave_event", "pointerleave")}} and {{domxref("HTMLElement/pointerout_event", "pointerout")}} events.
 
 ```js
-function pointerup_handler(ev) {
+function pointerupHandler(ev) {
   log(ev.type, ev);
   // Remove this pointer from the cache and reset the target's
   // background and border
@@ -176,7 +176,7 @@ These functions support the application but aren't directly involved in the even
 This function helps manage the global event caches `evCache`.
 
 ```js
-function remove_event(ev) {
+function removeEvent(ev) {
  // Remove this event from the target's cache
  const index = evCache.findIndex((cachedEv) => cachedEv.pointerId === ev.pointerId);
  evCache.splice(index, 1);

--- a/files/en-us/web/api/report/index.md
+++ b/files/en-us/web/api/report/index.md
@@ -79,9 +79,9 @@ function displayReports(reports) {
     listItem.appendChild(innerList);
     list.appendChild(listItem);
 
-    for (const key in reports[i].body) {
+    for (const key in report.body) {
       const innerListItem = document.createElement('li');
-      const keyValue = reports[i].body[key];
+      const keyValue = report.body[key];
       innerListItem.textContent = `${key}: ${keyValue}`;
       innerList.appendChild(innerListItem);
     }

--- a/files/en-us/web/api/resource_timing_api/using_the_resource_timing_api/index.md
+++ b/files/en-us/web/api/resource_timing_api/using_the_resource_timing_api/index.md
@@ -53,40 +53,40 @@ function calculate_load_times() {
   }
 
   console.log("= Calculate Load Times");
-  for (let i=0; i < resources.length; i++) {
-    console.log(`== Resource[${i}] - ${resources[i].name}`);
+  resources.forEach((resource, i) => {
+    console.log(`== Resource[${i}] - ${resource.name}`);
     // Redirect time
-    let t = resources[i].redirectEnd - resources[i].redirectStart;
+    let t = resource.redirectEnd - resource.redirectStart;
     console.log(`… Redirect time = ${t}`);
 
     // DNS time
-    t = resources[i].domainLookupEnd - resources[i].domainLookupStart;
+    t = resource.domainLookupEnd - resource.domainLookupStart;
     console.log(`… DNS lookup time = ${t}`);
 
     // TCP handshake time
-    t = resources[i].connectEnd - resources[i].connectStart;
+    t = resource.connectEnd - resource.connectStart;
     console.log(`… TCP time = ${t}`);
 
     // Secure connection time
-    t = (resources[i].secureConnectionStart > 0) ? (resources[i].connectEnd - resources[i].secureConnectionStart) : "0";
+    t = (resource.secureConnectionStart > 0) ? (resource.connectEnd - resource.secureConnectionStart) : "0";
     console.log(`… Secure connection time = ${t}`);
 
     // Response time
-    t = resources[i].responseEnd - resources[i].responseStart;
+    t = resource.responseEnd - resource.responseStart;
     console.log(`… Response time = ${t}`);
 
     // Fetch until response end
-    t = (resources[i].fetchStart > 0) ? (resources[i].responseEnd - resources[i].fetchStart) : "0";
+    t = (resource.fetchStart > 0) ? (resource.responseEnd - resource.fetchStart) : "0";
     console.log(`… Fetch until response end time = ${t}`);
 
     // Request start until response end
-    t = (resources[i].requestStart > 0) ? (resources[i].responseEnd - resources[i].requestStart) : "0";
+    t = (resource.requestStart > 0) ? (resource.responseEnd - resource.requestStart) : "0";
     console.log(`… Request start until response end time = ${t}`);
 
     // Start until response end
-    t = (resources[i].startTime > 0) ? (resources[i].responseEnd - resources[i].startTime) : "0";
+    t = (resource.startTime > 0) ? (resource.responseEnd - resource.startTime) : "0";
     console.log(`… Start until response end time = ${t}`);
-  }
+  });
 }
 ```
 
@@ -105,34 +105,34 @@ function display_size_data(){
     return;
   }
 
-  const list = performance.getEntriesByType("resource");
-  if (list === undefined) {
+  const entries = performance.getEntriesByType("resource");
+  if (entries === undefined) {
     console.log("= Display Size Data: performance.getEntriesByType() is NOT supported");
     return;
   }
 
   // For each "resource", display its *Size property values
   console.log("= Display Size Data");
-  for (let i=0; i < list.length; i++) {
-    console.log(`== Resource[${i}] - ${list[i].name}`);
-    if ("decodedBodySize" in list[i]) {
-      console.log(`… decodedBodySize[${i}] = ${list[i].decodedBodySize}`);
+  entries.forEach((entry, i) => {
+    console.log(`== Resource[${i}] - ${entry.name}`);
+    if ("decodedBodySize" in entry) {
+      console.log(`… decodedBodySize[${i}] = ${entry.decodedBodySize}`);
     } else {
       console.log(`… decodedBodySize[${i}] = NOT supported`);
     }
 
-    if ("encodedBodySize" in list[i]) {
-      console.log(`… encodedBodySize[${i}] = ${list[i].encodedBodySize}`);
+    if ("encodedBodySize" in entry) {
+      console.log(`… encodedBodySize[${i}] = ${entry.encodedBodySize}`);
     } else {
       console.log(`… encodedBodySize[${i}] = NOT supported`);
     }
 
-    if ("transferSize" in list[i]) {
-      console.log(`… transferSize[${i}] = ${list[i].transferSize}`);
+    if ("transferSize" in entry) {
+      console.log(`… transferSize[${i}] = ${entry.transferSize}`);
     } else {
       console.log(`… transferSize[${i}] = NOT supported`);
     }
-  }
+  });
 }
 ```
 

--- a/files/en-us/web/api/speechsynthesisvoice/name/index.md
+++ b/files/en-us/web/api/speechsynthesisvoice/name/index.md
@@ -26,7 +26,7 @@ A string representing the name of the voice.
 ## Examples
 
 ```js
-for (const voice of voices ; i++) {
+for (const voice of voices) {
   const option = document.createElement('option');
   option.textContent = `${voice.name} (${voice.lang})`;
 

--- a/files/en-us/web/api/speechsynthesisvoice/name/index.md
+++ b/files/en-us/web/api/speechsynthesisvoice/name/index.md
@@ -26,16 +26,16 @@ A string representing the name of the voice.
 ## Examples
 
 ```js
-for (let i = 0; i < voices.length ; i++) {
+for (const voice of voices ; i++) {
   const option = document.createElement('option');
-  option.textContent = `${voices[i].name} (${voices[i].lang})`;
+  option.textContent = `${voice.name} (${voice.lang})`;
 
-  if (voices[i].default) {
+  if (voice.default) {
     option.textContent += ' — DEFAULT';
   }
 
-  option.setAttribute('data-lang', voices[i].lang);
-  option.setAttribute('data-name', voices[i].name);
+  option.setAttribute('data-lang', voice.lang);
+  option.setAttribute('data-name', voice.name);
   voiceSelect.appendChild(option);
 }
 ```

--- a/files/en-us/web/api/structuredclone/index.md
+++ b/files/en-us/web/api/structuredclone/index.md
@@ -74,10 +74,8 @@ The following code shows how to clone an array and transfer its underlying resou
 On return, the original `uInt8Array.buffer` will be cleared.
 
 ```js
-const uInt8Array = new Uint8Array(1024 * 1024 * 16); // 16MB
-for (let i = 0; i < uInt8Array.length; ++i) {
-  uInt8Array[i] = i;
-}
+// 16MB = 1024 * 1024 * 16
+const uInt8Array = Uint8Array.from({ length: 1024 * 1024 * 16 }, (v, i) => i); 
 
 const transferred = structuredClone(uInt8Array, { transfer: [uInt8Array.buffer] });
 console.log(uInt8Array.byteLength);  // 0

--- a/files/en-us/web/api/texttrack/mode/index.md
+++ b/files/en-us/web/api/texttrack/mode/index.md
@@ -94,10 +94,9 @@ window.addEventListener("load", (event) => {
 
   track.mode = "showing";
 
-  for (let index  0; index < track.cues.length; index++) {
-    let cue = track.cues[index];
+  for (const cue of track.cues) {
     cue.pauseOnExit = true;
-  };
+  }
 });
 ```
 

--- a/files/en-us/web/api/texttrack/mode/index.md
+++ b/files/en-us/web/api/texttrack/mode/index.md
@@ -94,7 +94,7 @@ window.addEventListener("load", (event) => {
 
   track.mode = "showing";
 
-  for (let index=0; index < track.cues.length; index++) {
+  for (let index  0; index < track.cues.length; index++) {
     let cue = track.cues[index];
     cue.pauseOnExit = true;
   };

--- a/files/en-us/web/api/touch_events/multi-touch_interaction/index.md
+++ b/files/en-us/web/api/touch_events/multi-touch_interaction/index.md
@@ -94,10 +94,10 @@ function handle_pinch_zoom(ev) {
     // the 2-touch
     let point1 = -1;
     let point2 = -1;
-    for (let i = 0; i < tpCache.length; i++) {
-      if (tpCache[i].identifier === ev.targetTouches[0].identifier) point1 = i;
-      if (tpCache[i].identifier === ev.targetTouches[1].identifier) point2 = i;
-    }
+    tpCache.forEach((tp, i) => {
+      if (tp.identifier === ev.targetTouches[0].identifier) point1 = i;
+      if (tp.identifier === ev.targetTouches[1].identifier) point2 = i;
+    });
     if (point1 >= 0 && point2 >= 0) {
       // Calculate the difference between the start and move coordinates
       const diff1 = Math.abs(tpCache[point1].clientX - ev.targetTouches[0].clientX);

--- a/files/en-us/web/api/touch_events/multi-touch_interaction/index.md
+++ b/files/en-us/web/api/touch_events/multi-touch_interaction/index.md
@@ -92,12 +92,13 @@ function handle_pinch_zoom(ev) {
   if (ev.targetTouches.length === 2 && ev.changedTouches.length === 2) {
     // Check if the two target touches are the same ones that started
     // the 2-touch
-    let point1 = -1;
-    let point2 = -1;
-    tpCache.forEach((tp, i) => {
-      if (tp.identifier === ev.targetTouches[0].identifier) point1 = i;
-      if (tp.identifier === ev.targetTouches[1].identifier) point2 = i;
-    });
+    const point1 = tpCache.findLastIndex(
+      (tp) => tp.identifier === ev.targetTouches[0].identifier
+    );
+    const point2 = tpCache.findLastIndex(
+      (tp) => tp.identifier === ev.targetTouches[1].identifier
+    );
+
     if (point1 >= 0 && point2 >= 0) {
       // Calculate the difference between the start and move coordinates
       const diff1 = Math.abs(tpCache[point1].clientX - ev.targetTouches[0].clientX);


### PR DESCRIPTION
Classical `for` loops are error-prone (setting the right condition, not mixing indices…) and difficult to read when used to loop on all elements of an Array-like structure.

This PR changes some occurrences to use the modern `for…of`, or `.forEach()` in some occurrences.

Note that:
- I use `for…of` if I don't need the index
- I use `.forEach()` when I do, or on an object where `for…of` may not work.
- There were a couple of cases where the loop copied an Array into a new one; I used `Array.from()` instead.