### PR TITLE
Enhance examples with vh viewport value

### DIFF
--- a/files/en-us/web/css/height/index.md
+++ b/files/en-us/web/css/height/index.md
@@ -86,22 +86,33 @@ Ensure that elements set with a `height` aren't truncated and/or don't obscure o
 #### HTML
 
 ```html
-<div id="taller">I'm 50 pixels tall.</div>
-<div id="shorter">I'm 25 pixels tall.</div>
-<div id="parent">
-  <div id="child">
-    I'm half the height of my parent.
+<div id="container">
+  I'm three quarters the height of the<br/>viewport and at least 250 pixels tall. 
+  <div id="taller">I'm 50 pixels tall.</div>
+  <div id="shorter">I'm 25 pixels tall.</div>
+  <div id="parent">
+    I'm the parent.
+    <div id="child">
+      I'm half the height of my parent.
+    </div>
   </div>
-</div>
+</div>  
 ```
 
 #### CSS
 
 ```css
 div {
-  width: 250px;
-  margin-bottom: 5px;
+  width: auto;
+  margin: 3px;
   border: 2px solid blue;
+  padding: 3px;
+}
+
+#container {
+  width: 250px;
+  min-height: 250px;
+  height: 75vh;
 }
 
 #taller {
@@ -118,7 +129,6 @@ div {
 
 #child {
   height: 50%;
-  width: 75%;
 }
 ```
 


### PR DESCRIPTION
See #19583

Add vh viewport value to the examples code and reworked the existing example as per images below (before and after resizing the viewport). I chose 75vh rather than 50vh so the effect is seen quicker when resizing the viewport.
![mdn-css-height-examples](https://user-images.githubusercontent.com/90506472/184867119-4a214071-a8cf-4789-816c-1239869cf083.jpg)
#### Other comments
I am not sure what the style on MDN is about naming "containers". 
I think "three quarters" is better than "three-quarters" here, but that is a language style issue. 

This is my first **code** PR here, so I am not sure about the procedure. Please let me know if I have missed something.