### PR TITLE
Code block syntax highlighting list: add pug, yaml

### DIFF
--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -68,6 +68,7 @@ In MDN, writers will use code fences for example code blocks. They must specify 
 - `svg`
 - `xml`
 - `wasm` (for WebAssembly text format)
+- `yaml`
 
 For example:
 

--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -74,9 +74,13 @@ For example:
 
 ````plain
 ```js
-const greeting = "I will get syntax highlighting";
+const greeting = "I will get JavaScript syntax highlighting";
 ```
 ````
+
+If the highlighting that you wish to use is not listed above you should markup the code block as `plain`.
+Additional languages may be requested by following the [this process](https://github.com/orgs/mdn/discussions/170#discussioncomment-3404366).
+
 
 Writers will be able to supply any one of the following additional words, which must come after the language word:
 

--- a/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
+++ b/files/en-us/mdn/writing_guidelines/howto/markdown_in_mdn/index.md
@@ -62,6 +62,7 @@ In MDN, writers will use code fences for example code blocks. They must specify 
 - `js` (for JavaScript)
 - `json`
 - `php`
+- `pug` (for [pug templates](https://pugjs.org/api/getting-started.html), which may be used by [Express](/en-US/docs/Learn/Server-side/Express_Nodejs/Displaying_data/Template_primer))
 - `python`
 - `sql`
 - `svg`


### PR DESCRIPTION
Add `pug` to list of supported code syntaxes
- Added by https://github.com/mdn/yari/pull/6831/
- According to policy: https://github.com/orgs/mdn/discussions/170#discussioncomment-3404366