### PR TITLE
Update BCD info, part 36

### DIFF
--- a/files/en-us/web/api/xrhittestsource/cancel/index.md
+++ b/files/en-us/web/api/xrhittestsource/cancel/index.md
@@ -10,9 +10,10 @@ tags:
   - VR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRHitTestSource.cancel
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`cancel()`** method of the {{domxref("XRHitTestSource")}} interface unsubscribes a hit test.
 

--- a/files/en-us/web/api/xrhittestsource/index.md
+++ b/files/en-us/web/api/xrhittestsource/index.md
@@ -10,9 +10,10 @@ tags:
   - XR
   - AR
   - VR
+  - Experimental
 browser-compat: api.XRHitTestSource
 ---
-{{APIRef("WebXR Device API")}} {{secureContext_header}}
+{{APIRef("WebXR Device API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`XRHitTestSource`** interface of the [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API) handles hit test subscriptions. You can get an `XRHitTestSource` object by using the {{domxref("XRSession.requestHitTestSource()")}} method.
 
@@ -24,7 +25,7 @@ None.
 
 ## Methods
 
-- {{domxref("XRHitTestSource.cancel()")}}
+- {{domxref("XRHitTestSource.cancel()")}} {{Experimental_Inline}}
   - : Unsubscribes from the hit test.
 
 ## Examples

--- a/files/en-us/web/api/xrinputsource/gripspace/index.md
+++ b/files/en-us/web/api/xrinputsource/gripspace/index.md
@@ -6,7 +6,6 @@ tags:
   - API
   - AR
   - Augmented Reality
-  - Experimental
   - Property
   - Reference
   - VR

--- a/files/en-us/web/api/xrinputsource/index.md
+++ b/files/en-us/web/api/xrinputsource/index.md
@@ -6,7 +6,6 @@ tags:
   - API
   - AR
   - Augmented Reality
-  - Experimental
   - Input
   - Interface
   - Reference
@@ -18,13 +17,13 @@ tags:
   - control
 browser-compat: api.XRInputSource
 ---
-{{securecontext_header}}{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SecureContext_Header}}
 
 The [WebXR Device API's](/en-US/docs/Web/API/WebXR_Device_API) **`XRInputSource`** interface describes a single source of control input which is part of the user's WebXR-compatible virtual or augmented reality system. The device is specific to the platform being used, but provides the direction in which it is being aimed and optionally may generate events if the user triggers performs actions using the device.
 
 ## Properties
 
-- {{domxref("XRInputSource.gamepad", "gamepad")}} {{ReadOnlyInline}} {{experimental_inline}}
+- {{domxref("XRInputSource.gamepad", "gamepad")}} {{ReadOnlyInline}}
   - : A {{domxref("Gamepad")}} object describing the state of the buttons and axes on the XR input source, if it is a gamepad or comparable device. If the device isn't a gamepad-like device, this property's value is `null`.
 - {{domxref('XRInputSource.gripSpace', 'gripSpace')}} {{ReadOnlyInline}}
   - : An {{domxref("XRSpace")}} whose origin tracks the pose which is used to render objects which should appear as if they're held in the hand indicated by `handedness`. The orientation of this space indicates the angle at which the hand is gripping the object. Read on in the main article on {{domxref("XRInputSource.gripSpace", "gripSpace")}} for more details on how to use this space.

--- a/files/en-us/web/api/xrinputsourcearray/entries/index.md
+++ b/files/en-us/web/api/xrinputsourcearray/entries/index.md
@@ -17,9 +17,10 @@ tags:
   - WebXR Device API
   - XR
   - XRInputSourceArray
+  - Experimental
 browser-compat: api.XRInputSourceArray.entries
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The {{domxref("XRInputSourceArray")}} interface's
 **`entries()`** method returns a JavaScript

--- a/files/en-us/web/api/xrinputsourcearray/foreach/index.md
+++ b/files/en-us/web/api/xrinputsourcearray/foreach/index.md
@@ -20,9 +20,10 @@ tags:
   - XRInputSourceArray
   - augmented
   - forEach
+  - Experimental
 browser-compat: api.XRInputSourceArray.forEach
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The {{domxref("XRInputSourceArray")}}
 method **`forEach()`** executes the specified callback once for
@@ -46,15 +47,15 @@ forEach(callback, thisArg)
     - `currentValue`
       - : A {{domxref("XRInputSource")}} object which is the value of the item from within
         the `xrInputSourceArray` which is currently being processed.
-    - `currentIndex` {{optional_inline}}
+    - `currentIndex` {{Optional_Inline}}
       - : An integer value providing the index into the array at which the element given
         by `currentValue` is located. If you don't need to know the index
         number, you can omit this.
-    - `sourceList` {{optional_inline}}
+    - `sourceList` {{Optional_Inline}}
       - : The {{domxref("XRInputSourceArray")}} object which is being processed. If you
         don't need this information, you may omit this.
 
-- `thisArg` {{optional_inline}}
+- `thisArg` {{Optional_Inline}}
   - : The value to be used for
     [`this`](/en-US/docs/Web/JavaScript/Reference/Operators/this)
     while executing the callback. Note that if you use [arrow function notation](/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) (`=>`) to provide the callback, you can

--- a/files/en-us/web/api/xrinputsourcearray/keys/index.md
+++ b/files/en-us/web/api/xrinputsourcearray/keys/index.md
@@ -23,9 +23,10 @@ tags:
   - XRInputSourceArray
   - augmented
   - keys
+  - Experimental
 browser-compat: api.XRInputSourceArray.keys
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`keys()`** method in the
 {{domxref("XRInputSourceArray")}} interface returns a {{Glossary("JavaScript")}}

--- a/files/en-us/web/api/xrinputsourcearray/length/index.md
+++ b/files/en-us/web/api/xrinputsourcearray/length/index.md
@@ -21,9 +21,10 @@ tags:
   - augmented
   - controllers
   - count
+  - Experimental
 browser-compat: api.XRInputSourceArray.length
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only **`length`** property returns an integer value
 indicating the number of items in the input source list represented by

--- a/files/en-us/web/api/xrinputsourcearray/values/index.md
+++ b/files/en-us/web/api/xrinputsourcearray/values/index.md
@@ -22,9 +22,10 @@ tags:
   - XRInputSourceArray
   - augmented
   - values
+  - Experimental
 browser-compat: api.XRInputSourceArray.values
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The {{domxref("XRInputSourceArray")}}
 method **`values()`** returns a {{Glossary("JavaScript")}}

--- a/files/en-us/web/api/xrlayer/index.md
+++ b/files/en-us/web/api/xrlayer/index.md
@@ -10,9 +10,10 @@ tags:
   - XR
   - AR
   - VR
+  - Experimental
 browser-compat: api.XRLayer
 ---
-{{APIRef("WebXR Device API")}} {{secureContext_header}}
+{{APIRef("WebXR Device API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The **`XRLayer`** interface of the [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API) is the base class for WebXR layer types. It inherits methods from {{domxref("EventTarget")}}.
 

--- a/files/en-us/web/api/xrlightestimate/primarylightdirection/index.md
+++ b/files/en-us/web/api/xrlightestimate/primarylightdirection/index.md
@@ -14,7 +14,7 @@ tags:
   - WebXR Device API
 browser-compat: api.XRLightEstimate.primaryLightDirection
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The _read-only_ **`primaryLightDirection`** property of the {{DOMxRef("XRLightEstimate")}} interface returns a {{domxref("DOMPointReadOnly")}} representing the direction to the primary light source from the `probeSpace` of an {{domxref("XRLightProbe")}}.
 

--- a/files/en-us/web/api/xrlightestimate/primarylightintensity/index.md
+++ b/files/en-us/web/api/xrlightestimate/primarylightintensity/index.md
@@ -14,7 +14,7 @@ tags:
   - WebXR Device API
 browser-compat: api.XRLightEstimate.primaryLightIntensity
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The _read-only_ **`primaryLightIntensity`** property of the {{DOMxRef("XRLightEstimate")}} interface returns a {{domxref("DOMPointReadOnly")}} representing the intensity of the primary light source from the `probeSpace` of an {{domxref("XRLightProbe")}}.
 

--- a/files/en-us/web/api/xrlightestimate/sphericalharmonicscoefficients/index.md
+++ b/files/en-us/web/api/xrlightestimate/sphericalharmonicscoefficients/index.md
@@ -14,7 +14,7 @@ tags:
   - WebXR Device API
 browser-compat: api.XRLightEstimate.sphericalHarmonicsCoefficients
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The _read-only_ **`sphericalHarmonicsCoefficients`** property of the {{DOMxRef("XRLightEstimate")}} interface returns a {{jsxref("Float32Array")}} containing 9 spherical harmonics coefficients.
 

--- a/files/en-us/web/api/xrlightprobe/probespace/index.md
+++ b/files/en-us/web/api/xrlightprobe/probespace/index.md
@@ -14,7 +14,7 @@ tags:
   - WebXR Device API
 browser-compat: api.XRLightProbe.probeSpace
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The _read-only_ **`probeSpace`** property of the {{DOMxRef("XRLightProbe")}} interface returns an {{domxref("XRSpace")}} tracking the position and orientation that the lighting estimations are relative to.
 

--- a/files/en-us/web/api/xrlightprobe/reflectionchange_event/index.md
+++ b/files/en-us/web/api/xrlightprobe/reflectionchange_event/index.md
@@ -14,7 +14,7 @@ tags:
   - WebXR Device API
 browser-compat: api.XRLightProbe.reflectionchange_event
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The WebXR **`reflectionchange`** event fires each time the estimated reflection cube map changes. This happens in response to use movements through different lighting conditions or to direct changes to lighting itself. This event is not cancelable.
 

--- a/files/en-us/web/api/xrray/direction/index.md
+++ b/files/en-us/web/api/xrray/direction/index.md
@@ -14,7 +14,7 @@ tags:
   - WebXR Device API
 browser-compat: api.XRRay.direction
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The _read-only_ **`direction`** property of the {{DOMxRef("XRRay")}} interface is a {{domxref("DOMPointReadOnly")}} representing the ray's 3-dimensional directional vector, normalized to a [unit vector](https://en.wikipedia.org/wiki/Unit_vector) with a length of 1.0.
 

--- a/files/en-us/web/api/xrray/matrix/index.md
+++ b/files/en-us/web/api/xrray/matrix/index.md
@@ -14,7 +14,7 @@ tags:
   - WebXR Device API
 browser-compat: api.XRRay.matrix
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The _read-only_ **`matrix`** property of the {{DOMxRef("XRRay")}} interface is a transform that can be used to position objects along the `XRRay`. This is a 4 by 4 matrix given as a 16 element {{jsxref("Float32Array")}} in column major order.
 

--- a/files/en-us/web/api/xrray/origin/index.md
+++ b/files/en-us/web/api/xrray/origin/index.md
@@ -14,7 +14,7 @@ tags:
   - WebXR Device API
 browser-compat: api.XRRay.origin
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The _read-only_ **`origin`** property of the {{DOMxRef("XRRay")}} interface is a {{domxref("DOMPointReadOnly")}} representing the 3-dimensional point in space that the ray originates from, in meters.
 

--- a/files/en-us/web/api/xrray/xrray/index.md
+++ b/files/en-us/web/api/xrray/xrray/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - WebXR
   - XR
+  - Experimental
 browser-compat: api.XRRay.XRRay
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`XRRay()`** constructor creates a new {{domxref("XRRay")}} object which is a geometric ray described by an origin point and a direction vector.
 
@@ -25,11 +26,11 @@ new XRRay(transform)
 
 ### Parameters
 
-- `origin` {{optional_inline}}
+- `origin` {{Optional_Inline}}
   - : A point object defining the 3-dimensional point in space that the ray originates from, in meters. All dimensions are optional, however, if provided, the origin's `w` property must be 1.0. The object is initialized to `{ x: 0.0, y: 0.0, z: 0.0, w: 1.0 }` by default.
-- `direction` {{optional_inline}}
+- `direction` {{Optional_Inline}}
   - : A vector object defining the ray's 3-dimensional directional vector. All dimensions are optional, however, if provided, the direction's `w` property must be 0.0. The object is initialized to: `{ x: 0.0, y: 0.0, z: -1.0, w: 0.0 }` by default.
-- `transform` {{optional_inline}}
+- `transform` {{Optional_Inline}}
   - : An {{domxref("XRRigidTransform")}} object representing the position and orientation of the ray.
 
 ### Return value

--- a/files/en-us/web/api/xrrenderstate/baselayer/index.md
+++ b/files/en-us/web/api/xrrenderstate/baselayer/index.md
@@ -17,7 +17,7 @@ tags:
   - baseLayer
 browser-compat: api.XRRenderState.baseLayer
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only **`baseLayer`** property of the
 {{domxref("XRRenderState")}} interface returns the {{domxref("XRWebGLLayer")}} instance

--- a/files/en-us/web/api/xrrenderstate/depthfar/index.md
+++ b/files/en-us/web/api/xrrenderstate/depthfar/index.md
@@ -17,7 +17,7 @@ tags:
   - depthFar
 browser-compat: api.XRRenderState.depthFar
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`depthFar`** read-only property of the
 {{domxref("XRRenderState")}} interface returns the distance in meters of the far clip

--- a/files/en-us/web/api/xrrenderstate/depthnear/index.md
+++ b/files/en-us/web/api/xrrenderstate/depthnear/index.md
@@ -17,7 +17,7 @@ tags:
   - depthNear
 browser-compat: api.XRRenderState.depthNear
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`depthNear`** read-only property of the
 {{domxref("XRRenderState")}} interface returns the distance in meters of the near clip

--- a/files/en-us/web/api/xrrenderstate/inlineverticalfieldofview/index.md
+++ b/files/en-us/web/api/xrrenderstate/inlineverticalfieldofview/index.md
@@ -12,7 +12,7 @@ tags:
   - Experimental
 browser-compat: api.XRRenderState.inlineVerticalFieldOfView
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only **`inlineVerticalFieldOfView`**
 property of the {{DOMxRef("XRRenderState")}} interface returns the default vertical

--- a/files/en-us/web/api/xrsession/cancelanimationframe/index.md
+++ b/files/en-us/web/api/xrsession/cancelanimationframe/index.md
@@ -17,7 +17,7 @@ tags:
   - cancelAnimationFrame()
 browser-compat: api.XRSession.cancelAnimationFrame
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`cancelAnimationFrame()`** method of
 the {{domxref("XRSession")}} interface cancels an animation frame which was previously

--- a/files/en-us/web/api/xrsession/depthdataformat/index.md
+++ b/files/en-us/web/api/xrsession/depthdataformat/index.md
@@ -15,7 +15,7 @@ tags:
   - XRSession
 browser-compat: api.XRSession.depthDataFormat
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The *read-only* **`depthDataFormat`** property of an `immersive-ar`
 {{DOMxRef("XRSession")}} describes which depth sensing data format is used.

--- a/files/en-us/web/api/xrsession/depthusage/index.md
+++ b/files/en-us/web/api/xrsession/depthusage/index.md
@@ -15,7 +15,7 @@ tags:
   - XRSession
 browser-compat: api.XRSession.depthUsage
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The *read-only* **`depthUsage`** property of an `immersive-ar`
 {{DOMxRef("XRSession")}} describes which depth-sensing usage is used.

--- a/files/en-us/web/api/xrsession/domoverlaystate/index.md
+++ b/files/en-us/web/api/xrsession/domoverlaystate/index.md
@@ -15,7 +15,7 @@ tags:
   - XRSession
 browser-compat: api.XRSession.domOverlayState
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The *read-only* **`domOverlayState`** property of an `immersive-ar`
 {{DOMxRef("XRSession")}} provides information about the DOM overlay, if the feature is enabled.

--- a/files/en-us/web/api/xrsession/end/index.md
+++ b/files/en-us/web/api/xrsession/end/index.md
@@ -17,7 +17,7 @@ tags:
   - end()
 browser-compat: api.XRSession.end
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`end()`** method shuts down the
 {{domxref("XRSession")}} on which it's called, returning a promise which resolves once

--- a/files/en-us/web/api/xrsession/end_event/index.md
+++ b/files/en-us/web/api/xrsession/end_event/index.md
@@ -9,9 +9,10 @@ tags:
   - WebXR
   - XR
   - XRSession
+  - Experimental
 browser-compat: api.XRSession.end_event
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 An `end` event is fired at an {{DOMxRef("XRSession")}} object when the WebXR session has ended, either because the web application has chosen to stop the session, or because the {{Glossary("user agent")}} terminated the session.
 

--- a/files/en-us/web/api/xrsession/environmentblendmode/index.md
+++ b/files/en-us/web/api/xrsession/environmentblendmode/index.md
@@ -16,9 +16,10 @@ tags:
   - XRSession
   - augmented
   - environmentBlendMode
+  - Experimental
 browser-compat: api.XRSession.environmentBlendMode
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The {{domxref("XRSession")}} interface's *read-only* **`environmentBlendMode`**
 property identifies if, and to what degree, the computer-generated imagery is overlaid atop the real world.


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.

This covers files that have only `experimental` header modifications.