### PR TITLE
Add `inset` to the positioned layout properties

### DIFF
--- a/files/en-us/web/css/css_positioning/index.md
+++ b/files/en-us/web/css/css_positioning/index.md
@@ -21,6 +21,7 @@ spec-urls: https://drafts.csswg.org/css-position/
 - {{cssxref("right")}}
 - {{cssxref("bottom")}}
 - {{cssxref("left")}}
+- {{cssxref("inset")}}
 - {{cssxref("float")}}
 - {{cssxref("clear")}}
 - {{cssxref("position")}}

--- a/files/en-us/web/css/css_positioning/index.md
+++ b/files/en-us/web/css/css_positioning/index.md
@@ -22,6 +22,12 @@ spec-urls: https://drafts.csswg.org/css-position/
 - {{cssxref("bottom")}}
 - {{cssxref("left")}}
 - {{cssxref("inset")}}
+- {{cssxref("inset-inline")}}
+- {{cssxref("inset-inline-start")}}
+- {{cssxref("inset-inline-end")}}
+- {{cssxref("inset-block")}}
+- {{cssxref("inset-block-start")}}
+- {{cssxref("inset-block-end")}}
 - {{cssxref("float")}}
 - {{cssxref("clear")}}
 - {{cssxref("position")}}


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->
The `inset` CSS property is missing from the list on this page. It's a relatively new shorthand property for `top`, `right`, `bottom` and `left`.

#### Motivation
<!-- ❓ Why are you making this change? Help us understand how your changes help readers. -->
This property isn't all that well-known given that it's fairly new. But it's incredibly useful when styling pseudo-elements, plus it is unique to Positioned layouts.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->
https://developer.mozilla.org/en-US/docs/Web/CSS/inset

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
