### PR TITLE
Fix a description of the translate CSS property

### DIFF
--- a/files/en-us/web/css/translate/index.md
+++ b/files/en-us/web/css/translate/index.md
@@ -41,7 +41,7 @@ translate: unset;
 ### Values
 
 - Single {{cssxref("&lt;length-percentage&gt;")}} value
-  - : A {{cssxref("&lt;length&gt;")}} or {{cssxref("&lt;percentage&gt;")}} that specifies a 2D translation, with the same translation along both the X and Y axes. Equivalent to a `translate()` (2D translation) function with a single value specified.
+  - : A {{cssxref("&lt;length&gt;")}} or {{cssxref("&lt;percentage&gt;")}} that specifies a translation along the X-axis. Equivalent to a `translate()` (2D translation) function with a single value specified.
 - Two {{cssxref("&lt;length-percentage&gt;")}} values
   - : Two {{cssxref("&lt;length&gt;")}} or {{cssxref("&lt;percentage&gt;")}} that specify the X and Y axis translation values (respectively) of a 2D translation. Equivalent to a `translate()` (2D translation) function with two values specified.
 - Three values


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Fixes #19695.

Changed the description of the `translate` property that incorrectly explains the behavior when a single value is used with it. In this case y-coordinate of the translating vector defaults to `0px`, equivalent to the `translate()` function when only a single value is specified.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
