### PR TITLE
Replace `revert()` typo with `reverse()`

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/array/reverse/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/array/reverse/index.md
@@ -66,9 +66,9 @@ Array.prototype.reverse.call(obj); //same syntax for using apply()
 console.log(obj); // {0: 3, 1: 2, 2: 1, length: 3}
 ```
 
-### The revert() method returns the reference to the same array
+### The reverse() method returns the reference to the same array
 
-The `revert()` method returns reference to the original array, so mutating the returned array will mutate the original array as well.
+The `reverse()` method returns reference to the original array, so mutating the returned array will mutate the original array as well.
 
 ```js
 const numbers = [3, 2, 4, 1, 5];
@@ -78,12 +78,12 @@ reversed[0] = 5;
 console.log(numbers[0]); // 5
 ```
 
-In case you want `revert()` to not mutate the original array, but return a [shallow-copied](/en-US/docs/Glossary/Shallow_copy) array like other array methods (e.g. [`map()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map)) do, you can do a shallow copy before calling `revert()`, using the [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) or [`Array.from()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from).
+In case you want `reverse()` to not mutate the original array, but return a [shallow-copied](/en-US/docs/Glossary/Shallow_copy) array like other array methods (e.g. [`map()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map)) do, you can do a shallow copy before calling `reverse()`, using the [spread syntax](/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax) or [`Array.from()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from).
 
 ```js
 const numbers = [3, 2, 4, 1, 5];
-// [...numbers] creates a shallow copy, so revert() does not mutate the original
-const reverted = [...numbers].revert();
+// [...numbers] creates a shallow copy, so reverse() does not mutate the original
+const reverted = [...numbers].reverse();
 reverted[0] = 5;
 console.log(numbers[0]); // 3
 ```


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
`revert` is not a function of `Array`. `reverse` is.

#### Motivation

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
