### PR TITLE
CSS: update BCD Info

### DIFF
--- a/files/en-us/web/css/@font-face/font-display/index.md
+++ b/files/en-us/web/css/@font-face/font-display/index.md
@@ -8,7 +8,6 @@ tags:
   - CSS Descriptor
   - CSS Fonts
   - CSS Property
-  - Experimental
   - Fonts
   - Reference
   - font-display

--- a/files/en-us/web/css/@font-face/unicode-range/index.md
+++ b/files/en-us/web/css/@font-face/unicode-range/index.md
@@ -6,7 +6,6 @@ tags:
   - CSS
   - CSS Fonts
   - CSS Property
-  - Experimental
   - Layout
   - Reference
   - Web

--- a/files/en-us/web/css/@page/size/index.md
+++ b/files/en-us/web/css/@page/size/index.md
@@ -6,13 +6,12 @@ tags:
   - At-rule descriptor
   - CSS
   - CSS Descriptor
-  - Experimental
   - NeedsBrowserCompatibility
   - Reference
   - Web
 browser-compat: css.at-rules.page.size
 ---
-{{CSSRef}}{{SeeCompatTable}}
+{{CSSRef}}
 
 The **`size`** [CSS](/en-US/docs/Web/CSS) [at-rule](/en-US/docs/Web/CSS/At-rule) descriptor, used with the {{cssxref("@page")}} at-rule, defines the size and orientation of the box which is used to represent a page. Most of the time, this size corresponds to the target size of the printed page if applicable.
 

--- a/files/en-us/web/css/_colon_paused/index.md
+++ b/files/en-us/web/css/_colon_paused/index.md
@@ -8,7 +8,7 @@ tags:
   - paused
 browser-compat: css.selectors.paused
 ---
-{{CSSRef}}{{SeeCompatTable}}
+{{CSSRef}}
 
 The **`:paused`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) selector is a resource state pseudo-class that will match an audio, video, or similar resource that is capable of being "played" or "paused", when that element is "paused".
 

--- a/files/en-us/web/css/_colon_playing/index.md
+++ b/files/en-us/web/css/_colon_playing/index.md
@@ -8,7 +8,7 @@ tags:
   - playing
 browser-compat: css.selectors.playing
 ---
-{{CSSRef}}{{SeeCompatTable}}
+{{CSSRef}}
 
 The **`:playing`** [CSS](/en-US/docs/Web/CSS) [pseudo-class](/en-US/docs/Web/CSS/Pseudo-classes) selector is a resource state pseudo-class that will match an audio, video, or similar resource that is capable of being "played" or "paused", when that element is "playing".
 

--- a/files/en-us/web/css/cross-fade/index.md
+++ b/files/en-us/web/css/cross-fade/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Function
   - CSS-4 Images
-  - Experimental
   - Function
   - Reference
   - Web

--- a/files/en-us/web/css/css_motion_path/index.md
+++ b/files/en-us/web/css/css_motion_path/index.md
@@ -4,14 +4,13 @@ slug: Web/CSS/CSS_Motion_Path
 tags:
   - CSS
   - CSS Motion Path
-  - Experimental
   - Guide
   - Motion Path
   - Overview
   - Reference
 browser-compat: css.properties.offset-path
 ---
-{{CSSRef}}{{SeeCompatTable}}
+{{CSSRef}}
 
 **Motion Path** is a CSS module that allows authors to animate any graphical object along a custom path.
 

--- a/files/en-us/web/css/frequency-percentage/index.md
+++ b/files/en-us/web/css/frequency-percentage/index.md
@@ -11,7 +11,7 @@ tags:
   - values
 browser-compat: css.types.frequency-percentage
 ---
-{{CSSRef}}{{SeeCompatTable}}
+{{CSSRef}}
 
 The **`<frequency-percentage>`** [CSS](/en-US/docs/Web/CSS) [data type](/en-US/docs/Web/CSS/CSS_Types) represents a value that can be either a {{Cssxref("frequency")}} or a {{Cssxref("percentage")}}. Frequency values, e.g. the pitch of a speaking voice, are not currently used in any CSS properties.
 

--- a/files/en-us/web/css/image/paint/index.md
+++ b/files/en-us/web/css/image/paint/index.md
@@ -11,7 +11,7 @@ tags:
   - Web
 browser-compat: css.types.image.paint
 ---
-{{CSSRef}}{{SeeCompatTable}}
+{{CSSRef}}
 
 The **`paint()`** [CSS](/en-US/docs/Web/CSS) [function](/en-US/docs/Web/CSS/CSS_Functions) defines an {{cssxref("&lt;image&gt;")}} value generated with a PaintWorklet.
 

--- a/files/en-us/web/css/minmax/index.md
+++ b/files/en-us/web/css/minmax/index.md
@@ -5,7 +5,6 @@ tags:
   - CSS
   - CSS Function
   - CSS Grid
-  - Experimental
   - Function
   - Layout
   - Reference

--- a/files/en-us/web/css/var/index.md
+++ b/files/en-us/web/css/var/index.md
@@ -6,7 +6,6 @@ tags:
   - CSS Custom Properties
   - CSS Function
   - CSS Variables
-  - Experimental
   - Function
   - Reference
   - Variables


### PR DESCRIPTION
Same as https://github.com/mdn/content/pull/19185, but for CSS pages.

The PR updates tags, headers, and inline badges as per current BCD v5.1.10.

This focuses on removing 'experimental' status.

***
**Note:** We are simply synchronizing it with BCD. If you have objection with any compatibility status then raise an issue or PR in https://github.com/mdn/browser-compat-data repo.
