### PR TITLE
fix: minor typo in http/headers/accept/index.md

### DIFF
--- a/files/en-us/web/http/headers/accept/index.md
+++ b/files/en-us/web/http/headers/accept/index.md
@@ -10,7 +10,7 @@ browser-compat: http.headers.Accept
 ---
 {{HTTPSidebar}}
 
-The **`Accept`** request HTTP header indicates which content types, expressed as [MIME types](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types), the client is able to understand. The server uses [content negotiation](/en-US/docs/Web/HTTP/Content_negotiation) to select one of the proposals and informs the client of the choice with the {{HTTPHeader("Content-Type")}} response header. Browsers set required values for this header based on the context of the request. For example, a browser uses different values in a request when fetches a CSS stylesheet, image, video, or a script.
+The **`Accept`** request HTTP header indicates which content types, expressed as [MIME types](/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types), the client is able to understand. The server uses [content negotiation](/en-US/docs/Web/HTTP/Content_negotiation) to select one of the proposals and informs the client of the choice with the {{HTTPHeader("Content-Type")}} response header. Browsers set required values for this header based on the context of the request. For example, a browser uses different values in a request when fetching a CSS stylesheet, image, video, or a script.
 
 <table class="properties">
   <tbody>


### PR DESCRIPTION
#### Summary

Just a minor typo fix in `web/http/headers/accept/index.md` (en_US). 

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
