### PR TITLE
chore: update links for fetch-examples

### DIFF
--- a/files/en-us/web/api/fetch/index.md
+++ b/files/en-us/web/api/fetch/index.md
@@ -263,7 +263,7 @@ fetch('https://example.com/', {
 
 ## Examples
 
-In our [Fetch Request example](https://github.com/mdn/fetch-examples/tree/master/fetch-request) (see [Fetch Request live](https://mdn.github.io/fetch-examples/fetch-request/)) we
+In our [Fetch Request example](https://github.com/mdn/dom-examples/tree/master/fetch/fetch-request) (see [Fetch Request live](https://mdn.github.io/dom-examples/fetch/fetch-request/)) we
 create a new {{domxref("Request")}} object using the relevant constructor, then fetch it
 using a `fetch()` call. Since we are fetching an image, we run
 {{domxref("Response.blob()")}} on the response to give it the proper MIME type so it will be
@@ -288,7 +288,7 @@ fetch(myRequest)
   });
 ```
 
-In the [Fetch with init then Request example](https://github.com/mdn/fetch-examples/blob/master/fetch-with-init-then-request/index.html) (see [Fetch Request init live](https://mdn.github.io/fetch-examples/fetch-with-init-then-request/)), we do the same thing except that we pass in an
+In the [Fetch with init then Request example](https://github.com/mdn/dom-examples/tree/master/fetch/fetch-with-init-then-request/index.html) (see [Fetch Request init live](https://mdn.github.io/dom-examples/fetch/fetch-with-init-then-request/)), we do the same thing except that we pass in an
 `init` object when we invoke `fetch()`:
 
 ```js

--- a/files/en-us/web/api/fetch_api/using_fetch/index.md
+++ b/files/en-us/web/api/fetch_api/using_fetch/index.md
@@ -459,4 +459,4 @@ if (window.fetch) {
 - [HTTP access control (CORS)](/en-US/docs/Web/HTTP/CORS)
 - [HTTP](/en-US/docs/Web/HTTP)
 - [Fetch polyfill](https://github.com/github/fetch)
-- [Fetch examples on GitHub](https://github.com/mdn/fetch-examples/)
+- [Fetch examples on GitHub](https://github.com/mdn/dom-examples/tree/master/fetch)

--- a/files/en-us/web/api/request/request/index.md
+++ b/files/en-us/web/api/request/request/index.md
@@ -116,7 +116,7 @@ new Request(input, options)
 
 ## Examples
 
-In our [Fetch Request example](https://github.com/mdn/fetch-examples/tree/master/fetch-request) (see [Fetch Request live](https://mdn.github.io/fetch-examples/fetch-request/)) we
+In our [Fetch Request example](https://github.com/mdn/dom-examples/tree/master/fetch/fetch-request) (see [Fetch Request live](https://mdn.github.io/dom-examples/fetch/fetch-request/)) we
 create a new `Request` object using the constructor, then fetch it using a
 {{domxref("fetch()")}} call. Since we are fetching an image, we run
 {{domxref("Response.blob")}} on the response to give it the proper MIME type so it will be
@@ -136,7 +136,7 @@ fetch(myRequest)
   });
 ```
 
-In our [Fetch Request with init example](https://github.com/mdn/fetch-examples/tree/master/fetch-request-with-init) (see [Fetch Request init live](https://mdn.github.io/fetch-examples/fetch-request-with-init/)) we do the same thing except that we pass in an init object when we
+In our [Fetch Request with init example](https://github.com/mdn/dom-examples/tree/master/fetch/fetch-with-init-then-request) (see [Fetch Request init live](https://mdn.github.io/dom-examples/fetch/fetch-with-init-then-request/)) we do the same thing except that we pass in an init object when we
 invoke `fetch()`:
 
 ```js

--- a/files/en-us/web/api/request/url/index.md
+++ b/files/en-us/web/api/request/url/index.md
@@ -28,7 +28,7 @@ the script), then save the URL of the request in a variable:
 
 ```js
 const myRequest = new Request('flowers.jpg');
-const myURL = myRequest.url; // "https://mdn.github.io/fetch-examples/fetch-request/flowers.jpg"
+const myURL = myRequest.url; // "https://github.com/mdn/dom-examples/tree/master/fetch/fetch-request/flowers.jpg"
 ```
 
 ## Specifications

--- a/files/en-us/web/api/response/arraybuffer/index.md
+++ b/files/en-us/web/api/response/arraybuffer/index.md
@@ -35,7 +35,7 @@ A promise that resolves with an {{jsxref("ArrayBuffer")}}.
 
 ### Playing music
 
-In our [fetch array buffer live](https://mdn.github.io/fetch-examples/fetch-array-buffer/), we have a Play button. When pressed, the `getData()`
+In our [fetch array buffer live](https://github.com/mdn/dom-examples/tree/master/fetch/fetch-array-buffer), we have a Play button. When pressed, the `getData()`
 function is run. Note that before playing full audio file will be downloaded. If you
 need to play ogg during downloading (stream it) - consider
 {{domxref("HTMLAudioElement")}}:

--- a/files/en-us/web/api/response/blob/index.md
+++ b/files/en-us/web/api/response/blob/index.md
@@ -39,7 +39,7 @@ A promise that resolves with a {{domxref("Blob")}}.
 
 ## Examples
 
-In our [fetch request example](https://github.com/mdn/fetch-examples/tree/master/fetch-request) (run [fetch request live](https://mdn.github.io/fetch-examples/fetch-request/)), we
+In our [fetch request example](https://github.com/mdn/dom-examples/tree/master/fetch/fetch-request) (run [fetch request live](https://mdn.github.io/dom-examples/fetch/fetch-request/)), we
 create a new request using the {{domxref("Request.Request","Request()")}} constructor,
 then use it to fetch a JPG. When the fetch is successful, we read a {{domxref("Blob")}}
 out of the response using `blob()`, put it into an object URL using

--- a/files/en-us/web/api/response/bodyused/index.md
+++ b/files/en-us/web/api/response/bodyused/index.md
@@ -21,7 +21,7 @@ A boolean value.
 
 ## Examples
 
-In our [fetch request example](https://github.com/mdn/fetch-examples/tree/master/fetch-request) (run [fetch request live](https://mdn.github.io/fetch-examples/fetch-request/)),
+In our [fetch request example](https://github.com/mdn/dom-examples/tree/master/fetch/fetch-request) (run [fetch request live](https://mdn.github.io/dom-examples/fetch/fetch-request/)),
 we create a new request using the {{domxref("Request.Request","Request()")}} constructor,
 then use it to fetch a JPG. When the fetch is successful, we read a {{domxref("Blob")}} out of the response using `blob()`,
 put it into an object URL using {{domxref("URL.createObjectURL")}}, and then set that URL as the source of an {{htmlelement("img")}} element to display the image.

--- a/files/en-us/web/api/response/clone/index.md
+++ b/files/en-us/web/api/response/clone/index.md
@@ -49,7 +49,7 @@ A {{domxref("Response")}} object.
 
 ## Examples
 
-In our [Fetch Response clone example](https://github.com/mdn/dom-examples/blob/master/fetch/fetch-response-clone/index.html) (see [Fetch Response clone live](https://mdn.github.io/fetch-examples/fetch-response-clone/)) we create a new {{domxref("Request")}} object using the {{domxref("Request.Request","Request()")}} constructor, passing it a JPG path.
+In our [Fetch Response clone example](https://github.com/mdn/dom-examples/blob/master/fetch/fetch-response-clone/index.html) (see [Fetch Response clone live](https://mdn.github.io/dom-examples/fetch/fetch-response-clone/)) we create a new {{domxref("Request")}} object using the {{domxref("Request.Request","Request()")}} constructor, passing it a JPG path.
 We then fetch this request using {{domxref("fetch()")}}.
 When the fetch resolves successfully, we clone it, extract a blob from both responses using two {{domxref("Response.blob")}} calls, create object URLs out of the blobs using
 {{domxref("URL.createObjectURL")}}, and display them in two separate {{htmlelement("img")}} elements.

--- a/files/en-us/web/api/response/headers/index.md
+++ b/files/en-us/web/api/response/headers/index.md
@@ -23,7 +23,7 @@ A {{domxref("Headers")}} object.
 
 ## Examples
 
-In our [Fetch Response example](https://github.com/mdn/fetch-examples/tree/master/fetch-response) (see [Fetch Response live](https://mdn.github.io/fetch-examples/fetch-response/))
+In our [Fetch Response example](https://github.com/mdn/dom-examples/tree/master/fetch/fetch-response) (see [Fetch Response live](https://mdn.github.io/dom-examples/fetch/fetch-response/))
 we create a new {{domxref("Request")}} object using the {{domxref("Request.Request","Request()")}} constructor, passing it a JPG path.
 We then fetch this request using {{domxref("fetch()")}}, extract a blob from the response using {{domxref("Response.blob")}},
 create an object URL out of it using {{domxref("URL.createObjectURL")}}, and display this in an {{htmlelement("img")}}.

--- a/files/en-us/web/api/response/index.md
+++ b/files/en-us/web/api/response/index.md
@@ -68,7 +68,7 @@ You can create a new `Response` object using the {{domxref("Response.Response", 
 
 ### Fetching an image
 
-In our [basic fetch example](https://github.com/mdn/fetch-examples/tree/master/basic-fetch) ([run example live](https://mdn.github.io/fetch-examples/basic-fetch/)) we use a simple `fetch()` call to grab an image and display it in an {{htmlelement("img")}} element.
+In our [basic fetch example](https://github.com/mdn/dom-examples/tree/master/fetch/basic-fetch) ([run example live](https://mdn.github.io/dom-examples/fetch/basic-fetch/)) we use a simple `fetch()` call to grab an image and display it in an {{htmlelement("img")}} element.
 The `fetch()` call returns a promise, which resolves to the `Response` object associated with the resource fetch operation.
 
 You'll notice that since we are requesting an image, we need to run {{domxref("Response.blob")}} to give the response its correct MIME type.

--- a/files/en-us/web/api/response/ok/index.md
+++ b/files/en-us/web/api/response/ok/index.md
@@ -21,7 +21,7 @@ A boolean value.
 
 ## Examples
 
-In our [Fetch Response example](https://github.com/mdn/fetch-examples/tree/master/fetch-response) (see [Fetch Response live](https://mdn.github.io/fetch-examples/fetch-response/))
+In our [Fetch Response example](https://github.com/mdn/dom-examples/tree/master/fetch/fetch-response) (see [Fetch Response live](https://mdn.github.io/dom-examples/fetch/fetch-response/))
 we create a new {{domxref("Request")}} object using the {{domxref("Request.Request","Request()")}} constructor, passing it a JPG path.
 We then fetch this request using {{domxref("fetch()")}}, extract a blob from the response using {{domxref("Response.blob")}}, create an object URL out of it using {{domxref("URL.createObjectURL")}}, and display this in an {{htmlelement("img")}}.
 

--- a/files/en-us/web/api/response/response/index.md
+++ b/files/en-us/web/api/response/response/index.md
@@ -56,7 +56,7 @@ new Response(body, options)
 
 ## Examples
 
-In our [Fetch Response example](https://github.com/mdn/fetch-examples/tree/master/fetch-response) (see [Fetch Response live](https://mdn.github.io/fetch-examples/fetch-response/))
+In our [Fetch Response example](https://github.com/mdn/dom-examples/tree/master/fetch/fetch-response) (see [Fetch Response live](https://mdn.github.io/dom-examples/fetch/fetch-response/))
 we create a new `Response` object using the constructor, passing it a new {{domxref("Blob")}} as a body, and an init object containing a custom `status` and `statusText`:
 
 ```js

--- a/files/en-us/web/api/response/status/index.md
+++ b/files/en-us/web/api/response/status/index.md
@@ -24,7 +24,7 @@ This is one of the [HTTP response status codes](/en-US/docs/Web/HTTP/Status).
 
 ## Examples
 
-In our [Fetch Response example](https://github.com/mdn/fetch-examples/tree/master/fetch-response) (see [Fetch Response live](https://mdn.github.io/fetch-examples/fetch-response/))
+In our [Fetch Response example](https://github.com/mdn/dom-examples/tree/master/fetch/fetch-response) (see [Fetch Response live](https://mdn.github.io/dom-examples/fetch/fetch-response/))
 we create a new {{domxref("Request")}} object using the {{domxref("Request.Request","Request()")}} constructor, passing it a JPG path.
 We then fetch this request using {{domxref("fetch()")}}, extract a blob from the response using {{domxref("Response.blob")}}, create an object URL out of it using {{domxref("URL.createObjectURL")}}, and display this in an {{htmlelement("img")}}.
 

--- a/files/en-us/web/api/response/statustext/index.md
+++ b/files/en-us/web/api/response/statustext/index.md
@@ -27,7 +27,7 @@ Note that HTTP/2 [does not support](https://fetch.spec.whatwg.org/#concept-respo
 
 ## Examples
 
-In our [Fetch Response example](https://github.com/mdn/fetch-examples/tree/master/fetch-response) (see [Fetch Response live](https://mdn.github.io/fetch-examples/fetch-response/)) we create a new {{domxref("Request")}} object using the {{domxref("Request.Request","Request()")}} constructor, passing it a JPG path.
+In our [Fetch Response example](https://github.com/mdn/dom-examples/tree/master/fetch/fetch-response) (see [Fetch Response live](https://mdn.github.io/dom-examples/fetch/fetch-response/)) we create a new {{domxref("Request")}} object using the {{domxref("Request.Request","Request()")}} constructor, passing it a JPG path.
 We then fetch this request using {{domxref("fetch()")}}, extract a blob from the response using {{domxref("Response.blob")}}, create an object URL out of it using {{domxref("URL.createObjectURL")}}, and display this in an {{htmlelement("img")}}.
 
 Note that at the top of the `fetch()` block we log the response `statusText` value to the console.

--- a/files/en-us/web/api/response/text/index.md
+++ b/files/en-us/web/api/response/text/index.md
@@ -33,7 +33,7 @@ A Promise that resolves with a {{jsxref("String")}}.
 
 ## Examples
 
-In our [fetch text example](https://github.com/mdn/fetch-examples/tree/master/fetch-text) (run [fetch text live](https://mdn.github.io/fetch-examples/fetch-text/)), we have an {{htmlelement("article")}} element and three links (stored in the `myLinks` array.)
+In our [fetch text example](https://github.com/mdn/dom-examples/tree/master/fetch/fetch-text) (run [fetch text live](https://mdn.github.io/dom-examples/fetch/fetch-text/)), we have an {{htmlelement("article")}} element and three links (stored in the `myLinks` array.)
 First, we loop through all of these and give each one an `onclick` event handler so that the `getData()` function is run — with the link's `data-page` identifier passed to it as an argument — when one of the links is clicked.
 
 When `getData()` is run, we create a new request using the {{domxref("Request.Request","Request()")}} constructor, then use it to fetch a specific `.txt` file.

--- a/files/en-us/web/api/response/type/index.md
+++ b/files/en-us/web/api/response/type/index.md
@@ -35,7 +35,7 @@ A `ResponseType` string indicating the type of the response.
 
 ## Examples
 
-In our [Fetch Response example](https://github.com/mdn/fetch-examples/tree/master/fetch-response) (see [Fetch Response live](https://mdn.github.io/fetch-examples/fetch-response/)) we create a new {{domxref("Request")}} object using the {{domxref("Request.Request","Request()")}} constructor, passing it a JPG path.
+In our [Fetch Response example](https://github.com/mdn/dom-examples/tree/master/fetch/fetch-response) (see [Fetch Response live](https://mdn.github.io/dom-examples/fetch/fetch-response/)) we create a new {{domxref("Request")}} object using the {{domxref("Request.Request","Request()")}} constructor, passing it a JPG path.
 We then fetch this request using {{domxref("fetch()")}}, extract a blob from the response using {{domxref("Response.blob")}}, create an object URL out of it using {{domxref("URL.createObjectURL")}}, and display this in an {{htmlelement("img")}}.
 
 Note that at the top of the `fetch()` block we log the response `type` to the console.

--- a/files/en-us/web/api/response/url/index.md
+++ b/files/en-us/web/api/response/url/index.md
@@ -22,7 +22,7 @@ A string.
 
 ## Examples
 
-In our [Fetch Response example](https://github.com/mdn/fetch-examples/tree/master/fetch-response) (see [Fetch Response live](https://mdn.github.io/fetch-examples/fetch-response/)) we create a new {{domxref("Request")}} object using the {{domxref("Request.Request","Request()")}} constructor, passing it a JPG path.
+In our [Fetch Response example](https://github.com/mdn/dom-examples/tree/master/fetch/fetch-response) (see [Fetch Response live](https://mdn.github.io/dom-examples/fetch/fetch-response/)) we create a new {{domxref("Request")}} object using the {{domxref("Request.Request","Request()")}} constructor, passing it a JPG path.
 We then fetch this request using {{domxref("fetch()")}}, extract a blob from the response using {{domxref("Response.blob")}}, create an object URL out of it using {{domxref("URL.createObjectURL")}}, and display this in an {{htmlelement("img")}}.
 
 Note that at the top of the `fetch()` block we log the response `URL` to the console.


### PR DESCRIPTION
As part of moving the `fetch-examples` repo to `dom-examples`, this updates links in the content to the new location of the examples

fix #20010