### PR TITLE
Removed references to sectioning roots

### DIFF
--- a/files/en-us/web/html/element/figure/index.md
+++ b/files/en-us/web/html/element/figure/index.md
@@ -30,9 +30,9 @@ The **`<figure>`** [HTML](/en-US/docs/Web/HTML) element represents self-containe
         <a href="/en-US/docs/Web/Guide/HTML/Content_categories#flow_content"
           >Flow content</a
         >,
-        <a href="/en-US/docs/Web/HTML/Element/Heading_Elements#sectioning_roots"
-          >sectioning root</a
-        >, palpable content.
+        <a href="/en-US/docs/Web/Guide/HTML/Content_categories#palpable_content"
+          >palpable content</a
+        >.
       </td>
     </tr>
     <tr>
@@ -90,7 +90,6 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Global_a
 ## Usage notes
 
 - Usually a `<figure>` is an image, illustration, diagram, code snippet, etc., that is referenced in the main flow of a document, but that can be moved to another part of the document or to an appendix without affecting the main flow.
-- Being a [sectioning root](/en-US/docs/Web/HTML/Element/Heading_Elements#sectioning_roots), the outline of the content of the `<figure>` element is excluded from the main outline of the document.
 - A caption can be associated with the `<figure>` element by inserting a {{HTMLElement("figcaption")}} inside it (as the first or the last child). The first `<figcaption>` element found in the figure is presented as the figure's caption.
 
 ## Examples


### PR DESCRIPTION
#### Summary
I removed the references to sectioning roots and added an internal link to palpable content.

#### Motivation
The page contains references to `<figure>` being a sectioning root, but sectioning roots seem to have been deprecated. 

#### Supporting details
I couldn't find a specific reference to show that sectioning roots have been deprecated, but the fact that they appear in the [HTML 5.2 standard](https://www.w3.org/TR/2017/REC-html52-20171214/sections.html), but not the [living standard](https://html.spec.whatwg.org/multipage/sections.html), seems to indicate that they are deprecated.

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
