### PR TITLE
Reverse wrong 'Fix grammar'

### DIFF
--- a/files/en-us/learn/javascript/client-side_web_apis/manipulating_documents/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/manipulating_documents/index.md
@@ -277,7 +277,7 @@ To complete the exercise, follow the steps below, and make sure that the list be
 7. Append the span and the button as children of the list item.
 8. Set the text content of the span to the input element value you saved earlier, and the text content of the button to 'Delete'.
 9. Append the list item as a child of the list.
-10. Attach an event handler to the delete button, so that when clicked it will delete the entire list item inside it.
+10. Attach an event handler to the delete button, so that when clicked it will delete the entire list item it is inside.
 11. Finally, use the [`focus()`](/en-US/docs/Web/API/HTMLElement/focus) method to focus the input element ready for entering the next shopping list item.
 
 > **Note:** If you get really stuck, have a look at our [finished shopping list](https://github.com/mdn/learning-area/blob/main/javascript/apis/document-manipulation/shopping-list-finished.html) ([see it running live also](https://mdn.github.io/learning-area/javascript/apis/document-manipulation/shopping-list-finished.html).)

--- a/files/en-us/learn/javascript/client-side_web_apis/manipulating_documents/index.md
+++ b/files/en-us/learn/javascript/client-side_web_apis/manipulating_documents/index.md
@@ -277,7 +277,7 @@ To complete the exercise, follow the steps below, and make sure that the list be
 7. Append the span and the button as children of the list item.
 8. Set the text content of the span to the input element value you saved earlier, and the text content of the button to 'Delete'.
 9. Append the list item as a child of the list.
-10. Attach an event handler to the delete button, so that when clicked it will delete the entire list item it is inside.
+10. Attach an event handler to the delete button so that, when clicked, it will delete the entire list item (`<li>...</li>`).
 11. Finally, use the [`focus()`](/en-US/docs/Web/API/HTMLElement/focus) method to focus the input element ready for entering the next shopping list item.
 
 > **Note:** If you get really stuck, have a look at our [finished shopping list](https://github.com/mdn/learning-area/blob/main/javascript/apis/document-manipulation/shopping-list-finished.html) ([see it running live also](https://mdn.github.io/learning-area/javascript/apis/document-manipulation/shopping-list-finished.html).)


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

PR #19908 attempted to make the sentence clearer, but resulted in a different (wrong) meaning. Current version (that says "inside it") means that the list item is inside the button, which is incorrect. This PR reverses the changes made to the correct phrasing, i.e. "it is inside", that signifies that the button is inside the list item.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
