### PR TITLE
Update BCD info, part 31

### DIFF
--- a/files/en-us/web/api/otpcredential/index.md
+++ b/files/en-us/web/api/otpcredential/index.md
@@ -7,9 +7,10 @@ tags:
   - Interface
   - Reference
   - OTPCredential
+  - Experimental
 browser-compat: api.OTPCredential
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebOTP API")}}
+{{APIRef("WebOTP API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`OTPCredential`** interface of the {{domxref('WebOTP API','','',' ')}} contains the attributes that are returned when a new one-time password is retrieved.
 
@@ -19,7 +20,7 @@ The **`OTPCredential`** interface of the {{domxref('WebOTP API','','',' ')}} con
 
 _This interface also inherits properties from {{domxref("Credential")}}._
 
-- {{domxref("OTPCredential.code")}}
+- {{domxref("OTPCredential.code")}} {{Experimental_Inline}}
   - : The one-time password.
 
 ### Event handlers

--- a/files/en-us/web/api/performanceelementtiming/rendertime/index.md
+++ b/files/en-us/web/api/performanceelementtiming/rendertime/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - renderTime
   - PerformanceElementTiming
+  - Experimental
 browser-compat: api.PerformanceElementTiming.renderTime
 ---
-{{DefaultAPISidebar("Element Timing")}}
+{{APIRef("Element Timing")}}{{SeeCompatTable}}
 
 The **`renderTime`** read-only property of the {{domxref("PerformanceElementTiming")}} interface returns the render time of the associated element.
 

--- a/files/en-us/web/api/performanceelementtiming/tojson/index.md
+++ b/files/en-us/web/api/performanceelementtiming/tojson/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - toJSON()
   - PerformanceElementTiming
+  - Experimental
 browser-compat: api.PerformanceElementTiming.toJSON
 ---
-{{DefaultAPISidebar("Element Timing")}}
+{{APIRef("Element Timing")}}{{SeeCompatTable}}
 
 The **`toJSON()`** method of the {{domxref("PerformanceElementTiming")}} interface is a standard serializer. It returns a JSON representation of the object's properties.
 

--- a/files/en-us/web/api/performanceelementtiming/url/index.md
+++ b/files/en-us/web/api/performanceelementtiming/url/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - url
   - PerformanceElementTiming
+  - Experimental
 browser-compat: api.PerformanceElementTiming.url
 ---
-{{DefaultAPISidebar("Element Timing")}}
+{{APIRef("Element Timing")}}{{SeeCompatTable}}
 
 The **`url`** read-only property of the {{domxref("PerformanceElementTiming")}} interface returns the initial URL of the resource request when the element is an image.
 

--- a/files/en-us/web/api/performancelongtasktiming/index.md
+++ b/files/en-us/web/api/performancelongtasktiming/index.md
@@ -8,6 +8,7 @@ tags:
   - Long Tasks API
   - PerformanceLongTaskTiming
   - Reference
+  - Experimental
 browser-compat: api.PerformanceLongTaskTiming
 ---
 {{SeeCompatTable}}{{APIRef("Long Tasks")}}
@@ -18,7 +19,7 @@ The **`PerformanceLongTaskTiming`** interface of the [Long Tasks API](/en-US/doc
 
 ## Properties
 
-- {{domxref("PerformanceLongTaskTiming.attribution")}} {{ReadOnlyInline}}
+- {{domxref("PerformanceLongTaskTiming.attribution")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns a sequence of {{domxref('TaskAttributionTiming')}} instances.
 
 ## Specifications

--- a/files/en-us/web/api/periodicsyncevent/index.md
+++ b/files/en-us/web/api/periodicsyncevent/index.md
@@ -11,9 +11,10 @@ tags:
   - Reference
   - ServiceWorker
   - Workers
+  - Experimental
 browser-compat: api.PeriodicSyncEvent
 ---
-{{DefaultAPISidebar("Periodic Background Sync")}}
+{{APIRef("Periodic Background Sync")}}{{SeeCompatTable}}
 
 The **`PeriodicSyncEvent`** interface of the {{domxref('Web Periodic Background Synchronization API')}} provides a way to run tasks in the service worker with network connectivity.
 
@@ -23,12 +24,12 @@ An instance of this event is passed to the {{domxref('ServiceWorkerGlobalScope.p
 
 ## Constructor
 
-- {{domxref("PeriodicSyncEvent.PeriodicSyncEvent()")}}
+- {{domxref("PeriodicSyncEvent.PeriodicSyncEvent()")}} {{Experimental_Inline}}
   - : Creates a new `PeriodicSyncEvent` object. This constructor is not typically used. The browser creates these objects itself and provides them to {{domxref('ServiceWorkerGlobalScope.periodicsync_event', 'onperiodicsync')}} callback.
 
 ## Properties
 
-- {{domxref('PeriodicSyncEvent.tag')}} {{ReadOnlyInline}}
+- {{domxref('PeriodicSyncEvent.tag')}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns the developer-defined identifier for this `PeriodicSyncEvent`. Multiple tags can be used by the web app to run different periodic tasks at different frequencies.
 
 ## Methods

--- a/files/en-us/web/api/periodicsyncevent/tag/index.md
+++ b/files/en-us/web/api/periodicsyncevent/tag/index.md
@@ -10,9 +10,10 @@ tags:
   - Service Worker
   - Web Periodic Background Synchronization API
   - periodic sync
+  - Experimental
 browser-compat: api.PeriodicSyncEvent.tag
 ---
-{{DefaultAPISidebar("Periodic Background Sync")}}
+{{APIRef("Periodic Background Sync")}}{{SeeCompatTable}}
 
 The **`tag`** read-only property of the
 {{domxref("PeriodicSyncEvent")}} interface returns the developer-defined identifier for

--- a/files/en-us/web/api/periodicsyncmanager/gettags/index.md
+++ b/files/en-us/web/api/periodicsyncmanager/gettags/index.md
@@ -11,9 +11,10 @@ tags:
   - Service Worker
   - Web Periodic Background Synchronization API
   - periodic sync
+  - Experimental
 browser-compat: api.PeriodicSyncManager.getTags
 ---
-{{DefaultAPISidebar("Periodic Background Sync")}}
+{{APIRef("Periodic Background Sync")}}{{SeeCompatTable}}
 
 The **`getTags()`** method of the
 {{domxref("PeriodicSyncManager")}} interface returns a {{jsxref('Promise')}} that

--- a/files/en-us/web/api/periodicsyncmanager/register/index.md
+++ b/files/en-us/web/api/periodicsyncmanager/register/index.md
@@ -10,9 +10,10 @@ tags:
   - PeriodicSyncManager
   - Service Worker
   - Web Periodic Background Synchronization API
+  - Experimental
 browser-compat: api.PeriodicSyncManager.register
 ---
-{{DefaultAPISidebar("Periodic Background Sync")}}
+{{APIRef("Periodic Background Sync")}}{{SeeCompatTable}}
 
 The **`register()`** method of the
 {{domxref("PeriodicSyncManager")}} interface registers a periodic sync request with the

--- a/files/en-us/web/api/periodicsyncmanager/unregister/index.md
+++ b/files/en-us/web/api/periodicsyncmanager/unregister/index.md
@@ -10,9 +10,10 @@ tags:
   - PeriodicSyncManager
   - Service Worker
   - Web Periodic Background Synchronization API
+  - Experimental
 browser-compat: api.PeriodicSyncManager.unregister
 ---
-{{DefaultAPISidebar("Periodic Background Sync")}}
+{{APIRef("Periodic Background Sync")}}{{SeeCompatTable}}
 
 The **`unregister()`** method of the
 {{domxref("PeriodicSyncManager")}} interface unregisters the periodic sync request

--- a/files/en-us/web/api/presentation/defaultrequest/index.md
+++ b/files/en-us/web/api/presentation/defaultrequest/index.md
@@ -8,9 +8,10 @@ tags:
   - Property
   - Reference
   - Web
+  - Experimental
 browser-compat: api.Presentation.defaultRequest
 ---
-{{SeeCompatTable}}{{securecontext_header}}{{DefaultAPISidebar("Presentation API")}}
+{{APIRef("Presentation API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 In a [controlling user agent](https://www.w3.org/TR/presentation-api/#dfn-controlling-user-agent), the _`defaultRequest`_ attribute _MUST_ return the [default presentation request](https://www.w3.org/TR/presentation-api/#dfn-default-presentation-request) if any, otherwise `null`. In a [receiving browsing context](https://www.w3.org/TR/presentation-api/#dfn-receiving-browsing-context), it _MUST_ return `null`.
 

--- a/files/en-us/web/api/presentation/receiver/index.md
+++ b/files/en-us/web/api/presentation/receiver/index.md
@@ -10,9 +10,10 @@ tags:
   - Read-only
   - Reference
   - receiver
+  - Experimental
 browser-compat: api.Presentation.receiver
 ---
-{{APIRef("Presentation")}}
+{{APIRef("Presentation")}}{{SeeCompatTable}}
 
 The **read-only** {{domxref("Presentation")}} attribute
 `receiver`, which is only available in browser contexts which are

--- a/files/en-us/web/api/presentationconnection/binarytype/index.md
+++ b/files/en-us/web/api/presentationconnection/binarytype/index.md
@@ -14,9 +14,10 @@ tags:
   - Property
   - Reference
   - binaryType
+  - Experimental
 browser-compat: api.PresentationConnection.binaryType
 ---
-{{DefaultAPISidebar("Presentation API")}}
+{{APIRef("Presentation API")}}{{SeeCompatTable}}
 
 When a {{DOMxRef("PresentationConnection")}} object is created, its `binaryType` IDL attribute _MUST_ be set to the string `"arraybuffer"`. Upon getting, the attribute *MUST* return its most recent value (the value it was last set as). Upon setting, the user agent _MUST_ set the IDL attribute to the new value.
 

--- a/files/en-us/web/api/presentationconnection/close/index.md
+++ b/files/en-us/web/api/presentationconnection/close/index.md
@@ -11,9 +11,10 @@ tags:
   - Presentation
   - PresentationConnection
   - Reference
+  - Experimental
 browser-compat: api.PresentationConnection.close
 ---
-{{DefaultAPISidebar("Presentation API")}}
+{{APIRef("Presentation API")}}{{SeeCompatTable}}
 
 When the `close()` method is called on a {{domxref("PresentationConnection")}}, the {{Glossary("user agent")}} begins the process of closing the connection by sending an empty `closeMessage` with the `closeReason` set to `closed`.
 

--- a/files/en-us/web/api/presentationconnection/id/index.md
+++ b/files/en-us/web/api/presentationconnection/id/index.md
@@ -14,9 +14,10 @@ tags:
   - Reference
   - Web
   - id
+  - Experimental
 browser-compat: api.PresentationConnection.id
 ---
-{{DefaultAPISidebar("Presentation API")}}
+{{APIRef("Presentation API")}}{{SeeCompatTable}}
 
 The _`id`_ attribute specifies the [presentation identifier](https://www.w3.org/TR/presentation-api/#dfn-presentation-identifier) of a [presentation connection](https://www.w3.org/TR/presentation-api/#dfn-presentation-connection).
 

--- a/files/en-us/web/api/presentationconnection/send/index.md
+++ b/files/en-us/web/api/presentationconnection/send/index.md
@@ -14,7 +14,7 @@ tags:
   - send
 browser-compat: api.PresentationConnection.send
 ---
-{{APIRef("Presentation")}}
+{{APIRef("Presentation")}}{{SeeCompatTable}}
 
 The **`send()`** method of the
 {{domxref("PresentationConnection")}} interface tells a controlling browsing context to

--- a/files/en-us/web/api/presentationconnection/state/index.md
+++ b/files/en-us/web/api/presentationconnection/state/index.md
@@ -13,9 +13,10 @@ tags:
   - Property
   - Reference
   - state
+  - Experimental
 browser-compat: api.PresentationConnection.state
 ---
-{{DefaultAPISidebar("Presentation API")}}
+{{APIRef("Presentation API")}}{{SeeCompatTable}}
 
 The _`state`_ attribute reflects the [presentation connection](https://www.w3.org/TR/presentation-api/#dfn-presentation-connection)'s current state. Depending on the current [`PresentationConnectionState`](https://www.w3.org/TR/presentation-api/#idl-def-presentationconnectionstate), the *`state`* attribute can hold one of the following values.
 

--- a/files/en-us/web/api/presentationconnection/terminate/index.md
+++ b/files/en-us/web/api/presentationconnection/terminate/index.md
@@ -13,9 +13,10 @@ tags:
   - PresentationConnection
   - Reference
   - terminate
+  - Experimental
 browser-compat: api.PresentationConnection.terminate
 ---
-{{DefaultAPISidebar("Presentation API")}}
+{{APIRef("Presentation API")}}{{SeeCompatTable}}
 
 When the `terminate()` method is called on a {{domxref("PresentationConnection")}}, the {{Glossary("user agent")}} begins the process of terminating the presentation. The exact process differs depending on whether `terminate()` is called in the controlling or the presenting context.
 

--- a/files/en-us/web/api/presentationrequest/reconnect/index.md
+++ b/files/en-us/web/api/presentationrequest/reconnect/index.md
@@ -6,9 +6,10 @@ tags:
   - Promise
   - controlled presentations
   - presentation identifier
+  - Experimental
 browser-compat: api.PresentationRequest.reconnect
 ---
-{{DefaultAPISidebar("Presentation API")}}
+{{APIRef("Presentation API")}}{{SeeCompatTable}}
 
 When the `reconnect(presentationId)` method is called on a `PresentationRequest` _presentationRequest_, the [user agent](https://www.w3.org/TR/presentation-api/#dfn-user-agents) _MUST_ run the following steps to _reconnect to a presentation_:
 

--- a/files/en-us/web/api/reportingobserver/index.md
+++ b/files/en-us/web/api/reportingobserver/index.md
@@ -11,13 +11,13 @@ tags:
   - ReportingObserver
 browser-compat: api.ReportingObserver
 ---
-{{SeeCompatTable}}{{APIRef("Reporting API")}}
+{{APIRef("Reporting API")}}{{SeeCompatTable}}
 
 The `ReportingObserver` interface of the [Reporting API](/en-US/docs/Web/API/Reporting_API) allows you to collect and access reports.
 
 ## Constructor
 
-- {{domxref("ReportingObserver.ReportingObserver", "ReportingObserver()")}}
+- {{domxref("ReportingObserver.ReportingObserver", "ReportingObserver()")}} {{Experimental_Inline}}
   - : Creates a new `ReportingObserver` object instance, which can be used to collect and access reports.
 
 ## Properties
@@ -26,11 +26,11 @@ _This interface has no properties defined on it._
 
 ## Methods
 
-- {{domxref("ReportingObserver.disconnect()")}} {{experimental_inline}}
+- {{domxref("ReportingObserver.disconnect()")}} {{Experimental_Inline}}
   - : Stops a reporting observer that had previously started observing from collecting reports.
-- {{domxref("ReportingObserver.observe()")}} {{experimental_inline}}
+- {{domxref("ReportingObserver.observe()")}} {{Experimental_Inline}}
   - : Instructs a reporting observer to start collecting reports in its report queue.
-- {{domxref("ReportingObserver.takeRecords()")}} {{experimental_inline}}
+- {{domxref("ReportingObserver.takeRecords()")}} {{Experimental_Inline}}
   - : Returns the current list of reports contained in the observer's report queue, and empties the queue.
 
 ## Events

--- a/files/en-us/web/api/request/priority/index.md
+++ b/files/en-us/web/api/request/priority/index.md
@@ -9,9 +9,10 @@ tags:
   - Reference
   - priority
   - request
+  - Experimental
 browser-compat: api.Request.priority
 ---
-{{APIRef("Fetch")}}
+{{APIRef("Fetch")}}{{SeeCompatTable}}
 
 The **`priority`** read-only property of the {{domxref("Request")}}
 interface contains the hinted priority of the request relative to other

--- a/files/en-us/web/api/sanitizer/index.md
+++ b/files/en-us/web/api/sanitizer/index.md
@@ -6,9 +6,10 @@ tags:
   - HTML Sanitizer API
   - Interface
   - sanitize
+  - Experimental
 browser-compat: api.Sanitizer
 ---
-{{SeeCompatTable}}{{securecontext_header}}{{APIRef("Sanitizer")}}
+{{APIRef("Sanitizer")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`Sanitizer`** interface of the {{domxref('HTML Sanitizer API')}} provides methods to sanitize untrusted strings of HTML, {{domxref("Document")}} and {{domxref("DocumentFragment")}} objects.
 After sanitization, unwanted elements or attributes are removed, and the returned objects can safely be inserted into a document's DOM.
@@ -20,15 +21,15 @@ This configuration may be customized using constructor options.
 
 ## Constructors
 
-- {{domxref("Sanitizer.Sanitizer", "Sanitizer()")}}
+- {{domxref("Sanitizer.Sanitizer", "Sanitizer()")}} {{Experimental_Inline}}
   - : Creates and returns a `Sanitizer` object, optionally with custom sanitization behavior.
 
 ## Methods
 
-- {{domxref('Sanitizer.sanitize()')}}
+- {{domxref('Sanitizer.sanitize()')}} {{Experimental_Inline}}
   - : Returns a sanitized {{domxref('DocumentFragment')}} from an input {{domxref('Document')}} or {{domxref('DocumentFragment')}}
 
-- {{domxref('Sanitizer.sanitizeFor()')}}
+- {{domxref('Sanitizer.sanitizeFor()')}} {{Experimental_Inline}}
   - : Parses a string of HTML in the context a particular element, and returns an HTML element of that type containing the sanitized subtree.
 
 ## Examples

--- a/files/en-us/web/api/sanitizer/sanitize/index.md
+++ b/files/en-us/web/api/sanitizer/sanitize/index.md
@@ -6,9 +6,10 @@ tags:
   - HTML Sanitizer API
   - Method
   - sanitize
+  - Experimental
 browser-compat: api.Sanitizer.sanitize
 ---
-{{SeeCompatTable}}{{securecontext_header}}{{DefaultAPISidebar("HTML Sanitizer API")}}
+{{APIRef("HTML Sanitizer API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`sanitize()`** method of the {{domxref("Sanitizer")}} interface is used to sanitize a tree of DOM nodes, removing any unwanted elements or attributes.
 

--- a/files/en-us/web/api/sanitizer/sanitizefor/index.md
+++ b/files/en-us/web/api/sanitizer/sanitizefor/index.md
@@ -6,9 +6,10 @@ tags:
   - HTML Sanitizer API
   - Method
   - sanitizeFor
+  - Experimental
 browser-compat: api.Sanitizer.sanitizeFor
 ---
-{{SeeCompatTable}}{{securecontext_header}}{{DefaultAPISidebar("HTML Sanitizer API")}}
+{{APIRef("HTML Sanitizer API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`sanitizeFor()`** method of the {{domxref("Sanitizer")}} interface is used to parse and sanitize a string of HTML for insertion into the DOM at some later point.
 

--- a/files/en-us/web/api/sanitizer/sanitizer/index.md
+++ b/files/en-us/web/api/sanitizer/sanitizer/index.md
@@ -7,9 +7,10 @@ tags:
   - Constructor
   - HTML Sanitizer API
   - sanitize
+  - Experimental
 browser-compat: api.Sanitizer.Sanitizer
 ---
-{{SeeCompatTable}}{{securecontext_header}}{{DefaultAPISidebar("HTML Sanitizer API")}}
+{{APIRef("HTML Sanitizer API")}}{{SeeCompatTable}}{{SecureContext_Header}}
 
 The **`Sanitizer()`** constructor creates a new {{domxref("Sanitizer")}} object, which can be used to sanitize untrusted strings of HTML, or untrusted {{domxref("Document")}} or {{domxref("DocumentFragment")}} objects, making them safe for insertion into a document's DOM.
 

--- a/files/en-us/web/api/screen_wake_lock_api/index.md
+++ b/files/en-us/web/api/screen_wake_lock_api/index.md
@@ -10,9 +10,10 @@ tags:
   - Wake Lock
   - WakeLock
   - screen
+  - Experimental
 browser-compat: api.WakeLock
 ---
-{{DefaultAPISidebar("Screen Wake Lock API")}}
+{{DefaultAPISidebar("Screen Wake Lock API")}}{{SeeCompatTable}}
 
 The Screen Wake Lock API provides a way to prevent devices from dimming or locking the screen when an application needs to keep running.
 

--- a/files/en-us/web/api/serial/getports/index.md
+++ b/files/en-us/web/api/serial/getports/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - Serial.getPorts
   - Serial
+  - Experimental
 browser-compat: api.Serial.getPorts
 ---
-{{securecontext_header}}{{DefaultAPISidebar("Serial API")}}
+{{APIRef("Serial API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`getPorts()`** method of the {{domxref("Serial")}} interface returns a {{jsxref("Promise")}} that resolves with an array of {{domxref("SerialPort")}} objects representing serial ports connected to the host which the origin has permission to access.
 

--- a/files/en-us/web/api/serial/requestport/index.md
+++ b/files/en-us/web/api/serial/requestport/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - requestPort
   - Serial
+  - Experimental
 browser-compat: api.Serial.requestPort
 ---
-{{securecontext_header}}{{DefaultAPISidebar("Serial API")}}
+{{APIRef("Serial API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`Serial.requestPort()`** method of the {{domxref("Serial")}} interface returns a {{jsxref("Promise")}} that resolves with an instance of {{domxref("SerialPort")}} representing the device chosen by the user or rejects if no device was selected.
 

--- a/files/en-us/web/api/serialport/close/index.md
+++ b/files/en-us/web/api/serialport/close/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - close
   - SerialPort
+  - Experimental
 browser-compat: api.SerialPort.close
 ---
-{{securecontext_header}}{{DefaultAPISidebar("Serial API")}}
+{{APIRef("Serial API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`SerialPort.close()`** method of the {{domxref("SerialPort")}} interface returns a {{jsxref("Promise")}} that resolves when the port closes.
 

--- a/files/en-us/web/api/serialport/connect_event/index.md
+++ b/files/en-us/web/api/serialport/connect_event/index.md
@@ -7,9 +7,10 @@ tags:
   - Event
   - Reference
   - SerialPort
+  - Experimental
 browser-compat: api.SerialPort.connect_event
 ---
-{{securecontext_header}}{{APIRef("Serial API")}}
+{{APIRef("Serial API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`connect`** event of the {{domxref("SerialPort")}} interface is fired when a port has connected to the device. This event is only fired for ports associated with removable devices such as those connected via USB.
 


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.

This covers files that have only `experimental` header modifications.