### PR TITLE
Markup remaining pug code blocks

### DIFF
--- a/files/en-us/learn/server-side/express_nodejs/displaying_data/book_detail_page/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/displaying_data/book_detail_page/index.md
@@ -99,7 +99,7 @@ Almost everything in this template has been demonstrated in previous sections.
 
 > **Note:** The list of genres associated with the book is implemented in the template as below. This adds a comma after every genre associated with the book except for the last one.
 >
-> ```plain
+> ```pug
 >   p #[strong Genre:]
 >     each val, index in book.genre
 >       a(href=val.url) #{val.name}

--- a/files/en-us/learn/server-side/express_nodejs/displaying_data/template_primer/index.md
+++ b/files/en-us/learn/server-side/express_nodejs/displaying_data/template_primer/index.md
@@ -45,7 +45,7 @@ The example template file below shows off many of Pug's most useful features.
 
 The first thing to notice is that the file maps the structure of a typical HTML file, with the first word in (almost) every line being an HTML element, and indentation being used to indicate nested elements. So for example, the `body` element is inside an `html` element, and paragraph elements (`p`) are within the `body` element, etc. Non-nested elements (e.g. individual paragraphs) are on separate lines.
 
-```plain
+```pug
 doctype html
 html(lang="en")
   head
@@ -92,14 +92,14 @@ The values of all attributes are _escaped_ (e.g. characters like "`>`" are conve
 
 If a tag is followed by the equals sign, the following text is treated as a JavaScript _expression_. So for example, in the first line below, the content of the `h1` tag will be _variable_ `title` (either defined in the file or passed into the template from Express). In the second line the paragraph content is a text string concatenated with the `title` variable. In both cases the default behavior is to _escape_ the line.
 
-```plain
+```pug
 h1= title
 p= 'Evaluated and <em>escaped expression</em>:' + title
 ```
 
 If there is no equals symbol after the tag then the content is treated as plain text. Within the plain text you can insert escaped and unescaped data using the `#{}` and `!{}` syntax respectively, as shown below. You can also add raw HTML within the plain text.
 
-```plain
+```pug
 p This is a line with #[em some emphasis] and #[strong strong text] markup.
 p This line has an un-escaped string: !{'<em> is emphasized</em>'}, an escaped string: #{'<em> is not emphasized</em>'}, and escaped variables: #{title}.
 ```
@@ -108,14 +108,14 @@ p This line has an un-escaped string: !{'<em> is emphasized</em>'}, an escaped s
 
 You can use the pipe ('**|**') character at the beginning of a line to indicate "[plain text](https://pugjs.org/language/plain-text.html)". For example, the additional text shown below will be displayed on the same line as the preceding anchor, but will not be linked.
 
-```plain
+```pug
 a(href='http://someurl/') Link text
 | Plain text
 ```
 
 Pug allows you to perform conditional operations using `if`, `else` , `else if` and `unless`—for example:
 
-```plain
+```pug
 if title
   p A variable named "title" exists
 else
@@ -124,7 +124,7 @@ else
 
 You can also perform loop/iteration operations using `each-in` or `while` syntax. In the code fragment below we've looped through an array to display a list of variables (note the use of the 'li=' to evaluate the "val" as a variable below. The value you iterate across can also be passed into the template as a variable!
 
-```plain
+```pug
 ul
   each val in [1, 2, 3, 4, 5]
     li= val


### PR DESCRIPTION
Pug template rendering is now supported on MDN - see https://github.com/mdn/yari/pull/6831/

Most blocks were marked up. This adds the remaining ones.
