### PR TITLE
Remove {{GeckoRelease}} from kitchensink

### DIFF
--- a/files/en-us/mdn/kitchensink/index.md
+++ b/files/en-us/mdn/kitchensink/index.md
@@ -362,5 +362,3 @@ The [`AvailableInWorkers`](https://github.com/mdn/yari/blob/main/kumascript/macr
 {{Non-standard_Header}}
 {{Deprecated_Header}}
 [![Iceberg pic](iceberg.jpg)](iceberg.jpg)
-
-`geckoRelease:` {{ geckoRelease("1.9.3") }}


### PR DESCRIPTION
We are removing it from mdn/content. And its presence on this page breaks tests on mdn/yari (as it marks as deprecated now)