### PR TITLE
(chore) Make examples valid js in Glossary falsy

### DIFF
--- a/files/en-us/glossary/falsy/index.md
+++ b/files/en-us/glossary/falsy/index.md
@@ -29,14 +29,14 @@ The following table provides a complete list of JavaScript falsy values:
 Examples of _falsy_ values in JavaScript (which are coerced to false in Boolean contexts, and thus _bypass_ the `if` block):
 
 ```js
-if (false)
-if (null)
-if (undefined)
-if (0)
-if (-0)
-if (0n)
-if (NaN)
-if ("")
+if (false) {}
+if (null) {}
+if (undefined) {}
+if (0) {}
+if (-0) {}
+if (0n) {}
+if (NaN) {}
+if ("") {}
 ```
 
 ### The logical AND operator, &&
@@ -44,10 +44,10 @@ if ("")
 If the first object is falsy, it returns that object:
 
 ```js
-false && "dog"
+console.log(false && "dog");
 // ↪ false
 
-0 && "dog"
+console.log(0 && "dog");
 // ↪ 0
 ```
 


### PR DESCRIPTION
We prefer valid js to be tagged as `js`. Especially, statements that would be modified by Prettier to have a final `;`and errors that will be caught by ESLint.

I don't think this change makes the entry more complex to read.