### PR TITLE
Removed references to sectioning roots, <menu> types & fixed <input> …

### DIFF
--- a/files/en-us/web/guide/html/content_categories/index.md
+++ b/files/en-us/web/guide/html/content_categories/index.md
@@ -40,15 +40,13 @@ A few other elements belong to this category, but only if a specific condition i
 - {{HTMLElement("area")}}, if it is a descendant of a {{HTMLElement("map")}} element
 - {{HTMLElement("link")}}, if the [itemprop](/en-US/docs/Web/HTML/Global_attributes/itemprop) attribute is present
 - {{HTMLElement("meta")}}, if the [itemprop](/en-US/docs/Web/HTML/Global_attributes/itemprop) attribute is present
-- {{HTMLElement("style")}}, if the {{htmlattrxref("scoped","style")}} {{deprecated_inline}} attribute is present
+- {{HTMLElement("style")}}, if the `scoped` {{deprecated_inline}} attribute is present
 
 ### Sectioning content
 
 Sectioning content is a subset of flow content, and can be used everywhere flow content is expected. Elements belonging to the sectioning content model create a [section in the current outline](/en-US/docs/Web/HTML/Element/Heading_Elements) that defines the scope of {{HTMLElement("header")}} elements, {{HTMLElement("footer")}} elements, and [heading content](#heading_content).
 
 Elements belonging to this category are {{HTMLElement("article")}}, {{HTMLElement("aside")}}, {{HTMLElement("nav")}}, and {{HTMLElement("section")}}.
-
-> **Note:** Do not confuse this content model with the [sectioning root](/en-US/docs/Web/HTML/Element/Heading_Elements#sectioning_roots) category, which isolates its content from the regular outline.
 
 ### Heading content
 
@@ -87,8 +85,7 @@ Some elements belong to this category only under specific conditions:
 
 - {{HTMLElement("audio")}}, if the {{htmlattrxref("controls", "audio")}} attribute is present
 - {{HTMLElement("img")}}, if the {{htmlattrxref("usemap", "img")}} attribute is present
-- {{HTMLElement("input")}}, if the {{htmlattrxref("type", "input")}} attribute is not in the hidden state
-- {{HTMLElement("menu")}}, if the {{htmlattrxref("type", "menu")}} attribute is in the toolbar state
+- {{HTMLElement("input")}}, if the [type](/en-US/docs/Web/HTML/Element/input#type) attribute is not in the hidden state
 - {{HTMLElement("object")}}, if the {{htmlattrxref("usemap", "object")}} attribute is present
 - {{HTMLElement("video")}}, if the {{htmlattrxref("controls", "video")}} attribute is present
 
@@ -151,7 +148,3 @@ If those elements were removed, this fragment would still be valid HTML (if not 
 ```html
 <p>We hold these truths to be <em>sacred &amp; undeniable</em> self-evident.</p>
 ```
-
-## Other content models
-
-Sectioning root.


### PR DESCRIPTION
…anchor link

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
I removed the references to sectioning roots and `<menu>` type attributes and  replaced all the anchor for the `<input>` page link. 

#### Motivation
The page contains references to sectioning roots and `<menu>` type attributes, but both seem to have been depreciated. Also, a link to the `<input>` page used `htmlattrxref`, so its anchor was broken. 

#### Supporting details
I couldn't find a specific reference to show that sectioning roots have been deprecated, but the fact that they appear in the [HTML 5.2 standard](https://www.w3.org/TR/2017/REC-html52-20171214/sections.html), but not the [living standard](https://html.spec.whatwg.org/multipage/sections.html), seems to indicate that they are deprecated. 

The MDN [`<menu>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menu) page states that the `type` attribute of `<menu>` elements is deprecated. Also, they appear in the [HTML 5.2 standard][(https://www.w3.org/TR/2017/REC-html52-20171214/sections.html](https://www.w3.org/TR/2011/WD-html5-author-20110809/the-menu-element.html)), but not the [living standard](https://html.spec.whatwg.org/multipage/grouping-content.html#the-menu-element).

#### Related issues
 #19802 covers sectioning roots. #15725, #16660, #18361, #18923, #19199 and #19613 covered `htmlattrxref` for the `<input>` page.

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
