### PR TITLE
Fixing link to Accessible Names specification

### DIFF
--- a/files/en-us/web/accessibility/aria/attributes/aria-label/index.md
+++ b/files/en-us/web/accessibility/aria/attributes/aria-label/index.md
@@ -15,7 +15,7 @@ The `aria-label` attribute defines a string value that labels an interactive ele
 
 ## Description
 
-Sometimes the default [accessible name](https://w3c.github.io/aria/#dfn-accessible-name) of an element is missing, or does not accurately describe its contents, and there is no content visible in the DOM that can be associated with the object to give it meaning. A common example is a button containing an SVG or [icon font (which you shouldn't be using)](https://www.youtube.com/watch?v=9xXBYcWgCHA) without any text.
+Sometimes the default [accessible name](https://w3c.github.io/accname/#dfn-accessible-name) of an element is missing, or does not accurately describe its contents, and there is no content visible in the DOM that can be associated with the object to give it meaning. A common example is a button containing an SVG or [icon font (which you shouldn't be using)](https://www.youtube.com/watch?v=9xXBYcWgCHA) without any text.
 
 In cases where an interactive element has no accessible name, or an accessible name that isn't accurate, and there is no content visible in the DOM that can be referenced via the [`aria-labelledby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-labelledby) attribute, the `aria-label` attribute can be used to define a string that labels the interactive element on which it is set. This provides the element with its accessible name.
 


### PR DESCRIPTION
#### Summary
I fixed the external link to the definition of Accessible Names by directing it to the Accessible Names specification.

#### Motivation
The external link to the definition of Accessible Names in the ARIA specification was broken because it linked to an non-existent anchor. 

#### Metadata
- [ ] Adds a new document
- [ ] Rewrites (or significantly expands) a document
- [x] Fixes a typo, bug, or other error
