### PR TITLE
Update BCD info, part 37

### DIFF
--- a/files/en-us/web/api/elementinternals/role/index.md
+++ b/files/en-us/web/api/elementinternals/role/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - role
   - ElementInternals
+  - Experimental
 browser-compat: api.ElementInternals.role
 ---
-{{DefaultAPISidebar("DOM")}}
+{{APIRef("DOM")}}{{SeeCompatTable}}
 
 The **`role`** read-only property of the {{domxref("ElementInternals")}} interface returns the [WAI-ARIA role](/en-US/docs/Web/Accessibility/ARIA/Roles) for the element. For example, a checkbox might have [`role="checkbox`](/en-US/docs/Web/Accessibility/ARIA/Roles/checkbox_role)
 

--- a/files/en-us/web/api/serialport/disconnect_event/index.md
+++ b/files/en-us/web/api/serialport/disconnect_event/index.md
@@ -7,9 +7,10 @@ tags:
   - Event
   - Reference
   - SerialPort
+  - Experimental
 browser-compat: api.SerialPort.disconnect_event
 ---
-{{securecontext_header}}{{APIRef("Serial API")}}
+{{SecureContext_Header}}{{APIRef("Serial API")}}{{SeeCompatTable}}
 
 The **`disconnect`** event of the {{domxref("SerialPort")}} interface is fired when the port has disconnected from the device. This event is only fired for ports associated with removable devices such as those connected via USB.
 

--- a/files/en-us/web/api/serialport/getinfo/index.md
+++ b/files/en-us/web/api/serialport/getinfo/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - getInfo()
   - SerialPort
+  - Experimental
 browser-compat: api.SerialPort.getInfo
 ---
-{{securecontext_header}}{{DefaultAPISidebar("Serial API")}}
+{{SecureContext_Header}}{{APIRef("Serial API")}}{{SeeCompatTable}}
 
 The **`getInfo()`** method of the {{domxref("SerialPort")}} interface returns an object whose properties are the vendor ID and product ID of the device.
 

--- a/files/en-us/web/api/serialport/getsignals/index.md
+++ b/files/en-us/web/api/serialport/getsignals/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - getSignals()
   - SerialPort
+  - Experimental
 browser-compat: api.SerialPort.getSignals
 ---
-{{securecontext_header}}{{DefaultAPISidebar("Serial API")}}
+{{SecureContext_Header}}{{APIRef("Serial API")}}{{SeeCompatTable}}
 
 The **`SerialPort.getSignals()`** method of the {{domxref("SerialPort")}} interface returns a {{jsxref("Promise")}} that resolves with an object containing the current state of the port's control signals.
 

--- a/files/en-us/web/api/serialport/open/index.md
+++ b/files/en-us/web/api/serialport/open/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - open
   - SerialPort
+  - Experimental
 browser-compat: api.SerialPort.open
 ---
-{{securecontext_header}}{{DefaultAPISidebar("Serial API")}}
+{{SecureContext_Header}}{{APIRef("Serial API")}}{{SeeCompatTable}}
 
 The **`open()`** method of the {{domxref("SerialPort")}} interface returns a {{jsxref("Promise")}} that resolves when the port is opened. By default the port is opened with 8 data bits, 1 stop bit and no parity checking. The `baudRate` parameter is required.
 
@@ -28,15 +29,15 @@ open(options)
 
     - `baudRate`
       - : A positive, non-zero value indicating the baud rate at which serial communication should be established.
-    - `bufferSize` {{optional_inline}}
+    - `bufferSize` {{Optional_Inline}}
       - : An unsigned long integer indicating the size of the read and write buffers that are to be established. If not passed, defaults to 255.
-    - `dataBits` {{optional_inline}}
+    - `dataBits` {{Optional_Inline}}
       - : An integer value of 7 or 8 indicating the number of data bits per frame. If not passed, defaults to 8.
-    - `flowControl` {{optional_inline}}
+    - `flowControl` {{Optional_Inline}}
       - : The flow control type, either `"none"` or `"hardware"`. The default value is `"none:`.
-    - `parity` {{optional_inline}}
+    - `parity` {{Optional_Inline}}
       - : The parity mode, either `"none"`, `"even"`, or `"odd"`. The default value is `"none"`.
-    - `stopBits` {{optional_inline}}
+    - `stopBits` {{Optional_Inline}}
       - : An integer value of 1 or 2 indicating the number of stop bits at the end of the frame. If not passed, defaults to 1.
 
 ### Return value

--- a/files/en-us/web/api/serialport/readable/index.md
+++ b/files/en-us/web/api/serialport/readable/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - readable
   - SerialPort
+  - Experimental
 browser-compat: api.SerialPort.readable
 ---
-{{securecontext_header}}{{DefaultAPISidebar("Serial API")}}
+{{SecureContext_Header}}{{APIRef("Serial API")}}{{SeeCompatTable}}
 
 The **`readable`** read-only property of the {{domxref("SerialPort")}} interface returns a {{domxref("ReadableStream")}} for receiving data from the device connected to the port. Chunks read from this stream are instances of {{jsxref("Uint8Array")}}. This property is non-null as long as the port is open and has not encountered a fatal error.
 

--- a/files/en-us/web/api/serialport/setsignals/index.md
+++ b/files/en-us/web/api/serialport/setsignals/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - setSignals
   - SerialPort
+  - Experimental
 browser-compat: api.SerialPort.setSignals
 ---
-{{securecontext_header}}{{DefaultAPISidebar("Serial API")}}
+{{SecureContext_Header}}{{APIRef("Serial API")}}{{SeeCompatTable}}
 
 The **`setSignals()`** method of the {{domxref("SerialPort")}} interface sets control signals on the port and returns a {{jsxref("Promise")}} that resolves when they are set.
 
@@ -23,7 +24,7 @@ setSignals(options)
 
 ### Parameters
 
-- `options` {{optional_inline}}
+- `options` {{Optional_Inline}}
 
   - : An object with any of the following values:
 

--- a/files/en-us/web/api/serialport/writable/index.md
+++ b/files/en-us/web/api/serialport/writable/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - writable
   - SerialPort
+  - Experimental
 browser-compat: api.SerialPort.writable
 ---
-{{securecontext_header}}{{DefaultAPISidebar("Serial API")}}
+{{SecureContext_Header}}{{APIRef("Serial API")}}{{SeeCompatTable}}
 
 The **`writable`** read-only property of the {{domxref("SerialPort")}} interface returns a {{domxref("WritableStream")}} for sending data to the device connected to the port. Chunks written to this stream must be instances of {{jsxref("ArrayBuffer")}}, {{jsxref("TypedArray")}}, or {{jsxref("DataView")}}. This property is non-null as long as the port is open and has not encountered a fatal error.
 

--- a/files/en-us/web/api/urlpattern/urlpattern/index.md
+++ b/files/en-us/web/api/urlpattern/urlpattern/index.md
@@ -12,8 +12,7 @@ tags:
   - Experimental
 browser-compat: api.URLPattern.URLPattern
 ---
-
-{{APIRef("URLPattern API")}}
+{{APIRef("URLPattern API")}}{{SeeCompatTable}}
 
 The **`URLPattern()`** constructor returns a new {{domxref("URLPattern")}}
 object representing the url pattern defined by the parameters.
@@ -35,7 +34,7 @@ new URLPattern(input, baseURL)
     individually. The object members can be any of `protocol`, `username`,
     `password`, `hostname`, `port`, `pathname`, `search`, `hash`, or `baseURL`.
     Omitted parts in the object will be treated as wildcards (`*`).
-- `baseURL` {{optional_inline}}
+- `baseURL` {{Optional_Inline}}
   - : A string representing the base URL to use in cases where
     `input` is a relative pattern. If not specified, it defaults to `undefined`.
 

--- a/files/en-us/web/api/xrsession/inputsources/index.md
+++ b/files/en-us/web/api/xrsession/inputsources/index.md
@@ -17,7 +17,7 @@ tags:
   - inputSources
 browser-compat: api.XRSession.inputSources
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The *read-only* **`inputSources`** property of the
 {{DOMxRef("XRSession")}} interface returns an {{domxref("XRInputSourceArray")}} object

--- a/files/en-us/web/api/xrsession/inputsourceschange_event/index.md
+++ b/files/en-us/web/api/xrsession/inputsourceschange_event/index.md
@@ -10,9 +10,10 @@ tags:
   - XR
   - XRInputSources
   - XRSession
+  - Experimental
 browser-compat: api.XRSession.inputsourceschange_event
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`inputsourceschange`** event is sent to an {{domxref("XRSession")}} when the set of available WebXR input devices changes.
 

--- a/files/en-us/web/api/xrsession/interactionmode/index.md
+++ b/files/en-us/web/api/xrsession/interactionmode/index.md
@@ -16,9 +16,10 @@ tags:
   - XRSession
   - augmented
   - interactionMode
+  - Experimental
 browser-compat: api.XRSession.interactionMode
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The {{domxref("XRSession")}} interface's *read-only* **`interactionMode`** property
 describes the best space (according to the user agent) for the application to draw an interactive UI for the current session.

--- a/files/en-us/web/api/xrsession/preferredreflectionformat/index.md
+++ b/files/en-us/web/api/xrsession/preferredreflectionformat/index.md
@@ -14,7 +14,7 @@ tags:
   - WebXR Device API
 browser-compat: api.XRSession.preferredReflectionFormat
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The _read-only_ **`preferredReflectionFormat`** property of the {{DOMxRef("XRSession")}} interface returns this session's preferred reflection format used for lighting estimation texture data.
 

--- a/files/en-us/web/api/xrsession/renderstate/index.md
+++ b/files/en-us/web/api/xrsession/renderstate/index.md
@@ -17,7 +17,7 @@ tags:
   - renderState
 browser-compat: api.XRSession.renderState
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The
 *read-only* **`renderState`** property of an

--- a/files/en-us/web/api/xrsession/requestanimationframe/index.md
+++ b/files/en-us/web/api/xrsession/requestanimationframe/index.md
@@ -17,7 +17,7 @@ tags:
   - requestAnimationFrame()
 browser-compat: api.XRSession.requestAnimationFrame
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The {{domxref("XRSession")}}
 method **`requestAnimationFrame()`**, much like the

--- a/files/en-us/web/api/xrsession/requesthittestsource/index.md
+++ b/files/en-us/web/api/xrsession/requesthittestsource/index.md
@@ -17,7 +17,7 @@ tags:
   - XRSession
 browser-compat: api.XRSession.requestHitTestSource
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`requestHitTestSource()`** method of the
 {{domxref("XRSession")}} interface returns a {{jsxref("Promise")}} that resolves with an {{domxref("XRHitTestSource")}} object that can be passed to {{domxref("XRFrame.getHitTestResults()")}}.
@@ -34,12 +34,12 @@ requestHitTestSource(options)
   - : An object containing configuration options, specifically:
     - `space`
       - : The {{domxref("XRSpace")}} that will be tracked by the hit test source.
-    - `entityTypes` {{optional_inline}}
+    - `entityTypes` {{Optional_Inline}}
       - : An {{jsxref("Array")}} specifying the types of entities to be used for hit test source creation. If no entity type is specified, the array defaults to a single element with the `plane` type. Possible types:
         - `point`: Compute hit test results based on characteristic points detected.
         - `plane`: Compute hit test results based on real-world planes detected.
         - `mesh`: Compute hit test results based on meshes detected.
-    - `offsetRay` {{optional_inline}}
+    - `offsetRay` {{Optional_Inline}}
       - : The {{domxref("XRRay")}} object that will be used to perform hit test. If no `XRRay` object has been provided, a new `XRRay` object is constructed without any parameters.
 
 ### Return value

--- a/files/en-us/web/api/xrsession/requesthittestsourcefortransientinput/index.md
+++ b/files/en-us/web/api/xrsession/requesthittestsourcefortransientinput/index.md
@@ -17,7 +17,7 @@ tags:
   - XRSession
 browser-compat: api.XRSession.requestHitTestSourceForTransientInput
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`requestHitTestSourceForTransientInput()`** method of the
 {{domxref("XRSession")}} interface returns a {{jsxref("Promise")}} that resolves with an {{domxref("XRTransientInputHitTestSource")}} object that can be passed to {{domxref("XRFrame.getHitTestResultsForTransientInput()")}}.
@@ -34,12 +34,12 @@ requestHitTestSourceForTransientInput(options)
   - : An object containing configuration options, specifically:
     - `profile`
       - : A string specifying the [input profile name](/en-US/docs/Web/API/XRInputSource) of the transient input source that will be used to compute hit test results.
-    - `entityTypes` {{optional_inline}}
+    - `entityTypes` {{Optional_Inline}}
       - : An {{jsxref("Array")}} specifying the types of entities to be used for hit test source creation. If no entity type is specified, the array defaults to a single element with the `plane` type. Possible types:
         - `point`: Compute hit test results based on characteristic points detected.
         - `plane`: Compute hit test results based on real-world planes detected.
         - `mesh`: Compute hit test results based on meshes detected.
-    - `offsetRay` {{optional_inline}}
+    - `offsetRay` {{Optional_Inline}}
       - : The {{domxref("XRRay")}} object that will be used to perform hit test. If no `XRRay` object has been provided, a new `XRRay` object is constructed without any parameters.
 
 ### Return value

--- a/files/en-us/web/api/xrsession/requestlightprobe/index.md
+++ b/files/en-us/web/api/xrsession/requestlightprobe/index.md
@@ -17,7 +17,7 @@ tags:
   - XRSession
 browser-compat: api.XRSession.requestLightProbe
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`requestLightProbe()`** method of the
 {{domxref("XRSession")}} interface returns a {{jsxref("Promise")}} that resolves with an {{domxref("XRLightProbe")}} object that estimates lighting information at a given point in the user's environment.
@@ -31,7 +31,7 @@ requestLightProbe(options)
 
 ### Parameters
 
-- `options` {{optional_inline}}
+- `options` {{Optional_Inline}}
   - : An object containing configuration options, specifically:
     - `reflectionFormat`
       - : The internal reflection format indicating how the texture data is represented, either `srgba8` (default value) or `rgba16f`. See also {{domxref("XRSession.preferredReflectionFormat")}}.

--- a/files/en-us/web/api/xrsession/requestreferencespace/index.md
+++ b/files/en-us/web/api/xrsession/requestreferencespace/index.md
@@ -20,7 +20,7 @@ tags:
   - tracking
 browser-compat: api.XRSession.requestReferenceSpace
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`requestReferenceSpace()`** method of the
 {{DOMxRef("XRSession")}} interface returns a {{JSxRef("promise")}} that resolves with

--- a/files/en-us/web/api/xrsession/select_event/index.md
+++ b/files/en-us/web/api/xrsession/select_event/index.md
@@ -9,9 +9,10 @@ tags:
   - WebXR
   - XR
   - XRInputSourceEvent
+  - Experimental
 browser-compat: api.XRSession.select_event
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The WebXR **`select`** event is sent to an {{domxref("XRSession")}} when one of the session's input sources has completed a [primary action](/en-US/docs/Web/API/WebXR_Device_API/Inputs#primary_action).
 

--- a/files/en-us/web/api/xrsession/selectend_event/index.md
+++ b/files/en-us/web/api/xrsession/selectend_event/index.md
@@ -21,9 +21,10 @@ tags:
   - augmented
   - controllers
   - selectend
+  - Experimental
 browser-compat: api.XRSession.selectend_event
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The WebXR event **`selectend`** is sent to an {{domxref("XRSession")}} when one of its input sources ends its [primary action](/en-US/docs/Web/API/WebXR_Device_API/Inputs#primary_actions) or when an input source that's in the process of handling an ongoing primary action is disconnected without successfully completing the action.
 

--- a/files/en-us/web/api/xrsession/selectstart_event/index.md
+++ b/files/en-us/web/api/xrsession/selectstart_event/index.md
@@ -21,9 +21,10 @@ tags:
   - augmented
   - controllers
   - selectstart
+  - Experimental
 browser-compat: api.XRSession.selectstart_event
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The [WebXR](/en-US/docs/Web/API/WebXR_Device_API) **`selectstart`** event is sent to an {{domxref("XRSession")}} when the user begins a [primary action](/en-US/docs/Web/API/WebXR_Device_API/Inputs#primary_action) on one of its input sources.
 

--- a/files/en-us/web/api/xrsession/squeeze_event/index.md
+++ b/files/en-us/web/api/xrsession/squeeze_event/index.md
@@ -23,9 +23,10 @@ tags:
   - augmented
   - controllers
   - squeeze
+  - Experimental
 browser-compat: api.XRSession.squeeze_event
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The WebXR **`squeeze`** event is sent to an {{domxref("XRSession")}} when one of the session's input sources has completed a [primary squeeze action](/en-US/docs/Web/API/WebXR_Device_API/Inputs#primary_squeeze_actions). Examples of common kinds of primary action are users pressing triggers or buttons, tapping a touchpad, speaking a command, or performing a recognizable gesture when using a video tracking system or handheld controller with an accelerometer.
 

--- a/files/en-us/web/api/xrsession/squeezeend_event/index.md
+++ b/files/en-us/web/api/xrsession/squeezeend_event/index.md
@@ -22,9 +22,10 @@ tags:
   - actions
   - augmented
   - squeezeend
+  - Experimental
 browser-compat: api.XRSession.squeezeend_event
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The WebXR event **`squeezeend`** is sent to an {{domxref("XRSession")}} when one of its input sources ends its [primary action](/en-US/docs/Web/API/WebXR_Device_API/Inputs#primary_squeeze_actions) or when an input source that's in the process of handling an ongoing primary action is disconnected without successfully completing the action.
 

--- a/files/en-us/web/api/xrsession/squeezestart_event/index.md
+++ b/files/en-us/web/api/xrsession/squeezestart_event/index.md
@@ -23,9 +23,10 @@ tags:
   - augmented
   - controllers
   - squeezestart
+  - Experimental
 browser-compat: api.XRSession.squeezestart_event
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The [WebXR](/en-US/docs/Web/API/WebXR_Device_API) event **`squeezestart`** is sent to an {{domxref("XRSession")}} when the user begins a [primary squeeze action](/en-US/docs/Web/API/WebXR_Device_API/Inputs#primary_squeeze_actions) on one of its input sources.
 

--- a/files/en-us/web/api/xrsession/updaterenderstate/index.md
+++ b/files/en-us/web/api/xrsession/updaterenderstate/index.md
@@ -14,9 +14,10 @@ tags:
   - WebXR Device API
   - XR
   - XRSession
+  - Experimental
 browser-compat: api.XRSession.updateRenderState
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The `updateRenderState()` method of the {{DOMxRef("XRSession")}} interface of the [WebXR API](/en-US/docs/Web/API/WebXR_Device_API) schedules changes to be applied to the active render state ({{domxref("XRRenderState")}}) prior to rendering of the next frame.
 
@@ -29,13 +30,13 @@ updateRenderState(state)
 
 ### Parameters
 
-- `state` {{optional_inline}}
+- `state` {{Optional_Inline}}
   - : An optional object to configure the {{domxref("XRRenderState")}}. If none is provided, a default configuration will be used.
-    - `baseLayer`  {{optional_inline}}: An {{domxref("XRWebGLLayer")}} object from which the WebXR compositor will obtain imagery. This is  `null`  by default. To specify other (or multiple) layers, see the `layers` option.
-    - `depthFar`  {{optional_inline}}: A floating-point value specifying the distance in meters from the viewer to the far clip plane, which is a plane parallel to the display surface beyond which no further rendering will occur. All rendering will take place between the distances specified by  `depthNear`  and  `depthFar`. This is 1000 meters (1 kilometer) by default.
-    - `depthNear`  {{optional_inline}}: A floating-point value indicating the distance in meters from the viewer to a plane parallel to the display surface to be the  **near clip plane**. No part of the scene on the viewer's side of this plane will be rendered. This is 0.1 meters (10 centimeters) by default.
-    - `inlineVerticalFieldOfView`  {{optional_inline}}: A floating-point value indicating the default field of view, in radians, to be used when computing the projection matrix for an  `inline`  {{domxref("XRSession")}}. The projection matrix calculation also takes into account the output canvas's aspect ratio. This property _must not_ be specified for immersive sessions, so the value is  `null`  by default for immersive sessions. The default value is otherwise π \* 0.5 (half of the value of pi).
-    - `layers`  {{optional_inline}}: An ordered array of {{domxref("XRLayer")}} objects specifying the layers that should be presented to the XR device. Setting `layers` will override the `baseLayer` if one is present, with `baseLayer` reporting `null`. The order of the layers given is "back-to-front". For alpha blending of layers, see the {{domxref("XRCompositionLayer.blendTextureSourceAlpha")}} property.
+    - `baseLayer`  {{Optional_Inline}}: An {{domxref("XRWebGLLayer")}} object from which the WebXR compositor will obtain imagery. This is  `null`  by default. To specify other (or multiple) layers, see the `layers` option.
+    - `depthFar`  {{Optional_Inline}}: A floating-point value specifying the distance in meters from the viewer to the far clip plane, which is a plane parallel to the display surface beyond which no further rendering will occur. All rendering will take place between the distances specified by  `depthNear`  and  `depthFar`. This is 1000 meters (1 kilometer) by default.
+    - `depthNear`  {{Optional_Inline}}: A floating-point value indicating the distance in meters from the viewer to a plane parallel to the display surface to be the  **near clip plane**. No part of the scene on the viewer's side of this plane will be rendered. This is 0.1 meters (10 centimeters) by default.
+    - `inlineVerticalFieldOfView`  {{Optional_Inline}}: A floating-point value indicating the default field of view, in radians, to be used when computing the projection matrix for an  `inline`  {{domxref("XRSession")}}. The projection matrix calculation also takes into account the output canvas's aspect ratio. This property _must not_ be specified for immersive sessions, so the value is  `null`  by default for immersive sessions. The default value is otherwise π \* 0.5 (half of the value of pi).
+    - `layers`  {{Optional_Inline}}: An ordered array of {{domxref("XRLayer")}} objects specifying the layers that should be presented to the XR device. Setting `layers` will override the `baseLayer` if one is present, with `baseLayer` reporting `null`. The order of the layers given is "back-to-front". For alpha blending of layers, see the {{domxref("XRCompositionLayer.blendTextureSourceAlpha")}} property.
 
 ### Return value
 

--- a/files/en-us/web/api/xrsession/visibilitychange_event/index.md
+++ b/files/en-us/web/api/xrsession/visibilitychange_event/index.md
@@ -9,9 +9,10 @@ tags:
   - WebXR
   - XR
   - XRSession
+  - Experimental
 browser-compat: api.XRSession.visibilitychange_event
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`visibilitychange`** event is sent to an {{domxref("XRSession")}} to inform it when it becomes visible or hidden, or when it becomes visible but not currently focused. Upon receiving the event, you can check the value of the session's {{domxref("XRSession.visibilityState", "visibilityState")}} property to determine the new visibility state.
 

--- a/files/en-us/web/api/xrsession/visibilitystate/index.md
+++ b/files/en-us/web/api/xrsession/visibilitystate/index.md
@@ -17,7 +17,7 @@ tags:
   - visibilityState
 browser-compat: api.XRSession.visibilityState
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The *read-only* **`visibilityState`** property of the
 {{DOMxRef("XRSession")}} interface is a string indicating whether the WebXR content is

--- a/files/en-us/web/api/xrsystem/devicechange_event/index.md
+++ b/files/en-us/web/api/xrsystem/devicechange_event/index.md
@@ -13,9 +13,10 @@ tags:
   - XR
   - XRSystem
   - devicechange
+  - Experimental
 browser-compat: api.XRSystem.devicechange_event
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 A **`devicechange`** event is fired on an {{DOMxRef("XRSystem")}} object whenever the availability of immersive XR devices has changed; for example, a VR headset or AR goggles have been connected or disconnected. It's a generic {{DOMxRef("Event")}} with no added properties.
 

--- a/files/en-us/web/api/xrsystem/issessionsupported/index.md
+++ b/files/en-us/web/api/xrsystem/issessionsupported/index.md
@@ -17,7 +17,7 @@ tags:
   - isSessionSupported
 browser-compat: api.XRSystem.isSessionSupported
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The {{domxref("XRSystem")}} method
 **`isSessionSupported()`** returns a promise which resolves to
@@ -41,7 +41,7 @@ isSessionSupported(mode)
   - : A {{jsxref("String")}} specifying the WebXR session mode for which support is to
     be checked. Possible modes to check for:
 
-    - `immersive-ar` {{experimental_inline}}
+    - `immersive-ar` {{Experimental_Inline}}
     - `immersive-vr`
     - `inline`
 


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.

This covers files that have only `experimental` header modifications.