### PR TITLE
Ff104 relnote: Remove IDBFactory.open() options

### DIFF
--- a/files/en-us/mozilla/firefox/releases/104/index.md
+++ b/files/en-us/mozilla/firefox/releases/104/index.md
@@ -57,6 +57,11 @@ This article provides information about the changes in Firefox 104 that will aff
 
 #### Removals
 
+- The `options` argument to the [`IDBFactory.open()`](/en-US/docs/Web/API/IDBFactory/open) method has been removed.
+  This this option provided a non-standard, and Firefox-only way to make the indicated database persistent.
+  The option was previously deprecated, and users that need this functionality should already have migrated to {{domxref("StorageManager.persist()")}}.
+  (See {{bug(1354500)}} for more details.)
+
 ### WebAssembly
 
 #### Removals

--- a/files/en-us/web/api/storagemanager/index.md
+++ b/files/en-us/web/api/storagemanager/index.md
@@ -15,7 +15,7 @@ tags:
   - Usage
 browser-compat: api.StorageManager
 ---
-{{securecontext_header}}{{SeeCompatTable}}{{APIRef("Storage")}}
+{{securecontext_header}}{{APIRef("Storage")}}
 
 The **`StorageManager`** interface of the [Storage API](/en-US/docs/Web/API/Storage_API) provides an interface for managing persistence permissions and estimating available storage. You can get a reference to this interface using either {{domxref("navigator.storage")}} or {{domxref("WorkerNavigator.storage")}}.
 

--- a/files/en-us/web/api/storagemanager/persist/index.md
+++ b/files/en-us/web/api/storagemanager/persist/index.md
@@ -10,12 +10,9 @@ tags:
   - persist()
 browser-compat: api.StorageManager.persist
 ---
-{{securecontext_header}}{{APIRef("Storage")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("Storage")}}
 
-The **`persist()`** method of the
-{{domxref("StorageManager")}} interface requests permission to use persistent storage,
-and returns a {{jsxref('Promise')}} that resolves to `true` if permission
-is granted and box mode is persistent, and `false` otherwise.
+The **`persist()`** method of the {{domxref("StorageManager")}} interface requests permission to use persistent storage, and returns a {{jsxref('Promise')}} that resolves to `true` if permission is granted and box mode is persistent, and `false` otherwise.
 
 ## Syntax
 

--- a/files/en-us/web/api/storagemanager/persisted/index.md
+++ b/files/en-us/web/api/storagemanager/persisted/index.md
@@ -10,11 +10,9 @@ tags:
   - persisted()
 browser-compat: api.StorageManager.persisted
 ---
-{{securecontext_header}}{{APIRef("Storage")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("Storage")}}
 
-The **`persisted()`** method of the
-{{domxref("StorageManager")}} interface returns a {{jsxref('Promise')}} that resolves
-to `true` if box mode is persistent for your site's storage.
+The **`persisted()`** method of the {{domxref("StorageManager")}} interface returns a {{jsxref('Promise')}} that resolves to `true` if box mode is persistent for your site's storage.
 
 ## Syntax
 


### PR DESCRIPTION
FF104 removes the proprietary `options` option to [IDBFactory.open()](https://developer.mozilla.org/en-US/docs/Web/API/IDBFactory/open) in https://bugzilla.mozilla.org/show_bug.cgi?id=1354500. 

The docs fixes have already been done in #19578. This:
- Adds a release note
- Removes the experimental macro for the StorageManager - the methods are widely supported and not marked as experimental in BCD.

Other docs work for this can be tracked in #19575