### PR TITLE
[relnote] Reflects support for two contain property values

### DIFF
--- a/files/en-us/mozilla/firefox/releases/101/index.md
+++ b/files/en-us/mozilla/firefox/releases/101/index.md
@@ -23,7 +23,7 @@ No notable changes.
 
 - Three new viewport sizes have been introduced: small (`s`), large (`l`), and dynamic (`d`). These new sizes have added new [viewport-percentage length units](/en-US/docs/Web/CSS/length) in addition to the existing ones - `vh`, `vw`, `vmax`, and `vmin`. The new viewport-percentage length units include `svh`, `lvh`, `dvh`, `svw`, `lvw`, `dvw`, `svmax`, `lvmax`, `dvmax`, `svmin`, `lvmin`, and `dvmin` ({{bug(1610815)}}). Additionally, the units `vb` and `vi` are now supported by default ({{bug(1610815)}}).
 
-- Support for the new `inline-size` value for the [`contain`](/en-US/docs/Web/CSS/contain) property has been added. For more information, see  ({{bug(1755565)}}).
+- Support for the [`inline-size`](/en-US/docs/Web/CSS/contain#inline-size) value for the `contain` property has been added. For more information, see  ({{bug(1755565)}}).
 
 ### JavaScript
 

--- a/files/en-us/mozilla/firefox/releases/101/index.md
+++ b/files/en-us/mozilla/firefox/releases/101/index.md
@@ -23,6 +23,8 @@ No notable changes.
 
 - Three new viewport sizes have been introduced: small (`s`), large (`l`), and dynamic (`d`). These new sizes have added new [viewport-percentage length units](/en-US/docs/Web/CSS/length) in addition to the existing ones - `vh`, `vw`, `vmax`, and `vmin`. The new viewport-percentage length units include `svh`, `lvh`, `dvh`, `svw`, `lvw`, `dvw`, `svmax`, `lvmax`, `dvmax`, `svmin`, `lvmin`, and `dvmin` ({{bug(1610815)}}). Additionally, the units `vb` and `vi` are now supported by default ({{bug(1610815)}}).
 
+- Support for the new `inline-size` value for the [`contain`](/en-US/docs/Web/CSS/contain) property has been added. For more information, see  ({{bug(1755565)}}).
+
 ### JavaScript
 
 No notable changes.

--- a/files/en-us/mozilla/firefox/releases/103/index.md
+++ b/files/en-us/mozilla/firefox/releases/103/index.md
@@ -28,6 +28,7 @@ This article provides information about the changes in Firefox 103 that will aff
 - The {{CSSxRef("backdrop-filter")}} property (which can be used to apply graphical effects such as blurring or color shifting to the area behind an element) is now available by default. It was earlier behind a preference setting ({{bug(1578503)}}).
 - The {{CSSxRef("scroll-snap-stop")}} property is now available ({{bug(1312165)}}). You can use this property's `always` and `normal` values to specify whether or not to pass the snap points, even when scrolling fast.
 - Support has been added for the {{CSSxRef(":modal")}} pseudo class. It selects all elements that are in a state in which they exclude all interaction with other elements until the interaction has been dismissed ({{bug(1768535)}}).
+- The [`style`](/en-US/docs/Web/CSS/contain#style) value for the `contain` property is now supported. You can use this value for properties that can have effects on more than just an element and its descendants for effects don't escape the containing element. For more information, see ({{bug(1463600)}}).
 
 #### Removals
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Indicates support for two `contain` property values:
- `inline-size` in FF101
- `style` in FF103

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Doc issue tracker for `inline-size`: https://github.com/mdn/content/issues/18758
Doc issue tracker for `style`: https://github.com/mdn/content/issues/19452

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
