### PR TITLE
Further clarification of legacy behavior

### DIFF
--- a/files/en-us/web/api/window/load_event/index.md
+++ b/files/en-us/web/api/window/load_event/index.md
@@ -16,7 +16,8 @@ The **`load`** event is fired when the whole page has loaded, including all depe
 
 This event is not cancelable and does not bubble.
 
-> **Note:** The `load` event that is dispatched on the `Document` when the main document has finished loading will propagate to `Window`. However, _all other events named `load` will not propagate to `Window`_, including load events for resources inside the document (such as images) and custom events with `bubbles` initialized to `true`.
+> **Note:** _All events named `load` will not propagate to `Window`_, even with `bubbles` initialized to `true`. To catch `load` events on the `window`, that `load` event must be dispatched directly to the `window`.
+> **Note:** The `load` event that is dispatched when the main document has loaded _is_ dispatched on the `window`, but has two mutated properties: `target` is `document`, and `path` is `undefined`. These two properties are mutated due to legacy conformance.
 
 ## Syntax
 


### PR DESCRIPTION
Sorry guys.. I just had to take another look at the strange load event. I shouldn't have done that.. Sorry ;) The test is here:

https://jsfiddle.net/jo3rkLw5/3/
(behaves the same in Chrome and FF)

```html
<h1>hello world</h1>
<script>
  window.addEventListener("load", function(e){
    console.log("the one time `load` event propagates");
    console.log(e.target === document);
    console.log(e.currentTarget === window);
    console.log(e.bubbles === false);
    console.log(e.path === undefined);
    //e.composedPath() === [window]
    console.log(e.composedPath().length === 1); 
    console.log(e.composedPath()[0] === window);
  });
  document.addEventListener("load", function(e){
    console.log("this doesn't run.. The e.target === document is just a legacy thing..");
  }, true);
</script>
```

So. My best understanding of it now is:

1. all "load" events are stopped from propagating to the window except the "load" events that are directly dispatched to the window.
2. The special "load" event that is dispatched when the main document has finished loading is a special weird case, due to legacy issues. This special "load" event for the main document has .bubbles = false and is dispatched on window. But before this event is passed to any event listeners for "load" on the window, two of its properties are mutated:

* .target is changed to document
* .path is changed to undefined.

Note that e.composedPath() === [window] and e.currentTarget === window is not mutated on the main document "load" event.

Hehehe, I am not sure if I should take responsibility for this confusion.. :) What do you guys think?

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
