### PR TITLE
Update BCD info, part 29

### DIFF
--- a/files/en-us/web/api/imagedecoder/imagedecoder/index.md
+++ b/files/en-us/web/api/imagedecoder/imagedecoder/index.md
@@ -7,9 +7,10 @@ tags:
   - Constructor
   - Reference
   - ImageDecoder
+  - Experimental
 browser-compat: api.ImageDecoder.ImageDecoder
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`ImageDecoder()`** constructor creates a new {{domxref("ImageDecoder")}} object which unpacks and decodes image data.
 

--- a/files/en-us/web/api/imagedecoder/istypesupported/index.md
+++ b/files/en-us/web/api/imagedecoder/istypesupported/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - isTypeSupported
   - ImageDecoder
+  - Experimental
 browser-compat: api.ImageDecoder.isTypeSupported
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`ImageDecoder.isTypeSupported()`** static method checks if a given [MIME type](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) can be decoded by the user agent.
 

--- a/files/en-us/web/api/imagedecoder/reset/index.md
+++ b/files/en-us/web/api/imagedecoder/reset/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - reset
   - ImageDecoder
+  - Experimental
 browser-compat: api.ImageDecoder.reset
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`reset()`** method of the {{domxref("ImageDecoder")}} interface aborts all pending `decode()` operations; rejecting all pending promises. All other state will be unchanged. Class methods can continue to be invoked after `reset()`. E.g., calling `decode()` after `reset()` is permitted.
 

--- a/files/en-us/web/api/imagedecoder/tracks/index.md
+++ b/files/en-us/web/api/imagedecoder/tracks/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - tracks
   - ImageDecoder
+  - Experimental
 browser-compat: api.ImageDecoder.tracks
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`tracks`** read-only property of the {{domxref("ImageDecoder")}} interface returns a list of the tracks in the encoded image data.
 

--- a/files/en-us/web/api/imagedecoder/type/index.md
+++ b/files/en-us/web/api/imagedecoder/type/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - type
   - ImageDecoder
+  - Experimental
 browser-compat: api.ImageDecoder.type
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`type`** read-only property of the {{domxref("ImageDecoder")}} interface reflects the [MIME type](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types) configured during construction.
 

--- a/files/en-us/web/api/imagetrack/animated/index.md
+++ b/files/en-us/web/api/imagetrack/animated/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - animated
   - ImageTrack
+  - Experimental
 browser-compat: api.ImageTrack.animated
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`animated`** property of the {{domxref("ImageTrack")}} interface returns `true` if the track is animated and therefore has multiple frames.
 

--- a/files/en-us/web/api/imagetrack/framecount/index.md
+++ b/files/en-us/web/api/imagetrack/framecount/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - frameCount
   - ImageTrack
+  - Experimental
 browser-compat: api.ImageTrack.frameCount
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`frameCount`** property of the {{domxref("ImageTrack")}} interface returns the number of frames in the track.
 

--- a/files/en-us/web/api/imagetrack/repetitioncount/index.md
+++ b/files/en-us/web/api/imagetrack/repetitioncount/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - repetitionCount
   - ImageTrack
+  - Experimental
 browser-compat: api.ImageTrack.repetitionCount
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`repetitionCount`**  property of the {{domxref("ImageTrack")}} interface returns the number of repetitions of this track.
 

--- a/files/en-us/web/api/imagetrack/selected/index.md
+++ b/files/en-us/web/api/imagetrack/selected/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - selected
   - ImageTrack
+  - Experimental
 browser-compat: api.ImageTrack.selected
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`selected`** property of the {{domxref("ImageTrack")}} interface returns `true` if the track is selected for decoding.
 

--- a/files/en-us/web/api/imagetracklist/length/index.md
+++ b/files/en-us/web/api/imagetracklist/length/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - length
   - ImageTrackList
+  - Experimental
 browser-compat: api.ImageTrackList.length
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`length`** property of the {{domxref("ImageTrackList")}} interface returns the length of the `ImageTrackList`.
 

--- a/files/en-us/web/api/imagetracklist/ready/index.md
+++ b/files/en-us/web/api/imagetracklist/ready/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - ready
   - ImageTrackList
+  - Experimental
 browser-compat: api.ImageTrackList.ready
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`ready`** property of the {{domxref("ImageTrackList")}} interface returns a {{jsxref("Promise")}} that resolves when the `ImageTrackList` is populated with {{domxref("ImageTrack","tracks")}}.
 

--- a/files/en-us/web/api/imagetracklist/selectedindex/index.md
+++ b/files/en-us/web/api/imagetracklist/selectedindex/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - selectedIndex
   - ImageTrackList
+  - Experimental
 browser-compat: api.ImageTrackList.selectedIndex
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`selectedIndex`** property of the {{domxref("ImageTrackList")}} interface returns the `index` of the selected track.
 

--- a/files/en-us/web/api/imagetracklist/selectedtrack/index.md
+++ b/files/en-us/web/api/imagetracklist/selectedtrack/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - selectedTrack
   - ImageTrackList
+  - Experimental
 browser-compat: api.ImageTrackList.selectedTrack
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`selectedTrack`** property of the {{domxref("ImageTrackList")}} interface returns an {{domxref("ImageTrack")}} object representing the currently selected track.
 

--- a/files/en-us/web/api/inputdevicecapabilities/firestouchevents/index.md
+++ b/files/en-us/web/api/inputdevicecapabilities/firestouchevents/index.md
@@ -4,9 +4,10 @@ slug: Web/API/InputDeviceCapabilities/firesTouchEvents
 page-type: web-api-instance-property
 tags:
   - needsTags
+  - Experimental
 browser-compat: api.InputDeviceCapabilities.firesTouchEvents
 ---
-{{SeeCompatTable}}{{APIRef()}}
+{{APIRef}}{{SeeCompatTable}}
 
 The **`InputDeviceCapabilities.firesTouchEvents`** read-only
 property returns a boolean value that indicates whether the device dispatches

--- a/files/en-us/web/api/inputdevicecapabilities_api/index.md
+++ b/files/en-us/web/api/inputdevicecapabilities_api/index.md
@@ -30,7 +30,7 @@ myButton.addEventListener('mousedown', (e) => {
 
 ## Interfaces
 
-- {{DOMxRef("InputDeviceCapabilities")}}
+- {{DOMxRef("InputDeviceCapabilities")}} {{Experimental_Inline}}
   - : Provides logical information about an input device.
 
 ## Specifications

--- a/files/en-us/web/api/keyboard/getlayoutmap/index.md
+++ b/files/en-us/web/api/keyboard/getlayoutmap/index.md
@@ -11,6 +11,7 @@ tags:
   - Reference
   - getLayoutMap()
   - keyboard
+  - Experimental
 browser-compat: api.Keyboard.getLayoutMap
 ---
 {{APIRef("Keyboard API")}}{{SeeCompatTable}}{{securecontext_header}}

--- a/files/en-us/web/api/keyboard/lock/index.md
+++ b/files/en-us/web/api/keyboard/lock/index.md
@@ -10,6 +10,7 @@ tags:
   - Reference
   - keyboard
   - lock()
+  - Experimental
 browser-compat: api.Keyboard.lock
 ---
 {{APIRef("Keyboard Map API")}}{{SeeCompatTable}}{{securecontext_header}}

--- a/files/en-us/web/api/keyboard/unlock/index.md
+++ b/files/en-us/web/api/keyboard/unlock/index.md
@@ -10,6 +10,7 @@ tags:
   - Reference
   - keyboard
   - unLock
+  - Experimental
 browser-compat: api.Keyboard.unlock
 ---
 {{APIRef("Keyboard API")}}{{SeeCompatTable}}{{securecontext_header}}

--- a/files/en-us/web/api/largest_contentful_paint_api/index.md
+++ b/files/en-us/web/api/largest_contentful_paint_api/index.md
@@ -7,9 +7,10 @@ tags:
   - LargestContentfulPaint
   - Overview
   - Reference
+  - Experimental
 browser-compat: api.LargestContentfulPaint
 ---
-{{DefaultAPISidebar("Largest Contentful Paint API")}}
+{{DefaultAPISidebar("Largest Contentful Paint API")}}{{SeeCompatTable}}
 
 The **Largest Contentful Paint (LCP) API** enables monitoring the largest paint element triggered on screen.
 

--- a/files/en-us/web/api/largestcontentfulpaint/element/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/element/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - element
   - LargestContentfulPaint
+  - Experimental
 browser-compat: api.LargestContentfulPaint.element
 ---
-{{DefaultAPISidebar("Largest Contentful Paint API")}}
+{{APIRef("Largest Contentful Paint API")}}{{SeeCompatTable}}
 
 The **`element`** read-only property of the {{domxref("LargestContentfulPaint")}} interface returns an object representing the {{domxref("Element")}} that is the largest contentful paint.
 

--- a/files/en-us/web/api/largestcontentfulpaint/id/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/id/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - id
   - LargestContentfulPaint
+  - Experimental
 browser-compat: api.LargestContentfulPaint.id
 ---
-{{DefaultAPISidebar("Largest Contentful Paint API")}}
+{{APIRef("Largest Contentful Paint API")}}{{SeeCompatTable}}
 
 The **`id`** read-only property of the {{domxref("LargestContentfulPaint")}} interface returns the ID of the element that is the largest contentful paint.
 

--- a/files/en-us/web/api/largestcontentfulpaint/loadtime/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/loadtime/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - loadTime
   - LargestContentfulPaint
+  - Experimental
 browser-compat: api.LargestContentfulPaint.loadTime
 ---
-{{DefaultAPISidebar("Largest Contentful Paint API")}}
+{{APIRef("Largest Contentful Paint API")}}{{SeeCompatTable}}
 
 The **`loadTime`** read-only property of the {{domxref("LargestContentfulPaint")}} interface returns the time that the element was loaded.
 

--- a/files/en-us/web/api/largestcontentfulpaint/rendertime/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/rendertime/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - renderTime
   - LargestContentfulPaint
+  - Experimental
 browser-compat: api.LargestContentfulPaint.renderTime
 ---
-{{DefaultAPISidebar("Largest Contentful Paint API")}}
+{{APIRef("Largest Contentful Paint API")}}{{SeeCompatTable}}
 
 The **`renderTime`** read-only property of the {{domxref("LargestContentfulPaint")}} interface represents the time that the element was rendered to the screen.
 

--- a/files/en-us/web/api/largestcontentfulpaint/size/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/size/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - size
   - LargestContentfulPaint
+  - Experimental
 browser-compat: api.LargestContentfulPaint.size
 ---
-{{DefaultAPISidebar("Largest Contentful Paint API")}}
+{{APIRef("Largest Contentful Paint API")}}{{SeeCompatTable}}
 
 The **`size`** read-only property of the {{domxref("LargestContentfulPaint")}} interface returns the intrinsic size of the element that is the largest contentful paint.
 

--- a/files/en-us/web/api/largestcontentfulpaint/tojson/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/tojson/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - toJSON
   - LargestContentfulPaint
+  - Experimental
 browser-compat: api.LargestContentfulPaint.toJSON
 ---
-{{DefaultAPISidebar("Largest Contentful Paint API")}}
+{{APIRef("Largest Contentful Paint API")}}{{SeeCompatTable}}
 
 The **`toJSON()`** method of the {{domxref("LargestContentfulPaint")}} interface is a _serializer_, and returns a JSON representation of the `LargestContentfulPaint` object.
 

--- a/files/en-us/web/api/largestcontentfulpaint/url/index.md
+++ b/files/en-us/web/api/largestcontentfulpaint/url/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - url
   - LargestContentfulPaint
+  - Experimental
 browser-compat: api.LargestContentfulPaint.url
 ---
-{{DefaultAPISidebar("Largest Contentful Paint API")}}
+{{APIRef("Largest Contentful Paint API")}}{{SeeCompatTable}}
 
 The **`url`** read-only property of the {{domxref("LargestContentfulPaint")}} interface returns the request URL of the element, if the element is an image.
 

--- a/files/en-us/web/api/layout_instability_api/index.md
+++ b/files/en-us/web/api/layout_instability_api/index.md
@@ -7,9 +7,10 @@ tags:
   - Layout Instability API
   - Overview
   - Reference
+  - Experimental
 browser-compat: api.LayoutShift
 ---
-{{DefaultAPISidebar("Layout Instability API")}}
+{{DefaultAPISidebar("Layout Instability API")}}{{SeeCompatTable}}
 
 The **Layout Instability API** provides interfaces for measuring and reporting layout shifts.
 

--- a/files/en-us/web/api/layoutshift/index.md
+++ b/files/en-us/web/api/layoutshift/index.md
@@ -10,9 +10,10 @@ tags:
   - Performance
   - Reference
   - Web Performance
+  - Experimental
 browser-compat: api.LayoutShift
 ---
-{{APIRef("Layout Instability API")}}
+{{APIRef("Layout Instability API")}}{{SeeCompatTable}}
 
 The `LayoutShift` interface of the [Layout Instability API](/en-US/docs/Web/API/Layout_Instability_API) provides insights into the stability of web pages based on movements of the elements on the page.
 

--- a/files/en-us/web/api/layoutshiftattribution/currentrect/index.md
+++ b/files/en-us/web/api/layoutshiftattribution/currentrect/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - currentRect
   - LayoutShiftAttribution
+  - Experimental
 browser-compat: api.LayoutShiftAttribution.currentRect
 ---
-{{APIRef("Layout Instability API")}}
+{{APIRef("Layout Instability API")}}{{SeeCompatTable}}
 
 The **`currentRect`** read-only property of the {{domxref("LayoutShiftAttribution")}} interface returns a {{domxref("DOMRectReadOnly")}} object representing the position of the element after the shift.
 

--- a/files/en-us/web/api/layoutshiftattribution/node/index.md
+++ b/files/en-us/web/api/layoutshiftattribution/node/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - node
   - LayoutShiftAttribution
+  - Experimental
 browser-compat: api.LayoutShiftAttribution.node
 ---
-{{APIRef("Layout Instability API")}}
+{{APIRef("Layout Instability API")}}{{SeeCompatTable}}
 
 The **`node`** read-only property of the {{domxref("LayoutShiftAttribution")}} interface returns a {{domxref("node")}} representing the object that has shifted.
 

--- a/files/en-us/web/api/layoutshiftattribution/previousrect/index.md
+++ b/files/en-us/web/api/layoutshiftattribution/previousrect/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - previousRect
   - LayoutShiftAttribution
+  - Experimental
 browser-compat: api.LayoutShiftAttribution.previousRect
 ---
-{{APIRef("Layout Instability API")}}
+{{APIRef("Layout Instability API")}}{{SeeCompatTable}}
 
 The **`previousRect`** read-only property of the {{domxref("LayoutShiftAttribution")}} interface returns a {{domxref("DOMRectReadOnly")}} object representing the position of the element before the shift.
 

--- a/files/en-us/web/api/layoutshiftattribution/tojson/index.md
+++ b/files/en-us/web/api/layoutshiftattribution/tojson/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - toJSON
   - LayoutShiftAttribution
+  - Experimental
 browser-compat: api.LayoutShiftAttribution.toJSON
 ---
-{{APIRef("Layout Instability API")}}
+{{APIRef("Layout Instability API")}}{{SeeCompatTable}}
 
 The **`toJSON()`** method of the {{domxref("LayoutShiftAttribution")}} interface is a _serializer_ that returns a JSON representation of the `LayoutShiftAttribution` object.
 

--- a/files/en-us/web/api/magnetometer/magnetometer/index.md
+++ b/files/en-us/web/api/magnetometer/magnetometer/index.md
@@ -11,9 +11,10 @@ tags:
   - Sensor
   - Sensor APIs
   - Sensors
+  - Experimental
 browser-compat: api.Magnetometer.Magnetometer
 ---
-{{APIRef("Sensor API")}}
+{{APIRef("Sensor API")}}{{SeeCompatTable}}
 
 The **`Magnetometer()`** constructor
 creates a new {{domxref("Magnetometer")}} object which returns information about the

--- a/files/en-us/web/api/magnetometer/x/index.md
+++ b/files/en-us/web/api/magnetometer/x/index.md
@@ -12,9 +12,10 @@ tags:
   - Sensor APIs
   - Sensors
   - x
+  - Experimental
 browser-compat: api.Magnetometer.x
 ---
-{{APIRef("Sensor API")}}
+{{APIRef("Sensor API")}}{{SeeCompatTable}}
 
 The **`x`** read-only property of the
 {{domxref("Magnetometer")}} interface returns a double precision integer containing

--- a/files/en-us/web/api/magnetometer/y/index.md
+++ b/files/en-us/web/api/magnetometer/y/index.md
@@ -12,9 +12,10 @@ tags:
   - Sensor APIs
   - Sensors
   - 'y'
+  - Experimental
 browser-compat: api.Magnetometer.y
 ---
-{{APIRef("Sensor API")}}
+{{APIRef("Sensor API")}}{{SeeCompatTable}}
 
 The **`y`** read-only property of the
 {{domxref("Magnetometer")}} interface returns a double precision integer containing

--- a/files/en-us/web/api/magnetometer/z/index.md
+++ b/files/en-us/web/api/magnetometer/z/index.md
@@ -12,9 +12,10 @@ tags:
   - Sensor APIs
   - Sensors
   - z
+  - Experimental
 browser-compat: api.Magnetometer.z
 ---
-{{APIRef("Sensor API")}}
+{{APIRef("Sensor API")}}{{SeeCompatTable}}
 
 The **`z`** read-only property of the
 {{domxref("Magnetometer")}} interface returns a double-precision integer containing

--- a/files/en-us/web/api/mediasession/setcameraactive/index.md
+++ b/files/en-us/web/api/mediasession/setcameraactive/index.md
@@ -14,9 +14,10 @@ tags:
   - Video
   - setActionHandler
   - setCameraActive
+  - Experimental
 browser-compat: api.MediaSession.setCameraActive
 ---
-{{APIRef("Media Session API")}}
+{{APIRef("Media Session API")}}{{SeeCompatTable}}
 
 The {{domxref("MediaSession")}} method **`setCameraActive()`** is used to indicate to the user agent whether the user's camera is considered to be active.
 

--- a/files/en-us/web/api/mediasession/setmicrophoneactive/index.md
+++ b/files/en-us/web/api/mediasession/setmicrophoneactive/index.md
@@ -14,9 +14,10 @@ tags:
   - Video
   - setActionHandler
   - setMicrophoneActive
+  - Experimental
 browser-compat: api.MediaSession.setMicrophoneActive
 ---
-{{APIRef("Media Session API")}}
+{{APIRef("Media Session API")}}{{SeeCompatTable}}
 
 The {{domxref("MediaSession")}} method **`setMicrophoneActive()`** is used to indicate to the user agent whether the user's microphone is considered to be currently muted.
 

--- a/files/en-us/web/api/mediastreamtrackprocessor/readable/index.md
+++ b/files/en-us/web/api/mediastreamtrackprocessor/readable/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - readable
   - MediaStreamTrackProcessor
+  - Experimental
 browser-compat: api.MediaStreamTrackProcessor.readable
 ---
-{{DefaultAPISidebar("Insertable Streams for MediaStreamTrack API")}}
+{{APIRef("Insertable Streams for MediaStreamTrack API")}}{{SeeCompatTable}}
 
 The **`readable`**  property of the {{domxref("MediaStreamTrackProcessor")}} interface returns a {{domxref("ReadableStream")}}.
 

--- a/files/en-us/web/api/metadata/modificationtime/index.md
+++ b/files/en-us/web/api/metadata/modificationtime/index.md
@@ -12,9 +12,10 @@ tags:
   - Reference
   - metadata
   - modificationTime
+  - Experimental
 browser-compat: api.Metadata.modificationTime
 ---
-{{APIRef("File and Directory Entries API")}}{{Non-standard_header}}
+{{APIRef("File and Directory Entries API")}}{{Non-standard_header}}{{SeeCompatTable}}
 
 The read-only **`modificationTime`**
 property of the {{domxref("Metadata")}} interface is a {{jsxref("Date")}} object which

--- a/files/en-us/web/api/metadata/size/index.md
+++ b/files/en-us/web/api/metadata/size/index.md
@@ -12,9 +12,10 @@ tags:
   - Reference
   - metadata
   - size
+  - Experimental
 browser-compat: api.Metadata.size
 ---
-{{APIRef("File and Directory Entries API")}}{{Non-standard_header}}
+{{APIRef("File and Directory Entries API")}}{{Non-standard_header}}{{SeeCompatTable}}
 
 The read-only **`size`** property of
 the {{domxref("Metadata")}} interface specifies the size, in bytes, of the referenced

--- a/files/en-us/web/api/navigator/clearappbadge/index.md
+++ b/files/en-us/web/api/navigator/clearappbadge/index.md
@@ -9,9 +9,10 @@ tags:
   - Reference
   - clearAppBadge
   - Navigator
+  - Experimental
 browser-compat: api.Navigator.clearAppBadge
 ---
-{{DefaultAPISidebar("Badging API")}}
+{{APIRef("Badging API")}}{{SeeCompatTable}}
 
 The **`clearAppBadge()`** method of the {{domxref("Navigator")}} interface clears a badge on the current app's icon by setting it to `nothing`. The value `nothing` indicates that no badge is currently set, and the status of the badge is _cleared_.
 

--- a/files/en-us/web/api/navigator/clipboard/index.md
+++ b/files/en-us/web/api/navigator/clipboard/index.md
@@ -16,6 +16,8 @@ tags:
   - paste
 browser-compat: api.Navigator.clipboard
 ---
+{{APIRef("Clipboard API")}}
+
 The [Clipboard API](/en-US/docs/Web/API/Clipboard_API) adds to the **{{domxref("Navigator")}}** interface the
 read-only **`clipboard`** property, which returns the
 {{domxref("Clipboard")}} object used to read and write the clipboard's
@@ -60,5 +62,3 @@ text.
 ## Browser compatibility
 
 {{Compat}}
-
-{{APIRef("Clipboard API")}}

--- a/files/en-us/web/api/navigator/contacts/index.md
+++ b/files/en-us/web/api/navigator/contacts/index.md
@@ -10,9 +10,10 @@ tags:
   - Property
   - Read-only
   - contact picker
+  - Experimental
 browser-compat: api.Navigator.contacts
 ---
-{{DefaultAPISidebar("Contact Picker API")}}
+{{APIRef("Contact Picker API")}}{{SeeCompatTable}}
 
 The **`contacts`** read-only property of the
 {{domxref("Navigator")}} interface returns a {{domxref('ContactsManager')}} interface

--- a/files/en-us/web/api/navigator/devicememory/index.md
+++ b/files/en-us/web/api/navigator/devicememory/index.md
@@ -10,6 +10,7 @@ tags:
   - Reference
   - deviceMemory
   - memory
+  - Experimental
 browser-compat: api.Navigator.deviceMemory
 ---
 {{APIRef("Device Memory")}}{{securecontext_header}}{{SeeCompatTable}}

--- a/files/en-us/web/api/navigator/hid/index.md
+++ b/files/en-us/web/api/navigator/hid/index.md
@@ -9,6 +9,7 @@ tags:
   - WebHID API
   - Property
   - Reference
+  - Experimental
 browser-compat: api.Navigator.hid
 ---
 {{APIRef("WebHID API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/navigator/serial/index.md
+++ b/files/en-us/web/api/navigator/serial/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - serial
   - Navigator
+  - Experimental
 browser-compat: api.Navigator.serial
 ---
-{{APIRef("HTML DOM")}}
+{{APIRef("HTML DOM")}}{{SeeCompatTable}}
 
 The **`serial`** read-only property of the {{domxref("Navigator")}} interface returns a {{domxref("Serial")}} object which represents the entry point into the {{domxref("Web Serial API")}}.
 

--- a/files/en-us/web/api/navigator/setappbadge/index.md
+++ b/files/en-us/web/api/navigator/setappbadge/index.md
@@ -9,9 +9,10 @@ tags:
   - Reference
   - setAppBadge
   - Navigator
+  - Experimental
 browser-compat: api.Navigator.setAppBadge
 ---
-{{DefaultAPISidebar("Badging API")}}
+{{APIRef("Badging API")}}{{SeeCompatTable}}
 
 The **`setAppBadge()`** method of the {{domxref("Navigator")}} interface sets a badge on the icon associated with this app. If a value is passed to the method, this will be set as the value of the badge. Otherwise the badge will display as a dot, or other indicator as defined by the platform.
 

--- a/files/en-us/web/api/navigator/useragentdata/index.md
+++ b/files/en-us/web/api/navigator/useragentdata/index.md
@@ -8,9 +8,10 @@ tags:
   - Property
   - Reference
   - NavigatorUAData
+  - Experimental
 browser-compat: api.Navigator.userAgentData
 ---
-{{securecontext_header}}{{APIRef("User-Agent Client Hints API")}}
+{{securecontext_header}}{{APIRef("User-Agent Client Hints API")}}{{SeeCompatTable}}
 
 The **`userAgentData`** read-only property of the {{domxref("Navigator")}} interface returns a {{domxref("NavigatorUAData")}} object
 which can be used to access the {{domxref("User-Agent Client Hints API")}}.

--- a/files/en-us/web/api/navigator/wakelock/index.md
+++ b/files/en-us/web/api/navigator/wakelock/index.md
@@ -6,6 +6,7 @@ tags:
   - API
   - Reference
   - Screen Wake Lock API
+  - Experimental
 browser-compat: api.Navigator.wakeLock
 ---
 {{ApiRef("Screen Wake Lock API")}}{{SeeCompatTable}}{{securecontext_header}}


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.

This covers files that have only `experimental` header modifications.