### PR TITLE
fix: don't claim String.charCodeAt returns byte

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/map/index.md
@@ -165,8 +165,8 @@ const doubles = numbers.map((num) => num * 2);
 
 ### Using map generically
 
-This example shows how to use map on a {{jsxref("String")}} to get an array of bytes in
-the ASCII encoding representing the character values:
+This example shows how to use map on a {{jsxref("String")}} to get an array of numbers
+representing the Unicode character values:
 
 ```js
 const map = Array.prototype.map;

--- a/files/en-us/web/javascript/reference/global_objects/array/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/map/index.md
@@ -165,8 +165,7 @@ const doubles = numbers.map((num) => num * 2);
 
 ### Using map generically
 
-This example shows how to use map on a {{jsxref("String")}} to get an array of numbers
-representing the UTF-16 characters' code units:
+This example shows how to use map on a {{jsxref("String")}} to get an array of numbers representing the string's characters in UTF-16 code units:
 
 ```js
 const map = Array.prototype.map;

--- a/files/en-us/web/javascript/reference/global_objects/array/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/map/index.md
@@ -166,7 +166,7 @@ const doubles = numbers.map((num) => num * 2);
 ### Using map generically
 
 This example shows how to use map on a {{jsxref("String")}} to get an array of numbers
-representing the Unicode character values:
+representing the UTF-16 characters' code units:
 
 ```js
 const map = Array.prototype.map;


### PR DESCRIPTION
#### Summary

fix: don't claim String.charCodeAt returns byte

#### Motivation
It's misleading to say `String.charCodeAt` returns bytes.

It only happens to return numbers ≤ 255 in this case due to the specific example string used, but the wording made it sound like code is more generally capable of returning ASCII encoded byte arrays.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/charCodeAt

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
