### PR TITLE
Add missing id, referenced later in the example

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-multiselectable/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-multiselectable/index.md
@@ -28,7 +28,7 @@ If a tree, grid, tab list, or list box supports selection of more than one node,
 ## Example
 
 ```html
-<p>
+<p id="colorOptions">
   Choose the colors for your flag.
 </p>
 <ul


### PR DESCRIPTION
Add id attribute to element to associate label (the `p` element) and the form control (the `ul` element).

This change improves accessibility of the code and looks like it was simply forgotten as it was already referenced in the `aria-labelledby` attribute.
