### PR TITLE
Make lint annotations warnings

### DIFF
--- a/.github/workflows/markdownlint-problem-matcher.json
+++ b/.github/workflows/markdownlint-problem-matcher.json
@@ -2,6 +2,7 @@
   "problemMatcher": [
     {
       "owner": "markdownlint",
+      "severity": "warning",
       "pattern": [
         {
           "regexp": "^([^:]*):(\\d+):?(\\d+)?\\s([\\w-\\/]*)\\s(.*)$",

--- a/files/en-us/web/css/border/index.md
+++ b/files/en-us/web/css/border/index.md
@@ -17,7 +17,7 @@ The **`border`** [shorthand](/en-US/docs/Web/CSS/Shorthand_properties) [CSS](/en
 
 {{EmbedInteractiveExample("pages/css/border.html")}}
 
-## Constituent properties
+## Constituent properties 
 
 This property is a shorthand for the following CSS properties:
 


### PR DESCRIPTION
This makes the lint annotations orange:
![orange](https://camo.githubusercontent.com/03801835f59c485b361bc3d3bb850b5ae480905fe36cdd7b43bc02dff417ae82/68747470733a2f2f692e696d6775722e636f6d2f775157486d55562e706e67)

I've included one file with lint error for test.

cc: @teoli2003 