### PR TITLE
Prefer template literals in code blocks, part 2

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
@@ -68,10 +68,8 @@ function logStorageChange(changes, area) {
 
   for (let item of changedItems) {
     console.log(`${item} has changed:`);
-    console.log("Old value: ");
-    console.log(changes[item].oldValue);
-    console.log("New value: ");
-    console.log(changes[item].newValue);
+    console.log("Old value: ", changes[item].oldValue);
+    console.log("New value: ", changes[item].newValue);
   }
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
@@ -64,9 +64,9 @@ log its old value and its new value.
 function logStorageChange(changes, area) {
   console.log(`Change in storage area: ${area}`);
 
-  let changedItems = Object.keys(changes);
+  const changedItems = Object.keys(changes);
 
-  for (let item of changedItems) {
+  for (const item of changedItems) {
     console.log(`${item} has changed:`);
     console.log("Old value: ", changes[item].oldValue);
     console.log("New value: ", changes[item].newValue);

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/onchanged/index.md
@@ -62,12 +62,12 @@ then for each item changed,
 log its old value and its new value.
 */
 function logStorageChange(changes, area) {
-  console.log("Change in storage area: " + area);
+  console.log(`Change in storage area: ${area}`);
 
   let changedItems = Object.keys(changes);
 
   for (let item of changedItems) {
-    console.log(item + " has changed:");
+    console.log(`${item} has changed:`);
     console.log("Old value: ");
     console.log(changes[item].oldValue);
     console.log("New value: ");

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/onchanged/index.md
@@ -55,9 +55,9 @@ changes in the local storage.
 */
 function logStorageChange(changes) {
 
-  let changedItems = Object.keys(changes);
+  const changedItems = Object.keys(changes);
 
-  for (let item of changedItems) {
+  for (const item of changedItems) {
     console.log(`${item} has changed:`);
     console.log("Old value: ", changes[item].oldValue);
     console.log("New value: ", changes[item].newValue);

--- a/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/onchanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/storage/storagearea/onchanged/index.md
@@ -58,11 +58,9 @@ function logStorageChange(changes) {
   let changedItems = Object.keys(changes);
 
   for (let item of changedItems) {
-    console.log(item + " has changed:");
-    console.log("Old value: ");
-    console.log(changes[item].oldValue);
-    console.log("New value: ");
-    console.log(changes[item].newValue);
+    console.log(`${item} has changed:`);
+    console.log("Old value: ", changes[item].oldValue);
+    console.log("New value: ", changes[item].newValue);
   }
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onactivated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onactivated/index.md
@@ -62,8 +62,7 @@ Listen for and log tab activation events:
 
 ```js
 function handleActivated(activeInfo) {
-  console.log("Tab " + activeInfo.tabId +
-              " was activated");
+  console.log(`Tab ${activeInfo.tabId} was activated`);
 }
 
 browser.tabs.onActivated.addListener(handleActivated);

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onattached/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onattached/index.md
@@ -65,9 +65,9 @@ Listen for attach events, and log the info:
 
 ```js
 function handleAttached(tabId, attachInfo) {
-  console.log("Tab: " + tabId + " attached");
-  console.log("New window: " + attachInfo.newWindowId);
-  console.log("New index: " + attachInfo.newPosition);
+  console.log(`Tab: ${tabId} attached`);
+  console.log(`New window: ${attachInfo.newWindowId}`);
+  console.log(`New index: ${attachInfo.newPosition}`);
 }
 
 browser.tabs.onAttached.addListener(handleAttached);

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/ondetached/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/ondetached/index.md
@@ -65,9 +65,9 @@ Listen for detach events, and log the info:
 
 ```js
 function handleDetached(tabId, detachInfo) {
-  console.log("Tab: " + tabId + " moved");
-  console.log("Old window: " + detachInfo.oldWindowId);
-  console.log("Old index: " + detachInfo.oldPosition);
+  console.log(`Tab: ${tabId} moved`);
+  console.log(`Old window: ${detachInfo.oldWindowId}`);
+  console.log(`Old index: ${detachInfo.oldPosition}`);
 }
 
 browser.tabs.onDetached.addListener(handleDetached);

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onhighlighted/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onhighlighted/index.md
@@ -62,7 +62,7 @@ Listen for highlighting events, and log the IDs of highlighted tabs:
 
 ```js
 function handleHighlighted(highlightInfo) {
-  console.log("Highlighted tabs: " + highlightInfo.tabIds);
+  console.log(`Highlighted tabs: ${highlightInfo.tabIds}`);
 }
 
 browser.tabs.onHighlighted.addListener(handleHighlighted);

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onmoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onmoved/index.md
@@ -69,9 +69,7 @@ Listen for and log move events:
 
 ```js
 function handleMoved(tabId, moveInfo) {
-  console.log("Tab " + tabId +
-              " moved from " + moveInfo.fromIndex +
-              " to " + moveInfo.toIndex);
+  console.log(`Tab ${tabId} moved from ${moveInfo.fromIndex} to ${moveInfo.toIndex}`);
 }
 
 browser.tabs.onMoved.addListener(handleMoved);

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onremoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onremoved/index.md
@@ -65,9 +65,9 @@ Listen for close events, and log the info:
 
 ```js
 function handleRemoved(tabId, removeInfo) {
-  console.log("Tab: " + tabId + " is closing");
-  console.log("Window ID: " + removeInfo.windowId);
-  console.log("Window is closing: " + removeInfo.isWindowClosing);
+  console.log(`Tab: ${tabId} is closing`);
+  console.log(`Window ID: ${removeInfo.windowId}`);
+  console.log(`Window is closing: ${removeInfo.isWindowClosing}`);
 }
 
 browser.tabs.onRemoved.addListener(handleRemoved);

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onreplaced/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onreplaced/index.md
@@ -58,8 +58,8 @@ Listen for replacement events, and log the associated info:
 
 ```js
 function handleReplaced(addedTabId, removedTabId) {
-  console.log("New tab: " + addedTabId);
-  console.log("Old tab: " + removedTabId);
+  console.log(`New tab: ${addedTabId}`);
+  console.log(`Old tab: ${removedTabId}`);
 }
 
 browser.tabs.onReplaced.addListener(handleReplaced);

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
@@ -119,10 +119,8 @@ Listen for and log all the change info and new state:
 ```js
 function handleUpdated(tabId, changeInfo, tabInfo) {
   console.log(`Updated tab: ${tabId}`);
-  console.log("Changed attributes: ");
-  console.log(changeInfo);
-  console.log("New tab Info: ");
-  console.log(tabInfo);
+  console.log("Changed attributes: ", changeInfo);
+  console.log("New tab Info: ", tabInfo);
 }
 
 browser.tabs.onUpdated.addListener(handleUpdated);

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onupdated/index.md
@@ -118,7 +118,7 @@ Listen for and log all the change info and new state:
 
 ```js
 function handleUpdated(tabId, changeInfo, tabInfo) {
-  console.log("Updated tab: " + tabId);
+  console.log(`Updated tab: ${tabId}`);
   console.log("Changed attributes: ");
   console.log(changeInfo);
   console.log("New tab Info: ");
@@ -133,8 +133,7 @@ Log changes to URLs:
 ```js
 function handleUpdated(tabId, changeInfo, tabInfo) {
   if (changeInfo.url) {
-    console.log("Tab: " + tabId +
-                " URL changed to " + changeInfo.url);
+    console.log(`Tab: ${tabId} URL changed to ${changeInfo.url}`);
   }
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/tabs/onzoomchange/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/tabs/onzoomchange/index.md
@@ -64,9 +64,9 @@ Listen for zoom events and log the info:
 
 ```js
 function handleZoomed(zoomChangeInfo) {
-  console.log("Tab: " + zoomChangeInfo.tabId + " zoomed");
-  console.log("Old zoom: " + zoomChangeInfo.oldZoomFactor);
-  console.log("New zoom: " + zoomChangeInfo.newZoomFactor);
+  console.log(`Tab: ${zoomChangeInfo.tabId} zoomed`);
+  console.log(`Old zoom: ${zoomChangeInfo.oldZoomFactor}`);
+  console.log(`New zoom: ${zoomChangeInfo.newZoomFactor}`);
 }
 
 browser.tabs.onZoomChange.addListener(handleZoomed);

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/getcurrent/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/getcurrent/index.md
@@ -44,17 +44,14 @@ A [`Promise`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise). The 
 Gets the properties `frame` and `toolbar` colors of the current theme
 
 ```js
-function getStyle(themeInfo)
-{
-  if (themeInfo.colors)
-  {
-    console.log("accent color : " +  themeInfo.colors.frame);
-    console.log("toolbar : " + themeInfo.colors.toolbar);
+function getStyle(themeInfo) {
+  if (themeInfo.colors) {
+    console.log(`accent color: ${themeInfo.colors.frame}`);
+    console.log(`toolbar: ${themeInfo.colors.toolbar}`);
   }
 }
 
-async function getCurrentThemeInfo()
-{
+async function getCurrentThemeInfo() {
   let themeInfo = await browser.theme.getCurrent();
   getStyle(themeInfo);
 }

--- a/files/en-us/mozilla/add-ons/webextensions/api/theme/getcurrent/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/theme/getcurrent/index.md
@@ -52,7 +52,7 @@ function getStyle(themeInfo) {
 }
 
 async function getCurrentThemeInfo() {
-  let themeInfo = await browser.theme.getCurrent();
+  const themeInfo = await browser.theme.getCurrent();
   getStyle(themeInfo);
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
@@ -189,7 +189,7 @@ This code logs the URL for every resource requested which matches the [\<all_url
 
 ```js
 function logURL(requestDetails) {
-  console.log("Loading: " + requestDetails.url);
+  console.log(`Loading: ${requestDetails.url}`);
 }
 
 browser.webRequest.onBeforeRequest.addListener(
@@ -207,7 +207,7 @@ let pattern = "https://mdn.mozillademos.org/*";
 // cancel function returns an object
 // which contains a property `cancel` set to `true`
 function cancel(requestDetails) {
-  console.log("Canceling: " + requestDetails.url);
+  console.log(`Canceling: ${requestDetails.url}`);
   return {cancel: true};
 }
 
@@ -230,7 +230,7 @@ let pattern = "https://mdn.mozillademos.org/*";
 // returns an object with a property `redirectURL`
 // set to the new URL
 function redirect(requestDetails) {
-  console.log("Redirecting: " + requestDetails.url);
+  console.log(`Redirecting: ${requestDetails.url}`);
   return {
     redirectUrl: "https://38.media.tumblr.com/tumblr_ldbj01lZiP1qe0eclo1_500.gif"
   };
@@ -257,7 +257,7 @@ let redirectUrl = "https://38.media.tumblr.com/tumblr_ldbj01lZiP1qe0eclo1_500.gi
 // redirect function returns a Promise
 // which is resolved with the redirect URL when a timer expires
 function redirectAsync(requestDetails) {
-  console.log("Redirecting async: " + requestDetails.url);
+  console.log(`Redirecting async: ${requestDetails.url}`);
   return new Promise((resolve, reject) => {
     setTimeout(() => {
       resolve({redirectUrl});
@@ -287,7 +287,7 @@ let image = `
 `;
 
 function listener(details) {
-  let redirectUrl = "data:image/svg+xml," + encodeURIComponent(image);
+  let redirectUrl = `data:image/svg+xml,${encodeURIComponent(image)}`;
   return {redirectUrl};
 }
 
@@ -302,7 +302,7 @@ Here's another version:
 
 ```js
 function randomColor() {
-  return "#" + Math.floor(Math.random()*16777215).toString(16);
+  return `#${Math.floor(Math.random()*16777215).toString(16)}`;
 }
 
 let pattern = "https://mdn.mozillademos.org/*";
@@ -314,7 +314,7 @@ let image = `
 `;
 
 function listener(details) {
-  let redirectUrl = "data:image/svg+xml," + encodeURIComponent(image);
+  let redirectUrl = `data:image/svg+xml,${encodeURIComponent(image)}`;
   return {redirectUrl};
 }
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/webrequest/onbeforerequest/index.md
@@ -208,7 +208,7 @@ let pattern = "https://mdn.mozillademos.org/*";
 // which contains a property `cancel` set to `true`
 function cancel(requestDetails) {
   console.log(`Canceling: ${requestDetails.url}`);
-  return {cancel: true};
+  return { cancel: true };
 }
 
 // add the listener,
@@ -260,7 +260,7 @@ function redirectAsync(requestDetails) {
   console.log(`Redirecting async: ${requestDetails.url}`);
   return new Promise((resolve, reject) => {
     setTimeout(() => {
-      resolve({redirectUrl});
+      resolve({ redirectUrl });
     }, 2000);
   });
 }
@@ -287,8 +287,8 @@ let image = `
 `;
 
 function listener(details) {
-  let redirectUrl = `data:image/svg+xml,${encodeURIComponent(image)}`;
-  return {redirectUrl};
+  const redirectUrl = `data:image/svg+xml,${encodeURIComponent(image)}`;
+  return { redirectUrl };
 }
 
 browser.webRequest.onBeforeRequest.addListener(
@@ -305,7 +305,7 @@ function randomColor() {
   return `#${Math.floor(Math.random()*16777215).toString(16)}`;
 }
 
-let pattern = "https://mdn.mozillademos.org/*";
+const pattern = "https://mdn.mozillademos.org/*";
 
 let image = `
   <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%">
@@ -314,8 +314,8 @@ let image = `
 `;
 
 function listener(details) {
-  let redirectUrl = `data:image/svg+xml,${encodeURIComponent(image)}`;
-  return {redirectUrl};
+  const redirectUrl = `data:image/svg+xml,${encodeURIComponent(image)}`;
+  return { redirectUrl };
 }
 
 browser.webRequest.onBeforeRequest.addListener(

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/oncreated/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/oncreated/index.md
@@ -55,7 +55,7 @@ Log the IDs of new windows as they are created:
 
 ```js
 browser.windows.onCreated.addListener((window) => {
-  console.log("New window: " + window.id);
+  console.log(`New window: ${window.id}`);
 });
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/onfocuschanged/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/onfocuschanged/index.md
@@ -57,7 +57,7 @@ Log focus changes:
 
 ```js
 browser.windows.onFocusChanged.addListener((windowId) => {
-  console.log("Newly focused window: " + windowId);
+  console.log(`Newly focused window: ${windowId}`);
 });
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/api/windows/onremoved/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/windows/onremoved/index.md
@@ -55,7 +55,7 @@ Log the IDs of windows as they are removed.
 
 ```js
 browser.windows.onRemoved.addListener((windowId) => {
-  console.log("Closed window: " + windowId);
+  console.log(`Closed window: ${windowId}`);
 });
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/content_scripts/index.md
@@ -360,7 +360,7 @@ function connected(p) {
   portFromCS = p;
   portFromCS.postMessage({greeting: "hi there content script!"});
   portFromCS.onMessage.addListener((m) => {
-    portFromCS.postMessage({greeting: "In background script, received message from content script:" + m.greeting});
+    portFromCS.postMessage({greeting: `In background script, received message from content script: ${m.greeting}`});
   });
 }
 
@@ -439,7 +439,7 @@ window.addEventListener("message", (event) => {
     event.source === window &&
     event?.data?.direction === "from-page-script"
   ) {
-    alert("Content script received message: \"" + event.data.message + "\"");
+    alert(`Content script received message: "${event.data.message}"`);
   }
 });
 ```

--- a/files/en-us/mozilla/add-ons/webextensions/implement_a_settings_page/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/implement_a_settings_page/index.md
@@ -176,7 +176,7 @@ function onGot(item) {
   if (item.color) {
     color = item.color;
   }
-  document.body.style.border = "10px solid " + color;
+  document.body.style.border = `10px solid ${color}`;
 }
 
 let getting = browser.storage.sync.get("color");

--- a/files/en-us/mozilla/add-ons/webextensions/implement_a_settings_page/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/implement_a_settings_page/index.md
@@ -179,7 +179,7 @@ function onGot(item) {
   document.body.style.border = `10px solid ${color}`;
 }
 
-let getting = browser.storage.sync.get("color");
+const getting = browser.storage.sync.get("color");
 getting.then(onGot, onError);
 ```
 

--- a/files/en-us/mozilla/add-ons/webextensions/intercept_http_requests/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/intercept_http_requests/index.md
@@ -50,7 +50,7 @@ Next, create a file called "background.js" and add:
 
 ```js
 function logURL(requestDetails) {
-  console.log("Loading: " + requestDetails.url);
+  console.log(`Loading: ${requestDetails.url}`);
 }
 
 browser.webRequest.onBeforeRequest.addListener(
@@ -116,7 +116,7 @@ let pattern = "https://developer.mozilla.org/*";
 let targetUrl = "https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_second_WebExtension/frog.jpg";
 
 function redirect(requestDetails) {
-  console.log("Redirecting: " + requestDetails.url);
+  console.log(`Redirecting: ${requestDetails.url}`);
   if (requestDetails.url === targetUrl) {
     return;
   }

--- a/files/en-us/mozilla/add-ons/webextensions/intercept_http_requests/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/intercept_http_requests/index.md
@@ -113,7 +113,7 @@ Next, replace "background.js" with this:
 
 ```js
 let pattern = "https://developer.mozilla.org/*";
-let targetUrl = "https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_second_WebExtension/frog.jpg";
+const targetUrl = "https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Your_second_WebExtension/frog.jpg";
 
 function redirect(requestDetails) {
   console.log(`Redirecting: ${requestDetails.url}`);

--- a/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/native_messaging/index.md
@@ -181,7 +181,7 @@ let port = browser.runtime.connectNative("ping_pong");
 Listen for messages from the app.
 */
 port.onMessage.addListener((response) => {
-  console.log("Received: " + response);
+  console.log(`Received: ${response}`);
 });
 
 /*
@@ -212,7 +212,7 @@ Here's the example above, rewritten to use `runtime.sendNativeMessage()`:
 
 ```js
 function onResponse(response) {
-  console.log("Received " + response);
+  console.log(`Received ${response}`);
 }
 
 function onError(error) {

--- a/files/en-us/mozilla/add-ons/webextensions/safely_inserting_external_content_into_a_page/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/safely_inserting_external_content_into_a_page/index.md
@@ -31,7 +31,7 @@ A lightweight approach to inserting strings into a page is to use the native DOM
 let data = JSON.parse(responseText);
 let div = document.createElement("div");
 div.className = data.className;
-div.textContent = "Your favorite color is now " + data.color;
+div.textContent = `Your favorite color is now ${data.color}`;
 addonElement.appendChild(div);
 ```
 
@@ -41,9 +41,7 @@ However, beware, you can use native methods that aren't safe. Take the following
 
 ```js example-bad
 let data = JSON.parse(responseText);
-addonElement.innerHTML = "<div class='" + data.className + "'>" +
-                         "Your favorite color is now " + data.color +
-                         "</div>";
+addonElement.innerHTML = `<div class='${data.className}'>Your favorite color is now ${data.color}</div>`;
 ```
 
 Here, the contents of `data.className` or `data.color` could contain HTML that can close the tag early, insert arbitrary further HTML content, then open another tag.
@@ -55,7 +53,7 @@ When using jQuery, functions such as `attr()` and `text()` escape content as it'
 ```js example-good
 let node = $("</div>");
 node.addClass(data.className);
-node.text("Your favorite color is now " + data.color);
+node.text(`Your favorite color is now ${data.color}`);
 ```
 
 ## Working with HTML content

--- a/files/en-us/mozilla/add-ons/webextensions/sharing_objects_with_page_scripts/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/sharing_objects_with_page_scripts/index.md
@@ -146,7 +146,7 @@ Define a function in the content script's scope, then export it
 into the page script's scope.
 */
 function notify(message) {
-  browser.runtime.sendMessage({content: "Function call: " + message});
+  browser.runtime.sendMessage({content: `Function call: ${message}`});
 }
 
 exportFunction(notify, window, {defineAs:'notify'});
@@ -177,7 +177,7 @@ the `cloneFunctions` option.
 let messenger = {
   notify(message) {
     browser.runtime.sendMessage({
-      content: "Object method call: " + message
+      content: `Object method call: ${message}`
     });
   }
 };

--- a/files/en-us/web/accessibility/aria/aria_live_regions/index.md
+++ b/files/en-us/web/accessibility/aria/aria_live_regions/index.md
@@ -178,7 +178,7 @@ As an illustration of `aria-atomic`, consider a site with a simple clock, showin
 function updateClock() {
   const now = new Date();
   document.getElementById('clock-hours').innerHTML = now.getHours();
-  document.getElementById('clock-mins').innerHTML = ("0"+now.getMinutes()).substr(-2);
+  document.getElementById('clock-mins').innerHTML = (`0${now.getMinutes()}`).substr(-2);
 }
 
 /* first run */

--- a/files/en-us/web/css/_colon_modal/index.md
+++ b/files/en-us/web/css/_colon_modal/index.md
@@ -96,7 +96,7 @@ selectEl.addEventListener('change', (e) => {
 });
 // "Confirm" button of form triggers "close" on dialog because of [method="dialog"]
 favDialog.addEventListener('close', () => {
-  outputBox.value = favDialog.returnValue + " button clicked - " + (new Date()).toString();
+  outputBox.value = `${favDialog.returnValue} button clicked - ${(new Date()).toString()}`;
 });
 ```
 

--- a/files/en-us/web/css/_colon_scope/index.md
+++ b/files/en-us/web/css/_colon_scope/index.md
@@ -73,7 +73,7 @@ const selected = context.querySelectorAll(':scope > div');
 
 document.getElementById('results').innerHTML = Array.prototype.map.call(
   selected,
-  (element) => '#' + element.getAttribute('id'),
+  (element) => `#${element.getAttribute('id')}`,
 ).join(', ');
 ```
 

--- a/files/en-us/web/css/border-image-slice/index.md
+++ b/files/en-us/web/css/border-image-slice/index.md
@@ -156,7 +156,7 @@ const sliceOutput = document.getElementById('slice-output');
 const divElem = document.querySelector('div > div');
 
 widthSlider.addEventListener('input', () => {
-  const newValue = widthSlider.value + 'px';
+  const newValue = `${widthSlider.value}px`;
   divElem.style.borderWidth = newValue;
   widthOutput.textContent = newValue;
 })

--- a/files/en-us/web/css/cssom_view/coordinate_systems/index.md
+++ b/files/en-us/web/css/cssom_view/coordinate_systems/index.md
@@ -72,8 +72,8 @@ let inner = document.querySelector(".inner");
 let log = document.querySelector(".log");
 
 function setCoords(e, type) {
-  let idX = `${type}X`;
-  let idY = `${type}Y`;
+  const idX = `${type}X`;
+  const idY = `${type}Y`;
 
   document.getElementById(idX).innerText = e[idX];
   document.getElementById(idY).innerText = e[idY];

--- a/files/en-us/web/css/cssom_view/coordinate_systems/index.md
+++ b/files/en-us/web/css/cssom_view/coordinate_systems/index.md
@@ -72,8 +72,8 @@ let inner = document.querySelector(".inner");
 let log = document.querySelector(".log");
 
 function setCoords(e, type) {
-  let idX = type + "X";
-  let idY = type + "Y";
+  let idX = `${type}X`;
+  let idY = `${type}Y`;
 
   document.getElementById(idX).innerText = e[idX];
   document.getElementById(idY).innerText = e[idY];

--- a/files/en-us/web/css/font/index.md
+++ b/files/en-us/web/css/font/index.md
@@ -276,12 +276,12 @@ body, input {
 const textAreas = document.getElementsByClassName("curCss");
 
 function getProperties() {
-  return getCheckedValue("font_style") + " " +
-    getCheckedValue("font_variant") + " " +
-    getCheckedValue("font_weight") + " " +
-    getCheckedValue("font_size") +
-    getCheckedValue("line_height") + " " +
-    getCheckedValue("font_family");
+  return `${getCheckedValue("font_style")} `
+    + `${getCheckedValue("font_variant")} `
+    + `${getCheckedValue("font_weight")} `
+    + `${getCheckedValue("font_size")}`
+    + `${getCheckedValue("line_height")} `
+    + `${getCheckedValue("font_family")}`;
 }
 
 function getCheckedValue(radioName) {

--- a/files/en-us/web/css/place-content/index.md
+++ b/files/en-us/web/css/place-content/index.md
@@ -166,8 +166,8 @@ The first value is the {{CSSxRef("align-content")}} property value, the second t
 
 ```js hidden
 function update() {
-  document.getElementById("container").style.placeContent = document.getElementById("alignContentAlignment").value + " "
-    + document.getElementById("justifyContentAlignment").value;
+  document.getElementById("container").style.placeContent = `${document.getElementById("alignContentAlignment").value} `
+    + `${document.getElementById("justifyContentAlignment").value}`;
 }
 
 const alignContentAlignment = document.getElementById("alignContentAlignment");

--- a/files/en-us/web/events/creating_and_triggering_events/index.md
+++ b/files/en-us/web/events/creating_and_triggering_events/index.md
@@ -42,7 +42,7 @@ This will then allow you to access the additional data in the event listener:
 
 ```js
 function eventHandler(e) {
-  console.log('The time is: ' + e.detail);
+  console.log(`The time is: ${e.detail}`);
 }
 ```
 

--- a/files/en-us/web/events/detecting_device_orientation/index.md
+++ b/files/en-us/web/events/detecting_device_orientation/index.md
@@ -127,8 +127,8 @@ function handleOrientation(event) {
 
   // 10 is half the size of the ball
   // It center the positioning point to the center of the ball
-  ball.style.top  = (maxY*y/180 - 10) + "px";
-  ball.style.left = (maxX*x/180 - 10) + "px";
+  ball.style.top  = `${maxY * y / 180 - 10}px`;
+  ball.style.left = `${maxX * x / 180 - 10}px`;
 }
 
 window.addEventListener('deviceorientation', handleOrientation);

--- a/files/en-us/web/guide/ajax/getting_started/index.md
+++ b/files/en-us/web/guide/ajax/getting_started/index.md
@@ -184,7 +184,7 @@ function alertContents() {
       }
     }
   } catch (e) {
-    alert('Caught Exception: ' + e.description);
+    alert(`Caught Exception: ${e.description}`);
   }
 }
 ```

--- a/files/en-us/web/html/cors_enabled_image/index.md
+++ b/files/en-us/web/html/cors_enabled_image/index.md
@@ -88,8 +88,8 @@ The code that handles the newly-downloaded image is found in the `imageReceived(
 
 ```js
 function imageReceived() {
-  let canvas = document.createElement("canvas");
-  let context = canvas.getContext("2d");
+  const canvas = document.createElement("canvas");
+  const context = canvas.getContext("2d");
 
   canvas.width = downloadedImg.width;
   canvas.height = downloadedImg.height;
@@ -99,9 +99,8 @@ function imageReceived() {
 
   try {
     localStorage.setItem("saved-image-example", canvas.toDataURL("image/png"));
-  }
-  catch (err) {
-    console.log("Error: " + err);
+  } catch (err) {
+    console.error(`Error: ${err}`);
   }
 }
 ```

--- a/files/en-us/web/html/element/dialog/index.md
+++ b/files/en-us/web/html/element/dialog/index.md
@@ -177,7 +177,7 @@ selectEl.addEventListener('change', (e) => {
 });
 // "Confirm" button of form triggers "close" on dialog because of [method="dialog"]
 favDialog.addEventListener('close', () => {
-  outputBox.value = favDialog.returnValue + " button clicked - " + (new Date()).toString();
+  outputBox.value = `${favDialog.returnValue} button clicked - ${(new Date()).toString()}`;
 });
 ```
 

--- a/files/en-us/web/html/element/input/datetime-local/index.md
+++ b/files/en-us/web/html/element/input/datetime-local/index.md
@@ -549,7 +549,7 @@ function populateHours() {
   // populate the hours <select> with the 24 hours of the day
   for (let i = 0; i <= 23; i++) {
     const option = document.createElement('option');
-    option.textContent = (i < 10) ? ("0" + i) : i;
+    option.textContent = (i < 10) ? `0${i}` : i;
     hourSelect.appendChild(option);
   }
 }
@@ -558,7 +558,7 @@ function populateMinutes() {
   // populate the minutes <select> with the 60 hours of each minute
   for (let i = 0; i <= 59; i++) {
     const option = document.createElement('option');
-    option.textContent = (i < 10) ? ("0" + i) : i;
+    option.textContent = (i < 10) ? `0${i}` : i;
     minuteSelect.appendChild(option);
   }
 }

--- a/files/en-us/web/html/element/input/file/index.md
+++ b/files/en-us/web/html/element/input/file/index.md
@@ -408,11 +408,11 @@ The `returnFileSize()` function takes a number (of bytes, taken from the current
 ```js
 function returnFileSize(number) {
   if (number < 1024) {
-    return number + 'bytes';
+    return `${number} bytes`;
   } else if (number >= 1024 && number < 1048576) {
-    return (number/1024).toFixed(1) + 'KB';
+    return `${(number / 1024).toFixed(1)} KB`;
   } else if (number >= 1048576) {
-    return (number/1048576).toFixed(1) + 'MB';
+    return `${(number / 1048576).toFixed(1)} MB`;
   }
 }
 ```

--- a/files/en-us/web/html/element/input/time/index.md
+++ b/files/en-us/web/html/element/input/time/index.md
@@ -510,7 +510,7 @@ function populateMinutes() {
   // populate the minutes <select> with the 60 hours of each minute
   for (let i = 0; i <= 59; i++) {
     const option = document.createElement('option');
-    option.textContent = (i < 10) ? ("0" + i) : i;
+    option.textContent = (i < 10) ? `0${i}` : i;
     minuteSelect.appendChild(option);
   }
 }

--- a/files/en-us/web/html/element/input/week/index.md
+++ b/files/en-us/web/html/element/input/week/index.md
@@ -367,7 +367,7 @@ function populateWeeks() {
   // Populate the week select with 52 weeks
   for (let i = 1; i <= 52; i++) {
     const option = document.createElement('option');
-    option.textContent = (i < 10) ? ("0" + i) : i;
+    option.textContent = (i < 10) ? `0${i}` : i;
     weekSelect.appendChild(option);
   }
 }

--- a/files/en-us/web/http/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.md
+++ b/files/en-us/web/http/proxy_servers_and_tunneling/proxy_auto-configuration_pac_file/index.md
@@ -253,7 +253,7 @@ Pattern and mask specification is done the same way as for SOCKS configuration.
 #### Examples
 
 ```js
-function alert_eval(str) { alert(str + ' is ' + eval(str)) }
+function alert_eval(str) { alert(`${str} is ${eval(str)}`) }
 function FindProxyForURL(url, host) {
   alert_eval('isInNet(host, "63.245.213.24", "255.255.255.255")')
   // "PAC-alert: isInNet(host, "63.245.213.24", "255.255.255.255") is true"
@@ -538,7 +538,7 @@ Logs the message in the browser console.
 #### Examples
 
 ```js
-alert(host + " = " + dnsResolve(host));            // logs the host name and its IP address
+alert(`${host} = ${dnsResolve(host)}`);            // logs the host name and its IP address
 alert("Error: shouldn't reach this clause.");      // log a simple message
 ```
 

--- a/files/en-us/web/javascript/a_re-introduction_to_javascript/index.md
+++ b/files/en-us/web/javascript/a_re-introduction_to_javascript/index.md
@@ -772,10 +772,10 @@ function makePerson(first, last) {
   };
 }
 function personFullName(person) {
-  return person.first + ' ' + person.last;
+  return `${person.first} ${person.last}`;
 }
 function personFullNameReversed(person) {
-  return person.last + ', ' + person.first;
+  return `${person.last}, ${person.first}`;
 }
 
 const s = makePerson('Simon', 'Willison');
@@ -791,10 +791,10 @@ function makePerson(first, last) {
     first: first,
     last: last,
     fullName() {
-      return this.first + ' ' + this.last;
+      return `${this.first} ${this.last}`;
     },
     fullNameReversed() {
-      return this.last + ', ' + this.first;
+      return `${this.last}, ${this.first}`;
     }
   };
 }
@@ -823,10 +823,10 @@ function Person(first, last) {
   this.first = first;
   this.last = last;
   this.fullName = function() {
-    return this.first + ' ' + this.last;
+    return `${this.first} ${this.last}`;
   };
   this.fullNameReversed = function() {
-    return this.last + ', ' + this.first;
+    return `${this.last}, ${this.first}`;
   };
 }
 const s = new Person('Simon', 'Willison');
@@ -840,10 +840,10 @@ Our person objects are getting better, but there are still some ugly edges to th
 
 ```js
 function personFullName() {
-  return this.first + ' ' + this.last;
+  return `${this.first} ${this.last}`;
 }
 function personFullNameReversed() {
-  return this.last + ', ' + this.first;
+  return `${this.last}, ${this.first}`;
 }
 function Person(first, last) {
   this.first = first;
@@ -861,10 +861,10 @@ function Person(first, last) {
   this.last = last;
 }
 Person.prototype.fullName = function() {
-  return this.first + ' ' + this.last;
+  return `${this.first} ${this.last}`;
 };
 Person.prototype.fullNameReversed = function() {
-  return this.last + ', ' + this.first;
+  return `${this.last}, ${this.first}`;
 };
 ```
 
@@ -912,7 +912,7 @@ const s = new Person('Simon', 'Willison');
 s.toString(); // [object Object]
 
 Person.prototype.toString = function() {
-  return '<Person: ' + this.fullName() + '>';
+  return `<Person: ${this.fullName()}>`;
 }
 
 s.toString(); // "<Person: Simon Willison>"

--- a/files/en-us/web/javascript/guide/functions/index.md
+++ b/files/en-us/web/javascript/guide/functions/index.md
@@ -236,7 +236,7 @@ function getScore() {
   const num2 = 3;
 
   function add() {
-    return name + ' scored ' + (num1 + num2);
+    return `${name} scored ${num1 + num2}`;
   }
 
   return add();
@@ -320,9 +320,9 @@ function foo(i) {
   if (i < 0) {
     return;
   }
-  console.log('begin: ' + i);
+  console.log(`begin: ${i}`);
   foo(i - 1);
-  console.log('end: ' + i);
+  console.log(`end: ${i}`);
 }
 foo(3);
 

--- a/files/en-us/web/javascript/guide/grammar_and_types/index.md
+++ b/files/en-us/web/javascript/guide/grammar_and_types/index.md
@@ -102,18 +102,18 @@ An attempt to access an undeclared variable results in a {{jsxref("ReferenceErro
 
 ```js
 var a;
-console.log('The value of a is ' + a); // The value of a is undefined
+console.log(`The value of a is ${a}`); // The value of a is undefined
 
-console.log('The value of b is ' + b); // The value of b is undefined
+console.log(`The value of b is ${b}`); // The value of b is undefined
 var b;
 // This one may puzzle you until you read 'Variable hoisting' below
 
-console.log('The value of c is ' + c); // Uncaught ReferenceError: c is not defined
+console.log(`The value of c is ${c}`); // Uncaught ReferenceError: c is not defined
 
 let x;
-console.log('The value of x is ' + x); // The value of x is undefined
+console.log(`The value of x is ${x}`); // The value of x is undefined
 
-console.log('The value of y is ' + y); // Uncaught ReferenceError: y is not defined
+console.log(`The value of y is ${y}`); // Uncaught ReferenceError: y is not defined
 let y;
 ```
 
@@ -548,7 +548,7 @@ function carTypes(name) {
   if (name === 'Honda') {
     return name;
   } else {
-    return "Sorry, we don't sell " + name + ".";
+    return `Sorry, we don't sell ${name}.`;
   }
 }
 

--- a/files/en-us/web/javascript/guide/introduction/index.md
+++ b/files/en-us/web/javascript/guide/introduction/index.md
@@ -110,7 +110,7 @@ To get started with writing JavaScript, open the Web Console in multi-line mode,
   "use strict";
   /* Start of your code */
   function greetMe(yourName) {
-    alert('Hello ' + yourName);
+    alert(`Hello ${yourName}`);
   }
 
   greetMe('World');

--- a/files/en-us/web/javascript/reference/errors/deprecated_caller_or_arguments_usage/index.md
+++ b/files/en-us/web/javascript/reference/errors/deprecated_caller_or_arguments_usage/index.md
@@ -48,7 +48,7 @@ function myFunc() {
   if (myFunc.caller === null) {
     return 'The function was called from the top!';
   } else {
-    return 'This function\'s caller was ' + myFunc.caller;
+    return `This function's caller was ${myFunc.caller}`;
   }
 }
 
@@ -67,14 +67,14 @@ information).
 function f(n) { g(n - 1); }
 
 function g(n) {
-  console.log('before: ' + g.arguments[0]);
+  console.log(`before: ${g.arguments[0]}`);
   if (n > 0) { f(n); }
-  console.log('after: ' + g.arguments[0]);
+  console.log(`after: ${g.arguments[0]}`);
 }
 
 f(2);
 
-console.log('returned: ' + g.arguments);
+console.log(`returned: ${g.arguments}`);
 // TypeError: 'caller', 'callee', and 'arguments' properties may not be accessed on strict mode functions or the arguments objects for calls to them
 ```
 

--- a/files/en-us/web/javascript/reference/errors/missing_name_after_dot_operator/index.md
+++ b/files/en-us/web/javascript/reference/errors/missing_name_after_dot_operator/index.md
@@ -61,6 +61,8 @@ obj["foo"]["bar"]; // "baz"
 
 // computed properties require square brackets
 obj.foo["bar" + i]; // "baz2"
+// or as template literal
+obj.foo[`bar${i}`]; // "baz2"
 ```
 
 ### Property access vs. concatenation

--- a/files/en-us/web/javascript/reference/global_objects/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.md
@@ -376,7 +376,7 @@ myMap.set(0, 'zero');
 myMap.set(1, 'one');
 
 for (const [key, value] of myMap) {
-  console.log(`${key } = ${value}`);
+  console.log(`${key} = ${value}`);
 }
 // 0 = zero
 // 1 = one

--- a/files/en-us/web/javascript/reference/global_objects/string/indexof/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/indexof/index.md
@@ -107,7 +107,7 @@ The following example uses `indexOf()` to locate substrings in the string
 const str = 'Brave new world';
 
 console.log(`Index of first w from start is ${str.indexOf('w')}`); // logs 8
-console.log(`Index of "new" from start is ${ str.indexOf('new')}`); // logs 6
+console.log(`Index of "new" from start is ${str.indexOf('new')}`); // logs 6
 ```
 
 ### indexOf() and case-sensitivity

--- a/files/en-us/web/svg/attribute/pointer-events/index.md
+++ b/files/en-us/web/svg/attribute/pointer-events/index.md
@@ -69,14 +69,14 @@ html,body,svg { height:100% }
 ```js
 window.addEventListener('mouseup', (e) => {
   // Let's pick a random color between #000000 and #FFFFFF
-  const color = Math.round(Math.random() * 0xFFFFFF)
+  const color = Math.round(Math.random() * 0xFFFFFF);
 
   // Let's format the color to fit CSS requirements
-  const fill = '#' + color.toString(16).padStart(6,'0')
+  const fill = `#${color.toString(16).padStart(6, '0')}`;
 
   // Let's apply our color in the
   // element we actually clicked on
-  e.target.style.fill = fill
+  e.target.style.fill = fill;
 })
 ```
 

--- a/files/en-us/web/xpath/snippets/index.md
+++ b/files/en-us/web/xpath/snippets/index.md
@@ -80,7 +80,7 @@ You can now "query" the document with XPath expressions. Although walking the DO
 // display the last names of all people in the doc
 let results = evaluateXPath(people, "//person/@last-name");
 for (const i in results)
-  console.log("Person #" + i + " has the last name " + results[i].value);
+  console.log(`Person #${i} has the last name ${results[i].value}`);
 
 // get the 2nd person node
 results = evaluateXPath(people, "/people/person[2]");

--- a/files/en-us/webassembly/caching_modules/index.md
+++ b/files/en-us/webassembly/caching_modules/index.md
@@ -151,9 +151,9 @@ With the above library function defined, getting a wasm module instance and usin
 const wasmCacheVersion = 1;
 
 instantiateCachedURL(wasmCacheVersion, 'test.wasm').then((instance) =>
-  console.log("Instance says the answer is: " + instance.exports.answer())
+  console.log(`Instance says the answer is: ${instance.exports.answer()}`)
 ).catch((err) =>
-  console.error("Failure to instantiate: " + err)
+  console.error(`Failure to instantiate: ${err}`)
 );
 ```
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Changes string concatenation to template literals where possible.

I have tried to judge when change is improvement and when it's not and left out change that would not improve code readability.

Some cases where missing spaces between words, which is much easier to spot with template literals.

I also have changed some concatenations used in console logging to instead to use "," to not convert objects to string.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
