### PR TITLE
Changed order of if statements to match the output

### DIFF
--- a/files/en-us/web/javascript/reference/functions/arguments/callee/index.md
+++ b/files/en-us/web/javascript/reference/functions/arguments/callee/index.md
@@ -55,13 +55,14 @@ However, the design of `arguments.callee` has multiple issues. The first problem
 const global = this;
 
 const sillyFunction = function (recursed) {
-  if (!recursed) {
-    return arguments.callee(true);
-  }
   if (this !== global) {
     console.log('This is: ', this);
   } else {
     console.log('This is the global');
+  }
+
+  if (!recursed) {
+    return arguments.callee(true);
   }
 }
 


### PR DESCRIPTION
#### Summary
The code example's actual output does not match the commented output at the end of the example. I've reordered the `if` statements to match the commented output.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The code example did not work as I expected it to work (when I ran it), based on the commented output in the end. My change will make the code run to log the expected output.

#### Supporting details
None

#### Related issues
None

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
