### PR TITLE
fix: MD037 space in emphasis

### DIFF
--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/css_property_page_template/index.md
@@ -34,7 +34,7 @@ browser-compat: css.properties.NameOfTheProperty
 > ```
 >
 > - **title**
->   - : Title heading displayed at top of page. Format as _NameOfTheProperty.
+>   - : Title heading displayed at top of page. Format as _NameOfTheProperty_.
 >     For example, the [`background-color`](/en-US/docs/Web/CSS/background-color) property has a title of _background-color_.
 > - **slug**
 >   - : The end of the URL path after `https://developer.mozilla.org/en-US/docs/`). This will be formatted like `Web/CSS/NameOfTheProperty`.

--- a/files/en-us/web/accessibility/aria/roles/listbox_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/listbox_role/index.md
@@ -155,7 +155,7 @@ When the user clicks on an option, hits <kbd>Space</kbd> when focused on an opti
 1. Change the appearance of the option to reflect its selected state
 1. Update the [`aria-activedescendant`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-activedescendant) value on the listbox to the ID of the option the user just interacted with, even if they toggled the option to be unselected.
 
-> **Note: ** The first rule of ARIA use is you can use a native feature with the semantics and behavior you require already built in, instead of re-purposing an element and **adding** an ARIA role, state or property to make it accessible, then do so. The {{HTMLElement('select')}} element with descendant {{HTMLElement('option')}} elements handles all the needed interactions natively.
+> **Note:** The first rule of ARIA use is you can use a native feature with the semantics and behavior you require already built in, instead of re-purposing an element and **adding** an ARIA role, state or property to make it accessible, then do so. The {{HTMLElement('select')}} element with descendant {{HTMLElement('option')}} elements handles all the needed interactions natively.
 
 ## Examples
 

--- a/files/en-us/web/accessibility/aria/roles/slider_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/slider_role/index.md
@@ -187,7 +187,7 @@ For the optional <kbd>Page Up</kbd> and <kbd>Page Down</kbd> keys, the change in
 
 If the slider is describing the loading progress of a particular region of a page, include the [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) attribute to reference the slider status, and set the [`aria-busy`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-busy) attribute to `true` on the region until it is finished loading.
 
-HTML's `<input type="range">` implicitly has the `role` of `slider`. Do not use `aria-valuemax` or `aria-valuemin` attributes on `<input type="range">` elements; use `min` and `max` instead. Otherwise, any global aria-\* attributes and any other aria-\* attributes applicable to the slider role.
+HTML's `<input type="range">` implicitly has the `role` of `slider`. Do not use `aria-valuemax` or `aria-valuemin` attributes on `<input type="range">` elements; use `min` and `max` instead. Otherwise, any global `aria-*` attributes and any other `aria-*` attributes applicable to the slider role.
 
 ### Prefer HTML
 

--- a/files/en-us/web/accessibility/aria/roles/slider_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/slider_role/index.md
@@ -187,7 +187,7 @@ For the optional <kbd>Page Up</kbd> and <kbd>Page Down</kbd> keys, the change in
 
 If the slider is describing the loading progress of a particular region of a page, include the [`aria-describedby`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby) attribute to reference the slider status, and set the [`aria-busy`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-busy) attribute to `true` on the region until it is finished loading.
 
-HTML's `<input type="range">` implicitly has the `role` of `slider`. Do not use `aria-valuemax` or `aria-valuemin` attributes on `<input type="range">` elements; use `min` and `max` instead. Otherwise, any global aria-* attributes and any other aria-* attributes applicable to the slider role.
+HTML's `<input type="range">` implicitly has the `role` of `slider`. Do not use `aria-valuemax` or `aria-valuemin` attributes on `<input type="range">` elements; use `min` and `max` instead. Otherwise, any global aria-\* attributes and any other aria-\* attributes applicable to the slider role.
 
 ### Prefer HTML
 

--- a/files/en-us/web/accessibility/aria/roles/spinbutton_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/spinbutton_role/index.md
@@ -139,7 +139,7 @@ For the optional <kbd>Page Up</kbd> and <kbd>Page Down</kbd> keys, the change in
 
 ## Best practices
 
-HTML's `<input type="number">` implicitly has the `role` of `spinbutton`. HTML's `<input type="date">` has 3 nested spin buttons, one each for month, day, and year. When using semantic HTML form elements for their intended purposes, do not use `aria-valuemax` or `aria-valuemin` attributes; use `min` and `max` instead. Otherwise, any global aria-* attributes and any other aria-* attributes are applicable to the `spinbutton` role.
+HTML's `<input type="number">` implicitly has the `role` of `spinbutton`. HTML's `<input type="date">` has 3 nested spin buttons, one each for month, day, and year. When using semantic HTML form elements for their intended purposes, do not use `aria-valuemax` or `aria-valuemin` attributes; use `min` and `max` instead. Otherwise, any global aria-\* attributes and any other aria-\* attributes are applicable to the `spinbutton` role.
 
 ### Prefer semantic HTML
 

--- a/files/en-us/web/accessibility/aria/roles/spinbutton_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/spinbutton_role/index.md
@@ -139,7 +139,7 @@ For the optional <kbd>Page Up</kbd> and <kbd>Page Down</kbd> keys, the change in
 
 ## Best practices
 
-HTML's `<input type="number">` implicitly has the `role` of `spinbutton`. HTML's `<input type="date">` has 3 nested spin buttons, one each for month, day, and year. When using semantic HTML form elements for their intended purposes, do not use `aria-valuemax` or `aria-valuemin` attributes; use `min` and `max` instead. Otherwise, any global aria-\* attributes and any other aria-\* attributes are applicable to the `spinbutton` role.
+HTML's `<input type="number">` implicitly has the `role` of `spinbutton`. HTML's `<input type="date">` has 3 nested spin buttons, one each for month, day, and year. When using semantic HTML form elements for their intended purposes, do not use `aria-valuemax` or `aria-valuemin` attributes; use `min` and `max` instead. Otherwise, any global `aria-*` attributes and any other `aria-*` attributes are applicable to the `spinbutton` role.
 
 ### Prefer semantic HTML
 

--- a/files/en-us/web/html/element/iframe/index.md
+++ b/files/en-us/web/html/element/iframe/index.md
@@ -23,7 +23,7 @@ The **`<iframe>`** [HTML](/en-US/docs/Web/HTML) element represents a nested {{Gl
 
 {{EmbedInteractiveExample("pages/tabbed/iframe.html", "tabbed-standard")}}
 
-Each embedded browsing context has its own [session history](/en-US/docs/Web/API/History) and [document](/en-US/docs/Web/API/Document). The browsing context that embeds the others is called the *parent browsing context*. The *topmost* browsing context — the one with no parent — is usually the browser window, represented by the {{domxref("Window")}} object.
+Each embedded browsing context has its own [session history](/en-US/docs/Web/API/History) and [document](/en-US/docs/Web/API/Document). The browsing context that embeds the others is called the _parent browsing context_. The _topmost_ browsing context — the one with no parent — is usually the browser window, represented by the {{domxref("Window")}} object.
 
 > **Warning:** Because each browsing context is a complete document environment, every `<iframe>` in a page requires increased memory and other computing resources. While theoretically you can use as many `<iframe>`s as you like, check for performance problems.
 

--- a/files/en-us/web/html/element/iframe/index.md
+++ b/files/en-us/web/html/element/iframe/index.md
@@ -23,7 +23,7 @@ The **`<iframe>`** [HTML](/en-US/docs/Web/HTML) element represents a nested {{Gl
 
 {{EmbedInteractiveExample("pages/tabbed/iframe.html", "tabbed-standard")}}
 
-Each embedded browsing context has its own [session history](/en-US/docs/Web/API/History) and [document](/en-US/docs/Web/API/Document). The browsing context that embeds the others is called the \*_parent_ browsing context*. The *topmost\* browsing context — the one with no parent — is usually the browser window, represented by the {{domxref("Window")}} object.
+Each embedded browsing context has its own [session history](/en-US/docs/Web/API/History) and [document](/en-US/docs/Web/API/Document). The browsing context that embeds the others is called the *parent browsing context*. The *topmost* browsing context — the one with no parent — is usually the browser window, represented by the {{domxref("Window")}} object.
 
 > **Warning:** Because each browsing context is a complete document environment, every `<iframe>` in a page requires increased memory and other computing resources. While theoretically you can use as many `<iframe>`s as you like, check for performance problems.
 


### PR DESCRIPTION
There are a bunch of asterisks inside HTML elements that trip up this rule, so it can be fully turned on right now