### PR TITLE
Add @layer and remove not-implemented @color-profile

### DIFF
--- a/files/en-us/web/css/at-rule/index.md
+++ b/files/en-us/web/css/at-rule/index.md
@@ -51,7 +51,7 @@ A subset of nested statements, which can be used as a statement of a style sheet
 - {{cssxref("@counter-style")}} — Defines specific counter styles that are not part of the predefined set of styles. _(at the Candidate Recommendation stage, but only implemented in Gecko as of writing)_
 - {{cssxref("@font-feature-values")}} (plus `@swash`, `@ornaments`, `@annotation`, `@stylistic`, `@styleset` and `@character-variant`) — Define common names in {{cssxref("font-variant-alternates")}} for feature activated differently in OpenType. _(at the Candidate Recommendation stage, but only implemented in Gecko as of writing)_
 - {{cssxref("@property")}} {{experimental_inline}} — Describes the aspect of custom properties and variables. _(currently at the Working Draft stage)_
-- {{cssxref("@color-profile")}} {{experimental_inline}} — Allows a color profile to be defined for use by the {{cssxref("color_value/color", "color()")}} function.
+- {{cssxref("@layer")}} – Declares a cascade layer and defines the order of precedence in case of multiple cascade layers.
 
 ## Conditional group rules
 
@@ -68,7 +68,6 @@ Since each conditional group may also contain nested statements, there may be an
 ## Index
 
 - {{cssxref("@charset")}}
-- {{cssxref("@color-profile")}} {{experimental_inline}}
 - {{cssxref("@counter-style")}}
 - {{cssxref("@document")}} {{deprecated_inline}}
 - {{cssxref("@font-face")}}
@@ -81,6 +80,7 @@ Since each conditional group may also contain nested statements, there may be an
 - {{cssxref("@property")}} {{experimental_inline}}
 - {{cssxref("@supports")}}
 - {{cssxref("@viewport")}} {{deprecated_inline}}
+- {{cssxref("@layer")}}
 
 ## Specifications
 

--- a/files/en-us/web/css/at-rule/index.md
+++ b/files/en-us/web/css/at-rule/index.md
@@ -74,13 +74,13 @@ Since each conditional group may also contain nested statements, there may be an
 - {{cssxref("@font-feature-values")}}
 - {{cssxref("@import")}}
 - {{cssxref("@keyframes")}}
+- {{cssxref("@layer")}}
 - {{cssxref("@media")}}
 - {{cssxref("@namespace")}}
 - {{cssxref("@page")}}
 - {{cssxref("@property")}} {{experimental_inline}}
 - {{cssxref("@supports")}}
 - {{cssxref("@viewport")}} {{deprecated_inline}}
-- {{cssxref("@layer")}}
 
 ## Specifications
 


### PR DESCRIPTION
Fixes #19688

I also removed the mention of `@color-profile` not implemented (for almost a decade). We shouldn't have documented it in the first place. Once somebody implements it, we can add it again.