### PR TITLE
Update BCD info, part 33

### DIFF
--- a/files/en-us/web/api/urlpattern/hash/index.md
+++ b/files/en-us/web/api/urlpattern/hash/index.md
@@ -11,8 +11,7 @@ tags:
   - Experimental
 browser-compat: api.URLPattern.hash
 ---
-
-{{ APIRef("URL Pattern API") }}
+{{APIRef("URL Pattern API")}}{{SeeCompatTable}}
 
 The **`hash`** property of the {{domxref("URLPattern")}} interface is a
 string containing the pattern used to match the fragment part

--- a/files/en-us/web/api/urlpattern/hostname/index.md
+++ b/files/en-us/web/api/urlpattern/hostname/index.md
@@ -11,8 +11,7 @@ tags:
   - Experimental
 browser-compat: api.URLPattern.hostname
 ---
-
-{{ APIRef("URL Pattern API") }}
+{{APIRef("URL Pattern API")}}{{SeeCompatTable}}
 
 The **`hostname`** property of the {{domxref("URLPattern")}} interface is a
 string containing the pattern used to match the hostname part

--- a/files/en-us/web/api/urlpattern/password/index.md
+++ b/files/en-us/web/api/urlpattern/password/index.md
@@ -11,8 +11,7 @@ tags:
   - Experimental
 browser-compat: api.URLPattern.password
 ---
-
-{{ APIRef("URL Pattern API") }}
+{{APIRef("URL Pattern API")}}{{SeeCompatTable}}
 
 The **`password`** property of the {{domxref("URLPattern")}} interface is a
 string containing the pattern used to match the password part

--- a/files/en-us/web/api/urlpattern/pathname/index.md
+++ b/files/en-us/web/api/urlpattern/pathname/index.md
@@ -11,8 +11,7 @@ tags:
   - Experimental
 browser-compat: api.URLPattern.pathname
 ---
-
-{{ APIRef("URL Pattern API") }}
+{{APIRef("URL Pattern API")}}{{SeeCompatTable}}
 
 The **`pathname`** property of the {{domxref("URLPattern")}} interface is a
 string containing the pattern used to match the pathname part

--- a/files/en-us/web/api/urlpattern/port/index.md
+++ b/files/en-us/web/api/urlpattern/port/index.md
@@ -11,8 +11,7 @@ tags:
   - Experimental
 browser-compat: api.URLPattern.port
 ---
-
-{{ APIRef("URL Pattern API") }}
+{{APIRef("URL Pattern API")}}{{SeeCompatTable}}
 
 The **`port`** property of the {{domxref("URLPattern")}} interface is a
 string containing the pattern used to match the port part of a

--- a/files/en-us/web/api/urlpattern/protocol/index.md
+++ b/files/en-us/web/api/urlpattern/protocol/index.md
@@ -11,8 +11,7 @@ tags:
   - Experimental
 browser-compat: api.URLPattern.protocol
 ---
-
-{{ APIRef("URL Pattern API") }}
+{{APIRef("URL Pattern API")}}{{SeeCompatTable}}
 
 The **`protocol`** property of the {{domxref("URLPattern")}} interface is a
 string containing the pattern used to match the protocol part

--- a/files/en-us/web/api/urlpattern/search/index.md
+++ b/files/en-us/web/api/urlpattern/search/index.md
@@ -11,8 +11,7 @@ tags:
   - Experimental
 browser-compat: api.URLPattern.search
 ---
-
-{{ APIRef("URL Pattern API") }}
+{{APIRef("URL Pattern API")}}{{SeeCompatTable}}
 
 The **`search`** property of the {{domxref("URLPattern")}} interface is a
 string containing the pattern used to match the search part of

--- a/files/en-us/web/api/urlpattern/test/index.md
+++ b/files/en-us/web/api/urlpattern/test/index.md
@@ -12,8 +12,7 @@ tags:
   - Experimental
 browser-compat: api.URLPattern.test
 ---
-
-{{APIRef("URL Pattern API")}}
+{{APIRef("URL Pattern API")}}{{SeeCompatTable}}
 
 The **`test()`** method of the {{domxref("URLPattern")}} interface takes a URL or
 object of URL parts, and returns a boolean indicating if the given input matches

--- a/files/en-us/web/api/urlpattern/username/index.md
+++ b/files/en-us/web/api/urlpattern/username/index.md
@@ -11,8 +11,7 @@ tags:
   - Experimental
 browser-compat: api.URLPattern.username
 ---
-
-{{ APIRef("URL Pattern API") }}
+{{APIRef("URL Pattern API")}}{{SeeCompatTable}}
 
 The **`username`** property of the {{domxref("URLPattern")}} interface is a
 string containing the pattern used to match the username part

--- a/files/en-us/web/api/user-agent_client_hints_api/index.md
+++ b/files/en-us/web/api/user-agent_client_hints_api/index.md
@@ -7,9 +7,10 @@ tags:
   - User-Agent Client Hints API
   - Overview
   - Reference
+  - Experimental
 browser-compat: api.NavigatorUAData
 ---
-{{DefaultAPISidebar("User-Agent Client Hints API")}}
+{{DefaultAPISidebar("User-Agent Client Hints API")}}{{SeeCompatTable}}
 
 The User-Agent Client Hints API extends [Client Hints](/en-US/docs/Web/HTTP/Client_hints) to provide a way of exposing browser and platform information via User-Agent response and request headers, and a JavaScript API.
 

--- a/files/en-us/web/api/videocolorspace/videocolorspace/index.md
+++ b/files/en-us/web/api/videocolorspace/videocolorspace/index.md
@@ -7,9 +7,10 @@ tags:
   - Constructor
   - Reference
   - VideoColorSpace
+  - Experimental
 browser-compat: api.VideoColorSpace.VideoColorSpace
 ---
-{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
 
 The **`VideoColorSpace()`** constructor creates a new {{domxref("VideoColorSpace")}} object which represents a video color space.
 

--- a/files/en-us/web/api/videodecoder/close/index.md
+++ b/files/en-us/web/api/videodecoder/close/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - close
   - VideoDecoder
+  - Experimental
 browser-compat: api.VideoDecoder.close
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`close()`** method of the {{domxref("VideoDecoder")}} interface ends all pending work and releases system resources.
 

--- a/files/en-us/web/api/videodecoder/configure/index.md
+++ b/files/en-us/web/api/videodecoder/configure/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - configure
   - VideoDecoder
+  - Experimental
 browser-compat: api.VideoDecoder.configure
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`configure()`** method of the {{domxref("VideoDecoder")}} interface enqueues a control message to configure the video decoder for decoding chunks.
 

--- a/files/en-us/web/api/videodecoder/decode/index.md
+++ b/files/en-us/web/api/videodecoder/decode/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - decode
   - VideoDecoder
+  - Experimental
 browser-compat: api.VideoDecoder.decode
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`decode()`** method of the {{domxref("VideoDecoder")}} interface enqueues a control message to decode a given chunk of video.
 

--- a/files/en-us/web/api/videodecoder/decodequeuesize/index.md
+++ b/files/en-us/web/api/videodecoder/decodequeuesize/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - decodeQueueSize
   - VideoDecoder
+  - Experimental
 browser-compat: api.VideoDecoder.decodeQueueSize
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`decodeQueueSize`** read-only property of the {{domxref("VideoDecoder")}} interface returns the number of pending decode requests in the queue.
 

--- a/files/en-us/web/api/videodecoder/flush/index.md
+++ b/files/en-us/web/api/videodecoder/flush/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - flush
   - VideoDecoder
+  - Experimental
 browser-compat: api.VideoDecoder.flush
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`flush()`** method of the {{domxref("VideoDecoder")}} interface returns a Promise that resolves once all pending messages in the queue have been completed.
 

--- a/files/en-us/web/api/videodecoder/reset/index.md
+++ b/files/en-us/web/api/videodecoder/reset/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - reset
   - VideoDecoder
+  - Experimental
 browser-compat: api.VideoDecoder.reset
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`reset()`** method of the {{domxref("VideoDecoder")}} interface resets all states including configuration, control messages in the control message queue, and all pending callbacks.
 

--- a/files/en-us/web/api/videodecoder/state/index.md
+++ b/files/en-us/web/api/videodecoder/state/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - state
   - VideoDecoder
+  - Experimental
 browser-compat: api.VideoDecoder.state
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`state`**  property of the {{domxref("VideoDecoder")}} interface returns the current state of the underlying codec.
 

--- a/files/en-us/web/api/videodecoder/videodecoder/index.md
+++ b/files/en-us/web/api/videodecoder/videodecoder/index.md
@@ -7,9 +7,10 @@ tags:
   - Constructor
   - Reference
   - VideoDecoder
+  - Experimental
 browser-compat: api.VideoDecoder.VideoDecoder
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`VideoDecoder()`** constructor creates a new {{domxref("VideoDecoder")}} object with the provided `init.output` callback assigned as the output callback, the provided `init.error` callback as the error callback, and the {{domxref("VideoDecoder.state")}} set to `"unconfigured"`.
 

--- a/files/en-us/web/api/videoencoder/close/index.md
+++ b/files/en-us/web/api/videoencoder/close/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - close
   - VideoEncoder
+  - Experimental
 browser-compat: api.VideoEncoder.close
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`close()`** method of the {{domxref("VideoEncoder")}} interface ends all pending work and releases system resources.
 

--- a/files/en-us/web/api/videoencoder/configure/index.md
+++ b/files/en-us/web/api/videoencoder/configure/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - configure
   - VideoEncoder
+  - Experimental
 browser-compat: api.VideoEncoder.configure
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`configure()`** method of the {{domxref("VideoEncoder")}} interface enqueues a control message to configure the video encoder for encoding chunks.
 

--- a/files/en-us/web/api/videoencoder/encode/index.md
+++ b/files/en-us/web/api/videoencoder/encode/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - encode
   - VideoEncoder
+  - Experimental
 browser-compat: api.VideoEncoder.encode
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`encode()`** method of the {{domxref("VideoEncoder")}} interface enqueues a control message to encode a given {{domxref("VideoFrame")}}.
 

--- a/files/en-us/web/api/videoencoder/encodequeuesize/index.md
+++ b/files/en-us/web/api/videoencoder/encodequeuesize/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - encodeQueueSize
   - VideoEncoder
+  - Experimental
 browser-compat: api.VideoEncoder.encodeQueueSize
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`encodeQueueSize`** read-only property of the {{domxref("VideoEncoder")}} interface returns the number of pending encode requests in the queue.
 

--- a/files/en-us/web/api/videoencoder/flush/index.md
+++ b/files/en-us/web/api/videoencoder/flush/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - flush
   - VideoEncoder
+  - Experimental
 browser-compat: api.VideoEncoder.flush
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`flush()`** method of the {{domxref("VideoEncoder")}} interface returns a Promise that resolves once all pending messages in the queue have been completed.
 

--- a/files/en-us/web/api/videoencoder/isconfigsupported/index.md
+++ b/files/en-us/web/api/videoencoder/isconfigsupported/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - isConfigSupported
   - VideoEncoder
+  - Experimental
 browser-compat: api.VideoEncoder.isConfigSupported
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`isConfigSupported()`** static method of the {{domxref("VideoEncoder")}} interface checks if the given config is supported (that is, if {{domxref("VideoEncoder")}} objects can be successfully configured with the given config).
 

--- a/files/en-us/web/api/videoencoder/reset/index.md
+++ b/files/en-us/web/api/videoencoder/reset/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - reset
   - VideoEncoder
+  - Experimental
 browser-compat: api.VideoEncoder.reset
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`reset()`** method of the {{domxref("VideoEncoder")}} interface resets all states including configuration, control messages in the control message queue, and all pending callbacks.
 

--- a/files/en-us/web/api/videoencoder/state/index.md
+++ b/files/en-us/web/api/videoencoder/state/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - state
   - VideoEncoder
+  - Experimental
 browser-compat: api.VideoEncoder.state
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`state`** read-only property of the {{domxref("VideoEncoder")}} interface returns the current state of the underlying codec.
 

--- a/files/en-us/web/api/videoencoder/videoencoder/index.md
+++ b/files/en-us/web/api/videoencoder/videoencoder/index.md
@@ -7,9 +7,10 @@ tags:
   - Constructor
   - Reference
   - VideoEncoder
+  - Experimental
 browser-compat: api.VideoEncoder.VideoEncoder
 ---
-{{securecontext_header}}{{DefaultAPISidebar("WebCodecs API")}}
+{{APIRef("WebCodecs API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`VideoEncoder()`** constructor creates a new {{domxref("VideoEncoder")}} object with the provided `init.output` callback assigned as the output callback, the provided `init.error` callback as the error callback, and the {{domxref("VideoEncoder.state")}} set to `"unconfigured"`.
 

--- a/files/en-us/web/api/videoframe/allocationsize/index.md
+++ b/files/en-us/web/api/videoframe/allocationsize/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - allocationSize
   - VideoFrame
+  - Experimental
 browser-compat: api.VideoFrame.allocationSize
 ---
-{{DefaultAPISidebar("Web Codecs API")}}
+{{APIRef("Web Codecs API")}}{{SeeCompatTable}}
 
 The **`allocationSize()`** method of the {{domxref("VideoFrame")}} interface returns the number of bytes required to hold the video as filtered by options passed into the method.
 

--- a/files/en-us/web/api/videoframe/clone/index.md
+++ b/files/en-us/web/api/videoframe/clone/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - clone
   - VideoFrame
+  - Experimental
 browser-compat: api.VideoFrame.clone
 ---
-{{DefaultAPISidebar("Web Codecs API")}}
+{{APIRef("Web Codecs API")}}{{SeeCompatTable}}
 
 The **`clone()`** method of the {{domxref("VideoFrame")}} interface creates a new `VideoFrame` object with reference to the same media resource as the original.
 


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.

This covers files that have only `experimental` header modifications.