### PR TITLE
'initStorageEvent' not deprecated

### DIFF
--- a/files/en-us/web/api/storageevent/index.md
+++ b/files/en-us/web/api/storageevent/index.md
@@ -49,7 +49,7 @@ _In addition to the properties listed below, this interface inherits the propert
 
 _In addition to the methods listed below, this interface inherits the methods of its parent interface, {{domxref("Event")}}._
 
-- {{domxref("StorageEvent.initStorageEvent", "initStorageEvent()")}} {{deprecated_inline}}
+- {{domxref("StorageEvent.initStorageEvent", "initStorageEvent()")}}
   - : Initializes the event in a manner analogous to the similarly-named {{domxref("Event.initEvent", "initEvent()")}} method in the DOM
     Events interfaces. Use the constructor instead.
 

--- a/files/en-us/web/api/storageevent/initstorageevent/index.md
+++ b/files/en-us/web/api/storageevent/initstorageevent/index.md
@@ -5,13 +5,12 @@ page-type: web-api-instance-method
 tags:
   - API
   - Method
-  - Deprecated
   - Reference
   - StorageEvent
   - Web Storage API
 browser-compat: api.StorageEvent.initStorageEvent
 ---
-{{ ApiRef("Web Storage API") }}{{deprecated_header}}
+{{ ApiRef("Web Storage API") }}
 
 The **`StorageEvent.initStorageEvent()`** method is used to initialize the
 value of a {{ domxref("StorageEvent") }}.


### PR DESCRIPTION
### Summary
It's still in the latest specifications https://html.spec.whatwg.org/multipage/webstorage.html#the-storageevent-interface. Couldn't find any info about its deprecation.
Most of the browsers support it.
And we can still run:
```
const evt = document.createEvent('StorageEvent'); 
evt.initStorageEvent('storage', false, false, 'key', 'oldValue', 'newValue', 'url'); 
dispatchEvent(evt);
```