### PR TITLE
Remove unnecessary tag in the "Commonly-used macros"

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/macros/commonly_used_macros/index.md
@@ -160,7 +160,6 @@ Most macros will also take a second argument allowing you to change the display 
         <code>\{{HTTPStatus("404")}}</code> results in {{HTTPStatus("404")}}
       </td>
     </tr>
-    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Remove unnecessary tag in the "Commonly-used macros"
There is an extra `</tr>` tag.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
