### PR TITLE
WebDriver conformance changes for Firefox 104

### DIFF
--- a/files/en-us/mozilla/firefox/releases/104/index.md
+++ b/files/en-us/mozilla/firefox/releases/104/index.md
@@ -72,7 +72,16 @@ This article provides information about the changes in Firefox 104 that will aff
 
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
-#### Removals
+#### WebDriver BiDi
+
+- Added support for `source` to the `log.entryAdded` event ({{bug(1770792)}}).
+- Updated the `url` sent for `browsingContext.contextCreated` events to be `about:blank` for newly opened browsing contexts ({{bug(1775141)}}).
+
+#### Marionette
+
+- Improved stability and performance when minimizing or restoring windows on Linux ({{bug(1780212)}}).
+- Added support for `touch` actions ({{bug(1543337)}}).
+
 
 ## Changes for add-on developers
 


### PR DESCRIPTION
cc @whimboo 

I used https://bugzilla.mozilla.org/buglist.cgi?status_whiteboard=%5Bwebdriver%3Arelnote%5D&resolution=FIXED&query_format=advanced&v1=fixed&j_top=OR&status_whiteboard_type=substring&o1=equals&f1=cf_status_firefox104&list_id=16182535

Let me know if that's ok with you!