### PR TITLE
HSTS: clarify behavior when only HTTP used

### DIFF
--- a/files/en-us/web/http/headers/strict-transport-security/index.md
+++ b/files/en-us/web/http/headers/strict-transport-security/index.md
@@ -56,6 +56,7 @@ The HTTP Strict Transport Security header informs the browser that it should nev
 
 > **Note:** The `Strict-Transport-Security` header is **ignored** by the browser when your site has only been accessed using HTTP.
 > Once your site is accessed over HTTPS with no certificate errors, the browser knows your site is HTTPS capable and will honor the `Strict-Transport-Security` header.
+> Browsers do this as attackers may intercept HTTP connections to the site and inject or remove the header.
 
 ### An example scenario
 

--- a/files/en-us/web/http/headers/strict-transport-security/index.md
+++ b/files/en-us/web/http/headers/strict-transport-security/index.md
@@ -54,9 +54,8 @@ The redirect could be exploited to direct visitors to a malicious site instead o
 
 The HTTP Strict Transport Security header informs the browser that it should never load a site using HTTP and should automatically convert all attempts to access the site using HTTP to HTTPS requests instead.
 
-> **Note:** The `Strict-Transport-Security` header is **ignored** by the browser when your site is accessed using HTTP;
-> this is because an attacker may intercept HTTP connections and inject the header or remove it.
-> When your site is accessed over HTTPS with no certificate errors, the browser knows your site is HTTPS capable and will honor the `Strict-Transport-Security` header.
+> **Note:** The `Strict-Transport-Security` header is **ignored** by the browser when your site has only been accessed using HTTP.
+> Once your site is accessed over HTTPS with no certificate errors, the browser knows your site is HTTPS capable and will honor the `Strict-Transport-Security` header.
 
 ### An example scenario
 

--- a/files/en-us/web/http/headers/strict-transport-security/index.md
+++ b/files/en-us/web/http/headers/strict-transport-security/index.md
@@ -54,7 +54,7 @@ The redirect could be exploited to direct visitors to a malicious site instead o
 
 The HTTP Strict Transport Security header informs the browser that it should never load a site using HTTP and should automatically convert all attempts to access the site using HTTP to HTTPS requests instead.
 
-> **Note:** The `Strict-Transport-Security` header is **ignored** by the browser when your site has only been accessed using HTTP.
+> **Note:** The `Strict-Transport-Security` header is _ignored_ by the browser when your site has only been accessed using HTTP.
 > Once your site is accessed over HTTPS with no certificate errors, the browser knows your site is HTTPS capable and will honor the `Strict-Transport-Security` header.
 > Browsers do this as attackers may intercept HTTP connections to the site and inject or remove the header.
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
This PR clarifies the note on [/docs/Web/HTTP/Headers/Strict-Transport-Security#description](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security#description) that describes the browser's behavior when it encounters the `Strict-Transport-Security` header over HTTP.  I've tweaked the verbiage just slightly to clarify that the `Strict-Transport-Security` header will be ignored when the site has only been accessed via HTTP, and once the site has been accessed via HTTPS then subsequent HTTP requests will be converted to HTTPS.

I removed the bit about attackers injecting/removing the header based on feedback from the linked issue, but let me know if it is preferred to keep this.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The user who submitted the original issue https://github.com/mdn/content/issues/1378 was confused by this note since it seems to contradict the rest of the doc. This clarification will help future readers avoid the same confusion.

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Resolves https://github.com/mdn/content/issues/1378

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
