### PR TITLE
fix: MD042 no empty links

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -92,7 +92,6 @@
   "MD036": false,
   "MD037": false,
   "MD040": false,
-  "MD042": false,
   "MD045": false,
   "MD046": {
     "style": "fenced"

--- a/files/en-us/mdn/community/pull_requests/index.md
+++ b/files/en-us/mdn/community/pull_requests/index.md
@@ -118,7 +118,7 @@ As a rule, do:
 
 - Fix one issue per PR — it may be slightly more work for you, but it is much easier to review a single clear fix.
 - Ask questions using other mechanisms like [chat rooms](https://chat.mozilla.org/#/room/#mdn:mozilla.org) or [forums](<(https://discourse.mozilla.org/c/mdn/236)>) if you are not sure whether something is useful or have a simple question.
-- Read the [contributor documentation]() and [how to write documentation]() first to try to answer the question yourself before filing a pr.
+- Read the contributor documentation and how to write documentation first to try to answer the question yourself before filing a pr.
 
 Don't:
 

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_reference_page_template/index.md
@@ -91,10 +91,10 @@ _Also inherits methods from its parent interface, {{DOMxRef("NameOfParentInterfa
 
 Listen to these events using [`addEventListener()`](/en-US/docs/Web/API/EventTarget/addEventListener) or by assigning an event listener to the `oneventname` property of this interface.
 
-- [`eventname1`](#)
+- [`eventname1`](#\)
   - : Fired when (include the description of when the event fires).
     Also available via the `oneventname1` property.
-- [`eventname2`](#)
+- [`eventname2`](#\)
   - : Fired when _(include a description of when the event fires)_.
     Also available via the `oneventname2` property.
 - etc.

--- a/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_reference_page_template/index.md
+++ b/files/en-us/mdn/writing_guidelines/page_structures/page_types/api_reference_page_template/index.md
@@ -91,10 +91,10 @@ _Also inherits methods from its parent interface, {{DOMxRef("NameOfParentInterfa
 
 Listen to these events using [`addEventListener()`](/en-US/docs/Web/API/EventTarget/addEventListener) or by assigning an event listener to the `oneventname` property of this interface.
 
-- [`eventname1`](#\)
+- [`eventname1`](#eventname1)
   - : Fired when (include the description of when the event fires).
     Also available via the `oneventname1` property.
-- [`eventname2`](#\)
+- [`eventname2`](#eventname2)
   - : Fired when _(include a description of when the event fires)_.
     Also available via the `oneventname2` property.
 - etc.

--- a/files/en-us/mozilla/firefox/releases/49/index.md
+++ b/files/en-us/mozilla/firefox/releases/49/index.md
@@ -70,7 +70,7 @@ tags:
 ### JavaScript
 
 - The ES2015 {{jsxref("Global_Objects/Proxy/Proxy/getPrototypeOf", "getPrototypeOf()")}} and {{jsxref("Global_Objects/Proxy/Proxy/setPrototypeOf", "setPrototypeOf()")}} {{jsxref("Proxy")}} traps have been implemented ({{bug(888969)}}).
-- The ES2015 {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]\()")}}, {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]\()")}}, {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]\()")}}}, and {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]\()")}}} methods, and {{jsxref("RegExp.@@species", "RegExp[@@species]")}} getter have been implemented ({{bug(887016)}}).
+- The ES2015 {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]\()")}}, {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]\()")}}, {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]\()")}}, and {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]\()")}} methods, and {{jsxref("RegExp.@@species", "RegExp[@@species]")}} getter have been implemented ({{bug(887016)}}).
 - The deprecated, non-standard `flags` argument of `String.prototype.`{{jsxref("String.prototype.match", "match")}}/{{jsxref("String.prototype.search", "search")}}/{{jsxref("String.prototype.replace", "replace")}} has been removed ({{bug(1108382)}}).
 - The behavior of the {{jsxref("Date.parse()")}} method when parsing 2-digit years has been changed to be more interoperable with the Google Chrome browser ({{bug(1265136)}}).
 

--- a/files/en-us/mozilla/firefox/releases/49/index.md
+++ b/files/en-us/mozilla/firefox/releases/49/index.md
@@ -69,8 +69,9 @@ tags:
 
 ### JavaScript
 
+<!-- markdownlint-disable MD042 -->
 - The ES2015 {{jsxref("Global_Objects/Proxy/Proxy/getPrototypeOf", "getPrototypeOf()")}} and {{jsxref("Global_Objects/Proxy/Proxy/setPrototypeOf", "setPrototypeOf()")}} {{jsxref("Proxy")}} traps have been implemented ({{bug(888969)}}).
-- The ES2015 {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]\()")}}, {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]\()")}}, {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]\()")}}, and {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]\()")}} methods, and {{jsxref("RegExp.@@species", "RegExp[@@species]")}} getter have been implemented ({{bug(887016)}}).
+- The ES2015 {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]()")}}, {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]()")}}, {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]()")}}, and {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]()")}} methods, and {{jsxref("RegExp.@@species", "RegExp[@@species]")}} getter have been implemented ({{bug(887016)}}).
 - The deprecated, non-standard `flags` argument of `String.prototype.`{{jsxref("String.prototype.match", "match")}}/{{jsxref("String.prototype.search", "search")}}/{{jsxref("String.prototype.replace", "replace")}} has been removed ({{bug(1108382)}}).
 - The behavior of the {{jsxref("Date.parse()")}} method when parsing 2-digit years has been changed to be more interoperable with the Google Chrome browser ({{bug(1265136)}}).
 

--- a/files/en-us/mozilla/firefox/releases/49/index.md
+++ b/files/en-us/mozilla/firefox/releases/49/index.md
@@ -70,7 +70,7 @@ tags:
 ### JavaScript
 
 - The ES2015 {{jsxref("Global_Objects/Proxy/Proxy/getPrototypeOf", "getPrototypeOf()")}} and {{jsxref("Global_Objects/Proxy/Proxy/setPrototypeOf", "setPrototypeOf()")}} {{jsxref("Proxy")}} traps have been implemented ({{bug(888969)}}).
-- The ES2015 {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]()")}}, {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]()")}}, {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]()")}}, and {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]()")}} methods, and {{jsxref("RegExp.@@species", "RegExp[@@species]")}} getter have been implemented ({{bug(887016)}}).
+- The ES2015 {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]\()")}}, {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]\()")}}, {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]\()")}}}, and {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]\()")}}} methods, and {{jsxref("RegExp.@@species", "RegExp[@@species]")}} getter have been implemented ({{bug(887016)}}).
 - The deprecated, non-standard `flags` argument of `String.prototype.`{{jsxref("String.prototype.match", "match")}}/{{jsxref("String.prototype.search", "search")}}/{{jsxref("String.prototype.replace", "replace")}} has been removed ({{bug(1108382)}}).
 - The behavior of the {{jsxref("Date.parse()")}} method when parsing 2-digit years has been changed to be more interoperable with the Google Chrome browser ({{bug(1265136)}}).
 

--- a/files/en-us/web/accessibility/aria/roles/progressbar_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/progressbar_role/index.md
@@ -19,7 +19,7 @@ The `progressbar` role defines an element that displays the progress status for 
 
 The `progressbar` range widget indicates that a request has been received and the application is making progress toward completing the requested action.
 
-Authors **may** set aria-valuemin and aria-valuemax to indicate the minimum and maximum progress indicator values. Otherwise, their implicit values follow the same rules as HTML's `<input type="range"`>:
+Authors _may_ set `aria-valuemin` and `aria-valuemax` to indicate the minimum and maximum progress indicator values. Otherwise, their implicit values follow the same rules as HTML's [`<input type="range">`](/en-US/docs/Web/HTML/Element/input/range):
 
 - If [`aria-valuemin`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemin) is missing or not a number, it defaults to `0` (zero).
 - If [`aria-valuemax`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemax) is missing or not a number, it defaults to `100`.

--- a/files/en-us/web/accessibility/aria/roles/progressbar_role/index.md
+++ b/files/en-us/web/accessibility/aria/roles/progressbar_role/index.md
@@ -19,7 +19,7 @@ The `progressbar` role defines an element that displays the progress status for 
 
 The `progressbar` range widget indicates that a request has been received and the application is making progress toward completing the requested action.
 
-Authors **may** set aria-valuemin and aria-valuemax to indicate the minimum and maximum progress indicator values. Otherwise, their implicit values follow the same rules as HTML's [`<input type="range"`>]():
+Authors **may** set aria-valuemin and aria-valuemax to indicate the minimum and maximum progress indicator values. Otherwise, their implicit values follow the same rules as HTML's `<input type="range"`>:
 
 - If [`aria-valuemin`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemin) is missing or not a number, it defaults to `0` (zero).
 - If [`aria-valuemax`](/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuemax) is missing or not a number, it defaults to `100`.

--- a/files/en-us/web/api/mediakeystatusmap/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/index.md
@@ -21,6 +21,7 @@ The **`MediaKeyStatusMap`** interface of the [EncryptedMediaExtensions API](/en-
 
 ## Methods
 
+<!-- markdownlint-disable MD042 -->
 - {{domxref("MediaKeyStatusMap.entries()")}} {{ReadOnlyInline}}
   - : Returns a new `Iterator` object containing an array of `[key, value]` for each element in the status map, in insertion order.
 - {{domxref("MediaKeyStatusMap.forEach()","MediaKeyStatusMap.forEach(callback[, argument])")}} {{ReadOnlyInline}}
@@ -33,7 +34,7 @@ The **`MediaKeyStatusMap`** interface of the [EncryptedMediaExtensions API](/en-
   - : Returns a new `Iterator` object containing keys for each element in the status map, in insertion order.
 - {{domxref("MediaKeyStatusMap.values()")}} {{ReadOnlyInline}}
   - : Returns a new `Iterator` object containing values for each element in the status map, in insertion order.
-- {{domxref("MediaKeyStatusMap.[@@iterator]\()")}} {{ReadOnlyInline}}
+- {{domxref("MediaKeyStatusMap.[@@iterator]()")}} {{ReadOnlyInline}}
   - : Returns a new `Iterator` object containing an array of `[key, value]` for each element in the status map, in insertion order.
 
 ## Specifications

--- a/files/en-us/web/api/mediakeystatusmap/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/index.md
@@ -33,7 +33,7 @@ The **`MediaKeyStatusMap`** interface of the [EncryptedMediaExtensions API](/en-
   - : Returns a new `Iterator` object containing keys for each element in the status map, in insertion order.
 - {{domxref("MediaKeyStatusMap.values()")}} {{ReadOnlyInline}}
   - : Returns a new `Iterator` object containing values for each element in the status map, in insertion order.
-- {{domxref("MediaKeyStatusMap.[@@iterator]()")}} {{ReadOnlyInline}}
+- {{domxref("MediaKeyStatusMap.[@@iterator]\()")}}} {{ReadOnlyInline}}
   - : Returns a new `Iterator` object containing an array of `[key, value]` for each element in the status map, in insertion order.
 
 ## Specifications

--- a/files/en-us/web/api/mediakeystatusmap/index.md
+++ b/files/en-us/web/api/mediakeystatusmap/index.md
@@ -33,7 +33,7 @@ The **`MediaKeyStatusMap`** interface of the [EncryptedMediaExtensions API](/en-
   - : Returns a new `Iterator` object containing keys for each element in the status map, in insertion order.
 - {{domxref("MediaKeyStatusMap.values()")}} {{ReadOnlyInline}}
   - : Returns a new `Iterator` object containing values for each element in the status map, in insertion order.
-- {{domxref("MediaKeyStatusMap.[@@iterator]\()")}}} {{ReadOnlyInline}}
+- {{domxref("MediaKeyStatusMap.[@@iterator]\()")}} {{ReadOnlyInline}}
   - : Returns a new `Iterator` object containing an array of `[key, value]` for each element in the status map, in insertion order.
 
 ## Specifications

--- a/files/en-us/web/api/webgl2renderingcontext/drawbuffers/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/drawbuffers/index.md
@@ -64,5 +64,5 @@ gl.drawBuffers([gl.NONE, gl.COLOR_ATTACHMENT1]);
 
 ## See also
 
-- {{domxref("WebGL2RenderingContext.clearBuffer",
-    "WebGL2RenderingContext.clearBuffer[fiuv]\()")}}
+<!-- markdownlint-disable MD042 -->
+- {{domxref("WebGL2RenderingContext.clearBuffer", "WebGL2RenderingContext.clearBuffer[fiuv]()")}}

--- a/files/en-us/web/api/webgl2renderingcontext/drawbuffers/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/drawbuffers/index.md
@@ -65,4 +65,4 @@ gl.drawBuffers([gl.NONE, gl.COLOR_ATTACHMENT1]);
 ## See also
 
 - {{domxref("WebGL2RenderingContext.clearBuffer",
-    "WebGL2RenderingContext.clearBuffer[fiuv]()")}}
+    "WebGL2RenderingContext.clearBuffer[fiuv]\()")}}}

--- a/files/en-us/web/api/webgl2renderingcontext/drawbuffers/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/drawbuffers/index.md
@@ -65,4 +65,4 @@ gl.drawBuffers([gl.NONE, gl.COLOR_ATTACHMENT1]);
 ## See also
 
 - {{domxref("WebGL2RenderingContext.clearBuffer",
-    "WebGL2RenderingContext.clearBuffer[fiuv]\()")}}}
+    "WebGL2RenderingContext.clearBuffer[fiuv]\()")}}

--- a/files/en-us/web/api/webgl2renderingcontext/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/index.md
@@ -88,11 +88,12 @@ See the [WebGL constants](/en-US/docs/Web/API/WebGL_API/Constants) page.
 
 ## Uniforms and attributes
 
-- {{domxref("WebGL2RenderingContext.uniform()", "WebGL2RenderingContext.uniform[1234][uif][v]\()")}}
+<!-- markdownlint-disable MD042 -->
+- {{domxref("WebGL2RenderingContext.uniform()", "WebGL2RenderingContext.uniform[1234][uif][v]()")}}
   - : Methods specifying values of uniform variables.
 - {{domxref("WebGL2RenderingContext.uniformMatrix()", "WebGL2RenderingContext.uniformMatrix[234]x[234]fv()")}}
   - : Methods specifying matrix values for uniform variables.
-- {{domxref("WebGL2RenderingContext.vertexAttribI()", "WebGL2RenderingContext.vertexAttribI4[u]i[v]\()")}}
+- {{domxref("WebGL2RenderingContext.vertexAttribI()", "WebGL2RenderingContext.vertexAttribI4[u]i[v]()")}}
   - : Methods specifying integer values for generic vertex attributes.
 - {{domxref("WebGL2RenderingContext.vertexAttribIPointer()")}}
   - : Specifies integer data formats and locations of vertex attributes in a vertex attributes array.
@@ -109,7 +110,7 @@ See the [WebGL constants](/en-US/docs/Web/API/WebGL_API/Constants) page.
   - : Renders primitives from array data in a given range.
 - {{domxref("WebGL2RenderingContext.drawBuffers()")}}
   - : Specifies a list of color buffers to be drawn into.
-- {{domxref("WebGL2RenderingContext.clearBuffer()", "WebGL2RenderingContext.clearBuffer[fiuv]\()")}}
+- {{domxref("WebGL2RenderingContext.clearBuffer()", "WebGL2RenderingContext.clearBuffer[fiuv]()")}}
   - : Clears buffers from the currently bound framebuffer.
 
 ## Query objects
@@ -141,7 +142,7 @@ Methods for working with {{domxref("WebGLQuery")}} objects.
   - : Binds a given {{domxref("WebGLSampler")}} to a texture unit.
 - {{domxref("WebGL2RenderingContext.isSampler()")}}
   - : Returns `true` if a given object is a valid {{domxref("WebGLSampler")}} object.
-- {{domxref("WebGL2RenderingContext.samplerParameter()", "WebGL2RenderingContext.samplerParameter[if]\()")}}
+- {{domxref("WebGL2RenderingContext.samplerParameter()", "WebGL2RenderingContext.samplerParameter[if]()")}}
   - : Sets sampler parameters.
 - {{domxref("WebGL2RenderingContext.getSamplerParameter()")}}
   - : Returns sampler parameter information.

--- a/files/en-us/web/api/webgl2renderingcontext/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/index.md
@@ -88,11 +88,11 @@ See the [WebGL constants](/en-US/docs/Web/API/WebGL_API/Constants) page.
 
 ## Uniforms and attributes
 
-- {{domxref("WebGL2RenderingContext.uniform()", "WebGL2RenderingContext.uniform[1234][uif][v]()")}}
+- {{domxref("WebGL2RenderingContext.uniform()", "WebGL2RenderingContext.uniform[1234][uif][v]\()")}}}
   - : Methods specifying values of uniform variables.
 - {{domxref("WebGL2RenderingContext.uniformMatrix()", "WebGL2RenderingContext.uniformMatrix[234]x[234]fv()")}}
   - : Methods specifying matrix values for uniform variables.
-- {{domxref("WebGL2RenderingContext.vertexAttribI()", "WebGL2RenderingContext.vertexAttribI4[u]i[v]()")}}
+- {{domxref("WebGL2RenderingContext.vertexAttribI()", "WebGL2RenderingContext.vertexAttribI4[u]i[v]\()")}}}
   - : Methods specifying integer values for generic vertex attributes.
 - {{domxref("WebGL2RenderingContext.vertexAttribIPointer()")}}
   - : Specifies integer data formats and locations of vertex attributes in a vertex attributes array.
@@ -109,7 +109,7 @@ See the [WebGL constants](/en-US/docs/Web/API/WebGL_API/Constants) page.
   - : Renders primitives from array data in a given range.
 - {{domxref("WebGL2RenderingContext.drawBuffers()")}}
   - : Specifies a list of color buffers to be drawn into.
-- {{domxref("WebGL2RenderingContext.clearBuffer()", "WebGL2RenderingContext.clearBuffer[fiuv]()")}}
+- {{domxref("WebGL2RenderingContext.clearBuffer()", "WebGL2RenderingContext.clearBuffer[fiuv]\()")}}}
   - : Clears buffers from the currently bound framebuffer.
 
 ## Query objects
@@ -141,7 +141,7 @@ Methods for working with {{domxref("WebGLQuery")}} objects.
   - : Binds a given {{domxref("WebGLSampler")}} to a texture unit.
 - {{domxref("WebGL2RenderingContext.isSampler()")}}
   - : Returns `true` if a given object is a valid {{domxref("WebGLSampler")}} object.
-- {{domxref("WebGL2RenderingContext.samplerParameter()", "WebGL2RenderingContext.samplerParameter[if]()")}}
+- {{domxref("WebGL2RenderingContext.samplerParameter()", "WebGL2RenderingContext.samplerParameter[if]\()")}}}
   - : Sets sampler parameters.
 - {{domxref("WebGL2RenderingContext.getSamplerParameter()")}}
   - : Returns sampler parameter information.

--- a/files/en-us/web/api/webgl2renderingcontext/index.md
+++ b/files/en-us/web/api/webgl2renderingcontext/index.md
@@ -88,11 +88,11 @@ See the [WebGL constants](/en-US/docs/Web/API/WebGL_API/Constants) page.
 
 ## Uniforms and attributes
 
-- {{domxref("WebGL2RenderingContext.uniform()", "WebGL2RenderingContext.uniform[1234][uif][v]\()")}}}
+- {{domxref("WebGL2RenderingContext.uniform()", "WebGL2RenderingContext.uniform[1234][uif][v]\()")}}
   - : Methods specifying values of uniform variables.
 - {{domxref("WebGL2RenderingContext.uniformMatrix()", "WebGL2RenderingContext.uniformMatrix[234]x[234]fv()")}}
   - : Methods specifying matrix values for uniform variables.
-- {{domxref("WebGL2RenderingContext.vertexAttribI()", "WebGL2RenderingContext.vertexAttribI4[u]i[v]\()")}}}
+- {{domxref("WebGL2RenderingContext.vertexAttribI()", "WebGL2RenderingContext.vertexAttribI4[u]i[v]\()")}}
   - : Methods specifying integer values for generic vertex attributes.
 - {{domxref("WebGL2RenderingContext.vertexAttribIPointer()")}}
   - : Specifies integer data formats and locations of vertex attributes in a vertex attributes array.
@@ -109,7 +109,7 @@ See the [WebGL constants](/en-US/docs/Web/API/WebGL_API/Constants) page.
   - : Renders primitives from array data in a given range.
 - {{domxref("WebGL2RenderingContext.drawBuffers()")}}
   - : Specifies a list of color buffers to be drawn into.
-- {{domxref("WebGL2RenderingContext.clearBuffer()", "WebGL2RenderingContext.clearBuffer[fiuv]\()")}}}
+- {{domxref("WebGL2RenderingContext.clearBuffer()", "WebGL2RenderingContext.clearBuffer[fiuv]\()")}}
   - : Clears buffers from the currently bound framebuffer.
 
 ## Query objects
@@ -141,7 +141,7 @@ Methods for working with {{domxref("WebGLQuery")}} objects.
   - : Binds a given {{domxref("WebGLSampler")}} to a texture unit.
 - {{domxref("WebGL2RenderingContext.isSampler()")}}
   - : Returns `true` if a given object is a valid {{domxref("WebGLSampler")}} object.
-- {{domxref("WebGL2RenderingContext.samplerParameter()", "WebGL2RenderingContext.samplerParameter[if]\()")}}}
+- {{domxref("WebGL2RenderingContext.samplerParameter()", "WebGL2RenderingContext.samplerParameter[if]\()")}}
   - : Sets sampler parameters.
 - {{domxref("WebGL2RenderingContext.getSamplerParameter()")}}
   - : Returns sampler parameter information.

--- a/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.md
@@ -30,13 +30,14 @@ Once you have the uniform's location, you can access the uniform itself using on
 the other uniform access methods, passing in the uniform location as one of the
 inputs:
 
+<!-- markdownlint-disable MD042 -->
 - {{domxref("WebGLRenderingContext.getUniform", "getUniform()")}}
   - : Returns the value of the uniform at the given location.
-- {{domxref("WebGLRenderingContext.uniform", "uniform[1234][fi][v]\()")}}
+- {{domxref("WebGLRenderingContext.uniform", "uniform[1234][fi][v]()")}}
   - : Sets the uniform's value to the specified value, which may be a single floating
     point or integer number, or a 2-4 component vector specified either as a list of
     values or as a {{jsxref("Float32Array")}} or {{jsxref("Int32Array")}}.
-- {{domxref("WebGLRenderingContext.uniformMatrix", "uniformMatrix[234][fv]\()")}}
+- {{domxref("WebGLRenderingContext.uniformMatrix", "uniformMatrix[234][fv]()")}}
   - : Sets the uniform's value to the specified matrix, possibly with transposition. The
     value is represented as a sequence of `GLfloat` values or as a
     `Float32Array`.

--- a/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.md
@@ -32,11 +32,11 @@ inputs:
 
 - {{domxref("WebGLRenderingContext.getUniform", "getUniform()")}}
   - : Returns the value of the uniform at the given location.
-- {{domxref("WebGLRenderingContext.uniform", "uniform[1234][fi][v]\()")}}}
+- {{domxref("WebGLRenderingContext.uniform", "uniform[1234][fi][v]\()")}}
   - : Sets the uniform's value to the specified value, which may be a single floating
     point or integer number, or a 2-4 component vector specified either as a list of
     values or as a {{jsxref("Float32Array")}} or {{jsxref("Int32Array")}}.
-- {{domxref("WebGLRenderingContext.uniformMatrix", "uniformMatrix[234][fv]\()")}}}
+- {{domxref("WebGLRenderingContext.uniformMatrix", "uniformMatrix[234][fv]\()")}}
   - : Sets the uniform's value to the specified matrix, possibly with transposition. The
     value is represented as a sequence of `GLfloat` values or as a
     `Float32Array`.

--- a/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/getuniformlocation/index.md
@@ -32,11 +32,11 @@ inputs:
 
 - {{domxref("WebGLRenderingContext.getUniform", "getUniform()")}}
   - : Returns the value of the uniform at the given location.
-- {{domxref("WebGLRenderingContext.uniform", "uniform[1234][fi][v]()")}}
+- {{domxref("WebGLRenderingContext.uniform", "uniform[1234][fi][v]\()")}}}
   - : Sets the uniform's value to the specified value, which may be a single floating
     point or integer number, or a 2-4 component vector specified either as a list of
     values or as a {{jsxref("Float32Array")}} or {{jsxref("Int32Array")}}.
-- {{domxref("WebGLRenderingContext.uniformMatrix", "uniformMatrix[234][fv]()")}}
+- {{domxref("WebGLRenderingContext.uniformMatrix", "uniformMatrix[234][fv]\()")}}}
   - : Sets the uniform's value to the specified matrix, possibly with transposition. The
     value is represented as a sequence of `GLfloat` values or as a
     `Float32Array`.

--- a/files/en-us/web/api/webglrenderingcontext/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/index.md
@@ -277,11 +277,11 @@ The following properties and methods provide general information and functionali
   - : Returns information about a vertex attribute at a given position.
 - {{domxref("WebGLRenderingContext.getVertexAttribOffset()")}}
   - : Returns the address of a given vertex attribute.
-- {{domxref("WebGLRenderingContext.uniform()", "WebGLRenderingContext.uniform[1234][fi][v]\()")}}}
+- {{domxref("WebGLRenderingContext.uniform()", "WebGLRenderingContext.uniform[1234][fi][v]\()")}}
   - : Specifies a value for a uniform variable.
 - {{domxref("WebGLRenderingContext.uniformMatrix()", "WebGLRenderingContext.uniformMatrix[234]fv()")}}
   - : Specifies a matrix value for a uniform variable.
-- {{domxref("WebGLRenderingContext.vertexAttrib()", "WebGLRenderingContext.vertexAttrib[1234]f[v]\()")}}}
+- {{domxref("WebGLRenderingContext.vertexAttrib()", "WebGLRenderingContext.vertexAttrib[1234]f[v]\()")}}
   - : Specifies a value for a generic vertex attribute.
 - {{domxref("WebGLRenderingContext.vertexAttribPointer()")}}
   - : Specifies the data formats and locations of vertex attributes in a vertex attributes array.

--- a/files/en-us/web/api/webglrenderingcontext/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/index.md
@@ -277,11 +277,11 @@ The following properties and methods provide general information and functionali
   - : Returns information about a vertex attribute at a given position.
 - {{domxref("WebGLRenderingContext.getVertexAttribOffset()")}}
   - : Returns the address of a given vertex attribute.
-- {{domxref("WebGLRenderingContext.uniform()", "WebGLRenderingContext.uniform[1234][fi][v]()")}}
+- {{domxref("WebGLRenderingContext.uniform()", "WebGLRenderingContext.uniform[1234][fi][v]\()")}}}
   - : Specifies a value for a uniform variable.
 - {{domxref("WebGLRenderingContext.uniformMatrix()", "WebGLRenderingContext.uniformMatrix[234]fv()")}}
   - : Specifies a matrix value for a uniform variable.
-- {{domxref("WebGLRenderingContext.vertexAttrib()", "WebGLRenderingContext.vertexAttrib[1234]f[v]()")}}
+- {{domxref("WebGLRenderingContext.vertexAttrib()", "WebGLRenderingContext.vertexAttrib[1234]f[v]\()")}}}
   - : Specifies a value for a generic vertex attribute.
 - {{domxref("WebGLRenderingContext.vertexAttribPointer()")}}
   - : Specifies the data formats and locations of vertex attributes in a vertex attributes array.

--- a/files/en-us/web/api/webglrenderingcontext/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/index.md
@@ -259,6 +259,7 @@ The following properties and methods provide general information and functionali
 
 ## Uniforms and attributes
 
+<!-- markdownlint-disable MD042 -->
 - {{domxref("WebGLRenderingContext.disableVertexAttribArray()")}}
   - : Disables a vertex attribute array at a given position.
 - {{domxref("WebGLRenderingContext.enableVertexAttribArray()")}}
@@ -277,11 +278,11 @@ The following properties and methods provide general information and functionali
   - : Returns information about a vertex attribute at a given position.
 - {{domxref("WebGLRenderingContext.getVertexAttribOffset()")}}
   - : Returns the address of a given vertex attribute.
-- {{domxref("WebGLRenderingContext.uniform()", "WebGLRenderingContext.uniform[1234][fi][v]\()")}}
+- {{domxref("WebGLRenderingContext.uniform()", "WebGLRenderingContext.uniform[1234][fi][v]()")}}
   - : Specifies a value for a uniform variable.
 - {{domxref("WebGLRenderingContext.uniformMatrix()", "WebGLRenderingContext.uniformMatrix[234]fv()")}}
   - : Specifies a matrix value for a uniform variable.
-- {{domxref("WebGLRenderingContext.vertexAttrib()", "WebGLRenderingContext.vertexAttrib[1234]f[v]\()")}}
+- {{domxref("WebGLRenderingContext.vertexAttrib()", "WebGLRenderingContext.vertexAttrib[1234]f[v]()")}}
   - : Specifies a value for a generic vertex attribute.
 - {{domxref("WebGLRenderingContext.vertexAttribPointer()")}}
   - : Specifies the data formats and locations of vertex attributes in a vertex attributes array.

--- a/files/en-us/web/api/webglrenderingcontext/uniform/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/uniform/index.md
@@ -19,9 +19,10 @@ when the program object is linked successfully. They retain the values assigned 
 by a call to this method until the next successful link operation occurs on the program
 object, when they are once again initialized to 0.
 
+<!-- markdownlint-disable MD042 -->
 > **Note:** Many of the functions described here have expanded WebGL 2 interfaces, which can be
 > found under
-> {{domxref("WebGL2RenderingContext.uniform","WebGL2RenderingContext.uniform[1234][uif][v]\()")}}.
+> {{domxref("WebGL2RenderingContext.uniform","WebGL2RenderingContext.uniform[1234][uif][v]()")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/webglrenderingcontext/uniform/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/uniform/index.md
@@ -21,7 +21,7 @@ object, when they are once again initialized to 0.
 
 > **Note:** Many of the functions described here have expanded WebGL 2 interfaces, which can be
 > found under
-> {{domxref("WebGL2RenderingContext.uniform","WebGL2RenderingContext.uniform[1234][uif][v]()")}}.
+> {{domxref("WebGL2RenderingContext.uniform","WebGL2RenderingContext.uniform[1234][uif][v]\()")}}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/webglrenderingcontext/uniform/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/uniform/index.md
@@ -21,7 +21,7 @@ object, when they are once again initialized to 0.
 
 > **Note:** Many of the functions described here have expanded WebGL 2 interfaces, which can be
 > found under
-> {{domxref("WebGL2RenderingContext.uniform","WebGL2RenderingContext.uniform[1234][uif][v]\()")}}}.
+> {{domxref("WebGL2RenderingContext.uniform","WebGL2RenderingContext.uniform[1234][uif][v]\()")}}.
 
 ## Syntax
 

--- a/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.md
@@ -162,7 +162,7 @@ value.
 
 The default value is `vec4(0.0, 0.0, 0.0, 1.0)` by default but we can
 specify a different default value with
-{{domxref("WebGLRenderingContext.vertexAttrib()", "gl.vertexAttrib[1234]f[v]\()")}}}.
+{{domxref("WebGLRenderingContext.vertexAttrib()", "gl.vertexAttrib[1234]f[v]\()")}}.
 
 For example, your vertex shader may be using a position and a color attribute. Most
 meshes have the color specified at a per-vertex level, but some meshes are of a uniform

--- a/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.md
@@ -160,9 +160,10 @@ Similarly, if our vertex shader expects e.g. a 4-component attribute with
 on the array buffer, while the third and fourth components are taken from the default
 value.
 
+<!-- markdownlint-disable MD042 -->
 The default value is `vec4(0.0, 0.0, 0.0, 1.0)` by default but we can
 specify a different default value with
-{{domxref("WebGLRenderingContext.vertexAttrib()", "gl.vertexAttrib[1234]f[v]\()")}}.
+{{domxref("WebGLRenderingContext.vertexAttrib()", "gl.vertexAttrib[1234]f[v]()")}}.
 
 For example, your vertex shader may be using a position and a color attribute. Most
 meshes have the color specified at a per-vertex level, but some meshes are of a uniform

--- a/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.md
+++ b/files/en-us/web/api/webglrenderingcontext/vertexattribpointer/index.md
@@ -162,7 +162,7 @@ value.
 
 The default value is `vec4(0.0, 0.0, 0.0, 1.0)` by default but we can
 specify a different default value with
-{{domxref("WebGLRenderingContext.vertexAttrib()", "gl.vertexAttrib[1234]f[v]()")}}.
+{{domxref("WebGLRenderingContext.vertexAttrib()", "gl.vertexAttrib[1234]f[v]\()")}}}.
 
 For example, your vertex shader may be using a position and a color attribute. Most
 meshes have the color specified at a per-vertex level, but some meshes are of a uniform

--- a/files/en-us/web/javascript/reference/global_objects/bigint64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint64array/index.md
@@ -97,7 +97,7 @@ The **`BigInt64Array`** typed array represents an array of 64-bit signed integer
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "BigInt64Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "BigInt64Array.prototype[@@iterator]\()")}}}
+- {{jsxref("TypedArray.@@iterator", "BigInt64Array.prototype[@@iterator]\()")}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/bigint64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint64array/index.md
@@ -97,7 +97,7 @@ The **`BigInt64Array`** typed array represents an array of 64-bit signed integer
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "BigInt64Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "BigInt64Array.prototype[@@iterator]()")}}
+- {{jsxref("TypedArray.@@iterator", "BigInt64Array.prototype[@@iterator]\()")}}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/bigint64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/bigint64array/index.md
@@ -47,6 +47,7 @@ The **`BigInt64Array`** typed array represents an array of 64-bit signed integer
 
 ## Instance methods
 
+<!-- markdownlint-disable MD042 -->
 - {{jsxref("TypedArray.copyWithin", "BigInt64Array.prototype.copyWithin()")}}
   - : Copies a sequence of array elements within the array. See also {{jsxref("Array.prototype.copyWithin()")}}.
 - {{jsxref("TypedArray.entries", "BigInt64Array.prototype.entries()")}}
@@ -97,7 +98,7 @@ The **`BigInt64Array`** typed array represents an array of 64-bit signed integer
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "BigInt64Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "BigInt64Array.prototype[@@iterator]\()")}}
+- {{jsxref("TypedArray.@@iterator", "BigInt64Array.prototype[@@iterator]()")}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/biguint64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/biguint64array/index.md
@@ -47,6 +47,7 @@ The **`BigUint64Array`** typed array represents an array of 64-bit unsigned inte
 
 ## Instance methods
 
+<!-- markdownlint-disable MD042 -->
 - {{jsxref("TypedArray.copyWithin", "BigUint64Array.prototype.copyWithin()")}}
   - : Copies a sequence of array elements within the array. See also {{jsxref("Array.prototype.copyWithin()")}}.
 - {{jsxref("TypedArray.entries", "BigUint64Array.prototype.entries()")}}
@@ -97,7 +98,7 @@ The **`BigUint64Array`** typed array represents an array of 64-bit unsigned inte
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "BigUint64Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "BigUint64Array.prototype[@@iterator]\()")}}
+- {{jsxref("TypedArray.@@iterator", "BigUint64Array.prototype[@@iterator]()")}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/biguint64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/biguint64array/index.md
@@ -97,7 +97,7 @@ The **`BigUint64Array`** typed array represents an array of 64-bit unsigned inte
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "BigUint64Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "BigUint64Array.prototype[@@iterator]()")}}
+- {{jsxref("TypedArray.@@iterator", "BigUint64Array.prototype[@@iterator]\()")}}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/biguint64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/biguint64array/index.md
@@ -97,7 +97,7 @@ The **`BigUint64Array`** typed array represents an array of 64-bit unsigned inte
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "BigUint64Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "BigUint64Array.prototype[@@iterator]\()")}}}
+- {{jsxref("TypedArray.@@iterator", "BigUint64Array.prototype[@@iterator]\()")}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/float32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float32array/index.md
@@ -46,6 +46,7 @@ The **`Float32Array`** typed array represents an array of 32-bit floating point 
 
 ## Instance methods
 
+<!-- markdownlint-disable MD042 -->
 - {{jsxref("TypedArray.copyWithin", "Float32Array.prototype.copyWithin()")}}
   - : Copies a sequence of array elements within the array. See also {{jsxref("Array.prototype.copyWithin()")}}.
 - {{jsxref("TypedArray.entries", "Float32Array.prototype.entries()")}}
@@ -96,7 +97,7 @@ The **`Float32Array`** typed array represents an array of 32-bit floating point 
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Float32Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Float32Array.prototype[@@iterator]\()")}}
+- {{jsxref("TypedArray.@@iterator", "Float32Array.prototype[@@iterator]()")}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/float32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float32array/index.md
@@ -96,7 +96,7 @@ The **`Float32Array`** typed array represents an array of 32-bit floating point 
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Float32Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Float32Array.prototype[@@iterator]()")}}
+- {{jsxref("TypedArray.@@iterator", "Float32Array.prototype[@@iterator]\()")}}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/float32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float32array/index.md
@@ -96,7 +96,7 @@ The **`Float32Array`** typed array represents an array of 32-bit floating point 
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Float32Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Float32Array.prototype[@@iterator]\()")}}}
+- {{jsxref("TypedArray.@@iterator", "Float32Array.prototype[@@iterator]\()")}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/float64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float64array/index.md
@@ -46,6 +46,7 @@ The **`Float64Array`** typed array represents an array of 64-bit floating point 
 
 ## Instance methods
 
+<!-- markdownlint-disable MD042 -->
 - {{jsxref("TypedArray.copyWithin", "Float64Array.prototype.copyWithin()")}}
   - : Copies a sequence of array elements within the array. See also {{jsxref("Array.prototype.copyWithin()")}}.
 - {{jsxref("TypedArray.entries", "Float64Array.prototype.entries()")}}
@@ -96,7 +97,7 @@ The **`Float64Array`** typed array represents an array of 64-bit floating point 
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Float64Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Float64Array.prototype[@@iterator]\()")}}
+- {{jsxref("TypedArray.@@iterator", "Float64Array.prototype[@@iterator]()")}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/float64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float64array/index.md
@@ -96,7 +96,7 @@ The **`Float64Array`** typed array represents an array of 64-bit floating point 
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Float64Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Float64Array.prototype[@@iterator]()")}}
+- {{jsxref("TypedArray.@@iterator", "Float64Array.prototype[@@iterator]\()")}}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/float64array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/float64array/index.md
@@ -96,7 +96,7 @@ The **`Float64Array`** typed array represents an array of 64-bit floating point 
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Float64Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Float64Array.prototype[@@iterator]\()")}}}
+- {{jsxref("TypedArray.@@iterator", "Float64Array.prototype[@@iterator]\()")}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/int16array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int16array/index.md
@@ -96,7 +96,7 @@ The **`Int16Array`** typed array represents an array of twos-complement 16-bit s
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Int16Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Int16Array.prototype[@@iterator]\()")}}}
+- {{jsxref("TypedArray.@@iterator", "Int16Array.prototype[@@iterator]\()")}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/int16array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int16array/index.md
@@ -46,6 +46,7 @@ The **`Int16Array`** typed array represents an array of twos-complement 16-bit s
 
 ## Instance methods
 
+<!-- markdownlint-disable MD042 -->
 - {{jsxref("TypedArray.copyWithin", "Int16Array.prototype.copyWithin()")}}
   - : Copies a sequence of array elements within the array. See also {{jsxref("Array.prototype.copyWithin()")}}.
 - {{jsxref("TypedArray.entries", "Int16Array.prototype.entries()")}}
@@ -96,7 +97,7 @@ The **`Int16Array`** typed array represents an array of twos-complement 16-bit s
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Int16Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Int16Array.prototype[@@iterator]\()")}}
+- {{jsxref("TypedArray.@@iterator", "Int16Array.prototype[@@iterator]()")}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/int16array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int16array/index.md
@@ -96,7 +96,7 @@ The **`Int16Array`** typed array represents an array of twos-complement 16-bit s
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Int16Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Int16Array.prototype[@@iterator]()")}}
+- {{jsxref("TypedArray.@@iterator", "Int16Array.prototype[@@iterator]\()")}}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/int32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int32array/index.md
@@ -96,7 +96,7 @@ The **`Int32Array`** typed array represents an array of twos-complement 32-bit s
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Int32Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Int32Array.prototype[@@iterator]\()")}}}
+- {{jsxref("TypedArray.@@iterator", "Int32Array.prototype[@@iterator]\()")}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/int32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int32array/index.md
@@ -46,6 +46,7 @@ The **`Int32Array`** typed array represents an array of twos-complement 32-bit s
 
 ## Instance methods
 
+<!-- markdownlint-disable MD042 -->
 - {{jsxref("TypedArray.copyWithin", "Int32Array.prototype.copyWithin()")}}
   - : Copies a sequence of array elements within the array. See also {{jsxref("Array.prototype.copyWithin()")}}.
 - {{jsxref("TypedArray.entries", "Int32Array.prototype.entries()")}}
@@ -96,7 +97,7 @@ The **`Int32Array`** typed array represents an array of twos-complement 32-bit s
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Int32Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Int32Array.prototype[@@iterator]\()")}}
+- {{jsxref("TypedArray.@@iterator", "Int32Array.prototype[@@iterator]()")}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/int32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int32array/index.md
@@ -96,7 +96,7 @@ The **`Int32Array`** typed array represents an array of twos-complement 32-bit s
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Int32Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Int32Array.prototype[@@iterator]()")}}
+- {{jsxref("TypedArray.@@iterator", "Int32Array.prototype[@@iterator]\()")}}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/int8array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int8array/index.md
@@ -46,6 +46,7 @@ The **`Int8Array`** typed array represents an array of twos-complement 8-bit sig
 
 ## Instance methods
 
+<!-- markdownlint-disable MD042 -->
 - {{jsxref("TypedArray.copyWithin", "Int8Array.prototype.copyWithin()")}}
   - : Copies a sequence of array elements within the array. See also {{jsxref("Array.prototype.copyWithin()")}}.
 - {{jsxref("TypedArray.entries", "Int8Array.prototype.entries()")}}
@@ -96,7 +97,7 @@ The **`Int8Array`** typed array represents an array of twos-complement 8-bit sig
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Int8Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Int8Array.prototype[@@iterator]\()")}}
+- {{jsxref("TypedArray.@@iterator", "Int8Array.prototype[@@iterator]()")}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/int8array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int8array/index.md
@@ -96,7 +96,7 @@ The **`Int8Array`** typed array represents an array of twos-complement 8-bit sig
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Int8Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Int8Array.prototype[@@iterator]()")}}
+- {{jsxref("TypedArray.@@iterator", "Int8Array.prototype[@@iterator]\()")}}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/int8array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/int8array/index.md
@@ -96,7 +96,7 @@ The **`Int8Array`** typed array represents an array of twos-complement 8-bit sig
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Int8Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Int8Array.prototype[@@iterator]\()")}}}
+- {{jsxref("TypedArray.@@iterator", "Int8Array.prototype[@@iterator]\()")}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.md
@@ -302,7 +302,8 @@ console.log(contacts.size) // 1
 
 ### Iteration methods
 
-- {{jsxref("Map.@@iterator", "Map.prototype[@@iterator]\()")}}
+<!-- markdownlint-disable MD042 -->
+- {{jsxref("Map.@@iterator", "Map.prototype[@@iterator]()")}}
   - : Returns a new Iterator object that contains **an array of `[key, value]`**
     for each element in the `Map` object in insertion order.
 - {{jsxref("Map.prototype.keys()")}}

--- a/files/en-us/web/javascript/reference/global_objects/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.md
@@ -302,7 +302,7 @@ console.log(contacts.size) // 1
 
 ### Iteration methods
 
-- {{jsxref("Map.@@iterator", "Map.prototype[@@iterator]()")}}
+- {{jsxref("Map.@@iterator", "Map.prototype[@@iterator]\()")}}}
   - : Returns a new Iterator object that contains **an array of `[key, value]`**
     for each element in the `Map` object in insertion order.
 - {{jsxref("Map.prototype.keys()")}}

--- a/files/en-us/web/javascript/reference/global_objects/map/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/map/index.md
@@ -302,7 +302,7 @@ console.log(contacts.size) // 1
 
 ### Iteration methods
 
-- {{jsxref("Map.@@iterator", "Map.prototype[@@iterator]\()")}}}
+- {{jsxref("Map.@@iterator", "Map.prototype[@@iterator]\()")}}
   - : Returns a new Iterator object that contains **an array of `[key, value]`**
     for each element in the `Map` object in insertion order.
 - {{jsxref("Map.prototype.keys()")}}

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@match/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@match/index.md
@@ -130,8 +130,8 @@ console.log(result.group(3)); // 02
 
 - [Polyfill of `RegExp.prototype[@@match]` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.match()")}}
-- {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]()")}}
-- {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]()")}}
-- {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]()")}}
+- {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]\()")}}}
+- {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]\()")}}}
+- {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]\()")}}}
 - {{jsxref("RegExp.prototype.exec()")}}
 - {{jsxref("RegExp.prototype.test()")}}

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@match/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@match/index.md
@@ -128,10 +128,11 @@ console.log(result.group(3)); // 02
 
 ## See also
 
+<!-- markdownlint-disable MD042 -->
 - [Polyfill of `RegExp.prototype[@@match]` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.match()")}}
-- {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]\()")}}
-- {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]\()")}}
-- {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]\()")}}
+- {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]()")}}
+- {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]()")}}
+- {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]()")}}
 - {{jsxref("RegExp.prototype.exec()")}}
 - {{jsxref("RegExp.prototype.test()")}}

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@match/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@match/index.md
@@ -130,8 +130,8 @@ console.log(result.group(3)); // 02
 
 - [Polyfill of `RegExp.prototype[@@match]` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.match()")}}
-- {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]\()")}}}
-- {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]\()")}}}
-- {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]\()")}}}
+- {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]\()")}}
+- {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]\()")}}
+- {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]\()")}}
 - {{jsxref("RegExp.prototype.exec()")}}
 - {{jsxref("RegExp.prototype.test()")}}

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@replace/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@replace/index.md
@@ -128,12 +128,13 @@ console.log(newstr); // ###34567
 
 ## See also
 
+<!-- markdownlint-disable MD042 -->
 - [Polyfill of `RegExp.prototype[@@replace]` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.replace()")}}
 - {{jsxref("String.prototype.replaceAll()")}}
-- {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]\()")}}
-- {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]\()")}}
-- {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]\()")}}
+- {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]()")}}
+- {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]()")}}
+- {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]()")}}
 - {{jsxref("RegExp.prototype.exec()")}}
 - {{jsxref("RegExp.prototype.test()")}}
 - [`Symbol.replace`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/replace)

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@replace/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@replace/index.md
@@ -131,9 +131,9 @@ console.log(newstr); // ###34567
 - [Polyfill of `RegExp.prototype[@@replace]` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.replace()")}}
 - {{jsxref("String.prototype.replaceAll()")}}
-- {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]\()")}}}
-- {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]\()")}}}
-- {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]\()")}}}
+- {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]\()")}}
+- {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]\()")}}
+- {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]\()")}}
 - {{jsxref("RegExp.prototype.exec()")}}
 - {{jsxref("RegExp.prototype.test()")}}
 - [`Symbol.replace`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/replace)

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@replace/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@replace/index.md
@@ -131,9 +131,9 @@ console.log(newstr); // ###34567
 - [Polyfill of `RegExp.prototype[@@replace]` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.replace()")}}
 - {{jsxref("String.prototype.replaceAll()")}}
-- {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]()")}}
-- {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]()")}}
-- {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]()")}}
+- {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]\()")}}}
+- {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]\()")}}}
+- {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]\()")}}}
 - {{jsxref("RegExp.prototype.exec()")}}
 - {{jsxref("RegExp.prototype.test()")}}
 - [`Symbol.replace`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/replace)

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@search/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@search/index.md
@@ -103,10 +103,11 @@ console.log(result); // 3
 
 ## See also
 
+<!-- markdownlint-disable MD042 -->
 - [Polyfill of `RegExp.prototype[@@search]` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.search()")}}
-- {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]\()")}}
-- {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]\()")}}
-- {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]\()")}}
+- {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]()")}}
+- {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]()")}}
+- {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]()")}}
 - {{jsxref("RegExp.prototype.exec()")}}
 - {{jsxref("RegExp.prototype.test()")}}

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@search/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@search/index.md
@@ -105,8 +105,8 @@ console.log(result); // 3
 
 - [Polyfill of `RegExp.prototype[@@search]` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.search()")}}
-- {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]()")}}
-- {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]()")}}
-- {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]()")}}
+- {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]\()")}}}
+- {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]\()")}}}
+- {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]\()")}}}
 - {{jsxref("RegExp.prototype.exec()")}}
 - {{jsxref("RegExp.prototype.test()")}}

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@search/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@search/index.md
@@ -105,8 +105,8 @@ console.log(result); // 3
 
 - [Polyfill of `RegExp.prototype[@@search]` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.search()")}}
-- {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]\()")}}}
-- {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]\()")}}}
-- {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]\()")}}}
+- {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]\()")}}
+- {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]\()")}}
+- {{jsxref("RegExp.prototype.@@split()", "RegExp.prototype[@@split]\()")}}
 - {{jsxref("RegExp.prototype.exec()")}}
 - {{jsxref("RegExp.prototype.test()")}}

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@split/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@split/index.md
@@ -101,10 +101,11 @@ console.log(result); // ["(2016)", "(01)", "(02)"]
 
 ## See also
 
+<!-- markdownlint-disable MD042 -->
 - [Polyfill of `RegExp.prototype[@@split]` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.split()")}}
-- {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]\()")}}
-- {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]\()")}}
-- {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]\()")}}
+- {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]()")}}
+- {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]()")}}
+- {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]()")}}
 - {{jsxref("RegExp.prototype.exec()")}}
 - {{jsxref("RegExp.prototype.test()")}}

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@split/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@split/index.md
@@ -103,8 +103,8 @@ console.log(result); // ["(2016)", "(01)", "(02)"]
 
 - [Polyfill of `RegExp.prototype[@@split]` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.split()")}}
-- {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]\()")}}}
-- {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]\()")}}}
-- {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]\()")}}}
+- {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]\()")}}
+- {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]\()")}}
+- {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]\()")}}
 - {{jsxref("RegExp.prototype.exec()")}}
 - {{jsxref("RegExp.prototype.test()")}}

--- a/files/en-us/web/javascript/reference/global_objects/regexp/@@split/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/@@split/index.md
@@ -103,8 +103,8 @@ console.log(result); // ["(2016)", "(01)", "(02)"]
 
 - [Polyfill of `RegExp.prototype[@@split]` in `core-js`](https://github.com/zloirock/core-js#ecmascript-string-and-regexp)
 - {{jsxref("String.prototype.split()")}}
-- {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]()")}}
-- {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]()")}}
-- {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]()")}}
+- {{jsxref("RegExp.prototype.@@match()", "RegExp.prototype[@@match]\()")}}}
+- {{jsxref("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]\()")}}}
+- {{jsxref("RegExp.prototype.@@search()", "RegExp.prototype[@@search]\()")}}}
 - {{jsxref("RegExp.prototype.exec()")}}
 - {{jsxref("RegExp.prototype.test()")}}

--- a/files/en-us/web/javascript/reference/global_objects/regexp/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/index.md
@@ -102,15 +102,15 @@ Note that several of the {{JSxRef("RegExp")}} properties have both long and shor
   - : Tests for a match in its string parameter.
 - {{JSxRef("RegExp.prototype.toString()")}}
   - : Returns a string representing the specified object. Overrides the {{JSxRef("Object.prototype.toString()")}} method.
-- {{JSxRef("RegExp.prototype.@@match()", "RegExp.prototype[@@match]\()")}}}
+- {{JSxRef("RegExp.prototype.@@match()", "RegExp.prototype[@@match]\()")}}
   - : Performs match to given string and returns match result.
-- {{JSxRef("RegExp.prototype.@@matchAll()", "RegExp.prototype[@@matchAll]\()")}}}
+- {{JSxRef("RegExp.prototype.@@matchAll()", "RegExp.prototype[@@matchAll]\()")}}
   - : Returns all matches of the regular expression against a string.
-- {{JSxRef("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]\()")}}}
+- {{JSxRef("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]\()")}}
   - : Replaces matches in given string with new substring.
-- {{JSxRef("RegExp.prototype.@@search()", "RegExp.prototype[@@search]\()")}}}
+- {{JSxRef("RegExp.prototype.@@search()", "RegExp.prototype[@@search]\()")}}
   - : Searches the match in given string and returns the index the pattern found in the string.
-- {{JSxRef("RegExp.prototype.@@split()", "RegExp.prototype[@@split]\()")}}}
+- {{JSxRef("RegExp.prototype.@@split()", "RegExp.prototype[@@split]\()")}}
   - : Splits given string into an array by separating the string into substrings.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/regexp/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/index.md
@@ -102,15 +102,15 @@ Note that several of the {{JSxRef("RegExp")}} properties have both long and shor
   - : Tests for a match in its string parameter.
 - {{JSxRef("RegExp.prototype.toString()")}}
   - : Returns a string representing the specified object. Overrides the {{JSxRef("Object.prototype.toString()")}} method.
-- {{JSxRef("RegExp.prototype.@@match()", "RegExp.prototype[@@match]()")}}
+- {{JSxRef("RegExp.prototype.@@match()", "RegExp.prototype[@@match]\()")}}}
   - : Performs match to given string and returns match result.
-- {{JSxRef("RegExp.prototype.@@matchAll()", "RegExp.prototype[@@matchAll]()")}}
+- {{JSxRef("RegExp.prototype.@@matchAll()", "RegExp.prototype[@@matchAll]\()")}}}
   - : Returns all matches of the regular expression against a string.
-- {{JSxRef("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]()")}}
+- {{JSxRef("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]\()")}}}
   - : Replaces matches in given string with new substring.
-- {{JSxRef("RegExp.prototype.@@search()", "RegExp.prototype[@@search]()")}}
+- {{JSxRef("RegExp.prototype.@@search()", "RegExp.prototype[@@search]\()")}}}
   - : Searches the match in given string and returns the index the pattern found in the string.
-- {{JSxRef("RegExp.prototype.@@split()", "RegExp.prototype[@@split]()")}}
+- {{JSxRef("RegExp.prototype.@@split()", "RegExp.prototype[@@split]\()")}}}
   - : Splits given string into an array by separating the string into substrings.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/regexp/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/regexp/index.md
@@ -94,6 +94,7 @@ Note that several of the {{JSxRef("RegExp")}} properties have both long and shor
 
 ## Instance methods
 
+<!-- markdownlint-disable MD042 -->
 - {{JSxRef("RegExp.prototype.compile()")}} {{deprecated_inline}}
   - : (Re-)compiles a regular expression during execution of a script.
 - {{JSxRef("RegExp.prototype.exec()")}}
@@ -102,15 +103,15 @@ Note that several of the {{JSxRef("RegExp")}} properties have both long and shor
   - : Tests for a match in its string parameter.
 - {{JSxRef("RegExp.prototype.toString()")}}
   - : Returns a string representing the specified object. Overrides the {{JSxRef("Object.prototype.toString()")}} method.
-- {{JSxRef("RegExp.prototype.@@match()", "RegExp.prototype[@@match]\()")}}
+- {{JSxRef("RegExp.prototype.@@match()", "RegExp.prototype[@@match]()")}}
   - : Performs match to given string and returns match result.
-- {{JSxRef("RegExp.prototype.@@matchAll()", "RegExp.prototype[@@matchAll]\()")}}
+- {{JSxRef("RegExp.prototype.@@matchAll()", "RegExp.prototype[@@matchAll]()")}}
   - : Returns all matches of the regular expression against a string.
-- {{JSxRef("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]\()")}}
+- {{JSxRef("RegExp.prototype.@@replace()", "RegExp.prototype[@@replace]()")}}
   - : Replaces matches in given string with new substring.
-- {{JSxRef("RegExp.prototype.@@search()", "RegExp.prototype[@@search]\()")}}
+- {{JSxRef("RegExp.prototype.@@search()", "RegExp.prototype[@@search]()")}}
   - : Searches the match in given string and returns the index the pattern found in the string.
-- {{JSxRef("RegExp.prototype.@@split()", "RegExp.prototype[@@split]\()")}}
+- {{JSxRef("RegExp.prototype.@@split()", "RegExp.prototype[@@split]()")}}
   - : Splits given string into an array by separating the string into substrings.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/index.md
@@ -60,7 +60,7 @@ The `Set` [`has`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/has) m
 
 ### Iteration methods
 
-- {{jsxref("Set.prototype.@@iterator()", "Set.prototype[@@iterator]()")}}
+- {{jsxref("Set.prototype.@@iterator()", "Set.prototype[@@iterator]\()")}}}
   - : Returns a new iterator object that yields the **values** for each element in the `Set` object in insertion order.
 - {{jsxref("Set.prototype.values()")}}
   - : Returns a new iterator object that yields the **values** for each element in the `Set` object in insertion order.

--- a/files/en-us/web/javascript/reference/global_objects/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/index.md
@@ -60,7 +60,7 @@ The `Set` [`has`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/has) m
 
 ### Iteration methods
 
-- {{jsxref("Set.prototype.@@iterator()", "Set.prototype[@@iterator]\()")}}}
+- {{jsxref("Set.prototype.@@iterator()", "Set.prototype[@@iterator]\()")}}
   - : Returns a new iterator object that yields the **values** for each element in the `Set` object in insertion order.
 - {{jsxref("Set.prototype.values()")}}
   - : Returns a new iterator object that yields the **values** for each element in the `Set` object in insertion order.

--- a/files/en-us/web/javascript/reference/global_objects/set/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/set/index.md
@@ -60,7 +60,8 @@ The `Set` [`has`](/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/has) m
 
 ### Iteration methods
 
-- {{jsxref("Set.prototype.@@iterator()", "Set.prototype[@@iterator]\()")}}
+<!-- markdownlint-disable MD042 -->
+- {{jsxref("Set.prototype.@@iterator()", "Set.prototype[@@iterator]()")}}
   - : Returns a new iterator object that yields the **values** for each element in the `Set` object in insertion order.
 - {{jsxref("Set.prototype.values()")}}
   - : Returns a new iterator object that yields the **values** for each element in the `Set` object in insertion order.

--- a/files/en-us/web/javascript/reference/global_objects/string/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/index.md
@@ -371,7 +371,7 @@ You must be careful which level of characters you are iterating on. For example,
 - {{jsxref("String.prototype.valueOf()")}}
   - : Returns the primitive value of the specified object. Overrides the
     {{jsxref("Object.prototype.valueOf()")}} method.
-- {{jsxref("String.prototype.@@iterator()", "String.prototype[@@iterator]()")}}
+- {{jsxref("String.prototype.@@iterator()", "String.prototype[@@iterator]\()")}}}
   - : Returns a new iterator object that iterates over the code points of a String value,
     returning each code point as a String value.
 

--- a/files/en-us/web/javascript/reference/global_objects/string/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/index.md
@@ -371,7 +371,7 @@ You must be careful which level of characters you are iterating on. For example,
 - {{jsxref("String.prototype.valueOf()")}}
   - : Returns the primitive value of the specified object. Overrides the
     {{jsxref("Object.prototype.valueOf()")}} method.
-- {{jsxref("String.prototype.@@iterator()", "String.prototype[@@iterator]\()")}}}
+- {{jsxref("String.prototype.@@iterator()", "String.prototype[@@iterator]\()")}}
   - : Returns a new iterator object that iterates over the code points of a String value,
     returning each code point as a String value.
 

--- a/files/en-us/web/javascript/reference/global_objects/string/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/string/index.md
@@ -250,6 +250,7 @@ You must be careful which level of characters you are iterating on. For example,
 
 ## Instance methods
 
+<!-- markdownlint-disable MD042 -->
 - {{jsxref("String.prototype.at()", "String.prototype.at(<var>index</var>)")}}
   - : Returns the character (exactly one UTF-16 code unit) at the specified `index`. Accepts negative integers, which count back from the last string character.
 - {{jsxref("String.prototype.charAt()", "String.prototype.charAt(<var>index</var>)")}}
@@ -371,7 +372,7 @@ You must be careful which level of characters you are iterating on. For example,
 - {{jsxref("String.prototype.valueOf()")}}
   - : Returns the primitive value of the specified object. Overrides the
     {{jsxref("Object.prototype.valueOf()")}} method.
-- {{jsxref("String.prototype.@@iterator()", "String.prototype[@@iterator]\()")}}
+- {{jsxref("String.prototype.@@iterator()", "String.prototype[@@iterator]()")}}
   - : Returns a new iterator object that iterates over the code points of a String value,
     returning each code point as a String value.
 

--- a/files/en-us/web/javascript/reference/global_objects/symbol/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/index.md
@@ -124,7 +124,7 @@ The static properties are all well-known Symbols. In these Symbols' descriptions
   - : Returns a string containing the description of the Symbol. Overrides the {{jsxref("Object.prototype.toString()")}} method.
 - {{jsxref("Symbol.prototype.valueOf()")}}
   - : Returns the Symbol. Overrides the {{jsxref("Object.prototype.valueOf()")}} method.
-- {{jsxref("Symbol.prototype.@@toPrimitive()", "Symbol.prototype[@@toPrimitive]\()")}}}
+- {{jsxref("Symbol.prototype.@@toPrimitive()", "Symbol.prototype[@@toPrimitive]\()")}}
   - : Returns the Symbol.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/symbol/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/index.md
@@ -120,11 +120,12 @@ The static properties are all well-known Symbols. In these Symbols' descriptions
 
 ## Instance methods
 
+<!-- markdownlint-disable MD042 -->
 - {{jsxref("Symbol.prototype.toString()")}}
   - : Returns a string containing the description of the Symbol. Overrides the {{jsxref("Object.prototype.toString()")}} method.
 - {{jsxref("Symbol.prototype.valueOf()")}}
   - : Returns the Symbol. Overrides the {{jsxref("Object.prototype.valueOf()")}} method.
-- {{jsxref("Symbol.prototype.@@toPrimitive()", "Symbol.prototype[@@toPrimitive]\()")}}
+- {{jsxref("Symbol.prototype.@@toPrimitive()", "Symbol.prototype[@@toPrimitive]()")}}
   - : Returns the Symbol.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/symbol/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/index.md
@@ -124,7 +124,7 @@ The static properties are all well-known Symbols. In these Symbols' descriptions
   - : Returns a string containing the description of the Symbol. Overrides the {{jsxref("Object.prototype.toString()")}} method.
 - {{jsxref("Symbol.prototype.valueOf()")}}
   - : Returns the Symbol. Overrides the {{jsxref("Object.prototype.valueOf()")}} method.
-- {{jsxref("Symbol.prototype.@@toPrimitive()", "Symbol.prototype[@@toPrimitive]()")}}
+- {{jsxref("Symbol.prototype.@@toPrimitive()", "Symbol.prototype[@@toPrimitive]\()")}}}
   - : Returns the Symbol.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/symbol/iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/iterator/index.md
@@ -21,11 +21,11 @@ Whenever an object needs to be iterated (such as at the beginning of a `for..of`
 
 Some built-in types have a default iteration behavior, while other types (such as {{jsxref("Object")}}) do not. The built-in types with a `@@iterator` method are:
 
-- {{jsxref("Array.@@iterator", "Array.prototype[@@iterator]()")}}
-- {{jsxref("TypedArray.@@iterator", "TypedArray.prototype[@@iterator]()")}}
-- {{jsxref("String.@@iterator", "String.prototype[@@iterator]()")}}
-- {{jsxref("Map.@@iterator", "Map.prototype[@@iterator]()")}}
-- {{jsxref("Set.@@iterator", "Set.prototype[@@iterator]()")}}
+- {{jsxref("Array.@@iterator", "Array.prototype[@@iterator]\()")}}}
+- {{jsxref("TypedArray.@@iterator", "TypedArray.prototype[@@iterator]\()")}}}
+- {{jsxref("String.@@iterator", "String.prototype[@@iterator]\()")}}}
+- {{jsxref("Map.@@iterator", "Map.prototype[@@iterator]\()")}}}
+- {{jsxref("Set.@@iterator", "Set.prototype[@@iterator]\()")}}}
 
 See also [Iteration protocols](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) for more information.
 
@@ -91,8 +91,8 @@ nonWellFormedIterable[Symbol.iterator] = () => 1;
 
 - [Polyfill of `Symbol.iterator` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
 - [Iteration protocols](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols)
-- {{jsxref("Array.@@iterator", "Array.prototype[@@iterator]()")}}
-- {{jsxref("TypedArray.@@iterator", "TypedArray.prototype[@@iterator]()")}}
-- {{jsxref("String.@@iterator", "String.prototype[@@iterator]()")}}
-- {{jsxref("Map.@@iterator", "Map.prototype[@@iterator]()")}}
-- {{jsxref("Set.@@iterator", "Set.prototype[@@iterator]()")}}
+- {{jsxref("Array.@@iterator", "Array.prototype[@@iterator]\()")}}}
+- {{jsxref("TypedArray.@@iterator", "TypedArray.prototype[@@iterator]\()")}}}
+- {{jsxref("String.@@iterator", "String.prototype[@@iterator]\()")}}}
+- {{jsxref("Map.@@iterator", "Map.prototype[@@iterator]\()")}}}
+- {{jsxref("Set.@@iterator", "Set.prototype[@@iterator]\()")}}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/iterator/index.md
@@ -21,11 +21,12 @@ Whenever an object needs to be iterated (such as at the beginning of a `for..of`
 
 Some built-in types have a default iteration behavior, while other types (such as {{jsxref("Object")}}) do not. The built-in types with a `@@iterator` method are:
 
-- {{jsxref("Array.@@iterator", "Array.prototype[@@iterator]\()")}}
-- {{jsxref("TypedArray.@@iterator", "TypedArray.prototype[@@iterator]\()")}}
-- {{jsxref("String.@@iterator", "String.prototype[@@iterator]\()")}}
-- {{jsxref("Map.@@iterator", "Map.prototype[@@iterator]\()")}}
-- {{jsxref("Set.@@iterator", "Set.prototype[@@iterator]\()")}}
+<!-- markdownlint-disable MD042 -->
+- {{jsxref("Array.@@iterator", "Array.prototype[@@iterator]()")}}
+- {{jsxref("TypedArray.@@iterator", "TypedArray.prototype[@@iterator]()")}}
+- {{jsxref("String.@@iterator", "String.prototype[@@iterator]()")}}
+- {{jsxref("Map.@@iterator", "Map.prototype[@@iterator]()")}}
+- {{jsxref("Set.@@iterator", "Set.prototype[@@iterator]()")}}
 
 See also [Iteration protocols](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) for more information.
 
@@ -91,8 +92,8 @@ nonWellFormedIterable[Symbol.iterator] = () => 1;
 
 - [Polyfill of `Symbol.iterator` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
 - [Iteration protocols](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols)
-- {{jsxref("Array.@@iterator", "Array.prototype[@@iterator]\()")}}
-- {{jsxref("TypedArray.@@iterator", "TypedArray.prototype[@@iterator]\()")}}
-- {{jsxref("String.@@iterator", "String.prototype[@@iterator]\()")}}
-- {{jsxref("Map.@@iterator", "Map.prototype[@@iterator]\()")}}
-- {{jsxref("Set.@@iterator", "Set.prototype[@@iterator]\()")}}
+- {{jsxref("Array.@@iterator", "Array.prototype[@@iterator]()")}}
+- {{jsxref("TypedArray.@@iterator", "TypedArray.prototype[@@iterator]()")}}
+- {{jsxref("String.@@iterator", "String.prototype[@@iterator]()")}}
+- {{jsxref("Map.@@iterator", "Map.prototype[@@iterator]()")}}
+- {{jsxref("Set.@@iterator", "Set.prototype[@@iterator]()")}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/iterator/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/iterator/index.md
@@ -21,11 +21,11 @@ Whenever an object needs to be iterated (such as at the beginning of a `for..of`
 
 Some built-in types have a default iteration behavior, while other types (such as {{jsxref("Object")}}) do not. The built-in types with a `@@iterator` method are:
 
-- {{jsxref("Array.@@iterator", "Array.prototype[@@iterator]\()")}}}
-- {{jsxref("TypedArray.@@iterator", "TypedArray.prototype[@@iterator]\()")}}}
-- {{jsxref("String.@@iterator", "String.prototype[@@iterator]\()")}}}
-- {{jsxref("Map.@@iterator", "Map.prototype[@@iterator]\()")}}}
-- {{jsxref("Set.@@iterator", "Set.prototype[@@iterator]\()")}}}
+- {{jsxref("Array.@@iterator", "Array.prototype[@@iterator]\()")}}
+- {{jsxref("TypedArray.@@iterator", "TypedArray.prototype[@@iterator]\()")}}
+- {{jsxref("String.@@iterator", "String.prototype[@@iterator]\()")}}
+- {{jsxref("Map.@@iterator", "Map.prototype[@@iterator]\()")}}
+- {{jsxref("Set.@@iterator", "Set.prototype[@@iterator]\()")}}
 
 See also [Iteration protocols](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) for more information.
 
@@ -91,8 +91,8 @@ nonWellFormedIterable[Symbol.iterator] = () => 1;
 
 - [Polyfill of `Symbol.iterator` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
 - [Iteration protocols](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols)
-- {{jsxref("Array.@@iterator", "Array.prototype[@@iterator]\()")}}}
-- {{jsxref("TypedArray.@@iterator", "TypedArray.prototype[@@iterator]\()")}}}
-- {{jsxref("String.@@iterator", "String.prototype[@@iterator]\()")}}}
-- {{jsxref("Map.@@iterator", "Map.prototype[@@iterator]\()")}}}
-- {{jsxref("Set.@@iterator", "Set.prototype[@@iterator]\()")}}}
+- {{jsxref("Array.@@iterator", "Array.prototype[@@iterator]\()")}}
+- {{jsxref("TypedArray.@@iterator", "TypedArray.prototype[@@iterator]\()")}}
+- {{jsxref("String.@@iterator", "String.prototype[@@iterator]\()")}}
+- {{jsxref("Map.@@iterator", "Map.prototype[@@iterator]\()")}}
+- {{jsxref("Set.@@iterator", "Set.prototype[@@iterator]\()")}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/match/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/match/index.md
@@ -57,4 +57,4 @@ re[Symbol.match] = false;
 - {{jsxref("Symbol.replace")}}
 - {{jsxref("Symbol.search")}}
 - {{jsxref("Symbol.split")}}
-- {{jsxref("RegExp.@@match", "RegExp.prototype[@@match]\()")}}}
+- {{jsxref("RegExp.@@match", "RegExp.prototype[@@match]\()")}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/match/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/match/index.md
@@ -53,8 +53,9 @@ re[Symbol.match] = false;
 
 ## See also
 
+<!-- markdownlint-disable MD042 -->
 - [Polyfill of `Symbol.match` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
 - {{jsxref("Symbol.replace")}}
 - {{jsxref("Symbol.search")}}
 - {{jsxref("Symbol.split")}}
-- {{jsxref("RegExp.@@match", "RegExp.prototype[@@match]\()")}}
+- {{jsxref("RegExp.@@match", "RegExp.prototype[@@match]()")}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/match/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/match/index.md
@@ -57,4 +57,4 @@ re[Symbol.match] = false;
 - {{jsxref("Symbol.replace")}}
 - {{jsxref("Symbol.search")}}
 - {{jsxref("Symbol.split")}}
-- {{jsxref("RegExp.@@match", "RegExp.prototype[@@match]()")}}
+- {{jsxref("RegExp.@@match", "RegExp.prototype[@@match]\()")}}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/matchall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/matchall/index.md
@@ -17,7 +17,7 @@ The **`Symbol.matchAll`** well-known symbol returns an iterator, that yields mat
 
 ## Description
 
-This Symbol is used for {{jsxref("String.prototype.matchAll()")}} and specifically in {{jsxref("RegExp.@@matchAll", "RegExp.prototype[@@matchAll]\()")}}}. The following two examples return same result:
+This Symbol is used for {{jsxref("String.prototype.matchAll()")}} and specifically in {{jsxref("RegExp.@@matchAll", "RegExp.prototype[@@matchAll]\()")}}. The following two examples return same result:
 
 ```js
 'abc'.matchAll(/a/);
@@ -47,7 +47,7 @@ console.log(Array.from(str.matchAll(numbers)));
 //  Array ["2016", "01", "02", "2019", "03", "07"]
 ```
 
-See {{jsxref("String.prototype.matchAll()")}} and {{jsxref("RegExp.@@matchAll", "RegExp.prototype[@@matchAll]\()")}}} for more examples.
+See {{jsxref("String.prototype.matchAll()")}} and {{jsxref("RegExp.@@matchAll", "RegExp.prototype[@@matchAll]\()")}} for more examples.
 
 ## Specifications
 
@@ -61,4 +61,4 @@ See {{jsxref("String.prototype.matchAll()")}} and {{jsxref("RegExp.@@matchAll", 
 
 - [Polyfill of `Symbol.matchAll` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
 - {{jsxref("String.prototype.matchAll()")}}
-- {{jsxref("RegExp.@@matchAll", "RegExp.prototype[@@matchAll]\()")}}}
+- {{jsxref("RegExp.@@matchAll", "RegExp.prototype[@@matchAll]\()")}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/matchall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/matchall/index.md
@@ -17,7 +17,8 @@ The **`Symbol.matchAll`** well-known symbol returns an iterator, that yields mat
 
 ## Description
 
-This Symbol is used for {{jsxref("String.prototype.matchAll()")}} and specifically in {{jsxref("RegExp.@@matchAll", "RegExp.prototype[@@matchAll]\()")}}. The following two examples return same result:
+<!-- markdownlint-disable MD042 -->
+This Symbol is used for {{jsxref("String.prototype.matchAll()")}} and specifically in {{jsxref("RegExp.@@matchAll", "RegExp.prototype[@@matchAll]()")}}. The following two examples return same result:
 
 ```js
 'abc'.matchAll(/a/);
@@ -47,7 +48,7 @@ console.log(Array.from(str.matchAll(numbers)));
 //  Array ["2016", "01", "02", "2019", "03", "07"]
 ```
 
-See {{jsxref("String.prototype.matchAll()")}} and {{jsxref("RegExp.@@matchAll", "RegExp.prototype[@@matchAll]\()")}} for more examples.
+See {{jsxref("String.prototype.matchAll()")}} and {{jsxref("RegExp.@@matchAll", "RegExp.prototype[@@matchAll]()")}} for more examples.
 
 ## Specifications
 
@@ -61,4 +62,4 @@ See {{jsxref("String.prototype.matchAll()")}} and {{jsxref("RegExp.@@matchAll", 
 
 - [Polyfill of `Symbol.matchAll` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
 - {{jsxref("String.prototype.matchAll()")}}
-- {{jsxref("RegExp.@@matchAll", "RegExp.prototype[@@matchAll]\()")}}
+- {{jsxref("RegExp.@@matchAll", "RegExp.prototype[@@matchAll]()")}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/matchall/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/matchall/index.md
@@ -17,7 +17,7 @@ The **`Symbol.matchAll`** well-known symbol returns an iterator, that yields mat
 
 ## Description
 
-This Symbol is used for {{jsxref("String.prototype.matchAll()")}} and specifically in {{jsxref("RegExp.@@matchAll", "RegExp.prototype[@@matchAll]()")}}. The following two examples return same result:
+This Symbol is used for {{jsxref("String.prototype.matchAll()")}} and specifically in {{jsxref("RegExp.@@matchAll", "RegExp.prototype[@@matchAll]\()")}}}. The following two examples return same result:
 
 ```js
 'abc'.matchAll(/a/);
@@ -47,7 +47,7 @@ console.log(Array.from(str.matchAll(numbers)));
 //  Array ["2016", "01", "02", "2019", "03", "07"]
 ```
 
-See {{jsxref("String.prototype.matchAll()")}} and {{jsxref("RegExp.@@matchAll", "RegExp.prototype[@@matchAll]()")}} for more examples.
+See {{jsxref("String.prototype.matchAll()")}} and {{jsxref("RegExp.@@matchAll", "RegExp.prototype[@@matchAll]\()")}}} for more examples.
 
 ## Specifications
 
@@ -61,4 +61,4 @@ See {{jsxref("String.prototype.matchAll()")}} and {{jsxref("RegExp.@@matchAll", 
 
 - [Polyfill of `Symbol.matchAll` in `core-js`](https://github.com/zloirock/core-js#ecmascript-symbol)
 - {{jsxref("String.prototype.matchAll()")}}
-- {{jsxref("RegExp.@@matchAll", "RegExp.prototype[@@matchAll]()")}}
+- {{jsxref("RegExp.@@matchAll", "RegExp.prototype[@@matchAll]\()")}}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/replace/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/replace/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Symbol.replace
 
 The **`Symbol.replace`** well-known symbol specifies the method that replaces matched substrings of a string. This function is called by the {{jsxref("String.prototype.replace()")}} method.
 
-For more information, see {{jsxref("RegExp.@@replace", "RegExp.prototype[@@replace]()")}} and {{jsxref("String.prototype.replace()")}}.
+For more information, see {{jsxref("RegExp.@@replace", "RegExp.prototype[@@replace]\()")}}} and {{jsxref("String.prototype.replace()")}}.
 
 {{EmbedInteractiveExample("pages/js/symbol-replace.html")}}{{js_property_attributes(0,0,0)}}
 
@@ -49,4 +49,4 @@ console.log('football'.replace(new CustomReplacer('foo')));
 - {{jsxref("Symbol.match")}}
 - {{jsxref("Symbol.search")}}
 - {{jsxref("Symbol.split")}}
-- {{jsxref("RegExp.@@replace", "RegExp.prototype[@@replace]()")}}
+- {{jsxref("RegExp.@@replace", "RegExp.prototype[@@replace]\()")}}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/replace/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/replace/index.md
@@ -13,7 +13,8 @@ browser-compat: javascript.builtins.Symbol.replace
 
 The **`Symbol.replace`** well-known symbol specifies the method that replaces matched substrings of a string. This function is called by the {{jsxref("String.prototype.replace()")}} method.
 
-For more information, see {{jsxref("RegExp.@@replace", "RegExp.prototype[@@replace]\()")}} and {{jsxref("String.prototype.replace()")}}.
+<!-- markdownlint-disable MD042 -->
+For more information, see {{jsxref("RegExp.@@replace", "RegExp.prototype[@@replace]()")}} and {{jsxref("String.prototype.replace()")}}.
 
 {{EmbedInteractiveExample("pages/js/symbol-replace.html")}}{{js_property_attributes(0,0,0)}}
 
@@ -49,4 +50,4 @@ console.log('football'.replace(new CustomReplacer('foo')));
 - {{jsxref("Symbol.match")}}
 - {{jsxref("Symbol.search")}}
 - {{jsxref("Symbol.split")}}
-- {{jsxref("RegExp.@@replace", "RegExp.prototype[@@replace]\()")}}
+- {{jsxref("RegExp.@@replace", "RegExp.prototype[@@replace]()")}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/replace/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/replace/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Symbol.replace
 
 The **`Symbol.replace`** well-known symbol specifies the method that replaces matched substrings of a string. This function is called by the {{jsxref("String.prototype.replace()")}} method.
 
-For more information, see {{jsxref("RegExp.@@replace", "RegExp.prototype[@@replace]\()")}}} and {{jsxref("String.prototype.replace()")}}.
+For more information, see {{jsxref("RegExp.@@replace", "RegExp.prototype[@@replace]\()")}} and {{jsxref("String.prototype.replace()")}}.
 
 {{EmbedInteractiveExample("pages/js/symbol-replace.html")}}{{js_property_attributes(0,0,0)}}
 
@@ -49,4 +49,4 @@ console.log('football'.replace(new CustomReplacer('foo')));
 - {{jsxref("Symbol.match")}}
 - {{jsxref("Symbol.search")}}
 - {{jsxref("Symbol.split")}}
-- {{jsxref("RegExp.@@replace", "RegExp.prototype[@@replace]\()")}}}
+- {{jsxref("RegExp.@@replace", "RegExp.prototype[@@replace]\()")}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/search/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/search/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Symbol.search
 
 The **`Symbol.search`** well-known symbol specifies the method that returns the index within a string that matches the regular expression. This function is called by the {{jsxref("String.prototype.search()")}} method.
 
-For more information, see {{jsxref("RegExp.@@search", "RegExp.prototype[@@search]()")}} and {{jsxref("String.prototype.search()")}}.
+For more information, see {{jsxref("RegExp.@@search", "RegExp.prototype[@@search]\()")}}} and {{jsxref("String.prototype.search()")}}.
 
 {{EmbedInteractiveExample("pages/js/symbol-search.html")}}{{js_property_attributes(0,0,0)}}
 
@@ -49,4 +49,4 @@ console.log('foobar'.search(new caseInsensitiveSearch('BaR')));
 - {{jsxref("Symbol.match")}}
 - {{jsxref("Symbol.replace")}}
 - {{jsxref("Symbol.split")}}
-- {{jsxref("RegExp.@@search", "RegExp.prototype[@@search]()")}}
+- {{jsxref("RegExp.@@search", "RegExp.prototype[@@search]\()")}}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/search/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/search/index.md
@@ -13,7 +13,8 @@ browser-compat: javascript.builtins.Symbol.search
 
 The **`Symbol.search`** well-known symbol specifies the method that returns the index within a string that matches the regular expression. This function is called by the {{jsxref("String.prototype.search()")}} method.
 
-For more information, see {{jsxref("RegExp.@@search", "RegExp.prototype[@@search]\()")}} and {{jsxref("String.prototype.search()")}}.
+<!-- markdownlint-disable MD042 -->
+For more information, see {{jsxref("RegExp.@@search", "RegExp.prototype[@@search]()")}} and {{jsxref("String.prototype.search()")}}.
 
 {{EmbedInteractiveExample("pages/js/symbol-search.html")}}{{js_property_attributes(0,0,0)}}
 
@@ -49,4 +50,4 @@ console.log('foobar'.search(new caseInsensitiveSearch('BaR')));
 - {{jsxref("Symbol.match")}}
 - {{jsxref("Symbol.replace")}}
 - {{jsxref("Symbol.split")}}
-- {{jsxref("RegExp.@@search", "RegExp.prototype[@@search]\()")}}
+- {{jsxref("RegExp.@@search", "RegExp.prototype[@@search]()")}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/search/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/search/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Symbol.search
 
 The **`Symbol.search`** well-known symbol specifies the method that returns the index within a string that matches the regular expression. This function is called by the {{jsxref("String.prototype.search()")}} method.
 
-For more information, see {{jsxref("RegExp.@@search", "RegExp.prototype[@@search]\()")}}} and {{jsxref("String.prototype.search()")}}.
+For more information, see {{jsxref("RegExp.@@search", "RegExp.prototype[@@search]\()")}} and {{jsxref("String.prototype.search()")}}.
 
 {{EmbedInteractiveExample("pages/js/symbol-search.html")}}{{js_property_attributes(0,0,0)}}
 
@@ -49,4 +49,4 @@ console.log('foobar'.search(new caseInsensitiveSearch('BaR')));
 - {{jsxref("Symbol.match")}}
 - {{jsxref("Symbol.replace")}}
 - {{jsxref("Symbol.split")}}
-- {{jsxref("RegExp.@@search", "RegExp.prototype[@@search]\()")}}}
+- {{jsxref("RegExp.@@search", "RegExp.prototype[@@search]\()")}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/split/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/split/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Symbol.split
 
 The **`Symbol.split`** well-known symbol specifies the method that splits a string at the indices that match a regular expression. This function is called by the {{jsxref("String.prototype.split()")}} method.
 
-For more information, see {{jsxref("RegExp.@@split", "RegExp.prototype[@@split]\()")}}} and {{jsxref("String.prototype.split()")}}.
+For more information, see {{jsxref("RegExp.@@split", "RegExp.prototype[@@split]\()")}} and {{jsxref("String.prototype.split()")}}.
 
 {{EmbedInteractiveExample("pages/js/symbol-split.html")}}{{js_property_attributes(0,0,0)}}
 
@@ -47,4 +47,4 @@ console.log('Another one bites the dust'.split(new ReverseSplit()));
 - {{jsxref("Symbol.match")}}
 - {{jsxref("Symbol.replace")}}
 - {{jsxref("Symbol.search")}}
-- {{jsxref("RegExp.@@split", "RegExp.prototype[@@split]\()")}}}
+- {{jsxref("RegExp.@@split", "RegExp.prototype[@@split]\()")}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/split/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/split/index.md
@@ -13,7 +13,7 @@ browser-compat: javascript.builtins.Symbol.split
 
 The **`Symbol.split`** well-known symbol specifies the method that splits a string at the indices that match a regular expression. This function is called by the {{jsxref("String.prototype.split()")}} method.
 
-For more information, see {{jsxref("RegExp.@@split", "RegExp.prototype[@@split]()")}} and {{jsxref("String.prototype.split()")}}.
+For more information, see {{jsxref("RegExp.@@split", "RegExp.prototype[@@split]\()")}}} and {{jsxref("String.prototype.split()")}}.
 
 {{EmbedInteractiveExample("pages/js/symbol-split.html")}}{{js_property_attributes(0,0,0)}}
 
@@ -47,4 +47,4 @@ console.log('Another one bites the dust'.split(new ReverseSplit()));
 - {{jsxref("Symbol.match")}}
 - {{jsxref("Symbol.replace")}}
 - {{jsxref("Symbol.search")}}
-- {{jsxref("RegExp.@@split", "RegExp.prototype[@@split]()")}}
+- {{jsxref("RegExp.@@split", "RegExp.prototype[@@split]\()")}}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/split/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/split/index.md
@@ -13,7 +13,8 @@ browser-compat: javascript.builtins.Symbol.split
 
 The **`Symbol.split`** well-known symbol specifies the method that splits a string at the indices that match a regular expression. This function is called by the {{jsxref("String.prototype.split()")}} method.
 
-For more information, see {{jsxref("RegExp.@@split", "RegExp.prototype[@@split]\()")}} and {{jsxref("String.prototype.split()")}}.
+<!-- markdownlint-disable MD042 -->
+For more information, see {{jsxref("RegExp.@@split", "RegExp.prototype[@@split]()")}} and {{jsxref("String.prototype.split()")}}.
 
 {{EmbedInteractiveExample("pages/js/symbol-split.html")}}{{js_property_attributes(0,0,0)}}
 
@@ -47,4 +48,4 @@ console.log('Another one bites the dust'.split(new ReverseSplit()));
 - {{jsxref("Symbol.match")}}
 - {{jsxref("Symbol.replace")}}
 - {{jsxref("Symbol.search")}}
-- {{jsxref("RegExp.@@split", "RegExp.prototype[@@split]\()")}}
+- {{jsxref("RegExp.@@split", "RegExp.prototype[@@split]()")}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/toprimitive/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/toprimitive/index.md
@@ -60,7 +60,7 @@ console.log(obj2 + ''); // "true"    — hint is "default"
 
 ## See also
 
-- {{jsxref("Date.@@toPrimitive", "Date.prototype[@@toPrimitive]\()")}}}
-- {{jsxref("Symbol.@@toPrimitive", "Symbol.prototype[@@toPrimitive]\()")}}}
+- {{jsxref("Date.@@toPrimitive", "Date.prototype[@@toPrimitive]\()")}}
+- {{jsxref("Symbol.@@toPrimitive", "Symbol.prototype[@@toPrimitive]\()")}}
 - {{jsxref("Object.prototype.toString()")}}
 - {{jsxref("Object.prototype.valueOf()")}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/toprimitive/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/toprimitive/index.md
@@ -60,7 +60,7 @@ console.log(obj2 + ''); // "true"    — hint is "default"
 
 ## See also
 
-- {{jsxref("Date.@@toPrimitive", "Date.prototype[@@toPrimitive]()")}}
-- {{jsxref("Symbol.@@toPrimitive", "Symbol.prototype[@@toPrimitive]()")}}
+- {{jsxref("Date.@@toPrimitive", "Date.prototype[@@toPrimitive]\()")}}}
+- {{jsxref("Symbol.@@toPrimitive", "Symbol.prototype[@@toPrimitive]\()")}}}
 - {{jsxref("Object.prototype.toString()")}}
 - {{jsxref("Object.prototype.valueOf()")}}

--- a/files/en-us/web/javascript/reference/global_objects/symbol/toprimitive/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/symbol/toprimitive/index.md
@@ -60,7 +60,8 @@ console.log(obj2 + ''); // "true"    — hint is "default"
 
 ## See also
 
-- {{jsxref("Date.@@toPrimitive", "Date.prototype[@@toPrimitive]\()")}}
-- {{jsxref("Symbol.@@toPrimitive", "Symbol.prototype[@@toPrimitive]\()")}}
+<!-- markdownlint-disable MD042 -->
+- {{jsxref("Date.@@toPrimitive", "Date.prototype[@@toPrimitive]()")}}
+- {{jsxref("Symbol.@@toPrimitive", "Symbol.prototype[@@toPrimitive]()")}}
 - {{jsxref("Object.prototype.toString()")}}
 - {{jsxref("Object.prototype.valueOf()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/entries/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/entries/index.md
@@ -66,9 +66,10 @@ console.log(arrayEntries.next().value); // [4, 50]
 
 ## See also
 
+<!-- markdownlint-disable MD042 -->
 - [Polyfill of `TypedArray.prototype.entries` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("TypedArray")}}
 - {{jsxref("TypedArray.prototype.keys()")}}
 - {{jsxref("TypedArray.prototype.values()")}}
-- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]\()")}}
+- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/entries/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/entries/index.md
@@ -71,4 +71,4 @@ console.log(arrayEntries.next().value); // [4, 50]
 - {{jsxref("TypedArray")}}
 - {{jsxref("TypedArray.prototype.keys()")}}
 - {{jsxref("TypedArray.prototype.values()")}}
-- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]()")}}
+- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]\()")}}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/entries/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/entries/index.md
@@ -71,4 +71,4 @@ console.log(arrayEntries.next().value); // [4, 50]
 - {{jsxref("TypedArray")}}
 - {{jsxref("TypedArray.prototype.keys()")}}
 - {{jsxref("TypedArray.prototype.values()")}}
-- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]\()")}}}
+- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]\()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/index.md
@@ -237,7 +237,7 @@ Where _TypedArray_ is a constructor for one of the concrete types.
 - {{jsxref("TypedArray.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also
     {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]()")}}
+- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]\()")}}}
   - : Returns a new _array iterator_ object that contains the values for each index in the
     array.
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/index.md
@@ -237,7 +237,7 @@ Where _TypedArray_ is a constructor for one of the concrete types.
 - {{jsxref("TypedArray.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also
     {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]\()")}}}
+- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]\()")}}
   - : Returns a new _array iterator_ object that contains the values for each index in the
     array.
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/index.md
@@ -148,6 +148,7 @@ Where _TypedArray_ is a constructor for one of the concrete types.
 
 ## Instance methods
 
+<!-- markdownlint-disable MD042 -->
 - {{jsxref("TypedArray.prototype.at()")}}
   - : Takes an integer value and returns the item at that index. This method allows for negative integers, which count back from the last item.
 - {{jsxref("TypedArray.prototype.copyWithin()")}}
@@ -237,7 +238,7 @@ Where _TypedArray_ is a constructor for one of the concrete types.
 - {{jsxref("TypedArray.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also
     {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]\()")}}
+- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]()")}}
   - : Returns a new _array iterator_ object that contains the values for each index in the
     array.
 

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/keys/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/keys/index.md
@@ -66,11 +66,12 @@ console.log(arrKeys.next().value); // 4
 
 ## See also
 
+<!-- markdownlint-disable MD042 -->
 - [Polyfill of `TypedArray.prototype.keys` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("TypedArray")}}
 - {{jsxref("TypedArray.prototype.entries()")}}
 - {{jsxref("TypedArray.prototype.values()")}}
-- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]\()")}}
+- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]()")}}
 - [for...of](/en-US/docs/Web/JavaScript/Reference/Statements/for...of)
 - [Iteration protocols](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols)

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/keys/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/keys/index.md
@@ -71,6 +71,6 @@ console.log(arrKeys.next().value); // 4
 - {{jsxref("TypedArray")}}
 - {{jsxref("TypedArray.prototype.entries()")}}
 - {{jsxref("TypedArray.prototype.values()")}}
-- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]\()")}}}
+- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]\()")}}
 - [for...of](/en-US/docs/Web/JavaScript/Reference/Statements/for...of)
 - [Iteration protocols](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols)

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/keys/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/keys/index.md
@@ -71,6 +71,6 @@ console.log(arrKeys.next().value); // 4
 - {{jsxref("TypedArray")}}
 - {{jsxref("TypedArray.prototype.entries()")}}
 - {{jsxref("TypedArray.prototype.values()")}}
-- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]()")}}
+- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]\()")}}}
 - [for...of](/en-US/docs/Web/JavaScript/Reference/Statements/for...of)
 - [Iteration protocols](/en-US/docs/Web/JavaScript/Reference/Iteration_protocols)

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/values/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/values/index.md
@@ -66,4 +66,4 @@ console.log(values.next().value); // 50
 - {{jsxref("TypedArray")}}
 - {{jsxref("TypedArray.prototype.entries()")}}
 - {{jsxref("TypedArray.prototype.keys()")}}
-- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]()")}}
+- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]\()")}}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/values/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/values/index.md
@@ -66,4 +66,4 @@ console.log(values.next().value); // 50
 - {{jsxref("TypedArray")}}
 - {{jsxref("TypedArray.prototype.entries()")}}
 - {{jsxref("TypedArray.prototype.keys()")}}
-- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]\()")}}}
+- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]\()")}}

--- a/files/en-us/web/javascript/reference/global_objects/typedarray/values/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/typedarray/values/index.md
@@ -61,9 +61,10 @@ console.log(values.next().value); // 50
 
 ## See also
 
+<!-- markdownlint-disable MD042 -->
 - [Polyfill of `TypedArray.prototype.values` in `core-js`](https://github.com/zloirock/core-js#ecmascript-typed-arrays)
 - [JavaScript typed arrays](/en-US/docs/Web/JavaScript/Typed_arrays)
 - {{jsxref("TypedArray")}}
 - {{jsxref("TypedArray.prototype.entries()")}}
 - {{jsxref("TypedArray.prototype.keys()")}}
-- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]\()")}}
+- {{jsxref("TypedArray.prototype.@@iterator()", "TypedArray.prototype[@@iterator]()")}}

--- a/files/en-us/web/javascript/reference/global_objects/uint16array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint16array/index.md
@@ -96,7 +96,7 @@ The **`Uint16Array`** typed array represents an array of 16-bit unsigned integer
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Uint16Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Uint16Array.prototype[@@iterator]\()")}}}
+- {{jsxref("TypedArray.@@iterator", "Uint16Array.prototype[@@iterator]\()")}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/uint16array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint16array/index.md
@@ -46,6 +46,7 @@ The **`Uint16Array`** typed array represents an array of 16-bit unsigned integer
 
 ## Instance methods
 
+<!-- markdownlint-disable MD042 -->
 - {{jsxref("TypedArray.copyWithin", "Uint16Array.prototype.copyWithin()")}}
   - : Copies a sequence of array elements within the array. See also {{jsxref("Array.prototype.copyWithin()")}}.
 - {{jsxref("TypedArray.entries", "Uint16Array.prototype.entries()")}}
@@ -96,7 +97,7 @@ The **`Uint16Array`** typed array represents an array of 16-bit unsigned integer
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Uint16Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Uint16Array.prototype[@@iterator]\()")}}
+- {{jsxref("TypedArray.@@iterator", "Uint16Array.prototype[@@iterator]()")}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/uint16array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint16array/index.md
@@ -96,7 +96,7 @@ The **`Uint16Array`** typed array represents an array of 16-bit unsigned integer
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Uint16Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Uint16Array.prototype[@@iterator]()")}}
+- {{jsxref("TypedArray.@@iterator", "Uint16Array.prototype[@@iterator]\()")}}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/uint32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint32array/index.md
@@ -46,6 +46,7 @@ The **`Uint32Array`** typed array represents an array of 32-bit unsigned integer
 
 ## Instance methods
 
+<!-- markdownlint-disable MD042 -->
 - {{jsxref("TypedArray.copyWithin", "Uint32Array.prototype.copyWithin()")}}
   - : Copies a sequence of array elements within the array. See also {{jsxref("Array.prototype.copyWithin()")}}.
 - {{jsxref("TypedArray.entries", "Uint32Array.prototype.entries()")}}
@@ -96,7 +97,7 @@ The **`Uint32Array`** typed array represents an array of 32-bit unsigned integer
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Uint32Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Uint32Array.prototype[@@iterator]\()")}}
+- {{jsxref("TypedArray.@@iterator", "Uint32Array.prototype[@@iterator]()")}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/uint32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint32array/index.md
@@ -96,7 +96,7 @@ The **`Uint32Array`** typed array represents an array of 32-bit unsigned integer
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Uint32Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Uint32Array.prototype[@@iterator]\()")}}}
+- {{jsxref("TypedArray.@@iterator", "Uint32Array.prototype[@@iterator]\()")}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/uint32array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint32array/index.md
@@ -96,7 +96,7 @@ The **`Uint32Array`** typed array represents an array of 32-bit unsigned integer
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Uint32Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Uint32Array.prototype[@@iterator]()")}}
+- {{jsxref("TypedArray.@@iterator", "Uint32Array.prototype[@@iterator]\()")}}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/index.md
@@ -46,6 +46,7 @@ The **`Uint8Array`** typed array represents an array of 8-bit unsigned integers.
 
 ## Instance methods
 
+<!-- markdownlint-disable MD042 -->
 - {{jsxref("TypedArray.copyWithin", "Uint8Array.prototype.copyWithin()")}}
   - : Copies a sequence of array elements within the array. See also {{jsxref("Array.prototype.copyWithin()")}}.
 - {{jsxref("TypedArray.entries", "Uint8Array.prototype.entries()")}}
@@ -96,7 +97,7 @@ The **`Uint8Array`** typed array represents an array of 8-bit unsigned integers.
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Uint8Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Uint8Array.prototype[@@iterator]\()")}}
+- {{jsxref("TypedArray.@@iterator", "Uint8Array.prototype[@@iterator]()")}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/index.md
@@ -96,7 +96,7 @@ The **`Uint8Array`** typed array represents an array of 8-bit unsigned integers.
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Uint8Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Uint8Array.prototype[@@iterator]()")}}
+- {{jsxref("TypedArray.@@iterator", "Uint8Array.prototype[@@iterator]\()")}}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/uint8array/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8array/index.md
@@ -96,7 +96,7 @@ The **`Uint8Array`** typed array represents an array of 8-bit unsigned integers.
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Uint8Array.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Uint8Array.prototype[@@iterator]\()")}}}
+- {{jsxref("TypedArray.@@iterator", "Uint8Array.prototype[@@iterator]\()")}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/uint8clampedarray/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8clampedarray/index.md
@@ -96,7 +96,7 @@ The **`Uint8ClampedArray`** typed array represents an array of 8-bit unsigned in
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Uint8ClampedArray.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Uint8ClampedArray.prototype[@@iterator]\()")}}}
+- {{jsxref("TypedArray.@@iterator", "Uint8ClampedArray.prototype[@@iterator]\()")}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/uint8clampedarray/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8clampedarray/index.md
@@ -96,7 +96,7 @@ The **`Uint8ClampedArray`** typed array represents an array of 8-bit unsigned in
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Uint8ClampedArray.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Uint8ClampedArray.prototype[@@iterator]()")}}
+- {{jsxref("TypedArray.@@iterator", "Uint8ClampedArray.prototype[@@iterator]\()")}}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples

--- a/files/en-us/web/javascript/reference/global_objects/uint8clampedarray/index.md
+++ b/files/en-us/web/javascript/reference/global_objects/uint8clampedarray/index.md
@@ -46,6 +46,7 @@ The **`Uint8ClampedArray`** typed array represents an array of 8-bit unsigned in
 
 ## Instance methods
 
+<!-- markdownlint-disable MD042 -->
 - {{jsxref("TypedArray.copyWithin", "Uint8ClampedArray.prototype.copyWithin()")}}
   - : Copies a sequence of array elements within the array. See also {{jsxref("Array.prototype.copyWithin()")}}.
 - {{jsxref("TypedArray.entries", "Uint8ClampedArray.prototype.entries()")}}
@@ -96,7 +97,7 @@ The **`Uint8ClampedArray`** typed array represents an array of 8-bit unsigned in
   - : Returns a localized string representing the array and its elements. See also {{jsxref("Array.prototype.toLocaleString()")}}.
 - {{jsxref("TypedArray.toString", "Uint8ClampedArray.prototype.toString()")}}
   - : Returns a string representing the array and its elements. See also {{jsxref("Array.prototype.toString()")}}.
-- {{jsxref("TypedArray.@@iterator", "Uint8ClampedArray.prototype[@@iterator]\()")}}
+- {{jsxref("TypedArray.@@iterator", "Uint8ClampedArray.prototype[@@iterator]()")}}
   - : Returns a new _array iterator_ object that contains the values for each index in the array.
 
 ## Examples


### PR DESCRIPTION
Some of the macro values come up as empty links to markdown parsers, so attempt to escape a bracket.