### PR TITLE
chore: Split Markdownlint Actions

### DIFF
--- a/.github/workflows/pr-check_markdownlint.yml
+++ b/.github/workflows/pr-check_markdownlint.yml
@@ -1,15 +1,11 @@
-name: Markdownlint (All files)
+name: Markdownlint (PR files)
 
 on:
   pull_request:
     branches:
       - main
     paths:
-      - .markdownlint.json
-      - package.json
-      - yarn.lock
-      - .github/workflows/markdown-lint.yml
-      - .github/workflows/markdownlint-problem-matcher.json
+      - "**/*.md"
 
 jobs:
   docs:
@@ -17,6 +13,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v29.0.0
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
@@ -31,4 +31,4 @@ jobs:
       - name: Lint markdown files
         run: |
           echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"
-          yarn lint:md
+          yarn markdownlint ${{ steps.changed-files.outputs.all_changed_files }}

--- a/.github/workflows/pr-check_markdownlint.yml
+++ b/.github/workflows/pr-check_markdownlint.yml
@@ -17,6 +17,9 @@ jobs:
       - name: Get changed files
         id: changed-files
         uses: tj-actions/changed-files@v29.0.0
+        with:
+          files: |
+            **/*.md
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v3


### PR DESCRIPTION
Took the approach from https://github.com/mdn/content/pull/19884 while keeping the overall Markdownlint job to catch dependency updates and config changes seperate