### PR TITLE
Update BCD info, part 10

### DIFF
--- a/files/en-us/web/api/mediakeymessageevent/index.md
+++ b/files/en-us/web/api/mediakeymessageevent/index.md
@@ -11,7 +11,7 @@ tags:
   - Reference
 browser-compat: api.MediaKeyMessageEvent
 ---
-{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}
+{{APIRef("EncryptedMediaExtensions")}}
 
 The **`MediaKeyMessageEvent`** interface of the [EncryptedMediaExtensions API](/en-US/docs/Web/API/Encrypted_Media_Extensions_API) contains the content and related data when the content decryption module generates a message for the session.
 

--- a/files/en-us/web/api/mediakeys/createsession/index.md
+++ b/files/en-us/web/api/mediakeys/createsession/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - EncryptedMediaExtensions
-  - Experimental
   - Media
   - MediaKeys
   - Method
@@ -13,7 +12,7 @@ tags:
   - createSession
 browser-compat: api.MediaKeys.createSession
 ---
-{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}
+{{APIRef("EncryptedMediaExtensions")}}
 
 The `MediaKeys.createSession()` method returns a new
 {{domxref("MediaKeySession")}} object, which represents a context for message exchange

--- a/files/en-us/web/api/mediakeys/index.md
+++ b/files/en-us/web/api/mediakeys/index.md
@@ -14,7 +14,7 @@ tags:
   - Video
 browser-compat: api.MediaKeys
 ---
-{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}
+{{APIRef("EncryptedMediaExtensions")}}
 
 The **`MediaKeys`** interface of [EncryptedMediaExtensions API](/en-US/docs/Web/API/Encrypted_Media_Extensions_API) represents a set of keys that an associated {{domxref("HTMLMediaElement")}} can use for decryption of media data during playback.
 

--- a/files/en-us/web/api/mediakeys/setservercertificate/index.md
+++ b/files/en-us/web/api/mediakeys/setservercertificate/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - EncryptedMediaExtensions
-  - Experimental
   - Media
   - MediaKeys
   - Method
@@ -13,7 +12,7 @@ tags:
   - setServerCertificate
 browser-compat: api.MediaKeys.setServerCertificate
 ---
-{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}
+{{APIRef("EncryptedMediaExtensions")}}
 
 The **`MediaKeys.setServerCertificate()`** method provides a
 server certificate to be used to encrypt messages to the license server.

--- a/files/en-us/web/api/mediakeysession/close/index.md
+++ b/files/en-us/web/api/mediakeysession/close/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - EncryptedMediaExtensions
-  - Experimental
   - MediaKeySession
   - Method
   - NeedsExample

--- a/files/en-us/web/api/mediakeysession/closed/index.md
+++ b/files/en-us/web/api/mediakeysession/closed/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - EncryptedMediaExtensions
-  - Experimental
   - MediaKeySession
   - NeedsExample
   - Property

--- a/files/en-us/web/api/mediakeysession/expiration/index.md
+++ b/files/en-us/web/api/mediakeysession/expiration/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - EncryptedMediaExtensions
-  - Experimental
   - MediaKeySession
   - NeedsExample
   - Property

--- a/files/en-us/web/api/mediakeysession/generaterequest/index.md
+++ b/files/en-us/web/api/mediakeysession/generaterequest/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - EncryptedMediaExtensions
-  - Experimental
   - MediaKeySession
   - Method
   - NeedsExample

--- a/files/en-us/web/api/mediakeysession/keystatuses/index.md
+++ b/files/en-us/web/api/mediakeysession/keystatuses/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - EncryptedMediaExtensions
-  - Experimental
   - MediaKeySession
   - NeedsExample
   - Property

--- a/files/en-us/web/api/mediakeysession/load/index.md
+++ b/files/en-us/web/api/mediakeysession/load/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - EncryptedMediaExtensions
-  - Experimental
   - MediaKeySession
   - Method
   - NeedsExample

--- a/files/en-us/web/api/mediakeysession/remove/index.md
+++ b/files/en-us/web/api/mediakeysession/remove/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - EncryptedMediaExtensions
-  - Experimental
   - MediaKeySession
   - Method
   - NeedsExample

--- a/files/en-us/web/api/mediakeysession/sessionid/index.md
+++ b/files/en-us/web/api/mediakeysession/sessionid/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - EncryptedMediaExtensions
-  - Experimental
   - MediaKeySession
   - NeedsExample
   - Property

--- a/files/en-us/web/api/mediakeysession/update/index.md
+++ b/files/en-us/web/api/mediakeysession/update/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - EncryptedMediaExtensions
-  - Experimental
   - MediaKeySession
   - Method
   - NeedsExample

--- a/files/en-us/web/api/mediakeystatusmap/entries/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/entries/index.md
@@ -11,7 +11,7 @@ tags:
   - entries()
 browser-compat: api.MediaKeyStatusMap.entries
 ---
-{{APIRef("EncryptedMediaExtensions API")}}{{SeeCompatTable}}
+{{APIRef("EncryptedMediaExtensions API")}}
 
 The **`entries()`** read-only property
 of the {{domxref("MediaKeyStatusMap")}} interface returns a new Iterator object,

--- a/files/en-us/web/api/mediakeystatusmap/foreach/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/foreach/index.md
@@ -11,7 +11,7 @@ tags:
   - forEach()
 browser-compat: api.MediaKeyStatusMap.forEach
 ---
-{{APIRef("EncryptedMediaExtensions API")}}{{SeeCompatTable}}
+{{APIRef("EncryptedMediaExtensions API")}}
 
 The **`forEach`** property of the
 {{domxref("MediaKeyStatusMap")}} interface calls callback once for each key-value pair

--- a/files/en-us/web/api/mediakeystatusmap/get/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/get/index.md
@@ -11,7 +11,7 @@ tags:
   - get()
 browser-compat: api.MediaKeyStatusMap.get
 ---
-{{APIRef("MediaKeyStatusMap")}}
+{{APIRef("EncryptedMediaExtensions API")}}
 
 The **`get`** property of the
 {{domxref("MediaKeyStatusMap")}} interface returns the value associated with the given

--- a/files/en-us/web/api/mediakeystatusmap/get/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/get/index.md
@@ -11,7 +11,7 @@ tags:
   - get()
 browser-compat: api.MediaKeyStatusMap.get
 ---
-{{APIRef("MediaKeyStatusMap")}}{{SeeCompatTable}}
+{{APIRef("MediaKeyStatusMap")}}
 
 The **`get`** property of the
 {{domxref("MediaKeyStatusMap")}} interface returns the value associated with the given

--- a/files/en-us/web/api/mediakeystatusmap/has/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/has/index.md
@@ -11,7 +11,7 @@ tags:
   - has()
 browser-compat: api.MediaKeyStatusMap.has
 ---
-{{APIRef("EncryptedMediaExtensions API")}}{{SeeCompatTable}}
+{{APIRef("EncryptedMediaExtensions API")}}
 
 The **`has`** property of the
 {{domxref("MediaKeyStatusMap")}} interface returns a {{jsxref('Boolean')}}, asserting

--- a/files/en-us/web/api/mediakeystatusmap/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/index.md
@@ -10,7 +10,7 @@ tags:
   - Reference
 browser-compat: api.MediaKeyStatusMap
 ---
-{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}
+{{APIRef("EncryptedMediaExtensions")}}
 
 The **`MediaKeyStatusMap`** interface of the [EncryptedMediaExtensions API](/en-US/docs/Web/API/Encrypted_Media_Extensions_API) is a read-only map of media key statuses by key IDs.
 

--- a/files/en-us/web/api/mediakeystatusmap/keys/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/keys/index.md
@@ -11,7 +11,7 @@ tags:
   - keys()
 browser-compat: api.MediaKeyStatusMap.keys
 ---
-{{APIRef("EncryptedMediaExtensions API")}}{{SeeCompatTable}}
+{{APIRef("EncryptedMediaExtensions API")}}
 
 The **`keys`** property of the
 {{domxref("MediaKeyStatusMap")}} interface returns a new Iterator object, containing

--- a/files/en-us/web/api/mediakeystatusmap/size/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/size/index.md
@@ -11,7 +11,7 @@ tags:
   - size
 browser-compat: api.MediaKeyStatusMap.size
 ---
-{{SeeCompatTable}}{{APIRef("EncryptedMediaExtensions API")}}
+{{APIRef("EncryptedMediaExtensions API")}}
 
 The **`size`** read-only property of
 the {{domxref("MediaKeyStatusMap")}} interface returns the number of key/value paIrs

--- a/files/en-us/web/api/mediakeystatusmap/values/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/values/index.md
@@ -11,7 +11,7 @@ tags:
   - values()
 browser-compat: api.MediaKeyStatusMap.values
 ---
-{{APIRef("EncryptedMediaExtensions API")}}{{SeeCompatTable}}
+{{APIRef("EncryptedMediaExtensions API")}}
 
 The **`values`** property of the
 {{domxref("MediaKeyStatusMap")}} interface returns a new Iterator object, containing

--- a/files/en-us/web/api/mediakeysystemaccess/createmediakeys/index.md
+++ b/files/en-us/web/api/mediakeysystemaccess/createmediakeys/index.md
@@ -15,7 +15,7 @@ tags:
   - createMediaKeys
 browser-compat: api.MediaKeySystemAccess.createMediaKeys
 ---
-{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}
+{{APIRef("EncryptedMediaExtensions")}}
 
 The `MediaKeySystemAccess.createMediaKeys()` method returns a
 {{jsxref('Promise')}} that resolves to a new {{domxref('MediaKeys')}} object.

--- a/files/en-us/web/api/mediakeysystemaccess/getconfiguration/index.md
+++ b/files/en-us/web/api/mediakeysystemaccess/getconfiguration/index.md
@@ -15,7 +15,7 @@ tags:
   - getConfiguration
 browser-compat: api.MediaKeySystemAccess.getConfiguration
 ---
-{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}
+{{APIRef("EncryptedMediaExtensions")}}
 
 The `MediaKeySystemAccess.getConfiguration()` method returns an object with the supported combination of
 the following configuration options:

--- a/files/en-us/web/api/mediakeysystemaccess/index.md
+++ b/files/en-us/web/api/mediakeysystemaccess/index.md
@@ -14,7 +14,7 @@ tags:
   - Video
 browser-compat: api.MediaKeySystemAccess
 ---
-{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}
+{{APIRef("EncryptedMediaExtensions")}}
 
 The **`MediaKeySystemAccess`** interface of the [EncryptedMediaExtensions API](/en-US/docs/Web/API/Encrypted_Media_Extensions_API) provides access to a Key System for decryption and/or a content protection provider. You can request an instance of this object using the {{domxref("Navigator.requestMediaKeySystemAccess","Navigator.requestMediaKeySystemAccess()")}} method.
 

--- a/files/en-us/web/api/mediakeysystemaccess/keysystem/index.md
+++ b/files/en-us/web/api/mediakeysystemaccess/keysystem/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - EncryptedMediaExtensions
-  - Experimental
   - MediaKeySystemAccess
   - NeedsExample
   - Property
@@ -13,7 +12,7 @@ tags:
   - keySystem
 browser-compat: api.MediaKeySystemAccess.keySystem
 ---
-{{APIRef("EncryptedMediaExtensions")}}{{SeeCompatTable}}
+{{APIRef("EncryptedMediaExtensions")}}
 
 The `MediaKeySystemAccess.keySystem` read-only property returns a
 string identifying the key system being used.

--- a/files/en-us/web/api/mediametadata/album/index.md
+++ b/files/en-us/web/api/mediametadata/album/index.md
@@ -9,7 +9,7 @@ tags:
   - Reference
 browser-compat: api.MediaMetadata.album
 ---
-{{SeeCompatTable}}{{APIRef("Media Session API")}}
+{{APIRef("Media Session API")}}
 
 The **`album`** property of the
 {{domxref("MediaMetaData")}} interface returns or sets the name of the album or

--- a/files/en-us/web/api/mediametadata/artist/index.md
+++ b/files/en-us/web/api/mediametadata/artist/index.md
@@ -14,7 +14,7 @@ tags:
   - Property
 browser-compat: api.MediaMetadata.artist
 ---
-{{SeeCompatTable}}{{APIRef("Media Session API")}}
+{{APIRef("Media Session API")}}
 
 The **`artist`** property of the
 {{domxref("MediaMetaData")}} interface returns or sets the name of the artist, group,

--- a/files/en-us/web/api/mediametadata/artwork/index.md
+++ b/files/en-us/web/api/mediametadata/artwork/index.md
@@ -14,7 +14,7 @@ tags:
   - artwork
 browser-compat: api.MediaMetadata.artwork
 ---
-{{SeeCompatTable}}{{APIRef("Media Session API")}}
+{{APIRef("Media Session API")}}
 
 The **`artwork`** property of the
 {{domxref("MediaMetaData")}} interface returns or sets an array of

--- a/files/en-us/web/api/mediametadata/mediametadata/index.md
+++ b/files/en-us/web/api/mediametadata/mediametadata/index.md
@@ -4,7 +4,6 @@ slug: Web/API/MediaMetadata/MediaMetadata
 page-type: web-api-constructor
 tags:
   - Audio
-  - Experimental
   - Media
   - Media Session API
   - MediaMetadata
@@ -15,7 +14,7 @@ tags:
   - artwork
 browser-compat: api.MediaMetadata.MediaMetadata
 ---
-{{APIRef("Media Session API")}}{{SeeCompatTable}}
+{{APIRef("Media Session API")}}
 
 The **`MediaMetadata()`** constructor creates a new
 {{domxref("MediaMetadata")}} object.

--- a/files/en-us/web/api/mediametadata/title/index.md
+++ b/files/en-us/web/api/mediametadata/title/index.md
@@ -14,7 +14,7 @@ tags:
   - Video
 browser-compat: api.MediaMetadata.title
 ---
-{{SeeCompatTable}}{{APIRef("Media Session API")}}
+{{APIRef("Media Session API")}}
 
 The **`title`** property of the
 {{domxref("MediaMetaData")}} interface returns or sets the title of the media to be


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.
It focuses on files that have only left behind 'experimental' tags and headers.