### PR TITLE
don't yield value of resolved promise

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/asyncgenerator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/asyncgenerator/index.md
@@ -25,9 +25,9 @@ The `AsyncGenerator` constructor is not available globally. Instances of `AsyncG
 
 ```js
 async function* createAsyncGenerator() {
-  yield await Promise.resolve(1);
-  yield await Promise.resolve(2);
-  yield await Promise.resolve(3);
+  yield Promise.resolve(1);
+  yield Promise.resolve(2);
+  yield Promise.resolve(3);
 }
 const asyncGen = createAsyncGenerator();
 asyncGen.next()


### PR DESCRIPTION
I think yield await Promise.resolve(1); is misleading, because
`Promise.resolve(1);` is a promise but
`await Promise.resolve(1);`  is a value 1 (the resolved value of the promise)
yield 1  turns 1 into a promise, but it's a different promise than the  Promise.resolve(1)

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
