### PR TITLE
Add example of constructor without new for `String()`

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/string/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/index.md
@@ -113,12 +113,14 @@ will automatically wrap the string primitive and call the method or perform the 
 lookup on the wrapper object instead.
 
 ```js
-const strPrim = 'foo'; // A literal is a string primitive
-const strPrim2 = String(strPrim); // String without new returns a string primitive
+const strPrim = "foo"; // A literal is a string primitive
+const strPrim2 = String(1); // Coerced into the string primitive "1"
+const strPrim3 = String(true); // Coerced into the string primitive "true"
 const strObj = new String(strPrim); // String with new returns a string wrapper object.
 
 console.log(typeof strPrim); // Logs "string"
 console.log(typeof strPrim2); // Logs "string"
+console.log(typeof strPrim3); // Logs "string"
 console.log(typeof strObj);  // Logs "object"
 ```
 

--- a/files/en-us/web/javascript/reference/global_objects/string/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/index.md
@@ -113,10 +113,12 @@ will automatically wrap the string primitive and call the method or perform the 
 lookup on the wrapper object instead.
 
 ```js
-const strPrim = 'foo';
-const strObj = new String(strPrim);
+const strPrim = 'foo'; // A literal is a string primitive
+const strPrim2 = String(strPrim); // String without new returns a string primitive
+const strObj = new String(strPrim); // String with new returns a string wrapper object.
 
 console.log(typeof strPrim); // Logs "string"
+console.log(typeof strPrim2); // Logs "string"
 console.log(typeof strObj);  // Logs "object"
 ```
 


### PR DESCRIPTION
The `String()` constructor without new creates a string primitive, as listed in the prose. The example had the other cases, but not this one.