### PR TITLE
HTML: update BCD Info

### DIFF
--- a/files/en-us/web/html/element/applet/index.md
+++ b/files/en-us/web/html/element/applet/index.md
@@ -12,7 +12,7 @@ tags:
 browser-compat: html.elements.applet
 ---
 
-{{HTMLRef}}{{deprecated_header}}
+{{HTMLRef}}{{Deprecated_Header}}
 
 The obsolete **HTML Applet Element** (**`<applet>`**) embeds a Java applet into the document; this element has been deprecated in favor of {{HTMLElement("object")}}.
 
@@ -70,35 +70,35 @@ Use of Java applets on the Web is deprecated; most browsers no longer support us
 
 ## Attributes
 
-- {{HTMLAttrDef("align")}}
+- {{HTMLAttrDef("align")}} {{Deprecated_Inline}}
   - : This attribute is used to position the applet on the page relative to content that might flow around it. The HTML 4.01 specification defines values of `bottom`, `left`, `middle`, `right`, and `top`, whereas Microsoft and Netscape also might support `absbottom`, `absmiddle`, `baseline`, `center`, and `texttop`.
-- {{HTMLAttrDef("alt")}}
+- {{HTMLAttrDef("alt")}} {{Deprecated_Inline}}
   - : This attribute causes a descriptive text alternate to be displayed on browsers that do not support Java. Page designers should also remember that content enclosed within the `<applet>` element may also be rendered as alternative text.
-- {{HTMLAttrDef("archive")}}
+- {{HTMLAttrDef("archive")}} {{Deprecated_Inline}}
   - : This attribute refers to an archived or compressed version of the applet and its associated class files, which might help reduce download time.
-- {{HTMLAttrDef("code")}}
+- {{HTMLAttrDef("code")}} {{Deprecated_Inline}}
   - : This attribute specifies the URL of the applet's class file to be loaded and executed. Applet filenames are identified by a .class filename extension. The URL specified by code might be relative to the `codebase` attribute.
-- {{HTMLAttrDef("codebase")}}
+- {{HTMLAttrDef("codebase")}} {{Deprecated_Inline}}
   - : This attribute gives the absolute or relative URL of the directory where applets' .class files referenced by the code attribute are stored.
-- {{HTMLAttrDef("datafld")}}
+- {{HTMLAttrDef("datafld")}} {{Deprecated_Inline}}
   - : This attribute, supported by Internet Explorer 4 and higher, specifies the column name from the data source object that supplies the bound data. This attribute might be used to specify the various {{HTMLElement("param")}} elements passed to the Java applet.
-- {{HTMLAttrDef("datasrc")}}
+- {{HTMLAttrDef("datasrc")}} {{Deprecated_Inline}}
   - : Like `datafld`, this attribute is used for data binding under Internet Explorer 4. It indicates the id of the data source object that supplies the data that is bound to the {{HTMLElement("param")}} elements associated with the applet.
-- {{HTMLAttrDef("height")}}
+- {{HTMLAttrDef("height")}} {{Deprecated_Inline}}
   - : This attribute specifies the height, in pixels, that the applet needs.
-- {{HTMLAttrDef("hspace")}}
+- {{HTMLAttrDef("hspace")}} {{Deprecated_Inline}}
   - : This attribute specifies additional horizontal space, in pixels, to be reserved on either side of the applet.
-- {{HTMLAttrDef("mayscript")}}
+- {{HTMLAttrDef("mayscript")}} {{Deprecated_Inline}}
   - : In the Netscape implementation, this attribute allows access to an applet by programs in a scripting language embedded in the document.
-- {{HTMLAttrDef("name")}}
+- {{HTMLAttrDef("name")}} {{Deprecated_Inline}}
   - : This attribute assigns a name to the applet so that it can be identified by other resources; particularly scripts.
-- {{HTMLAttrDef("object")}}
+- {{HTMLAttrDef("object")}} {{Deprecated_Inline}}
   - : This attribute specifies the URL of a serialized representation of an applet.
-- {{HTMLAttrDef("src")}}
+- {{HTMLAttrDef("src")}} {{Deprecated_Inline}}
   - : As defined for Internet Explorer 4 and higher, this attribute specifies a URL for an associated file for the applet. The meaning and use is unclear and not part of the HTML standard.
-- {{HTMLAttrDef("vspace")}}
+- {{HTMLAttrDef("vspace")}} {{Deprecated_Inline}}
   - : This attribute specifies additional vertical space, in pixels, to be reserved above and below the applet.
-- {{HTMLAttrDef("width")}}
+- {{HTMLAttrDef("width")}} {{Deprecated_Inline}}
   - : This attribute specifies in pixels the width that the applet needs.
 
 ## Example

--- a/files/en-us/web/html/element/area/index.md
+++ b/files/en-us/web/html/element/area/index.md
@@ -93,7 +93,7 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/G
   - : The hyperlink target for the area.
     Its value is a valid URL.
     This attribute may be omitted; if so, the `<area>` element does not represent a hyperlink.
-- {{htmlattrdef("hreflang")}}
+- {{htmlattrdef("hreflang")}} {{Deprecated_Inline}}
   - : Indicates the language of the linked resource. Allowed values are defined by {{RFC(5646, "Tags for Identifying Languages (also known as BCP 47)")}}.
     Use this attribute only if the {{htmlattrxref("href", "area")}} attribute is present.
 - {{htmlattrdef("ping")}}

--- a/files/en-us/web/html/element/bgsound/index.md
+++ b/files/en-us/web/html/element/bgsound/index.md
@@ -7,14 +7,13 @@ tags:
   - Element
   - HTML
   - Internet Explorer
-  - Non-standard
   - Deprecated
   - Reference
   - Web
 browser-compat: html.elements.bgsound
 ---
 
-{{deprecated_header}}{{non-standard_header}}
+{{Deprecated_Header}}
 
 The **`<bgsound>`** [HTML](/en-US/docs/Web/HTML) element is deprecated. It sets up a sound file to play in the background while the page is used; use {{HTMLElement("audio")}} instead.
 

--- a/files/en-us/web/html/element/br/index.md
+++ b/files/en-us/web/html/element/br/index.md
@@ -26,7 +26,7 @@ This element's attributes include the [global attributes](/en-US/docs/Web/HTML/G
 
 ### Deprecated attributes
 
-- {{htmlattrdef("clear")}}
+- {{htmlattrdef("clear")}} {{Deprecated_Inline}}
   - : Indicates where to begin the next line after the break.
 
 ## Styling with CSS

--- a/files/en-us/web/html/element/content/index.md
+++ b/files/en-us/web/html/element/content/index.md
@@ -13,10 +13,11 @@ tags:
   - Web
   - Web Components
   - shadow dom
+  - Non-standard
 browser-compat: html.elements.content
 ---
 
-{{Deprecated_header}}
+{{Deprecated_Header}}{{Non-standard_header}}
 
 The **`<content>`** [HTML](/en-US/docs/Web/HTML) element—an obsolete part of the [Web Components](/en-US/docs/Web/Web_Components) suite of technologies—was used inside of [Shadow DOM](/en-US/docs/Web/Web_Components/Using_shadow_DOM) as an {{glossary("insertion point")}}, and wasn't meant to be used in ordinary HTML. It has now been replaced by the {{HTMLElement("slot")}} element, which creates a point in the DOM at which a shadow DOM can be inserted.
 

--- a/files/en-us/web/html/element/dd/index.md
+++ b/files/en-us/web/html/element/dd/index.md
@@ -77,7 +77,7 @@ The **`<dd>`** [HTML](/en-US/docs/Web/HTML) element provides the description, de
 
 This element's attributes include the [global attributes](/en-US/docs/Web/HTML/Global_attributes).
 
-- {{htmlattrdef("nowrap")}} {{Non-standard_inline}}
+- {{htmlattrdef("nowrap")}} {{Non-standard_inline}} {{Deprecated_Inline}}
   - : If the value of this attribute is set to `yes`, the definition text will not wrap. The default value is `no`.
 
 ## Examples

--- a/files/en-us/web/html/element/dir/index.md
+++ b/files/en-us/web/html/element/dir/index.md
@@ -14,7 +14,7 @@ tags:
 browser-compat: html.elements.dir
 ---
 
-{{HTMLRef}}{{deprecated_header}}
+{{HTMLRef}}{{Deprecated_Header}}
 
 The **`<dir>`** [HTML](/en-US/docs/Web/HTML) element is used as a container for a directory of files and/or folders, potentially with styles and icons applied by the {{Glossary("user agent")}}. Do not use this obsolete element; instead, you should use the {{HTMLElement("ul")}} element for lists, including lists of files.
 
@@ -28,7 +28,7 @@ This element implements the {{domxref("HTMLDirectoryElement")}} interface.
 
 Like all other HTML elements, this element supports the [global attributes](/en-US/docs/Web/HTML/Global_attributes).
 
-- {{htmlattrdef("compact")}}
+- {{htmlattrdef("compact")}} {{Deprecated_Inline}}
   - : This Boolean attribute hints that the list should be rendered in a compact style. The interpretation of this attribute depends on the user agent and it doesn't work in all browsers.
 
 ## Specifications

--- a/files/en-us/web/html/element/font/index.md
+++ b/files/en-us/web/html/element/font/index.md
@@ -12,8 +12,6 @@ browser-compat: html.elements.font
 
 {{Deprecated_Header}}
 
-## Summary
-
 The **`<font>`** [HTML](/en-US/docs/Web/HTML) element defines the font size, color and face for its content.
 
 > **Warning:** Do not use this element. Use the CSS [Fonts](/en-US/docs/Web/CSS/CSS_Fonts) properties to style text.

--- a/files/en-us/web/html/element/font/index.md
+++ b/files/en-us/web/html/element/font/index.md
@@ -10,7 +10,7 @@ tags:
 browser-compat: html.elements.font
 ---
 
-{{deprecated_header}}
+{{Deprecated_Header}}
 
 ## Summary
 
@@ -22,11 +22,11 @@ The **`<font>`** [HTML](/en-US/docs/Web/HTML) element defines the font size, col
 
 Like all other HTML elements, this element supports the [global attributes](/en-US/docs/Web/HTML/Global_attributes).
 
-- {{htmlattrdef("color")}}
+- {{htmlattrdef("color")}} {{Deprecated_Inline}}
   - : This attribute sets the text color using either a named color or a color specified in the hexadecimal #RRGGBB format.
-- {{htmlattrdef("face")}}
+- {{htmlattrdef("face")}} {{Deprecated_Inline}}
   - : This attribute contains a comma-separated list of one or more font names. The document text in the default style is rendered in the first font face that the client's browser supports. If no font listed is installed on the local system, the browser typically defaults to the proportional or fixed-width font for that system.
-- {{htmlattrdef("size")}}
+- {{htmlattrdef("size")}} {{Deprecated_Inline}}
   - : This attribute specifies the font size as either a numeric or relative value. Numeric values range from `1` to `7` with `1` being the smallest and `3` the default. It can be defined using a relative value, like `+2` or `-3`, which sets it relative to `3`, the default value.
 
 ## DOM interface

--- a/files/en-us/web/html/element/frame/index.md
+++ b/files/en-us/web/html/element/frame/index.md
@@ -10,7 +10,7 @@ tags:
 browser-compat: html.elements.frame
 ---
 
-{{HTMLRef}}{{Deprecated_header}}
+{{HTMLRef}}{{Deprecated_Header}}
 
 The **`<frame>`** [HTML](/en-US/docs/Web/HTML) element defines a particular area in which another HTML document can be displayed. A frame should be used within a {{HTMLElement("frameset")}}.
 
@@ -20,19 +20,19 @@ Using the `<frame>` element is not encouraged because of certain disadvantages s
 
 Like all other HTML elements, this element supports the [global attributes](/en-US/docs/Web/HTML/Global_attributes).
 
-- {{htmlattrdef("src")}}
+- {{htmlattrdef("src")}} {{Deprecated_Inline}}
   - : This attribute specifies the document that will be displayed by the frame.
-- {{htmlattrdef("name")}}
+- {{htmlattrdef("name")}} {{Deprecated_Inline}}
   - : This attribute is used for labeling frames. Without labeling, every link will open in the frame that it's in – the closest parent frame. See the {{htmlattrxref("target","a")}} attribute for more information.
-- {{htmlattrdef("noresize")}}
+- {{htmlattrdef("noresize")}} {{Deprecated_Inline}}
   - : This attribute prevents resizing of frames by users.
-- {{htmlattrdef("scrolling")}}
+- {{htmlattrdef("scrolling")}} {{Deprecated_Inline}}
   - : This attribute defines the existence of a scrollbar. If this attribute is not used, the browser adds a scrollbar when necessary. There are two choices: "yes" for forcing a scrollbar even when it is not necessary and "no" for forcing no scrollbar even when it _is_ necessary.
-- {{htmlattrdef("marginheight")}}
+- {{htmlattrdef("marginheight")}} {{Deprecated_Inline}}
   - : This attribute defines the height of the margin between frames.
-- {{htmlattrdef("marginwidth")}}
+- {{htmlattrdef("marginwidth")}} {{Deprecated_Inline}}
   - : This attribute defines the width of the margin between frames.
-- {{htmlattrdef("frameborder")}}
+- {{htmlattrdef("frameborder")}} {{Deprecated_Inline}}
   - : This attribute allows you to specify a frame's border.
 
 ## Example

--- a/files/en-us/web/html/element/frameset/index.md
+++ b/files/en-us/web/html/element/frameset/index.md
@@ -20,9 +20,9 @@ The **`<frameset>`** [HTML](/en-US/docs/Web/HTML) element is used to contain {{H
 
 Like all other HTML elements, this element supports the [global attributes](/en-US/docs/Web/HTML/Global_attributes).
 
-- {{htmlattrdef("cols")}}
+- {{htmlattrdef("cols")}} {{Deprecated_Inline}}
   - : This attribute specifies the number and size of horizontal spaces in a frameset.
-- {{htmlattrdef("rows")}}
+- {{htmlattrdef("rows")}} {{Deprecated_Inline}}
   - : This attribute specifies the number and size of vertical spaces in a frameset.
 
 ## Example

--- a/files/en-us/web/html/element/head/index.md
+++ b/files/en-us/web/html/element/head/index.md
@@ -79,7 +79,7 @@ The **`<head>`** [HTML](/en-US/docs/Web/HTML) element contains machine-readable 
 
 This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attributes).
 
-- {{htmlattrdef("profile")}} {{deprecated_inline}}
+- {{htmlattrdef("profile")}} {{deprecated_inline}} {{Non-standard_Inline}}
   - : The {{glossary("URI")}}s of one or more metadata profiles, separated by {{Glossary("whitespace", "white space")}}.
 
 ## Example

--- a/files/en-us/web/html/element/hr/index.md
+++ b/files/en-us/web/html/element/hr/index.md
@@ -69,15 +69,15 @@ Historically, this has been presented as a horizontal rule or line. While it may
 
 This element's attributes include the [global attributes](/en-US/docs/Web/HTML/Global_attributes).
 
-- {{htmlattrdef("align")}} {{deprecated_inline}}
+- {{htmlattrdef("align")}} {{deprecated_inline}} {{Non-standard_Inline}}
   - : Sets the alignment of the rule on the page. If no value is specified, the default value is `left`.
-- {{htmlattrdef("color")}} {{Non-standard_inline}}
+- {{htmlattrdef("color")}} {{Non-standard_inline}} {{Deprecated_Inline}}
   - : Sets the color of the rule through color name or hexadecimal value.
-- {{htmlattrdef("noshade")}} {{deprecated_inline}}
+- {{htmlattrdef("noshade")}} {{deprecated_inline}} {{Non-standard_Inline}}
   - : Sets the rule to have no shading.
-- {{htmlattrdef("size")}} {{deprecated_inline}}
+- {{htmlattrdef("size")}} {{deprecated_inline}} {{Non-standard_Inline}}
   - : Sets the height, in pixels, of the rule.
-- {{htmlattrdef("width")}} {{deprecated_inline}}
+- {{htmlattrdef("width")}} {{deprecated_inline}} {{Non-standard_Inline}}
   - : Sets the length of the rule on the page through a pixel or percentage value.
 
 ## Example

--- a/files/en-us/web/html/element/html/index.md
+++ b/files/en-us/web/html/element/html/index.md
@@ -67,7 +67,7 @@ The **`<html>`** [HTML](/en-US/docs/Web/HTML) element represents the root (top-l
 
 This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attributes).
 
-- {{htmlattrdef("manifest")}} {{deprecated_inline}}
+- {{htmlattrdef("manifest")}} {{deprecated_inline}} {{Non-standard_Inline}}
   - : Specifies the {{glossary("URI")}} of a resource manifest indicating resources that should be cached locally.
 - {{htmlattrdef("version")}} {{deprecated_inline}}
   - : Specifies the version of the HTML {{glossary("Doctype", "Document Type Definition")}} that governs the current document. This attribute is not needed, because it is redundant with the version information in the document type declaration.

--- a/files/en-us/web/html/element/html/manifest/index.md
+++ b/files/en-us/web/html/element/html/manifest/index.md
@@ -4,6 +4,8 @@ slug: Web/HTML/Element/html/manifest
 tags:
   - Cache
   - application cache
+  - Deprecated
+  - Non-standard
 browser-compat: html.elements.html.manifest
 ---
 

--- a/files/en-us/web/html/element/iframe/index.md
+++ b/files/en-us/web/html/element/iframe/index.md
@@ -95,7 +95,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
     > **Note:** This attribute is considered a legacy attribute and redefined as `allow="fullscreen"`.
 
-- {{htmlattrdef("allowpaymentrequest")}}
+- {{htmlattrdef("allowpaymentrequest")}} {{Experimental_Inline}}
 
   - : Set to `true` if a cross-origin `<iframe>` should be allowed to invoke the [Payment Request API](/en-US/docs/Web/API/Payment_Request_API).
 
@@ -104,7 +104,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 - {{htmlattrdef("csp")}} {{experimental_inline}}
   - : A [Content Security Policy](/en-US/docs/Web/HTTP/CSP) enforced for the embedded resource. See {{domxref("HTMLIFrameElement.csp")}} for details.
 
-- {{htmlattrdef("fetchpriority")}}
+- {{htmlattrdef("fetchpriority")}} {{Experimental_Inline}}
 
   - : Provides a hint of the relative priority to use when fetching the iframe document. Allowed values:
 

--- a/files/en-us/web/html/element/image/index.md
+++ b/files/en-us/web/html/element/image/index.md
@@ -12,7 +12,7 @@ tags:
   - Reference
 browser-compat: html.elements.image
 ---
-{{HTMLRef}}{{deprecated_header}}
+{{HTMLRef}}{{deprecated_header}}{{Non-standard_header}}
 
 The **`<image>`** [HTML](/en-US/docs/Web/HTML) element is an ancient and poorly supported precursor to the {{HTMLElement("img")}} element.
 **It should not be used**.

--- a/files/en-us/web/html/element/li/index.md
+++ b/files/en-us/web/html/element/li/index.md
@@ -87,7 +87,7 @@ This element includes the [global attributes](/en-US/docs/Web/HTML/Global_attrib
 
 - {{htmlattrdef("value")}}
   - : This integer attribute indicates the current ordinal value of the list item as defined by the {{HTMLElement("ol")}} element. The only allowed value for this attribute is a number, even if the list is displayed with Roman numerals or letters. List items that follow this one continue numbering from the value set. The **value** attribute has no meaning for unordered lists ({{HTMLElement("ul")}}) or for menus ({{HTMLElement("menu")}}).
-- {{htmlattrdef("type")}} {{Deprecated_inline}}
+- {{htmlattrdef("type")}} {{Deprecated_inline}} {{Non-standard_Inline}}
 
   - : This character attribute indicates the numbering type:
 

--- a/files/en-us/web/html/element/noembed/index.md
+++ b/files/en-us/web/html/element/noembed/index.md
@@ -6,14 +6,13 @@ tags:
   - Embedded content
   - Embedding
   - HTML
-  - Non-standard
   - Deprecated
   - Reference
   - noembed
 browser-compat: html.elements.noembed
 ---
 
-{{HTMLRef}}{{Non-standard_header}}{{deprecated_header}}
+{{HTMLRef}}{{deprecated_header}}
 
 The **`<noembed>`** [HTML](/en-US/docs/Web/HTML) element is an obsolete, non-standard way to provide alternative, or "fallback", content for browsers that do not support the {{HTMLElement("embed")}} element or do not support the type of [embedded content](/en-US/docs/Web/Guide/HTML/Content_categories#embedded_content) an author wishes to use. This element was deprecated in HTML 4.01 and above in favor of placing fallback content between the opening and closing tags of an {{HTMLElement("object")}} element.
 

--- a/files/en-us/web/html/element/portal/index.md
+++ b/files/en-us/web/html/element/portal/index.md
@@ -11,10 +11,11 @@ tags:
   - Reference
   - Web
   - Portal
+  - Experimental
 browser-compat: html.elements.portal
 ---
 
-{{HTMLRef}}
+{{HTMLRef}}{{SeeCompatTable}}
 
 The **`<portal>`** [HTML](/en-US/docs/Web/HTML) element enables the embedding of another HTML page into the current one for the purposes of allowing smoother navigation into new pages.
 

--- a/files/en-us/web/html/element/pre/index.md
+++ b/files/en-us/web/html/element/pre/index.md
@@ -79,9 +79,9 @@ This element only includes the [global attributes](/en-US/docs/Web/HTML/Global_a
 
 - {{htmlattrdef("cols")}} {{non-standard_inline}} {{deprecated_inline}}
   - : Contains the _preferred_ count of characters that a line should have. It was a non-standard synonym of {{htmlattrxref("width", "pre")}}. To achieve such an effect, use CSS {{Cssxref("width")}} instead.
-- {{htmlattrdef("width")}} {{deprecated_inline}}
+- {{htmlattrdef("width")}} {{deprecated_inline}} {{Non-standard_Inline}}
   - : Contains the _preferred_ count of characters that a line should have. Though technically still implemented, this attribute has no visual effect; to achieve such an effect, use CSS {{Cssxref("width")}} instead.
-- {{htmlattrdef("wrap")}} {{non-standard_inline}}
+- {{htmlattrdef("wrap")}} {{non-standard_inline}} {{Deprecated_Inline}}
   - : Is a _hint_ indicating how the overflow must happen. In modern browser this hint is ignored and no visual effect results in its present; to achieve such an effect, use CSS {{Cssxref("white-space")}} instead.
 
 ## Accessibility concerns


### PR DESCRIPTION
Same as https://github.com/mdn/content/pull/19185, but for HTML pages.

The PR updates tags, headers, and inline badges as per current BCD v5.1.10.

***
**Note:** We are simply synchronizing it with BCD. If you have objection with any compatibility status then raise an issue or PR in https://github.com/mdn/browser-compat-data repo. After BCD gets updated it'll be updated in HTML content automatically.
