### PR TITLE
Rename CSS sign() function page

### DIFF
--- a/files/en-us/_redirects.txt
+++ b/files/en-us/_redirects.txt
@@ -11352,7 +11352,8 @@
 /en-US/docs/Web/CSS/scrollbar-track-color	/en-US/docs/Web/CSS/scrollbar-color
 /en-US/docs/Web/CSS/shape-box	/en-US/docs/Web/CSS/shape-outside
 /en-US/docs/Web/CSS/shape-rendering	/en-US/docs/Web/SVG/Attribute/shape-rendering
-/en-US/docs/Web/CSS/sign()	/en-US/docs/Web/CSS/sign_function
+/en-US/docs/Web/CSS/sign()	/en-US/docs/Web/CSS/sign
+/en-US/docs/Web/CSS/sign_function	/en-US/docs/Web/CSS/sign
 /en-US/docs/Web/CSS/single-transition-timing-function	/en-US/docs/Web/CSS/easing-function
 /en-US/docs/Web/CSS/speak-as	/en-US/docs/Web/CSS/@counter-style/speak-as
 /en-US/docs/Web/CSS/static	/en-US/docs/Web/CSS/position

--- a/files/en-us/web/css/sign/index.md
+++ b/files/en-us/web/css/sign/index.md
@@ -1,6 +1,6 @@
 ---
 title: sign()
-slug: Web/CSS/sign_function
+slug: Web/CSS/sign
 tags:
   - CSS
   - CSS Function


### PR DESCRIPTION
This page moves the page for the CSS `sign()` function from https://developer.mozilla.org/en-US/docs/Web/CSS/sign_function to https://developer.mozilla.org/en-US/docs/Web/CSS/sign .

The `_function` suffix breaks the bit of csssyntax that does some [desperate munging of slugs](https://github.com/mdn/yari/blob/60747895d4058455707fd5d269f3c57a6bb76bfd/kumascript/macros/CSSSyntax.ejs#L75-L105) to try to find a valid webref identifier, which doesn't expect this kind of form for page slugs.

Instead of moving the page we might choose to adapt csssyntax instead, or change the macro call to take an explicit argument (and as  discussed in https://github.com/orgs/mdn/discussions/179 this would probably be better anyway in the long run) except that:

- we don't use suffixes for slugs unless there is an actual name clash (for example, we don't have `var_function` or `linear-gradient_function`)
- we don't use a `_function` suffix anywhere AFAIK, we only use `_value`

So this slug seems to be inconsistent with our practice everywhere else.