### PR TITLE
markup using yaml syntax highlighting

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_reference_page_template/index.md
@@ -16,7 +16,7 @@ The page front matter in the pages on MDN Web Docs comprises of the YAML headers
 > **Note:** _Remove this whole explanatory note before publishing._
 >
 >
-> ```plain
+> ```md
 > ---
 > title: NameOfTheInterface
 > slug: Web/API/NameOfTheInterface


### PR DESCRIPTION
YAML code syntax highlighting is now supported on MDN: https://github.com/mdn/yari/pull/6831

The only usage of it I could find was on the page structure docs. This adds it there. 