### PR TITLE
Change position of RenewBookModelForm warning

### DIFF
--- a/files/en-us/learn/server-side/django/testing/index.md
+++ b/files/en-us/learn/server-side/django/testing/index.md
@@ -480,7 +480,7 @@ The rest of the functions test that the form is valid for renewal dates just ins
 >
 > We also need to validate that the correct errors are raised if the form is invalid, however this is usually done as part of view processing, so we'll take care of that in the next section.
 
-> **Warning:** If you use the form class `RenewBookModelForm(forms.ModelForm)` instead of class `RenewBookForm(forms.Form)`, then the form field name is **'due_back'** instead of **'renewal_date'**.
+> **Warning:** If you use the [ModelForm](/en-US/docs/Learn/Server-side/Django/Forms#modelforms) class `RenewBookModelForm(forms.ModelForm)` instead of class `RenewBookForm(forms.Form)`, then the form field name would be **'due_back'** instead of **'renewal_date'**.
 
 That's all for forms; we do have some others, but they are automatically created by our generic class-based editing views, and should be tested there! Run the tests and confirm that our code still passes!
 

--- a/files/en-us/learn/server-side/django/testing/index.md
+++ b/files/en-us/learn/server-side/django/testing/index.md
@@ -480,6 +480,8 @@ The rest of the functions test that the form is valid for renewal dates just ins
 >
 > We also need to validate that the correct errors are raised if the form is invalid, however this is usually done as part of view processing, so we'll take care of that in the next section.
 
+> **Warning:** If you use the form class `RenewBookModelForm(forms.ModelForm)` instead of class `RenewBookForm(forms.Form)`, then the form field name is **'due_back'** instead of **'renewal_date'**.
+
 That's all for forms; we do have some others, but they are automatically created by our generic class-based editing views, and should be tested there! Run the tests and confirm that our code still passes!
 
 ### Views
@@ -875,8 +877,6 @@ Add the next test method, as shown below. This checks that the initial date for 
         date_3_weeks_in_future = datetime.date.today() + datetime.timedelta(weeks=3)
         self.assertEqual(response.context['form'].initial['renewal_date'], date_3_weeks_in_future)
 ```
-
-> **Warning:** If you use the form class `RenewBookModelForm(forms.ModelForm)` instead of class `RenewBookForm(forms.Form)`, then the form field name is **'due_back'** instead of **'renewal_date'**.
 
 The next test (add this to the class too) checks that the view redirects to a list of all borrowed books if renewal succeeds. What differs here is that for the first time we show how you can `POST` data using the client. The post _data_ is the second argument to the post function, and is specified as a dictionary of key/values.
 


### PR DESCRIPTION
The form class RenewBookModelForm is used instead of RenewBookForm first when creating Form test case.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Change position of RenewBookModelForm warning because the form class RenewBookModelForm is used instead of RenewBookForm first when creating Form test case.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
Help people who use RenewBookModelForm instead of RenewBookForm can easily spot the difference.
#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
