### PR TITLE
fix: examples in regexp/@@matchall/index.md

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@matchall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@matchall/index.md
@@ -37,9 +37,9 @@ An [iterable iterator](/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators
 This method is called internally in {{jsxref("String.prototype.matchAll()")}}. For example, the following two examples return the same result.
 
 ```js
-'abc'.matchAll(/a/g);
+"abc".matchAll(/a/g);
 
-/a/g[Symbol.matchAll]('abc');
+/a/g[Symbol.matchAll]("abc");
 ```
 
 Like [`@@split`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@split), `@@matchAll` starts by using [`@@species`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@species) to construct a new regex, thus avoiding mutating the original regexp in any way. [`lastIndex`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) starts as the original regex's value.
@@ -47,24 +47,28 @@ Like [`@@split`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/@@sp
 ```js
 const regexp = /[a-c]/g;
 regexp.lastIndex = 1;
-const str = 'abc';
+const str = "abc";
 Array.from(str.matchAll(regexp), (m) => `${regexp.lastIndex} ${m[0]}`);
-// Array [ "1 b", "1 c" ]
+// [ "1 b", "1 c" ]
 ```
 
 The validation that the input is a global regex happens in [`String.prototype.matchAll()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/matchAll). `@@matchAll` does not validate the input. If the regex is not global, the returned iterator yields the [`exec()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec) result once and then returns `undefined`. If the regexp is global, each time the returned iterator's `next()` method is called, the regex's [`exec()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec) is called and the result is yielded.
 
-When the regex is sticky and global, it would still perform sticky matches — i.e. it would fail to match any occurrences beyond the `lastIndex`.
+When the regex is sticky and global, it will still perform sticky matches — i.e. it will not match any occurrences beyond the `lastIndex`.
 
 ```js
-console.log(Array.from("ab-c".matchAll(/[abc]/gy))); // [ 'a', 'b' ]
+console.log(Array.from("ab-c".matchAll(/[abc]/gy)));
+// [ [ "a" ], [ "b" ] ]
 ```
 
-If the current match is an empty string, the [`lastIndex`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) would still be advanced — if the regex has the [`u`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode) flag, it would advance by one Unicode codepoint; otherwise, it advances by one UTF-16 code unit.
+If the current match is an empty string, the [`lastIndex`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex) will still be advanced.  If the regex has the [`u`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode) flag, it advances by one Unicode codepoint; otherwise, it advances by one UTF-16 codepoint.
 
 ```js
-console.log(Array.from("😄".matchAll(/(?:)/g))); // [ '', '', '' ]
-console.log(Array.from("😄".match(/(?:)/gu))); // [ '', '' ]
+console.log(Array.from("😄".matchAll(/(?:)/g)));
+// [ [ "" ], [ "" ], [ "" ] ]
+
+console.log(Array.from("😄".matchAll(/(?:)/gu)));
+// [ [ "" ], [ "" ] ]
 ```
 
 This method exists for customizing the behavior of `matchAll()` in {{jsxref('RegExp')}} subclasses.
@@ -77,11 +81,11 @@ This method can be used in almost the same way as {{jsxref("String.prototype.mat
 
 ```js
 const re = /[0-9]+/g;
-const str = '2016-01-02';
+const str = "2016-01-02";
 const result = re[Symbol.matchAll](str);
 
 console.log(Array.from(result, (x) => x[0]));
-// ["2016", "01", "02"]
+// [ "2016", "01", "02" ]
 ```
 
 ### Using @@matchAll in subclasses
@@ -98,11 +102,15 @@ class MyRegExp extends RegExp {
   }
 }
 
-const re = new MyRegExp('([0-9]+)-([0-9]+)-([0-9]+)', 'g');
-const str = '2016-01-02|2019-03-07';
+const re = new MyRegExp("([0-9]+)-([0-9]+)-([0-9]+)", "g");
+const str = "2016-01-02|2019-03-07";
 const result = str.matchAll(re);
-console.log(result[0]); // [ "2016-01-02", "2016", "01", "02" ]
-console.log(result[1]); // [ "2019-03-07", "2019", "03", "07" ]
+
+console.log(result[0]);
+// [ "2016-01-02", "2016", "01", "02" ]
+
+console.log(result[1]);
+// [ "2019-03-07", "2019", "03", "07" ]
 ```
 
 ## Specifications
@@ -116,5 +124,5 @@ console.log(result[1]); // [ "2019-03-07", "2019", "03", "07" ]
 ## See also
 
 - [Polyfill of `RegExp.prototype[@@matchAll]` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
-- {{JSxRef("String.prototype.matchAll()")}}
-- {{JSxRef("Symbol.matchAll")}}
+- {{jsxref("String.prototype.matchAll()")}}
+- {{jsxref("Symbol.matchAll")}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary

- fix typo from `.match` to `.matchAll`
- fix erroneous outputs from a couple examples (expected output was that of `.match`, not `.matchAll`)
- change some single quotes to double, add padding around array literal brackets (for consistent style)
- move some of the expected output comments to new lines (for improved readability)
- fix some other minor grammar and syntax issues

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

Since MDN is the de-facto standard for web documentation, readers have come to expect accuracy throughout. Just doing what I can to help improve readability and keep things running smoothly 😅

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
