### PR TITLE
Remove use of NodeList.forEach() polyfill

### DIFF
--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/example_3/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/example_3/index.md
@@ -160,14 +160,6 @@ This is the third example that explain [how to build custom form widgets](/en-US
 ### JavaScript Content
 
 ```js
-// ------- //
-// HELPERS //
-// ------- //
-
-NodeList.prototype.forEach = function (callback) {
-  Array.prototype.forEach.call(this, callback);
-}
-
 // -------------------- //
 // Function definitions //
 // -------------------- //

--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/example_4/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/example_4/index.md
@@ -164,14 +164,6 @@ This is the fourth example that explain [how to build custom form widgets](/en-U
 ### JavaScript Content
 
 ```js
-// ------- //
-// HELPERS //
-// ------- //
-
-NodeList.prototype.forEach = function (callback) {
-  Array.prototype.forEach.call(this, callback);
-}
-
 // -------------------- //
 // Function definitions //
 // -------------------- //

--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/example_5/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/example_5/index.md
@@ -160,14 +160,6 @@ This is the last example that explain [how to build custom form widgets](/en-US/
 ### JavaScript Content
 
 ```js
-// ------- //
-// HELPERS //
-// ------- //
-
-NodeList.prototype.forEach = function (callback) {
-  Array.prototype.forEach.call(this, callback);
-}
-
 // -------------------- //
 // Function definitions //
 // -------------------- //

--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/index.md
@@ -433,18 +433,8 @@ In the code we are about to build, we will use the standard JavaScript and DOM A
 
 1. {{domxref("element.classList","classList")}}
 2. {{domxref("EventTarget.addEventListener","addEventListener()")}}
-3. [`forEach`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach)
+3. {{domxref("NodeList.forEach")}}
 4. {{domxref("element.querySelector","querySelector()")}} and {{domxref("element.querySelectorAll","querySelectorAll()")}}
-
-Beyond the availability of those specific features, there is still one issue remaining before starting. The object returned by the {{domxref("element.querySelectorAll","querySelectorAll()")}} function is a {{domxref("NodeList")}} rather than an [`Array`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array). This is important because `Array` objects support the [`forEach`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach) function, but {{domxref("NodeList")}} doesn't. Because {{domxref("NodeList")}} really looks like an `Array` and because `forEach` is so convenient to use, we can easily add the support of `forEach` to {{domxref("NodeList")}} in order to make our life easier, like so:
-
-```js
-NodeList.prototype.forEach = function (callback) {
-  Array.prototype.forEach.call(this, callback);
-}
-```
-
-If you need to support legacy browsers, ensure the browsers support these features. If not, you can iterate through the list or you may need to use a library or polyfill.
 
 ### Building event callbacks
 

--- a/files/en-us/learn/forms/how_to_build_custom_form_controls/index.md
+++ b/files/en-us/learn/forms/how_to_build_custom_form_controls/index.md
@@ -433,7 +433,7 @@ In the code we are about to build, we will use the standard JavaScript and DOM A
 
 1. {{domxref("element.classList","classList")}}
 2. {{domxref("EventTarget.addEventListener","addEventListener()")}}
-3. {{domxref("NodeList.forEach")}}
+3. {{domxref("NodeList.forEach()")}}
 4. {{domxref("element.querySelector","querySelector()")}} and {{domxref("element.querySelectorAll","querySelectorAll()")}}
 
 ### Building event callbacks


### PR DESCRIPTION
This has been supported by all modern browsers (read: all but IE) for many years.

We don't need the added complexity of a polyfill replacing the method.