### PR TITLE
Ff104 idb factory open options

### DIFF
--- a/files/en-us/web/api/idbfactory/open/index.md
+++ b/files/en-us/web/api/idbfactory/open/index.md
@@ -39,18 +39,6 @@ open(name, version)
   - : Optional. The version to open the database with. If the version is not provided and the database exists, then a connection to the database will be opened without changing its version.
     If the version is not provided and the database does not exist, then it will be created with version `1`.
 
-#### Experimental Gecko options object
-
-- options (version and storage) {{optional_inline}} {{deprecated_inline}}
-
-  - : In Gecko, since [version 26](/en-US/docs/Mozilla/Firefox/Releases/26), you can include a non-standard `options` object as a parameter of {{domxref("IDBFactory.open") }} that contains the `version` number of the
-    database, plus a storage value that specifies whether you want to use `persistent` or `temporary` storage.
-
-    > **Warning:** The `storage` attribute is deprecated and will soon be removed from Gecko.
-    > You should use {{domxref("StorageManager.persist()")}} to get persistent storage instead.
-
-> **Note:** You can find out more information on the different available storage types, and how Firefox handles client-side data storage, at [Browser storage limits and eviction criteria](/en-US/docs/Web/API/IndexedDB_API/Browser_storage_limits_and_eviction_criteria).
-
 ### Return value
 
 A {{domxref("IDBOpenDBRequest")}} object on which subsequent events related to this request are fired.
@@ -68,7 +56,8 @@ Example of calling `open` with the current specification's `version` parameter:
 const request = window.indexedDB.open("toDoList", 4);
 ```
 
-In the following code snippet, we make a request to open a database, and include handlers for the success and error cases. For a full working example, see our [To-do Notifications](https://github.com/mdn/to-do-notifications/tree/gh-pages) app ([View the example live](https://mdn.github.io/to-do-notifications/)).
+In the following code snippet, we make a request to open a database, and include handlers for the success and error cases.
+For a full working example, see our [To-do Notifications](https://github.com/mdn/to-do-notifications/tree/gh-pages) app ([View the example live](https://mdn.github.io/to-do-notifications/)).
 
 ```js
 const note = document.querySelector("ul");
@@ -103,6 +92,7 @@ DBOpenRequest.onsuccess = (event) => {
 ## See also
 
 - [Using IndexedDB](/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB)
+- [Browser storage limits and eviction criteria](/en-US/docs/Web/API/IndexedDB_API/Browser_storage_limits_and_eviction_criteria).
 - Starting transactions: {{domxref("IDBDatabase")}}
 - Using transactions: {{domxref("IDBTransaction")}}
 - Setting a range of keys: {{domxref("IDBKeyRange")}}

--- a/files/en-us/web/api/idbfactory/open/index.md
+++ b/files/en-us/web/api/idbfactory/open/index.md
@@ -15,17 +15,12 @@ browser-compat: api.IDBFactory.open
 ---
 {{APIRef("IndexedDB")}}
 
-The **`open()`** method of the {{domxref("IDBFactory")}}
-interface requests opening a [connection to a database](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#database_connection).
+The **`open()`** method of the {{domxref("IDBFactory")}} interface requests opening a [connection to a database](/en-US/docs/Web/API/IndexedDB_API/Basic_Terminology#database_connection).
 
-The method returns an {{domxref("IDBOpenDBRequest")}} object immediately, and
-performs the open operation asynchronously. If the operation is successful, a
-`success` event is fired on the request object that is returned from this
-method, with its `result` attribute set to the new
-{{domxref("IDBDatabase")}} object for the connection.
+The method returns an {{domxref("IDBOpenDBRequest")}} object immediately, and performs the open operation asynchronously.
+If the operation is successful, a `success` event is fired on the request object that is returned from this method, with its `result` attribute set to the new {{domxref("IDBDatabase")}} object for the connection.
 
-May trigger `upgradeneeded`, `blocked` or
-`versionchange` events.
+May trigger `upgradeneeded`, `blocked` or `versionchange` events.
 
 {{AvailableInWorkers}}
 
@@ -41,32 +36,24 @@ open(name, version)
 - `name`
   - : The name of the database.
 - `version` {{optional_inline}}
-  - : Optional. The version to open the database with. If the version is not provided and
-    the database exists, then a connection to the database will be opened without changing
-    its version. If the version is not provided and the database does not exist, then it
-    will be created with version `1`.
+  - : Optional. The version to open the database with. If the version is not provided and the database exists, then a connection to the database will be opened without changing its version.
+    If the version is not provided and the database does not exist, then it will be created with version `1`.
 
 #### Experimental Gecko options object
 
 - options (version and storage) {{optional_inline}} {{deprecated_inline}}
 
-  - : In Gecko, since [version 26](/en-US/docs/Mozilla/Firefox/Releases/26), you can include
-    a non-standard `options` object as a parameter of {{
-    domxref("IDBFactory.open") }} that contains the `version` number of the
-    database, plus a storage value that specifies whether you want to
-    use `persistent` or `temporary` storage.
+  - : In Gecko, since [version 26](/en-US/docs/Mozilla/Firefox/Releases/26), you can include a non-standard `options` object as a parameter of {{domxref("IDBFactory.open") }} that contains the `version` number of the
+    database, plus a storage value that specifies whether you want to use `persistent` or `temporary` storage.
 
-    > **Warning:** The `storage` attribute is
-    > deprecated and will soon be removed from Gecko. You should use
-    > {{domxref("StorageManager.persist()")}} to get persistent storage instead.
+    > **Warning:** The `storage` attribute is deprecated and will soon be removed from Gecko.
+    > You should use {{domxref("StorageManager.persist()")}} to get persistent storage instead.
 
-> **Note:** You can find out more information on the different available
-> storage types, and how Firefox handles client-side data storage, at [Browser storage limits and eviction criteria](/en-US/docs/Web/API/IndexedDB_API/Browser_storage_limits_and_eviction_criteria).
+> **Note:** You can find out more information on the different available storage types, and how Firefox handles client-side data storage, at [Browser storage limits and eviction criteria](/en-US/docs/Web/API/IndexedDB_API/Browser_storage_limits_and_eviction_criteria).
 
 ### Return value
 
-A {{domxref("IDBOpenDBRequest")}} object on which subsequent events related to this
-request are fired.
+A {{domxref("IDBOpenDBRequest")}} object on which subsequent events related to this request are fired.
 
 ### Exceptions
 
@@ -75,15 +62,13 @@ request are fired.
 
 ## Examples
 
-Example of calling `open` with the current specification's
-`version` parameter:
+Example of calling `open` with the current specification's `version` parameter:
 
 ```js
 const request = window.indexedDB.open("toDoList", 4);
 ```
 
-In the following code snippet, we make a request to open a database, and include
-handlers for the success and error cases. For a full working example, see our [To-do Notifications](https://github.com/mdn/to-do-notifications/tree/gh-pages) app ([View the example live](https://mdn.github.io/to-do-notifications/)).
+In the following code snippet, we make a request to open a database, and include handlers for the success and error cases. For a full working example, see our [To-do Notifications](https://github.com/mdn/to-do-notifications/tree/gh-pages) app ([View the example live](https://mdn.github.io/to-do-notifications/)).
 
 ```js
 const note = document.querySelector("ul");


### PR DESCRIPTION
FF104 removes the proprietary `options` option to [IDBFactory.open()](https://developer.mozilla.org/en-US/docs/Web/API/IDBFactory/open) in https://bugzilla.mozilla.org/show_bug.cgi?id=1354500.

I've removed the information that was at https://developer.mozilla.org/en-US/docs/Web/API/IDBFactory/open#experimental_gecko_options_object
This is moved into the BCD as a "removed feature" in https://github.com/mdn/browser-compat-data/pull/17358.

I also did pure layout changes in the first commit, so this can be reviewed just from the second commit.

That makes sense because no one should be using this. It wasn't well documented and there was a warning since about FF60 about using it. 

Other docs work for this can be tracked in #19575