### PR TITLE
add missing alt attribute

### DIFF
--- a/files/en-us/web/html/element/map/index.md
+++ b/files/en-us/web/html/element/map/index.md
@@ -97,12 +97,12 @@ Click the left-hand parrot for JavaScript, or the right-hand parrot for CSS.
 <map name="primary">
   <area shape="circle" coords="75,75,75"
         href="https://developer.mozilla.org/docs/Web/JavaScript"
-        target="_blank" >
+        target="_blank" alt="JavaScript">
   <area shape="circle" coords="275,75,75"
         href="https://developer.mozilla.org/docs/Web/CSS"
-        target="_blank" >
+        target="_blank" alt="CSS" >
 </map>
-<img usemap="#primary" src="parrots.jpg" alt="350 x 150 pic">
+<img usemap="#primary" src="parrots.jpg" alt="350 x 150 picture of two parrots">
 ```
 
 #### Result


### PR DESCRIPTION
I can't believe this example didn't have alt attributes on `<area>`. Shame!

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
