### PR TITLE
CSS Font Loading API fixes - FF104

### DIFF
--- a/files/en-us/web/api/canvasrenderingcontext2d/fontstretch/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fontstretch/index.md
@@ -41,7 +41,6 @@ The stretch value is also displayed for each case by reading the property.
 ```js
 const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
-// let font_file = new FontFace('League Spartan', 'url(https://fonts.gstatic.com/s/bitter/v7/HEpP8tJXlWaYHimsnXgfCOvvDin1pK8aKteLpeZ5c0A.woff2) format("woff2")');
 let font_file = new FontFace('30px "Inconsolata"', 'url(https://fonts.gstatic.com/s/inconsolata/v31/QlddNThLqRwH-OJ1UHjlKENVzlm-WkL3GZQmAwPyya15.woff2) format("woff2")', {stretch: '50% 200%'});
 //font_file.stretch= 'normal semi-expanded'; // https://fonts.googleapis.com/css2?family=Inconsolata:wdth@50..200
 //font_file.stretch= '30% 200%';

--- a/files/en-us/web/api/canvasrenderingcontext2d/fontstretch/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fontstretch/index.md
@@ -41,14 +41,11 @@ The stretch value is also displayed for each case by reading the property.
 ```js
 const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
-let font_file = new FontFace('30px "Inconsolata"', 'url(https://fonts.gstatic.com/s/inconsolata/v31/QlddNThLqRwH-OJ1UHjlKENVzlm-WkL3GZQmAwPyya15.woff2) format("woff2")', {stretch: '50% 200%'});
-//font_file.stretch= 'normal semi-expanded'; // https://fonts.googleapis.com/css2?family=Inconsolata:wdth@50..200
-//font_file.stretch= '30% 200%';
+const fontFile = new FontFace('30px "Inconsolata"', 'url(https://fonts.gstatic.com/s/inconsolata/v31/QlddNThLqRwH-OJ1UHjlKENVzlm-WkL3GZQmAwPyya15.woff2) format("woff2")', {stretch: '50% 200%'});
 
-document.fonts.add(font_file);
+document.fonts.add(fontFile);
 
 document.fonts.load('30px "Inconsolata"').then(() => {
-
 ctx.font = '30px "Inconsolata"'
 // Default (normal)
 ctx.fillText(`Hello world (default: ${ctx.fontStretch})`, 5, 20);
@@ -89,8 +86,6 @@ ctx.fillText(`Hello world (${ctx.fontStretch})`, 5, 260);
 // Font stretch: ultra-expanded
 ctx.fontStretch = 'ultra-expanded';
 ctx.fillText(`Hello world (${ctx.fontStretch})`, 5, 290);
-
-
 },
 (err) => {
   console.error(err);

--- a/files/en-us/web/api/canvasrenderingcontext2d/fontstretch/index.md
+++ b/files/en-us/web/api/canvasrenderingcontext2d/fontstretch/index.md
@@ -41,13 +41,22 @@ The stretch value is also displayed for each case by reading the property.
 ```js
 const canvas = document.getElementById('canvas');
 const ctx = canvas.getContext('2d');
-ctx.font = '20px serif';
+// let font_file = new FontFace('League Spartan', 'url(https://fonts.gstatic.com/s/bitter/v7/HEpP8tJXlWaYHimsnXgfCOvvDin1pK8aKteLpeZ5c0A.woff2) format("woff2")');
+let font_file = new FontFace('30px "Inconsolata"', 'url(https://fonts.gstatic.com/s/inconsolata/v31/QlddNThLqRwH-OJ1UHjlKENVzlm-WkL3GZQmAwPyya15.woff2) format("woff2")', {stretch: '50% 200%'});
+//font_file.stretch= 'normal semi-expanded'; // https://fonts.googleapis.com/css2?family=Inconsolata:wdth@50..200
+//font_file.stretch= '30% 200%';
 
+document.fonts.add(font_file);
+
+document.fonts.load('30px "Inconsolata"').then(() => {
+
+ctx.font = '30px "Inconsolata"'
 // Default (normal)
 ctx.fillText(`Hello world (default: ${ctx.fontStretch})`, 5, 20);
 
 // Font stretch: ultra-condensed
-ctx.fontStretch = 'ultra-condensed';
+ctx.fontStretch = '60%';
+//ctx.fontStretch = 'ultra-condensed';
 ctx.fillText(`Hello world (${ctx.fontStretch})`, 5, 50);
 
 // Font stretch: extra-condensed
@@ -81,6 +90,12 @@ ctx.fillText(`Hello world (${ctx.fontStretch})`, 5, 260);
 // Font stretch: ultra-expanded
 ctx.fontStretch = 'ultra-expanded';
 ctx.fillText(`Hello world (${ctx.fontStretch})`, 5, 290);
+
+
+},
+(err) => {
+  console.error(err);
+});
 ```
 
 ### Result

--- a/files/en-us/web/api/css_font_loading_api/index.md
+++ b/files/en-us/web/api/css_font_loading_api/index.md
@@ -137,9 +137,9 @@ First we get the element to which we will log, and the canvas that will be used 
 ```js
 const log = document.getElementById('log');
 
-const mycanvas = document.getElementById("js-canvas");
-mycanvas.width = 650;
-mycanvas.height = 75;
+const canvas = document.getElementById("js-canvas");
+canvas.width = 650;
+canvas.height = 75;
 ```
 
 Next we define a `FontFace` that has a URL source that is a Google Font and add it to `document.fonts`.

--- a/files/en-us/web/api/css_font_loading_api/index.md
+++ b/files/en-us/web/api/css_font_loading_api/index.md
@@ -18,6 +18,95 @@ The CSS Font Loading API provides events and interfaces for dynamically loading 
 
 > **Note:** This feature is available in [Web Workers](/en-US/docs/Web/API/Web_Workers_API) (`self.fonts` provides access to {{domxref('FontFaceSet')}}).
 
+## Concepts and usage
+
+CSS stylesheets allow authors to use custom fonts; specifying fonts to download using the [`@font-face`](/en-US/docs/Web/CSS/@font-face) rule, and applying them to elements with the [`font-family`](/en-US/docs/Web/CSS/font-family) property.
+The point at which a font is downloaded is controlled by the user agent.
+Most agents only fetch and load fonts when they are first needed, which can result in a perceptible delay.
+
+The CSS Font Loading API overcomes this problem by allowing authors to control and track when a font is fetched and loaded, and when it is made available to the document or worker for drawing (or automated download).
+
+Font faces are defined in {{domxref('FontFace')}} objects, which specify a binary or URL font source and other properties of font in much the same way as the CSS [`@font-face`](/en-US/docs/Web/CSS/@font-face) rule.
+The {{domxref('FontFace.status')}} property indicates the font face loading status: `unloaded`, `loading`, `loaded` or `failed`.
+This status is initially `unloaded`.
+It is set to `loading` when the file is being downloaded or the font data is being processed, and to `failed` if the font definition is invalid or the font data cannot be loaded.
+The status is set to `loaded` when the font face data has been successfully fetched (if needed) and loaded.
+
+Font faces added to the document or worker {{domxref('FontFaceSet')}} ({{domxref("Document.fonts")}} and {{domxref("WorkerGlobalScope.fonts")}} respectively), which represents the set of custom font faces available to the user agent.
+Authors can use the `FontFaceSet` API to load the fonts, or the user agent will automatically do so when fonts are needed to render a particular element.
+
+Authors can also load fonts using the `FontFace` object (even before adding the font face to the document).
+Note however that a font can only be used for drawing if it has been both loaded and added to a `FontFaceSet`.
+
+Loading of individual `FontFace` can be tracked with promises returned by the `loading` property and `load()` method, while loading of all required fonts can be tracked for a `FontFaceSet` using both promise and event based mechanisms.
+
+### Defining a font face
+
+Font faces are created using the [`FontFace` constructor](/en-US/docs/Web/API/FontFace/FontFace), which takes as arguments: the font family, the font source, and optional descriptors.
+The format and grammar of these arguments is the same as the equivalent [`@font-face`](/en-US/docs/Web/CSS/@font-face) definition.
+
+The font source can either be binary data in an [`ArrayBuffer`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) or a font resource at an URL.
+A typical font face definition using a URL source might be as shown below.
+Note that the `url()` function is required for URL font sources.
+
+```js
+const font = new FontFace('myfont', 'url(myfont.woff)', {
+  style: 'italic',
+  weight: '400',
+  stretch: 'condensed'
+});
+```
+
+> **Note:** As with `@font-face`, some descriptors represent the expected data in the font data and are used for font matching, while others actually set/define properties of the generated font face.
+> For example, setting the `style` to "italic" indicates that the file contains italic fonts, but this could be incorrect.
+
+Font faces with a binary source are automatically loaded if the font definition is valid and the font data can be loaded ({{domxref('FontFace.status')}} is `loaded` on success and `failed` otherwise).  
+Font faces with a URL source are not automatically loaded ({{domxref('FontFace.status')}} is `unloaded`, or `failed` if the font definition is invalid).
+
+### Adding a font to a document or worker
+
+Font faces are usually added to the document or worker {{domxref('FontFaceSet')}} to allow the user agent to automatically load the font when needed, and _must_ be added in order for the font to be used for rendering text.
+
+The code below shows a font face being added to the document.
+
+```js
+//Define a FontFace
+const font = new FontFace('myfont', 'url(myfont.woff)', {
+  style: 'italic',
+  weight: '400',
+  stretch: 'condensed'
+});
+
+//Add to the document.fonts (FontFaceSet)
+document.fonts.add(font);
+```
+
+### Loading a font
+
+A font face can be loaded manually by calling {{domxref('FontFace.load()')}}, or by calling {{domxref('FontFaceSet.load()')}} if the font face has been added to the `FontFaceSet`.
+Note that attempting to load an already-loaded font has no effect.
+
+The code below shows how to define a font face, add it to the document fonts, and then initiate a font load.
+
+```js
+//Define a FontFace
+const font = new FontFace('myfont', 'url(myfont.woff)');
+
+//Add to the document.fonts (FontFaceSet)
+document.fonts.add(font);
+
+//Load the font
+font.load();
+
+//Wait until the fonts are all loaded
+document.fonts.ready.then( () => {
+  // Use the font to render text (for example, in a canvas) 
+});
+```
+
+Note that the `font.load()` returns a promise, so we could have handled the completion of font loading by chaining `then` afterwards.
+Using [`document.fonts.ready`](/en-US/docs/Web/API/FontFaceSet/ready) can be better in some circumstances, as it is only called when all fonts in the document have been resolved and layout is complete.
+
 ## Interfaces
 
 - {{domxref('FontFace')}}
@@ -26,6 +115,158 @@ The CSS Font Loading API provides events and interfaces for dynamically loading 
   - : An interface loading font faces and checking their download statuses.
 - {{domxref('FontFaceSetLoadEvent')}}
   - : Fired whenever a {{domxref("FontFaceSet")}} loads.
+
+
+## Examples
+
+### Basic font loading
+
+This is a very simple example that shows a font being loaded from Google Fonts and used to draw text to a canvas.
+The example also logs the `status` immediately after creation and after loading.
+
+#### HTML
+
+This code defines a canvas for drawing to and a textarea for logging.
+
+```html
+<canvas id="js-canvas"></canvas>
+<textarea id="log" rows="3" cols="100"></textarea>
+```
+
+#### JavaScript
+
+First we get the element to which we will log, and the canvas that will be used to render text in the downloaded font.
+
+```js
+const log = document.getElementById('log');
+
+const mycanvas = document.getElementById("js-canvas");
+mycanvas.width = 650;
+mycanvas.height = 75;
+```
+
+Next we define a `FontFace` that has a URL source that is a goggle font and add it to `document.fonts`.
+We then log the font status, which should be `unloaded`.
+
+```js
+let bitterFontFace = new FontFace('FontFamily Bitter', 'url(https://fonts.gstatic.com/s/bitter/v7/HEpP8tJXlWaYHimsnXgfCOvvDin1pK8aKteLpeZ5c0A.woff2)');
+document.fonts.add(bitterFontFace);
+log.textContent+=`Bitter font: ${bitterFontFace.status}\n`;  // > Bitter status: unloaded
+```
+
+Next we call {{domxref('FontFace.load()')}} method to load the font face, and wait on the returned promise.
+Once the promise resolves we log the loaded status (which should be `loaded`) and draw text in the loaded font to the canvas.
+
+```js
+bitterFontFace.load().then(() => {
+  log.textContent+=`Bitter font: ${bitterFontFace.status}\n`;  // > Bitter status: loaded
+
+  const ctx = mycanvas.getContext('2d')
+  ctx.font = '36px "FontFamily Bitter"'
+  ctx.fillText('Bitter font loaded', 20, 50)
+
+  },
+(err) => {
+  console.error(err)
+});
+```
+
+Note that we could also have waited on the promise returned by the {{domxref('FontFace.loaded')}} property, or on {{domxref('FontFaceSet.ready')}}.
+
+#### Result
+
+The result is shown below.
+It should show the name of the font drawn on the canvas in the downloaded font, and a log showing the load status before and after loading.
+
+{{ EmbedLiveSample('Basic font loading', 700, 180) }}
+
+### Font loading with events
+
+This example is similar to the last one, except that it uses {{domxref('FontFaceSet.load()')}} to load the font, 
+
+#### HTML
+
+```html
+<canvas id="js-canvas"></canvas>
+<textarea id="log" rows="25" cols="100"></textarea>
+```
+
+#### JavaScript
+
+This example is similar to the previous one except that it uses {{domxref('FontFaceSet.load()')}} to load to load the font.
+
+```js
+const log = document.getElementById('log');
+
+const mycanvas = document.getElementById("js-canvas");
+mycanvas.width = 650;
+mycanvas.height = 75;
+const ctx = mycanvas.getContext('2d')
+
+let oxygenFontFace = new FontFace('FontFamily Oxygen', 'url(https://fonts.gstatic.com/s/oxygen/v5/qBSyz106i5ud7wkBU-FrPevvDin1pK8aKteLpeZ5c0A.woff2)');
+document.fonts.add(oxygenFontFace);
+log.textContent+=`Oxygen status: ${oxygenFontFace.status}\n`;
+```
+
+Next we use `load()` on the font face set to load the font, specifying which of the fonts to load.
+On success we use the font to draw.
+
+```js
+document.fonts.load('36px FontFamily Oxygen').then((fonts) => {
+  log.textContent+=`Bitter font: ${fonts}\n`;  // > Oxygen font: loaded
+  log.textContent+=`Bitter font: ${oxygenFontFace.status}\n`;  // > Oxygen font: loaded
+  ctx.font = '36px "FontFamily Oxygen"'
+  ctx.fillText('Oxygen font loaded', 20, 50)
+  },
+(err) => {
+  console.error(err)
+});
+```
+
+We can also use events to track the font loading operation.
+For the `loading` and `loadingerror` event listeners we just log the number of font faces that are loading and errored.
+In the `loadingdone` event listener we additionally iterate through the font faces and log the family names.
+
+```js
+document.fonts.addEventListener('loading', (event) => { 
+  log.textContent+=`loading_event: ${event.fontfaces.length}\n`;
+});
+document.fonts.addEventListener('loadingerror', (event) => { 
+  log.textContent+=`loadingerror_event: ${event.fontfaces.length}\n`;
+});
+document.fonts.addEventListener('loadingdone', (event) => { 
+  log.textContent+=`loadingdone_event: ${event.fontfaces.length}\n`;
+  event.fontfaces.forEach( (value) => {
+    log.textContent+=`  fontface: ${value.family}\n`;
+  });
+});
+```
+
+Lastly we "additionally" monitor the completion of font loading using the promise returned by {{domxref('FontFaceSet.ready')}}.
+Unlike the other mechanisms this returns when all fonts defined in the document have been downloaded and layout is complete.
+
+When the promise resolves we iterate the values in the document's font faces.
+
+```js
+document.fonts.ready.then(function() {
+  
+  log.textContent+=(`\nFontFaces in document: ${document.fonts.size}.\n`);
+
+  for (const fontFace of document.fonts.values()) {
+    log.textContent+='FontFace:\n';
+    for (const property in fontFace) {
+      log.textContent+=`  ${property}: ${fontFace[property]}\n`;
+    }
+  }
+});
+```
+
+#### Result
+
+The output below shows the text drawn in "Oxygen" font.
+This also shows logging from the events and when the promise returned by `document.fonts.ready` resolves.
+
+{{ EmbedLiveSample('Font loading with events', 700, 520) }}
 
 ## Specifications
 

--- a/files/en-us/web/api/css_font_loading_api/index.md
+++ b/files/en-us/web/api/css_font_loading_api/index.md
@@ -40,7 +40,7 @@ The status is set to `loaded` when the font face data has been successfully fetc
 
 ### Defining a font face
 
-Font faces are created using the [`FontFace` constructor](/en-US/docs/Web/API/FontFace/FontFace), which takes as arguments: the font family, the font source, and optional descriptors.
+Font faces are created using the [`FontFace` constructor](/en-US/docs/Web/API/FontFace/FontFace), which takes as parameters: the font family, the font source, and optional descriptors.
 The format and grammar of these arguments is the same as the equivalent [`@font-face`](/en-US/docs/Web/CSS/@font-face) definition.
 
 The font source can either be binary data in an [`ArrayBuffer`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) or a font resource at an URL.
@@ -68,14 +68,14 @@ Font faces are usually added to the document or worker {{domxref('FontFaceSet')}
 The code below shows a font face being added to the document.
 
 ```js
-//Define a FontFace
+// Define a FontFace
 const font = new FontFace('myfont', 'url(myfont.woff)', {
   style: 'italic',
   weight: '400',
   stretch: 'condensed'
 });
 
-//Add to the document.fonts (FontFaceSet)
+// Add to the document.fonts (FontFaceSet)
 document.fonts.add(font);
 ```
 
@@ -87,16 +87,16 @@ Note that attempting to load an already-loaded font has no effect.
 The code below shows how to define a font face, add it to the document fonts, and then initiate a font load.
 
 ```js
-//Define a FontFace
+// Define a FontFace
 const font = new FontFace('myfont', 'url(myfont.woff)');
 
-//Add to the document.fonts (FontFaceSet)
+// Add to the document.fonts (FontFaceSet)
 document.fonts.add(font);
 
-//Load the font
+// Load the font
 font.load();
 
-//Wait until the fonts are all loaded
+// Wait until the fonts are all loaded
 document.fonts.ready.then( () => {
   // Use the font to render text (for example, in a canvas) 
 });
@@ -113,7 +113,6 @@ Using [`document.fonts.ready`](/en-US/docs/Web/API/FontFaceSet/ready) can be bet
   - : An interface loading font faces and checking their download statuses.
 - {{domxref('FontFaceSetLoadEvent')}}
   - : Fired whenever a {{domxref("FontFaceSet")}} loads.
-
 
 ## Examples
 
@@ -147,9 +146,9 @@ Next we define a `FontFace` that has a URL source that is a Google Font and add 
 We then log the font status, which should be `unloaded`.
 
 ```js
-let bitterFontFace = new FontFace('FontFamily Bitter', 'url(https://fonts.gstatic.com/s/bitter/v7/HEpP8tJXlWaYHimsnXgfCOvvDin1pK8aKteLpeZ5c0A.woff2)');
+const bitterFontFace = new FontFace('FontFamily Bitter', 'url(https://fonts.gstatic.com/s/bitter/v7/HEpP8tJXlWaYHimsnXgfCOvvDin1pK8aKteLpeZ5c0A.woff2)');
 document.fonts.add(bitterFontFace);
-log.textContent+=`Bitter font: ${bitterFontFace.status}\n`;  // > Bitter status: unloaded
+log.textContent += `Bitter font: ${bitterFontFace.status}\n`;  // > Bitter font: unloaded
 ```
 
 Then we call the {{domxref('FontFace.load()')}} method to load the font face, and wait on the returned promise.
@@ -157,9 +156,9 @@ Once the promise resolves we log the loaded status (which should be `loaded`) an
 
 ```js
 bitterFontFace.load().then(() => {
-  log.textContent+=`Bitter font: ${bitterFontFace.status}\n`;  // > Bitter status: loaded
+  log.textContent += `Bitter font: ${bitterFontFace.status}\n`;  // > Bitter font: loaded
 
-  const ctx = mycanvas.getContext('2d')
+  const ctx = canvas.getContext('2d')
   ctx.font = '36px "FontFamily Bitter"'
   ctx.fillText('Bitter font loaded', 20, 50)
 
@@ -197,14 +196,14 @@ The code below defines a canvas context for drawing text, defines a font face, a
 ```js
 const log = document.getElementById('log');
 
-const mycanvas = document.getElementById("js-canvas");
-mycanvas.width = 650;
-mycanvas.height = 75;
-const ctx = mycanvas.getContext('2d')
+const canvas = document.getElementById("js-canvas");
+canvas.width = 650;
+canvas.height = 75;
+const ctx = canvas.getContext('2d')
 
-let oxygenFontFace = new FontFace('FontFamily Oxygen', 'url(https://fonts.gstatic.com/s/oxygen/v5/qBSyz106i5ud7wkBU-FrPevvDin1pK8aKteLpeZ5c0A.woff2)');
+const oxygenFontFace = new FontFace('FontFamily Oxygen', 'url(https://fonts.gstatic.com/s/oxygen/v5/qBSyz106i5ud7wkBU-FrPevvDin1pK8aKteLpeZ5c0A.woff2)');
 document.fonts.add(oxygenFontFace);
-log.textContent+=`Oxygen status: ${oxygenFontFace.status}\n`;
+log.textContent += `Oxygen status: ${oxygenFontFace.status}\n`;
 ```
 
 Next we use `load()` on the font face set to load the font, specifying which of the fonts to load.
@@ -214,8 +213,8 @@ If it is rejected the error is logged.
 
 ```js
 document.fonts.load('36px FontFamily Oxygen').then((fonts) => {
-  log.textContent+=`Bitter font: ${fonts}\n`;  // > Oxygen font: loaded
-  log.textContent+=`Bitter font: ${oxygenFontFace.status}\n`;  // > Oxygen font: loaded
+  log.textContent += `Bitter font: ${fonts}\n`;  // > Oxygen font: loaded
+  log.textContent += `Bitter font: ${oxygenFontFace.status}\n`;  // > Oxygen font: loaded
   ctx.font = '36px "FontFamily Oxygen"'
   ctx.fillText('Oxygen font loaded', 20, 50)
   },
@@ -230,15 +229,15 @@ In the `loadingdone` event listener we additionally iterate through the font fac
 
 ```js
 document.fonts.addEventListener('loading', (event) => { 
-  log.textContent+=`loading_event: ${event.fontfaces.length}\n`;
+  log.textContent += `loading_event: ${event.fontfaces.length}\n`;
 });
 document.fonts.addEventListener('loadingerror', (event) => { 
-  log.textContent+=`loadingerror_event: ${event.fontfaces.length}\n`;
+  log.textContent += `loadingerror_event: ${event.fontfaces.length}\n`;
 });
 document.fonts.addEventListener('loadingdone', (event) => { 
-  log.textContent+=`loadingdone_event: ${event.fontfaces.length}\n`;
+  log.textContent += `loadingdone_event: ${event.fontfaces.length}\n`;
   event.fontfaces.forEach( (value) => {
-    log.textContent+=`  fontface: ${value.family}\n`;
+    log.textContent += `  fontface: ${value.family}\n`;
   });
 });
 ```
@@ -250,13 +249,12 @@ When the promise resolves we iterate the values in the document's font faces.
 
 ```js
 document.fonts.ready.then(function() {
-  
-  log.textContent+=(`\nFontFaces in document: ${document.fonts.size}.\n`);
+  log.textContent += (`\nFontFaces in document: ${document.fonts.size}.\n`);
 
   for (const fontFace of document.fonts.values()) {
-    log.textContent+='FontFace:\n';
+    log.textContent += 'FontFace:\n';
     for (const property in fontFace) {
-      log.textContent+=`  ${property}: ${fontFace[property]}\n`;
+      log.textContent += `  ${property}: ${fontFace[property]}\n`;
     }
   }
 });

--- a/files/en-us/web/api/css_font_loading_api/index.md
+++ b/files/en-us/web/api/css_font_loading_api/index.md
@@ -48,17 +48,17 @@ A typical font face definition using a URL source might be as shown below.
 Note that the `url()` function is required for URL font sources.
 
 ```js
-const font = new FontFace('myfont', 'url(myfont.woff)', {
-  style: 'italic',
-  weight: '400',
-  stretch: 'condensed'
+const font = new FontFace("myfont", "url(myfont.woff)", {
+  style: "italic",
+  weight: "400",
+  stretch: "condensed",
 });
 ```
 
 > **Note:** As with `@font-face`, some descriptors represent the expected data in the font data and are used for font matching, while others actually set/define properties of the generated font face.
 > For example, setting the `style` to "italic" indicates that the file contains italic fonts; it is up to the author to specify a file for which this is true.
 
-Font faces with a _binary source_ are automatically loaded if the font definition is valid and the font data can be loaded — {{domxref('FontFace.status')}} is set to `loaded` on success and `failed` otherwise.  
+Font faces with a _binary source_ are automatically loaded if the font definition is valid and the font data can be loaded — {{domxref('FontFace.status')}} is set to `loaded` on success and `failed` otherwise.
 Font faces with a URL source are validated but not automatically loaded — {{domxref('FontFace.status')}} is set `unloaded` if the font face definition is valid and `failed` otherwise.
 
 ### Adding a font to a document or worker
@@ -69,10 +69,10 @@ The code below shows a font face being added to the document.
 
 ```js
 // Define a FontFace
-const font = new FontFace('myfont', 'url(myfont.woff)', {
-  style: 'italic',
-  weight: '400',
-  stretch: 'condensed'
+const font = new FontFace("myfont", "url(myfont.woff)", {
+  style: "italic",
+  weight: "400",
+  stretch: "condensed",
 });
 
 // Add to the document.fonts (FontFaceSet)
@@ -88,7 +88,7 @@ The code below shows how to define a font face, add it to the document fonts, an
 
 ```js
 // Define a FontFace
-const font = new FontFace('myfont', 'url(myfont.woff)');
+const font = new FontFace("myfont", "url(myfont.woff)");
 
 // Add to the document.fonts (FontFaceSet)
 document.fonts.add(font);
@@ -97,8 +97,8 @@ document.fonts.add(font);
 font.load();
 
 // Wait until the fonts are all loaded
-document.fonts.ready.then( () => {
-  // Use the font to render text (for example, in a canvas) 
+document.fonts.ready.then(() => {
+  // Use the font to render text (for example, in a canvas)
 });
 ```
 
@@ -135,7 +135,7 @@ This code defines a canvas for drawing to and a textarea for logging.
 First we get the element to which we will log, and the canvas that will be used to render text in the downloaded font.
 
 ```js
-const log = document.getElementById('log');
+const log = document.getElementById("log");
 
 const canvas = document.getElementById("js-canvas");
 canvas.width = 650;
@@ -146,26 +146,30 @@ Next we define a `FontFace` that has a URL source that is a Google Font and add 
 We then log the font status, which should be `unloaded`.
 
 ```js
-const bitterFontFace = new FontFace('FontFamily Bitter', 'url(https://fonts.gstatic.com/s/bitter/v7/HEpP8tJXlWaYHimsnXgfCOvvDin1pK8aKteLpeZ5c0A.woff2)');
+const bitterFontFace = new FontFace(
+  "FontFamily Bitter",
+  "url(https://fonts.gstatic.com/s/bitter/v7/HEpP8tJXlWaYHimsnXgfCOvvDin1pK8aKteLpeZ5c0A.woff2)"
+);
 document.fonts.add(bitterFontFace);
-log.textContent += `Bitter font: ${bitterFontFace.status}\n`;  // > Bitter font: unloaded
+log.textContent += `Bitter font: ${bitterFontFace.status}\n`; // > Bitter font: unloaded
 ```
 
 Then we call the {{domxref('FontFace.load()')}} method to load the font face, and wait on the returned promise.
 Once the promise resolves we log the loaded status (which should be `loaded`) and draw text in the loaded font to the canvas.
 
 ```js
-bitterFontFace.load().then(() => {
-  log.textContent += `Bitter font: ${bitterFontFace.status}\n`;  // > Bitter font: loaded
+bitterFontFace.load().then(
+  () => {
+    log.textContent += `Bitter font: ${bitterFontFace.status}\n`; // > Bitter font: loaded
 
-  const ctx = canvas.getContext('2d')
-  ctx.font = '36px "FontFamily Bitter"'
-  ctx.fillText('Bitter font loaded', 20, 50)
-
+    const ctx = canvas.getContext("2d");
+    ctx.font = '36px "FontFamily Bitter"';
+    ctx.fillText("Bitter font loaded", 20, 50);
   },
-(err) => {
-  console.error(err)
-});
+  (err) => {
+    console.error(err);
+  }
+);
 ```
 
 Note that we could also have waited on the promise returned by the {{domxref('FontFace.loaded')}} property, or on {{domxref('FontFaceSet.ready')}}.
@@ -194,14 +198,17 @@ It also demonstrates how to listen for font loading events.
 The code below defines a canvas context for drawing text, defines a font face, and adds it to the document font face set.
 
 ```js
-const log = document.getElementById('log');
+const log = document.getElementById("log");
 
 const canvas = document.getElementById("js-canvas");
 canvas.width = 650;
 canvas.height = 75;
-const ctx = canvas.getContext('2d')
+const ctx = canvas.getContext("2d");
 
-const oxygenFontFace = new FontFace('FontFamily Oxygen', 'url(https://fonts.gstatic.com/s/oxygen/v5/qBSyz106i5ud7wkBU-FrPevvDin1pK8aKteLpeZ5c0A.woff2)');
+const oxygenFontFace = new FontFace(
+  "FontFamily Oxygen",
+  "url(https://fonts.gstatic.com/s/oxygen/v5/qBSyz106i5ud7wkBU-FrPevvDin1pK8aKteLpeZ5c0A.woff2)"
+);
 document.fonts.add(oxygenFontFace);
 log.textContent += `Oxygen status: ${oxygenFontFace.status}\n`;
 ```
@@ -212,15 +219,17 @@ If the promise is resolved we use the font to draw some text.
 If it is rejected the error is logged.
 
 ```js
-document.fonts.load('36px FontFamily Oxygen').then((fonts) => {
-  log.textContent += `Bitter font: ${fonts}\n`;  // > Oxygen font: loaded
-  log.textContent += `Bitter font: ${oxygenFontFace.status}\n`;  // > Oxygen font: loaded
-  ctx.font = '36px "FontFamily Oxygen"'
-  ctx.fillText('Oxygen font loaded', 20, 50)
+document.fonts.load("36px FontFamily Oxygen").then(
+  (fonts) => {
+    log.textContent += `Bitter font: ${fonts}\n`; // > Oxygen font: loaded
+    log.textContent += `Bitter font: ${oxygenFontFace.status}\n`; // > Oxygen font: loaded
+    ctx.font = '36px "FontFamily Oxygen"';
+    ctx.fillText("Oxygen font loaded", 20, 50);
   },
-(err) => {
-  console.error(err)
-});
+  (err) => {
+    console.error(err);
+  }
+);
 ```
 
 Instead of waiting on a promise we might instead use events to track the font loading operation.
@@ -228,15 +237,15 @@ The code below listens for the `loading` and `loadingerror` events and logs the 
 In the `loadingdone` event listener we additionally iterate through the font faces and log the family names.
 
 ```js
-document.fonts.addEventListener('loading', (event) => { 
+document.fonts.addEventListener("loading", (event) => {
   log.textContent += `loading_event: ${event.fontfaces.length}\n`;
 });
-document.fonts.addEventListener('loadingerror', (event) => { 
+document.fonts.addEventListener("loadingerror", (event) => {
   log.textContent += `loadingerror_event: ${event.fontfaces.length}\n`;
 });
-document.fonts.addEventListener('loadingdone', (event) => { 
+document.fonts.addEventListener("loadingdone", (event) => {
   log.textContent += `loadingdone_event: ${event.fontfaces.length}\n`;
-  event.fontfaces.forEach( (value) => {
+  event.fontfaces.forEach((value) => {
     log.textContent += `  fontface: ${value.family}\n`;
   });
 });
@@ -248,11 +257,11 @@ Unlike the other mechanisms this returns when all fonts defined in the document 
 When the promise resolves we iterate the values in the document's font faces.
 
 ```js
-document.fonts.ready.then(function() {
-  log.textContent += (`\nFontFaces in document: ${document.fonts.size}.\n`);
+document.fonts.ready.then(function () {
+  log.textContent += `\nFontFaces in document: ${document.fonts.size}.\n`;
 
   for (const fontFace of document.fonts.values()) {
-    log.textContent += 'FontFace:\n';
+    log.textContent += "FontFace:\n";
     for (const property in fontFace) {
       log.textContent += `  ${property}: ${fontFace[property]}\n`;
     }

--- a/files/en-us/web/api/document/fonts/index.md
+++ b/files/en-us/web/api/document/fonts/index.md
@@ -18,7 +18,7 @@ browser-compat: api.Document.fonts
 
 The **`fonts`** property of the {{domxref("Document")}} interface returns the {{domxref("FontFaceSet")}} interface of the document.
 
-This is part of the [CSS Font Loading API](/en-US/docs/Web/API/CSS_Font_Loading_API).
+This feature is part of the [CSS Font Loading API](/en-US/docs/Web/API/CSS_Font_Loading_API).
 
 ## Value
 

--- a/files/en-us/web/api/event/index.md
+++ b/files/en-us/web/api/event/index.md
@@ -43,6 +43,7 @@ Note that all event interfaces have names which end in "Event".
 - {{domxref("ErrorEvent")}}
 - {{domxref("FetchEvent")}}
 - {{domxref("FocusEvent")}}
+- {{domxref("FontFaceSetLoadEvent")}}
 - {{domxref("FormDataEvent")}}
 - {{domxref("GamepadEvent")}}
 - {{domxref("HashChangeEvent")}}

--- a/files/en-us/web/api/fontface/ascentoverride/index.md
+++ b/files/en-us/web/api/fontface/ascentoverride/index.md
@@ -13,11 +13,16 @@ browser-compat: api.FontFace.ascentOverride
 
 {{APIRef("CSS Font Loading API")}}
 
-The **`ascentOverride`** property of the {{domxref("FontFace")}} interface returns and sets the value of the {{cssxref("@font-face/ascent-override")}} descriptor. The possible values are `normal`, indicating that the metric used should be obtained from the font file, or a percentage.
+The **`ascentOverride`** property of the {{domxref("FontFace")}} interface returns and sets the ascent metric for the font.
+This is the height above the baseline that CSS uses to lay out line boxes in an inline formatting context
+
+This is equivalent to the {{cssxref("@font-face/ascent-override")}} descriptor of {{cssxref("@font-face")}}.
 
 ## Value
 
-A string.
+A string. The possible values are `normal`, indicating that the metric used should be obtained from the font file, or a percentage.
+
+This take the same values as the {{cssxref("@font-face/ascent-override")}} descriptor.
 
 ## Examples
 

--- a/files/en-us/web/api/fontface/ascentoverride/index.md
+++ b/files/en-us/web/api/fontface/ascentoverride/index.md
@@ -13,16 +13,16 @@ browser-compat: api.FontFace.ascentOverride
 
 {{APIRef("CSS Font Loading API")}}
 
-The **`ascentOverride`** property of the {{domxref("FontFace")}} interface returns and sets the ascent metric for the font.
-This is the height above the baseline that CSS uses to lay out line boxes in an inline formatting context
+The **`ascentOverride`** property of the {{domxref("FontFace")}} interface returns and sets the ascent metric for the font,
+the height above the baseline that CSS uses to lay out line boxes in an inline formatting context.
 
-This is equivalent to the {{cssxref("@font-face/ascent-override")}} descriptor of {{cssxref("@font-face")}}.
+This property is equivalent to the {{cssxref("@font-face/ascent-override")}} descriptor of {{cssxref("@font-face")}}.
 
 ## Value
 
 A string. The possible values are `normal`, indicating that the metric used should be obtained from the font file, or a percentage.
 
-This take the same values as the {{cssxref("@font-face/ascent-override")}} descriptor.
+This property accepts the same values as the {{cssxref("@font-face/ascent-override")}} descriptor.
 
 ## Examples
 

--- a/files/en-us/web/api/fontface/ascentoverride/index.md
+++ b/files/en-us/web/api/fontface/ascentoverride/index.md
@@ -13,8 +13,7 @@ browser-compat: api.FontFace.ascentOverride
 
 {{APIRef("CSS Font Loading API")}}
 
-The **`ascentOverride`** property of the {{domxref("FontFace")}} interface returns and sets the ascent metric for the font,
-the height above the baseline that CSS uses to lay out line boxes in an inline formatting context.
+The **`ascentOverride`** property of the {{domxref("FontFace")}} interface returns and sets the ascent metric for the font, the height above the baseline that CSS uses to lay out line boxes in an inline formatting context.
 
 This property is equivalent to the {{cssxref("@font-face/ascent-override")}} descriptor of {{cssxref("@font-face")}}.
 

--- a/files/en-us/web/api/fontface/descentoverride/index.md
+++ b/files/en-us/web/api/fontface/descentoverride/index.md
@@ -13,7 +13,8 @@ browser-compat: api.FontFace.descentOverride
 
 {{APIRef("CSS Font Loading API")}}
 
-The **`descentOverride`** property of the {{domxref("FontFace")}} interface returns and sets the value of the {{cssxref("@font-face/descent-override")}} descriptor. The possible values are `normal`, indicating that the metric used should be obtained from the font file, or a percentage.
+The **`descentOverride`** property of the {{domxref("FontFace")}} interface returns and sets the value of the {{cssxref("@font-face/descent-override")}} descriptor.
+The possible values are `normal`, indicating that the metric used should be obtained from the font file, or a percentage.
 
 ## Value
 

--- a/files/en-us/web/api/fontface/display/index.md
+++ b/files/en-us/web/api/fontface/display/index.md
@@ -16,46 +16,38 @@ browser-compat: api.FontFace.display
 
 {{APIRef("CSS Font Loading API")}}
 
-The **`display`** property of the {{domxref("FontFace")}}
-interface determines how a font face is displayed based on whether and when it is
-downloaded and ready to use. This property is equivalent to the CSS
-`font-display` descriptor.
+The **`display`** property of the {{domxref("FontFace")}} interface determines how a font face is displayed based on whether and when it is downloaded and ready to use.
+This property is equivalent to the CSS `font-display` descriptor.
 
-When this property is used, font loading has a timeline with three periods. The lengths
-of the first two periods depend on the value of the property and the user agent. (See
-below.)
+When this property is used, font loading has a timeline with three periods.
+The lengths of the first two periods depend on the value of the property and the user agent.
+(See below.)
 
 - block period
-  - : The browser invisibly prepares a fallback font. If the font face loads during this
-    time, it's used to display the text and display is complete.
+  - : The browser invisibly prepares a fallback font. If the font face loads during this time, it's used to display the text and display is complete.
 - swap period
-  - : If the font face is still not loaded, the fallback font will be shown. When the font
-    face loads, the fallback will be swapped for the downloaded font.
+  - : If the font face is still not loaded, the fallback font will be shown.
+    When the font face loads, the fallback will be swapped for the downloaded font.
 - failure period
-  - : If the font face still is not loaded, the fallback font will be shown and no swap
-    will occur.
+  - : If the font face still is not loaded, the fallback font will be shown and no swap will occur.
 
 ## Value
 
 A string with one of the following values.
 
-- `'auto'`
+- `auto`
   - : Use the font display strategy provided by the user agent.
-- `'block'`
-  - : Gives the font face a short block period and an infinite swap
-    period. The spec recommends 3 seconds for the block period, though this may vary from
-    browser to browser.
-- `'fallback'`
-  - : Gives the font face a short block period and a short swap
-    period. The spec recommends 100 ms or less for the block period and 3 seconds for the
-    swap period, though these values may vary from browser to browser.
-- `'optional'`
-  - : Gives the font face a short block period and no swap
-    period. The spec recommends 100 ms or less, though this may vary from browser to
-    browser.
-- `'swap'`
-  - : Gives the font face a 0 second block period and an infinite
-    swap period.
+- `block`
+  - : Gives the font face a short block period and an infinite swap period.
+    The spec recommends 3 seconds for the block period, though this may vary from browser to browser.
+- `fallback`
+  - : Gives the font face a short block period and a short swap period.
+    The spec recommends 100 ms or less for the block period and 3 seconds for the swap period, though these values may vary from browser to browser.
+- `optional`
+  - : Gives the font face a short block period and no swap period.
+    The spec recommends 100 ms or less, though this may vary from browser to browser.
+- `swap`
+  - : Gives the font face a 0 second block period and an infinite swap period.
 
 ## Specifications
 

--- a/files/en-us/web/api/fontface/family/index.md
+++ b/files/en-us/web/api/fontface/family/index.md
@@ -16,10 +16,8 @@ browser-compat: api.FontFace.family
 
 {{APIRef("CSS Font Loading API")}}
 
-The **`FontFace.family`** property
-allows the author to get or set the font family of a {{domxref("FontFace")}} object.
-This is equivalent to the {{cssxref("@font-face/font-family", "font-family")}}
-descriptor of {{cssxref("@font-face")}}.
+The **`FontFace.family`** property allows the author to get or set the font family of a {{domxref("FontFace")}} object.
+This is equivalent to the {{cssxref("@font-face/font-family", "font-family")}} descriptor of {{cssxref("@font-face")}}.
 
 ## Value
 

--- a/files/en-us/web/api/fontface/family/index.md
+++ b/files/en-us/web/api/fontface/family/index.md
@@ -21,7 +21,7 @@ The **`FontFace.family`** property allows the author to get or set the font fami
 The value is used for name matching against a particular font face when styling elements using the [`font-family`](/en-US/docs/Web/CSS/font-family) property.
 Any name may be used, and this overrides any name specified in the underlying font data.
 
-This is equivalent to the {{cssxref("@font-face/font-family", "font-family")}} descriptor of {{cssxref("@font-face")}}.
+This property is equivalent to the {{cssxref("@font-face/font-family", "font-family")}} descriptor of {{cssxref("@font-face")}}.
 
 ## Value
 

--- a/files/en-us/web/api/fontface/family/index.md
+++ b/files/en-us/web/api/fontface/family/index.md
@@ -17,6 +17,10 @@ browser-compat: api.FontFace.family
 {{APIRef("CSS Font Loading API")}}
 
 The **`FontFace.family`** property allows the author to get or set the font family of a {{domxref("FontFace")}} object.
+
+The value is used for name matching against a particular font face when styling elements using the [`font-family`](/en-US/docs/Web/CSS/font-family) property.
+Any name may be used, and this overrides any name specified in the underlying font data.
+
 This is equivalent to the {{cssxref("@font-face/font-family", "font-family")}} descriptor of {{cssxref("@font-face")}}.
 
 ## Value

--- a/files/en-us/web/api/fontface/featuresettings/index.md
+++ b/files/en-us/web/api/fontface/featuresettings/index.md
@@ -17,7 +17,8 @@ browser-compat: api.FontFace.featureSettings
 {{APIRef("CSS Font Loading API")}}
 
 The **`featureSettings`** property of the {{domxref("FontFace")}} interface retrieves or sets infrequently used font features that are not available from a font's variant properties.
-It is equivalent to the {{cssxref("font-feature-settings")}} descriptor.
+
+This property is equivalent to the {{cssxref("font-feature-settings")}} descriptor.
 
 ## Value
 

--- a/files/en-us/web/api/fontface/featuresettings/index.md
+++ b/files/en-us/web/api/fontface/featuresettings/index.md
@@ -16,10 +16,8 @@ browser-compat: api.FontFace.featureSettings
 
 {{APIRef("CSS Font Loading API")}}
 
-The **`featureSettings`** property of the
-{{domxref("FontFace")}} interface retrieves or sets infrequently used font features that
-are not available from a font's variant properties. It is equivalent to the
-{{cssxref("@font-face/font-feature-settings", "font-feature-settings")}} descriptor.
+The **`featureSettings`** property of the {{domxref("FontFace")}} interface retrieves or sets infrequently used font features that are not available from a font's variant properties.
+It is equivalent to the {{cssxref("font-feature-settings")}} descriptor.
 
 ## Value
 

--- a/files/en-us/web/api/fontface/fontface/index.md
+++ b/files/en-us/web/api/fontface/fontface/index.md
@@ -15,8 +15,7 @@ browser-compat: api.FontFace.FontFace
 
 {{APIRef("CSS Font Loading API")}}
 
-The **`FontFace()`** constructor creates a new
-{{domxref("FontFace")}} object.
+The **`FontFace()`** constructor creates a new {{domxref("FontFace")}} object.
 
 ## Syntax
 
@@ -28,19 +27,21 @@ new FontFace(family, source, descriptors)
 ### Parameters
 
 - `family`
-  - : Specifies a name that will be used as the font face value for font properties. Takes
-    the same type of values as the {{cssxref("@font-face/font-family", "font-family")}}
-    descriptor of {{cssxref("@font-face")}} .
+  - : Specifies a name that will be used as the font face value for font properties.
+    Takes the same type of values as the {{cssxref("@font-face/font-family", "font-family")}} descriptor of {{cssxref("@font-face")}}.
+
 - `source`
 
-  - : The font source. This can be either:
+  - : The font source.
+    This can be either:
 
-    - A URL
-    - Binary font data
+    - A URL to a font face file.
+    - Binary font face data in an [`ArrayBuffer`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) (or {{domxref("ArrayBufferView")}}).
 
 - `descriptors` {{optional_inline}}
 
-  - : A set of optional descriptors passed as an object. It can contain any of the descriptors available for `@font-face`:
+  - : A set of optional descriptors passed as an object.
+    It can contain any of the descriptors available for `@font-face`:
 
     - `ascentOverride`
       - : With an allowable value for {{cssxref("@font-face/ascent-override")}}.
@@ -62,6 +63,11 @@ new FontFace(family, source, descriptors)
       - : With an allowable value for {{cssxref("@font-face/font-variation-settings")}}.
     - `weight`
       - : With an allowable value for {{cssxref("@font-face/font-weight")}}.
+
+### Exceptions
+
+- `SyntaxError` {{domxref("DOMException")}}
+  - : A descriptor string does not match the grammar of the corresponding {{cssxref("@font-face")}} descriptor.
 
 ## Examples
 

--- a/files/en-us/web/api/fontface/fontface/index.md
+++ b/files/en-us/web/api/fontface/fontface/index.md
@@ -69,7 +69,7 @@ new FontFace(family, source, descriptors)
 ### Exceptions
 
 - `SyntaxError` {{domxref("DOMException")}}
-  - : A descriptor string does not match the grammar of the corresponding {{cssxref("@font-face")}} descriptor, or the specified binary source cannot be loaded.
+  - : Thrown when a descriptor string does not match the grammar of the corresponding {{cssxref("@font-face")}} descriptor, or the specified binary source cannot be loaded.
     This error results in {{domxref("FontFace.status")}} being set to `error`.
 
 ## Examples

--- a/files/en-us/web/api/fontface/fontface/index.md
+++ b/files/en-us/web/api/fontface/fontface/index.md
@@ -27,8 +27,10 @@ new FontFace(family, source, descriptors)
 ### Parameters
 
 - `family`
-  - : Specifies a name that will be used as the font face value for font properties.
+  - : Specifies a font family name that can be used to match against this font face when styling elements.
+
     Takes the same type of values as the {{cssxref("@font-face/font-family", "font-family")}} descriptor of {{cssxref("@font-face")}}.
+    This value may also be read and set using the [`FontFace.family`](/en-US/docs/Web/API/FontFace/family) property.
 
 - `source`
 

--- a/files/en-us/web/api/fontface/fontface/index.md
+++ b/files/en-us/web/api/fontface/fontface/index.md
@@ -46,25 +46,25 @@ new FontFace(family, source, descriptors)
   - : A set of optional descriptors passed as an object.
     It can contain any of the descriptors available for `@font-face`:
 
-    - [`ascentOverride`](/en-US/docs/Web/API/FontFace/ascentOverride)
+    - `ascentOverride`
       - : With an allowable value for {{cssxref("@font-face/ascent-override")}}.
-    - [`descentOverride`](/en-US/docs/Web/API/FontFace/descentOverride)
+    - `descentOverride`
       - : With an allowable value for {{cssxref("@font-face/descent-override")}}.
-    - [`featureSettings`](/en-US/docs/Web/API/FontFace/featureSettings)
+    - `featureSettings`
       - : With an allowable value for {{cssxref("font-feature-settings")}}.
-    - [`lineGapOverride`](/en-US/docs/Web/API/FontFace/lineGapOverride)
+    - `lineGapOverride`
       - : With an allowable value for {{cssxref("@font-face/line-gap-override")}}.
-    - [`stretch`](/en-US/docs/Web/API/FontFace/stretch)
+    - `stretch`
       - : With an allowable value for {{cssxref("@font-face/font-stretch")}}.
-    - [`style`](/en-US/docs/Web/API/FontFace/style)
+    - `style`
       - : With an allowable value for {{cssxref("@font-face/font-style")}}.
-    - [`unicodeRange`](/en-US/docs/Web/API/FontFace/unicodeRange)
+    - `unicodeRange`
       - : With an allowable value for {{cssxref("@font-face/unicode-range")}}.
-    - [`variant`](/en-US/docs/Web/API/FontFace/variant)
+    - `variant`
       - : With an allowable value for {{cssxref("@font-face/font-variant")}}.
-    - [`variationSettings`](/en-US/docs/Web/API/FontFace/variationSettings)
+    - `variationSettings`
       - : With an allowable value for {{cssxref("@font-face/font-variation-settings")}}.
-    - [`weight`](/en-US/docs/Web/API/FontFace/weight)
+    - `weight`
       - : With an allowable value for {{cssxref("@font-face/font-weight")}}.
 
 ### Exceptions

--- a/files/en-us/web/api/fontface/fontface/index.md
+++ b/files/en-us/web/api/fontface/fontface/index.md
@@ -45,25 +45,25 @@ new FontFace(family, source, descriptors)
   - : A set of optional descriptors passed as an object.
     It can contain any of the descriptors available for `@font-face`:
 
-    - `ascentOverride`
+    - [`ascentOverride`](/en-US/docs/Web/API/FontFace/ascentOverride)
       - : With an allowable value for {{cssxref("@font-face/ascent-override")}}.
-    - `descentOverride`
+    - [`descentOverride`](/en-US/docs/Web/API/FontFace/descentOverride)
       - : With an allowable value for {{cssxref("@font-face/descent-override")}}.
-    - `featureSettings`
+    - [`featureSettings`](/en-US/docs/Web/API/FontFace/featureSettings)
       - : With an allowable value for {{cssxref("font-feature-settings")}}.
-    - `lineGapOverride`
+    - [`lineGapOverride`](/en-US/docs/Web/API/FontFace/lineGapOverride)
       - : With an allowable value for {{cssxref("@font-face/line-gap-override")}}.
-    - `stretch`
+    - [`stretch`](/en-US/docs/Web/API/FontFace/stretch)
       - : With an allowable value for {{cssxref("@font-face/font-stretch")}}.
-    - `style`
+    - [`style`](/en-US/docs/Web/API/FontFace/style)
       - : With an allowable value for {{cssxref("@font-face/font-style")}}.
-    - `unicodeRange`
+    - [`unicodeRange`](/en-US/docs/Web/API/FontFace/unicodeRange)
       - : With an allowable value for {{cssxref("@font-face/unicode-range")}}.
-    - `variant`
+    - [`variant`](/en-US/docs/Web/API/FontFace/variant)
       - : With an allowable value for {{cssxref("@font-face/font-variant")}}.
-    - `variationSettings`
+    - [`variationSettings`](/en-US/docs/Web/API/FontFace/variationSettings)
       - : With an allowable value for {{cssxref("@font-face/font-variation-settings")}}.
-    - `weight`
+    - [`weight`](/en-US/docs/Web/API/FontFace/weight)
       - : With an allowable value for {{cssxref("@font-face/font-weight")}}.
 
 ### Exceptions

--- a/files/en-us/web/api/fontface/fontface/index.md
+++ b/files/en-us/web/api/fontface/fontface/index.md
@@ -67,7 +67,7 @@ new FontFace(family, source, descriptors)
 ### Exceptions
 
 - `SyntaxError` {{domxref("DOMException")}}
-  - : A descriptor string does not match the grammar of the corresponding {{cssxref("@font-face")}} descriptor.
+  - : A descriptor string does not match the grammar of the corresponding {{cssxref("@font-face")}} descriptor, or the specified binary source cannot be loaded.
     This error results in {{domxref("FontFace.status")}} being set to `error`.
 
 ## Examples

--- a/files/en-us/web/api/fontface/fontface/index.md
+++ b/files/en-us/web/api/fontface/fontface/index.md
@@ -27,6 +27,7 @@ new FontFace(family, source, descriptors)
 ### Parameters
 
 - `family`
+
   - : Specifies a font family name that can be used to match against this font face when styling elements.
 
     Takes the same type of values as the {{cssxref("@font-face/font-family", "font-family")}} descriptor of {{cssxref("@font-face")}}.
@@ -76,17 +77,17 @@ new FontFace(family, source, descriptors)
 
 ```js
 async function loadFonts() {
-    const font = new FontFace('myfont', 'url(myfont.woff)',{
-      style: 'normal',
-      weight: '400',
-      stretch: 'condensed'
-      });
-    // wait for font to be loaded
-    await font.load();
-    // add font to document
-    document.fonts.add(font);
-    // enable font with CSS class
-    document.body.classList.add('fonts-loaded');
+  const font = new FontFace("myfont", "url(myfont.woff)", {
+    style: "normal",
+    weight: "400",
+    stretch: "condensed",
+  });
+  // wait for font to be loaded
+  await font.load();
+  // add font to document
+  document.fonts.add(font);
+  // enable font with CSS class
+  document.body.classList.add("fonts-loaded");
 }
 ```
 

--- a/files/en-us/web/api/fontface/fontface/index.md
+++ b/files/en-us/web/api/fontface/fontface/index.md
@@ -48,7 +48,7 @@ new FontFace(family, source, descriptors)
     - `descentOverride`
       - : With an allowable value for {{cssxref("@font-face/descent-override")}}.
     - `featureSettings`
-      - : With an allowable value for {{cssxref("@font-face/font-feature-settings")}}.
+      - : With an allowable value for {{cssxref("font-feature-settings")}}.
     - `lineGapOverride`
       - : With an allowable value for {{cssxref("@font-face/line-gap-override")}}.
     - `stretch`
@@ -68,6 +68,7 @@ new FontFace(family, source, descriptors)
 
 - `SyntaxError` {{domxref("DOMException")}}
   - : A descriptor string does not match the grammar of the corresponding {{cssxref("@font-face")}} descriptor.
+    This error results in {{domxref("FontFace.status")}} being set to `error`.
 
 ## Examples
 

--- a/files/en-us/web/api/fontface/index.md
+++ b/files/en-us/web/api/fontface/index.md
@@ -17,7 +17,8 @@ browser-compat: api.FontFace
 
 The **`FontFace`** interface of the [CSS Font Loading API](/en-US/docs/Web/API/CSS_Font_Loading_API) represents a single usable font face.
 
-It allows control of the source of the font face, being a URL to an external resource, or a buffer; it also allows control of when the font face is loaded and its current status.
+The interface defines the source of a font face, either a URL to an external resource or a buffer, and font properties such as the style, weight, and so on.
+For URL font sources it allows authors to trigger when the remote font is fetched and loaded, and to track loading status.
 
 ## Constructor
 

--- a/files/en-us/web/api/fontface/index.md
+++ b/files/en-us/web/api/fontface/index.md
@@ -17,7 +17,7 @@ browser-compat: api.FontFace
 
 The **`FontFace`** interface of the [CSS Font Loading API](/en-US/docs/Web/API/CSS_Font_Loading_API) represents a single usable font face.
 
-The interface defines the source of a font face, either a URL to an external resource or a buffer, and font properties such as the style, weight, and so on.
+This interface defines the source of a font face, either a URL to an external resource or a buffer, and font properties such as `style`, `weight`, and so on.
 For URL font sources it allows authors to trigger when the remote font is fetched and loaded, and to track loading status.
 
 ## Constructor

--- a/files/en-us/web/api/fontface/index.md
+++ b/files/en-us/web/api/fontface/index.md
@@ -16,6 +16,7 @@ browser-compat: api.FontFace
 {{APIRef("CSS Font Loading API")}}
 
 The **`FontFace`** interface of the [CSS Font Loading API](/en-US/docs/Web/API/CSS_Font_Loading_API) represents a single usable font face.
+
 It allows control of the source of the font face, being a URL to an external resource, or a buffer; it also allows control of when the font face is loaded and its current status.
 
 ## Constructor

--- a/files/en-us/web/api/fontface/index.md
+++ b/files/en-us/web/api/fontface/index.md
@@ -58,6 +58,38 @@ For URL font sources it allows authors to trigger when the remote font is fetche
 - {{domxref("FontFace.load()")}}
   - : Loads a font based on current object's constructor-passed requirements, including a location or source buffer, and returns a {{jsxref('Promise')}} that resolves with the current FontFace object.
 
+## Examples
+
+The code below defines a font face using data at the URL "myfont.woff" with a few font descriptors.
+Just to show how it works, we then define the `stretch` descriptor using a property.
+
+```js
+//Define a FontFace
+const font = new FontFace('myfont', 'url(myfont.woff)', {
+  style: 'italic',
+  weight: '400'
+});
+
+font.stretch = 'condensed';
+```
+
+Next we load the font using {{domxref("FontFace.load()")}} and use the returned promise to track completion or report an error.
+
+```js
+//Load the font
+font.load().then(() => {
+  // Resolved - add font to document.fonts
+  },
+(err) => {
+  console.error(err)
+});
+```
+
+To actually _use_ the font we will need to add it to a {{domxref("FontFaceSet")}}.
+We could do that before or after loading the font.
+
+For additional examples see [CSS Font Loading API > Examples](/en-US/docs/Web/API/CSS_Font_Loading_API#examples).
+
 ## Specifications
 
 {{Specifications}}

--- a/files/en-us/web/api/fontface/index.md
+++ b/files/en-us/web/api/fontface/index.md
@@ -15,7 +15,8 @@ browser-compat: api.FontFace
 
 {{APIRef("CSS Font Loading API")}}
 
-The **`FontFace`** interface represents a single usable font face. It allows control of the source of the font face, being a URL to an external resource, or a buffer; it also allows control of when the font face is loaded and its current status.
+The **`FontFace`** interface of the [CSS Font Loading API](/en-US/docs/Web/API/CSS_Font_Loading_API) represents a single usable font face.
+It allows control of the source of the font face, being a URL to an external resource, or a buffer; it also allows control of when the font face is loaded and its current status.
 
 ## Constructor
 
@@ -33,7 +34,7 @@ The **`FontFace`** interface represents a single usable font face. It allows con
 - {{domxref("FontFace.family")}}
   - : A string that retrieves or sets the _family_ of the font. It is equivalent to the {{cssxref("@font-face/font-family", "font-family")}} descriptor.
 - {{domxref("FontFace.featureSettings")}}
-  - : A string that retrieves or sets infrequently used font features that are not available from a font's variant properties. It is equivalent to the {{cssxref("@font-face/font-feature-settings", "font-feature-settings")}} descriptor.
+  - : A string that retrieves or sets infrequently used font features that are not available from a font's variant properties. It is equivalent to the CSS {{cssxref("font-feature-settings")}} property.
 - {{domxref("FontFace.lineGapOverride")}}
   - : A string that retrieves or sets the _line-gap metric_ of the font. It is equivalent to the {{cssxref("@font-face/line-gap-override", "line-gap-override")}} descriptor.
 - {{domxref("FontFace.loaded")}} {{ReadOnlyInline}}

--- a/files/en-us/web/api/fontface/linegapoverride/index.md
+++ b/files/en-us/web/api/fontface/linegapoverride/index.md
@@ -13,7 +13,8 @@ browser-compat: api.FontFace.lineGapOverride
 
 {{APIRef("CSS Font Loading API")}}
 
-The **`lineGapOverride`** property of the {{domxref("FontFace")}} interface returns and sets the value of the {{cssxref("@font-face/line-gap-override")}} descriptor. The possible values are `normal`, indicating that the metric used should be obtained from the font file, or a percentage.
+The **`lineGapOverride`** property of the {{domxref("FontFace")}} interface returns and sets the value of the {{cssxref("@font-face/line-gap-override")}} descriptor.
+The possible values are `normal`, indicating that the metric used should be obtained from the font file, or a percentage.
 
 ## Value
 

--- a/files/en-us/web/api/fontface/load/index.md
+++ b/files/en-us/web/api/fontface/load/index.md
@@ -32,8 +32,7 @@ None.
 
 ### Return value
 
-A {{jsxref('Promise')}} that resolves with a reference to the current `FontFace` object when the font loads or rejects with a `NetworkError` {{domxref("DOMException")}} if the
-loading process fails.
+A {{jsxref('Promise')}} that resolves with a reference to the current `FontFace` object when the font loads or rejects with a `NetworkError` {{domxref("DOMException")}} if the loading process fails.
 
 ### Exceptions
 
@@ -49,27 +48,32 @@ This simple example loads a font and uses it to display some text in a canvas el
 ```
 
 ```js
-const mycanvas = document.getElementById("js-canvas");
+const canvas = document.getElementById("js-canvas");
 
 // load the "Bitter" font from Google Fonts
-const fontFile = new FontFace('FontFamily Style Bitter', 'url(https://fonts.gstatic.com/s/bitter/v7/HEpP8tJXlWaYHimsnXgfCOvvDin1pK8aKteLpeZ5c0A.woff2)');
+const fontFile = new FontFace(
+  "FontFamily Style Bitter",
+  "url(https://fonts.gstatic.com/s/bitter/v7/HEpP8tJXlWaYHimsnXgfCOvvDin1pK8aKteLpeZ5c0A.woff2)"
+);
 document.fonts.add(fontFile);
 
-fontFile.load().then(() => {
-  // font loaded successfully!
-  mycanvas.width = 650;
-  mycanvas.height = 100;
-  const ctx = mycanvas.getContext('2d')
+fontFile.load().then(
+  () => {
+    // font loaded successfully!
+    canvas.width = 650;
+    canvas.height = 100;
+    const ctx = canvas.getContext("2d");
 
-  ctx.font = '36px "FontFamily Style Bitter"'
-  ctx.fillText('Bitter font loaded', 20, 50)
+    ctx.font = '36px "FontFamily Style Bitter"';
+    ctx.fillText("Bitter font loaded", 20, 50);
   },
-(err) => {
-  console.error(err)
-});
+  (err) => {
+    console.error(err);
+  }
+);
 ```
 
-{{EmbedLiveSample('Examples')}}:
+{{EmbedLiveSample('Examples')}}
 
 ## Specifications
 

--- a/files/en-us/web/api/fontface/load/index.md
+++ b/files/en-us/web/api/fontface/load/index.md
@@ -52,10 +52,10 @@ This simple example loads a font and uses it to display some text in a canvas el
 const mycanvas = document.getElementById("js-canvas");
 
 // load the "Bitter" font from Google Fonts
-let font_file = new FontFace('FontFamily Style Bitter', 'url(https://fonts.gstatic.com/s/bitter/v7/HEpP8tJXlWaYHimsnXgfCOvvDin1pK8aKteLpeZ5c0A.woff2)');
-document.fonts.add(font_file);
+const fontFile = new FontFace('FontFamily Style Bitter', 'url(https://fonts.gstatic.com/s/bitter/v7/HEpP8tJXlWaYHimsnXgfCOvvDin1pK8aKteLpeZ5c0A.woff2)');
+document.fonts.add(fontFile);
 
-font_file.load().then(() => {
+fontFile.load().then(() => {
   // font loaded successfully!
   mycanvas.width = 650;
   mycanvas.height = 100;

--- a/files/en-us/web/api/fontface/load/index.md
+++ b/files/en-us/web/api/fontface/load/index.md
@@ -53,6 +53,7 @@ const mycanvas = document.getElementById("js-canvas");
 
 // load the "Bitter" font from Google Fonts
 let font_file = new FontFace('FontFamily Style Bitter', 'url(https://fonts.gstatic.com/s/bitter/v7/HEpP8tJXlWaYHimsnXgfCOvvDin1pK8aKteLpeZ5c0A.woff2)');
+document.fonts.add(font_file);
 
 font_file.load().then(() => {
   // font loaded successfully!

--- a/files/en-us/web/api/fontface/loaded/index.md
+++ b/files/en-us/web/api/fontface/loaded/index.md
@@ -16,10 +16,7 @@ browser-compat: api.FontFace.loaded
 
 {{APIRef("CSS Font Loading API")}}
 
-The **`loaded`** read-only property of the
-{{domxref("FontFace")}} interface returns a {{jsxref('Promise')}} that resolves with the
-current `FontFace` object when the font specified in the object's constructor
-is done loading or rejects with a `SyntaxError`.
+The **`loaded`** read-only property of the {{domxref("FontFace")}} interface returns a {{jsxref('Promise')}} that resolves with the current `FontFace` object when the font specified in the object's constructor is done loading or rejects with a `SyntaxError`.
 
 ## Value
 

--- a/files/en-us/web/api/fontface/status/index.md
+++ b/files/en-us/web/api/fontface/status/index.md
@@ -16,15 +16,11 @@ browser-compat: api.FontFace.status
 
 {{APIRef("CSS Font Loading API")}}
 
-The **`status`** read-only property of the
-{{domxref("FontFace")}} interface returns an enumerated value indicating the status of
-the font, one of `"unloaded"`, `"loading"`, `"loaded"`,
-or `"error"`.
+The **`status`** read-only property of the {{domxref("FontFace")}} interface returns an enumerated value indicating the status of the font, one of `"unloaded"`, `"loading"`, `"loaded"`, or `"error"`.
 
 ## Value
 
-One of `"unloaded"`, `"loading"`, `"loaded"`, or
-`"error"`.
+One of `"unloaded"`, `"loading"`, `"loaded"`, or `"error"`.
 
 ## Specifications
 

--- a/files/en-us/web/api/fontface/stretch/index.md
+++ b/files/en-us/web/api/fontface/stretch/index.md
@@ -17,7 +17,8 @@ browser-compat: api.FontFace.stretch
 {{APIRef("CSS Font Loading API")}}
 
 The **`stretch`** property of the {{domxref("FontFace")}} interface retrieves or sets how the font stretches.
-It is equivalent to the {{cssxref("@font-face/font-stretch", "font-stretch")}} descriptor.
+
+This property is equivalent to the {{cssxref("@font-face/font-stretch", "font-stretch")}} descriptor.
 
 ## Value
 

--- a/files/en-us/web/api/fontface/stretch/index.md
+++ b/files/en-us/web/api/fontface/stretch/index.md
@@ -16,14 +16,12 @@ browser-compat: api.FontFace.stretch
 
 {{APIRef("CSS Font Loading API")}}
 
-The **`stretch`** property of the
-{{domxref("FontFace")}} interface retrieves or sets how the font stretches. It is
-equivalent to the {{cssxref("@font-face/font-stretch", "font-stretch")}} descriptor.
+The **`stretch`** property of the {{domxref("FontFace")}} interface retrieves or sets how the font stretches.
+It is equivalent to the {{cssxref("@font-face/font-stretch", "font-stretch")}} descriptor.
 
 ## Value
 
-A string containing a descriptor as it would be defined in a style
-sheet's `@font-face` rule.
+A string containing a descriptor as it would be defined in a style sheet's `@font-face` rule.
 
 ## Specifications
 

--- a/files/en-us/web/api/fontface/style/index.md
+++ b/files/en-us/web/api/fontface/style/index.md
@@ -16,14 +16,12 @@ browser-compat: api.FontFace.style
 
 {{APIRef("CSS Font Loading API")}}
 
-The **`style`** property of the
-{{domxref("FontFace")}} interface retrieves or sets the font's style. It is equivalent
-to the {{cssxref("@font-face/font-style", "font-style")}} descriptor.
+The **`style`** property of the {{domxref("FontFace")}} interface retrieves or sets the font's style.
+It is equivalent to the {{cssxref("@font-face/font-style", "font-style")}} descriptor.
 
 ## Value
 
-A string containing the descriptors defined in the style sheet's
-`@font-face` rule.
+A string containing the descriptors defined in the style sheet's `@font-face` rule.
 
 ## Specifications
 

--- a/files/en-us/web/api/fontface/style/index.md
+++ b/files/en-us/web/api/fontface/style/index.md
@@ -17,7 +17,8 @@ browser-compat: api.FontFace.style
 {{APIRef("CSS Font Loading API")}}
 
 The **`style`** property of the {{domxref("FontFace")}} interface retrieves or sets the font's style.
-It is equivalent to the {{cssxref("@font-face/font-style", "font-style")}} descriptor.
+
+This property is equivalent to the {{cssxref("@font-face/font-style", "font-style")}} descriptor.
 
 ## Value
 

--- a/files/en-us/web/api/fontface/unicoderange/index.md
+++ b/files/en-us/web/api/fontface/unicoderange/index.md
@@ -16,15 +16,12 @@ browser-compat: api.FontFace.unicodeRange
 
 {{APIRef("CSS Font Loading API")}}
 
-The **`unicodeRange`** property of the
-{{domxref("FontFace")}} interface retrieves or sets the range of unicode codepoints
-encompassing the font. It is equivalent to the {{cssxref("@font-face/unicode-range",
-  "unicode-range")}} descriptor.
+The **`unicodeRange`** property of the {{domxref("FontFace")}} interface retrieves or sets the range of unicode codepoints encompassing the font.
+It is equivalent to the {{cssxref("@font-face/unicode-range", "unicode-range")}} descriptor.
 
 ## Value
 
-A string containing a descriptor as it would appear in a style
-sheet's `@font-face` rule.
+A string containing a descriptor as it would appear in a style sheet's `@font-face` rule.
 
 ## Specifications
 

--- a/files/en-us/web/api/fontface/unicoderange/index.md
+++ b/files/en-us/web/api/fontface/unicoderange/index.md
@@ -17,7 +17,8 @@ browser-compat: api.FontFace.unicodeRange
 {{APIRef("CSS Font Loading API")}}
 
 The **`unicodeRange`** property of the {{domxref("FontFace")}} interface retrieves or sets the range of unicode codepoints encompassing the font.
-It is equivalent to the {{cssxref("@font-face/unicode-range", "unicode-range")}} descriptor.
+
+This property is equivalent to the {{cssxref("@font-face/unicode-range", "unicode-range")}} descriptor.
 
 ## Value
 

--- a/files/en-us/web/api/fontface/variationsettings/index.md
+++ b/files/en-us/web/api/fontface/variationsettings/index.md
@@ -16,10 +16,8 @@ browser-compat: api.FontFace.variationSettings
 
 {{APIRef("CSS Font Loading API")}}
 
-The **`variationSettings`** property of the
-{{domxref("FontFace")}} interface retrieves or sets low-level OpenType or TrueType font variations.
-It is equivalent to the
-{{cssxref("@font-face/font-variation-settings", "font-variation-settings")}} descriptor.
+The **`variationSettings`** property of the {{domxref("FontFace")}} interface retrieves or sets low-level OpenType or TrueType font variations.
+It is equivalent to the {{cssxref("@font-face/font-variation-settings", "font-variation-settings")}} descriptor.
 
 ## Value
 

--- a/files/en-us/web/api/fontface/variationsettings/index.md
+++ b/files/en-us/web/api/fontface/variationsettings/index.md
@@ -17,7 +17,8 @@ browser-compat: api.FontFace.variationSettings
 {{APIRef("CSS Font Loading API")}}
 
 The **`variationSettings`** property of the {{domxref("FontFace")}} interface retrieves or sets low-level OpenType or TrueType font variations.
-It is equivalent to the {{cssxref("@font-face/font-variation-settings", "font-variation-settings")}} descriptor.
+
+This property is equivalent to the {{cssxref("@font-face/font-variation-settings", "font-variation-settings")}} descriptor.
 
 ## Value
 

--- a/files/en-us/web/api/fontface/weight/index.md
+++ b/files/en-us/web/api/fontface/weight/index.md
@@ -17,7 +17,8 @@ browser-compat: api.FontFace.weight
 {{APIRef("CSS Font Loading API")}}
 
 The **`weight`** property of the {{domxref("FontFace")}} interface retrieves or sets the weight of the font.
-It is equivalent to the {{cssxref("@font-face/font-weight", "font-weight")}} descriptor.
+
+This property is equivalent to the {{cssxref("@font-face/font-weight", "font-weight")}} descriptor.
 
 ## Value
 

--- a/files/en-us/web/api/fontface/weight/index.md
+++ b/files/en-us/web/api/fontface/weight/index.md
@@ -16,14 +16,12 @@ browser-compat: api.FontFace.weight
 
 {{APIRef("CSS Font Loading API")}}
 
-The **`weight`** property of the
-{{domxref("FontFace")}} interface retrieves or sets the weight of the font. It is
-equivalent to the {{cssxref("@font-face/font-weight", "font-weight")}} descriptor.
+The **`weight`** property of the {{domxref("FontFace")}} interface retrieves or sets the weight of the font.
+It is equivalent to the {{cssxref("@font-face/font-weight", "font-weight")}} descriptor.
 
 ## Value
 
-A string containing a descriptor as it would be defined in a style
-sheet's `@font-face` rule.
+A string containing a descriptor as it would be defined in a style sheet's `@font-face` rule.
 
 ## Specifications
 

--- a/files/en-us/web/api/fontfaceset/add/index.md
+++ b/files/en-us/web/api/fontfaceset/add/index.md
@@ -40,7 +40,7 @@ A new {{domxref("FontFaceSet")}}.
 In the following example a new {{domxref("FontFace")}} object is created and then added to the {{domxref("FontFaceSet")}}.
 
 ```js
-let font = new FontFace('MyFont', 'url(myFont.woff2)');
+let font = new FontFace("MyFont", "url(myFont.woff2)");
 document.fonts.add(font);
 ```
 

--- a/files/en-us/web/api/fontfaceset/add/index.md
+++ b/files/en-us/web/api/fontfaceset/add/index.md
@@ -40,7 +40,7 @@ A new {{domxref("FontFaceSet")}}.
 In the following example a new {{domxref("FontFace")}} object is created and then added to the {{domxref("FontFaceSet")}}.
 
 ```js
-let font = new FontFace("MyFont", "url(myFont.woff2)");
+const font = new FontFace("MyFont", "url(myFont.woff2)");
 document.fonts.add(font);
 ```
 

--- a/files/en-us/web/api/fontfaceset/delete/index.md
+++ b/files/en-us/web/api/fontfaceset/delete/index.md
@@ -19,8 +19,8 @@ Font faces that were added to the set using the CSS {{cssxref("@font-face")}} ru
 
 ## Syntax
 
-```js
-delete font
+```js-nolint
+delete(font)
 ```
 
 ### Parameters

--- a/files/en-us/web/api/fontfaceset/delete/index.md
+++ b/files/en-us/web/api/fontfaceset/delete/index.md
@@ -37,7 +37,7 @@ A boolean value which is `true` if the deletion was successful, and `false` othe
 In the following example a new {{domxref("FontFace")}} object is created and then deleted from the {{domxref("FontFaceSet")}}.
 
 ```js
-let font = new FontFace("MyFont", "url(myFont.woff2)");
+const font = new FontFace("MyFont", "url(myFont.woff2)");
 document.fonts.delete(font);
 ```
 

--- a/files/en-us/web/api/fontfaceset/delete/index.md
+++ b/files/en-us/web/api/fontfaceset/delete/index.md
@@ -20,7 +20,7 @@ Font faces that were added to the set using the CSS {{cssxref("@font-face")}} ru
 ## Syntax
 
 ```js
-delete(font)
+delete font
 ```
 
 ### Parameters
@@ -37,7 +37,7 @@ A boolean value which is `true` if the deletion was successful, and `false` othe
 In the following example a new {{domxref("FontFace")}} object is created and then deleted from the {{domxref("FontFaceSet")}}.
 
 ```js
-let font = new FontFace('MyFont', 'url(myFont.woff2)');
+let font = new FontFace("MyFont", "url(myFont.woff2)");
 document.fonts.delete(font);
 ```
 

--- a/files/en-us/web/api/fontfaceset/delete/index.md
+++ b/files/en-us/web/api/fontfaceset/delete/index.md
@@ -15,6 +15,8 @@ browser-compat: api.FontFaceSet.delete
 
 The **`delete()`** method of the {{domxref("FontFaceSet")}} interface removes a font from the set.
 
+Font faces that were added to the set using the CSS {{cssxref("@font-face")}} rule remain connected to the corresponding CSS, and cannot be deleted.
+
 ## Syntax
 
 ```js
@@ -28,9 +30,7 @@ delete(font)
 
 ### Return value
 
-A boolean value which is `true` if the deletion was successful.
-
-> **Note:** if the font passed into this method was added via the CSS {{cssxref("@font-face")}} rule, the method will return `false` as it is not possible to modify fonts added via CSS.
+A boolean value which is `true` if the deletion was successful, and `false` otherwise.
 
 ## Examples
 

--- a/files/en-us/web/api/fontfaceset/index.md
+++ b/files/en-us/web/api/fontfaceset/index.md
@@ -16,7 +16,7 @@ browser-compat: api.FontFaceSet
 
 The **`FontFaceSet`** interface of the [CSS Font Loading API](/en-US/docs/Web/API/CSS_Font_Loading_API) manages the loading of font-faces and querying of their download status.
 
-It is available as {{domxref("Document.fonts")}}, or `self.fonts` in [web workers](/en-US/docs/Web/API/Web_Workers_API).
+This property is available as {{domxref("Document.fonts")}}, or `self.fonts` in [web workers](/en-US/docs/Web/API/Web_Workers_API).
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/fontfaceset/index.md
+++ b/files/en-us/web/api/fontfaceset/index.md
@@ -14,7 +14,9 @@ browser-compat: api.FontFaceSet
 
 {{APIRef("CSS Font Loading API")}}
 
-The **`FontFaceSet`** interface of the [CSS Font Loading API](/en-US/docs/Web/API/CSS_Font_Loading_API) manages the loading of font-faces and querying of their download status. It is available as {{domxref("Document.fonts")}}.
+The **`FontFaceSet`** interface of the [CSS Font Loading API](/en-US/docs/Web/API/CSS_Font_Loading_API) manages the loading of font-faces and querying of their download status.
+
+It is available as {{domxref("Document.fonts")}}, or `self.fonts` in [web workers](/en-US/docs/Web/API/Web_Workers_API).
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/fontfaceset/load/index.md
+++ b/files/en-us/web/api/fontfaceset/load/index.md
@@ -14,8 +14,7 @@ browser-compat: api.FontFaceSet.load
 
 {{APIRef("CSS Font Loading API")}}
 
-The `load()` method of the {{domxref("FontFaceSet")}} forces all the fonts
-given in parameters to be loaded.
+The `load()` method of the {{domxref("FontFaceSet")}} forces all the fonts given in parameters to be loaded.
 
 ## Syntax
 

--- a/files/en-us/web/api/fontfaceset/loading_event/index.md
+++ b/files/en-us/web/api/fontfaceset/loading_event/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'FontFaceSet: loading event'
+title: "FontFaceSet: loading event"
 slug: Web/API/FontFaceSet/loading_event
 page-type: web-api-event
 tags:
@@ -20,9 +20,9 @@ The `loading` event fires when the document begins loading fonts.
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('loading', (event) => { });
+addEventListener("loading", (event) => {});
 
-onloading = (event) => { };
+onloading = (event) => {};
 ```
 
 ## Example
@@ -31,8 +31,8 @@ In the following example, when the font `Ephesis` starts to load, "Font is loadi
 
 ```js
 document.fonts.onloading = () => {
-  console.log('Font is loading');
-}
+  console.log("Font is loading");
+};
 
 (async () => {
   await document.fonts.load("16px Ephesis");

--- a/files/en-us/web/api/fontfaceset/loadingdone_event/index.md
+++ b/files/en-us/web/api/fontfaceset/loadingdone_event/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'FontFaceSet: loadingdone event'
+title: "FontFaceSet: loadingdone event"
 slug: Web/API/FontFaceSet/loadingdone_event
 page-type: web-api-event
 tags:
@@ -20,9 +20,9 @@ The `loadingdone` event fires when the document has loaded all fonts.
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('loadingdone', (event) => { });
+addEventListener("loadingdone", (event) => {});
 
-onloadingdone = (event) => { };
+onloadingdone = (event) => {};
 ```
 
 ## Example
@@ -31,8 +31,8 @@ In the following example, when the font `Ephesis` has finished loading, "Font lo
 
 ```js
 document.fonts.onloadingdone = () => {
-  console.log('Font loading complete');
-}
+  console.log("Font loading complete");
+};
 
 (async () => {
   await document.fonts.load("16px Ephesis");

--- a/files/en-us/web/api/fontfaceset/loadingerror_event/index.md
+++ b/files/en-us/web/api/fontfaceset/loadingerror_event/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'FontFaceSet: loadingerror event'
+title: "FontFaceSet: loadingerror event"
 slug: Web/API/FontFaceSet/loadingerror_event
 page-type: web-api-event
 tags:
@@ -20,9 +20,9 @@ The `loadingerror` event fires when fonts have finished loading, but some or all
 Use the event name in methods like {{domxref("EventTarget.addEventListener", "addEventListener()")}}, or set an event handler property.
 
 ```js
-addEventListener('loadingerror', (event) => { });
+addEventListener("loadingerror", (event) => {});
 
-onloadingerror = (event) => { };
+onloadingerror = (event) => {};
 ```
 
 ## Example
@@ -31,8 +31,8 @@ In the following example, if the font `Ephesis` fails to load, "Font loading err
 
 ```js
 document.fonts.onloadingerror = () => {
-  console.log('Font loading error');
-}
+  console.log("Font loading error");
+};
 
 (async () => {
   await document.fonts.load("16px Ephesis");

--- a/files/en-us/web/api/fontfaceset/ready/index.md
+++ b/files/en-us/web/api/fontfaceset/ready/index.md
@@ -16,8 +16,7 @@ browser-compat: api.FontFaceSet.ready
 
 {{APIRef("CSS Font Loading API")}}
 
-The `ready` read-only property of the {{domxref("FontFaceSet")}} interface
-returns a {{jsxref("Promise")}} that resolves to the given {{domxref("FontFaceSet")}}.
+The `ready` read-only property of the {{domxref("FontFaceSet")}} interface returns a {{jsxref("Promise")}} that resolves to the given {{domxref("FontFaceSet")}}.
 
 The promise will only resolve once the document has completed loading fonts, layout operations are completed, and no further font loads are needed.
 

--- a/files/en-us/web/api/fontfaceset/values/index.md
+++ b/files/en-us/web/api/fontfaceset/values/index.md
@@ -18,7 +18,7 @@ The **`values()`** method of the {{domxref("FontFaceSet")}} interface returns a 
 ## Syntax
 
 ```js
-values();
+values()
 ```
 
 ### Parameters

--- a/files/en-us/web/api/fontfaceset/values/index.md
+++ b/files/en-us/web/api/fontfaceset/values/index.md
@@ -18,7 +18,7 @@ The **`values()`** method of the {{domxref("FontFaceSet")}} interface returns a 
 ## Syntax
 
 ```js
-values()
+values();
 ```
 
 ### Parameters

--- a/files/en-us/web/api/fontfacesetloadevent/index.md
+++ b/files/en-us/web/api/fontfacesetloadevent/index.md
@@ -16,7 +16,9 @@ browser-compat: api.FontFaceSetLoadEvent
 
 {{APIRef("CSS Font Loading API")}}
 
-The **`FontFaceSetLoadEvent`** interface of the [CSS Font Loading API](/en-US/docs/Web/API/CSS_Font_Loading_API) is fired whenever a {{domxref("FontFaceSet")}} loads.
+The **`FontFaceSetLoadEvent`** interface of the [CSS Font Loading API](/en-US/docs/Web/API/CSS_Font_Loading_API) represents events fired at a {{domxref("FontFaceSet")}} after it starts loading font faces.
+
+Events are fired when font loading starts (`loading`), loading completes (`loadingdone`) or there is an error loading one of the fonts (`loadingerror`).
 
 {{InheritanceDiagram}}
 
@@ -27,8 +29,15 @@ The **`FontFaceSetLoadEvent`** interface of the [CSS Font Loading API](/en-US/do
 
 ## Properties
 
+_Also inherits properties from its parent {{domxref("Event")}}_.
+
 - {{domxref("FontFaceSetLoadEvent.fontfaces")}} {{ReadOnlyInline}}
-  - : Returns an array of {{domxref("FontFace")}} instances each of which represents a single usable font.
+  - : Returns an array of {{domxref("FontFace")}} instances.
+    Depending on the event, the array will contain font faces that are loading (`loading`), have successfully loaded (`loadingdone`), or have failed to load (`loadingerror`).
+
+## Methods
+
+_Inherits methods from its parent, {{domxref("Event")}}_.
 
 ## Specifications
 
@@ -37,3 +46,8 @@ The **`FontFaceSetLoadEvent`** interface of the [CSS Font Loading API](/en-US/do
 ## Browser compatibility
 
 {{Compat}}
+
+## See also
+
+- {{domxref("Document.fonts")}}
+- {{domxref("WorkerGlobalScope.fonts")}}

--- a/files/en-us/web/api/fontfacesetloadevent/index.md
+++ b/files/en-us/web/api/fontfacesetloadevent/index.md
@@ -18,7 +18,7 @@ browser-compat: api.FontFaceSetLoadEvent
 
 The **`FontFaceSetLoadEvent`** interface of the [CSS Font Loading API](/en-US/docs/Web/API/CSS_Font_Loading_API) represents events fired at a {{domxref("FontFaceSet")}} after it starts loading font faces.
 
-Events are fired when font loading starts (`loading`), loading completes (`loadingdone`) or there is an error loading one of the fonts (`loadingerror`).
+Events are fired when font loading starts ([`loading`](/en-US/docs/Web/API/FontFaceSet/loading_event)), loading completes ([`loadingdone`](/en-US/docs/Web/API/FontFaceSet/loadingdone_event)) or there is an error loading one of the fonts ([`loadingerror`](/en-US/docs/Web/API/FontFaceSet/loadingerror_event)).
 
 {{InheritanceDiagram}}
 

--- a/files/en-us/web/api/web_workers_api/index.md
+++ b/files/en-us/web/api/web_workers_api/index.md
@@ -61,7 +61,11 @@ The following functions are **only** available to workers:
 
 > **Note:** If a listed API is supported by a platform in a particular version, then it can generally be assumed to be available in web workers. You can also test support for a particular object/function using the site: <https://worker-playground.glitch.me/>
 
+<<<<<<< HEAD
 The following Web APIs are available to workers:
+=======
+The following Web APIs are available to workers: {{domxref("Barcode_Detection_API","Barcode Detection API")}}, {{domxref("Broadcast_Channel_API","Broadcast Channel API")}}, {{domxref("Cache", "Cache API")}}, {{domxref("Channel_Messaging_API", "Channel Messaging API")}}, {{domxref("Console API", "Console API")}}, [CSS Font Loading API](/en-US/docs/Web/API/CSS_Font_Loading_API), [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) ({{domxref("Crypto")}}), {{domxref("CustomEvent")}}, {{domxref("Encoding_API", "Encoding API")}} ({{domxref("TextEncoder")}}, {{domxref("TextDecoder")}}, etc.), {{domxref("Fetch_API", "Fetch API")}}, {{domxref("FileReader")}}, {{domxref("FileReaderSync")}} (only works in workers!), {{domxref("FormData")}}, {{domxref("ImageData")}}, {{domxref("IndexedDB_API", "IndexedDB")}}, [Network Information API](/en-US/docs/Web/API/Network_Information_API), {{domxref("Notifications_API", "Notifications API")}}, {{domxref("Performance_API","Performance API")}} (including: {{domxref("Performance")}}, {{domxref("PerformanceEntry")}}, {{domxref("PerformanceMeasure")}}, {{domxref("PerformanceMark")}}, {{domxref("PerformanceObserver")}}, {{domxref("PerformanceResourceTiming")}}), {{jsxref("Promise")}}, [Server-sent events](/en-US/docs/Web/API/Server-sent_events), {{domxref("ServiceWorkerRegistration")}}, {{ domxref("URL_API","URL API") }} (e.g. {{ domxref("URL") }}), [WebGL](/en-US/docs/Web/API/WebGL_API) with {{domxref("OffscreenCanvas")}} (enabled behind a feature preference setting `gfx.offscreencanvas.enabled`), {{domxref("WebSocket")}}, {{domxref("XMLHttpRequest")}}.
+>>>>>>> debf7bcffc (CSS Font Loading API fixes - FF104)
 
 - {{domxref("Barcode_Detection_API","Barcode Detection API")}}
 - {{domxref("Broadcast_Channel_API","Broadcast Channel API")}}

--- a/files/en-us/web/api/web_workers_api/index.md
+++ b/files/en-us/web/api/web_workers_api/index.md
@@ -61,11 +61,7 @@ The following functions are **only** available to workers:
 
 > **Note:** If a listed API is supported by a platform in a particular version, then it can generally be assumed to be available in web workers. You can also test support for a particular object/function using the site: <https://worker-playground.glitch.me/>
 
-<<<<<<< HEAD
 The following Web APIs are available to workers:
-=======
-The following Web APIs are available to workers: {{domxref("Barcode_Detection_API","Barcode Detection API")}}, {{domxref("Broadcast_Channel_API","Broadcast Channel API")}}, {{domxref("Cache", "Cache API")}}, {{domxref("Channel_Messaging_API", "Channel Messaging API")}}, {{domxref("Console API", "Console API")}}, [CSS Font Loading API](/en-US/docs/Web/API/CSS_Font_Loading_API), [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) ({{domxref("Crypto")}}), {{domxref("CustomEvent")}}, {{domxref("Encoding_API", "Encoding API")}} ({{domxref("TextEncoder")}}, {{domxref("TextDecoder")}}, etc.), {{domxref("Fetch_API", "Fetch API")}}, {{domxref("FileReader")}}, {{domxref("FileReaderSync")}} (only works in workers!), {{domxref("FormData")}}, {{domxref("ImageData")}}, {{domxref("IndexedDB_API", "IndexedDB")}}, [Network Information API](/en-US/docs/Web/API/Network_Information_API), {{domxref("Notifications_API", "Notifications API")}}, {{domxref("Performance_API","Performance API")}} (including: {{domxref("Performance")}}, {{domxref("PerformanceEntry")}}, {{domxref("PerformanceMeasure")}}, {{domxref("PerformanceMark")}}, {{domxref("PerformanceObserver")}}, {{domxref("PerformanceResourceTiming")}}), {{jsxref("Promise")}}, [Server-sent events](/en-US/docs/Web/API/Server-sent_events), {{domxref("ServiceWorkerRegistration")}}, {{ domxref("URL_API","URL API") }} (e.g. {{ domxref("URL") }}), [WebGL](/en-US/docs/Web/API/WebGL_API) with {{domxref("OffscreenCanvas")}} (enabled behind a feature preference setting `gfx.offscreencanvas.enabled`), {{domxref("WebSocket")}}, {{domxref("XMLHttpRequest")}}.
->>>>>>> debf7bcffc (CSS Font Loading API fixes - FF104)
 
 - {{domxref("Barcode_Detection_API","Barcode Detection API")}}
 - {{domxref("Broadcast_Channel_API","Broadcast Channel API")}}
@@ -73,6 +69,7 @@ The following Web APIs are available to workers: {{domxref("Barcode_Detection_AP
 - {{domxref("Channel_Messaging_API", "Channel Messaging API")}}
 - {{domxref("Console API", "Console API")}}
 - [Web Crypto API](/en-US/docs/Web/API/Web_Crypto_API) (e.g. {{domxref("Crypto")}})
+- [CSS Font Loading API](/en-US/docs/Web/API/CSS_Font_Loading_API)
 - {{domxref("CustomEvent")}}
 - {{domxref("Encoding_API", "Encoding API")}} (e.g. {{domxref("TextEncoder")}}, {{domxref("TextDecoder")}})
 - {{domxref("Fetch_API", "Fetch API")}}

--- a/files/en-us/web/api/workerglobalscope/fonts/index.md
+++ b/files/en-us/web/api/workerglobalscope/fonts/index.md
@@ -12,6 +12,7 @@ tags:
   - Property
 browser-compat: api.WorkerGlobalScope.fonts
 ---
+
 {{APIRef("DOM")}}
 
 The **`fonts`** property of the {{domxref("WorkerGlobalScope")}} interface returns the {{domxref("FontFaceSet")}} interface of the worker.

--- a/files/en-us/web/api/workerglobalscope/fonts/index.md
+++ b/files/en-us/web/api/workerglobalscope/fonts/index.md
@@ -1,28 +1,26 @@
 ---
-title: Document.fonts
-slug: Web/API/Document/fonts
+title: WorkerGlobalScope.fonts
+slug: Web/API/WorkerGlobalScope/fonts
 page-type: web-api-instance-property
 tags:
   - API
-  - DOM
-  - Font Loading API
+  - CSS Font Loading API
   - FontFace
   - FontFaceSet
   - Fonts
   - font
   - Property
-browser-compat: api.Document.fonts
+browser-compat: api.WorkerGlobalScope.fonts
 ---
-
 {{APIRef("DOM")}}
 
-The **`fonts`** property of the {{domxref("Document")}} interface returns the {{domxref("FontFaceSet")}} interface of the document.
+The **`fonts`** property of the {{domxref("WorkerGlobalScope")}} interface returns the {{domxref("FontFaceSet")}} interface of the worker.
 
 This is part of the [CSS Font Loading API](/en-US/docs/Web/API/CSS_Font_Loading_API).
 
 ## Value
 
-The returned value is the {{domxref("FontFaceSet")}} interface of the document.
+The returned value is the {{domxref("FontFaceSet")}} interface of the worker.
 The `FontFaceSet` interface is useful for loading new fonts, checking the status of previously loaded fonts etc.
 
 ## Examples
@@ -30,7 +28,7 @@ The `FontFaceSet` interface is useful for loading new fonts, checking the status
 ### Doing operation after all fonts are loaded
 
 ```js
-document.fonts.ready.then(() => {
+fonts.ready.then(() => {
   // Any operation that needs to be done only after all the fonts
   // have finished loading can go here.
 });

--- a/files/en-us/web/api/workerglobalscope/fonts/index.md
+++ b/files/en-us/web/api/workerglobalscope/fonts/index.md
@@ -16,7 +16,7 @@ browser-compat: api.WorkerGlobalScope.fonts
 
 The **`fonts`** property of the {{domxref("WorkerGlobalScope")}} interface returns the {{domxref("FontFaceSet")}} interface of the worker.
 
-This is part of the [CSS Font Loading API](/en-US/docs/Web/API/CSS_Font_Loading_API).
+This property is part of the [CSS Font Loading API](/en-US/docs/Web/API/CSS_Font_Loading_API).
 
 ## Value
 

--- a/files/en-us/web/api/workerglobalscope/index.md
+++ b/files/en-us/web/api/workerglobalscope/index.md
@@ -31,6 +31,8 @@ _This interface inherits properties from the {{domxref("EventTarget")}} interfac
   - : Returns a reference to the `WorkerGlobalScope` itself. Most of the time it is a specific scope like {{domxref("DedicatedWorkerGlobalScope")}}, {{domxref("SharedWorkerGlobalScope")}} or {{domxref("ServiceWorkerGlobalScope")}}.
 - {{domxref("WorkerGlobalScope.location")}} {{ReadOnlyInline}}
   - : Returns the {{domxref("WorkerLocation")}} associated with the worker. It is a specific location object, mostly a subset of the {{domxref("Location")}} for browsing scopes, but adapted to workers.
+- {{domxref("WorkerGlobalScope.fonts")}} {{ReadOnlyInline}}
+  - : Returns the {{domxref("FontFaceSet")}} associated with the worker.
 
 ### Non-standard properties
 

--- a/files/en-us/web/css/@font-face/font-family/index.md
+++ b/files/en-us/web/css/@font-face/font-family/index.md
@@ -13,7 +13,10 @@ browser-compat: css.at-rules.font-face.font-family
 
 {{CSSRef}}
 
-The **`font-family`** CSS descriptor allows authors to specify the font family for the font specified in an {{cssxref("@font-face")}} rule.
+The **`font-family`** CSS descriptor sets the font family for a font specified in an {{cssxref("@font-face")}} rule.
+
+The value is used for name matching against a particular `@font-face` when styling elements using the [`font-family`](/en-US/docs/Web/CSS/font-family) property.
+Any name may be used, and this overrides any name specified in the underlying font data.
 
 ## Syntax
 
@@ -51,8 +54,8 @@ font-family: examplefont;
 
 ```css
 @font-face {
-  font-family: examplefont;
-  src: url('examplefont.ttf');
+  font-family: "Some font family";
+  src: url('some_font_name.ttf');
 }
 ```
 

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -189,7 +189,8 @@
       "methods": [],
       "properties": [
         "Document.fonts",
-        "WorkerGlobalScope.fonts"],
+        "WorkerGlobalScope.fonts"
+      ],
       "events": [
         "FontFaceSet: loading event",
         "FontFaceSet: loadingdone event",

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -184,12 +184,17 @@
       "interfaces": [
         "FontFace",
         "FontFaceSet",
-        "FontFaceSource",
         "FontFaceSetLoadEvent"
       ],
       "methods": [],
-      "properties": [],
-      "events": []
+      "properties": [
+        "Document.fonts",
+        "WorkerGlobalScope.fonts"],
+      "events": [
+        "FontFaceSet: loading event",
+        "FontFaceSet: loadingdone event",
+        "FontFaceSet: loadingerror event"
+      ]
     },
     "CSS Painting API": {
       "overview": ["CSS Painting API"],

--- a/files/jsondata/GroupData.json
+++ b/files/jsondata/GroupData.json
@@ -181,16 +181,9 @@
     },
     "CSS Font Loading API": {
       "overview": ["CSS Font Loading API"],
-      "interfaces": [
-        "FontFace",
-        "FontFaceSet",
-        "FontFaceSetLoadEvent"
-      ],
+      "interfaces": ["FontFace", "FontFaceSet", "FontFaceSetLoadEvent"],
       "methods": [],
-      "properties": [
-        "Document.fonts",
-        "WorkerGlobalScope.fonts"
-      ],
+      "properties": ["Document.fonts", "WorkerGlobalScope.fonts"],
       "events": [
         "FontFaceSet: loading event",
         "FontFaceSet: loadingdone event",


### PR DESCRIPTION
Fixes to CSS Font Loading API following addition of worker support in FF104 (https://bugzilla.mozilla.org/show_bug.cgi?id=1072107).

This does lots of other minor fixes. The bit change is an update to the top level to add some live examples https://pr19990.content.dev.mdn.mozit.cloud/en-US/docs/Web/API/CSS_Font_Loading_API , and tidy up some info found in the spec.

I could go further - e.g. go through every single property etc and add examples blah blah. But this is now at the point where it is good enough that my other priorities ... take priority.

Related docs work in #18769

