### PR TITLE
Added: alt attribute to few images

### DIFF
--- a/files/en-us/learn/javascript/building_blocks/conditionals/index.md
+++ b/files/en-us/learn/javascript/building_blocks/conditionals/index.md
@@ -43,7 +43,7 @@ Human beings (and other animals) make decisions all the time that affect their l
 
 Conditional statements allow us to represent such decision making in JavaScript, from the choice that must be made (for example, "one cookie or two"), to the resulting outcome of those choices (perhaps the outcome of "ate one cookie" might be "still felt hungry", and the outcome of "ate two cookies" might be "felt full, but mom scolded me for eating all the cookies".)
 
-![The illustrations of a cartoon charactrer resembling a person and it is holding a cookie jar. The jar has a label that reads 'Cookies'. There is a question mark little above the top of the head of the character. There are two talk bubbles. The talk bubble on the left-hand side top corner has the illustration of one cookie. The talk bubble on the right-hand side top corner has an illustration of two cookies. All of these together imply that the character is trying to make a decision if it wants to eat one cookie or two cookies.](cookie-choice-small.png)
+![A cartoon character resembling a person holding a cookie jar labeled 'Cookies'. There is a question mark above the head of the character. There are two speech bubbles. The left speech bubble has one cookie. The right speech bubble has two cookies. Together it implies the character is trying to decide if it wants to one cookie or two cookies.](cookie-choice-small.png)
 
 ## if...else statements
 

--- a/files/en-us/learn/javascript/building_blocks/conditionals/index.md
+++ b/files/en-us/learn/javascript/building_blocks/conditionals/index.md
@@ -43,7 +43,7 @@ Human beings (and other animals) make decisions all the time that affect their l
 
 Conditional statements allow us to represent such decision making in JavaScript, from the choice that must be made (for example, "one cookie or two"), to the resulting outcome of those choices (perhaps the outcome of "ate one cookie" might be "still felt hungry", and the outcome of "ate two cookies" might be "felt full, but mom scolded me for eating all the cookies".)
 
-![](cookie-choice-small.png)
+![The illustrations of a cartoon charactrer resembling a person and it is holding a cookie jar. The jar has a label that reads 'Cookies'. There is a question mark little above the top of the head of the character. There are two talk bubbles. The talk bubble on the left-hand side top corner has the illustration of one cookie. The talk bubble on the right-hand side top corner has an illustration of two cookies. All of these together imply that the character is trying to make a decision if it wants to eat one cookie or two cookies.](cookie-choice-small.png)
 
 ## if...else statements
 

--- a/files/en-us/learn/javascript/client-side_web_apis/client-side_storage/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/client-side_storage/index.md
@@ -154,7 +154,7 @@ Let's apply this new-found knowledge by writing a working example to give you an
 
 You can find the example HTML at [personal-greeting.html](https://github.com/mdn/learning-area/blob/main/javascript/apis/client-side-storage/web-storage/personal-greeting.html) — this contains a website with a header, content, and footer, and a form for entering your name.
 
-![](web-storage-demo.png)
+![A Screenshot of a website that has a header, content and footer sections. The header has a welcome text to the left-hand side and a button labelled 'forget' to the right-hand side. The content has an heading followed by a two paragraphs of dummy text. The footer reads 'Copyright nobody. Use the code as you like'.](web-storage-demo.png)
 
 Let's build up the example, so you can understand how it works.
 
@@ -255,7 +255,7 @@ Here we'll run you through an example that allows you to store notes in your bro
 
 The app looks something like this:
 
-![](idb-demo.png)
+![A screenshot of a website that has 4 sections. The first section is the header that reads 'IndexedDB notes demo' which is the name of the exercise. The second section lists all the notes that are created. It has two notes and each note has a delete button. The third section has 2 input fields with labels 'Note title' and 'Note text' respectively and a button that is labelled 'Create new note'. The last section is a footer that reads 'Copyright nobody. Use the code as you like'.](idb-demo.png)
 
 Each note has a title and some body text, each individually editable. The JavaScript code we'll go through below has detailed comments to help you understand what's going on.
 
@@ -645,7 +645,7 @@ Let's walk through the most interesting parts of the example. We won't look at i
 
 The above example already shows how to create an app that will store large assets in an IndexedDB database, avoiding the need to download them more than once. This is already a great improvement to the user experience, but there is still one thing missing — the main HTML, CSS, and JavaScript files still need to be downloaded each time the site is accessed, meaning that it won't work when there is no network connection.
 
-![](ff-offline.png)
+![There is an illustration of a fictious cartoon character to the left-hand side. The character is holding a two pin plug in it's right hand and a two pin plug holder in it's left hand. The right-hand side displays a message saying that the user is in offline mode and there is a button to the right-hand bottom corner that is labelled 'Try again'.](ff-offline.png)
 
 This is where [Service workers](/en-US/docs/Web/API/Service_Worker_API) and the closely-related [Cache API](/en-US/docs/Web/API/Cache) come in.
 

--- a/files/en-us/learn/javascript/client-side_web_apis/client-side_storage/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/client-side_storage/index.md
@@ -255,7 +255,7 @@ Here we'll run you through an example that allows you to store notes in your bro
 
 The app looks something like this:
 
-![A screenshot of a website that has 4 sections. The first section is the header that reads 'IndexedDB notes demo' which is the name of the exercise. The second section lists all the notes that are created. It has two notes and each note has a delete button. The third section has 2 input fields with labels 'Note title' and 'Note text' respectively and a button that is labelled 'Create new note'. The last section is a footer that reads 'Copyright nobody. Use the code as you like'.](idb-demo.png)
+![IndexDB notes demo screenshot with 4 sections. The first section is the header. The second section lists all the notes that have been created. It has two notes, each with a delete button. A third section is a form with 2 input fields for 'Note title' and 'Note text' and a button labeled 'Create new note'. The bottom section footer reads 'Copyright nobody. Use the code as you like'.](idb-demo.png)
 
 Each note has a title and some body text, each individually editable. The JavaScript code we'll go through below has detailed comments to help you understand what's going on.
 
@@ -645,7 +645,7 @@ Let's walk through the most interesting parts of the example. We won't look at i
 
 The above example already shows how to create an app that will store large assets in an IndexedDB database, avoiding the need to download them more than once. This is already a great improvement to the user experience, but there is still one thing missing — the main HTML, CSS, and JavaScript files still need to be downloaded each time the site is accessed, meaning that it won't work when there is no network connection.
 
-![There is an illustration of a fictious cartoon character to the left-hand side. The character is holding a two pin plug in it's right hand and a two pin plug holder in it's left hand. The right-hand side displays a message saying that the user is in offline mode and there is a button to the right-hand bottom corner that is labelled 'Try again'.](ff-offline.png)
+![Firefox offline screen with an illustration of a cartoon character to the left-hand side holding a two-pin plug in its right hand and a two-pin socket in its left hand. On the right-hand side there is an Offline Mode message and  a button labeled 'Try again'.](ff-offline.png)
 
 This is where [Service workers](/en-US/docs/Web/API/Service_Worker_API) and the closely-related [Cache API](/en-US/docs/Web/API/Cache) come in.
 

--- a/files/en-us/learn/javascript/client-side_web_apis/drawing_graphics/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/drawing_graphics/index.md
@@ -144,7 +144,7 @@ OK, our template is done and it's time to move on.
 
 As we said above, all drawing operations are done by manipulating a {{domxref("CanvasRenderingContext2D")}} object (in our case, `ctx`). Many operations need to be given coordinates to pinpoint exactly where to draw something — the top left of the canvas is point (0, 0), the horizontal (x) axis runs from left to right, and the vertical (y) axis runs from top to bottom.
 
-![](canvas_default_grid.png)
+![A graph with small squares covering it's area which is considered as a canvas that has x axis and y axis. The top left corner of the canvas is point (0, 0). The horizontal (x) axis runs from left to right, and the vertical (y) axis runs from top to bottom. The center of the canvas has a quadrilateral filled with steelblue color. The top left corner of the quadrilateral is distanced at x units from y axis and y units from x axis. The height is along the y axis and the width is along the x axis.](canvas_default_grid.png)
 
 Drawing shapes tends to be done using the rectangle shape primitive, or by tracing a line along a certain path and then filling in the shape. Below we'll show how to do both.
 
@@ -267,7 +267,7 @@ Let's draw an equilateral triangle on the canvas.
     - The side next to the 60 degree angle is called the **adjacent** — which we know is 50 pixels, as it is half of the line we just drew.
     - The side opposite the 60 degree angle is called the **opposite**, which is the height of the triangle we want to calculate.
 
-    ![](trigonometry.png)
+    ![A triangle pointing downwards. A dotted line splits the triangle into two equal right-angled triangles. The angle between the top and and right side of the triangle is 60 degrees. The dotted line perpendicular to the top side of the inverted triangle and opposite to the 60 degrees angle intersects the bottom vertice of the inverted triangle. This line is called as the opposite side. A section of the side of the triangle joining the point of intersection of the opposite line with the top side of the triangle to the 60 degrees angle is called adjacent side. The right side of the triangle is called as hypotenuse and it is the longest side.](trigonometry.png)
 
     One of the basic trigonometric formulae states that the length of the adjacent multiplied by the tangent of the angle is equal to the opposite, hence we come up with `50 * Math.tan(degToRad(60))`. We use our `degToRad()` function to convert 60 degrees to radians, as {{jsxref("Math.tan()")}} expects an input value in radians.
 
@@ -545,7 +545,7 @@ Now let's create our own simple animation — we'll get a character from a certa
 
     Let's explain the spritesheet image (which we have respectfully borrowed from Mike Thomas' [Walking cycle using CSS animation](https://codepen.io/mikethomas/pen/kQjKLW) CodePen). The image looks like this:
 
-    ![](walk-right.png)
+    ![There are six images of a pixel character resembling a walking person from his/her right side at different instances of a single step forward. The character wears a white shirt with sky blue buttons, black trousers and black shoes. The whole sheet is called a sprite sheet. Each image is called a sprite. Each sprite is 102 pixels wide and 148 pixels high.](walk-right.png)
 
     It contains six sprites that make up the whole walking sequence — each one is 102 pixels wide and 148 pixels high. To display each sprite cleanly we will have to use `drawImage()` to chop out a single sprite image from the spritesheet and display only that part, like we did above with the Firefox logo. The X coordinate of the slice will have to be a multiple of 102, and the Y coordinate will always be 0. The slice size will always be 102 by 148 pixels.
 

--- a/files/en-us/learn/javascript/client-side_web_apis/drawing_graphics/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/drawing_graphics/index.md
@@ -144,7 +144,7 @@ OK, our template is done and it's time to move on.
 
 As we said above, all drawing operations are done by manipulating a {{domxref("CanvasRenderingContext2D")}} object (in our case, `ctx`). Many operations need to be given coordinates to pinpoint exactly where to draw something — the top left of the canvas is point (0, 0), the horizontal (x) axis runs from left to right, and the vertical (y) axis runs from top to bottom.
 
-![A graph with small squares covering it's area which is considered as a canvas that has x axis and y axis. The top left corner of the canvas is point (0, 0). The horizontal (x) axis runs from left to right, and the vertical (y) axis runs from top to bottom. The center of the canvas has a quadrilateral filled with steelblue color. The top left corner of the quadrilateral is distanced at x units from y axis and y units from x axis. The height is along the y axis and the width is along the x axis.](canvas_default_grid.png)
+![Gridded graph paper with small squares covering its area with a steelblue square in the middle. The top left corner of the canvas is point (0, 0) of the canvas x-axis and y-axis. . The horizontal (x) axis runs from left to right denoting the width, and the vertical (y) axis runs from top to bottom denotes the height. The top left corner of the blue square is labeled as being a distance of x units from the y-axis and y units from the x-axis.](canvas_default_grid.png)
 
 Drawing shapes tends to be done using the rectangle shape primitive, or by tracing a line along a certain path and then filling in the shape. Below we'll show how to do both.
 
@@ -267,7 +267,7 @@ Let's draw an equilateral triangle on the canvas.
     - The side next to the 60 degree angle is called the **adjacent** — which we know is 50 pixels, as it is half of the line we just drew.
     - The side opposite the 60 degree angle is called the **opposite**, which is the height of the triangle we want to calculate.
 
-    ![A triangle pointing downwards. A dotted line splits the triangle into two equal right-angled triangles. The angle between the top and and right side of the triangle is 60 degrees. The dotted line perpendicular to the top side of the inverted triangle and opposite to the 60 degrees angle intersects the bottom vertice of the inverted triangle. This line is called as the opposite side. A section of the side of the triangle joining the point of intersection of the opposite line with the top side of the triangle to the 60 degrees angle is called adjacent side. The right side of the triangle is called as hypotenuse and it is the longest side.](trigonometry.png)
+    ![A equilateral triangle pointing downwards with labeled angles and sides. The horizontal line at the top is labeled 'adjacent'. A perpendicular dotted line, from the middle of the adjacent line, labeled 'opposite', splits the triangle creating two equal right triangles.  The right side of the triangle is labeled the hypotenuse, as it is the hypotenuse of the right triangle formed by the line labeled 'opposite'. while all three-sided of the triangle are of equal length, the hypotenuse is the longest side of the right triangle.](trigonometry.png)
 
     One of the basic trigonometric formulae states that the length of the adjacent multiplied by the tangent of the angle is equal to the opposite, hence we come up with `50 * Math.tan(degToRad(60))`. We use our `degToRad()` function to convert 60 degrees to radians, as {{jsxref("Math.tan()")}} expects an input value in radians.
 
@@ -545,7 +545,7 @@ Now let's create our own simple animation — we'll get a character from a certa
 
     Let's explain the spritesheet image (which we have respectfully borrowed from Mike Thomas' [Walking cycle using CSS animation](https://codepen.io/mikethomas/pen/kQjKLW) CodePen). The image looks like this:
 
-    ![There are six images of a pixel character resembling a walking person from his/her right side at different instances of a single step forward. The character wears a white shirt with sky blue buttons, black trousers and black shoes. The whole sheet is called a sprite sheet. Each image is called a sprite. Each sprite is 102 pixels wide and 148 pixels high.](walk-right.png)
+    ![A sprite sheet with six sprite images of a pixelated character resembling a walking person from their right side at different instances of a single step forward. The character has a white shirt with sky blue buttons, black trousers, and black shoes. Each sprite is 102 pixels wide and 148 pixels high.](walk-right.png)
 
     It contains six sprites that make up the whole walking sequence — each one is 102 pixels wide and 148 pixels high. To display each sprite cleanly we will have to use `drawImage()` to chop out a single sprite image from the spritesheet and display only that part, like we did above with the Firefox logo. The X coordinate of the slice will have to be a multiple of 102, and the Y coordinate will always be 0. The slice size will always be 102 by 148 pixels.
 

--- a/files/en-us/learn/javascript/client-side_web_apis/introduction/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/introduction/index.md
@@ -48,7 +48,7 @@ Application Programming Interfaces (APIs) are constructs made available in progr
 
 As a real-world example, think about the electricity supply in your house, apartment, or other dwellings. If you want to use an appliance in your house, you plug it into a plug socket and it works. You don't try to wire it directly into the power supply — to do so would be really inefficient and, if you are not an electrician, difficult and dangerous to attempt.
 
-![](plug-socket.png)
+![Two multi-plug holders are plugged into two different plug sockets. Each multi-plug holder has a plug slot on it's top and to it's front side. Two plugs are plugged into each multi-plug holder.](plug-socket.png)
 
 _Image source: [Overloaded plug socket](https://www.flickr.com/photos/easy-pics/9518184890/in/photostream/lightbox/) by [The Clear Communication People](https://www.flickr.com/photos/easy-pics/), on Flickr._
 
@@ -63,7 +63,7 @@ Client-side JavaScript, in particular, has many APIs available to it — these a
 - **Browser APIs** are built into your web browser and are able to expose data from the browser and surrounding computer environment and do useful complex things with it. For example, the [Web Audio API](/en-US/docs/Web/API/Web_Audio_API) provides JavaScript constructs for manipulating audio in the browser — taking an audio track, altering its volume, applying effects to it, etc. In the background, the browser is actually using some complex lower-level code (e.g. C++ or Rust) to do the actual audio processing. But again, this complexity is abstracted away from you by the API.
 - **Third-party APIs** are not built into the browser by default, and you generally have to retrieve their code and information from somewhere on the Web. For example, the [Twitter API](https://developer.twitter.com/en/docs) allows you to do things like displaying your latest tweets on your website. It provides a special set of constructs you can use to query the Twitter service and return specific information.
 
-![](browser.png)
+![A sreenshot of the browser with the home page of firefox browser open. There are APIs built into the browser by default. Thrid party APIs are not built into the browser by default. Their code and information has to be retreived from somewhere on the web to utilise them.](browser.png)
 
 ### Relationship between JavaScript, APIs, and other JavaScript tools
 
@@ -278,7 +278,7 @@ WebAPI features are subject to the same security considerations as JavaScript an
 
 In addition, some WebAPIs request permission to be enabled from the user once calls to them are made in your code. As an example, the [Notifications API](/en-US/docs/Web/API/Notifications_API) asks for permission using a pop-up dialog box:
 
-![](notification-permission.png)
+![A screenshot of the notifications pop-up dialog provided by the Notifications API of the browser. 'mdn.github.io' website is asking for permissions to push notifications to the user-agent.](notification-permission.png)
 
 The Web Audio and {{domxref("HTMLMediaElement")}} APIs are subject to a security mechanism called [autoplay policy](/en-US/docs/Web/API/Web_Audio_API/Best_practices#autoplay_policy) — this basically means that you can't automatically play audio when a page loads — you've got to allow your users to initiate audio play through a control like a button. This is done because autoplaying audio is usually really annoying and we really shouldn't be subjecting our users to it.
 

--- a/files/en-us/learn/javascript/client-side_web_apis/introduction/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/introduction/index.md
@@ -48,7 +48,7 @@ Application Programming Interfaces (APIs) are constructs made available in progr
 
 As a real-world example, think about the electricity supply in your house, apartment, or other dwellings. If you want to use an appliance in your house, you plug it into a plug socket and it works. You don't try to wire it directly into the power supply — to do so would be really inefficient and, if you are not an electrician, difficult and dangerous to attempt.
 
-![Two multi-plug holders are plugged into two different plug sockets. Each multi-plug holder has a plug slot on it's top and to it's front side. Two plugs are plugged into each multi-plug holder.](plug-socket.png)
+![Two multi-plug holders are plugged into two different plug outlet sockets. Each multi-plug holder has a plug slot on it's top and to it's front side. Two plugs are plugged into each multi-plug holder.](plug-socket.png)
 
 _Image source: [Overloaded plug socket](https://www.flickr.com/photos/easy-pics/9518184890/in/photostream/lightbox/) by [The Clear Communication People](https://www.flickr.com/photos/easy-pics/), on Flickr._
 
@@ -278,7 +278,7 @@ WebAPI features are subject to the same security considerations as JavaScript an
 
 In addition, some WebAPIs request permission to be enabled from the user once calls to them are made in your code. As an example, the [Notifications API](/en-US/docs/Web/API/Notifications_API) asks for permission using a pop-up dialog box:
 
-![A screenshot of the notifications pop-up dialog provided by the Notifications API of the browser. 'mdn.github.io' website is asking for permissions to push notifications to the user-agent.](notification-permission.png)
+![A screenshot of the notifications pop-up dialog provided by the Notifications API of the browser. 'mdn.github.io' website is asking for permissions to push notifications to the user-agent with an X to close the dialog and drop-down menu of options with 'always receive notifications' selected by default.](notification-permission.png)
 
 The Web Audio and {{domxref("HTMLMediaElement")}} APIs are subject to a security mechanism called [autoplay policy](/en-US/docs/Web/API/Web_Audio_API/Best_practices#autoplay_policy) — this basically means that you can't automatically play audio when a page loads — you've got to allow your users to initiate audio play through a control like a button. This is done because autoplaying audio is usually really annoying and we really shouldn't be subjecting our users to it.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
* I have added alt attributes to a handful of items in the content
#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
* Adding the alt attribute to the image displays the value of `alt` attribute when the respective `image fails to load` rather than leaving the space blank.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
@estelle  has collected the list of images from the documentation that do not have the alt attribute. [link to the spreadsheet](https://docs.google.com/spreadsheets/d/1cDHee6mwDMlY6zANEmg8MjR8tL-wrCS86uawpWZ4XbA/edit#gid=0)
#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [X] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->