### PR TITLE
Deduplicate TypedArray ctor param description, add exceptions

### DIFF
--- a/files/en-us/web/javascript/reference/global_objects/bigint64array/bigint64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint64array/bigint64array/index.md
@@ -34,7 +34,13 @@ new BigInt64Array(buffer, byteOffset, length)
 
 > **Note:** `BigInt64Array()` can only be constructed with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). Attempting to call it without `new` throws a {{jsxref("TypeError")}}.
 
-For a detailed explanation of each constructor parameter, see the [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#constructor) page.
+### Parameters
+
+See [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#parameters).
+
+### Exceptions
+
+See [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#exceptions).
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/bigint64array/bigint64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint64array/bigint64array/index.md
@@ -34,32 +34,7 @@ new BigInt64Array(buffer, byteOffset, length)
 
 > **Note:** `BigInt64Array()` can only be constructed with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). Attempting to call it without `new` throws a {{jsxref("TypeError")}}.
 
-### Parameters
-
-- `length`
-  - : When called with a `length` argument, an internal array buffer
-    is created in memory, of size `length` _multiplied by
-    `BYTES_PER_ELEMENT`_ bytes, containing zeros.
-- `typedArray`
-  - : When called with a `typedArray` argument, which can be an
-    object of either of the {{glossary("bigint")}} typed-array types (such as {{JSxRef("BigUInt64Array")}}), the
-    `typedArray` gets copied into a new typed array. Each value in
-    `typedArray` is converted to the corresponding type of the
-    constructor before being copied into the new array. The length of the new typed array
-    will be same as the length of the `typedArray` argument.
-- `object`
-  - : When called with an `object` argument, a new typed array is
-    created as if by the `TypedArray.from()` method.
-- `buffer`, `byteOffset`,
-  `length`
-  - : When called with a `buffer`, and optionally a
-    `byteOffset` and a `length` argument, a
-    new typed array view is created that views the specified {{jsxref("ArrayBuffer")}}.
-    The `byteOffset` and `length` parameters
-    specify the memory range that will be exposed by the typed array view. If both are
-    omitted, all of `buffer` is viewed; if only
-    `length` is omitted, the remainder of
-    `buffer` is viewed.
+For a detailed explanation of each constructor parameter, see the [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#constructor) page.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/biguint64array/biguint64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/biguint64array/biguint64array/index.md
@@ -34,32 +34,7 @@ new BigUint64Array(buffer, byteOffset, length)
 
 > **Note:** `BigUint64Array()` can only be constructed with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). Attempting to call it without `new` throws a {{jsxref("TypeError")}}.
 
-### Parameters
-
-- `length`
-  - : When called with a `length` argument, an internal array buffer
-    is created in memory, of size `length` _multiplied by
-    `BYTES_PER_ELEMENT`_ bytes, containing zeros.
-- `typedArray`
-  - : When called with a `typedArray` argument, which can be an
-    object of either of the {{glossary("bigint")}} typed-array types (such as {{JSxRef("BigInt64Array")}}), the
-    `typedArray` gets copied into a new typed array. Each value in
-    `typedArray` is converted to the corresponding type of the
-    constructor before being copied into the new array. The length of the new typed array
-    will be same as the length of the `typedArray` argument.
-- `object`
-  - : When called with an `object` argument, a new typed array is
-    created as if by the `TypedArray.from()` method.
-- `buffer`, `byteOffset`,
-  `length`
-  - : When called with a `buffer`, and optionally a
-    `byteOffset` and a `length` argument, a
-    new typed array view is created that views the specified {{jsxref("ArrayBuffer")}}.
-    The `byteOffset` and `length` parameters
-    specify the memory range that will be exposed by the typed array view. If both are
-    omitted, all of `buffer` is viewed; if only
-    `length` is omitted, the remainder of
-    `buffer` is viewed.
+For a detailed explanation of each constructor parameter, see the [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#constructor) page.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/biguint64array/biguint64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/biguint64array/biguint64array/index.md
@@ -34,7 +34,13 @@ new BigUint64Array(buffer, byteOffset, length)
 
 > **Note:** `BigUint64Array()` can only be constructed with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). Attempting to call it without `new` throws a {{jsxref("TypeError")}}.
 
-For a detailed explanation of each constructor parameter, see the [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#constructor) page.
+### Parameters
+
+See [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#parameters).
+
+### Exceptions
+
+See [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#exceptions).
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/float32array/float32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float32array/float32array/index.md
@@ -35,7 +35,13 @@ new Float32Array(buffer, byteOffset, length)
 
 > **Note:** `Float32Array()` can only be constructed with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). Attempting to call it without `new` throws a {{jsxref("TypeError")}}.
 
-For a detailed explanation of each constructor parameter, see the [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#constructor) page.
+### Parameters
+
+See [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#parameters).
+
+### Exceptions
+
+See [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#exceptions).
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/float32array/float32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float32array/float32array/index.md
@@ -35,32 +35,7 @@ new Float32Array(buffer, byteOffset, length)
 
 > **Note:** `Float32Array()` can only be constructed with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). Attempting to call it without `new` throws a {{jsxref("TypeError")}}.
 
-### Parameters
-
-- `length`
-  - : When called with a `length` argument, an internal array buffer
-    is created in memory, of size `length` _multiplied by
-    `BYTES_PER_ELEMENT`_ bytes, containing zeros.
-- `typedArray`
-  - : When called with a `typedArray` argument, which can be an
-    object of any of the **non**-{{glossary("bigint")}} typed-array types (such as `Int32Array`), the
-    `typedArray` gets copied into a new typed array. Each value in
-    `typedArray` is converted to the corresponding type of the
-    constructor before being copied into the new array. The length of the new typed array
-    will be same as the length of the `typedArray` argument.
-- `object`
-  - : When called with an `object` argument, a new typed array is
-    created as if by the `TypedArray.from()` method.
-- `buffer`, `byteOffset`,
-  `length`
-  - : When called with a `buffer`, and optionally a
-    `byteOffset` and a `length` argument, a
-    new typed array view is created that views the specified {{jsxref("ArrayBuffer")}}.
-    The `byteOffset` and `length` parameters
-    specify the memory range that will be exposed by the typed array view. If both are
-    omitted, all of `buffer` is viewed; if only
-    `length` is omitted, the remainder of
-    `buffer` is viewed.
+For a detailed explanation of each constructor parameter, see the [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#constructor) page.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/float64array/float64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float64array/float64array/index.md
@@ -35,32 +35,7 @@ new Float64Array(buffer, byteOffset, length)
 
 > **Note:** `Float64Array()` can only be constructed with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). Attempting to call it without `new` throws a {{jsxref("TypeError")}}.
 
-### Parameters
-
-- `length`
-  - : When called with a `length` argument, an internal array buffer
-    is created in memory, of size `length` _multiplied by
-    `BYTES_PER_ELEMENT`_ bytes, containing zeros.
-- `typedArray`
-  - : When called with a `typedArray` argument, which can be an
-    object of any of the **non**-{{glossary("bigint")}} typed-array types (such as `Int32Array`), the
-    `typedArray` gets copied into a new typed array. Each value in
-    `typedArray` is converted to the corresponding type of the
-    constructor before being copied into the new array. The length of the new typed array
-    will be same as the length of the `typedArray` argument.
-- `object`
-  - : When called with an `object` argument, a new typed array is
-    created as if by the `TypedArray.from()` method.
-- `buffer`, `byteOffset`,
-  `length`
-  - : When called with a `buffer`, and optionally a
-    `byteOffset` and a `length` argument, a
-    new typed array view is created that views the specified {{jsxref("ArrayBuffer")}}.
-    The `byteOffset` and `length` parameters
-    specify the memory range that will be exposed by the typed array view. If both are
-    omitted, all of `buffer` is viewed; if only
-    `length` is omitted, the remainder of
-    `buffer` is viewed.
+For a detailed explanation of each constructor parameter, see the [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#constructor) page.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/float64array/float64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float64array/float64array/index.md
@@ -35,7 +35,13 @@ new Float64Array(buffer, byteOffset, length)
 
 > **Note:** `Float64Array()` can only be constructed with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). Attempting to call it without `new` throws a {{jsxref("TypeError")}}.
 
-For a detailed explanation of each constructor parameter, see the [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#constructor) page.
+### Parameters
+
+See [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#parameters).
+
+### Exceptions
+
+See [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#exceptions).
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/int16array/int16array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int16array/int16array/index.md
@@ -34,7 +34,13 @@ new Int16Array(buffer, byteOffset, length)
 
 > **Note:** `Int16Array()` can only be constructed with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). Attempting to call it without `new` throws a {{jsxref("TypeError")}}.
 
-For a detailed explanation of each constructor parameter, see the [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#constructor) page.
+### Parameters
+
+See [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#parameters).
+
+### Exceptions
+
+See [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#exceptions).
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/int16array/int16array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int16array/int16array/index.md
@@ -34,32 +34,7 @@ new Int16Array(buffer, byteOffset, length)
 
 > **Note:** `Int16Array()` can only be constructed with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). Attempting to call it without `new` throws a {{jsxref("TypeError")}}.
 
-### Parameters
-
-- `length`
-  - : When called with a `length` argument, an internal array buffer
-    is created in memory, of size `length` _multiplied by
-    `BYTES_PER_ELEMENT`_ bytes, containing zeros.
-- `typedArray`
-  - : When called with a `typedArray` argument, which can be an object of any
-    of the **non**-{{glossary("bigint")}} typed-array types (such as `Int32Array`), the
-    `typedArray` gets copied into a new typed array. Each value in
-    `typedArray` is converted to the corresponding type of the
-    constructor before being copied into the new array. The length of the new typed array
-    will be same as the length of the `typedArray` argument.
-- `object`
-  - : When called with an `object` argument, a new typed array is
-    created as if by the `TypedArray.from()` method.
-- `buffer`, `byteOffset`,
-  `length`
-  - : When called with a `buffer`, and optionally a
-    `byteOffset` and a `length` argument, a
-    new typed array view is created that views the specified {{jsxref("ArrayBuffer")}}.
-    The `byteOffset` and `length` parameters
-    specify the memory range that will be exposed by the typed array view. If both are
-    omitted, all of `buffer` is viewed; if only
-    `length` is omitted, the remainder of
-    `buffer` is viewed.
+For a detailed explanation of each constructor parameter, see the [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#constructor) page.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/int32array/int32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int32array/int32array/index.md
@@ -34,32 +34,7 @@ new Int32Array(buffer, byteOffset, length)
 
 > **Note:** `Int32Array()` can only be constructed with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). Attempting to call it without `new` throws a {{jsxref("TypeError")}}.
 
-### Parameters
-
-- `length`
-  - : When called with a `length` argument, an internal array buffer
-    is created in memory, of size `length` _multiplied by
-    `BYTES_PER_ELEMENT`_ bytes, containing zeros.
-- `typedArray`
-  - : When called with a `typedArray` argument, which can be an object of any
-    of the **non**-{{glossary("bigint")}} typed-array types (such as `Int32Array`), the
-    `typedArray` gets copied into a new typed array. Each value in
-    `typedArray` is converted to the corresponding type of the
-    constructor before being copied into the new array. The length of the new typed array
-    will be same as the length of the `typedArray` argument.
-- `object`
-  - : When called with an `object` argument, a new typed array is
-    created as if by the `TypedArray.from()` method.
-- `buffer`, `byteOffset`,
-  `length`
-  - : When called with a `buffer`, and optionally a
-    `byteOffset` and a `length` argument, a
-    new typed array view is created that views the specified {{jsxref("ArrayBuffer")}}.
-    The `byteOffset` and `length` parameters
-    specify the memory range that will be exposed by the typed array view. If both are
-    omitted, all of `buffer` is viewed; if only
-    `length` is omitted, the remainder of
-    `buffer` is viewed.
+For a detailed explanation of each constructor parameter, see the [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#constructor) page.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/int32array/int32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int32array/int32array/index.md
@@ -34,7 +34,13 @@ new Int32Array(buffer, byteOffset, length)
 
 > **Note:** `Int32Array()` can only be constructed with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). Attempting to call it without `new` throws a {{jsxref("TypeError")}}.
 
-For a detailed explanation of each constructor parameter, see the [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#constructor) page.
+### Parameters
+
+See [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#parameters).
+
+### Exceptions
+
+See [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#exceptions).
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/int8array/int8array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int8array/int8array/index.md
@@ -32,7 +32,13 @@ new Int8Array(buffer, byteOffset, length)
 
 > **Note:** `Int8Array()` can only be constructed with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). Attempting to call it without `new` throws a {{jsxref("TypeError")}}.
 
-For a detailed explanation of each constructor parameter, see the [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#constructor) page.
+### Parameters
+
+See [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#parameters).
+
+### Exceptions
+
+See [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#exceptions).
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/int8array/int8array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int8array/int8array/index.md
@@ -32,32 +32,7 @@ new Int8Array(buffer, byteOffset, length)
 
 > **Note:** `Int8Array()` can only be constructed with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). Attempting to call it without `new` throws a {{jsxref("TypeError")}}.
 
-### Parameters
-
-- `length`
-  - : When called with a `length` argument, an internal array buffer
-    is created in memory, of size `length` _multiplied by
-    `BYTES_PER_ELEMENT`_ bytes, containing zeros.
-- `typedArray`
-  - : When called with a `typedArray` argument, which can be an object of any
-    of the **non**-{{glossary("bigint")}} typed-array types (such as `Int32Array`), the
-    `typedArray` gets copied into a new typed array. Each value in
-    `typedArray` is converted to the corresponding type of the
-    constructor before being copied into the new array. The length of the new typed array
-    will be same as the length of the `typedArray` argument.
-- `object`
-  - : When called with an `object` argument, a new typed array is
-    created as if by the `TypedArray.from()` method.
-- `buffer`, `byteOffset`,
-  `length`
-  - : When called with a `buffer`, and optionally a
-    `byteOffset` and a `length` argument, a
-    new typed array view is created that views the specified {{jsxref("ArrayBuffer")}}.
-    The `byteOffset` and `length` parameters
-    specify the memory range that will be exposed by the typed array view. If both are
-    omitted, all of `buffer` is viewed; if only
-    `length` is omitted, the remainder of
-    `buffer` is viewed.
+For a detailed explanation of each constructor parameter, see the [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#constructor) page.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/index.md
@@ -24,22 +24,9 @@ methods that can be used with any typed array containing elements of any type.
 
 ## Description
 
-The `TypedArray` constructor is a hidden global that serves as
-the `[[Prototype]]` of all `TypedArray` constructors.
-This constructor is not directly exposed: there is no global `%TypedArray%`
-or `TypedArray` property. It is only directly accessible through
-`Object.getPrototypeOf(Int8Array)` and similar. All
-`TypedArray`s constructors inherit common properties from the
-`%TypedArray%` constructor function. Additionally, all typed array prototypes
-(`TypedArray.prototype`) have `%TypedArray%.prototype`
-as their `[[Prototype]]`.
+The `TypedArray` constructor (often referred to as `%TypedArray%` to indicate its "intrinsicness", since it does not correspond to any global exposed to a JavaScript program) serves as the common superclass of all `TypedArray` subclasses. Think about `%TypedArray%` as an "abstract class" providing a common interface of utility methods for all typed array subclasses. This constructor is not directly exposed: there is no global `TypedArray` property. It is only accessible through `Object.getPrototypeOf(Int8Array)` and similar.
 
-When creating an instance of a `TypedArray` (e.g.
-`Int8Array`), an array buffer is created internally in memory or, if an
-`ArrayBuffer` object is given as constructor argument, then this is used
-instead. The buffer address is saved as an internal property of the instance and all the
-methods of `%TypedArray%.prototype`, i.e. set value and get value
-etc., operate on that array buffer address.
+When creating an instance of a `TypedArray` subclass (e.g. `Int8Array`), an array buffer is created internally in memory or, if an `ArrayBuffer` object is given as constructor argument, that `ArrayBuffer` is used instead. The buffer address is saved as an internal property of the instance and all the methods of `%TypedArray%.prototype` will set and get values based on that array buffer address.
 
 ### TypedArray objects
 
@@ -59,10 +46,14 @@ etc., operate on that array buffer address.
 
 ## Constructor
 
-This object cannot be instantiated directly. Instead, you create an instance of an
-array of a particular type, such as a {{jsxref("Int8Array")}} or a
-{{jsxref("BigInt64Array")}}. These objects all have a common syntax for their
-constructors:
+This object cannot be instantiated directly — attempting to construct it with `new` throws a {{jsxref("TypeError")}}.
+
+```js
+new (Object.getPrototypeOf(Int8Array))();
+// TypeError: Abstract class TypedArray not directly constructable
+```
+
+Instead, you create an instance of a typed array of a particular type, such as an {{jsxref("Int8Array")}} or a {{jsxref("BigInt64Array")}}. These objects all have a common syntax for their constructors:
 
 ```js
 new TypedArray()
@@ -75,40 +66,35 @@ new TypedArray(buffer, byteOffset)
 new TypedArray(buffer, byteOffset, length)
 ```
 
-Where _TypedArray_ is a constructor for one of the concrete types.
+Where `TypedArray` is a constructor for one of the concrete types.
 
-> **Note:** All `TypedArray` constructors can only be constructed with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). Attempting to call one without `new` throws a {{jsxref("TypeError")}}.
+> **Note:** All `TypedArray` subclasses' constructors can only be constructed with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). Attempting to call one without `new` throws a {{jsxref("TypeError")}}.
 
 ### Parameters
 
-- `length`
-  - : When called with a `length` argument, an internal array buffer
-    is created in memory, of size `length` _multiplied by
-    `BYTES_PER_ELEMENT`_ bytes, containing zeros.
 - `typedArray`
-  - : When called with a `typedArray` argument, the `typedArray` gets copied
-    into a new typed array. For a **non-{{glossary("bigint")}}** `TypedArray`,
-    the `typedArray` parameter can be an object of only the
-    **non**-{{glossary("bigint")}} typed array types (such as
-    {{JSxRef("Int32Array")}}). Similarly, for a **{{glossary("bigint")}}**
-    `TypedArray`, the `typedArray` parameter can be an object of only the
-    {{glossary("bigint")}} typed array types (such as {{JSxRef("BigInt64Array")}}).
-    Each value in `typedArray` is converted to the corresponding type of the
-    constructor before being copied into the new array. The length of the new
-    typed array will be same as the length of the `typedArray` argument.
+  - : When called with an instance of a `TypedArray` subclass, the `typedArray` gets copied into a new typed array. For a non-[bigint](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) `TypedArray` constructor, the `typedArray` parameter can only be of one of the non-[bigint](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) types (such as {{JSxRef("Int32Array")}}). Similarly, for a [bigint](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) `TypedArray` constructor ({{JSxRef("BigInt64Array")}} or {{JSxRef("BigUint64Array")}}), the `typedArray` parameter can only be of one of the [bigint](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) types. Each value in `typedArray` is converted to the corresponding type of the constructor before being copied into the new array. The length of the new typed array will be same as the length of the `typedArray` argument.
 - `object`
-  - : When called with an `object` argument, a new typed array is
-    created as if by the `TypedArray.from()` method.
-- `buffer`, `byteOffset`,
-  `length`
-  - : When called with a `buffer`, and optionally a
-    `byteOffset` and a `length` argument, a
-    new typed array view is created that views the specified {{jsxref("ArrayBuffer")}}.
-    The `byteOffset` and `length` parameters
-    specify the memory range that will be exposed by the typed array view. If both are
-    omitted, all of `buffer` is viewed; if only
-    `length` is omitted, the remainder of
-    `buffer` is viewed.
+  - : When called with an object that's not a `TypedArray` instance, a new typed array is created in the same way as the [`TypedArray.from()`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/from) method.
+- `length` {{optional_inline}}
+  - : When called with a non-object, the parameter will be treated as a number specifying the length of the typed array. An internal array buffer is created in memory, of size `length` multiplied by [`BYTES_PER_ELEMENT`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/BYTES_PER_ELEMENT) bytes, filled with zeros. Omitting all parameters is equivalent to using `0` as `length`.
+- `buffer`, `byteOffset` {{optional_inline}}, `length` {{optional_inline}}
+  - : When called with an [`ArrayBuffer`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) or [`SharedArrayBuffer`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) instance, and optionally a `byteOffset` and a `length` argument, a new typed array view is created that views the specified buffer. The `byteOffset` and `length` parameters specify the memory range that will be exposed by the typed array view. If both are omitted, all of `buffer` is viewed; if only `length` is omitted, the remainder of `buffer` starting from `byteOffset` is viewed.
+
+### Exceptions
+
+All `TypeArray` subclass constructors operate in the same way. They would all throw the following exceptions:
+
+- {{jsxref("TypeError")}}
+  - : Thrown in one of the following cases:
+    - A `typedArray` is passed but it is a [bigint](/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) type while the current constructor is not, or vice versa.
+    - A `typedArray` is passed but the buffer it's viewing is detached, or a detached `buffer` is directly passed.
+- {{jsxref("RangeError")}}
+  - : Thrown in one of the following cases:
+    - The new typed array's length is too large.
+    - The length of `buffer` (if the `length` parameter is not specified) or `byteOffset` is not an integral multiple of the new typed array's element size.
+    - `byteOffset` is not a valid array index (an integer between 0 and 2<sup>53</sup> - 1).
+    - When creating a view from a buffer, the bounds are outside the buffer. In other words, `byteOffset + length * TypedArray.BYTES_PER_ELEMENT > buffer.byteLength`.
 
 ## Static properties
 

--- a/files/en-us/web/javascript/reference/global_objects/uint16array/uint16array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint16array/uint16array/index.md
@@ -30,7 +30,13 @@ new Uint16Array(buffer, byteOffset, length)
 
 > **Note:** `Uint16Array()` can only be constructed with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). Attempting to call it without `new` throws a {{jsxref("TypeError")}}.
 
-For a detailed explanation of each constructor parameter, see the [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#constructor) page.
+### Parameters
+
+See [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#parameters).
+
+### Exceptions
+
+See [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#exceptions).
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/uint16array/uint16array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint16array/uint16array/index.md
@@ -30,32 +30,7 @@ new Uint16Array(buffer, byteOffset, length)
 
 > **Note:** `Uint16Array()` can only be constructed with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). Attempting to call it without `new` throws a {{jsxref("TypeError")}}.
 
-### Parameters
-
-- `length`
-  - : When called with a `length` argument, an internal array buffer
-    is created in memory, of size `length` _multiplied by
-    `BYTES_PER_ELEMENT`_ bytes, containing zeros.
-- `typedArray`
-  - : When called with a `typedArray` argument, which can be an object of any
-    of the **non**-{{glossary("bigint")}} typed-array types (such as `Int32Array`), the
-    `typedArray` gets copied into a new typed array. Each value in
-    `typedArray` is converted to the corresponding type of the
-    constructor before being copied into the new array. The length of the new typed array
-    will be same as the length of the `typedArray` argument.
-- `object`
-  - : When called with an `object` argument, a new typed array is
-    created as if by the `TypedArray.from()` method.
-- `buffer`, `byteOffset`,
-  `length`
-  - : When called with a `buffer`, and optionally a
-    `byteOffset` and a `length` argument, a
-    new typed array view is created that views the specified {{jsxref("ArrayBuffer")}}.
-    The `byteOffset` and `length` parameters
-    specify the memory range that will be exposed by the typed array view. If both are
-    omitted, all of `buffer` is viewed; if only
-    `length` is omitted, the remainder of
-    `buffer` is viewed.
+For a detailed explanation of each constructor parameter, see the [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#constructor) page.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/uint32array/uint32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint32array/uint32array/index.md
@@ -34,7 +34,13 @@ new Uint32Array(buffer, byteOffset, length)
 
 > **Note:** `Uint32Array()` can only be constructed with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). Attempting to call it without `new` throws a {{jsxref("TypeError")}}.
 
-For a detailed explanation of each constructor parameter, see the [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#constructor) page.
+### Parameters
+
+See [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#parameters).
+
+### Exceptions
+
+See [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#exceptions).
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/uint32array/uint32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint32array/uint32array/index.md
@@ -34,32 +34,7 @@ new Uint32Array(buffer, byteOffset, length)
 
 > **Note:** `Uint32Array()` can only be constructed with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). Attempting to call it without `new` throws a {{jsxref("TypeError")}}.
 
-### Parameters
-
-- `length`
-  - : When called with a `length` argument, an internal array buffer
-    is created in memory, of size `length` _multiplied by
-    `BYTES_PER_ELEMENT`_ bytes, containing zeros.
-- `typedArray`
-  - : When called with a `typedArray` argument, which can be an object of any
-    of the **non**-{{glossary("bigint")}} typed-array types (such as `Int32Array`), the
-    `typedArray` gets copied into a new typed array. Each value in
-    `typedArray` is converted to the corresponding type of the
-    constructor before being copied into the new array. The length of the new typed array
-    will be same as the length of the `typedArray` argument.
-- `object`
-  - : When called with an `object` argument, a new typed array is
-    created as if by the `TypedArray.from()` method.
-- `buffer`, `byteOffset`,
-  `length`
-  - : When called with a `buffer`, and optionally a
-    `byteOffset` and a `length` argument, a
-    new typed array view is created that views the specified {{jsxref("ArrayBuffer")}}.
-    The `byteOffset` and `length` parameters
-    specify the memory range that will be exposed by the typed array view. If both are
-    omitted, all of `buffer` is viewed; if only
-    `length` is omitted, the remainder of
-    `buffer` is viewed.
+For a detailed explanation of each constructor parameter, see the [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#constructor) page.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/uint8array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/uint8array/index.md
@@ -32,32 +32,7 @@ new Uint8Array(buffer, byteOffset, length)
 
 > **Note:** `Uint8Array()` can only be constructed with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). Attempting to call it without `new` throws a {{jsxref("TypeError")}}.
 
-### Parameters
-
-- `length`
-  - : When called with a `length` argument, an internal array buffer
-    is created in memory, of size `length` _multiplied by
-    `BYTES_PER_ELEMENT`_ bytes, containing zeros.
-- `typedArray`
-  - : When called with a `typedArray` argument, which can be an object of any
-    of the **non**-{{glossary("bigint")}} typed-array types (such as `Int32Array`), the
-    `typedArray` gets copied into a new typed array. Each value in
-    `typedArray` is converted to the corresponding type of the
-    constructor before being copied into the new array. The length of the new typed array
-    will be same as the length of the `typedArray` argument.
-- `object`
-  - : When called with an `object` argument, a new typed array is
-    created as if by the `TypedArray.from()` method.
-- `buffer`, `byteOffset`,
-  `length`
-  - : When called with a `buffer`, and optionally a
-    `byteOffset` and a `length` argument, a
-    new typed array view is created that views the specified {{jsxref("ArrayBuffer")}}.
-    The `byteOffset` and `length` parameters
-    specify the memory range that will be exposed by the typed array view. If both are
-    omitted, all of `buffer` is viewed; if only
-    `length` is omitted, the remainder of
-    `buffer` is viewed.
+For a detailed explanation of each constructor parameter, see the [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#constructor) page.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/uint8array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/uint8array/index.md
@@ -32,7 +32,13 @@ new Uint8Array(buffer, byteOffset, length)
 
 > **Note:** `Uint8Array()` can only be constructed with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). Attempting to call it without `new` throws a {{jsxref("TypeError")}}.
 
-For a detailed explanation of each constructor parameter, see the [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#constructor) page.
+### Parameters
+
+See [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#parameters).
+
+### Exceptions
+
+See [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#exceptions).
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/uint8clampedarray/uint8clampedarray/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8clampedarray/uint8clampedarray/index.md
@@ -34,32 +34,7 @@ new Uint8ClampedArray(buffer, byteOffset, length)
 
 > **Note:** `Uint8ClampedArray()` can only be constructed with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). Attempting to call it without `new` throws a {{jsxref("TypeError")}}.
 
-### Parameters
-
-- `length`
-  - : When called with a `length` argument, an internal array buffer
-    is created in memory, of size `length` _multiplied by
-    `BYTES_PER_ELEMENT`_ bytes, containing zeros.
-- `typedArray`
-  - : When called with a `typedArray` argument, which can be an object of any
-    of the **non**-{{glossary("bigint")}} typed-array types (such as {{JSxRef("Int32Array")}}), the
-    `typedArray` gets copied into a new typed array. Each value in
-    `typedArray` is converted to the corresponding type of the
-    constructor before being copied into the new array. The length of the new typed array
-    will be same as the length of the `typedArray` argument.
-- `object`
-  - : When called with an `object` argument, a new typed array is
-    created as if by the `TypedArray.from()` method.
-- `buffer`, `byteOffset`,
-  `length`
-  - : When called with a `buffer`, and optionally a
-    `byteOffset` and a `length` argument, a
-    new typed array view is created that views the specified {{jsxref("ArrayBuffer")}}.
-    The `byteOffset` and `length` parameters
-    specify the memory range that will be exposed by the typed array view. If both are
-    omitted, all of `buffer` is viewed; if only
-    `length` is omitted, the remainder of
-    `buffer` is viewed.
+For a detailed explanation of each constructor parameter, see the [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#constructor) page.
 
 ## Examples
 

--- a/files/en-us/web/javascript/reference/global_objects/uint8clampedarray/uint8clampedarray/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8clampedarray/uint8clampedarray/index.md
@@ -34,7 +34,13 @@ new Uint8ClampedArray(buffer, byteOffset, length)
 
 > **Note:** `Uint8ClampedArray()` can only be constructed with [`new`](/en-US/docs/Web/JavaScript/Reference/Operators/new). Attempting to call it without `new` throws a {{jsxref("TypeError")}}.
 
-For a detailed explanation of each constructor parameter, see the [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#constructor) page.
+### Parameters
+
+See [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#parameters).
+
+### Exceptions
+
+See [`TypedArray`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#exceptions).
 
 ## Examples
 


### PR DESCRIPTION
<!-- 👀 Thanks for opening a PR! Read comments like this one to get your PR merged faster. -->
#### Summary
<!-- ✍️ In a sentence or two, describe your changes -->

#### Motivation

Fix mdn/content#18764

Any duplicated content is a maintenance hassle and may be confusing to readers as well. Condensing them in the same place improves visibility.

This decision is further motivated by the addition of the "exceptions" section. If we don't do the deduplication, people won't be reading the `TypedArray` constructor page, and they won't know about the exception info. I don't want to duplicate that section just for visibility.

#### Supporting details
<!-- 🔗 Link to supporting information, such as bug trackers, source control, release notes, and vendor docs. -->

#### Related issues
<!-- 🔨 If applicable, use "Fixes #XYZ" -->

#### Metadata
<!-- ✅ Check a box if applicable, like this: [x]

This PR…
-->
- [ ] Adds a new document
- [x] Rewrites (or significantly expands) a document
- [ ] Fixes a typo, bug, or other error

<!-- 👷‍♀️ After submitting, review the results of the "Checks" tab! -->
