### PR TITLE
Copy paint() example from CSS Painting API page to CSS/image/paint

### DIFF
--- a/files/en-us/web/css/image/paint/index.md
+++ b/files/en-us/web/css/image/paint/index.md
@@ -18,7 +18,7 @@ The **`paint()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_
 ## Syntax
 
 ```css
-paint(workletName, parameters)
+paint(workletName, ...parameters)
 ```
 
 where:
@@ -31,6 +31,35 @@ where:
 ## Examples
 
 ### Basic usage example
+
+In JavaScript, we register the [paint worklet](/en-US/docs/Web/API/PaintWorklet):
+
+```js
+CSS.paintWorklet.addModule('boxbg.js');
+```
+
+...then, in the CSS, we define the `background-image` as a `paint()` type with the worklet name, `boxbg`, along with any variables (ex. `--boxColor` and `--widthSubtractor`) the worklet will use:
+
+```css
+li {
+   background-image: paint(boxbg);
+   --boxColor: hsla(55, 90%, 60%, 1.0);
+}
+li:nth-of-type(3n) {
+   --boxColor: hsla(155, 90%, 60%, 1.0);
+   --widthSubtractor: 20;
+}
+li:nth-of-type(3n+1) {
+   --boxColor: hsla(255, 90%, 60%, 1.0);
+   --widthSubtractor: 40;
+}
+```
+
+The result will be the following:
+
+{{EmbedGHLiveSample("css-examples/houdini/css_painting_api/example-boxbg.html", '100%', 400)}}
+
+### With additional parameters
 
 You can pass additional arguments via the CSS paint() function. In this example, we passed two arguments: whether the background-image on a group of list items is filled or just has a stroke outline, and the width of that outline:
 
@@ -82,7 +111,7 @@ li:nth-of-type(3n+1) {
 
 We've included a custom property in the selector block defining a boxColor. Custom properties are accessible to the PaintWorklet.
 
-{{EmbedLiveSample("Examples", 300, 300)}}
+{{EmbedLiveSample("With additional parameters", 300, 300)}}
 
 ## Specifications
 


### PR DESCRIPTION
This PR updates the documentation for the CSS `paint()` function to include an example from the `CSS Painting API` page.  This provides examples for the type with both a single parameter and multiple parameters.

This was inspired by https://github.com/mdn/browser-compat-data/issues/17138.