### PR TITLE
`load` events almost never propagate from `Document` to `Window`

### DIFF
--- a/files/en-us/web/api/window/load_event/index.md
+++ b/files/en-us/web/api/window/load_event/index.md
@@ -16,6 +16,8 @@ The **`load`** event is fired when the whole page has loaded, including all depe
 
 This event is not cancelable and does not bubble.
 
+> **Note:** Events named `load` dnt propagate past `Document` to `Window`, except the `load` event that is dispatched on the document when the main document has finished loading. This applies both to load events the browser dispatches from images etc., but also from custom events made from script with `bubbles: true, composed: true settings.
+
 ## Syntax
 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
@@ -133,5 +135,4 @@ document.addEventListener('DOMContentLoaded', (event) => {
 
 ## See also
 
-- [`load` event not propagating to `window`](https://bugzilla.mozilla.org/show_bug.cgi?id=1784246)
 - Related events: {{domxref("Window/DOMContentLoaded_event", "DOMContentLoaded")}}, {{domxref("Document/readystatechange_event", "readystatechange")}}, {{domxref("Window/beforeunload_event", "beforeunload")}}, {{domxref("Window/unload_event", "unload")}}

--- a/files/en-us/web/api/window/load_event/index.md
+++ b/files/en-us/web/api/window/load_event/index.md
@@ -16,7 +16,7 @@ The **`load`** event is fired when the whole page has loaded, including all depe
 
 This event is not cancelable and does not bubble.
 
-> **Note:** Events named `load` dnt propagate past `Document` to `Window`, except the `load` event that is dispatched on the document when the main document has finished loading. This applies both to load events the browser dispatches from images etc., but also from custom events made from script with `bubbles: true, composed: true settings.
+> **Note:** The `load` event that is dispatched on the `Document` when the main document has finished loading will propagate to `Window`. However, _all other events named `load` will not propagate to `Window`_, including load events for resources inside the document (such as images) and custom events with `bubbles` initialized to `true`.
 
 ## Syntax
 

--- a/files/en-us/web/api/window/load_event/index.md
+++ b/files/en-us/web/api/window/load_event/index.md
@@ -133,4 +133,5 @@ document.addEventListener('DOMContentLoaded', (event) => {
 
 ## See also
 
+- [`load` event not propagating to `window`](https://bugzilla.mozilla.org/show_bug.cgi?id=1784246)
 - Related events: {{domxref("Window/DOMContentLoaded_event", "DOMContentLoaded")}}, {{domxref("Document/readystatechange_event", "readystatechange")}}, {{domxref("Window/beforeunload_event", "beforeunload")}}, {{domxref("Window/unload_event", "unload")}}


### PR DESCRIPTION
The load event doesn't propagate to `window`.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
