### PR TITLE
Reformat WebVTT overview page

### DIFF
--- a/files/en-us/web/api/webvtt_api/index.md
+++ b/files/en-us/web/api/webvtt_api/index.md
@@ -284,7 +284,7 @@ Some time ago in a place rather distant....
 
 The identifier is a name that identifies the cue. It can be used to reference the cue from a script. It must not contain a newline and cannot contain the string "`-->"`. It must end with a single new line. They do not have to be unique, although it is common to number them (e.g., 1, 2, 3).
 
-Here a few examples:
+Here are few examples:
 
 - A basic cue identifier
 

--- a/files/en-us/web/api/webvtt_api/index.md
+++ b/files/en-us/web/api/webvtt_api/index.md
@@ -434,7 +434,7 @@ The first line demonstrates no settings. The second line might be used to overla
 
 The payload is where the main information or content is located. In normal usage the payload contains the subtitles to be displayed. The payload text may contain newlines but it cannot contain a blank line, which is equivalent to two consecutive newlines. A blank line signifies the end of a cue.
 
-A cue text payload cannot contain the string `"-->"`, the ampersand character (`&`), or the less-than sign (`<`). Instead use the escape sequence `&amp;` for ampersand and `&lt;` for less-than. It is also recommended that you use the greater-than escape sequence `&gt;` instead of the greater-than character (`>`) to avoid confusion with tags. If you are using the WebVTT file for metadata these restrictions do not apply.
+A cue text payload cannot contain the string `-->`, the ampersand character (`&`), or the less-than sign (`<`). Instead use the escape sequence `&amp;` for ampersand and `&lt;` for less-than. It is also recommended that you use the greater-than escape sequence `&gt;` instead of the greater-than character (`>`) to avoid confusion with tags. If you are using the WebVTT file for metadata these restrictions do not apply.
 
 In addition to the three escape sequences mentioned above, there are fours others. They are listed in the table below.
 

--- a/files/en-us/web/api/webvtt_api/index.md
+++ b/files/en-us/web/api/webvtt_api/index.md
@@ -284,7 +284,7 @@ Some time ago in a place rather distant....
 
 The identifier is a name that identifies the cue. It can be used to reference the cue from a script. It must not contain a newline and cannot contain the string "`-->"`. It must end with a single new line. They do not have to be unique, although it is common to number them (e.g., 1, 2, 3).
 
-Here are few examples:
+Here are a few examples:
 
 - A basic cue identifier
 

--- a/files/en-us/web/api/webvtt_api/index.md
+++ b/files/en-us/web/api/webvtt_api/index.md
@@ -534,7 +534,7 @@ Different properties allowing to read and set the characteristics of the cue, li
 
 ### VTTRegion
 
-The {{domxref("VTTRegion"}} provides methods used for region are listed below along with description of their functionality, especially it allows to adjust the scrolling setting of all nodes present in the given region.
+The {{domxref("VTTRegion")}} provides methods used for region are listed below along with description of their functionality, especially it allows to adjust the scrolling setting of all nodes present in the given region.
 
 ## Tutorial on how to write a WebVTT file
 

--- a/files/en-us/web/api/webvtt_api/index.md
+++ b/files/en-us/web/api/webvtt_api/index.md
@@ -599,6 +599,6 @@ WebVTT was implemented in Firefox 24 behind the preference `media.webvtt.enabled
 
 Prior to Firefox 58, the `REGION` keyword was creating {{domxref("VTTRegion")}} objects, but they were not being used. Firefox 58 now fully supports `VTTRegion` and its use; however, this feature is disabled by default behind the preference `media.webvtt.regions.enabled`; set it to `true` to enable region support in Firefox 58. Regions are enabled by default starting in Firefox 59 (see bugs {{bug(1338030)}} and {{bug(1415805)}}).
 
-## See Also
+## See also
 
 - The CSS [`::cue` and `::cue()`](/en-US/docs/Web/CSS/::cue) pseudo-elements

--- a/files/en-us/web/api/webvtt_api/index.md
+++ b/files/en-us/web/api/webvtt_api/index.md
@@ -121,7 +121,7 @@ It is important to not use "extra" blank lines within a cue, for example between
 
 Comments are an optional component that can be used to add information to a WebVTT file. Comments are intended for those reading the file and are not seen by users. Comments may contain newlines but cannot contain a blank line, which is equivalent to two consecutive newlines. A blank line signifies the end of a comment.
 
-A comment cannot contain the string `"-->"`, the ampersand character (`&`), or the less-than sign (`<`). If you wish to use such characters, you need to escape them using for example `&amp;` for ampersand and `&lt;` for less-than. It is also recommended that you use the greater-than escape sequence (`&gt;`) instead of the greater-than character (`>`) to avoid confusion with tags.
+A comment cannot contain the string `-->`, the ampersand character (`&`), or the less-than sign (`<`). If you wish to use such characters, you need to escape them using for example `&amp;` for ampersand and `&lt;` for less-than. It is also recommended that you use the greater-than escape sequence (`&gt;`) instead of the greater-than character (`>`) to avoid confusion with tags.
 
 A comment consists of three parts:
 

--- a/files/en-us/web/api/webvtt_api/index.md
+++ b/files/en-us/web/api/webvtt_api/index.md
@@ -336,7 +336,7 @@ Where the components are defined as follows:
 - `mm`
   - : Represents minutes and must be between 00 and 59, inclusive.
 - `ss`
-  - : Represents seconds and must be between 00 and 59 ,inclusive.
+  - : Represents seconds and must be between 00 and 59, inclusive.
 - `ttt`
   - : Represents milliseconds and must be between 000 and 999, inclusive.
 

--- a/files/en-us/web/api/webvtt_api/index.md
+++ b/files/en-us/web/api/webvtt_api/index.md
@@ -18,6 +18,7 @@ tags:
 browser-compat:
   - api.VTTCue
   - api.TextTrack
+  - api.VTTRegion
 ---
 {{DefaultAPISidebar("WebVTT")}}
 
@@ -56,37 +57,39 @@ The structure of a WebVTT consists of the following components, some of them opt
 - Zero or more cues or comments.
 - Zero or more blank lines.
 
-##### Example 1 - Simplest possible WebVTT file
+### Examples
 
-```plain
-WEBVTT
-```
+- Simplest possible WebVTT file
 
-##### Example 2 - Very simple WebVTT file with a text header
+  ```plain
+  WEBVTT
+  ```
 
-```plain
-WEBVTT - This file has no cues.
-```
+- Very simple WebVTT file with a text header
 
-##### Example 3 - Common WebVTT example with a header and cues
+  ```plain
+  WEBVTT - This file has no cues.
+  ```
 
-```plain
-WEBVTT - This file has cues.
+- Common WebVTT example with a header and cues
 
-14
-00:01:14.815 --> 00:01:18.114
-- What?
-- Where are we now?
+  ```plain
+  WEBVTT - This file has cues.
 
-15
-00:01:18.171 --> 00:01:20.991
-- This is big bat country.
+  14
+  00:01:14.815 --> 00:01:18.114
+  - What?
+  - Where are we now?
 
-16
-00:01:21.058 --> 00:01:23.868
-- [ Bats Screeching ]
-- They won't get in your hair. They're after the bugs.
-```
+  15
+  00:01:18.171 --> 00:01:20.991
+  - This is big bat country.
+
+  16
+  00:01:21.058 --> 00:01:23.868
+  - [ Bats Screeching ]
+  - They won't get in your hair. They're after the bugs.
+  ```
 
 ### Inner structure of a WebVTT file
 
@@ -118,7 +121,7 @@ It is important to not use "extra" blank lines within a cue, for example between
 
 Comments are an optional component that can be used to add information to a WebVTT file. Comments are intended for those reading the file and are not seen by users. Comments may contain newlines but cannot contain a blank line, which is equivalent to two consecutive newlines. A blank line signifies the end of a comment.
 
-A comment cannot contain the string "`-->`", the ampersand character (&), or the less-than sign (<). If you wish to use such characters, you need to escape them using for example `&amp;` for ampersand and `&lt;` for less-than. It is also recommended that you use the greater-than escape sequence (`&gt;`) instead of the greater-than character (`>`) to avoid confusion with tags.
+A comment cannot contain the string `"-->"`, the ampersand character (`&`), or the less-than sign (`<`). If you wish to use such characters, you need to escape them using for example `&amp;` for ampersand and `&lt;` for less-than. It is also recommended that you use the greater-than escape sequence (`&gt;`) instead of the greater-than character (`>`) to avoid confusion with tags.
 
 A comment consists of three parts:
 
@@ -126,48 +129,50 @@ A comment consists of three parts:
 - A space or a newline.
 - Zero or more characters other than those noted above.
 
-##### Example 4 - Common WebVTT example
+### Examples
 
-```plain
-NOTE This is a comment
-```
+- Common WebVTT example
 
-##### Example 5 - Multi-line comment
+  ```plain
+  NOTE This is a comment
+  ```
 
-```plain
-NOTE
-One comment that is spanning
-more than one line.
+- Multi-line comment
 
-NOTE You can also make a comment
-across more than one line this way.
-```
+  ```plain
+  NOTE
+  One comment that is spanning
+  more than one line.
 
-##### Example 6 - Common comment usage
+  NOTE You can also make a comment
+  across more than one line this way.
+  ```
 
-```plain
-WEBVTT - Translation of that film I like
+- Common comment usage
 
-NOTE
-This translation was done by Kyle so that
-some friends can watch it with their parents.
+  ```plain
+  WEBVTT - Translation of that film I like
 
-1
-00:02:15.000 --> 00:02:20.000
-- Ta en kopp varmt te.
-- Det är inte varmt.
+  NOTE
+  This translation was done by Kyle so that
+  some friends can watch it with their parents.
 
-2
-00:02:20.000 --> 00:02:25.000
-- Har en kopp te.
-- Det smakar som te.
+  1
+  00:02:15.000 --> 00:02:20.000
+  - Ta en kopp varmt te.
+  - Det är inte varmt.
 
-NOTE This last line may not translate well.
+  2
+  00:02:20.000 --> 00:02:25.000
+  - Har en kopp te.
+  - Det smakar som te.
 
-3
-00:02:25.000 --> 00:02:30.000
-- Ta en kopp
-```
+  NOTE This last line may not translate well.
+
+  3
+  00:02:25.000 --> 00:02:30.000
+  - Ta en kopp
+  ```
 
 ## Styling WebVTT cues
 
@@ -259,7 +264,7 @@ What are you waiting for?
 
 ## WebVTT cues
 
-A cue is a single subtitle block that has a single start time, end time, and textual payload. Example 6 consists of the header, a blank line, and then five cues separated by blank lines. A cue consists of five components:
+A cue is a single subtitle block that has a single start time, end time, and textual payload. A cue consists of five components:
 
 - An optional cue identifier followed by a newline.
 - Cue timings.
@@ -267,7 +272,7 @@ A cue is a single subtitle block that has a single start time, end time, and tex
 - A single newline.
 - The cue payload text.
 
-##### Example 7 - Example of a cue
+Here is an example of a cue:
 
 ```plain
 1 - Title Crawl
@@ -279,29 +284,31 @@ Some time ago in a place rather distant....
 
 The identifier is a name that identifies the cue. It can be used to reference the cue from a script. It must not contain a newline and cannot contain the string "`-->"`. It must end with a single new line. They do not have to be unique, although it is common to number them (e.g., 1, 2, 3).
 
-##### Example 8 - Cue identifier from Example 7
+Here a few examples:
 
-```plain
-1 - Title Crawl
-```
+- A basic cue identifier
 
-##### Example 9 - Common usage of identifiers
+  ```plain
+  1 - Title Crawl
+  ```
 
-```plain
-WEBVTT
+- Common usage of identifiers
 
-1
-00:00:22.230 --> 00:00:24.606
-This is the first subtitle.
+  ```plain
+  WEBVTT
 
-2
-00:00:30.739 --> 00:00:34.074
-This is the second.
+  1
+  00:00:22.230 --> 00:00:24.606
+  This is the first subtitle.
 
-3
-00:00:34.159 --> 00:00:35.743
-Third
-```
+  2
+  00:00:30.739 --> 00:00:34.074
+  This is the second.
+
+  3
+  00:00:34.159 --> 00:00:35.743
+  Third
+  ```
 
 ### Cue timings
 
@@ -315,9 +322,7 @@ Each cue timing contains five components:
 - At least one space.
 - The string "`-->`".
 - At least one space.
-- Timestamp for end time.
-
-  - Which must be greater than the start time.
+- Timestamp for end time, which must be greater than the start time.
 
 The timestamps must be in one of two formats:
 
@@ -326,48 +331,42 @@ The timestamps must be in one of two formats:
 
 Where the components are defined as follows:
 
-- `hh` is hours.
+- `hh`
+  - : Represents hours and must be at least two digits. It can be greater than two digits (e.g., `9999:00:00.000`).
+- `mm`
+  - : Represents minutes and must be between 00 and 59, inclusive.
+- `ss`
+  - : Represents seconds and must be between 00 and 59 ,inclusive.
+- `ttt`
+  - : Represents milliseconds and must be between 000 and 999, inclusive.
 
-  - Must be at least two digits.
-  - Hours can be greater than two digits (e.g., 9999:00:00.000).
+Here are a few cue timing examples:
 
-- `mm` is minutes.
+- Basic cue timing examples
 
-  - Must be between 00 and 59 inclusive.
+  ```plain
+  00:00:22.230 --> 00:00:24.606
+  00:00:30.739 --> 00:00:34.074
+  00:00:34.159 --> 00:00:35.743
+  00:00:35.827 --> 00:00:40.122
+  ```
 
-- `ss` is seconds.
+- Overlapping cue timing examples
 
-  - Must be between 00 and 59 inclusive.
+  ```plain
+  00:00:00.000 --> 00:00:10.000
+  00:00:05.000 --> 00:01:00.000
+  00:00:30.000 --> 00:00:50.000
+  ```
 
-- `ttt` is milliseconds.
+- Non-overlapping cue timing examples
 
-  - Must be between 000 and 999 inclusive.
-
-##### Example 10 - Basic cue timing examples
-
-```plain
-00:00:22.230 --> 00:00:24.606
-00:00:30.739 --> 00:00:34.074
-00:00:34.159 --> 00:00:35.743
-00:00:35.827 --> 00:00:40.122
-```
-
-##### Example 11 - Overlapping cue timing examples
-
-```plain
-00:00:00.000 --> 00:00:10.000
-00:00:05.000 --> 00:01:00.000
-00:00:30.000 --> 00:00:50.000
-```
-
-##### Example 12 - Non-overlapping cue timing examples
-
-```plain
-00:00:00.000 --> 00:00:10.000
-00:00:10.000 --> 00:01:00.581
-00:01:00.581 --> 00:02:00.100
-00:02:01.000 --> 00:02:01.000
-```
+  ```plain
+  00:00:00.000 --> 00:00:10.000
+  00:00:10.000 --> 00:01:00.581
+  00:01:00.581 --> 00:02:00.100
+  00:02:01.000 --> 00:02:01.000
+  ```
 
 ### Cue settings
 
@@ -375,191 +374,52 @@ Cue settings are optional components used to position where the cue payload text
 
 The cue settings are added to the right of the cue timings. There must be one or more spaces between the cue timing and the first setting and between each setting. A setting's name and value are separated by a colon. The settings are case sensitive so use lower case as shown. There are five cue settings:
 
-- **vertical**
+- `vertical`
+  - : Indicates that the text will be displayed vertically rather than horizontally, such as in some Asian languages. There are two possible values:
+    - `rl`
+      - : The writing direction is right to left
+    - `lr`
+      - : The writing direction is left ot right
+- `line`
+  - : If vertical is not set, specifies where the text appears vertically. If vertical is set, line specifies where text appears horizontally. Its value can be:
+    - a line number
+      - : The number is the height of the first line of the cue as it appears on the video. Positive numbers indicate top down and negative numbers indicate bottom up.
+    - a percentage
+      - : It must be an integer (i.e., no decimals) between 0 and 100 inclusive and must be followed by a percent sign (%).
 
-  - Indicates that the text will be displayed vertically rather than horizontally, such as in some Asian languages.
+    | Line        | `vertical` omitted | `vertical:rl` | `vertical:lr` |
+    |-------------|--------------------|---------------|---------------|
+    | `line:0`    | top                | right         | left          |
+    | `line:-1`   | bottom             | left          | right         |
+    | `line:0%`   | top                | right         | left          |
+    | `line:100%` | bottom             | left          | right         |
 
-  <table>
-    <thead>
-      <tr>
-        <th colspan="2">Table 1 - vertical values</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <th><code>vertical:rl</code></th>
-        <td>writing direction is right to left</td>
-      </tr>
-      <tr>
-        <th><code>vertical:lr</code></th>
-        <td>writing direction is left to right</td>
-      </tr>
-    </tbody>
-  </table>
+- `position`
+  - : Specifies where the text will appear horizontally. If vertical is set, position specifies where the text will appear vertically. The value is a percentage, that is an integer (no decimals) between 0 and 100 inclusive followed by a percent sign (%).
+  
+    | Position        | `vertical` omitted | `vertical:rl` | `vertical:lr` |
+    |-----------------|--------------------|---------------|---------------|
+    | `position:0%`   | left               | top           | top           |
+    | `position:100%` | right              | bottom        | bottom        |
+  
+- `size`
+  - : Specifies the width of the text area. If vertical is set, size specifies the height of the text area. The value is a percentage, that is an integer (no decimals) between 0 and 100 inclusive followed by a percent sign (%).
 
-- **line**
+    | Size        | `vertical` omitted | `vertical:rl` | `vertical:lr` |
+    |-------------|--------------------|---------------|---------------|
+    | `size:100%` | full width         | full height   | full height   |
+    | `size:50%`  | half width         | half height   | half height   |
 
-  - Specifies where text appears vertically. If vertical is set, line specifies where text appears horizontally.
-  - Value can be a line number.
+- `align`
+  - : Specifies the alignment of the text. Text is aligned within the space given by the size cue setting if it is set.
 
-    - The line height is the height of the first line of the cue as it appears on the video.
-    - Positive numbers indicate top down.
-    - Negative numbers indicate bottom up.
+    | Align          | `vertical` omitted    | `vertical:rl`       | `vertical:lr`       |
+    |----------------|-----------------------|---------------------|---------------------|
+    | `align:start`  | left                  | top                 | top                 |
+    | `align:center` | centered horizontally | centered vertically | centered vertically |
+    | `align:end`    | right                 | bottom              | bottom              |
 
-  - Or value can be a percentage.
-
-    - Must be an integer (i.e., no decimals) between 0 and 100 inclusive.
-    - Must be followed by a percent sign (%).
-
-  <table>
-    <thead>
-      <tr>
-        <th colspan="4">Table 2 - line examples</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <th></th>
-        <th><code>vertical</code> omitted</th>
-        <th><code>vertical:rl</code></th>
-        <th><code>vertical:lr</code></th>
-      </tr>
-      <tr>
-        <th><code>line:0</code></th>
-        <td>top</td>
-        <td>right</td>
-        <td>left</td>
-      </tr>
-      <tr>
-        <th><code>line:-1</code></th>
-        <td>bottom</td>
-        <td>left</td>
-        <td>right</td>
-      </tr>
-      <tr>
-        <th><code>line:0%</code></th>
-        <td>top</td>
-        <td>right</td>
-        <td>left</td>
-      </tr>
-      <tr>
-        <th><code>line:100%</code></th>
-        <td>bottom</td>
-        <td>left</td>
-        <td>right</td>
-      </tr>
-    </tbody>
-  </table>
-
-- **position**
-
-  - Specifies where the text will appear horizontally. If vertical is set, position specifies where the text will appear vertically.
-  - Value is a percentage.
-  - Must be an integer (no decimals) between 0 and 100 inclusive.
-  - Must be followed by a percent sign (%).
-
-  <table>
-    <thead>
-      <tr>
-        <th colspan="4">Table 3 - position examples</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <th></th>
-        <th><code>vertical</code> omitted</th>
-        <th><code>vertical:rl</code></th>
-        <th><code>vertical:lr</code></th>
-      </tr>
-      <tr>
-        <th><code>position:0%</code></th>
-        <td>left</td>
-        <td>top</td>
-        <td>top</td>
-      </tr>
-      <tr>
-        <th><code>position:100%</code></th>
-        <td>right</td>
-        <td>bottom</td>
-        <td>bottom</td>
-      </tr>
-    </tbody>
-  </table>
-
-- **size**
-
-  - Specifies the width of the text area. If vertical is set, size specifies the height of the text area.
-  - Value is a percentage.
-  - Must be an integer (i.e., no decimals) between 0 and 100 inclusive.
-  - Must be followed by a percent sign (%).
-
-  <table>
-    <thead>
-      <tr>
-        <th colspan="4">Table 4 - size examples</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <th></th>
-        <th><code>vertical</code> omitted</th>
-        <th><code>vertical:rl</code></th>
-        <th><code>vertical:lr</code></th>
-      </tr>
-      <tr>
-        <th><code>size:100%</code></th>
-        <td>full width</td>
-        <td>full height</td>
-        <td>full height</td>
-      </tr>
-      <tr>
-        <th><code>size:50%</code></th>
-        <td>half width</td>
-        <td>half height</td>
-        <td>half height</td>
-      </tr>
-    </tbody>
-  </table>
-
-- **align**
-
-  - Specifies the alignment of the text. Text is aligned within the space given by the size cue setting if it is set.
-
-  <table>
-    <thead>
-      <tr>
-        <th colspan="4">Table 5 - align values</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <th></th>
-        <th><code>vertical</code> omitted</th>
-        <th><code>vertical:rl</code></th>
-        <th><code>vertical:lr</code></th>
-      </tr>
-      <tr>
-        <th><code>align:start</code></th>
-        <td>left</td>
-        <td>top</td>
-        <td>top</td>
-      </tr>
-      <tr>
-        <th><code>align:center</code></th>
-        <td>centred horizontally</td>
-        <td>centred vertically</td>
-        <td>centred vertically</td>
-      </tr>
-      <tr>
-        <th><code>align:end</code></th>
-        <td>right</td>
-        <td>bottom</td>
-        <td>bottom</td>
-      </tr>
-    </tbody>
-  </table>
-
-##### Example 13 - Cue setting examples
+Let's study an example of cue setting.
 
 The first line demonstrates no settings. The second line might be used to overlay text on a sign or label. The third line might be used for a title. The last line might be used for an Asian language.
 
@@ -574,150 +434,90 @@ The first line demonstrates no settings. The second line might be used to overla
 
 The payload is where the main information or content is located. In normal usage the payload contains the subtitles to be displayed. The payload text may contain newlines but it cannot contain a blank line, which is equivalent to two consecutive newlines. A blank line signifies the end of a cue.
 
-A cue text payload cannot contain the string "`-->"`, the ampersand character (&), or the less-than sign (<). Instead use the escape sequence "\&amp;" for ampersand and "\&lt;" for less-than. It is also recommended that you use the greater-than escape sequence "\&gt;" instead of the greater-than character (>) to avoid confusion with tags. If you are using the WebVTT file for metadata these restrictions do not apply.
+A cue text payload cannot contain the string `"-->"`, the ampersand character (`&`), or the less-than sign (`<`). Instead use the escape sequence `&amp;` for ampersand and `&lt;` for less-than. It is also recommended that you use the greater-than escape sequence `&gt;` instead of the greater-than character (`>`) to avoid confusion with tags. If you are using the WebVTT file for metadata these restrictions do not apply.
 
 In addition to the three escape sequences mentioned above, there are fours others. They are listed in the table below.
 
-<table>
-  <thead>
-    <tr>
-      <th colspan="3">Table 6 - Escape sequences</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <th>Name</th>
-      <th>Character</th>
-      <th>Escape Sequence</th>
-    </tr>
-    <tr>
-      <td>Ampersand</td>
-      <td>&#x26;</td>
-      <td><code>&#x26;amp;</code></td>
-    </tr>
-    <tr>
-      <td>Less-than</td>
-      <td>&#x3C;</td>
-      <td><code>&#x26;lt;</code></td>
-    </tr>
-    <tr>
-      <td>Greater-than</td>
-      <td>></td>
-      <td><code>&#x26;gt;</code></td>
-    </tr>
-    <tr>
-      <td>Left-to-right mark</td>
-      <td></td>
-      <td><code>&#x26;lrm;</code></td>
-    </tr>
-    <tr>
-      <td>Right-to-left mark</td>
-      <td></td>
-      <td><code>&#x26;rlm;</code></td>
-    </tr>
-    <tr>
-      <td>Non-breaking space</td>
-      <td><code>&nbsp;</code></td>
-      <td><code>&#x26;nbsp;</code></td>
-    </tr>
-  </tbody>
-</table>
+| Name               | Character | Escape sequence |
+|--------------------|-----------|-----------------|
+| Ampersand          | `&`       | `&amp;`         |
+| Less-than          | `<`       | `&lt;`          |
+| Greater-than       | `>`       | `&gt;`          |
+| Left-to-right mark | _none_    | `&lrm;`         |
+| Right-to-left mark | _none_    | `&rlm;`         |
+| Non-breaking space |           | `&nbsp;`        |
 
 ### Cue payload text tags
 
 There are a number of tags, such as `<bold>`, that can be used. However, if the WebVTT file is used in a {{HTMLElement("track")}} element where the attribute {{htmlattrxref("kind")}} is `chapters` then you cannot use tags.
 
-- **Timestamp tag**
+- Timestamp tag
+  - : The timestamp must be greater that the cue's start timestamp, greater than any previous timestamp in the cue payload, and less than the cue's end timestamp. The *active text* is the text between the timestamp and the next timestamp or to the end of the payload if there is not another timestamp in the payload. Any text before the _active text_ in the payload is _previous text_. Any text beyond the _active text_ is _future text_. This enables karaoke style captions.
 
-  - The timestamp must be greater that the cue's start timestamp, greater than any previous timestamp in the cue payload, and less than the cue's end timestamp. The *active text* is the text between the timestamp and the next timestamp or to the end of the payload if there is not another timestamp in the payload. Any text before the *active text* in the payload is *previous text* . Any text beyond the *active text* is *future text* . This enables karaoke style captions.
+    ```plain
+    1
+    00:16.500 --> 00:18.500
+    When the moon <00:17.500>hits your eye
 
-  ##### Example 14 - Karaoke style text
+    1
+    00:00:18.500 --> 00:00:20.500
+    Like a <00:19.000>big-a <00:19.500>pizza <00:20.000>pie
 
-  ```plain
-  1
-  00:16.500 --> 00:18.500
-  When the moon <00:17.500>hits your eye
-
-  1
-  00:00:18.500 --> 00:00:20.500
-  Like a <00:19.000>big-a <00:19.500>pizza <00:20.000>pie
-
-  1
-  00:00:20.500 --> 00:00:21.500
-  That's <00:00:21.000>amore
-  ```
+    1
+    00:00:20.500 --> 00:00:21.500
+    That's <00:00:21.000>amore
+    ```
 
 The following tags are the HTML tags allowed in a cue and require opening and closing tags (e.g., `<b>text</b>`).
 
-- **Class tag** (`<c></c>`)
+- Class tag (`<c></c>`)
+  - : Style the contained text using a CSS class.
 
-  - Style the contained text using a CSS class.
+    ```xml
+    <c.classname>text</c>
+    ```
 
-  ##### Example 15 - Class tag
+- Italics tag (`<i></i>`)
+  - : Italicize the contained text.
 
-  ```html
-  <c.classname>text</c>
-  ```
+    ```xml
+    <i>text</i>
+    ```
 
-- **Italics tag** (`<i></i>`)
+- Bold tag (`<b></b>`)
+  - : Bold the contained text.
 
-  - Italicize the contained text.
+    ```xml
+    <b>text</b>
+    ```
 
-  ##### Example 16 - Italics tag
+- Underline tag (`<u></u>`)
+  - : Underline the contained text.
 
-  ```html
-  <i>text</i>
-  ```
+    ```xml
+    <u>text</u>
+    ```
 
-- **Bold tag** (`<b></b>`)
+- Ruby tag (`<ruby></ruby>`)
+  - : Used with ruby text tags to display [ruby characters](https://en.wikipedia.org/wiki/Ruby_character) (i.e., small annotative characters above other characters).
 
-  - Bold the contained text.
+    ```xml
+    <ruby>WWW<rt>World Wide Web</rt>oui<rt>yes</rt></ruby>
+    ```
 
-  ##### Example 17 - Bold tag
+- Ruby text tag (`<rt></rt>`)
+  - : Used with ruby tags to display [ruby characters](https://en.wikipedia.org/wiki/Ruby_character) (i.e., small annotative characters above other characters).
 
-  ```html
-  <b>text</b>
-  ```
+    ```xml
+    <ruby>WWW<rt>World Wide Web</rt>oui<rt>yes</rt></ruby>
+    ```
 
-- **Underline tag** (`<u></u>`)
+- Voice tag (`<v></v>`)
+  - : Similar to class tag, also used to style the contained text using CSS.
 
-  - Underline the contained text.
-
-  ##### Example 18 - Underline tag
-
-  ```html
-  <u>text</u>
-  ```
-
-- **Ruby tag** (`<ruby></ruby>`)
-
-  - Used with ruby text tags to display [ruby characters](https://en.wikipedia.org/wiki/Ruby_character) (i.e., small annotative characters above other characters).
-
-  ##### Example 19 - Ruby tag
-
-  ```html
-  <ruby>WWW<rt>World Wide Web</rt>oui<rt>yes</rt></ruby>
-  ```
-
-- **Ruby text tag** (`<rt></rt>`)
-
-  - Used with ruby tags to display [ruby characters](https://en.wikipedia.org/wiki/Ruby_character) (i.e., small annotative characters above other characters).
-
-  ##### Example 20 - Ruby text tag
-
-  ```html
-  <ruby>WWW<rt>World Wide Web</rt>oui<rt>yes</rt></ruby>
-  ```
-
-- **Voice tag** (`<v></v>`)
-
-  - Similar to class tag, also used to style the contained text using CSS.
-
-  ##### Example 21 - Voice tag
-
-  ```html
-  <v Bob>text</v>
-  ```
+    ```xml
+    <v Bob>text</v>
+    ```
 
 ## Methods and properties
 
@@ -725,41 +525,36 @@ The methods used in WebVTT are those which are used to alter the cue or region a
 
 ### VTTCue
 
-- The methods which are available in this interface are:
+The methods which are available in the {{domxref("VTTCue")}} interface are:
 
-  - GetCueAsHTML to get the HTML of that Cue.
-  - VTT Constructor for creating new objects of Cues.
-  - Autokeyword.
-  - DirectionSetting: to set the direction of caption or text in a file.
-  - LineAlignment: to adjust the line alignment.
-  - PositionAlignSetting: to adjust the position of text.
+- {{domxref("VTTCue.getCueAsHTML", "getCueAsHTML()")}} to get the HTML of that cue.
+- A constructor, {{domxref("VTTCue.VTTCue", "VTTCue()")}} for creating new instances of this interface.
+
+Different properties allowing to read and set the characteristics of the cue, like its position, alignment or size are also available. Check {{domxref("VTTCue")}}) for a complete list.
 
 ### VTTRegion
 
-- The methods used for region are listed below along with description of their functionality:
-
-  - ScrollSetting: For adjusting the scrolling setting of all nodes present in given region.
-  - VTT Region Constructor: for construction of new VTT Regions.
+The {{domxref("VTTRegion"}} provides methods used for region are listed below along with description of their functionality, especially it allows to adjust the scrolling setting of all nodes present in the given region.
 
 ## Tutorial on how to write a WebVTT file
 
 There are few steps that can be followed to write a simple webVTT file. Before start, it must be noted that you can make use of a notepad and then save the file as '.vtt' file. Steps are given below:
 
-1. Open a notepad.
-2. The first line of WebVTT is standardized similar to the way some other languages require you to put headers as the file starts to indicate the file type. On the very first line you have to write:
+- Open a notepad.
+- The first line of WebVTT is standardized similar to the way some other languages require you to put headers as the file starts to indicate the file type. On the very first line you have to write:
 
-    ```plain
-    WEBVTT
-    ```
+  ```plain
+  WEBVTT
+  ```
 
-3. Leave the second line blank, and on the third line the time for first cue is to be specified. For example, for a first cue starting at time 1 second and ending at 5 seconds, it is written as:
+- Leave the second line blank, and on the third line the time for first cue is to be specified. For example, for a first cue starting at time 1 second and ending at 5 seconds, it is written as:
 
-```plain
-00:01.000 --> 00:05.000
-```
+  ```plain
+  00:01.000 --> 00:05.000
+  ```
 
-1. On the next line you can write the caption for this cue which will run from the first second to the fifth second, inclusive.
-2. Following the similar steps, a complete WebVTT file for specific video or audio file can be made.
+- On the next line you can write the caption for this cue which will run from the first second to the fifth second, inclusive.
+- Following the similar steps, a complete WebVTT file for specific video or audio file can be made.
 
 ## CSS pseudo-classes
 
@@ -781,10 +576,10 @@ In the above example it can be observed that we can use the identifier and pseud
 
 The type of pseudo class is determined by the selector it is using and working is similar in nature as it works in HTML. Following CSS pseudo classes can be used:
 
-- Lang (Language): e.g., p:lang(it).
-- Link: e.g., a:link.
-- Nth-last-child: e.g., p:nth-last-child(2).
-- Nth-child(n): e.g., p:nth-child(2).
+- `lang` (Language): e.g., `p:lang(it)`.
+- `link`: e.g., `a:link`.
+- `nth-last-child`: e.g., `p:nth-last-child(2)`.
+- `nth-child(n)`: e.g., `p:nth-child(2)`.
 
 Where p and a are the tags which are used in HTML for paragraph and link, respectively and they can be replaced by identifiers which are used for Cues in WebVTT file.
 
@@ -806,4 +601,4 @@ Prior to Firefox 58, the `REGION` keyword was creating {{domxref("VTTRegion")}} 
 
 ## See Also
 
-- The CSS [`::cue` and `::cue()`](/en-US/docs/Web/CSS/::cue) pseudo-element
+- The CSS [`::cue` and `::cue()`](/en-US/docs/Web/CSS/::cue) pseudo-elements


### PR DESCRIPTION
In #19883, we noticed that the structure of the WebVTT overview page was problematic. 

This fixes it.