### PR TITLE
Update BCD info, part 34

### DIFF
--- a/files/en-us/web/api/videoframe/close/index.md
+++ b/files/en-us/web/api/videoframe/close/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - close
   - VideoFrame
+  - Experimental
 browser-compat: api.VideoFrame.close
 ---
-{{DefaultAPISidebar("Web Codecs API")}}
+{{APIRef("Web Codecs API")}}{{SeeCompatTable}}
 
 The **`close()`** method of the {{domxref("VideoFrame")}} interface clears all states and releases the reference to the media resource.
 

--- a/files/en-us/web/api/videoframe/codedheight/index.md
+++ b/files/en-us/web/api/videoframe/codedheight/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - codedHeight
   - VideoFrame
+  - Experimental
 browser-compat: api.VideoFrame.codedHeight
 ---
-{{DefaultAPISidebar("Web Codecs API")}}
+{{APIRef("Web Codecs API")}}{{SeeCompatTable}}
 
 The **`codedHeight`** property of the {{domxref("VideoFrame")}} interface returns the height of the VideoFrame in pixels, potentially including non-visible padding, and prior to considering potential ratio adjustments.
 

--- a/files/en-us/web/api/videoframe/codedrect/index.md
+++ b/files/en-us/web/api/videoframe/codedrect/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - codedRect
   - VideoFrame
+  - Experimental
 browser-compat: api.VideoFrame.codedRect
 ---
-{{DefaultAPISidebar("Web Codecs API")}}
+{{APIRef("Web Codecs API")}}{{SeeCompatTable}}
 
 The **`codedRect`** property of the {{domxref("VideoFrame")}} interface returns a {{domxref("DOMRectReadOnly")}} with the width and height matching {{domxref("VideoFrame.codedWidth")}} and {{domxref("VideoFrame.codedHeight")}}.
 

--- a/files/en-us/web/api/videoframe/codedwidth/index.md
+++ b/files/en-us/web/api/videoframe/codedwidth/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - codedWidth
   - VideoFrame
+  - Experimental
 browser-compat: api.VideoFrame.codedWidth
 ---
-{{DefaultAPISidebar("Web Codecs API")}}
+{{APIRef("Web Codecs API")}}{{SeeCompatTable}}
 
 The **`codedWidth`** property of the {{domxref("VideoFrame")}} interface returns the width of the `VideoFrame` in pixels, potentially including non-visible padding, and prior to considering potential ratio adjustments.
 

--- a/files/en-us/web/api/videoframe/colorspace/index.md
+++ b/files/en-us/web/api/videoframe/colorspace/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - colorSpace
   - VideoFrame
+  - Experimental
 browser-compat: api.VideoFrame.colorSpace
 ---
-{{DefaultAPISidebar("Web Codecs API")}}
+{{APIRef("Web Codecs API")}}{{SeeCompatTable}}
 
 The **`colorSpace`** property of the {{domxref("VideoFrame")}} interface returns a {{domxref("VideoColorSpace")}} object representing the color space of the video.
 

--- a/files/en-us/web/api/videoframe/copyto/index.md
+++ b/files/en-us/web/api/videoframe/copyto/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - copyTo
   - VideoFrame
+  - Experimental
 browser-compat: api.VideoFrame.copyTo
 ---
-{{DefaultAPISidebar("Web Codecs API")}}
+{{APIRef("Web Codecs API")}}{{SeeCompatTable}}
 
 The **`copyTo()`** method of the {{domxref("VideoFrame")}} interface copies the contents of the `VideoFrame` to an `ArrayBuffer`.
 
@@ -25,15 +26,15 @@ copyTo(destination, options)
 
 - `destination`
   - : An `ArrayBuffer`, a {{jsxref("TypedArray")}}, or a {{jsxref("DataView")}} to copy to.
-- `options` {{optional_inline}}
+- `options` {{Optional_Inline}}
   - : An object containing the following:
-    - `rect` {{optional_inline}}
+    - `rect` {{Optional_Inline}}
       - : The rectangle of pixels to copy from the `VideoFrame`. If unspecified, the {{domxref("VideoFrame.visibleRect","visibleRect")}} will be used. This is in the format of a dictionary object containing:
         - `x`: The x-coordinate.
         - `y`: The y-coordinate.
         - `width`: The width of the frame.
         - `height`: The height of the frame.
-    - `layout` {{optional_inline}}
+    - `layout` {{Optional_Inline}}
       - : A list containing the following values for each plane in the `VideoFrame`:
         - `offset`
           - : An integer representing the offset in bytes where the given plane begins.

--- a/files/en-us/web/api/videoframe/displayheight/index.md
+++ b/files/en-us/web/api/videoframe/displayheight/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - displayHeight
   - VideoFrame
+  - Experimental
 browser-compat: api.VideoFrame.displayHeight
 ---
-{{DefaultAPISidebar("Web Codecs API")}}
+{{APIRef("Web Codecs API")}}{{SeeCompatTable}}
 
 The **`displayHeight`** property of the {{domxref("VideoFrame")}} interface returns the height of the `VideoFrame` after applying aspect ratio adjustments.
 

--- a/files/en-us/web/api/videoframe/displaywidth/index.md
+++ b/files/en-us/web/api/videoframe/displaywidth/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - displayWidth
   - VideoFrame
+  - Experimental
 browser-compat: api.VideoFrame.displayWidth
 ---
-{{DefaultAPISidebar("Web Codecs API")}}
+{{APIRef("Web Codecs API")}}{{SeeCompatTable}}
 
 The **`displayWidth`** property of the {{domxref("VideoFrame")}} interface returns the width of the `VideoFrame` after applying aspect ratio adjustments.
 

--- a/files/en-us/web/api/videoframe/duration/index.md
+++ b/files/en-us/web/api/videoframe/duration/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - duration
   - VideoFrame
+  - Experimental
 browser-compat: api.VideoFrame.duration
 ---
-{{DefaultAPISidebar("Web Codecs API")}}
+{{APIRef("Web Codecs API")}}{{SeeCompatTable}}
 
 The **`duration`** property of the {{domxref("VideoFrame")}} interface returns an integer indicating the duration of the video in microseconds.
 

--- a/files/en-us/web/api/videoframe/format/index.md
+++ b/files/en-us/web/api/videoframe/format/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - format
   - VideoFrame
+  - Experimental
 browser-compat: api.VideoFrame.format
 ---
-{{DefaultAPISidebar("Web Codecs API")}}
+{{APIRef("Web Codecs API")}}{{SeeCompatTable}}
 
 The **`format`** property of the {{domxref("VideoFrame")}} interface returns the pixel format of the `VideoFrame`.
 

--- a/files/en-us/web/api/videoframe/timestamp/index.md
+++ b/files/en-us/web/api/videoframe/timestamp/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - timestamp
   - VideoFrame
+  - Experimental
 browser-compat: api.VideoFrame.timestamp
 ---
-{{DefaultAPISidebar("Web Codecs API")}}
+{{APIRef("Web Codecs API")}}{{SeeCompatTable}}
 
 The **`timestamp`** property of the {{domxref("VideoFrame")}} interface returns an integer indicating the timestamp of the video in microseconds.
 

--- a/files/en-us/web/api/videoframe/videoframe/index.md
+++ b/files/en-us/web/api/videoframe/videoframe/index.md
@@ -7,9 +7,10 @@ tags:
   - Constructor
   - Reference
   - VideoFrame
+  - Experimental
 browser-compat: api.VideoFrame.VideoFrame
 ---
-{{DefaultAPISidebar("Web Codecs API")}}
+{{APIRef("Web Codecs API")}}{{SeeCompatTable}}
 
 The **`VideoFrame()`** constructor creates a new {{domxref("VideoFrame")}} object representing a frame of a video.
 
@@ -33,17 +34,17 @@ The first type of constructor (see above) creates a new {{domxref("VideoFrame")}
     an {{domxref("ImageBitmap")}},
     an {{domxref("OffscreenCanvas")}},
     or another {{domxref("VideoFrame")}}.
-- `init` {{optional_inline}}
+- `init` {{Optional_Inline}}
   - : A dictionary object containing the following:
-    - `duration` {{optional_inline}}
+    - `duration` {{Optional_Inline}}
       - : An integer representing the duration of the frame in microseconds.
     - `timestamp`
       - : An integer representing the timestamp of the frame in microseconds.
-    - `alpha` {{optional_inline}}
+    - `alpha` {{Optional_Inline}}
       - : A string, describing how the user agent should behave when dealing with alpha channels. The default value is "keep".
         - `"keep"`: Indicates that the user agent should preserve alpha channel data.
         - `"discard"`: Indicates that the user agent should ignore or remove alpha channel data.
-    - `visibleRect` {{optional_inline}}
+    - `visibleRect` {{Optional_Inline}}
       - : A dictionary representing the visible rectangle of the `VideoFrame`, containing the following:
         - `x`
           - : The x-coordinate.
@@ -53,9 +54,9 @@ The first type of constructor (see above) creates a new {{domxref("VideoFrame")}
           - : The width of the frame.
         - `height`
           - : The height of the frame.
-    - `displayWidth` {{optional_inline}}
+    - `displayWidth` {{Optional_Inline}}
       - : The width of the `VideoFrame` when displayed after applying aspect-ratio adjustments.
-    - `displayHeight` {{optional_inline}}
+    - `displayHeight` {{Optional_Inline}}
       - : The height of the `VideoFrame` when displayed after applying aspect-ratio adjustments.
 
 The second type of constructor (see above) creates a new {{domxref("VideoFrame")}} from an {{jsxref("ArrayBuffer")}}. Its parameters are:
@@ -81,16 +82,16 @@ The second type of constructor (see above) creates a new {{domxref("VideoFrame")
       - : Height of the `VideoFrame` in pixels, potentially including non-visible padding, and prior to considering potential ratio adjustments.
     - `timestamp`
       - : An integer representing the timestamp of the frame in microseconds.
-    - `duration` {{optional_inline}}
+    - `duration` {{Optional_Inline}}
       - : An integer representing the duration of the frame in microseconds.
-    - `layout` {{optional_inline}}
+    - `layout` {{Optional_Inline}}
       - : A list containing the following values for each plane in the `VideoFrame`:
         - `offset`
           - : An integer representing the offset in bytes where the given plane begins.
         - `stride`
           - : An integer representing the number of bytes, including padding, used by each row of the plane.
         Planes may not overlap. If no `layout` is specified, the planes will be tightly packed.
-    - `visibleRect` {{optional_inline}}
+    - `visibleRect` {{Optional_Inline}}
       - : A dictionary representing the visible rectangle of the `VideoFrame`, containing the following:
         - `x`
           - : The x-coordinate.
@@ -100,9 +101,9 @@ The second type of constructor (see above) creates a new {{domxref("VideoFrame")
           - : The width of the frame.
         - `height`
           - : The height of the frame.
-    - `displayWidth` {{optional_inline}}
+    - `displayWidth` {{Optional_Inline}}
       - : The width of the `VideoFrame` when displayed after applying aspect ratio adjustments.
-    - `displayHeight` {{optional_inline}}
+    - `displayHeight` {{Optional_Inline}}
       - : The height of the `VideoFrame` when displayed after applying aspect ratio adjustments.
     - `colorSpace`
       - : A dictionary representing the color space of the `VideoFrame`, containing the following:

--- a/files/en-us/web/api/videoframe/visiblerect/index.md
+++ b/files/en-us/web/api/videoframe/visiblerect/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - visibleRect
   - VideoFrame
+  - Experimental
 browser-compat: api.VideoFrame.visibleRect
 ---
-{{DefaultAPISidebar("Web Codecs API")}}
+{{APIRef("Web Codecs API")}}{{SeeCompatTable}}
 
 The **`visibleRect`**  property of the {{domxref("VideoFrame")}} interface returns a {{domxref("DOMRectReadOnly")}} describing the visible rectangle of pixels for this `VideoFrame`.
 

--- a/files/en-us/web/api/wakelock/index.md
+++ b/files/en-us/web/api/wakelock/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.WakeLock
 ---
-{{securecontext_header}} {{ ApiRef("Screen Wake Lock API") }}
+{{APIRef("Screen Wake Lock API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`WakeLock`** interface of the [Screen Wake Lock API](/en-US/docs/Web/API/Screen_Wake_Lock_API) prevents device screens from dimming or locking when an application needs to keep running.
 
@@ -19,7 +19,7 @@ The system wake lock is exposed through the global {{domxref('Navigator.wakeLock
 
 ## Methods
 
-- {{domxref("WakeLock.request", "request()")}}
+- {{domxref("WakeLock.request", "request()")}} {{Experimental_Inline}}
   - : Requests a {{domxref("WakeLockSentinel")}} object, which returns a {{jsxref("Promise")}} that resolves with a {{domxref("WakeLockSentinel")}} object.
 
 ## Examples

--- a/files/en-us/web/api/wakelock/request/index.md
+++ b/files/en-us/web/api/wakelock/request/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - Screen Wake Lock API
   - WakeLock
+  - Experimental
 browser-compat: api.WakeLock.request
 ---
-{{securecontext_header}}{{DefaultAPISidebar("Screen Wake Lock API")}}
+{{APIRef("Screen Wake Lock API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`request()`** method of the
 {{domxref("WakeLock")}} interface returns a {{jsxref("Promise")}} that resolves with a

--- a/files/en-us/web/api/wakelocksentinel/release/index.md
+++ b/files/en-us/web/api/wakelocksentinel/release/index.md
@@ -10,9 +10,10 @@ tags:
   - Wake Lock
   - WakeLockSentinel
   - screen
+  - Experimental
 browser-compat: api.WakeLockSentinel.release
 ---
-{{securecontext_header}}{{DefaultAPISidebar("Screen Wake Lock API")}}
+{{APIRef("Screen Wake Lock API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`release()`** method of the
 {{domxref("WakeLockSentinel")}} interface releases the

--- a/files/en-us/web/api/wakelocksentinel/release_event/index.md
+++ b/files/en-us/web/api/wakelocksentinel/release_event/index.md
@@ -10,9 +10,10 @@ tags:
   - WakeLockSentinel
   - screen
   - screen wake lock
+  - Experimental
 browser-compat: api.WakeLockSentinel.release_event
 ---
-{{securecontext_header}}{{DefaultAPISidebar("Screen Wake Lock API")}}
+{{APIRef("Screen Wake Lock API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`release`** event of the {{domxref("WakeLockSentinel")}} interface is fired when the sentinel object's handle has been released.
 

--- a/files/en-us/web/api/wakelocksentinel/released/index.md
+++ b/files/en-us/web/api/wakelocksentinel/released/index.md
@@ -7,9 +7,10 @@ tags:
   - Read-only
   - Screen Wake Lock API
   - WakeLockSentinel
+  - Experimental
 browser-compat: api.WakeLockSentinel.released
 ---
-{{DefaultAPISidebar("Screen Wake Lock API")}}
+{{APIRef("Screen Wake Lock API")}}{{SeeCompatTable}}
 
 The read-only **`released`** property of the
 {{domxref("WakeLockSentinel")}} interface returns a boolean that indicates whether

--- a/files/en-us/web/api/wakelocksentinel/type/index.md
+++ b/files/en-us/web/api/wakelocksentinel/type/index.md
@@ -9,9 +9,10 @@ tags:
   - Wake Lock
   - WakeLockSentinel
   - screen
+  - Experimental
 browser-compat: api.WakeLockSentinel.type
 ---
-{{securecontext_header}}{{DefaultAPISidebar("Screen Wake Lock API")}}
+{{APIRef("Screen Wake Lock API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The read-only **`type`** property of the
 {{domxref("WakeLockSentinel")}} interface returns a string

--- a/files/en-us/web/api/web_bluetooth_api/index.md
+++ b/files/en-us/web/api/web_bluetooth_api/index.md
@@ -8,6 +8,7 @@ tags:
   - Overview
   - Reference
   - Web Bluetooth API
+  - Experimental
 browser-compat: api.Bluetooth
 ---
 {{DefaultAPISidebar("Bluetooth API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/web_periodic_background_synchronization_api/index.md
+++ b/files/en-us/web/api/web_periodic_background_synchronization_api/index.md
@@ -13,11 +13,10 @@ tags:
   - Sync
   - Web Periodic Background Synchronization API
   - periodic
+  - Experimental
 browser-compat: api.PeriodicSyncManager
 ---
-{{securecontext_header}}
-
-{{DefaultAPISidebar("Periodic Background Sync")}}
+{{DefaultAPISidebar("Periodic Background Sync")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The Web Periodic Background Synchronization API provides a way to register tasks to be run in a {{domxref('Service Worker API','service worker')}} at periodic intervals with network connectivity. These tasks are referred to as periodic background sync requests.
 

--- a/files/en-us/web/api/web_serial_api/index.md
+++ b/files/en-us/web/api/web_serial_api/index.md
@@ -7,9 +7,10 @@ tags:
   - Web Serial
   - Overview
   - Reference
+  - Experimental
 browser-compat: api.Serial
 ---
-{{securecontext_header}}{{DefaultAPISidebar("Web Serial API")}}
+{{DefaultAPISidebar("Web Serial API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **Web Serial API** provides a way for websites to read from and write to serial devices. These devices may be connected via a serial port, or be USB or Bluetooth devices that emulate a serial port.
 

--- a/files/en-us/web/api/webglrenderingcontext/commit/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/commit/index.md
@@ -8,9 +8,10 @@ tags:
   - OffscreenCanvas
   - Reference
   - WebGL
+  - Experimental
 browser-compat: api.WebGLRenderingContext.commit
 ---
-{{APIRef("WebGL")}}
+{{APIRef("WebGL")}}{{SeeCompatTable}}
 
 The
 **`WebGLRenderingContext.commit()`**

--- a/files/en-us/web/api/webhid_api/index.md
+++ b/files/en-us/web/api/webhid_api/index.md
@@ -7,6 +7,7 @@ tags:
   - Advanced
   - WebHID
   - WebHID API
+  - Experimental
 browser-compat: api.HID
 ---
 {{DefaultAPISidebar("WebHID API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/webxr_device_api/index.md
+++ b/files/en-us/web/api/webxr_device_api/index.md
@@ -14,9 +14,10 @@ tags:
   - WebXR API
   - WebXR Device API
   - XR
+  - Experimental
 browser-compat: api.Navigator.xr
 ---
-{{DefaultAPISidebar("WebXR Device API")}} {{SecureContext_Header}}
+{{DefaultAPISidebar("WebXR Device API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 **WebXR** is a group of standards which are used together to support rendering 3D scenes to hardware designed for presenting virtual worlds (**virtual reality**, or **VR**), or for adding graphical imagery to the real world, (**augmented reality**, or **AR**). The **WebXR Device API** implements the core of the WebXR feature set, managing the selection of output devices, render the 3D scene to the chosen device at the appropriate frame rate, and manage motion vectors created using input controllers.
 

--- a/files/en-us/web/api/window/showopenfilepicker/index.md
+++ b/files/en-us/web/api/window/showopenfilepicker/index.md
@@ -8,9 +8,10 @@ tags:
   - Method
   - Window
   - working with files
+  - Experimental
 browser-compat: api.Window.showOpenFilePicker
 ---
-{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
+{{APIRef("File System Access API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`showOpenFilePicker()`** method of the
 {{domxref("Window")}} interface shows a file picker that allows a user to select a file
@@ -24,7 +25,7 @@ showOpenFilePicker()
 
 ### Parameters
 
-- `options` {{optional_inline}}
+- `options` {{Optional_Inline}}
 
   - : An object containing options, which are as follows:
 

--- a/files/en-us/web/api/window/showsavefilepicker/index.md
+++ b/files/en-us/web/api/window/showsavefilepicker/index.md
@@ -9,9 +9,10 @@ tags:
   - Method
   - Window
   - working with files
+  - Experimental
 browser-compat: api.Window.showSaveFilePicker
 ---
-{{securecontext_header}}{{DefaultAPISidebar("File System Access API")}}
+{{APIRef("File System Access API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`showSaveFilePicker()`** method of the
 {{domxref("Window")}} interface shows a file picker that allows a user to save a file.
@@ -25,7 +26,7 @@ showSaveFilePicker()
 
 ### Parameters
 
-- `options` {{optional_inline}}
+- `options` {{Optional_Inline}}
 
   - : An object containing options, which are as follows:
 

--- a/files/en-us/web/api/window_controls_overlay_api/index.md
+++ b/files/en-us/web/api/window_controls_overlay_api/index.md
@@ -8,6 +8,7 @@ tags:
   - Overview
   - Reference
   - Progressive Web Apps
+  - Experimental
 browser-compat: api.WindowControlsOverlay
 ---
 {{DefaultAPISidebar("Window Controls Overlay API")}}{{SeeCompatTable}}

--- a/files/en-us/web/api/windowcontrolsoverlay/geometrychange_event/index.md
+++ b/files/en-us/web/api/windowcontrolsoverlay/geometrychange_event/index.md
@@ -8,9 +8,10 @@ tags:
   - Progressive Web Apps
   - Window Controls Overlay
   - events
+  - Experimental
 browser-compat: api.WindowControlsOverlay.geometrychange_event
 ---
-{{APIRef("EyeDropper API")}}
+{{APIRef("EyeDropper API")}}{{SeeCompatTable}}
 
 The `geometrychange` event is fired when the position, size, or visibility of a Progressive Web App's title bar area changes.
 

--- a/files/en-us/web/api/windowcontrolsoverlay/gettitlebararearect/index.md
+++ b/files/en-us/web/api/windowcontrolsoverlay/gettitlebararearect/index.md
@@ -8,6 +8,7 @@ tags:
   - Reference
   - WindowControlsOverlay
   - Progressive Web Apps
+  - Experimental
 browser-compat: api.WindowControlsOverlay.getTitlebarAreaRect
 ---
 {{APIRef("Window Controls Overlay API")}}{{SeeCompatTable}}


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.

This covers files that have only `experimental` header modifications.