### PR TITLE
Update BCD info, part 9

### DIFF
--- a/files/en-us/web/api/elementinternals/index.md
+++ b/files/en-us/web/api/elementinternals/index.md
@@ -9,7 +9,7 @@ tags:
   - ElementInternals
 browser-compat: api.ElementInternals
 ---
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}
 
 The **`ElementInternals`** interface of the [Document Object Model](/en-US/docs/Web/API/Document_Object_Model) gives web developers a way to allow custom elements to fully participate in HTML forms. It provides utilities for working with these elements in the same way you would work with any standard HTML form element, and also exposes the [Accessibility Object Model](https://wicg.github.io/aom/explainer.html) to the element.
 
@@ -23,7 +23,7 @@ This interface has no constructor. An `ElementInternals` object is returned when
   - : Returns the {{domxref("ShadowRoot")}} object associated with this element.
 - {{domxref("ElementInternals.form")}} {{ReadOnlyInline}}
   - : Returns the {{domxref("HTMLFormElement")}} associated with this element.
-- {{domxref("ElementInternals.states")}} {{ReadOnlyInline}}
+- {{domxref("ElementInternals.states")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the {{domxref("CustomStateSet")}} associated with this element.
 - {{domxref("ElementInternals.willValidate")}} {{ReadOnlyInline}}
   - : A boolean value which returns true if the element is a submittable element that is a candidate for
@@ -93,7 +93,7 @@ The `ElementInternals` interface includes the following properties, defined on t
   - : A string reflecting the [`aria-pressed`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed) attribute, which indicates the current "pressed" state of toggle buttons.
 - {{domxref("ElementInternals.ariaReadOnly")}}
   - : A string reflecting the [`aria-readonly`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-readonly) attribute, which indicates that the element is not editable, but is otherwise operable.
-- {{domxref("ElementInternals.ariaRelevant")}}
+- {{domxref("ElementInternals.ariaRelevant")}} {{Non-standard_Inline}}
   - : A string reflecting the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant) attribute, which indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. This is used to describe what changes in an `aria-live` region are relevant and should be announced.
 - {{domxref("ElementInternals.ariaRequired")}}
   - : A string reflecting the [`aria-required`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-required) attribute, which indicates that user input is required on the element before a form may be submitted.

--- a/files/en-us/web/api/fetchevent/isreload/index.md
+++ b/files/en-us/web/api/fetchevent/isreload/index.md
@@ -4,7 +4,6 @@ slug: Web/API/FetchEvent/isReload
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - FetchEvent
   - Property
   - Reference
@@ -13,9 +12,10 @@ tags:
   - Workers
   - isReload
   - Deprecated
+  - Non-standard
 browser-compat: api.FetchEvent.isReload
 ---
-{{APIRef("Service Workers API")}}{{deprecated_header}}
+{{APIRef("Service Workers API")}}{{deprecated_header}}{{Non-standard_header}}
 
 The **`isReload`** read-only property of the
 {{domxref("FetchEvent")}} interface returns `true` if the event was

--- a/files/en-us/web/api/hmdvrdevice/geteyeparameters/index.md
+++ b/files/en-us/web/api/hmdvrdevice/geteyeparameters/index.md
@@ -4,7 +4,6 @@ slug: Web/API/HMDVRDevice/getEyeParameters
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - HMDVRDevice
   - Method
   - Reference
@@ -12,9 +11,10 @@ tags:
   - Virtual Reality
   - WebVR
   - Deprecated
+  - Non-standard
 browser-compat: api.HMDVRDevice.getEyeParameters
 ---
-{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}
+{{deprecated_header}}{{APIRef("WebVR API")}}{{Non-standard_header}}
 
 The **`getEyeParameters()`** method of the {{domxref("HMDVRDevice")}} interface returns current parameters for the eye specified as its argument ("left" or "right") — stored in a {{domxref("VREyeParameters")}} object.
 

--- a/files/en-us/web/api/hmdvrdevice/setfieldofview/index.md
+++ b/files/en-us/web/api/hmdvrdevice/setfieldofview/index.md
@@ -4,7 +4,6 @@ slug: Web/API/HMDVRDevice/setFieldOfView
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - HMDVRDevice
   - Method
   - Reference
@@ -12,9 +11,10 @@ tags:
   - Virtual Reality
   - WebVR
   - Deprecated
+  - Non-standard
 browser-compat: api.HMDVRDevice.setFieldOfView
 ---
-{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}
+{{deprecated_header}}{{APIRef("WebVR API")}}{{Non-standard_header}}
 
 The **`setFieldOfView()`** method of the {{domxref("HMDVRDevice")}} interface can be used to set the field of view for one eye, or both eyes simultaneously.
 

--- a/files/en-us/web/api/htmlmediaelement/seektonextframe/index.md
+++ b/files/en-us/web/api/htmlmediaelement/seektonextframe/index.md
@@ -4,16 +4,15 @@ slug: Web/API/HTMLMediaElement/seekToNextFrame
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - HTMLMediaElement
   - Method
-  - Non-standard
   - Reference
   - Web
   - seekToNextFrame
+  - Deprecated
 browser-compat: api.HTMLMediaElement.seekToNextFrame
 ---
-{{APIRef("HTML DOM")}} {{non-standard_header}} {{SeeCompatTable}}
+{{APIRef("HTML DOM")}}{{Deprecated_Header}}
 
 The **`HTMLMediaElement.seekToNextFrame()`** method
 asynchronously advances the current play position to the next frame in the media.

--- a/files/en-us/web/api/htmlvideoelement/getvideoplaybackquality/index.md
+++ b/files/en-us/web/api/htmlvideoelement/getvideoplaybackquality/index.md
@@ -4,7 +4,6 @@ slug: Web/API/HTMLVideoElement/getVideoPlaybackQuality
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Frames
   - HTML DOM
   - HTMLVideoElement

--- a/files/en-us/web/api/htmlvideoelement/requestpictureinpicture/index.md
+++ b/files/en-us/web/api/htmlvideoelement/requestpictureinpicture/index.md
@@ -4,7 +4,6 @@ slug: Web/API/HTMLVideoElement/requestPictureInPicture
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - HTML DOM
   - HTMLVideoElement
   - Media

--- a/files/en-us/web/api/imagebitmap/close/index.md
+++ b/files/en-us/web/api/imagebitmap/close/index.md
@@ -4,14 +4,13 @@ slug: Web/API/ImageBitmap/close
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - ImageBitmap
   - Method
   - OffscreenCanvas
   - Reference
 browser-compat: api.ImageBitmap.close
 ---
-{{APIRef("Canvas API")}} {{SeeCompatTable}}
+{{APIRef("Canvas API")}}
 
 The **`ImageBitmap.close()`**
 method disposes of all graphical resources associated with an `ImageBitmap`.

--- a/files/en-us/web/api/imagebitmaprenderingcontext/index.md
+++ b/files/en-us/web/api/imagebitmaprenderingcontext/index.md
@@ -5,13 +5,12 @@ page-type: web-api-interface
 tags:
   - API
   - Canvas
-  - Experimental
   - Interface
   - OffscreenCanvas
   - Reference
 browser-compat: api.ImageBitmapRenderingContext
 ---
-{{APIRef("Canvas API")}} {{SeeCompatTable}}
+{{APIRef("Canvas API")}}
 
 The **`ImageBitmapRenderingContext`** interface is a canvas rendering context that provides the functionality to replace the canvas's contents with the given {{domxref("ImageBitmap")}}. Its context id (the first argument to {{domxref("HTMLCanvasElement.getContext()")}} or {{domxref("OffscreenCanvas.getContext()")}}) is `"bitmaprenderer"`.
 

--- a/files/en-us/web/api/imagebitmaprenderingcontext/transferfromimagebitmap/index.md
+++ b/files/en-us/web/api/imagebitmaprenderingcontext/transferfromimagebitmap/index.md
@@ -4,7 +4,6 @@ slug: Web/API/ImageBitmapRenderingContext/transferFromImageBitmap
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - ImageBitmapRenderingContext
   - Method
   - OffscreenCanvas
@@ -12,7 +11,7 @@ tags:
   - transferFromImageBitmap
 browser-compat: api.ImageBitmapRenderingContext.transferFromImageBitmap
 ---
-{{APIRef("Canvas API")}} {{SeeCompatTable}}
+{{APIRef("Canvas API")}}
 
 The **`ImageBitmapRenderingContext.transferFromImageBitmap()`**
 method displays the given {{domxref("ImageBitmap")}} in the canvas associated with this

--- a/files/en-us/web/api/inputdevicecapabilities/index.md
+++ b/files/en-us/web/api/inputdevicecapabilities/index.md
@@ -7,9 +7,10 @@ tags:
   - InputDeviceCapabilities
   - Interface
   - Reference
+  - Experimental
 browser-compat: api.InputDeviceCapabilities
 ---
-{{APIRef("InputDeviceCapabilities API")}}
+{{APIRef("InputDeviceCapabilities API")}}{{SeeCompatTable}}
 
 The **`InputDeviceCapabilities`** interface of the [Input Device Capabilities API](/en-US/docs/Web/API/InputDeviceCapabilities_API) provides information about the physical device or a group of related devices responsible for generating input events. Events caused by the same physical input device get the same instance of this object, but the converse isn't true. For example, two mice with the same capabilities in a system may appear as a single `InputDeviceCapabilities` instance.
 

--- a/files/en-us/web/api/inputdevicecapabilities/index.md
+++ b/files/en-us/web/api/inputdevicecapabilities/index.md
@@ -4,13 +4,12 @@ slug: Web/API/InputDeviceCapabilities
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - InputDeviceCapabilities
   - Interface
   - Reference
 browser-compat: api.InputDeviceCapabilities
 ---
-{{APIRef("InputDeviceCapabilities API")}}{{SeeCompatTable}}
+{{APIRef("InputDeviceCapabilities API")}}
 
 The **`InputDeviceCapabilities`** interface of the [Input Device Capabilities API](/en-US/docs/Web/API/InputDeviceCapabilities_API) provides information about the physical device or a group of related devices responsible for generating input events. Events caused by the same physical input device get the same instance of this object, but the converse isn't true. For example, two mice with the same capabilities in a system may appear as a single `InputDeviceCapabilities` instance.
 

--- a/files/en-us/web/api/inputdevicecapabilities_api/index.md
+++ b/files/en-us/web/api/inputdevicecapabilities_api/index.md
@@ -9,7 +9,7 @@ tags:
   - Reference
 browser-compat: api.InputDeviceCapabilities
 ---
-{{DefaultAPISidebar("InputDeviceCapabilities API")}}{{SeeCompatTable}}
+{{DefaultAPISidebar("InputDeviceCapabilities API")}}
 
 The InputDeviceCapabilities API provides details about the underlying sources of input events. The API attempts to describe how the device behaves rather than what it is. For example, the first version of the API indicates whether a device fires touch events rather than whether it is a touch screen.
 

--- a/files/en-us/web/api/inputdevicecapabilities_api/index.md
+++ b/files/en-us/web/api/inputdevicecapabilities_api/index.md
@@ -7,9 +7,10 @@ tags:
   - InputDeviceCapabilities
   - Overview
   - Reference
+  - Experimental
 browser-compat: api.InputDeviceCapabilities
 ---
-{{DefaultAPISidebar("InputDeviceCapabilities API")}}
+{{DefaultAPISidebar("InputDeviceCapabilities API")}}{{SeeCompatTable}}
 
 The InputDeviceCapabilities API provides details about the underlying sources of input events. The API attempts to describe how the device behaves rather than what it is. For example, the first version of the API indicates whether a device fires touch events rather than whether it is a touch screen.
 

--- a/files/en-us/web/api/installevent/installevent/index.md
+++ b/files/en-us/web/api/installevent/installevent/index.md
@@ -15,8 +15,6 @@ browser-compat: api.InstallEvent.InstallEvent
 ---
 {{APIRef("Service Workers API")}}{{Deprecated_Header}}{{Non-standard_header}}
 
-{{non-standard_header}}{{deprecated_header}}{{SeeCompatTable}}
-
 The **`InstallEvent()`** constructor creates a new {{domxref("InstallEvent")}} object.
 
 ## Syntax

--- a/files/en-us/web/api/installevent/installevent/index.md
+++ b/files/en-us/web/api/installevent/installevent/index.md
@@ -5,15 +5,15 @@ page-type: web-api-constructor
 tags:
   - API
   - Constructor
-  - Experimental
   - InstallEvent
   - Reference
   - Service Workers
   - ServiceWorker
+  - Deprecated
+  - Non-standard
 browser-compat: api.InstallEvent.InstallEvent
 ---
-
-{{APIRef("Service Workers API")}}
+{{APIRef("Service Workers API")}}{{Deprecated_Header}}{{Non-standard_header}}
 
 {{non-standard_header}}{{deprecated_header}}{{SeeCompatTable}}
 

--- a/files/en-us/web/api/intersectionobserver/rootmargin/index.md
+++ b/files/en-us/web/api/intersectionobserver/rootmargin/index.md
@@ -12,7 +12,7 @@ tags:
   - rootMargin
 browser-compat: api.IntersectionObserver.rootMargin
 ---
-{{APIRef("Intersection Observer API")}}{{SeeCompatTable}}
+{{APIRef("Intersection Observer API")}}
 
 The {{domxref("IntersectionObserver")}} interface's read-only
 **`rootMargin`** property is a string with syntax similar to

--- a/files/en-us/web/api/issecurecontext/index.md
+++ b/files/en-us/web/api/issecurecontext/index.md
@@ -12,7 +12,7 @@ tags:
   - isSecureContext
 browser-compat: api.isSecureContext
 ---
-{{APIRef}}{{SeeCompatTable}}
+{{APIRef}}
 
 The global **`isSecureContext`** read-only property returns a boolean indicating whether
 the current [context is secure](/en-US/docs/Web/Security/Secure_Contexts)

--- a/files/en-us/web/api/lock/index.md
+++ b/files/en-us/web/api/lock/index.md
@@ -4,14 +4,13 @@ slug: Web/API/Lock
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - Interface
   - Reference
   - Web Locks API
   - lock
 browser-compat: api.Lock
 ---
-{{SeeCompatTable}}{{APIRef("Web Locks")}}
+{{APIRef("Web Locks")}}
 
 The **`Lock`** interface of the [Web Locks API](/en-US/docs/Web/API/Web_Locks_API) provides the name and mode of a lock.
 This may be a newly requested lock that is received in the callback to {{domxref('LockManager.request','LockManager.request()')}}, or a record of an active or queued lock returned by {{domxref('LockManager.query()')}}.

--- a/files/en-us/web/api/lock/mode/index.md
+++ b/files/en-us/web/api/lock/mode/index.md
@@ -4,7 +4,6 @@ slug: Web/API/Lock/mode
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - Web Locks API
@@ -12,7 +11,7 @@ tags:
   - mode
 browser-compat: api.Lock.mode
 ---
-{{SeeCompatTable}}{{APIRef("Web Locks")}}
+{{APIRef("Web Locks")}}
 
 The **`mode`** read-only property of the {{domxref("Lock")}} interface returns the access mode passed to {{domxref('LockManager.request()')}} when the lock was requested.
 The mode is either `"exclusive"` (the default) or `"shared"`.

--- a/files/en-us/web/api/lock/name/index.md
+++ b/files/en-us/web/api/lock/name/index.md
@@ -4,7 +4,6 @@ slug: Web/API/Lock/name
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - Web Locks API
@@ -13,7 +12,7 @@ tags:
   - name
 browser-compat: api.Lock.name
 ---
-{{SeeCompatTable}}{{APIRef("Web Locks")}}
+{{APIRef("Web Locks")}}
 
 The **`name`** read-only property of
 the {{domxref("Lock")}} interface returns the _name_ passed to

--- a/files/en-us/web/api/lockmanager/index.md
+++ b/files/en-us/web/api/lockmanager/index.md
@@ -4,7 +4,6 @@ slug: Web/API/LockManager
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - Interface
   - LockManager
   - Reference
@@ -12,7 +11,7 @@ tags:
   - lock
 browser-compat: api.LockManager
 ---
-{{SeeCompatTable}}{{APIRef("Web Locks")}}
+{{APIRef("Web Locks")}}
 
 The **`LockManager`** interface of the [Web Locks API](/en-US/docs/Web/API/Web_Locks_API) provides methods for requesting a new {{domxref('Lock')}} object and querying for an existing `Lock` object. To get an instance of `LockManager`, call {{domxref('navigator.locks')}}.
 

--- a/files/en-us/web/api/lockmanager/query/index.md
+++ b/files/en-us/web/api/lockmanager/query/index.md
@@ -4,7 +4,6 @@ slug: Web/API/LockManager/query
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - LockManager
   - Method
   - Reference
@@ -12,7 +11,7 @@ tags:
   - query()
 browser-compat: api.LockManager.query
 ---
-{{APIRef("Web Locks")}}{{SeeCompatTable}}
+{{APIRef("Web Locks")}}
 
 The **`query()`** method of the {{domxref("LockManager")}} interface returns a {{jsxref('Promise')}} that resolves with an object containing information about held and pending locks.
 

--- a/files/en-us/web/api/lockmanager/request/index.md
+++ b/files/en-us/web/api/lockmanager/request/index.md
@@ -4,7 +4,6 @@ slug: Web/API/LockManager/request
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - LockManager
   - Method
   - Reference
@@ -12,7 +11,7 @@ tags:
   - request()
 browser-compat: api.LockManager.request
 ---
-{{APIRef("Web Locks")}}{{SeeCompatTable}}
+{{APIRef("Web Locks")}}
 
 The **`request()`** method of the {{domxref("LockManager")}} interface requests a {{domxref('Lock')}} object with parameters specifying its name and characteristics.
 The requested `Lock` is passed to a callback, while the function itself returns a {{jsxref('Promise')}} that resolves with {{jsxref('undefined')}}.

--- a/files/en-us/web/api/media_capabilities_api/index.md
+++ b/files/en-us/web/api/media_capabilities_api/index.md
@@ -4,7 +4,6 @@ slug: Web/API/Media_Capabilities_API
 page-type: web-api-overview
 tags:
   - API
-  - Experimental
   - Media Capabilities
   - Overview
   - Reference

--- a/files/en-us/web/api/mediacapabilities/decodinginfo/index.md
+++ b/files/en-us/web/api/mediacapabilities/decodinginfo/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Audio
-  - Experimental
   - Media Capabilities API
   - MediaCapabilities
   - Method

--- a/files/en-us/web/api/mediacapabilities/encodinginfo/index.md
+++ b/files/en-us/web/api/mediacapabilities/encodinginfo/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Audio
-  - Experimental
   - Media Capabilities API
   - MediaCapabilities
   - Method

--- a/files/en-us/web/api/mediacapabilities/index.md
+++ b/files/en-us/web/api/mediacapabilities/index.md
@@ -5,7 +5,6 @@ page-type: web-api-interface
 tags:
   - API
   - Audio
-  - Experimental
   - Interface
   - Media
   - MediaCapabilities

--- a/files/en-us/web/api/mediadeviceinfo/deviceid/index.md
+++ b/files/en-us/web/api/mediadeviceinfo/deviceid/index.md
@@ -4,14 +4,13 @@ slug: Web/API/MediaDeviceInfo/deviceId
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Media
   - MediaDevicesInfo
   - Property
   - deviceId
 browser-compat: api.MediaDeviceInfo.deviceId
 ---
-{{SeeCompatTable}}{{APIRef("Media Capture")}}
+{{APIRef("Media Capture")}}
 
 The **`deviceId`** readonly property
 of the {{domxref("MediaDeviceInfo")}} interface returns a string

--- a/files/en-us/web/api/mediadeviceinfo/kind/index.md
+++ b/files/en-us/web/api/mediadeviceinfo/kind/index.md
@@ -4,14 +4,13 @@ slug: Web/API/MediaDeviceInfo/kind
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Media
   - MediaDevicesInfo
   - Property
   - kind
 browser-compat: api.MediaDeviceInfo.kind
 ---
-{{SeeCompatTable}}{{APIRef("Media Capture")}}
+{{APIRef("Media Capture")}}
 
 The **`kind`** readonly property of
 the {{domxref("MediaDeviceInfo")}} interface returns an enumerated value, that is

--- a/files/en-us/web/api/mediakeymessageevent/mediakeymessageevent/index.md
+++ b/files/en-us/web/api/mediakeymessageevent/mediakeymessageevent/index.md
@@ -7,11 +7,10 @@ tags:
   - Constructor
   - EncryptedMediaExtensions
   - MediaKeyMessageEvent
-  - Experimental
   - Reference
 browser-compat: api.MediaKeyMessageEvent.MediaKeyMessageEvent
 ---
-{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}
+{{APIRef("EncryptedMediaExtensions")}}
 
 The **`MediaKeyMessageEvent`** constructor creates a new {{domxref("MediaKeyMessageEvent")}} object.
 

--- a/files/en-us/web/api/mediakeymessageevent/message/index.md
+++ b/files/en-us/web/api/mediakeymessageevent/message/index.md
@@ -5,14 +5,13 @@ page-type: web-api-instance-property
 tags:
   - API
   - EncryptedMediaExtensions
-  - Experimental
   - MediaKeyMessageEvent
   - Property
   - Reference
   - message
 browser-compat: api.MediaKeyMessageEvent.message
 ---
-{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}
+{{APIRef("EncryptedMediaExtensions")}}
 
 The **`MediaKeyMessageEvent.message`** read-only property
 returns an {{jsxref("ArrayBuffer")}} with a message from the content decryption module.

--- a/files/en-us/web/api/mediakeymessageevent/messagetype/index.md
+++ b/files/en-us/web/api/mediakeymessageevent/messagetype/index.md
@@ -5,14 +5,13 @@ page-type: web-api-instance-property
 tags:
   - API
   - EncryptedMediaExtensions
-  - Experimental
   - MediaKeyMessageEvent
   - Property
   - Reference
   - messageType
 browser-compat: api.MediaKeyMessageEvent.messageType
 ---
-{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}
+{{APIRef("EncryptedMediaExtensions")}}
 
 The **`MediaKeyMessageEvent.messageType`** read-only property indicates the
 type of message. It may be one of `license-request`,


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.
It focuses on files that have only left behind 'experimental' tags and headers.