### PR TITLE
(chore) Improve HTML comments

### DIFF
--- a/files/en-us/learn/performance/css/index.md
+++ b/files/en-us/learn/performance/css/index.md
@@ -19,7 +19,7 @@ CSS can scope styles to particular conditions with media queries. Media queries 
 <!-- Loading and parsing styles.css is render-blocking -->
 <link rel="stylesheet" href="styles.css">
 
-<!-- Loading and parsing print.css is render-blocking  -->
+<!-- Loading and parsing print.css is not render-blocking  -->
 <link rel="stylesheet" href="print.css" media="print"> 
 
 <!-- Loading and parsing mobile.css is render-blocking on large screens -->

--- a/files/en-us/learn/performance/css/index.md
+++ b/files/en-us/learn/performance/css/index.md
@@ -16,9 +16,14 @@ Painting an unstyled page, and then repainting it once styles are parsed would b
 CSS can scope styles to particular conditions with media queries. Media queries are important for a responsive web design and help us optimize a critical rendering path. The browser blocks rendering until it parses all of these styles but will not block rendering on styles it knows it will not use, such the print stylesheets. By splitting the CSS into multiple files based on media queries, you can prevent render blocking during download of unused CSS. To create a non-blocking CSS link, move the not-immediately used styles, such as print styles, into separate file, add a [`<link>`](/en-US/docs/Web/HTML/Element/link) to the HTML mark up, and add a media query, in this case stating it's a print stylesheet.
 
 ```html
-<link rel="stylesheet" href="styles.css"> <!-- blocking -->
-<link rel="stylesheet" href="print.css" media="print"> <!-- not blocking -->
-<link rel="stylesheet" href="mobile.css" media="screen and (max-width: 480px)"> <!-- not blocking on large screens -->
+<!-- Loading and parsing styless.css is blocking rendering -->
+<link rel="stylesheet" href="styles.css">
+
+<!-- Loading and parsing print.css is blocking rendering  -->
+<link rel="stylesheet" href="print.css" media="print"> 
+
+<!-- Loading and parsing mobile.css is blocking rendering on large screens -->
+<link rel="stylesheet" href="mobile.css" media="screen and (max-width: 480px)"> 
 ```
 
 By default the browser assumes that each specified style sheet is render blocking. Tell the browser when the style sheet should be applied by adding a `media` attribute with the [media query](/en-US/docs/Web/CSS/Media_Queries/Using_media_queries). When the browser sees a style sheet it knows that it only needs to apply it for a specific scenario, it still downloads the stylesheet, but doesn't render block. By separating out the CSS into multiple files, the main render-blocking file, in this case `styles.css`, is much smaller, reducing the time that rendering is blocked.

--- a/files/en-us/learn/performance/css/index.md
+++ b/files/en-us/learn/performance/css/index.md
@@ -22,7 +22,7 @@ CSS can scope styles to particular conditions with media queries. Media queries 
 <!-- Loading and parsing print.css is not render-blocking  -->
 <link rel="stylesheet" href="print.css" media="print"> 
 
-<!-- Loading and parsing mobile.css is render-blocking on large screens -->
+<!-- Loading and parsing mobile.css is not render-blocking on large screens -->
 <link rel="stylesheet" href="mobile.css" media="screen and (max-width: 480px)"> 
 ```
 

--- a/files/en-us/learn/performance/css/index.md
+++ b/files/en-us/learn/performance/css/index.md
@@ -16,7 +16,7 @@ Painting an unstyled page, and then repainting it once styles are parsed would b
 CSS can scope styles to particular conditions with media queries. Media queries are important for a responsive web design and help us optimize a critical rendering path. The browser blocks rendering until it parses all of these styles but will not block rendering on styles it knows it will not use, such the print stylesheets. By splitting the CSS into multiple files based on media queries, you can prevent render blocking during download of unused CSS. To create a non-blocking CSS link, move the not-immediately used styles, such as print styles, into separate file, add a [`<link>`](/en-US/docs/Web/HTML/Element/link) to the HTML mark up, and add a media query, in this case stating it's a print stylesheet.
 
 ```html
-<!-- Loading and parsing styless.css is render-blocking -->
+<!-- Loading and parsing styles.css is render-blocking -->
 <link rel="stylesheet" href="styles.css">
 
 <!-- Loading and parsing print.css is render-blocking  -->

--- a/files/en-us/learn/performance/css/index.md
+++ b/files/en-us/learn/performance/css/index.md
@@ -16,13 +16,13 @@ Painting an unstyled page, and then repainting it once styles are parsed would b
 CSS can scope styles to particular conditions with media queries. Media queries are important for a responsive web design and help us optimize a critical rendering path. The browser blocks rendering until it parses all of these styles but will not block rendering on styles it knows it will not use, such the print stylesheets. By splitting the CSS into multiple files based on media queries, you can prevent render blocking during download of unused CSS. To create a non-blocking CSS link, move the not-immediately used styles, such as print styles, into separate file, add a [`<link>`](/en-US/docs/Web/HTML/Element/link) to the HTML mark up, and add a media query, in this case stating it's a print stylesheet.
 
 ```html
-<!-- Loading and parsing styless.css is blocking rendering -->
+<!-- Loading and parsing styless.css is render-blocking -->
 <link rel="stylesheet" href="styles.css">
 
-<!-- Loading and parsing print.css is blocking rendering  -->
+<!-- Loading and parsing print.css is render-blocking  -->
 <link rel="stylesheet" href="print.css" media="print"> 
 
-<!-- Loading and parsing mobile.css is blocking rendering on large screens -->
+<!-- Loading and parsing mobile.css is render-blocking on large screens -->
 <link rel="stylesheet" href="mobile.css" media="screen and (max-width: 480px)"> 
 ```
 


### PR DESCRIPTION
HTML comments must be before what they explain.

(Prettier will enforce one HTML element per line, and it would be after, making no sense.