### PR TITLE
Add note about using an Image element to get a local resource

### DIFF
--- a/files/en-us/web/http/cors/errors/corsmissingallowcredentials/index.md
+++ b/files/en-us/web/http/cors/errors/corsmissingallowcredentials/index.md
@@ -39,7 +39,7 @@ credentials.
   default value).
 - If using the [Fetch API](/en-US/docs/Web/API/Fetch_API), make sure
   {{domxref("Request.credentials")}} is `"omit"`.
-- If using the [HTMLImageElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement) make sure you're setting the {{domxref("HTMLImageElement.crossOrigin")}} attribute to `anonymous`.
+- If using the [HTMLImageElement](/en-US/docs/Web/API/HTMLImageElement) make sure you're setting the {{domxref("HTMLImageElement.crossOrigin")}} attribute to `anonymous`.
 
 To eliminate this error by changing the server's configuration, adjust the server's
 configuration to set the `Access-Control-Allow-Credentials` header's value to

--- a/files/en-us/web/http/cors/errors/corsmissingallowcredentials/index.md
+++ b/files/en-us/web/http/cors/errors/corsmissingallowcredentials/index.md
@@ -39,6 +39,7 @@ credentials.
   default value).
 - If using the [Fetch API](/en-US/docs/Web/API/Fetch_API), make sure
   {{domxref("Request.credentials")}} is `"omit"`.
+- If using the [HTMLImageElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement) make sure you're setting the {{domxref("HTMLImageElement.crossOrigin")}} attribute to `anonymous`.
 
 To eliminate this error by changing the server's configuration, adjust the server's
 configuration to set the `Access-Control-Allow-Credentials` header's value to


### PR DESCRIPTION
Add fix description when using an Image element to get a local resource.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Propose a fix for the scenario where the local network access failure happens when using an Image element.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Using Image(HTMLImageElement) and setting the `src` attribute to a local resource, issues a GET request to obtain the image. This can fail if CORS Preflight requests is enabled and the `Access-Control-Allow-Credentials` header is set to false. Readers can find a solution to this as described by the changes here proposed.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
By setting the "crossOrigin" attribute to "anonymous" the credentials mode is set to "same-origin", which is compatible - In the way credentials are not intended to be shared - with CORS "Access-Control-Allow-Credentials=false".

For Image see:
https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/crossOrigin  
For CORS Preflight see:
https://fetch.spec.whatwg.org/#cors-preflight-request
For credentials mode see:
https://fetch.spec.whatwg.org/#concept-request-credentials-mode
 

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
