### PR TITLE
`BeforeUnloadEvent` clarifications

### DIFF
--- a/files/en-us/web/api/beforeunloadevent/index.md
+++ b/files/en-us/web/api/beforeunloadevent/index.md
@@ -9,9 +9,9 @@ browser-compat: api.BeforeUnloadEvent
 ---
 {{APIRef}}
 
-`BeforeUnloadEvent` is an interface for the {{domxref("Window/beforeunload_event", "beforeunload")}} event.
+**`BeforeUnloadEvent`** is an interface for the {{domxref("Window/beforeunload_event", "beforeunload")}} event.
 
-The **`beforeunload`** event is fired when the window, the document and its resources are about to be unloaded.
+The `beforeunload` event is fired when the window, the document and its resources are about to be unloaded.
 
 When a non-empty string is assigned to the `returnValue` Event property, a dialog box appears, asking the users for confirmation to leave the page (see example below). When no value is provided, the event is processed silently. Some implementations only show the dialog box if the frame or any embedded frame receives a user gesture or user interaction. See [Browser compatibility](#browser_compatibility) for more information.
 

--- a/files/en-us/web/api/beforeunloadevent/index.md
+++ b/files/en-us/web/api/beforeunloadevent/index.md
@@ -13,6 +13,10 @@ The **`beforeunload`** event is fired when the window, the document and its reso
 
 When a non-empty string is assigned to the `returnValue` Event property, a dialog box appears, asking the users for confirmation to leave the page (see example below). When no value is provided, the event is processed silently. Some implementations only show the dialog box if the frame or any embedded frame receives a user gesture or user interaction. See [Browser compatibility](#browser_compatibility) for more information.
 
+> **Note:** In older browsers, the `returnValue` of the event was displayed in the dialog box. 
+> Starting with Firefox 44, Chrome 51, Opera 38, and Safari 9.1, a generic string not under the control of the webpage is shown instead of the returned string.
+
+
 {{InheritanceDiagram}}
 
 <table class="properties">

--- a/files/en-us/web/api/beforeunloadevent/index.md
+++ b/files/en-us/web/api/beforeunloadevent/index.md
@@ -15,8 +15,7 @@ The `beforeunload` event is fired when the window, the document and its resource
 
 When a non-empty string is assigned to the `returnValue` Event property, a dialog box appears, asking the users for confirmation to leave the page (see example below). When no value is provided, the event is processed silently. Some implementations only show the dialog box if the frame or any embedded frame receives a user gesture or user interaction. See [Browser compatibility](#browser_compatibility) for more information.
 
-> **Note:** In older browsers, the `returnValue` of the event was displayed in the dialog box. 
-> Starting with Firefox 44, Chrome 51, Opera 38, and Safari 9.1, a generic string not under the control of the webpage is shown instead of the returned string.
+> **Note:** For security reasons, only a generic string not under the control of the webpage is shown instead of the returned string.
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/beforeunloadevent/index.md
+++ b/files/en-us/web/api/beforeunloadevent/index.md
@@ -18,7 +18,6 @@ When a non-empty string is assigned to the `returnValue` Event property, a dialo
 > **Note:** In older browsers, the `returnValue` of the event was displayed in the dialog box. 
 > Starting with Firefox 44, Chrome 51, Opera 38, and Safari 9.1, a generic string not under the control of the webpage is shown instead of the returned string.
 
-
 {{InheritanceDiagram}}
 
 <table class="properties">

--- a/files/en-us/web/api/beforeunloadevent/index.md
+++ b/files/en-us/web/api/beforeunloadevent/index.md
@@ -9,6 +9,8 @@ browser-compat: api.BeforeUnloadEvent
 ---
 {{APIRef}}
 
+`BeforeUnloadEvent` is an interface for the {{domxref("Window/beforeunload_event", "beforeunload")}} event.
+
 The **`beforeunload`** event is fired when the window, the document and its resources are about to be unloaded.
 
 When a non-empty string is assigned to the `returnValue` Event property, a dialog box appears, asking the users for confirmation to leave the page (see example below). When no value is provided, the event is processed silently. Some implementations only show the dialog box if the frame or any embedded frame receives a user gesture or user interaction. See [Browser compatibility](#browser_compatibility) for more information.

--- a/files/en-us/web/api/window/beforeunload_event/index.md
+++ b/files/en-us/web/api/window/beforeunload_event/index.md
@@ -31,7 +31,7 @@ onbeforeunload = (event) => { };
 
 ## Event type
 
-A generic {{domxref("Event")}}.
+A {{domxref("BeforeUnloadEvent")}}. Inherits from {{domxref("Event")}}.
 
 ## Event handler aliases
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

* I updated the "[`BeforeUnloadEvent`](https://developer.mozilla.org/en-US/docs/Web/API/BeforeUnloadEvent)" doc to specify that the `BeforeUnloadEvent` is an interface for the `beforeunload` event. I also added a note about current browsers not displaying the `returnValue` in the dialog box that is presented.
* I updated the "[Window: `beforeunload` event](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event)" doc to clarify that the event type is a `BeforeUnloadEvent` rather than a generic `Event`.  

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
The user who initially reported https://github.com/mdn/content/issues/16226 asked for a note to be added about modern browsers not displaying the `returnValue`. While working on this I felt that it was worth adding a few clarifications to help future readers understand the relationship / distinction between the two docs.


#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
JSFiddle that shows that the event is a `BeforeUnloadEvent` rather than a generic `Event`: https://jsfiddle.net/82sn3vmk/

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->
Resolves https://github.com/mdn/content/issues/16226

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
