### PR TITLE
Updated alt attributes on the CSS image-rendering property page.

### DIFF
--- a/files/en-us/web/css/image-rendering/index.md
+++ b/files/en-us/web/css/image-rendering/index.md
@@ -65,9 +65,9 @@ In practical use, the `pixelated` and `crisp-edges` rules can be combined to pro
 
 ```html hidden
 <div>
-  <img class="auto" alt="auto" src="blumen.jpg" />
-  <img class="pixelated" alt="pixelated" src="blumen.jpg" />
-  <img class="crisp-edges" alt="crisp-edges" src="blumen.jpg" />
+  <img class="auto" alt="A small photo of some white and yellow flower against a leafy green background. The image is about 33% smaller than the size it is being displayed at. This upscaling causes the image to appear blurry, with notable soft edges between objects." src="blumen.jpg" />
+  <img class="pixelated" alt="The same photo as the previous image, which is also being upscaled the same amount. Browsers that support the pixelated value for the image-rendering property display the image as very pixelated. Individual pixels are clearly visible and edges appear much sharper." src="blumen.jpg" />
+  <img class="crisp-edges" alt="The same photo as the previous images, which is also being upscaled the same amount. Browsers that support the crisp-edges value for the image-rendering property display the image as very pixelated. In these examples, there is virtually no percievable difference between the pixelated and crisp-edges versions." src="blumen.jpg" />
 </div>
 ```
 


### PR DESCRIPTION
#### Summary
As mentioned in https://github.com/mdn/content/issues/19334 there are many missing or incomplete alt attributes for images. This PR adds some descriptive alt text for 3 images on the CSS image-rendering property page.

#### Motivation
Accessibility! For anyone using a screen reader, or if the images don't load etc. 

#### Supporting details
List of missing alt attributes: https://docs.google.com/spreadsheets/d/1cDHee6mwDMlY6zANEmg8MjR8tL-wrCS86uawpWZ4XbA/edit?usp=sharing

#### Related issues
https://github.com/mdn/content/issues/19334

#### Metadata

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
