### PR TITLE
Minor: Remove CSS vendor  prefixing

### DIFF
--- a/files/en-us/learn/forms/form_validation/index.md
+++ b/files/en-us/learn/forms/form_validation/index.md
@@ -533,7 +533,6 @@ p * {
 }
 
 input[type=email]{
-  -webkit-appearance: none;
   appearance: none;
 
   width: 100%;
@@ -710,8 +709,8 @@ p * {
 }
 
 input.mail {
-  -webkit-appearance: none;
-
+  appearance: none;
+  
   width: 100%;
   border: 1px solid #333;
   margin: 0;

--- a/files/en-us/learn/forms/form_validation/index.md
+++ b/files/en-us/learn/forms/form_validation/index.md
@@ -710,7 +710,6 @@ p * {
 
 input.mail {
   appearance: none;
-  
   width: 100%;
   border: 1px solid #333;
   margin: 0;

--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/example_1/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/example_1/index.md
@@ -62,7 +62,6 @@ This is the first example of code that explains [how to build a custom form widg
   font-size   : 0.625em; /* 10px */
   font-family : Verdana, Arial, sans-serif;
 
-  -moz-box-sizing : border-box;
   box-sizing : border-box;
 
   padding : 0.1em 2.5em 0.2em 0.5em; /* 1px 25px 2px 5px */
@@ -98,7 +97,6 @@ This is the first example of code that explains [how to build a custom form widg
 
   padding-top : .1em;
 
-  -moz-box-sizing : border-box;
   box-sizing : border-box;
 
   text-align : center;
@@ -235,7 +233,6 @@ This is the first example of code that explains [how to build a custom form widg
 
   padding-top : .1em;
 
-  -moz-box-sizing : border-box;
   box-sizing : border-box;
 
   text-align : center;
@@ -337,7 +334,6 @@ This is the first example of code that explains [how to build a custom form widg
   font-size   : 0.625em; /* 10px */
   font-family : Verdana, Arial, sans-serif;
 
-  -moz-box-sizing : border-box;
   box-sizing : border-box;
 
   padding : 0.1em 2.5em 0.2em 0.5em; /* 1px 25px 2px 5px */
@@ -398,7 +394,6 @@ This is the first example of code that explains [how to build a custom form widg
 
   box-shadow: 0 .2em .4em rgba(0,0,0,.4);
 
-  -moz-box-sizing : border-box;
   box-sizing : border-box;
 
   min-width : 100%;

--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/example_2/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/example_2/index.md
@@ -79,7 +79,6 @@ This is the second example that explain [how to build custom form widgets](/en-U
   font-size   : 0.625em; /* 10px */
   font-family : Verdana, Arial, sans-serif;
 
-  -moz-box-sizing : border-box;
   box-sizing : border-box;
 
   padding : 0.1em 2.5em 0.2em 0.5em; /* 1px 25px 2px 5px */
@@ -116,7 +115,6 @@ This is the second example that explain [how to build custom form widgets](/en-U
 
   padding-top : .1em;
 
-  -moz-box-sizing : border-box;
   box-sizing : border-box;
 
   text-align : center;
@@ -142,7 +140,6 @@ This is the second example that explain [how to build custom form widgets](/en-U
 
   box-shadow: 0 .2em .4em rgba(0,0,0,.4);
 
-  -moz-box-sizing : border-box;
   box-sizing : border-box;
 
   min-width : 100%;

--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/example_3/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/example_3/index.md
@@ -79,7 +79,6 @@ This is the third example that explain [how to build custom form widgets](/en-US
   font-size   : 0.625em; /* 10px */
   font-family : Verdana, Arial, sans-serif;
 
-  -moz-box-sizing : border-box;
   box-sizing : border-box;
 
   padding : 0.1em 2.5em 0.2em 0.5em; /* 1px 25px 2px 5px */
@@ -116,7 +115,6 @@ This is the third example that explain [how to build custom form widgets](/en-US
 
   padding-top : .1em;
 
-  -moz-box-sizing : border-box;
   box-sizing : border-box;
 
   text-align : center;
@@ -142,7 +140,6 @@ This is the third example that explain [how to build custom form widgets](/en-US
 
   box-shadow: 0 .2em .4em rgba(0,0,0,.4);
 
-  -moz-box-sizing : border-box;
   box-sizing : border-box;
 
   min-width : 100%;

--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/example_4/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/example_4/index.md
@@ -83,7 +83,6 @@ This is the fourth example that explain [how to build custom form widgets](/en-U
   font-size   : 0.625em; /* 10px */
   font-family : Verdana, Arial, sans-serif;
 
-  -moz-box-sizing : border-box;
   box-sizing : border-box;
 
   padding : 0.1em 2.5em 0.2em 0.5em; /* 1px 25px 2px 5px */
@@ -120,7 +119,6 @@ This is the fourth example that explain [how to build custom form widgets](/en-U
 
   padding-top : .1em;
 
-  -moz-box-sizing : border-box;
   box-sizing : border-box;
 
   text-align : center;
@@ -146,7 +144,6 @@ This is the fourth example that explain [how to build custom form widgets](/en-U
 
   box-shadow: 0 .2em .4em rgba(0,0,0,.4);
 
-  -moz-box-sizing : border-box;
   box-sizing : border-box;
 
   min-width : 100%;

--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/example_5/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/example_5/index.md
@@ -79,7 +79,6 @@ This is the last example that explain [how to build custom form widgets](/en-US/
   font-size   : 0.625em; /* 10px */
   font-family : Verdana, Arial, sans-serif;
 
-  -moz-box-sizing : border-box;
   box-sizing : border-box;
 
   padding : 0.1em 2.5em 0.2em 0.5em; /* 1px 25px 2px 5px */
@@ -116,7 +115,6 @@ This is the last example that explain [how to build custom form widgets](/en-US/
 
   padding-top : .1em;
 
-  -moz-box-sizing : border-box;
   box-sizing : border-box;
 
   text-align : center;
@@ -142,7 +140,6 @@ This is the last example that explain [how to build custom form widgets](/en-US/
 
   box-shadow: 0 .2em .4em rgba(0,0,0,.4);
 
-  -moz-box-sizing : border-box;
   box-sizing : border-box;
 
   min-width : 100%;

--- a/files/en-us/learn/forms/property_compatibility_table_for_form_controls/index.md
+++ b/files/en-us/learn/forms/property_compatibility_table_for_form_controls/index.md
@@ -42,7 +42,6 @@ For each property there are two possible renderings:
 ```css
 * {
   /* Turn off the native look and feel */
-  -webkit-appearance: none;
   appearance: none;
 
 /* for Internet Explorer */

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_todo_list_beginning/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/react_todo_list_beginning/index.md
@@ -297,7 +297,7 @@ button {
   line-height: normal;
   -webkit-font-smoothing: inherit;
   -moz-osx-font-smoothing: inherit;
-  -webkit-appearance: none;
+  appearance: none;
 }
 button::-moz-focus-inner {
   border: 0;

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_todo_list_beginning/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/svelte_todo_list_beginning/index.md
@@ -425,7 +425,7 @@ button {
   line-height: normal;
   -webkit-font-smoothing: inherit;
   -moz-osx-font-smoothing: inherit;
-  -webkit-appearance: none;
+  appearance: none;
 }
 button::-moz-focus-inner {
   border: 0;

--- a/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_styling/index.md
+++ b/files/en-us/learn/tools_and_testing/client-side_javascript_frameworks/vue_styling/index.md
@@ -100,7 +100,7 @@ button {
   line-height: normal;
   -webkit-font-smoothing: inherit;
   -moz-osx-font-smoothing: inherit;
-  -webkit-appearance: none;
+  appearance: none;
 }
 button::-moz-focus-inner {
   border: 0;
@@ -374,8 +374,6 @@ Next, copy the following CSS into the newly created `<style>` element:
   padding: 5px;
   border: 2px solid #0b0c0c;
   border-radius: 0;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
 }
 .custom-checkbox > input:focus {

--- a/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_styles/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/user_interface/browser_styles/index.md
@@ -322,8 +322,6 @@ button.panel-section-tabs-button {
   background-color: unset;
   font: inherit;
   text-shadow: inherit;
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   border: none;
 }

--- a/files/en-us/web/css/@media/any-pointer/index.md
+++ b/files/en-us/web/css/@media/any-pointer/index.md
@@ -48,8 +48,6 @@ input[type="checkbox"]:checked {
 
 @media (any-pointer: fine) {
   input[type="checkbox"] {
-    -moz-appearance: none;
-    -webkit-appearance: none;
     appearance: none;
     width: 15px;
     height: 15px;
@@ -59,8 +57,6 @@ input[type="checkbox"]:checked {
 
 @media (any-pointer: coarse) {
   input[type="checkbox"] {
-    -moz-appearance: none;
-    -webkit-appearance: none;
     appearance: none;
     width: 30px;
     height: 30px;

--- a/files/en-us/web/css/@media/pointer/index.md
+++ b/files/en-us/web/css/@media/pointer/index.md
@@ -42,7 +42,6 @@ This example creates a small checkbox for users with fine primary pointers and a
 ```css
 input[type="checkbox"] {
   -moz-appearance: none;
-  -webkit-appearance: none;
   appearance: none;
   border: solid;
   margin: 0;

--- a/files/en-us/web/css/@media/pointer/index.md
+++ b/files/en-us/web/css/@media/pointer/index.md
@@ -41,7 +41,6 @@ This example creates a small checkbox for users with fine primary pointers and a
 
 ```css
 input[type="checkbox"] {
-  -moz-appearance: none;
   appearance: none;
   border: solid;
   margin: 0;

--- a/files/en-us/web/css/_doublecolon_-webkit-meter-bar/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-meter-bar/index.md
@@ -37,10 +37,8 @@ Not part of any standard.
 
 ```css
 meter {
-  /* Reset the default appearance */
+  /* Reset the default appearance for -webkit- only */
   -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
 }
 
 meter::-webkit-meter-bar {

--- a/files/en-us/web/css/_doublecolon_-webkit-meter-inner-element/index.md
+++ b/files/en-us/web/css/_doublecolon_-webkit-meter-inner-element/index.md
@@ -38,10 +38,8 @@ This will only work in WebKit and Blink-based browsers, such as Safari, Chrome, 
 
 ```css
 meter {
-  /* Reset the default appearance */
+  /* Reset the default appearance for -webkit- only */
   -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
 }
 
 meter::-webkit-meter-inner-element {

--- a/files/en-us/web/css/css_grid_layout/css_grid_and_progressive_enhancement/index.md
+++ b/files/en-us/web/css/css_grid_layout/css_grid_and_progressive_enhancement/index.md
@@ -32,7 +32,7 @@ The IE version has additional properties not required in the new specification o
 
 ### Autoprefixer grid layout support
 
-The popular tool _[Autoprefixer](https://github.com/postcss/autoprefixer)_ has been updated to support the `-ms-` grid version. By default, grid prefixes are disabled, but you can enable it with `grid: true` option.
+If you are still supporting Internet Explorer, the popular tool _[Autoprefixer](https://github.com/postcss/autoprefixer)_ has been updated to support the `-ms-` grid version. By default, grid prefixes are disabled, but you can enable it with `grid: true` option.
 
 ```js
 autoprefixer({ grid: 'autoplace' })
@@ -42,15 +42,15 @@ Grid prefixes are disabled by default because some properties can't be prefixed.
 
 ## Is it safe to use CSS grids for my layout?
 
-As with any front-end technology choice, the decision to use CSS Grid Layout will come down to the browsers your site visitors are typically using. If they tend to use up-to-date versions of Firefox, Chrome, Opera, and Safari, then it would make sense to start using CSS grids once those browsers update. If your site serves a market sector that is tied to older browsers, however, it may not make sense yet. However, my suggestion is not to make assumptions based on how new specifications have been rolled out in browsers in the past. CSS Grid Layout is very different, in terms of the amount of time it has been in development, and the work of the various browser vendors to ensure that what ships works in the same way for everyone.
+Yes. As with any front-end technology choice, the decision to use CSS Grid Layout will come down to the browsers your site visitors are typically using. If your site serves a market sector that is tied to older browsers, you may consider the above `-ms-` fallback for IE.
 
 ## Starting to use Grid in production
 
-It is worth noting that you do not have to use grid in an _all or nothing_ way. You could start by enhancing elements in your design with grid, that could otherwise display using an older method. Overwriting of legacy methods with grid layout works surprisingly well, due to the way grid interacts with these other methods.
+It is worth noting that you do not have to use grid in an _all or nothing_ way. Start by enhancing elements in your design with grid, that could otherwise display using an older method. Overwriting of legacy methods with grid layout works surprisingly well, due to the way grid interacts with these other methods.
 
 ### Floats
 
-We have typically used [floats](/en-US/docs/Learn/CSS/CSS_layout/Floats) to create multiple column layouts. If you have floated an item, which is also a grid item in a supporting browser, the float will no longer apply to the item. The fact is that _a grid item takes precedence._ In the example below, I have a simple media object. In a non-supporting browser, I use {{cssxref("float")}}, however I have also defined the container as a grid container, in order to use the alignment properties that are implemented in CSS Grids.
+[Floats](/en-US/docs/Learn/CSS/CSS_layout/Floats) used to be used to create multiple column layouts. If you're supporting an old codebase with floated layouts, there will be no conflict. Grid items ignore the float property; the fact is that _a grid item takes precedence._ In the example below, I have a simple media object. If the {{cssxref("float")}} is not removed from legacy CSS, as the container is a grid container, it's OK. We can use the alignment properties that are implemented in CSS Grids.
 
 The {{cssxref("float")}} no longer applies, and I can use the CSS Box Alignment property {{cssxref("align-self")}} to align my content to the end of the container:
 
@@ -75,14 +75,16 @@ img {
     display: block;
     clear: both;
 }
+.media .text {
+    padding: 10px;
+    align-self: end;
+}
+
+\* old code we can't remove *\
 .media .image {
     float: left;
     width: 150px;
     margin-right: 20px;
-}
-.media .text {
-    padding: 10px;
-    align-self: end;
 }
 ```
 
@@ -97,7 +99,7 @@ img {
 
 The image below shows the media object in a non-supporting browser on the left, and a supporting one on the right:
 
-![A simple example of overriding a floated layout using grid.](10-float-simple-override.png)
+![A simple example of overriding a floated layout using grid. Both have the image aligned left. The text is vertically aligned at top in the float example and at the bottom in the grid example.](10-float-simple-override.png)
 
 ### Using feature queries
 
@@ -169,13 +171,13 @@ In this next example, I have a set of floated cards. I have given the cards a {{
 
 The example demonstrates the typical problem that we have with floated layouts: if additional content is added to any one card, the layout breaks.
 
-![A floated cards layout demonstrating the problem caused by uneven content height.](10-floated-cards.png)
+![A floated cards layout demonstrating the problem caused by uneven content height. The top row has 3 cards. The fourth card is floated under the third card. Then a bottom row has contains the fifth and sixth cards. There is a largish empty space under the fourth card. ](10-floated-cards.png)
 
 As a concession for older browsers, I have set a {{cssxref("min-height")}} on the items, and hope that my content editors won't add too much content and make a mess of the layout!
 
 I then enhance the layout using grid. I can turn my {{HTMLElement("ul")}} into a grid container with three column tracks. However, the width I have assigned to the list items themselves still applies, and it now makes those items a third of the width of the track:
 
-![After applying grid to our container, the width of the items is now incorrect as they display at one third of the item width.](10-float-width-problem.png)
+![Six very tall, very narrow grid items with text overflowing on the right. After applying grid to our container, the width of the items is now incorrect as they display at one third of the item width.](10-float-width-problem.png)
 
 If I reset the width to `auto`, then this will stop the float behavior happening for older browsers. I need to be able to define the width for older browsers, and remove the width for grid supporting browsers. Thanks to [CSS Feature Queries](/en-US/docs/Web/CSS/@supports) I can do this, right in my CSS.
 
@@ -366,7 +368,7 @@ The CSS Grid Layout specification details why we can overwrite the behavior of c
 - [Grid Items](https://drafts.csswg.org/css-grid/#grid-items)
 - [Grid Item Display](https://drafts.csswg.org/css-grid/#grid-item-display)
 
-As this behavior is detailed in the specification, you are safe to rely on using these overrides in your support for older browsers. Nothing that I am describing here should be seen as a "hack", we are taking advantage of the fact that the grid specification details the interaction between different layout methods.
+As this behavior is detailed in the specification, you are safe to rely on using these overrides in your support for older browsers. Nothing described here should be seen as a "hack". Rather, we are taking advantage of the fact that the grid specification details the interaction between different layout methods.
 
 ### Other values of display
 
@@ -388,7 +390,7 @@ You can also use multiple column layout as your legacy browser plan, as the `col
 
 ## Further reading
 
-- For an excellent explanation of feature queries, and how to use them well, see [Using Feature Queries in CSS](https://hacks.mozilla.org/2016/08/using-feature-queries-in-css/).
-- A write-up of the differences between the IE/Edge (≤15) Grid implementation and the modern implementation, also covering _autoprefixer_ support, take a look at: _[Should I try to use the IE implementation of CSS Grid Layout?](https://rachelandrew.co.uk/archives/2016/11/26/should-i-try-to-use-the-ie-implementation-of-css-grid-layout/)_
+- For an excellent explanation of feature queries, and how to use them well, see [Using Feature Queries in CSS (2016)](https://hacks.mozilla.org/2016/08/using-feature-queries-in-css/).
+- A write-up of the differences between the IE/Edge (≤15) Grid implementation and the modern implementation, also covering _autoprefixer_ support, take a look at: _[Should I try to use the IE implementation of CSS Grid Layout? (2016)](https://rachelandrew.co.uk/archives/2016/11/26/should-i-try-to-use-the-ie-implementation-of-css-grid-layout/)_
 - [Autoprefixer and Grid Autoplacement support in IE](https://github.com/postcss/autoprefixer#grid-autoplacement-support-in-ie)
-- [CSS Grid and the New Autoprefixer](https://css-tricks.com/css-grid-in-ie-css-grid-and-the-new-autoprefixer/)
+- [CSS Grid and the New Autoprefixer (2018)](https://css-tricks.com/css-grid-in-ie-css-grid-and-the-new-autoprefixer/)

--- a/files/en-us/web/css/filter/index.md
+++ b/files/en-us/web/css/filter/index.md
@@ -135,8 +135,6 @@ body {
 #img2 {
   width:100%;
   height:auto;
-  -webkit-filter:blur(5px);
-  -ms-filter:blur(5px);
   filter:blur(5px); }
 table.standard-table {
   border: 1px solid rgb(187, 187, 187);
@@ -239,9 +237,6 @@ body {
 #img2 {
   width:100%;
   height:auto;
-  -moz-filter:brightness(2);
-  -webkit-filter:brightness(2);
-  -ms-filter:brightness(2);
   filter:brightness(2); }
 table.standard-table {
   border: 1px solid rgb(187, 187, 187);
@@ -336,9 +331,6 @@ body {
 #img2 {
   width:100%;
   height:auto;
-  -moz-filter:contrast(200%);
-  -webkit-filter:contrast(200%);
-  -ms-filter:contrast(200%);
   filter:contrast(200%); }
 table.standard-table {
   border: 1px solid rgb(187, 187, 187);
@@ -472,17 +464,11 @@ body {
 #img2 {
   width:100%;
   height:auto;
-  -moz-filter: drop-shadow(16px 16px 10px black);
-  -webkit-filter: drop-shadow(16px 16px 10px black);
-  -ms-filter: drop-shadow(16px 16px 10px black);
   filter: drop-shadow(16px 16px 10px black);
 }
 #img12 {
   width:100%;
   height:auto;
-  -moz-filter: drop-shadow(8px 9px 5px rgba(0,0,0,.8));
-  -webkit-filter: drop-shadow(8px 9px 5px rgba(0,0,0,.8));
-  -ms-filter: drop-shadow(8px 9px 5px rgba(0,0,0,.8));
   filter: drop-shadow(8px 9px 5px rgba(0,0,0,.8));
 }
 table.standard-table {
@@ -570,9 +556,6 @@ body {
 #img2 {
   width:100%;
   height:auto;
-  -moz-filter:grayscale(100%);
-  -webkit-filter:grayscale(100%);
-  -ms-filter:grayscale(100%);
   filter:grayscale(100%); }
 table.standard-table {
   border: 1px solid rgb(187, 187, 187);
@@ -652,9 +635,6 @@ body {
 #img2 {
   width:100%;
   height:auto;
-  -moz-filter:hue-rotate(90deg);
-  -webkit-filter:hue-rotate(90deg);
-  -ms-filter:hue-rotate(90deg);
   filter:hue-rotate(90deg); }
 table.standard-table {
   border: 1px solid rgb(187, 187, 187);
@@ -745,9 +725,6 @@ body {
 #img2 {
   width:100%;
   height:auto;
-  -moz-filter: invert(100%);
-  -webkit-filter: invert(100%);
-  -ms-filter: invert(100%);
   filter: invert(100%); }
 table.standard-table {
   border: 1px solid rgb(187, 187, 187);
@@ -828,9 +805,6 @@ body {
 #img2 {
   width:100%;
   height:auto;
-  -moz-filter: opacity(50%);
-  -webkit-filter: opacity(50%);
-  -ms-filter: opacity(50%);
   filter: opacity(50%); }
 table.standard-table {
   border: 1px solid rgb(187, 187, 187);
@@ -910,9 +884,6 @@ body {
 #img2 {
   width:100%;
   height:auto;
-  -moz-filter: saturate(200%);
-  -webkit-filter: saturate(200%);
-  -ms-filter: saturate(200%);
   filter: saturate(200%); }
 table.standard-table {
   border: 1px solid rgb(187, 187, 187);
@@ -995,9 +966,6 @@ body {
 #img2 {
   width:100%;
   height:auto;
-  -moz-filter: sepia(100%);
-  -webkit-filter: sepia(100%);
-  -ms-filter: sepia(100%);
   filter: sepia(100%); }
 table.standard-table {
   border: 1px solid rgb(187, 187, 187);
@@ -1069,9 +1037,6 @@ body {
 #img2 {
   width:100%;
   height:auto;
-  -moz-filter: contrast(175%) brightness(103%);
-  -webkit-filter: contrast(175%) brightness(103%);
-  -ms-filter: contrast(175%) brightness(103%);
   filter: contrast(175%) brightness(103%);
 }
 table.standard-table {

--- a/files/en-us/web/guide/mobile/index.md
+++ b/files/en-us/web/guide/mobile/index.md
@@ -45,14 +45,10 @@ Finally, you can take advantage of the new possibilities offered by mobile devic
 To create web sites that will work acceptably across different mobile browsers:
 
 - Try to avoid using browser-specific features, such as vendor-prefixed CSS properties.
-- If you do need to use these features, check whether other browsers implement their own versions of these features, and target them too.
-- For browsers that don't support these features, provide an acceptable fallback.
-
-For example, if you set a gradient as a background for some text using a vendor-prefixed property like `-webkit-linear-gradient`, it's best to include the other vendor-prefixed versions of the {{cssxref("linear-gradient", "linear-gradient()")}} property. If you don't do that, at least make sure that the default background contrasts with the text: that way, the page will at least be usable in a browser which is not targeted by your `linear-gradient` rule.
+- For browsers that don't support these features, as long as the content is still usable, do not provide a vendor prefixed fallback. Vendor-prefixed property like `-webkit-border-radius`, harm performance in browsers that are so old they don't support modern standards.
+- To use new features with fallbacks that don't harm performance, style to target current browsers, then use the [`@supports`](/en-US/docs/Web/CSS/@supports) feature query to serve modern CSS to supporting browsers.
 
 See this [list of Gecko-specific properties](/en-US/docs/Web/CSS/Mozilla_Extensions), and this [list of WebKit-specific properties](/en-US/docs/Web/CSS/WebKit_Extensions), and Peter Beverloo's [table of vendor-specific properties](https://peter.sh/experiments/vendor-prefixed-css-property-overview/).
-
-Using tools like [CSS Lint](http://csslint.net/) can help find problems like this in code, and preprocessors like [SASS](https://sass-lang.com/) and [LESS](https://lesscss.org/) can help you to produce cross-browser code.
 
 ### Take care with user agent sniffing
 

--- a/files/en-us/web/html/element/blink/index.md
+++ b/files/en-us/web/html/element/blink/index.md
@@ -37,21 +37,7 @@ If you really do need a polyfill, then you can use the following CSS polyfill. W
 
 ```css
 blink {
-  -webkit-animation: 2s linear infinite condemned_blink_effect; /* for Safari 4.0 - 8.0 */
   animation: 2s linear infinite condemned_blink_effect;
-}
-
-/* for Safari 4.0 - 8.0 */
-@-webkit-keyframes condemned_blink_effect {
-  0% {
-    visibility: hidden;
-  }
-  50% {
-    visibility: hidden;
-  }
-  100% {
-    visibility: visible;
-  }
 }
 
 @keyframes condemned_blink_effect {

--- a/files/en-us/web/html/element/input/radio/index.md
+++ b/files/en-us/web/html/element/input/radio/index.md
@@ -280,8 +280,6 @@ label {
 }
 
 input {
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
 
   border-radius: 50%;

--- a/files/en-us/web/html/element/select/index.md
+++ b/files/en-us/web/html/element/select/index.md
@@ -250,11 +250,7 @@ html body form fieldset#custom div.select[data-multiple] div.header {
 
 html body form fieldset#custom div.select div.header {
   content: '↓';
-  display: -webkit-inline-box;
-  display: -ms-inline-flexbox;
   display: inline-flex;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
   align-items: center;
   padding: 0;
   position: relative;
@@ -276,8 +272,6 @@ html body form fieldset#custom div.select div.header:hover:after {
 }
 
 .select .header select {
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   font-family: inherit;
   font-size: inherit;
@@ -326,8 +320,6 @@ html body form fieldset#custom div.select[data-open] datalist {
 }
 
 html body form fieldset#custom div.select datalist {
-  -webkit-appearance: none;
-  -moz-appearance: none;
   appearance: none;
   position: absolute;
   border-style: solid;

--- a/files/en-us/web/progressive_web_apps/responsive/responsive_design_building_blocks/index.md
+++ b/files/en-us/web/progressive_web_apps/responsive/responsive_design_building_blocks/index.md
@@ -79,8 +79,6 @@ The padding does not affect the overall width and height of the containers becau
 *,
 *:before,
 *:after {
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
 ```
@@ -222,19 +220,11 @@ This rule changes the width of the gallery images so now there are two per line.
     width: 100%;
     position: absolute;
     z-index: 1000;
-
-    display: -webkit-flex;
-    display: -moz-flex;
-    display: -ms-flexbox;
     display: flex;
   }
 
   nav button {
     font-size: 6.8vw;
-
-    -webkit-flex: 1;
-    -moz-flex: 1;
-    -ms-flex: 1;
     flex: 1;
 
     border-left: 1px solid rgba(100,100,100,0.4);
@@ -300,10 +290,6 @@ We also came across some problems with orientation: the mobile-app layout of our
 @media all and (max-width: 480px) and (orientation: landscape) {
   nav {
     width: auto;
-
-    -webkit-flex-direction: column;
-    -moz-flex-direction: column;
-    -ms-flex-direction: column;
     flex-direction: column;
   }
 
@@ -388,8 +374,7 @@ button {
   background: url(images/low-res-header.jpg) 1rem center;
 }
 
-@media only screen and (-webkit-min-device-pixel-ratio: 2),
-       only screen and (min-resolution: 192dpi),
+@media only screen and (min-resolution: 192dpi),
        only screen and (min-resolution: 2dppx) {
   button {
     background: url(images/high-res-header.jpg) 1rem center;


### PR DESCRIPTION
All browsers support appearance: none;
only WebKit should be used if styling WebKit shadow dom.
removed other no longer needed prefixes
added note NOT to use prefixing for old properties as they harm perfomance.


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
