### PR TITLE
GroupData: add navigator.mediaCapabilities in eponymous group

### DIFF
--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -784,7 +784,7 @@
         "mediaCapabilities.decodingInfo()",
         "mediaCapabilities.encodingInfo()"
       ],
-      "properties": [],
+      "properties": ["navigator.mediaCapabilities"],
       "events": [],
       "dictionaries": []
     },


### PR DESCRIPTION
It is part of Media Capabilities API; it is important to be able to navigate to it quickly from anywhere in this API.