### PR TITLE
Update BCD info, part 17

### DIFF
--- a/files/en-us/web/api/videoplaybackquality/index.md
+++ b/files/en-us/web/api/videoplaybackquality/index.md
@@ -4,7 +4,6 @@ slug: Web/API/VideoPlaybackQuality
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - Frames
   - HTML DOM
   - Interface
@@ -35,9 +34,9 @@ _The `VideoPlaybackQuality` interface doesn't inherit properties from any other 
 
 ### Obsolete properties
 
-- {{domxref("VideoPlaybackQuality.corruptedVideoFrames", "corruptedVideoFrames")}} {{readonlyInline}}
+- {{domxref("VideoPlaybackQuality.corruptedVideoFrames", "corruptedVideoFrames")}} {{readonlyInline}} {{Deprecated_Inline}}
   - : An `unsigned long` giving the number of video frames corrupted since the creation of the associated {{domxref("HTMLVideoElement")}}. A corrupted frame may be created or dropped.
-- {{domxref("VideoPlaybackQuality.totalFrameDelay", "totalFrameDelay")}} {{readonlyInline}} {{deprecated_inline}}
+- {{domxref("VideoPlaybackQuality.totalFrameDelay", "totalFrameDelay")}} {{readonlyInline}} {{deprecated_inline}} {{Non-standard_Inline}}
   - : A `double` containing the sum of the frame delay since the creation of the associated {{domxref("HTMLVideoElement")}}. The frame delay is the difference between a frame's theoretical presentation time and its effective display time.
 
 ## Methods

--- a/files/en-us/web/api/videoplaybackquality/totalvideoframes/index.md
+++ b/files/en-us/web/api/videoplaybackquality/totalvideoframes/index.md
@@ -4,7 +4,6 @@ slug: Web/API/VideoPlaybackQuality/totalVideoFrames
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Frames
   - HTML DOM
   - Media

--- a/files/en-us/web/api/visual_viewport_api/index.md
+++ b/files/en-us/web/api/visual_viewport_api/index.md
@@ -4,7 +4,6 @@ slug: Web/API/Visual_Viewport_API
 page-type: web-api-overview
 tags:
   - API
-  - Experimental
   - Layout
   - Overview
   - Reference

--- a/files/en-us/web/api/vrfieldofview/downdegrees/index.md
+++ b/files/en-us/web/api/vrfieldofview/downdegrees/index.md
@@ -4,7 +4,6 @@ slug: Web/API/VRFieldOfView/downDegrees
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - VR
@@ -12,9 +11,11 @@ tags:
   - Virtual Reality
   - WebVR
   - downDegrees
+  - Deprecated
+  - Non-standard
 browser-compat: api.VRFieldOfView.downDegrees
 ---
-{{APIRef("WebVR API")}}{{SeeCompatTable}}{{Deprecated_header}}
+{{APIRef("WebVR API")}}{{Deprecated_header}}{{Non-standard_header}}
 
 The **`downDegrees`** read-only property of the {{domxref("VRFieldOfView")}} interface returns the number of degrees downwards that the field of view extends in.
 

--- a/files/en-us/web/api/vrfieldofview/index.md
+++ b/files/en-us/web/api/vrfieldofview/index.md
@@ -4,16 +4,17 @@ slug: Web/API/VRFieldOfView
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - Interface
   - Reference
   - VR
   - VRFieldOfView
   - Virtual Reality
   - WebVR
+  - Deprecated
+  - Non-standard
 browser-compat: api.VRFieldOfView
 ---
-{{APIRef("WebVR API")}}{{SeeCompatTable}}{{Deprecated_header}}
+{{APIRef("WebVR API")}}{{Deprecated_header}}{{Non-standard_header}}
 
 The **`VRFieldOfView`** interface of the [WebVR API](/en-US/docs/Web/API/WebVR_API) represents a field of view defined by 4 different degree values describing the view from a center point.
 
@@ -21,13 +22,13 @@ The **`VRFieldOfView`** interface of the [WebVR API](/en-US/docs/Web/API/WebVR_A
 
 ## Properties
 
-- {{domxref("VRFieldOfView.upDegrees")}} {{deprecated_inline}} {{readonlyInline}}
+- {{domxref("VRFieldOfView.upDegrees")}} {{deprecated_inline}} {{readonlyInline}} {{Non-standard_Inline}}
   - : The number of degrees upwards that the field of view extends in.
-- {{domxref("VRFieldOfView.rightDegrees")}} {{deprecated_inline}} {{readonlyInline}}
+- {{domxref("VRFieldOfView.rightDegrees")}} {{deprecated_inline}} {{readonlyInline}} {{Non-standard_Inline}}
   - : The number of degrees to the right that the field of view extends in.
-- {{domxref("VRFieldOfView.downDegrees")}} {{deprecated_inline}} {{readonlyInline}}
+- {{domxref("VRFieldOfView.downDegrees")}} {{deprecated_inline}} {{readonlyInline}} {{Non-standard_Inline}}
   - : The number of degrees downwards that the field of view extends in.
-- {{domxref("VRFieldOfView.leftDegrees")}} {{deprecated_inline}} {{readonlyInline}}
+- {{domxref("VRFieldOfView.leftDegrees")}} {{deprecated_inline}} {{readonlyInline}} {{Non-standard_Inline}}
   - : The number of degrees to the left that the field of view extends in.
 
 ## Examples

--- a/files/en-us/web/api/vrfieldofview/leftdegrees/index.md
+++ b/files/en-us/web/api/vrfieldofview/leftdegrees/index.md
@@ -4,7 +4,6 @@ slug: Web/API/VRFieldOfView/leftDegrees
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - VR
@@ -12,9 +11,11 @@ tags:
   - Virtual Reality
   - WebVR
   - leftDegrees
+  - Deprecated
+  - Non-standard
 browser-compat: api.VRFieldOfView.leftDegrees
 ---
-{{APIRef("WebVR API")}}{{SeeCompatTable}}{{Deprecated_header}}
+{{APIRef("WebVR API")}}{{Deprecated_header}}{{Non-standard_header}}
 
 The **`leftDegrees`** read-only property of the {{domxref("VRFieldOfView")}} interface returns the number of degrees to the left that the field of view extends in.
 

--- a/files/en-us/web/api/vrfieldofview/rightdegrees/index.md
+++ b/files/en-us/web/api/vrfieldofview/rightdegrees/index.md
@@ -4,7 +4,6 @@ slug: Web/API/VRFieldOfView/rightDegrees
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - VR
@@ -12,9 +11,11 @@ tags:
   - Virtual Reality
   - WebVR
   - rightDegrees
+  - Deprecated
+  - Non-standard
 browser-compat: api.VRFieldOfView.rightDegrees
 ---
-{{APIRef("WebVR API")}}{{SeeCompatTable}}{{Deprecated_header}}
+{{APIRef("WebVR API")}}{{Deprecated_header}}{{Non-standard_header}}
 
 The **`rightDegrees`** read-only property of the {{domxref("VRFieldOfView")}} interface returns the number of degrees to the right that the field of view extends in.
 

--- a/files/en-us/web/api/vrfieldofview/updegrees/index.md
+++ b/files/en-us/web/api/vrfieldofview/updegrees/index.md
@@ -4,7 +4,6 @@ slug: Web/API/VRFieldOfView/upDegrees
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - VR
@@ -12,9 +11,11 @@ tags:
   - Virtual Reality
   - WebVR
   - upDegrees
+  - Deprecated
+  - Non-standard
 browser-compat: api.VRFieldOfView.upDegrees
 ---
-{{APIRef("WebVR API")}}{{SeeCompatTable}}{{Deprecated_header}}
+{{APIRef("WebVR API")}}{{Deprecated_header}}{{Non-standard_header}}
 
 The **`upDegrees`** read-only property of the {{domxref("VRFieldOfView")}} interface returns the number of degrees upwards that the field of view extends in.
 

--- a/files/en-us/web/api/web_animations_api/keyframe_formats/index.md
+++ b/files/en-us/web/api/web_animations_api/keyframe_formats/index.md
@@ -13,7 +13,7 @@ tags:
   - web animations api
 browser-compat: api.Element.animate
 ---
-{{ APIRef("Web Animations API") }}
+{{APIRef("Web Animations API")}}
 
 {{domxref("Element.animate()")}}, {{domxref("KeyframeEffect.KeyframeEffect", "KeyframeEffect()")}}, and {{domxref("KeyframeEffect.setKeyframes()")}} all accept objects formatted to represent a set of keyframes. There are several options to this format, which are explained below.
 

--- a/files/en-us/web/api/web_animations_api/keyframe_formats/index.md
+++ b/files/en-us/web/api/web_animations_api/keyframe_formats/index.md
@@ -5,7 +5,6 @@ page-type: guide
 tags:
   - API
   - Animation
-  - Experimental
   - KeyframeEffect()
   - Reference
   - animate()
@@ -14,7 +13,7 @@ tags:
   - web animations api
 browser-compat: api.Element.animate
 ---
-{{ SeeCompatTable() }}{{ APIRef("Web Animations API") }}
+{{ APIRef("Web Animations API") }}
 
 {{domxref("Element.animate()")}}, {{domxref("KeyframeEffect.KeyframeEffect", "KeyframeEffect()")}}, and {{domxref("KeyframeEffect.setKeyframes()")}} all accept objects formatted to represent a set of keyframes. There are several options to this format, which are explained below.
 

--- a/files/en-us/web/api/webglquery/index.md
+++ b/files/en-us/web/api/webglquery/index.md
@@ -4,7 +4,6 @@ slug: Web/API/WebGLQuery
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - Reference
   - WebGL
   - WebGL2

--- a/files/en-us/web/api/webglrenderingcontext/commit/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/commit/index.md
@@ -4,7 +4,6 @@ slug: Web/API/WebGLRenderingContext/commit
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Method
   - OffscreenCanvas
   - Reference

--- a/files/en-us/web/api/webglrenderingcontext/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/index.md
@@ -43,7 +43,7 @@ The following properties and methods provide general information and functionali
 
 - {{domxref("WebGLRenderingContext.canvas")}}
   - : A read-only back-reference to the {{domxref("HTMLCanvasElement")}}. Might be [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) if it is not associated with a {{HTMLElement("canvas")}} element.
-- {{domxref("WebGLRenderingContext.commit()")}} {{experimental_inline}}
+- {{domxref("WebGLRenderingContext.commit()")}}
   - : Pushes frames back to the original {{domxref("HTMLCanvasElement")}}, if the context is not directly fixed to a specific canvas.
 - {{domxref("WebGLRenderingContext.drawingBufferWidth")}}
   - : The read-only width of the current drawing buffer. Should match the width of the canvas element associated with this context.

--- a/files/en-us/web/api/webglsampler/index.md
+++ b/files/en-us/web/api/webglsampler/index.md
@@ -4,7 +4,6 @@ slug: Web/API/WebGLSampler
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - Reference
   - WebGL
   - WebGL2

--- a/files/en-us/web/api/webglsync/index.md
+++ b/files/en-us/web/api/webglsync/index.md
@@ -4,7 +4,6 @@ slug: Web/API/WebGLSync
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - Reference
   - WebGL
   - WebGL2

--- a/files/en-us/web/api/webvr_api/index.md
+++ b/files/en-us/web/api/webvr_api/index.md
@@ -5,16 +5,16 @@ page-type: web-api-overview
 tags:
   - API
   - Deprecated
-  - Experimental
   - Landing
   - Deprecated
   - Reference
   - VR
   - Virtual Reality
   - WebVR
+  - Non-standard
 browser-compat: api.Navigator.getVRDisplays
 ---
-{{DefaultAPISidebar("WebVR API")}}{{Deprecated_Header}}
+{{DefaultAPISidebar("WebVR API")}}{{Deprecated_Header}}{{Non-standard_header}}
 
 > **Note:** WebVR API is replaced by [WebXR API](/en-US/docs/Web/API/WebXR_Device_API). WebVR was never ratified as a standard, was implemented and enabled by default in very few browsers and supported a small number of devices.
 

--- a/files/en-us/web/api/window/cancelanimationframe/index.md
+++ b/files/en-us/web/api/window/cancelanimationframe/index.md
@@ -6,7 +6,6 @@ tags:
   - API
   - Animation
   - DOM
-  - Experimental
   - Method
   - Reference
   - Window

--- a/files/en-us/web/api/window/cancelidlecallback/index.md
+++ b/files/en-us/web/api/window/cancelidlecallback/index.md
@@ -13,7 +13,7 @@ tags:
   - polyfill
 browser-compat: api.Window.cancelIdleCallback
 ---
-{{APIRef}}{{SeeCompatTable}}
+{{APIRef}}
 
 ## Summary
 

--- a/files/en-us/web/api/window/requestidlecallback/index.md
+++ b/files/en-us/web/api/window/requestidlecallback/index.md
@@ -13,7 +13,7 @@ tags:
   - polyfill
 browser-compat: api.Window.requestIdleCallback
 ---
-{{APIRef("HTML DOM")}}{{SeeCompatTable}}
+{{APIRef("HTML DOM")}}
 
 The **`window.requestIdleCallback()`** method queues a function
 to be called during a browser's idle periods. This enables developers to perform

--- a/files/en-us/web/api/window/scheduler/index.md
+++ b/files/en-us/web/api/window/scheduler/index.md
@@ -8,10 +8,9 @@ tags:
   - scheduler
   - Window
   - WorkerGlobalScope
-  - Experimental
 browser-compat: api.scheduler
 ---
-{{APIRef("Prioritized Task Scheduling API")}} {{SeeCompatTable}}
+{{APIRef("Prioritized Task Scheduling API")}}
 
 The global read-only **`scheduler`** property is the entry point for using the [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API).
 

--- a/files/en-us/web/api/windowclient/focus/index.md
+++ b/files/en-us/web/api/windowclient/focus/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Client
-  - Experimental
   - Focus
   - Method
   - Reference

--- a/files/en-us/web/api/windowclient/focused/index.md
+++ b/files/en-us/web/api/windowclient/focused/index.md
@@ -4,7 +4,6 @@ slug: Web/API/WindowClient/focused
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - Service Workers

--- a/files/en-us/web/api/windowclient/index.md
+++ b/files/en-us/web/api/windowclient/index.md
@@ -5,7 +5,6 @@ page-type: web-api-interface
 tags:
   - API
   - Client
-  - Experimental
   - Interface
   - Reference
   - Service Workers

--- a/files/en-us/web/api/windowclient/navigate/index.md
+++ b/files/en-us/web/api/windowclient/navigate/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Client
-  - Experimental
   - Method
   - Navigate
   - Reference

--- a/files/en-us/web/api/windowclient/visibilitystate/index.md
+++ b/files/en-us/web/api/windowclient/visibilitystate/index.md
@@ -4,7 +4,6 @@ slug: Web/API/WindowClient/visibilityState
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - Service Workers

--- a/files/en-us/web/api/workernavigator/connection/index.md
+++ b/files/en-us/web/api/workernavigator/connection/index.md
@@ -5,13 +5,12 @@ page-type: web-api-instance-property
 tags:
   - API
   - Connection
-  - Experimental
   - Property
   - Reference
   - WorkerNavigator
 browser-compat: api.WorkerNavigator.connection
 ---
-{{APIRef("Network Information API")}}{{SeeCompatTable}}
+{{APIRef("Network Information API")}}
 
 The **`WorkerNavigator.connection`** read-only property returns
 a {{domxref("NetworkInformation")}} object containing information about the system's

--- a/files/en-us/web/api/workernavigator/languages/index.md
+++ b/files/en-us/web/api/workernavigator/languages/index.md
@@ -4,7 +4,6 @@ slug: Web/API/WorkerNavigator/languages
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - WorkerNavigator
   - Property
   - Read-only
@@ -12,7 +11,7 @@ tags:
   - languages
 browser-compat: api.WorkerNavigator.languages
 ---
-{{APIRef("HTML DOM")}}{{SeeCompatTable}}
+{{APIRef("HTML DOM")}}
 
 The **`WorkerNavigator.languages`** read-only property
 returns an array of strings representing the user's preferred

--- a/files/en-us/web/api/workernavigator/locks/index.md
+++ b/files/en-us/web/api/workernavigator/locks/index.md
@@ -4,14 +4,13 @@ slug: Web/API/WorkerNavigator/locks
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - LockManager
   - Property
   - Reference
   - Web Locks API
 browser-compat: api.WorkerNavigator.locks
 ---
-{{SeeCompatTable}}{{APIRef("Web Locks")}}
+{{APIRef("Web Locks")}}
 
 The **`locks`** read-only property of
 the {{domxref("WorkerNavigator")}} interface returns a {{domxref("LockManager")}}

--- a/files/en-us/web/api/worklet/addmodule/index.md
+++ b/files/en-us/web/api/worklet/addmodule/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Background
-  - Experimental
   - Houdini
   - Method
   - Multiprocessor
@@ -16,7 +15,7 @@ tags:
   - addModule
 browser-compat: api.Worklet.addModule
 ---
-{{APIRef("Worklets")}}{{SeeCompatTable}}
+{{APIRef("Worklets")}}
 
 The **`addModule()`** method of the
 {{domxref("Worklet")}} interface loads the module in the given JavaScript file and

--- a/files/en-us/web/api/worklet/index.md
+++ b/files/en-us/web/api/worklet/index.md
@@ -10,7 +10,7 @@ tags:
   - Worklets
 browser-compat: api.Worklet
 ---
-{{APIRef("Worklets")}}{{SeeCompatTable}}
+{{APIRef("Worklets")}}
 
 The **`Worklet`** interface is a lightweight version of {{domxref("Worker", "Web Workers")}} and gives developers access to low-level parts of the rendering pipeline.
 
@@ -92,7 +92,7 @@ _The Worklet interface does not define any properties._
 
 ## Methods
 
-- {{domxref("Worklet.addModule()")}} {{experimental_inline}}
+- {{domxref("Worklet.addModule()")}}
   - : Adds the script module at the given URL to the current worklet.
 
 ## Specifications

--- a/files/en-us/web/api/writablestreamdefaultcontroller/index.md
+++ b/files/en-us/web/api/writablestreamdefaultcontroller/index.md
@@ -4,7 +4,6 @@ slug: Web/API/WritableStreamDefaultController
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - Fetch
   - Interface
   - Reference

--- a/files/en-us/web/api/writablestreamdefaultwriter/abort/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/abort/index.md
@@ -4,7 +4,6 @@ slug: Web/API/WritableStreamDefaultWriter/abort
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Method
   - Reference
   - Streams
@@ -12,7 +11,7 @@ tags:
   - abort
 browser-compat: api.WritableStreamDefaultWriter.abort
 ---
-{{SeeCompatTable}}{{APIRef("Streams")}}
+{{APIRef("Streams")}}
 
 The **`abort()`** method of the
 {{domxref("WritableStreamDefaultWriter")}} interface aborts the stream, signaling that

--- a/files/en-us/web/api/writablestreamdefaultwriter/close/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/close/index.md
@@ -4,7 +4,6 @@ slug: Web/API/WritableStreamDefaultWriter/close
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Method
   - Reference
   - Streams
@@ -12,7 +11,7 @@ tags:
   - close
 browser-compat: api.WritableStreamDefaultWriter.close
 ---
-{{SeeCompatTable}}{{APIRef("Streams")}}
+{{APIRef("Streams")}}
 
 The **`close()`** method of the
 {{domxref("WritableStreamDefaultWriter")}} interface closes the associated writable

--- a/files/en-us/web/api/writablestreamdefaultwriter/closed/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/closed/index.md
@@ -4,7 +4,6 @@ slug: Web/API/WritableStreamDefaultWriter/closed
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - Streams
@@ -12,7 +11,7 @@ tags:
   - closed
 browser-compat: api.WritableStreamDefaultWriter.closed
 ---
-{{SeeCompatTable}}{{APIRef("Streams")}}
+{{APIRef("Streams")}}
 
 The **`closed`** read-only property of the
 {{domxref("WritableStreamDefaultWriter")}} interface returns a

--- a/files/en-us/web/api/writablestreamdefaultwriter/desiredsize/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/desiredsize/index.md
@@ -4,7 +4,6 @@ slug: Web/API/WritableStreamDefaultWriter/desiredSize
 page-type: web-api-instance-property
 tags:
   - API
-  - Experimental
   - Property
   - Reference
   - Streams
@@ -12,7 +11,7 @@ tags:
   - desiredSize
 browser-compat: api.WritableStreamDefaultWriter.desiredSize
 ---
-{{SeeCompatTable}}{{APIRef("Streams")}}
+{{APIRef("Streams")}}
 
 The **`desiredSize`** read-only property of the
 {{domxref("WritableStreamDefaultWriter")}} interface returns the desired size required

--- a/files/en-us/web/api/writablestreamdefaultwriter/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/index.md
@@ -4,7 +4,6 @@ slug: Web/API/WritableStreamDefaultWriter
 page-type: web-api-interface
 tags:
   - API
-  - Experimental
   - Interface
   - Reference
   - Streams
@@ -12,7 +11,7 @@ tags:
   - WritableStream
 browser-compat: api.WritableStreamDefaultWriter
 ---
-{{SeeCompatTable}}{{APIRef("Streams")}}
+{{APIRef("Streams")}}
 
 The **`WritableStreamDefaultWriter`** interface of the [Streams API](/en-US/docs/Web/API/Streams_API) is the object returned by {{domxref("WritableStream.getWriter()")}} and once created locks the writer to the `WritableStream` ensuring that no other streams can write to the underlying sink.
 

--- a/files/en-us/web/api/writablestreamdefaultwriter/ready/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/ready/index.md
@@ -13,7 +13,7 @@ tags:
   - WritableStreamDefaultWriter
 browser-compat: api.WritableStreamDefaultWriter.ready
 ---
-{{SeeCompatTable}}{{APIRef("Streams")}}
+{{APIRef("Streams")}}
 
 The **`ready`** read-only property of the
 {{domxref("WritableStreamDefaultWriter")}} interface returns a {{jsxref("Promise")}}

--- a/files/en-us/web/api/writablestreamdefaultwriter/releaselock/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/releaselock/index.md
@@ -4,7 +4,6 @@ slug: Web/API/WritableStreamDefaultWriter/releaseLock
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Method
   - Reference
   - Streams
@@ -12,7 +11,7 @@ tags:
   - releaseLock
 browser-compat: api.WritableStreamDefaultWriter.releaseLock
 ---
-{{APIRef("Streams")}}{{SeeCompatTable}}
+{{APIRef("Streams")}}
 
 The **`releaseLock()`** method of the
 {{domxref("WritableStreamDefaultWriter")}} interface releases the writer's lock on the

--- a/files/en-us/web/api/writablestreamdefaultwriter/writablestreamdefaultwriter/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/writablestreamdefaultwriter/index.md
@@ -5,13 +5,12 @@ page-type: web-api-constructor
 tags:
   - API
   - Constructor
-  - Experimental
   - Reference
   - Streams
   - WritableStreamDefaultWriter
 browser-compat: api.WritableStreamDefaultWriter.WritableStreamDefaultWriter
 ---
-{{SeeCompatTable}}{{APIRef("Streams")}}
+{{APIRef("Streams")}}
 
 The **`WritableStreamDefaultWriter()`**
 constructor creates a new {{domxref("WritableStreamDefaultWriter")}} object instance.

--- a/files/en-us/web/api/writablestreamdefaultwriter/write/index.md
+++ b/files/en-us/web/api/writablestreamdefaultwriter/write/index.md
@@ -4,7 +4,6 @@ slug: Web/API/WritableStreamDefaultWriter/write
 page-type: web-api-instance-method
 tags:
   - API
-  - Experimental
   - Method
   - Reference
   - Streams
@@ -12,7 +11,7 @@ tags:
   - write
 browser-compat: api.WritableStreamDefaultWriter.write
 ---
-{{APIRef("Streams")}}{{SeeCompatTable}}
+{{APIRef("Streams")}}
 
 The **`write()`** method of the
 {{domxref("WritableStreamDefaultWriter")}} interface writes a passed chunk of data to a

--- a/files/en-us/web/api/xsltprocessor/index.md
+++ b/files/en-us/web/api/xsltprocessor/index.md
@@ -10,7 +10,7 @@ tags:
   - XSLT
 browser-compat: api.XSLTProcessor
 ---
-{{Non-standard_header}}{{SeeCompatTable}}{{APIRef("XSLT")}}
+{{APIRef("XSLT")}}
 
 An **`XSLTProcessor`** applies an [XSLT](/en-US/docs/Web/XSLT) stylesheet transformation to an XML document to
 produce a new XML document as output. It has methods to load the XSLT stylesheet, to


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.
It focuses on files that have only left behind 'experimental' tags and headers.