### PR TITLE
Update BCD info, part 21

### DIFF
--- a/files/en-us/web/api/directoryentrysync/index.md
+++ b/files/en-us/web/api/directoryentrysync/index.md
@@ -9,9 +9,10 @@ tags:
   - Offline
   - Reference
   - filesystem
+  - Non-standard
 browser-compat: api.DirectoryEntrySync
 ---
-{{APIRef("File and Directory Entries API")}}{{Non-standard_header}}
+{{APIRef("File and Directory Entries API")}}{{Non-standard_Header}}
 
 The `DirectoryEntrySync` interface represents a directory in a file system. It includes methods for creating, reading, looking up, and recursively removing files in a directory.
 

--- a/files/en-us/web/api/directoryreadersync/index.md
+++ b/files/en-us/web/api/directoryreadersync/index.md
@@ -5,9 +5,10 @@ page-type: web-api-interface
 tags:
   - API
   - Reference
+  - Non-standard
 browser-compat: api.DirectoryReaderSync
 ---
-{{APIRef("File and Directory Entries API")}}{{Non-standard_header}}
+{{APIRef("File and Directory Entries API")}}{{Non-standard_Header}}
 
 The `DirectoryReaderSync` interface lets you read the entries in a directory.
 

--- a/files/en-us/web/api/document/visibilitystate/index.md
+++ b/files/en-us/web/api/document/visibilitystate/index.md
@@ -12,7 +12,7 @@ tags:
   - Web
 browser-compat: api.Document.visibilityState
 ---
-{{ ApiRef("DOM") }}
+{{ApiRef("DOM")}}
 
 The **`Document.visibilityState`**
 read-only property returns the visibility of the {{domxref('document')}}, that is in
@@ -29,7 +29,7 @@ values are:
   - : The page content is not visible to the user. In practice this means that the
     document is either a background tab or part of a minimized window, or the OS screen
     lock is active.
-- `prerender` {{deprecated_inline}}
+- `prerender` {{Deprecated_Inline}} {{Non-standard_Inline}}
   - : The page content is being prerendered and is not visible to the user (considered
     hidden for purposes of
     [`document.hidden`](/en-US/docs/Web/API/Document/hidden)). The

--- a/files/en-us/web/api/element/ariarelevant/index.md
+++ b/files/en-us/web/api/element/ariarelevant/index.md
@@ -10,9 +10,10 @@ tags:
   - AriaAttributes
   - AriaMixin
   - Element
+  - Non-standard
 browser-compat: api.Element.ariaRelevant
 ---
-{{DefaultAPISidebar("DOM")}}{{SeeCompatTable}}
+{{APIRef("DOM")}}{{Non-standard_Header}}
 
 The **`ariaRelevant`** property of the {{domxref("Element")}} interface reflects the value of the [`aria-relevant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant) attribute, which indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified. This is used to describe what changes in an `aria-live` region are relevant and should be announced.
 

--- a/files/en-us/web/api/federatedcredential/federatedcredential/index.md
+++ b/files/en-us/web/api/federatedcredential/federatedcredential/index.md
@@ -10,9 +10,10 @@ tags:
   - NeedsExample
   - Reference
   - credential management
+  - Experimental
 browser-compat: api.FederatedCredential.FederatedCredential
 ---
-{{APIRef("Credential Management API")}}{{Non-standard_header}}
+{{APIRef("Credential Management API")}}{{SeeCompatTable}}
 
 The **`FederatedCredential()`**
 constructor creates a new {{domxref("FederatedCredential")}} object. In

--- a/files/en-us/web/api/file/lastmodifieddate/index.md
+++ b/files/en-us/web/api/file/lastmodifieddate/index.md
@@ -12,9 +12,10 @@ tags:
   - Read-only
   - Reference
   - lastModifiedDate
+  - Non-standard
 browser-compat: api.File.lastModifiedDate
 ---
-{{APIRef("File API") }} {{deprecated_header}}
+{{APIRef("File API")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The **`File.lastModifiedDate`** read-only property returns the last modified date of the file. Files without a known last modified date returns the current date .
 

--- a/files/en-us/web/api/filesystemdirectoryentry/removerecursively/index.md
+++ b/files/en-us/web/api/filesystemdirectoryentry/removerecursively/index.md
@@ -14,7 +14,7 @@ tags:
   - Deprecated
 browser-compat: api.FileSystemDirectoryEntry.removeRecursively
 ---
-{{APIRef("File and Directory Entries API")}}{{deprecated_header}}{{SeeCompatTable}}
+{{APIRef("File and Directory Entries API")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The {{domxref("FileSystemDirectoryEntry")}} interface's method
 **`removeRecursively()`** removes

--- a/files/en-us/web/api/filesystementry/copyto/index.md
+++ b/files/en-us/web/api/filesystementry/copyto/index.md
@@ -14,7 +14,7 @@ tags:
   - Deprecated
 browser-compat: api.FileSystemEntry.copyTo
 ---
-{{APIRef("File and Directory Entries API")}}{{deprecated_header}}
+{{APIRef("File and Directory Entries API")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The {{domxref("FileSystemEntry")}} interface's method
 **`copyTo()`** copies the file

--- a/files/en-us/web/api/filesystementry/getmetadata/index.md
+++ b/files/en-us/web/api/filesystementry/getmetadata/index.md
@@ -14,7 +14,7 @@ tags:
   - Deprecated
 browser-compat: api.FileSystemEntry.getMetadata
 ---
-{{APIRef("File and Directory Entries API")}}{{deprecated_header}}
+{{APIRef("File and Directory Entries API")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The {{domxref("FileSystemEntry")}} interface's method
 **`getMetadata()`** obtains a

--- a/files/en-us/web/api/filesystementry/moveto/index.md
+++ b/files/en-us/web/api/filesystementry/moveto/index.md
@@ -14,7 +14,7 @@ tags:
   - Deprecated
 browser-compat: api.FileSystemEntry.moveTo
 ---
-{{APIRef("File and Directory Entries API")}}{{deprecated_header}}
+{{APIRef("File and Directory Entries API")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The {{domxref("FileSystemEntry")}} interface's method
 **`moveTo()`** moves the file

--- a/files/en-us/web/api/filesystementry/remove/index.md
+++ b/files/en-us/web/api/filesystementry/remove/index.md
@@ -15,7 +15,7 @@ tags:
   - Deprecated
 browser-compat: api.FileSystemEntry.remove
 ---
-{{APIRef("File and Directory Entries API")}}{{deprecated_header}}
+{{APIRef("File and Directory Entries API")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The {{domxref("FileSystemEntry")}} interface's method
 **`remove()`** deletes the file

--- a/files/en-us/web/api/filesystementry/tourl/index.md
+++ b/files/en-us/web/api/filesystementry/tourl/index.md
@@ -14,7 +14,7 @@ tags:
   - Deprecated
 browser-compat: api.FileSystemEntry.toURL
 ---
-{{APIRef("File and Directory Entry API")}}{{deprecated_header}}
+{{APIRef("File and Directory Entry API")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The {{domxref("FileSystemEntry")}} interface's method
 **`toURL()`** creates and

--- a/files/en-us/web/api/gamepad/displayid/index.md
+++ b/files/en-us/web/api/gamepad/displayid/index.md
@@ -12,9 +12,10 @@ tags:
   - WebVR
   - displayId
   - Deprecated
+  - Non-standard
 browser-compat: api.Gamepad.displayId
 ---
-{{DefaultAPISidebar("WebVR API")}}{{Deprecated_Header}}
+{{APIRef("WebVR API")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The **`displayId`** read-only property of the {{domxref("Gamepad")}} interface _returns the {{domxref("VRDisplay.displayId")}} of the associated {{domxref("VRDisplay")}} — the `VRDisplay` that the gamepad is controlling the displayed scene of._
 

--- a/files/en-us/web/api/gamepad/vibrationactuator/index.md
+++ b/files/en-us/web/api/gamepad/vibrationactuator/index.md
@@ -10,9 +10,10 @@ tags:
   - Property
   - Reference
   - vibrationActuator
+  - Non-standard
 browser-compat: api.Gamepad.vibrationActuator
 ---
-{{APIRef("Gamepad")}}{{SeeCompatTable}}
+{{APIRef("Gamepad")}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 The **`vibrationActuator`** read-only property of the {{domxref("Gamepad")}} interface returns a {{domxref("GamepadHapticActuator")}} object, which represents haptic feedback hardware available on the controller.
 

--- a/files/en-us/web/api/gamepadhapticactuator/playeffect/index.md
+++ b/files/en-us/web/api/gamepadhapticactuator/playeffect/index.md
@@ -11,9 +11,10 @@ tags:
   - Method
   - Reference
   - playEffect
+  - Non-standard
 browser-compat: api.GamepadHapticActuator.playEffect
 ---
-{{APIRef("Gamepad")}}{{SeeCompatTable}}
+{{APIRef("Gamepad")}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 The **`playEffect()`** method of the {{domxref("GamepadHapticActuator")}} interface makes the hardware play a specific vibration pattern.
 

--- a/files/en-us/web/api/htmlcanvaselement/mozfetchasstream/index.md
+++ b/files/en-us/web/api/htmlcanvaselement/mozfetchasstream/index.md
@@ -9,9 +9,10 @@ tags:
   - Method
   - Reference
   - Deprecated
+  - Non-standard
 browser-compat: api.HTMLCanvasElement.mozFetchAsStream
 ---
-{{APIRef("Canvas API")}} {{deprecated_header}}
+{{APIRef("Canvas API")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The **`HTMLCanvasElement.mozFetchAsStream()`** internal method
 used to create a new input stream that, when ready, would provide the contents of the

--- a/files/en-us/web/api/htmlcontentelement/getdistributednodes/index.md
+++ b/files/en-us/web/api/htmlcontentelement/getdistributednodes/index.md
@@ -9,9 +9,10 @@ tags:
   - Reference
   - Web Components
   - Deprecated
+  - Non-standard
 browser-compat: api.HTMLContentElement.getDistributedNodes
 ---
-{{ APIRef("Web Components") }}{{Deprecated_header}}
+{{APIRef("Web Components")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The **`HTMLContentElement.getDistributedNodes()`** method
 returns a static {{domxref("NodeList")}} of the {{glossary("distributed nodes")}}

--- a/files/en-us/web/api/htmlcontentelement/select/index.md
+++ b/files/en-us/web/api/htmlcontentelement/select/index.md
@@ -9,9 +9,10 @@ tags:
   - Reference
   - Web Components
   - Deprecated
+  - Non-standard
 browser-compat: api.HTMLContentElement.select
 ---
-{{ APIRef("Web Components") }}{{Deprecated_header}}
+{{APIRef("Web Components")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The **`HTMLContentElement.select`** property reflects the
 `select` attribute. It is a string containing a

--- a/files/en-us/web/api/htmlelement/contextmenu/index.md
+++ b/files/en-us/web/api/htmlelement/contextmenu/index.md
@@ -11,9 +11,10 @@ tags:
   - Property
   - Reference
   - UX
+  - Non-standard
 browser-compat: api.HTMLElement.contextMenu
 ---
-{{APIRef("HTML DOM")}}{{Deprecated_Header}}
+{{APIRef("HTML DOM")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The **`HTMLElement.contextMenu`** property refers to the
 context menu assigned to an element using the {{htmlattrxref("contextmenu")}}

--- a/files/en-us/web/api/htmliframeelement/allowpaymentrequest/index.md
+++ b/files/en-us/web/api/htmliframeelement/allowpaymentrequest/index.md
@@ -12,9 +12,10 @@ tags:
   - Reference HTMLIFrameElement
   - allowPaymentRequest
   - Deprecated
+  - Non-standard
 browser-compat: api.HTMLIFrameElement.allowPaymentRequest
 ---
-{{APIRef("HTML DOM")}}{{deprecated_header}}{{non-standard_header}}
+{{APIRef("HTML DOM")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The **`allowPaymentRequest`** property of the
 {{domxref("HTMLIFrameElement")}} interface returns a boolean value indicating

--- a/files/en-us/web/api/htmlkeygenelement/index.md
+++ b/files/en-us/web/api/htmlkeygenelement/index.md
@@ -9,9 +9,10 @@ tags:
   - NeedsNewLayout
   - Reference
   - Deprecated
+  - Non-standard
 browser-compat: api.HTMLKeygenElement
 ---
-{{deprecated_header}} {{ APIRef("HTML DOM") }}
+{{APIRef("HTML DOM")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 > **Note:** This page describes the Keygen Element interface as specified, not as currently implemented by Gecko. See {{Bug(101019)}} for details and status.
 

--- a/files/en-us/web/api/htmlmediaelement/controller/index.md
+++ b/files/en-us/web/api/htmlmediaelement/controller/index.md
@@ -9,9 +9,10 @@ tags:
   - Property
   - Web
   - Deprecated
+  - Non-standard
 browser-compat: api.HTMLMediaElement.controller
 ---
-{{APIRef("HTML DOM")}}{{deprecated_header}}
+{{APIRef("HTML DOM")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The **`HTMLMediaElement.controller`** property represents the media controller assigned to the element.
 

--- a/files/en-us/web/api/htmlmediaelement/mediagroup/index.md
+++ b/files/en-us/web/api/htmlmediaelement/mediagroup/index.md
@@ -9,9 +9,10 @@ tags:
   - Property
   - Web
   - Deprecated
+  - Non-standard
 browser-compat: api.HTMLMediaElement.mediaGroup
 ---
-{{APIRef("HTML DOM")}}{{deprecated_header}}
+{{APIRef("HTML DOM")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The **`HTMLMediaElement.mediaGroup`** property reflects the {{htmlattrxref("mediaGroup", "video")}} HTML attribute, which indicates the name of the group of elements it belongs to. A group of media elements shares a common `controller`.
 

--- a/files/en-us/web/api/htmlmenuitemelement/index.md
+++ b/files/en-us/web/api/htmlmenuitemelement/index.md
@@ -9,9 +9,10 @@ tags:
   - HTMLMenuItemElement
   - Interface
   - Reference
+  - Non-standard
 browser-compat: api.HTMLMenuItemElement
 ---
-{{APIRef("HTML DOM")}}{{Deprecated_Header}}
+{{APIRef("HTML DOM")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The **`HTMLMenuItemElement`** interface provides special properties (beyond those defined on the regular {{DOMxRef("HTMLElement")}} interface it also has available to it by inheritance) for manipulating {{HTMLElement("menuitem")}} elements.
 

--- a/files/en-us/web/api/htmlshadowelement/getdistributednodes/index.md
+++ b/files/en-us/web/api/htmlshadowelement/getdistributednodes/index.md
@@ -9,9 +9,10 @@ tags:
   - Reference
   - Web Components
   - Deprecated
+  - Non-standard
 browser-compat: api.HTMLShadowElement.getDistributedNodes
 ---
-{{APIRef("Web Components")}}{{Deprecated_header}}
+{{APIRef("Web Components")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The **`HTMLShadowElement.getDistributedNodes()`** method
 returns a static {{domxref("NodeList")}} of the {{glossary("distributed nodes")}}

--- a/files/en-us/web/api/idbindex/isautolocale/index.md
+++ b/files/en-us/web/api/idbindex/isautolocale/index.md
@@ -12,9 +12,10 @@ tags:
   - Reference
   - Storage
   - isAutoLocale
+  - Non-standard
 browser-compat: api.IDBIndex.isAutoLocale
 ---
-{{APIRef("IndexedDB")}}{{SeeCompatTable}}
+{{APIRef("IndexedDB")}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 The **`isAutoLocale`** read-only property of the {{domxref("IDBIndex")}} interface returns a boolean value indicating whether the index had a `locale` value of `auto` specified upon its creation (see [`createIndex()`'s optionalParameters](/en-US/docs/Web/API/IDBObjectStore/createIndex#parameters).)
 

--- a/files/en-us/web/api/idbindex/locale/index.md
+++ b/files/en-us/web/api/idbindex/locale/index.md
@@ -12,9 +12,10 @@ tags:
   - Property
   - Reference
   - Storage
+  - Non-standard
 browser-compat: api.IDBIndex.locale
 ---
-{{APIRef("IndexedDB")}}{{SeeCompatTable}}
+{{APIRef("IndexedDB")}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 The **`locale`** read-only property of the {{domxref("IDBIndex")}} interface returns the locale of the index (for example `en-US`, or `pl`) if it had a `locale` value specified upon its creation (see [`createIndex()`'s optionalParameters](/en-US/docs/Web/API/IDBObjectStore/createIndex#parameters).) Note that this property always returns the current locale being used in this index, in other words, it never returns `"auto"`.
 

--- a/files/en-us/web/api/idblocaleawarekeyrange/index.md
+++ b/files/en-us/web/api/idblocaleawarekeyrange/index.md
@@ -11,9 +11,10 @@ tags:
   - Interface
   - Reference
   - Storage
+  - Non-standard
 browser-compat: api.IDBLocaleAwareKeyRange
 ---
-{{non-standard_header}}{{APIRef("IndexedDB")}}{{SeeCompatTable}}
+{{APIRef("IndexedDB")}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 The **`IDBLocaleAwareKeyRange`** interface of the [IndexedDB API](/en-US/docs/Web/API/IndexedDB_API) is a Firefox-specific version of {{domxref("IDBKeyRange")}} — it functions in exactly the same fashion, and has the same properties and methods, but it is intended for use with {{domxref("IDBIndex")}} objects when the original index had a `locale` value specified upon its creation (see [`createIndex()`'s optionalParameters](/en-US/docs/Web/API/IDBObjectStore/createIndex#parameters)) — that is, it has [locale aware sorting](/en-US/docs/Web/API/IndexedDB_API/Using_IndexedDB#locale-aware_sorting) enabled.
 

--- a/files/en-us/web/api/keyboardevent/charcode/index.md
+++ b/files/en-us/web/api/keyboardevent/charcode/index.md
@@ -11,7 +11,7 @@ tags:
   - Reference
 browser-compat: api.KeyboardEvent.charCode
 ---
-{{APIRef("UI Events")}} {{non-standard_header}} {{deprecated_header}}
+{{APIRef("UI Events")}}{{Deprecated_Header}}
 
 The **`charCode`** read-only property of the
 {{domxref("KeyboardEvent")}} interface returns the Unicode value of a character key

--- a/files/en-us/web/api/mediastreamevent/mediastreamevent/index.md
+++ b/files/en-us/web/api/mediastreamevent/mediastreamevent/index.md
@@ -11,7 +11,7 @@ tags:
   - WebRTC
 browser-compat: api.MediaStreamEvent.MediaStreamEvent
 ---
-{{APIRef("WebRTC")}}{{deprecated_header}}
+{{APIRef("WebRTC")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The **`MediaStreamEvent()`** constructor creates a new {{domxref("MediaStreamEvent")}} object.
 


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.

Deprecation related changes are done. This focuses on `non-standard` status related changes.