### PR TITLE
Fix return value for RTCPeerConnection.addTransceiver()

### DIFF
--- a/files/en-us/web/api/rtcpeerconnection/addtransceiver/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addtransceiver/index.md
@@ -51,7 +51,7 @@ addTransceiver(trackOrKind, init)
 
 ### Return value
 
-None ({{jsxref("undefined")}}).
+The {{domxref("RTCRtpTransceiver")}} object which will be used to transmit and/or receive the media data.
 
 ### Exceptions
 

--- a/files/en-us/web/api/rtcpeerconnection/addtransceiver/index.md
+++ b/files/en-us/web/api/rtcpeerconnection/addtransceiver/index.md
@@ -51,7 +51,7 @@ addTransceiver(trackOrKind, init)
 
 ### Return value
 
-The {{domxref("RTCRtpTransceiver")}} object which will be used to transmit and/or receive the media data.
+The {{domxref("RTCRtpTransceiver")}} object which will be used to exchange the media data.
 
 ### Exceptions
 


### PR DESCRIPTION
#### Summary

PR updates the return value of `RTCPeerConnection.addTransceiver()`.

#### Motivation

I just stumbled upon this while implementing some WebRTC application logic and couldn't figure out why the return value would be `undefined` as it made state tracking so much inconvenient having to use separate API calls to retrieve the newly added transceiver. Looking at the specs and also testing a couple browser's implementations it seems it's returned as I'd expect.

#### Supporting details

https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-addtransceiver

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error