### PR TITLE
(chore) Add missing spaces after //

### DIFF
--- a/files/en-us/glossary/local_variable/index.md
+++ b/files/en-us/glossary/local_variable/index.md
@@ -13,7 +13,7 @@ A {{glossary("variable")}} whose name is bound to its {{glossary("value")}} only
 ```js
 let global = 5; // A global variable
 
-function fun(){
+function fun() {
   let local = 10; // A local variable
 }
 ```

--- a/files/en-us/glossary/local_variable/index.md
+++ b/files/en-us/glossary/local_variable/index.md
@@ -11,10 +11,10 @@ A {{glossary("variable")}} whose name is bound to its {{glossary("value")}} only
 ## Example
 
 ```js
-let global = 5; //is a global variable
+let global = 5; // A global variable
 
 function fun(){
-  let local = 10; //is a local variable
+  let local = 10; // A local variable
 }
 ```
 


### PR DESCRIPTION
We want a space right after `//`.