### PR TITLE
Update BCD info, part 28

### DIFF
--- a/files/en-us/web/api/eyedropper/index.md
+++ b/files/en-us/web/api/eyedropper/index.md
@@ -8,6 +8,7 @@ tags:
   - EyeDropper
   - Interface
   - Reference
+  - Experimental
 browser-compat: api.EyeDropper
 ---
 {{securecontext_header}}{{APIRef("EyeDropper API")}}{{SeeCompatTable}}
@@ -16,14 +17,14 @@ The **`EyeDropper`** interface represents an instance of an eyedropper tool that
 
 ## Constructor
 
-- {{DOMxRef("EyeDropper.EyeDropper", "EyeDropper()")}}
+- {{DOMxRef("EyeDropper.EyeDropper", "EyeDropper()")}} {{Experimental_Inline}}
   - : Returns a new `EyeDropper` instance.
 
 ## Methods
 
 _The `EyeDropper` interface doesn't inherit any methods_.
 
-- {{DOMxRef("EyeDropper.open()")}}
+- {{DOMxRef("EyeDropper.open()")}} {{Experimental_Inline}}
   - : Returns a promise that resolves to an object that gives access to the selected color.
 
 ## Examples

--- a/files/en-us/web/api/filereader/readasdataurl/index.md
+++ b/files/en-us/web/api/filereader/readasdataurl/index.md
@@ -12,6 +12,8 @@ tags:
   - Reference
 browser-compat: api.FileReader.readAsDataURL
 ---
+{{APIRef("File API")}}
+
 The `readAsDataURL` method is used to read the contents of the specified
 {{domxref("Blob")}} or {{domxref("File")}}. When the read operation is finished, the
 {{domxref("FileReader.readyState","readyState")}} becomes `DONE`, and the
@@ -126,5 +128,3 @@ function previewFiles() {
 
 - {{domxref("FileReader")}}
 - {{domxref("URL.createObjectURL()")}}
-
-{{APIRef("File API")}}

--- a/files/en-us/web/api/filesystemhandle/querypermission/index.md
+++ b/files/en-us/web/api/filesystemhandle/querypermission/index.md
@@ -8,9 +8,10 @@ tags:
   - File System Access API
   - FileSystemHandle
   - Method
+  - Experimental
 browser-compat: api.FileSystemHandle.queryPermission
 ---
-{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
+{{securecontext_header}}{{APIRef("File System Access API")}}{{SeeCompatTable}}
 
 The **`queryPermission()`** method of the
 {{domxref("FileSystemHandle")}} interface queries the current permission state of the

--- a/files/en-us/web/api/filesystemhandle/requestpermission/index.md
+++ b/files/en-us/web/api/filesystemhandle/requestpermission/index.md
@@ -8,9 +8,10 @@ tags:
   - File System Access API
   - FileSystemHandle
   - Method
+  - Experimental
 browser-compat: api.FileSystemHandle.requestPermission
 ---
-{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
+{{securecontext_header}}{{APIRef("File System Access API")}}{{SeeCompatTable}}
 
 The **`requestPermission()`** method of the
 {{domxref("FileSystemHandle")}} interface requests read or readwrite permissions for the

--- a/files/en-us/web/api/filesystemsync/index.md
+++ b/files/en-us/web/api/filesystemsync/index.md
@@ -10,9 +10,10 @@ tags:
   - Offline
   - filesystem
   - Non-standard
+  - Deprecated
 browser-compat: api.FileSystemSync
 ---
-{{APIRef("File and Directory Entries API")}}{{Non-standard_Header}}
+{{APIRef("File and Directory Entries API")}}{{Non-standard_Header}}{{Deprecated_Header}}
 
 In the [File and Directory Entries API](/en-US/docs/Web/API/File_and_Directory_Entries_API/Introduction), a `FileSystemSync` object represents a file system. It has two properties.
 
@@ -25,9 +26,9 @@ The `FileSystemSync` object is your gateway to the entire API and you will use i
 
 ## Properties
 
-- `name` {{ReadOnlyInline}} {{Non-standard_Inline}}
+- `name` {{ReadOnlyInline}} {{Non-standard_Inline}} {{Deprecated_Inline}}
   - : A string that represents the name of the file system. The name must be unique across the list of exposed file systems.
-- `root` {{ReadOnlyInline}} {{Non-standard_Inline}}
+- `root` {{ReadOnlyInline}} {{Non-standard_Inline}} {{Deprecated_Inline}}
   - : A `DirectoryEntry` that is the root directory of the file system.
 
 ## Specifications

--- a/files/en-us/web/api/filesystemwritablefilestream/seek/index.md
+++ b/files/en-us/web/api/filesystemwritablefilestream/seek/index.md
@@ -9,9 +9,10 @@ tags:
   - Method
   - stream
   - write
+  - Experimental
 browser-compat: api.FileSystemWritableFileStream.seek
 ---
-{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
+{{securecontext_header}}{{APIRef("File System Access API")}}{{SeeCompatTable}}
 
 The **`seek()`** method of the
 {{domxref("FileSystemWritableFileStream")}} interface updates the current file cursor

--- a/files/en-us/web/api/filesystemwritablefilestream/truncate/index.md
+++ b/files/en-us/web/api/filesystemwritablefilestream/truncate/index.md
@@ -9,9 +9,10 @@ tags:
   - Method
   - stream
   - write
+  - Experimental
 browser-compat: api.FileSystemWritableFileStream.truncate
 ---
-{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
+{{securecontext_header}}{{APIRef("File System Access API")}}{{SeeCompatTable}}
 
 The **`truncate()`** method of the
 {{domxref("FileSystemWritableFileStream")}} interface resizes the file associated with

--- a/files/en-us/web/api/filesystemwritablefilestream/write/index.md
+++ b/files/en-us/web/api/filesystemwritablefilestream/write/index.md
@@ -10,9 +10,10 @@ tags:
   - stream
   - working with files
   - write
+  - Experimental
 browser-compat: api.FileSystemWritableFileStream.write
 ---
-{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
+{{securecontext_header}}{{APIRef("File System Access API")}}{{SeeCompatTable}}
 
 The **`write()`** method of the
 {{domxref("FileSystemWritableFileStream")}} interface writes content into the file the

--- a/files/en-us/web/api/htmliframeelement/csp/index.md
+++ b/files/en-us/web/api/htmliframeelement/csp/index.md
@@ -10,9 +10,10 @@ tags:
   - HTMLIFrameElement
   - Property
   - Reference
+  - Experimental
 browser-compat: api.HTMLIFrameElement.csp
 ---
-{{SeeCompatTable}}{{APIRef("HTML DOM")}}
+{{APIRef("HTML DOM")}}{{SeeCompatTable}}
 
 The **`csp`** property of the {{domxref("HTMLIFrameElement")}}
 interface specifies the [Content Security Policy](/en-US/docs/Web/HTTP/CSP) that an

--- a/files/en-us/web/api/htmliframeelement/featurepolicy/index.md
+++ b/files/en-us/web/api/htmliframeelement/featurepolicy/index.md
@@ -9,6 +9,7 @@ tags:
   - HTMLIFrameElement
   - Policy
   - Property
+  - Experimental
 browser-compat: api.HTMLIFrameElement.featurePolicy
 ---
 {{APIRef("Feature Policy API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/htmliframeelement/fetchpriority/index.md
+++ b/files/en-us/web/api/htmliframeelement/fetchpriority/index.md
@@ -9,9 +9,10 @@ tags:
   - Property
   - Reference
   - fetchPriority
+  - Experimental
 browser-compat: api.HTMLIFrameElement.fetchPriority
 ---
-{{APIRef}}
+{{APIRef}}{{SeeCompatTable}}
 
 The **`fetchPriority`** property of the
 {{domxref("HTMLIFrameElement")}} interface represents a hint given to the

--- a/files/en-us/web/api/htmlimageelement/fetchpriority/index.md
+++ b/files/en-us/web/api/htmlimageelement/fetchpriority/index.md
@@ -9,9 +9,10 @@ tags:
   - Property
   - Reference
   - fetchPriority
+  - Experimental
 browser-compat: api.HTMLImageElement.fetchPriority
 ---
-{{APIRef}}
+{{APIRef}}{{SeeCompatTable}}
 
 The **`fetchPriority`** property of the
 {{domxref("HTMLImageElement")}} interface represents a hint given to the browser on how

--- a/files/en-us/web/api/htmllinkelement/fetchpriority/index.md
+++ b/files/en-us/web/api/htmllinkelement/fetchpriority/index.md
@@ -11,6 +11,7 @@ tags:
   - Property
   - Reference
   - fetchPriority
+  - Experimental
 browser-compat: api.HTMLLinkElement.fetchPriority
 ---
 {{SeeCompatTable}}{{APIRef("HTML DOM")}}

--- a/files/en-us/web/api/idle_detection_api/index.md
+++ b/files/en-us/web/api/idle_detection_api/index.md
@@ -7,9 +7,10 @@ tags:
   - IdleDetector
   - Overview
   - Reference
+  - Experimental
 browser-compat: api.IdleDetector
 ---
-{{securecontext_header}}{{DefaultAPISidebar("Idle Detection API")}}
+{{securecontext_header}}{{DefaultAPISidebar("Idle Detection API")}}{{SeeCompatTable}}
 
 The Idle Detection API provides a means to detect the user's idle status, active, idle, and locked, specifically, and to be notified of changes to idle status without polling from a script.
 
@@ -19,7 +20,7 @@ Native applications and browser extensions use idle detection base user experien
 
 ## Interfaces
 
-- {{domxref("IdleDetector")}}
+- {{domxref("IdleDetector")}} {{Experimental_Inline}}
   - : Provides methods and events for detecting user activity on a device or screen.
 
 ## Examples

--- a/files/en-us/web/api/idledetector/change_event/index.md
+++ b/files/en-us/web/api/idledetector/change_event/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - onchange
   - IdleDetector
+  - Experimental
 browser-compat: api.IdleDetector.change_event
 ---
-{{securecontext_header}}{{DefaultAPISidebar("Idle Detection API")}}
+{{securecontext_header}}{{APIRef("Idle Detection API")}}{{SeeCompatTable}}
 
 The **`change`** event of the {{domxref("IdleDetector")}} interface fires when the value of `userState` or `screenState` has changed.
 

--- a/files/en-us/web/api/idledetector/idledetector/index.md
+++ b/files/en-us/web/api/idledetector/idledetector/index.md
@@ -7,9 +7,10 @@ tags:
   - Constructor
   - Reference
   - IdleDetector
+  - Experimental
 browser-compat: api.IdleDetector.IdleDetector
 ---
-{{securecontext_header}}{{DefaultAPISidebar("Idle Detection API")}}
+{{securecontext_header}}{{APIRef("Idle Detection API")}}{{SeeCompatTable}}
 
 The **`IdleDetector()`** constructor creates a new {{domxref("IdleDetector")}}
 object which provides events indicating when the user is no longer interacting

--- a/files/en-us/web/api/idledetector/requestpermission/index.md
+++ b/files/en-us/web/api/idledetector/requestpermission/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - requestPermission
   - IdleDetector
+  - Experimental
 browser-compat: api.IdleDetector.requestPermission
 ---
-{{securecontext_header}}{{DefaultAPISidebar("Idle Detection API")}}
+{{securecontext_header}}{{APIRef("Idle Detection API")}}{{SeeCompatTable}}
 
 The **`requestPermission()`** method of the {{domxref("IdleDetector")}}
 interface returns a {{jsxref('Promise')}} that resolves with a string when the user has chosen

--- a/files/en-us/web/api/idledetector/screenstate/index.md
+++ b/files/en-us/web/api/idledetector/screenstate/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - screenState
   - IdleDetector
+  - Experimental
 browser-compat: api.IdleDetector.screenState
 ---
-{{securecontext_header}}{{DefaultAPISidebar("Idle Detection API")}}
+{{securecontext_header}}{{APIRef("Idle Detection API")}}{{SeeCompatTable}}
 
 The **`screenState`** read-only property of the {{domxref("IdleDetector")}} interface
 returns a string indicating whether the screen is locked, one of `"locked"` or

--- a/files/en-us/web/api/idledetector/start/index.md
+++ b/files/en-us/web/api/idledetector/start/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - start
   - IdleDetector
+  - Experimental
 browser-compat: api.IdleDetector.start
 ---
-{{securecontext_header}}{{DefaultAPISidebar("Idle Detection API")}}
+{{securecontext_header}}{{APIRef("Idle Detection API")}}{{SeeCompatTable}}
 
 The **`start()`** method of the {{domxref("IdleDetector")}} interface returns a
 {{jsxref("Promise")}} that resolves when the detector starts listening for changes in the

--- a/files/en-us/web/api/idledetector/userstate/index.md
+++ b/files/en-us/web/api/idledetector/userstate/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - userState
   - IdleDetector
+  - Experimental
 browser-compat: api.IdleDetector.userState
 ---
-{{securecontext_header}}{{DefaultAPISidebar("Idle Detection API")}}
+{{securecontext_header}}{{APIRef("Idle Detection API")}}{{SeeCompatTable}}
 
 The **`userState`** read-only property of the {{domxref("IdleDetector")}} interface returns a string indicating whether the user has interacted with the device since the call to `start()`.
 

--- a/files/en-us/web/api/imagecapture/getphotocapabilities/index.md
+++ b/files/en-us/web/api/imagecapture/getphotocapabilities/index.md
@@ -15,7 +15,7 @@ tags:
   - getPhotoCapabilities
 browser-compat: api.ImageCapture.getPhotoCapabilities
 ---
-{{APIRef("MediaStream Image")}}
+{{APIRef("MediaStream Image")}}{{SeeCompatTable}}
 
 The **`getPhotoCapabilities()`**
 method of the {{domxref("ImageCapture")}} interface returns a {{jsxref("Promise")}}

--- a/files/en-us/web/api/imagecapture/getphotosettings/index.md
+++ b/files/en-us/web/api/imagecapture/getphotosettings/index.md
@@ -15,7 +15,7 @@ tags:
   - getPhotoSettings
 browser-compat: api.ImageCapture.getPhotoSettings
 ---
-{{APIRef("MediaStream Image")}}
+{{APIRef("MediaStream Image")}}{{SeeCompatTable}}
 
 The **`getPhotoSettings()`** method of
 the {{domxref("ImageCapture")}} interface returns a {{jsxref("Promise")}} that

--- a/files/en-us/web/api/imagecapture/grabframe/index.md
+++ b/files/en-us/web/api/imagecapture/grabframe/index.md
@@ -15,7 +15,7 @@ tags:
   - grabFrame
 browser-compat: api.ImageCapture.grabFrame
 ---
-{{APIRef("MediaStream Image")}}
+{{APIRef("MediaStream Image")}}{{SeeCompatTable}}
 
 The **`grabFrame()`** method of the
 {{domxref("ImageCapture")}} interface takes a snapshot of the live video in a

--- a/files/en-us/web/api/imagecapture/imagecapture/index.md
+++ b/files/en-us/web/api/imagecapture/imagecapture/index.md
@@ -14,7 +14,7 @@ tags:
   - Reference
 browser-compat: api.ImageCapture.ImageCapture
 ---
-{{APIRef("MediaStream Image")}}
+{{APIRef("MediaStream Image")}}{{SeeCompatTable}}
 
 The **`ImageCapture()`** constructor
 creates a new {{domxref("ImageCapture")}} object.

--- a/files/en-us/web/api/imagecapture/takephoto/index.md
+++ b/files/en-us/web/api/imagecapture/takephoto/index.md
@@ -14,7 +14,7 @@ tags:
   - takePhoto
 browser-compat: api.ImageCapture.takePhoto
 ---
-{{APIRef("MediaStream Image")}}
+{{APIRef("MediaStream Image")}}{{SeeCompatTable}}
 
 The **`takePhoto()`** method of the
 {{domxref("ImageCapture")}} interface takes a single exposure using the video capture

--- a/files/en-us/web/api/imagecapture/track/index.md
+++ b/files/en-us/web/api/imagecapture/track/index.md
@@ -14,7 +14,7 @@ tags:
   - Reference
 browser-compat: api.ImageCapture.track
 ---
-{{APIRef("MediaStream Image")}}
+{{APIRef("MediaStream Image")}}{{SeeCompatTable}}
 
 The **`track`** read-only property of the
 {{domxref("ImageCapture")}} interface returns a reference to the

--- a/files/en-us/web/api/imagedecoder/close/index.md
+++ b/files/en-us/web/api/imagedecoder/close/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - close
   - ImageDecoder
+  - Experimental
 browser-compat: api.ImageDecoder.close
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`close()`** method of the {{domxref("ImageDecoder")}} interface ends all pending work and releases system resources.
 

--- a/files/en-us/web/api/imagedecoder/complete/index.md
+++ b/files/en-us/web/api/imagedecoder/complete/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - complete
   - ImageDecoder
+  - Experimental
 browser-compat: api.ImageDecoder.complete
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`complete`** read-only property of the {{domxref("ImageDecoder")}} interface returns true if encoded data has completed buffering.
 

--- a/files/en-us/web/api/imagedecoder/completed/index.md
+++ b/files/en-us/web/api/imagedecoder/completed/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - completed
   - ImageDecoder
+  - Experimental
 browser-compat: api.ImageDecoder.completed
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`completed`** read-only property of the {{domxref("ImageDecoder")}} interface returns a promise that resolves once encoded data has finished buffering.
 

--- a/files/en-us/web/api/imagedecoder/decode/index.md
+++ b/files/en-us/web/api/imagedecoder/decode/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - decode
   - ImageDecoder
+  - Experimental
 browser-compat: api.ImageDecoder.decode
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`decode()`** method of the {{domxref("ImageDecoder")}} interface enqueues a control message to decode the frame of an image.
 


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.

This covers files that have only `experimental` header modifications.