### PR TITLE
remove note about <menu> and role=menu being equivalent

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/menu_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/menu_role/index.md
@@ -32,8 +32,6 @@ Menu items include [`menuitem`](/en-US/docs/Web/Accessibility/ARIA/Roles/menuite
 
 Menu items can be grouped in elements with the [`group`](/en-US/docs/Web/Accessibility/ARIA/Roles/group_role) role, and separated by elements with role [`separator`](/en-US/docs/Web/Accessibility/ARIA/Roles/separator_role). Neither `group` nor `separator` receive focus or are interactive.
 
-> **Note:** The `menu` role is similar to the HTML {{HTMLElement('menu')}} element. Using `<menu role="menu">` may seem redundant, but as most browsers expose the `<menu>` as a [`list`](../list_role/), when using the native `<menu>`, including the `menu` role and providing keyboard navigation are necessary..
-
 If a `menu` is opened as a result of a context action, <kbd>Escape</kbd> or <kbd>Enter</kbd> may return focus to the invoking context. If focus was on the menu button, <kbd>Enter</kbd> opens the menu, giving focus to the first menu item. If focus is on the menu itself, <kbd>Escape</kbd> closes the menu and returns focus to the menu button or parent menubar item (or the context action that opened the menu).
 
 Elements with the role `menu` have an implicit [`aria-orientation`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-orientation) value of `vertical`. Include `aria-orientation="horizontal"`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-orientation).


### PR DESCRIPTION
this is not accurate per the menu element being semantically equivalent to the `<ul>` element - per HTML spec update from 2019 and browsers consistently exposing the element as a list - save for webkit which presently exposes the menu element as generic.
