### PR TITLE
[CSS] New property page for animation-composition

### DIFF
--- a/files/en-us/glossary/composite_operation/index.md
+++ b/files/en-us/glossary/composite_operation/index.md
@@ -1,0 +1,19 @@
+---
+title: Composite operation
+slug: Glossary/Composite_operation
+tags:
+  - Animations
+  - Glossary
+---
+In CSS, the value of a property in a CSS rule is the _underlying value_ of that property, and the value of that same property in a [keyframe](/en-US/docs/Web/CSS/@keyframes) is its _effect value_.
+
+The _composite operation_ is the specific operation that is used to combine an effect value with an underlying value to produce the final keyframe effect value. There are three types of composite operations:
+
+- **replace**: The effect value replaces the underlying value. The final effect value in this case is the original effect value itself.
+- **add**: The effect value is added to the underlying value.
+- **accumulate**: The effect value is combined with the underlying value.
+
+## See also
+
+- [`animation-composition`](/en-us/web/css/animation-composition)
+- [`KeyframeEffect.composite`](/en-US/docs/Web/API/KeyframeEffect/composite)

--- a/files/en-us/glossary/composite_operation/index.md
+++ b/files/en-us/glossary/composite_operation/index.md
@@ -13,7 +13,7 @@ The _composite operation_ is the specific operation that is used to combine an e
 - **add**: The effect value is added to the underlying value.
 - **accumulate**: The effect value is combined with the underlying value.
 
-> **Note:** Currently, composite operation in CSS only applies to animations. There has been a discussion about more general additive syntax, but as of late 2022, there are no other CSS properties to which `add` and `accumulate` apply.
+> **Note:** Composite operation in CSS only applies to animations.
 
 ## See also
 

--- a/files/en-us/glossary/composite_operation/index.md
+++ b/files/en-us/glossary/composite_operation/index.md
@@ -13,6 +13,8 @@ The _composite operation_ is the specific operation that is used to combine an e
 - **add**: The effect value is added to the underlying value.
 - **accumulate**: The effect value is combined with the underlying value.
 
+> **Note:** Currently, composite operation in CSS only applies to animations. There has been a discussion about more general additive syntax, but as of late 2022, there are no other CSS properties to which `add` and `accumulate` apply.
+
 ## See also
 
 - [`animation-composition`](/en-us/web/css/animation-composition)

--- a/files/en-us/web/api/keyframeeffect/composite/index.md
+++ b/files/en-us/web/api/keyframeeffect/composite/index.md
@@ -39,4 +39,5 @@ To understand these values, take the example of a `keyframeEffect` value of `blu
 ## See also
 
 - [Web Animations API](/en-US/docs/Web/API/Web_Animations_API)
-- Property of {{domxref("KeyframeEffect")}} objects.
+- Property of {{domxref("KeyframeEffect")}} objects
+- {{Glossary("Composite operation")}}

--- a/files/en-us/web/css/animation-composition/index.md
+++ b/files/en-us/web/css/animation-composition/index.md
@@ -40,14 +40,14 @@ animation-composition: revert-layer;
 animation-composition: unset;
 ```
 
-> **Note:** When you specify multiple comma-separated values on an `animation-*` property, they will be assigned to the animations specified in the {{cssxref("animation-name")}} property in different ways depending on how many there are. For more information, see [Setting multiple animation property values](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations#setting_multiple_animation_property_values).
+> **Note:** When you specify multiple comma-separated values on an `animation-*` property, they will be applied to the animations in the order in which the {{cssxref("animation-name")}}s appear. If the number of animations and compositions differ, the values listed in the `animation-composition` property will cycle from the first to the last `animation-name`, looping until all the animations have an assigned `animation-composition` value. For more information, see [Setting multiple animation property values](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations#setting_multiple_animation_property_values).
 
 ### Values
 
 - `replace`
-  - : The effect value overrides the underlying value of the property. This is the default composite operation.
+  - : The effect value overrides the underlying value of the property. This is the default value.
 - `add`
-  - : The effect value builds on the underlying value of the property. This values produces an additive effect. For animation types where the addition operation is not commutative, the order of the operands is underlying value followed by the effect value.
+  - : The effect value builds on the underlying value of the property. This operation produces an additive effect. For animation types where the addition operation is not commutative, the order of the operands is underlying value followed by the effect value.
 - `accumulate`
   - : The effect and underlying values are combined. For animation types where the addition operation is not commutative, the order of the operands is underlying value followed by the effect value.
 
@@ -68,7 +68,7 @@ For example, in the CSS below, `blur(5px)` is the underlying value, and `blur(10
   0% {
     filter: blur(10px);
   }
-  10% {
+  100% {
     filter: blur(20px);
   }
 }
@@ -77,7 +77,7 @@ For example, in the CSS below, `blur(5px)` is the underlying value, and `blur(10
 Consider different values for the `animation-composition` property in the above example. The final effect value in each of those cases will be calculated as explained below:
 
 - With `replace`, `blur(10px)` will replace `blur(5px)` in the `0%` keyframe. This is the default behavior of the property.
-- With `add`, the composite effect value in `0%` keyframe will be `blur(5px) blur(10px)`.
+- With `add`, the composite effect value in the `0%` keyframe will be `blur(5px) blur(10px)`.
 - With `accumulate`, the composite effect value in `0%` keyframe will be `blur(15px)`.
 
 > **Note:** A composite operation can also be specified in a keyframe. In that case, the specified composite operation is used for each property first within that keyframe and then on each property in the next keyframe.
@@ -112,12 +112,18 @@ The example below shows the effect of different `animation-composition` values s
 
 #### CSS
 
-Here the underlying value is `translateX(50px) rotate(90deg)`.
+Here the underlying value is `translateX(50px) rotate(45deg)`.
 
 ```css
 @keyframes slide {
-  from {transform: translateX(100px);}
-  to {transform: translateX(150px);}
+  20%, 40% {
+    transform: translateX(100px);
+    background: yellow;
+  }
+  80%, 100% {
+    transform: translateX(150px);
+    background: orange;    
+  }
 }
 .container {
   width: 240px;
@@ -130,9 +136,12 @@ Here the underlying value is `translateX(50px) rotate(90deg)`.
   height: 50px;
   background: green;
   border-radius: 10px;
-  transform: translateX(50px) rotate(90deg);
-  animation: slide 2s linear infinite;
+  transform: translateX(50px) rotate(45deg);
+  animation: slide 5s linear infinite;
 }
+.target:hover {
+   animation-play-state: paused;
+ }
 #replace {
   animation-composition: replace;
 }
@@ -148,9 +157,9 @@ Here the underlying value is `translateX(50px) rotate(90deg)`.
 
 {{EmbedLiveSample("Reversing the animation direction","100%","250")}}
 
-- With `replace`, the composite effect value in the `from` keyframe is `transform: translateX(100px)` (replacing `translateX(50px) rotate(90deg)`).
-- With `add`, the composite effect value in the `from` keyframe is `translateX(50px) rotate(90deg)` followed by `transform: translateX(100px)`.
-- With `accumulate`, the composite effect value in the `from` keyframe is `translateX(150px) rotate(90deg)`.
+- With `replace`, the final effect value for the `transform` property in the `20%, 40%` keyframe is `translateX(100px)` (completely replacing the underlying value `translateX(50px) rotate(45deg)`). In this case, the element rotates from 45deg to 0deg as it animates from the default value set on the element itself to the non-rotated value set at the 20% mark. This is the default behavior.
+- With `add`, the final effect value for the `transform` property in the `20%, 40%` keyframe is `translateX(50px) rotate(45deg)` followed by `translateX(100px)`. So the element is moved `50px` to the right, rotated `45deg`, then translated `100px` more along the redirected X axis.
+- With `accumulate`, the final effect value in the `20%, 40%` keyframe is `translateX(150px) rotate(45deg)`. This means that the two X-axis translation values of `50px` and `100px` are combined or "accumulated".
 
 ## Specifications
 

--- a/files/en-us/web/css/animation-composition/index.md
+++ b/files/en-us/web/css/animation-composition/index.md
@@ -11,7 +11,7 @@ browser-compat: css.properties.animation-composition
 ---
 {{CSSRef}}
 
-The **`animation-composition`** [CSS](/en-US/docs/Web/CSS) property specifies the composite operation to use when multiple animations affect the same property simultaneously.
+The **`animation-composition`** [CSS](/en-US/docs/Web/CSS) property specifies the {{Glossary("composite operation")}} to use when multiple animations affect the same property simultaneously.
 
 <!--the interactive example will be created in a separate PR. Will uncomment the macro below when I have an interactive example in place. Note that this property is still behind a flag in FF and not yet implemented in Safari and Chrome.-->
 <!-- {{EmbedInteractiveExample("pages/css/animation-composition.html")}} -->
@@ -47,9 +47,9 @@ animation-composition: unset;
 - `replace`
   - : The effect value overrides the underlying value of the property. This is the default value.
 - `add`
-  - : The effect value builds on the underlying value of the property. This operation produces an additive effect. For animation types where the addition operation is not commutative, the order of the operands is underlying value followed by the effect value.
+  - : The effect value builds on the underlying value of the property. This operation produces an additive effect. For animation types where the addition operation is not commutative, the order of the operands is the underlying value followed by the effect value.
 - `accumulate`
-  - : The effect and underlying values are combined. For animation types where the addition operation is not commutative, the order of the operands is underlying value followed by the effect value.
+  - : The effect and underlying values are combined. For animation types where the addition operation is not commutative, the order of the operands is the underlying value followed by the effect value.
 
 ## Description
 
@@ -60,7 +60,7 @@ For example, in the CSS below, `blur(5px)` is the underlying value, and `blur(10
 ```css
 .icon:hover {
   filter: blur(5px);
-  animation: pulse 3s infinite;
+  animation: 3s infinite pulse;
   animation-composition: add;
 }
 

--- a/files/en-us/web/css/animation-composition/index.md
+++ b/files/en-us/web/css/animation-composition/index.md
@@ -11,13 +11,13 @@ browser-compat: css.properties.animation-composition
 ---
 {{CSSRef}}
 
-The **`animation-composition`** [CSS](/en-US/docs/Web/CSS) property specifies how to treat the multiple property values when multiple animations affect that same property simultaneously. You can choose the property values to be applied cumulatively, to be combined, or one to be replaced by the other.
+The **`animation-composition`** [CSS](/en-US/docs/Web/CSS) property specifies the composite operation to use when multiple animations affect the same property simultaneously.
 
-When used in a keyframe, the defined composite operation is used for each property first within that keyframe and then on each property in the next keyframe.
+<!--the interactive example will be created in a separate PR. Will uncomment the macro below when I have an interactive example in place. Note that this property is still behind a flag in FF and not yet implemented in Safari and Chrome.-->
+<!-- {{EmbedInteractiveExample("pages/css/animation-composition.html")}} -->
 
-{{EmbedInteractiveExample("pages/css/animation-composition.html")}}
-
-It is often convenient to use the shorthand property {{cssxref("animation")}} to set all animation properties at once.
+<!--only longhand animation-composition is enabled in FF104, so commenting out the sentence below for now. Not removing the sentence because it can be uncommented when support in shorthand animation property is added.-->
+<!-- It is often convenient to use the shorthand property {{cssxref("animation")}} to set all animation properties at once.-->
 
 ## Syntax
 
@@ -40,16 +40,47 @@ animation-composition: revert-layer;
 animation-composition: unset;
 ```
 
+> **Note:** When you specify multiple comma-separated values on an `animation-*` property, they will be assigned to the animations specified in the {{cssxref("animation-name")}} property in different ways depending on how many there are. For more information, see [Setting multiple animation property values](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations#setting_multiple_animation_property_values).
+
 ### Values
 
 - `replace`
-  - : Overrides the value of the property with which it is combined. This is the default value.
+  - : The effect value overrides the underlying value of the property. This is the default composite operation.
 - `add`
-  - : Adds along with the property value with which it is combined.
+  - : The effect value builds on the underlying value of the property. This values produces an additive effect. For animation types where the addition operation is not commutative, the order of the operands is underlying value followed by the effect value.
 - `accumulate`
-  - : Gathers up a cumulative value with the property value with which it is combined.
+  - : The effect and underlying values are combined. For animation types where the addition operation is not commutative, the order of the operands is underlying value followed by the effect value.
 
-> **Note:** When you specify multiple comma-separated values on an `animation-*` property, they will be assigned to the animations specified in the {{cssxref("animation-name")}} property in different ways depending on how many there are. For more information, see [Setting multiple animation property values](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations#setting_multiple_animation_property_values).
+## Description
+
+Each property that is targeted by the [@keyframes](/en-US/docs/Web/CSS/@keyframes) at-rule is associated with an effect stack. The value of the effect stack is calculated by combining the (underlying) value of a property in a CSS style rule with the (effect) value of that property in the keyframe. The `animation-composition` property helps to specify how to combine the underlying value with the effect value.
+
+For example, in the CSS below, `blur(5px)` is the underlying value, and `blur(10px)` is the effect value. The `filter` property is affected by both animations, `pulse` and `brightness-pulse`. The `animation-composition` property specifies the operation to perform to produce the final effect value after compositing the effect of the underlying value and the effect value.
+
+```css
+.icon:hover {
+  filter: blur(5px);
+  animation: brightness-pulse 3s infinite;
+  animation-composition: add;
+}
+
+@keyframes pulse {
+  0% {
+    filter: blur(10px);
+  }
+  10% {
+    filter: blur(20px);
+  }
+}
+```
+
+Consider different values for the `animation-composition` property in the above example. The final effect value in each of those cases will be calculated as explained below:
+
+- With `replace`, `blur(10px)` will replace `blur(5px)` in the `0%` keyframe.
+- With `add`, the composite effect value in `0%` will be `blur(5px) blur(10px)`.
+- With `accumulate`, the composite effect value in `0%` will be `blur(15px)`.
+
+> **Note:** A composite operation can also be specified in a keyframe. In that case, the specified composite operation is used for each property first within that keyframe and then on each property in the next keyframe.
 
 ## Formal definition
 
@@ -61,43 +92,65 @@ animation-composition: unset;
 
 ## Examples
 
-### Combining property values
+### Understanding the animation-composition values
+
+The example below shows the effect of different `animation-composition` values side-by-side.
 
 #### HTML
 
 ```html
-<div class="box"></div>
+<div class="container">replace
+  <div id="replace" class="target"></div>
+</div>
+<div class="container">add
+  <div id="add" class="target"></div>
+</div>
+<div class="container">accumulate
+  <div id="accumulate" class="target"></div>
+</div>
 ```
 
 #### CSS
 
+Here the underlying value is `translateX(50px) rotate(90deg)`.
+
 ```css
-.box {
-  background-color: rebeccapurple;
+@keyframes slide {
+  from {transform: translateX(100px);}
+  to {transform: translateX(150px);}
+}
+.container {
+  width: 240px;
+  height: 220px;
+  background: cyan;
+  display: inline-block;
+}
+.target {
+  width: 20px;
+  height: 50px;
+  background: green;
   border-radius: 10px;
-  width: 100px;
-  height: 100px;
+  transform: translateX(50px) rotate(90deg);
+  animation: slide 2s linear infinite;
 }
-
-.box:hover {
-  animation-name: rotate;
-  animation-duration: 0.7s;
-  animation-direction: reverse;
+#replace {
+  animation-composition: replace;
 }
-
-@keyframes rotate {
-  0% {
-    transform: rotate(0);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
+#add {
+  animation-composition: add;
+}
+#accumulate {
+  animation-composition: accumulate;
 }
 ```
 
 #### Result
 
 {{EmbedLiveSample("Reversing the animation direction","100%","250")}}
+
+- With `replace`, the composite effect value in the `from` keyframe is `transform: translateX(100px)` (replacing `translateX(50px) rotate(90deg)`).
+- With `add`, the composite effect value in the `from` keyframe is `translateX(50px) rotate(90deg)` followed by `transform: translateX(100px)`.
+- With `accumulate`, the composite effect value in the `from` keyframe is `translateX(150px) rotate(90deg)`.
 
 ## Specifications
 

--- a/files/en-us/web/css/animation-composition/index.md
+++ b/files/en-us/web/css/animation-composition/index.md
@@ -53,7 +53,7 @@ animation-composition: unset;
 
 ## Description
 
-Each property that is targeted by the [@keyframes](/en-US/docs/Web/CSS/@keyframes) at-rule is associated with an effect stack. The value of the effect stack is calculated by combining the (underlying) value of a property in a CSS style rule with the (effect) value of that property in the keyframe. The `animation-composition` property helps to specify how to combine the underlying value with the effect value.
+Each property that is targeted by the [@keyframes](/en-US/docs/Web/CSS/@keyframes) at-rule is associated with an effect stack. The value of the effect stack is calculated by combining the _underlying value_ of a property in a CSS style rule with the _effect value_ of that property in the keyframe. The `animation-composition` property helps to specify how to combine the underlying value with the effect value.
 
 For example, in the CSS below, `blur(5px)` is the underlying value, and `blur(10px)` is the effect value. The `filter` property is affected by both animations, `pulse` and `brightness-pulse`. The `animation-composition` property specifies the operation to perform to produce the final effect value after compositing the effect of the underlying value and the effect value.
 
@@ -76,9 +76,9 @@ For example, in the CSS below, `blur(5px)` is the underlying value, and `blur(10
 
 Consider different values for the `animation-composition` property in the above example. The final effect value in each of those cases will be calculated as explained below:
 
-- With `replace`, `blur(10px)` will replace `blur(5px)` in the `0%` keyframe.
-- With `add`, the composite effect value in `0%` will be `blur(5px) blur(10px)`.
-- With `accumulate`, the composite effect value in `0%` will be `blur(15px)`.
+- With `replace`, `blur(10px)` will replace `blur(5px)` in the `0%` keyframe. This is the default behavior of the property.
+- With `add`, the composite effect value in `0%` keyframe will be `blur(5px) blur(10px)`.
+- With `accumulate`, the composite effect value in `0%` keyframe will be `blur(15px)`.
 
 > **Note:** A composite operation can also be specified in a keyframe. In that case, the specified composite operation is used for each property first within that keyframe and then on each property in the next keyframe.
 

--- a/files/en-us/web/css/animation-composition/index.md
+++ b/files/en-us/web/css/animation-composition/index.md
@@ -60,7 +60,7 @@ For example, in the CSS below, `blur(5px)` is the underlying value, and `blur(10
 ```css
 .icon:hover {
   filter: blur(5px);
-  animation: brightness-pulse 3s infinite;
+  animation: pulse 3s infinite;
   animation-composition: add;
 }
 

--- a/files/en-us/web/css/animation-composition/index.md
+++ b/files/en-us/web/css/animation-composition/index.md
@@ -13,12 +13,6 @@ browser-compat: css.properties.animation-composition
 
 The **`animation-composition`** [CSS](/en-US/docs/Web/CSS) property specifies the {{Glossary("composite operation")}} to use when multiple animations affect the same property simultaneously.
 
-<!--the interactive example will be created in a separate PR. Will uncomment the macro below when I have an interactive example in place. Note that this property is still behind a flag in FF and not yet implemented in Safari and Chrome.-->
-<!-- {{EmbedInteractiveExample("pages/css/animation-composition.html")}} -->
-
-<!--only longhand animation-composition is enabled in FF104, so commenting out the sentence below for now. Not removing the sentence because it can be uncommented when support in shorthand animation property is added.-->
-<!-- It is often convenient to use the shorthand property {{cssxref("animation")}} to set all animation properties at once.-->
-
 ## Syntax
 
 ```css

--- a/files/en-us/web/css/animation-composition/index.md
+++ b/files/en-us/web/css/animation-composition/index.md
@@ -1,0 +1,113 @@
+---
+title: animation-composition
+slug: Web/CSS/animation-composition
+tags:
+  - CSS
+  - CSS Animations
+  - CSS Property
+  - Reference
+  - recipe:css-property
+browser-compat: css.properties.animation-composition
+---
+{{CSSRef}}
+
+The **`animation-composition`** [CSS](/en-US/docs/Web/CSS) property specifies how to treat the multiple property values when multiple animations affect that same property simultaneously. You can choose the property values to be applied cumulatively, to be combined, or one to be replaced by the other.
+
+When used in a keyframe, the defined composite operation is used for each property first within that keyframe and then on each property in the next keyframe.
+
+{{EmbedInteractiveExample("pages/css/animation-composition.html")}}
+
+It is often convenient to use the shorthand property {{cssxref("animation")}} to set all animation properties at once.
+
+## Syntax
+
+```css
+/* Single animation */
+animation-composition: replace;
+animation-composition: add;
+animation-composition: accumulate;
+
+/* Multiple animations */
+animation-composition: replace, add;
+animation-composition: add, accumulate;
+animation-composition: replace, add, accumulate;
+
+/* Global values */
+animation-composition: inherit;
+animation-composition: initial;
+animation-composition: revert;
+animation-composition: revert-layer;
+animation-composition: unset;
+```
+
+### Values
+
+- `replace`
+  - : Overrides the value of the property with which it is combined. This is the default value.
+- `add`
+  - : Adds along with the property value with which it is combined.
+- `accumulate`
+  - : Gathers up a cumulative value with the property value with which it is combined.
+
+> **Note:** When you specify multiple comma-separated values on an `animation-*` property, they will be assigned to the animations specified in the {{cssxref("animation-name")}} property in different ways depending on how many there are. For more information, see [Setting multiple animation property values](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations#setting_multiple_animation_property_values).
+
+## Formal definition
+
+{{cssinfo}}
+
+## Formal syntax
+
+{{csssyntax}}
+
+## Examples
+
+### Combining property values
+
+#### HTML
+
+```html
+<div class="box"></div>
+```
+
+#### CSS
+
+```css
+.box {
+  background-color: rebeccapurple;
+  border-radius: 10px;
+  width: 100px;
+  height: 100px;
+}
+
+.box:hover {
+  animation-name: rotate;
+  animation-duration: 0.7s;
+  animation-direction: reverse;
+}
+
+@keyframes rotate {
+  0% {
+    transform: rotate(0);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+```
+
+#### Result
+
+{{EmbedLiveSample("Reversing the animation direction","100%","250")}}
+
+## Specifications
+
+{{Specifications}}
+
+## Browser compatibility
+
+{{Compat}}
+
+## See also
+
+- [Using CSS animations](/en-US/docs/Web/CSS/CSS_Animations/Using_CSS_animations)
+- [Composite property of KeyFrameEffect](/en-US/docs/Web/API/KeyframeEffect/composite)


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
- This PR adds documentation for the new CSS property `animation-composition`, supported in FF104.
- This property is behind a preference in FF104, so you would need to enable `layout.css.animation-composition.enabled` in Beta or Nightly to see the 'Example' in action.

#### Notes

- This property is not yet supported in the shorthand `animation` property.
- The property is not yet implemented in Chrome and not shipped in Safari.
- Because of its limited support right now, I am going to put in backlog the following tasks:
   - adding an interactive example
   - updating other `animation` property pages with link to `animation-composition`

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
Bug tracker: https://bugzilla.mozilla.org/show_bug.cgi?id=1293490
Doc tracker: https://github.com/mdn/content/issues/18771
Spec: https://drafts.csswg.org/css-animations-2/#animation-composition
PR for BCD update: https://github.com/mdn/browser-compat-data/pull/17518
PR for experimental feature update: https://github.com/mdn/content/pull/19849

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [x] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
