### PR TITLE
Update BCD info, part 15

### DIFF
--- a/files/en-us/web/api/pluginarray/index.md
+++ b/files/en-us/web/api/pluginarray/index.md
@@ -6,9 +6,9 @@ tags:
   - API
   - Add-ons
   - DOM
-  - Experimental
   - NeedsContent
   - Plugins
+  - Deprecated
 browser-compat: api.PluginArray
 ---
 {{APIRef("HTML DOM")}}{{deprecated_header}}
@@ -19,16 +19,16 @@ The `PluginArray` interface is used to store a list of {{DOMxRef("Plugin")}} obj
 
 ## Properties
 
-- {{DOMxRef("PluginArray.length")}} {{ReadOnlyInline}}
+- {{DOMxRef("PluginArray.length")}} {{ReadOnlyInline}} {{Deprecated_Inline}}
   - : The number of plugins in the array.
 
 ## Methods
 
-- {{DOMxRef("PluginArray.item")}}
+- {{DOMxRef("PluginArray.item")}} {{Deprecated_Inline}}
   - : Returns the {{DOMxRef("Plugin")}} at the specified index into the array.
-- {{DOMxRef("PluginArray.namedItem")}}
+- {{DOMxRef("PluginArray.namedItem")}} {{Deprecated_Inline}}
   - : Returns the {{DOMxRef("Plugin")}} with the specified name.
-- {{DOMxRef("PluginArray.refresh")}}
+- {{DOMxRef("PluginArray.refresh")}} {{Deprecated_Inline}}
   - : Refreshes all plugins on the current page, optionally reloading documents.
 
 ## Examples

--- a/files/en-us/web/api/pushevent/index.md
+++ b/files/en-us/web/api/pushevent/index.md
@@ -14,7 +14,7 @@ tags:
   - Workers
 browser-compat: api.PushEvent
 ---
-{{APIRef("Push API")}}{{SeeCompatTable()}}
+{{APIRef("Push API")}}
 
 The **`PushEvent`** interface of the [Push API](/en-US/docs/Web/API/Push_API) represents a push message that has been received. This event is sent to the [global scope](/en-US/docs/Web/API/ServiceWorkerGlobalScope) of a {{domxref("ServiceWorker")}}. It contains the information sent from an application server to a {{domxref("PushSubscription")}}.
 

--- a/files/en-us/web/api/sourcebuffer/appendbuffer/index.md
+++ b/files/en-us/web/api/sourcebuffer/appendbuffer/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Audio
-  - Experimental
   - MSE
   - Media
   - Media Source Extensions
@@ -16,7 +15,7 @@ tags:
   - appendBuffer
 browser-compat: api.SourceBuffer.appendBuffer
 ---
-{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
+{{APIRef("Media Source Extensions")}}
 
 The **`appendBuffer()`** method of the
 {{domxref("SourceBuffer")}} interface appends media segment data from an

--- a/files/en-us/web/api/sourcebuffer/appendbufferasync/index.md
+++ b/files/en-us/web/api/sourcebuffer/appendbufferasync/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Audio
-  - Experimental
   - MSE
   - Media
   - Media Source Extensions
@@ -17,7 +16,7 @@ tags:
   - appendBufferAsync
 browser-compat: api.SourceBuffer.appendBufferAsync
 ---
-{{APIRef("Media Source Extensions")}}{{non-standard_header}}{{SeeCompatTable}}
+{{APIRef("Media Source Extensions")}}{{non-standard_header}}
 
 The **`appendBufferAsync()`** method
 of the {{domxref("SourceBuffer")}} interface begins the process of asynchronously

--- a/files/en-us/web/api/sourcebuffer/appendstream/index.md
+++ b/files/en-us/web/api/sourcebuffer/appendstream/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Audio
-  - Experimental
   - MSE
   - Media Source Extensions
   - Method
@@ -13,9 +12,11 @@ tags:
   - SourceBuffer
   - Video
   - appendstream
+  - Deprecated
+  - Non-standard
 browser-compat: api.SourceBuffer.appendStream
 ---
-{{APIRef("Media Source Extensions")}}{{deprecated_header}}
+{{APIRef("Media Source Extensions")}}{{deprecated_header}}{{Non-standard_header}}
 
 The **`appendStream()`** method of the
 {{domxref("SourceBuffer")}} interface appends media segment data from a

--- a/files/en-us/web/api/sourcebuffer/appendwindowend/index.md
+++ b/files/en-us/web/api/sourcebuffer/appendwindowend/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - Audio
-  - Experimental
   - MSE
   - Media Source Extensions
   - Property
@@ -15,7 +14,7 @@ tags:
   - appendWindowEnd
 browser-compat: api.SourceBuffer.appendWindowEnd
 ---
-{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
+{{APIRef("Media Source Extensions")}}
 
 The **`appendWindowEnd`** property of the
 {{domxref("SourceBuffer")}} interface controls the timestamp for the end of the [append window](https://w3c.github.io/media-source/#append-window), a

--- a/files/en-us/web/api/sourcebuffer/appendwindowstart/index.md
+++ b/files/en-us/web/api/sourcebuffer/appendwindowstart/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - Audio
-  - Experimental
   - MSE
   - Media Source Extensions
   - Property
@@ -15,7 +14,7 @@ tags:
   - appendWindowStart
 browser-compat: api.SourceBuffer.appendWindowStart
 ---
-{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
+{{APIRef("Media Source Extensions")}}
 
 The **`appendWindowStart`** property of the
 {{domxref("SourceBuffer")}} interface controls the timestamp for the start of the [append window](https://w3c.github.io/media-source/#append-window), a

--- a/files/en-us/web/api/sourcebuffer/audiotracks/index.md
+++ b/files/en-us/web/api/sourcebuffer/audiotracks/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - Audio
-  - Experimental
   - MSE
   - Media Source Extensions
   - Property
@@ -14,7 +13,7 @@ tags:
   - audiotracks
 browser-compat: api.SourceBuffer.audioTracks
 ---
-{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
+{{APIRef("Media Source Extensions")}}
 
 The **`audioTracks`** read-only property of the
 {{domxref("SourceBuffer")}} interface returns a list of the audio tracks currently

--- a/files/en-us/web/api/sourcebuffer/buffered/index.md
+++ b/files/en-us/web/api/sourcebuffer/buffered/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - Audio
-  - Experimental
   - MSE
   - Media Source Extensions
   - Property
@@ -15,7 +14,7 @@ tags:
   - buffered
 browser-compat: api.SourceBuffer.buffered
 ---
-{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
+{{APIRef("Media Source Extensions")}}
 
 The **`buffered`** read-only property of the
 {{domxref("SourceBuffer")}} interface returns the time ranges that are currently

--- a/files/en-us/web/api/sourcebuffer/mode/index.md
+++ b/files/en-us/web/api/sourcebuffer/mode/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - Audio
-  - Experimental
   - MSE
   - Media Source Extensions
   - Property
@@ -15,7 +14,7 @@ tags:
   - mode
 browser-compat: api.SourceBuffer.mode
 ---
-{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
+{{APIRef("Media Source Extensions")}}
 
 The **`mode`** property of the {{domxref("SourceBuffer")}}
 interface controls whether media segments can be appended to the

--- a/files/en-us/web/api/sourcebuffer/remove/index.md
+++ b/files/en-us/web/api/sourcebuffer/remove/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Audio
-  - Experimental
   - MSE
   - Media Source Extensions
   - Method
@@ -15,7 +14,7 @@ tags:
   - remove
 browser-compat: api.SourceBuffer.remove
 ---
-{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
+{{APIRef("Media Source Extensions")}}
 
 The **`remove()`** method of the {{domxref("SourceBuffer")}}
 interface removes media segments within a specific time range from the

--- a/files/en-us/web/api/sourcebuffer/removeasync/index.md
+++ b/files/en-us/web/api/sourcebuffer/removeasync/index.md
@@ -9,7 +9,6 @@ tags:
   - Media
   - Media Source Extensions
   - Method
-  - Experimental
   - Non-standard
   - Reference
   - SourceBuffer
@@ -17,7 +16,7 @@ tags:
   - removeAsync
 browser-compat: api.SourceBuffer.removeAsync
 ---
-{{APIRef("Media Source Extensions")}}{{non-standard_header}}{{SeeCompatTable}}
+{{APIRef("Media Source Extensions")}}{{non-standard_header}}
 
 The **`removeAsync()`** method of the
 {{domxref("SourceBuffer")}} interface starts the process of asynchronously removing

--- a/files/en-us/web/api/sourcebuffer/texttracks/index.md
+++ b/files/en-us/web/api/sourcebuffer/texttracks/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SourceBuffer/textTracks
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - MSE
   - Media Source Extensions
   - Property
@@ -14,7 +13,7 @@ tags:
   - textTracks
 browser-compat: api.SourceBuffer.textTracks
 ---
-{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
+{{APIRef("Media Source Extensions")}}
 
 The **`textTracks`** read-only property of the
 {{domxref("SourceBuffer")}} interface returns a list of the text tracks currently

--- a/files/en-us/web/api/sourcebuffer/timestampoffset/index.md
+++ b/files/en-us/web/api/sourcebuffer/timestampoffset/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - Audio
-  - Experimental
   - MSE
   - Media Source Extensions
   - Property
@@ -15,7 +14,7 @@ tags:
   - timestampOffset
 browser-compat: api.SourceBuffer.timestampOffset
 ---
-{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
+{{APIRef("Media Source Extensions")}}
 
 The **`timestampOffset`** property of the
 {{domxref("SourceBuffer")}} interface controls the offset applied to timestamps inside

--- a/files/en-us/web/api/sourcebuffer/updating/index.md
+++ b/files/en-us/web/api/sourcebuffer/updating/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - Audio
-  - Experimental
   - MSE
   - Media Source Extensions
   - Property
@@ -15,7 +14,7 @@ tags:
   - Video
 browser-compat: api.SourceBuffer.updating
 ---
-{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
+{{APIRef("Media Source Extensions")}}
 
 The **`updating`** read-only property of the
 {{domxref("SourceBuffer")}} interface indicates whether the `SourceBuffer` is

--- a/files/en-us/web/api/sourcebuffer/videotracks/index.md
+++ b/files/en-us/web/api/sourcebuffer/videotracks/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SourceBuffer/videoTracks
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - MSE
   - Media Source Extensions
   - Property
@@ -14,7 +13,7 @@ tags:
   - videoTracks
 browser-compat: api.SourceBuffer.videoTracks
 ---
-{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
+{{APIRef("Media Source Extensions")}}
 
 The **`videoTracks`** read-only property of the
 {{domxref("SourceBuffer")}} interface returns a list of the video tracks currently

--- a/files/en-us/web/api/sourcebufferlist/index.md
+++ b/files/en-us/web/api/sourcebufferlist/index.md
@@ -5,7 +5,6 @@ page-type: web-api-interface
 tags:
   - API
   - Audio
-  - Experimental
   - Interface
   - MSE
   - Media Source Extensions
@@ -14,7 +13,7 @@ tags:
   - Video
 browser-compat: api.SourceBufferList
 ---
-{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
+{{APIRef("Media Source Extensions")}}
 
 The **`SourceBufferList`** interface represents a simple container list for multiple {{domxref("SourceBuffer")}} objects.
 

--- a/files/en-us/web/api/sourcebufferlist/length/index.md
+++ b/files/en-us/web/api/sourcebufferlist/length/index.md
@@ -14,7 +14,7 @@ tags:
   - length
 browser-compat: api.SourceBufferList.length
 ---
-{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}
+{{APIRef("Media Source Extensions")}}
 
 The **`length`** read-only property of the
 {{domxref("SourceBufferList")}} interface returns the number of

--- a/files/en-us/web/api/speechrecognitionalternative/confidence/index.md
+++ b/files/en-us/web/api/speechrecognitionalternative/confidence/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SpeechRecognitionAlternative/confidence
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognitionAlternative
@@ -14,7 +13,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognitionAlternative.confidence
 ---
-{{APIRef("Web Speech API")}}{{ SeeCompatTable() }}
+{{APIRef("Web Speech API")}}
 
 The **`confidence`** read-only property of the
 {{domxref("SpeechRecognitionResult")}} interface returns a numeric estimate of how

--- a/files/en-us/web/api/speechrecognitionalternative/index.md
+++ b/files/en-us/web/api/speechrecognitionalternative/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SpeechRecognitionAlternative
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - Interface
   - Reference
   - SpeechRecognitionAlternative
@@ -13,7 +12,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognitionAlternative
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`SpeechRecognitionAlternative`** interface of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) represents a single word that has been recognized by the speech recognition service.
 

--- a/files/en-us/web/api/speechrecognitionalternative/transcript/index.md
+++ b/files/en-us/web/api/speechrecognitionalternative/transcript/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SpeechRecognitionAlternative/transcript
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognitionAlternative
@@ -14,7 +13,7 @@ tags:
   - transcript
 browser-compat: api.SpeechRecognitionAlternative.transcript
 ---
-{{APIRef("Web Speech API")}}{{ SeeCompatTable() }}
+{{APIRef("Web Speech API")}}
 
 The **`transcript`** read-only property of the
 {{domxref("SpeechRecognitionResult")}} interface returns a string containing the

--- a/files/en-us/web/api/speechrecognitionerrorevent/error/index.md
+++ b/files/en-us/web/api/speechrecognitionerrorevent/error/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - Error
-  - Experimental
   - Property
   - Reference
   - SpeechRecognitionErrorEvent
@@ -14,7 +13,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognitionErrorEvent.error
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`error`** read-only property of the
 {{domxref("SpeechRecognitionErrorEvent")}} interface returns the type of error raised.

--- a/files/en-us/web/api/speechrecognitionerrorevent/message/index.md
+++ b/files/en-us/web/api/speechrecognitionerrorevent/message/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SpeechRecognitionErrorEvent/message
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognitionErrorEvent
@@ -14,7 +13,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognitionErrorEvent.message
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`message`** read-only property of the
 {{domxref("SpeechRecognitionErrorEvent")}} interface returns a message describing the

--- a/files/en-us/web/api/speechrecognitionevent/emma/index.md
+++ b/files/en-us/web/api/speechrecognitionevent/emma/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SpeechRecognitionEvent/emma
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognitionEvent
@@ -12,9 +11,11 @@ tags:
   - emma
   - recognition
   - speech
+  - Deprecated
+  - Non-standard
 browser-compat: api.SpeechRecognitionEvent.emma
 ---
-{{APIRef("Web Speech API")}}{{deprecated_header}}
+{{APIRef("Web Speech API")}}{{deprecated_header}}{{Non-standard_header}}
 
 The **`emma`** read-only property of the
 {{domxref("SpeechRecognitionEvent")}} interface returns an Extensible


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.
It focuses on files that have only left behind 'experimental' tags and headers.