### PR TITLE
remove `{{warning}}` macro call from en-US

### DIFF
--- a/files/en-us/learn/forms/form_validation/index.md
+++ b/files/en-us/learn/forms/form_validation/index.md
@@ -67,7 +67,8 @@ There are three main reasons:
 - **We want to get the right data, in the right format.** Our applications won't work properly if our users' data is stored in the wrong format, is incorrect, or is omitted altogether.
 - **We want to protect our users' data**. Forcing our users to enter secure passwords makes it easier to protect their account information.
 - **We want to protect ourselves**. There are many ways that malicious users can misuse unprotected forms to damage the application. See [Website security](/en-US/docs/Learn/Server-side/First_steps/Website_security).
-  {{warning("Never trust data passed to your server from the client. Even if your form is validating correctly and preventing malformed input on the client-side, a malicious user can still alter the network request.")}}
+  
+  > **Warning:** Never trust data passed to your server from the client. Even if your form is validating correctly and preventing malformed input on the client-side, a malicious user can still alter the network request.
 
 ## Different types of client-side validation
 

--- a/files/en-us/web/css/box-align/index.md
+++ b/files/en-us/web/css/box-align/index.md
@@ -10,7 +10,9 @@ tags:
   - recipe:css-property
 browser-compat: css.properties.box-align
 ---
-{{CSSRef}}{{Non-standard_header}}{{warning("This is a property of the original CSS Flexible Box Layout Module draft, and has been replaced by a newer standard.")}}
+{{CSSRef}}{{Non-standard_header}}
+
+> **Warning:** This is a property of the original CSS Flexible Box Layout Module draft, and has been replaced by a newer standard.
 
 The **`box-align`** [CSS](/en-US/docs/Web/CSS) property specifies how an element aligns its contents across its layout in a perpendicular direction. The effect of the property is only visible if there is extra space in the box.
 


### PR DESCRIPTION
#### Summary

Remove the last two `{{warning}}` macro calls from en-US. After that, we can deprecate the macro in mdn/yari.

#### Metadata

- [x] Fixes a typo, bug, or other error
