### PR TITLE
Remove CSS vendor prefixes

### DIFF
--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/html_and_css/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/html_and_css/index.md
@@ -226,7 +226,7 @@ Another set of problems comes with CSS prefixes — these are a mechanism origin
 
 - Mozilla uses `-moz-`
 - Chrome/Opera/Safari use `-webkit-`
-- Microsoft uses `-ms-`
+- Internet Explorer uses `-ms-`
 
 Here's some examples:
 

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/html_and_css/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/html_and_css/index.md
@@ -224,9 +224,10 @@ form > #date
 
 Another set of problems comes with CSS prefixes — these are a mechanism originally used to allow browser vendors to implement their own version of a CSS (or JavaScript) feature while the technology is in an experimental state, so they can play with it and get it right without conflicting with other browser's implementations, or the final unprefixed implementations. So for example:
 
-- Mozilla uses `-moz-`
-- Chrome/Opera/Safari use `-webkit-`
-- Internet Explorer uses `-ms-`
+- Firefox uses `-moz-`
+- Chrome/Edge/Opera/Safari use `-webkit-`
+
+More prefixes were used in the past: Internet Explorer and early versions of Edge used `-ms-`, and old versions of Opera used `-o`.
 
 Here's some examples:
 
@@ -236,11 +237,11 @@ Here's some examples:
 transform: rotate(90deg);
 ```
 
-While the transform propert does not require a prefix, you may encounter this old CSS in a codebase. The first line shows a {{cssxref("transform")}} property with a `-webkit-` prefix — this was needed to make transforms work in older versions of Safari and Chrome until the prefix-free feature was supported.
+While the `transform` property does not require a prefix, you may encounter this old CSS in a codebase. The first line shows the {{cssxref("transform")}} property with a `-webkit-` prefix — this was needed to make transforms work in older versions of Safari and Chrome until the prefix-free feature was supported.
 
-The second line has a `-moz-` prefix. Also no longer needed. The third one has no prefix. This third version shows the final version of the syntax supported in all evergreen browsers.
+The second line has a `-moz-` prefix, which is also no longer needed. The third one has no prefix. This third version shows the final version of the syntax supported in all evergreen browsers.
 
-Prefixed features were never supposed to be used in production websites — they are subject to change or removal without warning, and cause cross browser issues. This is particularly a problem when developers decide to only use say, the `-webkit-` version of a property — meaning that the site won't work in other browsers. This actually happened so much that other browsers implemented `-webkit-` prefixed versions of several CSS properties. While browsers still support some prefixed property names, property values, and pseudo classes, now experimental features are put behind flags so developers can test them during development.
+Prefixed features were never supposed to be used in production websites — they are subject to change or removal without warning and cause cross-browser issues. This is particularly a problem, for example, when developers decide to use only the `-webkit-` version of a property, which implied that the site won't work in other browsers. This actually happened so much that other browser vendors implemented `-webkit-` prefixed versions of several CSS properties. While browsers still support some prefixed property names, property values, and pseudo classes, now experimental features are put behind flags so that web developers can test them during development.
 
 If you insist on using prefixed features, make sure you use the right ones. You can look up what browsers require prefixes on MDN reference pages, and sites like [caniuse.com](https://caniuse.com/). If you are unsure, you can also find out by doing some testing directly in browsers.
 

--- a/files/en-us/learn/tools_and_testing/cross_browser_testing/html_and_css/index.md
+++ b/files/en-us/learn/tools_and_testing/cross_browser_testing/html_and_css/index.md
@@ -232,17 +232,13 @@ Here's some examples:
 
 ```css
 -webkit-transform: rotate(90deg);
-
-background-image: -moz-linear-gradient(left ,green, yellow);
-background-image: -webkit-gradient(linear, left center, right center, from(green), to(yellow));
-background-image: linear-gradient(to right, green, yellow);
+-moz-transform: rotate(90deg);
+transform: rotate(90deg);
 ```
 
-While none of these properties requires a prefix, you may encounter this old CSS in a codebase. The first line shows a {{cssxref("transform")}} property with a `-webkit-` prefix — this was needed to make transforms work in older versions of Safari and Chrome until the prefix-free feature was supported.
+While the transform propert does not require a prefix, you may encounter this old CSS in a codebase. The first line shows a {{cssxref("transform")}} property with a `-webkit-` prefix — this was needed to make transforms work in older versions of Safari and Chrome until the prefix-free feature was supported.
 
-The last three lines show three different versions of the [`linear-gradient()`](/en-US/docs/Web/CSS/gradient/linear-gradient) function, which is originally how linear gradient were written:
-
-The first one has a `-moz-` prefix, the second a `-webkit-` prefix, and the third one has no prefix. This third version shows the final version of the syntax supported in all evergreen browsers.
+The second line has a `-moz-` prefix. Also no longer needed. The third one has no prefix. This third version shows the final version of the syntax supported in all evergreen browsers.
 
 Prefixed features were never supposed to be used in production websites — they are subject to change or removal without warning, and cause cross browser issues. This is particularly a problem when developers decide to only use say, the `-webkit-` version of a property — meaning that the site won't work in other browsers. This actually happened so much that other browsers implemented `-webkit-` prefixed versions of several CSS properties. While browsers still support some prefixed property names, property values, and pseudo classes, now experimental features are put behind flags so developers can test them during development.
 

--- a/files/en-us/web/accessibility/aria/roles/switch_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/switch_role/index.md
@@ -166,10 +166,7 @@ label.switch {
   line-height: 20px;
   user-select: none;
   vertical-align: middle;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  -webkit-user-select: none;
-  -o-user-select: none;
+  user-select: none;
 }
 ```
 

--- a/files/en-us/web/css/user-select/index.md
+++ b/files/en-us/web/css/user-select/index.md
@@ -33,23 +33,6 @@ user-select: initial;
 user-select: revert;
 user-select: revert-layer;
 user-select: unset;
-
-/* Mozilla-specific values */
--moz-user-select: none;
--moz-user-select: text;
--moz-user-select: all;
-
-/* WebKit-specific values */
--webkit-user-select: none;
--webkit-user-select: text;
--webkit-user-select: all; /* Doesn't work in Safari; use only
-                             "none" or "text", or else it will
-                             allow typing in the <html> container */
-
-/* Microsoft-specific values */
--ms-user-select: none;
--ms-user-select: text;
--ms-user-select: element;
 ```
 
 > **Note:** `user-select` is not an inherited property, though the initial `auto` value makes it behave like it is inherited most of the time. WebKit/Chromium-based browsers _do_ implement the property as inherited, which violates the behavior described in the spec, and this will bring some issues. Until now, Chromium chooses to [fix the issues](https://chromium.googlesource.com/chromium/src/+/b01af0b296ecb855aac95c4ed335d188e6eac2de), make the final behavior meets the specifications.
@@ -101,19 +84,19 @@ user-select: unset;
 
 ```css
 .unselectable {
-  -moz-user-select: none;
-  -webkit-user-select: none;
-  -ms-user-select: none;
+  -webkit-user-select: none; /* Safari */
+  -ms-user-select: none; /* IE 10+ */
   user-select: none;
 }
 
 .all {
-  -moz-user-select: all;
   -webkit-user-select: all;
   -ms-user-select: all;
   user-select: all;
 }
 ```
+
+> **Note:** `-webkit-user-select: all;` doesn't work in Safari; use only "none" or "text", or else it will allow typing in the `<html>` container. See the [browser compatability table](#browser-compatibility) for up to date information.
 
 ### Result
 

--- a/files/en-us/web/css/user-select/index.md
+++ b/files/en-us/web/css/user-select/index.md
@@ -35,7 +35,7 @@ user-select: revert-layer;
 user-select: unset;
 ```
 
-> **Note:** `user-select` is not an inherited property, though the initial `auto` value makes it behave like it is inherited most of the time. WebKit/Chromium-based browsers _do_ implement the property as inherited, which violates the behavior described in the spec, and this will bring some issues. Until now, Chromium chooses to [fix the issues](https://chromium.googlesource.com/chromium/src/+/b01af0b296ecb855aac95c4ed335d188e6eac2de), make the final behavior meets the specifications.
+> **Note:** `user-select` is not an inherited property, though the initial `auto` value makes it behave like it is inherited most of the time. WebKit/Chromium-based browsers _do_ implement the property as inherited, which violates the behavior described in the spec, and this will bring some issues. Until now, Chromium has chosen to [fix the issues](https://chromium.googlesource.com/chromium/src/+/b01af0b296ecb855aac95c4ed335d188e6eac2de) to make the final behavior meet the specifications.
 
 ### Values
 
@@ -96,7 +96,7 @@ user-select: unset;
 }
 ```
 
-> **Note:** `-webkit-user-select: all;` doesn't work in Safari; use only "none" or "text", or else it will allow typing in the `<html>` container. See the [browser compatability table](#browser-compatibility) for up to date information.
+> **Note:** `-webkit-user-select: all;` doesn't work in Safari; use only "none" or "text", or else it will allow typing in the `<html>` container. See the [browser compatability table](#browser-compatibility) for up-to-date information.
 
 ### Result
 

--- a/files/en-us/web/css/writing-mode/index.md
+++ b/files/en-us/web/css/writing-mode/index.md
@@ -148,32 +148,22 @@ The CSS that adjusts the directionality of the content looks like this:
 ```css
 .example.Text1 span, .example.Text1 {
   writing-mode: horizontal-tb;
-  -webkit-writing-mode: horizontal-tb;
-  -ms-writing-mode: horizontal-tb;
 }
 
 .example.Text2 span, .example.Text2 {
   writing-mode: vertical-lr;
-  -webkit-writing-mode: vertical-lr;
-  -ms-writing-mode: vertical-lr;
 }
 
 .example.Text3 span, .example.Text3 {
   writing-mode: vertical-rl;
-  -webkit-writing-mode: vertical-rl;
-  -ms-writing-mode: vertical-rl;
 }
 
 .example.Text4 span, .example.Text4 {
   writing-mode: sideways-lr;
-  -webkit-writing-mode: sideways-lr;
-  -ms-writing-mode: sideways-lr;
 }
 
 .example.Text5 span, .example.Text5 {
   writing-mode: sideways-rl;
-  -webkit-writing-mode: sideways-rl;
-  -ms-writing-mode: sideways-rl;
 }
 ```
 


### PR DESCRIPTION
I had some issues with github today, but this should be OK.

[Remove prefix: supported without prefix](https://github.com/mdn/content/commit/53fa629e3b73f87dd657d122587b4cc6354e4167)
[Remove prefix: prefix should NOT be in syntax box](https://github.com/mdn/content/commit/ce2764c3aeaf8b3c6d3647125a6517f91a7d70c8)
[Remove prefix: all browsers support none value for user select](https://github.com/mdn/content/commit/fd5870832795e9e3f8a3edf8596c8ab7b235d0c1)
[IE is -ms-](https://github.com/mdn/content/commit/5b4ac2db1c73ee5247531a3d10a825aea8b157eb)<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
