### PR TITLE
Disginguish a generator function from its output

### DIFF
--- a/files/en-us/web/javascript/reference/statements/for...of/index.md
+++ b/files/en-us/web/javascript/reference/statements/for...of/index.md
@@ -180,8 +180,8 @@ console.log('done');
 
 ### Iterating over generators
 
-You can also iterate over [generators](/en-US/docs/Web/JavaScript/Reference/Statements/function*), i.e.
-functions generating an iterable object:
+You can also iterate over [generators](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator), i.e.
+the output of [generator functions](/en-US/docs/Web/JavaScript/Reference/Statements/function*):
 
 ```js
 function* fibonacci() { // a generator function

--- a/files/en-us/web/javascript/reference/statements/for...of/index.md
+++ b/files/en-us/web/javascript/reference/statements/for...of/index.md
@@ -180,8 +180,7 @@ console.log('done');
 
 ### Iterating over generators
 
-You can also iterate over [generators](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator), i.e.
-the output of [generator functions](/en-US/docs/Web/JavaScript/Reference/Statements/function*):
+You can also iterate over [generators](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Generator), which are returned from [generator functions](/en-US/docs/Web/JavaScript/Reference/Statements/function*):
 
 ```js
 function* fibonacci() { // a generator function


### PR DESCRIPTION
Clarify that you can iterate over the output of a generator function, not the generator function itself.

#### Motivation

The existing sentence conflates generators and generator functions.  This may be clear enough for informal discussion, but updating the sentence to be precise also makes it clearer.

Problems with the existing sentence:
* The link with text "generator" links to generator functions, but should link to generators.
* Generators are said to be functions that return an iterable object.  This should say that generator *functions* are functions that return an iterable object.
And, while a generator function does return an iterable object (an object conforming to the iterable protocol), the returned object is also an iterator (an object conforming to the iterator protocol).
To say only that a generator function return an iterable object leaves out the whole truth, which could lead to confusion.  It's better to say that generator functions return generators, and leave it at that.

#### Supporting details

#### Related issues

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
