### PR TITLE
Document beforexrselect event (under Element)

### DIFF
--- a/files/en-us/web/api/element/beforexrselect_event/index.md
+++ b/files/en-us/web/api/element/beforexrselect_event/index.md
@@ -1,0 +1,69 @@
+---
+title: 'beforexrselect event'
+slug: Web/API/Element/beforexrselect_event
+page-type: web-api-event
+tags:
+   - API
+   - Event
+   - Reference
+browser-compat: api.Element.beforexrselect_event
+---
+{{APIRef}}
+
+The **`beforexrselect`** event is fired before WebXR select events ({{domxref("XRSession/select_event", "select")}}, {{domxref("XRSession/selectstart_event", "selectstart")}}, {{domxref("XRSession/selectend_event", "selectend")}}) are dispatched. It can be used to suppress XR world input events while the user is interacting with a DOM overlay UI.
+
+This event [bubbles](/en-US/docs/Learn/JavaScript/Building_blocks/Events#event_bubbling_and_capture), is [cancelable](/en-US/docs/Web/API/Event/cancelable) and is [composed](/en-US/docs/Web/API/Event/composed).
+
+## Syntax
+
+Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
+
+```js
+addEventListener('beforexrselect', event => { });
+
+onbeforexrselect = event => { };
+```
+
+## Event type
+
+An {{domxref("XRSessionEvent")}}. Inherits from {{domxref("Event")}}.
+
+{{InheritanceDiagram("XRSessionEvent")}}
+
+## Event properties
+
+- {{domxref("XRSessionEvent.session", "session")}} {{ReadOnlyInline}}
+  - : The {{domxref("XRSession")}} to which the event refers.
+
+## Event availability
+
+The **`beforexrselect`** event is a global event and available to the following interfaces:
+
+- {{domxref("Window")}}
+- {{domxref("Document")}}
+- {{domxref("HTMLElement")}}
+- {{domxref("SVGElement")}}
+- {{domxref("MathMLElement")}}
+
+## Examples
+
+To suppress WebXR select events ({{domxref("XRSession/select_event", "select")}}, {{domxref("XRSession/selectstart_event", "selectstart")}}, {{domxref("XRSession/selectend_event", "selectend")}}), an application can listen for the `beforexrselect` event. The event bubbles, so a call to {{domxref("Event/preventDefault", "preventDefault()")}} on the DOM overlay element will prevent any WebXR select events within this container allowing interaction with the DOM element and avoiding duplicate event input to the XR world.
+
+```js
+document.getElementById('xr-overlay').addEventListener(
+  'beforexrselect', ev => ev.preventDefault());
+```
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- {{domxref("XRSession/select_event", "select")}} event
+- {{domxref("XRSession/selectstart_event", "selectstart")}} event
+- {{domxref("XRSession/selectend_event", "selectend")}} event

--- a/files/en-us/web/api/element/beforexrselect_event/index.md
+++ b/files/en-us/web/api/element/beforexrselect_event/index.md
@@ -51,7 +51,7 @@ To suppress WebXR select events ({{domxref("XRSession/select_event", "select")}}
 
 ```js
 document.getElementById('xr-overlay').addEventListener(
-  'beforexrselect', ev => ev.preventDefault());
+  'beforexrselect', (ev) => ev.preventDefault());
 ```
 
 ## Specifications

--- a/files/en-us/web/api/xrsession/domoverlaystate/index.md
+++ b/files/en-us/web/api/xrsession/domoverlaystate/index.md
@@ -53,3 +53,7 @@ if (session.domOverlayState) {
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("Element.beforexrselect_event", "beforexrselect")}}

--- a/files/en-us/web/api/xrsession/select_event/index.md
+++ b/files/en-us/web/api/xrsession/select_event/index.md
@@ -95,3 +95,4 @@ xrSession.onselect = (event) => {
 ## See also
 
 - {{domxref("XRSession.selectstart_event", "selectstart")}} and {{domxref("XRSession.selectend_event", "selectend")}}
+- {{domxref("Element.beforexrselect_event", "beforexrselect")}}

--- a/files/en-us/web/api/xrsession/select_event/index.md
+++ b/files/en-us/web/api/xrsession/select_event/index.md
@@ -15,6 +15,8 @@ browser-compat: api.XRSession.select_event
 
 The WebXR **`select`** event is sent to an {{domxref("XRSession")}} when one of the session's input sources has completed a [primary action](/en-US/docs/Web/API/WebXR_Device_API/Inputs#primary_action).
 
+The {{domxref("Element.beforexrselect_event", "beforexrselect")}} is fired before this event and can prevent this event from being raised.
+
 ## Syntax
 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.

--- a/files/en-us/web/api/xrsession/selectend_event/index.md
+++ b/files/en-us/web/api/xrsession/selectend_event/index.md
@@ -27,6 +27,8 @@ browser-compat: api.XRSession.selectend_event
 
 The WebXR event **`selectend`** is sent to an {{domxref("XRSession")}} when one of its input sources ends its [primary action](/en-US/docs/Web/API/WebXR_Device_API/Inputs#primary_actions) or when an input source that's in the process of handling an ongoing primary action is disconnected without successfully completing the action.
 
+The {{domxref("Element.beforexrselect_event", "beforexrselect")}} is fired before this event and can prevent this event from being raised.
+
 ## Syntax
 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.

--- a/files/en-us/web/api/xrsession/selectend_event/index.md
+++ b/files/en-us/web/api/xrsession/selectend_event/index.md
@@ -81,3 +81,4 @@ See the [`selectstart`](/en-US/docs/Web/API/XRSession/selectstart_event#examples
 ## See also
 
 - {{domxref("XRSession.select_event", "select")}} and {{domxref("XRSession.selectstart_event", "selectstart")}}
+- {{domxref("Element.beforexrselect_event", "beforexrselect")}}

--- a/files/en-us/web/api/xrsession/selectstart_event/index.md
+++ b/files/en-us/web/api/xrsession/selectstart_event/index.md
@@ -131,3 +131,4 @@ xrSession.onselectend = onSelectionEvent;
 ## See also
 
 - {{domxref("XRSession.select_event", "select")}} and {{domxref("XRSession.selectend_event", "selectend")}}
+- {{domxref("Element.beforexrselect_event", "beforexrselect")}}

--- a/files/en-us/web/api/xrsession/selectstart_event/index.md
+++ b/files/en-us/web/api/xrsession/selectstart_event/index.md
@@ -27,6 +27,8 @@ browser-compat: api.XRSession.selectstart_event
 
 The [WebXR](/en-US/docs/Web/API/WebXR_Device_API) **`selectstart`** event is sent to an {{domxref("XRSession")}} when the user begins a [primary action](/en-US/docs/Web/API/WebXR_Device_API/Inputs#primary_action) on one of its input sources.
 
+The {{domxref("Element.beforexrselect_event", "beforexrselect")}} is fired before this event and can  prevent this event from being raised.
+
 ## Syntax
 
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.


### PR DESCRIPTION
Replaces https://github.com/mdn/content/pull/15376
BCD PR is at https://github.com/mdn/browser-compat-data/pull/17462

(first content PR after being away for 3 months 😊)