### PR TITLE
Css fix: use double colon before "after" and "before"

### DIFF
--- a/files/en-us/web/api/location/index.md
+++ b/files/en-us/web/api/location/index.md
@@ -27,15 +27,15 @@ body { display: table-cell; text-align: center; vertical-align: middle; font-fam
 
 [title] { position: relative; display: inline-block; box-sizing: border-box; line-height: 2em; cursor: pointer; }
 
-[title]:before { content: attr(title); font-family: monospace; position: absolute; top: 100%; width: 100%; left: 50%; margin-left: -50%; font-size: 40%; line-height: 1.5; background: black; }
+[title]::before { content: attr(title); font-family: monospace; position: absolute; top: 100%; width: 100%; left: 50%; margin-left: -50%; font-size: 40%; line-height: 1.5; background: black; }
 
-[title]:hover:before, :target:before { background: black; color: yellow; }
+[title]:hover::before, :target::before { background: black; color: yellow; }
 
-[title] [title]:before { margin-top: 1.5em; }
+[title] [title]::before { margin-top: 1.5em; }
 
-[title] [title] [title]:before { margin-top: 3em; }
+[title] [title] [title]::before { margin-top: 3em; }
 
-[title] [title] [title] [title]:before { margin-top: 4.5em; }
+[title] [title] [title] [title]::before { margin-top: 4.5em; }
 
 [title]:hover, :target { position: relative; z-index: 1; outline: 50em solid rgba(255, 255, 255, .8); }
 ```

--- a/files/en-us/web/css/clip-path/index.md
+++ b/files/en-us/web/css/clip-path/index.md
@@ -450,7 +450,7 @@ html,body {
 .container {
   display: inline-block;
   border: 1px dotted grey;
-  position:relative;
+  position: relative;
 }
 
 .container::before {

--- a/files/en-us/web/css/clip-path/index.md
+++ b/files/en-us/web/css/clip-path/index.md
@@ -453,7 +453,7 @@ html,body {
   position:relative;
 }
 
-.container:before {
+.container::before {
   content: 'margin';
   position: absolute;
   top: 2px;
@@ -465,7 +465,7 @@ html,body {
   box-shadow: 1rem 1rem 0 #EFEFEF inset, -1rem -1rem 0 #EFEFEF inset;
 }
 
-.container.viewbox:after {
+.container.viewbox::after {
   content: 'viewbox';
   position: absolute;
   left: 1.1rem;

--- a/files/en-us/web/css/flex-basis/index.md
+++ b/files/en-us/web/css/flex-basis/index.md
@@ -117,7 +117,7 @@ The `flex-basis` property is specified as either the keyword `content` or a `<'w
   position: relative;
 }
 
-.flex:after {
+.flex::after {
   position: absolute;
   z-index: 1;
   left: 0;
@@ -132,7 +132,7 @@ The `flex-basis` property is specified as either the keyword `content` or a `<'w
   flex-basis: auto;
 }
 
-.flex1:after {
+.flex1::after {
   content: 'auto';
 }
 
@@ -140,7 +140,7 @@ The `flex-basis` property is specified as either the keyword `content` or a `<'w
   flex-basis: max-content;
 }
 
-.flex2:after {
+.flex2::after {
   content: 'max-content';
 }
 
@@ -148,7 +148,7 @@ The `flex-basis` property is specified as either the keyword `content` or a `<'w
   flex-basis: min-content;
 }
 
-.flex3:after {
+.flex3::after {
   content: 'min-content';
 }
 
@@ -156,7 +156,7 @@ The `flex-basis` property is specified as either the keyword `content` or a `<'w
   flex-basis: fit-content;
 }
 
-.flex4:after {
+.flex4::after {
   content: 'fit-content';
 }
 
@@ -164,7 +164,7 @@ The `flex-basis` property is specified as either the keyword `content` or a `<'w
    flex-basis: content;
 }
 
-.flex5:after {
+.flex5::after {
   content: 'content';
 }
 ```

--- a/files/en-us/web/css/font/index.md
+++ b/files/en-us/web/css/font/index.md
@@ -253,13 +253,13 @@ body, input {
   border-bottom-color: red;
 }
 
-.cf:before,
-.cf:after {
+.cf::before,
+.cf::after {
   content: " ";
   display: table;
 }
 
-.cf:after {
+.cf::after {
   clear: both;
 }
 

--- a/files/en-us/web/guide/css/getting_started/challenge_solutions/index.md
+++ b/files/en-us/web/guide/css/getting_started/challenge_solutions/index.md
@@ -157,7 +157,7 @@ The challenges on page are:
   - : Add this rule to your stylesheet:
 
     ```css
-    p::before{
+    p::before {
       content: url("yellow-pin.png");
     }
     ```
@@ -212,7 +212,7 @@ The challenges on page [Boxes](/en-US/docs/Learn/CSS/Building_blocks) are:
     ```css
     ul {
       border: 10px solid lightblue;
-      width:  100px;
+      width: 100px;
     }
     ```
 
@@ -237,7 +237,7 @@ The challenges on page [Layout](/en-US/docs/Learn/CSS/CSS_layout) are:
 
     ```css
     #fixed-pin {
-      position:fixed;
+      position: fixed;
       top: 3px;
       right: 3px;
     }
@@ -257,7 +257,7 @@ The challenges on page [Tables](/en-US/docs/Learn/CSS/Building_blocks/Styling_ta
 
     ```css
     #demo-table tbody td {
-      border:1px solid #7a7;
+      border: 1px solid #7a7;
     }
     ```
 

--- a/files/en-us/web/guide/css/getting_started/challenge_solutions/index.md
+++ b/files/en-us/web/guide/css/getting_started/challenge_solutions/index.md
@@ -157,7 +157,7 @@ The challenges on page are:
   - : Add this rule to your stylesheet:
 
     ```css
-    p:before{
+    p::before{
       content: url("yellow-pin.png");
     }
     ```
@@ -191,7 +191,7 @@ The challenges on page [Lists](/en-US/docs/Learn/CSS/Styling_text/Styling_lists)
     ```css
     /* numbered headings */
     body {counter-reset: headnum;}
-    h3:before {
+    h3::before {
       content: "(" counter(headnum, upper-latin) ") ";
       counter-increment: headnum;
     }

--- a/files/en-us/web/html/attributes/pattern/index.md
+++ b/files/en-us/web/html/attributes/pattern/index.md
@@ -99,13 +99,13 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
+input:invalid+span::after {
   position: absolute;
   content: '✖';
   padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid+span::after {
   position: absolute;
   content: '✓';
   padding-left: 5px;

--- a/files/en-us/web/html/attributes/pattern/index.md
+++ b/files/en-us/web/html/attributes/pattern/index.md
@@ -99,13 +99,13 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span::after {
+input:invalid + span::after {
   position: absolute;
   content: '✖';
   padding-left: 5px;
 }
 
-input:valid+span::after {
+input:valid + span::after {
   position: absolute;
   content: '✓';
   padding-left: 5px;

--- a/files/en-us/web/html/element/input/datetime-local/index.md
+++ b/files/en-us/web/html/element/input/datetime-local/index.md
@@ -236,18 +236,18 @@ label {
   width: 300px;
 }
 
-input:invalid+span::after {
-    content: '✖';
-    padding-left: 5px;
+input:invalid + span::after {
+  content: "✖";
+  padding-left: 5px;
 }
 
-input:valid+span::after {
-    content: '✓';
-    padding-left: 5px;
+input:valid + span::after {
+  content: "✓";
+  padding-left: 5px;
 }
 ```
 
-> **Warning:** HTML form validation is _not_ a substitute for scripts that ensure that the entered data is in the proper format.  It's far too easy for someone to make adjustments to the HTML that allow them to bypass the validation, or to remove it entirely. It's also possible for someone to bypass your HTML entirely and submit the data directly to your server. If your server-side code fails to validate the data it receives, disaster could strike when improperly-formatted data is submitted (or data which is too large, is of the wrong type, and so forth).
+> **Warning:** HTML form validation is _not_ a substitute for scripts that ensure that the entered data is in the proper format. It's far too easy for someone to make adjustments to the HTML that allow them to bypass the validation, or to remove it entirely. It's also possible for someone to bypass your HTML entirely and submit the data directly to your server. If your server-side code fails to validate the data it receives, disaster could strike when improperly-formatted data is submitted (or data which is too large, is of the wrong type, and so forth).
 
 ## Handling browser support
 
@@ -424,13 +424,13 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span::after {
+input:invalid + span::after {
   position: absolute;
   content: '✖';
   padding-left: 5px;
 }
 
-input:valid+span::after {
+input:valid + span::after {
   position: absolute;
   content: '✓';
   padding-left: 5px;

--- a/files/en-us/web/html/element/input/datetime-local/index.md
+++ b/files/en-us/web/html/element/input/datetime-local/index.md
@@ -236,12 +236,12 @@ label {
   width: 300px;
 }
 
-input:invalid+span:after {
+input:invalid+span::after {
     content: '✖';
     padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid+span::after {
     content: '✓';
     padding-left: 5px;
 }
@@ -299,7 +299,7 @@ input:invalid + span {
   position: relative;
 }
 
-input:invalid + span:after {
+input:invalid + span::after {
   content: '✖';
   position: absolute;
   right: -18px;
@@ -309,7 +309,7 @@ input:valid + span {
   position: relative;
 }
 
-input:valid + span:after {
+input:valid + span::after {
   content: '✓';
   position: absolute;
   right: -18px;
@@ -424,13 +424,13 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
+input:invalid+span::after {
   position: absolute;
   content: '✖';
   padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid+span::after {
   position: absolute;
   content: '✓';
   padding-left: 5px;

--- a/files/en-us/web/html/element/input/month/index.md
+++ b/files/en-us/web/html/element/input/month/index.md
@@ -259,13 +259,13 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span::after {
+input:invalid + span::after {
   position: absolute;
   content: '✖';
   padding-left: 5px;
 }
 
-input:valid+span::after {
+input:valid + span::after {
   position: absolute;
   content: '✓';
   padding-left: 5px;
@@ -339,13 +339,13 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span::after {
+input:invalid + span::after {
   position: absolute;
   content: '✖';
   padding-left: 5px;
 }
 
-input:valid+span::after {
+input:valid + span::after {
   position: absolute;
   content: '✓';
   padding-left: 5px;
@@ -422,13 +422,13 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span::after {
+input:invalid + span::after {
   position: absolute;
   content: '✖';
   padding-left: 5px;
 }
 
-input:valid+span::after {
+input:valid + span::after {
   position: absolute;
   content: '✓';
   padding-left: 5px;

--- a/files/en-us/web/html/element/input/month/index.md
+++ b/files/en-us/web/html/element/input/month/index.md
@@ -259,13 +259,13 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
+input:invalid+span::after {
   position: absolute;
   content: '✖';
   padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid+span::after {
   position: absolute;
   content: '✓';
   padding-left: 5px;
@@ -339,13 +339,13 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
+input:invalid+span::after {
   position: absolute;
   content: '✖';
   padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid+span::after {
   position: absolute;
   content: '✓';
   padding-left: 5px;
@@ -422,13 +422,13 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
+input:invalid+span::after {
   position: absolute;
   content: '✖';
   padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid+span::after {
   position: absolute;
   content: '✓';
   padding-left: 5px;

--- a/files/en-us/web/html/element/input/number/index.md
+++ b/files/en-us/web/html/element/input/number/index.md
@@ -274,12 +274,12 @@ div {
   margin-bottom: 10px;
 }
 
-input:invalid+span:after {
+input:invalid+span::after {
   content: '✖';
   padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid+span::after {
   content: '✓';
   padding-left: 5px;
 }
@@ -356,13 +356,13 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
+input:invalid+span::after {
   position: absolute;
   content: '✖';
   padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid+span::after {
   position: absolute;
   content: '✓';
   padding-left: 5px;

--- a/files/en-us/web/html/element/input/number/index.md
+++ b/files/en-us/web/html/element/input/number/index.md
@@ -274,13 +274,13 @@ div {
   margin-bottom: 10px;
 }
 
-input:invalid+span::after {
-  content: '✖';
+input:invalid + span::after {
+  content: "✖";
   padding-left: 5px;
 }
 
-input:valid+span::after {
-  content: '✓';
+input:valid + span::after {
+  content: "✓";
   padding-left: 5px;
 }
 ```
@@ -356,15 +356,15 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span::after {
+input:invalid + span::after {
   position: absolute;
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
 }
 
-input:valid+span::after {
+input:valid + span::after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
 }
 ```

--- a/files/en-us/web/html/element/input/search/index.md
+++ b/files/en-us/web/html/element/input/search/index.md
@@ -284,13 +284,13 @@ The result is this wider input box:
 There are useful pseudo-classes available for styling valid/invalid form elements: {{cssxref(":valid")}} and {{cssxref(":invalid")}}. In this section, we'll use the following CSS, which will place a check (tick) next to inputs containing valid values, and a cross next to inputs containing invalid values.
 
 ```css
-input:invalid ~ span:after {
+input:invalid ~ span::after {
     content: '✖';
     padding-left: 5px;
     position: absolute;
 }
 
-input:valid ~ span:after {
+input:valid ~ span::after {
     content: '✓';
     padding-left: 5px;
     position: absolute;
@@ -319,13 +319,13 @@ input {
   margin-right: 10px;
 }
 
-input:invalid ~ span:after {
+input:invalid ~ span::after {
     content: '✖';
     padding-left: 5px;
     position: absolute;
 }
 
-input:valid ~ span:after {
+input:valid ~ span::after {
     content: '✓';
     padding-left: 5px;
     position: absolute;
@@ -366,13 +366,13 @@ input {
   margin-right: 10px;
 }
 
-input:invalid ~ span:after {
+input:invalid ~ span::after {
     content: '✖';
     padding-left: 5px;
     position: absolute;
 }
 
-input:valid ~ span:after {
+input:valid ~ span::after {
     content: '✓';
     padding-left: 5px;
     position: absolute;
@@ -409,13 +409,13 @@ input {
   margin-right: 10px;
 }
 
-input:invalid ~ span:after {
+input:invalid ~ span::after {
     content: '✖';
     padding-left: 5px;
     position: absolute;
 }
 
-input:valid ~ span:after {
+input:valid ~ span::after {
     content: '✓';
     padding-left: 5px;
     position: absolute;

--- a/files/en-us/web/html/element/input/tel/index.md
+++ b/files/en-us/web/html/element/input/tel/index.md
@@ -262,7 +262,7 @@ Here's a screenshot of what that might look like:
 
 As we've touched on before, it's quite difficult to provide a one-size-fits-all client-side validation solution for phone numbers. So what can we do? Let's consider some options.
 
-> **Warning:** HTML form validation is _not_ a substitute for server-side scripts that ensure the entered data is in the proper format before it is allowed into the database.  It's far too easy for someone to make adjustments to the HTML that allow them to bypass the validation, or to remove it entirely. It's also possible for someone to bypass your HTML entirely and submit the data directly to your server. If your server-side code fails to validate the data it receives, disaster could strike when improperly-formatted data (or data which is too large, is of the wrong type, and so forth) is entered into your database.
+> **Warning:** HTML form validation is _not_ a substitute for server-side scripts that ensure the entered data is in the proper format before it is allowed into the database. It's far too easy for someone to make adjustments to the HTML that allow them to bypass the validation, or to remove it entirely. It's also possible for someone to bypass your HTML entirely and submit the data directly to your server. If your server-side code fails to validate the data it receives, disaster could strike when improperly-formatted data (or data which is too large, is of the wrong type, and so forth) is entered into your database.
 
 ### Making telephone numbers required
 
@@ -297,15 +297,16 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span::after {
-  position: absolute; content: '✖';
+input:invalid + span::after {
+  position: absolute;
+  content: "✖";
   padding-left: 5px;
   color: #8b0000;
 }
 
-input:valid+span::after {
+input:valid + span::after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
   color: #009000;
 }
@@ -349,15 +350,16 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span::after {
-  position: absolute; content: '✖';
+input:invalid + span::after {
+  position: absolute;
+  content: "✖";
   padding-left: 5px;
   color: #8b0000;
 }
 
-input:valid+span::after {
+input:valid + span::after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
   color: #009000;
 }
@@ -470,8 +472,8 @@ It makes you wonder if it is worth going to all this trouble on the client-side,
 
 ```css hidden
 div {
-margin-bottom: 10px;
-position: relative;
+  margin-bottom: 10px;
+  position: relative;
 }
 
 input[type="number"] {
@@ -482,15 +484,16 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span::after {
-  position: absolute; content: '✖';
+input:invalid + span::after {
+  position: absolute;
+  content: "✖";
   padding-left: 5px;
   color: #8b0000;
 }
 
-input:valid+span::after {
+input:valid + span::after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
   color: #009000;
 }

--- a/files/en-us/web/html/element/input/tel/index.md
+++ b/files/en-us/web/html/element/input/tel/index.md
@@ -297,13 +297,13 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
+input:invalid+span::after {
   position: absolute; content: '✖';
   padding-left: 5px;
   color: #8b0000;
 }
 
-input:valid+span:after {
+input:valid+span::after {
   position: absolute;
   content: '✓';
   padding-left: 5px;
@@ -349,13 +349,13 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
+input:invalid+span::after {
   position: absolute; content: '✖';
   padding-left: 5px;
   color: #8b0000;
 }
 
-input:valid+span:after {
+input:valid+span::after {
   position: absolute;
   content: '✓';
   padding-left: 5px;
@@ -482,13 +482,13 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
+input:invalid+span::after {
   position: absolute; content: '✖';
   padding-left: 5px;
   color: #8b0000;
 }
 
-input:valid+span:after {
+input:valid+span::after {
   position: absolute;
   content: '✓';
   padding-left: 5px;

--- a/files/en-us/web/html/element/input/text/index.md
+++ b/files/en-us/web/html/element/input/text/index.md
@@ -252,13 +252,14 @@ input + span {
 }
 
 input:invalid + span::after {
-  position: absolute; content: '✖';
+  position: absolute;
+  content: "✖";
   padding-left: 5px;
 }
 
 input:valid + span::after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
 }
 ```
@@ -290,14 +291,14 @@ div {
 input + span {
   padding-right: 30px;
 }
-input:invalid+span::after {
+input:invalid + span::after {
   position: absolute;
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
 }
-input:valid+span::after {
+input:valid + span::after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
 }
 ```
@@ -337,14 +338,14 @@ div {
 input + span {
   padding-right: 30px;
 }
-input:invalid+span::after {
+input:invalid + span::after {
   position: absolute;
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
 }
-input:valid+span::after {
+input:valid + span::after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
 }
 ```
@@ -393,15 +394,15 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span::after {
+input:invalid + span::after {
   position: absolute;
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
 }
 
-input:valid+span::after {
+input:valid + span::after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
 }
 ```

--- a/files/en-us/web/html/element/input/text/index.md
+++ b/files/en-us/web/html/element/input/text/index.md
@@ -251,12 +251,12 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid + span:after {
+input:invalid + span::after {
   position: absolute; content: '✖';
   padding-left: 5px;
 }
 
-input:valid + span:after {
+input:valid + span::after {
   position: absolute;
   content: '✓';
   padding-left: 5px;
@@ -290,12 +290,12 @@ div {
 input + span {
   padding-right: 30px;
 }
-input:invalid+span:after {
+input:invalid+span::after {
   position: absolute;
   content: '✖';
   padding-left: 5px;
 }
-input:valid+span:after {
+input:valid+span::after {
   position: absolute;
   content: '✓';
   padding-left: 5px;
@@ -337,12 +337,12 @@ div {
 input + span {
   padding-right: 30px;
 }
-input:invalid+span:after {
+input:invalid+span::after {
   position: absolute;
   content: '✖';
   padding-left: 5px;
 }
-input:valid+span:after {
+input:valid+span::after {
   position: absolute;
   content: '✓';
   padding-left: 5px;
@@ -393,13 +393,13 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
+input:invalid+span::after {
   position: absolute;
   content: '✖';
   padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid+span::after {
   position: absolute;
   content: '✓';
   padding-left: 5px;

--- a/files/en-us/web/html/element/input/time/index.md
+++ b/files/en-us/web/html/element/input/time/index.md
@@ -268,15 +268,15 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span::after {
+input:invalid + span::after {
   position: absolute;
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
 }
 
-input:valid+span::after {
+input:valid + span::after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
 }
 ```
@@ -383,15 +383,15 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span::after {
+input:invalid + span::after {
   position: absolute;
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
 }
 
-input:valid+span::after {
+input:valid + span::after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
 }
 ```
@@ -448,15 +448,15 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span::after {
+input:invalid + span::after {
   position: absolute;
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
 }
 
-input:valid+span::after {
+input:valid + span::after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
 }
 ```

--- a/files/en-us/web/html/element/input/time/index.md
+++ b/files/en-us/web/html/element/input/time/index.md
@@ -268,13 +268,13 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
+input:invalid+span::after {
   position: absolute;
   content: '✖';
   padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid+span::after {
   position: absolute;
   content: '✓';
   padding-left: 5px;
@@ -383,13 +383,13 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
+input:invalid+span::after {
   position: absolute;
   content: '✖';
   padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid+span::after {
   position: absolute;
   content: '✓';
   padding-left: 5px;
@@ -448,13 +448,13 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
+input:invalid+span::after {
   position: absolute;
   content: '✖';
   padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid+span::after {
   position: absolute;
   content: '✓';
   padding-left: 5px;

--- a/files/en-us/web/html/element/input/url/index.md
+++ b/files/en-us/web/html/element/input/url/index.md
@@ -338,12 +338,12 @@ div {
     padding-right: 30px;
   }
 
-  input:invalid+span:after {
+  input:invalid+span::after {
     position: absolute; content: '✖';
     padding-left: 5px;
   }
 
-  input:valid+span:after {
+  input:valid+span::after {
     position: absolute;
     content: '✓';
     padding-left: 5px;

--- a/files/en-us/web/html/element/input/url/index.md
+++ b/files/en-us/web/html/element/input/url/index.md
@@ -328,26 +328,27 @@ Since inputs of type `url` validate against both the standard URL validation _an
 div {
   margin-bottom: 10px;
   position: relative;
-  }
+}
 
-  input[type="number"] {
-    width: 100px;
-  }
+input[type="number"] {
+  width: 100px;
+}
 
-  input + span {
-    padding-right: 30px;
-  }
+input + span {
+  padding-right: 30px;
+}
 
-  input:invalid+span::after {
-    position: absolute; content: '✖';
-    padding-left: 5px;
-  }
+input:invalid + span::after {
+  position: absolute;
+  content: "✖";
+  padding-left: 5px;
+}
 
-  input:valid+span::after {
-    position: absolute;
-    content: '✓';
-    padding-left: 5px;
-  }
+input:valid + span::after {
+  position: absolute;
+  content: "✓";
+  padding-left: 5px;
+}
 ```
 
 ```html

--- a/files/en-us/web/html/element/input/week/index.md
+++ b/files/en-us/web/html/element/input/week/index.md
@@ -199,15 +199,15 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span::after {
+input:invalid + span::after {
   position: absolute;
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
 }
 
-input:valid+span::after {
+input:valid + span::after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
 }
 ```
@@ -315,15 +315,15 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span::after {
+input:invalid + span::after {
   position: absolute;
-  content: '✖';
+  content: "✖";
   padding-left: 5px;
 }
 
-input:valid+span::after {
+input:valid + span::after {
   position: absolute;
-  content: '✓';
+  content: "✓";
   padding-left: 5px;
 }
 ```

--- a/files/en-us/web/html/element/input/week/index.md
+++ b/files/en-us/web/html/element/input/week/index.md
@@ -199,13 +199,13 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
+input:invalid+span::after {
   position: absolute;
   content: '✖';
   padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid+span::after {
   position: absolute;
   content: '✓';
   padding-left: 5px;
@@ -315,13 +315,13 @@ input + span {
   padding-right: 30px;
 }
 
-input:invalid+span:after {
+input:invalid+span::after {
   position: absolute;
   content: '✖';
   padding-left: 5px;
 }
 
-input:valid+span:after {
+input:valid+span::after {
   position: absolute;
   content: '✓';
   padding-left: 5px;

--- a/files/en-us/web/html/element/select/index.md
+++ b/files/en-us/web/html/element/select/index.md
@@ -267,7 +267,7 @@ html body form fieldset#custom div.select div.header::after {
   padding: .5em;
 }
 
-html body form fieldset#custom div.select div.header:hover:after {
+html body form fieldset#custom div.select div.header:hover::after {
   background-color: blue;
 }
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Use double colons with "after" and "before". Not required, but recommended

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

https://developer.mozilla.org/en-US/docs/Web/CSS/::before#syntax

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
