### PR TITLE
fix(functions/set): return val argument back

### DIFF
--- a/files/en-us/web/javascript/reference/functions/set/index.md
+++ b/files/en-us/web/javascript/reference/functions/set/index.md
@@ -20,8 +20,8 @@ property.
 ## Syntax
 
 ```js
-{ set prop() { /* … */ } }
-{ set [expression]() { /* … */ } }
+{ set prop(val) { /* … */ } }
+{ set [expression](val) { /* … */ } }
 ```
 
 ### Parameters


### PR DESCRIPTION
 



<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Hello, it looks like syntax got a little broken after this [automatic(?) commit](https://github.com/mdn/content/commit/a6785a8e4ddad80069acf2de418235c0640688e7#diff-a463e2df163ccc60d9a1b7626d5b5c20f5396baa34bba3cc4011b64317607b11), which removed value argument for a setter.

I wonder if there are more cases like this one

#### Motivation
Fixing a mistake

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
