### PR TITLE
Add formal syntax for (some) CSS data types

### DIFF
--- a/files/en-us/web/css/alpha-value/index.md
+++ b/files/en-us/web/css/alpha-value/index.md
@@ -25,6 +25,10 @@ If given as a number, the useful range is 0 (fully transparent) to 1.0 (fully op
 
 If the alpha value is given as a percentage, 0% corresponds to fully transparent while 100% indicates fully opaque.
 
+## Formal syntax
+
+{{csssyntax}}
+
 ## Interpolation
 
 When animated, values of the `<alpha-value>` CSS data type are {{Glossary("interpolation", "interpolated")}} as real, floating-point numbers. The speed of the interpolation is determined by the [timing function](/en-US/docs/Web/CSS/easing-function) associated with the animation.

--- a/files/en-us/web/css/angle-percentage/index.md
+++ b/files/en-us/web/css/angle-percentage/index.md
@@ -15,13 +15,15 @@ browser-compat: css.types.angle-percentage
 
 The **`<angle-percentage>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/CSS_Types) represents a value that can be either a {{Cssxref("angle")}} or a {{Cssxref("percentage")}}.
 
+Where an `<angle-percentage>` is specified as an allowable type, this means that the percentage resolves to an angle and therefore can be used in a {{Cssxref("calc", "calc()")}} expression.
+
 ## Syntax
 
 Refer to the documentation for {{Cssxref("angle")}} and {{Cssxref("percentage")}} for details of the individual syntaxes allowed by this type.
 
-## Use in calc()
+## Formal syntax
 
-Where an `<angle-percentage>` is specified as an allowable type, this means that the percentage resolves to an angle and therefore can be used in a {{Cssxref("calc", "calc()")}} expression.
+{{csssyntax}}
 
 ## Specifications
 

--- a/files/en-us/web/css/blend-mode/index.md
+++ b/files/en-us/web/css/blend-mode/index.md
@@ -80,6 +80,10 @@ For each pixel among the layers to which it is applied, a blend mode takes the c
 
 Changes between blend modes are not interpolated. Any change occurs immediately.
 
+## Formal syntax
+
+{{csssyntax}}
+
 ## Examples
 
 ### Example using "normal"

--- a/files/en-us/web/css/color_value/index.md
+++ b/files/en-us/web/css/color_value/index.md
@@ -166,6 +166,10 @@ In animations and [gradients](/en-US/docs/Web/CSS/CSS_Images/Using_CSS_gradients
 
 Some people have difficulty distinguishing colors. The [WCAG 2.0](https://www.w3.org/TR/WCAG/#visual-audio-contrast) recommendation strongly advises against using color as the only means of conveying a specific message, action, or result. See [Color and color contrast](/en-US/docs/Learn/Accessibility/CSS_and_JavaScript#color_and_color_contrast) for more information.
 
+## Formal syntax
+
+{{csssyntax}}
+
 ## Examples
 
 ### Color value tester

--- a/files/en-us/web/css/display-box/index.md
+++ b/files/en-us/web/css/display-box/index.md
@@ -35,6 +35,10 @@ Current implementations in most browsers will remove from the [accessibility tre
 - [More accessible markup with display: contents | Hidde de Vries](https://hidde.blog/more-accessible-markup-with-display-contents/)
 - [Display: Contents Is Not a CSS Reset | Adrian Roselli](https://adrianroselli.com/2018/05/display-contents-is-not-a-css-reset.html)
 
+## Formal syntax
+
+{{csssyntax}}
+
 ## Examples
 
 In this first example, the paragraph with a class of secret is set to `display: none`; the box and any content is now not rendered.

--- a/files/en-us/web/css/display-inside/index.md
+++ b/files/en-us/web/css/display-inside/index.md
@@ -46,6 +46,10 @@ Valid `<display-inside>` values:
 
 > **Note:** Browsers that support the two value syntax, on finding the inner value only, such as when `display: flex` or `display: grid` is specified, will set their outer value to `block`. This will result in expected behavior; for example if you specify an element to be `display: grid`, you would expect that the box created on the grid container would be a block level box.
 
+## Formal syntax
+
+{{csssyntax}}
+
 ## Examples
 
 In this example the parent box has been given `display: flow-root` and so establishes a new BFC and contains the floated item.

--- a/files/en-us/web/css/display-internal/index.md
+++ b/files/en-us/web/css/display-internal/index.md
@@ -45,6 +45,10 @@ Valid `<display-internal>` values:
 - `ruby-text-container` {{Experimental_Inline}}
   - : These elements behave like {{HTMLElement("rtc")}} HTML elements.
 
+## Formal syntax
+
+{{csssyntax}}
+
 ## Examples
 
 ### CSS tables example

--- a/files/en-us/web/css/display-legacy/index.md
+++ b/files/en-us/web/css/display-legacy/index.md
@@ -47,6 +47,10 @@ Valid `<display-legacy>` values:
 
     It is equivalent to `inline grid`.
 
+## Formal syntax
+
+{{csssyntax}}
+
 ## Examples
 
 In the below example, we are creating an inline flex container with the legacy keyword inline-flex.

--- a/files/en-us/web/css/display-listitem/index.md
+++ b/files/en-us/web/css/display-listitem/index.md
@@ -23,6 +23,10 @@ A single value of `list-item` will cause the element to behave like a list item.
 
 > **Note:** In browsers that support the two-value syntax, if no inner value is specified it will default to `flow`. If no outer value is specified, the principal box will have an outer display type of `block`.
 
+## Formal syntax
+
+{{csssyntax}}
+
 ## Examples
 
 ### HTML

--- a/files/en-us/web/css/display-outside/index.md
+++ b/files/en-us/web/css/display-outside/index.md
@@ -25,6 +25,10 @@ Valid `<display-outside>` values:
 
 > **Note:** Browsers that support the two value syntax, on finding the outer value only, such as when `display: block` or `display: inline` is specified, will set the inner value to `flow`. This will result in expected behavior; for example if you specify an element to be block, you would expect that the children of that element would participate in block and inline normal flow layout.
 
+## Formal syntax
+
+{{csssyntax}}
+
 ## Examples
 
 In the following example, span elements (normally displayed as inline elements) are set to `display: block` and so break onto new lines and expand to fill their container in the inline dimension.

--- a/files/en-us/web/css/easing-function/index.md
+++ b/files/en-us/web/css/easing-function/index.md
@@ -29,24 +29,42 @@ However, certain properties will restrict the output if it goes outside an allow
 
 ![Graph of the easing function showing the output ratio reaching 1, and then staying at 1 for the rest of the time.](tf_with_output_gt_than_1_clipped.png)
 
-### Easing functions
+## Syntax
 
-The value of an `<easing-function>` type describes the easing function using one of the three types that
-CSS supports: linear, the subset of the [cubic Bézier curves](/en-US/docs/Glossary/Bezier_curve) that are functions, and staircase functions. The most useful of these functions are given a keyword that allows them to be easily referenced.
+```css
+/* linear function */
+linear;
 
-#### The linear class of easing functions
+/* cubic-bezier functions */
+cubic-bezier(x1, y1, x2, y2);
+ease;
+ease-in;
+ease-out;
+ease-in-out;
 
-##### linear
+/* step functions */
+steps(4, end);
+step-start;
+step-end;
+```
+
+The value of an `<easing-function>` type describes the easing function using one of the following three methods:
+
+- linear functions
+- cubic Bézier curves
+- step functions.
+
+### Linear functions
+
+The interpolation is done at a constant rate from beginning to end. Use the `linear` keyword for this function. This represents the easing function `cubic-bezier(0.0, 0.0, 1.0, 1.0)`.
 
 ![A graph with X and Y ranges from 0 to 1, with the X axis labeled 'Time ratio' and the Y axis labeled 'Output ratio'. A straight diagonal line extends from the origin to the X 1 Y 1 position.](cubic-bezier-linear.png)
 
-The interpolation is done at a constant rate from beginning to end. This keyword represents the easing function `cubic-bezier(0.0, 0.0, 1.0, 1.0)`.
-
-#### The cubic-bezier() class of easing functions
-
-![A graph with X and Y ranges from 0 to 1, with the X axis labeled 'Time ratio' and the Y axis labeled 'Output ratio'. A curved line extends from the origin to the X 1 Y 1 position. The X 0 Y 0 point of the line is labeled  'P₀ = (0, 0)'. Extending from the X 0 Y 0 point is a Bezier handle labeled 'P₁ = (0.075, 0.75)'. The X 1 Y 1 point of the line is labeled 'P₃ = (1, 1)'. Extending from the X 1 Y 1 point is a Bezier handle labeled 'P₂ = (0.0875, 0.36)'.](cubic-bezier-example.png)
+### Cubic Bézier functions
 
 The `cubic-bezier()` functional notation defines a [cubic Bézier curve](/en-US/docs/Glossary/Bezier_curve). As these curves are continuous, they are often used to smooth down the start and end of the interpolation and are therefore sometimes called _easing functions_.
+
+![A graph with X and Y ranges from 0 to 1, with the X axis labeled 'Time ratio' and the Y axis labeled 'Output ratio'. A curved line extends from the origin to the X 1 Y 1 position. The X 0 Y 0 point of the line is labeled  'P₀ = (0, 0)'. Extending from the X 0 Y 0 point is a Bezier handle labeled 'P₁ = (0.075, 0.75)'. The X 1 Y 1 point of the line is labeled 'P₃ = (1, 1)'. Extending from the X 1 Y 1 point is a Bezier handle labeled 'P₂ = (0.0875, 0.36)'.](cubic-bezier-example.png)
 
 A cubic Bézier curve is defined by four points P0, P1, P2, and P3. P0 and P3 are the start and the end of the curve and, in CSS these points are fixed as the coordinates are ratios (the abscissa the ratio of time, the ordinate the ratio of the output range). P0 is `(0, 0)` and represents the initial time or position and the initial state, P3 is `(1, 1)` and represents the final time or position and the final state.
 
@@ -56,7 +74,7 @@ Cubic Bézier curves with the P1 or P2 ordinate outside the `[0, 1]` range may g
 
 When you specify an invalid `cubic-bezier` curve, CSS ignores the whole property.
 
-##### Syntax
+The syntax of a cubic-bezier function is:
 
 ```css
 cubic-bezier(x1, y1, x2, y2)
@@ -69,35 +87,31 @@ where:
 
 #### Keywords for common cubic-bezier easing functions
 
-##### ease
+- `ease`
+    - : The interpolation starts slowly, accelerates sharply, and then slows gradually towards the end. This keyword represents the easing function `cubic-bezier(0.25, 0.1, 0.25, 1.0)`. It is similar to [`ease-in-out`](#ease-in-out), though it accelerates more sharply at the beginning.
 
 ![A graph with X and Y ranges from 0 to 1, with the X axis labeled 'Time ratio' and the Y axis labeled 'Output ratio'. A curving line extends from the origin to the X 1 Y 1 position, quickly rising and arcing.](cubic-bezier-ease.png)
 
-The interpolation starts slowly, accelerates sharply, and then slows gradually towards the end. This keyword represents the easing function `cubic-bezier(0.25, 0.1, 0.25, 1.0)`. It is similar to [`ease-in-out`](#ease-in-out), though it accelerates more sharply at the beginning.
-
-##### ease-in
+- `ease-in`
+    - : The interpolation starts slowly, and then progressively speeds up until the end, at which point it stops abruptly. This keyword represents the easing function `cubic-bezier(0.42, 0.0, 1.0, 1.0)`.
 
 ![A graph with X and Y ranges from 0 to 1, with the X axis labeled 'Time ratio' and the Y axis labeled 'Output ratio'. A slightly curving line extends from the origin to the X 1 Y 1 position, with most of the curve close to the origin, straightening out as it approaches X 1 Y 1.](cubic-bezier-ease-in.png)
 
-The interpolation starts slowly, and then progressively speeds up until the end, at which point it stops abruptly. This keyword represents the easing function `cubic-bezier(0.42, 0.0, 1.0, 1.0)`.
-
-##### `ease-in-out`
+- `ease-in-out`
+    - : The interpolation starts slowly, speeds up, and then slows down towards the end. This keyword represents the easing function `cubic-bezier(0.42, 0.0, 0.58, 1.0)`. At the beginning, it behaves like the [`ease-in`](#ease-in) function; at the end, it is like the [`ease-out`](#ease-out) function.
 
 ![A graph with X and Y ranges from 0 to 1, with the X axis labeled 'Time ratio' and the Y axis labeled 'Output ratio'. A slightly curving line extends from the origin to the X 1 Y 1 position. The curve is symmetrical, resembling a stretched out letter S.](cubic-bezier-ease-in-out.png)
 
-The interpolation starts slowly, speeds up, and then slows down towards the end. This keyword represents the easing function `cubic-bezier(0.42, 0.0, 0.58, 1.0)`. At the beginning, it behaves like the [`ease-in`](#ease-in) function; at the end, it is like the [`ease-out`](#ease-out) function.
-
-##### ease-out
+- `ease-out`
+    - : The interpolation starts abruptly, and then progressively slows down towards the end. This keyword represents the easing function `cubic-bezier(0.0, 0.0, 0.58, 1.0)`.
 
 ![A graph with X and Y ranges from 0 to 1, with the X axis labeled 'Time ratio' and the Y axis labeled 'Output ratio'. A slightly curving line extends from the origin to the X 1 Y 1 position, starting as an almost straight diagonal line and curving as it gets close to X 1 Y 1.](cubic-bezer-ease-out.png)
 
-The interpolation starts abruptly, and then progressively slows down towards the end. This keyword represents the easing function `cubic-bezier(0.0, 0.0, 0.58, 1.0)`.
-
-#### The steps() class of easing functions
+### Step functions
 
 The `steps()` functional notation defines a [step function](https://en.wikipedia.org/wiki/Step_function) dividing the domain of output values in equidistant steps. This subclass of step functions are sometimes also called _staircase functions_.
 
-##### Syntax
+Step functions are given using the syntax:
 
 ```css
 steps(number_of_steps, direction)
@@ -120,7 +134,7 @@ where:
 
     `end` is the default.
 
-##### steps( n, \<direction> )
+#### Examples
 
 - `steps(2, jump-start)`
   `steps(2, start)`
@@ -139,13 +153,21 @@ where:
 
   ![A graph with X and Y ranges from 0 to 1, with the X axis labeled 'Time ratio' and the Y axis labeled 'Output ratio'. Five dots are present, the first at the X 0 Y 0 position, the second at the X 0 Y 0.25 position, the third at the X 0.5 Y 0.5 position, the fourth at the X 0.75 Y 0.75 position, and the fifth at the X 1 Y 1 position. The second, third, and fourth dots have horizontal lines extending 0.25 units forwards away from the Y axis.](step3both.png)
 
-##### step-start
+#### Step function keywords
 
-![A graph with X and Y ranges from 0 to 1, with the X axis labeled 'Time ratio' and the Y axis labeled 'Output ratio'. Two dots are present, the first at the X 0 Y 0 position, and the second at the X 1 Y 1 position. The second dot has a horizontal lines extending 1 units back towards the Y axis.](steps-1-start.png) The interpolation jumps immediately to its final state, where it stays until the end. This keyword represents the easing function `steps(1, jump-start)` or `steps(1, start)`.
+- `step-start`
+    - :  The interpolation jumps immediately to its final state, where it stays until the end. This keyword represents the easing function `steps(1, jump-start)` or `steps(1, start)`.
 
-##### step-end
+![A graph with X and Y ranges from 0 to 1, with the X axis labeled 'Time ratio' and the Y axis labeled 'Output ratio'. Two dots are present, the first at the X 0 Y 0 position, and the second at the X 1 Y 1 position. The second dot has a horizontal lines extending 1 units back towards the Y axis.](steps-1-start.png)
 
-![A graph with X and Y ranges from 0 to 1, with the X axis labeled 'Time ratio' and the Y axis labeled 'Output ratio'. Two dots are present, the first at the X 0 Y 0 position, and the second at the X 1 Y 1 position. The first dot has a horizontal lines extending 1 unit forwards away from the Y axis.](steps-1-end.png) The interpolation stays in its initial state until the end, at which point it jumps directly to its final state. This keyword represents the easing function `steps(1, jump-end)` or `steps(1, end)`.
+- `step-end`
+    - : The interpolation stays in its initial state until the end, at which point it jumps directly to its final state. This keyword represents the easing function `steps(1, jump-end)` or `steps(1, end)`.
+
+![A graph with X and Y ranges from 0 to 1, with the X axis labeled 'Time ratio' and the Y axis labeled 'Output ratio'. Two dots are present, the first at the X 0 Y 0 position, and the second at the X 1 Y 1 position. The first dot has a horizontal lines extending 1 unit forwards away from the Y axis.](steps-1-end.png)
+
+## Formal syntax
+
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/filter-function/index.md
+++ b/files/en-us/web/css/filter-function/index.md
@@ -39,6 +39,10 @@ The `<filter-function>` data type is specified using one of the filter functions
 - {{cssxref("filter-function/sepia", "sepia()")}}
   - : Converts the image to sepia.
 
+## Formal syntax
+
+{{csssyntax}}
+
 ## Examples
 
 ### Filter function comparison

--- a/files/en-us/web/css/frequency-percentage/index.md
+++ b/files/en-us/web/css/frequency-percentage/index.md
@@ -25,6 +25,10 @@ The value of a `<frequency-percentage>` is either a {{Cssxref("frequency")}} or 
 
 Where a `<frequency-percentage>` is specified as an allowable type, this means that the percentage resolves to a frequency and therefore can be used in a [`calc()`](/en-US/docs/Web/CSS/calc) expression.
 
+## Formal syntax
+
+{{csssyntax}}
+
 ## Examples
 
 ### Valid percentage values

--- a/files/en-us/web/css/gradient/conic-gradient/index.md
+++ b/files/en-us/web/css/gradient/conic-gradient/index.md
@@ -117,7 +117,7 @@ background-size: 25% 25%;
 
 And, yes, you can mix and match different angle units, but don't. The above is hard to read.
 
-### Formal syntax
+## Formal syntax
 
 {{csssyntax}}
 

--- a/files/en-us/web/css/gradient/linear-gradient/index.md
+++ b/files/en-us/web/css/gradient/linear-gradient/index.md
@@ -117,7 +117,7 @@ linear-gradient(red 0%, orange 10% 30%, yellow 50% 70%, green 90% 100%);
 
 By default, if there is no color with a 0% stop, the first color declared will be at that point. Similarly, the last color will continue to the 100% mark, or be at the 100% mark if no length has been declared on that last stop.
 
-### Formal syntax
+## Formal syntax
 
 {{csssyntax}}
 

--- a/files/en-us/web/css/gradient/radial-gradient/index.md
+++ b/files/en-us/web/css/gradient/radial-gradient/index.md
@@ -75,7 +75,7 @@ To create a smooth gradient, the `radial-gradient()` function draws a series of 
 
 Color-stop points are positioned on a _virtual gradient ray_ that extends horizontally from the center towards the right. Percentage-based color-stop positions are relative to the intersection between the ending shape and this gradient ray, which represents `100%`. Each shape is a single color determined by the color on the gradient ray it intersects.
 
-### Formal syntax
+## Formal syntax
 
 {{csssyntax}}
 

--- a/files/en-us/web/css/image/index.md
+++ b/files/en-us/web/css/image/index.md
@@ -65,6 +65,10 @@ Browsers do not provide any special information on background images to assistiv
 - [MDN Understanding WCAG, Guideline 1.1 explanations](/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable#guideline_1.1_%e2%80%94_providing_text_alternatives_for_non-text_content)
 - [Understanding Success Criterion 1.1.1 | W3C Understanding WCAG 2.0](https://www.w3.org/TR/2016/NOTE-UNDERSTANDING-WCAG20-20161007/text-equiv-all.html)
 
+## Formal syntax
+
+{{csssyntax}}
+
 ## Examples
 
 ### Valid images

--- a/files/en-us/web/css/length-percentage/index.md
+++ b/files/en-us/web/css/length-percentage/index.md
@@ -19,6 +19,10 @@ The **`<length-percentage>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs
 
 Refer to the documentation for {{Cssxref("length")}} and {{Cssxref("percentage")}} for details of the individual syntaxes allowed by this type.
 
+## Formal syntax
+
+{{csssyntax}}
+
 ## Examples
 
 ### length-percentage examples

--- a/files/en-us/web/css/position_value/index.md
+++ b/files/en-us/web/css/position_value/index.md
@@ -43,25 +43,15 @@ value value              /* A value for each direction (horizontal then vertical
 keyword value keyword value /* Each value is an offset from the keyword that precedes it */
 ```
 
-### Formal syntax
-
-```css
-[
- [ left | center | right ] || [ top | center | bottom ]
-|
- [ left | center | right | <length> | <percentage> ]
- [ top | center | bottom | <length> | <percentage> ]?
-|
- [ [ left | right ] [ <length> | <percentage> ] ] &&
- [ [ top | bottom ] [ <length> | <percentage> ] ]
-]
-```
-
 > **Note:** The {{cssxref("background-position")}} property also accepts a three-value syntax. This is not allowed in other properties that use `<position>`.
 
 ## Interpolation
 
 When animated, a point's abscissa and ordinate values are interpolated independently. However, because the speed of the interpolation is determined by a single [timing function](/en-US/docs/Web/CSS/easing-function) for both coordinates, the point will move in a straight line.
+
+## Formal syntax
+
+{{csssyntax}}
 
 ## Examples
 

--- a/files/en-us/web/css/ratio/index.md
+++ b/files/en-us/web/css/ratio/index.md
@@ -20,6 +20,10 @@ In Media Queries Level 3, the `<ratio>` data type consisted of a strictly positi
 
 In Media Queries Level 4, the `<ratio>` date type is updated to consist of a strictly positive {{cssxref("&lt;number&gt;")}} followed by a forward slash ('/', Unicode `U+002F SOLIDUS`) and a second strictly positive {{cssxref("&lt;number&gt;")}}. In addition a single {{cssxref("&lt;number&gt;")}} as a value is allowable.
 
+## Formal syntax
+
+{{csssyntax}}
+
 ## Examples
 
 ### Use in a media query

--- a/files/en-us/web/css/time-percentage/index.md
+++ b/files/en-us/web/css/time-percentage/index.md
@@ -19,6 +19,10 @@ The **`<time-percentage>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/W
 
 Refer to the documentation for {{Cssxref("time")}} and {{Cssxref("percentage")}} for details of the individual syntaxes allowed by this type.
 
+## Formal syntax
+
+{{csssyntax}}
+
 ## Examples
 
 ### Use in calc()


### PR DESCRIPTION
This PR adds formal syntax to those CSS data types for which formal syntax exists in webref (mostly, this is all except the "primitive" things like `<string>`).

It also tries to rationalize them to have formal syntax as an H2 before "Examples", as we do for properties.

I made bigger changes to the structure of https://developer.mozilla.org/en-US/docs/Web/CSS/easing-function, since it seemed to be needed.
