### PR TITLE
FF101 Relnote: SVG images in UI respect color-scheme of embedder

### DIFF
--- a/files/en-us/mozilla/firefox/releases/101/index.md
+++ b/files/en-us/mozilla/firefox/releases/101/index.md
@@ -53,6 +53,11 @@ No notable changes.
   Note that zero if a valid frame rate value, but is interpreted by Firefox as "no frame rate limit".
   For more information, see {{bug(1611957)}}.
 
+#### SVG
+
+- SVG images in the Firefox UI that are styled using [`prefers-color-scheme`](/en-US/docs/Web/CSS/@media/prefers-color-scheme) will respect the [`color-scheme`](/en-US/docs/Web/CSS/color-scheme) of the embedder (previously `prefers-color-scheme` ignored the `color-scheme` of the embedder and triggered off either the device or browser theme).
+  This ensures that a favicon, for example, is always styled to match the theme of the elements that nest it, and not necessarily the (potentially different) theme of the device. ({{bug(1764354)}}).
+
 ### WebDriver conformance (WebDriver BiDi, Marionette)
 
 Starting with this release of Firefox the [WebDriver BiDi](https://wiki.mozilla.org/WebDriver/RemoteProtocol/WebDriver_BiDi) protocol will be enabled by default. A WebDriver BiDi session can be requested by using WebDriver classic (geckodriver, Marionette) and setting the [`webSocketURL` capability](/en-US/docs/Web/WebDriver/Capabilities/webSocketUrl) to `true` when creating a new WebDriver session. The same capability will then contain the WebSocket end-point for BiDi clients to connect to.


### PR DESCRIPTION
FF101 ensures that SVG Images in the FF UI have the correct light/dark theme for their underlying elements in https://bugzilla.mozilla.org/show_bug.cgi?id=1764354

This fixes a bug where the device might have a dark theme, and the browser a light theme, and the SVG image triggered incorrectly. 

Other docs work for this can be tracked in #19450

Note, that this will be generalized to everything reflecting the color-scheme of the embedder everywhere (e.g. in frames) in FF105.

