### PR TITLE
Fix variable name in HTMLFormElement example

### DIFF
--- a/files/en-us/web/api/htmlformelement/formdata_event/index.md
+++ b/files/en-us/web/api/htmlformelement/formdata_event/index.md
@@ -51,8 +51,8 @@ formElem.addEventListener('submit', (e) => {
   // on form submission, prevent default
   e.preventDefault();
 
-  console.log(form.querySelector('input[name="field1"]')); // FOO
-  console.log(form.querySelector('input[name="field2"]')); // BAR
+  console.log(formElem.querySelector('input[name="field1"]')); // FOO
+  console.log(formElem.querySelector('input[name="field2"]')); // BAR
 
   // construct a FormData object, which fires the formdata event
   const formData = new FormData(formElem);


### PR DESCRIPTION
The example was referencing `form` which is not defined, should be `formElem`

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Updated `form` to `formElem` in the example.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Because it was incorrect which can be confusing.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
