### PR TITLE
Support for splitting header lines is deprecated

### DIFF
--- a/files/en-us/web/http/headers/content-security-policy/default-src/index.md
+++ b/files/en-us/web/http/headers/content-security-policy/default-src/index.md
@@ -75,16 +75,7 @@ Content-Security-Policy: default-src 'self'; script-src https://example.com
 is the same as:
 
 ```
-Content-Security-Policy: connect-src 'self';
-                         font-src 'self';
-                         frame-src 'self';
-                         img-src 'self';
-                         manifest-src 'self';
-                         media-src 'self';
-                         object-src 'self';
-                         script-src https://example.com;
-                         style-src 'self';
-                         worker-src 'self'
+Content-Security-Policy: connect-src 'self'; font-src 'self'; frame-src 'self'; img-src 'self'; manifest-src 'self'; media-src 'self'; object-src 'self'; script-src https://example.com; style-src 'self'; worker-src 'self'
 ```
 
 ## Specifications


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

There is a wrong example of `Content-Security-Policy` HTTP header where `Policy` is split into the new lines, which is deprecated.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

The support for splitting header lines is deprecated in RFC 7230:

From [RFC 7230 section 3.2.4](https://datatracker.ietf.org/doc/pdf/rfc7230.pdf)

> Historically, HTTP header field values could be extended over
multiple lines by preceding each extra line with at least one space
or horizontal tab (obs-fold). This specification deprecates such
line folding except within the message/http media type

Credit to: [Richard Smith](https://stackoverflow.com/questions/50018881/is-it-ok-to-put-line-breaks-in-add-header-in-nginx-configuration/50043114#50043114)

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

[RFC 7230 section 3.2.4](https://datatracker.ietf.org/doc/pdf/rfc7230.pdf)

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
