### PR TITLE
Update BCD info, part 27

### DIFF
--- a/files/en-us/web/api/ambientlightsensor/ambientlightsensor/index.md
+++ b/files/en-us/web/api/ambientlightsensor/ambientlightsensor/index.md
@@ -8,9 +8,10 @@ tags:
   - AmbientLightSensor
   - Constructor
   - Reference
+  - Experimental
 browser-compat: api.AmbientLightSensor.AmbientLightSensor
 ---
-{{APIRef("Sensor API")}}
+{{APIRef("Sensor API")}}{{SeeCompatTable}}
 
 The **`AmbientLightSensor()`** constructor creates a new {{domxref("AmbientLightSensor")}} object, which returns the current light level or illuminance of the ambient light around the hosting device.
 

--- a/files/en-us/web/api/ambientlightsensor/illuminance/index.md
+++ b/files/en-us/web/api/ambientlightsensor/illuminance/index.md
@@ -12,9 +12,10 @@ tags:
   - Sensor APIs
   - Sensors
   - illuminance
+  - Experimental
 browser-compat: api.AmbientLightSensor.illuminance
 ---
-{{APIRef("Sensor API")}}
+{{APIRef("Sensor API")}}{{SeeCompatTable}}
 
 The **`illuminance`** property of the {{domxref("AmbientLightSensor")}} interface returns the current light level in [lux](https://en.wikipedia.org/wiki/Lux) of the ambient light level around the hosting device.
 

--- a/files/en-us/web/api/ambientlightsensor/index.md
+++ b/files/en-us/web/api/ambientlightsensor/index.md
@@ -12,9 +12,10 @@ tags:
   - Sensor
   - Sensor APIs
   - Sensors
+  - Experimental
 browser-compat: api.AmbientLightSensor
 ---
-{{APIRef("Sensor API")}}
+{{APIRef("Sensor API")}}{{SeeCompatTable}}
 
 The **`AmbientLightSensor`** interface of the [Sensor APIs](/en-US/docs/Web/API/Sensor_APIs) returns the current light level or illuminance of the ambient light around the hosting device.
 
@@ -26,12 +27,12 @@ If a feature policy blocks use of a feature it is because your code is inconsist
 
 ## Constructor
 
-- {{domxref("AmbientLightSensor.AmbientLightSensor()", "AmbientLightSensor()")}}
+- {{domxref("AmbientLightSensor.AmbientLightSensor()", "AmbientLightSensor()")}} {{Experimental_Inline}}
   - : Creates a new `AmbientLightSensor` object.
 
 ## Properties
 
-- {{domxref('AmbientLightSensor.illuminance')}}
+- {{domxref('AmbientLightSensor.illuminance')}} {{Experimental_Inline}}
   - : Returns the current light level in [lux](https://en.wikipedia.org/wiki/Lux) of the ambient light level around the hosting device.
 
 ## Methods

--- a/files/en-us/web/api/csstransformcomponent/index.md
+++ b/files/en-us/web/api/csstransformcomponent/index.md
@@ -13,20 +13,20 @@ tags:
   - Reference
 browser-compat: api.CSSTransformComponent
 ---
-{{APIRef("CSS Typed OM")}}
+{{APIRef("CSS Typed OM")}}{{SeeCompatTable}}
 
 The **`CSSTransformComponent`** interface of the {{domxref('CSS_Object_Model#css_typed_object_model','','',' ')}} is part of the {{domxref('CSSTransformValue')}} interface.
 
 ## Properties
 
-- {{domxref("CSSTransformComponent.is2D")}} {{ReadOnlyInline}}
+- {{domxref("CSSTransformComponent.is2D")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a boolean indicting whether the transform is 2D or 3D.
 
 ## Methods
 
-- {{domxref("CSSTransformComponent.toMatrix()")}}
+- {{domxref("CSSTransformComponent.toMatrix()")}} {{Experimental_Inline}}
   - : Returns a new {{domxref('DOMMatrix')}} object.
-- {{domxref("CSSTransformComponent.toString()")}}
+- {{domxref("CSSTransformComponent.toString()")}} {{Experimental_Inline}}
 
   - : A string in the form of a CSS {{cssxref("transform-function","Transforms function")}}.
 

--- a/files/en-us/web/api/customstateset/index.md
+++ b/files/en-us/web/api/customstateset/index.md
@@ -7,9 +7,10 @@ tags:
   - Interface
   - Reference
   - CustomStateSet
+  - Experimental
 browser-compat: api.CustomStateSet
 ---
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}{{SeeCompatTable}}
 
 The **`CustomStateSet`** interface of the [Document Object Model](/en-US/docs/Web/API/Document_Object_Model) stores a list of possible states for a custom element to be in, and allows states to be added and removed from the set.
 
@@ -29,26 +30,26 @@ you can use a custom state pseudo-class to select a custom element that is in a 
 
 ## Properties
 
-- {{domxref("CustomStateSet.size")}}
+- {{domxref("CustomStateSet.size")}} {{Experimental_Inline}}
   - : Returns the number of values in the `CustomStateSet`.
 
 ## Methods
 
-- {{domxref("CustomStateSet.add()")}}
+- {{domxref("CustomStateSet.add()")}} {{Experimental_Inline}}
   - : Adds a value to the set, first checking that the _value_ is a `<dashed-ident>`.
-- {{domxref("CustomStateSet.clear()")}}
+- {{domxref("CustomStateSet.clear()")}} {{Experimental_Inline}}
   - : Removes all elements from the `CustomStateSet` object.
-- {{domxref("CustomStateSet.delete()")}}
+- {{domxref("CustomStateSet.delete()")}} {{Experimental_Inline}}
   - : Removes one value from the `CustomStateSet` object.
-- {{domxref("CustomStateSet.entries()")}}
+- {{domxref("CustomStateSet.entries()")}} {{Experimental_Inline}}
   - : Returns a new iterator with the values for each element in the `CustomStateSet` in insertion order.
-- {{domxref("CustomStateSet.forEach()")}}
+- {{domxref("CustomStateSet.forEach()")}} {{Experimental_Inline}}
   - : Executes a provided function for each value in the `CustomStateSet` object.
-- {{domxref("CustomStateSet.has()")}}
+- {{domxref("CustomStateSet.has()")}} {{Experimental_Inline}}
   - : Returns a {{jsxref("Boolean")}} asserting whether an element is present with the given value.
-- {{domxref("CustomStateSet.keys()")}}
+- {{domxref("CustomStateSet.keys()")}} {{Experimental_Inline}}
   - : An alias for {{domxref("CustomStateSet.values()")}}.
-- {{domxref("CustomStateSet.values()")}}
+- {{domxref("CustomStateSet.values()")}} {{Experimental_Inline}}
   - : Returns a new iterator object that yields the values for each element in the `CustomStateSet` object in insertion order.
 
 ## Examples

--- a/files/en-us/web/api/datatransferitemlist/clear/index.md
+++ b/files/en-us/web/api/datatransferitemlist/clear/index.md
@@ -13,6 +13,8 @@ tags:
   - drag and drop
 browser-compat: api.DataTransferItemList.clear
 ---
+{{APIRef("HTML Drag and Drop API")}}
+
 The {{domxref("DataTransferItemList")}} method
 **`clear()`** removes all {{domxref("DataTransferItem")}}
 objects from the drag data items list, leaving the list empty.
@@ -135,5 +137,3 @@ function dragend_handler(ev) {
 ## Browser compatibility
 
 {{Compat}}
-
-{{APIRef("HTML Drag and Drop API")}}

--- a/files/en-us/web/api/datatransferitemlist/length/index.md
+++ b/files/en-us/web/api/datatransferitemlist/length/index.md
@@ -17,6 +17,8 @@ tags:
   - length
 browser-compat: api.DataTransferItemList.length
 ---
+{{APIRef("HTML Drag and Drop API")}}
+
 The read-only **`length`** property of the
 {{domxref("DataTransferItemList")}} interface returns the number of items currently in
 the drag item list.
@@ -124,5 +126,3 @@ div {
 ## Browser compatibility
 
 {{Compat}}
-
-{{APIRef("HTML Drag and Drop API")}}

--- a/files/en-us/web/api/directoryentrysync/index.md
+++ b/files/en-us/web/api/directoryentrysync/index.md
@@ -10,9 +10,10 @@ tags:
   - Reference
   - filesystem
   - Non-standard
+  - Deprecated
 browser-compat: api.DirectoryEntrySync
 ---
-{{APIRef("File and Directory Entries API")}}{{Non-standard_Header}}
+{{APIRef("File and Directory Entries API")}}{{Non-standard_Header}}{{Deprecated_Header}}
 
 The `DirectoryEntrySync` interface represents a directory in a file system. It includes methods for creating, reading, looking up, and recursively removing files in a directory.
 

--- a/files/en-us/web/api/directoryreadersync/index.md
+++ b/files/en-us/web/api/directoryreadersync/index.md
@@ -6,9 +6,10 @@ tags:
   - API
   - Reference
   - Non-standard
+  - Deprecated
 browser-compat: api.DirectoryReaderSync
 ---
-{{APIRef("File and Directory Entries API")}}{{Non-standard_Header}}
+{{APIRef("File and Directory Entries API")}}{{Non-standard_Header}}{{Deprecated_Header}}
 
 The `DirectoryReaderSync` interface lets you read the entries in a directory.
 

--- a/files/en-us/web/api/document/createevent/index.md
+++ b/files/en-us/web/api/document/createevent/index.md
@@ -9,10 +9,10 @@ tags:
   - Reference
 browser-compat: api.Document.createEvent
 ---
+{{APIRef("DOM")}}
+
 > **Warning:** Many methods used with `createEvent`, such as `initCustomEvent`, are deprecated.
 > Use [event constructors](/en-US/docs/Web/API/CustomEvent) instead.
-
-{{ApiRef("DOM")}}
 
 Creates an [event](/en-US/docs/Web/API/Event) of the type specified. The
 returned object should be first initialized and can then be passed to

--- a/files/en-us/web/api/document/forms/index.md
+++ b/files/en-us/web/api/document/forms/index.md
@@ -13,6 +13,8 @@ tags:
   - Reference
 browser-compat: api.Document.forms
 ---
+{{APIRef("DOM")}}
+
 The **`forms`** read-only property of
 the {{domxref("Document")}} interface returns an {{domxref("HTMLCollection")}} listing
 all the {{HTMLElement("form")}} elements contained in the document.
@@ -103,5 +105,3 @@ const selectFormElement = document.forms[index].elements[index];
 
 - [HTML forms](/en-US/docs/Learn/Forms)
 - {{HTMLElement("form")}} and the {{domxref("HTMLFormElement")}} interface
-
-{{APIRef("DOM")}}

--- a/files/en-us/web/api/element/beforexrselect_event/index.md
+++ b/files/en-us/web/api/element/beforexrselect_event/index.md
@@ -6,9 +6,10 @@ tags:
    - API
    - Event
    - Reference
+   - Experimental
 browser-compat: api.Element.beforexrselect_event
 ---
-{{APIRef}}
+{{APIRef}}{{SeeCompatTable}}
 
 The **`beforexrselect`** event is fired before WebXR select events ({{domxref("XRSession/select_event", "select")}}, {{domxref("XRSession/selectstart_event", "selectstart")}}, {{domxref("XRSession/selectend_event", "selectend")}}) are dispatched. It can be used to suppress XR world input events while the user is interacting with a DOM overlay UI.
 

--- a/files/en-us/web/api/encodedaudiochunk/bytelength/index.md
+++ b/files/en-us/web/api/encodedaudiochunk/bytelength/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - byteLength
   - EncodedAudioChunk
+  - Experimental
 browser-compat: api.EncodedAudioChunk.byteLength
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`byteLength`** read-only property of the {{domxref("EncodedAudioChunk")}} interface returns the length in bytes of the encoded audio data.
 

--- a/files/en-us/web/api/encodedaudiochunk/copyto/index.md
+++ b/files/en-us/web/api/encodedaudiochunk/copyto/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - copyTo
   - EncodedAudioChunk
+  - Experimental
 browser-compat: api.EncodedAudioChunk.copyTo
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`copyTo()`** method of the {{domxref("EncodedAudioChunk")}} interface copies the encoded chunk of audio data.
 

--- a/files/en-us/web/api/encodedaudiochunk/duration/index.md
+++ b/files/en-us/web/api/encodedaudiochunk/duration/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - duration
   - EncodedAudioChunk
+  - Experimental
 browser-compat: api.EncodedAudioChunk.duration
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`duration`** read-only property of the {{domxref("EncodedAudioChunk")}} interface returns an integer indicating the duration of the audio in microseconds.
 

--- a/files/en-us/web/api/encodedaudiochunk/encodedaudiochunk/index.md
+++ b/files/en-us/web/api/encodedaudiochunk/encodedaudiochunk/index.md
@@ -7,9 +7,10 @@ tags:
   - Constructor
   - Reference
   - EncodedAudioChunk
+  - Experimental
 browser-compat: api.EncodedAudioChunk.EncodedAudioChunk
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`EncodedAudioChunk()`** constructor creates a new {{domxref("EncodedAudioChunk")}} object representing a chunk of encoded audio.
 

--- a/files/en-us/web/api/encodedaudiochunk/timestamp/index.md
+++ b/files/en-us/web/api/encodedaudiochunk/timestamp/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - timestamp
   - EncodedAudioChunk
+  - Experimental
 browser-compat: api.EncodedAudioChunk.timestamp
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`timestamp`** read-only property of the {{domxref("EncodedAudioChunk")}} interface returns an integer indicating the timestamp of the audio in microseconds.
 

--- a/files/en-us/web/api/encodedaudiochunk/type/index.md
+++ b/files/en-us/web/api/encodedaudiochunk/type/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - type
   - EncodedAudioChunk
+  - Experimental
 browser-compat: api.EncodedAudioChunk.type
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`type`** read-only property of the {{domxref("EncodedAudioChunk")}} interface returns a value indicating whether the audio chunk is a key chunk, which does not relying on other frames for decoding.
 

--- a/files/en-us/web/api/encodedvideochunk/bytelength/index.md
+++ b/files/en-us/web/api/encodedvideochunk/bytelength/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - byteLength
   - EncodedVideoChunk
+  - Experimental
 browser-compat: api.EncodedVideoChunk.byteLength
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`byteLength`** read-only property of the {{domxref("EncodedVideoChunk")}} interface returns the length in bytes of the encoded video data.
 

--- a/files/en-us/web/api/encodedvideochunk/copyto/index.md
+++ b/files/en-us/web/api/encodedvideochunk/copyto/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - copyTo
   - EncodedVideoChunk
+  - Experimental
 browser-compat: api.EncodedVideoChunk.copyTo
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`copyTo()`** method of the {{domxref("EncodedVideoChunk")}} interface copies the encoded chunk of video data.
 

--- a/files/en-us/web/api/encodedvideochunk/duration/index.md
+++ b/files/en-us/web/api/encodedvideochunk/duration/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - duration
   - EncodedVideoChunk
+  - Experimental
 browser-compat: api.EncodedVideoChunk.duration
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`duration`** read-only property of the {{domxref("EncodedVideoChunk")}} interface returns an integer indicating the duration of the video in microseconds.
 

--- a/files/en-us/web/api/encodedvideochunk/encodedvideochunk/index.md
+++ b/files/en-us/web/api/encodedvideochunk/encodedvideochunk/index.md
@@ -7,9 +7,10 @@ tags:
   - Constructor
   - Reference
   - EncodedVideoChunk
+  - Experimental
 browser-compat: api.EncodedVideoChunk.EncodedVideoChunk
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`EncodedVideoChunk()`** constructor creates a new {{domxref("EncodedVideoChunk")}} object representing a chunk of encoded video.
 

--- a/files/en-us/web/api/encodedvideochunk/timestamp/index.md
+++ b/files/en-us/web/api/encodedvideochunk/timestamp/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - timestamp
   - EncodedVideoChunk
+  - Experimental
 browser-compat: api.EncodedVideoChunk.timestamp
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`timestamp`** read-only property of the {{domxref("EncodedVideoChunk")}} interface returns an integer indicating the timestamp of the video in microseconds.
 

--- a/files/en-us/web/api/encodedvideochunk/type/index.md
+++ b/files/en-us/web/api/encodedvideochunk/type/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - type
   - EncodedVideoChunk
+  - Experimental
 browser-compat: api.EncodedVideoChunk.type
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`type`** read-only property of the {{domxref("EncodedVideoChunk")}} interface returns a value indicating whether the video chunk is a key chunk, which does not rely on other frames for decoding.
 

--- a/files/en-us/web/api/eyedropper/eyedropper/index.md
+++ b/files/en-us/web/api/eyedropper/eyedropper/index.md
@@ -7,6 +7,7 @@ tags:
   - Constructor
   - Reference
   - EyeDropper
+  - Experimental
 browser-compat: api.EyeDropper.EyeDropper
 ---
 {{APIRef("EyeDropper API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/eyedropper/open/index.md
+++ b/files/en-us/web/api/eyedropper/open/index.md
@@ -8,6 +8,7 @@ tags:
   - Reference
   - EyeDropper
   - open
+  - Experimental
 browser-compat: api.EyeDropper.open
 ---
 {{APIRef("EyeDropper API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/featurepolicy/allowedfeatures/index.md
+++ b/files/en-us/web/api/featurepolicy/allowedfeatures/index.md
@@ -9,6 +9,7 @@ tags:
   - Feature-Policy
   - FeaturePolicy
   - Reference
+  - Experimental
 browser-compat: api.FeaturePolicy.allowedFeatures
 ---
 {{APIRef("Feature Policy API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/featurepolicy/getallowlistforfeature/index.md
+++ b/files/en-us/web/api/featurepolicy/getallowlistforfeature/index.md
@@ -7,6 +7,7 @@ tags:
   - Feature Policy
   - Feature-Policy
   - Reference
+  - Experimental
 browser-compat: api.FeaturePolicy.getAllowlistForFeature
 ---
 {{APIRef("Feature Policy API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/federatedcredential/provider/index.md
+++ b/files/en-us/web/api/federatedcredential/provider/index.md
@@ -10,6 +10,7 @@ tags:
   - Property
   - Reference
   - credential management
+  - Experimental
 browser-compat: api.FederatedCredential.provider
 ---
 {{SeeCompatTable}}{{APIRef("Credential Management API")}}

--- a/files/en-us/web/api/fileentrysync/index.md
+++ b/files/en-us/web/api/fileentrysync/index.md
@@ -9,9 +9,10 @@ tags:
   - Interface
   - Non-standard
   - Reference
+  - Deprecated
 browser-compat: api.FileEntrySync
 ---
-{{APIRef("File and Directory Entries API")}} {{Non-standard_header}}
+{{APIRef("File and Directory Entries API")}} {{Non-standard_header}}{{Deprecated_Header}}
 
 The `FileEntrySync` interface represents a file in a file system. It lets you write content to a file.
 


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.

This mainly focuses on adding missing `experimental` headers.