### PR TITLE
Improve NodeList (remove mention of limitation of IE)

### DIFF
--- a/files/en-us/web/api/nodelist/index.md
+++ b/files/en-us/web/api/nodelist/index.md
@@ -14,12 +14,10 @@ browser-compat: api.NodeList
 **`NodeList`** objects are collections of [nodes](/en-US/docs/Web/API/Node), usually returned by properties such as {{domxref("Node.childNodes")}} and methods such as {{domxref("document.querySelectorAll()")}}.
 
 > **Note:** Although `NodeList` is not an `Array`, it is possible to iterate over it with `forEach()`. It can also be converted to a real `Array` using {{jsxref("Array.from()")}}.
->
-> However, some older browsers have not implemented `NodeList.forEach()` nor `Array.from()`. This can be circumvented by using {{jsxref("Array.forEach()", "Array.prototype.forEach()")}} — see this document's [Example](#example).
 
 ## Live vs. Static NodeLists
 
-Although they are both considered `NodeList`s, there are 2 varieties of NodeList: _live_ and _static_.
+Although they are both considered `NodeList` objects, there are 2 varieties of NodeList: _live_ and _static_.
 
 ### Live NodeLists
 
@@ -29,10 +27,10 @@ For example, {{domxref("Node.childNodes")}} is live:
 
 ```js
 const parent = document.getElementById('parent');
-let child_nodes = parent.childNodes;
-console.log(child_nodes.length); // let's assume "2"
+let childNodes = parent.childNodes;
+console.log(childNodes.length); // let's assume "2"
 parent.appendChild(document.createElement('div'));
-console.log(child_nodes.length); // outputs "3"
+console.log(childNodes.length); // outputs "3"
 ```
 
 ### Static NodeLists
@@ -84,7 +82,7 @@ for (const checkbox of list) {
 }
 ```
 
-Browsers also support iterator methods ({{domxref("NodeList.forEach()", "forEach()")}}) as well as {{domxref("NodeList.entries()", "entries()")}}, {{domxref("NodeList.values()", "values()")}}, and {{domxref("NodeList.keys()", "keys()")}}.
+Browsers also support the iterator method ({{domxref("NodeList.forEach()", "forEach()")}}) as well as {{domxref("NodeList.entries()", "entries()")}}, {{domxref("NodeList.values()", "values()")}}, and {{domxref("NodeList.keys()", "keys()")}}.
 
 ## Specifications
 


### PR DESCRIPTION
Only IE doesn't support `forEach()`, time to remove the compatibility warning.