### PR TITLE
Modify the style to make it more friendly.

### DIFF
--- a/files/en-us/web/guide/css/block_formatting_context/index.md
+++ b/files/en-us/web/guide/css/block_formatting_context/index.md
@@ -171,14 +171,14 @@ Creating a new BFC to avoid the [margin collapsing](/en-US/docs/Web/CSS/CSS_Box_
 ```html
 <div class="blue"></div>
 <div class="red-outer">
-  <div class="red-inner">red inner</div>
+  <div class="yellow-inner">yellow inner</div>
 </div>
 ```
 
 #### CSS
 
 ```css
-.blue, .red-inner {
+.blue, .yellow-inner {
   height: 50px;
   margin: 10px 0;
 }
@@ -190,6 +190,10 @@ Creating a new BFC to avoid the [margin collapsing](/en-US/docs/Web/CSS/CSS_Box_
 .red-outer {
   overflow: hidden;
   background: red;
+}
+
+.yellow-inner {
+  background: yellow;
 }
 ```
 


### PR DESCRIPTION
#### Summary
For visual demonstration, modify the demonstration of the internal div to yellow.

#### Motivation
Both inside and outside are red, which makes it difficult for readers to intuitively feel how BFC avoids the margin merger of two adjacent divs.
For visual demonstration, modify the demonstration of the internal div to yellow.
#### Supporting details
none

#### Related issues
none

#### Metadata
This PR
- [ ] Rewrites (or significantly expands) a document
