### PR TITLE
CSS property media queries

### DIFF
--- a/files/en-us/web/css/@media/-webkit-animation/index.md
+++ b/files/en-us/web/css/@media/-webkit-animation/index.md
@@ -21,7 +21,7 @@ Apple has [a description in Safari CSS Reference](https://developer.apple.com/li
 
 ## Syntax
 
-The `-webkit-animation` media feature is a Boolean whose value is `true` if the vendor-prefixed CSS animation properties are supported AND the browser supports prefixed property media queries.
+The `-webkit-animation` media feature is a Boolean whose value is `true` if the vendor-prefixed CSS animation properties are supported _and_ the browser supports prefixed property media queries.
 
 ### Values
 

--- a/files/en-us/web/css/@media/-webkit-animation/index.md
+++ b/files/en-us/web/css/@media/-webkit-animation/index.md
@@ -11,7 +11,7 @@ browser-compat: css.at-rules.media.-webkit-animation
 ---
 {{ CSSRef }} {{ Non-standard_header }}
 
-> **Note:** All browsers support the [`animation`](g/en-US/docs/Web/CSS/animation#browser_compatibility) property without vendor prefixes. Only WebKit (Safari), and not Chromium, based browsers supports the `-webkit-animation` media feature. No browsers support `animation`, without the prefix, as a media query. Use the [`@supports (animation)`](/en-US/docs/Web/CSS/@supports) feature query instead.
+> **Note:** All browsers support the [`animation`](/en-US/docs/Web/CSS/animation#browser_compatibility) property without vendor prefixes. Only WebKit (Safari), and not Chromium, based browsers supports the `-webkit-animation` media feature. No browsers support `animation`, without the prefix, as a media query. Use the [`@supports (animation)`](/en-US/docs/Web/CSS/@supports) feature query instead.
 
 The **`-webkit-animation`** Boolean [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#media_features) is a [WebKit extension](/en-US/docs/Web/CSS/WebKit_Extensions) whose value is `true` if vendor-prefixed CSS {{cssxref("animation")}}s are supported.
 

--- a/files/en-us/web/css/@media/-webkit-animation/index.md
+++ b/files/en-us/web/css/@media/-webkit-animation/index.md
@@ -54,3 +54,7 @@ Not part of any standard.
 - [`-webkit-transform-2d`](/en-US/docs/Web/CSS/@media/-webkit-transform-2d) 
 - [`-webkit-transition`](/en-US/docs/Web/CSS/@media/-webkit-transition)
 - [Test page at quirksmode.org](https://www.quirksmode.org/css/tests/mediaqueries/animation.html)
+- {{cssxref("animation")}} and [using CSS animations](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations)
+- {{cssxref("@media")}} and [Using media queries](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries)
+- {{cssxref("@supports")}} and [using feature queries](/en-US/docs/Web/CSS/CSS_Conditional_Rules/Using_Feature_Queries)
+

--- a/files/en-us/web/css/@media/-webkit-animation/index.md
+++ b/files/en-us/web/css/@media/-webkit-animation/index.md
@@ -11,7 +11,9 @@ browser-compat: css.at-rules.media.-webkit-animation
 ---
 {{ CSSRef }} {{ Non-standard_header }}
 
-The **`-webkit-animation`** Boolean [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#media_features) is a [Chrome extension](/en-US/docs/Web/CSS/WebKit_Extensions) whose value is `true` if vendor-prefixed CSS {{cssxref("animation")}}s are supported.
+> **Note:** All browsers support the [`animation`](g/en-US/docs/Web/CSS/animation#browser_compatibility) property without vendor prefixes. Only WebKit (Safari), and not Chromium, based browsers supports the `-webkit-animation` media feature. No browsers support `animation`, without the prefix, as a media query. Use the [`@supports (animation)`](/en-US/docs/Web/CSS/@supports) feature query instead.
+
+The **`-webkit-animation`** Boolean [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#media_features) is a [WebKit extension](/en-US/docs/Web/CSS/WebKit_Extensions) whose value is `true` if vendor-prefixed CSS {{cssxref("animation")}}s are supported.
 
 Apple has [a description in Safari CSS Reference](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariCSSRef/Articles/OtherStandardCSS3Features.html#//apple_ref/doc/uid/TP40007601-SW3).
 
@@ -19,12 +21,12 @@ Apple has [a description in Safari CSS Reference](https://developer.apple.com/li
 
 ## Syntax
 
-The `-webkit-animation` media feature is a Boolean whose value is `true` if the vendor-prefixed CSS animation properties are supported.
+The `-webkit-animation` media feature is a Boolean whose value is `true` if the vendor-prefixed CSS animation properties are supported AND the browser supports prefixed property media queries.
 
 ### Values
 
 - `true`
-  - : The browser supports `-webkit` prefixed CSS {{cssxref("animation")}}s.
+  - : The browser supports `-webkit` prefixed CSS {{cssxref("animation")}}.
 - `false`
   - : The browser doesn't support these prefixed CSS animations.
 
@@ -34,7 +36,7 @@ The `-webkit-animation` media feature is a Boolean whose value is `true` if the 
 
 ```css
 @media (-webkit-animation) {
-  /* CSS to use if animations are supported */
+  /* CSS to use if -webkit- prefixed animations are supported AND the browser supports prefixed properties as media queries */
 }
 ```
 
@@ -49,6 +51,6 @@ Not part of any standard.
 ## See also
 
 - [`-webkit-transform-3d`](/en-US/docs/Web/CSS/@media/-webkit-transform-3d)
-- [`-webkit-transform-2d`](/en-US/docs/Web/CSS/@media/-webkit-transform-2d)
+- [`-webkit-transform-2d`](/en-US/docs/Web/CSS/@media/-webkit-transform-2d) 
 - [`-webkit-transition`](/en-US/docs/Web/CSS/@media/-webkit-transition)
 - [Test page at quirksmode.org](https://www.quirksmode.org/css/tests/mediaqueries/animation.html)

--- a/files/en-us/web/css/@media/-webkit-device-pixel-ratio/index.md
+++ b/files/en-us/web/css/@media/-webkit-device-pixel-ratio/index.md
@@ -4,7 +4,6 @@ slug: Web/CSS/@media/-webkit-device-pixel-ratio
 tags:
   - '@media'
   - CSS
-  - NeedsBrowserCompatibility
   - Non-standard
   - WebKit
   - media feature
@@ -14,7 +13,7 @@ browser-compat: css.at-rules.media.-webkit-device-pixel-ratio
 
 The **`-webkit-device-pixel-ratio`** is a non-standard Boolean [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#media_features) which is an alternative to the standard [`resolution`](/en-US/docs/Web/CSS/@media/resolution) media feature.
 
-> **Note:** This media feature is a WebKit feature. If possible, use the [`resolution`](/en-US/docs/Web/CSS/@media/resolution) media feature query instead.
+> **Note:** If possible, use the [`resolution`](/en-US/docs/Web/CSS/@media/resolution) media feature query instead, which is a standard media feature. While this prefixed media feature is a WebKit feature, other browser engines may support it. See [browser compatibility](#browser-compatibility) below. 
 
 ## Syntax
 

--- a/files/en-us/web/css/@media/-webkit-transform-2d/index.md
+++ b/files/en-us/web/css/@media/-webkit-transform-2d/index.md
@@ -12,7 +12,9 @@ browser-compat: css.at-rules.media.-webkit-transform-2d
 ---
 {{ Non-standard_header }}
 
-The **`-webkit-transform-2d`** Boolean [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#media_features) is a [Chrome extension](/en-US/docs/Web/CSS/WebKit_Extensions) whose value is `true` if vendor-prefixed CSS 2D {{cssxref("transform")}}s are supported.
+> **Note:** All browsers support the [`transition`](/en-US/docs/Web/CSS/animation#browser_compatibility) property without vendor prefixes. Only WebKit (Safari), and not Chromium, based browsers supports the `-webkit-transition-2d` media feature. No browsers support `transition`, without the prefix or `2d` extension, as a media query. Use the [`@supports (transition)`](/en-US/docs/Web/CSS/@supports) feature query instead.
+
+The **`-webkit-transform-2d`** Boolean [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#media_features) is a [WebKit extension](/en-US/docs/Web/CSS/WebKit_Extensions) whose value is `true` if vendor-prefixed CSS 2D {{cssxref("transform")}}s and non-standard vendor-prefixed media queries are supported.
 
 Apple has [a description in Safari CSS Reference](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariCSSRef/Articles/OtherStandardCSS3Features.html#//apple_ref/doc/uid/TP40007601-SW3).
 
@@ -63,5 +65,8 @@ Not part of any standard.
 - {{cssxref("@media/-webkit-transition", "-webkit-transition")}}
 - {{cssxref("@media/-webkit-animation", "-webkit-animation")}}
 - [Test page at quirksmode.org](https://www.quirksmode.org/css/tests/mediaqueries/animation.html)
+- {{cssxref("transform")}} and [using CSS transforms](/en-US/docs/Web/CSS/CSS_Transforms/Using_CSS_transforms)
+- {{cssxref("@media")}} and [Using media queries](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries)
+- {{cssxref("@supports")}} and [using feature queries](/en-US/docs/Web/CSS/CSS_Conditional_Rules/Using_Feature_Queries)
 
 {{ CSSRef }}

--- a/files/en-us/web/css/@media/-webkit-transform-3d/index.md
+++ b/files/en-us/web/css/@media/-webkit-transform-3d/index.md
@@ -15,9 +15,9 @@ browser-compat: css.at-rules.media.-webkit-transform-3d
 ---
 {{ Non-standard_header }}
 
-The **`-webkit-transform-3d`** Boolean [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#media_features) is a [Chrome extension](/en-US/docs/Web/CSS/WebKit_Extensions) whose value is `true` if vendor-prefixed CSS 3D {{cssxref("transform")}}s are supported.
+The **`-webkit-transform-3d`** Boolean [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#media_features) is a [WebKit extension](/en-US/docs/Web/CSS/WebKit_Extensions) whose value is `true` if vendor-prefixed CSS 3D {{cssxref("transform")}}s are supported.
 
-> **Note:** This media feature is only supported by WebKit and Blink. If possible, use an {{cssxref("@supports")}} feature query instead.
+> **Note:** While this media feature is currently  [supported by most browsers](#browser-compatibility). If possible, use an {{cssxref("@supports")}} feature query instead.
 
 ## Syntax
 
@@ -26,7 +26,7 @@ The **`-webkit-transform-3d`** Boolean [CSS](/en-US/docs/Web/CSS) [media feature
 ### Values
 
 - `true`
-  - : The browser supports the 3D CSS transforms with the `-webkit` prefix.
+  - : The browser supports the 3D CSS transforms with the `-webkit` prefix and supports non-standard, prefixed media queries.
 - `false`
   - : The 3D CSS transforms prefixed with `-webkit` are not supported by the browser.
 
@@ -40,12 +40,16 @@ The **`-webkit-transform-3d`** Boolean [CSS](/en-US/docs/Web/CSS) [media feature
     transform-style: preserve-3d;
   }
 }
+```
+A better method for checking for browser support is using a feature query: 
 
-@media (-webkit-transform-3d: 1) {
+```css
+@supports (transform-style) {
   .foo {
     transform-style: preserve-3d;
   }
 }
+
 ```
 
 ## Specifications
@@ -62,5 +66,8 @@ The **`-webkit-transform-3d`** Boolean [CSS](/en-US/docs/Web/CSS) [media feature
 - {{cssxref("@media/-webkit-transition", "-webkit-transition")}}
 - {{cssxref("@media/-webkit-animation", "-webkit-animation")}}
 - [Test page at quirksmode.org](https://www.quirksmode.org/css/tests/mediaqueries/animation.html)
+- {{cssxref("transform")}} and [using CSS transforms](/en-US/docs/Web/CSS/CSS_Transforms/Using_CSS_transforms)
+- {{cssxref("@media")}} and [Using media queries](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries)
+- {{cssxref("@supports")}} and [using feature queries](/en-US/docs/Web/CSS/CSS_Conditional_Rules/Using_Feature_Queries)
 
 {{ CSSRef }}

--- a/files/en-us/web/css/@media/-webkit-transform-3d/index.md
+++ b/files/en-us/web/css/@media/-webkit-transform-3d/index.md
@@ -17,7 +17,7 @@ browser-compat: css.at-rules.media.-webkit-transform-3d
 
 The **`-webkit-transform-3d`** Boolean [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#media_features) is a [WebKit extension](/en-US/docs/Web/CSS/WebKit_Extensions) whose value is `true` if vendor-prefixed CSS 3D {{cssxref("transform")}}s are supported.
 
-> **Note:** While this media feature is currently  [supported by most browsers](#browser-compatibility). If possible, use an {{cssxref("@supports")}} feature query instead.
+> **Note:** While this media feature is currently [supported by most browsers](#browser-compatibility). If possible, use an {{cssxref("@supports")}} feature query instead.
 
 ## Syntax
 

--- a/files/en-us/web/css/@media/-webkit-transition/index.md
+++ b/files/en-us/web/css/@media/-webkit-transition/index.md
@@ -19,7 +19,7 @@ The **`-webkit-transition`** Boolean non-standard[CSS](/en-US/docs/Web/CSS) [med
 
 Apple has [a description in Safari CSS Reference](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariCSSRef/Articles/OtherStandardCSS3Features.html#//apple_ref/doc/uid/TP40007601-SW3); this is now called `transition` there.
 
-> **Note:** You should not use this media feature; it was never specified, has never been widely implemented, and has been [removed from most browsers](#browser-compatibility). Use an {{cssxref("@supports")}} feature query instead.
+> **Note:** You should not use this media feature; it was never specified, has never been widely implemented, and has been [removed from most browsers](#browser-compatibility). Use a {{cssxref("@supports")}} feature query instead.
 
 ## Syntax
 

--- a/files/en-us/web/css/@media/-webkit-transition/index.md
+++ b/files/en-us/web/css/@media/-webkit-transition/index.md
@@ -3,7 +3,6 @@ title: '-webkit-transition'
 slug: Web/CSS/@media/-webkit-transition
 tags:
   - '@media'
-  - Blink
   - CSS
   - Deprecated
   - Non-standard
@@ -14,17 +13,19 @@ browser-compat: css.at-rules.media.-webkit-transition
 ---
 {{ CSSRef }} {{deprecated_header}} {{ Non-standard_header }}
 
-The **`-webkit-transition`** Boolean [CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#media_features) is a [Chrome extension](/en-US/docs/Web/CSS/WebKit_Extensions) whose value is `true` if the browsing context supports [CSS transitions](/en-US/docs/Web/CSS/CSS_Transitions). It was never supported in browsers not based on WebKit or Blink.
+> **Note:** All browsers support the [`transition`](/en-US/docs/Web/CSS/animation#browser_compatibility) property without vendor prefixes. Only WebKit (Safari), and not Chromium, based browsers support the `-webkit-transition` media feature. No browsers support `transition` without the prefix as a media query (though some browsers do support - {{cssxref("@media/-webkit-transform-3d", "-webkit-transform-3d")}}). Use the [`@supports (transition)`](/en-US/docs/Web/CSS/@supports) feature query instead.
+
+The **`-webkit-transition`** Boolean non-standard[CSS](/en-US/docs/Web/CSS) [media feature](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#media_features) is a [WebKit extension](/en-US/docs/Web/CSS/WebKit_Extensions) whose value is `true` if the browsing context supports [CSS transitions](/en-US/docs/Web/CSS/CSS_Transitions). 
 
 Apple has [a description in Safari CSS Reference](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariCSSRef/Articles/OtherStandardCSS3Features.html#//apple_ref/doc/uid/TP40007601-SW3); this is now called `transition` there.
 
-> **Note:** You should not use this media feature; it was never specified, has never been widely implemented, and has been removed from all browsers. Use an {{cssxref("@supports")}} feature query instead.
+> **Note:** You should not use this media feature; it was never specified, has never been widely implemented, and has been [removed from most browsers](#browser-compatibility). Use an {{cssxref("@supports")}} feature query instead.
 
 ## Syntax
 
 ```css
 @media (-webkit-transition) {
-  /* CSS to use if transitions are supported */
+  /* CSS to use if this media feature and prefixed transitions are supported */
 }
 ```
 
@@ -60,7 +61,11 @@ Not part of any standard.
 
 ## See also
 
-- [Using media queries](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries)
-- [Using CSS transitions](/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions)
-- {{cssxref("@supports")}}
-- {{cssxref("transition")}}
+- {{cssxref("@media/-webkit-transform-3d", "-webkit-transform-3d")}}
+- {{cssxref("@media/-webkit-transform-2d", "-webkit-transform-2d")}}
+- {{cssxref("@media/-webkit-animation", "-webkit-animation")}}
+- [Test page at quirksmode.org](https://www.quirksmode.org/css/tests/mediaqueries/animation.html)
+- {{cssxref("transition")}} and [using CSS transitions](/en-US/docs/Web/CSS/CSS_Transitions/Using_CSS_transitions)
+- {{cssxref("@media")}} and [Using media queries](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries)
+- {{cssxref("@supports")}} and [using feature queries](/en-US/docs/Web/CSS/CSS_Conditional_Rules/Using_Feature_Queries)
+


### PR DESCRIPTION
These were all listed as being in chrome, but the only browser to support all of them is Safari and the only feature that is supported outside of safari is transform-3d, which is supported everywhere.

That said, no one should be using any of these, so I tried making that clearer with more options.

Also, -webkit-device-pixel ration is supported everywhere.

Basically, this section was a bit of a shitshow because the feature is a shitshow, but tried making the documentation less so.


<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
