### PR TITLE
Event loop: use getTime instead of getSeconds

### DIFF
--- a/files/en-us/web/javascript/eventloop/index.md
+++ b/files/en-us/web/javascript/eventloop/index.md
@@ -91,15 +91,15 @@ The function [`setTimeout`](/en-US/docs/Web/API/setTimeout) is called with 2 arg
 Here is an example that demonstrates this concept (`setTimeout` does not run immediately after its timer expires):
 
 ```js
-const seconds = new Date().getSeconds();
+const seconds = new Date().getTime()/1000;
 
 setTimeout(() => {
   // prints out "2", meaning that the callback is not called immediately after 500 milliseconds.
-  console.log(`Ran after ${new Date().getSeconds() - seconds} seconds`);
+  console.log(`Ran after ${new Date().getTime()/1000 - seconds} seconds`);
 }, 500)
 
 while (true) {
-  if (new Date().getSeconds() - seconds >= 2) {
+  if (new Date().getTime()/1000 - seconds >= 2) {
     console.log("Good, looped for 2 seconds");
     break;
   }

--- a/files/en-us/web/javascript/eventloop/index.md
+++ b/files/en-us/web/javascript/eventloop/index.md
@@ -91,15 +91,15 @@ The function [`setTimeout`](/en-US/docs/Web/API/setTimeout) is called with 2 arg
 Here is an example that demonstrates this concept (`setTimeout` does not run immediately after its timer expires):
 
 ```js
-const seconds = new Date().getTime()/1000;
+const seconds = new Date().getTime() / 1000;
 
 setTimeout(() => {
   // prints out "2", meaning that the callback is not called immediately after 500 milliseconds.
-  console.log(`Ran after ${new Date().getTime()/1000 - seconds} seconds`);
+  console.log(`Ran after ${new Date().getTime() / 1000 - seconds} seconds`);
 }, 500)
 
 while (true) {
-  if (new Date().getTime()/1000 - seconds >= 2) {
+  if (new Date().getTime() / 1000 - seconds >= 2) {
     console.log("Good, looped for 2 seconds");
     break;
   }


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
Replaced use of getSeconds with getTime to remove the edge condition where the code doesn't work.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
To make the code more reliable.

Fix https://github.com/mdn/content/issues/19837

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->


#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
