### PR TITLE
Update information about the framebuffer parameter

### DIFF
--- a/files/en-us/web/api/webglrenderingcontext/bindframebuffer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/bindframebuffer/index.md
@@ -13,8 +13,7 @@ browser-compat: api.WebGLRenderingContext.bindFramebuffer
 {{APIRef("WebGL")}}
 
 The **`WebGLRenderingContext.bindFramebuffer()`** method of the
-[WebGL API](/en-US/docs/Web/API/WebGL_API) binds a given
-{{domxref("WebGLFramebuffer")}} to a target.
+[WebGL API](/en-US/docs/Web/API/WebGL_API) binds to the specified target the default {{domxref("WebGLFramebuffer")}}, or, if the second argument is non-null, the provided {{domxref("WebGLFramebuffer")}}.
 
 ## Syntax
 
@@ -41,8 +40,7 @@ bindFramebuffer(target, framebuffer)
       - : Used as a source for reading operations such as `gl.readPixels` and `gl.blitFramebuffer`.
 
 - `framebuffer`
-  - : A {{domxref("WebGLFramebuffer")}} object to bind.
-    If `framebuffer` is null, then the canvas (which has no {{domxref("WebGLFramebuffer")}} object) is bound.
+  - : A {{domxref("WebGLFramebuffer")}} object to bind, or [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) for binding the {{domxref("Canvas")}} or {{domxref("OffscreenCanvas")}} object associated with the rendering context.
 
 ### Return value
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

Clarified the text for the second parameter (`framebuffer`) and updated the text for the overall purpose of the function

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

The preexisting text  is vague about what is bound to the target in case `null` is provided.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
frameBuffer: https://registry.khronos.org/webgl/specs/latest/2.0/#3.7.1
Canvas, OffscreenCanvas: https://registry.khronos.org/webgl/specs/latest/2.0/#2

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

https://github.com/mdn/content/issues/1578

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
