### PR TITLE
improve description of the defineProperty() method

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md
@@ -44,7 +44,7 @@ property enumeration ({{jsxref("Statements/for...in", "for...in")}} loop or
 {{jsxref("Object.keys")}} method), whose values may be changed, and which may be
 {{jsxref("Operators/delete", "deleted", "", 1)}}. This method allows these extra details
 to be changed from their defaults. By default, properties added using
-`Object.defineProperty()` are not writable nor enumerable.
+`Object.defineProperty()` are not writable nor enumerable nor configurable.
 
 Property descriptors present in objects come in two main flavors: data descriptors and
 accessor descriptors. A **data descriptor** is a property that has a

--- a/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md
@@ -43,8 +43,8 @@ Normal property addition through assignment creates properties which show up dur
 property enumeration ({{jsxref("Statements/for...in", "for...in")}} loop or
 {{jsxref("Object.keys")}} method), whose values may be changed, and which may be
 {{jsxref("Operators/delete", "deleted", "", 1)}}. This method allows these extra details
-to be changed from their defaults. By default, values added using
-`Object.defineProperty()` are immutable and not enumerable.
+to be changed from their defaults. By default, Properties added using
+`Object.defineProperty()` are not writable nor enumerable.
 
 Property descriptors present in objects come in two main flavors: data descriptors and
 accessor descriptors. A **data descriptor** is a property that has a

--- a/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md
@@ -44,7 +44,7 @@ property enumeration ({{jsxref("Statements/for...in", "for...in")}} loop or
 {{jsxref("Object.keys")}} method), whose values may be changed, and which may be
 {{jsxref("Operators/delete", "deleted", "", 1)}}. This method allows these extra details
 to be changed from their defaults. By default, values added using
-`Object.defineProperty()` are immutable and not enumerable.
+`Object.defineProperty()` are not writable nor enumerable.
 
 Property descriptors present in objects come in two main flavors: data descriptors and
 accessor descriptors. A **data descriptor** is a property that has a

--- a/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/object/defineproperty/index.md
@@ -44,7 +44,7 @@ property enumeration ({{jsxref("Statements/for...in", "for...in")}} loop or
 {{jsxref("Object.keys")}} method), whose values may be changed, and which may be
 {{jsxref("Operators/delete", "deleted", "", 1)}}. This method allows these extra details
 to be changed from their defaults. By default, properties added using
-`Object.defineProperty()` are not writable nor enumerable nor configurable.
+`Object.defineProperty()` are not writable, not enumerable, and not configurable.
 
 Property descriptors present in objects come in two main flavors: data descriptors and
 accessor descriptors. A **data descriptor** is a property that has a


### PR DESCRIPTION
values added using Object.defineProperty() is not by default immutable, it depends on the value itself.

<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
