### PR TITLE
Update BCD info, part 38

### DIFF
--- a/files/en-us/web/api/mouseevent/layerx/index.md
+++ b/files/en-us/web/api/mouseevent/layerx/index.md
@@ -12,7 +12,6 @@ tags:
   - Non-standard
 browser-compat: api.MouseEvent.layerX
 ---
-
 {{APIRef("UI Events")}}{{Non-standard_Header}}
 
 The **`MouseEvent.layerX`** read-only property returns the

--- a/files/en-us/web/api/mouseevent/layery/index.md
+++ b/files/en-us/web/api/mouseevent/layery/index.md
@@ -12,7 +12,6 @@ tags:
   - Non-standard
 browser-compat: api.MouseEvent.layerY
 ---
-
 {{APIRef("UI Events")}}{{Non-standard_Header}}
 
 The **`MouseEvent.layerY`** read-only property returns the

--- a/files/en-us/web/api/xrsession/select_event/index.md
+++ b/files/en-us/web/api/xrsession/select_event/index.md
@@ -9,9 +9,10 @@ tags:
   - WebXR
   - XR
   - XRInputSourceEvent
+  - Experimental
 browser-compat: api.XRSession.select_event
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The WebXR **`select`** event is sent to an {{domxref("XRSession")}} when one of the session's input sources has completed a [primary action](/en-US/docs/Web/API/WebXR_Device_API/Inputs#primary_action).
 

--- a/files/en-us/web/api/xrsession/selectend_event/index.md
+++ b/files/en-us/web/api/xrsession/selectend_event/index.md
@@ -21,9 +21,10 @@ tags:
   - augmented
   - controllers
   - selectend
+  - Experimental
 browser-compat: api.XRSession.selectend_event
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The WebXR event **`selectend`** is sent to an {{domxref("XRSession")}} when one of its input sources ends its [primary action](/en-US/docs/Web/API/WebXR_Device_API/Inputs#primary_actions) or when an input source that's in the process of handling an ongoing primary action is disconnected without successfully completing the action.
 

--- a/files/en-us/web/api/xrsession/selectstart_event/index.md
+++ b/files/en-us/web/api/xrsession/selectstart_event/index.md
@@ -21,9 +21,10 @@ tags:
   - augmented
   - controllers
   - selectstart
+  - Experimental
 browser-compat: api.XRSession.selectstart_event
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The [WebXR](/en-US/docs/Web/API/WebXR_Device_API) **`selectstart`** event is sent to an {{domxref("XRSession")}} when the user begins a [primary action](/en-US/docs/Web/API/WebXR_Device_API/Inputs#primary_action) on one of its input sources.
 

--- a/files/en-us/web/api/xrsession/squeeze_event/index.md
+++ b/files/en-us/web/api/xrsession/squeeze_event/index.md
@@ -23,9 +23,10 @@ tags:
   - augmented
   - controllers
   - squeeze
+  - Experimental
 browser-compat: api.XRSession.squeeze_event
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The WebXR **`squeeze`** event is sent to an {{domxref("XRSession")}} when one of the session's input sources has completed a [primary squeeze action](/en-US/docs/Web/API/WebXR_Device_API/Inputs#primary_squeeze_actions). Examples of common kinds of primary action are users pressing triggers or buttons, tapping a touchpad, speaking a command, or performing a recognizable gesture when using a video tracking system or handheld controller with an accelerometer.
 

--- a/files/en-us/web/api/xrsession/squeezeend_event/index.md
+++ b/files/en-us/web/api/xrsession/squeezeend_event/index.md
@@ -22,9 +22,10 @@ tags:
   - actions
   - augmented
   - squeezeend
+  - Experimental
 browser-compat: api.XRSession.squeezeend_event
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The WebXR event **`squeezeend`** is sent to an {{domxref("XRSession")}} when one of its input sources ends its [primary action](/en-US/docs/Web/API/WebXR_Device_API/Inputs#primary_squeeze_actions) or when an input source that's in the process of handling an ongoing primary action is disconnected without successfully completing the action.
 

--- a/files/en-us/web/api/xrsession/squeezestart_event/index.md
+++ b/files/en-us/web/api/xrsession/squeezestart_event/index.md
@@ -23,9 +23,10 @@ tags:
   - augmented
   - controllers
   - squeezestart
+  - Experimental
 browser-compat: api.XRSession.squeezestart_event
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The [WebXR](/en-US/docs/Web/API/WebXR_Device_API) event **`squeezestart`** is sent to an {{domxref("XRSession")}} when the user begins a [primary squeeze action](/en-US/docs/Web/API/WebXR_Device_API/Inputs#primary_squeeze_actions) on one of its input sources.
 

--- a/files/en-us/web/api/xrsession/updaterenderstate/index.md
+++ b/files/en-us/web/api/xrsession/updaterenderstate/index.md
@@ -14,9 +14,10 @@ tags:
   - WebXR Device API
   - XR
   - XRSession
+  - Experimental
 browser-compat: api.XRSession.updateRenderState
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The `updateRenderState()` method of the {{DOMxRef("XRSession")}} interface of the [WebXR API](/en-US/docs/Web/API/WebXR_Device_API) schedules changes to be applied to the active render state ({{domxref("XRRenderState")}}) prior to rendering of the next frame.
 
@@ -29,13 +30,13 @@ updateRenderState(state)
 
 ### Parameters
 
-- `state` {{optional_inline}}
+- `state` {{Optional_Inline}}
   - : An optional object to configure the {{domxref("XRRenderState")}}. If none is provided, a default configuration will be used.
-    - `baseLayer`  {{optional_inline}}: An {{domxref("XRWebGLLayer")}} object from which the WebXR compositor will obtain imagery. This is  `null`  by default. To specify other (or multiple) layers, see the `layers` option.
-    - `depthFar`  {{optional_inline}}: A floating-point value specifying the distance in meters from the viewer to the far clip plane, which is a plane parallel to the display surface beyond which no further rendering will occur. All rendering will take place between the distances specified by  `depthNear`  and  `depthFar`. This is 1000 meters (1 kilometer) by default.
-    - `depthNear`  {{optional_inline}}: A floating-point value indicating the distance in meters from the viewer to a plane parallel to the display surface to be the  **near clip plane**. No part of the scene on the viewer's side of this plane will be rendered. This is 0.1 meters (10 centimeters) by default.
-    - `inlineVerticalFieldOfView`  {{optional_inline}}: A floating-point value indicating the default field of view, in radians, to be used when computing the projection matrix for an  `inline`  {{domxref("XRSession")}}. The projection matrix calculation also takes into account the output canvas's aspect ratio. This property _must not_ be specified for immersive sessions, so the value is  `null`  by default for immersive sessions. The default value is otherwise π \* 0.5 (half of the value of pi).
-    - `layers`  {{optional_inline}}: An ordered array of {{domxref("XRLayer")}} objects specifying the layers that should be presented to the XR device. Setting `layers` will override the `baseLayer` if one is present, with `baseLayer` reporting `null`. The order of the layers given is "back-to-front". For alpha blending of layers, see the {{domxref("XRCompositionLayer.blendTextureSourceAlpha")}} property.
+    - `baseLayer`  {{Optional_Inline}}: An {{domxref("XRWebGLLayer")}} object from which the WebXR compositor will obtain imagery. This is  `null`  by default. To specify other (or multiple) layers, see the `layers` option.
+    - `depthFar`  {{Optional_Inline}}: A floating-point value specifying the distance in meters from the viewer to the far clip plane, which is a plane parallel to the display surface beyond which no further rendering will occur. All rendering will take place between the distances specified by  `depthNear`  and  `depthFar`. This is 1000 meters (1 kilometer) by default.
+    - `depthNear`  {{Optional_Inline}}: A floating-point value indicating the distance in meters from the viewer to a plane parallel to the display surface to be the  **near clip plane**. No part of the scene on the viewer's side of this plane will be rendered. This is 0.1 meters (10 centimeters) by default.
+    - `inlineVerticalFieldOfView`  {{Optional_Inline}}: A floating-point value indicating the default field of view, in radians, to be used when computing the projection matrix for an  `inline`  {{domxref("XRSession")}}. The projection matrix calculation also takes into account the output canvas's aspect ratio. This property _must not_ be specified for immersive sessions, so the value is  `null`  by default for immersive sessions. The default value is otherwise π \* 0.5 (half of the value of pi).
+    - `layers`  {{Optional_Inline}}: An ordered array of {{domxref("XRLayer")}} objects specifying the layers that should be presented to the XR device. Setting `layers` will override the `baseLayer` if one is present, with `baseLayer` reporting `null`. The order of the layers given is "back-to-front". For alpha blending of layers, see the {{domxref("XRCompositionLayer.blendTextureSourceAlpha")}} property.
 
 ### Return value
 

--- a/files/en-us/web/api/xrsession/visibilitychange_event/index.md
+++ b/files/en-us/web/api/xrsession/visibilitychange_event/index.md
@@ -9,9 +9,10 @@ tags:
   - WebXR
   - XR
   - XRSession
+  - Experimental
 browser-compat: api.XRSession.visibilitychange_event
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`visibilitychange`** event is sent to an {{domxref("XRSession")}} to inform it when it becomes visible or hidden, or when it becomes visible but not currently focused. Upon receiving the event, you can check the value of the session's {{domxref("XRSession.visibilityState", "visibilityState")}} property to determine the new visibility state.
 

--- a/files/en-us/web/api/xrsession/visibilitystate/index.md
+++ b/files/en-us/web/api/xrsession/visibilitystate/index.md
@@ -17,7 +17,7 @@ tags:
   - visibilityState
 browser-compat: api.XRSession.visibilityState
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The *read-only* **`visibilityState`** property of the
 {{DOMxRef("XRSession")}} interface is a string indicating whether the WebXR content is

--- a/files/en-us/web/api/xrspace/index.md
+++ b/files/en-us/web/api/xrspace/index.md
@@ -6,7 +6,6 @@ tags:
   - API
   - AR
   - Augmented Realty
-  - Experimental
   - Interface
   - Reference
   - VR
@@ -16,7 +15,7 @@ tags:
   - XRSpace
 browser-compat: api.XRSpace
 ---
-{{securecontext_header}}{{APIRef("WebXR Device API")}}
+{{SecureContext_Header}}{{APIRef("WebXR Device API")}}
 
 The **`XRSpace`** interface of the [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API) is an abstract interface providing a common basis for every class which represents a virtual coordinate system within the virtual world, in which its origin corresponds to a physical location. Spatial data in WebXR is always expressed relative to an object based upon one of the descendant interfaces of `XRSpace`, at the time at which a given {{domxref("XRFrame")}} takes place.
 

--- a/files/en-us/web/api/xrsystem/devicechange_event/index.md
+++ b/files/en-us/web/api/xrsystem/devicechange_event/index.md
@@ -13,9 +13,10 @@ tags:
   - XR
   - XRSystem
   - devicechange
+  - Experimental
 browser-compat: api.XRSystem.devicechange_event
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 A **`devicechange`** event is fired on an {{DOMxRef("XRSystem")}} object whenever the availability of immersive XR devices has changed; for example, a VR headset or AR goggles have been connected or disconnected. It's a generic {{DOMxRef("Event")}} with no added properties.
 

--- a/files/en-us/web/api/xrsystem/index.md
+++ b/files/en-us/web/api/xrsystem/index.md
@@ -17,7 +17,7 @@ tags:
   - XRSystem
 browser-compat: api.XRSystem
 ---
-{{APIRef("WebXR Device API")}}{{SecureContext_Header}}
+{{APIRef("WebXR Device API")}}{{SecureContext_Header}}{{SeeCompatTable}}
 
 The [WebXR Device API](/en-US/docs/Web/API/WebXR_Device_API) interface **`XRSystem`** provides methods which let you get access to an {{domxref("XRSession")}} object representing a WebXR session. With that `XRSession` in hand, you can use it to interact with the Augmented Reality (AR) or Virtual Reality (VR) device.
 
@@ -39,7 +39,7 @@ _In addition to inheriting methods from its parent interface, {{domxref("EventTa
 
 ## Events
 
-- {{domxref("XRSystem.devicechange_event", "devicechange")}} {{experimental_inline}}
+- {{domxref("XRSystem.devicechange_event", "devicechange")}} {{Experimental_Inline}}
   - : Sent when the set of available XR devices has changed.
     Also available using the `ondevicechange` event handler.
 

--- a/files/en-us/web/api/xrsystem/issessionsupported/index.md
+++ b/files/en-us/web/api/xrsystem/issessionsupported/index.md
@@ -17,7 +17,7 @@ tags:
   - isSessionSupported
 browser-compat: api.XRSystem.isSessionSupported
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The {{domxref("XRSystem")}} method
 **`isSessionSupported()`** returns a promise which resolves to
@@ -41,7 +41,7 @@ isSessionSupported(mode)
   - : A {{jsxref("String")}} specifying the WebXR session mode for which support is to
     be checked. Possible modes to check for:
 
-    - `immersive-ar` {{experimental_inline}}
+    - `immersive-ar` {{Experimental_Inline}}
     - `immersive-vr`
     - `inline`
 

--- a/files/en-us/web/api/xrsystem/requestsession/index.md
+++ b/files/en-us/web/api/xrsystem/requestsession/index.md
@@ -18,7 +18,7 @@ tags:
   - requestSession
 browser-compat: api.XRSystem.requestSession
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **{{domxref("XRSystem")}}** interface's
 **`requestSession()`** method returns a {{jsxref("promise")}}
@@ -41,7 +41,7 @@ requestSession(mode, options)
 
   - : A {{jsxref("String")}} defining the XR session mode. The supported modes are:
 
-    - {{experimental_inline}} `immersive-ar`: The session's output will be given exclusive access to the immersive device,
+    - {{Experimental_Inline}} `immersive-ar`: The session's output will be given exclusive access to the immersive device,
       but the rendered content will be blended with the real-world environment.
       The session's {{DOMxRef("XRSession.environmentBlendMode", "environmentBlendMode")}} indicates the method
       to be used to blend the content together.
@@ -54,15 +54,15 @@ requestSession(mode, options)
       and may or may not have viewer tracking available. Inline sessions don't require special hardware and should be
       available on any {{Glossary("user agent")}} offering WebXR API support.
 
-- `options` {{optional_inline}}
+- `options` {{Optional_Inline}}
 
   - : An object to configure the {{domxref("XRSession")}}. If none are included, the device will use a default feature configuration for all options.
-    - `requiredFeatures` {{optional_inline}}: An array of values which the returned {{domxref("XRSession")}}
+    - `requiredFeatures` {{Optional_Inline}}: An array of values which the returned {{domxref("XRSession")}}
       _must_ support. See [Session features](#session_features) below.
-    - `optionalFeatures` {{optional_inline}}: An array of values identifying features which the returned
+    - `optionalFeatures` {{Optional_Inline}}: An array of values identifying features which the returned
       {{domxref("XRSession")}} may optionally support. See [Session features](#session_features) below.
-    - `domOverlay` {{optional_inline}}: An object with a required `root` property that specifies the overlay element that will be displayed to the user as the content of the DOM overlay. See the [example below](#requesting_a_session_with_a_dom_overlay).
-    - `depthSensing` {{optional_inline}}: An object with two required properties {{domxref("XRSession.depthUsage", "usagePreference")}} and {{domxref("XRSession.depthDataFormat", "dataFormatPreference")}} to configure how to perform depth sensing. See the [example below](#requesting_a_depth-sensing_session).
+    - `domOverlay` {{Optional_Inline}}: An object with a required `root` property that specifies the overlay element that will be displayed to the user as the content of the DOM overlay. See the [example below](#requesting_a_session_with_a_dom_overlay).
+    - `depthSensing` {{Optional_Inline}}: An object with two required properties {{domxref("XRSession.depthUsage", "usagePreference")}} and {{domxref("XRSession.depthDataFormat", "dataFormatPreference")}} to configure how to perform depth sensing. See the [example below](#requesting_a_depth-sensing_session).
 
 ### Return value
 

--- a/files/en-us/web/api/xrtransientinputhittestresult/inputsource/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestresult/inputsource/index.md
@@ -14,7 +14,7 @@ tags:
   - WebXR Device API
 browser-compat: api.XRTransientInputHitTestResult.inputSource
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The _read-only_ **`inputSource`** property of the {{DOMxRef("XRTransientInputHitTestResult")}} interface represents an {{domxref("XRInputSource")}} object that was used to compute the {{domxref("XRTransientInputHitTestResult.results", "results")}} array.
 

--- a/files/en-us/web/api/xrtransientinputhittestresult/results/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestresult/results/index.md
@@ -14,7 +14,7 @@ tags:
   - WebXR Device API
 browser-compat: api.XRTransientInputHitTestResult.results
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The _read-only_ **`results`** property of the {{DOMxRef("XRTransientInputHitTestResult")}} interface represents an array of {{domxref("XRHitTestResult")}} objects containing the hit test results for the input source, ordered by the distance along the ray used to perform the hit test, with the closest result at position 0.
 

--- a/files/en-us/web/api/xrtransientinputhittestsource/cancel/index.md
+++ b/files/en-us/web/api/xrtransientinputhittestsource/cancel/index.md
@@ -10,9 +10,10 @@ tags:
   - VR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRTransientInputHitTestSource.cancel
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`cancel()`** method of the {{domxref("XRTransientInputHitTestSource")}} interface unsubscribes a transient input hit test.
 

--- a/files/en-us/web/api/xrview/eye/index.md
+++ b/files/en-us/web/api/xrview/eye/index.md
@@ -18,9 +18,10 @@ tags:
   - XR
   - XRView
   - augmented
+  - Experimental
 browser-compat: api.XRView.eye
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The {{domxref("XRView")}} interface's read-only **`eye`**
 property is a string indicating which eye's viewpoint the `XRView` represents: `left` or

--- a/files/en-us/web/api/xrview/isfirstpersonobserver/index.md
+++ b/files/en-us/web/api/xrview/isfirstpersonobserver/index.md
@@ -14,9 +14,10 @@ tags:
   - XR
   - XRView
   - Augmented Reality
+  - Experimental
 browser-compat: api.XRView.isFirstPersonObserver
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The {{domxref("XRView")}} interface's read-only **`isFirstPersonObserver`** property is a boolean indicating if the `XRView` is a first-person observer view.
 

--- a/files/en-us/web/api/xrview/projectionmatrix/index.md
+++ b/files/en-us/web/api/xrview/projectionmatrix/index.md
@@ -19,9 +19,10 @@ tags:
   - augmented
   - perspective
   - projectionMatrix
+  - Experimental
 browser-compat: api.XRView.projectionMatrix
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The {{domxref("XRView")}} interface's read-only
 **`projectionMatrix`** property specifies the projection matrix

--- a/files/en-us/web/api/xrview/recommendedviewportscale/index.md
+++ b/files/en-us/web/api/xrview/recommendedviewportscale/index.md
@@ -10,9 +10,10 @@ tags:
   - VR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRView.recommendedViewportScale
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only **`recommendedViewportScale`** property of the {{domxref("XRView")}} interface is the recommended viewport scale value that you can use for {{domxref("XRView.requestViewportScale()")}} if the user agent has such a recommendation; [`null`](/en-US/docs/Web/JavaScript/Reference/Operators/null) otherwise.
 

--- a/files/en-us/web/api/xrview/requestviewportscale/index.md
+++ b/files/en-us/web/api/xrview/requestviewportscale/index.md
@@ -10,9 +10,10 @@ tags:
   - VR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRView.requestViewportScale
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`requestViewportScale()`** method of the {{domxref("XRView")}} interface requests that the user agent sets the requested viewport scale for this viewport to the given value. This is used for dynamic viewport scaling which allows rendering to a subset of the WebXR viewport using a scale factor that can be changed every animation frame.
 

--- a/files/en-us/web/api/xrview/transform/index.md
+++ b/files/en-us/web/api/xrview/transform/index.md
@@ -23,9 +23,10 @@ tags:
   - augmented
   - camera
   - transform
+  - Experimental
 browser-compat: api.XRView.transform
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The read-only **`transform`** property of the
 {{domxref("XRView")}} interface is an {{domxref("XRRigidTransform")}} object which

--- a/files/en-us/web/api/xrwebglbinding/getdepthinformation/index.md
+++ b/files/en-us/web/api/xrwebglbinding/getdepthinformation/index.md
@@ -9,9 +9,10 @@ tags:
   - AR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRWebGLBinding.getDepthInformation
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`getDepthInformation()`** method of the {{domxref("XRWebGLBinding")}} interface returns an {{domxref("XRWebGLDepthInformation")}} object containing WebGL depth information.
 

--- a/files/en-us/web/api/xrwebglbinding/getreflectioncubemap/index.md
+++ b/files/en-us/web/api/xrwebglbinding/getreflectioncubemap/index.md
@@ -9,9 +9,10 @@ tags:
   - AR
   - XR
   - WebXR
+  - Experimental
 browser-compat: api.XRWebGLBinding.getReflectionCubeMap
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`getReflectionCubeMap()`** method of the {{domxref("XRWebGLBinding")}} interface returns a {{domxref("WebGLTexture")}} object containing a reflection cube map texture.
 

--- a/files/en-us/web/api/xrwebglbinding/xrwebglbinding/index.md
+++ b/files/en-us/web/api/xrwebglbinding/xrwebglbinding/index.md
@@ -8,9 +8,10 @@ tags:
   - Reference
   - WebXR
   - XR
+  - Experimental
 browser-compat: api.XRWebGLBinding.XRWebGLBinding
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`XRWebGLBinding()`** constructor creates and
 returns a new {{domxref("XRWebGLBinding")}} object.

--- a/files/en-us/web/api/xrwebgldepthinformation/texture/index.md
+++ b/files/en-us/web/api/xrwebgldepthinformation/texture/index.md
@@ -14,7 +14,7 @@ tags:
   - WebXR Device API
 browser-compat: api.XRWebGLDepthInformation.texture
 ---
-{{APIRef("WebXR Device API")}}
+{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The _read-only_ **`texture`** property of the {{DOMxRef("XRWebGLDepthInformation")}} interface is a {{domxref("WebGLTexture")}} containing depth buffer information as an opaque texture.
 

--- a/files/en-us/web/api/xrwebgllayer/index.md
+++ b/files/en-us/web/api/xrwebgllayer/index.md
@@ -17,7 +17,7 @@ tags:
   - XRWebGLLayer
 browser-compat: api.XRWebGLLayer
 ---
-{{SecureContext_Header}}{{APIRef("WebXR Device API")}}
+{{SecureContext_Header}}{{APIRef("WebXR Device API")}}{{SeeCompatTable}}
 
 The **`XRWebGLLayer`** interface of the WebXR Device API provides a linkage between the WebXR device (or simulated XR device, in the case of an inline session) and a WebGL context used to render the scene for display on the device. In particular, it provides access to the WebGL framebuffer and viewport to ease access to the context.
 

--- a/files/en-us/web/api/xrwebgllayer/index.md
+++ b/files/en-us/web/api/xrwebgllayer/index.md
@@ -6,7 +6,6 @@ tags:
   - API
   - AR
   - Augmented Reality
-  - Experimental
   - Interface
   - Reference
   - VR
@@ -17,7 +16,7 @@ tags:
   - XRWebGLLayer
 browser-compat: api.XRWebGLLayer
 ---
-{{securecontext_header}}{{APIRef("WebXR Device API")}}
+{{SecureContext_Header}}{{APIRef("WebXR Device API")}}
 
 The **`XRWebGLLayer`** interface of the WebXR Device API provides a linkage between the WebXR device (or simulated XR device, in the case of an inline session) and a WebGL context used to render the scene for display on the device. In particular, it provides access to the WebGL framebuffer and viewport to ease access to the context.
 

--- a/files/en-us/web/api/xrwebgllayer/index.md
+++ b/files/en-us/web/api/xrwebgllayer/index.md
@@ -6,6 +6,7 @@ tags:
   - API
   - AR
   - Augmented Reality
+  - Experimental
   - Interface
   - Reference
   - VR


### PR DESCRIPTION
Adding to #19185 

The PR updates BCD info in WebAPI docs.

This covers files that have only `experimental` header modifications.