### PR TITLE
Fix two+ trailing spaces in text

### DIFF
--- a/files/en-us/mdn/writing_guidelines/what_we_write/index.md
+++ b/files/en-us/mdn/writing_guidelines/what_we_write/index.md
@@ -6,7 +6,7 @@ tags:
   - meta
   - writing-guide
 ---
-{{MDNSidebar}}  
+{{MDNSidebar}}
 
 MDN Web Docs contains _browser-neutral_ documentation that enables web developers to write _browser-agnostic_ code. In this article, you'll find information about whether or not a given topic and/or type of content should be included on MDN Web Docs.
 

--- a/files/en-us/mdn/writing_guidelines/writing_style_guide/index.md
+++ b/files/en-us/mdn/writing_guidelines/writing_style_guide/index.md
@@ -126,7 +126,7 @@ The following checklist is good to keep in mind while writing and reviewing cont
 
 - **Ensure that pages aren't too similar**: If the content on different pages is similar textually, search engines will assume that the pages are about the same thing even if they aren't.
   For example, if an interface has the properties `width` and `height`, it's easy for the text to be surprisingly similar on the two pages documenting these two properties, with just a few words swapped out and using the same example. This makes it hard for search engines to know which is which, and they wind up sharing page rank, resulting in both being harder to find than they ought to be.
-  
+
   It's important, then, to ensure that every page has its own content. Here are some suggestions to help you accomplish that:
 
   - **Explain more unique concepts**: Consider use cases where there might be more differences than one would think. For instance, in the case of documenting `width` and `height` properties, perhaps write about the ways horizontal space and vertical space are used differently, and provide a discussion about the appropriate concepts. Perhaps you can mention the use of `width` in terms of making room for a sidebar, while using `height` to handle vertical scrolling or footers. Including information about accessibility issues is a useful and important idea as well.
@@ -179,7 +179,7 @@ An abbreviation is a shortened version of a longer word, while an acronym is a n
 
   - **Correct**: ... web browsers, and so on.
   - **Incorrect**: ... web browsers, etc.
-  
+
   - **Correct**: Web browsers such as Firefox can be used ...
   - **Incorrect**: Web browsers e.g. Firefox can be used ...
 

--- a/files/en-us/web/api/cssrule/type/index.md
+++ b/files/en-us/web/api/cssrule/type/index.md
@@ -58,7 +58,7 @@ for (const rule of rules) {
   - : The rule is a {{domxref("CSSViewportRule")}}.
 - `CSSRule.REGION_STYLE_RULE` (`16`)
   - : The rule is a {{domxref("CSSRegionStyleRule")}}.
-  
+
 Both `CSSRule.UNKNOWN_RULE` (`0`) and `CSSRule.CHARSET_RULE` (`2`) are deprecated and cannot be obtained any more
 
 ## Examples

--- a/files/en-us/web/api/headers/foreach/index.md
+++ b/files/en-us/web/api/headers/foreach/index.md
@@ -64,7 +64,7 @@ myHeaders.append("compression", "gzip");
 // Display the key/value pairs
 myHeaders.forEach((value, key) => {
   console.log(`${key} ==> ${value}`);
-})  
+})
 ```
 
 The result is:

--- a/files/en-us/web/api/idbkeyrange/loweropen/index.md
+++ b/files/en-us/web/api/idbkeyrange/loweropen/index.md
@@ -51,7 +51,7 @@ the range.
 function displayData() {
   const keyRangeValue = IDBKeyRange.bound("F", "W", true, true);
   console.log(keyRangeValue.lowerOpen);
-  
+
   const transaction = db.transaction(["fThings"], "readonly");
   const objectStore = transaction.objectStore("fThings");
   objectStore.openCursor(keyRangeValue).onsuccess = (event) => {

--- a/files/en-us/web/api/svgstyleelement/index.md
+++ b/files/en-us/web/api/svgstyleelement/index.md
@@ -34,7 +34,7 @@ _This interface also inherits properties from its parent interface, {{domxref("S
 
 - {{domxref("SVGStyleElement.sheet")}} {{ReadOnlyInline}}
   - : Returns the {{domxref("CSSStyleSheet")}} object associated with the given element, or `null` if there is none.
-  
+
 - {{domxref("SVGStyleElement.disabled")}}
   - : A boolean value indicating whether or not the associated stylesheet is disabled.
 

--- a/files/en-us/web/api/xsltprocessor/index.md
+++ b/files/en-us/web/api/xsltprocessor/index.md
@@ -21,7 +21,7 @@ transformation to documents.
 ## Constructor
 
 - {{domxref("XSLTProcessor.XSLTProcessor", "XSLTProcessor()")}}
-  - : Create a new `XSLTProcessor`.  
+  - : Create a new `XSLTProcessor`.
 
 ## Methods
 

--- a/files/en-us/web/css/css_scroll_snap/basic_concepts/index.md
+++ b/files/en-us/web/css/css_scroll_snap/basic_concepts/index.md
@@ -17,7 +17,7 @@ The key properties of the Scroll Snap specification are:
 
 - {{CSSxRef("scroll-snap-type")}}: This property is used on the [scroll container](/en-US/docs/Glossary/Scroll_container) to state the type and direction of scrolling.
 - {{CSSxRef("scroll-snap-align")}}: This property must be used on child elements in order to set the position that scrolling will snap to.
-  
+
 The example below demonstrates scroll snapping along the vertical axis, which is defined by `scroll-snap-type`. Additionally, `scroll-snap-align` is used on the section element to dictate the point where the scrolling should stop.
 
 {{EmbedGHLiveSample("css-examples/scroll-snap/mandatory-y.html", '100%', 700)}}

--- a/files/en-us/web/tutorials/index.md
+++ b/files/en-us/web/tutorials/index.md
@@ -77,7 +77,7 @@ These resources are created by forward-thinking companies and web developers who
   - : This module carries on where [CSS first steps](/en-US/docs/Learn/CSS/First_steps) left off — now you've gained familiarity with the language and its syntax, and got some basic experience with using it, its time to dive a bit deeper. This module looks at the cascade and inheritance, all the selector types we have available, units, sizing, styling backgrounds and borders, debugging, and lots more.
 
     The aim here is to provide you with a toolkit for writing competent CSS and help you understand all the essential theory, before moving on to more specific disciplines like [text styling](/en-US/docs/Learn/CSS/Styling_text) and [CSS layout](/en-US/docs/Learn/CSS/CSS_layout).
-  
+
 - [Selectors](/en-US/docs/Learn/CSS/Building_blocks/Selectors)
   - : Target HTML elements, including based on element state, with CSS.
 


### PR DESCRIPTION
The test in [PR #19863](https://github.com/mdn/content/pull/19863/commits/aec8a9c44d4d839e2a721464eabbe4a5e07db7f9) shows that the  markdownlinter or the current configuration doesn't detect more than one trailing spaces.

Fixing the spaces in text first.

cc: @teoli2003, @nschonni 