### PR TITLE
Edits: remove 5 from HTML

### DIFF
--- a/files/en-us/learn/accessibility/wai-aria_basics/index.md
+++ b/files/en-us/learn/accessibility/wai-aria_basics/index.md
@@ -194,7 +194,7 @@ Now if we use VoiceOver to look at this example, we get some improvements:
 
 Beyond this, the site is more likely to be accessible to users of older browsers such as IE8; it is worth including ARIA roles for that purpose. And if for some reason your site is built using just `<div>`s, you should definitely include the ARIA roles to provide these much needed semantics!
 
-The improved semantics of the search form have shown what is made possible when ARIA goes beyond the semantics available in HTML5. You'll see a lot more about these semantics and the power of ARIA properties/attributes below, especially in the [Accessibility of non-semantic controls](#accessibility_of_non-semantic_controls) section. For now though, let's look at how ARIA can help with dynamic content updates.
+The improved semantics of the search form have shown what is made possible when ARIA goes beyond the semantics available in HTML. You'll see a lot more about these semantics and the power of ARIA properties/attributes below, especially in the [Accessibility of non-semantic controls](#accessibility_of_non-semantic_controls) section. For now though, let's look at how ARIA can help with dynamic content updates.
 
 ### Dynamic content updates
 

--- a/files/en-us/learn/forms/basic_native_form_controls/index.md
+++ b/files/en-us/learn/forms/basic_native_form_controls/index.md
@@ -104,7 +104,7 @@ Another original text control is the `hidden` input type. This is used to create
 
 If you create such an element, it's required to set its `name` and `value` attributes. The value can be dynamically set via JavaScript. The `hidden` input type should not have an associated label.
 
-Other text input types, like {{HTMLElement("input/search", "search")}}, {{HTMLElement("input/url", "url")}}, and {{HTMLElement("input/tel", "tel")}}, were added with HTML5. Those will be covered in the next tutorial, [HTML5 input types](/en-US/docs/Learn/Forms/HTML5_input_types).
+Other text input types, like {{HTMLElement("input/search", "search")}}, {{HTMLElement("input/url", "url")}}, and {{HTMLElement("input/tel", "tel")}}, will be covered in the next tutorial, [HTML5 input types](/en-US/docs/Learn/Forms/HTML5_input_types).
 
 ## Checkable items: checkboxes and radio buttons
 
@@ -369,7 +369,7 @@ You've reached the end of this article, but can you remember the most important 
 
 ## Summary
 
-This article has covered the older input types — the original set introduced in the early days of HTML that is well supported in all browsers. In the next section, we'll take a look at the newer values of the `type` attribute that were added in HTML5.
+This article has covered the older input types — the original set introduced in the early days of HTML that is well supported in all browsers. In the next section, we'll take a look at the more modern values of the `type` attribute.
 
 {{PreviousMenuNext("Learn/Forms/How_to_structure_a_web_form", "Learn/Forms/HTML5_input_types", "Learn/Forms")}}
 

--- a/files/en-us/mozilla/firefox/releases/4/index.md
+++ b/files/en-us/mozilla/firefox/releases/4/index.md
@@ -25,7 +25,7 @@ Gecko now uses the [HTML5](/en-US/docs/Glossary/HTML5) parser, which fixes bugs,
 - [Meet the HTML5 parser](/en-US/docs/Learn/HTML)
   - : A look at what the HTML5 parser means to you, and how to embed SVG and MathML into your content inline.
 - [Forms in HTML5](/en-US/docs/Learn/Forms)
-  - : A look at improvements to web forms in HTML5. Among these changes are added input types in the {{HTMLElement("input")}} element, data validation, and more.
+  - : A look at improvements to web forms. Among these changes are added input types in the {{HTMLElement("input")}} element, data validation, and more.
 - [HTML5 Sections](/en-US/docs/Web/HTML/Element/Heading_Elements)
   - : Gecko now supports the new HTML5 elements related to sections in a document: {{HTMLElement("article")}}, {{HTMLElement("section")}}, {{HTMLElement("nav")}}, {{HTMLElement("aside")}}, {{HTMLElement("hgroup")}}, {{HTMLElement("header")}} and {{HTMLElement("footer")}}.
 - [HTML5 hidden attribute](/en-US/docs/Web/HTML/Global_attributes#hidden)

--- a/files/en-us/mozilla/firefox/releases/9/index.md
+++ b/files/en-us/mozilla/firefox/releases/9/index.md
@@ -14,7 +14,7 @@ Firefox 9 was released for Windows on December 20, 2011. Mac and Linux version 9
 
 ### HTML
 
-- The `value` attribute of {{ HTMLElement("li") }} now can be negative as specified in HTML5. Previously negative values were converted to 0.
+- The `value` attribute of {{ HTMLElement("li") }} now can be negative. Previously negative values were converted to 0.
 - You can now [specify the start and stop time of media](/en-US/docs/Learn/HTML/Multimedia_and_embedding/Video_and_audio_content#specifying_playback_range) in the URI of the media when using {{ HTMLElement("audio") }} and {{ HTMLElement("video") }} elements.
 - {{ HTMLElement("input") }} and {{ HTMLElement("textarea") }} elements [now respect the value of the `lang` attribute](/en-US/docs/Web/HTML/Global_attributes/spellcheck#controlling_the_spellchecker_language) when invoking the spell checker.
 - Firefox on Android now lets users snap photos with their phone's camera without leaving the browser when the {{ HTMLElement("input") }} element is used with `type="file"` and `accept="image/*"`.

--- a/files/en-us/web/accessibility/understanding_wcag/text_labels_and_names/index.md
+++ b/files/en-us/web/accessibility/understanding_wcag/text_labels_and_names/index.md
@@ -181,7 +181,7 @@ In addition to having a {{htmlelement("label")}} for every form element, those l
 
 Frame elements, both {{htmlelement("iframe")}} and the older, obsolete {{htmlelement("frame")}}, must have a title to describe the contents of the frame. Use the `title` attribute to label a frame element. Without a title, users of assistive technologies have to navigate into the frame in order to understand what it contains, which can be difficult and confusing.
 
-The {{HTMLElement('frame')}} element is no longer part of the HTML specification as of HTML5. Support for it may be dropped by browsers in the future. In addition, it is difficult for screen readers to navigate pages with {{HTMLElement('frame')}} elements. For best accessibility and future maintenance, redesign any pages that use frames to use CSS to achieve a similar layout.
+The {{HTMLElement('frame')}} element is no longer part of the HTML specification. Support for it may be dropped by browsers in the future. In addition, it is difficult for screen readers to navigate pages with {{HTMLElement('frame')}} elements. For best accessibility and future maintenance, redesign any pages that use frames to use CSS to achieve a similar layout.
 
 As a best practice, also provide a {{htmlelement("title")}} for the document that is enclosed in the frame, with content identical to the frame's `title` attribute. (This assumes that the enclosed document is under your control; if not, try to match the frame's `title` attribute to the document's title.) Some screen readers replace the contents of the `title` attribute with the contents of the enclosed document's {{htmlelement("title")}}. It's safest and most accessible to provide the same title in both places.
 

--- a/files/en-us/web/api/htmlformelement/enctype/index.md
+++ b/files/en-us/web/api/htmlformelement/enctype/index.md
@@ -19,7 +19,7 @@ to submit the form to the server. Possible values are:
 - `application/x-www-form-urlencoded`: The initial default type.
 - `multipart/form-data`: The type that allows file {{HTMLElement("input")}}
   element(s) to upload file data.
-- `text/plain`: A type introduced in HTML5.
+- `text/plain`: Ambiguous format, human readable content not reliably interpretable by computer.
 
 This value can be overridden by a {{htmlattrxref("formenctype", "button")}} attribute
 on a {{HTMLElement("button")}} or {{HTMLElement("input")}} element.

--- a/files/en-us/web/api/window/showmodaldialog/index.md
+++ b/files/en-us/web/api/window/showmodaldialog/index.md
@@ -100,11 +100,6 @@ showModalDialog(uri, arguments, options)
 
  Holds the `returnValue` property as set by the document specified by `uri`.
 
-## Notes
-
-`showModalDialog()` was briefly standardized as part of HTML5. The third
-argument for additional options was not present in the HTML5 version.
-
 ## Specifications
 
 - [MSDN page for `showModalDialog`](<https://msdn.microsoft.com/library/ms536759(VS.85).aspx>)

--- a/files/en-us/web/guide/writing_forward-compatible_websites/index.md
+++ b/files/en-us/web/guide/writing_forward-compatible_websites/index.md
@@ -25,7 +25,7 @@ When an event handler content attribute (`onclick`, `onmouseover`, and so forth)
 
 then clicking on the text alerts the `ownerDocument` of the `div`. This happens even if there is an `ownerDocument` variable declared in the global scope.
 
-What this means is that any time you access a global variable in an event handler content attribute, including calling any function declared globally, you can end up with a name collision if a specification adds a new DOM property to elements or documents which has the same name as your function or variable, and a browser implements it. If that happens, then suddenly your function stops being called. This has happened multiple times to various sites already during the evolution of HTML5.
+What this means is that any time you access a global variable in an event handler content attribute, including calling any function declared globally, you can end up with a name collision if a specification adds a new DOM property to elements or documents which has the same name as your function or variable, and a browser implements it. If that happens, then suddenly your function stops being called. This has happened multiple times to various sites already during the evolution of HTML.
 
 To avoid this, fully qualify global variable access using "window.", like so:
 

--- a/files/en-us/web/html/block-level_elements/index.md
+++ b/files/en-us/web/html/block-level_elements/index.md
@@ -49,7 +49,7 @@ There are a couple of key differences between block-level elements and inline el
 - Default formatting
   - : By default, block-level elements begin on new lines, but inline elements can start anywhere in a line.
 
-The distinction of block-level vs. inline elements was used in HTML specifications up to 4.01. In HTML5, this binary distinction is replaced with a more complex set of [content categories](/en-US/docs/Web/Guide/HTML/Content_categories). While the "inline" category roughly corresponds to the category of [phrasing content](/en-US/docs/Web/Guide/HTML/Content_categories#phrasing_content), the "block-level" category doesn't directly correspond to any HTML content category, but _"block-level" and "inline" elements combined together_ correspond to the [flow content](/en-US/docs/Web/Guide/HTML/Content_categories#flow_content) in HTML5. There are also additional categories, e.g. [interactive content](/en-US/docs/Web/Guide/HTML/Content_categories#interactive_content).
+The distinction of block-level vs. inline elements was used in HTML specifications up to 4.01. In HTML5, this binary distinction is replaced with a more complex set of [content categories](/en-US/docs/Web/Guide/HTML/Content_categories). While the "inline" category roughly corresponds to the category of [phrasing content](/en-US/docs/Web/Guide/HTML/Content_categories#phrasing_content), the "block-level" category doesn't directly correspond to any HTML content category, but _"block-level" and "inline" elements combined together_ correspond to the [flow content](/en-US/docs/Web/Guide/HTML/Content_categories#flow_content) in HTML. There are also additional categories, e.g. [interactive content](/en-US/docs/Web/Guide/HTML/Content_categories#interactive_content).
 
 ## Elements
 

--- a/files/en-us/web/html/element/small/index.md
+++ b/files/en-us/web/html/element/small/index.md
@@ -102,7 +102,7 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Global_a
 
 ## Notes
 
-Although the `<small>` element, like the {{htmlelement("b")}} and {{htmlelement("i")}} elements, may be perceived to violate the principle of separation between structure and presentation, all three are valid in HTML5. Authors are encouraged to use their best judgement when determining whether to use `<small>` or CSS.
+Although the `<small>` element, like the {{htmlelement("b")}} and {{htmlelement("i")}} elements, may be perceived to violate the principle of separation between structure and presentation, all three are valid in HTML. Authors are encouraged to use their best judgement when determining whether to use `<small>` or CSS.
 
 ## Specifications
 

--- a/files/en-us/web/html/element/strike/index.md
+++ b/files/en-us/web/html/element/strike/index.md
@@ -14,7 +14,7 @@ browser-compat: html.elements.strike
 
 The **`<strike>`** [HTML](/en-US/docs/Web/HTML) element places a strikethrough (horizontal line) over text.
 
-> **Warning:** This element is deprecated in HTML 4 and XHTML 1, and obsoleted in HTML5. If semantically appropriate, i.e., if it represents _deleted_ content, use {{HTMLElement("del")}} instead. In all other cases use {{HTMLElement("s")}}.
+> **Warning:** This element is deprecated in HTML 4 and XHTML 1, and obsoleted in the [HTML Living Standard](https://html.spec.whatwg.org/#strike). If semantically appropriate, i.e., if it represents _deleted_ content, use {{HTMLElement("del")}} instead. In all other cases use {{HTMLElement("s")}}.
 
 <table class="properties">
   <tbody>

--- a/files/en-us/web/html/element/tfoot/index.md
+++ b/files/en-us/web/html/element/tfoot/index.md
@@ -46,11 +46,9 @@ The **`<tfoot>`** [HTML](/en-US/docs/Web/HTML) element defines a set of rows sum
         {{HTMLElement("caption")}},
         {{HTMLElement("colgroup")}}, {{HTMLElement("thead")}},
         {{HTMLElement("tbody")}}, or {{HTMLElement("tr")}}
-        element. Note that this is the requirement as of HTML5.<br />In HTML4,
-        the {{HTMLElement("tfoot")}} element cannot be placed after any
-        {{HTMLElement("tbody")}} and {{HTMLElement("tr")}}
-        element. Note that this directly contradicts the above normative
-        requirement from HTML5.
+        element. Note that this is the requirement in HTML.<br />Originally, in HTML4, the opposite was true: the {{HTMLElement("tfoot")}} element could not be placed after any
+        {{HTMLElement("tbody")}} or {{HTMLElement("tr")}}
+        element.
       </td>
     </tr>
     <tr>

--- a/files/en-us/web/html/element/wbr/index.md
+++ b/files/en-us/web/html/element/wbr/index.md
@@ -82,8 +82,6 @@ On UTF-8 encoded pages, `<wbr>` behaves like the `U+200B ZERO-WIDTH SPACE` code 
 
 For the same reason, the `<wbr>` element does not introduce a hyphen at the line break point. To make a hyphen appear only at the end of a line, use the soft hyphen character entity (`&shy;`) instead.
 
-This element was first implemented in Internet Explorer 5.5 and was officially defined in HTML5.
-
 ## Example
 
 _[The Yahoo Style Guide](https://web.archive.org/web/20121014054923/http://styleguide.yahoo.com/)_ recommends [breaking a URL _before_ punctuation](https://web.archive.org/web/20121105171040/http://styleguide.yahoo.com/editing/treat-abbreviations-capitalization-and-titles-consistently/website-names-and-addresses), to avoid leaving a punctuation mark at the end of the line, which the reader might mistake for the end of the URL.

--- a/files/en-us/web/html/element/xmp/index.md
+++ b/files/en-us/web/html/element/xmp/index.md
@@ -18,7 +18,7 @@ The **`<xmp>`** [HTML](/en-US/docs/Web/HTML) element renders text between the st
 
 > **Note:** Do not use this element.
 >
-> - It has been deprecated since HTML3.2 and was not implemented in a consistent way. It was completely removed from the language in HTML5.
+> - It has been deprecated since HTML3.2 and was not implemented in a consistent way. It was completely removed from current HTML.
 > - Use the {{HTMLElement("pre")}} element or, if semantically adequate, the {{HTMLElement("code")}} element instead. Note that you will need to escape the '`<`' character as '`&lt;`' to make sure it is not interpreted as markup.
 > - A monospaced font can also be obtained on any element, by applying an adequate [CSS](/en-US/docs/Web/CSS) style using `monospace` as the generic-font value for the {{cssxref("font-family")}} property.
 

--- a/files/en-us/web/html/quirks_mode_and_standards_mode/index.md
+++ b/files/en-us/web/html/quirks_mode_and_standards_mode/index.md
@@ -32,7 +32,7 @@ For [HTML](/en-US/docs/Web/HTML) documents, browsers use a DOCTYPE in the beginn
 </html>
 ```
 
-The DOCTYPE shown in the example, `<!DOCTYPE html>`, is the simplest possible, and the one recommended by HTML5. Earlier versions of the HTML standard recommended other variants, but all existing browsers today will use full standards mode for this DOCTYPE, even the dated Internet Explorer 6. There are no valid reasons to use a more complicated DOCTYPE. If you do use another DOCTYPE, you may risk choosing one which triggers almost standards mode or quirks mode.
+The DOCTYPE shown in the example, `<!DOCTYPE html>`, is the simplest possible, and the one recommended by current HTML standards. Earlier versions of the HTML standard recommended other variants, but all existing browsers today will use full standards mode for this DOCTYPE, even the dated Internet Explorer 6. There are no valid reasons to use a more complicated DOCTYPE. If you do use another DOCTYPE, you may risk choosing one which triggers almost standards mode or quirks mode.
 
 Make sure you put the DOCTYPE right at the beginning of your HTML document. Anything before the DOCTYPE, like a comment or an XML declaration will trigger quirks mode in Internet Explorer 9 and older.
 

--- a/files/en-us/web/svg/element/use/index.md
+++ b/files/en-us/web/svg/element/use/index.md
@@ -34,7 +34,7 @@ That's why the circles have different x positions, but the same stroke value.
 
 {{EmbedLiveSample('Example', 100, 100)}}
 
-The effect is the same as if the nodes were deeply cloned into a non-exposed DOM, then pasted where the `use` element is, much like cloned [template elements](/en-US/docs/Web/HTML/Element/template) in HTML5.
+The effect is the same as if the nodes were deeply cloned into a non-exposed DOM, then pasted where the `use` element is, much like cloned [template elements](/en-US/docs/Web/HTML/Element/template).
 
 Most attributes on `use` do **not** override those already on the element *referenced* by `use`. (This differs from how CSS style attributes override those set 'earlier' in the cascade). **Only** the attributes {{SVGAttr("x")}}, {{SVGAttr("y")}}, {{SVGAttr("width")}}, {{SVGAttr("height")}} and {{SVGAttr("href")}} on the `use` element will override those set on the referenced element. However, *any other attributes* not set on the referenced element **will** be applied to the `use` element.
 


### PR DESCRIPTION
HTML is a living standard. Removed references to "new in HTML5" since it's not new and it isn't moving beyond 5.


 <!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
