### PR TITLE
Remove reference to setVersion method.

### DIFF
--- a/files/en-us/web/api/idbtransaction/index.md
+++ b/files/en-us/web/api/idbtransaction/index.md
@@ -129,16 +129,9 @@ Transactions can have one of three modes:
       <td>"versionchange" (2 in Chrome)</td>
       <td>
         Allows any operation to be performed, including ones that delete and
-        create object stores and indexes. This mode is for updating the version
-        number of transactions that were started using the
-        <a href="/en-US/docs/Web/API/IDBDatabase#setversion"
-          ><code>setVersion()</code></a
-        >
-        method of
-        <a href="/en-US/docs/Web/API/IDBDatabase">IDBDatabase</a> objects.
-        Transactions of this mode cannot run concurrently with other
-        transactions. Transactions in this mode are known as "upgrade
-        transactions."
+        create object stores and indexes. Transactions of this mode cannot run
+        concurrently with other transactions. Transactions in this mode are
+        known as "upgrade transactions."
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
Since the setVersion method on IDBDatabase is deprecated, including it here is confusing.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
