### PR TITLE
Revert newly added {{SeeCompatTable}} macros, part 1

### DIFF
--- a/files/en-us/web/api/audiodata/allocationsize/index.md
+++ b/files/en-us/web/api/audiodata/allocationsize/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.AudioData.allocationSize
 ---
-{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{APIRef("WebCodecs API")}}
 
 The **`allocationSize()`** method of the {{domxref("AudioData")}} interface returns the size in bytes required to hold the current sample as filtered by options passed into the method.
 

--- a/files/en-us/web/api/audiodata/audiodata/index.md
+++ b/files/en-us/web/api/audiodata/audiodata/index.md
@@ -10,7 +10,7 @@ tags:
   - Experimental
 browser-compat: api.AudioData.AudioData
 ---
-{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{APIRef("WebCodecs API")}}
 
 The **`AudioData()`** constructor creates a new {{domxref("AudioData")}} object which represents an individual audio sample.
 

--- a/files/en-us/web/api/audiodata/clone/index.md
+++ b/files/en-us/web/api/audiodata/clone/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.AudioData.clone
 ---
-{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{APIRef("WebCodecs API")}}
 
 The **`clone()`** method of the {{domxref("AudioData")}} interface creates a new `AudioData` object with reference to the same media resource as the original.
 

--- a/files/en-us/web/api/audiodata/close/index.md
+++ b/files/en-us/web/api/audiodata/close/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.AudioData.close
 ---
-{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{APIRef("WebCodecs API")}}
 
 The **`close()`** method of the {{domxref("AudioData")}} interface clears all states and releases the reference to the media resource.
 

--- a/files/en-us/web/api/audiodata/copyto/index.md
+++ b/files/en-us/web/api/audiodata/copyto/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.AudioData.copyTo
 ---
-{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{APIRef("WebCodecs API")}}
 
 The **`copyTo()`** method of the {{domxref("AudioData")}} interface copies a plane of an `AudioData` object to a destination buffer.
 

--- a/files/en-us/web/api/audiodata/duration/index.md
+++ b/files/en-us/web/api/audiodata/duration/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.AudioData.duration
 ---
-{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{APIRef("WebCodecs API")}}
 
 The **`duration`** read-only property of the {{domxref("AudioData")}} interface returns the duration in microseconds of this `AudioData` object.
 

--- a/files/en-us/web/api/audiodata/format/index.md
+++ b/files/en-us/web/api/audiodata/format/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.AudioData.format
 ---
-{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{APIRef("WebCodecs API")}}
 
 The **`format`** read-only property of the {{domxref("AudioData")}} interface returns the sample format of the `AudioData` object.
 

--- a/files/en-us/web/api/audiodata/index.md
+++ b/files/en-us/web/api/audiodata/index.md
@@ -10,7 +10,7 @@ tags:
   - Experimental
 browser-compat: api.AudioData
 ---
-{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{APIRef("WebCodecs API")}}
 
 The **`AudioData`** interface of the [WebCodecs API](/en-US/docs/Web/API/WebCodecs_API) represents an audio sample.
 

--- a/files/en-us/web/api/audiodata/numberofchannels/index.md
+++ b/files/en-us/web/api/audiodata/numberofchannels/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.AudioData.numberOfChannels
 ---
-{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{APIRef("WebCodecs API")}}
 
 The **`numberOfChannels`** read-only property of the {{domxref("AudioData")}} interface returns the number of channels in the `AudioData` object.
 

--- a/files/en-us/web/api/audiodata/numberofframes/index.md
+++ b/files/en-us/web/api/audiodata/numberofframes/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.AudioData.numberOfFrames
 ---
-{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{APIRef("WebCodecs API")}}
 
 The **`numberOfFrames`** read-only property of the {{domxref("AudioData")}} interface returns the number of frames in the `AudioData` object.
 

--- a/files/en-us/web/api/audiodata/samplerate/index.md
+++ b/files/en-us/web/api/audiodata/samplerate/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.AudioData.sampleRate
 ---
-{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{APIRef("WebCodecs API")}}
 
 The **`sampleRate`** read-only property of the {{domxref("AudioData")}} interface returns the sample rate in Hz.
 

--- a/files/en-us/web/api/audiodata/timestamp/index.md
+++ b/files/en-us/web/api/audiodata/timestamp/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.AudioData.timestamp
 ---
-{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{APIRef("WebCodecs API")}}
 
 The **`duration`** read-only property of the {{domxref("AudioData")}} interface returns the timestamp of this `AudioData` object.
 

--- a/files/en-us/web/api/audiodecoder/audiodecoder/index.md
+++ b/files/en-us/web/api/audiodecoder/audiodecoder/index.md
@@ -10,7 +10,7 @@ tags:
   - Experimental
 browser-compat: api.AudioDecoder.AudioDecoder
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}
 
 The **`AudioDecoder()`** constructor creates a new {{domxref("AudioDecoder")}} object with the provided `init.output` callback assigned as the output callback, the provided `init.error` callback as the error callback, and the {{domxref("AudioDecoder.state")}} set to `"unconfigured"`.
 

--- a/files/en-us/web/api/audiodecoder/close/index.md
+++ b/files/en-us/web/api/audiodecoder/close/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.AudioDecoder.close
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}
 
 The **`close()`** method of the {{domxref("AudioDecoder")}} interface ends all pending work and releases system resources.
 

--- a/files/en-us/web/api/audiodecoder/configure/index.md
+++ b/files/en-us/web/api/audiodecoder/configure/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.AudioDecoder.configure
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}
 
 The **`configure()`** method of the {{domxref("AudioDecoder")}} interface enqueues a control message to configure the audio decoder for decoding chunks.
 

--- a/files/en-us/web/api/audiodecoder/decode/index.md
+++ b/files/en-us/web/api/audiodecoder/decode/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.AudioDecoder.decode
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}
 
 The **`decode()`** method of the {{domxref("AudioDecoder")}} interface enqueues a control message to decode a given chunk of audio.
 

--- a/files/en-us/web/api/audiodecoder/decodequeuesize/index.md
+++ b/files/en-us/web/api/audiodecoder/decodequeuesize/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.AudioDecoder.decodeQueueSize
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}
 
 The **`decodeQueueSize`** read-only property of the {{domxref("AudioDecoder")}} interface returns the number of pending decode requests in the queue.
 

--- a/files/en-us/web/api/audiodecoder/flush/index.md
+++ b/files/en-us/web/api/audiodecoder/flush/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.AudioDecoder.flush
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}
 
 The **`flush()`** method of the {{domxref("AudioDecoder")}} interface returns a Promise that resolves once all pending messages in the queue have been completed.
 

--- a/files/en-us/web/api/audiodecoder/index.md
+++ b/files/en-us/web/api/audiodecoder/index.md
@@ -10,7 +10,7 @@ tags:
   - Experimental
 browser-compat: api.AudioDecoder
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}
 
 The **`AudioDecoder`** interface of the {{domxref('WebCodecs API','','',' ')}} decodes chunks of audio.
 

--- a/files/en-us/web/api/audiodecoder/reset/index.md
+++ b/files/en-us/web/api/audiodecoder/reset/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.AudioDecoder.reset
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}
 
 The **`reset()`** method of the {{domxref("AudioDecoder")}} interface resets all states including configuration, control messages in the control message queue, and all pending callbacks.
 

--- a/files/en-us/web/api/audiodecoder/state/index.md
+++ b/files/en-us/web/api/audiodecoder/state/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.AudioDecoder.state
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}
 
 The **`state`** read-only property of the {{domxref("AudioDecoder")}} interface returns the current state of the underlying codec.
 

--- a/files/en-us/web/api/audioencoder/audioencoder/index.md
+++ b/files/en-us/web/api/audioencoder/audioencoder/index.md
@@ -10,7 +10,7 @@ tags:
   - Experimental
 browser-compat: api.AudioEncoder.AudioEncoder
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}
 
 The **`AudioEncoder()`** constructor creates a new {{domxref("AudioEncoder")}} object with the provided `init.output` callback assigned as the output callback, the provided `init.error` callback as the error callback, and the {{domxref("AudioEncoder.state")}} set to `"unconfigured"`.
 

--- a/files/en-us/web/api/audioencoder/close/index.md
+++ b/files/en-us/web/api/audioencoder/close/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.AudioEncoder.close
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}
 
 The **`close()`** method of the {{domxref("AudioEncoder")}} interface ends all pending work and releases system resources.
 

--- a/files/en-us/web/api/audioencoder/configure/index.md
+++ b/files/en-us/web/api/audioencoder/configure/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.AudioEncoder.configure
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}
 
 The **`configure()`** method of the {{domxref("AudioEncoder")}} interface enqueues a control message to configure the audio encoder for encoding chunks.
 

--- a/files/en-us/web/api/audioencoder/encode/index.md
+++ b/files/en-us/web/api/audioencoder/encode/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.AudioEncoder.encode
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}
 
 The **`encode()`** method of the {{domxref("AudioEncoder")}} interface enqueues a control message to encode a given {{domxref("AudioData")}} object.
 

--- a/files/en-us/web/api/audioencoder/encodequeuesize/index.md
+++ b/files/en-us/web/api/audioencoder/encodequeuesize/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.AudioEncoder.encodeQueueSize
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}
 
 The **`encodeQueueSize`** read-only property of the {{domxref("AudioEncoder")}} interface returns the number of pending encode requests in the queue.
 

--- a/files/en-us/web/api/audioencoder/flush/index.md
+++ b/files/en-us/web/api/audioencoder/flush/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.AudioEncoder.flush
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}
 
 The **`flush()`** method of the {{domxref("AudioEncoder")}} interface returns a Promise that resolves once all pending messages in the queue have been completed.
 

--- a/files/en-us/web/api/audioencoder/index.md
+++ b/files/en-us/web/api/audioencoder/index.md
@@ -10,7 +10,7 @@ tags:
   - Experimental
 browser-compat: api.AudioEncoder
 ---
-{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{APIRef("WebCodecs API")}}
 The **`AudioEncoder`** interface of the [WebCodecs API](/en-US/docs/Web/API/WebCodecs_API) encodes {{domxref("AudioData")}} objects.
 
 ## Constructor

--- a/files/en-us/web/api/audioencoder/reset/index.md
+++ b/files/en-us/web/api/audioencoder/reset/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.AudioEncoder.reset
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}
 
 The **`reset()`** method of the {{domxref("AudioEncoder")}} interface resets all states including configuration, control messages in the control message queue, and all pending callbacks.
 

--- a/files/en-us/web/api/audioencoder/state/index.md
+++ b/files/en-us/web/api/audioencoder/state/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.AudioEncoder.state
 ---
-{{securecontext_header}}{{APIRef("WebCodecs API")}}{{SeeCompatTable}}
+{{securecontext_header}}{{APIRef("WebCodecs API")}}
 
 The **`state`** read-only property of the {{domxref("AudioEncoder")}} interface returns the current state of the underlying codec.
 

--- a/files/en-us/web/api/background_synchronization_api/index.md
+++ b/files/en-us/web/api/background_synchronization_api/index.md
@@ -15,7 +15,7 @@ tags:
   - Experimental
 browser-compat: api.SyncManager
 ---
-{{securecontext_header}}{{SeeCompatTable}}
+{{securecontext_header}}
 
 {{DefaultAPISidebar("Background Sync")}}
 

--- a/files/en-us/web/api/backgroundfetchevent/backgroundfetchevent/index.md
+++ b/files/en-us/web/api/backgroundfetchevent/backgroundfetchevent/index.md
@@ -10,7 +10,7 @@ tags:
   - Experimental
 browser-compat: api.BackgroundFetchEvent.BackgroundFetchEvent
 ---
-{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+{{APIRef("Background Fetch API")}}
 
 The **`BackgroundFetchEvent()`** constructor creates a new {{domxref("BackgroundFetchEvent")}} object. This constructor is not typically used as the browser creates these objects itself and provides them to background fetch event callbacks.
 

--- a/files/en-us/web/api/backgroundfetchevent/index.md
+++ b/files/en-us/web/api/backgroundfetchevent/index.md
@@ -10,7 +10,7 @@ tags:
   - Experimental
 browser-compat: api.BackgroundFetchEvent
 ---
-{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+{{APIRef("Background Fetch API")}}
 
 The **`BackgroundFetchEvent`** interface of the {{domxref('Background Fetch API','','',' ')}} is the event type for background fetch events dispatched on the {{domxref("ServiceWorkerGlobalScope", "service worker global scope")}}.
 

--- a/files/en-us/web/api/backgroundfetchevent/registration/index.md
+++ b/files/en-us/web/api/backgroundfetchevent/registration/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.BackgroundFetchEvent.registration
 ---
-{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+{{APIRef("Background Fetch API")}}
 
 The **`registration`** read-only property of the {{domxref("BackgroundFetchEvent")}} interface returns a {{domxref("BackgroundFetchRegistration")}} object.
 

--- a/files/en-us/web/api/backgroundfetchmanager/fetch/index.md
+++ b/files/en-us/web/api/backgroundfetchmanager/fetch/index.md
@@ -13,7 +13,7 @@ tags:
   - Fetch
 browser-compat: api.BackgroundFetchManager.fetch
 ---
-{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+{{APIRef("Background Fetch API")}}
 
 The **`fetch()`** method of the {{domxref("BackgroundFetchManager")}} interface returns a {{jsxref("Promise")}} that resolves with a {{domxref("BackgroundFetchRegistration")}} object for a supplied array of URLs and {{domxref("Request")}} objects.
 

--- a/files/en-us/web/api/backgroundfetchmanager/get/index.md
+++ b/files/en-us/web/api/backgroundfetchmanager/get/index.md
@@ -13,7 +13,7 @@ tags:
   - Fetch
 browser-compat: api.BackgroundFetchManager.get
 ---
-{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+{{APIRef("Background Fetch API")}}
 
 The **`get()`** method of the {{domxref("BackgroundFetchManager")}} interface returns a {{jsxref("Promise")}} that resolves with the {{domxref("BackgroundFetchRegistration")}} associated with the provided `id` or {{jsxref("undefined")}} if the `id` is not found.
 

--- a/files/en-us/web/api/backgroundfetchmanager/getids/index.md
+++ b/files/en-us/web/api/backgroundfetchmanager/getids/index.md
@@ -13,7 +13,7 @@ tags:
   - Fetch
 browser-compat: api.BackgroundFetchManager.getIds
 ---
-{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+{{APIRef("Background Fetch API")}}
 
 The **`getIds()`** method of the {{domxref("BackgroundFetchManager")}} interface returns the IDs of all registered background fetches.
 

--- a/files/en-us/web/api/backgroundfetchmanager/index.md
+++ b/files/en-us/web/api/backgroundfetchmanager/index.md
@@ -12,7 +12,7 @@ tags:
   - Fetch
 browser-compat: api.BackgroundFetchManager
 ---
-{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+{{APIRef("Background Fetch API")}}
 
 The **`BackgroundFetchManager`** interface of the {{domxref('Background Fetch API','','',' ')}} is a map where the keys are background fetch IDs and the values are {{domxref("BackgroundFetchRegistration")}} objects.
 

--- a/files/en-us/web/api/backgroundfetchrecord/index.md
+++ b/files/en-us/web/api/backgroundfetchrecord/index.md
@@ -10,7 +10,7 @@ tags:
   - Experimental
 browser-compat: api.BackgroundFetchRecord
 ---
-{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+{{APIRef("Background Fetch API")}}
 
 The **`BackgroundFetchRecord`** interface of the {{domxref('Background Fetch API','','',' ')}} represents an individual request and response.
 

--- a/files/en-us/web/api/backgroundfetchrecord/request/index.md
+++ b/files/en-us/web/api/backgroundfetchrecord/request/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.BackgroundFetchRecord.request
 ---
-{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+{{APIRef("Background Fetch API")}}
 
 The **`request`** read-only property of the {{domxref("BackgroundFetchRecord")}} interface returns the details of the resource to be fetched.
 

--- a/files/en-us/web/api/backgroundfetchrecord/responseready/index.md
+++ b/files/en-us/web/api/backgroundfetchrecord/responseready/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.BackgroundFetchRecord.responseReady
 ---
-{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+{{APIRef("Background Fetch API")}}
 
 The **`responseReady`** read-only property of the {{domxref("BackgroundFetchRecord")}} interface returns a {{jsxref("Promise")}} that resolves with a {{domxref("Response")}}.
 

--- a/files/en-us/web/api/backgroundfetchregistration/abort/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/abort/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.BackgroundFetchRegistration.abort
 ---
-{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+{{APIRef("Background Fetch API")}}
 
 The **`abort()`** method of the {{domxref("BackgroundFetchRegistration")}} interface aborts an active background fetch.
 

--- a/files/en-us/web/api/backgroundfetchregistration/downloaded/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/downloaded/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.BackgroundFetchRegistration.downloaded
 ---
-{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+{{APIRef("Background Fetch API")}}
 
 The **`downloaded`** read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns the size in bytes that has been downloaded, initially `0`.
 

--- a/files/en-us/web/api/backgroundfetchregistration/downloadtotal/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/downloadtotal/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.BackgroundFetchRegistration.downloadTotal
 ---
-{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+{{APIRef("Background Fetch API")}}
 
 The **`downloadTotal`** read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns the total size in bytes of this download. This is set when the background fetch was registered, or `0` if not set.
 

--- a/files/en-us/web/api/backgroundfetchregistration/failurereason/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/failurereason/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.BackgroundFetchRegistration.failureReason
 ---
-{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+{{APIRef("Background Fetch API")}}
 
 The **`failureReason`** read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns a string with a value that indicates a reason for a background fetch failure.
 

--- a/files/en-us/web/api/backgroundfetchregistration/id/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/id/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.BackgroundFetchRegistration.id
 ---
-{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+{{APIRef("Background Fetch API")}}
 
 The **`id`** read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns a copy of the background fetch's `ID`.
 

--- a/files/en-us/web/api/backgroundfetchregistration/match/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/match/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.BackgroundFetchRegistration.match
 ---
-{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+{{APIRef("Background Fetch API")}}
 
 The **`match()`** method of the {{domxref("BackgroundFetchRegistration")}} interface returns the first matching {{domxref("BackgroundFetchRecord")}}.
 

--- a/files/en-us/web/api/backgroundfetchregistration/matchall/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/matchall/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.BackgroundFetchRegistration.matchAll
 ---
-{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+{{APIRef("Background Fetch API")}}
 
 The **`matchAll()`** method of the {{domxref("BackgroundFetchRegistration")}} interface returns an array of matching {{domxref("BackgroundFetchRecord")}} objects.
 

--- a/files/en-us/web/api/backgroundfetchregistration/progress_event/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/progress_event/index.md
@@ -10,7 +10,7 @@ tags:
   - Experimental
 browser-compat: api.BackgroundFetchRegistration.progress_event
 ---
-{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+{{APIRef("Background Fetch API")}}
 
 The **`progress`** event of the {{domxref("BackgroundFetchRegistration")}} interface thrown when the associated background fetch progresses.
 

--- a/files/en-us/web/api/backgroundfetchregistration/recordsavailable/index.md
+++ b/files/en-us/web/api/backgroundfetchregistration/recordsavailable/index.md
@@ -11,7 +11,7 @@ tags:
   - Experimental
 browser-compat: api.BackgroundFetchRegistration.recordsAvailable
 ---
-{{APIRef("Background Fetch API")}}{{SeeCompatTable}}
+{{APIRef("Background Fetch API")}}
 
 The **`recordsAvailable`** read-only property of the {{domxref("BackgroundFetchRegistration")}} interface returns `true` if there are requests and responses to be accessed. If this returns false then {{domxref("BackgroundFetchRegistration.match()","match()")}} and {{domxref("BackgroundFetchRegistration.matchAll()","matchAll()")}} can't be used.
 


### PR DESCRIPTION
Addresses https://github.com/mdn/content/pull/19911#pullrequestreview-1084154438

> We are gradually trying to remove the `{{SeeCompatTable}}` macros. 
> We have been removing this macro for some time now. Please change this throughout.

This reverts `{{SeeCompatTable}}` macros that were added in PR series https://github.com/mdn/content/pull/19185.

***
cc/ @jpmedley, @teoli2003 