### PR TITLE
Replace last {{CSS_key_concepts}}

### DIFF
--- a/files/en-us/web/css/syntax/index.md
+++ b/files/en-us/web/css/syntax/index.md
@@ -75,4 +75,12 @@ There is another group of statements – the **nested statements**. These are st
 
 ## See also
 
-- {{ CSS_key_concepts()}}
+- CSS Key Concepts: [CSS syntax](/en-US/docs/Web/CSS/Syntax), [at-rule](/en-US/docs/Web/CSS/At-rule), [comments](/en-US/docs/Web/CSS/Comments),
+  [specificity](/en-US/docs/Web/CSS/Specificity) and [inheritance](/en-US/docs/Web/CSS/inheritance),
+  the [box](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model),
+  [layout modes](/en-US/docs/Web/CSS/Layout_mode) and [visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model),
+  and [margin collapsing](/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing),
+  or the [initial](/en-US/docs/Web/CSS/initial_value), [computed](/en-US/docs/Web/CSS/computed_value), [resolved](/en-US/docs/Web/CSS/resolved_value),
+  [specified](/en-US/docs/Web/CSS/specified_value), [used](/en-US/docs/Web/CSS/used_value), and [actual](/en-US/docs/Web/CSS/actual_value) values.
+  Definitions of [value syntax](/en-US/docs/Web/CSS/Value_definition_syntax), [shorthand properties](/en-US/docs/Web/CSS/Shorthand_properties)
+  and [replaced elements](/en-US/docs/Web/CSS/Replaced_element).

--- a/files/en-us/web/css/syntax/index.md
+++ b/files/en-us/web/css/syntax/index.md
@@ -75,12 +75,20 @@ There is another group of statements – the **nested statements**. These are st
 
 ## See also
 
-- CSS Key Concepts: [CSS syntax](/en-US/docs/Web/CSS/Syntax), [at-rule](/en-US/docs/Web/CSS/At-rule), [comments](/en-US/docs/Web/CSS/Comments),
-  [specificity](/en-US/docs/Web/CSS/Specificity) and [inheritance](/en-US/docs/Web/CSS/inheritance),
-  the [box](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model),
-  [layout modes](/en-US/docs/Web/CSS/Layout_mode) and [visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model),
-  and [margin collapsing](/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing),
-  or the [initial](/en-US/docs/Web/CSS/initial_value), [computed](/en-US/docs/Web/CSS/computed_value), [resolved](/en-US/docs/Web/CSS/resolved_value),
-  [specified](/en-US/docs/Web/CSS/specified_value), [used](/en-US/docs/Web/CSS/used_value), and [actual](/en-US/docs/Web/CSS/actual_value) values.
-  Definitions of [value syntax](/en-US/docs/Web/CSS/Value_definition_syntax), [shorthand properties](/en-US/docs/Web/CSS/Shorthand_properties)
-  and [replaced elements](/en-US/docs/Web/CSS/Replaced_element).
+- CSS key concepts:
+  - [CSS syntax](/en-US/docs/Web/CSS/Syntax)
+  - [Comments](/en-US/docs/Web/CSS/Comments)
+  - [Specificity](/en-US/docs/Web/CSS/Specificity)
+  - [Inheritance](/en-US/docs/Web/CSS/inheritance)
+  - [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
+  - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
+  - [Visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model)
+  - [Margin collapsing](/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing)
+  - Values
+    - [Initial values](/en-US/docs/Web/CSS/initial_value)
+    - [Computed values](/en-US/docs/Web/CSS/computed_value)
+    - [Used values](/en-US/docs/Web/CSS/used_value)
+    - [Actual values](/en-US/docs/Web/CSS/actual_value)
+  - [Value definition syntax](/en-US/docs/Web/CSS/Value_definition_syntax)
+  - [Shorthand properties](/en-US/docs/Web/CSS/Shorthand_properties)
+  - [Replaced elements](/en-US/docs/Web/CSS/Replaced_element)

--- a/files/en-us/web/css/used_value/index.md
+++ b/files/en-us/web/css/used_value/index.md
@@ -103,4 +103,12 @@ CSS 2.0 defined only _computed value_ as the last step in a property's calculati
 ## See also
 
 - {{domxref("window.getComputedStyle")}}
-- {{CSS_key_concepts}}
+- CSS Key Concepts: [CSS syntax](/en-US/docs/Web/CSS/Syntax), [at-rule](/en-US/docs/Web/CSS/At-rule), [comments](/en-US/docs/Web/CSS/Comments),
+  [specificity](/en-US/docs/Web/CSS/Specificity) and [inheritance](/en-US/docs/Web/CSS/inheritance),
+  the [box](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model),
+  [layout modes](/en-US/docs/Web/CSS/Layout_mode) and [visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model),
+  and [margin collapsing](/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing),
+  or the [initial](/en-US/docs/Web/CSS/initial_value), [computed](/en-US/docs/Web/CSS/computed_value), [resolved](/en-US/docs/Web/CSS/resolved_value),
+  [specified](/en-US/docs/Web/CSS/specified_value), [used](/en-US/docs/Web/CSS/used_value), and [actual](/en-US/docs/Web/CSS/actual_value) values.
+  Definitions of [value syntax](/en-US/docs/Web/CSS/Value_definition_syntax), [shorthand properties](/en-US/docs/Web/CSS/Shorthand_properties)
+  and [replaced elements](/en-US/docs/Web/CSS/Replaced_element).

--- a/files/en-us/web/css/used_value/index.md
+++ b/files/en-us/web/css/used_value/index.md
@@ -103,12 +103,20 @@ CSS 2.0 defined only _computed value_ as the last step in a property's calculati
 ## See also
 
 - {{domxref("window.getComputedStyle")}}
-- CSS Key Concepts: [CSS syntax](/en-US/docs/Web/CSS/Syntax), [at-rule](/en-US/docs/Web/CSS/At-rule), [comments](/en-US/docs/Web/CSS/Comments),
-  [specificity](/en-US/docs/Web/CSS/Specificity) and [inheritance](/en-US/docs/Web/CSS/inheritance),
-  the [box](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model),
-  [layout modes](/en-US/docs/Web/CSS/Layout_mode) and [visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model),
-  and [margin collapsing](/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing),
-  or the [initial](/en-US/docs/Web/CSS/initial_value), [computed](/en-US/docs/Web/CSS/computed_value), [resolved](/en-US/docs/Web/CSS/resolved_value),
-  [specified](/en-US/docs/Web/CSS/specified_value), [used](/en-US/docs/Web/CSS/used_value), and [actual](/en-US/docs/Web/CSS/actual_value) values.
-  Definitions of [value syntax](/en-US/docs/Web/CSS/Value_definition_syntax), [shorthand properties](/en-US/docs/Web/CSS/Shorthand_properties)
-  and [replaced elements](/en-US/docs/Web/CSS/Replaced_element).
+- CSS key concepts:
+  - [CSS syntax](/en-US/docs/Web/CSS/Syntax)
+  - [Comments](/en-US/docs/Web/CSS/Comments)
+  - [Specificity](/en-US/docs/Web/CSS/Specificity)
+  - [Inheritance](/en-US/docs/Web/CSS/inheritance)
+  - [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
+  - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
+  - [Visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model)
+  - [Margin collapsing](/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing)
+  - Values
+    - [Initial values](/en-US/docs/Web/CSS/initial_value)
+    - [Computed values](/en-US/docs/Web/CSS/computed_value)
+    - [Used values](/en-US/docs/Web/CSS/used_value)
+    - [Actual values](/en-US/docs/Web/CSS/actual_value)
+  - [Value definition syntax](/en-US/docs/Web/CSS/Value_definition_syntax)
+  - [Shorthand properties](/en-US/docs/Web/CSS/Shorthand_properties)
+  - [Replaced elements](/en-US/docs/Web/CSS/Replaced_element)

--- a/files/en-us/web/css/value_definition_syntax/index.md
+++ b/files/en-us/web/css/value_definition_syntax/index.md
@@ -386,4 +386,12 @@ But not:
 
 ## See also
 
-- {{CSS_key_concepts}}
+- CSS Key Concepts: [CSS syntax](/en-US/docs/Web/CSS/Syntax), [at-rule](/en-US/docs/Web/CSS/At-rule), [comments](/en-US/docs/Web/CSS/Comments),
+  [specificity](/en-US/docs/Web/CSS/Specificity) and [inheritance](/en-US/docs/Web/CSS/inheritance),
+  the [box](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model),
+  [layout modes](/en-US/docs/Web/CSS/Layout_mode) and [visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model),
+  and [margin collapsing](/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing),
+  or the [initial](/en-US/docs/Web/CSS/initial_value), [computed](/en-US/docs/Web/CSS/computed_value), [resolved](/en-US/docs/Web/CSS/resolved_value),
+  [specified](/en-US/docs/Web/CSS/specified_value), [used](/en-US/docs/Web/CSS/used_value), and [actual](/en-US/docs/Web/CSS/actual_value) values.
+  Definitions of [value syntax](/en-US/docs/Web/CSS/Value_definition_syntax), [shorthand properties](/en-US/docs/Web/CSS/Shorthand_properties)
+  and [replaced elements](/en-US/docs/Web/CSS/Replaced_element).

--- a/files/en-us/web/css/value_definition_syntax/index.md
+++ b/files/en-us/web/css/value_definition_syntax/index.md
@@ -386,12 +386,20 @@ But not:
 
 ## See also
 
-- CSS Key Concepts: [CSS syntax](/en-US/docs/Web/CSS/Syntax), [at-rule](/en-US/docs/Web/CSS/At-rule), [comments](/en-US/docs/Web/CSS/Comments),
-  [specificity](/en-US/docs/Web/CSS/Specificity) and [inheritance](/en-US/docs/Web/CSS/inheritance),
-  the [box](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model),
-  [layout modes](/en-US/docs/Web/CSS/Layout_mode) and [visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model),
-  and [margin collapsing](/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing),
-  or the [initial](/en-US/docs/Web/CSS/initial_value), [computed](/en-US/docs/Web/CSS/computed_value), [resolved](/en-US/docs/Web/CSS/resolved_value),
-  [specified](/en-US/docs/Web/CSS/specified_value), [used](/en-US/docs/Web/CSS/used_value), and [actual](/en-US/docs/Web/CSS/actual_value) values.
-  Definitions of [value syntax](/en-US/docs/Web/CSS/Value_definition_syntax), [shorthand properties](/en-US/docs/Web/CSS/Shorthand_properties)
-  and [replaced elements](/en-US/docs/Web/CSS/Replaced_element).
+- CSS key concepts:
+  - [CSS syntax](/en-US/docs/Web/CSS/Syntax)
+  - [Comments](/en-US/docs/Web/CSS/Comments)
+  - [Specificity](/en-US/docs/Web/CSS/Specificity)
+  - [Inheritance](/en-US/docs/Web/CSS/inheritance)
+  - [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
+  - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
+  - [Visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model)
+  - [Margin collapsing](/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing)
+  - Values
+    - [Initial values](/en-US/docs/Web/CSS/initial_value)
+    - [Computed values](/en-US/docs/Web/CSS/computed_value)
+    - [Used values](/en-US/docs/Web/CSS/used_value)
+    - [Actual values](/en-US/docs/Web/CSS/actual_value)
+  - [Value definition syntax](/en-US/docs/Web/CSS/Value_definition_syntax)
+  - [Shorthand properties](/en-US/docs/Web/CSS/Shorthand_properties)
+  - [Replaced elements](/en-US/docs/Web/CSS/Replaced_element)

--- a/files/en-us/web/css/visual_formatting_model/index.md
+++ b/files/en-us/web/css/visual_formatting_model/index.md
@@ -142,12 +142,20 @@ A block box is a block-level box that is also a block container. As described in
 
 ## See also
 
-- CSS Key Concepts: [CSS syntax](/en-US/docs/Web/CSS/Syntax), [at-rule](/en-US/docs/Web/CSS/At-rule), [comments](/en-US/docs/Web/CSS/Comments),
-  [specificity](/en-US/docs/Web/CSS/Specificity) and [inheritance](/en-US/docs/Web/CSS/inheritance),
-  the [box](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model),
-  [layout modes](/en-US/docs/Web/CSS/Layout_mode) and [visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model),
-  and [margin collapsing](/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing),
-  or the [initial](/en-US/docs/Web/CSS/initial_value), [computed](/en-US/docs/Web/CSS/computed_value), [resolved](/en-US/docs/Web/CSS/resolved_value),
-  [specified](/en-US/docs/Web/CSS/specified_value), [used](/en-US/docs/Web/CSS/used_value), and [actual](/en-US/docs/Web/CSS/actual_value) values.
-  Definitions of [value syntax](/en-US/docs/Web/CSS/Value_definition_syntax), [shorthand properties](/en-US/docs/Web/CSS/Shorthand_properties)
-  and [replaced elements](/en-US/docs/Web/CSS/Replaced_element).
+- CSS key concepts:
+  - [CSS syntax](/en-US/docs/Web/CSS/Syntax)
+  - [Comments](/en-US/docs/Web/CSS/Comments)
+  - [Specificity](/en-US/docs/Web/CSS/Specificity)
+  - [Inheritance](/en-US/docs/Web/CSS/inheritance)
+  - [Box model](/en-US/docs/Web/CSS/CSS_Box_Model/Introduction_to_the_CSS_box_model)
+  - [Layout modes](/en-US/docs/Web/CSS/Layout_mode)
+  - [Visual formatting models](/en-US/docs/Web/CSS/Visual_formatting_model)
+  - [Margin collapsing](/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing)
+  - Values
+    - [Initial values](/en-US/docs/Web/CSS/initial_value)
+    - [Computed values](/en-US/docs/Web/CSS/computed_value)
+    - [Used values](/en-US/docs/Web/CSS/used_value)
+    - [Actual values](/en-US/docs/Web/CSS/actual_value)
+  - [Value definition syntax](/en-US/docs/Web/CSS/Value_definition_syntax)
+  - [Shorthand properties](/en-US/docs/Web/CSS/Shorthand_properties)
+  - [Replaced elements](/en-US/docs/Web/CSS/Replaced_element)


### PR DESCRIPTION
In mdn/yari#6819, we deprecated `{{CSS_key_concepts}}`.

Funnily, three different people (1 dev, 1 writer, 1 volunteer) looked for all occurrences to be gone.

We forgot 3, they got detected via the flaw dashboard. This PR fix them.