### PR TITLE
Update BCD info, part 30

### DIFF
--- a/files/en-us/web/api/navigator/windowcontrolsoverlay/index.md
+++ b/files/en-us/web/api/navigator/windowcontrolsoverlay/index.md
@@ -8,9 +8,10 @@ tags:
   - Property
   - Reference
   - Progressive Web Apps
+  - Experimental
 browser-compat: api.Navigator.windowControlsOverlay
 ---
-{{securecontext_header}}{{APIRef("")}}
+{{SecureContext_Header}}{{APIRef("")}}{{SeeCompatTable}}
 
 The **`windowControlsOverlay`** property of the {{domxref("Navigator")}}
 interface returns the {{domxref("WindowControlsOverlay")}} interface, which exposes

--- a/files/en-us/web/api/navigator/xr/index.md
+++ b/files/en-us/web/api/navigator/xr/index.md
@@ -15,9 +15,10 @@ tags:
   - Virtual Reality
   - WebXR
   - XR
+  - Experimental
 browser-compat: api.Navigator.xr
 ---
-{{APIRef("WebXR Device API")}} {{SecureContext_Header}}
+{{APIRef("WebXR Device API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The read-only **`xr`** property
 provided by the {{domxref("Navigator")}} interface returns an {{domxref("XRSystem")}} object

--- a/files/en-us/web/api/navigatoruadata/brands/index.md
+++ b/files/en-us/web/api/navigatoruadata/brands/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - brands
   - NavigatorUAData
+  - Experimental
 browser-compat: api.NavigatorUAData.brands
 ---
-{{DefaultAPISidebar("User-Agent Client Hints API")}}
+{{APIRef("User-Agent Client Hints API")}}{{SeeCompatTable}}
 
 The **`brands`** read-only property of the {{domxref("NavigatorUAData")}} interface returns an array of brand information.
 

--- a/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.md
+++ b/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.NavigatorUAData.getHighEntropyValues
 ---
-{{APIRef("")}}{{SeeCompatTable}}
+{{APIRef("User-Agent Client Hints API")}}{{SeeCompatTable}}
 
 The **`getHighEntropyValues()`** method of the {{domxref("NavigatorUAData")}} interface is a {{jsxref("Promise")}} that resolves with a dictionary object containing the _high entropy_ values the user-agent returns.
 

--- a/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.md
+++ b/files/en-us/web/api/navigatoruadata/gethighentropyvalues/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - getHighEntropyValues
   - NavigatorUAData
+  - Experimental
 browser-compat: api.NavigatorUAData.getHighEntropyValues
 ---
-{{DefaultAPISidebar("")}}
+{{APIRef("")}}{{SeeCompatTable}}
 
 The **`getHighEntropyValues()`** method of the {{domxref("NavigatorUAData")}} interface is a {{jsxref("Promise")}} that resolves with a dictionary object containing the _high entropy_ values the user-agent returns.
 
@@ -35,7 +36,7 @@ getHighEntropyValues(hints)
     - `"bitness"`
     - `"model"`
     - `"platformVersion"`
-    - `"uaFullVersion"` {{deprecated_inline}}
+    - `"uaFullVersion"` {{Deprecated_Inline}}
     - `"fullVersionList"`
 
 ### Return value
@@ -63,7 +64,7 @@ A {{jsxref("Promise")}} that resolves to an object containing some or all of the
 - `platformVersion`
   - : A string containing the platform version. Platform name itself is always available as low-entropy hint `platform`. For example, `"10.0"`.
       Note that this information can be sent to a server in the {{HTTPHeader("Sec-CH-UA-Platform-Version")}} header if the server explicitly requests it in the {{HTTPHeader("Accept-CH")}} header.
-- `uaFullVersion` {{deprecated_inline}}
+- `uaFullVersion` {{Deprecated_Inline}}
   - : A string containing the full browser version. For example, `"103.0.5060.134"`. Deprecated in favor of `fullVersionList`.
       Note that this information can be sent to a server in the {{HTTPHeader("Sec-CH-UA-Full-Version")}} header if the server explicitly requests it in the {{HTTPHeader("Accept-CH")}} header.
 - `fullVersionList`

--- a/files/en-us/web/api/navigatoruadata/mobile/index.md
+++ b/files/en-us/web/api/navigatoruadata/mobile/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - mobile
   - NavigatorUAData
+  - Experimental
 browser-compat: api.NavigatorUAData.mobile
 ---
-{{DefaultAPISidebar("User-Agent Client Hints API")}}
+{{APIRef("User-Agent Client Hints API")}}{{SeeCompatTable}}
 
 The **`mobile`** read-only property of the {{domxref("NavigatorUAData")}} interface returns a value indicating whether the device is a mobile device.
 

--- a/files/en-us/web/api/navigatoruadata/platform/index.md
+++ b/files/en-us/web/api/navigatoruadata/platform/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - platform
   - NavigatorUAData
+  - Experimental
 browser-compat: api.NavigatorUAData.platform
 ---
-{{DefaultAPISidebar("User-Agent Client Hints API")}}
+{{APIRef("User-Agent Client Hints API")}}{{SeeCompatTable}}
 
 The **`platform`** read-only property of the {{domxref("NavigatorUAData")}} interface returns the platform brand information.
 

--- a/files/en-us/web/api/navigatoruadata/tojson/index.md
+++ b/files/en-us/web/api/navigatoruadata/tojson/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.NavigatorUAData.toJSON
 ---
-{{APIRef}}{{SeeCompatTable}}
+{{APIRef("User-Agent Client Hints API")}}{{SeeCompatTable}}
 
 The **`toJSON()`** method of the {{domxref("NavigatorUAData")}} interface is a _serializer_ that returns a JSON representation of the _low entropy_ properties of the `NavigatorUAData` object.
 

--- a/files/en-us/web/api/navigatoruadata/tojson/index.md
+++ b/files/en-us/web/api/navigatoruadata/tojson/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - toJSON
   - NavigatorUAData
+  - Experimental
 browser-compat: api.NavigatorUAData.toJSON
 ---
-{{DefaultAPISidebar("")}}
+{{APIRef}}{{SeeCompatTable}}
 
 The **`toJSON()`** method of the {{domxref("NavigatorUAData")}} interface is a _serializer_ that returns a JSON representation of the _low entropy_ properties of the `NavigatorUAData` object.
 

--- a/files/en-us/web/api/ndefmessage/ndefmessage/index.md
+++ b/files/en-us/web/api/ndefmessage/ndefmessage/index.md
@@ -7,9 +7,10 @@ tags:
   - Constructor
   - Reference
   - NDEFMessage
+  - Experimental
 browser-compat: api.NDEFMessage.NDEFMessage
 ---
-{{securecontext_header}}{{APIRef()}}
+{{SecureContext_Header}}{{APIRef}}{{SeeCompatTable}}
 
 The **`NDEFMessage()`** constructor creates a new {{domxref("NDEFMessage")}} object, initialized with the given NDEF records.
 

--- a/files/en-us/web/api/ndefmessage/records/index.md
+++ b/files/en-us/web/api/ndefmessage/records/index.md
@@ -7,9 +7,10 @@ tags:
   - Reference
   - Web NFC
   - Property
+  - Experimental
 browser-compat: api.NDEFMessage.records
 ---
-{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
+{{SecureContext_Header}}{{SeeCompatTable}}{{APIRef}}
 
 The `records` property of
 {{DOMxRef("NDEFMessage")}} interface represents a list of {{DOMxRef("NDEFRecord")}}s

--- a/files/en-us/web/api/ndefreader/index.md
+++ b/files/en-us/web/api/ndefreader/index.md
@@ -6,9 +6,10 @@ tags:
   - NDEF
   - Reference
   - Web NFC
+  - Experimental
 browser-compat: api.NDEFReader
 ---
-{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
+{{SecureContext_Header}}{{SeeCompatTable}}{{APIRef}}
 
 The **`NDEFReader`** interface of the [Web NFC API](/en-US/docs/Web/API/Web_NFC_API) is used to read from and write data to compatible NFC devices, e.g. NFC tags supporting NDEF, when these devices are within the reader's magnetic induction field.
 

--- a/files/en-us/web/api/ndefreader/ndefreader/index.md
+++ b/files/en-us/web/api/ndefreader/ndefreader/index.md
@@ -7,9 +7,10 @@ tags:
   - Reference
   - Web NFC
   - Constructor
+  - Experimental
 browser-compat: api.NDEFReader.NDEFReader
 ---
-{{securecontext_header}}{{APIRef()}}
+{{SecureContext_Header}}{{APIRef}}{{SeeCompatTable}}
 
 The **`NDEFReader()`**
 constructor of the {{domxref("NDEFReader")}} interface returns a

--- a/files/en-us/web/api/ndefreader/reading_event/index.md
+++ b/files/en-us/web/api/ndefreader/reading_event/index.md
@@ -7,9 +7,10 @@ tags:
   - Reference
   - Web NFC
   - Event
+  - Experimental
 browser-compat: api.NDEFReader.reading_event
 ---
-{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
+{{SecureContext_Header}}{{SeeCompatTable}}{{APIRef}}
 
 The `reading` event of the {{DOMxRef("NDEFReader")}} interface is fired whenever a new reading is available from compatible NFC devices (e.g. NFC tags supporting NDEF) when these devices are within the reader's magnetic induction field.
 

--- a/files/en-us/web/api/ndefreader/readingerror_event/index.md
+++ b/files/en-us/web/api/ndefreader/readingerror_event/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - Web NFC
   - Property
+  - Experimental
 browser-compat: api.NDEFReader.readingerror_event
 ---
-{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
+{{SecureContext_Header}}{{SeeCompatTable}}{{APIRef}}
 
 The `readingerror` event of the {{DOMxRef("NDEFReader")}} interface is fired whenever an error occurs during reading of NFC tags, e.g. when tags leave the reader's magnetic induction field.
 

--- a/files/en-us/web/api/ndefreader/scan/index.md
+++ b/files/en-us/web/api/ndefreader/scan/index.md
@@ -7,9 +7,10 @@ tags:
   - Reference
   - Web NFC
   - Method
+  - Experimental
 browser-compat: api.NDEFReader.scan
 ---
-{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
+{{SecureContext_Header}}{{SeeCompatTable}}{{APIRef}}
 
 The `scan()` method of the {{DOMxRef("NDEFReader")}} interface activates a reading device and returns a {{jsxref("Promise")}} that either resolves when an NFC tag is read or rejects if a hardware or permission error is encountered. This method triggers a permission prompt if the "nfc" permission has not been previously granted.
 

--- a/files/en-us/web/api/ndefreader/write/index.md
+++ b/files/en-us/web/api/ndefreader/write/index.md
@@ -7,9 +7,10 @@ tags:
   - Reference
   - Web NFC
   - Method
+  - Experimental
 browser-compat: api.NDEFReader.write
 ---
-{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
+{{SecureContext_Header}}{{SeeCompatTable}}{{APIRef}}
 
 The `write()` method of the {{DOMxRef("NDEFReader")}} interface attempts to write an NDEF message to a tag and returns a {{jsxref("Promise")}} that either resolves when a message has been written to the tag or rejects if a hardware or permission error is encountered. This method triggers a permission prompt if the "nfc" permission has not been previously granted.
 

--- a/files/en-us/web/api/ndefrecord/data/index.md
+++ b/files/en-us/web/api/ndefrecord/data/index.md
@@ -6,9 +6,10 @@ tags:
   - NDEF
   - Reference
   - Web NFC
+  - Experimental
 browser-compat: api.NDEFRecord.data
 ---
-{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
+{{SecureContext_Header}}{{SeeCompatTable}}{{APIRef}}
 
 The **`data`**
 property of the {{DOMxRef("NDEFRecord")}} interface returns a

--- a/files/en-us/web/api/ndefrecord/encoding/index.md
+++ b/files/en-us/web/api/ndefrecord/encoding/index.md
@@ -7,9 +7,10 @@ tags:
   - NDEF
   - Reference
   - Web NFC
+  - Experimental
 browser-compat: api.NDEFRecord.encoding
 ---
-{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
+{{SecureContext_Header}}{{SeeCompatTable}}{{APIRef}}
 
 The **`encoding`**
 property of the {{DOMxRef("NDEFRecord")}} interface returns the encoding of

--- a/files/en-us/web/api/ndefrecord/id/index.md
+++ b/files/en-us/web/api/ndefrecord/id/index.md
@@ -7,9 +7,10 @@ tags:
   - NDEFRecord
   - Reference
   - Web NFC
+  - Experimental
 browser-compat: api.NDEFRecord.id
 ---
-{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
+{{SecureContext_Header}}{{SeeCompatTable}}{{APIRef}}
 
 The **`id`** property of the
 {{DOMxRef("NDEFRecord")}} interface returns the record identifier, which is an

--- a/files/en-us/web/api/ndefrecord/index.md
+++ b/files/en-us/web/api/ndefrecord/index.md
@@ -6,9 +6,10 @@ tags:
   - NDEF
   - Reference
   - Web NFC
+  - Experimental
 browser-compat: api.NDEFRecord
 ---
-{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
+{{SecureContext_Header}}{{SeeCompatTable}}{{APIRef}}
 
 The **`NDEFRecord`** interface of the [Web NFC API](/en-US/docs/Web/API/Web_NFC_API) provides data that can be read from, or written to, compatible NFC devices, e.g. NFC tags supporting NDEF.
 

--- a/files/en-us/web/api/ndefrecord/lang/index.md
+++ b/files/en-us/web/api/ndefrecord/lang/index.md
@@ -6,9 +6,10 @@ tags:
   - NDEF
   - Reference
   - Web NFC
+  - Experimental
 browser-compat: api.NDEFRecord.lang
 ---
-{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
+{{SecureContext_Header}}{{SeeCompatTable}}{{APIRef}}
 
 The **`lang`**
 property of the {{DOMxRef("NDEFRecord")}} interface returns the language of

--- a/files/en-us/web/api/ndefrecord/mediatype/index.md
+++ b/files/en-us/web/api/ndefrecord/mediatype/index.md
@@ -6,9 +6,10 @@ tags:
   - NDEF
   - Reference
   - Web NFC
+  - Experimental
 browser-compat: api.NDEFRecord.mediaType
 ---
-{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
+{{SecureContext_Header}}{{SeeCompatTable}}{{APIRef}}
 
 The **`mediaType`**
 property of the {{DOMxRef("NDEFRecord")}} interface returns the {{Glossary("MIME type")}} of the record. This value will be `null` if `recordType` is not equal to `"mime"`.

--- a/files/en-us/web/api/ndefrecord/ndefrecord/index.md
+++ b/files/en-us/web/api/ndefrecord/ndefrecord/index.md
@@ -6,9 +6,10 @@ tags:
   - NDEF
   - Reference
   - Web NFC
+  - Experimental
 browser-compat: api.NDEFRecord.NDEFRecord
 ---
-{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
+{{SecureContext_Header}}{{SeeCompatTable}}{{APIRef}}
 
 The **`NDEFRecord()`**
 constructor of the [Web NFC API](/en-US/docs/Web/API/Web_NFC_API) returns a

--- a/files/en-us/web/api/ndefrecord/recordtype/index.md
+++ b/files/en-us/web/api/ndefrecord/recordtype/index.md
@@ -6,9 +6,10 @@ tags:
   - NDEF
   - Reference
   - Web NFC
+  - Experimental
 browser-compat: api.NDEFRecord.recordType
 ---
-{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
+{{SecureContext_Header}}{{SeeCompatTable}}{{APIRef}}
 
 The **`recordType`**
 property of the {{DOMxRef("NDEFRecord")}} interface returns the record type of the record.

--- a/files/en-us/web/api/ndefrecord/torecords/index.md
+++ b/files/en-us/web/api/ndefrecord/torecords/index.md
@@ -6,9 +6,10 @@ tags:
   - NDEF
   - Reference
   - Web NFC
+  - Experimental
 browser-compat: api.NDEFRecord.toRecords
 ---
-{{securecontext_header}}{{SeeCompatTable}}{{APIRef()}}
+{{SecureContext_Header}}{{SeeCompatTable}}{{APIRef}}
 
 The **`toRecords()`**
 method of the {{DOMxRef("NDEFRecord")}} interface converts

--- a/files/en-us/web/api/notification/actions/index.md
+++ b/files/en-us/web/api/notification/actions/index.md
@@ -10,9 +10,10 @@ tags:
   - Property
   - Reference
   - actions
+  - Experimental
 browser-compat: api.Notification.actions
 ---
-{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
+{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`actions`** read-only property of the {{domxref("Notification")}} interface provides the actions available for users to choose from for interacting with the notification.
 

--- a/files/en-us/web/api/notification/badge/index.md
+++ b/files/en-us/web/api/notification/badge/index.md
@@ -10,9 +10,10 @@ tags:
   - Property
   - Reference
   - badge
+  - Experimental
 browser-compat: api.Notification.badge
 ---
-{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
+{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`badge`** property of the {{domxref("Notification")}}
 interface returns the URL of the image used to represent the notification when there is

--- a/files/en-us/web/api/notification/image/index.md
+++ b/files/en-us/web/api/notification/image/index.md
@@ -10,9 +10,10 @@ tags:
   - Notifications API
   - Property
   - Reference
+  - Experimental
 browser-compat: api.Notification.image
 ---
-{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
+{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The `image` read-only property of the
 {{domxref("Notification")}} interface contains the URL of an image to be displayed as

--- a/files/en-us/web/api/notification/maxactions/index.md
+++ b/files/en-us/web/api/notification/maxactions/index.md
@@ -10,9 +10,10 @@ tags:
   - Property
   - Reference
   - actions
+  - Experimental
 browser-compat: api.Notification.maxActions
 ---
-{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
+{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`maxActions`** attribute of the
 {{domxref("Notification")}} interface returns the maximum number of actions supported by

--- a/files/en-us/web/api/notification/renotify/index.md
+++ b/files/en-us/web/api/notification/renotify/index.md
@@ -11,7 +11,7 @@ tags:
   - renotify
 browser-compat: api.Notification.renotify
 ---
-{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
+{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`renotify`** read-only property of the
 {{domxref("Notification")}} interface specifies whether the user should be notified

--- a/files/en-us/web/api/notification/requireinteraction/index.md
+++ b/files/en-us/web/api/notification/requireinteraction/index.md
@@ -11,9 +11,10 @@ tags:
   - Reference
   - Web
   - requireInteraction
+  - Experimental
 browser-compat: api.Notification.requireInteraction
 ---
-{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
+{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`requireInteraction`** read-only property of the {{domxref("Notification")}} interface returns a boolean value indicating that a notification should remain active until the user clicks or dismisses it, rather than closing automatically.
 

--- a/files/en-us/web/api/notification/silent/index.md
+++ b/files/en-us/web/api/notification/silent/index.md
@@ -10,9 +10,10 @@ tags:
   - Property
   - Reference
   - silent
+  - Experimental
 browser-compat: api.Notification.silent
 ---
-{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
+{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`silent`** read-only property of the
 {{domxref("Notification")}} interface specifies whether the notification should be

--- a/files/en-us/web/api/notification/timestamp/index.md
+++ b/files/en-us/web/api/notification/timestamp/index.md
@@ -10,9 +10,10 @@ tags:
   - Property
   - Reference
   - timeStamp
+  - Experimental
 browser-compat: api.Notification.timestamp
 ---
-{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
+{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`timestamp`** read-only property of the
 {{domxref("Notification")}} interface returns a {{domxref("DOMTimeStamp")}}, as

--- a/files/en-us/web/api/notification/vibrate/index.md
+++ b/files/en-us/web/api/notification/vibrate/index.md
@@ -11,9 +11,10 @@ tags:
   - Property
   - Reference
   - vibrate
+  - Experimental
 browser-compat: api.Notification.vibrate
 ---
-{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{securecontext_header}}
+{{APIRef("Web Notifications")}}{{AvailableInWorkers}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The `vibrate` read-only property of the {{domxref("Notification")}}
 interface specifies a [vibration pattern](/en-US/docs/Web/API/Vibration_API#vibration_patterns)

--- a/files/en-us/web/api/otpcredential/code/index.md
+++ b/files/en-us/web/api/otpcredential/code/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - code
   - OTPCredential
+  - Experimental
 browser-compat: api.OTPCredential.code
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebOTP API")}}
+{{SecureContext_Header}}{{APIRef("WebOTP API")}}{{SeeCompatTable}}
 
 The **`code`** property of the {{domxref("OTPCredential")}} interface returns the one-time password.
 

--- a/files/en-us/web/api/passwordcredential/iconurl/index.md
+++ b/files/en-us/web/api/passwordcredential/iconurl/index.md
@@ -10,6 +10,7 @@ tags:
   - Property
   - Reference
   - credential management
+  - Experimental
 browser-compat: api.PasswordCredential.iconURL
 ---
 {{SeeCompatTable}}{{APIRef("Credential Management API")}}

--- a/files/en-us/web/api/passwordcredential/name/index.md
+++ b/files/en-us/web/api/passwordcredential/name/index.md
@@ -10,6 +10,7 @@ tags:
   - Property
   - Reference
   - credential management
+  - Experimental
 browser-compat: api.PasswordCredential.name
 ---
 {{SeeCompatTable}}{{APIRef("Credential Management API")}}

--- a/files/en-us/web/api/passwordcredential/password/index.md
+++ b/files/en-us/web/api/passwordcredential/password/index.md
@@ -10,6 +10,7 @@ tags:
   - Property
   - Reference
   - credential management
+  - Experimental
 browser-compat: api.PasswordCredential.password
 ---
 {{SeeCompatTable}}{{APIRef("Credential Management API")}}

--- a/files/en-us/web/api/paymentrequestevent/openwindow/index.md
+++ b/files/en-us/web/api/paymentrequestevent/openwindow/index.md
@@ -10,6 +10,7 @@ tags:
   - Reference
   - openWindow()
   - payment
+  - Experimental
 browser-compat: api.PaymentRequestEvent.openWindow
 ---
 {{APIRef("Payment Request API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/paymentrequestevent/paymentrequestid/index.md
+++ b/files/en-us/web/api/paymentrequestevent/paymentrequestid/index.md
@@ -10,6 +10,7 @@ tags:
   - Reference
   - payment
   - paymentRequestId
+  - Experimental
 browser-compat: api.PaymentRequestEvent.paymentRequestId
 ---
 {{SeeCompatTable}}{{APIRef("Payment Request API")}}

--- a/files/en-us/web/api/paymentrequestevent/paymentrequestorigin/index.md
+++ b/files/en-us/web/api/paymentrequestevent/paymentrequestorigin/index.md
@@ -10,6 +10,7 @@ tags:
   - Reference
   - payment
   - paymentRequestOrigin
+  - Experimental
 browser-compat: api.PaymentRequestEvent.paymentRequestOrigin
 ---
 {{SeeCompatTable}}{{APIRef("Payment Request API")}}

--- a/files/en-us/web/api/paymentrequestevent/respondwith/index.md
+++ b/files/en-us/web/api/paymentrequestevent/respondwith/index.md
@@ -10,6 +10,7 @@ tags:
   - Reference
   - payment
   - respondWith()
+  - Experimental
 browser-compat: api.PaymentRequestEvent.respondWith
 ---
 {{APIRef("Payment Request API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/paymentrequestevent/toporigin/index.md
+++ b/files/en-us/web/api/paymentrequestevent/toporigin/index.md
@@ -10,6 +10,7 @@ tags:
   - Reference
   - payment
   - topLevelOrigin
+  - Experimental
 browser-compat: api.PaymentRequestEvent.topOrigin
 ---
 {{SeeCompatTable}}{{APIRef("Payment Request API")}}

--- a/files/en-us/web/api/paymentrequestevent/total/index.md
+++ b/files/en-us/web/api/paymentrequestevent/total/index.md
@@ -10,6 +10,7 @@ tags:
   - Reference
   - payment
   - total
+  - Experimental
 browser-compat: api.PaymentRequestEvent.total
 ---
 {{SeeCompatTable}}{{APIRef("Payment Request API")}}

--- a/files/en-us/web/api/performanceelementtiming/element/index.md
+++ b/files/en-us/web/api/performanceelementtiming/element/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - element
   - PerformanceElementTiming
+  - Experimental
 browser-compat: api.PerformanceElementTiming.element
 ---
-{{DefaultAPISidebar("Element Timing")}}
+{{APIRef("Element Timing")}}{{SeeCompatTable}}
 
 The **`element`** read-only property of the {{domxref("PerformanceElementTiming")}} interface returns an {{domxref("Element")}} which is a literal representation of the associated element.
 

--- a/files/en-us/web/api/performanceelementtiming/id/index.md
+++ b/files/en-us/web/api/performanceelementtiming/id/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - id
   - PerformanceElementTiming
+  - Experimental
 browser-compat: api.PerformanceElementTiming.id
 ---
-{{DefaultAPISidebar("Element Timing")}}
+{{APIRef("Element Timing")}}{{SeeCompatTable}}
 
 The **`id`** read-only property of the {{domxref("PerformanceElementTiming")}} interface returns the {{htmlattrxref("id")}} of the associated element.
 

--- a/files/en-us/web/api/performanceelementtiming/identifier/index.md
+++ b/files/en-us/web/api/performanceelementtiming/identifier/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - identifier
   - PerformanceElementTiming
+  - Experimental
 browser-compat: api.PerformanceElementTiming.identifier
 ---
-{{DefaultAPISidebar("Element Timing")}}
+{{APIRef("Element Timing")}}{{SeeCompatTable}}
 
 The **`identifier`** read-only property of the {{domxref("PerformanceElementTiming")}} interface returns the value of the [`elementtiming`](/en-US/docs/Web/HTML/Attributes/elementtiming) attribute on the element.
 

--- a/files/en-us/web/api/performanceelementtiming/intersectionrect/index.md
+++ b/files/en-us/web/api/performanceelementtiming/intersectionrect/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - intersectionRect
   - PerformanceElementTiming
+  - Experimental
 browser-compat: api.PerformanceElementTiming.intersectionRect
 ---
-{{DefaultAPISidebar("Element Timing")}}
+{{APIRef("Element Timing")}}{{SeeCompatTable}}
 
 The **`intersectionRect`** read-only property of the {{domxref("PerformanceElementTiming")}} interface returns the rectangle of the element within the viewport.
 

--- a/files/en-us/web/api/performanceelementtiming/loadtime/index.md
+++ b/files/en-us/web/api/performanceelementtiming/loadtime/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - loadTime
   - PerformanceElementTimingnull
+  - Experimental
 browser-compat: api.PerformanceElementTiming.loadTime
 ---
-{{DefaultAPISidebar("Element Timing")}}
+{{APIRef("Element Timing")}}{{SeeCompatTable}}
 
 The **`loadTime`** read-only property of the {{domxref("PerformanceElementTiming")}} interface always returns 0 for text. For images it returns the time which is the latest between the time the image resource is loaded and the time it is attached to the element.
 

--- a/files/en-us/web/api/performanceelementtiming/naturalheight/index.md
+++ b/files/en-us/web/api/performanceelementtiming/naturalheight/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - naturalHeight
   - PerformanceElementTiming
+  - Experimental
 browser-compat: api.PerformanceElementTiming.naturalHeight
 ---
-{{DefaultAPISidebar("Element Timing")}}
+{{APIRef("Element Timing")}}{{SeeCompatTable}}
 
 The **`naturalHeight`** read-only property of the {{domxref("PerformanceElementTiming")}} interface returns the intrinsic height of the image element.
 

--- a/files/en-us/web/api/performanceelementtiming/naturalwidth/index.md
+++ b/files/en-us/web/api/performanceelementtiming/naturalwidth/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - naturalWidth
   - PerformanceElementTiming
+  - Experimental
 browser-compat: api.PerformanceElementTiming.naturalWidth
 ---
-{{DefaultAPISidebar("Element Timing")}}
+{{APIRef("Element Timing")}}{{SeeCompatTable}}
 
 The **`naturalWidth`** read-only property of the {{domxref("PerformanceElementTiming")}} interface returns the intrinsic width of the image element.
 


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.

This covers files that have only `experimental` header modifications.