### PR TITLE
Lint only modified files

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -19,17 +19,23 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v28.0.0
+        with:
+          files: |
+            **/*.md
+          
       - name: Setup Node.js environment
+        if: steps.changed-files.outputs.any_changed == 'true'
         uses: actions/setup-node@v3
         with:
           node-version: "16"
           cache: yarn
 
-      - name: Install all yarn packages
-        run: |
-          yarn --frozen-lockfile
-
       - name: Lint markdown files
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
+          npm install --location=global markdownlint-cli
           echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"
-          yarn lint:md
+          markdownlint ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -23,8 +23,7 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v28.0.0
         with:
-          files: |
-            **/*.md
+          files: '**/*.md'
           
       - name: Setup Node.js environment
         if: steps.changed-files.outputs.any_changed == 'true'


### PR DESCRIPTION
Linting all the files creates errors in unrelated PRs and unnecessarily tags contributors' commits failed :x:
For example:
- https://github.com/mdn/content/pull/19871
The last two commits got check failed badge and the PR was merged with failed checks.

To test the fix, see the dummy PR https://github.com/OnkarRuikar/content/pull/1
***
Additional improvements:
- It avoids `yarn install` (saves ~20s). Installing `markdownlint-cli` directly and linting is way faster refer following run:
  https://github.com/OnkarRuikar/content/runs/7978431283?check_suite_focus=true
- If no `.md` files is modified in a PR, then the script avoids further processing (installing nodejs, markdownlint-cli, and the linting). Refer following run:
  https://github.com/OnkarRuikar/content/runs/7978294101?check_suite_focus=true

cc:/ @teoli2003, @nschonni , @caugner 