### PR TITLE
Executing JavaScript examples in Toolbox clarification

### DIFF
--- a/files/en-us/mozilla/add-ons/webextensions/api/index.md
+++ b/files/en-us/mozilla/add-ons/webextensions/api/index.md
@@ -49,7 +49,7 @@ Not all browsers support all the APIs: for the details, see [Browser support for
 
 ## Examples
 
-Throughout the JavaScript API listings, you will find short code examples that illustrate how the API is used. You can experiment using these examples—_without_ needing to create a web extension—using the console in the [Toolbox](https://extensionworkshop.com/documentation/develop/debugging/#developer-tools-toolbox).
+Throughout the JavaScript API listings, short code examples illustrate how the API is used. You can experiment with most of these examples using the console in the [Toolbox](https://extensionworkshop.com/documentation/develop/debugging/#developer-tools-toolbox). However, you need Toolbox running in the context of a web extension. To do this, open `about:debugging` then **This Firefox**, click **Inspect** against any installed or temporary extension, and open **Console**. You can then paste and run the example code in the console.
 
 For example, here is the first code example on this page running in the Toolbox console in Firefox Developer Edition:
 


### PR DESCRIPTION
#### Summary
Clarifies that to run the JavaScript code examples provided in the API documentation in the Toolbox, the Toolbox needs to be running in the context of a web extension.

#### Related issues
Fixes #18544

#### Metadata
This PR…

- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error
