### PR TITLE
Update BCD info, part 14

### DIFF
--- a/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
+++ b/files/en-us/web/api/animationeffect/getcomputedtiming/index.md
@@ -12,7 +12,7 @@ tags:
   - web animations api
 browser-compat: api.AnimationEffect.getComputedTiming
 ---
-{{ SeeCompatTable() }}{{ APIRef("Web Animations API") }}
+{{ APIRef("Web Animations API") }}
 
 The `getComputedTiming()` method of the {{domxref("AnimationEffect")}} interface returns the calculated timing properties for this animation effect.
 

--- a/files/en-us/web/api/animationeffect/gettiming/index.md
+++ b/files/en-us/web/api/animationeffect/gettiming/index.md
@@ -12,7 +12,7 @@ tags:
   - web animations api
 browser-compat: api.AnimationEffect.getTiming
 ---
-{{ SeeCompatTable() }}{{ APIRef("Web Animations API") }}
+{{ APIRef("Web Animations API") }}
 
 The `AnimationEffect.getTiming()` method of the {{domxref("AnimationEffect")}} interface returns an object containing the timing properties for the Animation Effect.
 

--- a/files/en-us/web/api/animationeffect/index.md
+++ b/files/en-us/web/api/animationeffect/index.md
@@ -11,7 +11,7 @@ tags:
   - web animations api
 browser-compat: api.AnimationEffect
 ---
-{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}
+{{ APIRef("Web Animations") }}
 
 The `AnimationEffect` interface of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) defines current and future _animation effects_ like {{domxref("KeyframeEffect")}}, which can be passed to {{domxref("Animation")}} objects for playing, and {{domxref("KeyframeEffect")}} (which is used by [CSS Animations](/en-US/docs/Web/CSS/CSS_Animations) and [Transitions](/en-US/docs/Web/CSS/CSS_Transitions)).
 

--- a/files/en-us/web/api/animationtimeline/currenttime/index.md
+++ b/files/en-us/web/api/animationtimeline/currenttime/index.md
@@ -15,7 +15,7 @@ tags:
   - web animations api
 browser-compat: api.AnimationTimeline.currentTime
 ---
-{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}
+{{ APIRef("Web Animations") }}
 
 The **`currentTime`** read-only property of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API)'s {{domxref("AnimationTimeline")}} interface returns the timeline's current time in milliseconds, or `null` if the timeline is inactive.
 

--- a/files/en-us/web/api/animationtimeline/index.md
+++ b/files/en-us/web/api/animationtimeline/index.md
@@ -13,7 +13,7 @@ tags:
   - web animations api
 browser-compat: api.AnimationTimeline
 ---
-{{ SeeCompatTable() }}{{ APIRef("Web Animations") }}
+{{ APIRef("Web Animations") }}
 
 The `AnimationTimeline` interface of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) represents the timeline of an animation. This interface exists to define timeline features (inherited by {{domxref("DocumentTimeline")}} and future timeline types) and is not itself directly used by developers. Anywhere you see `AnimationTimeline`, you should use `DocumentTimeline` or any other timeline type instead.
 

--- a/files/en-us/web/api/credential_management_api/index.md
+++ b/files/en-us/web/api/credential_management_api/index.md
@@ -12,7 +12,7 @@ tags:
   - credential management
 browser-compat: api.Credential
 ---
-{{DefaultAPISidebar("Credential Management API")}}{{ SeeCompatTable() }}
+{{DefaultAPISidebar("Credential Management API")}}
 
 The Credential Management API lets a website store and retrieve password, public key, and federated credentials. These capabilities allow users to sign in without typing passwords, see the federated account they used to sign in to a site, and resume a session without the explicit sign-in flow of an expired session.
 

--- a/files/en-us/web/api/documenttimeline/documenttimeline/index.md
+++ b/files/en-us/web/api/documenttimeline/documenttimeline/index.md
@@ -13,7 +13,7 @@ tags:
   - web animations api
 browser-compat: api.DocumentTimeline.DocumentTimeline
 ---
-{{ SeeCompatTable() }}{{ APIRef("Web Animations API") }}
+{{ APIRef("Web Animations API") }}
 
 The **`DocumentTimeline()`** constructor of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) creates a new instance of the {{domxref("DocumentTimeline")}} object associated with the active document of the current browsing context.
 

--- a/files/en-us/web/api/documenttimeline/index.md
+++ b/files/en-us/web/api/documenttimeline/index.md
@@ -14,7 +14,7 @@ tags:
   - web animations api
 browser-compat: api.DocumentTimeline
 ---
-{{ APIRef("Web Animations") }}{{ SeeCompatTable() }}
+{{ APIRef("Web Animations") }}
 
 The **`DocumentTimeline`** interface of the [Web Animations API](/en-US/docs/Web/API/Web_Animations_API) represents animation timelines, including the default document timeline (accessed via {{domxref("Document.timeline")}}).
 

--- a/files/en-us/web/api/idbtransaction/objectstorenames/index.md
+++ b/files/en-us/web/api/idbtransaction/objectstorenames/index.md
@@ -13,7 +13,7 @@ tags:
   - db
 browser-compat: api.IDBTransaction.objectStoreNames
 ---
-{{ APIRef("IndexedDB") }} {{SeeCompatTable}}
+{{ APIRef("IndexedDB") }}
 
 The **`objectStoreNames`** read-only property of the
 {{domxref("IDBTransaction")}} interface returns a {{domxref("DOMStringList")}} of names

--- a/files/en-us/web/api/idledeadline/timeremaining/index.md
+++ b/files/en-us/web/api/idledeadline/timeremaining/index.md
@@ -11,7 +11,7 @@ tags:
   - timeRemaining
 browser-compat: api.IdleDeadline.timeRemaining
 ---
-{{APIRef("Background Tasks")}}{{SeeCompatTable}}
+{{APIRef("Background Tasks")}}
 
 The **`timeRemaining()`** method
 on the {{domxref("IdleDeadline")}} interface returns the estimated number of

--- a/files/en-us/web/api/mediametadata/index.md
+++ b/files/en-us/web/api/mediametadata/index.md
@@ -13,7 +13,7 @@ tags:
   - Video
 browser-compat: api.MediaMetadata
 ---
-{{SeeCompatTable}}{{APIRef("Media Session API")}}
+{{APIRef("Media Session API")}}
 
 The **`MediaMetadata`** interface of the [Media Session API](/en-US/docs/Web/API/Media_Session_API) allows a web page to provide rich media metadata for display in a platform UI.
 

--- a/files/en-us/web/api/mediarecorder/audiobitspersecond/index.md
+++ b/files/en-us/web/api/mediarecorder/audiobitspersecond/index.md
@@ -11,7 +11,7 @@ tags:
   - Reference
 browser-compat: api.MediaRecorder.audioBitsPerSecond
 ---
-{{SeeCompatTable}}{{APIRef("MediaStream Recording")}}
+{{APIRef("MediaStream Recording")}}
 
 The **`audioBitsPerSecond`** read-only
 property of the {{domxref("MediaRecorder")}} interface returns the audio encoding bit

--- a/files/en-us/web/api/mediarecorder/videobitspersecond/index.md
+++ b/files/en-us/web/api/mediarecorder/videobitspersecond/index.md
@@ -6,7 +6,7 @@ tags:
 - Property
 browser-compat: api.MediaRecorder.videoBitsPerSecond
 ---
-{{SeeCompatTable}}{{APIRef("MediaStream Recording")}}
+{{APIRef("MediaStream Recording")}}
 
 The **`videoBitsPerSecond`** read-only
 property of the {{domxref("MediaRecorder")}} interface returns the video encoding

--- a/files/en-us/web/api/overconstrainederror/constraint/index.md
+++ b/files/en-us/web/api/overconstrainederror/constraint/index.md
@@ -15,8 +15,7 @@ tags:
   - constraint
 browser-compat: api.OverconstrainedError.constraint
 ---
-{{securecontext_header}}{{APIRef("Media Capture and
-  Streams")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("Media Capture and Streams")}}
 
 The **`constraint`** read-only property of the
 {{domxref("OverconstrainedError")}} interface returns the constraint that was supplied

--- a/files/en-us/web/api/performanceeventtiming/index.md
+++ b/files/en-us/web/api/performanceeventtiming/index.md
@@ -12,6 +12,7 @@ tags:
   - Web Performance
 browser-compat: api.PerformanceEventTiming
 ---
+
 The `PerformanceEventTiming` interface of the Event Timing API provides timing information for the event types listed below.
 
 - {{domxref("Element/auxclick_event", "auxclick")}}


### PR DESCRIPTION
Adding to #19185.

Continuing #19569, without `DeprecationReportBody` and `InterventionReportBody` pages.

The PR updates BCD info in WebAPI docs.
It focuses on files that have only left behind 'experimental' tags and headers.