### PR TITLE
Use the actual method name

### DIFF
--- a/files/en-us/web/api/serviceworkercontainer/register/index.md
+++ b/files/en-us/web/api/serviceworkercontainer/register/index.md
@@ -65,7 +65,7 @@ register(scriptURL, options)
             worker contexts.
 
     - `updateViaCache`
-      - : A string indicating how much of a service worker's resources will be updated when a call is made to {{domxref('ServiceWorkerRegistration.updateViaCache')}}. Valid values are:
+      - : A string indicating how much of a service worker's resources will be updated when a call is made to {{domxref('ServiceWorkerRegistration.update()')}}. Valid values are:
 
         - `'all'`
           - : The service worker script and all of its imports will be updated.


### PR DESCRIPTION
A name of a property was used where the name of the method was expected. (Typo-like change)

Fixes #19551