### PR TITLE
Fixed typo in WebAuhtn API index.md

### DIFF
--- a/files/en-us/web/api/web_authentication_api/index.md
+++ b/files/en-us/web/api/web_authentication_api/index.md
@@ -24,7 +24,7 @@ The Web Authentication API is an extension of the [Credential Management API](/e
 
 ## Web authentication concepts and usage
 
-The Web Authentication API (also referred to as WebAuthn) uses [asymmetric (public-ke](https://en.wikipedia.org/wiki/Public-key_cryptography) instead of passwords or SMS texts for registering, authenticating, and [second-factor authentication](https://en.wikipedia.org/wiki/Multi-factor_authentication) with websites. This has some benefits:
+The Web Authentication API (also referred to as WebAuthn) uses [asymmetric (public-key)](https://en.wikipedia.org/wiki/Public-key_cryptography) instead of passwords or SMS texts for registering, authenticating, and [second-factor authentication](https://en.wikipedia.org/wiki/Multi-factor_authentication) with websites. This has some benefits:
 
 - **Protection against phishing:** An attacker who creates a fake login website can't login as the user because the signature changes with the [origin](/en-US/docs/Glossary/Origin) of the website.
 - **Reduced impact of data breaches:** Developers don't need to hash the public key, and if an attacker gets access to the public key used to verify the authentication, it can't authenticate because it needs the private key.


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
I fixed a typo in the WebAuthn API docs.

#### Motivation
I was reading the docs and found this typo in the "public-key" part, it said "public-ke". It looked off so I fixed it.

This PR fixes a typo in the WebAuthn API docs. File "index.md", line 27 had the following text:
> "The Web Authentication API (also referred to as WebAuthn) uses [asymmetric **(public-ke]** ..."

And I have corrected it to:

> "The Web Authentication API (also referred to as WebAuthn) uses [asymmetric **(public-key)]** ..."

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
