### PR TITLE
Fix tags for CSS Syntax

### DIFF
--- a/files/en-us/web/css/align-tracks/index.md
+++ b/files/en-us/web/css/align-tracks/index.md
@@ -3,6 +3,7 @@ title: align-tracks
 slug: Web/CSS/align-tracks
 tags:
   - CSS
+  - CSS Property
   - Experimental
   - Property
   - Reference

--- a/files/en-us/web/css/image/image/index.md
+++ b/files/en-us/web/css/image/image/index.md
@@ -18,7 +18,7 @@ The **`image()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_
 
 ## Syntax
 
-{{CSSSyntax("image()")}}
+{{CSSSyntax}}
 
 where:
 

--- a/files/en-us/web/css/justify-tracks/index.md
+++ b/files/en-us/web/css/justify-tracks/index.md
@@ -4,7 +4,7 @@ slug: Web/CSS/justify-tracks
 tags:
   - CSS
   - Experimental
-  - Property
+  - CSS Property
   - Reference
   - grid
   - justify-tracks

--- a/files/en-us/web/css/masonry-auto-flow/index.md
+++ b/files/en-us/web/css/masonry-auto-flow/index.md
@@ -4,7 +4,7 @@ slug: Web/CSS/masonry-auto-flow
 tags:
   - CSS
   - Experimental
-  - Property
+  - CSS Property
   - Reference
   - grid
   - masonry

--- a/files/en-us/web/css/padding-block/index.md
+++ b/files/en-us/web/css/padding-block/index.md
@@ -3,6 +3,7 @@ title: padding-block
 slug: Web/CSS/padding-block
 tags:
   - CSS
+  - CSS Property
   - padding-block
   - recipe:css-shorthand-property
 browser-compat: css.properties.padding-block

--- a/files/en-us/web/css/padding-inline/index.md
+++ b/files/en-us/web/css/padding-inline/index.md
@@ -3,6 +3,7 @@ title: padding-inline
 slug: Web/CSS/padding-inline
 tags:
   - CSS
+  - CSS Property
   - recipe:css-shorthand-property
 browser-compat: css.properties.padding-inline
 ---

--- a/files/en-us/web/css/paint-order/index.md
+++ b/files/en-us/web/css/paint-order/index.md
@@ -3,6 +3,7 @@ title: paint-order
 slug: Web/CSS/paint-order
 tags:
   - CSS
+  - CSS Property
   - Reference
   - SVG
   - Web

--- a/files/en-us/web/css/scrollbar-gutter/index.md
+++ b/files/en-us/web/css/scrollbar-gutter/index.md
@@ -3,7 +3,7 @@ title: scrollbar-gutter
 slug: Web/CSS/scrollbar-gutter
 tags:
   - CSS
-  - Property
+  - CSS Property
   - Reference
   - scrollbar-gutter
 browser-compat: css.properties.scrollbar-gutter

--- a/files/en-us/web/css/text-decoration-thickness/index.md
+++ b/files/en-us/web/css/text-decoration-thickness/index.md
@@ -4,7 +4,7 @@ slug: Web/CSS/text-decoration-thickness
 tags:
   - CSS
   - CSS Text Decoration
-  - Property
+  - CSS Property
   - Reference
   - recipe:css-property
   - text-decoration

--- a/files/en-us/web/css/text-underline-offset/index.md
+++ b/files/en-us/web/css/text-underline-offset/index.md
@@ -4,7 +4,7 @@ slug: Web/CSS/text-underline-offset
 tags:
   - CSS
   - CSS Text Decoration
-  - Property
+  - CSS Property
   - Reference
   - recipe:css-property
   - text-decoration


### PR DESCRIPTION
This PR updates tags and in one case fixes a macro call so CSS formal syntax is displayed properly on these pages, per https://github.com/mdn/content/issues/18780#issuecomment-1213256936.