### PR TITLE
Fix capitalization of NumberFormat

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/intl/numberformat/formattoparts/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/intl/numberformat/formattoparts/index.md
@@ -14,7 +14,7 @@ browser-compat: javascript.builtins.Intl.NumberFormat.formatToParts
 ---
 {{JSRef}}
 
-The **`Intl.Numberformat.prototype.formatToParts()`** method
+The **`Intl.NumberFormat.prototype.formatToParts()`** method
 allows locale-aware formatting of strings produced by `NumberFormat`
 formatters.
 


### PR DESCRIPTION
Fixes the capitalization of `NumberFormat` in `Intl.Numberformat.prototype.formatToParts()`.

This pull request fixes a typo, bug, or other error.