### PR TITLE
Fix definition lists

### DIFF
--- a/files/en-us/web/api/layoutshift/index.md
+++ b/files/en-us/web/api/layoutshift/index.md
@@ -20,18 +20,18 @@ The `LayoutShift` interface of the [Layout Instability API](/en-US/docs/Web/API/
 
 ## Properties
 
-- **`{{domxref("LayoutShift.value")}}`**
+- {{domxref("LayoutShift.value")}}
   - : Returns the `impact fraction` (fraction of the viewport that was shifted) times the `distance fraction` (distance moved as a fraction of viewport).
-- **`{{domxref("LayoutShift.hadRecentInput")}}`**
+- {{domxref("LayoutShift.hadRecentInput")}}
   - : Returns `true` if there was a user input in the past 500 milliseconds.
-- **`{{domxref("LayoutShift.lastInputTime")}}`**
+- {{domxref("LayoutShift.lastInputTime")}}
   - : Returns the time of the most recent user input.
-- **`{{domxref("LayoutShift.sources")}}`**
+- {{domxref("LayoutShift.sources")}}
   - : Returns an array of {{domxref('LayoutShiftAttribution')}} objects with information on the elements that were shifted.
 
 ## Methods
 
-- **`{{domxref("LayoutShift.toJSON()")}}`**
+- {{domxref("LayoutShift.toJSON()")}}
   - : Converts the properties to JSON.
 
 ## Examples

--- a/files/en-us/web/api/performanceeventtiming/index.md
+++ b/files/en-us/web/api/performanceeventtiming/index.md
@@ -56,18 +56,18 @@ The `PerformanceEventTiming` interface of the Event Timing API provides timing i
 
 ## Properties
 
-- **`{{domxref("PerformanceEventTiming.processingStart")}}`**
+- {{domxref("PerformanceEventTiming.processingStart")}}
   - : Returns the time at which event dispatch started.
-- **`{{domxref("PerformanceEventTiming.processingEnd")}}`**
+- {{domxref("PerformanceEventTiming.processingEnd")}}
   - : Returns the time at which the event dispatch ended.
-- **`{{domxref("PerformanceEventTiming.cancelable")}}`**
+- {{domxref("PerformanceEventTiming.cancelable")}}
   - : Returns the associated event's cancelable attribute.
-- **`{{domxref("PerformanceEventTiming.target")}}`**
+- {{domxref("PerformanceEventTiming.target")}}
   - : Returns the associated event's last target, if it is not removed.
 
 ## Methods
 
-- **`{{domxref("PerformanceEventTiming.toJSON()")}}`**
+- {{domxref("PerformanceEventTiming.toJSON()")}}
   - : Converts the PerformanceEventTiming object to JSON.
 
 ## Examples

--- a/files/en-us/web/api/usbendpoint/index.md
+++ b/files/en-us/web/api/usbendpoint/index.md
@@ -18,14 +18,14 @@ The `USBEndpoint` interface of the [WebUSB API](/en-US/docs/Web/API/WebUSB_API) 
 
 ## Constructor
 
-- **`{{domxref("USBEndpoint.USBEndpoint", "USBEndpoint()")}}`**
+- {{domxref("USBEndpoint.USBEndpoint", "USBEndpoint()")}}
   - : Creates a new `USBEndpoint` object which will be populated with information about the endpoint on the provided {{domxref('USBAlternateInterface')}} with the given endpoint number and transfer direction.
 
 ## Properties
 
-- **`{{domxref("USBEndpoint.endpointNumber")}}`**
+- {{domxref("USBEndpoint.endpointNumber")}}
   - : Returns this endpoint's "endpoint number" which is a value from 1 to 15 extracted from the `bEndpointAddress` field of the endpoint descriptor defining this endpoint. This value is used to identify the endpoint when calling methods on `USBDevice`.
-- **`{{domxref("USBEndpoint.direction")}}`**
+- {{domxref("USBEndpoint.direction")}}
 
   - : Returns the direction in which this endpoint transfers data, one of:
 
@@ -35,7 +35,7 @@ The `USBEndpoint` interface of the [WebUSB API](/en-US/docs/Web/API/WebUSB_API) 
 
     - `"out"` - Data is transferred from host to device.
 
-- **`{{domxref("USBEndpoint.type")}}`**
+- {{domxref("USBEndpoint.type")}}
 
   - : Returns the type of this endpoint, one of:
 
@@ -51,7 +51,7 @@ The `USBEndpoint` interface of the [WebUSB API](/en-US/docs/Web/API/WebUSB_API) 
 
 <!---->
 
-- **`{{domxref("USBEndpoint.packetSize")}}`**
+- {{domxref("USBEndpoint.packetSize")}}
   - : Returns the size of the packets that data sent through this endpoint will be divided into.
 
 ## Examples

--- a/files/en-us/web/api/usbinterface/index.md
+++ b/files/en-us/web/api/usbinterface/index.md
@@ -30,7 +30,7 @@ The `USBInterface` interface of the [WebUSB API](/en-US/docs/Web/API/WebUSB_API)
   - : Returns the currently selected alternative configuration of this interface. By default this is the `USBAlternateInterface` from `alternates` with `alternateSetting` equal to `0`. It can be changed by calling `USBDevice.selectAlternateInterface()` with any other value found in `alternates`.
 - {{domxref("USBInterface.alternates")}} {{ReadOnlyInline}}
   - : Returns an array containing instances of the `USBAlternateInterface` interface describing each of the alternative configurations possible for this interface.
-- **{{domxref("USBInterface.claimed")}}**{{ReadOnlyInline}}
+- {{domxref("USBInterface.claimed")}} {{ReadOnlyInline}}
   - : Returns whether or not this interface has been claimed by the current page by calling `USBDevice.claimInterface()`.
 
 ## Specifications


### PR DESCRIPTION
The macros add code fences themselves so no need to provide extra styles ``` **` ```.