### PR TITLE
fix code block tags - these are not css

### DIFF
--- a/files/en-us/web/api/background_fetch_api/index.md
+++ b/files/en-us/web/api/background_fetch_api/index.md
@@ -41,7 +41,7 @@ The Background Fetch API will enable the fetch to happen if the user starts the 
 
 Before using Background Fetch, check for browser support.
 
-```css
+```js
 if (!('BackgroundFetchManager' in self)) {
   // Provide fallback downloading.
 }

--- a/files/en-us/web/api/cssstylesheet/cssstylesheet/index.md
+++ b/files/en-us/web/api/cssstylesheet/cssstylesheet/index.md
@@ -43,8 +43,8 @@ new CSSStyleSheet(options)
 In the following example, a new {{domxref("CSSStyleSheet")}} is constructed with a media rule of `"print"`.
 Printing {{domxref("StyleSheet.media")}} to the console returns a {{domxref("MediaList")}} with a single entry for this print rule.
 
-```css
-let stylesheet = new CSSStyleSheet({media: 'print'});
+```js
+let stylesheet = new CSSStyleSheet({ media: "print" });
 console.log(stylesheet.media);
 ```
 
@@ -74,8 +74,8 @@ We can modify the stylesheets after they have been added to the array.
 Below we append a new rule to the same sheet using {{domxref("CSSStyleSheet.insertRule()")}}.
 
 ```js
- sheet.insertRule("* { background-color: blue; }");
- // The document will now have blue background.
+sheet.insertRule("* { background-color: blue; }");
+// The document will now have blue background.
 ```
 
 The same sheet can be shared with multiple shadow subtrees in the same document.

--- a/files/en-us/web/api/fontface/ascentoverride/index.md
+++ b/files/en-us/web/api/fontface/ascentoverride/index.md
@@ -20,10 +20,14 @@ A string.
 
 ## Examples
 
-```css
-let fontFace = new FontFace('Roboto', 'url(https://fonts.example.com/roboto.woff2)', {'ascentOverride':'90%'});
+```js
+let fontFace = new FontFace(
+  "Roboto",
+  "url(https://fonts.example.com/roboto.woff2)",
+  { ascentOverride: "90%" }
+);
 console.log(fontFace.ascentOverride); // 90%
-fontFace.ascentOverride = 'normal';
+fontFace.ascentOverride = "normal";
 console.log(fontFace.ascentOverride); // 'normal'
 ```
 

--- a/files/en-us/web/api/fontface/descentoverride/index.md
+++ b/files/en-us/web/api/fontface/descentoverride/index.md
@@ -20,11 +20,15 @@ A string.
 
 ## Examples
 
-```css
-let fontFace = new FontFace('Roboto', 'url(https://fonts.example.com/roboto.woff2)', {'descentOverride':'90%'});
-  console.log(fontFace.descentOverride); // 90%
-  fontFace.descentOverride = 'normal';
-  console.log(fontFace.descentOverride); // 'normal'
+```js
+let fontFace = new FontFace(
+  "Roboto",
+  "url(https://fonts.example.com/roboto.woff2)",
+  { descentOverride: "90%" }
+);
+console.log(fontFace.descentOverride); // 90%
+fontFace.descentOverride = "normal";
+console.log(fontFace.descentOverride); // 'normal'
 ```
 
 ## Specifications

--- a/files/en-us/web/api/fontface/linegapoverride/index.md
+++ b/files/en-us/web/api/fontface/linegapoverride/index.md
@@ -20,10 +20,14 @@ A string.
 
 ## Examples
 
-```css
-let fontFace = new FontFace('Roboto', 'url(https://fonts.example.com/roboto.woff2)', {'lineGapOverride':'90%'});
+```js
+let fontFace = new FontFace(
+  "Roboto",
+  "url(https://fonts.example.com/roboto.woff2)",
+  { lineGapOverride: "90%" }
+);
 console.log(fontFace.lineGapOverride); // 90%
-fontFace.lineGapOverride = 'normal';
+fontFace.lineGapOverride = "normal";
 console.log(fontFace.lineGapOverride); // 'normal'
 ```
 

--- a/files/en-us/web/api/hiddevice/open/index.md
+++ b/files/en-us/web/api/hiddevice/open/index.md
@@ -42,7 +42,7 @@ A {{jsxref("Promise")}} that resolves with `undefined` once the connection is op
 
 In the following example, we wait for the HID connection to open before attempting to send or receive data.
 
-```css
+```js
 await device.open();
 ```
 

--- a/files/en-us/web/api/htmlselectelement/item/index.md
+++ b/files/en-us/web/api/htmlselectelement/item/index.md
@@ -51,9 +51,9 @@ item(index)
 
 ### JavaScript
 
-```css
+```js
 // Returns the HTMLOptionElement representing #o2
-elem1 = document.forms[0]['myFormControl'][1];
+elem1 = document.forms[0]["myFormControl"][1];
 ```
 
 ## Specifications

--- a/files/en-us/web/api/medialist/index.md
+++ b/files/en-us/web/api/medialist/index.md
@@ -36,7 +36,7 @@ The **`MediaList`** interface represents the media queries of a stylesheet, e.g.
 
 The following would log to the console a textual representation of the `MediaList` of the first stylesheet applied to the current document.
 
-```css
+```js
 const stylesheets = document.styleSheets;
 let stylesheet = stylesheets[0];
 console.log(stylesheet.media.mediaText);

--- a/files/en-us/web/api/medialist/mediatext/index.md
+++ b/files/en-us/web/api/medialist/mediatext/index.md
@@ -39,7 +39,7 @@ string, i.e. the value will be set to
 The following would log to the console a textual representation of the
 `MediaList` of the first stylesheet applied to the current document.
 
-```css
+```js
 const stylesheets = document.styleSheets;
 let stylesheet = stylesheets[0];
 console.log(stylesheet.media.mediaText);

--- a/files/en-us/web/api/pushsubscriptionoptions/uservisibleonly/index.md
+++ b/files/en-us/web/api/pushsubscriptionoptions/uservisibleonly/index.md
@@ -22,12 +22,12 @@ A boolean value that indicates whether the returned push subscription will only 
 
 In the example below the value of `userVisibleOnly` is printed to the console.
 
-```css
+```js
 navigator.serviceWorker.ready.then((reg) => {
   reg.pushManager.getSubscription().then((subscription) => {
     const options = subscription.options;
     console.log(options.userVisibleOnly); // true if this is a user visible subscription
-  })
+  });
 });
 ```
 

--- a/files/en-us/web/css/_colon_has/index.md
+++ b/files/en-us/web/css/_colon_has/index.md
@@ -14,7 +14,7 @@ browser-compat: css.selectors.has
 
 The **`:has()`** CSS [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) represents an element if any of the selectors passed as parameters (relative to the {{cssxref(":scope")}} of the given element) match at least one element.
 
-```css
+```js
 /* Selects any <a>, as long as it has an <img> element directly inside it  */
 let test = document.querySelector('a:has(> img)');
 ```

--- a/files/en-us/web/css/css_grid_layout/auto-placement_in_css_grid_layout/index.md
+++ b/files/en-us/web/css/css_grid_layout/auto-placement_in_css_grid_layout/index.md
@@ -446,7 +446,7 @@ Having done this, grid will now backfill the gaps, as it moves through the grid 
 
 There is a mention in the specification of anonymous grid items. These are created if you have a string of text inside your grid container, that is not wrapped in any other element. In the example below we have three grid items, assuming you had set the parent with a class of `grid` to `display: grid`. The first is an anonymous item as it has no enclosing markup, this item will always be dealt with via the auto-placement rules. The other two are grid items enclosed in a div, they might be auto-placed or you could place these with a positioning method onto your grid.
 
-```css
+```html
 <div class="grid">
   I am a string and will become an anonymous item
   <div>A grid item</div>

--- a/files/en-us/web/css/css_values_and_units/index.md
+++ b/files/en-us/web/css/css_values_and_units/index.md
@@ -61,7 +61,7 @@ Pre-defined keywords are text values defined by the specification for that prope
 
 When viewing CSS property value syntax in a CSS specification or the MDN property page, allowable keywords will be listed in the following form. The following values are the pre-defined keyword values allowed for {{cssxref("float")}}.
 
-```css
+```plain
 left | right | none | inline-start | inline-end
 ```
 

--- a/files/en-us/web/css/dimension/index.md
+++ b/files/en-us/web/css/dimension/index.md
@@ -25,7 +25,7 @@ The syntax of `<dimension>` is a {{CSSxRef("&lt;number&gt;")}} immediately follo
 
 ### Valid dimensions
 
-```css example-good
+```plain example-good
 12px      12 pixels
 1rem      1 rem
 1.2pt     1.2 points
@@ -37,7 +37,7 @@ The syntax of `<dimension>` is a {{CSSxRef("&lt;number&gt;")}} immediately follo
 
 ### Invalid dimensions
 
-```css example-bad
+```plain example-bad
 12 px       The unit must come immediately after the number.
 12"px"      Units are identifiers and therefore unquoted.
 3sec        The seconds unit is abbreviated "s" not "sec".

--- a/files/en-us/web/css/flex_value/index.md
+++ b/files/en-us/web/css/flex_value/index.md
@@ -22,7 +22,7 @@ The `<flex>` data type is specified as a {{cssxref("&lt;number&gt;")}} followed 
 
 ### Examples of correct values for the fr data type
 
-```css
+```plain
 1fr    /* Using an integer value */
 2.5fr  /* Using a float value */
 ```

--- a/files/en-us/web/css/integer/index.md
+++ b/files/en-us/web/css/integer/index.md
@@ -27,7 +27,7 @@ When animated, values of the `<integer>` data type are {{Glossary("interpolation
 
 ### Valid integers
 
-```css example-good
+```plain example-good
 12          Positive integer (without a leading + sign)
 +123        Positive integer (with a leading + sign)
 -456        Negative integer

--- a/files/en-us/web/css/number/index.md
+++ b/files/en-us/web/css/number/index.md
@@ -26,7 +26,7 @@ When animated, values of the `<number>` CSS data type are interpolated as real, 
 
 ### Valid numbers
 
-```css example-good
+```plain example-good
 12          A raw <integer> is also a <number>.
 4.01        Positive fraction
 -456.8      Negative fraction
@@ -40,7 +40,7 @@ When animated, values of the `<number>` CSS data type are interpolated as real, 
 
 ### Invalid numbers
 
-```css example-bad
+```plain example-bad
 12.         Decimal points must be followed by at least one digit.
 +-12.2      Only one leading +/- is allowed.
 12.1.1      Only one decimal point is allowed.

--- a/files/en-us/web/css/position_value/index.md
+++ b/files/en-us/web/css/position_value/index.md
@@ -57,7 +57,7 @@ When animated, a point's abscissa and ordinate values are interpolated independe
 
 ### Valid positions
 
-```css example-good
+```plain example-good
 center
 left
 center top

--- a/files/en-us/web/html/global_attributes/nonce/index.md
+++ b/files/en-us/web/html/global_attributes/nonce/index.md
@@ -34,7 +34,7 @@ There are a few steps involved to allow-list an inline script using the nonce me
 From your web server, generate a random base64-encoded string of at least 128 bits of data from a cryptographically secure
 random number generator. Nonces should be generated differently each time the page loads (nonce only once!). For example, in nodejs:
 
-```css
+```js
 const crypto = require('crypto');
 crypto.randomBytes(16).toString('base64');
 // '8IBTHwOdqNKAWeKl7plt8g=='


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Code blocks were marked as "css" when they weren't. Changed some css -> plain, when there weren't actually css code but text examples.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
