### PR TITLE
Include audio/video fallback downloads.

### DIFF
--- a/files/en-us/learn/html/cheatsheet/index.md
+++ b/files/en-us/learn/html/cheatsheet/index.md
@@ -212,7 +212,7 @@ format&#x3C;/code>.</pre
         <pre class="brush: html">
 &#x3C;audio controls="controls">
   &#x3C;source="t-rex-roar.mp3" type="audio/mpeg">
-  Your browser does not support Audio.
+  &#x3C;a href="t-rex-roar.mp3">Download MP3&#x3C;/a>
 &#x3C;/audio></pre
         >
         {{EmbedLiveSample("audio-example", 100, 80)}}
@@ -225,7 +225,7 @@ format&#x3C;/code>.</pre
         <pre class="brush: html">
 &#x3C;video controls width="250"
   src="https://archive.org/download/ElephantsDream/ed_hd.ogv" >
-  The &#x3C;code>video&#x3C;/code> element is unsupported.
+  &#x3C;a href="https://archive.org/download/ElephantsDream/ed_hd.ogv">Download OGV video&#x3C;/a>
 &#x3C;/video></pre
         >
         {{EmbedLiveSample("video-example", 100, 200)}}

--- a/files/en-us/web/html/element/audio/index.md
+++ b/files/en-us/web/html/element/audio/index.md
@@ -243,8 +243,8 @@ Browsers don't all support the same [file types](/en-US/docs/Web/Media/Formats/C
 <audio controls>
   <source src="myAudio.mp3" type="audio/mpeg">
   <source src="myAudio.ogg" type="audio/ogg">
-  <p>Your browser doesn't support HTML audio. Here is
-     a <a href="myAudio.mp3">link to the audio</a> instead.</p>
+  <p>Download <a href="myAudio.mp3">MP3</a> or
+     <a href="myAudio.ogg">OGG</a> audio.</p>
 </audio>
 ```
 
@@ -313,7 +313,7 @@ The following example shows simple usage of the `<audio>` element to play an OGG
 <audio
   src="AudioTest.ogg"
   autoplay>
-  Your browser does not support the <code>audio</code> element.
+  <a href="AudioTest.ogg">Download OGG audio</a>.
 </audio>
 ```
 
@@ -326,7 +326,7 @@ This example specifies which audio track to embed using the `src` attribute on a
 ```html
 <audio controls>
   <source src="foo.wav" type="audio/wav">
-  Your browser does not support the <code>audio</code> element.
+  <a href="foo.wav">Download WAV audio</a>.
 </audio>
 ```
 
@@ -373,8 +373,7 @@ Also it's a good practice to provide some content (such as the direct download l
   <source src="myAudio.mp3" type="audio/mpeg">
   <source src="myAudio.ogg" type="audio/ogg">
   <p>
-    Your browser doesn't support HTML audio.
-    Here is a <a href="myAudio.mp3">link to download the audio</a> instead.
+    Download <a href="myAudio.mp3">MP3</a> or <a href="myAudio.ogg">OGG</a> audio.
   </p>
 </audio>
 ```

--- a/files/en-us/web/html/element/video/index.md
+++ b/files/en-us/web/html/element/video/index.md
@@ -407,7 +407,10 @@ This example builds on the last one, offering three different sources for the me
     src="https://archive.org/download/ElephantsDream/ed_1024_512kb.mp4"
     type="video/mp4">
 
-  Your browser doesn't support HTML video tag.
+Sorry, your browser doesn't support embedded videos,
+but don't worry, you can <a href="https://archive.org/download/ElephantsDream/ed_1024_512kb.mp4">download the MP4</a>
+and watch it with your favorite video player!
+
 </video>
 ```
 


### PR DESCRIPTION
#### Summary

As per e.g. the MDN audio help, “it's a good practice to provide some content (such as the direct download link) as a fallback for viewers” so include this good practice in the examples.

#### Motivation

I saw someone copying the example from the audio page and thereby not providing any good fallback content.

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

Connects with https://github.com/mdn/interactive-examples/pull/2254 to update the interactive example.