### PR TITLE
Remove unused contenteditable recommendation

### DIFF
--- a/files/en-us/web/accessibility/aria/roles/gridcell_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/gridcell_role/index.md
@@ -24,7 +24,7 @@ Elements that have `role="gridcell"` applied to them must be the child of an ele
 </div>
 ```
 
-The first rule of ARIA is if a native HTML element or attribute has the semantics and behavior you require, use it instead of re-purposing an element and adding ARIA. Instead use the HTML {{HTMLElement('td')}} element in conjunction with the and [`contenteditable` attribute](/en-US/docs/Web/HTML/Global_attributes/contenteditable):
+The first rule of ARIA is if a native HTML element or attribute has the semantics and behavior you require, use it instead of re-purposing an element and adding ARIA. Instead use the HTML {{HTMLElement('td')}} element:
 
 ```html
 <td>Potato</td>


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
Removes a recommendation to use `contenteditable` with `<td>` that doesn't make sense in the context of the article.

#### Motivation
I think this might be a copy-paste error–the context doesn't mention `contenteditable` at all, and the sample code below the "use `<td>` in conjunction with `contenteditable`" recommendation... doesn't actually use contenteditable.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
