### PR TITLE
use `JavaScript` instead of `JS`

### DIFF
--- a/files/en-us/web/api/window/load_event/index.md
+++ b/files/en-us/web/api/window/load_event/index.md
@@ -17,6 +17,7 @@ The **`load`** event is fired when the whole page has loaded, including all depe
 This event is not cancelable and does not bubble.
 
 > **Note:** _All events named `load` will not propagate to `Window`_, even with `bubbles` initialized to `true`. To catch `load` events on the `window`, that `load` event must be dispatched directly to the `window`.
+
 > **Note:** The `load` event that is dispatched when the main document has loaded _is_ dispatched on the `window`, but has two mutated properties: `target` is `document`, and `path` is `undefined`. These two properties are mutated due to legacy conformance.
 
 ## Syntax

--- a/files/en-us/web/api/window/load_event/index.md
+++ b/files/en-us/web/api/window/load_event/index.md
@@ -96,7 +96,7 @@ label, button {
 }
 ```
 
-#### JS
+#### JavaScript
 
 ```js
 const log = document.querySelector('.event-log-contents');


### PR DESCRIPTION
#### Summary

use `JavaScript` instead of `JS`

I'm not really sure about line 19-20, should we add a empty line there?

#### Metadata

- [x] Fixes a typo, bug, or other error
