### PR TITLE
Update BCD info, part 12

### DIFF
--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/feature_detection/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/feature_detection/index.md
@@ -82,7 +82,7 @@ Let's implement something that demonstrates this, although we'll keep it simple 
     <script src="html5shiv.min.js"></script>
     ```
 
-> **Note:** This step is no longer needed. All modern browsers are able to render semantic elements.
+    > **Note:** This step is no longer needed. All modern browsers are able to render semantic elements.
 
 3. Have a look at your example CSS files — you'll see that `basic-styling.css` handles all the styling that we want to give to every browser, whereas the other two CSS files contain the CSS we want to selectively apply to browsers depending on their support levels. You can look at the different effects these two files have by manually changing the CSS file referred to by the second {{htmlelement("link")}} element, but let's instead implement some JavaScript to automatically swap them as needed.
 4. First, remove the contents of the second `<link>` element's `href` attribute. We will fill this in dynamically later on.

--- a/files/en-us/web/api/origin/index.md
+++ b/files/en-us/web/api/origin/index.md
@@ -13,7 +13,7 @@ tags:
   - origin
 browser-compat: api.origin
 ---
-{{APIRef()}}{{SeeCompatTable}}
+{{APIRef()}}
 
 The global **`origin`** read-only property returns the origin of the global
 scope, serialized as a string.

--- a/files/en-us/web/api/overconstrainederror/index.md
+++ b/files/en-us/web/api/overconstrainederror/index.md
@@ -14,7 +14,7 @@ tags:
   - Video
 browser-compat: api.OverconstrainedError
 ---
-{{securecontext_header}}{{APIRef("Media Capture and Streams")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("Media Capture and Streams")}}
 
 The **`OverconstrainedError`** interface of the [Media Capture and Streams API](/en-US/docs/Web/API/Media_Streams_API) indicates that the set of desired capabilities for the current {{domxref('MediaStreamTrack')}} cannot currently be met. When this event is thrown on a MediaStreamTrack, it is muted until either the current constraints can be established or until satisfiable constraints are applied.
 

--- a/files/en-us/web/api/overconstrainederror/overconstrainederror/index.md
+++ b/files/en-us/web/api/overconstrainederror/overconstrainederror/index.md
@@ -14,7 +14,7 @@ tags:
   - Video
 browser-compat: api.OverconstrainedError.OverconstrainedError
 ---
-{{securecontext_header}}{{APIRef("Media Capture and Streams")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("Media Capture and Streams")}}
 
 The **`OverconstrainedError`** constructor
 creates a new {{domxref("OverconstrainedError")}} object which indicates that the set of

--- a/files/en-us/web/api/paintworklet/index.md
+++ b/files/en-us/web/api/paintworklet/index.md
@@ -14,7 +14,7 @@ tags:
   - paintWorklet
 browser-compat: api.PaintWorkletGlobalScope
 ---
-{{APIRef("CSS Painting API")}} {{SeeCompatTable}}
+{{APIRef("CSS Painting API")}}
 
 The **`PaintWorklet`** interface of the {{domxref('CSS Painting API','','',' ')}} programmatically generates an image where a CSS property expects a file. Access this interface through {{DOMxRef("CSS.paintWorklet")}}.
 

--- a/files/en-us/web/api/paymentrequest/abort/index.md
+++ b/files/en-us/web/api/paymentrequest/abort/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PaymentRequest/abort
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Payment Request API
   - PaymentRequest
   - Reference
@@ -12,7 +11,7 @@ tags:
   - abort
 browser-compat: api.PaymentRequest.abort
 ---
-{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Payment Request API")}}
+{{securecontext_header}}{{APIRef("Payment Request API")}}
 
 The `PaymentRequest.abort()` method of the {{domxref('PaymentRequest')}}
 interface causes the user agent to end the payment request and to remove any user

--- a/files/en-us/web/api/paymentrequest/canmakepayment/index.md
+++ b/files/en-us/web/api/paymentrequest/canmakepayment/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PaymentRequest/canMakePayment
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Method
   - Payment Request
   - Payment Request API

--- a/files/en-us/web/api/paymentrequest/id/index.md
+++ b/files/en-us/web/api/paymentrequest/id/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PaymentRequest/id
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Payment Request
   - Payment Request API
   - PaymentRequest
@@ -13,7 +12,7 @@ tags:
   - id
 browser-compat: api.PaymentRequest.id
 ---
-{{SeeCompatTable}}{{APIRef("Payment Request API")}}
+{{APIRef("Payment Request API")}}
 
 The **`id`** read-only attribute of the
 {{domxref("PaymentRequest")}} interface returns a unique identifier for a particular

--- a/files/en-us/web/api/paymentrequest/shippingaddress/index.md
+++ b/files/en-us/web/api/paymentrequest/shippingaddress/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PaymentRequest/shippingAddress
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Payment Request
   - Payment Request API
   - PaymentRequest
@@ -12,6 +11,8 @@ tags:
   - Reference
   - Secure context
   - shippingAddress
+  - Deprecated
+  - Non-standard
 browser-compat: api.PaymentRequest.shippingAddress
 ---
 {{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}

--- a/files/en-us/web/api/paymentrequest/shippingtype/index.md
+++ b/files/en-us/web/api/paymentrequest/shippingtype/index.md
@@ -4,13 +4,14 @@ slug: Web/API/PaymentRequest/shippingType
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Payment Request
   - Payment Request API
   - PaymentRequest
   - Reference
   - Secure context
   - shippingType
+  - Deprecated
+  - Non-standard
 browser-compat: api.PaymentRequest.shippingType
 ---
 {{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}

--- a/files/en-us/web/api/paymentrequest/show/index.md
+++ b/files/en-us/web/api/paymentrequest/show/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Commerce
-  - Experimental
   - Method
   - Payment Request
   - Payment Request API

--- a/files/en-us/web/api/paymentrequestupdateevent/index.md
+++ b/files/en-us/web/api/paymentrequestupdateevent/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PaymentRequestUpdateEvent
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - Interface
   - Payment Request
   - Payment Request API

--- a/files/en-us/web/api/paymentrequestupdateevent/paymentrequestupdateevent/index.md
+++ b/files/en-us/web/api/paymentrequestupdateevent/paymentrequestupdateevent/index.md
@@ -5,7 +5,6 @@ page-type: web-api-constructor
 tags:
   - API
   - Constructor
-  - Experimental
   - Payment Request
   - Payment Request API
   - PaymentRequestUpdateEvent

--- a/files/en-us/web/api/paymentrequestupdateevent/updatewith/index.md
+++ b/files/en-us/web/api/paymentrequestupdateevent/updatewith/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Change
-  - Experimental
   - Method
   - Payment Change
   - Payment Details

--- a/files/en-us/web/api/paymentresponse/complete/index.md
+++ b/files/en-us/web/api/paymentresponse/complete/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PaymentResponse/complete
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Method
   - Payment Request
   - Payment Request API

--- a/files/en-us/web/api/paymentresponse/details/index.md
+++ b/files/en-us/web/api/paymentresponse/details/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PaymentResponse/details
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Payment Request
   - Payment Request API
   - PaymentResponse
@@ -14,7 +13,7 @@ tags:
   - details
 browser-compat: api.PaymentResponse.details
 ---
-{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Payment Request API")}}
+{{securecontext_header}}{{APIRef("Payment Request API")}}
 
 The **`details`** read-only property of the
 {{domxref("PaymentResponse")}} interface returns a JSON-serializable object that

--- a/files/en-us/web/api/paymentresponse/methodname/index.md
+++ b/files/en-us/web/api/paymentresponse/methodname/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - Commerce
-  - Experimental
   - Payment Request
   - Payment Request API
   - PaymentResponse

--- a/files/en-us/web/api/paymentresponse/payeremail/index.md
+++ b/files/en-us/web/api/paymentresponse/payeremail/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PaymentResponse/payerEmail
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Payment Request
   - Payment Request API
   - PaymentResponse
@@ -12,6 +11,8 @@ tags:
   - Reference
   - Secure context
   - payerEmail
+  - Deprecated
+  - Non-standard
 browser-compat: api.PaymentResponse.payerEmail
 ---
 {{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}

--- a/files/en-us/web/api/paymentresponse/payername/index.md
+++ b/files/en-us/web/api/paymentresponse/payername/index.md
@@ -4,13 +4,14 @@ slug: Web/API/PaymentResponse/payerName
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Payment Request
   - Payment Request API
   - PaymentResponse
   - Property
   - Reference
   - Secure context
+  - Deprecated
+  - Non-standard
 browser-compat: api.PaymentResponse.payerName
 ---
 {{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}

--- a/files/en-us/web/api/paymentresponse/payerphone/index.md
+++ b/files/en-us/web/api/paymentresponse/payerphone/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PaymentResponse/payerPhone
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Payment Request
   - Payment Request API
   - PaymentResponse
@@ -12,6 +11,8 @@ tags:
   - Reference
   - Secure context
   - payerPhone
+  - Deprecated
+  - Non-standard
 browser-compat: api.PaymentResponse.payerPhone
 ---
 {{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}

--- a/files/en-us/web/api/paymentresponse/requestid/index.md
+++ b/files/en-us/web/api/paymentresponse/requestid/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PaymentResponse/requestId
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Payment Request
   - Payment Request API
   - PaymentResponse
@@ -13,7 +12,7 @@ tags:
   - requestId
 browser-compat: api.PaymentResponse.requestId
 ---
-{{SeeCompatTable}}{{APIRef("Payment Request API")}}
+{{APIRef("Payment Request API")}}
 
 The **`requestId`** read-only property of the
 {{domxref("PaymentResponse")}} interface returns the free-form identifier supplied by

--- a/files/en-us/web/api/paymentresponse/shippingaddress/index.md
+++ b/files/en-us/web/api/paymentresponse/shippingaddress/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PaymentResponse/shippingAddress
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Payment Request
   - Payment Request API
   - PaymentResponse
@@ -12,6 +11,8 @@ tags:
   - Reference
   - Secure context
   - shippingAddress
+  - Deprecated
+  - Non-standard
 browser-compat: api.PaymentResponse.shippingAddress
 ---
 {{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}

--- a/files/en-us/web/api/paymentresponse/shippingoption/index.md
+++ b/files/en-us/web/api/paymentresponse/shippingoption/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PaymentResponse/shippingOption
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Payment Request
   - PaymentResponse
   - Property
@@ -12,6 +11,8 @@ tags:
   - Request Payment API
   - Secure context
   - shippingOption
+  - Deprecated
+  - Non-standard
 browser-compat: api.PaymentResponse.shippingOption
 ---
 {{securecontext_header}}{{APIRef("Payment Request API")}}{{Deprecated_header}}{{Non-standard_header}}

--- a/files/en-us/web/api/performancenavigationtiming/domcomplete/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/domcomplete/index.md
@@ -9,7 +9,7 @@ tags:
   - Web Performance
 browser-compat: api.PerformanceNavigationTiming.domComplete
 ---
-{{APIRef("Navigation Timing")}}{{SeeCompatTable}}
+{{APIRef("Navigation Timing")}}
 
 The **`domComplete`** read-only property returns a
 {{domxref("DOMHighResTimeStamp","timestamp")}} representing the time value equal to the

--- a/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventend/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventend/index.md
@@ -9,7 +9,7 @@ tags:
   - Web Performance
 browser-compat: api.PerformanceNavigationTiming.domContentLoadedEventEnd
 ---
-{{APIRef("Navigation Timing")}}{{SeeCompatTable}}
+{{APIRef("Navigation Timing")}}
 
 The **`domContentLoadedEventEnd`** read-only property returns a
 {{domxref("DOMHighResTimeStamp","timestamp")}} representing the time value equal to the

--- a/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventstart/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/domcontentloadedeventstart/index.md
@@ -9,7 +9,7 @@ tags:
   - Web Performance
 browser-compat: api.PerformanceNavigationTiming.domContentLoadedEventStart
 ---
-{{APIRef("Navigation Timing")}}{{SeeCompatTable}}
+{{APIRef("Navigation Timing")}}
 
 The **`domContentLoadedEventStart`** read-only property returns
 a {{domxref("DOMHighResTimeStamp","timestamp")}} representing the time value equal to

--- a/files/en-us/web/api/performancenavigationtiming/dominteractive/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/dominteractive/index.md
@@ -9,7 +9,7 @@ tags:
   - Web Performance
 browser-compat: api.PerformanceNavigationTiming.domInteractive
 ---
-{{APIRef("Navigation Timing")}}{{SeeCompatTable}}
+{{APIRef("Navigation Timing")}}
 
 The **`domInteractive`** read-only property returns a
 {{domxref("DOMHighResTimeStamp","timestamp")}} representing the time value equal to the

--- a/files/en-us/web/api/performancenavigationtiming/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/index.md
@@ -11,7 +11,7 @@ tags:
   - Web Performance
 browser-compat: api.PerformanceNavigationTiming
 ---
-{{APIRef("Navigation Timing")}}{{SeeCompatTable}}
+{{APIRef("Navigation Timing")}}
 
 The **`PerformanceNavigationTiming`** interface provides methods and properties to store and retrieve metrics regarding the browser's document navigation events. For example, this interface can be used to determine how much time it takes to load or unload a document.
 

--- a/files/en-us/web/api/performancenavigationtiming/loadeventend/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/loadeventend/index.md
@@ -9,7 +9,7 @@ tags:
   - Web Performance
 browser-compat: api.PerformanceNavigationTiming.loadEventEnd
 ---
-{{APIRef("Navigation Timing")}}{{SeeCompatTable}}
+{{APIRef("Navigation Timing")}}
 
 The **`loadEventEnd`** read-only property returns a
 {{domxref("DOMHighResTimeStamp","timestamp")}} which is equal to the time when the load

--- a/files/en-us/web/api/performancenavigationtiming/loadeventstart/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/loadeventstart/index.md
@@ -9,7 +9,7 @@ tags:
   - Web Performance
 browser-compat: api.PerformanceNavigationTiming.loadEventStart
 ---
-{{APIRef("Navigation Timing")}}{{SeeCompatTable}}
+{{APIRef("Navigation Timing")}}
 
 The **`loadEventStart`** read-only property returns a
 {{domxref("DOMHighResTimeStamp","timestamp")}} representing the time value equal to the

--- a/files/en-us/web/api/performancenavigationtiming/redirectcount/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/redirectcount/index.md
@@ -9,7 +9,7 @@ tags:
   - Web Performance
 browser-compat: api.PerformanceNavigationTiming.redirectCount
 ---
-{{APIRef("Navigation Timing")}}{{SeeCompatTable}}
+{{APIRef("Navigation Timing")}}
 
 The **`redirectCount`** property returns a
 {{domxref("DOMHighResTimeStamp","timestamp")}} representing the number of redirects

--- a/files/en-us/web/api/performancenavigationtiming/tojson/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/tojson/index.md
@@ -9,7 +9,7 @@ tags:
   - Web Performance
 browser-compat: api.PerformanceNavigationTiming.toJSON
 ---
-{{APIRef("Navigation Timing")}}{{SeeCompatTable}}
+{{APIRef("Navigation Timing")}}
 
 The **`toJSON()`** method is a _serializer_ - it returns
 a JSON representation of the {{domxref("PerformanceNavigationTiming")}} object.

--- a/files/en-us/web/api/performancenavigationtiming/type/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/type/index.md
@@ -9,7 +9,7 @@ tags:
   - Web Performance
 browser-compat: api.PerformanceNavigationTiming.type
 ---
-{{APIRef("Navigation Timing")}}{{SeeCompatTable}}
+{{APIRef("Navigation Timing")}}
 
 The **`type`** read-only property returns the type of navigation.
 

--- a/files/en-us/web/api/performancenavigationtiming/unloadeventend/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/unloadeventend/index.md
@@ -9,7 +9,7 @@ tags:
   - Web Performance
 browser-compat: api.PerformanceNavigationTiming.unloadEventEnd
 ---
-{{APIRef("Navigation Timing")}}{{SeeCompatTable}}
+{{APIRef("Navigation Timing")}}
 
 The **`unloadEventEnd`** read-only property returns a
 {{domxref("DOMHighResTimeStamp","timestamp")}} representing the time value equal to the

--- a/files/en-us/web/api/performancenavigationtiming/unloadeventstart/index.md
+++ b/files/en-us/web/api/performancenavigationtiming/unloadeventstart/index.md
@@ -9,7 +9,7 @@ tags:
   - Web Performance
 browser-compat: api.PerformanceNavigationTiming.unloadEventStart
 ---
-{{APIRef("Navigation Timing")}}{{SeeCompatTable}}
+{{APIRef("Navigation Timing")}}
 
 The **`unloadEventStart`** read-only property returns a
 {{domxref("DOMHighResTimeStamp","timestamp")}} representing the time value equal to the

--- a/files/en-us/web/api/permissions/revoke/index.md
+++ b/files/en-us/web/api/permissions/revoke/index.md
@@ -4,12 +4,12 @@ slug: Web/API/Permissions/revoke
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Method
   - Permissions
   - Permissions API
   - Reference
   - revoke
+  - Deprecated
 browser-compat: api.Permissions.revoke
 ---
 {{APIRef("Permissions API")}}{{deprecated_header}}

--- a/files/en-us/web/api/permissionstatus/change_event/index.md
+++ b/files/en-us/web/api/permissionstatus/change_event/index.md
@@ -11,7 +11,7 @@ tags:
   - change
 browser-compat: api.PermissionStatus.change_event
 ---
-{{APIRef("Permissions API")}}{{SeeCompatTable}}
+{{APIRef("Permissions API")}}
 
 The **`change`** event of the {{domxref("PermissionStatus")}} interface fires whenever the {{domxref("PermissionStatus.state")}} property changes.
 

--- a/files/en-us/web/api/permissionstatus/index.md
+++ b/files/en-us/web/api/permissionstatus/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PermissionStatus
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - Interface
   - PermissionStatus
   - Permissions
@@ -12,7 +11,7 @@ tags:
   - Reference
 browser-compat: api.PermissionStatus
 ---
-{{APIRef("Permissions API")}}{{SeeCompatTable}}
+{{APIRef("Permissions API")}}
 
 The **`PermissionStatus`** interface of the [Permissions API](Permissions_API) provides the state of an object and an event handler for monitoring changes to said state.
 

--- a/files/en-us/web/api/permissionstatus/name/index.md
+++ b/files/en-us/web/api/permissionstatus/name/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - Event Handler
-  - Experimental
   - PermissionStatus
   - Permissions
   - Permissions API
@@ -14,7 +13,7 @@ tags:
   - status
 browser-compat: api.PermissionStatus.name
 ---
-{{APIRef("Permissions API")}}{{SeeCompatTable}}
+{{APIRef("Permissions API")}}
 
 The **`name`** read-only property of the {{domxref("PermissionStatus")}} interface returns the name of a requested permission.
 

--- a/files/en-us/web/api/permissionstatus/state/index.md
+++ b/files/en-us/web/api/permissionstatus/state/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - Event Handler
-  - Experimental
   - PermissionStatus
   - Permissions
   - Permissions API
@@ -14,7 +13,7 @@ tags:
   - status
 browser-compat: api.PermissionStatus.state
 ---
-{{APIRef("Permissions API")}}{{SeeCompatTable}}
+{{APIRef("Permissions API")}}
 
 The **`state`** read-only property of the
 {{domxref("PermissionStatus")}} interface returns the state of a requested permission.

--- a/files/en-us/web/api/pointerevent/getcoalescedevents/index.md
+++ b/files/en-us/web/api/pointerevent/getcoalescedevents/index.md
@@ -11,7 +11,7 @@ tags:
   - Reference
 browser-compat: api.PointerEvent.getCoalescedEvents
 ---
-{{APIRef("Pointer Events")}}{{SeeCompatTable}}
+{{APIRef("Pointer Events")}}
 
 The **`getCoalescedEvents()`** method of the
 {{domxref("PointerEvent")}} interface returns a sequence of all

--- a/files/en-us/web/api/positionsensorvrdevice/getimmediatestate/index.md
+++ b/files/en-us/web/api/positionsensorvrdevice/getimmediatestate/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PositionSensorVRDevice/getImmediateState
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Method
   - Deprecated
   - PositionSensorVRDevice
@@ -12,9 +11,10 @@ tags:
   - VR
   - Virtual Reality
   - WebVR
+  - Non-standard
 browser-compat: api.PositionSensorVRDevice.getImmediateState
 ---
-{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}
+{{deprecated_header}}{{APIRef("WebVR API")}}{{Non-standard_header}}
 
 The **`getImmediateState()`** method of the {{domxref("VRDisplay")}} interface returns the current instantaneous position sensor state. This is intended to only be used rarely, for certain special uses, for example sampling the immediate position of a hand orientation sensor — or at least it will be, in the future.
 

--- a/files/en-us/web/api/positionsensorvrdevice/getstate/index.md
+++ b/files/en-us/web/api/positionsensorvrdevice/getstate/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PositionSensorVRDevice/getState
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Method
   - Deprecated
   - PositionSensorVRDevice
@@ -12,9 +11,10 @@ tags:
   - VR
   - Virtual Reality
   - WebVR
+  - Non-standard
 browser-compat: api.PositionSensorVRDevice.getState
 ---
-{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}
+{{deprecated_header}}{{APIRef("WebVR API")}}{{Non-standard_header}}
 
 The **`getState()`** method of the {{domxref("PositionSensorVRDevice")}} interface returns the current state of the position sensor for the current frame (e.g. within the current {{domxref("window.requestAnimationFrame")}} callback) or for the previous frame, contained with a {{domxref("VRPose")}} object. This is the method you'd normally want to use, vs. {{domxref("PositionSensorVRDevice.getImmediateState")}}.
 

--- a/files/en-us/web/api/positionsensorvrdevice/resetsensor/index.md
+++ b/files/en-us/web/api/positionsensorvrdevice/resetsensor/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PositionSensorVRDevice/resetSensor
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Method
   - Deprecated
   - PositionSensorVRDevice
@@ -13,9 +12,10 @@ tags:
   - Virtual Reality
   - WebVR
   - resetSensor
+  - Non-standard
 browser-compat: api.PositionSensorVRDevice.resetSensor
 ---
-{{deprecated_header}}{{APIRef("WebVR API")}}{{SeeCompatTable}}
+{{deprecated_header}}{{APIRef("WebVR API")}}{{Non-standard_header}}
 
 The **`resetSensor()`** method of the {{domxref("VRDisplay")}} interface _can be used to reset the sensor if desired, returning the_ position and orientation values to zero.
 

--- a/files/en-us/web/api/prioritized_task_scheduling_api/index.md
+++ b/files/en-us/web/api/prioritized_task_scheduling_api/index.md
@@ -7,10 +7,9 @@ tags:
   - Prioritized Task Scheduling API
   - Reference
   - Landing
-  - Experimental
 browser-compat: api.Scheduler
 ---
-{{DefaultAPISidebar("Prioritized Task Scheduling API")}} {{SeeCompatTable}} {{AvailableInWorkers}}
+{{DefaultAPISidebar("Prioritized Task Scheduling API")}} {{AvailableInWorkers}}
 
 The **Prioritized Task Scheduling API** provides a standardized way to prioritize all tasks belonging to an application, whether they defined in a website developer's code, or in third party libraries and frameworks.
 

--- a/files/en-us/web/api/pushevent/data/index.md
+++ b/files/en-us/web/api/pushevent/data/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PushEvent/data
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Push
   - PushEvent

--- a/files/en-us/web/api/pushevent/data/index.md
+++ b/files/en-us/web/api/pushevent/data/index.md
@@ -11,7 +11,7 @@ tags:
   - data
 browser-compat: api.PushEvent.data
 ---
-{{APIRef("Push API")}}{{SeeCompatTable()}}
+{{APIRef("Push API")}}
 
 The `data` read-only property of the **`PushEvent`** interface returns a reference to a {{domxref("PushMessageData")}} object containing data sent to the {{domxref("PushSubscription")}}.
 

--- a/files/en-us/web/api/pushevent/pushevent/index.md
+++ b/files/en-us/web/api/pushevent/pushevent/index.md
@@ -12,7 +12,7 @@ tags:
   - Service Workers
 browser-compat: api.PushEvent.PushEvent
 ---
-{{APIRef("Push API")}}{{SeeCompatTable()}}
+{{APIRef("Push API")}}
 
 The **`PushEvent()`** constructor creates a new
 {{domxref("PushEvent")}} object. Note that this constructor is exposed only to a

--- a/files/en-us/web/api/pushevent/pushevent/index.md
+++ b/files/en-us/web/api/pushevent/pushevent/index.md
@@ -5,7 +5,6 @@ page-type: web-api-constructor
 tags:
   - API
   - Constructor
-  - Experimental
   - Push
   - Push API
   - PushEvent

--- a/files/en-us/web/api/pushmanager/getsubscription/index.md
+++ b/files/en-us/web/api/pushmanager/getsubscription/index.md
@@ -4,14 +4,13 @@ slug: Web/API/PushManager/getSubscription
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Method
   - PushManager
   - Reference
   - Service Workers
 browser-compat: api.PushManager.getSubscription
 ---
-{{SeeCompatTable}}{{ApiRef("Push API")}}
+{{ApiRef("Push API")}}
 
 The **`PushManager.getSubscription()`** method of the {{domxref("PushManager")}} interface retrieves an existing push subscription.
 

--- a/files/en-us/web/api/pushmanager/permissionstate/index.md
+++ b/files/en-us/web/api/pushmanager/permissionstate/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PushManager/permissionState
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Method
   - PushManager
   - Reference
@@ -12,7 +11,7 @@ tags:
   - permissionState
 browser-compat: api.PushManager.permissionState
 ---
-{{SeeCompatTable}}{{ApiRef("Push API")}}
+{{ApiRef("Push API")}}
 
 The **`permissionState()`** method of the
 {{domxref("PushManager")}} interface returns a {{jsxref("Promise")}} that resolves to a

--- a/files/en-us/web/api/pushmanager/subscribe/index.md
+++ b/files/en-us/web/api/pushmanager/subscribe/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PushManager/subscribe
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Method
   - PushManager
   - Reference
@@ -12,7 +11,7 @@ tags:
   - subscribe
 browser-compat: api.PushManager.subscribe
 ---
-{{SeeCompatTable}}{{ApiRef("Push API")}}
+{{ApiRef("Push API")}}
 
 The **`subscribe()`** method of the {{domxref("PushManager")}}
 interface subscribes to a push service.

--- a/files/en-us/web/api/pushmanager/supportedcontentencodings/index.md
+++ b/files/en-us/web/api/pushmanager/supportedcontentencodings/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PushManager/supportedContentEncodings
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - PushManager
   - Reference
@@ -12,7 +11,7 @@ tags:
   - supportedContentEncodings
 browser-compat: api.PushManager.supportedContentEncodings
 ---
-{{SeeCompatTable}}{{APIRef("Push API")}}
+{{APIRef("Push API")}}
 
 The **`supportedContentEncodings`** read-only property of the
 {{domxref("PushManager")}} interface returns an array of supported content codings that

--- a/files/en-us/web/css/easing-function/index.md
+++ b/files/en-us/web/css/easing-function/index.md
@@ -88,22 +88,22 @@ where:
 #### Keywords for common cubic-bezier easing functions
 
 - `ease`
-    - : The interpolation starts slowly, accelerates sharply, and then slows gradually towards the end. This keyword represents the easing function `cubic-bezier(0.25, 0.1, 0.25, 1.0)`. It is similar to [`ease-in-out`](#ease-in-out), though it accelerates more sharply at the beginning.
+  - : The interpolation starts slowly, accelerates sharply, and then slows gradually towards the end. This keyword represents the easing function `cubic-bezier(0.25, 0.1, 0.25, 1.0)`. It is similar to [`ease-in-out`](#ease-in-out), though it accelerates more sharply at the beginning.
 
 ![A graph with X and Y ranges from 0 to 1, with the X axis labeled 'Time ratio' and the Y axis labeled 'Output ratio'. A curving line extends from the origin to the X 1 Y 1 position, quickly rising and arcing.](cubic-bezier-ease.png)
 
 - `ease-in`
-    - : The interpolation starts slowly, and then progressively speeds up until the end, at which point it stops abruptly. This keyword represents the easing function `cubic-bezier(0.42, 0.0, 1.0, 1.0)`.
+  - : The interpolation starts slowly, and then progressively speeds up until the end, at which point it stops abruptly. This keyword represents the easing function `cubic-bezier(0.42, 0.0, 1.0, 1.0)`.
 
 ![A graph with X and Y ranges from 0 to 1, with the X axis labeled 'Time ratio' and the Y axis labeled 'Output ratio'. A slightly curving line extends from the origin to the X 1 Y 1 position, with most of the curve close to the origin, straightening out as it approaches X 1 Y 1.](cubic-bezier-ease-in.png)
 
 - `ease-in-out`
-    - : The interpolation starts slowly, speeds up, and then slows down towards the end. This keyword represents the easing function `cubic-bezier(0.42, 0.0, 0.58, 1.0)`. At the beginning, it behaves like the [`ease-in`](#ease-in) function; at the end, it is like the [`ease-out`](#ease-out) function.
+  - : The interpolation starts slowly, speeds up, and then slows down towards the end. This keyword represents the easing function `cubic-bezier(0.42, 0.0, 0.58, 1.0)`. At the beginning, it behaves like the [`ease-in`](#ease-in) function; at the end, it is like the [`ease-out`](#ease-out) function.
 
 ![A graph with X and Y ranges from 0 to 1, with the X axis labeled 'Time ratio' and the Y axis labeled 'Output ratio'. A slightly curving line extends from the origin to the X 1 Y 1 position. The curve is symmetrical, resembling a stretched out letter S.](cubic-bezier-ease-in-out.png)
 
 - `ease-out`
-    - : The interpolation starts abruptly, and then progressively slows down towards the end. This keyword represents the easing function `cubic-bezier(0.0, 0.0, 0.58, 1.0)`.
+  - : The interpolation starts abruptly, and then progressively slows down towards the end. This keyword represents the easing function `cubic-bezier(0.0, 0.0, 0.58, 1.0)`.
 
 ![A graph with X and Y ranges from 0 to 1, with the X axis labeled 'Time ratio' and the Y axis labeled 'Output ratio'. A slightly curving line extends from the origin to the X 1 Y 1 position, starting as an almost straight diagonal line and curving as it gets close to X 1 Y 1.](cubic-bezer-ease-out.png)
 
@@ -156,12 +156,12 @@ where:
 #### Step function keywords
 
 - `step-start`
-    - :  The interpolation jumps immediately to its final state, where it stays until the end. This keyword represents the easing function `steps(1, jump-start)` or `steps(1, start)`.
+  - :  The interpolation jumps immediately to its final state, where it stays until the end. This keyword represents the easing function `steps(1, jump-start)` or `steps(1, start)`.
 
 ![A graph with X and Y ranges from 0 to 1, with the X axis labeled 'Time ratio' and the Y axis labeled 'Output ratio'. Two dots are present, the first at the X 0 Y 0 position, and the second at the X 1 Y 1 position. The second dot has a horizontal lines extending 1 units back towards the Y axis.](steps-1-start.png)
 
 - `step-end`
-    - : The interpolation stays in its initial state until the end, at which point it jumps directly to its final state. This keyword represents the easing function `steps(1, jump-end)` or `steps(1, end)`.
+  - : The interpolation stays in its initial state until the end, at which point it jumps directly to its final state. This keyword represents the easing function `steps(1, jump-end)` or `steps(1, end)`.
 
 ![A graph with X and Y ranges from 0 to 1, with the X axis labeled 'Time ratio' and the Y axis labeled 'Output ratio'. Two dots are present, the first at the X 0 Y 0 position, and the second at the X 1 Y 1 position. The first dot has a horizontal lines extending 1 unit forwards away from the Y axis.](steps-1-end.png)
 


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.
It focuses on files that have only left behind 'experimental' tags and headers.