### PR TITLE
fix: helloMessage is not a function

### DIFF
--- a/files/en-us/glossary/first-class_function/index.md
+++ b/files/en-us/glossary/first-class_function/index.md
@@ -31,7 +31,7 @@ function sayHello() {
   return "Hello, ";
 }
 function greeting(helloMessage, name) {
-  console.log(helloMessage() + name);
+  console.log(helloMessage + name);
 }
 // Pass `sayHello` as an argument to `greeting` function
 greeting(sayHello, "JavaScript!");


### PR DESCRIPTION
Remove the parenthesis in the ´´´console.log(helloMessage + name);´´´ to avoid the error message VM727:2 Uncaught TypeError: helloMessage is not a function.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
