### PR TITLE
Update BCD info, part 22

### DIFF
--- a/files/en-us/web/api/mediastreamtrack/overconstrained_event/index.md
+++ b/files/en-us/web/api/mediastreamtrack/overconstrained_event/index.md
@@ -9,9 +9,10 @@ tags:
   - Event
   - Reference
   - WebRTC
+  - Non-standard
 browser-compat: api.MediaStreamTrack.overconstrained_event
 ---
-{{ APIRef("Media Capture and Streams") }}{{deprecated_header}}
+{{APIRef("Media Capture and Streams")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The **`overconstrained`** event fires when the track has too many conflicting constraints.
 

--- a/files/en-us/web/api/mediastreamtrack/remote/index.md
+++ b/files/en-us/web/api/mediastreamtrack/remote/index.md
@@ -9,9 +9,10 @@ tags:
   - Read-only
   - Reference
   - WebRTC
+  - Non-standard
 browser-compat: api.MediaStreamTrack.remote
 ---
-{{APIRef("Media Capture and Streams")}}{{deprecated_header}}
+{{APIRef("Media Capture and Streams")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The **`MediaStreamTrack.remote`** read-only property allows Javascript to know whether a WebRTC MediaStreamTrack is from a remote source or a local one.
 It returns a boolean value that is `true` if the track is sourced remotely (that is, sourced by an {{domxref("RTCPeerConnection")}}), or `false` if it is sourced locally.

--- a/files/en-us/web/api/mediastreamtrackgenerator/mediastreamtrackgenerator/index.md
+++ b/files/en-us/web/api/mediastreamtrackgenerator/mediastreamtrackgenerator/index.md
@@ -7,9 +7,11 @@ tags:
   - Constructor
   - Reference
   - MediaStreamTrackGenerator
+  - Experimental
+  - Non-standard
 browser-compat: api.MediaStreamTrackGenerator.MediaStreamTrackGenerator
 ---
-{{DefaultAPISidebar("Insertable Streams for MediaStreamTrack API")}}
+{{APIRef("Insertable Streams for MediaStreamTrack API")}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 The **`MediaStreamTrackGenerator()`** constructor creates a new {{domxref("MediaStreamTrackGenerator")}} object which consumes a stream of media frames and exposes a {{domxref("MediaStreamTrack")}}.
 

--- a/files/en-us/web/api/mediastreamtrackgenerator/writable/index.md
+++ b/files/en-us/web/api/mediastreamtrackgenerator/writable/index.md
@@ -8,9 +8,11 @@ tags:
   - Reference
   - writable
   - MediaStreamTrackGenerator
+  - Experimental
+  - Non-standard
 browser-compat: api.MediaStreamTrackGenerator.writable
 ---
-{{DefaultAPISidebar("Insertable Streams for MediaStreamTrack API")}}
+{{APIRef("Insertable Streams for MediaStreamTrack API")}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 The **`writable`**  property of the {{domxref("MediaStreamTrackGenerator")}} interface returns a {{domxref("WritableStream")}}. This allows the writing of media frames to the `MediaStreamTrackGenerator`. The frames will be audio or video. The type is dictated by the kind of `MediaStreamTrackGenerator` that was created.
 

--- a/files/en-us/web/api/mediastreamtrackprocessor/mediastreamtrackprocessor/index.md
+++ b/files/en-us/web/api/mediastreamtrackprocessor/mediastreamtrackprocessor/index.md
@@ -7,9 +7,11 @@ tags:
   - Constructor
   - Reference
   - MediaStreamTrackProcessor
+  - Experimental
+  - Non-standard
 browser-compat: api.MediaStreamTrackProcessor.MediaStreamTrackProcessor
 ---
-{{DefaultAPISidebar("Insertable Streams for MediaStreamTrack API")}}
+{{APIRef("Insertable Streams for MediaStreamTrack API")}}{{SeeCompatTable}}{{Non-standard_Header}}
 
 The **`MediaStreamTrackProcessor()`** constructor creates a new {{domxref("MediaStreamTrackProcessor")}} object which consumes a {{domxref("MediaStreamTrack")}} object's source and generates a stream of media frames.
 

--- a/files/en-us/web/api/mouseevent/layerx/index.md
+++ b/files/en-us/web/api/mouseevent/layerx/index.md
@@ -9,9 +9,10 @@ tags:
   - Read-only
   - Reference
   - MouseEvent
+  - Non-standard
 browser-compat: api.MouseEvent.layerX
 ---
-{{APIRef("UI Events")}} {{Non-standard_header}}
+{{APIRef("UI Events")}}{{Non-standard_Header}}
 
 The **`MouseEvent.layerX`** read-only property returns the
 horizontal coordinate of the event relative to the current layer.

--- a/files/en-us/web/api/mouseevent/layery/index.md
+++ b/files/en-us/web/api/mouseevent/layery/index.md
@@ -9,9 +9,10 @@ tags:
   - Read-only
   - Reference
   - MouseEvent
+  - Non-standard
 browser-compat: api.MouseEvent.layerY
 ---
-{{APIRef("UI Events")}}{{Non-standard_header}}
+{{APIRef("UI Events")}}{{Non-standard_Header}}
 
 The **`MouseEvent.layerY`** read-only property returns the
 vertical coordinate of the event relative to the current layer.

--- a/files/en-us/web/api/mousescrollevent/index.md
+++ b/files/en-us/web/api/mousescrollevent/index.md
@@ -10,9 +10,10 @@ tags:
   - Event
   - Interface
   - Reference
+  - Non-standard
 browser-compat: api.MouseScrollEvent
 ---
-{{APIRef("UI Events")}}{{ non-standard_header() }}{{deprecated_header}}
+{{APIRef("UI Events")}}{{ Non-standard_Header }}{{Deprecated_Header}}
 
 The **`MouseScrollEvent`** interface represents events that occur due to the user moving a mouse wheel or similar input device.
 

--- a/files/en-us/web/api/navigator/activevrdisplays/index.md
+++ b/files/en-us/web/api/navigator/activevrdisplays/index.md
@@ -13,9 +13,10 @@ tags:
   - Virtual Reality
   - WebVR
   - activeVRDisplays
+  - Non-standard
 browser-compat: api.Navigator.activeVRDisplays
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebVR API")}}{{deprecated_header}}
+{{APIRef("WebVR API")}}{{SecureContext_Header}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The **`activeVRDisplays`** read-only property of the
 {{domxref("Navigator")}} interface returns an array containing every

--- a/files/en-us/web/api/navigator/buildid/index.md
+++ b/files/en-us/web/api/navigator/buildid/index.md
@@ -8,9 +8,10 @@ tags:
   - HTML DOM
   - Navigator
   - Property
+  - Non-standard
 browser-compat: api.Navigator.buildID
 ---
-{{ ApiRef("HTML DOM") }}
+{{ApiRef("HTML DOM")}}{{Non-standard_Header}}
 
 Returns the build identifier of the browser. In modern browsers this property now returns a fixed timestamp as a privacy measure, e.g. `20181001000000` in Firefox 64 onwards.
 

--- a/files/en-us/web/api/navigator/getvrdisplays/index.md
+++ b/files/en-us/web/api/navigator/getvrdisplays/index.md
@@ -14,9 +14,10 @@ tags:
   - Virtual Reality
   - WebVR
   - getVRDisplays()
+  - Non-standard
 browser-compat: api.Navigator.getVRDisplays
 ---
-{{DefaultAPISidebar("WebVR API")}}{{deprecated_header}}
+{{APIRef("WebVR API")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The **`getVRDisplays()`** method of the
 {{domxref("Navigator")}} interface returns a promise that resolves to an array of

--- a/files/en-us/web/api/passwordcredential/passwordcredential/index.md
+++ b/files/en-us/web/api/passwordcredential/passwordcredential/index.md
@@ -9,9 +9,10 @@ tags:
   - PasswordCredential
   - Reference
   - credential management
+  - Experimental
 browser-compat: api.PasswordCredential.PasswordCredential
 ---
-{{APIRef("Credential Management API")}}{{Non-standard_header}}
+{{APIRef("Credential Management API")}}{{SeeCompatTable}}
 
 The **`PasswordCredential()`**
 constructor creates a new {{domxref("PasswordCredential")}} object. In

--- a/files/en-us/web/api/paymentrequest/merchantvalidation_event/index.md
+++ b/files/en-us/web/api/paymentrequest/merchantvalidation_event/index.md
@@ -19,7 +19,7 @@ tags:
   - Deprecated
 browser-compat: api.PaymentRequest.merchantvalidation_event
 ---
-{{APIRef("Payment Request API")}}{{SecureContext_Header}}{{Deprecated_Header}}{{Non-standard_Header}}
+{{APIRef("Payment Request API")}}{{SecureContext_Header}}{{Deprecated_Header}}
 
 **`merchantvalidation`** events are delivered by the [Payment Request API](/en-US/docs/Web/API/Payment_Request_API) to a {{domxref("PaymentRequest")}} object when a payment handler requires that the merchant requesting the purchase validate itself as permitted to use the payment handler.
 

--- a/files/en-us/web/api/presentationrequest/presentationrequest/index.md
+++ b/files/en-us/web/api/presentationrequest/presentationrequest/index.md
@@ -11,7 +11,7 @@ tags:
   - Reference
 browser-compat: api.PresentationRequest.PresentationRequest
 ---
-{{DefaultAPISidebar("Presentation API")}}{{Non-standard_header}}
+{{APIRef("Presentation API")}}{{SeeCompatTable}}
 
 The **`PresentationRequest()`**
 constructor creates a new {{domxref("PresentationRequest")}} object which creates a

--- a/files/en-us/web/api/rtcdatachannel/reliable/index.md
+++ b/files/en-us/web/api/rtcdatachannel/reliable/index.md
@@ -12,7 +12,7 @@ tags:
   - reliable
 browser-compat: api.RTCDataChannel.reliable
 ---
-{{APIRef("WebRTC")}}{{deprecated_header}}
+{{APIRef("WebRTC")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The read-only `RTCDataChannel` property
 **`reliable`** indicates whether or not the data channel is

--- a/files/en-us/web/api/rtcicecandidatepairstats/readable/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/readable/index.md
@@ -15,9 +15,10 @@ tags:
   - WebRTC
   - WebRTC API
   - readable
+  - Non-standard
 browser-compat: api.RTCIceCandidatePairStats.readable
 ---
-{{APIRef("WebRTC")}}{{deprecated_header}}
+{{APIRef("WebRTC")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The _obsolete_ {{domxref("RTCIceCandidatePairStats")}}
 property **`readable`** reports whether or not the connection

--- a/files/en-us/web/api/rtcicecandidatepairstats/writable/index.md
+++ b/files/en-us/web/api/rtcicecandidatepairstats/writable/index.md
@@ -15,9 +15,10 @@ tags:
   - WebRTC
   - WebRTC API
   - writable
+  - Non-standard
 browser-compat: api.RTCIceCandidatePairStats.writable
 ---
-{{APIRef("WebRTC")}}{{deprecated_header}}
+{{APIRef("WebRTC")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The _obsolete_ {{domxref("RTCIceCandidatePairStats")}}
 property **`writable`** reports whether or not the connection

--- a/files/en-us/web/api/rtcpeerconnection/addstream_event/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addstream_event/index.md
@@ -14,9 +14,10 @@ tags:
   - WebRTC API
   - addStream
   - events
+  - Non-standard
 browser-compat: api.RTCPeerConnection.addstream_event
 ---
-{{APIRef("WebRTC")}}{{deprecated_header}}
+{{APIRef("WebRTC")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The obsolete **`addstream`** event is sent to an {{domxref("RTCPeerConnection")}} when new media, in the form of a {{domxref("MediaStream")}} object, has been added to it.
 
@@ -46,7 +47,7 @@ An {{domxref("MediaStreamEvent")}}. Inherits from {{domxref("Event")}}.
 
 _A {{domxref("MediaStreamEvent")}} being an {{domxref("Event")}}, this event also implements these properties_.
 
-- {{domxref("MediaStreamEvent.stream")}} {{readOnlyInline}}
+- {{domxref("MediaStreamEvent.stream")}} {{ReadOnlyInline}}
   - : Contains the {{domxref("MediaStream")}} containing the stream associated with the event.
 
 ## Examples

--- a/files/en-us/web/api/rtcpeerconnection/removestream/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/removestream/index.md
@@ -10,9 +10,10 @@ tags:
   - Reference
   - WebRTC
   - removeStream
+  - Non-standard
 browser-compat: api.RTCPeerConnection.removeStream
 ---
-{{APIRef("WebRTC")}}{{deprecated_header}}
+{{APIRef("WebRTC")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The
 **`RTCPeerConnection.removeStream()`** method removes a

--- a/files/en-us/web/api/rtcpeerconnection/removestream_event/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/removestream_event/index.md
@@ -16,9 +16,10 @@ tags:
   - WebRTC API
   - removeStream
   - Deprecated
+  - Non-standard
 browser-compat: api.RTCPeerConnection.removestream_event
 ---
-{{APIRef("WebRTC")}}{{deprecated_header}}
+{{APIRef("WebRTC")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The obsolete **`removestream`** event was sent to an {{domxref("RTCPeerConnection")}} to inform it that a {{domxref("MediaStream")}} had been removed from the connection.
 You can use the `RTCPeerConnection` interface's `onremovestream` property to set a handler for this event.
@@ -49,7 +50,7 @@ An {{domxref("MediaStreamEvent")}}. Inherits from {{domxref("Event")}}.
 
 _A {{domxref("MediaStreamEvent")}} being an {{domxref("Event")}}, this event also implements these properties_.
 
-- {{domxref("MediaStreamEvent.stream")}} {{readOnlyInline}}
+- {{domxref("MediaStreamEvent.stream")}} {{ReadOnlyInline}}
   - : Contains the {{domxref("MediaStream")}} containing the stream associated with the event.
 
 ## Browser compatibility

--- a/files/en-us/web/api/screen/orientationchange_event/index.md
+++ b/files/en-us/web/api/screen/orientationchange_event/index.md
@@ -9,9 +9,10 @@ tags:
   - Event Handler
   - Property
   - Screen Orientation
+  - Non-standard
 browser-compat: api.Screen.orientationchange_event
 ---
-{{APIRef("Screen Orientation API")}}{{Deprecated_Header}}
+{{APIRef("Screen Orientation API")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The `orientationchange` event fires when the device's orientation has changed.
 

--- a/files/en-us/web/api/selection/modify/index.md
+++ b/files/en-us/web/api/selection/modify/index.md
@@ -8,12 +8,11 @@ tags:
   - API:WebKit Extensions
   - HTML Editing
   - Method
-  - Non-standard
   - Reference
   - Selection
 browser-compat: api.Selection.modify
 ---
-{{APIRef("DOM")}}{{Non-standard_Header}}
+{{APIRef("DOM")}}
 
 The **`Selection.modify()`** method applies a change to the
 current selection or cursor position, using simple textual commands.

--- a/files/en-us/web/api/serviceworkerregistration/sync/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/sync/index.md
@@ -12,7 +12,7 @@ tags:
   - Sync
 browser-compat: api.ServiceWorkerRegistration.sync
 ---
-{{Non-standard_header}}{{APIRef("Service Workers API")}}
+{{APIRef("Service Workers API")}}{{SeeCompatTable}}
 
 The **`sync`** property of the
 {{domxref("ServiceWorkerRegistration")}} interface returns a reference to the

--- a/files/en-us/web/api/sourcebuffer/changetype/index.md
+++ b/files/en-us/web/api/sourcebuffer/changetype/index.md
@@ -10,13 +10,12 @@ tags:
   - Media Source
   - Media Source Extensions
   - Method
-  - Non-standard
   - SourceBuffer
   - Video
   - changeType
 browser-compat: api.SourceBuffer.changeType
 ---
-{{APIRef("Media Source Extensions")}}{{SeeCompatTable}}{{Non-standard_Header}}
+{{APIRef("Media Source Extensions")}}
 
 The **`changeType()`** method of the
 {{domxref("SourceBuffer")}} interface sets the MIME type that future calls to

--- a/files/en-us/web/api/speechgrammar/speechgrammar/index.md
+++ b/files/en-us/web/api/speechgrammar/speechgrammar/index.md
@@ -11,9 +11,10 @@ tags:
   - Web
   - Web Speech API
   - speech
+  - Non-standard
 browser-compat: api.SpeechGrammar.SpeechGrammar
 ---
-{{APIRef("Web Speech API")}}{{Non-standard_header}}
+{{APIRef("Web Speech API")}}{{Non-standard_Header}}{{SeeCompatTable}}
 
 The **`SpeechGrammar()`** constructor of the
 {{domxref("SpeechGrammar")}} interface creates a new `SpeechGrammar` object

--- a/files/en-us/web/api/syncmanager/gettags/index.md
+++ b/files/en-us/web/api/syncmanager/gettags/index.md
@@ -12,7 +12,7 @@ tags:
   - getTags
 browser-compat: api.SyncManager.getTags
 ---
-{{APIRef("Service Workers API")}}{{Non-standard_header}}
+{{APIRef("Service Workers API")}}{{SeeCompatTable}}
 
 The **`SyncManager.getTags`** method of the
 {{domxref("SyncManager")}} interface returns a list of developer-defined identifiers for

--- a/files/en-us/web/api/syncmanager/register/index.md
+++ b/files/en-us/web/api/syncmanager/register/index.md
@@ -12,7 +12,7 @@ tags:
   - register
 browser-compat: api.SyncManager.register
 ---
-{{APIRef("Service Workers API")}}{{Non-standard_header}}
+{{APIRef("Service Workers API")}}{{SeeCompatTable}}
 
 The **`SyncManager.register`** method of the
 {{domxref("SyncManager")}} interface returns a {{jsxref("Promise")}} that resolves to a

--- a/files/en-us/web/api/transitionevent/inittransitionevent/index.md
+++ b/files/en-us/web/api/transitionevent/inittransitionevent/index.md
@@ -11,9 +11,10 @@ tags:
   - Method
   - Reference
   - TransitionEvent
+  - Non-standard
 browser-compat: api.TransitionEvent.initTransitionEvent
 ---
-{{ apiref("CSSOM") }} {{deprecated_header}}{{non-standard_header}}
+{{ apiref("CSSOM") }}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The **`TransitionEvent.initTransitionEvent()`** method
 Initializes a transition event created using the deprecated

--- a/files/en-us/web/api/vrdisplay/cancelanimationframe/index.md
+++ b/files/en-us/web/api/vrdisplay/cancelanimationframe/index.md
@@ -12,9 +12,10 @@ tags:
   - Virtual Reality
   - WebVR
   - cancelAnimationFrame()
+  - Non-standard
 browser-compat: api.VRDisplay.cancelAnimationFrame
 ---
-{{APIRef("WebVR API")}}{{Deprecated_Header}}
+{{APIRef("WebVR API")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The **`cancelAnimationFrame()`** method of the {{domxref("VRDisplay")}} interface is a special implementation of {{domxref("Window.cancelAnimationFrame")}} that unregisters callbacks registered with {{domxref("VRDisplay.requestAnimationFrame()")}}.
 

--- a/files/en-us/web/api/vrdisplay/capabilities/index.md
+++ b/files/en-us/web/api/vrdisplay/capabilities/index.md
@@ -12,9 +12,10 @@ tags:
   - Virtual Reality
   - WebVR
   - capabilities
+  - Non-standard
 browser-compat: api.VRDisplay.capabilities
 ---
-{{APIRef("WebVR API")}}{{Deprecated_Header}}
+{{APIRef("WebVR API")}}{{Deprecated_Header}}{{Non-standard_Header}}
 
 The **`capabilities`** read-only property of the {{domxref("VRDisplay")}} interface returns a {{domxref("VRDisplayCapabilities")}} object that indicates the various capabilities of the `VRDisplay`.
 


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.
This focuses on `non-standard` status related changes.