### PR TITLE
Update: remove HTML5Rocks links

### DIFF
--- a/files/en-us/games/techniques/audio_for_web_games/index.md
+++ b/files/en-us/games/techniques/audio_for_web_games/index.md
@@ -417,8 +417,6 @@ This is especially useful in a three-dimensional environment rendered using WebG
 
 - [Web Audio API on MDN](/en-US/docs/Web/API/Web_Audio_API)
 - [`<audio>` on MDN](/en-US/docs/Web/HTML/Element/audio)
-- [Developing Game Audio with the Web Audio API (HTML5Rocks)](https://www.html5rocks.com/en/tutorials/webaudio/games/)
-- [Mixing Positional Audio and WebGL (HTML5Rocks)](https://www.html5rocks.com/en/tutorials/webaudio/positional_audio/)
 - [Songs of Diridum: Pushing the Web Audio API to Its Limits](https://hacks.mozilla.org/2013/10/songs-of-diridum-pushing-the-web-audio-api-to-its-limits/)
 - [Making HTML5 Audio Actually Work on Mobile](https://pupunzi.open-lab.com/2013/03/13/making-html5-audio-actually-work-on-mobile/)
 - [Audio Sprites (and fixes for iOS)](https://remysharp.com/2010/12/23/audio-sprites/)

--- a/files/en-us/web/api/canvas_api/tutorial/optimizing_canvas/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/optimizing_canvas/index.md
@@ -133,7 +133,6 @@ canvas.style.height = `${rect.height}px`;
 
 ## See also
 
-- [Improving HTML5 Canvas Performance – HTML5 Rocks](https://www.html5rocks.com/en/tutorials/canvas/performance/#toc-ref)
 - [Optimizing your JavaScript game for Firefox OS – Mozilla Hacks](https://hacks.mozilla.org/2013/05/optimizing-your-javascript-game-for-firefox-os/)
 
 {{PreviousNext("Web/API/Canvas_API/Tutorial/Pixel_manipulation_with_canvas", "Web/API/Canvas_API/Tutorial/Finale")}}

--- a/files/en-us/web/api/canvasrenderingcontext2d/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/index.md
@@ -296,7 +296,7 @@ Most of these APIs are [deprecated and were removed shortly after Chrome 36](htt
 ### WebKit only
 
 - `CanvasRenderingContext2D.webkitBackingStorePixelRatio` {{non-standard_inline}} {{deprecated_inline}}
-  - : The backing store size in relation to the canvas element. See [High DPI Canvas](https://www.html5rocks.com/en/tutorials/canvas/hidpi/).
+  - : The backing store size in relation to the canvas element. 
 - `CanvasRenderingContext2D.webkitGetImageDataHD` {{non-standard_inline}} {{deprecated_inline}}
   - : Intended for HD backing stores, but removed from canvas specifications.
 - `CanvasRenderingContext2D.webkitPutImageDataHD` {{non-standard_inline}} {{deprecated_inline}}

--- a/files/en-us/web/api/document/scroll_event/index.md
+++ b/files/en-us/web/api/document/scroll_event/index.md
@@ -40,9 +40,9 @@ Since `scroll` events can fire at a high rate, the event handler shouldn't execu
 
 Note, however, that input events and animation frames are fired at about the same rate, and therefore the optimization below is often unnecessary. This example optimizes the `scroll` event for `requestAnimationFrame`.
 
-```js
-// Reference: http://www.html5rocks.com/en/tutorials/speed/animations/
+<!--Reference: http://www.html5rocks.com/en/tutorials/speed/animations/ no longer exists. -->
 
+```js
 let lastKnownScrollPosition = 0;
 let ticking = false;
 

--- a/files/en-us/web/api/element/scroll_event/index.md
+++ b/files/en-us/web/api/element/scroll_event/index.md
@@ -37,10 +37,9 @@ A generic {{domxref("Event")}}.
 Since `scroll` events can fire at a high rate, the event handler shouldn't execute computationally expensive operations such as DOM modifications. Instead, it is recommended to throttle the event using {{DOMxRef("Window.requestAnimationFrame()", "requestAnimationFrame()")}}, {{DOMxRef("setTimeout()")}}, or a {{DOMxRef("CustomEvent")}}, as follows.
 
 Note, however, that input events and animation frames are fired at about the same rate, and therefore the optimization below is often unnecessary. This example optimizes the `scroll` event for `requestAnimationFrame`.
+<!--Reference: http://www.html5rocks.com/en/tutorials/speed/animations/ no longer exists. -->
 
 ```js
-// Reference: http://www.html5rocks.com/en/tutorials/speed/animations/
-
 let last_known_scroll_position = 0;
 let ticking = false;
 

--- a/files/en-us/web/api/filesystementry/index.md
+++ b/files/en-us/web/api/filesystementry/index.md
@@ -22,7 +22,7 @@ You don't create `FileSystemEntry` objects directly. Instead, you will receive a
 
 The `FileSystemEntry` interface includes methods that you would expect for manipulating files and directories, but it also includes a convenient method for obtaining the URL of the entry: [`toURL()`](#tourl). It also introduces a new URL scheme: `filesystem:`.
 
-You can use the `filesystem:` scheme on Google Chrome to see all the files and folders that are stored in the origin of your app. Just use `filesystem:` scheme for the root directory of the origin of the app. For example, if your app is in [`http://www.html5rocks.com`](https://www.html5rocks.com), open `filesystem:http://www.html5rocks.com/temporary/` in a tab. Chrome shows a read-only list of all the files and folders stored the origin of your app.
+You can use the `filesystem:` scheme on Google Chrome to see all the files and folders that are stored in the origin of your app. Just use `filesystem:` scheme for the root directory of the origin of the app. For example, if your app is in [`http://www.example.com`](https://www.example.com), open `filesystem:http://www.example.com/temporary/` in a tab. Chrome shows a read-only list of all the files and folders stored the origin of your app.
 
 ### Example
 

--- a/files/en-us/web/api/indexeddb_api/using_indexeddb/index.md
+++ b/files/en-us/web/api/indexeddb_api/using_indexeddb/index.md
@@ -663,7 +663,7 @@ Further reading for you to find out more information if desired.
 
 ### Tutorials and guides
 
-- [Databinding UI Elements with IndexedDB](https://www.html5rocks.com/en/tutorials/indexeddb/uidatabinding/)
+- [Databinding UI Elements with IndexedDB (2012)](https://web.dev/indexeddb-uidatabinding/)
 - [IndexedDB — The Store in Your Browser](https://docs.microsoft.com/en-us/previous-versions/msdn10/gg679063(v=msdn.10))
 
 ### Libraries

--- a/files/en-us/web/api/rtcpeerconnection/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/index.md
@@ -300,5 +300,5 @@ Listen to these events using {{domxref("EventTarget.addEventListener", "addEvent
 ## See also
 
 - <https://github.com/jesup/nightly-gupshup/blob/master/static/js/chat.js>
-- [http://www.html5rocks.com/en/tutorials/webrtc/basics/#toc-simple](https://www.html5rocks.com/en/tutorials/webrtc/basics/#toc-simple)
-- [TutorRoom](https://github.com/chrisjohndigital/TutorRoom): Node.js HTML5 video capture, peer-to-peer video and filesharing application ([source on GitHub](https://github.com/chrisjohndigital/TutorRoom))
+- [Get started with WebRTC](https://web.dev/webrtc-basics/)
+- [TutorRoom](https://github.com/chrisjohndigital/TutorRoom): Node.js HTML video capture, peer-to-peer video and filesharing application ([source on GitHub](https://github.com/chrisjohndigital/TutorRoom))

--- a/files/en-us/web/api/web_audio_api/advanced_techniques/index.md
+++ b/files/en-us/web/api/web_audio_api/advanced_techniques/index.md
@@ -549,7 +549,7 @@ A common problem with digital audio applications is getting the sounds to play i
 
 We could schedule our voices to play within a `for` loop; however, the biggest problem with this is updating while it is playing, and we've already implemented UI controls to do so. Also, it would be really nice to consider an instrument-wide BPM control. The best way to get our voices to play on the beat is to create a scheduling system, whereby we look ahead at when the notes will play and push them into a queue. We can start them at a precise time with the `currentTime` property and also consider any changes.
 
-> **Note:** This is a much stripped down version of [Chris Wilson's A Tale Of Two Clocks](https://www.html5rocks.com/en/tutorials/audio/scheduling/) article, which goes into this method with much more detail. There's no point repeating it all here, but we highly recommend reading this article and using this method. Much of the code here is taken from his [metronome example](https://github.com/cwilso/metronome/blob/master/js/metronome.js), which he references in the article.
+> **Note:** This is a much stripped down version of [Chris Wilson's A Tale Of Two Clocks (2013)](https://web.dev/audio-scheduling/) article, which goes into this method with much more detail. There's no point repeating it all here, but we highly recommend reading this article and using this method. Much of the code here is taken from his [metronome example](https://github.com/cwilso/metronome/blob/master/js/metronome.js), which he references in the article.
 
 Let's start by setting up our default BPM (beats per minute), which will also be user-controllable via — you guessed it — another range input.
 

--- a/files/en-us/web/api/web_audio_api/index.md
+++ b/files/en-us/web/api/web_audio_api/index.md
@@ -220,8 +220,8 @@ You can find a number of examples at our [webaudio-example repo](https://github.
 - [Visualizations with Web Audio API](/en-US/docs/Web/API/Web_Audio_API/Visualizations_with_Web_Audio_API)
 - [Web audio spatialization basics](/en-US/docs/Web/API/Web_Audio_API/Web_audio_spatialization_basics)
 - [Controlling multiple parameters with ConstantSourceNode](/en-US/docs/Web/API/Web_Audio_API/Controlling_multiple_parameters_with_ConstantSourceNode)
-- [Mixing Positional Audio and WebGL](https://www.html5rocks.com/en/tutorials/webaudio/positional_audio/)
-- [Developing Game Audio with the Web Audio API](https://www.html5rocks.com/en/tutorials/webaudio/games/)
+- [Mixing Positional Audio and WebGL (2012)](https://web.dev/webaudio-positional-audio/)
+- [Developing Game Audio with the Web Audio API (2012)](https://auth.web.dev/webaudio-games/)
 - [Porting webkitAudioContext code to standards based AudioContext](/en-US/docs/Web/API/Web_Audio_API/Migrating_from_webkitAudioContext)
 
 ### Libraries

--- a/files/en-us/web/api/workernavigator/online/index.md
+++ b/files/en-us/web/api/workernavigator/online/index.md
@@ -13,29 +13,16 @@ browser-compat: api.WorkerNavigator.onLine
 ---
 {{ApiRef("HTML DOM")}}
 
-Returns the online status of the browser. The property returns a boolean value, with
-`true` meaning online and `false` meaning offline. The property
-sends updates whenever the browser's ability to connect to the network changes. The
-update occurs when the user follows links or when a script requests a remote page. For
-example, the property should return `false` when users click links soon after
-they lose internet connection.
+Returns the online status of the browser. The property returns a boolean value, with `true` meaning online and `false` meaning offline. The property sends updates whenever the browser's ability to connect to the network changes. The update occurs when the user follows links or when a script requests a remote page.
+
+For example, the property should return `false` when users click links soon after they lose internet connection.
 
 Browsers implement this property differently.
 
-In Chrome and Safari, if the browser is not able to connect to a local area network
-(LAN) or a router, it is offline; all other conditions return `true`. So
-while you can assume that the browser is offline when it returns a `false`
-value, you cannot assume that a true value necessarily means that the browser can access
-the internet. You could be getting false positives, such as in cases where the computer
-is running a virtualization software that has virtual ethernet adapters that are always
-"connected." Therefore, if you really want to determine the online status of the
-browser, you should develop additional means for checking. To learn more, see the HTML5
-Rocks article, [Working Off the Grid](https://www.html5rocks.com/en/mobile/workingoffthegrid/).
+In Chrome and Safari, if the browser is not able to connect to a local area network (LAN) or a router, it is offline; all other conditions return `true`. So while you can assume that the browser is offline when it returns a `false` value, you cannot assume that a true value necessarily means that the browser can access the internet. You could be getting false positives, such as in cases where the computer is running a virtualization software that has virtual ethernet adapters that are always
+"connected." Therefore, if you really want to determine the online status of the browser, you should develop additional means for checking. To learn more, see the 2011 article, [Working Off the Grid](https://web.dev/workingoffthegrid/).
 
-In Firefox and Internet Explorer, switching the browser to offline mode sends a
-`false` value. Until Firefox 41, all other conditions return a
-`true` value; testing actual behavior on Nightly 68 on Windows shows that it
-only looks for LAN connection like Chrome and Safari giving false positives.
+In Firefox and Internet Explorer, switching the browser to offline mode sends a `false` value. 
 
 ## Value
 
@@ -45,8 +32,7 @@ only looks for LAN connection like Chrome and Safari giving false positives.
 
 ### Basic usage
 
-To check if you are online in a worker, query `navigator.onLine`, as in the
-following example:
+To check if you are online in a worker, query `navigator.onLine`, as in the following example:
 
 ```js
 if (navigator.onLine) {
@@ -56,15 +42,11 @@ if (navigator.onLine) {
 }
 ```
 
-If the browser doesn't support `navigator.onLine` the above example will
-always come out as `false`/`undefined`.
+If the browser doesn't support `navigator.onLine` the above example will always come out as `false`/`undefined`.
 
 ### Listening for changes in network status
 
-To see changes in the network state, use
-[`addEventListener`](/en-US/docs/Web/API/EventTarget/addEventListener) to
-listen for the events on `online` and `offline`, as
-in the following example:
+To see changes in the network state, use [`addEventListener`](/en-US/docs/Web/API/EventTarget/addEventListener) to listen for the events on `online` and `offline`, as in the following example:
 
 ```js
 addEventListener('offline', (e) => { console.log('offline'); });

--- a/files/en-us/web/api/xmlhttprequest/index.md
+++ b/files/en-us/web/api/xmlhttprequest/index.md
@@ -136,5 +136,5 @@ _This interface also inherits properties of {{domxref("XMLHttpRequestEventTarget
   - [HTML in XMLHttpRequest](/en-US/docs/Web/API/XMLHttpRequest/HTML_in_XMLHttpRequest)
   - [Fetch API](/en-US/docs/Web/API/Fetch_API)
 
-- [HTML5 Rocks — New Tricks in XMLHttpRequest2](https://www.html5rocks.com/en/tutorials/file/xhr2/)
+- [New Tricks in XMLHttpRequest2 (2011)](https://web.dev/xhr2/)
 - Feature-Policy directive {{httpheader("Feature-Policy/sync-xhr", "sync-xhr")}}

--- a/files/en-us/web/guide/api/webrtc/peer-to-peer_communications_with_webrtc/index.md
+++ b/files/en-us/web/guide/api/webrtc/peer-to-peer_communications_with_webrtc/index.md
@@ -25,7 +25,7 @@ A high-level description of what happens in an `RTCPeerConnection` was shown in 
 
 ## Resources
 
-- A good tutorial on basic features in WebRTC is at [HTML5 Rocks](https://www.html5rocks.com/en/tutorials/webrtc/basics/).   A collection of basic test pages to support development are at [webrtc-landing](https://mozilla.github.io/webrtc-landing/).
+- A good tutorial on basic features in WebRTC is at [web.dev](https://web.dev/webrtc-basics/).   A collection of basic test pages to support development are at [webrtc-landing](https://mozilla.github.io/webrtc-landing/).
 - You can make simple person-to-person calls using [apprtc](https://github.com/webrtc/apprtc).
 - A high-level description of what happens in an `RTCPeerConnection` was shown in the [Mozilla Hacks](https://hacks.mozilla.org/category/webrtc/) blog article [Embedding WebRTC video chat](https://hacks.mozilla.org/2013/05/embedding-webrtc-video-chat-right-into-your-website/).
 

--- a/files/en-us/web/guide/audio_and_video_manipulation/index.md
+++ b/files/en-us/web/guide/audio_and_video_manipulation/index.md
@@ -357,7 +357,7 @@ Libraries currently exist for the following formats :
 - [Web audio spatialization basics](/en-US/docs/Web/API/Web_Audio_API/Web_audio_spatialization_basics)
 - [Using Video frames as a WebGL Texture](/en-US/docs/Web/API/WebGL_API/Tutorial/Animating_textures_in_WebGL#using_the_video_frames_as_a_texture) (You can also the [THREE.js](https://threejs.org) WebGL library (and others) to [achieve this effect](https://stemkoski.github.io/Three.js/Video.html))
 - [Animating Textures in WebGL](/en-US/docs/Web/API/WebGL_API/Tutorial/Animating_textures_in_WebGL)
-- [Developing Game Audio with the Web Audio API (Room effects and filters)](https://www.html5rocks.com/en/tutorials/webaudio/games/#toc-room)
+- [Developing Game Audio with the Web Audio API (Room effects and filters) (2012)](https://web.dev/webaudio-games/#room-effects-and-filters)
 
 ### Reference
 

--- a/files/en-us/web/http/index.md
+++ b/files/en-us/web/http/index.md
@@ -63,5 +63,5 @@ Helpful tools and resources for understanding and debugging HTTP.
   - : A project designed to help developers, system administrators, and security professionals configure their sites safely and securely.
 - [RedBot](https://redbot.org/)
   - : Tools to check your cache-related headers.
-- [How Browsers Work](https://www.html5rocks.com/en/tutorials/internals/howbrowserswork/)
+- [How Browsers Work (2011)](https://web.dev/howbrowserswork/)
   - : A very comprehensive article on browser internals and request flow through HTTP protocol. A MUST-READ for any web developer.

--- a/files/en-us/web/javascript/reference/errors/already_has_pragma/index.md
+++ b/files/en-us/web/javascript/reference/errors/already_has_pragma/index.md
@@ -47,4 +47,4 @@ X-SourceMap: /path/to/file.js.map
 ## See also
 
 - [How to use a source map – Firefox Tools documentation](https://firefox-source-docs.mozilla.org/devtools-user/debugger/how_to/use_a_source_map/index.html)
-- [Introduction to source maps – HTML5 rocks](https://www.html5rocks.com/en/tutorials/developertools/sourcemaps/)
+- [Introduction to source maps (2012)](https://developer.chrome.com/blog/sourcemaps/)

--- a/files/en-us/web/javascript/reference/errors/already_has_pragma/index.md
+++ b/files/en-us/web/javascript/reference/errors/already_has_pragma/index.md
@@ -26,7 +26,7 @@ A warning. JavaScript execution won't be halted.
 
 A source map has been specified more than once for a given JavaScript source.
 
-JavaScript sources are often combined and minified to make delivering them from the server more efficient. With [source maps](https://www.html5rocks.com/en/tutorials/developertools/sourcemaps/), the debugger can map the code being executed to the original source files. There are two ways to assign a source map, either by using a comment or by setting a header to the JavaScript file.
+JavaScript sources are often combined and minified to make delivering them from the server more efficient. With [source maps](https://developer.chrome.com/blog/sourcemaps/), the debugger can map the code being executed to the original source files. There are two ways to assign a source map, either by using a comment or by setting a header to the JavaScript file.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/errors/deprecated_source_map_pragma/index.md
+++ b/files/en-us/web/javascript/reference/errors/deprecated_source_map_pragma/index.md
@@ -29,7 +29,7 @@ A warning that a {{jsxref("SyntaxError")}} occurred. JavaScript execution won't 
 
 There is a deprecated source map syntax in a JavaScript source.
 
-JavaScript sources are often combined and minified to make delivering them from the server more efficient. With [source maps](https://www.html5rocks.com/en/tutorials/developertools/sourcemaps/), the debugger can map the code being executed to the original source files.
+JavaScript sources are often combined and minified to make delivering them from the server more efficient. With [source maps](https://firefox-source-docs.mozilla.org/devtools-user/debugger/how_to/use_a_source_map/index.html), the debugger can map the code being executed to the original source files.
 
 The source map specification changed the syntax due to a conflict with IE whenever it was found in the page after `//@cc_on` was interpreted to turn on conditional compilation in the IE JScript engine. The [conditional compilation comment](https://stackoverflow.com/questions/24473882/what-does-this-comment-cc-on-0-do-inside-an-if-statement-in-javascript) in IE is a little known feature, but it broke source maps with [jQuery](https://bugs.jquery.com/ticket/13274) and other libraries.
 
@@ -60,5 +60,5 @@ SourceMap: /path/to/file.js.map
 ## See also
 
 - [How to use a source map – Firefox Tools documentation](https://firefox-source-docs.mozilla.org/devtools-user/debugger/how_to/use_a_source_map/index.html)
-- [Introduction to source maps – HTML5 rocks](https://www.html5rocks.com/en/tutorials/developertools/sourcemaps/)
+- [Introduction to source maps](https://developer.chrome.com/blog/sourcemaps/)
 - {{HTTPHeader("SourceMap")}}

--- a/files/en-us/web/javascript/reference/errors/deprecated_source_map_pragma/index.md
+++ b/files/en-us/web/javascript/reference/errors/deprecated_source_map_pragma/index.md
@@ -60,5 +60,5 @@ SourceMap: /path/to/file.js.map
 ## See also
 
 - [How to use a source map – Firefox Tools documentation](https://firefox-source-docs.mozilla.org/devtools-user/debugger/how_to/use_a_source_map/index.html)
-- [Introduction to source maps](https://developer.chrome.com/blog/sourcemaps/)
+- [Introduction to source maps (2012)](https://developer.chrome.com/blog/sourcemaps/)
 - {{HTTPHeader("SourceMap")}}

--- a/files/en-us/web/javascript/typed_arrays/index.md
+++ b/files/en-us/web/javascript/typed_arrays/index.md
@@ -174,5 +174,5 @@ const normalArray = Array.prototype.slice.call(typedArray);
 
 - [Getting `ArrayBuffer`s or typed arrays from Base64-encoded strings](/en-US/docs/Glossary/Base64#appendix_decode_a_base64_string_to_uint8array_or_arraybuffer)
 - [Faster Canvas Pixel Manipulation with Typed Arrays](https://hacks.mozilla.org/2011/12/faster-canvas-pixel-manipulation-with-typed-arrays/)
-- [Typed Arrays: Binary Data in the Browser](https://www.html5rocks.com/en/tutorials/webgl/typed_arrays/)
+- [Typed Arrays: Binary Data in the Browser](https://web.dev/webgl-typed-arrays/)
 - [Endianness](/en-US/docs/Glossary/Endianness)


### PR DESCRIPTION
HTML5 Rocks no longer exists.
Most of the files have been ported to web.dev
However, they are all from 2010 - 2013. 

I tried to find the articles or equivalent articles, but some were better off just removed.

I included the year of the article b/c they are so old; people should know before clicking; and if we decide to delete old links at some point this helps.


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
