### PR TITLE
Update BCD info, part 11

### DIFF
--- a/files/en-us/web/api/mediasession/index.md
+++ b/files/en-us/web/api/mediasession/index.md
@@ -13,7 +13,7 @@ tags:
   - Video
 browser-compat: api.MediaSession
 ---
-{{SeeCompatTable}}{{APIRef("Media Session API")}}
+{{APIRef("Media Session API")}}
 
 The **`MediaSession`** interface of the [Media Session API](/en-US/docs/Web/API/Media_Session_API) allows a web page to provide custom behaviors for standard media playback interactions, and to report metadata that can be sent by the user agent to the device or operating system for presentation in standardized user interface elements.
 

--- a/files/en-us/web/api/mediasession/metadata/index.md
+++ b/files/en-us/web/api/mediasession/metadata/index.md
@@ -13,7 +13,7 @@ tags:
   - metadata
 browser-compat: api.MediaSession.metadata
 ---
-{{SeeCompatTable}}{{APIRef("Media Session API")}}
+{{APIRef("Media Session API")}}
 
 The **`metadata`** property of the {{domxref("MediaSession")}}
 interface contains a {{domxref("MediaMetadata")}} object providing descriptive

--- a/files/en-us/web/api/mediasource/activesourcebuffers/index.md
+++ b/files/en-us/web/api/mediasource/activesourcebuffers/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - Audio
-  - Experimental
   - MSE
   - MediaSource
   - MediaSourceExtensions

--- a/files/en-us/web/api/mediasource/clearliveseekablerange/index.md
+++ b/files/en-us/web/api/mediasource/clearliveseekablerange/index.md
@@ -15,7 +15,7 @@ tags:
   - clearLiveSeekableRange()
 browser-compat: api.MediaSource.clearLiveSeekableRange
 ---
-{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
+{{APIRef("Media Source Extensions")}}
 
 The **`clearLiveSeekableRange()`** method of the
 {{domxref("MediaSource")}} interface clears a seekable range previously set with a call

--- a/files/en-us/web/api/mediasource/duration/index.md
+++ b/files/en-us/web/api/mediasource/duration/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - Audio
-  - Experimental
   - MSE
   - Media Source Extensions
   - MediaSource
@@ -15,7 +14,7 @@ tags:
   - duration
 browser-compat: api.MediaSource.duration
 ---
-{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
+{{APIRef("Media Source Extensions")}}
 
 The **`duration`** property of the {{domxref("MediaSource")}}
 interface gets and sets the duration of the current media being presented.

--- a/files/en-us/web/api/mediasource/endofstream/index.md
+++ b/files/en-us/web/api/mediasource/endofstream/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Audio
-  - Experimental
   - MSE
   - Media Source Extensions
   - MediaSource
@@ -15,7 +14,7 @@ tags:
   - endOfStream
 browser-compat: api.MediaSource.endOfStream
 ---
-{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
+{{APIRef("Media Source Extensions")}}
 
 The **`endOfStream()`** method of the
 {{domxref("MediaSource")}} interface signals the end of the stream.

--- a/files/en-us/web/api/mediasource/index.md
+++ b/files/en-us/web/api/mediasource/index.md
@@ -5,7 +5,6 @@ page-type: web-api-interface
 tags:
   - API
   - Audio
-  - Experimental
   - Extensions
   - Interface
   - MSE
@@ -16,7 +15,7 @@ tags:
   - Video
 browser-compat: api.MediaSource
 ---
-{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
+{{APIRef("Media Source Extensions")}}
 
 The **`MediaSource`** interface of the [Media Source Extensions API](/en-US/docs/Web/API/Media_Source_Extensions_API) represents a source of media data for an {{domxref("HTMLMediaElement")}} object. A `MediaSource` object can be attached to a {{domxref("HTMLMediaElement")}} to be played in the user agent.
 

--- a/files/en-us/web/api/mediasource/istypesupported/index.md
+++ b/files/en-us/web/api/mediasource/istypesupported/index.md
@@ -5,7 +5,6 @@ page-type: web-api-static-method
 tags:
   - API
   - Audio
-  - Experimental
   - MSE
   - Media Source Extensions
   - MediaSource

--- a/files/en-us/web/api/mediasource/mediasource/index.md
+++ b/files/en-us/web/api/mediasource/mediasource/index.md
@@ -6,7 +6,6 @@ tags:
   - API
   - Audio
   - Constructor
-  - Experimental
   - MSE
   - Media Source Extensions
   - MediaSource
@@ -14,7 +13,7 @@ tags:
   - Video
 browser-compat: api.MediaSource.MediaSource
 ---
-{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
+{{APIRef("Media Source Extensions")}}
 
 The **`MediaSource()`** constructor of the
 {{domxref("MediaSource")}} interface constructs and returns a new

--- a/files/en-us/web/api/mediasource/readystate/index.md
+++ b/files/en-us/web/api/mediasource/readystate/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - Audio
-  - Experimental
   - MSE
   - Media Source Extensions
   - MediaSource
@@ -15,7 +14,7 @@ tags:
   - readyState
 browser-compat: api.MediaSource.readyState
 ---
-{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
+{{APIRef("Media Source Extensions")}}
 
 The **`readyState`** read-only property of the
 {{domxref("MediaSource")}} interface returns an enum representing the state of the

--- a/files/en-us/web/api/mediasource/removesourcebuffer/index.md
+++ b/files/en-us/web/api/mediasource/removesourcebuffer/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Audio
-  - Experimental
   - MSE
   - Media Source Extensions
   - MediaSource
@@ -15,7 +14,7 @@ tags:
   - removeSourceBuffer
 browser-compat: api.MediaSource.removeSourceBuffer
 ---
-{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
+{{APIRef("Media Source Extensions")}}
 
 The **`removeSourceBuffer()`** method of the
 {{domxref("MediaSource")}} interface removes the given {{domxref("SourceBuffer")}} from

--- a/files/en-us/web/api/mediasource/setliveseekablerange/index.md
+++ b/files/en-us/web/api/mediasource/setliveseekablerange/index.md
@@ -15,7 +15,7 @@ tags:
   - setLiveSeekableRange()
 browser-compat: api.MediaSource.setLiveSeekableRange
 ---
-{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
+{{APIRef("Media Source Extensions")}}
 
 The **`setLiveSeekableRange()`** method of the
 {{domxref("MediaSource")}} interface sets the range that the user can seek to in the

--- a/files/en-us/web/api/mediasource/sourcebuffers/index.md
+++ b/files/en-us/web/api/mediasource/sourcebuffers/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - Audio
-  - Experimental
   - MSE
   - Media Source Extensions
   - MediaSource
@@ -15,7 +14,7 @@ tags:
   - sourceBuffers
 browser-compat: api.MediaSource.sourceBuffers
 ---
-{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
+{{APIRef("Media Source Extensions")}}
 
 The **`sourceBuffers`** read-only property of the
 {{domxref("MediaSource")}} interface returns a {{domxref("SourceBufferList")}} object

--- a/files/en-us/web/api/mediastream/getaudiotracks/index.md
+++ b/files/en-us/web/api/mediastream/getaudiotracks/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Audio
-  - Experimental
   - Media
   - Media Capture and Streams API
   - Media Streams API

--- a/files/en-us/web/api/mediastream/gettracks/index.md
+++ b/files/en-us/web/api/mediastream/gettracks/index.md
@@ -4,7 +4,6 @@ slug: Web/API/MediaStream/getTracks
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Media Streams API
   - MediaStream
   - MediaStreamTrack
@@ -13,7 +12,7 @@ tags:
   - getTracks
 browser-compat: api.MediaStream.getTracks
 ---
-{{APIRef("Media Capture and Streams")}}{{SeeCompatTable}}
+{{APIRef("Media Capture and Streams")}}
 
 The **_`getTracks()`_** method of the
 {{domxref("MediaStream")}} interface returns a sequence that represents all the

--- a/files/en-us/web/api/mediastreamevent/stream/index.md
+++ b/files/en-us/web/api/mediastreamevent/stream/index.md
@@ -3,15 +3,16 @@ title: MediaStreamEvent.stream
 slug: Web/API/MediaStreamEvent/stream
 page-type: web-api-instance-property
 tags:
-  - Experimental
   - MediaStreamEvent
   - Property
   - Read-only
   - Reference
   - WebRTC
+  - Deprecated
+  - Non-standard
 browser-compat: api.MediaStreamEvent.stream
 ---
-{{APIRef("WebRTC")}}{{deprecated_header}}
+{{APIRef("WebRTC")}}{{deprecated_header}}{{Non-standard_header}}
 
 The read-only property **`MediaStreamEvent.stream`** returns
 the {{domxref("MediaStream")}} associated with the event.

--- a/files/en-us/web/api/navigationpreloadmanager/index.md
+++ b/files/en-us/web/api/navigationpreloadmanager/index.md
@@ -12,7 +12,7 @@ tags:
   - Service Workers
 browser-compat: api.NavigationPreloadManager
 ---
-{{APIRef("Service Workers API")}}{{SeeCompatTable}}
+{{APIRef("Service Workers API")}}
 
 The **`NavigationPreloadManager`** interface of the [Service Worker API](/en-US/docs/Web/API/Service_Worker_API) provides methods for managing the preloading of resources in parallel with service worker bootup.
 

--- a/files/en-us/web/api/navigator/donottrack/index.md
+++ b/files/en-us/web/api/navigator/donottrack/index.md
@@ -4,11 +4,11 @@ slug: Web/API/Navigator/doNotTrack
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - HTML DOM
   - Navigator
   - Property
   - Reference
+  - Deprecated
 browser-compat: api.Navigator.doNotTrack
 ---
 {{ApiRef("HTML DOM")}}{{Deprecated_header}}

--- a/files/en-us/web/api/navigator/getgamepads/index.md
+++ b/files/en-us/web/api/navigator/getgamepads/index.md
@@ -4,7 +4,6 @@ slug: Web/API/Navigator/getGamepads
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Gamepad API
   - Games
   - Method
@@ -12,7 +11,7 @@ tags:
   - Reference
 browser-compat: api.Navigator.getGamepads
 ---
-{{APIRef("Gamepad API")}}{{SeeCompatTable}}{{securecontext_header}}
+{{APIRef("Gamepad API")}}{{securecontext_header}}
 
 The **`Navigator.getGamepads()`** method returns an array of
 {{domxref("Gamepad")}} objects, one for each gamepad connected to the device.

--- a/files/en-us/web/api/navigator/languages/index.md
+++ b/files/en-us/web/api/navigator/languages/index.md
@@ -4,7 +4,6 @@ slug: Web/API/Navigator/languages
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Navigator
   - Property
   - Read-only
@@ -12,7 +11,7 @@ tags:
   - languages
 browser-compat: api.Navigator.languages
 ---
-{{APIRef("HTML DOM")}}{{SeeCompatTable}}
+{{APIRef("HTML DOM")}}
 
 The **`Navigator.languages`** read-only property
 returns an array of strings representing the user's preferred

--- a/files/en-us/web/api/navigator/locks/index.md
+++ b/files/en-us/web/api/navigator/locks/index.md
@@ -4,7 +4,6 @@ slug: Web/API/Navigator/locks
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - LockManager
   - Property
   - Reference
@@ -12,7 +11,7 @@ tags:
   - locks
 browser-compat: api.Navigator.locks
 ---
-{{SeeCompatTable}}{{APIRef("Web Locks")}}
+{{APIRef("Web Locks")}}
 
 The **`locks`** read-only property of
 the {{domxref("Navigator")}} interface returns a {{domxref("LockManager")}} object

--- a/files/en-us/web/api/navigator/mediacapabilities/index.md
+++ b/files/en-us/web/api/navigator/mediacapabilities/index.md
@@ -4,14 +4,12 @@ slug: Web/API/Navigator/mediaCapabilities
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Media
   - Media Capabilities API
   - MediaCapabilities
   - Navigator
 browser-compat: api.Navigator.mediaCapabilities
 ---
-{{SeeCompatTable}}
 
 The **`Navigator.mediaCapabilities`** read-only property
 returns a {{domxref("MediaCapabilities")}} object that can expose information about the

--- a/files/en-us/web/api/navigator/permissions/index.md
+++ b/files/en-us/web/api/navigator/permissions/index.md
@@ -4,14 +4,13 @@ slug: Web/API/Navigator/permissions
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Navigator
   - Permissions
   - Property
   - Reference
 browser-compat: api.Navigator.permissions
 ---
-{{APIRef("HTML DOM")}}{{SeeCompatTable}}
+{{APIRef("HTML DOM")}}
 
 The **`Navigator.permissions`** read-only property returns a
 {{domxref("Permissions")}} object that can be used to query and update permission

--- a/files/en-us/web/api/navigator/webdriver/index.md
+++ b/files/en-us/web/api/navigator/webdriver/index.md
@@ -10,7 +10,7 @@ tags:
   - WebDriver
 browser-compat: api.Navigator.webdriver
 ---
-{{SeeCompatTable}}{{APIRef("WebDriver")}}
+{{APIRef("WebDriver")}}
 
 The **`webdriver`** read-only property
 of the {{domxref("navigator")}} interface indicates whether the user agent is

--- a/files/en-us/web/api/nodeiterator/pointerbeforereferencenode/index.md
+++ b/files/en-us/web/api/nodeiterator/pointerbeforereferencenode/index.md
@@ -5,12 +5,11 @@ page-type: web-api-instance-property
 tags:
   - API
   - DOM
-  - Experimental
   - NodeIterator
   - Property
 browser-compat: api.NodeIterator.pointerBeforeReferenceNode
 ---
-{{APIRef("DOM")}} {{SeeCompatTable}}
+{{APIRef("DOM")}}
 
 The **`NodeIterator.pointerBeforeReferenceNode`** read-only
 property returns a boolean flag that indicates whether the

--- a/files/en-us/web/api/nodeiterator/referencenode/index.md
+++ b/files/en-us/web/api/nodeiterator/referencenode/index.md
@@ -5,12 +5,11 @@ page-type: web-api-instance-property
 tags:
   - API
   - DOM
-  - Experimental
   - NodeIterator
   - Property
 browser-compat: api.NodeIterator.referenceNode
 ---
-{{APIRef("DOM")}}{{ SeeCompatTable }}
+{{APIRef("DOM")}}
 
 The **`NodeIterator.referenceNode`** read-only returns the
 {{domxref("Node")}} to which the iterator is anchored; as new nodes are inserted, the

--- a/files/en-us/web/api/notificationevent/action/index.md
+++ b/files/en-us/web/api/notificationevent/action/index.md
@@ -4,7 +4,6 @@ slug: Web/API/NotificationEvent/action
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - NotificationEvent
   - Notifications
   - Property

--- a/files/en-us/web/api/notificationevent/index.md
+++ b/files/en-us/web/api/notificationevent/index.md
@@ -4,7 +4,6 @@ slug: Web/API/NotificationEvent
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - Interface
   - NotificationEvent
   - Notifications

--- a/files/en-us/web/api/notificationevent/notification/index.md
+++ b/files/en-us/web/api/notificationevent/notification/index.md
@@ -4,7 +4,6 @@ slug: Web/API/NotificationEvent/notification
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - NotificationEvent
   - Notifications
   - Property

--- a/files/en-us/web/api/notificationevent/notificationevent/index.md
+++ b/files/en-us/web/api/notificationevent/notificationevent/index.md
@@ -5,7 +5,6 @@ page-type: web-api-constructor
 tags:
   - API
   - Constructor
-  - Experimental
   - NotificationEvent
   - Reference
   - Service Workers


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.
It focuses on files that have only left behind 'experimental' tags and headers.