### PR TITLE
Change arrow function in .get() to anonymous function

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/mongoose/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/mongoose/index.md
@@ -656,7 +656,7 @@ AuthorSchema
 // Virtual for author's URL
 AuthorSchema
   .virtual('url')
-  .get(() => {
+  .get(function() {
     return `/catalog/author/${this._id}`;
   });
 
@@ -695,7 +695,7 @@ const BookSchema = new Schema(
 // Virtual for book's URL
 BookSchema
   .virtual('url')
-  .get(() => {
+  .get(function() {
     return '/catalog/book/' + this._id;
   });
 
@@ -730,7 +730,7 @@ const BookInstanceSchema = new Schema(
 // Virtual for bookinstance's URL
 BookInstanceSchema
   .virtual('url')
-  .get(() => {
+  .get(function() {
     return `/catalog/bookinstance/${this._id}`;
   });
 

--- a/files/en-us/learn/server-side/express_nodejs/mongoose/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/mongoose/index.md
@@ -656,7 +656,7 @@ AuthorSchema
 // Virtual for author's URL
 AuthorSchema
   .virtual('url')
-  .get(function() {
+  .get(function() { // We don't use an arrow function as we'll need the this object
     return `/catalog/author/${this._id}`;
   });
 
@@ -695,7 +695,7 @@ const BookSchema = new Schema(
 // Virtual for book's URL
 BookSchema
   .virtual('url')
-  .get(function() {
+  .get(function() { // We don't use an arrow function as we'll need the this object
     return '/catalog/book/' + this._id;
   });
 
@@ -730,7 +730,7 @@ const BookInstanceSchema = new Schema(
 // Virtual for bookinstance's URL
 BookInstanceSchema
   .virtual('url')
-  .get(function() {
+  .get(function() { // We don't use an arrow function as we'll need the this object
     return `/catalog/bookinstance/${this._id}`;
   });
 


### PR DESCRIPTION
#### Summary
In the sample code of https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/mongoose we are passing in an arrow function to .get() which means we don't have access to 'this' 
I have updated the example to use an anonymous function instead of an arrow function so we still have access to this._id

```
Cast to ObjectId failed for value "undefined" (type string) at path "_id" for model "genre"
CastError: Cast to ObjectId failed for value "undefined" (type string) at path "_id" for model "genre"
...
```


#### Motivation
Updating so once the user gets to this section https://developer.mozilla.org/en-US/docs/Learn/Server-side/Express_Nodejs/Displaying_data/Genre_detail_page their code will actually work and they won't have to google the reason as to why this._id returns undefined.



#### Supporting details
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#Lexical_this

There is a note saying to use mongoose.Types.ObjectId() but that doesn't work because there is no id to convert.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
