### PR TITLE
Use map instead of from to create a new Uint8Array

### DIFF
--- a/files/en-us/glossary/transferable_objects/index.md
+++ b/files/en-us/glossary/transferable_objects/index.md
@@ -34,7 +34,7 @@ After transfer any attempt to read or write `uInt8Array` from the main thread wi
 
 ```js
 // Create an 8MB "file" and fill it. 8MB = 1024 * 1024 * 8 B
-const uInt8Array = Uint8Array.from({ length: 1024 * 1024 * 8 }, (v, i) => i);
+const uInt8Array = new Uint8Array(1024 * 1024 * 8).map((v, i) => i);
 console.log(uInt8Array.byteLength);  // 8388608
 
 // Transfer the underlying buffer to a worker

--- a/files/en-us/web/api/web_workers_api/using_web_workers/index.md
+++ b/files/en-us/web/api/web_workers_api/using_web_workers/index.md
@@ -572,7 +572,7 @@ For example, when transferring an {{jsxref("ArrayBuffer")}} from your main app t
 
 ```js
 // Create a 32MB "file" and fill it with consecutive values from 0 to 255 – 32MB = 1024 * 1024 * 32
-const uInt8Array = Uint8Array.from({ length: 1024 * 1024 * 32 }, (v, i) => i);
+const uInt8Array = new Uint8Array(1024 * 1024 * 32).map((v, i) => i);
 worker.postMessage(uInt8Array.buffer, [uInt8Array.buffer]);
 ```
 

--- a/files/en-us/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.md
+++ b/files/en-us/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.md
@@ -97,7 +97,7 @@ You can send JavaScript typed arrays as binary data as well.
 
 ```js
 // Create a new array with fake data (Consecutive numbers (0 - 255), looping back to 0) 
-const largeUInt8Array = new Uint8Array(512).map((v, i) => i % 256);
+const largeUInt8Array = new Uint8Array(512).map((v, i) => i);
 
 const xhr = new XMLHttpRequest;
 xhr.open("POST", url, false);

--- a/files/en-us/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.md
+++ b/files/en-us/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.md
@@ -8,7 +8,7 @@ tags:
   - MIME
   - XMLHttpRequest
 ---
-The `responseType` property of the XMLHttpRequest object can be set to change the expected response type from the server. Possible values are the empty string (default), `"arraybuffer"`, `"blob"`, `"document"`, `"json"`, and `"text"`. The `response` property will contain the entity body according to `responseType`, as an `ArrayBuffer`, `Blob`, `Document`, `JSON`, or string. This is `null` if the request is not complete or was not successful.
+The `responseType` property of the XMLHttpRequest object can be set to change the expected response type from the server. Possible values are the empty string (default), `"arraybuffer"`, `"blob"`, `"document"`, `"jsonEt "`, and `"text"`. The `response` property will contain the entity body according to `responseType`, as an `ArrayBuffer`, `Blob`, `Document`, `JSON`, or string. This is `null` if the request is not complete or was not successful.
 
 This example reads an image as a binary file and creates an 8-bit unsigned integer array from the raw bytes. Note that this will not decode the image and read the pixels. You will need a [png decoding library](https://github.com/foliojs/png.js) for that.
 
@@ -83,7 +83,7 @@ The following example creates a text file on-the-fly and uses the `POST` method 
 const req = new XMLHttpRequest();
 req.open("POST", url, true);
 req.onload = (event) => {
-  // Uploaded.
+  // Uploaded
 };
 
 const blob = new Blob(['abc123'], { type: 'text/plain' });
@@ -96,13 +96,12 @@ req.send(blob);
 You can send JavaScript typed arrays as binary data as well.
 
 ```js
-const array = new ArrayBuffer(512);
 // Create a new array with fake data (Consecutive numbers (0 - 255), looping back to 0) 
-const longInt8View = Uint8Array.from(array, (v, i) => i % 256);
+const largeUInt8Array = new Uint8Array(512).map((v, i) => i % 256);
 
 const xhr = new XMLHttpRequest;
 xhr.open("POST", url, false);
-xhr.send(myArray);
+xhr.send(largeUInt8Array);
 ```
 
 This is building a 512-byte array of 8-bit integers and sending it; you can use any binary data you'd like, of course.

--- a/files/en-us/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.md
+++ b/files/en-us/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.md
@@ -97,11 +97,11 @@ You can send JavaScript typed arrays as binary data as well.
 
 ```js
 // Create a new array with fake data (Consecutive numbers (0 - 255), looping back to 0) 
-const largeUInt8Array = new Uint8Array(512).map((v, i) => i);
+const array = new Uint8Array(512).map((v, i) => i);
 
 const xhr = new XMLHttpRequest;
 xhr.open("POST", url, false);
-xhr.send(largeUInt8Array);
+xhr.send(array);
 ```
 
 This is building a 512-byte array of 8-bit integers and sending it; you can use any binary data you'd like, of course.

--- a/files/en-us/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.md
+++ b/files/en-us/web/api/xmlhttprequest/sending_and_receiving_binary_data/index.md
@@ -8,7 +8,7 @@ tags:
   - MIME
   - XMLHttpRequest
 ---
-The `responseType` property of the XMLHttpRequest object can be set to change the expected response type from the server. Possible values are the empty string (default), `"arraybuffer"`, `"blob"`, `"document"`, `"jsonEt "`, and `"text"`. The `response` property will contain the entity body according to `responseType`, as an `ArrayBuffer`, `Blob`, `Document`, `JSON`, or string. This is `null` if the request is not complete or was not successful.
+The `responseType` property of the XMLHttpRequest object can be set to change the expected response type from the server. Possible values are the empty string (default), `"arraybuffer"`, `"blob"`, `"document"`, `"json"`, and `"text"`. The `response` property will contain the entity body according to `responseType`, as an `ArrayBuffer`, `Blob`, `Document`, `JSON`, or string. This is `null` if the request is not complete or was not successful.
 
 This example reads an image as a binary file and creates an 8-bit unsigned integer array from the raw bytes. Note that this will not decode the image and read the pixels. You will need a [png decoding library](https://github.com/foliojs/png.js) for that.
 


### PR DESCRIPTION
See https://github.com/mdn/content/pull/19823#issuecomment-1222394840

Note that I can confirm that:
- it is simpler, much easier to understand
- much quicker on V8 (I have a 4x difference!)
- as quick as `from` on Gecko (< 1% difference), which is 50% quicker than V8.
- 
Thanks, @zloirock 