### PR TITLE
Improve :focus-visible fallback code example

### DIFF
--- a/files/en-us/web/css/_colon_focus-visible/index.md
+++ b/files/en-us/web/css/_colon_focus-visible/index.md
@@ -71,19 +71,12 @@ A custom control, such as a custom element button, can use `:focus-visible` to s
   margin: 10px;
 }
 
-.custom-button:focus {
-  /* Provide a fallback style for browsers
-     that don't support :focus-visible */
-  outline: 2px solid red;
-  background: lightgrey;
-}
-
-@supports selector(:focus-visible) {
+@supports not selector(:focus-visible) {
   .custom-button:focus {
-    /* Remove the focus indicator on mouse-focus for browsers
-       that do support :focus-visible */
-    outline: none;
-    background: transparent;
+    /* Provide a fallback style for browsers
+       that don't support :focus-visible */
+    outline: 2px solid red;
+    background: lightgrey;
   }
 }
 


### PR DESCRIPTION
#### Summary

It makes more sense to apply the `:focus` fallback within a `@supports not` rule, so that it applies only to browsers that actually don’t support `:focus-visible`.

#### Motivation

To fix the code. Applying `:focus` to all browsers and then immediately resetting those styles in browsers that support `:focus-visible` is not a good idea.

#### Supporting details

See this video: https://twitter.com/simevidas/status/1561786393826889728

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error