### PR TITLE
Update BCD info, part 13

### DIFF
--- a/files/en-us/web/api/pushmanager/index.md
+++ b/files/en-us/web/api/pushmanager/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PushManager
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - Interface
   - Push
   - Push API

--- a/files/en-us/web/api/pushmessagedata/arraybuffer/index.md
+++ b/files/en-us/web/api/pushmessagedata/arraybuffer/index.md
@@ -12,7 +12,7 @@ tags:
   - Service Workers
 browser-compat: api.PushMessageData.arrayBuffer
 ---
-{{APIRef("Push API")}}{{SeeCompatTable()}}
+{{APIRef("Push API")}}
 
 The **`arrayBuffer()`** method of the {{domxref("PushMessageData")}} interface extracts push message data as an {{jsxref("ArrayBuffer")}} object.
 

--- a/files/en-us/web/api/pushmessagedata/arraybuffer/index.md
+++ b/files/en-us/web/api/pushmessagedata/arraybuffer/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - ArrayBuffer
-  - Experimental
   - Method
   - Push
   - PushMessageData

--- a/files/en-us/web/api/pushmessagedata/blob/index.md
+++ b/files/en-us/web/api/pushmessagedata/blob/index.md
@@ -12,7 +12,7 @@ tags:
   - Service Workers
 browser-compat: api.PushMessageData.blob
 ---
-{{APIRef("Push API")}}{{SeeCompatTable()}}
+{{APIRef("Push API")}}
 
 The **`blob()`** method of the {{domxref("PushMessageData")}} interface extracts push message data as a {{domxref("Blob")}} object.
 

--- a/files/en-us/web/api/pushmessagedata/blob/index.md
+++ b/files/en-us/web/api/pushmessagedata/blob/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Blob
-  - Experimental
   - Method
   - Push
   - PushMessageData

--- a/files/en-us/web/api/pushmessagedata/index.md
+++ b/files/en-us/web/api/pushmessagedata/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PushMessageData
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - Interface
   - Push
   - Push API

--- a/files/en-us/web/api/pushmessagedata/index.md
+++ b/files/en-us/web/api/pushmessagedata/index.md
@@ -12,7 +12,7 @@ tags:
   - Service Workers
 browser-compat: api.PushMessageData
 ---
-{{APIRef("Push API")}}{{SeeCompatTable()}}
+{{APIRef("Push API")}}
 
 The **`PushMessageData`** interface of the [Push API](/en-US/docs/Web/API/Push_API) provides methods which let you retrieve the push data sent by a server in various formats.
 

--- a/files/en-us/web/api/pushmessagedata/json/index.md
+++ b/files/en-us/web/api/pushmessagedata/json/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PushMessageData/json
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - JSON
   - Method
   - Push

--- a/files/en-us/web/api/pushmessagedata/json/index.md
+++ b/files/en-us/web/api/pushmessagedata/json/index.md
@@ -12,7 +12,7 @@ tags:
   - Service Workers
 browser-compat: api.PushMessageData.json
 ---
-{{APIRef("Push API")}}{{SeeCompatTable()}}
+{{APIRef("Push API")}}
 
 The **`json()`** method of the {{domxref("PushMessageData")}} interface extracts push message data by parsing it as a [JSON](/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON) string and returning the result.
 

--- a/files/en-us/web/api/pushmessagedata/text/index.md
+++ b/files/en-us/web/api/pushmessagedata/text/index.md
@@ -13,7 +13,7 @@ tags:
   - Text
 browser-compat: api.PushMessageData.text
 ---
-{{APIRef("Push API")}}{{SeeCompatTable()}}
+{{APIRef("Push API")}}
 
 The **`text()`** method of the {{domxref("PushMessageData")}} interface extracts push message data as a plain text string.
 

--- a/files/en-us/web/api/pushmessagedata/text/index.md
+++ b/files/en-us/web/api/pushmessagedata/text/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PushMessageData/text
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Method
   - Plain text
   - Push

--- a/files/en-us/web/api/pushsubscription/endpoint/index.md
+++ b/files/en-us/web/api/pushsubscription/endpoint/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PushSubscription/endpoint
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Push
   - Push API
@@ -14,7 +13,7 @@ tags:
   - endPoint
 browser-compat: api.PushSubscription.endpoint
 ---
-{{SeeCompatTable}}{{APIRef("Push API")}}
+{{APIRef("Push API")}}
 
 The **`endpoint`** read-only property of the
 {{domxref("PushSubscription")}} interface returns a string containing

--- a/files/en-us/web/api/pushsubscription/expirationtime/index.md
+++ b/files/en-us/web/api/pushsubscription/expirationtime/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PushSubscription/expirationTime
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Push API
   - PushManager
@@ -13,7 +12,7 @@ tags:
   - Service Worker
 browser-compat: api.PushSubscription.expirationTime
 ---
-{{SeeCompatTable}}{{APIRef("Push API")}}
+{{APIRef("Push API")}}
 
 The **`expirationTime`** read-only property of the
 {{domxref("PushSubscription")}} interface returns a {{domxref("DOMHighResTimeStamp")}}

--- a/files/en-us/web/api/pushsubscription/getkey/index.md
+++ b/files/en-us/web/api/pushsubscription/getkey/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PushSubscription/getKey
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Method
   - Push
   - Push API
@@ -14,7 +13,7 @@ tags:
   - getKey
 browser-compat: api.PushSubscription.getKey
 ---
-{{SeeCompatTable}}{{APIRef("Push API")}}
+{{APIRef("Push API")}}
 
 The `getKey()` method of the {{domxref("PushSubscription")}} interface
 returns an {{jsxref("ArrayBuffer")}} representing a client public key, which can then

--- a/files/en-us/web/api/pushsubscription/index.md
+++ b/files/en-us/web/api/pushsubscription/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PushSubscription
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - Interface
   - Push
   - Push API
@@ -13,7 +12,7 @@ tags:
   - Service Workers
 browser-compat: api.PushSubscription
 ---
-{{SeeCompatTable}}{{ApiRef("Push API")}}
+{{ApiRef("Push API")}}
 
 The `PushSubscription` interface of the [Push API](/en-US/docs/Web/API/Push_API) provides a subscription's URL endpoint and allows unsubscribing from a push service.
 

--- a/files/en-us/web/api/pushsubscription/options/index.md
+++ b/files/en-us/web/api/pushsubscription/options/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PushSubscription/options
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Push API
   - PushManager
@@ -12,7 +11,7 @@ tags:
   - Service Worker
 browser-compat: api.PushSubscription.options
 ---
-{{SeeCompatTable}}{{APIRef("Push API")}}
+{{APIRef("Push API")}}
 
 The **`options`** read-only property
 of the {{domxref("PushSubscription")}} interface is an object containing the options

--- a/files/en-us/web/api/pushsubscription/subscriptionid/index.md
+++ b/files/en-us/web/api/pushsubscription/subscriptionid/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - Deprecated
-  - Experimental
   - Property
   - Push
   - Push API

--- a/files/en-us/web/api/pushsubscription/tojson/index.md
+++ b/files/en-us/web/api/pushsubscription/tojson/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PushSubscription/toJSON
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Method
   - Push
   - Push API
@@ -15,7 +14,7 @@ tags:
   - toJSON
 browser-compat: api.PushSubscription.toJSON
 ---
-{{SeeCompatTable}}{{APIRef("Push API")}}
+{{APIRef("Push API")}}
 
 The `toJSON()` method of the {{domxref("PushSubscription")}} interface is a
 standard serializer: it returns a JSON representation of the subscription properties,

--- a/files/en-us/web/api/pushsubscription/unsubscribe/index.md
+++ b/files/en-us/web/api/pushsubscription/unsubscribe/index.md
@@ -4,7 +4,6 @@ slug: Web/API/PushSubscription/unsubscribe
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Method
   - Push
   - Push API
@@ -14,7 +13,7 @@ tags:
   - unsubscribe
 browser-compat: api.PushSubscription.unsubscribe
 ---
-{{SeeCompatTable}}{{APIRef("Push API")}}
+{{APIRef("Push API")}}
 
 The `unsubscribe()` method of the {{domxref("PushSubscription")}} interface
 returns a {{jsxref("Promise")}} that resolves to a boolean value when the

--- a/files/en-us/web/api/range/comparepoint/index.md
+++ b/files/en-us/web/api/range/comparepoint/index.md
@@ -6,13 +6,12 @@ tags:
   - API
   - DOM
   - DOM Reference
-  - Experimental
   - Method
   - Range
   - Reference
 browser-compat: api.Range.comparePoint
 ---
-{{ApiRef("DOM")}} {{SeeCompatTable}}
+{{ApiRef("DOM")}}
 
 The **`Range.comparePoint()`** method returns `-1`,
 `0`, or `1` depending on whether the `referenceNode` is

--- a/files/en-us/web/api/range/getboundingclientrect/index.md
+++ b/files/en-us/web/api/range/getboundingclientrect/index.md
@@ -5,13 +5,12 @@ page-type: web-api-instance-method
 tags:
   - API
   - CSSOM View
-  - Experimental
   - Method
   - Range
   - Reference
 browser-compat: api.Range.getBoundingClientRect
 ---
-{{ApiRef("DOM")}}{{SeeCompatTable}}
+{{ApiRef("DOM")}}
 
 The **`Range.getBoundingClientRect()`** method returns a {{
   domxref("DOMRect") }} object that bounds the contents of the range; this is a rectangle

--- a/files/en-us/web/api/range/getclientrects/index.md
+++ b/files/en-us/web/api/range/getclientrects/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - CSSOM View
-  - Experimental
   - Method
   - Range
   - Reference

--- a/files/en-us/web/api/range/intersectsnode/index.md
+++ b/files/en-us/web/api/range/intersectsnode/index.md
@@ -5,13 +5,12 @@ page-type: web-api-instance-method
 tags:
   - API
   - DOM
-  - Experimental
   - Method
   - Range
   - Reference
 browser-compat: api.Range.intersectsNode
 ---
-{{ApiRef("DOM")}} {{SeeCompatTable}}
+{{ApiRef("DOM")}}
 
 The **`Range.intersectsNode()`** method returns a boolean
 indicating whether the given {{domxref("Node")}} intersects the {{domxref("Range")}}.

--- a/files/en-us/web/api/range/ispointinrange/index.md
+++ b/files/en-us/web/api/range/ispointinrange/index.md
@@ -5,13 +5,12 @@ page-type: web-api-instance-method
 tags:
   - API
   - DOM
-  - Experimental
   - Method
   - Range
   - Reference
 browser-compat: api.Range.isPointInRange
 ---
-{{ApiRef("DOM")}}{{SeeCompatTable}}
+{{ApiRef("DOM")}}
 
 The **`Range.isPointInRange()`** method returns a boolean
 indicating whether the given point is in the {{domxref("Range")}}. It returns

--- a/files/en-us/web/api/range/range/index.md
+++ b/files/en-us/web/api/range/range/index.md
@@ -7,12 +7,11 @@ tags:
   - Constructor
   - DOM
   - DOM Reference
-  - Experimental
   - Range
   - Reference
 browser-compat: api.Range.Range
 ---
-{{ APIRef("DOM") }} {{SeeCompatTable}}
+{{ APIRef("DOM") }}
 
 The **`Range()`** constructor returns a newly created
 {{domxref("Range")}} object whose start and end is the global {{domxref("Document")}}

--- a/files/en-us/web/api/resizeobserver/index.md
+++ b/files/en-us/web/api/resizeobserver/index.md
@@ -5,7 +5,6 @@ page-type: web-api-interface
 tags:
   - API
   - Bounding Box
-  - Experimental
   - Interface
   - Reference
   - Resize Observer API

--- a/files/en-us/web/api/rtcdatachannel/closing_event/index.md
+++ b/files/en-us/web/api/rtcdatachannel/closing_event/index.md
@@ -16,10 +16,9 @@ tags:
   - closing
   - events
   - Event
-  - Experimental
 browser-compat: api.RTCDataChannel.closing_event
 ---
-{{APIRef("WebRTC")}}{{SeeCompatTable}}
+{{APIRef("WebRTC")}}
 
 The **`closing`** event is sent to an {{domxref("RTCDataChannel")}} just before the channel begins the process of shutting down its underlying data transport.
 

--- a/files/en-us/web/api/rtcdtlstransport/index.md
+++ b/files/en-us/web/api/rtcdtlstransport/index.md
@@ -5,7 +5,6 @@ page-type: web-api-interface
 tags:
   - API
   - Draft
-  - Experimental
   - Interface
   - NeedsContent
   - NeedsExample

--- a/files/en-us/web/api/rtcdtmftonechangeevent/tone/index.md
+++ b/files/en-us/web/api/rtcdtmftonechangeevent/tone/index.md
@@ -7,7 +7,7 @@ tags:
   - Property
   - RTCDTMFToneChangeEvent
   - Reference
-  - Touch-
+  - Touch
   - WebRTC
   - WebRTC API
   - tone

--- a/files/en-us/web/api/rtciceserver/credential/index.md
+++ b/files/en-us/web/api/rtciceserver/credential/index.md
@@ -4,7 +4,6 @@ slug: Web/API/RTCIceServer/credential
 page-type: web-api-instance-property
 tags:
   - Credential
-  - Experimental
   - Property
   - RTCIceServer
   - Reference
@@ -12,7 +11,7 @@ tags:
   - WebRTC
 browser-compat: api.RTCIceServer.credential
 ---
-{{APIRef("WebRTC")}}{{SeeCompatTable}}
+{{APIRef("WebRTC")}}
 
 The {{domxref("RTCIceServer")}} dictionary's
 **`credential`** property is a string providing the credential

--- a/files/en-us/web/api/rtciceserver/index.md
+++ b/files/en-us/web/api/rtciceserver/index.md
@@ -6,13 +6,12 @@ tags:
   - Authentication
   - Configuration
   - Dictionary
-  - Experimental
   - ICE
   - RTCIceServer
   - WebRTC
 browser-compat: api.RTCIceServer
 ---
-{{DefaultAPISidebar("WebRTC")}}
+{{APIRef("WebRTC")}}
 
 The **`RTCIceServer`** dictionary defines how to connect to a single ICE server (such as a {{Glossary("STUN")}} or {{Glossary("TURN")}} server). Objects of this type are provided in the [configuration](/en-US/docs/Web/API/RTCPeerConnection/RTCPeerConnection#parameters) of an {{domxref("RTCPeerConnection")}}, in the `iceServers` array.
 

--- a/files/en-us/web/api/rtciceserver/url/index.md
+++ b/files/en-us/web/api/rtciceserver/url/index.md
@@ -3,7 +3,6 @@ title: RTCIceServer.url
 slug: Web/API/RTCIceServer/url
 page-type: web-api-instance-property
 tags:
-  - Experimental
   - Deprecated
   - Property
   - RTCIceServer

--- a/files/en-us/web/api/rtciceserver/urls/index.md
+++ b/files/en-us/web/api/rtciceserver/urls/index.md
@@ -3,7 +3,6 @@ title: RTCIceServers.urls
 slug: Web/API/RTCIceServer/urls
 page-type: web-api-instance-property
 tags:
-  - Experimental
   - Property
   - RTCIceServer
   - Reference
@@ -11,7 +10,7 @@ tags:
   - urls
 browser-compat: api.RTCIceServer.urls
 ---
-{{APIRef("WebRTC")}}{{SeeCompatTable}}
+{{APIRef("WebRTC")}}
 
 The {{domxref("RTCIceServer")}} dictionary's **`urls`**
 property specifies the URL or URLs of the servers to be used for ICE negotiations. These

--- a/files/en-us/web/api/rtciceserver/username/index.md
+++ b/files/en-us/web/api/rtciceserver/username/index.md
@@ -3,7 +3,6 @@ title: RTCIceServer.username
 slug: Web/API/RTCIceServer/username
 page-type: web-api-instance-property
 tags:
-  - Experimental
   - Property
   - RTCIceServer
   - Reference

--- a/files/en-us/web/api/rtciceserver/username/index.md
+++ b/files/en-us/web/api/rtciceserver/username/index.md
@@ -12,8 +12,6 @@ browser-compat: api.RTCIceServer.username
 ---
 {{APIRef("WebRTC")}}
 
-{{SeeCompatTable}}
-
 The {{domxref("RTCIceServer")}} dictionary's **`username`**
 property is a string which specifies the username to use when authenticating with the
 {{Glossary("ICE")}} server being described.

--- a/files/en-us/web/api/rtcpeerconnectioniceevent/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceevent/index.md
@@ -4,7 +4,6 @@ slug: Web/API/RTCPeerConnectionIceEvent
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - Interface
   - RTCIceCandidateEvent
   - Reference

--- a/files/en-us/web/api/rtcpeerconnectioniceevent/rtcpeerconnectioniceevent/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceevent/rtcpeerconnectioniceevent/index.md
@@ -5,7 +5,6 @@ page-type: web-api-constructor
 tags:
   - API
   - Constructor
-  - Experimental
   - RTCPeerConnectionIceEvent
   - Reference
   - WebRTC

--- a/files/en-us/web/api/rtcpeerconnectioniceevent/rtcpeerconnectioniceevent/index.md
+++ b/files/en-us/web/api/rtcpeerconnectioniceevent/rtcpeerconnectioniceevent/index.md
@@ -10,8 +10,7 @@ tags:
   - WebRTC
 browser-compat: api.RTCPeerConnectionIceEvent.RTCPeerConnectionIceEvent
 ---
-
-{{APIRef("WebRTC")}}{{SeeCompatTable}}
+{{APIRef("WebRTC")}}
 
 The **`RTCPeerConnectionIceEvent()`** constructor creates a new
 {{domxref("RTCPeerConnectionIceEvent")}} object.

--- a/files/en-us/web/api/rtcsctptransport/index.md
+++ b/files/en-us/web/api/rtcsctptransport/index.md
@@ -3,7 +3,6 @@ title: RTCSctpTransport
 slug: Web/API/RTCSctpTransport
 page-type: web-api-interface
 tags:
-  - Experimental
   - Interface
   - NeedsExample
   - RTCSctpTransport
@@ -12,7 +11,7 @@ tags:
   - WebRTC
 browser-compat: api.RTCSctpTransport
 ---
-{{APIRef("WebRTC")}}{{SeeCompatTable}}
+{{APIRef("WebRTC")}}
 
 The **`RTCSctpTransport`** interface provides information which describes a Stream Control Transmission Protocol (**{{Glossary("SCTP")}}**) transport. This provides information about limitations of the transport, but also provides a way to access the underlying Datagram Transport Layer Security (**{{Glossary("DTLS")}}**) transport over which SCTP packets for all of an {{DOMxRef("RTCPeerConnection")}}'s data channels are sent and received.
 

--- a/files/en-us/web/api/rtcsctptransport/state/index.md
+++ b/files/en-us/web/api/rtcsctptransport/state/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - Draft
-  - Experimental
   - NeedsCompatTable
   - NeedsExample
   - Property
@@ -16,7 +15,7 @@ tags:
   - state
 browser-compat: api.RTCSctpTransport.state
 ---
-{{APIRef("WebRTC")}}{{SeeCompatTable}}
+{{APIRef("WebRTC")}}
 
 The **`state`** read-only property of the
 {{DOMxRef("RTCSctpTransport")}} interface provides information which describes a Stream

--- a/files/en-us/web/api/rtcsessiondescription/index.md
+++ b/files/en-us/web/api/rtcsessiondescription/index.md
@@ -5,7 +5,6 @@ page-type: web-api-interface
 tags:
   - API
   - Audio
-  - Experimental
   - Interface
   - Media
   - Reference

--- a/files/en-us/web/api/rtcsessiondescription/index.md
+++ b/files/en-us/web/api/rtcsessiondescription/index.md
@@ -13,8 +13,7 @@ tags:
   - WebRTC
 browser-compat: api.RTCSessionDescription
 ---
-
-{{APIRef("WebRTC")}}{{SeeCompatTable}}
+{{APIRef("WebRTC")}}
 
 The **`RTCSessionDescription`** interface describes one end of a connection—or potential connection—and how it's configured. Each `RTCSessionDescription` consists of a description {{domxref("RTCSessionDescription.type", "type")}} indicating which part of the offer/answer negotiation process it describes and of the {{Glossary("SDP")}} descriptor of the session.
 

--- a/files/en-us/web/api/rtcsessiondescription/rtcsessiondescription/index.md
+++ b/files/en-us/web/api/rtcsessiondescription/rtcsessiondescription/index.md
@@ -5,7 +5,6 @@ page-type: web-api-constructor
 tags:
   - Constructor
   - Deprecated
-  - Experimental
   - Media
   - RTCSessionDescription
   - Reference
@@ -13,8 +12,7 @@ tags:
   - WebRTC
 browser-compat: api.RTCSessionDescription.RTCSessionDescription
 ---
-
-{{APIRef("WebRTC")}}{{SeeCompatTable}}{{deprecated_header}}
+{{APIRef("WebRTC")}}{{deprecated_header}}
 
 The **`RTCSessionDescription()`** constructor creates a new
 {{domxref("RTCSessionDescription")}} with its properties initialized as described in the

--- a/files/en-us/web/api/rtcsessiondescription/sdp/index.md
+++ b/files/en-us/web/api/rtcsessiondescription/sdp/index.md
@@ -3,7 +3,6 @@ title: RTCSessionDescription.sdp
 slug: Web/API/RTCSessionDescription/sdp
 page-type: web-api-instance-property
 tags:
-  - Experimental
   - Property
   - RTCSessionDescription
   - Reference

--- a/files/en-us/web/api/rtcsessiondescription/sdp/index.md
+++ b/files/en-us/web/api/rtcsessiondescription/sdp/index.md
@@ -10,8 +10,7 @@ tags:
   - WebRTC
 browser-compat: api.RTCSessionDescription.sdp
 ---
-
-{{APIRef("WebRTC")}}{{SeeCompatTable}}
+{{APIRef("WebRTC")}}
 
 The property **`RTCSessionDescription.sdp`** is a read-only
 string containing the {{Glossary("SDP")}} which describes the session.

--- a/files/en-us/web/api/rtcsessiondescription/tojson/index.md
+++ b/files/en-us/web/api/rtcsessiondescription/tojson/index.md
@@ -3,7 +3,6 @@ title: RTCSessionDescription.toJSON()
 slug: Web/API/RTCSessionDescription/toJSON
 page-type: web-api-instance-method
 tags:
-  - Experimental
   - Method
   - RTCSessionDescription
   - Reference
@@ -11,7 +10,7 @@ tags:
   - WebRTC
 browser-compat: api.RTCSessionDescription.toJSON
 ---
-{{APIRef("WebRTC")}}{{SeeCompatTable}}
+{{APIRef("WebRTC")}}
 
 The **`RTCSessionDescription.toJSON()`** method generates a
 {{Glossary("JSON")}} description of the object. Both properties,

--- a/files/en-us/web/api/rtcsessiondescription/type/index.md
+++ b/files/en-us/web/api/rtcsessiondescription/type/index.md
@@ -11,8 +11,7 @@ tags:
   - WebRTC
 browser-compat: api.RTCSessionDescription.type
 ---
-
-{{APIRef("WebRTC")}}{{SeeCompatTable}}
+{{APIRef("WebRTC")}}
 
 The property **`RTCSessionDescription.type`** is a read-only
 string value which describes the description's type.

--- a/files/en-us/web/api/rtcsessiondescription/type/index.md
+++ b/files/en-us/web/api/rtcsessiondescription/type/index.md
@@ -3,7 +3,6 @@ title: RTCSessionDescription.type
 slug: Web/API/RTCSessionDescription/type
 page-type: web-api-instance-property
 tags:
-  - Experimental
   - Property
   - RTCSessionDescription
   - Reference

--- a/files/en-us/web/api/scheduler/index.md
+++ b/files/en-us/web/api/scheduler/index.md
@@ -6,10 +6,9 @@ tags:
   - Interface
   - Reference
   - Scheduler
-  - Experimental
 browser-compat: api.Scheduler
 ---
-{{APIRef("Prioritized Task Scheduling API")}} {{SeeCompatTable}}
+{{APIRef("Prioritized Task Scheduling API")}}
 
 The **`Scheduler`** interface of the [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API) provides the {{domxref('Scheduler.postTask()')}} method that can be used for adding prioritized tasks to be scheduled.
 

--- a/files/en-us/web/api/scheduler/posttask/index.md
+++ b/files/en-us/web/api/scheduler/posttask/index.md
@@ -7,10 +7,9 @@ tags:
   - Reference
   - Scheduler
   - API
-  - Experimental
 browser-compat: api.Scheduler.postTask
 ---
-{{APIRef("Prioritized Task Scheduling API")}} {{SeeCompatTable}}
+{{APIRef("Prioritized Task Scheduling API")}}
 
 The **`postTask()`** method of the {{domxref("Scheduler")}} interface is used for adding tasks to be [scheduled](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API) according to their [priority](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#task_priorities).
 

--- a/files/en-us/web/api/screen/orientation/index.md
+++ b/files/en-us/web/api/screen/orientation/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - CSSOM View
-  - Experimental
   - Property
   - Read-only
   - Screen Orientation

--- a/files/en-us/web/api/securitypolicyviolationevent/columnnumber/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/columnnumber/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - CSP
-  - Experimental
   - HTTP
   - Property
   - Reference
@@ -14,7 +13,7 @@ tags:
   - columnNumber
 browser-compat: api.SecurityPolicyViolationEvent.columnNumber
 ---
-{{HTTPSidebar}}"
+{{HTTPSidebar}}
 
 The **`columnNumber`** read-only property of the
 {{domxref("SecurityPolicyViolationEvent")}} interface is the column number in the

--- a/files/en-us/web/api/securitypolicyviolationevent/referrer/index.md
+++ b/files/en-us/web/api/securitypolicyviolationevent/referrer/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - CSP
-  - Experimental
   - HTTP
   - Property
   - Reference

--- a/files/en-us/web/api/serviceworkercontainer/controllerchange_event/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/controllerchange_event/index.md
@@ -4,7 +4,6 @@ slug: Web/API/ServiceWorkerContainer/controllerchange_event
 page-type: web-api-event
 tags:
   - API
-  - Experimental
   - Interface
   - Event
   - Reference

--- a/files/en-us/web/api/serviceworkercontainer/controllerchange_event/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/controllerchange_event/index.md
@@ -13,7 +13,7 @@ tags:
   - controllerchange
 browser-compat: api.ServiceWorkerContainer.controllerchange_event
 ---
-{{APIRef("Service Workers API")}}{{ SeeCompatTable() }}
+{{APIRef("Service Workers API")}}
 
 The **`controllerchange`** event of the
 {{domxref("ServiceWorkerContainer")}} interface fires when the document's associated

--- a/files/en-us/web/api/serviceworkercontainer/error_event/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/error_event/index.md
@@ -4,16 +4,17 @@ slug: Web/API/ServiceWorkerContainer/error_event
 page-type: web-api-event
 tags:
   - API
-  - Experimental
   - Event
   - Reference
   - Service Workers
   - ServiceWorker
   - ServiceWorkerContainer
   - error
+  - Deprecated
+  - Non-standard
 browser-compat: api.ServiceWorkerContainer.error_event
 ---
-{{APIRef("Service Workers API")}}{{Deprecated_header}}
+{{APIRef("Service Workers API")}}{{Deprecated_header}}{{Non-standard_header}}
 
 The `error` event fires when an error occurs in the service worker.
 

--- a/files/en-us/web/api/serviceworkercontainer/getregistrations/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/getregistrations/index.md
@@ -4,7 +4,6 @@ slug: Web/API/ServiceWorkerContainer/getRegistrations
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Method
   - Reference
   - Service Workers

--- a/files/en-us/web/api/serviceworkercontainer/startmessages/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/startmessages/index.md
@@ -4,7 +4,6 @@ slug: Web/API/ServiceWorkerContainer/startMessages
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Reference
   - Service Workers
   - ServiceWorkerContainer

--- a/files/en-us/web/api/serviceworkerregistration/getnotifications/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/getnotifications/index.md
@@ -4,7 +4,6 @@ slug: Web/API/ServiceWorkerRegistration/getNotifications
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Method
   - Notifications
   - Reference

--- a/files/en-us/web/api/serviceworkerregistration/shownotification/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/shownotification/index.md
@@ -4,7 +4,6 @@ slug: Web/API/ServiceWorkerRegistration/showNotification
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Method
   - NeedsExample
   - Reference

--- a/files/en-us/web/api/sourcebuffer/abort/index.md
+++ b/files/en-us/web/api/sourcebuffer/abort/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Audio
-  - Experimental
   - MSE
   - Media Source Extensions
   - Method
@@ -15,7 +14,7 @@ tags:
   - abort
 browser-compat: api.SourceBuffer.abort
 ---
-{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
+{{APIRef("Media Source Extensions")}}
 
 The **`abort()`** method of the {{domxref("SourceBuffer")}}
 interface aborts the current segment and resets the segment parser.


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.
It focuses on files that have only left behind 'experimental' tags and headers.