### PR TITLE
Fix definition lists

### DIFF
--- a/files/en-us/web/css/forced-color-adjust/index.md
+++ b/files/en-us/web/css/forced-color-adjust/index.md
@@ -41,7 +41,7 @@ The `forced-color-adjust` property's value must be one of the following keywords
 
 - `auto`
   - : The element's colors are adjusted by the {{Glossary("user agent")}} in forced colors mode. This is the default.
-- **`none`**
+- `none`
   - : The element's colors are not automatically adjusted by the {{Glossary("user agent")}} in forced colors mode.
 
 ## Usage notes

--- a/files/en-us/web/css/print-color-adjust/index.md
+++ b/files/en-us/web/css/print-color-adjust/index.md
@@ -43,7 +43,7 @@ The `print-color-adjust` property's value must be one of the following keywords.
   - : The user agent is allowed to make adjustments to the element as it deems appropriate and prudent in order to optimize the output for the device it's being rendered for.
     For example, when printing, a browser might opt to leave out all background images and to adjust text colors to be sure the contrast is optimized for reading on white paper.
     This is the default.
-- **`exact`**
+- `exact`
   - : The element's content has been specifically and carefully crafted to use colors, images, and styles in a thoughtful and/or important way, such that being altered by the browser might actually make things worse rather than better.
     The appearance of the content should not be changed except by the user's request.
     For example, a page might include a list of information with rows whose background colors alternate between white and a light grey.

--- a/files/en-us/web/http/headers/www-authenticate/index.md
+++ b/files/en-us/web/http/headers/www-authenticate/index.md
@@ -125,7 +125,7 @@ Generally you will need to check the relevant specifications for these (keys for
   - : A case-insensitive flag indicating that the previous request from the client was rejected because the `nonce` used is too old (stale).
     If this is `true` the request can be re-tried using the same username/password encrypted using the new `nonce`.
     If it is any other value then the username/password are invalid and must be re-requested from the user.
-- `algorithm`   {{optional_inline}}
+- `algorithm` {{optional_inline}}
   - : Algorithm used to produce the digest.
     Valid non-session values are: `"MD5"` (default if not specified), `"SHA-256"`, `"SHA-512"`.
     Valid session values are: `"MD5-sess"`, `"SHA-256-sess"`, `"SHA-512-sess"`.

--- a/files/en-us/web/http/headers/www-authenticate/index.md
+++ b/files/en-us/web/http/headers/www-authenticate/index.md
@@ -98,45 +98,45 @@ Generally you will need to check the relevant specifications for these (keys for
 
 ### Basic
 
-- **`<realm>`** {{optional_inline}}
+- `<realm>` {{optional_inline}}
   - : As above.
-- **`charset="UTF-8"`** {{optional_inline}}
+- `charset="UTF-8"` {{optional_inline}}
   - : Tells the client the server's preferred encoding scheme when submitting a username and password.
     The only allowed value is the case-insensitive string "UTF-8".
     This does not relate to the encoding of the realm string.
 
 ### Digest
 
-- **`<realm>`** {{optional_inline}}
+- `<realm>` {{optional_inline}}
   - : String indicating which username/password to use.
     Minimally should include the host name, but might indicate the users or group that have access.
-- **`domain`** {{optional_inline}}
+- `domain` {{optional_inline}}
   - : A quoted, space-separated list of URI prefixes that define all the locations where the authentication information may be used.
     If this key is not specified then the authentication information may be used anywhere on the web root.
-- **`nonce`**
+- `nonce`
   - : A server-specified quoted string that the server can use to control the lifetime in which particular credentials will be considered valid.
     This must be uniquely generated each time a 401 response is made, and may be regenerated more often (for example, allowing a digest to be used only once).
     The specification contains advice on possible algorithms for generating this value.
     The nonce value is opaque to the client.
-- **`opaque`**
+- `opaque`
   - : A server-specified quoted string that should be returned unchanged in the {{HTTPHeader("Authorization")}}.
     This is opaque to the client. The server is recommended to include Base64 or hexadecimal data.
-- **`stale`** {{optional_inline}}
+- `stale` {{optional_inline}}
   - : A case-insensitive flag indicating that the previous request from the client was rejected because the `nonce` used is too old (stale).
     If this is `true` the request can be re-tried using the same username/password encrypted using the new `nonce`.
     If it is any other value then the username/password are invalid and must be re-requested from the user.
-- **`algorithm`**   {{optional_inline}}
+- `algorithm`   {{optional_inline}}
   - : Algorithm used to produce the digest.
     Valid non-session values are: `"MD5"` (default if not specified), `"SHA-256"`, `"SHA-512"`.
     Valid session values are: `"MD5-sess"`, `"SHA-256-sess"`, `"SHA-512-sess"`.
-- **`qop`**
+- `qop`
   - : Quoted string indicating the quality of protection supported by the server. This must be supplied, and unrecognized options must be ignored.
     - `"auth"`: Authentication
     - `"auth-int"`: Authentication with integrity protection
-- **`charset="UTF-8"`** {{optional_inline}}
+- `charset="UTF-8"` {{optional_inline}}
   - : Tells the client the server's preferred encoding scheme when submitting a username and password.
     The only allowed value is the case-insensitive string "UTF-8".
-- **`userhash`** {{optional_inline}}
+- `userhash` {{optional_inline}}
   - : A server may specify `"true"` to indicate that it supports username hashing (default is `"false"`)
 
 ## Examples


### PR DESCRIPTION
- Similar to #19785

Making some definition terms bold is not that distinguishable also no special meaning is conveyed.
And it is not consistent with reset of the site.