### PR TITLE
Update BCD info, part 16

### DIFF
--- a/files/en-us/web/api/speechrecognitionevent/interpretation/index.md
+++ b/files/en-us/web/api/speechrecognitionevent/interpretation/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SpeechRecognitionEvent/interpretation
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognitionEvent
@@ -12,9 +11,11 @@ tags:
   - interpretation
   - recognition
   - speech
+  - Deprecated
+  - Non-standard
 browser-compat: api.SpeechRecognitionEvent.interpretation
 ---
-{{APIRef("Web Speech API")}}{{deprecated_header}}
+{{APIRef("Web Speech API")}}{{deprecated_header}}{{Non-standard_header}}
 
 The **`interpretation`** read-only property of the
 {{domxref("SpeechRecognitionEvent")}} interface returns the semantic meaning of what the

--- a/files/en-us/web/api/speechrecognitionevent/resultindex/index.md
+++ b/files/en-us/web/api/speechrecognitionevent/resultindex/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SpeechRecognitionEvent/resultIndex
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognitionEvent
@@ -14,7 +13,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognitionEvent.resultIndex
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`resultIndex`** read-only property of the
 {{domxref("SpeechRecognitionEvent")}} interface returns the lowest index value result in

--- a/files/en-us/web/api/speechrecognitionevent/results/index.md
+++ b/files/en-us/web/api/speechrecognitionevent/results/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SpeechRecognitionEvent/results
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognitionEvent
@@ -14,7 +13,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognitionEvent.results
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`results`** read-only property of the
 {{domxref("SpeechRecognitionEvent")}} interface returns a

--- a/files/en-us/web/api/speechrecognitionresult/index.md
+++ b/files/en-us/web/api/speechrecognitionresult/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SpeechRecognitionResult
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - Interface
   - Reference
   - SpeechRecognitionResult
@@ -13,7 +12,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognitionResult
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`SpeechRecognitionResult`** interface of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) represents a single recognition match, which may contain multiple {{domxref("SpeechRecognitionAlternative")}} objects.
 

--- a/files/en-us/web/api/speechrecognitionresult/isfinal/index.md
+++ b/files/en-us/web/api/speechrecognitionresult/isfinal/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SpeechRecognitionResult/isFinal
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognitionResult
@@ -14,7 +13,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognitionResult.isFinal
 ---
-{{APIRef("Web Speech API")}}{{ SeeCompatTable() }}
+{{APIRef("Web Speech API")}}
 
 The **`isFinal`** read-only property of the
 {{domxref("SpeechRecognitionResult")}} interface is a boolean value that states

--- a/files/en-us/web/api/speechrecognitionresult/item/index.md
+++ b/files/en-us/web/api/speechrecognitionresult/item/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SpeechRecognitionResult/item
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Getter
   - Method
   - Reference
@@ -15,7 +14,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognitionResult.item
 ---
-{{APIRef("Web Speech API")}}{{ SeeCompatTable() }}
+{{APIRef("Web Speech API")}}
 
 The **`item`** getter of the
 {{domxref("SpeechRecognitionResult")}} interface is a standard getter that allows

--- a/files/en-us/web/api/speechrecognitionresult/length/index.md
+++ b/files/en-us/web/api/speechrecognitionresult/length/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SpeechRecognitionResult/length
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognitionResult
@@ -14,7 +13,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognitionResult.length
 ---
-{{APIRef("Web Speech API")}}{{ SeeCompatTable() }}
+{{APIRef("Web Speech API")}}
 
 The **`length`** read-only property of the
 {{domxref("SpeechRecognitionResult")}} interface returns the length of the "array"

--- a/files/en-us/web/api/speechrecognitionresultlist/index.md
+++ b/files/en-us/web/api/speechrecognitionresultlist/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SpeechRecognitionResultList
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - Interface
   - Reference
   - SpeechRecognitionResultList
@@ -13,7 +12,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognitionResultList
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`SpeechRecognitionResultList`** interface of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) represents a list of {{domxref("SpeechRecognitionResult")}} objects, or a single one if results are being captured in {{domxref("SpeechRecognition.continuous","continuous")}} mode.
 

--- a/files/en-us/web/api/speechrecognitionresultlist/item/index.md
+++ b/files/en-us/web/api/speechrecognitionresultlist/item/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SpeechRecognitionResultList/item
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Getter
   - Method
   - Reference
@@ -15,7 +14,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognitionResultList.item
 ---
-{{APIRef("Web Speech API")}}{{ SeeCompatTable() }}
+{{APIRef("Web Speech API")}}
 
 The **`item`** getter of the
 {{domxref("SpeechRecognitionResultList")}} interface is a standard getter — it allows

--- a/files/en-us/web/api/speechrecognitionresultlist/length/index.md
+++ b/files/en-us/web/api/speechrecognitionresultlist/length/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SpeechRecognitionResultList/length
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - SpeechRecognitionResultList
@@ -14,7 +13,7 @@ tags:
   - speech
 browser-compat: api.SpeechRecognitionResultList.length
 ---
-{{APIRef("Web Speech API")}}{{ SeeCompatTable() }}
+{{APIRef("Web Speech API")}}
 
 The **`length`** read-only property of the
 {{domxref("SpeechRecognitionResultList")}} interface returns the length of the

--- a/files/en-us/web/api/speechsynthesiserrorevent/index.md
+++ b/files/en-us/web/api/speechsynthesiserrorevent/index.md
@@ -4,7 +4,6 @@ slug: Web/API/SpeechSynthesisErrorEvent
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - Interface
   - Reference
   - SpeechSynthesisErrorEvent
@@ -13,7 +12,7 @@ tags:
   - synthesis
 browser-compat: api.SpeechSynthesisErrorEvent
 ---
-{{APIRef("Web Speech API")}}{{SeeCompatTable}}
+{{APIRef("Web Speech API")}}
 
 The **`SpeechSynthesisErrorEvent`** interface of the [Web Speech API](/en-US/docs/Web/API/Web_Speech_API) contains information about any errors that occur while processing {{domxref("SpeechSynthesisUtterance")}} objects in the speech service.
 

--- a/files/en-us/web/api/taskcontroller/setpriority/index.md
+++ b/files/en-us/web/api/taskcontroller/setpriority/index.md
@@ -7,10 +7,9 @@ tags:
   - Method
   - Reference
   - setPriority
-  - Experimental
 browser-compat: api.TaskController.setPriority
 ---
-{{APIRef("Prioritized Task Scheduling API")}} {{SeeCompatTable}}
+{{APIRef("Prioritized Task Scheduling API")}}
 
 The **`setPriority()`** method of the {{domxref("TaskController")}} interface can be called to set a new [priority](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#task_priorities) for this controller's [`signal`](/en-US/docs/Web/API/TaskController#taskcontroller.signal).
 If a prioritized task is [configured](/en-US/docs/Web/API/Scheduler/postTask#signal) to use the signal, this will also change the task priority.

--- a/files/en-us/web/api/textdecoder/decode/index.md
+++ b/files/en-us/web/api/textdecoder/decode/index.md
@@ -5,12 +5,11 @@ page-type: web-api-instance-method
 tags:
   - API
   - Encoding
-  - Experimental
   - Method
   - TextDecoder
 browser-compat: api.TextDecoder.decode
 ---
-{{APIRef("Encoding API")}}{{SeeCompatTable}}
+{{APIRef("Encoding API")}}
 
 The **`TextDecode.decode()`** method returns a
 string containing the text, given in parameters, decoded with the

--- a/files/en-us/web/api/textdecoder/encoding/index.md
+++ b/files/en-us/web/api/textdecoder/encoding/index.md
@@ -5,13 +5,12 @@ page-type: web-api-instance-property
 tags:
   - API
   - Encoding
-  - Experimental
   - Property
   - Read-only
   - TextDecoder
 browser-compat: api.TextDecoder.encoding
 ---
-{{APIRef("Encoding API")}}{{SeeCompatTable}}
+{{APIRef("Encoding API")}}
 
 The **`TextDecoder.encoding`** read-only property
 returns a string containing the name of the decoding algorithm used by

--- a/files/en-us/web/api/textdecoder/index.md
+++ b/files/en-us/web/api/textdecoder/index.md
@@ -6,7 +6,6 @@ tags:
   - API
   - DOM
   - Encoding
-  - Experimental
   - Interface
   - Reference
   - TextDecoder

--- a/files/en-us/web/api/textdecoder/textdecoder/index.md
+++ b/files/en-us/web/api/textdecoder/textdecoder/index.md
@@ -6,7 +6,6 @@ tags:
   - API
   - Constructor
   - Encoding
-  - Experimental
   - Reference
   - TextDecoder
 browser-compat: api.TextDecoder.TextDecoder

--- a/files/en-us/web/api/textencoder/encodeinto/index.md
+++ b/files/en-us/web/api/textencoder/encodeinto/index.md
@@ -4,14 +4,13 @@ slug: Web/API/TextEncoder/encodeInto
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Method
   - Reference
   - TextEncoder
   - encodeInto
 browser-compat: api.TextEncoder.encodeInto
 ---
-{{APIRef("Encoding API")}}{{SeeCompatTable}}
+{{APIRef("Encoding API")}}
 
 The **`TextEncoder.encodeInto()`** method takes a
 string to encode and a destination {{jsxref("Uint8Array")}} to put

--- a/files/en-us/web/api/textencoder/index.md
+++ b/files/en-us/web/api/textencoder/index.md
@@ -5,7 +5,6 @@ page-type: web-api-interface
 tags:
   - API
   - Encoding
-  - Experimental
   - Interface
   - Reference
   - TextEncoder

--- a/files/en-us/web/api/textmetrics/actualboundingboxascent/index.md
+++ b/files/en-us/web/api/textmetrics/actualboundingboxascent/index.md
@@ -4,7 +4,6 @@ slug: Web/API/TextMetrics/actualBoundingBoxAscent
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - TextMetrics

--- a/files/en-us/web/api/textmetrics/actualboundingboxdescent/index.md
+++ b/files/en-us/web/api/textmetrics/actualboundingboxdescent/index.md
@@ -4,7 +4,6 @@ slug: Web/API/TextMetrics/actualBoundingBoxDescent
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - TextMetrics

--- a/files/en-us/web/api/textmetrics/actualboundingboxleft/index.md
+++ b/files/en-us/web/api/textmetrics/actualboundingboxleft/index.md
@@ -4,7 +4,6 @@ slug: Web/API/TextMetrics/actualBoundingBoxLeft
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - TextMetrics

--- a/files/en-us/web/api/textmetrics/actualboundingboxright/index.md
+++ b/files/en-us/web/api/textmetrics/actualboundingboxright/index.md
@@ -4,7 +4,6 @@ slug: Web/API/TextMetrics/actualBoundingBoxRight
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - TextMetrics

--- a/files/en-us/web/api/textmetrics/fontboundingboxascent/index.md
+++ b/files/en-us/web/api/textmetrics/fontboundingboxascent/index.md
@@ -4,7 +4,6 @@ slug: Web/API/TextMetrics/fontBoundingBoxAscent
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - TextMetrics

--- a/files/en-us/web/api/textmetrics/fontboundingboxdescent/index.md
+++ b/files/en-us/web/api/textmetrics/fontboundingboxdescent/index.md
@@ -4,7 +4,6 @@ slug: Web/API/TextMetrics/fontBoundingBoxDescent
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - TextMetrics

--- a/files/en-us/web/api/touch/identifier/index.md
+++ b/files/en-us/web/api/touch/identifier/index.md
@@ -12,7 +12,7 @@ tags:
   - touch
 browser-compat: api.Touch.identifier
 ---
-{{ APIRef("Touch Events") }}{{SeeCompatTable}}
+{{ APIRef("Touch Events") }}
 
 The **`Touch.identifier`** returns a value uniquely identifying
 this point of contact with the touch surface. This value remains consistent for every

--- a/files/en-us/web/api/touch/index.md
+++ b/files/en-us/web/api/touch/index.md
@@ -49,8 +49,6 @@ _This interface has no parent, and doesn't inherit or implement other properties
 
 ### Touch area
 
-{{SeeCompatTable}}
-
 - {{domxref("Touch.radiusX")}} {{readonlyInline}}
   - : Returns the X radius of the ellipse that most closely circumscribes the area of contact with the screen. The value is in pixels of the same scale as `screenX`.
 - {{domxref("Touch.radiusY")}} {{readonlyInline}}

--- a/files/en-us/web/api/touch/index.md
+++ b/files/en-us/web/api/touch/index.md
@@ -21,7 +21,7 @@ The {{ domxref("Touch.radiusX") }}, {{ domxref("Touch.radiusY") }}, and {{ domxr
 
 ## Constructor
 
-- {{domxref("Touch.Touch", "Touch()")}} {{experimental_inline}}
+- {{domxref("Touch.Touch", "Touch()")}}
   - : Creates a Touch object.
 
 ## Properties
@@ -51,13 +51,13 @@ _This interface has no parent, and doesn't inherit or implement other properties
 
 {{SeeCompatTable}}
 
-- {{domxref("Touch.radiusX")}} {{readonlyInline}} {{experimental_inline}}
+- {{domxref("Touch.radiusX")}} {{readonlyInline}}
   - : Returns the X radius of the ellipse that most closely circumscribes the area of contact with the screen. The value is in pixels of the same scale as `screenX`.
-- {{domxref("Touch.radiusY")}} {{readonlyInline}} {{experimental_inline}}
+- {{domxref("Touch.radiusY")}} {{readonlyInline}}
   - : Returns the Y radius of the ellipse that most closely circumscribes the area of contact with the screen. The value is in pixels of the same scale as `screenY`.
-- {{domxref("Touch.rotationAngle")}} {{readonlyInline}} {{experimental_inline}}
+- {{domxref("Touch.rotationAngle")}} {{readonlyInline}}
   - : Returns the angle (in degrees) that the ellipse described by radiusX and radiusY must be rotated, clockwise, to most accurately cover the area of contact between the user and the surface.
-- {{domxref("Touch.force")}} {{readonlyInline}} {{experimental_inline}}
+- {{domxref("Touch.force")}} {{readonlyInline}}
   - : Returns the amount of pressure being applied to the surface by the user, as a `float` between `0.0` (no pressure) and `1.0` (maximum pressure).
 
 ## Methods

--- a/files/en-us/web/api/videoplaybackquality/corruptedvideoframes/index.md
+++ b/files/en-us/web/api/videoplaybackquality/corruptedvideoframes/index.md
@@ -6,7 +6,6 @@ tags:
   - API
   - Corruption
   - Data Loss
-  - Experimental
   - Frames
   - Media
   - Media Playback Quality
@@ -18,6 +17,7 @@ tags:
   - Video
   - VideoPlaybackQuality
   - corruptedVideoFrames
+  - Deprecated
 browser-compat: api.VideoPlaybackQuality.corruptedVideoFrames
 ---
 {{APIRef("HTML DOM")}}{{deprecated_header}}

--- a/files/en-us/web/api/videoplaybackquality/creationtime/index.md
+++ b/files/en-us/web/api/videoplaybackquality/creationtime/index.md
@@ -4,7 +4,6 @@ slug: Web/API/VideoPlaybackQuality/creationTime
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Media
   - Media Playback Quality
   - Media Playback Quality API

--- a/files/en-us/web/api/videoplaybackquality/droppedvideoframes/index.md
+++ b/files/en-us/web/api/videoplaybackquality/droppedvideoframes/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-property
 tags:
   - API
   - Data Loss
-  - Experimental
   - Frames
   - Media
   - Media Playback Quality

--- a/files/en-us/web/api/videoplaybackquality/totalframedelay/index.md
+++ b/files/en-us/web/api/videoplaybackquality/totalframedelay/index.md
@@ -4,7 +4,6 @@ slug: Web/API/VideoPlaybackQuality/totalFrameDelay
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Media Source Extensions
   - Deprecated
   - Property
@@ -12,9 +11,10 @@ tags:
   - Video
   - VideoPlaybackQuality
   - totalFrameDelay
+  - Non-standard
 browser-compat: api.VideoPlaybackQuality.totalFrameDelay
 ---
-{{APIRef("Media Source Extensions")}}{{deprecated_header}}
+{{APIRef("Media Source Extensions")}}{{deprecated_header}}{{Non-standard_header}}
 
 The **`VideoPlaybackQuality.totalFrameDelay`** read-only
 property returns a `double` containing the sum of the frame delay since the


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.
It focuses on files that have only left behind 'experimental' tags and headers.