### PR TITLE
Fix links to archived MSDN page in `Error.prototype.stack` docs

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/error/stack/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/error/stack/index.md
@@ -17,11 +17,11 @@ The non-standard **`stack`** property of {{jsxref("Error")}} objects offer a tra
 
 Each step will be separated by a newline, with the first part of the line being the function name (if not a call from the global scope), then by an at (@) sign, the file location (except when the function is the error constructor as the error is being thrown), a colon, and, if there is a file location, the line number. (Note that the {{jsxref("Error")}} object also possesses the `fileName`, `lineNumber` and `columnNumber` properties for retrieving these from the error thrown (but only the error, and not its trace).)
 
-Note that this is the format used by Firefox. There is no standard formatting. However, Safari 6+ and Opera 12- use a very similar format. Browsers using the V8 JavaScript engine (such as Chrome, Opera 15+, Android Browser) and IE10+, on the other hand, uses a different format (see [the archived MSDN error.stack docs](https://web.archive.org/web/20220312071445/https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack)).
+Note that this is the format used by Firefox. There is no standard formatting. However, Safari 6+ and Opera 12- use a very similar format. Browsers using the V8 JavaScript engine (such as Chrome, Opera 15+, Android Browser) and IE10+, on the other hand, uses a different format (see [the archived MSDN error.stack docs](https://web.archive.org/web/20180618201428/https://docs.microsoft.com/en-us/scripting/javascript/reference/stack-property-error-javascript)).
 
 **Argument values in the stack**: Prior to Firefox 14, the function name would be followed by the argument values converted to string in parentheses immediately before the at (`@`) sign. While an object (or array, etc.) would appear in the converted form `"[object Object]"`, and as such could not be evaluated back into the actual objects, scalar values could be retrieved (though it may be — it is still possible in Firefox 14 — easier to use `arguments.callee.caller.arguments`, as could the function name be retrieved by `arguments.callee.caller.name`). `"undefined"` is listed as `"(void 0)"`. Note that if string arguments were passed in with values such as `"@"`, `"("`, `")"` (or if in file names), you could not easily rely on these for breaking the line into its component parts. Thus, in Firefox 14 and later this is less of an issue.
 
-Different browsers set this value at different times. For example, Firefox sets it when creating an {{jsxref("Error")}} object, while PhantomJS sets it only when throwing the {{jsxref("Error")}}, and [archived MSDN docs](https://web.archive.org/web/20220312071445/https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack) also seem to match the PhantomJS implementation.
+Different browsers set this value at different times. For example, Firefox sets it when creating an {{jsxref("Error")}} object, while PhantomJS sets it only when throwing the {{jsxref("Error")}}, and [archived MSDN docs](https://web.archive.org/web/20180618201428/https://docs.microsoft.com/en-us/scripting/javascript/reference/stack-property-error-javascript) also seem to match the PhantomJS implementation.
 
 ## Examples
 
@@ -121,5 +121,5 @@ Not part of any standard.
 ## See also
 
 - External projects: [TraceKit](https://github.com/csnover/TraceKit/) and [javascript-stacktrace](https://github.com/stacktracejs/stacktrace.js)
-- MSDN: [archived error.stack docs](https://web.archive.org/web/20220312071445/https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack)
+- MSDN: [archived error.stack docs](https://web.archive.org/web/20180618201428/https://docs.microsoft.com/en-us/scripting/javascript/reference/stack-property-error-javascript)
 - [Overview of the V8 JavaScript stack trace API](https://v8.dev/docs/stack-trace-api)


### PR DESCRIPTION
#### Summary
This pull-request fixes a broken link to an archived page on MSDN (Microsoft Developer's Network) that was recorded before Microsoft started redirecting back to MDN instead. This is probably what's caused the current links to point to an archived copy of MDN instead of the cited resource.

#### Supporting details
The last version of the cited MSDN page was saved by the Wayback Machine on June 18th, 2018.[^1]

[^1]: https://web.archive.org/web/20180618201428/https://docs.microsoft.com/en-us/scripting/javascript/reference/stack-property-error-javascript

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
