### PR TITLE
docs: uniform semicolon and quotation marks

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/map/foreach/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/foreach/index.md
@@ -88,9 +88,9 @@ The following code logs a line for each element in an `Map` object:
 
 ```js
 function logMapElements(value, key, map) {
-  console.log(`map.get('${key}') = ${value}`)
+  console.log(`map.get('${key}') = ${value}`);
 }
-new Map([['foo', 3], ['bar', {}], ['baz', undefined]]).forEach(logMapElements)
+new Map([['foo', 3], ['bar', {}], ['baz', undefined]]).forEach(logMapElements);
 // logs:
 // "map.get('foo') = 3"
 // "map.get('bar') = [object Object]"

--- a/files/en-us/web/javascript/reference/global_objects/map/has/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/has/index.md
@@ -39,7 +39,7 @@ otherwise `false`.
 
 ```js
 const myMap = new Map();
-myMap.set('bar', "foo");
+myMap.set('bar', 'foo');
 
 myMap.has('bar'); // returns true
 myMap.has('baz'); // returns false

--- a/files/en-us/web/javascript/reference/global_objects/map/keys/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/keys/index.md
@@ -22,7 +22,7 @@ that contains the keys for each element in the `Map` object in insertion order. 
 ## Syntax
 
 ```js
-keys();
+keys()
 ```
 
 ### Return value
@@ -35,9 +35,9 @@ A new {{jsxref("Map")}} iterator object.
 
 ```js
 const myMap = new Map();
-myMap.set("0", "foo");
-myMap.set(1, "bar");
-myMap.set({}, "baz");
+myMap.set('0', 'foo');
+myMap.set(1, 'bar');
+myMap.set({}, 'baz');
 
 const mapIter = myMap.keys();
 

--- a/files/en-us/web/javascript/reference/global_objects/map/size/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/size/index.md
@@ -31,7 +31,7 @@ myMap.set('a', 'alpha');
 myMap.set('b', 'beta');
 myMap.set('g', 'gamma');
 
-myMap.size // 3
+myMap.size; // 3
 ```
 
 ## Specifications


### PR DESCRIPTION
#### Summary

- Use the semicolon if it is needed, and remove it if it is not.
- Single quotation marks are preferred for strings

#### Metadata

- [x] Fixes a typo, bug, or other error


