### PR TITLE
Update BCD info, part 35

### DIFF
--- a/files/en-us/web/api/windowcontrolsoverlay/visible/index.md
+++ b/files/en-us/web/api/windowcontrolsoverlay/visible/index.md
@@ -9,9 +9,10 @@ tags:
   - Reference
   - WindowControlsOverlay
   - Progressive Web Apps
+  - Experimental
 browser-compat: api.WindowControlsOverlay.visible
 ---
-{{ApiRef("Window Controls Overlay API")}}
+{{APIRef("Window Controls Overlay API")}}{{SeeCompatTable}}
 
 The **`visible`** property of a {{domxref("WindowControlsOverlay")}} object returns a {{Glossary("Boolean")}} that indicates whether the window controls overlay is visible or not.
 

--- a/files/en-us/web/api/windowcontrolsoverlaygeometrychangeevent/titlebararearect/index.md
+++ b/files/en-us/web/api/windowcontrolsoverlaygeometrychangeevent/titlebararearect/index.md
@@ -6,9 +6,10 @@ tags:
   - API
   - WindowControlsOverlayGeometryChangeEvent
   - Property
+  - Experimental
 browser-compat: api.WindowControlsOverlayGeometryChangeEvent.titlebarAreaRect
 ---
-{{APIRef("Window Controls Overlay API")}}
+{{APIRef("Window Controls Overlay API")}}{{SeeCompatTable}}
 
 The **`titlebarAreaRect`** read-only property of the {{domxref("WindowControlsOverlayGeometryChangeEvent")}} is a {{domxref("DOMRect")}} representing the position and size of the area occupied by the title bar in a desktop-installed Progressive Web App.
 

--- a/files/en-us/web/api/windowcontrolsoverlaygeometrychangeevent/visible/index.md
+++ b/files/en-us/web/api/windowcontrolsoverlaygeometrychangeevent/visible/index.md
@@ -6,9 +6,10 @@ tags:
   - API
   - WindowControlsOverlayGeometryChangeEvent
   - Property
+  - Experimental
 browser-compat: api.WindowControlsOverlayGeometryChangeEvent.visible
 ---
-{{APIRef("Window Controls Overlay API")}}
+{{APIRef("Window Controls Overlay API")}}{{SeeCompatTable}}
 
 The **`visible`** read-only property of the {{domxref("WindowControlsOverlayGeometryChangeEvent")}} is a boolean flag that indicates whether the window controls overlay is visible or not in a desktop-installed Progressive Web App.
 

--- a/files/en-us/web/api/windowcontrolsoverlaygeometrychangeevent/windowcontrolsoverlaygeometrychangeevent/index.md
+++ b/files/en-us/web/api/windowcontrolsoverlaygeometrychangeevent/windowcontrolsoverlaygeometrychangeevent/index.md
@@ -7,9 +7,10 @@ tags:
   - Constructor
   - DOM Events
   - WindowControlsOverlayGeometryChangeEvent
+  - Experimental
 browser-compat: api.WindowControlsOverlayGeometryChangeEvent.WindowControlsOverlayGeometryChangeEvent
 ---
-{{APIRef("Window Controls Overlay API")}}
+{{APIRef("Window Controls Overlay API")}}{{SeeCompatTable}}
 
 The **`WindowControlsOverlayGeometryChangeEvent()`** constructor returns a newly created
 {{domxref("WindowControlsOverlayGeometryChangeEvent")}}, representing the current geometry of a desktop Progressive Web App's title bar area.

--- a/files/en-us/web/api/workernavigator/serial/index.md
+++ b/files/en-us/web/api/workernavigator/serial/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - serial
   - WorkerNavigator
+  - Experimental
 browser-compat: api.WorkerNavigator.serial
 ---
-{{APIRef("Web Workers API")}}
+{{APIRef("Web Workers API")}}{{SeeCompatTable}}
 
 The **`serial`** read-only property of the {{domxref("WorkerNavigator")}} interface returns a {{domxref("Serial")}} object which represents the entry point into the {{domxref("Web Serial API")}}.
 

--- a/files/en-us/web/api/workernavigator/useragentdata/index.md
+++ b/files/en-us/web/api/workernavigator/useragentdata/index.md
@@ -8,9 +8,10 @@ tags:
   - Property
   - Reference
   - NavigatorUAData
+  - Experimental
 browser-compat: api.WorkerNavigator.userAgentData
 ---
-{{APIRef("User-Agent Client Hints API")}}
+{{APIRef("User-Agent Client Hints API")}}{{SeeCompatTable}}
 
 The **`userAgentData`** read-only property of the {{domxref("WorkerNavigator")}} interface returns an {{domxref("NavigatorUAData")}} object
 which can be used to access the {{domxref("User-Agent Client Hints API")}}.

--- a/files/en-us/web/api/xranchor/anchorspace/index.md
+++ b/files/en-us/web/api/xranchor/anchorspace/index.md
@@ -10,9 +10,10 @@ tags:
   - VR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRAnchor.anchorSpace
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only **`anchorSpace`** property of the {{domxref("XRAnchor")}} interface returns an {{domxref("XRSpace")}} object to locate the anchor relative to other `XRSpace` objects. It can be passed to {{domxref("XRFrame.getPose()")}} subsequently.
 

--- a/files/en-us/web/api/xranchor/delete/index.md
+++ b/files/en-us/web/api/xranchor/delete/index.md
@@ -10,9 +10,10 @@ tags:
   - VR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRAnchor.delete
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`delete()`** method of the {{domxref("XRAnchor")}} interface removes an anchor. This can be useful when an application is no longer interested in receiving updates to an anchor.
 

--- a/files/en-us/web/api/xranchor/index.md
+++ b/files/en-us/web/api/xranchor/index.md
@@ -10,20 +10,21 @@ tags:
   - XR
   - AR
   - VR
+  - Experimental
 browser-compat: api.XRAnchor
 ---
-{{APIRef("WebXR Device API")}} {{secureContext_header}}
+{{APIRef("WebXR Device API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`XRAnchor`** interface creates anchors which keep track of the pose that is fixed relative to the real world. With anchors, you can specify poses in the world that need to be updated to correctly reflect the evolving understanding of the world, such that the poses remain aligned with the same place in the physical world. That helps to build an illusion that the placed objects are really present in the user's environment.
 
 ## Properties
 
-- {{domxref("XRAnchor.anchorSpace")}} {{ReadOnlyInline}}
+- {{domxref("XRAnchor.anchorSpace")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : Returns an {{domxref("XRSpace")}} object to locate the anchor relative to other `XRSpace` objects.
 
 ## Methods
 
-- {{domxref("XRAnchor.delete()")}}
+- {{domxref("XRAnchor.delete()")}} {{Experimental_Inline}}
   - : Removes the anchor.
 
 ## Examples

--- a/files/en-us/web/api/xranchorset/index.md
+++ b/files/en-us/web/api/xranchorset/index.md
@@ -10,9 +10,10 @@ tags:
   - XR
   - AR
   - VR
+  - Experimental
 browser-compat: api.XRAnchorSet
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`XRAnchorSet`** interface exposes a collection of anchors. It is returned by {{domxref("XRFrame.trackedAnchors")}} and is a {{jsxref("Set")}}-like object.
 

--- a/files/en-us/web/api/xrboundedreferencespace/boundsgeometry/index.md
+++ b/files/en-us/web/api/xrboundedreferencespace/boundsgeometry/index.md
@@ -22,9 +22,10 @@ tags:
   - augmented
   - boundsGeometry
   - space
+  - Experimental
 browser-compat: api.XRBoundedReferenceSpace.boundsGeometry
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only {{domxref("XRBoundedReferenceSpace")}}
 property **`boundsGeometry`** is an array of

--- a/files/en-us/web/api/xrboundedreferencespace/index.md
+++ b/files/en-us/web/api/xrboundedreferencespace/index.md
@@ -16,9 +16,10 @@ tags:
   - XR
   - XRBoundedReferenceSpace
   - augmented
+  - Experimental
 browser-compat: api.XRBoundedReferenceSpace
 ---
-{{APIRef("WebXR Device API")}}{{secureContext_header}}
+{{APIRef("WebXR Device API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API)'s **`XRBoundedReferenceSpace`** interface describes a virtual world [reference space](/en-US/docs/Web/API/WebXR_Device_API/Geometry) which has preset boundaries. This extends {{domxref("XRReferenceSpace")}}, which describes an essentially unrestricted space around the viewer's position. These bounds are defined using an array of points, each of which defines a vertex in a polygon inside which the user is allowed to move.
 
@@ -30,7 +31,7 @@ This is typically used when the XR system is capable of tracking the user's phys
 
 _In addition to the properties of {{domxref("XRReferenceSpace")}}, `XRBoundedReferenceSpace` includes the following:_
 
-- {{domxref("XRBoundedReferenceSpace.boundsGeometry", "boundsGeometry")}} {{ReadOnlyInline}}
+- {{domxref("XRBoundedReferenceSpace.boundsGeometry", "boundsGeometry")}} {{ReadOnlyInline}} {{Experimental_Inline}}
   - : An array of {{domxref("DOMPointReadOnly")}} objects, each of which defines a vertex in the polygon defining the boundaries within which the user will be required to remain. These vertices *must* be sorted such that they move *clockwise* around the viewer's position.
 
 ## Methods

--- a/files/en-us/web/api/xrcpudepthinformation/data/index.md
+++ b/files/en-us/web/api/xrcpudepthinformation/data/index.md
@@ -14,7 +14,7 @@ tags:
   - WebXR Device API
 browser-compat: api.XRCPUDepthInformation.data
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The *read-only* **`data`** property of the {{DOMxRef("XRCPUDepthInformation")}} interface is an {{jsxref("ArrayBuffer")}} containing depth-buffer information in raw format.
 

--- a/files/en-us/web/api/xrcpudepthinformation/getdepthinmeters/index.md
+++ b/files/en-us/web/api/xrcpudepthinformation/getdepthinmeters/index.md
@@ -14,7 +14,7 @@ tags:
   - WebXR Device API
 browser-compat: api.XRCPUDepthInformation.getDepthInMeters
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`getDepthInMeters()`** method of the {{DOMxRef("XRCPUDepthInformation")}} interface returns the depth in meters at (x, y) in normalized view coordinates (origin in the top left corner).
 

--- a/files/en-us/web/api/xrdepthinformation/height/index.md
+++ b/files/en-us/web/api/xrdepthinformation/height/index.md
@@ -14,7 +14,7 @@ tags:
   - WebXR Device API
 browser-compat: api.XRDepthInformation.height
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The *read-only* **`height`** property of the {{DOMxRef("XRDepthInformation")}} interface contains the height of the depth buffer (number of rows).
 

--- a/files/en-us/web/api/xrdepthinformation/normdepthbufferfromnormview/index.md
+++ b/files/en-us/web/api/xrdepthinformation/normdepthbufferfromnormview/index.md
@@ -14,7 +14,7 @@ tags:
   - WebXR Device API
 browser-compat: api.XRDepthInformation.normDepthBufferFromNormView
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The *read-only* **`normDepthBufferFromNormView`** property of the {{DOMxRef("XRDepthInformation")}} interface contains the 3D geometric transform that needs to be applied when indexing into the depth buffer.
 

--- a/files/en-us/web/api/xrdepthinformation/rawvaluetometers/index.md
+++ b/files/en-us/web/api/xrdepthinformation/rawvaluetometers/index.md
@@ -14,7 +14,7 @@ tags:
   - WebXR Device API
 browser-compat: api.XRDepthInformation.rawValueToMeters
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The *read-only* **`rawValueToMeters`** property of the {{DOMxRef("XRDepthInformation")}} interface contains the scale factor by which the raw depth values must be multiplied in order to get the depths in meters.
 

--- a/files/en-us/web/api/xrdepthinformation/width/index.md
+++ b/files/en-us/web/api/xrdepthinformation/width/index.md
@@ -14,7 +14,7 @@ tags:
   - WebXR Device API
 browser-compat: api.XRDepthInformation.width
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The *read-only* **`width`** property of the {{DOMxRef("XRDepthInformation")}} interface contains the width of the depth buffer (number of columns).
 

--- a/files/en-us/web/api/xrframe/createanchor/index.md
+++ b/files/en-us/web/api/xrframe/createanchor/index.md
@@ -10,9 +10,10 @@ tags:
   - VR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRFrame.createAnchor
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`createAnchor()`** method of the {{domxref("XRFrame")}} interface creates a free-floating {{domxref("XRAnchor")}} which will be fixed relative to the real world.
 

--- a/files/en-us/web/api/xrframe/getdepthinformation/index.md
+++ b/files/en-us/web/api/xrframe/getdepthinformation/index.md
@@ -9,9 +9,10 @@ tags:
   - AR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRFrame.getDepthInformation
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`getDepthInformation()`** method of the {{domxref("XRFrame")}} interface returns an {{domxref("XRCPUDepthInformation")}} object containing CPU depth information for the active and animated frame.
 

--- a/files/en-us/web/api/xrframe/gethittestresults/index.md
+++ b/files/en-us/web/api/xrframe/gethittestresults/index.md
@@ -9,9 +9,10 @@ tags:
   - AR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRFrame.getHitTestResults
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`getHitTestResults()`** method of the {{domxref("XRFrame")}} interface returns an array of {{domxref("XRHitTestResult")}} objects containing hit test results for a given {{domxref("XRHitTestSource")}}.
 

--- a/files/en-us/web/api/xrframe/gethittestresultsfortransientinput/index.md
+++ b/files/en-us/web/api/xrframe/gethittestresultsfortransientinput/index.md
@@ -9,9 +9,10 @@ tags:
   - AR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRFrame.getHitTestResultsForTransientInput
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`getHitTestResultsForTransientInput()`** method of the {{domxref("XRFrame")}} interface returns an array of {{domxref("XRTransientInputHitTestResult")}} objects containing transient input hit test results for a given {{domxref("XRTransientInputHitTestSource")}}.
 

--- a/files/en-us/web/api/xrframe/getlightestimate/index.md
+++ b/files/en-us/web/api/xrframe/getlightestimate/index.md
@@ -9,9 +9,10 @@ tags:
   - AR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRFrame.getLightEstimate
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`getLightEstimate()`** method of the {{domxref("XRFrame")}} interface returns an {{domxref("XRLightEstimate")}} object containing estimated lighting values for a given {{domxref("XRLightProbe")}}.
 

--- a/files/en-us/web/api/xrframe/getpose/index.md
+++ b/files/en-us/web/api/xrframe/getpose/index.md
@@ -15,9 +15,10 @@ tags:
   - WebXR Device API
   - XRFrame
   - getPose
+  - Experimental
 browser-compat: api.XRFrame.getPose
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The {{domxref("XRFrame")}} method **`getPose()`** returns the relative position and
 orientation—the pose—of one {{domxref("XRSpace")}} to that of another space. With this, you can observe the motion of objects relative to each other and to fixed locations throughout the scene.

--- a/files/en-us/web/api/xrframe/getviewerpose/index.md
+++ b/files/en-us/web/api/xrframe/getviewerpose/index.md
@@ -16,9 +16,10 @@ tags:
   - XRFrame
   - getViewerPose
   - pose
+  - Experimental
 browser-compat: api.XRFrame.getViewerPose
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`getViewerPose()`** method, a member of the {{domxref("XRFrame")}} interface, returns a {{domxref("XRViewerPose")}} object which describes the viewer's pose (position and orientation) relative to the specified reference space.
 

--- a/files/en-us/web/api/xrframe/session/index.md
+++ b/files/en-us/web/api/xrframe/session/index.md
@@ -15,9 +15,10 @@ tags:
   - WebXR Device API
   - XR
   - XRFrame
+  - Experimental
 browser-compat: api.XRFrame.session
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 An `XRFrame` object's *read-only* **`session`** property returns the {{domxref("XRSession")}} object that generated the frame.
 

--- a/files/en-us/web/api/xrframe/trackedanchors/index.md
+++ b/files/en-us/web/api/xrframe/trackedanchors/index.md
@@ -10,9 +10,10 @@ tags:
   - VR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRFrame.trackedAnchors
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only **`trackedAnchor`** property of the {{domxref("XRFrame")}} interface returns an {{domxref("XRAnchorSet")}} object containing all anchors still tracked in the frame.
 

--- a/files/en-us/web/api/xrhittestresult/createanchor/index.md
+++ b/files/en-us/web/api/xrhittestresult/createanchor/index.md
@@ -10,9 +10,10 @@ tags:
   - VR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRHitTestResult.createAnchor
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`createAnchor()`** method of the {{domxref("XRHitTestResult")}} interface creates an {{domxref("XRAnchor")}} from a hit test result that is attached to a real world object.
 

--- a/files/en-us/web/api/xrhittestresult/getpose/index.md
+++ b/files/en-us/web/api/xrhittestresult/getpose/index.md
@@ -10,9 +10,10 @@ tags:
   - VR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRHitTestResult.getPose
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`getPose()`** method of the {{domxref("XRHitTestResult")}} interface returns the {{domxref("XRPose")}} of the hit test result relative to the given base space.
 

--- a/files/en-us/web/api/xrhittestresult/index.md
+++ b/files/en-us/web/api/xrhittestresult/index.md
@@ -10,9 +10,10 @@ tags:
   - XR
   - AR
   - VR
+  - Experimental
 browser-compat: api.XRHitTestResult
 ---
-{{APIRef("WebXR Device API")}} {{secureContext_header}}
+{{APIRef("WebXR Device API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`XRHitTestResult`** interface of the [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API) contains a single result of a hit test. You can get an array of `XRHitTestResult` objects for a frame by calling {{domxref("XRFrame.getHitTestResults()")}}.
 
@@ -22,9 +23,9 @@ None.
 
 ## Methods
 
-- {{domxref("XRHitTestResult.createAnchor()")}}
+- {{domxref("XRHitTestResult.createAnchor()")}} {{Experimental_Inline}}
   - : Returns a {{jsxref("Promise")}} that resolves with an {{domxref("XRAnchor")}} created from the hit test result.
-- {{domxref("XRHitTestResult.getPose()")}}
+- {{domxref("XRHitTestResult.getPose()")}} {{Experimental_Inline}}
   - : Returns the {{domxref("XRPose")}} of the hit test result relative to the given base space.
 
 ## Examples


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.

This covers files that have only `experimental` header modifications.