### PR TITLE
Update BCD info, part 32

### DIFF
--- a/files/en-us/web/api/serviceworkerglobalscope/periodicsync_event/index.md
+++ b/files/en-us/web/api/serviceworkerglobalscope/periodicsync_event/index.md
@@ -8,9 +8,10 @@ tags:
   - Periodic Background Synchronization
   - ServiceWorkerGlobalScope
   - events
+  - Experimental
 browser-compat: api.ServiceWorkerGlobalScope.periodicsync_event
 ---
-{{DefaultAPISidebar("Periodic Background Sync")}}
+{{APIRef("Periodic Background Sync")}}{{SeeCompatTable}}
 
 The **`periodicsync`** event of the {{domxref("ServiceWorkerGlobalScope")}} interface is fired at timed intervals, specified when registering a {{domxref('PeriodicSyncManager')}}.
 

--- a/files/en-us/web/api/serviceworkerregistration/index/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/index/index.md
@@ -12,9 +12,10 @@ tags:
   - ServiceWorkerRegistration
   - content index
   - content indexing
+  - Experimental
 browser-compat: api.ServiceWorkerRegistration.index
 ---
-{{APIRef("Service Workers API")}}
+{{APIRef("Service Workers API")}}{{SeeCompatTable}}
 
 The **`index`** read-only property of the
 {{domxref("ServiceWorkerRegistration")}} interface returns a reference to the

--- a/files/en-us/web/api/serviceworkerregistration/periodicsync/index.md
+++ b/files/en-us/web/api/serviceworkerregistration/periodicsync/index.md
@@ -13,7 +13,7 @@ tags:
   - periodicSync
 browser-compat: api.ServiceWorkerRegistration.periodicSync
 ---
-{{APIRef("Service Workers API")}}
+{{APIRef("Service Workers API")}}{{SeeCompatTable}}
 
 The **`periodicSync`** read-only property of
 the {{domxref("ServiceWorkerRegistration")}} interface returns a reference to the

--- a/files/en-us/web/api/sourcebuffer/appendbufferasync/index.md
+++ b/files/en-us/web/api/sourcebuffer/appendbufferasync/index.md
@@ -14,9 +14,10 @@ tags:
   - SourceBuffer
   - Video
   - appendBufferAsync
+  - Experimental
 browser-compat: api.SourceBuffer.appendBufferAsync
 ---
-{{APIRef("Media Source Extensions")}}{{non-standard_header}}
+{{APIRef("Media Source Extensions")}}{{Non-standard_Header}}{{SeeCompatTable}}
 
 The **`appendBufferAsync()`** method
 of the {{domxref("SourceBuffer")}} interface begins the process of asynchronously

--- a/files/en-us/web/api/sourcebuffer/removeasync/index.md
+++ b/files/en-us/web/api/sourcebuffer/removeasync/index.md
@@ -14,9 +14,10 @@ tags:
   - SourceBuffer
   - Video
   - removeAsync
+  - Experimental
 browser-compat: api.SourceBuffer.removeAsync
 ---
-{{APIRef("Media Source Extensions")}}{{non-standard_header}}
+{{APIRef("Media Source Extensions")}}{{Non-standard_Header}}{{SeeCompatTable}}
 
 The **`removeAsync()`** method of the
 {{domxref("SourceBuffer")}} interface starts the process of asynchronously removing

--- a/files/en-us/web/api/stylepropertymap/append/index.md
+++ b/files/en-us/web/api/stylepropertymap/append/index.md
@@ -10,6 +10,7 @@ tags:
   - Reference
   - StylePropertyMap
   - append()
+  - Experimental
 browser-compat: api.StylePropertyMap.append
 ---
 {{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/stylepropertymap/clear/index.md
+++ b/files/en-us/web/api/stylepropertymap/clear/index.md
@@ -10,6 +10,7 @@ tags:
   - Reference
   - StylePropertyMap
   - clear()
+  - Experimental
 browser-compat: api.StylePropertyMap.clear
 ---
 {{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/stylepropertymap/delete/index.md
+++ b/files/en-us/web/api/stylepropertymap/delete/index.md
@@ -10,6 +10,7 @@ tags:
   - Reference
   - StylePropertyMap
   - delete()
+  - Experimental
 browser-compat: api.StylePropertyMap.delete
 ---
 {{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/stylepropertymap/set/index.md
+++ b/files/en-us/web/api/stylepropertymap/set/index.md
@@ -10,6 +10,7 @@ tags:
   - Reference
   - StylePropertyMap
   - set()
+  - Experimental
 browser-compat: api.StylePropertyMap.set
 ---
 {{APIRef("CSS Typed Object Model API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/svgimageelement/decode/index.md
+++ b/files/en-us/web/api/svgimageelement/decode/index.md
@@ -5,7 +5,6 @@ page-type: web-api-instance-method
 tags:
   - API
   - Decode
-  - Experimental
   - Image
   - Method
   - NeedsExample

--- a/files/en-us/web/api/taskattributiontiming/containerid/index.md
+++ b/files/en-us/web/api/taskattributiontiming/containerid/index.md
@@ -9,9 +9,10 @@ tags:
   - Property
   - Reference
   - TaskAttributionTiming
+  - Experimental
 browser-compat: api.TaskAttributionTiming.containerId
 ---
-{{SeeCompatTable}}{{APIRef("Long Tasks")}}
+{{APIRef("Long Tasks")}}{{SeeCompatTable}}
 
 The **`containerId`** readonly property of the
 {{domxref("TaskAttributionTiming")}} interface returns the container's `id`

--- a/files/en-us/web/api/taskattributiontiming/containername/index.md
+++ b/files/en-us/web/api/taskattributiontiming/containername/index.md
@@ -9,9 +9,10 @@ tags:
   - Property
   - Reference
   - TaskAttributionTiming
+  - Experimental
 browser-compat: api.TaskAttributionTiming.containerName
 ---
-{{SeeCompatTable}}{{APIRef("Long Tasks")}}
+{{APIRef("Long Tasks")}}{{SeeCompatTable}}
 
 The **`containerName`** readonly property of the
 {{domxref("TaskAttributionTiming")}} interface returns the container's `name`

--- a/files/en-us/web/api/taskattributiontiming/containersrc/index.md
+++ b/files/en-us/web/api/taskattributiontiming/containersrc/index.md
@@ -9,9 +9,10 @@ tags:
   - Property
   - Reference
   - TaskAttributionTiming
+  - Experimental
 browser-compat: api.TaskAttributionTiming.containerSrc
 ---
-{{SeeCompatTable}}{{APIRef("Long Tasks")}}
+{{APIRef("Long Tasks")}}{{SeeCompatTable}}
 
 The **`containerSrc`** readonly property of the
 {{domxref("TaskAttributionTiming")}} interface returns the container's `src`

--- a/files/en-us/web/api/taskattributiontiming/containertype/index.md
+++ b/files/en-us/web/api/taskattributiontiming/containertype/index.md
@@ -9,9 +9,10 @@ tags:
   - Property
   - Reference
   - TaskAttributionTiming
+  - Experimental
 browser-compat: api.TaskAttributionTiming.containerType
 ---
-{{SeeCompatTable}}{{APIRef("Long Tasks")}}
+{{APIRef("Long Tasks")}}{{SeeCompatTable}}
 
 The **`containerType`** readonly property of the
 {{domxref("TaskAttributionTiming")}} interface returns the type of frame container, one

--- a/files/en-us/web/api/taskcontroller/index.md
+++ b/files/en-us/web/api/taskcontroller/index.md
@@ -7,10 +7,9 @@ tags:
   - Interface
   - Reference
   - TaskController
-  - Experimental
 browser-compat: api.TaskController
 ---
-{{APIRef("Prioritized Task Scheduling API")}} {{SeeCompatTable}}
+{{APIRef("Prioritized Task Scheduling API")}}
 
 The **`TaskController`** interface of the [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API) represents a controller object that can be used to both abort and change the [priority](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#task_priorities) of one or more prioritized tasks.
 If there is no need to change task priorities, then {{domxref("AbortController")}} can be used instead.

--- a/files/en-us/web/api/taskcontroller/taskcontroller/index.md
+++ b/files/en-us/web/api/taskcontroller/taskcontroller/index.md
@@ -7,10 +7,9 @@ tags:
   - Constructor
   - Reference
   - TaskController
-  - Experimental
 browser-compat: api.TaskController.TaskController
 ---
-{{APIRef("Prioritized Task Scheduling API")}} {{SeeCompatTable}}
+{{APIRef("Prioritized Task Scheduling API")}}
 
 The **`TaskController()`** constructor creates a new {{domxref("TaskController")}} object, optionally setting the initial [priority](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#task_priorities) of its associated [`signal`](/en-US/docs/Web/API/TaskController#taskcontroller.signal).
 

--- a/files/en-us/web/api/taskprioritychangeevent/index.md
+++ b/files/en-us/web/api/taskprioritychangeevent/index.md
@@ -8,11 +8,10 @@ tags:
   - TaskPriorityChangeEvent
   - Event
   - prioritychange_event
-  - Experimental
 
 browser-compat: api.TaskPriorityChangeEvent
 ---
-{{APIRef("Prioritized Task Scheduling API")}} {{SeeCompatTable}}
+{{APIRef("Prioritized Task Scheduling API")}}
 
 The **`TaskPriorityChangeEvent`** is the interface for the [`prioritychange`](/en-US/docs/Web/API/TaskSignal/prioritychange_event) event.
 

--- a/files/en-us/web/api/taskprioritychangeevent/previouspriority/index.md
+++ b/files/en-us/web/api/taskprioritychangeevent/previouspriority/index.md
@@ -6,10 +6,9 @@ tags:
   - Property
   - Reference
   - TaskPriorityChangeEvent
-  - Experimental
 browser-compat: api.TaskPriorityChangeEvent.previousPriority
 ---
-{{APIRef("Prioritized Task Scheduling API")}} {{SeeCompatTable}}
+{{APIRef("Prioritized Task Scheduling API")}}
 
 The readonly **`previousPriority`** property of the {{domxref("TaskPriorityChangeEvent")}} interface returns the priority of the corresponding {{domxref("TaskSignal")}} before it was changed and this [`prioritychange`](/en-US/docs/Web/API/TaskSignal/prioritychange_event) event was emitted.
 

--- a/files/en-us/web/api/taskprioritychangeevent/taskprioritychangeevent/index.md
+++ b/files/en-us/web/api/taskprioritychangeevent/taskprioritychangeevent/index.md
@@ -8,10 +8,9 @@ tags:
   - Reference
   - TaskPriorityChangeEvent
   - Prioritized Task Scheduling API
-  - Experimental
 browser-compat: api.TaskPriorityChangeEvent.TaskPriorityChangeEvent
 ---
-{{APIRef("Prioritized Task Scheduling API")}} {{SeeCompatTable}}
+{{APIRef("Prioritized Task Scheduling API")}}
 
 The **`TaskPriorityChangeEvent()`** constructor creates a new {{domxref("TaskPriorityChangeEvent")}} object.
 

--- a/files/en-us/web/api/tasksignal/index.md
+++ b/files/en-us/web/api/tasksignal/index.md
@@ -7,10 +7,9 @@ tags:
   - Interface
   - Reference
   - TaskSignal
-  - Experimental
 browser-compat: api.TaskSignal
 ---
-{{APIRef("Prioritized Task Scheduling API")}} {{SeeCompatTable}}
+{{APIRef("Prioritized Task Scheduling API")}}
 
 The **`TaskSignal`** interface of the [Prioritized Task Scheduling API](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API) represents a signal object that allows you to communicate with a prioritized task, and abort it or change the [priority](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#task_priorities) (if required) via a {{domxref('TaskController')}} object.
 

--- a/files/en-us/web/api/tasksignal/priority/index.md
+++ b/files/en-us/web/api/tasksignal/priority/index.md
@@ -7,10 +7,9 @@ tags:
   - Property
   - Reference
   - priority
-  - Experimental
 browser-compat: api.TaskSignal.priority
 ---
-{{APIRef("Prioritized Task Scheduling API")}} {{SeeCompatTable}}
+{{APIRef("Prioritized Task Scheduling API")}}
 
 The read-only **`priority`** property of the {{domxref("TaskSignal")}} interface indicates the signal [priority](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#task_priorities).
 

--- a/files/en-us/web/api/tasksignal/prioritychange_event/index.md
+++ b/files/en-us/web/api/tasksignal/prioritychange_event/index.md
@@ -7,10 +7,9 @@ tags:
   - Reference
   - Prioritized Task Scheduling API
   - prioritychange
-  - Experimental
 browser-compat: api.TaskSignal.prioritychange_event
 ---
-{{APIRef("Prioritized Task Scheduling API")}} {{SeeCompatTable}}
+{{APIRef("Prioritized Task Scheduling API")}}
 
 The **`prioritychange`** event is sent to a {{domxref('TaskSignal')}} if its [priority](/en-US/docs/Web/API/Prioritized_Task_Scheduling_API#task_priorities) is changed.
 

--- a/files/en-us/web/api/textmetrics/alphabeticbaseline/index.md
+++ b/files/en-us/web/api/textmetrics/alphabeticbaseline/index.md
@@ -10,7 +10,7 @@ tags:
   - TextMetrics
 browser-compat: api.TextMetrics.alphabeticBaseline
 ---
-{{APIRef("Canvas API")}}
+{{APIRef("Canvas API")}}{{SeeCompatTable}}
 
 The read-only `alphabeticBaseline` property of the {{domxref("TextMetrics")}} interface is a `double` giving the distance from the horizontal line indicated by the {{domxref("CanvasRenderingContext2D.textBaseline")}} property to the alphabetic baseline of the line box, in CSS pixels.
 

--- a/files/en-us/web/api/textmetrics/emheightascent/index.md
+++ b/files/en-us/web/api/textmetrics/emheightascent/index.md
@@ -10,7 +10,7 @@ tags:
   - TextMetrics
 browser-compat: api.TextMetrics.emHeightAscent
 ---
-{{APIRef("Canvas API")}}
+{{APIRef("Canvas API")}}{{SeeCompatTable}}
 
 The read-only `emHeightAscent` property of the {{domxref("TextMetrics")}} interface is a `double` giving the distance from the horizontal line indicated by the {{domxref("CanvasRenderingContext2D.textBaseline")}} property to the top of the _em_ square in the line box, in CSS pixels.
 

--- a/files/en-us/web/api/textmetrics/emheightdescent/index.md
+++ b/files/en-us/web/api/textmetrics/emheightdescent/index.md
@@ -10,7 +10,7 @@ tags:
   - TextMetrics
 browser-compat: api.TextMetrics.emHeightDescent
 ---
-{{APIRef("Canvas API")}}
+{{APIRef("Canvas API")}}{{SeeCompatTable}}
 
 The read-only `emHeightDescent` property of the {{domxref("TextMetrics")}} interface is a `double` giving the distance from the horizontal line indicated by the {{domxref("CanvasRenderingContext2D.textBaseline")}} property to the bottom of the _em_ square in the line box, in CSS pixels.
 

--- a/files/en-us/web/api/textmetrics/hangingbaseline/index.md
+++ b/files/en-us/web/api/textmetrics/hangingbaseline/index.md
@@ -10,7 +10,7 @@ tags:
   - TextMetrics
 browser-compat: api.TextMetrics.hangingBaseline
 ---
-{{APIRef("Canvas API")}}
+{{APIRef("Canvas API")}}{{SeeCompatTable}}
 
 The read-only `hangingBaseline` property of the {{domxref("TextMetrics")}} interface is a `double` giving the distance from the horizontal line indicated by the {{domxref("CanvasRenderingContext2D.textBaseline")}} property to the hanging baseline of the line box, in CSS pixels.
 

--- a/files/en-us/web/api/textmetrics/ideographicbaseline/index.md
+++ b/files/en-us/web/api/textmetrics/ideographicbaseline/index.md
@@ -10,7 +10,7 @@ tags:
   - TextMetrics
 browser-compat: api.TextMetrics.ideographicBaseline
 ---
-{{APIRef("Canvas API")}}
+{{APIRef("Canvas API")}}{{SeeCompatTable}}
 
 The read-only `ideographicBaseline` property of the {{domxref("TextMetrics")}} interface is a `double` giving the distance from the horizontal line indicated by the {{domxref("CanvasRenderingContext2D.textBaseline")}} property to the ideographic baseline of the line box, in CSS pixels.
 

--- a/files/en-us/web/api/uievent/sourcecapabilities/index.md
+++ b/files/en-us/web/api/uievent/sourcecapabilities/index.md
@@ -8,6 +8,7 @@ tags:
   - Property
   - Reference
   - UIEvent
+  - Experimental
 browser-compat: api.UIEvent.sourceCapabilities
 ---
 {{APIRef("UI Events")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/url_pattern_api/index.md
+++ b/files/en-us/web/api/url_pattern_api/index.md
@@ -9,10 +9,10 @@ tags:
   - URLPattern
   - URL Pattern API
   - Web
+  - Experimental
 browser-compat: api.URLPattern
 ---
-
-{{DefaultAPISidebar("URL Pattern API")}}
+{{DefaultAPISidebar("URL Pattern API")}}{{SeeCompatTable}}
 
 The URL Pattern API defines a syntax that is used to create URL pattern
 matchers. These patterns can be matched against URLs or individual URL
@@ -40,7 +40,7 @@ section below.
 
 The URL Pattern API only has a single related interface:
 
-- {{domxref("URLPattern")}}
+- {{domxref("URLPattern")}} {{Experimental_Inline}}
 
 ## Pattern syntax
 

--- a/files/en-us/web/api/urlpattern/exec/index.md
+++ b/files/en-us/web/api/urlpattern/exec/index.md
@@ -12,8 +12,7 @@ tags:
   - Experimental
 browser-compat: api.URLPattern.exec
 ---
-
-{{APIRef("URL Pattern API")}}
+{{APIRef("URL Pattern API")}}{{SeeCompatTable}}
 
 The **`exec()`** method of the {{domxref("URLPattern")}} interface takes a URL or
 object of URL parts, and returns either an object containing the results of


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.

This covers files that have only `experimental` header modifications.