### PR TITLE
Update fr team - Removing audrasjb

### DIFF
--- a/files/en-us/mdn/community/contributing/translated_content/index.md
+++ b/files/en-us/mdn/community/contributing/translated_content/index.md
@@ -30,7 +30,7 @@ We have frozen all localized content (meaning that we won't accept any edits to 
 ### French (fr)
 
 - Discussions : [Matrix (#l10n-fr channel)](https://chat.mozilla.org/#/room/#l10n-fr:mozilla.org)
-- Current contributors: [cw118](https://github.com/cw118), [Jb Audras](https://github.com/audrasjb), [SphinxKnight](https://github.com/SphinxKnight), [tristantheb](https://github.com/tristantheb)
+- Current contributors: [cw118](https://github.com/cw118), [SphinxKnight](https://github.com/SphinxKnight), [tristantheb](https://github.com/tristantheb)
 
 ### Japanese (ja)
 


### PR DESCRIPTION
#### Summary
@audrasjb is not active in the team, which he confirmed in a discussion. As a consequence, I updated the team accordingly.

#### Motivation
See summary. Keeping things clean.

#### Supporting details
https://github.com/mdn/translated-content/commits?author=audrasjb
1:1 discussion. May provide it if necessary on a private channel.

#### Related issues
See incoming PR for fr and issue for GH Team update
https://github.com/mdn/translated-content/pull/7912

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

