### PR TITLE
update the param's name

### DIFF
--- a/files/en-us/web/api/fetchevent/request/index.md
+++ b/files/en-us/web/api/fetchevent/request/index.md
@@ -21,7 +21,7 @@ The **`request`** read-only property of the
 the event handler.
 
 This property is non-nullable (since version 46, in the case of Firefox.) If a request
-is not provided by some other means, the constructor `init` object must
+is not provided by some other means, the constructor `options` object must
 contain a request (see {{domxref("FetchEvent.FetchEvent", "FetchEvent()")}}.)
 
 ## Value


### PR DESCRIPTION
#### Summary

See the [`FetchEvent` constructor](https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent/FetchEvent#syntax). The second param is now named `options`. Update the param reference in `FetchEvent.request`.

#### Metadata

- [x] Fixes a typo, bug, or other error
