### PR TITLE
Improve the fallback example for :focus-visible

### DIFF
--- a/files/en-us/web/css/_colon_focus-visible/index.md
+++ b/files/en-us/web/css/_colon_focus-visible/index.md
@@ -90,14 +90,6 @@ If your code has to work in old browser versions that do not support `:focus-vis
     outline-offset: 3px;
   }
 }
-
-.button.without-fallback:focus {
-  /*
-  ** Or just don't specify anything as a fallback.
-  ** Then browsers that don't support :focus-visible
-  ** will simply render the default focus style.
-  */
-}
 ```
 
 {{EmbedLiveSample("Selectively_showing_the_focus_indicator", "100%", 72)}}

--- a/files/en-us/web/css/_colon_focus-visible/index.md
+++ b/files/en-us/web/css/_colon_focus-visible/index.md
@@ -59,40 +59,50 @@ input, button {
 
 ### Selectively showing the focus indicator
 
-A custom control, such as a custom element button, can use `:focus-visible` to selectively apply a focus indicator only on keyboard-focus. This matches the native focus behavior for controls like {{htmlelement("button")}}.
+Users may still have browsers that do not support `:focus-visible`. For them, you can, by checking for the `:focus-visible` non-support, repeat the same focus styling, but with `:focus`. But even if you do not specify anything at all for `: focus`, then in old browsers there will simply be a native outline, which is also not bad.
 
 ```html
-<button class="custom-button">Click Me</button>
+<button class="button with-fallback" type="button">
+  Button with fallback
+</button>
+<button class="button without-fallback" type="button">
+  Button without fallback
+</button>
 ```
 
 ```css
-.custom-button {
-  display: inline-block;
+.button {
   margin: 10px;
+  border: 2px solid darkgray;
+  border-radius: 4px;
 }
 
-.custom-button:focus {
-  /* Provide a fallback style for browsers
-     that don't support :focus-visible */
-  outline: 2px solid red;
-  background: lightgrey;
+.button:focus-visible {
+  /* 
+  ** Draw the focus style you need for keyboard focus
+  ** in browsers that support :focus-visible.
+  */
+  outline: 3px solid deepskyblue;
+  outline-offset: 3px;
 }
 
-@supports selector(:focus-visible) {
-  .custom-button:focus {
-    /* Remove the focus indicator on mouse-focus for browsers
-       that do support :focus-visible */
-    outline: none;
-    background: transparent;
+@supports not selector(:focus-visible) {
+  .button.with-fallback:focus {
+    /*
+    ** Provide the same focus styles as a fallback
+    ** for browsers that don't support :focus-visible.
+    */
+    outline: 3px solid deepskyblue;
+    outline-offset: 3px;
   }
 }
 
-.custom-button:focus-visible {
-  /* Draw a very noticeable focus style for
-     keyboard-focus on browsers that do support
-     :focus-visible */
-  outline: 4px dashed darkorange;
-  background: transparent;
+.button.without-fallback:focus {
+  /*
+  ** Or just don't specify anything as a fallback.
+  ** Then browsers that don't support :focus-visible
+  ** will simply render the default focus style.
+  */
 }
 ```
 

--- a/files/en-us/web/css/_colon_focus-visible/index.md
+++ b/files/en-us/web/css/_colon_focus-visible/index.md
@@ -59,7 +59,7 @@ input, button {
 
 ### Providing a :focus fallback
 
-If your code has to work in old browser versions that do not support `:focus-visible`, check supports of `:focus-visible` with {{cssxref("@supports"}} and repeat the same focus styling in it, but inside a `:focus` rule. Note that even if you do not specify anything at all for `:focus`, old browsers will simply display the native outline, which can be enough.
+If your code has to work in old browser versions that do not support `:focus-visible`, check supports of `:focus-visible` with {{cssxref("@supports")}} and repeat the same focus styling in it, but inside a `:focus` rule. Note that even if you do not specify anything at all for `:focus`, old browsers will simply display the native outline, which can be enough.
 
 ```html
 <button class="button with-fallback" type="button">

--- a/files/en-us/web/css/_colon_focus-visible/index.md
+++ b/files/en-us/web/css/_colon_focus-visible/index.md
@@ -57,7 +57,7 @@ input, button {
 
 {{EmbedLiveSample("Basic_example", "100%", 300)}}
 
-### Selectively showing the focus indicator
+### Providing a :focus fallback
 
 Users may still have browsers that do not support `:focus-visible`. For them, you can, by checking for the `:focus-visible` non-support, repeat the same focus styling, but with `:focus`. But even if you do not specify anything at all for `: focus`, then in old browsers there will simply be a native outline, which is also not bad.
 

--- a/files/en-us/web/css/_colon_focus-visible/index.md
+++ b/files/en-us/web/css/_colon_focus-visible/index.md
@@ -85,10 +85,7 @@ If your code has to work in old browser versions that do not support `:focus-vis
 
 @supports not selector(:focus-visible) {
   .button.with-fallback:focus {
-    /*
-    ** Provide the same focus styles as a fallback
-    ** for browsers that don't support :focus-visible.
-    */
+    /* Fallback for browsers without :focus-visible support */
     outline: 3px solid deepskyblue;
     outline-offset: 3px;
   }

--- a/files/en-us/web/css/_colon_focus-visible/index.md
+++ b/files/en-us/web/css/_colon_focus-visible/index.md
@@ -59,7 +59,7 @@ input, button {
 
 ### Providing a :focus fallback
 
-Users may still have browsers that do not support `:focus-visible`. For them, you can, by checking for the `:focus-visible` non-support, repeat the same focus styling, but with `:focus`. But even if you do not specify anything at all for `: focus`, then in old browsers there will simply be a native outline, which is also not bad.
+If your code has to work in old browser versions that do not support `:focus-visible`, check supports of `:focus-visible` with {{cssxref("@supports"}} and repeat the same focus styling in it, but inside a `:focus` rule. Note that even if you do not specify anything at all for `:focus`, old browsers will simply display the native outline, which can be enough.
 
 ```html
 <button class="button with-fallback" type="button">

--- a/files/en-us/web/css/_colon_focus-visible/index.md
+++ b/files/en-us/web/css/_colon_focus-visible/index.md
@@ -78,10 +78,7 @@ If your code has to work in old browser versions that do not support `:focus-vis
 }
 
 .button:focus-visible {
-  /* 
-  ** Draw the focus style you need for keyboard focus
-  ** in browsers that support :focus-visible.
-  */
+  /* Draw the focus when :focus-visible is supported */
   outline: 3px solid deepskyblue;
   outline-offset: 3px;
 }


### PR DESCRIPTION
#### Summary

Improved code example for fallback on `:focus` and updated section text to match new code.

#### Motivation

After replacing the custom button with a native button in the previous change to this example, the styles of the example now affect the native styles of the button. It is better to move the properties that change the appearance of the button itself into its general styles.

In addition, this example has always been difficult to understand for beginners due to different styles for different focus pseudo-classes. Making the example look more realistic and practical will make it more useful for developers.

#### Supporting details

@simevidas [suggested](https://twitter.com/simevidas/status/1560611832473145345) the `@supports not selector()` method and [noticed](https://twitter.com/simevidas/status/1561786393826889728) that setting/resetting background is causing the button to lose the native appearance on click.

And @pepelsbey [suggested](https://web-standards.ru/podcast/332/#00:56:59) not styling `:focus` at all, so older browsers would just have a native focus outline.

[This code](https://codepen.io/firefoxic/pen/xxWeWve) works well in newer browsers and fallbacks to `:focus` in older ones as expected. Checked in Safari 14.1:

https://user-images.githubusercontent.com/3382798/186868461-2ae27247-a8cf-47ef-a466-f81d362ced0f.mp4

## Metadata

- [x] Rewrites (or significantly expands) a document
