### PR TITLE
Document important behavior of link="preload"

### DIFF
--- a/files/en-us/web/html/link_types/preload/index.md
+++ b/files/en-us/web/html/link_types/preload/index.md
@@ -14,7 +14,7 @@ browser-compat: html.elements.link.rel.preload
 
 The `preload` value of the {{htmlelement("link")}} element's {{htmlattrxref("rel", "link")}} attribute lets you declare fetch requests in the
 HTML's {{htmlelement("head")}}, specifying resources that your page will need very soon, which you want to start loading early in the page lifecycle,
-before browsers' main rendering machinery kicks in. This ensures they are available earlier and are less likely to block the page's render, improving performance. Even though the name contains "load", it does not actually load(or execute) the script, but only fetches and caches it with high priority.
+before browsers' main rendering machinery kicks in. This ensures they are available earlier and are less likely to block the page's render, improving performance. Even though the name contains the term _load_, it doesn't load and execute the script but only schedules it to be downloaded and cached with a higher priority.
 
 ## The basics
 

--- a/files/en-us/web/html/link_types/preload/index.md
+++ b/files/en-us/web/html/link_types/preload/index.md
@@ -14,7 +14,7 @@ browser-compat: html.elements.link.rel.preload
 
 The `preload` value of the {{htmlelement("link")}} element's {{htmlattrxref("rel", "link")}} attribute lets you declare fetch requests in the
 HTML's {{htmlelement("head")}}, specifying resources that your page will need very soon, which you want to start loading early in the page lifecycle,
-before browsers' main rendering machinery kicks in. This ensures they are available earlier and are less likely to block the page's render, improving performance.
+before browsers' main rendering machinery kicks in. This ensures they are available earlier and are less likely to block the page's render, improving performance. Even though the name contains "load", it does not actually load(or execute) the script, but only fetches and caches it with high priority.
 
 ## The basics
 


### PR DESCRIPTION
Document important behavior of link="preload". It does not actually load the script, only fetches with high priority.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Document important behavior of link="preload". It does not actually load the script, only fetches with high priority.


#### Motivation
It is confusing that preload does not do any script loading, so this behavior should be documented upfront for new readers/beginners.

#### Supporting details
https://3perf.com/blog/link-rels/#preload

#### Related issues

#### Metadata
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
