### PR TITLE
Add notes on the new linear(...) easing function

### DIFF
--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -471,6 +471,46 @@ For more information see {{bug(1676791)}} and {{bug(1676782)}}.
   </tbody>
 </table>
 
+### Linear Easing Function
+`linear(...)` [easing function](/en-US/docs/Web/CSS/easing-function) defines a piecewise linear function, allowing you to approximate more complex animations.
+(See {{bug(1764126)}} for more details.)
+
+<table>
+  <thead>
+    <tr>
+      <th>Release channel</th>
+      <th>Version added</th>
+      <th>Enabled by default?</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>Nightly</th>
+      <td>104</td>
+      <td>Yes</td>
+    </tr>
+    <tr>
+      <th>Developer Edition</th>
+      <td>104</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Beta</th>
+      <td>104</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Release</th>
+      <td>104</td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <th>Preference name</th>
+      <td colspan="2"><code>layout.css.linear-easing-function.enabled</code></td>
+    </tr>
+  </tbody>
+</table>
+
 ## SVG
 
 ### SVGPathSeg APIs

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -471,7 +471,7 @@ For more information see {{bug(1676791)}} and {{bug(1676782)}}.
   </tbody>
 </table>
 
-### Linear Easing Function
+### linear() easing function
 `linear(...)` [easing function](/en-US/docs/Web/CSS/easing-function) defines a piecewise linear function, allowing you to approximate more complex animations.
 (See {{bug(1764126)}} for more details.)
 

--- a/files/en-us/mozilla/firefox/experimental_features/index.md
+++ b/files/en-us/mozilla/firefox/experimental_features/index.md
@@ -472,7 +472,7 @@ For more information see {{bug(1676791)}} and {{bug(1676782)}}.
 </table>
 
 ### linear() easing function
-`linear(...)` [easing function](/en-US/docs/Web/CSS/easing-function) defines a piecewise linear function, allowing you to approximate more complex animations.
+The `linear(...)` [easing function](/en-US/docs/Web/CSS/easing-function) defines a piecewise linear function, allowing you to approximate more complex animations.
 (See {{bug(1764126)}} for more details.)
 
 <table>


### PR DESCRIPTION
#### Summary
Add note on  `linear(...)` easing function, which is behind a pref.
This supplants PR #19636

#### Motivation
Enable web developers to test drive the new easing function, especially since it's behind a pref.
Implementation is complete as per [draft spec](https://drafts.csswg.org/css-easing-2/#the-linear-easing-function), which is [under review](https://github.com/w3ctag/design-reviews/issues/761).

#### Supporting details
* https://bugzilla.mozilla.org/show_bug.cgi?id=1764126
* https://drafts.csswg.org/css-easing-2/#the-linear-easing-function
* https://github.com/w3ctag/design-reviews/issues/761

#### Related issues
N/A

#### Metadata

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
