### PR TITLE
remove `{{Link}}` macro

### DIFF
--- a/files/en-us/glossary/javascript/index.md
+++ b/files/en-us/glossary/javascript/index.md
@@ -26,9 +26,9 @@ Recently, JavaScript's popularity has expanded even further through the successf
 ## See also
 
 - [JavaScript](https://en.wikipedia.org/wiki/JavaScript) on Wikipedia
-- The {{Link("/en-US/docs/Web/JavaScript/Guide")}} on MDN
+- The [JavaScript Guide](/en-US/docs/Web/JavaScript/Guide) on MDN
 - [The "javascripting" workshop on NodeSchool](https://nodeschool.io/#workshoppers)
 - [The JavaScript course on codecademy.com](https://www.codecademy.com/catalog/language/javascript)
 - [The latest ECMAScript standard](https://www.ecma-international.org/publications-and-standards/standards/ecma-262/)
-- The {{Link("/en-US/docs/Web/JavaScript/reference")}} on MDN
+- The [JavaScript reference](/en-US/docs/Web/JavaScript/reference) on MDN
 - [The _Eloquent JavaScript_ book](https://eloquentjavascript.net/)

--- a/files/en-us/glossary/json/index.md
+++ b/files/en-us/glossary/json/index.md
@@ -15,4 +15,4 @@ JSON can represent numbers, booleans, strings, `null`, arrays (ordered sequences
 ## See also
 
 - [JSON](https://en.wikipedia.org/wiki/JSON) on Wikipedia
-- {{Link("/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON")}} on MDN
+- [JSON](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON) on MDN


### PR DESCRIPTION
#### Summary

There are only 3 usages of `{{Link}}` macro in en-US. There is a [discuession](https://github.com/orgs/mdn/discussions/187) about to  remove it.

#### Metadata

- [x] Fixes a typo, bug, or other error
